### PR TITLE
(low priority) Mode crossing in uniqueness analysis

### DIFF
--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -1205,6 +1205,7 @@ module Linearity = struct
   end
 
   include Common (Obj)
+  open Obj
 
   let many = of_const Many
 
@@ -1213,6 +1214,8 @@ module Linearity = struct
   let legacy = of_const Const.legacy
 
   let zap_to_legacy = zap_to_floor
+  
+  let meet_with c m = Solver.via_monotone obj (Meet_with c) (disallow_right m)
 end
 
 module Uniqueness = struct
@@ -1228,6 +1231,7 @@ module Uniqueness = struct
   end
 
   include Common (Obj)
+  open Obj
 
   let shared = of_const Shared
 
@@ -1236,7 +1240,10 @@ module Uniqueness = struct
   let legacy = of_const Const.legacy
 
   let zap_to_legacy = zap_to_ceil
+
+  let meet_with c m = Solver.via_monotone obj (Join_with c) (disallow_right m)
 end
+
 
 let regional_to_local m =
   S.Positive.via_monotone Locality.Obj.obj C.Regional_to_local m

--- a/ocaml/typing/mode_intf.mli
+++ b/ocaml/typing/mode_intf.mli
@@ -195,6 +195,8 @@ module type S = sig
     val once : lr
 
     val zap_to_legacy : (allowed * 'r) t -> Const.t
+
+    val meet_with : Const.t -> ('l * 'r) t -> ('l * disallowed) t
   end
 
   module Uniqueness : sig
@@ -215,6 +217,8 @@ module type S = sig
     val unique : lr
 
     val zap_to_legacy : ('l * allowed) t -> Const.t
+
+    val meet_with : Const.t -> ('l * 'r) t -> ('l * disallowed) t
   end
 
   (** The most general mode. Used in most type checking,

--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -1229,7 +1229,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
             (id,
              {exp_desc =
               Texp_ident(path, mknoloc (Longident.Lident (Ident.name id)), vd,
-                         Id_value, shared_many_use);
+                         Id_value, unique_use);
               exp_loc = Location.none; exp_extra = [];
               exp_type = Ctype.instance vd.val_type;
               exp_attributes = []; (* check *)
@@ -1409,7 +1409,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
              let expr =
                {exp_desc =
                 Texp_ident(path, mknoloc(Longident.Lident (Ident.name id)),vd,
-                           Id_value, shared_many_use);
+                           Id_value, unique_use);
                 exp_loc = Location.none; exp_extra = [];
                 exp_type = ty;
                 exp_attributes = [];

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -53,13 +53,23 @@ type unique_barrier = Mode.Uniqueness.r option
 
 type unique_use = Mode.Uniqueness.r * Mode.Linearity.l
 
-type texp_field_boxing =
-  | Boxing of Mode.Alloc.r * unique_use
-  | Non_boxing of unique_use
+type unique_bounds = Mode.Uniqueness.Const.t * Mode.Linearity.Const.t
 
-let shared_many_use =
-  ( Mode.Uniqueness.disallow_left Mode.Uniqueness.shared,
-    Mode.Linearity.disallow_right Mode.Linearity.many )
+let unique_use =
+  Uniqueness.disallow_left Uniqueness.shared,
+  Linearity.disallow_right Linearity.many
+
+let unique_bounds : unique_bounds = Shared, Once
+
+let meet_unique_bounds (uni0, lin0) (uni1, lin1) =
+  Uniqueness.Const.meet uni0 uni1,
+  Linearity.Const.meet lin0 lin1
+
+type unique_use_with_bounds = unique_use * unique_bounds
+
+type texp_field_boxing =
+  | Boxing of Mode.Alloc.r * unique_use_with_bounds
+  | Non_boxing of unique_use
 
 type pattern = value general_pattern
 and 'k general_pattern = 'k pattern_desc pattern_data

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -72,15 +72,23 @@ type unique_barrier = Mode.Uniqueness.r option
 
 type unique_use = Mode.Uniqueness.r * Mode.Linearity.l
 
+type unique_bounds = Mode.Uniqueness.Const.t * Mode.Linearity.Const.t
+
+val unique_use : unique_use
+
+val unique_bounds : unique_bounds
+
+val meet_unique_bounds : unique_bounds -> unique_bounds -> unique_bounds
+
+type unique_use_with_bounds = unique_use * unique_bounds
+
 type texp_field_boxing =
-  | Boxing of Mode.Alloc.r * unique_use
+  | Boxing of Mode.Alloc.r * unique_use_with_bounds
   (** Projection requires boxing. [unique_use] describes the usage of the
       unboxed field as argument to boxing. *)
   | Non_boxing of unique_use
   (** Projection does not require boxing. [unique_use] describes the usage of
       the field as the result of direct projection. *)
-
-val shared_many_use : unique_use
 
 type pattern = value general_pattern
 and 'k general_pattern = 'k pattern_desc pattern_data


### PR DESCRIPTION
This PR tries to add mode crossing to uniqueness analysis.

(won't be working on this for a while; so create a PR as a reminder)

Consider the example:
```
let foo () =
  let r = {x =3; y = 5} in
  ignore (unique_id r.x);
  ignore (unique_id r)
```
UA would sequence the usage `u0` of `r.x` and the usage `u1` of `r`, which will force both to be `shared, many`.
- The real sequencing will happen node-wise: on the `r` node, we will sequence `empty` with `u1 = maybe_unique _`, which is fine. On the `r.x` node, we will sequence `u0 = maybe_unique _` with `maybe_unique _`, where the second one is inherited from `u1`.

Note that the `unique_use` in `u0` would be mode-crossed and not affected by the forcing. The `unique_use` in `u1` cannot cross-modes and will trigger error.

The solution (unfinished yet in this PR) is to attach the uniqueness/linearity upper bounds to each `Borrowed/Maybe_shared/Shared/Maybe_unique` usage, and when we `seq` or `par` two usages, we will take the meet of the upper bounds in those two usages, and use that to mode cross both `unique_use`.

- In `UsageTree.seq`, the upper bounds of parent node should not propagate to child node.
- Where to get the upper_bounds? Each typedtree node has `texp_type` which can be checked. Is this too expensive?