### PR TITLE
Pattern match on float record/array can allocate local float

### DIFF
--- a/ocaml/.depend
+++ b/ocaml/.depend
@@ -142,7 +142,6 @@ utils/language_extension_kernel.cmo : \
 utils/language_extension_kernel.cmx : \
     utils/language_extension_kernel.cmi
 utils/language_extension_kernel.cmi :
-utils/language_extension_kernel_intf.cmi :
 utils/lazy_backtrack.cmo : \
     utils/lazy_backtrack.cmi
 utils/lazy_backtrack.cmx : \
@@ -3588,6 +3587,7 @@ middle_end/convert_primitives.cmo : \
     lambda/printlambda.cmi \
     typing/primitive.cmi \
     utils/misc.cmi \
+    typing/layouts.cmi \
     lambda/lambda.cmi \
     middle_end/clambda_primitives.cmi \
     middle_end/convert_primitives.cmi
@@ -3595,6 +3595,7 @@ middle_end/convert_primitives.cmx : \
     lambda/printlambda.cmx \
     typing/primitive.cmx \
     utils/misc.cmx \
+    typing/layouts.cmx \
     lambda/lambda.cmx \
     middle_end/clambda_primitives.cmx \
     middle_end/convert_primitives.cmi
@@ -3720,7 +3721,6 @@ lambda/lambda.cmo : \
     utils/misc.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
-    typing/layouts.cmi \
     typing/ident.cmi \
     typing/env.cmi \
     lambda/debuginfo.cmi \
@@ -3736,7 +3736,6 @@ lambda/lambda.cmx : \
     utils/misc.cmx \
     parsing/longident.cmx \
     parsing/location.cmx \
-    typing/layouts.cmx \
     typing/ident.cmx \
     typing/env.cmx \
     lambda/debuginfo.cmx \
@@ -3751,7 +3750,6 @@ lambda/lambda.cmi : \
     typing/primitive.cmi \
     typing/path.cmi \
     parsing/location.cmi \
-    typing/layouts.cmi \
     typing/ident.cmi \
     typing/env.cmi \
     lambda/debuginfo.cmi \
@@ -3761,6 +3759,7 @@ lambda/matching.cmo : \
     typing/types.cmi \
     typing/typeopt.cmi \
     typing/typedtree.cmi \
+    lambda/translmode.cmi \
     lambda/switch.cmi \
     typing/printpat.cmi \
     lambda/printlambda.cmi \
@@ -3784,6 +3783,7 @@ lambda/matching.cmx : \
     typing/types.cmx \
     typing/typeopt.cmx \
     typing/typedtree.cmx \
+    lambda/translmode.cmx \
     lambda/switch.cmx \
     typing/printpat.cmx \
     lambda/printlambda.cmx \

--- a/ocaml/compilerlibs/Makefile.compilerlibs
+++ b/ocaml/compilerlibs/Makefile.compilerlibs
@@ -133,8 +133,8 @@ TYPING_CMI = \
 LAMBDA = \
   lambda/printlambda.cmo \
   lambda/switch.cmo \
-  lambda/matching.cmo \
   lambda/translmode.cmo \
+  lambda/matching.cmo \
   lambda/transl_comprehension_utils.cmo \
   lambda/transl_array_comprehension.cmo \
   lambda/transl_list_comprehension.cmo \

--- a/ocaml/testsuite/tests/typing-local/alloc.heap.reference
+++ b/ocaml/testsuite/tests/typing-local/alloc.heap.reference
@@ -3,6 +3,10 @@
             big: Allocation
          dupbig: Allocation
           float: Allocation
+pat_floatrecord_noescape: Allocation
+pat_floatrecord_escape: Allocation
+pat_floatarray_noescape: Allocation
+pat_floatarray_escape: Allocation
       projfloat: Allocation
        dupfloat: Allocation
     polyvariant: Allocation

--- a/ocaml/testsuite/tests/typing-local/alloc.ml
+++ b/ocaml/testsuite/tests/typing-local/alloc.ml
@@ -153,6 +153,34 @@ let projfloat n =
 
 let floatconst = {x=0.; y=0.; z=0.}
 
+let pat_floatrecord_noescape a =
+  let foo {x;y;_} = local_ (x,y) in
+  ignore_local (foo {x=a;y=a;z=a});
+  ()
+
+let pat_floatrecord_escape a =
+  let foo {x;y;_} = (x,y) in
+  ignore_local (foo {x=a;y=a;z=a});
+  ()
+
+let pat_floatarray_noescape a =
+  let foo arr = local_
+  match arr with
+  | [| x; y |] -> (x, y)
+  | _ -> (42.0, 43.0)
+  in
+  ignore_local (foo [| a; a |]);
+  ()
+
+let pat_floatarray_escape a =
+  let foo arr =
+  match arr with
+  | [| x; y |] -> (x, y)
+  | _ -> (42.0, 43.0)
+  in
+  ignore_local (foo [| a; a |]);
+  ()
+
 let dupfloat n =
   ignore_local {n with x=42.};
   ()
@@ -452,6 +480,10 @@ let () =
   run "big" makebig 42;
   run "dupbig" dupbig bigconst;
   run "float" makefloat 42.;
+  run "pat_floatrecord_noescape" pat_floatrecord_noescape 42.;
+  run "pat_floatrecord_escape" pat_floatrecord_escape 42.;
+  run "pat_floatarray_noescape" pat_floatarray_noescape 42.;
+  run "pat_floatarray_escape" pat_floatarray_escape 42.;
   run "projfloat" projfloat 42.;
   run "dupfloat" dupfloat floatconst;
   run "polyvariant" makepolyvariant 42;
@@ -482,6 +514,7 @@ let () =
   run "manylong" makemanylong 100;
   run "optionalarg" optionalarg (fun_with_optional_arg, 10);
   run "optionaleta" optionaleta ()
+
 
   (* The following test commented out as it require more memory than the CI has
      *)

--- a/ocaml/testsuite/tests/typing-local/alloc.stack.reference
+++ b/ocaml/testsuite/tests/typing-local/alloc.stack.reference
@@ -3,6 +3,10 @@
             big: No Allocation
          dupbig: No Allocation
           float: No Allocation
+pat_floatrecord_noescape: No Allocation
+pat_floatrecord_escape: Allocation
+pat_floatarray_noescape: No Allocation
+pat_floatarray_escape: Allocation
       projfloat: No Allocation
        dupfloat: No Allocation
     polyvariant: No Allocation

--- a/ocaml/typing/patterns.mli
+++ b/ocaml/typing/patterns.mli
@@ -45,8 +45,9 @@ module Simple : sig
         Longident.t loc * constructor_description * pattern list
     | `Variant of label * pattern option * row_desc ref
     | `Record of
-        (Longident.t loc * label_description * pattern) list * closed_flag
-    | `Array of mutable_flag * pattern list
+        (Longident.t loc * label_description * pattern * alloc_mode option) list
+          * closed_flag
+    | `Array of mutable_flag * (pattern * alloc_mode) list
     | `Lazy of pattern
   ]
   type pattern = view pattern_data
@@ -82,14 +83,14 @@ module Head : sig
     | Construct of constructor_description
     | Constant of constant
     | Tuple of int
-    | Record of label_description list
+    | Record of (label_description * alloc_mode option) list
     | Variant of
         { tag: label; has_arg: bool;
           cstr_row: row_desc ref;
           type_row : unit -> row_desc; }
           (* the row of the type may evolve if [close_variant] is called,
              hence the (unit -> ...) delay *)
-    | Array of mutable_flag * int
+    | Array of mutable_flag * alloc_mode list
     | Lazy
 
   type t = desc pattern_data

--- a/ocaml/typing/printpat.ml
+++ b/ocaml/typing/printpat.ml
@@ -81,11 +81,11 @@ let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
   | Tpat_record (lvs,_) ->
       let filtered_lvs = List.filter
           (function
-            | (_,_,{pat_desc=Tpat_any}) -> false (* do not show lbl=_ *)
+            | (_,_,{pat_desc=Tpat_any},_) -> false (* do not show lbl=_ *)
             | _ -> true) lvs in
       begin match filtered_lvs with
       | [] -> fprintf ppf "_"
-      | (_, lbl, _) :: q ->
+      | (_, lbl, _, _) :: q ->
           let elision_mark ppf =
             (* we assume that there is no label repetitions here *)
              if Array.length lbl.lbl_all > 1 + List.length q then
@@ -99,7 +99,8 @@ let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
         | Mutable   -> '|'
         | Immutable -> ':'
       in
-      fprintf ppf "@[[%c %a %c]@]" punct (pretty_vals " ;") vs punct
+      let vs' = List.map fst vs in
+      fprintf ppf "@[[%c %a %c]@]" punct (pretty_vals " ;") vs' punct
   | Tpat_lazy v ->
       fprintf ppf "@[<2>lazy@ %a@]" pretty_arg v
   | Tpat_alias (v, x, _, _) ->
@@ -142,9 +143,9 @@ and pretty_vals sep ppf = function
 
 and pretty_lvals ppf = function
   | [] -> ()
-  | [_,lbl,v] ->
+  | [_,lbl,v,_] ->
       fprintf ppf "%s=%a" lbl.lbl_name pretty_val v
-  | (_, lbl,v)::rest ->
+  | (_, lbl,v,_)::rest ->
       fprintf ppf "%s=%a;@ %a"
         lbl.lbl_name pretty_val v pretty_lvals rest
 

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -289,7 +289,7 @@ and pattern : type k . _ -> _ -> k general_pattern -> unit = fun i ppf x ->
       list i longident_x_pattern ppf l;
   | Tpat_array (am, l) ->
       line i ppf "Tpat_array %a\n" fmt_mutable_flag am;
-      list i pattern ppf l;
+      list i pattern_am ppf l;
   | Tpat_lazy p ->
       line i ppf "Tpat_lazy\n";
       pattern i ppf p;
@@ -995,9 +995,14 @@ and label_decl i ppf {ld_id; ld_name = _; ld_mutable; ld_type; ld_loc;
 and field_decl i ppf (ty, _) =
   core_type (i+1) ppf ty
 
-and longident_x_pattern i ppf (li, _, p) =
+and longident_x_pattern i ppf (li, _, p, am) =
   line i ppf "%a\n" fmt_longident li;
+  alloc_mode_option i ppf am;
   pattern (i+1) ppf p;
+
+and pattern_am i ppf (p, am) =
+  alloc_mode i ppf am;
+  pattern (i+1) ppf p
 
 and comprehension i ppf {comp_body; comp_clauses} =
   line i ppf "comprehension\n";

--- a/ocaml/typing/tast_iterator.ml
+++ b/ocaml/typing/tast_iterator.ml
@@ -179,8 +179,8 @@ let pat
       List.iter (sub.pat sub) l;
       Option.iter (fun (_ids, ct) -> sub.typ sub ct) vto
   | Tpat_variant (_, po, _) -> Option.iter (sub.pat sub) po
-  | Tpat_record (l, _) -> List.iter (fun (_, _, i) -> sub.pat sub i) l
-  | Tpat_array (_, l) -> List.iter (sub.pat sub) l
+  | Tpat_record (l, _) -> List.iter (fun (_, _, i, _) -> sub.pat sub i) l
+  | Tpat_array (_, l) -> List.iter (fun (pat, _) -> sub.pat sub pat) l
   | Tpat_alias (p, _, _, _) -> sub.pat sub p
   | Tpat_lazy p -> sub.pat sub p
   | Tpat_value p -> sub.pat sub (p :> pattern)

--- a/ocaml/typing/tast_mapper.ml
+++ b/ocaml/typing/tast_mapper.ml
@@ -72,6 +72,7 @@ type mapper =
 let id x = x
 let tuple2 f1 f2 (x, y) = (f1 x, f2 y)
 let tuple3 f1 f2 f3 (x, y, z) = (f1 x, f2 y, f3 z)
+let tuple4 f1 f2 f3 f4 (x, y, z, w) = (f1 x, f2 y, f3 z, f4 w)
 
 let structure sub {str_items; str_type; str_final_env} =
   {
@@ -233,8 +234,9 @@ let pat
     | Tpat_variant (l, po, rd) ->
         Tpat_variant (l, Option.map (sub.pat sub) po, rd)
     | Tpat_record (l, closed) ->
-        Tpat_record (List.map (tuple3 id id (sub.pat sub)) l, closed)
-    | Tpat_array (am, l) -> Tpat_array (am, List.map (sub.pat sub) l)
+        Tpat_record (List.map (tuple4 id id (sub.pat sub) id) l, closed)
+    | Tpat_array (am, l) ->
+        Tpat_array (am, List.map (fun (pat,am) -> (sub.pat sub pat, am)) l)
     | Tpat_alias (p, id, s, m) -> Tpat_alias (sub.pat sub p, id, s, m)
     | Tpat_lazy p -> Tpat_lazy (sub.pat sub p)
     | Tpat_value p ->

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -1074,14 +1074,14 @@ and build_as_type_aux ~refine ~mode (env : Env.t ref) p =
       in
       ty, mode
   | Tpat_record (lpl,_) ->
-      let lbl = snd3 (List.hd lpl) in
+      let lbl = snd4 (List.hd lpl) in
       if lbl.lbl_private = Private then p.pat_type, mode else
       (* The layout here is filled in via unification with [ty_res] in
          [unify_pat]. *)
       (* CR layouts v2: This should be a sort variable and could be now (but
          think about when it gets defaulted.) *)
       let ty = newvar (Layout.any ~why:Dummy_layout) in
-      let ppl = List.map (fun (_, l, p) -> l.lbl_num, p) lpl in
+      let ppl = List.map (fun (_, l, p, _) -> l.lbl_num, p) lpl in
       let do_label lbl =
         let _, ty_arg, ty_res = instance_label false lbl in
         unify_pat ~refine env {p with pat_type = ty} ty_res;
@@ -1882,10 +1882,10 @@ let type_label_a_list
 let check_recordpat_labels loc lbl_pat_list closed =
   match lbl_pat_list with
   | [] -> ()                            (* should not happen *)
-  | (_, label1, _) :: _ ->
+  | (_, label1, _, _) :: _ ->
       let all = label1.lbl_all in
       let defined = Array.make (Array.length all) false in
-      let check_defined (_, label, _) =
+      let check_defined (_, label, _, _) =
         if defined.(label.lbl_num)
         then raise(Error(loc, Env.empty, Label_multiply_defined label.lbl_name))
         else defined.(label.lbl_num) <- true in
@@ -2275,13 +2275,18 @@ and type_pat_aux
        shouldn't be too bad.  We can inline this when we upstream this code and
        combine the two array pattern constructors. *)
     let ty_elt = solve_Ppat_array ~refine loc env mutability expected_ty in
-      map_fold_cont (fun p ->
-        let alloc_mode =
+      map_fold_cont (fun p k ->
+        let base_mode =
           match mutability with
-          | Mutable -> simple_pat_mode Value_mode.global
-          | Immutable -> alloc_mode
+          | Mutable -> Value_mode.global
+          | Immutable -> alloc_mode.mode
         in
-        type_pat ~alloc_mode tps Value p ty_elt) spl (fun pl ->
+        let alloc_mode = Value_mode.newvar_above base_mode in
+        let am = register_allocation_value_mode alloc_mode in
+        let alloc_mode = simple_pat_mode alloc_mode in
+        type_pat ~alloc_mode tps Value p ty_elt (fun pat -> k (pat, am))
+        )
+        spl (fun pl ->
           rvp k {
           pat_desc = Tpat_array (mutability, pl);
           pat_loc = loc; pat_extra=[];
@@ -2583,9 +2588,17 @@ and type_pat_aux
           | Global -> Value_mode.global
           | Unrestricted -> alloc_mode.mode
         in
+        let alloc_mode, am =
+          match label.lbl_repres with
+          | Record_float ->
+            let m = Value_mode.newvar_above alloc_mode in
+            let am = register_allocation_value_mode m in
+            m, Some am
+          | _ -> alloc_mode, None
+        in
         let alloc_mode = simple_pat_mode alloc_mode in
         type_pat tps Value ~alloc_mode sarg ty_arg (fun arg ->
-          k (label_lid, label, arg))
+          k (label_lid, label, arg, am))
       in
       let make_record_pat lbl_pat_list =
         check_recordpat_labels loc lbl_pat_list closed;

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -110,16 +110,18 @@ and 'k pattern_desc =
             See {!Types.row_desc} for an explanation of the last parameter.
          *)
   | Tpat_record :
-      (Longident.t loc * Types.label_description * value general_pattern) list *
-        closed_flag ->
-      value pattern_desc
+      (Longident.t loc * Types.label_description * value general_pattern
+        * Types.alloc_mode option) list * closed_flag -> value pattern_desc
         (** { l1=P1; ...; ln=Pn }     (flag = Closed)
             { l1=P1; ...; ln=Pn; _}   (flag = Open)
 
             Invariant: n > 0
+
+            [alloc_mode option] only not none when it is a float record
          *)
   | Tpat_array :
-      mutable_flag * value general_pattern list -> value pattern_desc
+      mutable_flag * (value general_pattern * Types.alloc_mode) list
+        -> value pattern_desc
         (** [| P1; ...; Pn |]    (flag = Mutable)
             [: P1; ...; Pn :]    (flag = Immutable) *)
   | Tpat_lazy : value general_pattern -> value pattern_desc

--- a/ocaml/typing/types.mli
+++ b/ocaml/typing/types.mli
@@ -881,6 +881,8 @@ module Alloc_mode : sig
 
   val join : t list -> t
 
+  val meet : t list -> t
+
   (* Force a mode variable to its upper bound *)
   val constrain_upper : t -> const
 
@@ -987,6 +989,8 @@ module Value_mode : sig
   val newvar : unit -> t
 
   val newvar_below : t -> t
+
+  val newvar_above : t -> t
 
   val check_const : t -> const option
 

--- a/ocaml/typing/untypeast.ml
+++ b/ocaml/typing/untypeast.ml
@@ -374,10 +374,10 @@ let pattern : type k . _ -> k T.general_pattern -> _ = fun sub pat ->
     | Tpat_variant (label, pato, _) ->
         Ppat_variant (label, Option.map (sub.pat sub) pato)
     | Tpat_record (list, closed) ->
-        Ppat_record (List.map (fun (lid, _, pat) ->
+        Ppat_record (List.map (fun (lid, _, pat, _) ->
             map_loc sub lid, sub.pat sub pat) list, closed)
     | Tpat_array (am, list) -> begin
-        let pats = List.map (sub.pat sub) list in
+        let pats = List.map (fun (pat, _) -> sub.pat sub pat) list in
         match am with
         | Mutable   -> Ppat_array pats
         | Immutable ->


### PR DESCRIPTION
This PR improves the allocation when pattern matching on a float record, so that the float fields will be allocated on stack if possible. 

Please note that the PR only changes the allocation behaviour - the typing is not changed at all. That means 
- The float field resulted from pattern matching on a `local` float record must be used as `local`. Using it as `global` is type error. However, it used to be the case that this float will still be allocated on heap; this PR makes it always allocate on stack.
- The float field resulted from pattern matching on a `global` float record can be used as either `local` or `global`. It used to be always allocated on heap; This PR makes it allocate on stack or heap depending on how it's used.

Similar improvement for float array is also included. 

