### PR TITLE
Simplify checking whether flambda2 is enabled in Makefile

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -450,23 +450,18 @@ runtest-upstream:
 	cp _build1/default/ocaml/ocamltest/ocamltest.byte \
 	  _runtest/ocamltest/ocamltest
 	grep -v '^#' testsuite/flambda2-test-list > _runtest/flambda2-test-list
-	if _build2/install/default/bin/ocamlopt.opt -config \
-	  | grep "flambda2: true" > /dev/null; \
-	then touch _runtest/is-flambda2; \
-	else rm -f _runtest/is-flambda2; \
-	fi
 	(export OCAMLSRCDIR=$$(pwd)/_runtest; \
 	 export CAML_LD_LIBRARY_PATH=$$(pwd)/_runtest/lib/ocaml/stublibs; \
 	 cd _runtest/testsuite \
 	  && if $$(which parallel > /dev/null 2>&1); \
              then \
-               if [ -f ../is-flambda2 ]; then \
+               if [ "$(middle_end)" = "flambda2" ]; then \
                  make list-parallel FILE=$$(pwd)/../flambda2-test-list; \
 	       else \
                  make parallel; \
                fi \
              else \
-               if [ -f ../is-flambda2 ]; then \
+               if [ "$(middle_end)" = "flambda2" ]; then \
                  make list FILE=$$(pwd)/../flambda2-test-list; \
 	       else \
                  make all; \

--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,7 @@ AC_ARG_ENABLE([middle-end],
   [AS_CASE([$enable_middle_end],
     [closure], [middle_end=closure middle_end_arg=--disable-flambda],
     [flambda], [middle_end=flambda middle_end_arg=--enable-flambda],
-    [flambda2], [middle_end=flambda middle_end_arg=--enable-flambda2],
+    [flambda2], [middle_end=flambda2 middle_end_arg=--enable-flambda2],
     [*], [AC_MSG_ERROR([Bad middle end (not closure, flambda or flambda2)])])],
   [AC_MSG_ERROR([--enable-middle-end=closure|flambda|flambda2 must be provided])])
 


### PR DESCRIPTION
Currently we have a rather roundabout way of figuring out whether flambda2 is enabled when we run the upstream tests. Since the Makefile is getting generated by autoconf anyway, we can just check a Make-level variable instead.

Note that the `middle_end` variable is currently completely unused, both in `configure.ac` and in `Makefile.in`, so changing its value here is safe.

(It would further improve things to use a Make-level conditional rather than a shell `if` to make for better log output, but the combined foibles of Make and shell syntax make it hard to find a not-horrendous way to do this.)