### PR TITLE
Add @local_opt to Sys.opaque_identity

### DIFF
--- a/ocaml/stdlib/sys.ml.in
+++ b/ocaml/stdlib/sys.ml.in
@@ -159,7 +159,7 @@ let ocaml_release = {
 
 (* Optimization *)
 
-external opaque_identity : 'a -> 'a = "%opaque"
+external opaque_identity : ('a[@local_opt]) -> ('a[@local_opt]) = "%opaque"
 
 module Immediate64 = struct
   module type Non_immediate = sig

--- a/ocaml/stdlib/sys.mli
+++ b/ocaml/stdlib/sys.mli
@@ -415,7 +415,7 @@ val runtime_warnings_enabled: unit -> bool
 
 (** {1 Optimization} *)
 
-external opaque_identity : 'a -> 'a = "%opaque"
+external opaque_identity : ('a[@local_opt]) -> ('a[@local_opt]) = "%opaque"
 (** For the purposes of optimization, [opaque_identity] behaves like an
     unknown (and thus possibly side-effecting) function.
 

--- a/ocaml/testsuite/tests/async-exns/async_exns_1.ml
+++ b/ocaml/testsuite/tests/async-exns/async_exns_1.ml
@@ -2,6 +2,10 @@
    modules = "async_exns_stubs.c"
 *)
 
+external global_opaque_identity : 'a -> 'a = "%identity"
+
+(* Ensure that [Sys.Break] can be raised and caught as an async exception. *)
+
 let () = Sys.catch_break true
 
 (* Lifted out to ensure this works in bytecode, where [b] is easily
@@ -32,7 +36,7 @@ let () =
           r := None;
           while true do
             (* This allocation will eventually trigger the finaliser *)
-            let _ = Sys.opaque_identity (42, Random.int 42) in
+            let _ = global_opaque_identity (42, Random.int 42) in
             ()
           done
         with exn -> Printf.printf "1. wrong handler\n%!"; assert false
@@ -48,7 +52,7 @@ let () =
 let () =
   try
     Sys.with_async_exns (fun () ->
-      try raise (Sys.opaque_identity Sys.Break)
+      try raise (global_opaque_identity Sys.Break)
       with Sys.Break -> Printf.printf "2. OK\n%!"
     )
   with
@@ -62,7 +66,7 @@ let raise_break_from_finaliser () =
   try
     r := None;
     while true do
-      let _ = Sys.opaque_identity (42, Random.int 42) in
+      let _ = global_opaque_identity (42, Random.int 42) in
       ()
     done
   with exn -> Printf.printf "3a/b/c/d. wrong handler\n%!"; exit 1

--- a/ocaml/testsuite/tests/callback/signals_alloc.ml
+++ b/ocaml/testsuite/tests/callback/signals_alloc.ml
@@ -6,6 +6,7 @@
    ** native
 *)
 external raise_sigusr1 : unit -> unit = "raise_sigusr1"
+external global_opaque_identity : 'a -> 'a = "%opaque"
 
 let do_test () =
   let seen_states = Array.make 5 (-1) in
@@ -21,7 +22,7 @@ let do_test () =
   seen_states.(!pos) <- 1; pos := !pos + 1;
   raise_sigusr1 ();
   seen_states.(!pos) <- 2; pos := !pos + 1;
-  let _ = Sys.opaque_identity (ref 1) in
+  let _ = global_opaque_identity (ref 1) in
   seen_states.(!pos) <- 4; pos := !pos + 1;
   Sys.set_signal Sys.sigusr1 Sys.Signal_default;
   Array.iter (Printf.printf "%d") seen_states;

--- a/ocaml/testsuite/tests/typing-local/loop_regions.ml
+++ b/ocaml/testsuite/tests/typing-local/loop_regions.ml
@@ -9,7 +9,6 @@
 
 external local_stack_offset : unit -> int = "caml_local_stack_offset"
 let local_stack_offset () = local_stack_offset () / (Sys.word_size / 8)
-external opaque_local : ('a[@local_opt]) -> ('a[@local_opt]) = "%opaque"
 
 let print_offsets (name,allocs) =
   let p xs = String.concat "; " (List.map Int.to_string xs) in
@@ -22,7 +21,7 @@ let loc_for () =
   let offset1 = local_stack_offset () in
   for i = 0 to 0 do [%exclave] (
     let z = local_ (Some (Sys.opaque_identity 42)) in
-    let _ = (opaque_local z) in
+    let _ = (Sys.opaque_identity z) in
     offset_loop := local_stack_offset ()
   )
   done;
@@ -35,7 +34,7 @@ let nonloc_for () =
   let offset1 = local_stack_offset () in
   for i = 0 to 0 do
     let z = local_ (Some (Sys.opaque_identity 42)) in
-    let _ = (opaque_local z) in
+    let _ = (Sys.opaque_identity z) in
     offset_loop := local_stack_offset ()
   done;
   let offset2 = local_stack_offset () in
@@ -48,7 +47,7 @@ let loc_while_body () =
   let cond = ref true in
   while !cond do [%exclave] (
     let z = local_ (Some (Sys.opaque_identity 42)) in
-    let _ = (opaque_local z) in
+    let _ = (Sys.opaque_identity z) in
     offset_loop := local_stack_offset ();
     cond := false
   )
@@ -63,7 +62,7 @@ let nonloc_while_body () =
   let cond = ref true in
   while !cond do
     let z = local_ (Some (Sys.opaque_identity 42)) in
-    let _ = (opaque_local z) in
+    let _ = (Sys.opaque_identity z) in
     offset_loop := local_stack_offset ();
     cond := false
   done;
@@ -76,7 +75,7 @@ let[@inline never] loc_while_cond () =
   let offset1 = local_stack_offset () in
   while [%exclave] (
     let z = local_ (Some (Sys.opaque_identity 42)) in
-    let _ = (opaque_local z) in
+    let _ = (Sys.opaque_identity z) in
     offset_loop := local_stack_offset ();
     Sys.opaque_identity false
   )
@@ -92,7 +91,7 @@ let[@inline never] nonloc_while_cond () =
   let offset1 = local_stack_offset () in
   while
     let z = local_ (Some (Sys.opaque_identity 42)) in
-    let _ = (opaque_local z) in
+    let _ = (Sys.opaque_identity z) in
     offset_loop := local_stack_offset ();
     Sys.opaque_identity false
   do
@@ -106,7 +105,7 @@ let[@inline never] loc_func () =
   let fun_exclave r =
     [%exclave] (
         let z = local_ (Some (Sys.opaque_identity 42)) in
-        let _ = (opaque_local z) in
+        let _ = (Sys.opaque_identity z) in
         r := local_stack_offset ()
     ) in
   let offset1 = local_stack_offset () in
@@ -119,7 +118,7 @@ let[@inline never] nonloc_func () =
   let offset_func = ref (-1) in
   let fun_nonexclave r =
     let z = local_ (Some (Sys.opaque_identity 42)) in
-    let _ = (opaque_local z) in
+    let _ = (Sys.opaque_identity z) in
     r := local_stack_offset ()
   in
   let offset1 = local_stack_offset () in

--- a/ocaml/testsuite/tests/typing-local/pr902.ml
+++ b/ocaml/testsuite/tests/typing-local/pr902.ml
@@ -7,7 +7,6 @@
    overapplication) *)
 
 external local_stack_offset : unit -> int = "caml_local_stack_offset"
-external opaque_identity : ('a[@local_opt]) -> ('a[@local_opt]) = "%opaque"
 external is_stack : local_ 'a -> bool = "caml_obj_is_stack"
 
 let f2 p () = p
@@ -19,7 +18,7 @@ let f1 () x : (unit -> local_ (int * int)) =
      overapplication below is wrongly Heap, then caml_apply will be used
      instead, which will open its own region for this allocation. *)
   let p = local_ (x, x) in
-  local_ ((opaque_identity f2) p) [@nontail]
+  local_ ((Sys.opaque_identity f2) p) [@nontail]
 
 let[@inline never] to_be_overapplied () () = Sys.opaque_identity f1
 

--- a/ocaml/testsuite/tests/typing-local/regions.ml
+++ b/ocaml/testsuite/tests/typing-local/regions.ml
@@ -5,8 +5,8 @@
    ** native *)
 
 external local_stack_offset : unit -> int = "caml_local_stack_offset"
-external opaque_identity : ('a[@local_opt]) -> ('a[@local_opt]) = "%opaque"
-let[@inline never] ignore_local (local_ x) = let _ = opaque_identity x in ()
+external global_opaque_identity : 'a -> 'a = "%opaque"
+let[@inline never] ignore_local (local_ x) = let _ = Sys.opaque_identity x in ()
 let last_offset = ref 0
 
 let check_empty name =
@@ -44,7 +44,7 @@ let[@inline never] int_as_pointer_local x =
   leak_in_current_region x;
   (* The region should be preserved by the following call; hence no stack space
      leaking *)
-  let _ = opaque_identity (follow ext) in
+  let _ = Sys.opaque_identity (follow ext) in
   ()
 
 let[@inline never] int_as_pointer_global x =
@@ -52,7 +52,7 @@ let[@inline never] int_as_pointer_global x =
      function calls don't allocate on the region (superficially). The first call
      secretly does, hence stack space leaking. *)
   leak_in_current_region x;
-  let _ = Sys.opaque_identity (follow ext) in
+  let _ = global_opaque_identity (follow ext) in
   ()
 
 let () =
@@ -65,7 +65,7 @@ let () =
 
 let[@inline never] uses_local x =
   let local_ r = ref x in
-  let _ = opaque_identity r in
+  let _ = Sys.opaque_identity r in
   ()
 let () =
   uses_local 42;
@@ -73,7 +73,7 @@ let () =
 
 let[@inline never] uses_exclave x =
   let local_ r = ref x in
-  let _ = opaque_identity r in
+  let _ = Sys.opaque_identity r in
   [%exclave] (
     check_empty "cleanup upon exclave"
   )
@@ -84,8 +84,8 @@ let () =
 let[@inline never] uses_local_try x =
   try
     let r = local_ ref x in
-    if opaque_identity false then raise Exit;
-    let _ = opaque_identity r in
+    if Sys.opaque_identity false then raise Exit;
+    let _ = Sys.opaque_identity r in
     ()
   with Exit -> ()
 let () =
@@ -94,7 +94,7 @@ let () =
 
 let[@inline never][@specialise never][@local never] do_tailcall f =
   let local_ r = ref 42 in
-  let _ = opaque_identity r in
+  let _ = Sys.opaque_identity r in
   f ()
 let () =
   do_tailcall (fun () -> check_empty "during indirect tailcall");
@@ -105,7 +105,7 @@ let[@inline always] tailcalled_function () =
   check_empty "during direct tailcall"
 let[@inline never] do_direct_tailcall () =
   let local_ r = ref 42 in
-  let _ = opaque_identity r in
+  let _ = Sys.opaque_identity r in
   tailcalled_function ()
 let () =
   do_direct_tailcall ();
@@ -114,24 +114,24 @@ let () =
 
 let[@inline never][@specialise never][@local never] do_overtailcall f =
   let local_ r = ref 42 in
-  let _ = opaque_identity r in
+  let _ = Sys.opaque_identity r in
   f () ()
 let () =
   do_overtailcall (fun () ->
     let local_ r = ref 42 in
-    let _ = opaque_identity r in
+    let _ = Sys.opaque_identity r in
     fun () ->
       check_empty "during indirect overtail");
   check_empty "after indirect overtail"
 
 let[@inline always] overtailcalled_function () =
   let local_ r = ref 42 in
-  let _ = opaque_identity r in
+  let _ = Sys.opaque_identity r in
   fun () ->
     check_empty "during direct overtail"
 let[@inline never] do_direct_overtailcall () =
   let local_ r = ref 42 in
-  let _ = opaque_identity r in
+  let _ = Sys.opaque_identity r in
   overtailcalled_function () ()
 let () =
   do_direct_overtailcall ();
@@ -140,7 +140,7 @@ let () =
 
 let[@inline always] do_inlined_tailcall g =
   let local_ r = ref 42 in
-  let _ = opaque_identity r in
+  let _ = Sys.opaque_identity r in
   g ()
 
 let () =
@@ -161,7 +161,7 @@ let () =
 
 let () =
   let local_ z = ref 1000 in
-  let _ = opaque_identity z in
+  let _ = Sys.opaque_identity z in
   ()
 let () = check_empty "toplevel binding"
 
@@ -169,14 +169,14 @@ let () = check_empty "toplevel binding"
 let rec foo = 1 :: bar
 and bar =
   let local_ z = ref 1000 in
-  let _ = opaque_identity z in
+  let _ = Sys.opaque_identity z in
   1 :: foo
 let () = check_empty "toplevel rec binding"
 
 
 ;;
 (let local_ z = ref 1000 in
- let _ = opaque_identity z in
+ let _ = Sys.opaque_identity z in
  ());;
 let () = check_empty "toplevel eval"
 
@@ -191,7 +191,7 @@ module type T = sig val x : int end
 let _ =
   let module M : T =
     (val (let local_ r = ref 42 in
-          let _ = opaque_identity r in
+          let _ = Sys.opaque_identity r in
           ((module struct let x = !r + 1 end) : (module T)))) in
   M.x
 let () = check_empty "first class mod"
@@ -199,16 +199,16 @@ let () = check_empty "first class mod"
 class d x =
   let z =
     let r = local_ ref 1000 in
-    let _ = opaque_identity r in
+    let _ = Sys.opaque_identity r in
     !r + 1
   in
   object
     val p =
-      let r = opaque_identity (local_ ref 42) in
+      let r = Sys.opaque_identity (local_ ref 42) in
       !r
     initializer
       let r = local_ ref 42 in
-      let _ = opaque_identity r in
+      let _ = Sys.opaque_identity r in
       ()
     method getd =
       z + p + x
@@ -219,20 +219,20 @@ let () = check_empty "class d definition"
 class c =
   let z =
     let r = local_ ref 1000 in
-    let _ = opaque_identity r in
+    let _ = Sys.opaque_identity r in
     !r + 1
   in
   object
     initializer
       let r = local_ ref 42 in
-      let _ = opaque_identity r in
+      let _ = Sys.opaque_identity r in
       ()
     val q =
-      let r = opaque_identity (local_ ref 42) in
+      let r = Sys.opaque_identity (local_ ref 42) in
       !r
     inherit d (
       let r = local_ ref 42 in
-      let _ = opaque_identity r in
+      let _ = Sys.opaque_identity r in
       42)
     method getc =
       z + p + q
@@ -240,7 +240,7 @@ class c =
 
 class e = d (
   let r = local_ ref 42 in
-  let _ = opaque_identity r in
+  let _ = Sys.opaque_identity r in
   !r)
 
 let () = check_empty "class definitions"
@@ -282,8 +282,8 @@ let () =
 
 type t = { x : int } [@@unboxed]
 let[@inline never] create_local () =
-  let local_ _extra = opaque_identity (Some (opaque_identity ())) in
-  local_ { x = opaque_identity 0 }
+  let local_ _extra = Sys.opaque_identity (Some (opaque_identity ())) in
+  local_ { x = Sys.opaque_identity 0 }
 let create_and_ignore () =
   let x = create_local () in
   ignore (Sys.opaque_identity x : t)
@@ -295,13 +295,13 @@ let () =
 let[@inline never] allocate_in_exclave a =
   (* This needs to be a [while] so that we're allowed to have an [exclave_] *)
   while
-    let pair = local_ opaque_identity (a, a) in
+    let pair = local_ Sys.opaque_identity (a, a) in
     let b, _ = pair in
     let b : int = b in
     exclave_ (
       (* This should allocate in the function's region - in particular, the
          function needs to have one *)
-      let pair = local_ opaque_identity (b, b) in
+      let pair = local_ Sys.opaque_identity (b, b) in
       let c, _ = pair in
       c = 42)
   do

--- a/tests/backend/caml_apply_split_max_arity/t.ml
+++ b/tests/backend/caml_apply_split_max_arity/t.ml
@@ -28,7 +28,6 @@ let go x =
 (* The next few changes are checking that splitting caml_apply does not
    erase local allocations made in a previous region *)
 external globalize : local_ 'a -> 'a = "%obj_dup"
-external opaque : ('a[@local_opt]) -> ('a[@local_opt]) = "%opaque"
 
 external local_stack_offset : unit -> int = "caml_local_stack_offset"
 
@@ -41,7 +40,7 @@ let rec grow_local_stack n (local_ acc) =
 let[@inline never] foo (local_ a0) (local_ a1) =
   let local_ r = a0 +. a1 in
   local_ fun (local_ a2) (local_ a3) a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15 a16 a17 a18 a19 a20 a21 a22 a23 a24 a25 a26 a27 a28 a29 a30 a31 a32 a33 a34 a35 a36 a37 a38 a39 a40 a41 a42 a43 a44 a45 a46 a47 a48 a49 a50 a51 a52 a53 a54 a55 a56 a57 a58 a59 a60 a61 a62 a63 a64 a65 a66 a67 a68 a69 a70 a71 a72 a73 a74 a75 a76 a77 a78 a79 a80 a81 a82 a83 a84 a85 a86 a87 a88 a89 a90 a91 a92 a93 a94 a95 a96 a97 a98 a99 a100 a101 a102 a103 a104 a105 a106 a107 a108 a109 a110 a111 a112 a113 a114 a115 a116 a117 a118 a119 a120 a121 a122 a123 a124 a125 a126 a127 a128 a129 a130 a131 a132 a133 a134 a135 a136 a137 a138 a139 a140 a141 a142 a143 a144 a145 a146 a147 a148 a149 a150 a151 a152 a153 a154 a155 a156 a157 a158 a159 a160 a161 a162 a163 a164 a165 a166 a167 a168 a169 a170 a171 a172 a173 a174 a175 a176 a177 a178 a179 a180 a181 a182 a183 a184 a185 a186 a187 a188 a189 a190 a191 a192 a193 a194 a195 a196 a197 a198 a199 a200 a201 a202 a203 a204 a205 a206 a207 a208 a209 a210 a211 a212 a213 a214 a215 a216 a217 a218 a219 a220 a221 a222 a223 a224 a225 a226 a227 a228 a229 a230 a231 a232 a233 a234 a235 a236 a237 a238 a239 a240 a241 a242 a243 a244 a245 a246 a247 a248 a249 a250 a251 a252 a253 a254 a255 a256 ->
-    let local_ z = opaque (a2 +. a3) in
+    let local_ z = Sys.opaque_identity (a2 +. a3) in
     let z = globalize z in
     globalize r +. z +.a4+.a5+.a6+.a7+.a8+.a9+.a10+.a11+.a12+.a13+.a14+.a15+.a16+.a17+.a18+.a19+.a20+.a21+.a22+.a23+.a24+.a25+.a26+.a27+.a28+.a29+.a30+.a31+.a32+.a33+.a34+.a35+.a36+.a37+.a38+.a39+.a40+.a41+.a42+.a43+.a44+.a45+.a46+.a47+.a48+.a49+.a50+.a51+.a52+.a53+.a54+.a55+.a56+.a57+.a58+.a59+.a60+.a61+.a62+.a63+.a64+.a65+.a66+.a67+.a68+.a69+.a70+.a71+.a72+.a73+.a74+.a75+.a76+.a77+.a78+.a79+.a80+.a81+.a82+.a83+.a84+.a85+.a86+.a87+.a88+.a89+.a90+.a91+.a92+.a93+.a94+.a95+.a96+.a97+.a98+.a99+.a100+.a101+.a102+.a103+.a104+.a105+.a106+.a107+.a108+.a109+.a110+.a111+.a112+.a113+.a114+.a115+.a116+.a117+.a118+.a119+.a120+.a121+.a122+.a123+.a124+.a125+.a126+.a127+.a128+.a129+.a130+.a131+.a132+.a133+.a134+.a135+.a136+.a137+.a138+.a139+.a140+.a141+.a142+.a143+.a144+.a145+.a146+.a147+.a148+.a149+.a150+.a151+.a152+.a153+.a154+.a155+.a156+.a157+.a158+.a159+.a160+.a161+.a162+.a163+.a164+.a165+.a166+.a167+.a168+.a169+.a170+.a171+.a172+.a173+.a174+.a175+.a176+.a177+.a178+.a179+.a180+.a181+.a182+.a183+.a184+.a185+.a186+.a187+.a188+.a189+.a190+.a191+.a192+.a193+.a194+.a195+.a196+.a197+.a198+.a199+.a200+.a201+.a202+.a203+.a204+.a205+.a206+.a207+.a208+.a209+.a210+.a211+.a212+.a213+.a214+.a215+.a216+.a217+.a218+.a219+.a220+.a221+.a222+.a223+.a224+.a225+.a226+.a227+.a228+.a229+.a230+.a231+.a232+.a233+.a234+.a235+.a236+.a237+.a238+.a239+.a240+.a241+.a242+.a243+.a244+.a245+.a246+.a247+.a248+.a249+.a250+.a251+.a252+.a253+.a254+.a255+.a256
 


### PR DESCRIPTION
Otherwise the type checker thinks this causes local values to escape.