### PR TITLE
Flambda 2 implementation of -x-dir-inlining

### DIFF
--- a/backend/asmpackager.ml
+++ b/backend/asmpackager.ml
@@ -249,6 +249,7 @@ let build_package_cmx members cmxfile =
           List.exists (fun info -> info.ui_force_link) units;
       ui_export_info;
       ui_checks;
+      ui_in_current_dir = None;
     } in
   Compilenv.write_unit_info pkg_infos cmxfile
 

--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -124,6 +124,12 @@ let mk_debug_long_frames_threshold f =
 let mk_caml_apply_inline_fast_path f =
   "-caml-apply-inline-fast-path", Arg.Unit f, " Inline the fast path of caml_applyN"
 
+let mk_x_dir_inlining f =
+  "-x-dir-inlining", Arg.Unit f, " Allow inlining as normal from .cmx files in directories other than that containing the source file"
+
+let mk_no_x_dir_inlining f =
+  "-no-x-dir-inlining", Arg.Unit f, " Only inline from .cmx files in directories other than that containing the source file if inlining attributes are present"
+
 let mk_dump_inlining_paths f =
   "-dump-inlining-paths", Arg.Unit f, " Dump inlining paths when dumping flambda2 terms"
 
@@ -582,6 +588,10 @@ module type Flambda_backend_options = sig
   val long_frames_threshold : int -> unit
 
   val caml_apply_inline_fast_path : unit -> unit
+
+  val x_dir_inlining : unit -> unit
+  val no_x_dir_inlining : unit -> unit
+
   val internal_assembler : unit -> unit
 
   val gc_timings : unit -> unit
@@ -683,6 +693,9 @@ struct
     mk_debug_long_frames_threshold F.long_frames_threshold;
 
     mk_caml_apply_inline_fast_path F.caml_apply_inline_fast_path;
+
+    mk_x_dir_inlining F.x_dir_inlining;
+    mk_no_x_dir_inlining F.no_x_dir_inlining;
 
     mk_internal_assembler F.internal_assembler;
 
@@ -832,6 +845,12 @@ module Flambda_backend_options_impl = struct
 
   let caml_apply_inline_fast_path =
     set' Flambda_backend_flags.caml_apply_inline_fast_path
+
+  let x_dir_inlining =
+    set' Flambda_backend_flags.x_dir_inlining
+
+  let no_x_dir_inlining =
+    clear' Flambda_backend_flags.x_dir_inlining
 
   let internal_assembler = set' Flambda_backend_flags.internal_assembler
 

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -55,6 +55,8 @@ module type Flambda_backend_options = sig
   val long_frames_threshold : int -> unit
 
   val caml_apply_inline_fast_path : unit -> unit
+  val x_dir_inlining : unit -> unit
+  val no_x_dir_inlining : unit -> unit
   val internal_assembler : unit -> unit
 
   val gc_timings : unit -> unit

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -51,6 +51,8 @@ let long_frames_threshold = ref max_long_frames_threshold (* -debug-long-frames-
 
 let caml_apply_inline_fast_path = ref false  (* -caml-apply-inline-fast-path *)
 
+let x_dir_inlining = ref true  (* -[no-]x-dir-inlining *)
+
 type function_result_types = Never | Functors_only | All_functions
 type opt_level = Oclassic | O2 | O3
 type 'a or_default = Set of 'a | Default

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -51,7 +51,8 @@ let long_frames_threshold = ref max_long_frames_threshold (* -debug-long-frames-
 
 let caml_apply_inline_fast_path = ref false  (* -caml-apply-inline-fast-path *)
 
-let x_dir_inlining = ref true  (* -[no-]x-dir-inlining *)
+(* XXX mshinwell: temporarily set to [false] for testing *)
+let x_dir_inlining = ref false  (* -[no-]x-dir-inlining *)
 
 type function_result_types = Never | Functors_only | All_functions
 type opt_level = Oclassic | O2 | O3

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -49,6 +49,8 @@ val max_long_frames_threshold : int
 val long_frames_threshold : int ref
 val caml_apply_inline_fast_path : bool ref
 
+val x_dir_inlining : bool ref
+
 type function_result_types = Never | Functors_only | All_functions
 type opt_level = Oclassic | O2 | O3
 type 'a or_default = Set of 'a | Default

--- a/dune
+++ b/dune
@@ -309,6 +309,7 @@
   flambda2_identifiers
   flambda2_cmx
   compiler_owee
+  unix
   gc_timings
   dwarf_low
   dwarf_high))

--- a/file_formats/cmx_format.mli
+++ b/file_formats/cmx_format.mli
@@ -66,7 +66,9 @@ type unit_infos =
     mutable ui_generic_fns: generic_fns;  (* Generic functions needed *)
     mutable ui_export_info: export_info;
     mutable ui_checks: Checks.t;
-    mutable ui_force_link: bool }         (* Always linked *)
+    mutable ui_force_link: bool;           (* Always linked *)
+    ui_in_current_dir : bool option;       (* Unit is in current directory *)
+  }
 
 type unit_infos_raw =
   { uir_unit: Compilation_unit.t;

--- a/middle_end/compilenv.mli
+++ b/middle_end/compilenv.mli
@@ -62,8 +62,13 @@ val get_global_export_info : Compilation_unit.t -> Cmx_format.export_info option
         (* Middle-end-agnostic means of getting the export info found in the
            .cmx file of the given unit. *)
 
+type in_current_dir = private
+  | In_current_dir
+  | Not_in_current_dir
+  | Unknown
+
 val get_unit_export_info
-  : Compilation_unit.t -> Cmx_format.export_info option
+  : Compilation_unit.t -> (Cmx_format.export_info * in_current_dir) option
 
 val flambda2_set_export_info : Flambda2_cmx.Flambda_cmx_format.t -> unit
         (* Set the export information for the current unit (Flambda 2 only). *)

--- a/middle_end/flambda2/cmx/exported_code.ml
+++ b/middle_end/flambda2/cmx/exported_code.ml
@@ -121,8 +121,8 @@ let iter_code t ~f =
       Code_or_metadata.iter_code code_or_metadata ~f)
     t
 
-let from_raw ~sections t =
-  Code_id.Map.map (Code_or_metadata.from_raw ~sections) t
+let from_raw ~sections ~in_current_dir t =
+  Code_id.Map.map (Code_or_metadata.from_raw ~sections ~in_current_dir) t
 
 let to_raw ~add_section t =
   Code_id.Map.map (Code_or_metadata.to_raw ~add_section) t

--- a/middle_end/flambda2/cmx/exported_code.mli
+++ b/middle_end/flambda2/cmx/exported_code.mli
@@ -52,7 +52,11 @@ val remove_unused_value_slots_from_result_types_and_shortcut_aliases :
 
 val iter_code : t -> f:(Code.t -> unit) -> unit
 
-val from_raw : sections:Flambda_backend_utils.File_sections.t -> raw -> t
+val from_raw :
+  sections:Flambda_backend_utils.File_sections.t ->
+  in_current_dir:In_current_dir.t ->
+  raw ->
+  t
 
 val to_raw : add_section:(Obj.t -> int) -> t -> raw
 

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -19,7 +19,8 @@ module T = Flambda2_types
 module TE = Flambda2_types.Typing_env
 
 type loader =
-  { get_module_info : Compilation_unit.t -> Flambda_cmx_format.t option;
+  { get_module_info :
+      Compilation_unit.t -> (Flambda_cmx_format.t * In_current_dir.t) option;
     mutable imported_names : Name.Set.t;
     mutable imported_code : Exported_code.t;
     mutable imported_units :
@@ -42,9 +43,9 @@ let load_cmx_file_contents loader comp_unit =
       loader.imported_units
         <- Compilation_unit.Name.Map.add cmx_file None loader.imported_units;
       None
-    | Some cmx ->
+    | Some (cmx, in_current_dir) ->
       let typing_env, all_code =
-        Flambda_cmx_format.import_typing_env_and_code cmx
+        Flambda_cmx_format.import_typing_env_and_code cmx ~in_current_dir
       in
       let newly_imported_names = TE.Serializable.name_domain typing_env in
       loader.imported_names

--- a/middle_end/flambda2/cmx/flambda_cmx.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx.mli
@@ -20,7 +20,9 @@
 type loader
 
 val create_loader :
-  get_module_info:(Compilation_unit.t -> Flambda_cmx_format.t option) -> loader
+  get_module_info:
+    (Compilation_unit.t -> (Flambda_cmx_format.t * In_current_dir.t) option) ->
+  loader
 
 val get_imported_names : loader -> unit -> Name.Set.t
 

--- a/middle_end/flambda2/cmx/flambda_cmx_format.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx_format.mli
@@ -32,7 +32,9 @@ val create :
   t
 
 val import_typing_env_and_code :
-  t -> Flambda2_types.Typing_env.Serializable.t * Exported_code.t
+  t ->
+  in_current_dir:In_current_dir.t ->
+  Flambda2_types.Typing_env.Serializable.t * Exported_code.t
 
 val exported_offsets : t -> Exported_offsets.t
 

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -32,16 +32,23 @@ let get_module_info comp_unit =
   then None
   else
     match Compilenv.get_unit_export_info comp_unit with
-    | None | Some (Flambda2 None) -> None
-    | Some (Flambda2 (Some info)) -> Some info
-    | Some (Clambda _) ->
+    | None | Some (Flambda2 None, _) -> None
+    | Some (Flambda2 (Some info), in_current_dir) ->
+      let in_current_dir : Flambda2_term_basics.In_current_dir.t =
+        match in_current_dir with
+        | In_current_dir -> In_current_dir
+        | Not_in_current_dir -> Not_in_current_dir
+        | Unknown -> Unknown
+      in
+      Some (info, in_current_dir)
+    | Some (Clambda _, _) ->
       (* CR mshinwell: This should be a user error, not a fatal error. Same
          below. *)
       Misc.fatal_errorf
         "The .cmx file for unit %a was compiled with the Closure middle-end, \
          not Flambda 2, and cannot be loaded"
         Compilation_unit.Name.print cmx_name
-    | Some (Flambda1 _) ->
+    | Some (Flambda1 _, _) ->
       Misc.fatal_errorf
         "The .cmx file for unit %a was compiled with the Flambda 1 middle-end, \
          not Flambda 2, and cannot be loaded"

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -259,11 +259,17 @@ module Inlining = struct
           | Always_inlined _ | Hint_inlined ->
             Call_site_inlining_decision_type.Attribute_always, Inlinable code
           | Default_inlined | Unroll _ ->
-            (* Closure ignores completely [@unrolled] attributes, so it seems
-               safe to do the same. *)
-            ( Call_site_inlining_decision_type.Definition_says_inline
-                { was_inline_always = false },
-              Inlinable code )
+            if (not !Flambda_backend_flags.x_dir_inlining)
+               && Code_metadata.inline_only_with_attribute metadata
+            then
+              ( Call_site_inlining_decision_type.X_dir_inlining_forbidden,
+                Not_inlinable )
+            else
+              (* Closure ignores completely [@unrolled] attributes, so it seems
+                 safe to do the same. *)
+              ( Call_site_inlining_decision_type.Definition_says_inline
+                  { was_inline_always = false },
+                Inlinable code )
         in
         Inlining_report.record_decision_at_call_site_for_known_function ~tracker
           ~apply ~pass:After_closure_conversion ~unrolling_depth:None

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -144,11 +144,15 @@ let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr
     ~return_arity : Call_site_inlining_decision_type.t =
   let denv = DA.denv dacc in
   let env_prohibits_inlining = not (DE.can_inline denv) in
-  let decision =
-    Code_or_metadata.code_metadata code_or_metadata
-    |> Code_metadata.inlining_decision
-  in
-  if Function_decl_inlining_decision_type.must_be_inlined decision
+  let code_metadata = Code_or_metadata.code_metadata code_or_metadata in
+  let decision = Code_metadata.inlining_decision code_metadata in
+  if (not !Flambda_backend_flags.x_dir_inlining)
+     && Code_metadata.inline_only_with_attribute code_metadata
+  then
+    if Function_decl_inlining_decision_type.has_attribute_inline decision
+    then Definition_says_inline { was_inline_always = true }
+    else X_dir_inlining_forbidden
+  else if Function_decl_inlining_decision_type.must_be_inlined decision
   then
     Definition_says_inline
       { was_inline_always =

--- a/middle_end/flambda2/simplify/inlining/function_decl_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/function_decl_inlining_decision.ml
@@ -17,8 +17,6 @@
 let make_decision ~inlining_arguments:args ~inline ~stub ~cost_metrics:metrics
     ~is_a_functor ~(recursive : Recursive.t) :
     Function_decl_inlining_decision_type.t =
-  (* At present, we follow Closure, taking inlining decisions without first
-     examining call sites. *)
   match (inline : Inline_attribute.t) with
   | Never_inline -> Never_inline_attribute
   | Always_inline -> Attribute_inline

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.ml
@@ -47,6 +47,7 @@ type t =
         evaluated_to : float;
         threshold : float
       }
+  | X_dir_inlining_forbidden
 
 let [@ocamlformat "disable"] print ppf t =
   match t with
@@ -101,6 +102,8 @@ let [@ocamlformat "disable"] print ppf t =
       Cost_metrics.print cost_metrics
       evaluated_to
       threshold
+  | X_dir_inlining_forbidden ->
+    Format.fprintf ppf "X_dir_inlining_forbidden"
 
 type can_inline =
   | Do_not_inline of { erase_attribute_if_ignored : bool }
@@ -139,6 +142,8 @@ let can_inline (t : t) : can_inline =
   | Speculatively_inline _ ->
     Inline { unroll_to = None; was_inline_always = false }
   | Attribute_always -> Inline { unroll_to = None; was_inline_always = true }
+  | X_dir_inlining_forbidden ->
+    Do_not_inline { erase_attribute_if_ignored = false }
 
 let report_reason fmt t =
   match (t : t) with
@@ -183,6 +188,10 @@ let report_reason fmt t =
       "the@ function@ was@ inlined@ after@ speculation@ as@ its@ cost@ metrics \
        were=%a,@ which@ was@ evaluated@ to@ %f <= threshold %f"
       Cost_metrics.print cost_metrics evaluated_to threshold
+  | X_dir_inlining_forbidden ->
+    Format.fprintf fmt
+      "this@ function@ is@ from@ a@ compilation@ unit@ that@ is@ restricted@ \
+       by -x-dir-inlining"
 
 let report fmt t =
   Format.fprintf fmt

--- a/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
+++ b/middle_end/flambda2/simplify_shared/call_site_inlining_decision_type.mli
@@ -40,6 +40,7 @@ type t =
         evaluated_to : float;
         threshold : float
       }
+  | X_dir_inlining_forbidden
 
 val print : Format.formatter -> t -> unit
 

--- a/middle_end/flambda2/term_basics/in_current_dir.ml
+++ b/middle_end/flambda2/term_basics/in_current_dir.ml
@@ -2,11 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*                       Pierre Chambart, OCamlPro                        *)
-(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                      Mark Shinwell, Jane Street                        *)
 (*                                                                        *)
-(*   Copyright 2013--2019 OCamlPro SAS                                    *)
-(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*   Copyright 2023 Jane Street Group LLC                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,18 +12,13 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Translate Lambda code to Cmm using Flambda 2. *)
+type t =
+  | In_current_dir
+  | Not_in_current_dir
+  | Unknown
 
-(** This function is not currently re-entrant. *)
-val lambda_to_cmm :
-  ppf_dump:Format.formatter ->
-  prefixname:string ->
-  filename:string ->
-  keep_symbol_tables:bool ->
-  Lambda.program ->
-  Cmm.phrase list
-
-val get_module_info :
-  Compilation_unit.t ->
-  (Flambda2_cmx.Flambda_cmx_format.t * Flambda2_term_basics.In_current_dir.t)
-  option
+let print ppf t =
+  match t with
+  | In_current_dir -> Format.fprintf ppf "In_current_dir"
+  | Not_in_current_dir -> Format.fprintf ppf "Not_in_current_dir"
+  | Unknown -> Format.fprintf ppf "Unknown"

--- a/middle_end/flambda2/term_basics/in_current_dir.mli
+++ b/middle_end/flambda2/term_basics/in_current_dir.mli
@@ -2,11 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*                       Pierre Chambart, OCamlPro                        *)
-(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                      Mark Shinwell, Jane Street                        *)
 (*                                                                        *)
-(*   Copyright 2013--2019 OCamlPro SAS                                    *)
-(*   Copyright 2014--2019 Jane Street Group LLC                           *)
+(*   Copyright 2023 Jane Street Group LLC                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,18 +12,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Translate Lambda code to Cmm using Flambda 2. *)
+type t =
+  | In_current_dir
+  | Not_in_current_dir
+  | Unknown
 
-(** This function is not currently re-entrant. *)
-val lambda_to_cmm :
-  ppf_dump:Format.formatter ->
-  prefixname:string ->
-  filename:string ->
-  keep_symbol_tables:bool ->
-  Lambda.program ->
-  Cmm.phrase list
-
-val get_module_info :
-  Compilation_unit.t ->
-  (Flambda2_cmx.Flambda_cmx_format.t * Flambda2_term_basics.In_current_dir.t)
-  option
+val print : Format.formatter -> t -> unit

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -48,6 +48,8 @@ module type Code_metadata_accessors_result_type = sig
 
   val inline : 'a t -> Inline_attribute.t
 
+  val inline_only_with_attribute : 'a t -> bool
+
   val check : 'a t -> Check_attribute.t
 
   val poll_attribute : 'a t -> Poll_attribute.t
@@ -129,3 +131,5 @@ val ids_for_export : t -> Ids_for_export.t
 val approx_equal : t -> t -> bool
 
 val map_result_types : t -> f:(Flambda2_types.t -> Flambda2_types.t) -> t
+
+val adjust_for_current_dir : t -> In_current_dir.t -> t

--- a/middle_end/flambda2/terms/code_or_metadata.ml
+++ b/middle_end/flambda2/terms/code_or_metadata.ml
@@ -94,18 +94,21 @@ let code_status_metadata = function
 
 let create code = Code_present { code_status = Loaded code }
 
-let from_raw ~sections raw =
+let from_raw ~sections ~in_current_dir raw =
   match raw.code_present with
-  | Absent -> Metadata_only raw.metadata
+  | Absent ->
+    let metadata =
+      Code_metadata.adjust_for_current_dir raw.metadata in_current_dir
+    in
+    Metadata_only metadata
   | Present { index } ->
+    let metadata =
+      Code_metadata.adjust_for_current_dir raw.metadata in_current_dir
+    in
     Code_present
       { code_status =
           Not_loaded
-            { sections;
-              index;
-              metadata = raw.metadata;
-              delayed_renaming = Renaming.empty
-            }
+            { sections; index; metadata; delayed_renaming = Renaming.empty }
       }
 
 let to_raw ~add_section t : raw =

--- a/middle_end/flambda2/terms/code_or_metadata.mli
+++ b/middle_end/flambda2/terms/code_or_metadata.mli
@@ -36,7 +36,11 @@ val create : Code.t -> t
 
 val create_metadata_only : Code_metadata.t -> t
 
-val from_raw : sections:Flambda_backend_utils.File_sections.t -> raw -> t
+val from_raw :
+  sections:Flambda_backend_utils.File_sections.t ->
+  in_current_dir:In_current_dir.t ->
+  raw ->
+  t
 
 val to_raw : add_section:(Obj.t -> int) -> t -> raw
 


### PR DESCRIPTION
An experiment to provide better control of `.cmx` visibility.  The idea is as follows: when the new flag `-no-x-dir-inlining` is provided, functions will only be inlined from `.cmx` files in directories different from that containing the source file if the inlining decision is entirely driven by attributes.  This is off by default (equivalent to `-x-dir-inlining`).

The idea is to be able to remove the existing system used at JS where the fast build mode hides all `.cmx` files except those for the current library.  The problem with this is that there is no way to make an exception, preventing for example the insertion of a zero-alloc check that can be achieved with simple inlining, and thus able to pass even in fast-build mode.  With something like this PR, we should be able to make all `.cmx` files visible, but severely restrict the total amount of inlining performed to (nearly) maintain compilation performance.