### PR TITLE
Add --enable-dev configure option + use -O3 for the compiler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         include:
           - name: closure
-            config: --enable-middle-end=closure
+            config: --enable-middle-end=closure --enable-dev
             os: ubuntu-latest
             ocamlparam: ''
             check_arch: true
@@ -18,22 +18,22 @@ jobs:
             ocamlrunparam: "v=0,V=1"
 
           - name: closure_cfg
-            config: --enable-middle-end=closure --enable-poll-insertion
+            config: --enable-middle-end=closure --enable-poll-insertion --enable-dev
             os: ubuntu-latest
             ocamlparam: _,ocamlcfg=1
 
           - name: flambda1
-            config: --enable-middle-end=flambda
+            config: --enable-middle-end=flambda --enable-dev
             os: ubuntu-latest
             ocamlparam: ''
 
           - name: flambda1_frame_pointers
-            config: --enable-middle-end=flambda --enable-frame-pointers --enable-poll-insertion
+            config: --enable-middle-end=flambda --enable-frame-pointers --enable-poll-insertion --enable-dev
             os: ubuntu-latest
             ocamlparam: ''
 
           - name: flambda1_cfg
-            config: --enable-middle-end=flambda --enable-poll-insertion
+            config: --enable-middle-end=flambda --enable-poll-insertion --enable-dev
             os: ubuntu-latest
             ocamlparam: _,ocamlcfg=1
 
@@ -52,26 +52,26 @@ jobs:
             ocamlrunparam: "v=0,V=1"
 
           - name: flambda2_nnp
-            config: --enable-middle-end=flambda2 --disable-naked-pointers
+            config: --enable-middle-end=flambda2 --disable-naked-pointers --enable-dev
             os: ubuntu-latest
             ocamlparam: ''
 
           - name: flambda2_frame_pointers
-            config: --enable-middle-end=flambda2 --enable-frame-pointers --enable-poll-insertion
+            config: --enable-middle-end=flambda2 --enable-frame-pointers --enable-poll-insertion --enable-dev
             os: ubuntu-latest
             ocamlparam: ''
 
           - name: flambda2_cfg
-            config: --enable-middle-end=flambda2
+            config: --enable-middle-end=flambda2 --enable-dev
             os: ubuntu-latest
             ocamlparam: _,ocamlcfg=1
 
           - name: flambda2_macos
-            config: --enable-middle-end=flambda2
+            config: --enable-middle-end=flambda2 --enable-dev
             os: macos-latest
 
           - name: irc
-            config: --enable-middle-end=flambda2
+            config: --enable-middle-end=flambda2 --enable-dev
             os: ubuntu-latest
             ocamlparam: ''
             check_arch: true

--- a/ocaml/.github/workflows/build.yml
+++ b/ocaml/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
             check_arch: true
 
           - name: flambda-local
-            config: --enable-flambda --enable-stack-allocation
+            config: --enable-flambda --enable-stack-allocation --enable-dev
             os: ubuntu-latest
             use_runtime: d
             ocamlrunparam: "v=0,V=1"

--- a/ocaml/Makefile.common-jst
+++ b/ocaml/Makefile.common-jst
@@ -108,7 +108,7 @@ _build/_bootinstall: Makefile.config $(dune_config_targets)
 	echo -n '$(NATDYNLINKOPTS)' > $(ocamldir)/otherlibs/dynlink/natdynlinkops
 
 # flags.sexp
-	echo '(:standard $(if $(filter true,$(FUNCTION_SECTIONS)),-function-sections,))' > ocamlopt_flags.sexp
+	echo '(:standard $(if $(filter true,$(OCAML_DEVELOPMENT_VERSION)),-opaque -warn-error +a,-O3) $(if $(filter true,$(FUNCTION_SECTIONS)),-function-sections,))' > ocamlopt_flags.sexp
 	echo '( $(OC_CFLAGS) )' > oc_cflags.sexp
 	echo '( $(OC_CPPFLAGS) )' > oc_cppflags.sexp
 	echo '( $(SHAREDLIB_CFLAGS) )' > sharedlib_cflags.sexp

--- a/ocaml/build-aux/ocaml_version.m4
+++ b/ocaml/build-aux/ocaml_version.m4
@@ -22,11 +22,6 @@
 # use a single underscore, since the two families of macros coexist
 # in configure.ac.
 
-# The following macro, OCAML__DEVELOPMENT_VERSION, should be either
-# [true] of [false].
-
-m4_define([OCAML__DEVELOPMENT_VERSION], [false])
-
 # The three following components (major, minor and patch level) MUST be
 # integers. They MUST NOT be left-padded with zeros and all of them,
 # including the patchlevel, are mandatory.

--- a/ocaml/configure
+++ b/ocaml/configure
@@ -703,6 +703,7 @@ CFLAGS
 LIBTOOL
 ac_ct_LD
 LD
+OCAML_DEVELOPMENT_VERSION
 DEFAULT_STRING
 WINDOWS_UNICODE_MODE
 DLLIBS
@@ -818,7 +819,6 @@ OCAML_VERSION_PATCHLEVEL
 OCAML_VERSION_MINOR
 OCAML_VERSION_MAJOR
 OCAML_RELEASE_EXTRA
-OCAML_DEVELOPMENT_VERSION
 VERSION
 native_compiler
 CONFIGURE_ARGS
@@ -902,6 +902,7 @@ enable_flat_float_array
 enable_function_sections
 with_afl
 enable_stack_allocation
+enable_dev
 enable_poll_insertion
 with_flexdll
 enable_shared
@@ -1603,6 +1604,8 @@ Optional Features:
                           do not emit each function in a separate section
   --enable-stack-allocation
                           enable stack allocation of local values
+  --enable-dev            enable development mode (build in -opaque, low
+                          optimization, warnings as errors)
   --enable-poll-insertion enable insertion of poll points
   --enable-shared[=PKGS]  build shared libraries [default=yes]
   --enable-static[=PKGS]  build static libraries [default=yes]
@@ -3181,8 +3184,6 @@ bootstrapping_flexdll=false
 
 VERSION=4.14.1+jst
 
-OCAML_DEVELOPMENT_VERSION=false
-
 OCAML_RELEASE_EXTRA='Some (Plus, "jst")'
 
 OCAML_VERSION_MAJOR=4
@@ -3842,6 +3843,22 @@ if test ${enable_stack_allocation+y}
 then :
   enableval=$enable_stack_allocation;
 fi
+
+
+# Check whether --enable-dev was given.
+if test ${enable_dev+y}
+then :
+  enableval=$enable_dev;
+fi
+
+
+if test x"$enable_dev" = "xyes"
+then :
+  enable_dev_subst=true
+else $as_nop
+  enable_dev_subst=false
+fi
+OCAML_DEVELOPMENT_VERSION=$enable_dev_subst
 
 
 # Check whether --enable-poll-insertion was given.
@@ -13564,7 +13581,7 @@ case $ocaml_cv_cc_vendor in #(
   cc_warnings='-Wall -Wdeclaration-after-statement' ;;
 esac
 
-case $enable_warn_error,false in #(
+case $enable_warn_error,$enable_dev in #(
   yes,*|,true) :
     cc_warnings="$cc_warnings $warn_error_flag" ;; #(
   *) :
@@ -18888,7 +18905,7 @@ fi
 
 
 
-case $enable_ocamltest,false in #(
+case $enable_ocamltest,$enable_dev in #(
   yes,*|,true) :
     ocamltest='ocamltest' ;; #(
   *) :

--- a/ocaml/configure.ac
+++ b/ocaml/configure.ac
@@ -72,7 +72,6 @@ AC_CONFIG_AUX_DIR([build-aux])
 AC_SUBST([CONFIGURE_ARGS])
 AC_SUBST([native_compiler])
 AC_SUBST([VERSION], [AC_PACKAGE_VERSION])
-AC_SUBST([OCAML_DEVELOPMENT_VERSION], [OCAML__DEVELOPMENT_VERSION])
 AC_SUBST([OCAML_RELEASE_EXTRA], [OCAML__RELEASE_EXTRA])
 AC_SUBST([OCAML_VERSION_MAJOR], [OCAML__VERSION_MAJOR])
 AC_SUBST([OCAML_VERSION_MINOR], [OCAML__VERSION_MINOR])
@@ -440,6 +439,15 @@ AC_ARG_ENABLE([stack-allocation],
   [AS_HELP_STRING([--enable-stack-allocation],
     [enable stack allocation of local values])])
 
+AC_ARG_ENABLE([dev],
+  [AS_HELP_STRING([--enable-dev],
+    [enable development mode (build in -opaque, low optimization, warnings as errors)])])
+
+AS_IF([test x"$enable_dev" = "xyes"],
+  [enable_dev_subst=true],
+  [enable_dev_subst=false])
+AC_SUBST([OCAML_DEVELOPMENT_VERSION], [$enable_dev_subst])
+
 AC_ARG_ENABLE([poll-insertion],
   [AS_HELP_STRING([--enable-poll-insertion],
     [enable insertion of poll points])])
@@ -627,7 +635,7 @@ AS_CASE([$ocaml_cv_cc_vendor],
   warn_error_flag='-Werror'
   cc_warnings='-Wall -Wdeclaration-after-statement'])
 
-AS_CASE([$enable_warn_error,OCAML__DEVELOPMENT_VERSION],
+AS_CASE([$enable_warn_error,$enable_dev],
   [yes,*|,true],
     [cc_warnings="$cc_warnings $warn_error_flag"])
 
@@ -1944,7 +1952,7 @@ AS_IF([test "x$documentation_tool_cmd" = 'x']
 
 
 
-AS_CASE([$enable_ocamltest,OCAML__DEVELOPMENT_VERSION],
+AS_CASE([$enable_ocamltest,$enable_dev],
   [yes,*|,true],[ocamltest='ocamltest'],
   [ocamltest=''])
 


### PR DESCRIPTION
This adds a new `configure` option called `--enable-dev`.  The idea is that this should be specified for normal development.  It builds everything with `-opaque`, which should be faster, together with warnings-as-errors (for both OCaml and C code).  Furthermore `ocamltest` will be built.

When _not_ specifying `--enable-dev`, this now uses `-O3` to build the compiler itself (for the dune builds).  Currently it seems that e.g. Closure is faster in the typechecker than Flambda 2, probably because the default optimization level for the latter is a strange intermediate state that isn't classic mode, but is lower than `-O2` (we should fix this separately).  This change should hopefully close that gap.