### PR TITLE
Move recursive type definitions out of recursive modules in flambda.ml

### DIFF
--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -1125,16 +1125,17 @@ and static_consts env (const1 : Static_const_or_code.t)
   match const1, const2 with
   | Code code1, Code code2 ->
     codes env code1 code2
-    |> Comparison.map ~f:(fun code1' -> Static_const_or_code.Code code1')
+    |> Comparison.map ~f:(fun code1' : Static_const_or_code.t -> Code code1')
   | ( Static_const (Block (tag1, mut1, fields1)),
       Static_const (Block (tag2, mut2, fields2)) ) ->
     blocks env (tag1, mut1, fields1) (tag2, mut2, fields2)
-    |> Comparison.map ~f:(fun (tag1', mut1', fields1') ->
-           Static_const_or_code.Static_const (Block (tag1', mut1', fields1')))
+    |> Comparison.map
+         ~f:(fun (tag1', mut1', fields1') : Static_const_or_code.t ->
+           Static_const (Block (tag1', mut1', fields1')))
   | Static_const (Set_of_closures set1), Static_const (Set_of_closures set2) ->
     sets_of_closures env set1 set2
-    |> Comparison.map ~f:(fun set1' ->
-           Static_const_or_code.Static_const (Set_of_closures set1'))
+    |> Comparison.map ~f:(fun set1' : Static_const_or_code.t ->
+           Static_const (Set_of_closures set1'))
   | _, _ ->
     if Static_const_or_code.equal const1 const2
     then Equivalent

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1042,8 +1042,7 @@ let close_program ~symbol_for_global ~big_endian ~module_ident
       in
       let named =
         Named.create_static_consts
-          (Static_const_group.create
-             [Static_const_or_code.Static_const static_const])
+          (Static_const_group.create [Static_const static_const])
       in
       Let_with_acc.create acc
         (Bound_pattern.symbols bound_symbols)
@@ -1125,8 +1124,7 @@ let close_program ~symbol_for_global ~big_endian ~module_ident
           Bound_symbols.singleton (Bound_symbols.Pattern.block_like symbol)
         in
         let defining_expr =
-          Static_const_group.create
-            [Static_const_or_code.Static_const static_const]
+          Static_const_group.create [Static_const static_const]
           |> Named.create_static_consts
         in
         Let_with_acc.create acc

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -491,11 +491,11 @@ end
 module Let_with_acc = struct
   let create acc let_bound named ~body =
     let cost_metrics_of_defining_expr =
-      match named with
-      | Named.Prim (prim, _) -> Code_size.prim prim |> Cost_metrics.from_size
-      | Named.Simple simple -> Code_size.simple simple |> Cost_metrics.from_size
-      | Named.Static_consts _consts -> Cost_metrics.zero
-      | Named.Set_of_closures set_of_closures ->
+      match (named : Named.t) with
+      | Prim (prim, _) -> Code_size.prim prim |> Cost_metrics.from_size
+      | Simple simple -> Code_size.simple simple |> Cost_metrics.from_size
+      | Static_consts _consts -> Cost_metrics.zero
+      | Set_of_closures set_of_closures ->
         let code_mapping = Acc.code acc in
         Cost_metrics.set_of_closures
           ~find_code_characteristics:(fun code_id ->
@@ -504,7 +504,7 @@ module Let_with_acc = struct
               params_arity = List.length (Code.params_arity code)
             })
           set_of_closures
-      | Named.Rec_info _ -> Cost_metrics.zero
+      | Rec_info _ -> Cost_metrics.zero
     in
     let acc =
       Acc.increment_metrics

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -644,9 +644,8 @@ and dynamic_let_expr env vars (defining_expr : Flambda.Named.t) body :
 
 and static_let_expr env bound_symbols defining_expr body : Fexpr.expr =
   let static_consts =
-    match defining_expr with
-    | Flambda.Named.Static_consts static_consts ->
-      static_consts |> Static_const_group.to_list
+    match (defining_expr : Named.t) with
+    | Static_consts static_consts -> static_consts |> Static_const_group.to_list
     | _ -> assert false
   in
   let bound_symbols = bound_symbols |> Bound_symbols.to_list in

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -364,7 +364,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
         ~name:(Closure_id.to_string callee's_closure_id ^ "_partial")
         (Compilation_unit.get_current_exn ())
     in
-    let code =
+    let code : Static_const_or_code.t =
       let free_names = Function_params_and_body.free_names params_and_body in
       let code =
         Code.create code_id
@@ -376,7 +376,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
           ~inlining_arguments:(DE.inlining_arguments (DA.denv dacc))
           ~dbg ~is_tupled:false ~inlining_decision:Stub
       in
-      Static_const_or_code.Code code
+      Code code
     in
     let function_decls =
       Function_declarations.create

--- a/middle_end/flambda2/terms/flambda_unit.ml
+++ b/middle_end/flambda2/terms/flambda_unit.ml
@@ -155,12 +155,13 @@ module Iter = struct
         named t bound_pattern f_c f_s e;
         expr f_c f_s body)
 
-  and let_cont f_c f_s = function
-    | Let_cont.Non_recursive { handler; _ } ->
+  and let_cont f_c f_s (let_cont : Flambda.Let_cont.t) =
+    match let_cont with
+    | Non_recursive { handler; _ } ->
       Non_recursive_let_cont_handler.pattern_match handler ~f:(fun k ~body ->
           let h = Non_recursive_let_cont_handler.handler handler in
           let_cont_aux f_c f_s k h body)
-    | Let_cont.Recursive handlers ->
+    | Recursive handlers ->
       Recursive_let_cont_handlers.pattern_match handlers ~f:(fun ~body conts ->
           assert (not (Continuation_handlers.contains_exn_handler conts));
           let_cont_rec f_c f_s conts body)

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -772,15 +772,15 @@ and decide_inline_cont h k ~num_free_occurrences ~is_applied_with_traps =
   && (not is_applied_with_traps)
   && cont_is_known_to_have_exactly_one_occurrence k num_free_occurrences
 
-and let_cont env res = function
-  | Let_cont.Non_recursive
-      { handler; num_free_occurrences; is_applied_with_traps } ->
+and let_cont env res (let_cont : Flambda.Let_cont.t) =
+  match let_cont with
+  | Non_recursive { handler; num_free_occurrences; is_applied_with_traps } ->
     Non_recursive_let_cont_handler.pattern_match handler ~f:(fun k ~body ->
         let h = Non_recursive_let_cont_handler.handler handler in
         if decide_inline_cont h k ~num_free_occurrences ~is_applied_with_traps
         then let_cont_inline env res k h body
         else let_cont_jump env res k h body)
-  | Let_cont.Recursive handlers ->
+  | Recursive handlers ->
     Recursive_let_cont_handlers.pattern_match handlers ~f:(fun ~body conts ->
         assert (not (Continuation_handlers.contains_exn_handler conts));
         let_cont_rec env res conts body)


### PR DESCRIPTION
Next the recursive functions will be moved out, at which point the modules do not need to be recursive any more.

Depends on #320, #321, #325 and #326.