### PR TITLE
Propagate Uids for local variables and function parameters

### DIFF
--- a/middle_end/backend_var.ml
+++ b/middle_end/backend_var.ml
@@ -16,6 +16,8 @@
 
 include Ident
 
+module Uid = Flambda2_identifiers.Flambda_uid
+
 type backend_var = t
 
 let name_for_debugger t =
@@ -35,9 +37,10 @@ module Provenance = struct
     module_path : Path.t;
     location : Debuginfo.t;
     original_ident : Ident.t;
+    uid : Uid.t
   }
 
-  let print ppf { module_path; location; original_ident; } =
+  let print ppf { module_path; location; original_ident; uid } =
     let printf fmt = Format.fprintf ppf fmt in
     printf "@[<hov 1>(";
     printf "@[<hov 1>(module_path@ %a)@]@ "
@@ -45,19 +48,22 @@ module Provenance = struct
     if !Clflags.locations then
       printf "@[<hov 1>(location@ %a)@]@ "
         Debuginfo.print_compact location;
-    printf "@[<hov 1>(original_ident@ %a)@]"
-      Ident.print original_ident;
+    printf "@[<hov 1>(original_ident@ %a,uid=%a)@]"
+      Ident.print original_ident
+      Uid.print uid;
     printf ")@]"
 
-  let create ~module_path ~location ~original_ident =
+  let create ~module_path ~location ~original_ident ~uid =
     { module_path;
       location;
       original_ident;
+      uid
     }
 
   let module_path t = t.module_path
   let location t = t.location
   let original_ident t = t.original_ident
+  let uid t = t.uid
 
   let equal t1 t2 = Stdlib.compare t1 t2 = 0
 end

--- a/middle_end/backend_var.mli
+++ b/middle_end/backend_var.mli
@@ -19,6 +19,8 @@
 
 include module type of struct include Ident end
 
+module Uid = Flambda2_identifiers.Flambda_uid
+
 type backend_var = t
 
 val name_for_debugger : t -> string
@@ -31,11 +33,13 @@ module Provenance : sig
      : module_path:Path.t
     -> location:Debuginfo.t
     -> original_ident:Ident.t
+    -> uid:Uid.t
     -> t
 
   val module_path : t -> Path.t
   val location : t -> Debuginfo.t
   val original_ident : t -> Ident.t
+  val uid : t -> Uid.t
 
   val print : Format.formatter -> t -> unit
 

--- a/middle_end/flambda2/bound_identifiers/bound_parameter.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_parameter.ml
@@ -15,36 +15,48 @@
 (**************************************************************************)
 
 module Simple = Int_ids.Simple
+module Uid = Shape.Uid
 
 type t =
   { param : Variable.t;
+    uid : Flambda_uid.t;
     kind : Flambda_kind.With_subkind.t
   }
 
 include Container_types.Make (struct
   type nonrec t = t
 
-  let compare { param = param1; kind = kind1 } { param = param2; kind = kind2 }
-      =
+  let compare { param = param1; kind = kind1; uid = uid1 }
+      { param = param2; kind = kind2; uid = uid2 } =
     let c = Variable.compare param1 param2 in
-    if c <> 0 then c else Flambda_kind.With_subkind.compare kind1 kind2
+    if c <> 0
+    then c
+    else
+      let c = Flambda_kind.With_subkind.compare kind1 kind2 in
+      if c <> 0 then c else Flambda_uid.compare uid1 uid2
 
   let equal t1 t2 = compare t1 t2 = 0
 
-  let hash { param; kind } =
-    Hashtbl.hash (Variable.hash param, Flambda_kind.With_subkind.hash kind)
+  let hash { param; kind; uid } =
+    Hashtbl.hash
+      ( Variable.hash param,
+        Flambda_kind.With_subkind.hash kind,
+        Flambda_uid.hash uid )
 
-  let [@ocamlformat "disable"] print ppf { param; kind; } =
-    Format.fprintf ppf "@[(%t%a%t @<1>\u{2237} %a)@]"
+  let [@ocamlformat "disable"] print ppf { param; kind; uid } =
+    Format.fprintf ppf "@[(%t%a,uid=%a%t @<1>\u{2237} %a)@]"
       Flambda_colours.parameter
       Variable.print param
+      Flambda_uid.print uid
       Flambda_colours.pop
       Flambda_kind.With_subkind.print kind
 end)
 
-let create param kind = { param; kind }
+let create param kind uid = { param; kind; uid }
 
 let var t = t.param
+
+let var_and_uid t = t.param, t.uid
 
 let name t = Name.var (var t)
 
@@ -58,12 +70,12 @@ let rename t = { t with param = Variable.rename t.param }
 
 let equal_kinds t1 t2 = Flambda_kind.With_subkind.equal t1.kind t2.kind
 
-let free_names ({ param = _; kind = _ } as t) =
-  Name_occurrences.singleton_variable (var t) Name_mode.normal
+let free_names { param; kind = _; uid = _ } =
+  Name_occurrences.singleton_variable param Name_mode.normal
 
-let apply_renaming { param; kind } renaming =
+let apply_renaming { param; kind; uid } renaming =
   let param = Renaming.apply_variable renaming param in
-  create param kind
+  create param kind uid
 
-let ids_for_export { param; kind = _ } =
+let ids_for_export { param; kind = _; uid = _ } =
   Ids_for_export.add_variable Ids_for_export.empty param

--- a/middle_end/flambda2/bound_identifiers/bound_parameter.mli
+++ b/middle_end/flambda2/bound_identifiers/bound_parameter.mli
@@ -14,14 +14,19 @@
 (*                                                                        *)
 (**************************************************************************)
 
+module Uid = Shape.Uid
+
 (** A parameter (to a function, continuation, etc.) together with its kind. *)
 type t
 
 (** Create a kinded parameter. *)
-val create : Variable.t -> Flambda_kind.With_subkind.t -> t
+val create : Variable.t -> Flambda_kind.With_subkind.t -> Flambda_uid.t -> t
 
 (** The underlying variable. *)
+
 val var : t -> Variable.t
+
+val var_and_uid : t -> Variable.t * Flambda_uid.t
 
 val name : t -> Name.t
 

--- a/middle_end/flambda2/bound_identifiers/bound_parameters.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_parameters.ml
@@ -50,6 +50,8 @@ let cardinal t = List.length t
 
 let vars t = List.map BP.var t
 
+let vars_and_uids t = List.map BP.var_and_uid t
+
 let simples t = List.map BP.simple t
 
 let to_set t = Bound_parameter.Set.of_list t

--- a/middle_end/flambda2/bound_identifiers/bound_parameters.mli
+++ b/middle_end/flambda2/bound_identifiers/bound_parameters.mli
@@ -42,6 +42,8 @@ val to_set : t -> Bound_parameter.Set.t
 
 val vars : t -> Variable.t list
 
+val vars_and_uids : t -> (Variable.t * Flambda_uid.t) list
+
 val var_set : t -> Variable.Set.t
 
 val filter : (Bound_parameter.t -> bool) -> t -> t

--- a/middle_end/flambda2/bound_identifiers/bound_var.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_var.ml
@@ -16,18 +16,21 @@
 
 type t =
   { var : Variable.t;
+    uid : Flambda_uid.t;
     name_mode : Name_mode.t
   }
 
-let [@ocamlformat "disable"] print ppf { var; name_mode = _; } =
-  Variable.print ppf var
+let [@ocamlformat "disable"] print ppf { var; uid; name_mode = _; } =
+  Format.fprintf ppf "%a,uid=%a" Variable.print var Flambda_uid.print uid
 
-let create var name_mode =
+let create var uid name_mode =
   (* Note that [name_mode] might be [In_types], e.g. when dealing with function
      return types and also using [Typing_env.add_definition]. *)
-  { var; name_mode }
+  { var; uid; name_mode }
 
 let var t = t.var
+
+let uid t = t.uid
 
 let name_mode t = t.name_mode
 
@@ -42,9 +45,9 @@ let apply_renaming t renaming =
 
 let free_names t = Name_occurrences.singleton_variable t.var t.name_mode
 
-let ids_for_export { var; name_mode = _ } =
+let ids_for_export { var; uid = _; name_mode = _ } =
   Ids_for_export.add_variable Ids_for_export.empty var
 
-let renaming { var; name_mode = _ } ~guaranteed_fresh =
-  let { var = guaranteed_fresh; name_mode = _ } = guaranteed_fresh in
+let renaming { var; uid = _; name_mode = _ } ~guaranteed_fresh =
+  let { var = guaranteed_fresh; uid = _; name_mode = _ } = guaranteed_fresh in
   Renaming.add_fresh_variable Renaming.empty var ~guaranteed_fresh

--- a/middle_end/flambda2/bound_identifiers/bound_var.mli
+++ b/middle_end/flambda2/bound_identifiers/bound_var.mli
@@ -19,9 +19,11 @@
 
 type t
 
-val create : Variable.t -> Name_mode.t -> t
+val create : Variable.t -> Flambda_uid.t -> Name_mode.t -> t
 
 val var : t -> Variable.t
+
+val uid : t -> Flambda_uid.t
 
 val name_mode : t -> Name_mode.t
 

--- a/middle_end/flambda2/from_lambda/closure_conversion.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion.mli
@@ -25,7 +25,7 @@ module Expr_with_acc = Closure_conversion_aux.Expr_with_acc
 val close_let :
   Acc.t ->
   Env.t ->
-  (Ident.t * Flambda_kind.With_subkind.t) list ->
+  (Ident.t * Flambda_uid.t * Flambda_kind.With_subkind.t) list ->
   IR.user_visible ->
   IR.named ->
   body:(Acc.t -> Env.t -> Expr_with_acc.t) ->
@@ -44,7 +44,8 @@ val close_let_cont :
   Env.t ->
   name:Continuation.t ->
   is_exn_handler:bool ->
-  params:(Ident.t * IR.user_visible * Flambda_kind.With_subkind.t) list ->
+  params:
+    (Ident.t * Flambda_uid.t * IR.user_visible * Flambda_kind.With_subkind.t) list ->
   recursive:Asttypes.rec_flag ->
   handler:(Acc.t -> Env.t -> Expr_with_acc.t) ->
   body:(Acc.t -> Env.t -> Expr_with_acc.t) ->

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -14,6 +14,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+module Uid = Shape.Uid
+
 module IR = struct
   type simple =
     | Var of Ident.t
@@ -21,7 +23,7 @@ module IR = struct
 
   type exn_continuation =
     { exn_handler : Continuation.t;
-      extra_args : (simple * Flambda_kind.With_subkind.t) list
+      extra_args : (simple * Flambda_uid.t * Flambda_kind.With_subkind.t) list
     }
 
   type trap_action =
@@ -225,7 +227,7 @@ module Env = struct
   let add_vars_like t ids =
     let vars =
       List.map
-        (fun (id, (user_visible : IR.user_visible), kind) ->
+        (fun (id, _uid, (user_visible : IR.user_visible), kind) ->
           let user_visible =
             match user_visible with
             | Not_user_visible -> None
@@ -234,7 +236,7 @@ module Env = struct
           Variable.create_with_same_name_as_ident ?user_visible id, kind)
         ids
     in
-    add_vars t (List.map (fun (id, _, _) -> id) ids) vars, List.map fst vars
+    add_vars t (List.map (fun (id, _, _, _) -> id) ids) vars, List.map fst vars
 
   let find_var t id =
     try Ident.Map.find id t.variables
@@ -678,6 +680,7 @@ module Function_decls = struct
   module Function_decl = struct
     type param =
       { name : Ident.t;
+        var_uid : Flambda_uid.t;
         kind : Flambda_kind.With_subkind.t;
         attributes : Lambda.parameter_attribute;
         mode : Lambda.alloc_mode
@@ -685,6 +688,7 @@ module Function_decls = struct
 
     type t =
       { let_rec_ident : Ident.t;
+        let_rec_uid : Flambda_uid.t;
         function_slot : Function_slot.t;
         kind : Lambda.function_kind;
         params : param list;
@@ -704,10 +708,10 @@ module Function_decls = struct
         contains_no_escaping_local_allocs : bool
       }
 
-    let create ~let_rec_ident ~function_slot ~kind ~params ~params_arity
-        ~removed_params ~return ~return_continuation ~exn_continuation
-        ~my_region ~body ~(attr : Lambda.function_attribute) ~loc
-        ~free_idents_of_body recursive ~closure_alloc_mode
+    let create ~let_rec_ident ~let_rec_uid ~function_slot ~kind ~params
+        ~params_arity ~removed_params ~return ~return_continuation
+        ~exn_continuation ~my_region ~body ~(attr : Lambda.function_attribute)
+        ~loc ~free_idents_of_body recursive ~closure_alloc_mode
         ~first_complex_local_param ~contains_no_escaping_local_allocs =
       let let_rec_ident =
         match let_rec_ident with
@@ -715,6 +719,7 @@ module Function_decls = struct
         | Some let_rec_ident -> let_rec_ident
       in
       { let_rec_ident;
+        let_rec_uid;
         function_slot;
         kind;
         params;

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -14,6 +14,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+module Uid = Shape.Uid
+
 (** Environments and auxiliary structures used during closure conversion. *)
 
 module IR : sig
@@ -23,7 +25,7 @@ module IR : sig
 
   type exn_continuation =
     { exn_handler : Continuation.t;
-      extra_args : (simple * Flambda_kind.With_subkind.t) list
+      extra_args : (simple * Flambda_uid.t * Flambda_kind.With_subkind.t) list
     }
 
   type trap_action =
@@ -130,7 +132,8 @@ module Env : sig
 
   val add_vars_like :
     t ->
-    (Ident.t * IR.user_visible * Flambda_kind.With_subkind.t) list ->
+    (Ident.t * Flambda_uid.t * IR.user_visible * Flambda_kind.With_subkind.t)
+    list ->
     t * Variable.t list
 
   val find_name : t -> Ident.t -> Name.t
@@ -303,6 +306,7 @@ module Function_decls : sig
 
     type param =
       { name : Ident.t;
+        var_uid : Flambda_uid.t;
         kind : Flambda_kind.With_subkind.t;
         attributes : Lambda.parameter_attribute;
         mode : Lambda.alloc_mode
@@ -310,6 +314,7 @@ module Function_decls : sig
 
     val create :
       let_rec_ident:Ident.t option ->
+      let_rec_uid:Flambda_uid.t ->
       function_slot:Function_slot.t ->
       kind:Lambda.function_kind ->
       params:param list ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_env.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_env.mli
@@ -44,7 +44,7 @@ val register_unboxed_product :
   t ->
   unboxed_product:Ident.t ->
   before_unarization:[`Complex] Flambda_arity.Component_for_creation.t ->
-  fields:(Ident.t * Flambda_kind.With_subkind.t) list ->
+  fields:(Ident.t * Flambda_uid.t * Flambda_kind.With_subkind.t) list ->
   t
 
 val get_unboxed_product_fields :
@@ -55,7 +55,7 @@ val get_unboxed_product_fields :
 type add_continuation_result = private
   { body_env : t;
     handler_env : t;
-    extra_params : (Ident.t * Flambda_kind.With_subkind.t) list
+    extra_params : (Ident.t * Flambda_uid.t * Flambda_kind.With_subkind.t) list
   }
 
 val add_continuation :
@@ -81,7 +81,9 @@ val get_try_stack_at_handler : t -> Continuation.t -> Continuation.t list
 val extra_args_for_continuation : t -> Continuation.t -> Ident.t list
 
 val extra_args_for_continuation_with_kinds :
-  t -> Continuation.t -> (Ident.t * Flambda_kind.With_subkind.t) list
+  t ->
+  Continuation.t ->
+  (Ident.t * Flambda_uid.t * Flambda_kind.With_subkind.t) list
 
 val get_mutable_variable_with_kind :
   t -> Ident.t -> Ident.t * Flambda_kind.With_subkind.t

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -256,17 +256,27 @@ let rec bind_rec acc exn_cont ~register_const0 (prim : expr_primitive)
       ~body ~is_exn_handler:false ~is_cold:false
   | If_then_else (cond, ifso, ifnot) ->
     let cond_result = Variable.create "cond_result" in
-    let cond_result_pat = Bound_var.create cond_result Name_mode.normal in
+    let cond_result_pat =
+      Bound_var.create cond_result Flambda_uid.internal_not_actually_unique
+        Name_mode.normal
+    in
     let ifso_cont = Continuation.create () in
     let ifso_result = Variable.create "ifso_result" in
-    let ifso_result_pat = Bound_var.create ifso_result Name_mode.normal in
+    let ifso_result_pat =
+      Bound_var.create ifso_result Flambda_uid.internal_not_actually_unique
+        Name_mode.normal
+    in
     let ifnot_cont = Continuation.create () in
     let ifnot_result = Variable.create "ifnot_result" in
-    let ifnot_result_pat = Bound_var.create ifnot_result Name_mode.normal in
+    let ifnot_result_pat =
+      Bound_var.create ifnot_result Flambda_uid.internal_not_actually_unique
+        Name_mode.normal
+    in
     let join_point_cont = Continuation.create () in
     let result_var = Variable.create "if_then_else_result" in
     let result_param =
       Bound_parameter.create result_var Flambda_kind.With_subkind.any_value
+        Flambda_uid.internal_not_actually_unique
     in
     bind_rec acc exn_cont ~register_const0 cond dbg @@ fun acc cond ->
     let compute_cond_and_switch acc =
@@ -332,7 +342,9 @@ and bind_rec_primitive acc exn_cont ~register_const0 (prim : simple_or_prim)
   | Simple s -> cont acc s
   | Prim p ->
     let var = Variable.create "prim" in
-    let var' = VB.create var Name_mode.normal in
+    let var' =
+      VB.create var Flambda_uid.internal_not_actually_unique Name_mode.normal
+    in
     let cont acc (named : Named.t) =
       let acc, body = cont acc (Simple.var var) in
       Let_with_acc.create acc (Bound_pattern.singleton var') named ~body

--- a/middle_end/flambda2/identifiers/flambda_uid.ml
+++ b/middle_end/flambda2/identifiers/flambda_uid.ml
@@ -1,0 +1,62 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                   Mark Shinwell, Jane Street Europe                    *)
+(*                                                                        *)
+(*   Copyright 2023 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+module Uid = Shape.Uid
+
+type t =
+  | Uid of Uid.t
+  | Proj of Uid.t * int
+
+let internal_not_actually_unique = Uid Uid.internal_not_actually_unique
+
+let uid u = Uid u
+
+let proj u ~field = Proj (u, field)
+
+module T0 = struct
+  type nonrec t = t
+
+  let print ppf t =
+    match t with
+    | Uid uid -> Format.fprintf ppf "@[<hov 1>(uid@ %a)@]" Uid.print uid
+    | Proj (uid, field) ->
+      Format.fprintf ppf
+        "@[<hov 1>(@[<hov 1>(uid@ %a)@]@ @[<hov 1>(field@ %d)@])@]" Uid.print
+        uid field
+
+  let compare t1 t2 =
+    match t1, t2 with
+    | Uid uid1, Uid uid2 -> Uid.compare uid1 uid2
+    | Proj (uid1, field1), Proj (uid2, field2) ->
+      let c = Uid.compare uid1 uid2 in
+      if c <> 0 then c else Int.compare field1 field2
+    | Uid _, Proj _ -> -1
+    | Proj _, Uid _ -> 1
+
+  let equal t1 t2 =
+    match t1, t2 with
+    | Uid uid1, Uid uid2 -> Uid.equal uid1 uid2
+    | Proj (uid1, field1), Proj (uid2, field2) ->
+      Uid.equal uid1 uid2 && Int.equal field1 field2
+    | Uid _, Proj _ | Proj _, Uid _ -> false
+
+  let hash t =
+    match t with
+    | Uid uid -> Hashtbl.hash (0, Uid.hash uid)
+    | Proj (uid, field) -> Hashtbl.hash (1, (Uid.hash uid, field))
+
+  let output _ _ = Misc.fatal_error "Not implemented"
+end
+
+include Identifiable.Make (T0)

--- a/middle_end/flambda2/identifiers/flambda_uid.mli
+++ b/middle_end/flambda2/identifiers/flambda_uid.mli
@@ -2,11 +2,9 @@
 (*                                                                        *)
 (*                                 OCaml                                  *)
 (*                                                                        *)
-(*      Pierre Chambart, Vincent Laviron and Louis Gesbert, OCamlPro      *)
-(*           Mark Shinwell and Leo White, Jane Street Europe              *)
+(*                   Mark Shinwell, Jane Street Europe                    *)
 (*                                                                        *)
-(*   Copyright 2018 OCamlPro SAS                                          *)
-(*   Copyright 2018 Jane Street Group LLC                                 *)
+(*   Copyright 2023 Jane Street Group LLC                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -14,17 +12,17 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Compile let-rec defining non-function values into separate allocation and
-    assignments. *)
+(** Augmented version of [Shape.Uid.t] that can track variables forming parts
+    of unboxed products. *)
 
-type dissected =
-  | Dissected of Lambda.lambda
-  | Unchanged
+type t = private
+  | Uid of Shape.Uid.t
+  | Proj of Shape.Uid.t * int
 
-(** [dissect_letrec] assumes that bindings have not been dissected yet. In
-    particular, that no arguments of function call are recursive. *)
-val dissect_letrec :
-  bindings:(Ident.t * Shape.Uid.t * Lambda.lambda) list ->
-  body:Lambda.lambda ->
-  free_vars_kind:(Ident.t -> Lambda.layout option) ->
-  dissected
+val internal_not_actually_unique : t
+
+val uid : Shape.Uid.t -> t
+
+val proj : Shape.Uid.t -> field:int -> t
+
+include Identifiable.S with type t := t

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -577,7 +577,11 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
     let bound_vars, env =
       let convert_binding env (var, _) : Bound_var.t * env =
         let var, env = fresh_var env var in
-        let var = Bound_var.create var Name_mode.normal in
+        (* CR tnowak: verify *)
+        let var =
+          Bound_var.create var Flambda_uid.internal_not_actually_unique
+            Name_mode.normal
+        in
         var, env
       in
       map_accum_left convert_binding env vars_and_closure_bindings
@@ -604,7 +608,10 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
     let named = defining_expr env d in
     let id, env = fresh_var env var in
     let body = expr env body in
-    let var = Bound_var.create id Name_mode.normal in
+    let var =
+      Bound_var.create id Flambda_uid.internal_not_actually_unique
+        Name_mode.normal
+    in
     let bound = Bound_pattern.singleton var in
     Flambda.Let.create bound named ~body ~free_names_of_body:Unknown
     |> Flambda.Expr.create_let
@@ -633,7 +640,10 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
         (fun ({ param; kind } : Fexpr.kinded_parameter) (env, args) ->
           let var, env = fresh_var env param in
           let param =
-            Bound_parameter.create var (value_kind_with_subkind_opt kind)
+            Bound_parameter.create var
+              (value_kind_with_subkind_opt kind)
+              Flambda_uid.internal_not_actually_unique
+            (* CR tnowak: verify *)
           in
           env, param :: args)
         params (env, [])
@@ -842,7 +852,10 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
               (fun env ({ param; kind } : Fexpr.kinded_parameter) ->
                 let var, env = fresh_var env param in
                 let param =
-                  Bound_parameter.create var (value_kind_with_subkind_opt kind)
+                  Bound_parameter.create var
+                    (value_kind_with_subkind_opt kind)
+                    Flambda_uid.internal_not_actually_unique
+                  (* CR tnowak: verify *)
                 in
                 param, env)
               env params

--- a/middle_end/flambda2/simplify/apply_cont_rewrite.ml
+++ b/middle_end/flambda2/simplify/apply_cont_rewrite.ml
@@ -174,7 +174,9 @@ let make_rewrite rewrite ~ctx id args =
             simple, [], Simple.free_names simple, Name_occurrences.empty
           | New_let_binding (temp, prim) ->
             let extra_let =
-              ( Bound_var.create temp Name_mode.normal,
+              (* CR tnowak: verify *)
+              ( Bound_var.create temp Flambda_uid.internal_not_actually_unique
+                  Name_mode.normal,
                 Code_size.prim prim,
                 Flambda.Named.create_prim prim Debuginfo.none )
             in
@@ -193,7 +195,9 @@ let make_rewrite rewrite ~ctx id args =
                    since they are already named."
             in
             let extra_let =
-              ( Bound_var.create temp Name_mode.normal,
+              (* CR tnowak: verify *)
+              ( Bound_var.create temp Flambda_uid.internal_not_actually_unique
+                  Name_mode.normal,
                 Code_size.prim prim,
                 Flambda.Named.create_prim prim Debuginfo.none )
             in

--- a/middle_end/flambda2/simplify/common_subexpression_elimination.ml
+++ b/middle_end/flambda2/simplify/common_subexpression_elimination.ml
@@ -223,7 +223,9 @@ let join_one_cse_equation ~cse_at_each_use prim bound_to_map
       let prim_result_kind = P.result_kind' (EP.to_primitive prim) in
       let var = Variable.create "cse_param" in
       let extra_param =
-        BP.create var (K.With_subkind.create prim_result_kind Anything)
+        BP.create var
+          (K.With_subkind.create prim_result_kind Anything)
+          Flambda_uid.internal_not_actually_unique (* CR tnowak: verify *)
       in
       let bound_to = RI.Map.map Rhs_kind.bound_to bound_to_map in
       let cse = EP.Map.add prim (Simple.var var) cse in

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -320,7 +320,8 @@ let add_equation_on_name t name ty =
 let define_parameters t ~params =
   List.fold_left
     (fun t param ->
-      let var = Bound_var.create (BP.var param) Name_mode.normal in
+      let param_var, param_uid = BP.var_and_uid param in
+      let var = Bound_var.create param_var param_uid Name_mode.normal in
       define_variable t var (K.With_subkind.kind (BP.kind param)))
     t
     (Bound_parameters.to_list params)
@@ -341,7 +342,8 @@ let add_parameters ?(name_mode = Name_mode.normal) ?at_unit_toplevel t params
   in
   List.fold_left2
     (fun t param param_type ->
-      let var = Bound_var.create (BP.var param) name_mode in
+      let param_var, param_uid = BP.var_and_uid param in
+      let var = Bound_var.create param_var param_uid name_mode in
       add_variable0 t var param_type ~at_unit_toplevel)
     t params param_types
 

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -284,7 +284,9 @@ let create_coerced_singleton_let uacc var defining_expr
         (* Generate [let uncoerced_var = <defining_expr>] *)
         let ((_body, _uacc, outer_result) as outer) =
           let bound =
-            Bound_pattern.singleton (VB.create uncoerced_var name_mode)
+            Bound_pattern.singleton
+              (VB.create uncoerced_var Flambda_uid.internal_not_actually_unique
+                 name_mode)
           in
           create_let uacc bound defining_expr ~free_names_of_defining_expr ~body
             ~cost_metrics_of_defining_expr
@@ -567,7 +569,9 @@ let create_let_symbols uacc lifted_constant ~body =
       let free_names_of_defining_expr = Named.free_names defining_expr in
       let expr, uacc, _ =
         create_coerced_singleton_let uacc
-          (VB.create var Name_mode.normal)
+          (* CR tnowak: verify *)
+          (VB.create var Flambda_uid.internal_not_actually_unique
+             Name_mode.normal)
           defining_expr ~coercion_from_defining_expr_to_var
           ~free_names_of_defining_expr ~body:expr ~cost_metrics_of_defining_expr
       in
@@ -759,11 +763,11 @@ let rewrite_fixed_arity_continuation0 uacc cont_or_apply_cont ~use_id arity :
          binds [kinded_params]. *)
       let params =
         List.map
-          (fun _kind -> Variable.create "param")
+          (fun kind ->
+            BP.create (Variable.create "param") kind
+              Flambda_uid.internal_not_actually_unique
+            (* CR tnowak: verify *))
           (Flambda_arity.unarized_components arity)
-      in
-      let params =
-        List.map2 BP.create params (Flambda_arity.unarized_components arity)
       in
       let args = List.map BP.simple params in
       let params = Bound_parameters.create params in

--- a/middle_end/flambda2/simplify/flow/mutable_unboxing.ml
+++ b/middle_end/flambda2/simplify/flow/mutable_unboxing.ml
@@ -462,7 +462,9 @@ module Fold_prims = struct
               (fun i kind ->
                 let name = Variable.unique_name block_needed in
                 let var = Variable.create (Printf.sprintf "%s_%i" name i) in
-                Bound_parameter.create var kind)
+                Bound_parameter.create var kind
+                  Flambda_uid.internal_not_actually_unique
+                (* CR tnowak: verify *))
               fields_kinds
           in
           let env =

--- a/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
+++ b/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
@@ -38,6 +38,7 @@ let make_inlined_body ~callee ~unroll_to ~params ~args ~my_closure ~my_region
   in
   let my_closure =
     Bound_parameter.create my_closure Flambda_kind.With_subkind.any_value
+      Flambda_uid.internal_not_actually_unique (* CR tnowak: maybe here? *)
   in
   let bind_params ~params ~args ~body =
     if List.compare_lengths params args <> 0
@@ -48,14 +49,19 @@ let make_inlined_body ~callee ~unroll_to ~params ~args ~my_closure ~my_region
         Simple.List.print args;
     ListLabels.fold_left2 (List.rev params) (List.rev args) ~init:body
       ~f:(fun expr param arg ->
-        let var = Bound_var.create (BP.var param) Name_mode.normal in
+        let param_var, param_uid = BP.var_and_uid param in
+        let var = Bound_var.create param_var param_uid Name_mode.normal in
         Let.create
           (Bound_pattern.singleton var)
           (Named.create_simple arg) ~body:expr ~free_names_of_body:Unknown
         |> Expr.create_let)
   in
   let bind_depth ~my_depth ~rec_info ~body =
-    let bound = Bound_pattern.singleton (VB.create my_depth Name_mode.normal) in
+    let bound =
+      Bound_pattern.singleton
+        (VB.create my_depth Flambda_uid.internal_not_actually_unique
+           Name_mode.normal)
+    in
     Let.create bound
       (Named.create_rec_info rec_info)
       ~body ~free_names_of_body:Unknown

--- a/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
@@ -43,7 +43,8 @@ let inline_linearly_used_continuation uacc ~create_apply_cont ~params:params'
     let bindings_outermost_first =
       ListLabels.map2 params args ~f:(fun param arg ->
           let let_bound =
-            Bound_var.create (BP.var param) Name_mode.normal
+            let param_var, param_uid = BP.var_and_uid param in
+            Bound_var.create param_var param_uid Name_mode.normal
             |> Bound_pattern.singleton
           in
           let named = Named.create_simple arg in

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -179,7 +179,10 @@ let split_direct_over_application apply
       let over_application_results =
         List.mapi
           (fun i kind ->
-            BP.create (Variable.create ("result" ^ string_of_int i)) kind)
+            BP.create
+              (Variable.create ("result" ^ string_of_int i))
+              kind
+              Flambda_uid.internal_not_actually_unique (* CR tnowak: verify *))
           (Flambda_arity.unarized_components (Apply.return_arity apply))
       in
       let call_return_continuation, call_return_continuation_free_names =
@@ -199,7 +202,8 @@ let split_direct_over_application apply
       let handler_expr =
         Let.create
           (Bound_pattern.singleton
-             (Bound_var.create (Variable.create "unit") Name_mode.normal))
+             (Bound_var.create (Variable.create "unit")
+                Flambda_uid.internal_not_actually_unique Name_mode.normal))
           (Named.create_prim
              (Unary (End_region, Simple.var region))
              (Apply.dbg apply))
@@ -224,7 +228,10 @@ let split_direct_over_application apply
   in
   let after_full_application = Continuation.create () in
   let after_full_application_handler =
-    let func_param = BP.create func_var K.With_subkind.any_value in
+    let func_param =
+      BP.create func_var K.With_subkind.any_value
+        Flambda_uid.internal_not_actually_unique (* CR tnowak: maybe? *)
+    in
     Continuation_handler.create
       (Bound_parameters.create [func_param])
       ~handler:perform_over_application
@@ -259,7 +266,9 @@ let split_direct_over_application apply
   | None -> both_applications
   | Some (region, _) ->
     Let.create
-      (Bound_pattern.singleton (Bound_var.create region Name_mode.normal))
+      (Bound_pattern.singleton
+         (Bound_var.create region Flambda_uid.internal_not_actually_unique
+            (* CR tnowak: verify *) Name_mode.normal))
       (Named.create_prim (Nullary Begin_region) (Apply.dbg apply))
       ~body:both_applications
       ~free_names_of_body:

--- a/middle_end/flambda2/simplify/simplify_extcall.ml
+++ b/middle_end/flambda2/simplify/simplify_extcall.ml
@@ -44,7 +44,9 @@ let apply_cont cont v ~dbg =
   free_names, expr
 
 let let_prim ~dbg v prim (free_names, body) =
-  let v' = Bound_var.create v Name_mode.normal in
+  let v' =
+    Bound_var.create v Flambda_uid.internal_not_actually_unique Name_mode.normal
+  in
   let bindable = Bound_pattern.singleton v' in
   let named = Named.create_prim prim dbg in
   let free_names_of_body = Or_unknown.Known free_names in

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -220,7 +220,11 @@ let extra_params_for_continuation_param_aliases cont uacc rewrite_ids =
           (Variable.Map.find var aliases_kind)
           Anything
       in
-      EPA.add ~extra_param:(Bound_parameter.create var var_kind) ~extra_args epa)
+      EPA.add
+        ~extra_param:
+          (Bound_parameter.create var var_kind
+             Flambda_uid.internal_not_actually_unique (* CR tnowak: maybe? *))
+        ~extra_args epa)
     required_extra_args.extra_args_for_aliases EPA.empty
 
 let add_extra_params_for_mutable_unboxing cont uacc extra_params_and_args =
@@ -466,7 +470,10 @@ let add_lets_around_handler cont at_unit_toplevel uacc handler =
     Variable.Map.fold
       (fun var bound_to (handler, uacc) ->
         let bound_pattern =
-          Bound_pattern.singleton (Bound_var.create var Name_mode.normal)
+          (* CR tnowak: verify *)
+          Bound_pattern.singleton
+            (Bound_var.create var Flambda_uid.internal_not_actually_unique
+               Name_mode.normal)
         in
         let named = Named.create_simple (Simple.var bound_to) in
         let handler, uacc =
@@ -502,9 +509,9 @@ let add_phantom_params_bindings uacc handler new_phantom_params =
   let new_phantom_param_bindings_outermost_first =
     List.map
       (fun param ->
-        let var = BP.var param in
+        let param_var, param_uid = BP.var_and_uid param in
         let kind = K.With_subkind.kind (BP.kind param) in
-        let var = Bound_var.create var Name_mode.phantom in
+        let var = Bound_var.create param_var param_uid Name_mode.phantom in
         let let_bound = Bound_pattern.singleton var in
         let prim = Flambda_primitive.(Nullary (Optimised_out kind)) in
         let named = Named.create_prim prim Debuginfo.none in

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -44,7 +44,8 @@ let dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_region
       (* This happens in the stub case, where we are only simplifying code, not
          a set of closures. *)
       DE.add_variable denv
-        (Bound_var.create my_closure NM.normal)
+        (Bound_var.create my_closure Flambda_uid.internal_not_actually_unique
+           NM.normal)
         (T.unknown K.value)
     | Some function_slot -> (
       match
@@ -60,15 +61,22 @@ let dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_region
       | name ->
         let name = Bound_name.name name in
         DE.add_variable denv
-          (Bound_var.create my_closure NM.normal)
+          (Bound_var.create my_closure Flambda_uid.internal_not_actually_unique
+             NM.normal)
           (T.alias_type_of K.value (Simple.name name)))
   in
   let denv =
-    let my_region = Bound_var.create my_region Name_mode.normal in
+    let my_region =
+      Bound_var.create my_region Flambda_uid.internal_not_actually_unique
+        Name_mode.normal
+    in
     DE.add_variable denv my_region (T.unknown K.region)
   in
   let denv =
-    let my_depth = Bound_var.create my_depth Name_mode.normal in
+    let my_depth =
+      Bound_var.create my_depth Flambda_uid.internal_not_actually_unique
+        Name_mode.normal
+    in
     DE.add_variable denv my_depth (T.unknown K.rec_info)
   in
   let denv =
@@ -169,10 +177,13 @@ let simplify_function_body context ~outer_dacc function_slot_opt
       ~implicit_params:
         (Bound_parameters.create
            [ Bound_parameter.create my_closure
-               Flambda_kind.With_subkind.any_value;
-             Bound_parameter.create my_region Flambda_kind.With_subkind.region;
+               Flambda_kind.With_subkind.any_value
+               Flambda_uid.internal_not_actually_unique;
+             (* CR tnowak: maybe? verify those three *)
+             Bound_parameter.create my_region Flambda_kind.With_subkind.region
+               Flambda_uid.internal_not_actually_unique;
              Bound_parameter.create my_depth Flambda_kind.With_subkind.rec_info
-           ])
+               Flambda_uid.internal_not_actually_unique ])
       ~loopify_state ~params
   with
   | body, uacc ->
@@ -335,7 +346,8 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
       (fun i kind_with_subkind ->
         BP.create
           (Variable.create ("result" ^ string_of_int i))
-          kind_with_subkind)
+          kind_with_subkind
+          Flambda_uid.internal_not_actually_unique (* CR tnowak: verify *))
       (Flambda_arity.unarized_components result_arity)
     |> Bound_parameters.create
   in

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -333,11 +333,18 @@ let rebuild_switch_with_single_arg_to_same_destination uacc ~dacc_before_switch
       match must_untag_lookup_table_result with
       | Leave_as_tagged_immediate -> body
       | Must_untag ->
-        let bound = BPt.singleton (BV.create final_arg_var NM.normal) in
+        let bound =
+          BPt.singleton
+            (BV.create final_arg_var Flambda_uid.internal_not_actually_unique
+               NM.normal)
+        in
         let untag_arg = Named.create_prim untag_arg_prim dbg in
         RE.create_let rebuilding bound untag_arg ~body ~free_names_of_body
     in
-    let bound = BPt.singleton (BV.create arg_var NM.normal) in
+    let bound =
+      BPt.singleton
+        (BV.create arg_var Flambda_uid.internal_not_actually_unique NM.normal)
+    in
     RE.create_let rebuilding bound load_from_block ~body ~free_names_of_body
   in
   let extra_free_names =
@@ -505,7 +512,9 @@ let rebuild_switch ~original ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
                   Debuginfo.none
               in
               let bound =
-                VB.create not_scrutinee NM.normal |> Bound_pattern.singleton
+                VB.create not_scrutinee Flambda_uid.internal_not_actually_unique
+                  NM.normal
+                |> Bound_pattern.singleton
               in
               let apply_cont =
                 Apply_cont.create dest ~args:[not_scrutinee'] ~dbg
@@ -603,7 +612,9 @@ let simplify_switch ~simplify_let ~simplify_function_body dacc switch
   let let_expr =
     (* [body] won't be looked at (see below). *)
     Let.create
-      (Bound_pattern.singleton (Bound_var.create tagged_scrutinee NM.normal))
+      (Bound_pattern.singleton
+         (Bound_var.create tagged_scrutinee
+            Flambda_uid.internal_not_actually_unique NM.normal))
       tagging_prim
       ~body:(Expr.create_switch switch)
       ~free_names_of_body:Unknown

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -556,7 +556,9 @@ let simplify_obj_dup dbg dacc ~original_term ~arg ~arg_ty ~result_var =
         in
         let bind_contents =
           { Expr_builder.let_bound =
-              Bound_pattern.singleton (Bound_var.create contents_var NM.normal);
+              Bound_pattern.singleton
+                (Bound_var.create contents_var
+                   Flambda_uid.internal_not_actually_unique NM.normal);
             simplified_defining_expr = Simplified_named.create contents_expr;
             original_defining_expr = None
           }
@@ -564,7 +566,8 @@ let simplify_obj_dup dbg dacc ~original_term ~arg ~arg_ty ~result_var =
         let contents_simple = Simple.var contents_var in
         let dacc =
           DA.add_variable dacc
-            (Bound_var.create contents_var NM.normal)
+            (Bound_var.create contents_var
+               Flambda_uid.internal_not_actually_unique NM.normal)
             contents_ty
         in
         ( [bind_contents],

--- a/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
+++ b/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
@@ -27,7 +27,11 @@ let add_equation_on_var denv var shape =
   | Bottom -> Misc.fatal_errorf "Meet failed whereas prove previously succeeded"
 
 let denv_of_number_decision naked_kind shape param_var naked_var denv : DE.t =
-  let naked_name = VB.create naked_var Name_mode.normal in
+  (* CR tnowak: verify *)
+  let naked_name =
+    VB.create naked_var Flambda_uid.internal_not_actually_unique
+      Name_mode.normal
+  in
   let denv = DE.define_variable denv naked_name naked_kind in
   add_equation_on_var denv param_var shape
 
@@ -41,7 +45,11 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
     let denv =
       List.fold_left
         (fun denv ({ epa = { param = var; _ }; _ } : U.field_decision) ->
-          let v = VB.create var Name_mode.normal in
+          (* CR tnowak: verify *)
+          let v =
+            VB.create var Flambda_uid.internal_not_actually_unique
+              Name_mode.normal
+          in
           DE.define_variable denv v field_kind)
         denv fields
     in
@@ -62,7 +70,11 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
     let denv =
       Value_slot.Map.fold
         (fun _ ({ epa = { param = var; _ }; kind; _ } : U.field_decision) denv ->
-          let v = VB.create var Name_mode.normal in
+          (* CR tnowak: verify *)
+          let v =
+            VB.create var Flambda_uid.internal_not_actually_unique
+              Name_mode.normal
+          in
           DE.define_variable denv v (K.With_subkind.kind kind))
         vars_within_closure denv
     in
@@ -83,7 +95,11 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
       vars_within_closure denv
   | Unbox (Variant { tag; const_ctors; fields_by_tag }) ->
     (* Adapt the denv for the tag *)
-    let tag_v = VB.create tag.param Name_mode.normal in
+    (* CR tnowak: verify *)
+    let tag_v =
+      VB.create tag.param Flambda_uid.internal_not_actually_unique
+        Name_mode.normal
+    in
     let denv = DE.define_variable denv tag_v K.naked_immediate in
     let denv =
       DE.add_equation_on_variable denv tag.param
@@ -98,7 +114,11 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
       match const_ctors with
       | Zero -> denv
       | At_least_one { is_int; _ } ->
-        let is_int_v = VB.create is_int.param Name_mode.normal in
+        (* CR tnowak: verify *)
+        let is_int_v =
+          VB.create is_int.param Flambda_uid.internal_not_actually_unique
+            Name_mode.normal
+        in
         let denv = DE.define_variable denv is_int_v K.naked_immediate in
         let denv =
           DE.add_equation_on_variable denv is_int.param
@@ -119,7 +139,11 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
       | At_least_one { ctor = Do_not_unbox _; _ } ->
         denv, T.unknown K.naked_immediate
       | At_least_one { ctor = Unbox (Number (Naked_immediate, ctor_epa)); _ } ->
-        let v = VB.create ctor_epa.param Name_mode.normal in
+        (* CR tnowak: verify *)
+        let v =
+          VB.create ctor_epa.param Flambda_uid.internal_not_actually_unique
+            Name_mode.normal
+        in
         let denv = DE.define_variable denv v K.naked_immediate in
         let ty =
           T.alias_type_of K.naked_immediate (Simple.var ctor_epa.param)
@@ -144,7 +168,11 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
         (fun _ block_fields denv ->
           List.fold_left
             (fun denv ({ epa = { param = var; _ }; _ } : U.field_decision) ->
-              let v = VB.create var Name_mode.normal in
+              (* CR tnowak: verify *)
+              let v =
+                VB.create var Flambda_uid.internal_not_actually_unique
+                  Name_mode.normal
+              in
               DE.define_variable denv v K.value)
             denv block_fields)
         fields_by_tag denv

--- a/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
@@ -400,7 +400,10 @@ let add_extra_params_and_args extra_params_and_args decision =
     | Unbox (Unique_tag_and_size { tag = _; fields }) ->
       List.fold_left
         (fun extra_params_and_args ({ epa; decision; kind } : U.field_decision) ->
-          let extra_param = BP.create epa.param kind in
+          let extra_param =
+            BP.create epa.param kind
+              Flambda_uid.internal_not_actually_unique (* CR tnowak: maybe? *)
+          in
           let extra_params_and_args =
             EPA.add extra_params_and_args ~extra_param ~extra_args:epa.args
           in
@@ -410,7 +413,10 @@ let add_extra_params_and_args extra_params_and_args decision =
       Value_slot.Map.fold
         (fun _ ({ epa; decision; kind } : U.field_decision)
              extra_params_and_args ->
-          let extra_param = BP.create epa.param kind in
+          let extra_param =
+            BP.create epa.param kind
+              Flambda_uid.internal_not_actually_unique (* CR tnowak: maybe? *)
+          in
           let extra_params_and_args =
             EPA.add extra_params_and_args ~extra_param ~extra_args:epa.args
           in
@@ -423,7 +429,11 @@ let add_extra_params_and_args extra_params_and_args decision =
             List.fold_left
               (fun extra_params_and_args
                    ({ epa; decision; kind } : U.field_decision) ->
-                let extra_param = BP.create epa.param kind in
+                let extra_param =
+                  BP.create epa.param kind
+                    Flambda_uid.internal_not_actually_unique
+                  (* CR tnowak: maybe? *)
+                in
                 let extra_params_and_args =
                   EPA.add extra_params_and_args ~extra_param
                     ~extra_args:epa.args
@@ -438,18 +448,21 @@ let add_extra_params_and_args extra_params_and_args decision =
         | At_least_one { is_int; ctor = Do_not_unbox _; _ } ->
           let extra_param =
             BP.create is_int.param K.With_subkind.naked_immediate
+              Flambda_uid.internal_not_actually_unique (* CR tnowak: maybe? *)
           in
           EPA.add extra_params_and_args ~extra_param ~extra_args:is_int.args
         | At_least_one { is_int; ctor = Unbox (Number (Naked_immediate, ctor)) }
           ->
           let extra_param =
             BP.create is_int.param K.With_subkind.naked_immediate
+              Flambda_uid.internal_not_actually_unique (* CR tnowak: maybe? *)
           in
           let extra_params_and_args =
             EPA.add extra_params_and_args ~extra_param ~extra_args:is_int.args
           in
           let extra_param =
             BP.create ctor.param K.With_subkind.naked_immediate
+              Flambda_uid.internal_not_actually_unique (* CR tnowak: maybe? *)
           in
           EPA.add extra_params_and_args ~extra_param ~extra_args:ctor.args
         | At_least_one
@@ -466,13 +479,19 @@ let add_extra_params_and_args extra_params_and_args decision =
             "Trying to unbox the constant constructor of a variant with a kind \
              other than Naked_immediate."
       in
-      let extra_param = BP.create tag.param K.With_subkind.naked_immediate in
+      let extra_param =
+        BP.create tag.param K.With_subkind.naked_immediate
+          Flambda_uid.internal_not_actually_unique (* CR tnowak: maybe? *)
+      in
       EPA.add extra_params_and_args ~extra_param ~extra_args:tag.args
     | Unbox (Number (naked_number_kind, epa)) ->
       let kind_with_subkind =
         K.With_subkind.of_naked_number_kind naked_number_kind
       in
-      let extra_param = BP.create epa.param kind_with_subkind in
+      let extra_param =
+        BP.create epa.param kind_with_subkind
+          Flambda_uid.internal_not_actually_unique (* CR tnowak: maybe? *)
+      in
       EPA.add extra_params_and_args ~extra_param ~extra_args:epa.args
   in
   aux extra_params_and_args decision

--- a/middle_end/flambda2/simplify_shared/inlining_helpers.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_helpers.ml
@@ -71,7 +71,10 @@ let wrap_inlined_body_for_exn_extra_args acc ~extra_args ~apply_exn_continuation
       in
       let kinded_params =
         List.map
-          (fun k -> Bound_parameter.create (Variable.create "wrapper_return") k)
+          (fun k ->
+            Bound_parameter.create
+              (Variable.create "wrapper_return")
+              k Flambda_uid.internal_not_actually_unique (* CR tnowak: verify *))
           (Flambda_arity.unarized_components result_arity)
       in
       let trap_action =
@@ -88,7 +91,8 @@ let wrap_inlined_body_for_exn_extra_args acc ~extra_args ~apply_exn_continuation
   in
   let param = Variable.create "exn" in
   let wrapper_handler_params =
-    [Bound_parameter.create param Flambda_kind.With_subkind.any_value]
+    [ Bound_parameter.create param Flambda_kind.With_subkind.any_value
+        Flambda_uid.internal_not_actually_unique (* CR tnowak: verify *) ]
     |> Bound_parameters.create
   in
   let exn_handler = Exn_continuation.exn_handler apply_exn_continuation in

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -572,7 +572,9 @@ and print_function_params_and_body ppf t =
   let print ~return_continuation ~exn_continuation params ~body ~my_closure
       ~is_my_closure_used:_ ~my_region ~my_depth ~free_names_of_body:_ =
     let my_closure =
-      Bound_parameter.create my_closure (K.With_subkind.create K.value Anything)
+      Bound_parameter.create my_closure
+        (K.With_subkind.create K.value Anything)
+        Flambda_uid.internal_not_actually_unique (* CR tnowak: verify *)
     in
     fprintf ppf
       "@[<hov 1>(%t@<1>\u{03bb}%t@[<hov \

--- a/middle_end/flambda2/tests/meet_test.ml
+++ b/middle_end/flambda2/tests/meet_test.ml
@@ -17,7 +17,10 @@ let create_env () =
 let test_meet_chains_two_vars () =
   let env = create_env () in
   let var1 = Variable.create "var1" in
-  let var1' = Bound_var.create var1 Name_mode.normal in
+  let var1' =
+    Bound_var.create var1 Flambda_uid.internal_not_actually_unique
+      Name_mode.normal
+  in
   let env = TE.add_definition env (Bound_name.create_var var1') K.value in
   let env =
     TE.add_equation env (Name.var var1)
@@ -25,7 +28,10 @@ let test_meet_chains_two_vars () =
          Alloc_mode.For_types.heap ~fields:[T.any_tagged_immediate])
   in
   let var2 = Variable.create "var2" in
-  let var2' = Bound_var.create var2 Name_mode.normal in
+  let var2' =
+    Bound_var.create var2 Flambda_uid.internal_not_actually_unique
+      Name_mode.normal
+  in
   let env = TE.add_definition env (Bound_name.create_var var2') K.value in
   let first_type_for_var2 = T.alias_type_of K.value (Simple.var var1) in
   let env = TE.add_equation env (Name.var var2) first_type_for_var2 in
@@ -50,7 +56,10 @@ let test_meet_chains_two_vars () =
 let test_meet_chains_three_vars () =
   let env = create_env () in
   let var1 = Variable.create "var1" in
-  let var1' = Bound_var.create var1 Name_mode.normal in
+  let var1' =
+    Bound_var.create var1 Flambda_uid.internal_not_actually_unique
+      Name_mode.normal
+  in
   let env = TE.add_definition env (Bound_name.create_var var1') K.value in
   let env =
     TE.add_equation env (Name.var var1)
@@ -58,12 +67,18 @@ let test_meet_chains_three_vars () =
          Alloc_mode.For_types.heap ~fields:[T.any_tagged_immediate])
   in
   let var2 = Variable.create "var2" in
-  let var2' = Bound_var.create var2 Name_mode.normal in
+  let var2' =
+    Bound_var.create var2 Flambda_uid.internal_not_actually_unique
+      Name_mode.normal
+  in
   let env = TE.add_definition env (Bound_name.create_var var2') K.value in
   let first_type_for_var2 = T.alias_type_of K.value (Simple.var var1) in
   let env = TE.add_equation env (Name.var var2) first_type_for_var2 in
   let var3 = Variable.create "var3" in
-  let var3' = Bound_var.create var3 Name_mode.normal in
+  let var3' =
+    Bound_var.create var3 Flambda_uid.internal_not_actually_unique
+      Name_mode.normal
+  in
   let env = TE.add_definition env (Bound_name.create_var var3') K.value in
   let first_type_for_var3 = T.alias_type_of K.value (Simple.var var2) in
   let env = TE.add_equation env (Name.var var3) first_type_for_var3 in
@@ -88,7 +103,10 @@ let test_meet_chains_three_vars () =
 let meet_variants_don't_lose_aliases () =
   let env = create_env () in
   let define env v =
-    let v' = Bound_var.create v Name_mode.normal in
+    let v' =
+      Bound_var.create v Flambda_uid.internal_not_actually_unique
+        Name_mode.normal
+    in
     TE.add_definition env (Bound_name.create_var v') K.value
   in
   let defines env l = List.fold_left define env l in
@@ -136,7 +154,10 @@ let meet_variants_don't_lose_aliases () =
 
 let test_meet_two_blocks () =
   let define env v =
-    let v' = Bound_var.create v Name_mode.normal in
+    let v' =
+      Bound_var.create v Flambda_uid.internal_not_actually_unique
+        Name_mode.normal
+    in
     TE.add_definition env (Bound_name.create_var v') K.value
   in
   let defines env l = List.fold_left define env l in

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -85,7 +85,8 @@ let unit0 ~offsets ~all_code ~reachable_names flambda_unit =
     C.bound_parameters env
       (Bound_parameters.create
          [ Bound_parameter.create (Variable.create "*ret*")
-             Flambda_kind.With_subkind.any_value ])
+             Flambda_kind.With_subkind.any_value
+             Flambda_uid.internal_not_actually_unique (* CR tnowak: verify *) ])
   in
   let return_cont, env =
     Env.add_jump_cont env
@@ -95,7 +96,8 @@ let unit0 ~offsets ~all_code ~reachable_names flambda_unit =
   (* See comment in [To_cmm_set_of_closures] about binding [my_region] *)
   let env, toplevel_region_var =
     Env.create_bound_parameter env
-      (Flambda_unit.toplevel_my_region flambda_unit)
+      ( Flambda_unit.toplevel_my_region flambda_unit,
+        Flambda_uid.internal_not_actually_unique (* CR tnowak: verify *) )
   in
   let r =
     R.create ~reachable_names

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -282,7 +282,7 @@ let exported_offsets t = t.offsets
 
 (* Variables *)
 
-let gen_variable v =
+let gen_variable ~uid v =
   let user_visible = Variable.user_visible v in
   let name = Variable.name v in
   let v = Backend_var.create_local name in
@@ -296,7 +296,7 @@ let gen_variable v =
          be reworked soon *)
       Some
         (Backend_var.Provenance.create ~module_path:(Path.Pident v)
-           ~location:Debuginfo.none ~original_ident:v)
+           ~location:Debuginfo.none ~original_ident:v ~uid)
   in
   Backend_var.With_provenance.create ?provenance v
 
@@ -306,12 +306,12 @@ let add_bound_param env v v' =
   let vars = Variable.Map.add v (C.var v'', free_vars) env.vars in
   { env with vars }
 
-let create_bound_parameter env v =
+let create_bound_parameter env (v, uid) =
   if Variable.Map.mem v env.vars
   then
     Misc.fatal_errorf "Cannot rebind variable %a in To_cmm environment"
       Variable.print v;
-  let v' = gen_variable v in
+  let v' = gen_variable v ~uid in
   let env = add_bound_param env v v' in
   env, v'
 
@@ -416,7 +416,7 @@ let is_cmm_simple cmm =
 
 (* Helper function to create bindings *)
 
-let create_binding_aux (type a) effs var ~(inline : a inline)
+let create_binding_aux (type a) effs (var : Bound_var.t) ~(inline : a inline)
     (bound_expr : a bound_expr) =
   let order =
     let incr =
@@ -427,7 +427,7 @@ let create_binding_aux (type a) effs var ~(inline : a inline)
     next_order := !next_order + incr;
     !next_order
   in
-  let cmm_var = gen_variable var in
+  let cmm_var = gen_variable ~uid:(Bound_var.uid var) (Bound_var.var var) in
   let binding = Binding { order; inline; effs; cmm_var; bound_expr } in
   binding
 
@@ -664,13 +664,13 @@ let bind_variable_with_decision (type a) ?extra env res var ~inline
     ~(defining_expr : a bound_expr) ~effects_and_coeffects_of_defining_expr:effs
     =
   let binding = create_binding ~inline effs var defining_expr in
-  add_binding_to_env ?extra env res var binding
+  add_binding_to_env ?extra env res (Bound_var.var var) binding
 
 let bind_variable ?extra env res var ~defining_expr ~free_vars_of_defining_expr
     ~num_normal_occurrences_of_bound_vars
     ~effects_and_coeffects_of_defining_expr =
   let inline =
-    To_cmm_effects.classify_let_binding var
+    To_cmm_effects.classify_let_binding (Bound_var.var var)
       ~effects_and_coeffects_of_defining_expr
       ~num_normal_occurrences_of_bound_vars
   in
@@ -855,6 +855,7 @@ let split_binding_and_rebind ~num_occurrences_of_var env res ~var ~alias_of
 let add_alias env res ~var ~alias_of ~num_normal_occurrences_of_bound_vars =
   let alias_of = resolve_alias env alias_of in
   let num_occurrences_of_var : Num_occurrences.t =
+    let var = Bound_var.var var in
     match Variable.Map.find var num_normal_occurrences_of_bound_vars with
     | exception Not_found ->
       Misc.fatal_errorf
@@ -868,7 +869,7 @@ let add_alias env res ~var ~alias_of ~num_normal_occurrences_of_bound_vars =
     | Zero ->
       let env = remove_binding env alias_of in
       env, res
-    | One -> make_alias env res var alias_of
+    | One -> make_alias env res (Bound_var.var var) alias_of
     | More_than_one ->
       let env = remove_binding env alias_of in
       split_binding_and_rebind ~num_occurrences_of_var env res ~var ~alias_of b)

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -132,11 +132,11 @@ val exported_offsets : t -> Exported_offsets.t
     the new environment and the created variable. Will produce a fatal error if
     the given variable is already bound. *)
 val create_bound_parameter :
-  t -> Variable.t -> t * Backend_var.With_provenance.t
+  t -> Variable.t * Flambda_uid.t -> t * Backend_var.With_provenance.t
 
 (** Same as {!create_variable} but for a list of variables. *)
 val create_bound_parameters :
-  t -> Variable.t list -> t * Backend_var.With_provenance.t list
+  t -> (Variable.t * Flambda_uid.t) list -> t * Backend_var.With_provenance.t list
 
 (** {2 Delayed let-bindings}
 
@@ -232,7 +232,7 @@ val bind_variable_to_primitive :
   ?extra:extra_info ->
   t ->
   To_cmm_result.t ->
-  Variable.t ->
+  Bound_var.t ->
   inline:'a inline ->
   defining_expr:'a bound_expr ->
   effects_and_coeffects_of_defining_expr:Effects_and_coeffects.t ->
@@ -244,7 +244,7 @@ val bind_variable :
   ?extra:extra_info ->
   t ->
   To_cmm_result.t ->
-  Variable.t ->
+  Bound_var.t ->
   defining_expr:Cmm.expression ->
   free_vars_of_defining_expr:free_vars ->
   num_normal_occurrences_of_bound_vars:Num_occurrences.t Variable.Map.t ->
@@ -254,7 +254,7 @@ val bind_variable :
 val add_alias :
   t ->
   To_cmm_result.t ->
-  var:Variable.t ->
+  var:Bound_var.t ->
   alias_of:Variable.t ->
   num_normal_occurrences_of_bound_vars:Num_occurrences.t Variable.Map.t ->
   t * To_cmm_result.t

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -205,8 +205,9 @@ let simple_list ?consider_inlining_effectful_expressions ~dbg env res l =
   List.rev args, free_vars, env, res, effs
 
 let bound_parameters env l =
-  let flambda_vars = Bound_parameters.vars l in
-  let env, cmm_vars = To_cmm_env.create_bound_parameters env flambda_vars in
+  let env, cmm_vars =
+    To_cmm_env.create_bound_parameters env (Bound_parameters.vars_and_uids l)
+  in
   let vars =
     List.map2
       (fun v v' -> v, machtype_of_kinded_parameter v')

--- a/middle_end/flambda2/types/join_levels.ml
+++ b/middle_end/flambda2/types/join_levels.ml
@@ -46,7 +46,10 @@ let join_types ~env_at_fork envs_with_levels =
                     let kind = TEL.find_kind level var in
                     TE.add_definition base_env
                       (Bound_name.create_var
-                         (Bound_var.create var Name_mode.in_types))
+                         (* CR tnowak: verify *)
+                         (Bound_var.create var
+                            Flambda_uid.internal_not_actually_unique
+                            Name_mode.in_types))
                       kind)
                 vars base_env)
             (TEL.variables_by_binding_time level)

--- a/native_toplevel/opttoploop.ml
+++ b/native_toplevel/opttoploop.ml
@@ -122,7 +122,9 @@ let close_phrase lam =
              [Lprim (Pgetglobal glb, [], Loc_unknown)],
              Loc_unknown)
     in
-    Llet(Strict, Lambda.layout_module_field, id, glob, l)
+    (* CR tnowak: verify *)
+    let uid = Shape.Uid.internal_not_actually_unique in
+    Llet(Strict, Lambda.layout_module_field, id, uid, glob, l)
   ) (free_variables lam) lam
 
 let toplevel_value id =

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -16,6 +16,8 @@
 open Misc
 open Asttypes
 
+module Uid = Shape.Uid
+
 type mutable_flag = Immutable | Immutable_unique | Mutable
 
 type compile_time_constant =
@@ -552,6 +554,8 @@ type parameter_attribute = No_attributes
 
 type lparam = {
   name : Ident.t;
+  (* This is the uid of the variable, not of the type of the variable. *)
+  var_uid : Uid.t;
   layout : layout;
   attributes : parameter_attribute;
   mode : alloc_mode
@@ -563,15 +567,15 @@ type lambda =
   | Lconst of structured_constant
   | Lapply of lambda_apply
   | Lfunction of lfunction
-  | Llet of let_kind * layout * Ident.t * lambda * lambda
-  | Lmutlet of layout * Ident.t * lambda * lambda
-  | Lletrec of (Ident.t * lambda) list * lambda
+  | Llet of let_kind * layout * Ident.t * Uid.t * lambda * lambda
+  | Lmutlet of layout * Ident.t * Uid.t * lambda * lambda
+  | Lletrec of (Ident.t * Uid.t * lambda) list * lambda
   | Lprim of primitive * lambda list * scoped_location
   | Lswitch of lambda * lambda_switch * scoped_location * layout
   | Lstringswitch of
       lambda * (string * lambda) list * lambda option * scoped_location * layout
   | Lstaticraise of static_label * lambda list
-  | Lstaticcatch of lambda * (static_label * (Ident.t * layout) list) * lambda * layout
+  | Lstaticcatch of lambda * (static_label * (Ident.t * Uid.t * layout) list) * lambda * layout
   | Ltrywith of lambda * Ident.t * lambda * layout
   | Lifthenelse of lambda * lambda * lambda * layout
   | Lsequence of lambda * lambda
@@ -769,20 +773,22 @@ let make_key e =
         Lapply {ap with ap_func = tr_rec env ap.ap_func;
                         ap_args = tr_recs env ap.ap_args;
                         ap_loc = Loc_unknown}
-    | Llet (Alias,_k,x,ex,e) -> (* Ignore aliases -> substitute *)
+    | Llet (Alias,_k,x,_x_uid,ex,e) -> (* Ignore aliases -> substitute *)
         let ex = tr_rec env ex in
         tr_rec (Ident.add x ex env) e
-    | Llet ((Strict | StrictOpt),_k,x,ex,Lvar v) when Ident.same v x ->
+    | Llet ((Strict | StrictOpt),_k,x,_x_uid,ex,Lvar v) when Ident.same v x ->
         tr_rec env ex
-    | Llet (str,k,x,ex,e) ->
+    | Llet (str,k,x,x_uid,ex,e) ->
      (* Because of side effects, keep other lets with normalized names *)
         let ex = tr_rec env ex in
         let y = make_key x in
-        Llet (str,k,y,ex,tr_rec (Ident.add x (Lvar y) env) e)
-    | Lmutlet (k,x,ex,e) ->
+        (* CR tnowak: verify *)
+        Llet (str,k,y,x_uid,ex,tr_rec (Ident.add x (Lvar y) env) e)
+    | Lmutlet (k,x,x_uid,ex,e) ->
         let ex = tr_rec env ex in
         let y = make_key x in
-        Lmutlet (k,y,ex,tr_rec (Ident.add x (Lmutvar y) env) e)
+        (* CR tnowak: verify *)
+        Lmutlet (k,y,x_uid,ex,tr_rec (Ident.add x (Lmutvar y) env) e)
     | Lprim (p,es,_) ->
         Lprim (p,tr_recs env es, Loc_unknown)
     | Lswitch (e,sw,loc,kind) ->
@@ -840,7 +846,8 @@ let name_lambda strict arg layout fn =
     Lvar id -> fn id
   | _ ->
       let id = Ident.create_local "let" in
-      Llet(strict, layout, id, arg, fn id)
+      let uid = Uid.internal_not_actually_unique in
+      Llet(strict, layout, id, uid, arg, fn id)
 
 let name_lambda_list args fn =
   let rec name_list names = function
@@ -849,7 +856,8 @@ let name_lambda_list args fn =
       name_list (arg :: names) rem
   | (arg, layout) :: rem ->
       let id = Ident.create_local "let" in
-      Llet(Strict, layout, id, arg, name_list (Lvar id :: names) rem) in
+      let uid = Uid.internal_not_actually_unique in
+      Llet(Strict, layout, id, uid, arg, name_list (Lvar id :: names) rem) in
   name_list [] args
 
 
@@ -865,12 +873,12 @@ let shallow_iter ~tail ~non_tail:f = function
       f fn; List.iter f args
   | Lfunction{body} ->
       f body
-  | Llet(_, _k, _id, arg, body)
-  | Lmutlet(_k, _id, arg, body) ->
+  | Llet(_, _k, _id, _, arg, body)
+  | Lmutlet(_k, _id, _, arg, body) ->
       f arg; tail body
   | Lletrec(decl, body) ->
       tail body;
-      List.iter (fun (_id, exp) -> f exp) decl
+      List.iter (fun (_id, _uid, exp) -> f exp) decl
   | Lprim (Psequand, [l1; l2], _)
   | Lprim (Psequor, [l1; l2], _) ->
       f l1;
@@ -925,14 +933,14 @@ let rec free_variables = function
   | Lfunction{body; params} ->
       Ident.Set.diff (free_variables body)
         (Ident.Set.of_list (List.map (fun p -> p.name) params))
-  | Llet(_, _k, id, arg, body)
-  | Lmutlet(_k, id, arg, body) ->
+  | Llet(_, _k, id, _uid, arg, body)
+  | Lmutlet(_k, id, _uid, arg, body) ->
       Ident.Set.union
         (free_variables arg)
         (Ident.Set.remove id (free_variables body))
   | Lletrec(decl, body) ->
-      let set = free_variables_list (free_variables body) (List.map snd decl) in
-      Ident.Set.diff set (Ident.Set.of_list (List.map fst decl))
+      let set = free_variables_list (free_variables body) (List.map thd3 decl) in
+      Ident.Set.diff set (Ident.Set.of_list (List.map fst3 decl))
   | Lprim(_p, args, _loc) ->
       free_variables_list Ident.Set.empty args
   | Lswitch(arg, sw,_,_) ->
@@ -961,7 +969,7 @@ let rec free_variables = function
       Ident.Set.union
         (Ident.Set.diff
            (free_variables handler)
-           (Ident.Set.of_list (List.map fst params)))
+           (Ident.Set.of_list (List.map fst3 params)))
         (free_variables body)
   | Ltrywith(body, param, handler, _) ->
       Ident.Set.union
@@ -1013,15 +1021,15 @@ let staticfail = Lstaticraise (0,[])
 
 let rec is_guarded = function
   | Lifthenelse(_cond, _body, Lstaticraise (0,[]),_) -> true
-  | Llet(_str, _k, _id, _lam, body) -> is_guarded body
+  | Llet(_str, _k, _id, _uid, _lam, body) -> is_guarded body
   | Levent(lam, _ev) -> is_guarded lam
   | _ -> false
 
 let rec patch_guarded patch = function
   | Lifthenelse (cond, body, Lstaticraise (0,[]), kind) ->
       Lifthenelse (cond, body, patch, kind)
-  | Llet(str, k, id, lam, body) ->
-      Llet (str, k, id, lam, patch_guarded patch body)
+  | Llet(str, k, id, uid, lam, body) ->
+      Llet (str, k, id, uid, lam, patch_guarded patch body)
   | Levent(lam, ev) ->
       Levent (patch_guarded patch lam, ev)
   | _ -> fatal_error "Lambda.patch_guarded"
@@ -1087,13 +1095,14 @@ let subst update_env ?(freshen_bound_variables = false) s input_lam =
      scope, mapped to either themselves or freshened versions of
      themselves when [freshen_bound_variables] is set. *)
   let bind id l =
+    (* CR tnowak: verify whether uid has to be also passed here *)
     let id' = if not freshen_bound_variables then id else Ident.rename id in
     id', Ident.Map.add id id' l
   in
   let bind_many ids l =
-    List.fold_right (fun (id, rhs) (ids', l) ->
+    List.fold_right (fun (id, uid, rhs) (ids', l) ->
         let id', l = bind id l in
-        ((id', rhs) :: ids' , l)
+        ((id', uid, rhs) :: ids' , l)
       ) ids ([], l)
   in
   let bind_params params l =
@@ -1128,12 +1137,12 @@ let subst update_env ?(freshen_bound_variables = false) s input_lam =
     | Lfunction lf ->
         let params, l' = bind_params lf.params l in
         Lfunction {lf with params; body = subst s l' lf.body}
-    | Llet(str, k, id, arg, body) ->
+    | Llet(str, k, id, uid, arg, body) ->
         let id, l' = bind id l in
-        Llet(str, k, id, subst s l arg, subst s l' body)
-    | Lmutlet(k, id, arg, body) ->
+        Llet(str, k, id, uid, subst s l arg, subst s l' body)
+    | Lmutlet(k, id, uid, arg, body) ->
         let id, l' = bind id l in
-        Lmutlet(k, id, subst s l arg, subst s l' body)
+        Lmutlet(k, id, uid, subst s l arg, subst s l' body)
     | Lletrec(decl, body) ->
         let decl, l' = bind_many decl l in
         Lletrec(List.map (subst_decl s l') decl, subst s l' body)
@@ -1210,7 +1219,7 @@ let subst update_env ?(freshen_bound_variables = false) s input_lam =
     | Lexclave e ->
         Lexclave (subst s l e)
   and subst_list s l li = List.map (subst s l) li
-  and subst_decl s l (id, exp) = (id, subst s l exp)
+  and subst_decl s l (id, uid, exp) = (id, uid, subst s l exp)
   and subst_case s l (key, case) = (key, subst s l case)
   and subst_strcase s l (key, case) = (key, subst s l case)
   and subst_opt s l = function
@@ -1255,12 +1264,12 @@ let shallow_map ~tail ~non_tail:f = function
   | Lfunction { kind; params; return; body; attr; loc; mode; region } ->
       Lfunction { kind; params; return; body = f body; attr; loc;
                   mode; region }
-  | Llet (str, layout, v, e1, e2) ->
-      Llet (str, layout, v, f e1, tail e2)
-  | Lmutlet (layout, v, e1, e2) ->
-      Lmutlet (layout, v, f e1, tail e2)
+  | Llet (str, layout, v, uid, e1, e2) ->
+      Llet (str, layout, v, uid, f e1, tail e2)
+  | Lmutlet (layout, v, uid, e1, e2) ->
+      Lmutlet (layout, v, uid, f e1, tail e2)
   | Lletrec (idel, e2) ->
-      Lletrec (List.map (fun (v, e) -> (v, f e)) idel, tail e2)
+      Lletrec (List.map (fun (v, uid, e) -> (v, uid, f e)) idel, tail e2)
   | Lprim (Psequand as p, [l1; l2], loc)
   | Lprim (Psequor as p, [l1; l2], loc) ->
       Lprim(p, [f l1; tail l2], loc)
@@ -1317,10 +1326,10 @@ let map f =
 
 (* To let-bind expressions to variables *)
 
-let bind_with_layout str (var, layout) exp body =
+let bind_with_layout str (var, uid, layout) exp body =
   match exp with
     Lvar var' when Ident.same var var' -> body
-  | _ -> Llet(str, layout, var, exp, body)
+  | _ -> Llet(str, layout, var, uid, exp, body)
 
 let negate_integer_comparison = function
   | Ceq -> Cne
@@ -1615,11 +1624,11 @@ let compute_expr_layout free_vars_kind lam =
     | Lfunction _ -> layout_function
     | Lapply { ap_result_layout; _ } -> ap_result_layout
     | Lsend (_, _, _, _, _, _, _, layout) -> layout
-    | Llet(_, kind, id, _, body) | Lmutlet(kind, id, _, body) ->
+    | Llet(_, kind, id, _uid, _, body) | Lmutlet(kind, id, _uid, _, body) ->
       compute_expr_layout (Ident.Map.add id kind kinds) body
     | Lletrec(defs, body) ->
       let kinds =
-        List.fold_left (fun kinds (id, _) -> Ident.Map.add id layout_letrec kinds)
+        List.fold_left (fun kinds (id, _uid, _) -> Ident.Map.add id layout_letrec kinds)
           kinds defs
       in
       compute_expr_layout kinds body

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -17,6 +17,8 @@
 
 open Asttypes
 
+module Uid = Shape.Uid
+
 (* Overriding Asttypes.mutable_flag *)
 type mutable_flag = Immutable | Immutable_unique | Mutable
 
@@ -449,6 +451,7 @@ type parameter_attribute = No_attributes
 
 type lparam = {
   name : Ident.t;
+  var_uid : Uid.t;
   layout : layout;
   attributes : parameter_attribute;
   mode : alloc_mode
@@ -462,9 +465,9 @@ type lambda =
   | Lconst of structured_constant
   | Lapply of lambda_apply
   | Lfunction of lfunction
-  | Llet of let_kind * layout * Ident.t * lambda * lambda
-  | Lmutlet of layout * Ident.t * lambda * lambda
-  | Lletrec of (Ident.t * lambda) list * lambda
+  | Llet of let_kind * layout * Ident.t * Uid.t * lambda * lambda
+  | Lmutlet of layout * Ident.t * Uid.t * lambda * lambda
+  | Lletrec of (Ident.t * Uid.t * lambda) list * lambda
   | Lprim of primitive * lambda list * scoped_location
   | Lswitch of lambda * lambda_switch * scoped_location * layout
 (* switch on strings, clauses are sorted by string order,
@@ -472,7 +475,7 @@ type lambda =
   | Lstringswitch of
       lambda * (string * lambda) list * lambda option * scoped_location * layout
   | Lstaticraise of static_label * lambda list
-  | Lstaticcatch of lambda * (static_label * (Ident.t * layout) list) * lambda * layout
+  | Lstaticcatch of lambda * (static_label * (Ident.t * Uid.t * layout) list) * lambda * layout
   | Ltrywith of lambda * Ident.t * lambda * layout
 (* Lifthenelse (e, t, f, layout) evaluates t if e evaluates to 0, and evaluates f if
    e evaluates to any other value; layout must be the layout of [t] and [f] *)
@@ -684,7 +687,7 @@ val shallow_map  :
   (** Rewrite each immediate sub-term with the function. *)
 
 val bind_with_layout:
-  let_kind -> (Ident.t * layout) -> lambda -> lambda -> lambda
+  let_kind -> (Ident.t * Uid.t * layout) -> lambda -> lambda -> lambda
 
 val negate_integer_comparison : integer_comparison -> integer_comparison
 val swap_integer_comparison : integer_comparison -> integer_comparison

--- a/ocaml/lambda/printlambda.ml
+++ b/ocaml/lambda/printlambda.ml
@@ -751,8 +751,9 @@ let rec lam ppf = function
             List.iter (fun (p : Lambda.lparam) ->
                 (* Make sure we change this once there are attributes *)
                 let No_attributes = p.attributes in
-                fprintf ppf "@ %a%s%a"
-                  Ident.print p.name (alloc_kind p.mode) layout p.layout) params
+                fprintf ppf "@ %a%s%a,uid=%a"
+                  Ident.print p.name (alloc_kind p.mode) layout p.layout
+                  Uid.print p.var_uid) params
         | Tupled ->
             fprintf ppf " (";
             let first = ref true in
@@ -772,7 +773,7 @@ let rec lam ppf = function
         function_attribute attr return_kind (rmode, return) lam body
   | Llet _ | Lmutlet _ as expr ->
       let let_kind = begin function
-        | Llet(str,_,_,_,_) ->
+        | Llet(str,_,_,_,_,_) ->
            begin match str with
              Alias -> "a" | Strict -> "" | StrictOpt -> "o"
            end
@@ -781,11 +782,11 @@ let rec lam ppf = function
         end
       in
       let rec letbody ~sp = function
-        | Llet(_, k, id, arg, body)
-        | Lmutlet(k, id, arg, body) as l ->
+        | Llet(_, k, id, uid, arg, body)
+        | Lmutlet(k, id, uid, arg, body) as l ->
            if sp then fprintf ppf "@ ";
-           fprintf ppf "@[<2>%a =%s%a@ %a@]"
-             Ident.print id (let_kind l) layout k lam arg;
+           fprintf ppf "@[<2>%a,uid=%a =%s%a@ %a@]"
+             Ident.print id Uid.print uid (let_kind l) layout k lam arg;
            letbody ~sp:true body
         | expr -> expr in
       fprintf ppf "@[<2>(let@ @[<hv 1>(";
@@ -795,9 +796,9 @@ let rec lam ppf = function
       let bindings ppf id_arg_list =
         let spc = ref false in
         List.iter
-          (fun (id, l) ->
+          (fun (id, uid, l) ->
             if !spc then fprintf ppf "@ " else spc := true;
-            fprintf ppf "@[<2>%a@ %a@]" Ident.print id lam l)
+            fprintf ppf "@[<2>%a@,uid=%a %a@]" Ident.print id Uid.print uid lam l)
           id_arg_list in
       fprintf ppf
         "@[<2>(letrec@ (@[<hv 1>%a@])@ %a)@]" bindings id_arg_list lam body
@@ -853,7 +854,7 @@ let rec lam ppf = function
         lam lbody i
         (fun ppf vars ->
            List.iter
-             (fun (x, k) -> fprintf ppf " %a%a" Ident.print x layout k)
+             (fun (x, uid, k) -> fprintf ppf " %a%a,uid=%a" Ident.print x layout k Uid.print uid)
              vars
         )
         vars

--- a/ocaml/lambda/simplif.ml
+++ b/ocaml/lambda/simplif.ml
@@ -35,12 +35,12 @@ let rec eliminate_ref id = function
       if Ident.Set.mem id (free_variables lam)
       then raise Real_reference
       else lam
-  | Llet(str, kind, v, e1, e2) ->
-      Llet(str, kind, v, eliminate_ref id e1, eliminate_ref id e2)
-  | Lmutlet(kind, v, e1, e2) ->
-      Lmutlet(kind, v, eliminate_ref id e1, eliminate_ref id e2)
+  | Llet(str, kind, v, v_uid, e1, e2) ->
+      Llet(str, kind, v, v_uid, eliminate_ref id e1, eliminate_ref id e2)
+  | Lmutlet(kind, v, v_uid, e1, e2) ->
+      Lmutlet(kind, v, v_uid, eliminate_ref id e1, eliminate_ref id e2)
   | Lletrec(idel, e2) ->
-      Lletrec(List.map (fun (v, e) -> (v, eliminate_ref id e)) idel,
+      Lletrec(List.map (fun (v, v_uid, e) -> (v, v_uid, eliminate_ref id e)) idel,
               eliminate_ref id e2)
   | Lprim(Pfield (0, _sem), [Lvar v], _) when Ident.same v id ->
       Lmutvar id
@@ -132,11 +132,11 @@ let simplify_exits lam =
       count ~try_depth ap.ap_func;
       List.iter (count ~try_depth) ap.ap_args
   | Lfunction {body} -> count ~try_depth body
-  | Llet(_, _kind, _v, l1, l2)
-  | Lmutlet(_kind, _v, l1, l2) ->
+  | Llet(_, _kind, _v, _v_uid, l1, l2)
+  | Lmutlet(_kind, _v, _v_uid, l1, l2) ->
       count ~try_depth l2; count ~try_depth l1
   | Lletrec(bindings, body) ->
-      List.iter (fun (_v, l) -> count ~try_depth l) bindings;
+      List.iter (fun (_v, _v_uid, l) -> count ~try_depth l) bindings;
       count ~try_depth body
   | Lprim(_p, ll, _) -> List.iter (count ~try_depth) ll
   | Lswitch(l, sw, _loc, _kind) ->
@@ -236,12 +236,12 @@ let simplify_exits lam =
   | Lfunction{kind; params; return; mode; region; body = l; attr; loc} ->
      lfunction ~kind ~params ~return ~mode ~region
        ~body:(simplif ~layout:None ~try_depth l) ~attr ~loc
-  | Llet(str, kind, v, l1, l2) ->
-      Llet(str, kind, v, simplif ~layout:None ~try_depth l1, simplif ~layout ~try_depth l2)
-  | Lmutlet(kind, v, l1, l2) ->
-      Lmutlet(kind, v, simplif ~layout:None ~try_depth l1, simplif ~layout ~try_depth l2)
+  | Llet(str, kind, v, v_uid, l1, l2) ->
+      Llet(str, kind, v, v_uid, simplif ~layout:None ~try_depth l1, simplif ~layout ~try_depth l2)
+  | Lmutlet(kind, v, v_uid, l1, l2) ->
+      Lmutlet(kind, v, v_uid, simplif ~layout:None ~try_depth l1, simplif ~layout ~try_depth l2)
   | Lletrec(bindings, body) ->
-      Lletrec(List.map (fun (v, l) -> (v, simplif ~layout:None ~try_depth l)) bindings,
+      Lletrec(List.map (fun (v, v_uid, l) -> (v, v_uid, simplif ~layout:None ~try_depth l)) bindings,
       simplif ~layout ~try_depth body)
   | Lprim(p, ll, loc) -> begin
     let ll = List.map (simplif ~layout:None ~try_depth) ll in
@@ -288,10 +288,10 @@ let simplify_exits lam =
       let ls = List.map (simplif ~layout:None ~try_depth) ls in
       begin try
         let xs,handler =  Hashtbl.find subst i in
-        let ys = List.map (fun (x, k) -> Ident.rename x, k) xs in
+        let ys = List.map (fun (x, uid, k) -> x, uid, k) xs in
         let env =
           List.fold_right2
-            (fun (x, _) (y, _) env -> Ident.Map.add x y env)
+            (fun (x, _, _) (y, _, _) env -> Ident.Map.add x y env)
             xs ys Ident.Map.empty
         in
         (* The evaluation order for Lstaticraise arguments is currently
@@ -301,7 +301,7 @@ let simplify_exits lam =
            so will be evaluated last).
         *)
         List.fold_left2
-          (fun r (y, kind) l -> Llet (Strict, kind, y, l, r))
+          (fun r (y, uid, kind) l -> Llet (Strict, kind, y, uid, l, r))
           (Lambda.rename env handler) ys ls
       with
       | Not_found -> Lstaticraise (i,ls)
@@ -374,7 +374,7 @@ let exact_application {kind; params; _} args =
 
 let beta_reduce params body args =
   List.fold_left2
-    (fun l param arg -> Llet(Strict, param.layout, param.name, arg, l))
+    (fun l param arg -> Llet(Strict, param.layout, param.name, param.var_uid, arg, l))
     body params args
 
 (* Simplification of lets *)
@@ -441,20 +441,20 @@ let simplify_lets lam =
       end
   | Lfunction {body} ->
       count Ident.Map.empty body
-  | Llet(_str, _k, v, Lvar w, l2) when optimize ->
+  | Llet(_str, _k, v, _v_uid, Lvar w, l2) when optimize ->
       (* v will be replaced by w in l2, so each occurrence of v in l2
          increases w's refcount *)
       count (bind_var bv v) l2;
       use_var bv w (count_var v)
-  | Llet(str, _kind, v, l1, l2) ->
+  | Llet(str, _kind, v, _v_uid, l1, l2) ->
       count (bind_var bv v) l2;
       (* If v is unused, l1 will be removed, so don't count its variables *)
       if str = Strict || count_var v > 0 then count bv l1
-  | Lmutlet(_kind, _v, l1, l2) ->
+  | Lmutlet(_kind, _v, _v_uid, l1, l2) ->
      count bv l1;
      count bv l2
   | Lletrec(bindings, body) ->
-      List.iter (fun (_v, l) -> count bv l) bindings;
+      List.iter (fun (_v, _v_uid, l) -> count bv l) bindings;
       count bv body
   | Lprim(_p, ll, _) -> List.iter (count bv) ll
   | Lswitch(l, sw, _loc, _kind) ->
@@ -522,16 +522,16 @@ let simplify_lets lam =
 (* This (small)  optimisation is always legal, it may uncover some
    tail call later on. *)
 
-  let mklet str kind v e1 e2 =
+  let mklet str kind v v_uid e1 e2 =
     match e2 with
     | Lvar w when optimize && Ident.same v w -> e1
-    | _ -> Llet (str, kind,v,e1,e2)
+    | _ -> Llet (str, kind,v,v_uid,e1,e2)
   in
 
-  let mkmutlet kind v e1 e2 =
+  let mkmutlet kind v v_uid e1 e2 =
     match e2 with
     | Lmutvar w when optimize && Ident.same v w -> e1
-    | _ -> Lmutlet (kind,v,e1,e2)
+    | _ -> Lmutlet (kind,v,v_uid,e1,e2)
   in
 
   let rec simplif = function
@@ -575,10 +575,10 @@ let simplify_lets lam =
       | kind, region, body ->
           lfunction ~kind ~params ~return:outer_return ~body ~attr ~loc ~mode ~region
       end
-  | Llet(_str, _k, v, Lvar w, l2) when optimize ->
+  | Llet(_str, _k, v, _v_uid, Lvar w, l2) when optimize ->
       Hashtbl.add subst v (simplif (Lvar w));
       simplif l2
-  | Llet(Strict, kind, v,
+  | Llet(Strict, kind, v, v_uid,
          Lprim(Pmakeblock(0, Mutable, kind_ref, _mode) as prim, [linit], loc),
          lbody)
     when optimize ->
@@ -590,25 +590,25 @@ let simplify_lets lam =
           | Some [field_kind] -> Pvalue field_kind
           | Some _ -> assert false
         in
-        mkmutlet kind v slinit (eliminate_ref v slbody)
+        mkmutlet kind v v_uid slinit (eliminate_ref v slbody)
       with Real_reference ->
-        mklet Strict kind v (Lprim(prim, [slinit], loc)) slbody
+        mklet Strict kind v v_uid (Lprim(prim, [slinit], loc)) slbody
       end
-  | Llet(Alias, kind, v, l1, l2) ->
+  | Llet(Alias, kind, v, v_uid, l1, l2) ->
       begin match count_var v with
         0 -> simplif l2
       | 1 when optimize -> Hashtbl.add subst v (simplif l1); simplif l2
-      | _ -> Llet(Alias, kind, v, simplif l1, simplif l2)
+      | _ -> Llet(Alias, kind, v, v_uid, simplif l1, simplif l2)
       end
-  | Llet(StrictOpt, kind, v, l1, l2) ->
+  | Llet(StrictOpt, kind, v, v_uid, l1, l2) ->
       begin match count_var v with
         0 -> simplif l2
-      | _ -> mklet StrictOpt kind v (simplif l1) (simplif l2)
+      | _ -> mklet StrictOpt kind v v_uid (simplif l1) (simplif l2)
       end
-  | Llet(str, kind, v, l1, l2) -> mklet str kind v (simplif l1) (simplif l2)
-  | Lmutlet(kind, v, l1, l2) -> mkmutlet kind v (simplif l1) (simplif l2)
+  | Llet(str, kind, v, v_uid, l1, l2) -> mklet str kind v v_uid (simplif l1) (simplif l2)
+  | Lmutlet(kind, v, v_uid, l1, l2) -> mkmutlet kind v v_uid (simplif l1) (simplif l2)
   | Lletrec(bindings, body) ->
-      Lletrec(List.map (fun (v, l) -> (v, simplif l)) bindings, simplif body)
+      Lletrec(List.map (fun (v, v_uid, l) -> (v, v_uid, simplif l)) bindings, simplif body)
   | Lprim(p, ll, loc) -> Lprim(p, List.map simplif ll, loc)
   | Lswitch(l, sw, loc, kind) ->
       let new_l = simplif l
@@ -680,12 +680,12 @@ let rec emit_tail_infos is_tail lambda =
       list_emit_tail_infos false ap.ap_args
   | Lfunction {body = lam} ->
       emit_tail_infos true lam
-  | Llet (_, _k, _, lam, body)
-  | Lmutlet (_k, _, lam, body) ->
+  | Llet (_, _k, _, _, lam, body)
+  | Lmutlet (_k, _, _, lam, body) ->
       emit_tail_infos false lam;
       emit_tail_infos is_tail body
   | Lletrec (bindings, body) ->
-      List.iter (fun (_, lam) -> emit_tail_infos false lam) bindings;
+      List.iter (fun (_, _, lam) -> emit_tail_infos false lam) bindings;
       emit_tail_infos is_tail body
   | Lprim ((Pbytes_to_string | Pbytes_of_string |
             Parray_to_iarray | Parray_of_iarray),
@@ -758,7 +758,7 @@ and list_emit_tail_infos is_tail =
    'Some' constructor, only to deconstruct it immediately in the
    function's body. *)
 
-let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
+let split_default_wrapper ~id:fun_id ~uid:fun_uid ~kind ~params ~return ~body
       ~attr ~loc ~mode ~region:orig_region =
   let rec aux map add_region = function
     (* When compiling [fun ?(x=expr) -> body], this is first translated
@@ -776,7 +776,7 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
        which is why we need a deep pattern matching on the expected result of
        the pattern-matching compiler for options.
     *)
-    | Llet(Strict, k, id,
+    | Llet(Strict, k, id, uid,
            (Lifthenelse(Lprim (Pisint _, [Lvar optparam], _), _, _, _) as def),
            rest) when
         String.starts_with (Ident.name optparam) ~prefix:"*opt*" &&
@@ -784,7 +784,7 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
           && not (List.mem_assoc optparam map)
       ->
         let wrapper_body, inner = aux ((optparam, id) :: map) add_region rest in
-        Llet(Strict, k, id, def, wrapper_body), inner
+        Llet(Strict, k, id, uid, def, wrapper_body), inner
     | Lregion (rest, _) -> aux map true rest
     | Lexclave rest -> aux map true rest
     | _ when map = [] -> raise Exit
@@ -795,11 +795,13 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
         List.iter (fun (id, _) -> if Ident.Set.mem id fv then raise Exit) map;
 
         let inner_id = Ident.create_local (Ident.name fun_id ^ "_inner") in
+        let inner_uid = Uid.internal_not_actually_unique in
         let map_param (p : Lambda.lparam) =
           try
             (* If the param is optional, then it must be a value *)
             {
               name = List.assoc p.name map;
+              var_uid = Uid.internal_not_actually_unique; (* CR tnowak: verify *)
               layout = Lambda.layout_field;
               attributes = Lambda.default_param_attribute;
               mode = p.mode
@@ -838,7 +840,7 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
             ~params:new_ids
             ~return ~body ~attr ~loc ~mode ~region:true
         in
-        (wrapper_body, (inner_id, inner_fun))
+        (wrapper_body, (inner_id, inner_uid, inner_fun))
   in
   try
     (* TODO: enable this optimisation even in the presence of local returns *)
@@ -849,9 +851,9 @@ let split_default_wrapper ~id:fun_id ~kind ~params ~return ~body
     end;
     let body, inner = aux [] false body in
     let attr = { default_stub_attribute with check = attr.check } in
-    [(fun_id, lfunction ~kind ~params ~return ~body ~attr ~loc ~mode ~region:true); inner]
+    [(fun_id, fun_uid, lfunction ~kind ~params ~return ~body ~attr ~loc ~mode ~region:true); inner]
   with Exit ->
-    [(fun_id, lfunction ~kind ~params ~return ~body ~attr ~loc ~mode ~region:orig_region)]
+    [(fun_id, fun_uid, lfunction ~kind ~params ~return ~body ~attr ~loc ~mode ~region:orig_region)]
 
 (* Simplify local let-bound functions: if all occurrences are
    fully-applied function calls in the same "tail scope", replace the
@@ -906,7 +908,7 @@ let simplify_local_functions lam =
     | Some sco -> sco == scope
   in
   let rec tail = function
-    | Llet (_str, _kind, id, Lfunction lf, cont) when enabled lf.attr ->
+    | Llet (_str, _kind, id, _uid, Lfunction lf, cont) when enabled lf.attr ->
         let r =
           {func = lf; function_scope = !current_function_scope; scope = None}
         in
@@ -1001,7 +1003,7 @@ let simplify_local_functions lam =
   let rec rewrite lam0 =
     let lam =
       match lam0 with
-      | Llet (_, _, id, _, cont) when Hashtbl.mem static_id id ->
+      | Llet (_, _, id, _uid, _, cont) when Hashtbl.mem static_id id ->
           rewrite cont
       | Lapply {ap_func = Lvar id; ap_args; _} when Hashtbl.mem static_id id ->
          let st = Hashtbl.find static_id id in
@@ -1016,7 +1018,7 @@ let simplify_local_functions lam =
     in
     let new_params lf =
       List.map
-        (fun p -> (p.name, p.layout)) lf.params
+        (fun p -> (p.name, p.var_uid, p.layout)) lf.params
     in
     List.fold_right
       (fun (st, lf) lam ->

--- a/ocaml/lambda/simplif.mli
+++ b/ocaml/lambda/simplif.mli
@@ -31,6 +31,7 @@ val simplify_lambda: lambda -> lambda
 
 val split_default_wrapper
    : id:Ident.t
+  -> uid:Uid.t
   -> kind:function_kind
   -> params:Lambda.lparam list
   -> return:Lambda.layout
@@ -39,4 +40,4 @@ val split_default_wrapper
   -> loc:Lambda.scoped_location
   -> mode:Lambda.alloc_mode
   -> region:bool
-  -> (Ident.t * lambda) list
+  -> (Ident.t * Uid.t * lambda) list

--- a/ocaml/lambda/transl_array_comprehension.ml
+++ b/ocaml/lambda/transl_array_comprehension.ml
@@ -235,7 +235,7 @@ end = struct
     let y = y.Let_binding.var in
     let open (val Lambda_utils.int_ops ~loc) in
     let product =
-      Let_binding.make (Immutable Alias) (Pvalue Pintval) "product" (x * y)
+      Let_binding.make (Immutable Alias) (Pvalue Pintval) "product" Uid.internal_not_actually_unique (x * y)
     in
     (* [x * y] is safe, for strictly positive [x] and [y], iff you can undo the
        multiplication: [(x * y)/y = x].  We assume the inputs are values, so we
@@ -265,7 +265,7 @@ end = struct
   let safe_product_pos ?(variable_name = "x") ~loc factors =
     let factors =
       List.map (Let_binding.make (Immutable Strict) (Pvalue Pintval)
-                       variable_name) factors
+                       variable_name Uid.internal_not_actually_unique) factors
     in
     Let_binding.let_all factors (safe_product_pos_vals ~loc factors)
 end
@@ -371,7 +371,7 @@ module Iterator_bindings = struct
              still might overflow *)
           let range_size =
             Let_binding.make (Immutable Alias) (Pvalue Pintval)
-              "range_size" (high - low + l1)
+              "range_size" Uid.internal_not_actually_unique (high - low + l1)
           in
           Let_binding.let_one range_size
             (* If the computed size of the range is positive, there was no
@@ -450,7 +450,7 @@ let iterator ~transl_exp ~scopes ~loc
   | Texp_comp_range { ident; pattern = _; start; stop; direction } ->
       let bound name value =
         Let_binding.make (Immutable Strict) (Pvalue Pintval)
-          name (transl_exp ~scopes Jkind.Sort.for_predef_value value)
+          name Uid.internal_not_actually_unique (transl_exp ~scopes Jkind.Sort.for_predef_value value)
       in
       let start = bound "start" start in
       let stop  = bound "stop"  stop  in
@@ -467,14 +467,14 @@ let iterator ~transl_exp ~scopes ~loc
   | Texp_comp_in { pattern; sequence = iter_arr_exp } ->
       let iter_arr =
         Let_binding.make (Immutable Strict) (Pvalue Pgenval)
-          "iter_arr" (transl_exp ~scopes Jkind.Sort.for_predef_value iter_arr_exp)
+          "iter_arr" Uid.internal_not_actually_unique (transl_exp ~scopes Jkind.Sort.for_predef_value iter_arr_exp)
       in
       let iter_arr_kind = Typeopt.array_kind iter_arr_exp in
       let iter_len =
         (* Extra let-binding if we're not in the fixed-size array case; the
            middle-end will simplify this for us *)
         Let_binding.make (Immutable Alias) (Pvalue Pintval)
-          "iter_len"
+          "iter_len" Uid.internal_not_actually_unique
           (Lprim(Parraylength iter_arr_kind, [iter_arr.var], loc))
       in
       let iter_ix = Ident.create_local "iter_ix" in
@@ -621,7 +621,7 @@ let clauses ~transl_exp ~scopes ~loc = function
       in
       let array_size =
         Let_binding.make (Immutable Alias) (Pvalue Pintval)
-          "array_size"
+          "array_size" Uid.internal_not_actually_unique
           (Iterator_bindings.Fixed_size_array.total_size_nonempty
              ~loc var_bindings)
       in
@@ -632,7 +632,7 @@ let clauses ~transl_exp ~scopes ~loc = function
   | clauses ->
       let array_size =
         Let_binding.make Mutable (Pvalue Pintval)
-          "array_size" (int Resizable_array.starting_size)
+          "array_size" Uid.internal_not_actually_unique (int Resizable_array.starting_size)
       in
       let make_comprehension =
         Cps_utils.compose_map (clause ~transl_exp ~loc ~scopes) clauses
@@ -702,7 +702,7 @@ let initial_array ~loc ~array_kind ~array_size ~array_sizing =
     | Dynamic_size, Pfloatarray ->
         Mutable, Resizable_array.make ~loc array_kind (float 0.)
   in
-  Let_binding.make array_let_kind (Pvalue Pgenval) "array" array_value
+  Let_binding.make array_let_kind (Pvalue Pgenval) "array" Uid.internal_not_actually_unique array_value
 
 (** Generate the code for the body of an array comprehension.  This involves
     translating the body expression (a [Typedtree.expression], which is the
@@ -776,7 +776,7 @@ let body
   let set_element_known_kind_in_bounds = match array_kind with
     | Pgenarray ->
         let is_first_iteration = (index.var = l0) in
-        let elt = Let_binding.make (Immutable Strict) (Pvalue Pgenval) "elt" body in
+        let elt = Let_binding.make (Immutable Strict) (Pvalue Pgenval) "elt" Uid.internal_not_actually_unique body in
         let make_array = match array_sizing with
           | Fixed_size ->
               make_vect ~loc ~length:array_size.var ~init:elt.var
@@ -807,7 +807,7 @@ let comprehension
   let array =
     initial_array ~loc ~array_kind ~array_size ~array_sizing
   in
-  let index = Let_binding.make Mutable (Pvalue Pintval) "index" (int 0) in
+  let index = Let_binding.make Mutable (Pvalue Pintval) "index" Uid.internal_not_actually_unique (int 0) in
   (* The core of the comprehension: the array, the index, and the iteration that
      fills everything in.  The translation of the clauses will produce a check
      to see if we can avoid doing the hard work of growing the array, which is

--- a/ocaml/lambda/transl_comprehension_utils.ml
+++ b/ocaml/lambda/transl_comprehension_utils.ml
@@ -11,21 +11,22 @@ module Let_binding = struct
     { let_kind   : Let_kind.t
     ; layout : layout
     ; id         : Ident.t
+    ; uid        : Shape.Uid.t
     ; init       : lambda
     ; var        : lambda }
 
-  let make (let_kind : Let_kind.t) layout name init =
+  let make (let_kind : Let_kind.t) layout name uid init =
     let id = Ident.create_local name in
     let var = match let_kind with
       | Mutable -> Lmutvar id
       | Immutable _ -> Lvar id
     in
-    {let_kind; layout; id; init; var}
+    {let_kind; layout; id; uid; init; var}
 
-  let let_one {let_kind; layout; id; init} body =
+  let let_one {let_kind; layout; id; uid; init} body =
     match let_kind with
-    | Immutable let_kind -> Llet(let_kind, layout, id, init, body)
-    | Mutable            -> Lmutlet(layout, id, init, body)
+    | Immutable let_kind -> Llet(let_kind, layout, id, uid, init, body)
+    | Mutable            -> Lmutlet(layout, id, uid, init, body)
 
   let let_all = List.fold_right let_one
 end

--- a/ocaml/lambda/transl_comprehension_utils.mli
+++ b/ocaml/lambda/transl_comprehension_utils.mli
@@ -29,13 +29,14 @@ module Let_binding : sig
     { let_kind   : Let_kind.t
     ; layout     : layout
     ; id         : Ident.t
+    ; uid        : Shape.Uid.t
     ; init       : lambda   (* initial value *)
     ; var        : lambda   (* occurrence of this variable *)
     }
 
   (** Create a fresh local identifier (with name as given by the string
       argument) to bind to an initial value given by the lambda argument. *)
-  val make : Let_kind.t -> layout -> string -> lambda -> t
+  val make : Let_kind.t -> layout -> string -> Shape.Uid.t -> lambda -> t
 
   (** Create a Lambda let-binding (with [Llet]) from a first-class let
       binding, providing the body. *)

--- a/ocaml/lambda/transl_list_comprehension.ml
+++ b/ocaml/lambda/transl_list_comprehension.ml
@@ -172,7 +172,7 @@ let iterator ~transl_exp ~scopes = function
       let transl_bound var bound =
         Let_binding.make
           (Immutable Strict) (Pvalue Pintval)
-          var (transl_exp ~scopes Jkind.Sort.for_predef_value bound)
+          var Uid.internal_not_actually_unique (transl_exp ~scopes Jkind.Sort.for_predef_value bound)
       in
       let start = transl_bound "start" start in
       let stop  = transl_bound "stop"  stop  in
@@ -187,7 +187,7 @@ let iterator ~transl_exp ~scopes = function
   | Texp_comp_in { pattern; sequence } ->
       let iter_list =
         Let_binding.make (Immutable Strict) (Pvalue Pgenval)
-          "iter_list" (transl_exp ~scopes Jkind.Sort.for_predef_value sequence)
+          "iter_list" Uid.internal_not_actually_unique (transl_exp ~scopes Jkind.Sort.for_predef_value sequence)
       in
       (* Create a fresh variable to use as the function argument *)
       let element = Ident.create_local "element" in
@@ -246,11 +246,14 @@ let rec translate_bindings
              local, [nlocal] has to be equal to the number of parameters *)
           ~params:[
             {name = element;
+             (* CR tnowak: verify (I see that I'm not the only one that is unsure here...) *)
+             var_uid = Uid.internal_not_actually_unique;
              layout = element_kind;
              attributes = Lambda.default_param_attribute;
              (* CR ncourant: check *)
              mode = alloc_heap};
             {name = inner_acc;
+             var_uid = Uid.internal_not_actually_unique;
              layout = Pvalue Pgenval;
              attributes = Lambda.default_param_attribute;
              mode = alloc_local}

--- a/ocaml/lambda/translcore.ml
+++ b/ocaml/lambda/translcore.ml
@@ -89,8 +89,8 @@ let transl_object =
 let probe_handlers = ref []
 let clear_probe_handlers () = probe_handlers := []
 let declare_probe_handlers lam =
-  List.fold_left (fun acc (funcid, func) ->
-      Llet(Strict, Lambda.layout_function, funcid, func, acc))
+  List.fold_left (fun acc (funcid, funcuid, func) ->
+      Llet(Strict, Lambda.layout_function, funcid, funcuid, func, acc))
     lam
     !probe_handlers
 
@@ -757,7 +757,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       let loc = of_location ~scopes e.exp_loc in
       let self = transl_value_path loc e.exp_env path_self in
       let cpy = Ident.create_local "copy" in
-      Llet(Strict, Lambda.layout_object, cpy,
+      Llet(Strict, Lambda.layout_object, cpy, Uid.internal_not_actually_unique,
            Lapply{
              ap_loc=Loc_unknown;
              ap_func=Translobj.oo_prim "copy";
@@ -785,13 +785,15 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         let mod_scopes = enter_module_definition ~scopes id in
         !transl_module ~scopes:mod_scopes Tcoerce_none None modl
       in
-      Llet(Strict, Lambda.layout_module, id, defining_expr,
+      Llet(Strict, Lambda.layout_module, id, Uid.internal_not_actually_unique, defining_expr,
            transl_exp ~scopes sort body)
   | Texp_letmodule(_, _, Mp_absent, _, body) ->
       transl_exp ~scopes sort body
   | Texp_letexception(cd, body) ->
+    (* CR tnowak: verify *)
+    let uid = Uid.internal_not_actually_unique in
       Llet(Strict, Lambda.layout_block,
-           cd.ext_id, transl_extension_constructor ~scopes e.exp_env None cd,
+           cd.ext_id, uid, transl_extension_constructor ~scopes e.exp_env None cd,
            transl_exp ~scopes sort body)
   | Texp_pack modl ->
       !transl_module ~scopes Tcoerce_none None modl
@@ -845,6 +847,8 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
          let scopes = enter_lazy ~scopes in
          let fn = lfunction ~kind:(Curried {nlocal=0})
                             ~params:[{ name = Ident.create_local "param";
+                                       var_uid = Uid.internal_not_actually_unique
+                                     (* CR tnowak: verify *);
                                        layout = Lambda.layout_unit;
                                        attributes = Lambda.default_param_attribute;
                                        mode = alloc_heap}]
@@ -892,14 +896,18 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                module.  When that changes, some adjustments may be needed
                here. *)
             List.fold_left (fun (body, pos) id ->
-              Llet(Alias, Lambda.layout_module_field, id,
+              (* CR tnowak: verify *)
+              let uid = Uid.internal_not_actually_unique in
+              Llet(Alias, Lambda.layout_module_field, id, uid,
                    Lprim(mod_field pos, [Lvar oid],
                          of_location ~scopes od.open_loc), body),
               pos + 1
             ) (transl_exp ~scopes sort e, 0)
               (bound_value_identifiers od.open_bound_items)
           in
-          Llet(pure, Lambda.layout_module, oid,
+          (* CR tnowak: verify *)
+          let ouid = Uid.internal_not_actually_unique in
+          Llet(pure, Lambda.layout_module, oid, ouid,
                !transl_module ~scopes Tcoerce_none None od.open_expr, body)
       end
   | Texp_probe {name; handler=exp; enabled_at_init} ->
@@ -961,6 +969,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           tmc_candidate = false;
         } in
       let funcid = Ident.create_local ("probe_handler_" ^ name) in
+      let funcuid = Uid.internal_not_actually_unique in
       let return_layout = layout_unit (* Probe bodies have type unit. *) in
       let handler =
         let assume_zero_alloc = get_assume_zero_alloc ~scopes in
@@ -969,7 +978,12 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           ~kind:(Curried {nlocal=0})
           (* CR layouts: Adjust param layouts when we allow other things in
              probes. *)
-          ~params:(List.map (fun name -> { name; layout = layout_probe_arg; attributes = Lambda.default_param_attribute; mode = alloc_heap }) param_idents)
+          ~params:(List.map (fun name -> { name;
+                                           var_uid = Uid.internal_not_actually_unique
+                                         (* CR tnowak: verify *);
+                                           layout = layout_probe_arg;
+                                           attributes = Lambda.default_param_attribute;
+                                           mode = alloc_heap }) param_idents)
           ~return:return_layout
           ~body
           ~loc:(of_location ~scopes exp.exp_loc)
@@ -992,14 +1006,14 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       in
       begin match Config.flambda || Config.flambda2 with
       | true ->
-          Llet(Strict, Lambda.layout_function, funcid, handler, Lapply app)
+          Llet(Strict, Lambda.layout_function, funcid, funcuid, handler, Lapply app)
       | false ->
         (* Needs to be lifted to top level manually here,
            because functions that contain other function declarations
            are not inlined by Closure. For example, adding a probe into
            the body of function foo will prevent foo from being inlined
            into another function. *)
-        probe_handlers := (funcid, handler)::!probe_handlers;
+        probe_handlers := (funcid, funcuid, handler)::!probe_handlers;
         Lapply app
       end
     end else begin
@@ -1133,7 +1147,8 @@ and transl_apply ~scopes
             Lvar _ | Lconst _ -> (lam, layout)
           | _ ->
               let id = Ident.create_local name in
-              defs := (id, layout, lam) :: !defs;
+              let uid = Uid.internal_not_actually_unique in
+              defs := (id, uid, layout, lam) :: !defs;
               (Lvar id, layout)
         in
         let lam =
@@ -1171,6 +1186,7 @@ and transl_apply ~scopes
           let layout_arg = layout_of_sort (to_location loc) sort_arg in
           let params = [{
               name = id_arg;
+              var_uid = Uid.internal_not_actually_unique (* CR tnowak: verify *);
               layout = layout_arg;
               attributes = Lambda.default_param_attribute;
               mode = arg_mode
@@ -1180,7 +1196,7 @@ and transl_apply ~scopes
                     ~attr:default_stub_attribute ~loc
         in
         List.fold_right
-          (fun (id, layout, lam) body -> Llet(Strict, layout, id, lam, body))
+          (fun (id, uid, layout, lam) body -> Llet(Strict, layout, id, uid, lam, body))
           !defs body
     | Arg (arg, _) :: l -> build_apply lam (arg :: args) loc pos ap_mode l
     | [] -> lapply lam (List.rev args) loc pos ap_mode result_layout
@@ -1195,6 +1211,17 @@ and transl_apply ~scopes
       sargs
   in
   build_apply lam [] loc position mode args
+
+and uids_of_vars cases =
+  let tbl = ref (Ident.Tbl.create 42) in
+  let add_case (case : Typedtree.value Typedtree.case) =
+    let var_list = Typedtree.pat_bound_idents_full Jkind.Sort.value case.c_lhs in
+    List.iter (fun (ident, _loc, _type_expr, uid, _mode) ->
+        Ident.Tbl.add !tbl ident uid)
+      var_list
+  in
+  List.iter add_case cases;
+  !tbl
 
 and transl_curried_function
       ~scopes ~arg_sort ~arg_layout ~arg_mode ~return_sort ~return_layout loc repr ~region
@@ -1242,6 +1269,8 @@ and transl_curried_function
         let arg_mode = transl_alloc_mode arg_mode in
         let params = {
           name = param ;
+          var_uid = Ident.Tbl.find_opt (uids_of_vars cases) param
+                    |> Option.value ~default:Uid.internal_not_actually_unique ;
           layout = arg_layout ;
           attributes = Lambda.default_param_attribute ;
           mode = arg_mode
@@ -1261,8 +1290,8 @@ and transl_curried_function
         | Partial -> ()
         end;
         transl_tupled_function ~scopes ~arg_sort ~arg_layout ~arg_mode
-          ~return_sort:ret_sort ~return_layout ~arity ~region ~curry loc repr
-          partial param cases
+          ~return_sort:ret_sort ~return_layout ~arity ~region ~curry
+          loc repr partial param cases
       end
     | curry, cases ->
       transl_tupled_function ~scopes ~arg_sort ~arg_layout ~arg_mode ~return_sort
@@ -1305,6 +1334,7 @@ and transl_tupled_function
         let tparams =
           List.map (fun kind -> {
                 name = Ident.create_local "param";
+                var_uid = Uid.internal_not_actually_unique (* CR tnowak: verify *);
                 layout = kind;
                 attributes = Lambda.default_param_attribute;
                 mode = alloc_heap
@@ -1322,7 +1352,8 @@ and transl_tupled_function
         loc ~region ~partial_mode repr partial param cases
       end
   | _ -> transl_function0 ~scopes ~arg_sort ~arg_layout ~arg_mode ~return_sort
-           ~return_layout loc ~region ~partial_mode repr partial param cases
+           ~return_layout loc ~region ~partial_mode
+           repr partial param cases
 
 and transl_function0
       ~scopes ~arg_sort ~arg_layout ~arg_mode ~return_sort ~return_layout loc ~region
@@ -1341,6 +1372,8 @@ and transl_function0
     let arg_mode = transl_alloc_mode arg_mode in
     ((Curried {nlocal},
       [{ name = param;
+         var_uid = Ident.Tbl.find_opt (uids_of_vars cases) param
+            |> Option.value ~default:Uid.internal_not_actually_unique;
          layout = arg_layout;
          attributes = Lambda.default_param_attribute;
          mode = arg_mode}],
@@ -1382,8 +1415,8 @@ and transl_function ~in_new_scope ~scopes e alloc_mode param arg_mode arg_sort r
            function_return_layout e.exp_env e.exp_loc return_sort e.exp_type
          in
          transl_curried_function ~arg_sort ~arg_layout ~arg_mode ~return_sort
-           ~return_layout ~scopes e.exp_loc repr ~region ~curry partial warnings
-           param pl)
+           ~return_layout ~scopes e.exp_loc repr ~region ~curry
+           partial warnings param pl)
   in
   let attr = default_function_attribute in
   let loc = of_location ~scopes e.exp_loc in
@@ -1454,7 +1487,9 @@ and transl_let ~scopes ~return_layout ?(add_regions=false) ?(in_structure=false)
         let lam =
           if add_regions then maybe_region_exp vb_sort expr lam else lam
         in
-        (id, lam) in
+        (* CR tnowak: verify *)
+        let uid = Uid.internal_not_actually_unique in
+        (id, uid, lam) in
       let lam_bds = List.map2 transl_case pat_expr_list idlist in
       fun body -> Lletrec(lam_bds, body)
 
@@ -1478,6 +1513,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
        taken from init_expr if any *)
     (* CR layouts v5: allow non-value fields beyond just float# *)
     let init_id = Ident.create_local "init" in
+    let init_uid = Uid.internal_not_actually_unique in
     let lv =
       Array.mapi
         (fun i (lbl, definition) ->
@@ -1567,13 +1603,14 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
     in
     begin match opt_init_expr with
       None -> lam
-    | Some init_expr -> Llet(Strict, Lambda.layout_block, init_id,
+    | Some init_expr -> Llet(Strict, Lambda.layout_block, init_id, init_uid,
                              transl_exp ~scopes Jkind.Sort.for_record init_expr, lam)
     end
   end else begin
     (* Take a shallow copy of the init record, then mutate the fields
        of the copy *)
     let copy_id = Ident.create_local "newrecord" in
+    let copy_uid = Uid.internal_not_actually_unique in
     let update_field cont (lbl, definition) =
       (* CR layouts v5: allow more unboxed types here. *)
       let lbl_sort = Jkind.sort_of_jkind lbl.lbl_jkind in
@@ -1606,7 +1643,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
       None -> assert false
     | Some init_expr ->
         assert (is_heap_mode (Option.get mode)); (* Pduprecord must be Alloc_heap and not unboxed *)
-        Llet(Strict, Lambda.layout_block, copy_id,
+        Llet(Strict, Lambda.layout_block, copy_id, copy_uid,
              Lprim(Pduprecord (repres, size),
                    [transl_exp ~scopes Jkind.Sort.for_record init_expr],
                    of_location ~scopes loc),
@@ -1641,10 +1678,10 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
         (* Simplif doesn't like it if binders are not uniq, so we make sure to
            use different names in the value and the exception branches. *)
         let ids_full = Typedtree.pat_bound_idents_full arg_sort pv in
-        let ids = List.map (fun (id, _, _, _) -> id) ids_full in
+        let ids = List.map (fun (id, _, _, _, _) -> id) ids_full in
         let ids_kinds =
-          List.map (fun (id, {Location.loc; _}, ty, s) ->
-            id, Typeopt.layout pv.pat_env loc s ty)
+          List.map (fun (id, {Location.loc; _}, ty, uid, s) ->
+            id, uid, Typeopt.layout pv.pat_env loc s ty)
             ids_full
         in
         let vids = List.map Ident.rename ids in
@@ -1710,7 +1747,8 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
             (fun (arg,s) ->
                let layout = layout_exp s arg in
                let id = Typecore.name_pattern "val" [] in
-               (id, layout), (Lvar id, s, layout))
+               let uid = Uid.internal_not_actually_unique in
+               (id, uid, layout), (Lvar id, s, layout))
             argl
           |> List.split
         in
@@ -1725,8 +1763,9 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
         e.exp_loc None (transl_exp ~scopes arg_sort arg) val_cases partial
     | arg, _ :: _ ->
         let val_id = Typecore.name_pattern "val" (List.map fst val_cases) in
+        let val_uid = Uid.internal_not_actually_unique in
         let arg_layout = layout_exp arg_sort arg in
-        static_catch [transl_exp ~scopes arg_sort arg] [val_id, arg_layout]
+        static_catch [transl_exp ~scopes arg_sort arg] [val_id, val_uid, arg_layout]
           (Matching.for_function ~scopes ~arg_sort ~arg_layout ~return_layout
              e.exp_loc None (Lvar val_id) val_cases partial)
   in
@@ -1740,7 +1779,9 @@ and transl_letop ~scopes loc env let_ ands param param_sort case case_sort
     | [] -> prev_lam
     | and_ :: rest ->
         let left_id = Ident.create_local "left" in
+        let left_uid = Uid.internal_not_actually_unique in
         let right_id = Ident.create_local "right" in
+        let right_uid = Uid.internal_not_actually_unique in
         let op =
           transl_ident (of_location ~scopes and_.bop_op_name.loc) env
             and_.bop_op_type and_.bop_op_path and_.bop_op_val Id_value
@@ -1752,7 +1793,7 @@ and transl_letop ~scopes loc env let_ ands param param_sort case case_sort
             and_.bop_op_type
         in
         let lam =
-          bind_with_layout Strict (right_id, right_layout) exp
+          bind_with_layout Strict (right_id, right_uid, right_layout) exp
             (Lapply{
                ap_loc = of_location ~scopes and_.bop_loc;
                ap_func = op;
@@ -1766,7 +1807,7 @@ and transl_letop ~scopes loc env let_ ands param param_sort case case_sort
                ap_probe=None;
              })
         in
-        bind_with_layout Strict (left_id, prev_layout) prev_lam (loop result_layout lam rest)
+        bind_with_layout Strict (left_id, left_uid, prev_layout) prev_lam (loop result_layout lam rest)
   in
   let op =
     transl_ident (of_location ~scopes let_.bop_op_name.loc) env

--- a/ocaml/lambda/translmod.ml
+++ b/ocaml/lambda/translmod.ml
@@ -98,7 +98,7 @@ let transl_type_extension ~scopes env rootpath tyext body =
         transl_extension_constructor ~scopes env
           (field_path rootpath ext.ext_id) ext
       in
-      Llet(Strict, Lambda.layout_block, ext.ext_id, lam, body))
+      Llet(Strict, Lambda.layout_block, ext.ext_id, Uid.internal_not_actually_unique, lam, body))
     tyext.tyext_constructors
     body
 
@@ -125,7 +125,9 @@ let rec apply_coercion loc strict restr arg =
       let param = Ident.create_local "funarg" in
       let carg = apply_coercion loc Alias cc_arg (Lvar param) in
       apply_coercion_result loc strict arg
-        [{name = param; layout = Lambda.layout_module;
+        [{name = param;
+          var_uid = Uid.internal_not_actually_unique (* CR tnowak: verify *);
+          layout = Lambda.layout_module;
           attributes = Lambda.default_param_attribute; mode = alloc_heap}]
         [carg] cc_res
   | Tcoerce_primitive { pc_desc; pc_env; pc_type; pc_poly_mode } ->
@@ -145,6 +147,7 @@ and apply_coercion_result loc strict funct params args cc_res =
     let arg = apply_coercion loc Alias cc_arg (Lvar param) in
     apply_coercion_result loc strict funct
       ({ name = param;
+         var_uid = Uid.internal_not_actually_unique (* CR tnowak: verify *);
          layout = Lambda.layout_module;
          attributes = Lambda.default_param_attribute;
          mode = alloc_heap } :: params)
@@ -187,7 +190,7 @@ and wrap_id_pos_list loc id_pos_list get_field lam =
     List.fold_left (fun (lam, s) (id',pos,c) ->
       if Ident.Set.mem id' fv then
         let id'' = Ident.create_local (Ident.name id') in
-        (Llet(Alias, Lambda.layout_module_field, id'',
+        (Llet(Alias, Lambda.layout_module_field, id'', Uid.internal_not_actually_unique,
              apply_coercion loc Alias c (get_field pos),lam),
          Ident.Map.add id' id'' s)
       else (lam, s))
@@ -279,7 +282,7 @@ let preallocate_letrec ~bindings ~body =
            ~alloc:true
        in
        let size : lambda = Lconst (Const_base (Const_int size)) in
-       Llet (Strict, Lambda.layout_block, id,
+       Llet (Strict, Lambda.layout_block, id, Uid.internal_not_actually_unique,
              Lprim (Pccall desc, [size], Loc_unknown), body))
     body_with_initialization bindings
 
@@ -432,7 +435,7 @@ let eval_rec_bindings bindings cont =
   | (_, None, _) :: rem ->
       bind_inits rem
   | (Id id, Some(loc, shape), _rhs) :: rem ->
-      Llet(Strict, Lambda.layout_module, id,
+      Llet(Strict, Lambda.layout_module, id, Uid.internal_not_actually_unique,
            Lapply{
              ap_loc=Loc_unknown;
              ap_func=mod_prim "init_mod";
@@ -452,7 +455,7 @@ let eval_rec_bindings bindings cont =
   | (Ignore_loc loc, None, rhs) :: rem ->
       Lsequence(Lprim(Pignore, [rhs], loc), bind_strict rem)
   | (Id id, None, rhs) :: rem ->
-      Llet(Strict, Lambda.layout_module, id, rhs, bind_strict rem)
+      Llet(Strict, Lambda.layout_module, id, Uid.internal_not_actually_unique, rhs, bind_strict rem)
   | (_id, Some _, _rhs) :: rem ->
       bind_strict rem
   and patch_forwards = function
@@ -562,11 +565,12 @@ let rec compile_functor ~scopes mexp coercion root_path loc =
         let arg = apply_coercion loc Alias arg_coercion (Lvar param') in
         let params = {
           name = param';
+          var_uid = Uid.internal_not_actually_unique (* CR tnowak: verify *);
           layout = Lambda.layout_module;
           attributes = Lambda.default_param_attribute;
           mode = alloc_heap
         } :: params in
-        let body = Llet (Alias, Lambda.layout_module, param, arg, body) in
+        let body = Llet (Alias, Lambda.layout_module, param, Uid.internal_not_actually_unique, arg, body) in
         params, body)
       ([], transl_module ~scopes res_coercion body_path body)
       functor_params_rev
@@ -724,7 +728,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
           let body, size =
             transl_structure ~scopes loc (id::fields) cc rootpath final_env rem
           in
-          Llet(Strict, Lambda.layout_block, id,
+          Llet(Strict, Lambda.layout_block, id, Uid.internal_not_actually_unique,
                transl_extension_constructor ~scopes
                                             item.str_env
                                             path
@@ -755,7 +759,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                                of_location ~scopes mb.mb_name.loc), body),
               size
           | Some id ->
-              Llet(pure_module mb.mb_expr, Lambda.layout_module, id, module_body, body), size
+              Llet(pure_module mb.mb_expr, Lambda.layout_module, id, Uid.internal_not_actually_unique, module_body, body), size
           end
       | Tstr_module ({mb_presence=Mp_absent}) ->
           transl_structure ~scopes loc fields cc rootpath final_env rem
@@ -788,7 +792,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
             preallocate_letrec ~bindings:class_bindings ~body, size
           else
             let class_bindings =
-              List.map (fun (id, lam, _) -> id, lam) class_bindings
+              List.map (fun (id, lam, _) -> id, Uid.internal_not_actually_unique, lam) class_bindings
             in
             Lletrec(class_bindings, body), size
       | Tstr_include incl ->
@@ -802,7 +806,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                 let body, size =
                   rebind_idents (pos + 1) (id :: newfields) ids
                 in
-                Llet(Alias, Lambda.layout_module_field, id,
+                Llet(Alias, Lambda.layout_module_field, id, Uid.internal_not_actually_unique,
                      Lprim(mod_field pos, [Lvar mid],
                            of_location ~scopes incl.incl_loc), body),
                 size
@@ -820,7 +824,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                 Strict, transl_include_functor ~generative:true modl ccs
                           scopes loc
           in
-          Llet(let_kind, Lambda.layout_module, mid, modl, body),
+          Llet(let_kind, Lambda.layout_module, mid, Uid.internal_not_actually_unique, modl, body),
           size
 
       | Tstr_open od ->
@@ -842,13 +846,13 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                   let body, size =
                     rebind_idents (pos + 1) (id :: newfields) ids
                   in
-                  Llet(Alias, Lambda.layout_module_field, id,
+                  Llet(Alias, Lambda.layout_module_field, id, Uid.internal_not_actually_unique,
                       Lprim(mod_field pos, [Lvar mid],
                             of_location ~scopes od.open_loc), body),
                   size
               in
               let body, size = rebind_idents 0 fields ids in
-              Llet(pure, Lambda.layout_module, mid,
+              Llet(pure, Lambda.layout_module, mid, Uid.internal_not_actually_unique,
                    transl_module ~scopes Tcoerce_none None od.open_expr, body),
               size
           end
@@ -1165,7 +1169,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
                                            path
                                            ext.tyexn_constructor
             in
-            Lsequence(Llet(Strict, Lambda.layout_block, id,
+            Lsequence(Llet(Strict, Lambda.layout_block, id, Uid.internal_not_actually_unique,
                            Lambda.subst no_env_update subst lam,
                            store_ident loc id),
                       transl_store ~scopes rootpath
@@ -1195,7 +1199,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
             (* Careful: see next case *)
             let subst = !transl_store_subst in
             Lsequence(lam,
-                      Llet(Strict, Lambda.layout_module, id,
+                      Llet(Strict, Lambda.layout_module, id, Uid.internal_not_actually_unique,
                            Lambda.subst no_env_update subst
                              (Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
                                     List.map (fun id -> Lvar id)
@@ -1224,7 +1228,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
             let subst = !transl_store_subst in
             let field = field_of_str loc str in
             Lsequence(lam,
-                      Llet(Strict, Lambda.layout_module, id,
+                      Llet(Strict, Lambda.layout_module, id, Uid.internal_not_actually_unique,
                            Lambda.subst no_env_update subst
                              (Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
                                     List.map field map, loc)),
@@ -1248,7 +1252,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
                the compilation unit (add_ident true returns subst unchanged).
                If not, we can use the value from the global
                (add_ident true adds id -> Pgetglobal... to subst). *)
-            Llet(Strict, Lambda.layout_module, id, Lambda.subst no_env_update subst lam,
+            Llet(Strict, Lambda.layout_module, id, Uid.internal_not_actually_unique, Lambda.subst no_env_update subst lam,
                  Lsequence(store_ident (of_location ~scopes loc) id,
                            transl_store ~scopes rootpath
                              (add_ident true id subst)
@@ -1281,7 +1285,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
                   ~body
               else
                 let class_bindings =
-                  List.map (fun (id, lam, _) -> id, lam) class_bindings
+                  List.map (fun (id, lam, _) -> id, Uid.internal_not_actually_unique, lam) class_bindings
                 in
                 Lletrec(class_bindings, body)
             in
@@ -1314,7 +1318,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
                   transl_store ~scopes rootpath (add_idents true ids0 subst)
                     cont rem
               | id :: ids, arg :: args ->
-                  Llet(Alias, Lambda.layout_module_field, id,
+                  Llet(Alias, Lambda.layout_module_field, id, Uid.internal_not_actually_unique,
                        Lambda.subst no_env_update subst (field arg),
                        Lsequence(store_ident (of_location ~scopes loc) id,
                                  loop ids args))
@@ -1339,7 +1343,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
               | [] -> transl_store
                         ~scopes rootpath (add_idents true ids subst) cont rem
               | id :: idl ->
-                  Llet(Alias, Lambda.layout_module_field, id, Lprim(mod_field pos, [Lvar mid],
+                  Llet(Alias, Lambda.layout_module_field, id, Uid.internal_not_actually_unique, Lprim(mod_field pos, [Lvar mid],
                                                  loc),
                        Lsequence(store_ident loc id,
                                  store_idents (pos + 1) idl))
@@ -1352,7 +1356,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
               | Tincl_gen_functor ccs ->
                   transl_include_functor ~generative:true modl ccs scopes loc
             in
-            Llet(Strict, Lambda.layout_module, mid,
+            Llet(Strict, Lambda.layout_module, mid, Uid.internal_not_actually_unique,
                  Lambda.subst no_env_update subst modl,
                  store_idents 0 ids)
         | Tstr_open od ->
@@ -1369,7 +1373,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
                   | [] -> transl_store ~scopes rootpath
                             (add_idents true ids0 subst) cont rem
                   | id :: idl ->
-                      Llet(Alias, Lambda.layout_module_field, id, Lvar ids.(pos),
+                      Llet(Alias, Lambda.layout_module_field, id, Uid.internal_not_actually_unique, Lvar ids.(pos),
                            Lsequence(store_ident loc id,
                                      store_idents (pos + 1) idl))
                 in
@@ -1392,14 +1396,14 @@ let transl_store_structure ~scopes glob map prims aliases str =
                         [] -> transl_store ~scopes rootpath
                                 (add_idents true ids subst) cont rem
                       | id :: idl ->
-                          Llet(Alias, Lambda.layout_module_field, id,
+                          Llet(Alias, Lambda.layout_module_field, id, Uid.internal_not_actually_unique,
                                Lprim(mod_field pos,
                                      [Lvar mid], loc),
                                Lsequence(store_ident loc id,
                                          store_idents (pos + 1) idl))
                     in
                     Llet(
-                      pure, Lambda.layout_module, mid,
+                      pure, Lambda.layout_module, mid, Uid.internal_not_actually_unique,
                       Lambda.subst no_env_update subst
                         (transl_module ~scopes Tcoerce_none None od.open_expr),
                       store_idents 0 ids)
@@ -1613,7 +1617,7 @@ let toploop_setvalue id lam =
 let toploop_setvalue_id id = toploop_setvalue id (Lvar id)
 
 let close_toplevel_term (lam, ()) =
-  Ident.Set.fold (fun id l -> Llet(Strict, Lambda.layout_any_value, id,
+  Ident.Set.fold (fun id l -> Llet(Strict, Lambda.layout_any_value, id, Uid.internal_not_actually_unique,
                                   toploop_getvalue id, l))
                 (free_variables lam) lam
 
@@ -1681,7 +1685,7 @@ let transl_toplevel_item ~scopes item =
         preallocate_letrec ~bindings:class_bindings ~body
       else
         let class_bindings =
-          List.map (fun (id, lam, _) -> id, lam) class_bindings
+          List.map (fun (id, lam, _) -> id, Uid.internal_not_actually_unique, lam) class_bindings
         in
         Lletrec(class_bindings, body)
   | Tstr_include incl ->
@@ -1705,7 +1709,7 @@ let transl_toplevel_item ~scopes item =
           Lsequence(toploop_setvalue id
                       (Lprim(mod_field pos, [Lvar mid], Loc_unknown)),
                     set_idents (pos + 1) ids) in
-      Llet(Strict, Lambda.layout_module, mid, modl, set_idents 0 ids)
+      Llet(Strict, Lambda.layout_module, mid, Uid.internal_not_actually_unique, modl, set_idents 0 ids)
   | Tstr_primitive descr ->
       record_primitive descr.val_val;
       lambda_unit
@@ -1728,7 +1732,7 @@ let transl_toplevel_item ~scopes item =
                             (Lprim(mod_field pos, [Lvar mid], Loc_unknown)),
                           set_idents (pos + 1) ids)
           in
-          Llet(pure, Lambda.layout_module, mid,
+          Llet(pure, Lambda.layout_module, mid, Uid.internal_not_actually_unique,
                transl_module ~scopes Tcoerce_none None od.open_expr,
                set_idents 0 ids)
       end
@@ -1818,7 +1822,7 @@ let transl_package_set_fields component_names target_name coercion =
       in
       let blk = Ident.create_local "block" in
       (List.length pos_cc_list,
-       Llet (Strict, Lambda.layout_module, blk,
+       Llet (Strict, Lambda.layout_module, blk, Uid.internal_not_actually_unique,
              apply_coercion Loc_unknown Strict coercion components,
              make_sequence
                (fun pos _id ->

--- a/ocaml/lambda/translobj.ml
+++ b/ocaml/lambda/translobj.ml
@@ -97,10 +97,12 @@ let transl_label_init_general f =
          let const =
            Lprim (Popaque layout, [Lconst c], Debuginfo.Scoped_location.Loc_unknown)
          in
+         (* CR tnowak: verify *)
+         let uid = Uid.internal_not_actually_unique in
          (* CR ncourant: this *should* not be too precise for the moment,
             but we should take care, or fix the underlying cause that led
             us to using [Popaque]. *)
-         Llet(Alias, layout, id, const, expr))
+         Llet(Alias, layout, id, uid, const, expr))
       consts expr
   in
   (*let expr =
@@ -116,6 +118,7 @@ let transl_label_init_flambda f =
   assert(Config.flambda || Config.flambda2);
   let method_cache_id = Ident.create_local "method_cache" in
   method_cache := Lvar method_cache_id;
+  let uid = Uid.internal_not_actually_unique in
   (* Calling f (usually Translmod.transl_struct) requires the
      method_cache variable to be initialised to be able to generate
      method accesses. *)
@@ -123,7 +126,7 @@ let transl_label_init_flambda f =
   let expr =
     if !method_count = 0 then expr
     else
-      Llet (Strict, Lambda.layout_array Pgenarray, method_cache_id,
+      Llet (Strict, Lambda.layout_array Pgenarray, method_cache_id, uid,
         Lprim (Pccall prim_makearray,
                [int !method_count; int 0],
                Loc_unknown),
@@ -191,7 +194,8 @@ let oo_wrap env req f x =
                         [lambda_unit; lambda_unit; lambda_unit],
                         Loc_unknown)
                 in
-                Llet(StrictOpt, Lambda.layout_class, id,
+                let uid = Uid.internal_not_actually_unique in
+                Llet(StrictOpt, Lambda.layout_class, id, uid,
                      Lprim (Popaque Lambda.layout_class, [cl], Loc_unknown),
                      lambda))
              lambda !classes

--- a/ocaml/lambda/translprim.ml
+++ b/ocaml/lambda/translprim.ml
@@ -800,7 +800,7 @@ let lambda_of_prim prim_name prim loc args arg_exps =
         | Some [exn_exp; _] -> event_after loc exn_exp (Lvar vexn)
         | Some _ -> assert false
       in
-      Llet(Strict, Lambda.layout_block, vexn, exn,
+      Llet(Strict, Lambda.layout_block, vexn, Uid.internal_not_actually_unique, exn,
            Lsequence(Lprim(Pccall caml_restore_raw_backtrace,
                            [Lvar vexn; bt],
                            loc),
@@ -908,6 +908,7 @@ let transl_primitive loc p env ty ~poly_mode path =
           let arg_mode = to_locality arg in
           let params, return = make_params ret_ty repr_args repr_res in
           { name = Ident.create_local "prim";
+            var_uid = Uid.internal_not_actually_unique; (* CR tnowak: verify *)
             layout = arg_layout;
             attributes = Lambda.default_param_attribute;
             mode = arg_mode }

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -923,17 +923,17 @@ let iter_pattern_full ~both_sides_of_or f sort pat =
 
 let rev_pat_bound_idents_full sort pat =
   let idents_full = ref [] in
-  let add id sloc typ _uid _ sort =
-    idents_full := (id, sloc, typ, sort) :: !idents_full
+  let add id sloc typ uid _ sort =
+    idents_full := (id, sloc, typ, uid, sort) :: !idents_full
   in
   iter_pattern_full ~both_sides_of_or:false add sort pat;
   !idents_full
 
 let rev_only_idents idents_full =
-  List.rev_map (fun (id,_,_,_) -> id) idents_full
+  List.rev_map (fun (id,_,_,_,_) -> id) idents_full
 
 let rev_only_idents_and_types idents_full =
-  List.rev_map (fun (id,_,ty,_) -> (id,ty)) idents_full
+  List.rev_map (fun (id,_,ty,_,_) -> (id,ty)) idents_full
 
 let pat_bound_idents_full sort pat =
   List.rev (rev_pat_bound_idents_full sort pat)

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -225,7 +225,11 @@ and expression_desc =
         (** let P1 = E1 and ... and Pn = EN in E       (flag = Nonrecursive)
             let rec P1 = E1 and ... and Pn = EN in E   (flag = Recursive)
          *)
-  | Texp_function of { arg_label : arg_label; param : Ident.t;
+  | Texp_function of { arg_label : arg_label;
+      (** [param] is either a freshly generated name or
+          an existing parameter name that appears in the case list.
+      *)
+      param : Ident.t;
       cases : value case list; partial : partial;
       region : bool; curry : fun_curry_state;
       warnings : Warnings.state;
@@ -984,7 +988,7 @@ val pat_bound_idents_with_types:
   'k general_pattern -> (Ident.t * Types.type_expr) list
 val pat_bound_idents_full:
   Jkind.sort -> 'k general_pattern
-  -> (Ident.t * string loc * Types.type_expr * Jkind.sort) list
+  -> (Ident.t * string loc * Types.type_expr * Uid.t * Jkind.sort) list
 
 (** Splits an or pattern into its value (left) and exception (right) parts. *)
 val split_pattern:


### PR DESCRIPTION
This is split out of #1852 and was mostly written by @tonowak .  It attaches `Uid.t` values, as used by the existing `Shape` infrastructure in the type checker, to at least some of the bound names in `Lambda`.  After that they make their way through Flambda 2, using a new `Flambda_uid` module (which I added) to keep track of situations where the corresponding variables are actually unboxed products.  They are then attached to `Backend_var.t` values which gets them into the DWARF emission code.

The remaining code in #1852 will then use these uids to look up the "shapes" of OCaml types, in order that they may be encoded into DWARF types.  The shape resolution code should in due course be able to deal with all of the complicated cases (for functors etc.), avoiding the need for something like the separate `libmonda` library on the debugger side.

I think this is ready for an initial look through at a high level from maybe two reviewers, one for the front end and one for Flambda 2 - I will come and ask people.  I'd like to get this in fairly soon as the potential for conflicts is high.