### PR TITLE
Use -O2 not -O3 for building flambda2

### DIFF
--- a/middle_end/flambda2/algorithms/dune
+++ b/middle_end/flambda2/algorithms/dune
@@ -6,5 +6,5 @@
  (flags
   (:standard -principal -nostdlib))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O2))
  (libraries stdlib ocamlcommon))

--- a/middle_end/flambda2/bound_identifiers/dune
+++ b/middle_end/flambda2/bound_identifiers/dune
@@ -18,7 +18,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O2))
  (libraries
   stdlib
   ocamlcommon

--- a/middle_end/flambda2/cmx/dune
+++ b/middle_end/flambda2/cmx/dune
@@ -28,7 +28,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O2))
  (libraries
   stdlib
   ocamlcommon

--- a/middle_end/flambda2/compare/dune
+++ b/middle_end/flambda2/compare/dune
@@ -12,5 +12,5 @@
    -open
    Flambda2_algorithms))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O2))
  (libraries stdlib ocamlcommon flambda2_algorithms flambda2_terms))

--- a/middle_end/flambda2/dune
+++ b/middle_end/flambda2/dune
@@ -22,7 +22,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O2))
  (modules flambda2)
  (libraries
   stdlib

--- a/middle_end/flambda2/from_lambda/dune
+++ b/middle_end/flambda2/from_lambda/dune
@@ -30,7 +30,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O2))
  (libraries
   stdlib
   ocamlcommon

--- a/middle_end/flambda2/identifiers/dune
+++ b/middle_end/flambda2/identifiers/dune
@@ -16,7 +16,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O2))
  (libraries
   stdlib
   ocamlcommon

--- a/middle_end/flambda2/kinds/dune
+++ b/middle_end/flambda2/kinds/dune
@@ -14,7 +14,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O2))
  (libraries
   stdlib
   ocamlcommon

--- a/middle_end/flambda2/lattices/dune
+++ b/middle_end/flambda2/lattices/dune
@@ -14,7 +14,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O2))
  (libraries
   stdlib
   ocamlcommon

--- a/middle_end/flambda2/nominal/dune
+++ b/middle_end/flambda2/nominal/dune
@@ -14,7 +14,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O2))
  (libraries
   stdlib
   ocamlcommon

--- a/middle_end/flambda2/numbers/dune
+++ b/middle_end/flambda2/numbers/dune
@@ -12,5 +12,5 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O2))
  (libraries stdlib ocamlcommon flambda2_algorithms flambda2_ui))

--- a/middle_end/flambda2/parser/dune
+++ b/middle_end/flambda2/parser/dune
@@ -117,7 +117,7 @@
    -open
    Flambda2_nominal))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O2))
  (modules
   (:standard \ flambda_parser_in))
  ; ignore inputs to sed

--- a/middle_end/flambda2/simplify/dune
+++ b/middle_end/flambda2/simplify/dune
@@ -32,7 +32,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O2))
  (libraries
   stdlib
   ocamlcommon

--- a/middle_end/flambda2/term_basics/dune
+++ b/middle_end/flambda2/term_basics/dune
@@ -20,7 +20,7 @@
    -open
    Flambda2_numbers))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O2))
  (libraries
   stdlib
   ocamlcommon

--- a/middle_end/flambda2/terms/dune
+++ b/middle_end/flambda2/terms/dune
@@ -26,7 +26,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O2))
  (libraries
   stdlib
   ocamlcommon

--- a/middle_end/flambda2/to_cmm/dune
+++ b/middle_end/flambda2/to_cmm/dune
@@ -28,7 +28,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O2))
  (libraries
   stdlib
   ocamlcommon

--- a/middle_end/flambda2/types/dune
+++ b/middle_end/flambda2/types/dune
@@ -28,7 +28,7 @@
    -open
    Flambda2_ui))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O2))
  (libraries
   stdlib
   ocamlcommon

--- a/middle_end/flambda2/ui/dune
+++ b/middle_end/flambda2/ui/dune
@@ -6,5 +6,5 @@
  (flags
   (:standard -principal -nostdlib))
  (ocamlopt_flags
-  (:standard -O3))
+  (:standard -O2))
  (libraries stdlib ocamlcommon))


### PR DESCRIPTION
The recent change to make `-O3` more aggressive has slowed build times down for flambda2 significantly (+10 minutes for the CI checks).  I think `-O2` is sufficient for this part of the code for the moment.