### PR TITLE
`mutable` no longer implies `global`

### DIFF
--- a/ocaml/ocamldoc/odoc_sig.ml
+++ b/ocaml/ocamldoc/odoc_sig.ml
@@ -440,7 +440,7 @@ module Analyser =
       let comment_opt = analyze_alerts comment_opt ld_attributes in
       {
         rf_name = field_name ;
-        rf_mutable = mutable_flag = Mutable ;
+        rf_mutable = Types.is_mutable mutable_flag;
         rf_type = Odoc_env.subst_type env type_expr ;
         rf_text = comment_opt
       }

--- a/ocaml/stdlib/array.mli
+++ b/ocaml/stdlib/array.mli
@@ -33,6 +33,8 @@ open! Stdlib
 type 'a t = 'a array
 (** An alias for the type of arrays. *)
 
+(* CR zqian: fix the following primitive wrt mutable() logic. *)
+
 external length : 'a array -> int = "%array_length"
 (** Return the length (number of elements) of the given array. *)
 

--- a/ocaml/stdlib/stdlib.ml
+++ b/ocaml/stdlib/stdlib.ml
@@ -241,8 +241,8 @@ external snd : ('a * 'b[@local_opt]) -> ('b[@local_opt]) = "%field1_immut"
 (* References *)
 
 type 'a ref = { mutable contents : 'a }
-external ref : 'a -> ('a ref[@local_opt]) = "%makemutable"
-external ( ! ) : ('a ref[@local_opt]) -> 'a = "%field0"
+external ref : ('a [@local_opt]) -> ('a ref[@local_opt]) = "%makemutable"
+external ( ! ) : ('a ref[@local_opt]) -> ('a [@local_opt]) = "%field0"
 external ( := ) : ('a ref[@local_opt]) -> 'a -> unit = "%setfield0"
 external incr : (int ref[@local_opt]) -> unit = "%incr"
 external decr : (int ref[@local_opt]) -> unit = "%decr"

--- a/ocaml/stdlib/stdlib.mli
+++ b/ocaml/stdlib/stdlib.mli
@@ -1220,10 +1220,10 @@ type 'a ref = { mutable contents : 'a }
 (** The type of references (mutable indirection cells) containing
    a value of type ['a]. *)
 
-external ref : 'a -> ('a ref[@local_opt]) = "%makemutable"
+external ref : ('a [@local_opt]) -> ('a ref[@local_opt]) = "%makemutable"
 (** Return a fresh reference containing the given value. *)
 
-external ( ! ) : ('a ref[@local_opt]) -> 'a = "%field0"
+external ( ! ) : ('a ref[@local_opt]) -> ('a [@local_opt]) = "%field0"
 (** [!r] returns the current contents of reference [r].
    Equivalent to [fun r -> r.contents].
    Unary operator, see {!Ocaml_operators} for more information.

--- a/ocaml/testsuite/tests/typing-core-bugs/const_int_hint.ml
+++ b/ocaml/testsuite/tests/typing-core-bugs/const_int_hint.ml
@@ -187,12 +187,12 @@ Error: This pattern matches values of type int
        but a pattern was expected which matches values of type int32
   Hint: Did you mean `0b1000_1101l'?
 |}]
-type t1 = {f1: int32};; let _ = fun x -> x.f1 <- 1_000n;;
+type t1 = {mutable f1: int32};; let _ = fun x -> x.f1 <- 1_000n;;
 [%%expect{|
-type t1 = { f1 : int32; }
-Line 1, characters 49-55:
-1 | type t1 = {f1: int32};; let _ = fun x -> x.f1 <- 1_000n;;
-                                                     ^^^^^^
+type t1 = { mutable f1 : int32; }
+Line 1, characters 57-63:
+1 | type t1 = {mutable f1: int32};; let _ = fun x -> x.f1 <- 1_000n;;
+                                                             ^^^^^^
 Error: This expression has type nativeint
        but an expression was expected of type int32
   Hint: Did you mean `1_000l'?

--- a/ocaml/testsuite/tests/typing-local/exclave.ml
+++ b/ocaml/testsuite/tests/typing-local/exclave.ml
@@ -3,9 +3,7 @@
 
 (* typing tests *)
 
-let escape x =
-  let _ = ref x in
-  ()
+let escape : 'a -> unit = fun _ -> ()
 [%%expect{|
 val escape : 'a -> unit = <fun>
 |}]
@@ -56,11 +54,11 @@ let foo x =
   exclave_
     let local_ y = None in
     (* y is not global *)
-    ref y
+    escape y
 [%%expect{|
-Line 5, characters 8-9:
-5 |     ref y
-            ^
+Line 5, characters 11-12:
+5 |     escape y
+               ^
 Error: This value escapes its region
 |}]
 

--- a/ocaml/testsuite/tests/typing-modes/mutable.ml
+++ b/ocaml/testsuite/tests/typing-modes/mutable.ml
@@ -3,21 +3,82 @@
    flags = "-extension unique"
 *)
 
-(* Our current approach is to treat "mutable implying global" only in typecore,
-   this simplifies printing, but also means the following duplication cannot be
-   detected. But on the other hand, what would be the error message? A specially
-   tailored message pointing to `mutable` and says "mutable implies global" -
-   that's too much effort for something that will be gone very soon.
+(* mutable current means mutable(m0) where m0 = legacy = global, many, shared).
+*)
+type t = {mutable a : string }
 
-   Also note that the legacy syntax [mutable global_ x : string] is not parsable
-   anyway. *)
-type r = {mutable x : string @@ global}
+let unique_use : 'a @ unique -> unit = fun _ -> ()
+
+(* A function that forces everything to legacy. *)
+let id_legacy : 'a -> 'a = fun a -> a
 [%%expect{|
-type r = { mutable global_ x : string; }
+type t = { mutable a : string; }
+val unique_use : unique_ 'a -> unit = <fun>
+val id_legacy : 'a -> 'a = <fun>
 |}]
 
-(* Since [mutable] implies [global] modality, which in turns implies [shared]
-   and [many] modalities, the effect of mutable in isolation is not testable
-   yet. *)
+(* Upon construction, the usual constraint applies: mode of the record will be
+   the join of fields. *)
+let foo (a @ local) =
+    let r = {a} in
+    r
+[%%expect{|
+Line 3, characters 4-5:
+3 |     r
+        ^
+Error: This value escapes its region
+  Hint: Cannot return a local value without an "exclave_" annotation
+|}]
 
-(* CR zqian: add test for mutable when mutable is decoupled from modalities. *)
+(* In addition, upon construction, mutable(m0) forces the comonadic fragment of
+   the record to be higher than [m0]. Because [m0] currently is fixed to be
+   [global, many] which is min, so this doesn't impose anything.
+   *)
+(* CR zqian: add tests when we have mutable(m0) syntax. *)
+
+(* Upon projection, the usual constraint applies: mode of the projection will be
+   higher than the record. *)
+let foo (local_ r) =
+    let a = r.a in
+    a
+[%%expect{|
+val foo : local_ t -> local_ string = <fun>
+|}]
+
+(* In addition, upon projection, mutable(m0) forces the monadic fragment of the
+   projection to be higher than m0. Note that [m0] is currently fixed to be
+   [shared] which is max, so this is testable. *)
+let foo (unique_ r) =
+    unique_use r.a
+[%%expect{|
+Line 2, characters 15-18:
+2 |     unique_use r.a
+                   ^^^
+Error: Found a shared value where a unique value was expected
+|}]
+
+(* Upon mutation, we simply require the new value to be constrained by [m0], and
+ nothing else. The default [m0] means it requires [many, global], even if the
+ record is [once, local]. *)
+let foo () =
+    let a @ local once = "hello" in
+    let r @ local once = {a="world"} in
+    r.a <- a
+[%%expect{|
+Line 4, characters 11-12:
+4 |     r.a <- a
+               ^
+Error: This value escapes its region
+|}]
+
+(* The default [m0] also means mutation requires [shared], which is vacant. That
+    means you can write a shared field to a unique record. *)
+let foo () =
+    let r @ unique = {a = "hello"} in
+    let a = "world" in
+    r.a <- id_legacy a
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+(* CR zqian: Similar tests for mutable array. *)

--- a/ocaml/testsuite/tests/typing-modes/mutable.ml
+++ b/ocaml/testsuite/tests/typing-modes/mutable.ml
@@ -1,0 +1,23 @@
+(* TEST
+   * expect
+   flags = "-extension unique"
+*)
+
+(* Our current approach is to treat "mutable implying global" only in typecore,
+   this simplifies printing, but also means the following duplication cannot be
+   detected. But on the other hand, what would be the error message? A specially
+   tailored message pointing to `mutable` and says "mutable implies global" -
+   that's too much effort for something that will be gone very soon.
+
+   Also note that the legacy syntax [mutable global_ x : string] is not parsable
+   anyway. *)
+type r = {mutable x : string @@ global}
+[%%expect{|
+type r = { mutable global_ x : string; }
+|}]
+
+(* Since [mutable] implies [global] modality, which in turns implies [shared]
+   and [many] modalities, the effect of mutable in isolation is not testable
+   yet. *)
+
+(* CR zqian: add test for mutable when mutable is decoupled from modalities. *)

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -4304,12 +4304,12 @@ let add_method env label priv virt ty sign =
   sign.csig_meths <- meths
 
 type add_instance_variable_failure =
-  | Mutability_mismatch of mutable_flag
+  | Mutability_mismatch of Asttypes.mutable_flag
   | Type_mismatch of Errortrace.unification_error
 
 exception Add_instance_variable_failed of add_instance_variable_failure
 
-let check_mutability mut mut' =
+let check_mutability (mut:Asttypes.mutable_flag) (mut':Asttypes.mutable_flag) =
   match mut, mut' with
   | Mutable, Mutable -> ()
   | Immutable, Immutable -> ()
@@ -5286,10 +5286,10 @@ let match_class_sig_shape ~strict sign1 sign2 =
   in
   let errors =
     Vars.fold
-      (fun lab (mut, vr, _) err ->
+      (fun lab ((mut:Asttypes.mutable_flag), vr, _) err ->
          match Vars.find lab sign1.csig_vars with
          | exception Not_found -> CM_Missing_value lab::err
-         | (mut', vr', _) ->
+         | ((mut':Asttypes.mutable_flag), vr', _) ->
              match mut', mut with
              | Immutable, Mutable -> CM_Non_mutable_value lab::err
              | _, _ ->

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -414,13 +414,13 @@ val add_method : Env.t ->
   label -> private_flag -> virtual_flag -> type_expr -> class_signature -> unit
 
 type add_instance_variable_failure =
-  | Mutability_mismatch of mutable_flag
+  | Mutability_mismatch of Asttypes.mutable_flag
   | Type_mismatch of Errortrace.unification_error
 
 exception Add_instance_variable_failed of add_instance_variable_failure
 
 val add_instance_variable : strict:bool -> Env.t ->
-  label -> mutable_flag -> virtual_flag -> type_expr -> class_signature -> unit
+  label -> Asttypes.mutable_flag -> virtual_flag -> type_expr -> class_signature -> unit
 
 type inherit_class_signature_failure =
   | Self_type_mismatch of Errortrace.unification_error

--- a/ocaml/typing/env.ml
+++ b/ocaml/typing/env.ml
@@ -123,13 +123,13 @@ let label_usage_complaint priv mut lu
   | Asttypes.Private, _ ->
       if lu.lu_projection then None
       else Some Unused
-  | Asttypes.Public, Asttypes.Immutable -> begin
+  | Asttypes.Public, Types.Immutable -> begin
       match lu.lu_projection, lu.lu_construct with
       | true, _ -> None
       | false, false -> Some Unused
       | false, true -> Some Not_read
     end
-  | Asttypes.Public, Asttypes.Mutable -> begin
+  | Asttypes.Public, Types.Mutable _ -> begin
       match lu.lu_projection, lu.lu_mutation, lu.lu_construct with
       | true, true, _ -> None
       | false, false, false -> Some Unused

--- a/ocaml/typing/mode_intf.mli
+++ b/ocaml/typing/mode_intf.mli
@@ -234,10 +234,14 @@ module type S = sig
         uniqueness : 'c
       }
 
-    module Const :
-      Lattice
-        with type t =
-          (Regionality.Const.t, Linearity.Const.t, Uniqueness.Const.t) modes
+    module Const : sig
+      include
+        Lattice
+          with type t =
+            (Regionality.Const.t, Linearity.Const.t, Uniqueness.Const.t) modes
+
+      val split : t -> (Monadic.Const.t, Comonadic.Const.t) monadic_comonadic
+    end
 
     type error =
       [ `Regionality of Regionality.error

--- a/ocaml/typing/oprint.ml
+++ b/ocaml/typing/oprint.ml
@@ -441,6 +441,10 @@ let is_initially_labeled_tuple ty =
   | Otyp_tuple ((Some _, _) :: _) -> true
   | _ -> false
 
+let string_of_gbl_space = function
+  | Ogf_global -> "global_ "
+  | Ogf_unrestricted -> ""
+
 let rec print_out_type_0 mode ppf =
   function
   | Otyp_alias {non_gen; aliased; alias } ->
@@ -618,15 +622,14 @@ and print_typargs ppf =
       pp_print_char ppf ')';
       pp_close_box ppf ();
       pp_print_space ppf ()
-and print_out_label ppf (name, mut_or_gbl, arg) =
+and print_out_label ppf (name, mut, arg, gbl) =
   (* See the notes [NON-LEGACY MODES] *)
-  let flag =
-    match mut_or_gbl with
-    | Ogom_mutable -> "mutable "
-    | Ogom_global -> "global_ "
-    | Ogom_immutable -> ""
-  in
-  fprintf ppf "@[<2>%s%s :@ %a@];" flag name print_out_type arg
+  let mut = if mut then "mutable " else "" in
+  fprintf ppf "@[<2>%s%s%s :@ %a@];"
+    mut
+    (string_of_gbl_space gbl)
+    name
+    print_out_type arg
 
 let out_label = ref print_out_label
 

--- a/ocaml/typing/oprint.mli
+++ b/ocaml/typing/oprint.mli
@@ -18,7 +18,7 @@ open Outcometree
 
 val out_ident : (formatter -> out_ident -> unit) ref
 val out_value : (formatter -> out_value -> unit) ref
-val out_label : (formatter -> string * out_mutable_or_global * out_type -> unit) ref
+val out_label : (formatter -> string * bool * out_type * out_global -> unit) ref
 val out_type : (formatter -> out_type -> unit) ref
 val out_type_args : (formatter -> out_type list -> unit) ref
 val out_constr : (formatter -> out_constructor -> unit) ref

--- a/ocaml/typing/outcometree.mli
+++ b/ocaml/typing/outcometree.mli
@@ -66,11 +66,6 @@ type out_type_param =
     oparam_injectivity : Asttypes.injectivity;
     oparam_jkind : out_jkind option }
 
-type out_mutable_or_global =
-  | Ogom_mutable
-  | Ogom_global
-  | Ogom_immutable
-
 type out_global =
   | Ogf_global
   | Ogf_unrestricted
@@ -87,7 +82,7 @@ type out_type =
   | Otyp_constr of out_ident * out_type list
   | Otyp_manifest of out_type * out_type
   | Otyp_object of { fields: (string * out_type) list; open_row:bool}
-  | Otyp_record of (string * out_mutable_or_global * out_type) list
+  | Otyp_record of (string * bool * out_type * out_global) list
   | Otyp_stuff of string
   | Otyp_sum of out_constructor list
   | Otyp_tuple of (string option * out_type) list

--- a/ocaml/typing/parmatch.ml
+++ b/ocaml/typing/parmatch.ml
@@ -541,10 +541,7 @@ let do_set_args ~erase_mutable q r = match q with
     make_pat
       (Tpat_record
          (List.map2 (fun (lid, lbl,_) arg ->
-           if
-             erase_mutable &&
-             (match lbl.lbl_mut with
-             | Mutable -> true | Immutable -> false)
+           if erase_mutable && Types.is_mutable lbl.lbl_mut
            then
              lid, lbl, omega
            else
@@ -2150,7 +2147,7 @@ let inactive ~partial pat =
   | Total -> begin
       let rec loop pat =
         match pat.pat_desc with
-        | Tpat_lazy _ | Tpat_array (Mutable, _, _) ->
+        | Tpat_lazy _ | Tpat_array (Mutable _, _, _) ->
           false
         | Tpat_any | Tpat_var _ | Tpat_variant (_, None, _) ->
             true

--- a/ocaml/typing/printpat.ml
+++ b/ocaml/typing/printpat.ml
@@ -103,10 +103,7 @@ let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
             pretty_lvals filtered_lvs elision_mark
       end
   | Tpat_array (am, _arg_sort, vs) ->
-      let punct = match am with
-        | Mutable   -> '|'
-        | Immutable -> ':'
-      in
+      let punct = if Types.is_mutable am then '|' else ':' in
       fprintf ppf "@[[%c %a %c]@]" punct (pretty_vals " ;") vs punct
   | Tpat_lazy v ->
       fprintf ppf "@[<2>lazy@ %a@]" pretty_arg v

--- a/ocaml/typing/printtyp.ml
+++ b/ocaml/typing/printtyp.ml
@@ -1570,13 +1570,21 @@ let param_jkind ty =
   | _ -> None (* this is (C2.2) from Note [When to print jkind annotations] *)
 
 let tree_of_label l =
-  let gom =
-    match l.ld_mutable, l.ld_global with
-    | Mutable, _ -> Ogom_mutable
-    | Immutable, Global -> Ogom_global
-    | Immutable, Unrestricted -> Ogom_immutable
+  let gbl =
+    match l.ld_global with
+    | Global -> Ogf_global
+    | Unrestricted -> Ogf_unrestricted
   in
-  (Ident.name l.ld_id, gom, tree_of_typexp Type l.ld_type)
+  let mut =
+    match l.ld_mutable with
+    | Immutable -> false
+    | Mutable m ->
+        if Misc.eq_from_le Alloc.Const.le m Alloc.Const.legacy then
+          true
+        else
+          Misc.fatal_errorf "Unexpected mutable(%a)" Alloc.Const.print m
+  in
+  (Ident.name l.ld_id, mut, tree_of_typexp Type l.ld_type, gbl)
 
 let tree_of_constructor_arguments = function
   | Cstr_tuple l -> List.map tree_of_typ_gf l
@@ -2017,7 +2025,7 @@ let rec tree_of_class_type mode params =
       let csil =
         List.fold_left
           (fun csil (l, m, v, t) ->
-            Ocsg_value (l, m = Mutable, v = Virtual, tree_of_typexp mode t)
+            Ocsg_value (l, m = Asttypes.Mutable, v = Virtual, tree_of_typexp mode t)
             :: csil)
           csil all_vars
       in

--- a/ocaml/typing/printtyped.ml
+++ b/ocaml/typing/printtyped.ml
@@ -76,10 +76,20 @@ let fmt_constant f x =
   | Const_unboxed_int64 (i) -> fprintf f "Const_unboxed_int64 %Ld" i
   | Const_unboxed_nativeint (i) -> fprintf f "Const_unboxed_nativeint %nd" i
 
-let fmt_mutable_flag f x =
+let fmt_mutable_flag f (x : Asttypes.mutable_flag) =
   match x with
   | Immutable -> fprintf f "Immutable"
   | Mutable -> fprintf f "Mutable"
+
+let fmt_mutable_mode_flag f (x : Types.mutable_flag) =
+  match x with
+  | Immutable -> fprintf f "Immutable"
+  | Mutable m ->
+    if Misc.eq_from_le Mode.Alloc.Const.le m Mode.Alloc.Const.legacy
+    then fprintf f "Mutable"
+    else
+      Misc.fatal_errorf "Unexpected mutable(%a)"
+        Mode.Alloc.Const.print m
 
 let fmt_virtual_flag f x =
   match x with
@@ -306,7 +316,7 @@ and pattern : type k . _ -> _ -> k general_pattern -> unit = fun i ppf x ->
       line i ppf "Tpat_record\n";
       list i longident_x_pattern ppf l;
   | Tpat_array (am, arg_sort, l) ->
-      line i ppf "Tpat_array %a\n" fmt_mutable_flag am;
+      line i ppf "Tpat_array %a\n" fmt_mutable_mode_flag am;
       line i ppf "%a\n" Jkind.Sort.format arg_sort;
       list i pattern ppf l;
   | Tpat_lazy p ->
@@ -478,7 +488,7 @@ and expression i ppf x =
       longident i ppf li;
       expression i ppf e2;
   | Texp_array (amut, sort, l, amode) ->
-      line i ppf "Texp_array %a\n" fmt_mutable_flag amut;
+      line i ppf "Texp_array %a\n" fmt_mutable_mode_flag amut;
       line i ppf "%a\n" Jkind.Sort.format sort;
       alloc_mode i ppf amode;
       list i expression ppf l;
@@ -486,7 +496,7 @@ and expression i ppf x =
       line i ppf "Texp_list_comprehension\n";
       comprehension i ppf comp
   | Texp_array_comprehension (amut, sort, comp) ->
-      line i ppf "Texp_array_comprehension %a\n" fmt_mutable_flag amut;
+      line i ppf "Texp_array_comprehension %a\n" fmt_mutable_mode_flag amut;
       line i ppf "%a\n" Jkind.Sort.format sort;
       comprehension i ppf comp
   | Texp_ifthenelse (e1, e2, eo) ->
@@ -1047,7 +1057,7 @@ and label_decl i ppf {ld_id; ld_name = _; ld_mutable; ld_type; ld_loc;
                       ld_attributes} =
   line i ppf "%a\n" fmt_location ld_loc;
   attributes i ppf ld_attributes;
-  line (i+1) ppf "%a\n" fmt_mutable_flag ld_mutable;
+  line (i+1) ppf "%a\n" fmt_mutable_mode_flag ld_mutable;
   line (i+1) ppf "%a" fmt_ident ld_id;
   core_type (i+1) ppf ld_type
 

--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -103,7 +103,7 @@ type error =
   | Non_collapsable_conjunction of
       Ident.t * Types.class_declaration * Errortrace.unification_error
   | Self_clash of Errortrace.unification_error
-  | Mutability_mismatch of string * mutable_flag
+  | Mutability_mismatch of string * Asttypes.mutable_flag
   | No_overriding of string * string
   | Duplicate of string * string
   | Closing_self_type of class_signature
@@ -531,7 +531,7 @@ type intermediate_class_field =
         attributes : attribute list; }
   | Virtual_val of
       { label : string loc;
-        mut : mutable_flag;
+        mut : Asttypes.mutable_flag;
         id : Ident.t;
         cty : core_type;
         already_declared : bool;
@@ -539,7 +539,7 @@ type intermediate_class_field =
         attributes : attribute list; }
   | Concrete_val of
       { label : string loc;
-        mut : mutable_flag;
+        mut : Asttypes.mutable_flag;
         id : Ident.t;
         override : override_flag;
         definition : expression;
@@ -2262,8 +2262,10 @@ let report_error env ppf = function
            fprintf ppf "but actually has type")
   | Mutability_mismatch (_lab, mut) ->
       let mut1, mut2 =
-        if mut = Immutable then "mutable", "immutable"
-        else "immutable", "mutable" in
+        match mut with
+        | Immutable -> "mutable", "immutable"
+        | Mutable -> "immutable", "mutable"
+      in
       fprintf ppf
         "@[The instance variable is %s;@ it cannot be redefined as %s@]"
         mut1 mut2

--- a/ocaml/typing/typeclass.mli
+++ b/ocaml/typing/typeclass.mli
@@ -121,7 +121,7 @@ type error =
   | Non_collapsable_conjunction of
       Ident.t * Types.class_declaration * Errortrace.unification_error
   | Self_clash of Errortrace.unification_error
-  | Mutability_mismatch of string * mutable_flag
+  | Mutability_mismatch of string * Asttypes.mutable_flag
   | No_overriding of string * string
   | Duplicate of string * string
   | Closing_self_type of class_signature

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -879,8 +879,6 @@ let project_mutable m0 m =
      Value.Monadic.of_const m0.monadic]
   in
   {monadic; comonadic}
-    (* CR zqian: decouple mutable and global. *)
-    |> modality_unbox_left Global
 
 let project_maybe_mutable mut m =
   match mut with
@@ -906,8 +904,6 @@ let construct_mutable m0 m =
       which is min, so this call cannot fail."
   );
   m |> Value.disallow_left
-    (* CR zqian: decouple mutable and global *)
-    |> modality_box_right Global
 
 let _construct_maybe_mutable mut m =
   match mut with
@@ -920,8 +916,6 @@ let _construct_maybe_mutable mut m =
 let mutate_mutable m0 (_ : (allowed * _) Value.t) =
   let m0 = Const.alloc_as_value m0 in
   m0 |> Value.of_const |> Value.disallow_left
-    (* CR zqian: decouple mutable and global. *)
-     |> modality_box_right Global
 
 (* Typing of patterns *)
 

--- a/ocaml/typing/typedecl.ml
+++ b/ocaml/typing/typedecl.ml
@@ -362,10 +362,13 @@ let transl_labels ~new_var_jkind env univars closed lbls =
     Builtin_attributes.warning_scope attrs
       (fun () ->
          let gbl =
-           match mut with
-           | Mutable -> Mode.Global_flag.Global
-           | Immutable -> Typemode.transl_global_flags
+            Typemode.transl_global_flags
               (Jane_syntax.Mode_expr.of_attrs arg.ptyp_attributes |> fst)
+         in
+         let mut : Types.mutable_flag =
+          match mut with
+          | Immutable -> Immutable
+          | Mutable -> Mutable Mode.Alloc.Const.legacy
          in
          let arg = Ast_helper.Typ.force_poly arg in
          let cty = transl_simple_type ~new_var_jkind env ?univars ~closed Mode.Alloc.Const.legacy arg in

--- a/ocaml/typing/typedecl_variance.ml
+++ b/ocaml/typing/typedecl_variance.ml
@@ -256,7 +256,8 @@ let for_constr = function
   | Types.Cstr_tuple l -> List.map (fun (ty,_) -> false, ty) l
   | Types.Cstr_record l ->
       List.map
-        (fun {Types.ld_mutable; ld_type} -> (ld_mutable = Mutable, ld_type))
+        (fun {Types.ld_mutable; ld_type} ->
+          (Types.is_mutable ld_mutable, ld_type))
         l
 
 let compute_variance_gadt env ~check (required, loc as rloc) decl
@@ -353,7 +354,7 @@ let compute_variance_decl env ~check decl (required, _ as rloc) =
       | Type_record (ftl, _) ->
           compute_variance_type env ~check rloc decl
             (mn @ List.map (fun {Types.ld_mutable; ld_type} ->
-                 (ld_mutable = Mutable, ld_type)) ftl)
+                 (Types.is_mutable ld_mutable, ld_type)) ftl)
     in
     if mn = [] || not abstract then
       List.map Variance.strengthen vari

--- a/ocaml/typing/typedtree.ml
+++ b/ocaml/typing/typedtree.ml
@@ -369,7 +369,7 @@ and class_field_desc =
       override_flag * class_expr * string option * (string * Ident.t) list *
         (string * Ident.t) list
     (* Inherited instance variables and concrete methods *)
-  | Tcf_val of string loc * mutable_flag * Ident.t * class_field_kind * bool
+  | Tcf_val of string loc * Asttypes.mutable_flag * Ident.t * class_field_kind * bool
   | Tcf_method of string loc * private_flag * class_field_kind
   | Tcf_constraint of core_type * core_type
   | Tcf_initializer of expression
@@ -751,7 +751,7 @@ and class_type_field = {
 
 and class_type_field_desc =
   | Tctf_inherit of class_type
-  | Tctf_val of (string * mutable_flag * virtual_flag * core_type)
+  | Tctf_val of (string * Asttypes.mutable_flag * virtual_flag * core_type)
   | Tctf_method of (string * private_flag * virtual_flag * core_type)
   | Tctf_constraint of (core_type * core_type)
   | Tctf_attribute of attribute

--- a/ocaml/typing/typedtree.mli
+++ b/ocaml/typing/typedtree.mli
@@ -163,7 +163,7 @@ and 'k pattern_desc =
             Invariant: n > 0
          *)
   | Tpat_array :
-      mutable_flag * Jkind.sort * value general_pattern list -> value pattern_desc
+      Types.mutable_flag * Jkind.sort * value general_pattern list -> value pattern_desc
         (** [| P1; ...; Pn |]    (flag = Mutable)
             [: P1; ...; Pn :]    (flag = Immutable) *)
   | Tpat_lazy : value general_pattern -> value pattern_desc
@@ -348,9 +348,9 @@ and expression_desc =
       expression * Mode.Locality.l * Longident.t loc *
       Types.label_description * expression
     (** [alloc_mode] translates to the [modify_mode] of the record *)
-  | Texp_array of mutable_flag * Jkind.Sort.t * expression list * Mode.Alloc.r
+  | Texp_array of Types.mutable_flag * Jkind.Sort.t * expression list * Mode.Alloc.r
   | Texp_list_comprehension of comprehension
-  | Texp_array_comprehension of mutable_flag * Jkind.sort * comprehension
+  | Texp_array_comprehension of Types.mutable_flag * Jkind.sort * comprehension
   | Texp_ifthenelse of expression * expression * expression option
   | Texp_sequence of expression * Jkind.sort * expression
   | Texp_while of {
@@ -510,7 +510,7 @@ and 'k case =
     }
 
 and record_label_definition =
-  | Kept of Types.type_expr * mutable_flag * unique_use
+  | Kept of Types.type_expr * Types.mutable_flag * unique_use
   | Overridden of Longident.t loc * expression
 
 and binding_op =
@@ -594,7 +594,7 @@ and class_field_desc =
       override_flag * class_expr * string option * (string * Ident.t) list *
         (string * Ident.t) list
     (* Inherited instance variables and concrete methods *)
-  | Tcf_val of string loc * mutable_flag * Ident.t * class_field_kind * bool
+  | Tcf_val of string loc * Asttypes.mutable_flag * Ident.t * class_field_kind * bool
   | Tcf_method of string loc * private_flag * class_field_kind
   | Tcf_constraint of core_type * core_type
   | Tcf_initializer of expression
@@ -899,7 +899,7 @@ and label_declaration =
     {
      ld_id: Ident.t;
      ld_name: string loc;
-     ld_mutable: mutable_flag;
+     ld_mutable: Types.mutable_flag;
      ld_global: Mode.Global_flag.t;
      ld_type: core_type;
      ld_loc: Location.t;
@@ -984,7 +984,7 @@ and class_type_field = {
 
 and class_type_field_desc =
   | Tctf_inherit of class_type
-  | Tctf_val of (string * mutable_flag * virtual_flag * core_type)
+  | Tctf_val of (string * Asttypes.mutable_flag * virtual_flag * core_type)
   | Tctf_method of (string * private_flag * virtual_flag * core_type)
   | Tctf_constraint of (core_type * core_type)
   | Tctf_attribute of attribute

--- a/ocaml/typing/typeopt.ml
+++ b/ocaml/typing/typeopt.ml
@@ -17,7 +17,6 @@
 
 open Path
 open Types
-open Asttypes
 open Typedtree
 open Lambda
 
@@ -478,9 +477,7 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
           (fun (is_mutable, num_nodes_visited)
                (label:Types.label_declaration) ->
               let is_mutable =
-                match label.ld_mutable with
-                | Mutable -> true
-                | Immutable -> is_mutable
+                Types.is_mutable label.ld_mutable || is_mutable
               in
               let num_nodes_visited = num_nodes_visited + 1 in
               let num_nodes_visited, field =
@@ -548,9 +545,7 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
           (fun (is_mutable, num_nodes_visited)
                (label:Types.label_declaration) ->
             let is_mutable =
-              match label.ld_mutable with
-              | Mutable -> true
-              | Immutable -> is_mutable
+              Types.is_mutable label.ld_mutable || is_mutable
             in
             let num_nodes_visited = num_nodes_visited + 1 in
             let num_nodes_visited, field =

--- a/ocaml/typing/types.ml
+++ b/ocaml/typing/types.ml
@@ -19,6 +19,14 @@ open Asttypes
 
 type jkind = Jkind.t
 
+type mutable_flag =
+  | Immutable
+  | Mutable of Mode.Alloc.Const.t
+
+let is_mutable = function
+  | Immutable -> false
+  | Mutable _ -> true
+
 (* Type expressions for the core language *)
 
 type transient_expr =
@@ -110,7 +118,7 @@ module Vars = Misc.Stdlib.String.Map
 type value_kind =
     Val_reg                             (* Regular value *)
   | Val_prim of Primitive.description   (* Primitive *)
-  | Val_ivar of mutable_flag * string   (* Instance variable (mutable ?) *)
+  | Val_ivar of Asttypes.mutable_flag * string   (* Instance variable (mutable ?) *)
   | Val_self of
       class_signature * self_meths * Ident.t Vars.t * string
                                         (* Self *)
@@ -124,7 +132,7 @@ and self_meths =
 and class_signature =
   { csig_self: type_expr;
     mutable csig_self_row: type_expr;
-    mutable csig_vars: (mutable_flag * virtual_flag * type_expr) Vars.t;
+    mutable csig_vars: (Asttypes.mutable_flag * virtual_flag * type_expr) Vars.t;
     mutable csig_meths: (method_privacy * virtual_flag * type_expr) Meths.t; }
 
 and method_privacy =

--- a/ocaml/typing/types.mli
+++ b/ocaml/typing/types.mli
@@ -28,6 +28,16 @@ open Asttypes
 (* CR layouts v2.8: Say more here. *)
 type jkind = Jkind.t
 
+(** The mutable_flag used in typed tree. *)
+type mutable_flag =
+  | Immutable
+  | Mutable of Mode.Alloc.Const.t
+  (** The upper bound of the new field value upon mutation. *)
+
+(** Returns [true] is the [mutable_flag] is mutable. Should be called if not
+    interested in the payload of [Mutable]. *)
+val is_mutable : mutable_flag -> bool
+
 (** Type expressions for the core language.
 
     The [type_desc] variant defines all the possible type expressions one can
@@ -384,7 +394,7 @@ module Vars  : Map.S with type key = string
 type value_kind =
     Val_reg                             (* Regular value *)
   | Val_prim of Primitive.description   (* Primitive *)
-  | Val_ivar of mutable_flag * string   (* Instance variable (mutable ?) *)
+  | Val_ivar of Asttypes.mutable_flag * string   (* Instance variable (mutable ?) *)
   | Val_self of class_signature * self_meths * Ident.t Vars.t * string
                                         (* Self *)
   | Val_anc of class_signature * Ident.t Meths.t * string
@@ -397,7 +407,7 @@ and self_meths =
 and class_signature =
   { csig_self: type_expr;
     mutable csig_self_row: type_expr;
-    mutable csig_vars: (mutable_flag * virtual_flag * type_expr) Vars.t;
+    mutable csig_vars: (Asttypes.mutable_flag * virtual_flag * type_expr) Vars.t;
     mutable csig_meths: (method_privacy * virtual_flag * type_expr) Meths.t; }
 
 and method_privacy =

--- a/ocaml/utils/misc.ml
+++ b/ocaml/utils/misc.ml
@@ -1429,3 +1429,5 @@ end
 module type T4 = sig
   type ('a, 'b, 'c, 'd) t
 end
+
+let eq_from_le le a b = le a b && le b a

--- a/ocaml/utils/misc.mli
+++ b/ocaml/utils/misc.mli
@@ -892,3 +892,6 @@ end
 type filepath = string
 
 type alerts = string Stdlib.String.Map.t
+
+(** Construct an equality function from a less-or-equal function. *)
+val eq_from_le : ('a -> 'a -> bool) -> 'a -> 'a -> bool


### PR DESCRIPTION
Based on https://github.com/ocaml-flambda/flambda-backend/pull/2369

Won't be working on this for a while, so create a draft PR as a reminder.

Still need to do:
- fix `array.mli` in stdlib
- add array tests to `typing-modes/mutable`

Before this can be merged, lots of work need to be done in our internal code base.