### PR TITLE
Relax comparison criteria for Apply_cont_expr

### DIFF
--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -519,6 +519,9 @@ let create_switch uacc ~scrutinee ~arms =
         UA.add_free_names uacc (Apply_cont.free_names action)
         |> UA.notify_added ~code_size:(Code_size.apply_cont action)
       in
+      (* The resulting [Debuginfo] on the [Apply_cont] will be arbitrarily
+         chosen from amongst the [Debuginfo] values on the arms, but this seems
+         fine. *)
       RE.create_apply_cont action, uacc
     in
     match Targetint_31_63.Map.get_singleton arms with

--- a/middle_end/flambda2/terms/apply_cont_expr.ml
+++ b/middle_end/flambda2/terms/apply_cont_expr.ml
@@ -89,11 +89,8 @@ include Container_types.Make (struct
 
   let hash _ = Misc.fatal_error "Not yet implemented"
 
-  (* CR mshinwell: I wonder if the Debuginfo should be excluded from this. For
-     example at the moment we could get a Switch with two arms that go to the
-     same place but differ only on Debuginfo. *)
-  let compare { k = k1; args = args1; trap_action = trap_action1; dbg = dbg1 }
-      { k = k2; args = args2; trap_action = trap_action2; dbg = dbg2 } =
+  let compare { k = k1; args = args1; trap_action = trap_action1; dbg = _ }
+      { k = k2; args = args2; trap_action = trap_action2; dbg = _ } =
     let c = Continuation.compare k1 k2 in
     if c <> 0
     then c
@@ -101,9 +98,7 @@ include Container_types.Make (struct
       let c = Misc.Stdlib.List.compare Simple.compare args1 args2 in
       if c <> 0
       then c
-      else
-        let c = Option.compare Trap_action.compare trap_action1 trap_action2 in
-        if c <> 0 then c else Debuginfo.compare dbg1 dbg2
+      else Option.compare Trap_action.compare trap_action1 trap_action2
 
   let equal t1 t2 = compare t1 t2 = 0
 end)

--- a/middle_end/flambda2/terms/apply_cont_expr.mli
+++ b/middle_end/flambda2/terms/apply_cont_expr.mli
@@ -64,4 +64,5 @@ val clear_trap_action : t -> t
 
 val to_one_arg_without_trap_action : t -> Simple.t option
 
+(** Note that [compare] ignores the [Debuginfo.t]. *)
 include Container_types.S with type t := t


### PR DESCRIPTION
There was an old CR about this.  This patch enables more switch expressions to be squashed out to just "goto".