### PR TITLE
Correct order of printed quantified type vars

### DIFF
--- a/ocaml/testsuite/tests/typing-layouts/annots.ml
+++ b/ocaml/testsuite/tests/typing-layouts/annots.ml
@@ -226,8 +226,8 @@ let f : (_ : immediate) -> (_ : value) = fun _ -> assert false
 let g : (_ : value) -> (_ : immediate) = fun _ -> assert false
 
 [%%expect {|
-val f : 'b ('a : immediate). 'a -> 'b = <fun>
-val g : ('b : immediate) 'a. 'a -> 'b = <fun>
+val f : ('a : immediate) 'b. 'a -> 'b = <fun>
+val g : 'a ('b : immediate). 'a -> 'b = <fun>
 |}]
 
 (********************************************)
@@ -551,13 +551,13 @@ val f : ('a : immediate). 'a -> 'a = <fun>
 let f = fun x y (type (a : immediate)) (z : a) -> z
 
 [%%expect{|
-val f : ('a : immediate) 'c 'b. 'b -> 'c -> 'a -> 'a = <fun>
+val f : 'b 'c ('a : immediate). 'b -> 'c -> 'a -> 'a = <fun>
 |}]
 
 let f = fun x y (type a : immediate) (z : a) -> z
 
 [%%expect{|
-val f : ('a : immediate) 'c 'b. 'b -> 'c -> 'a -> 'a = <fun>
+val f : 'b 'c ('a : immediate). 'b -> 'c -> 'a -> 'a = <fun>
 |}]
 (* CR layouts: canonicalizing the order of quantification here
    would reduce wibbles in error messages *)
@@ -574,7 +574,7 @@ exception E : ('a : immediate) ('b : any). 'b t2_any * 'a list -> exn
 
 [%%expect{|
 type (_ : any) t2_any
-exception E : ('a : immediate) ('b : any). 'b t2_any * 'a list -> exn
+exception E : ('b : any) ('a : immediate). 'b t2_any * 'a list -> exn
 |}]
 
 

--- a/ocaml/testsuite/tests/typing-layouts/basics.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics.ml
@@ -649,7 +649,7 @@ end;;
 module M11_3f :
   sig
     type ('a : float64) t = 'a
-    val foo : 'b ('a : float64). < usefloat : 'a t -> 'b; .. > -> 'a t -> 'b
+    val foo : ('a : float64) 'b. < usefloat : 'a t -> 'b; .. > -> 'a t -> 'b
   end
 |}];;
 
@@ -1265,7 +1265,7 @@ let q () =
     ()
 
 [%%expect{|
-val ( let* ) : 'b ('a : float64). 'a -> 'b -> unit = <fun>
+val ( let* ) : ('a : float64) 'b. 'a -> 'b -> unit = <fun>
 val ( and* ) : 'a -> 'b -> t_float64 = <fun>
 val q : unit -> unit = <fun>
 |}]

--- a/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
+++ b/ocaml/testsuite/tests/typing-layouts/basics_alpha.ml
@@ -1455,7 +1455,7 @@ let q () =
     ()
 
 [%%expect{|
-val ( let* ) : 'b ('a : float64). 'a -> 'b -> unit = <fun>
+val ( let* ) : ('a : float64) 'b. 'a -> 'b -> unit = <fun>
 val ( and* ) : 'a -> 'b -> t_float64 = <fun>
 val q : unit -> unit = <fun>
 |}]

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -1540,6 +1540,10 @@ let zap_qtvs_if_boring qtvs =
    This implements Case (C3) from Note [When to print jkind annotations]. *)
 let extract_qtvs tyl =
   let fvs = Ctype.free_non_row_variables_of_list tyl in
+  (* The [Ctype.free*variables] family of functions returns the free
+     variables in reverse order they were encountered in the list of types.
+  *)
+  let fvs = List.rev fvs in
   let tfvs = List.map Transient_expr.repr fvs in
   let vars_jkinds = tree_of_qtvs tfvs in
   zap_qtvs_if_boring vars_jkinds


### PR DESCRIPTION
Print quantified type vars in the order they appear in the provided types, not the reverse of that order. Quantified type vars are just printed for types schemes quantified over non-value layouts.

This will improve merlin's output in [this PR](https://github.com/janestreet/merlin-jst/pull/32).