### PR TITLE
Make inlining parameters more aggressive

### DIFF
--- a/ocaml/utils/clflags.ml
+++ b/ocaml/utils/clflags.ml
@@ -606,7 +606,7 @@ module Flambda2 = struct
     }
 
     let o2_arguments = {
-      max_depth = Some 2;
+      max_depth = Some 10;
       call_cost = Some (2.0 *. Default.call_cost);
       alloc_cost = Some (2.0 *. Default.alloc_cost);
       prim_cost = Some (2.0 *. Default.prim_cost);
@@ -619,16 +619,16 @@ module Flambda2 = struct
     }
 
     let o3_arguments = {
-      max_depth = Some 3;
+      max_depth = Some 20;
       call_cost = Some (3.0 *. Default.call_cost);
       alloc_cost = Some (3.0 *. Default.alloc_cost);
       prim_cost = Some (3.0 *. Default.prim_cost);
       branch_cost = Some (3.0 *. Default.branch_cost);
       indirect_call_cost = Some (3.0 *. Default.indirect_call_cost);
       poly_compare_cost = Some (3.0 *. Default.poly_compare_cost);
-      small_function_size = Some (3 * Default.small_function_size);
-      large_function_size = Some (8 * Default.large_function_size);
-      threshold = Some 50.;
+      small_function_size = Some (10 * Default.small_function_size);
+      large_function_size = Some (100 * Default.large_function_size);
+      threshold = Some 100.;
     }
   end
 


### PR DESCRIPTION
The max-depth parameters can now be increased thanks to the `Rec_info` work.

The large function size is too low for `-O3`.  I also suspect the small function size is too small and the inlining threshold is a bit low.  I'm not sure exactly where these should be set, but based on some experiments inside JS, these new settings should be better.  We can always adjust again.

We also need to add an attribute which forces functions to be saved in the `.cmx` files even if they are over the large function threshold.