### PR TITLE
Add emacs hacking commands

### DIFF
--- a/ocaml/Makefile.common-jst
+++ b/ocaml/Makefile.common-jst
@@ -328,10 +328,11 @@ promote-one: install_for_test
 hacking: _build/_bootinstall
 	$(dune) build $(ws_boot) -w $(boot_targets)
 
-# The hacking-emacs-poller and hacking-emacs-builder targets make it
-# possible to run the polling build from emacs compile mode.
-# You should make hacking-emacs-poller from the git repo, and
-# make hacking-emacs-builder as the emacs compilation command.
+# The `hacking-emacs-poller` and `hacking-emacs-builder` targets make it
+# possible to run the polling build with Emacs's `M-x compile`.  You should run
+# `make hacking-emacs-poller` in your terminal from the root directory of the
+# repo, and set Emacs's `compile-command` to `make hacking-emacs-builder` (from
+# the appropriate directory).
 
 .PHONY: hacking-emacs-poller
 hacking-emacs-poller: _build/_bootinstall


### PR DESCRIPTION
Add commands to get the benefits of fast, polling builds from emacs.

From your git repo, run:

```
$ make hacking-emacs-poller
```

From the emacs `project-compile` command, run:

```
make hacking-emacs-builder
```

Now, when you recompile from emacs, you get the answer quickly.

In contrast, running `make hacking` from emacs compile mode doesn't really work, because errors from previous "passes" of the build (read: previous times you saved a file) stick around in the minibuffer, which interacts poorly with `next-error`/`previous-error`.