### PR TITLE
Tweak error messages in `Compenv`

### DIFF
--- a/ocaml/driver/compenv.ml
+++ b/ocaml/driver/compenv.ml
@@ -429,11 +429,11 @@ let read_one_param ppf position name v =
       Flambda2.Inlining.poly_compare_cost
   | "flambda2-inline-small-function-size" ->
     Int_arg_helper.parse v
-      "Bad syntax in OCAMLPARAM for 'flambda2-small-function-size'"
+      "Bad syntax in OCAMLPARAM for 'flambda2-inline-small-function-size'"
       Flambda2.Inlining.small_function_size
   | "flambda2-inline-large-function-size" ->
     Int_arg_helper.parse v
-      "Bad syntax in OCAMLPARAM for 'flambda2-large-function-size'"
+      "Bad syntax in OCAMLPARAM for 'flambda2-inline-large-function-size'"
       Flambda2.Inlining.large_function_size
   | "flambda2-inline-threshold" ->
     Float_arg_helper.parse v


### PR DESCRIPTION
This (useless) pull request fixes two error messages in
`Compenv` which are referring to nonexistent flags.

(It was the cause of a misconfiguration when I copy/pasted
the wrong string...)