### PR TITLE
Remove bad prefix setting in build_upstream target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,7 +379,6 @@ _build_upstream/config.status: ocaml/configure.ac
 	rsync -a $$(pwd)/ocaml/ $$(pwd)/_build_upstream
 	(cd _build_upstream && \
 	  ./configure -C $(CONFIGURE_ARGS) --prefix=$$(pwd)/_install \
-	    --prefix=@prefix@ \
 	    --disable-ocamldoc \
 	    --enable-ocamltest)
 


### PR DESCRIPTION
I forgot that `build_upstream` was used for building 32-bit x86 compilers.  There are two problems in the rule: the configure arguments are expanded incorrectly (meaning that something like `CC=\"gcc -m32\"` doesn't work any more) and a bogus prefix setting.  This patch fixes the second of these.