### PR TITLE
Simple cmov insertion

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3619,7 +3619,7 @@ let sequence x y =
   | _, _ -> Csequence (x, y)
 
 let rec is_small_and_pure_int_expr ~size_bias ~size ~toplevel expr =
-  if size > 12 + size_bias
+  if size > 12 - size_bias
   then None
   else
     match expr with


### PR DESCRIPTION
This causes conditional moves to be used rather than branches for `Cifthenelse (cond, ifso, ifnot)` where `ifso` and `ifnot` are integer-valued, small and pure Cmm expressions.  If both such expressions also look as if they finish by tagging an integer, the tagging is moved out so it happens after the conditional move.

For example:
```
type t = A | B

let foo t (x : int) (y : int) =
  match t with
  | A -> x > y
  | B -> x < y
```

Before:
```
camlK__foo_0_1_code:
        cmpq    $1, %rax
        jne     .L103
        cmpq    %rdi, %rbx
        setg    %al
        movzbq  %al, %rax
        leaq    1(%rax,%rax), %rax
        ret
        .align  4
.L103:
        cmpq    %rdi, %rbx
        setl    %al
        movzbq  %al, %rax
        leaq    1(%rax,%rax), %rax
        ret
```

With this PR:
```
camlK.foo_0_1_code:
        movq    %rax, %rsi
        cmpq    %rdi, %rbx
        setl    %al
        movzbq  %al, %rdx
        cmpq    %rdi, %rbx
        setg    %al
        movzbq  %al, %rax
        cmpq    $1, %rsi
        cmove   %rax, %rdx
        leaq    1(%rdx,%rdx), %rax
        ret
```
