### PR TITLE
Better region tracking in flambda1

### DIFF
--- a/middle_end/flambda/flambda.ml
+++ b/middle_end/flambda/flambda.ml
@@ -911,10 +911,6 @@ module With_free_variables = struct
         free_vars_of_body;
       }
 
-  let create_region (t : expr t) =
-    let Expr (body, fv) = t in
-    Expr (Region body, fv)
-
   let expr (t : expr t) =
     match t with
     | Expr (expr, free_vars) -> Named (Expr expr, free_vars)
@@ -939,7 +935,7 @@ let fold_lets_option
   let finish ~last_body ~acc ~rev_lets =
     let module W = With_free_variables in
     let acc, t =
-      List.fold_left (fun (acc, t) (has_region, var, defining_expr) ->
+      List.fold_left (fun (acc, t) (var, defining_expr) ->
           let free_vars_of_body = W.free_variables t in
           let acc, var, defining_expr =
             filter_defining_expr acc var defining_expr free_vars_of_body
@@ -950,7 +946,6 @@ let fold_lets_option
             | Some defining_expr ->
               W.of_expr (W.create_let_reusing_body var defining_expr t)
           in
-          let t = if has_region then W.create_region t else t in
           acc, t)
         (acc, W.of_expr last_body)
         rev_lets
@@ -959,13 +954,11 @@ let fold_lets_option
   in
   let rec loop (t : t) ~acc ~rev_lets =
     match t with
-    | Let { var; defining_expr; body; _ }
-    | Region (Let { var; defining_expr; body; _ }) ->
+    | Let { var; defining_expr; body; _ } ->
       let acc, var, defining_expr =
         for_defining_expr acc var defining_expr
       in
-      let has_region = match t with Region _ -> true | _ -> false in
-      let rev_lets = (has_region, var, defining_expr) :: rev_lets in
+      let rev_lets = (var, defining_expr) :: rev_lets in
       loop body ~acc ~rev_lets
     | t ->
       let last_body, acc = for_last_body acc t in

--- a/middle_end/flambda/inline_and_simplify_aux.ml
+++ b/middle_end/flambda/inline_and_simplify_aux.ml
@@ -437,14 +437,18 @@ let initial_inlining_toplevel_threshold ~round : Inlining_cost.Threshold.t =
     (unscaled * Inlining_cost.scale_inline_threshold_by)
 
 module Result = struct
+  type region = { may_be_used : bool; }
+
   type t =
     { approx : Simple_value_approx.t;
       used_static_exceptions : Static_exception.Set.t;
       inlining_threshold : Inlining_cost.Threshold.t option;
       benefit : Inlining_cost.Benefit.t;
       num_direct_applications : int;
-      may_use_region : bool;
+      regions : region list;
     }
+
+  let create_region () = { may_be_used = false; }
 
   let create () =
     { approx = Simple_value_approx.value_unknown Other;
@@ -452,7 +456,7 @@ module Result = struct
       inlining_threshold = None;
       benefit = Inlining_cost.Benefit.zero;
       num_direct_applications = 0;
-      may_use_region = false;
+      regions = [ ];
     }
 
   let approx t = t.approx
@@ -473,10 +477,41 @@ module Result = struct
 
   let used_static_exceptions t = t.used_static_exceptions
 
-  let set_region_use t b =
-    { t with may_use_region = b }
+  let no_current_region () =
+    Misc.fatal_error "No current region"
 
-  let may_use_region t = t.may_use_region
+  let enter_region t =
+    { t with regions = create_region () :: t.regions }
+
+  let leave_region t =
+    match t.regions with
+    | _region :: regions -> { t with regions }
+    | [] -> no_current_region ()
+
+  let set_region_used t =
+    match t.regions with
+    | _ :: regions ->
+        { t with regions = { may_be_used = true } :: regions }
+    | [] -> t
+
+  type exclave = { from_region : region }
+
+  let enter_exclave t =
+    match t.regions with
+    | region :: regions ->
+        let exclave = { from_region = region } in
+        exclave, { t with regions = regions }
+    | [] -> no_current_region ()
+
+  let leave_exclave t { from_region } =
+    { t with regions = from_region :: t.regions }
+
+  let current_region t =
+    match t.regions with
+    | region :: _ -> region
+    | [] -> no_current_region ()
+
+  let may_use_region t = (current_region t).may_be_used
 
   let exit_scope_catch t i =
     { t with

--- a/middle_end/flambda/inline_and_simplify_aux.mli
+++ b/middle_end/flambda/inline_and_simplify_aux.mli
@@ -296,11 +296,29 @@ module Result : sig
   (** Mark that the given static exception has been used. *)
   val use_static_exception : t -> Static_exception.t -> t
 
-  (** Mark/clear whether local allocations may be made in
-      the nearest enclosing region *)
-  val set_region_use : t -> bool -> t
+  (** Enter the scope of a region.  A subsequent call to [set_region_used] will
+      affect this region. *)
+  val enter_region : t -> t
 
-  (** Whether [set_region_use _ true] has been called *)
+  (** Leave the scope of a region, restoring the previous one as the new
+      innermost region. *)
+  val leave_region : t -> t
+
+  type exclave
+
+  (** Enter an exclave.  A subsequent call to [set_region_used] will now affect
+      the outer region.  Returns a value that must be passed to the
+      corresponding [leave_exclave]. *)
+  val enter_exclave : t -> exclave * t
+
+  (** Leave an exclave, effectively re-entering the outer region. *)
+  val leave_exclave : t -> exclave -> t
+
+  (** Mark that local allocations may be made in
+      the nearest enclosing region *)
+  val set_region_used : t -> t
+
+  (** Whether [set_region_used _] has been called *)
   val may_use_region : t -> bool
 
   (** Mark that we are moving up out of the scope of a static-catch block


### PR DESCRIPTION
Regions are currently not tracked very precisely in flambda1. In particular, it is assumed that nothing in a region block can affect the parent region, which is not true when there are explicit exclaves. Also, some old traversal code tends to ignore region borders entirely, which is almost certainly causing subtle bugs somewhere (and adding region lifting makes it cause unsubtle bugs everywhere).

Adding an actual region stack makes it easy to be precise, and will also help remove regions that have exclaves (see PR #1524).