### PR TITLE
Add flambda_oclassic attribute

### DIFF
--- a/ocaml/parsing/builtin_attributes.ml
+++ b/ocaml/parsing/builtin_attributes.ml
@@ -342,6 +342,12 @@ let nolabels_attribute attr =
   clflags_attribute_without_payload attr
     ~name:"nolabels" Clflags.classic
 
+let flambda_oclassic_attribute attr =
+  clflags_attribute_without_payload' attr
+    ~name:"flambda_oclassic"
+    ~f:(fun () ->
+      if Config.flambda || Config.flambda2 then Clflags.set_oclassic ())
+
 let flambda_o3_attribute attr =
   clflags_attribute_without_payload' attr
     ~name:"flambda_o3"
@@ -378,4 +384,5 @@ let parse_standard_implementation_attributes attr =
   nolabels_attribute attr;
   inline_attribute attr;
   afl_inst_ratio_attribute attr;
-  flambda_o3_attribute attr
+  flambda_o3_attribute attr;
+  flambda_oclassic_attribute attr

--- a/ocaml/parsing/builtin_attributes.mli
+++ b/ocaml/parsing/builtin_attributes.mli
@@ -31,6 +31,7 @@
     - ocaml.inline
     - ocaml.afl_inst_ratio
     - ocaml.flambda_o3
+    - ocaml.flambda_oclassic
 
     {b Warning:} this module is unstable and part of
   {{!Compiler_libs}compiler-libs}.


### PR DESCRIPTION
This mirrors the existing `flambda_o3` attribute and will help for very large source files that should always be compiled in classic mode.