### PR TITLE
Register allocation: threshold for stack slots optimization

### DIFF
--- a/backend/regalloc/regalloc_stack_slots.ml
+++ b/backend/regalloc/regalloc_stack_slots.ml
@@ -283,8 +283,17 @@ with type slots := t = struct
               bucket))
 end
 
+let optimization_enabled (t : t) : bool =
+  match size_for_all_stack_classes t with
+  | 0 -> false
+  | total_num_slots -> (
+    match find_param_value "STACK_SLOTS_THRESHOLD" with
+    | None -> true
+    | Some stack_slots_threshold ->
+      total_num_slots < int_of_string stack_slots_threshold)
+
 let optimize (t : t) (cfg_with_infos : Cfg_with_infos.t) : unit =
-  if size_for_all_stack_classes t > 0
+  if optimization_enabled t
   then (
     (* First, compute the intervals for all stack slots *)
     let intervals = Intervals.build_from_cfg t cfg_with_infos in


### PR DESCRIPTION
This pull request adds a register-allocation
parameter, namely `STACK_SLOTS_THRESHOLD`,
to control the value over which the stack
slots optimization is automatically disabled.

(The parameter is meant to disappear once
benchmarking determines a good value.)