### PR TITLE
Unsigned comparisons

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -911,7 +911,7 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Pufloatfield _ | Psetufloatfield _ | Psequand | Psequor | Pnot | Pnegint
       | Pmixedfield _ | Psetmixedfield _ | Paddint | Psubint | Pmulint
       | Pdivint _ | Pmodint _ | Pandint | Porint | Pxorint | Plslint | Plsrint
-      | Pasrint | Pintcomp _ | Pcompare_ints | Pcompare_floats _
+      | Pasrint | Pintcomp _ | Pcompare_ints _ | Pcompare_floats _
       | Pcompare_bints _ | Poffsetint _ | Poffsetref _ | Pintoffloat _
       | Pfloatofint (_, _)
       | Pfloatoffloat32 _ | Pfloat32offloat _

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -383,12 +383,14 @@ let rec_catch_for_for_loop env loc ident start stop
   let stop_ident = Ident.create_local "for_stop" in
   let first_test : L.lambda =
     match dir with
-    | Upto -> Lprim (Pintcomp Cle, [L.Lvar start_ident; L.Lvar stop_ident], loc)
+    | Upto -> Lprim (Pintcomp { comp = Cle; signed =true },
+                     [L.Lvar start_ident; L.Lvar stop_ident], loc)
     | Downto ->
-      Lprim (Pintcomp Cge, [L.Lvar start_ident; L.Lvar stop_ident], loc)
+      Lprim (Pintcomp { comp = Cge; signed = true },
+             [L.Lvar start_ident; L.Lvar stop_ident], loc)
   in
   let subsequent_test : L.lambda =
-    Lprim (Pintcomp Cne, [L.Lvar ident; L.Lvar stop_ident], loc)
+    Lprim (Pintcomp { comp = Cne; signed = true }, [L.Lvar ident; L.Lvar stop_ident], loc)
   in
   let one : L.lambda = Lconst (Const_base (Const_int 1)) in
   let next_value_of_counter =
@@ -671,7 +673,7 @@ let primitive_can_raise (prim : Lambda.primitive) =
   | Pmakeufloatblock _ | Pufloatfield _ | Psetufloatfield _ | Psequand | Psequor
   | Pmixedfield _ | Psetmixedfield _ | Pmakemixedblock _ | Pnot | Pnegint
   | Paddint | Psubint | Pmulint | Pandint | Porint | Pxorint | Plslint | Plsrint
-  | Pasrint | Pintcomp _ | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _
+  | Pasrint | Pintcomp _ | Pcompare_ints _ | Pcompare_floats _ | Pcompare_bints _
   | Poffsetint _ | Poffsetref _ | Pintoffloat _
   | Pfloatofint (_, _)
   | Pfloatoffloat32 _ | Pfloat32offloat _

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -21,37 +21,42 @@ module I_or_f = K.Standard_int_or_float
 module L = Lambda
 module P = Flambda_primitive
 
-let convert_integer_comparison_prim (comp : L.integer_comparison) :
-    P.binary_primitive =
+let convert_signed signed = if signed then P.Signed else P.Unsigned
+
+let convert_integer_comparison_prim (comp : L.integer_comparison)
+      (signed : bool) :
+  P.binary_primitive =
+  let signed = convert_signed signed in
   match comp with
   | Ceq -> Phys_equal Eq
   | Cne -> Phys_equal Neq
-  | Clt -> Int_comp (Tagged_immediate, Yielding_bool (Lt Signed))
-  | Cgt -> Int_comp (Tagged_immediate, Yielding_bool (Gt Signed))
-  | Cle -> Int_comp (Tagged_immediate, Yielding_bool (Le Signed))
-  | Cge -> Int_comp (Tagged_immediate, Yielding_bool (Ge Signed))
+  | Clt -> Int_comp (Tagged_immediate, Yielding_bool (Lt signed))
+  | Cgt -> Int_comp (Tagged_immediate, Yielding_bool (Gt signed))
+  | Cle -> Int_comp (Tagged_immediate, Yielding_bool (Le signed))
+  | Cge -> Int_comp (Tagged_immediate, Yielding_bool (Ge signed))
 
 let convert_boxed_integer_comparison_prim (kind : L.boxed_integer)
-    (comp : L.integer_comparison) : P.binary_primitive =
+      (comp : L.integer_comparison) (signed : bool) : P.binary_primitive =
+  let signed = convert_signed signed in
   match kind, comp with
   | Pint32, Ceq -> Int_comp (Naked_int32, Yielding_bool Eq)
   | Pint32, Cne -> Int_comp (Naked_int32, Yielding_bool Neq)
-  | Pint32, Clt -> Int_comp (Naked_int32, Yielding_bool (Lt Signed))
-  | Pint32, Cgt -> Int_comp (Naked_int32, Yielding_bool (Gt Signed))
-  | Pint32, Cle -> Int_comp (Naked_int32, Yielding_bool (Le Signed))
-  | Pint32, Cge -> Int_comp (Naked_int32, Yielding_bool (Ge Signed))
+  | Pint32, Clt -> Int_comp (Naked_int32, Yielding_bool (Lt signed))
+  | Pint32, Cgt -> Int_comp (Naked_int32, Yielding_bool (Gt signed))
+  | Pint32, Cle -> Int_comp (Naked_int32, Yielding_bool (Le signed))
+  | Pint32, Cge -> Int_comp (Naked_int32, Yielding_bool (Ge signed))
   | Pint64, Ceq -> Int_comp (Naked_int64, Yielding_bool Eq)
   | Pint64, Cne -> Int_comp (Naked_int64, Yielding_bool Neq)
-  | Pint64, Clt -> Int_comp (Naked_int64, Yielding_bool (Lt Signed))
-  | Pint64, Cgt -> Int_comp (Naked_int64, Yielding_bool (Gt Signed))
-  | Pint64, Cle -> Int_comp (Naked_int64, Yielding_bool (Le Signed))
-  | Pint64, Cge -> Int_comp (Naked_int64, Yielding_bool (Ge Signed))
+  | Pint64, Clt -> Int_comp (Naked_int64, Yielding_bool (Lt signed))
+  | Pint64, Cgt -> Int_comp (Naked_int64, Yielding_bool (Gt signed))
+  | Pint64, Cle -> Int_comp (Naked_int64, Yielding_bool (Le signed))
+  | Pint64, Cge -> Int_comp (Naked_int64, Yielding_bool (Ge signed))
   | Pnativeint, Ceq -> Int_comp (Naked_nativeint, Yielding_bool Eq)
   | Pnativeint, Cne -> Int_comp (Naked_nativeint, Yielding_bool Neq)
-  | Pnativeint, Clt -> Int_comp (Naked_nativeint, Yielding_bool (Lt Signed))
-  | Pnativeint, Cgt -> Int_comp (Naked_nativeint, Yielding_bool (Gt Signed))
-  | Pnativeint, Cle -> Int_comp (Naked_nativeint, Yielding_bool (Le Signed))
-  | Pnativeint, Cge -> Int_comp (Naked_nativeint, Yielding_bool (Ge Signed))
+  | Pnativeint, Clt -> Int_comp (Naked_nativeint, Yielding_bool (Lt signed))
+  | Pnativeint, Cgt -> Int_comp (Naked_nativeint, Yielding_bool (Gt signed))
+  | Pnativeint, Cle -> Int_comp (Naked_nativeint, Yielding_bool (Le signed))
+  | Pnativeint, Cge -> Int_comp (Naked_nativeint, Yielding_bool (Ge signed))
 
 let convert_float_comparison (comp : L.float_comparison) : unit P.comparison =
   match comp with
@@ -1097,17 +1102,17 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
   | Pasrint, [[arg1]; [arg2]] ->
     [Binary (Int_shift (I.Tagged_immediate, Asr), arg1, untag_int arg2)]
   | Pnot, [[arg]] -> [Unary (Boolean_not, arg)]
-  | Pintcomp comp, [[arg1]; [arg2]] ->
-    [tag_int (Binary (convert_integer_comparison_prim comp, arg1, arg2))]
-  | Pbintcomp (kind, comp), [[arg1]; [arg2]] ->
+  | Pintcomp { comp; signed }, [[arg1]; [arg2]] ->
+    [tag_int (Binary (convert_integer_comparison_prim comp signed, arg1, arg2))]
+  | Pbintcomp { size = kind; comp; signed }, [[arg1]; [arg2]] ->
     let arg1 = unbox_bint kind arg1 in
     let arg2 = unbox_bint kind arg2 in
     [ tag_int
-        (Binary (convert_boxed_integer_comparison_prim kind comp, arg1, arg2))
+        (Binary (convert_boxed_integer_comparison_prim kind comp signed, arg1, arg2))
     ]
-  | Punboxed_int_comp (kind, comp), [[arg1]; [arg2]] ->
+  | Punboxed_int_comp { size = kind; comp; signed }, [[arg1]; [arg2]] ->
     [ tag_int
-        (Binary (convert_boxed_integer_comparison_prim kind comp, arg1, arg2))
+        (Binary (convert_boxed_integer_comparison_prim kind comp signed, arg1, arg2))
     ]
   | Pfloatoffloat32 mode, [[arg]] ->
     let src = K.Standard_int_or_float.Naked_float32 in
@@ -1896,11 +1901,12 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
   | Punboxed_int32_array_set_128 { unsafe }, [[array]; [index]; [new_value]] ->
     [ array_like_set_128 ~dbg ~size_int ~unsafe Naked_int32s array index
         new_value ]
-  | Pcompare_ints, [[i1]; [i2]] ->
+  | Pcompare_ints { signed }, [[i1]; [i2]] ->
+    let signed = convert_signed signed in
     [ tag_int
         (Binary
            ( Int_comp
-               (Tagged_immediate, Yielding_int_like_compare_functions Signed),
+               (Tagged_immediate, Yielding_int_like_compare_functions signed),
              i1,
              i2 )) ]
   | Pcompare_floats Pfloat64, [[f1]; [f2]] ->
@@ -1915,13 +1921,14 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
            ( Float_comp (Float32, Yielding_int_like_compare_functions ()),
              Prim (Unary (Unbox_number Naked_float32, f1)),
              Prim (Unary (Unbox_number Naked_float32, f2)) )) ]
-  | Pcompare_bints int_kind, [[i1]; [i2]] ->
+  | Pcompare_bints { size = int_kind; signed }, [[i1]; [i2]] ->
     let unboxing_kind = boxable_number_of_boxed_integer int_kind in
+    let signed = convert_signed signed in
     [ tag_int
         (Binary
            ( Int_comp
                ( standard_int_of_boxed_integer int_kind,
-                 Yielding_int_like_compare_functions Signed ),
+                 Yielding_int_like_compare_functions signed ),
              Prim (Unary (Unbox_number unboxing_kind, i1)),
              Prim (Unary (Unbox_number unboxing_kind, i2)) )) ]
   | Pprobe_is_enabled { name }, [] ->
@@ -2021,7 +2028,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
             | Pfloatarray_ref _ | Punboxedfloatarray_ref _
             | Punboxedintarray_ref _ ),
             _ )
-      | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _ | Patomic_exchange
+      | Pcompare_ints _ | Pcompare_floats _ | Pcompare_bints _ | Patomic_exchange
       | Patomic_fetch_add ),
       ( []
       | [_]

--- a/ocaml/bytecomp/bytegen.ml
+++ b/ocaml/bytecomp/bytegen.ml
@@ -132,7 +132,7 @@ let preserve_tailcall_for_prim = function
   | Paddfloat (_, _) | Psubfloat (_, _) | Pmulfloat (_, _)
   | Pdivfloat (_, _) | Pfloatcomp (_, _) | Punboxed_float_comp (_, _)
   | Pstringlength | Pstringrefu  | Pstringrefs
-  | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _
+  | Pcompare_ints _ | Pcompare_floats _ | Pcompare_bints _
   | Pbyteslength | Pbytesrefu | Pbytessetu | Pbytesrefs | Pbytessets
   | Pmakearray _ | Pduparray _ | Parraylength _ | Parrayrefu _ | Parraysetu _
   | Parrayrefs _ | Parraysets _ | Pisint _ | Pisout | Pbintofint _ | Pintofbint _
@@ -375,11 +375,25 @@ let comp_primitive stack_info p sz args =
   | Psetglobal cu ->
       Ksetglobal (cu |> Compilation_unit.to_global_ident_for_bytecode)
   | Pgetpredef id -> Kgetglobal id
-  | Pintcomp cmp -> Kintcomp cmp
-  | Pcompare_ints -> Kccall("caml_int_compare", 2)
+  | Pintcomp { comp = cmp; signed = true } -> Kintcomp cmp
+  | Pintcomp { comp = (Ceq|Cne); signed = false } ->
+    Misc.fatal_error "Pintcomp: unsigned equal and not_equal are not supported."
+  | Pintcomp { comp = Clt; signed = false } ->
+    Kccall("caml_int_lessthan_unsigned", 2)
+  | Pintcomp { comp = Cgt; signed = false } ->
+    Kccall("caml_int_greaterthan_unsigned", 2)
+  | Pintcomp { comp = Cle; signed = false } ->
+    Kccall("caml_int_lessequal_unsigned", 2)
+  | Pintcomp { comp = Cge; signed = false } ->
+    Kccall("caml_int_greaterequal_unsigned", 2)
+  | Pcompare_ints { signed = true } -> Kccall("caml_int_compare", 2)
+  | Pcompare_ints { signed = false } -> Kccall("caml_int_compare_unsigned", 2)
   | Pcompare_floats Pfloat64 -> Kccall("caml_float_compare", 2)
   | Pcompare_floats Pfloat32 -> Kccall("caml_float32_compare", 2)
-  | Pcompare_bints bi -> comp_bint_primitive bi "compare" args
+  | Pcompare_bints { size = bi; signed = true } ->
+    comp_bint_primitive bi "compare" args
+  | Pcompare_bints { size = bi; signed = false } ->
+    comp_bint_primitive bi "compare_unsigned" args
   | Pfield (n, _ptr, _sem) -> Kgetfield n
   | Pfield_computed _sem -> Kgetvectitem
   | Psetfield(n, _ptr, _init) -> Ksetfield n
@@ -540,12 +554,40 @@ let comp_primitive stack_info p sz args =
   | Plslbint(bi,_) -> comp_bint_primitive bi "shift_left" args
   | Plsrbint(bi,_) -> comp_bint_primitive bi "shift_right_unsigned" args
   | Pasrbint(bi,_) -> comp_bint_primitive bi "shift_right" args
-  | Pbintcomp(_, Ceq) | Punboxed_int_comp(_, Ceq) -> Kccall("caml_equal", 2)
-  | Pbintcomp(_, Cne) | Punboxed_int_comp(_, Cne) -> Kccall("caml_notequal", 2)
-  | Pbintcomp(_, Clt) | Punboxed_int_comp(_, Clt) -> Kccall("caml_lessthan", 2)
-  | Pbintcomp(_, Cgt) | Punboxed_int_comp(_, Cgt) -> Kccall("caml_greaterthan", 2)
-  | Pbintcomp(_, Cle) | Punboxed_int_comp(_, Cle) -> Kccall("caml_lessequal", 2)
-  | Pbintcomp(_, Cge) | Punboxed_int_comp(_, Cge) -> Kccall("caml_greaterequal", 2)
+  | Pbintcomp { size =_; signed = _; comp = Ceq }
+  | Punboxed_int_comp { size =_; signed = _; comp = Ceq} ->
+    Kccall("caml_equal", 2)
+  | Pbintcomp { size = _; signed = _; comp = Cne }
+  | Punboxed_int_comp { size = _; signed = _; comp = Cne } ->
+    Kccall("caml_notequal", 2)
+  | Pbintcomp { size = _; signed = true; comp = Clt }
+  | Punboxed_int_comp { size = _; signed = true; comp = Clt } ->
+    Kccall("caml_lessthan", 2)
+  | Pbintcomp { size = _; signed = true; comp = Cgt }
+  | Punboxed_int_comp { size = _; signed = true; comp = Cgt } ->
+    Kccall("caml_greaterthan", 2)
+  | Pbintcomp { size = _; signed = true; comp = Cle }
+  | Punboxed_int_comp { size = _; signed = true; comp = Cle } ->
+    Kccall("caml_lessequal", 2)
+  | Pbintcomp { size = _; signed = true; comp = Cge }
+  | Punboxed_int_comp { size = _; signed = true; comp = Cge } ->
+    Kccall("caml_greaterequal", 2)
+  | Pbintcomp { size = bi; signed = false; comp = Clt } ->
+    comp_bint_primitive bi "lessthan_unsigned" args
+  | Punboxed_int_comp { size = bi; signed = false; comp = Clt } ->
+    comp_bint_primitive bi "lessthan_unsigned_unboxed" args
+  | Pbintcomp { size = bi; signed = false; comp = Cgt } ->
+    comp_bint_primitive bi "greaterthan_unsigned" args
+  | Punboxed_int_comp { size = bi; signed = false; comp = Cgt } ->
+    comp_bint_primitive bi "greaterthan_unsigned_unboxed" args
+  | Pbintcomp { size = bi; signed = false; comp = Cle } ->
+    comp_bint_primitive bi "lessequal_unsigned" args
+  | Punboxed_int_comp { size = bi; signed = false; comp = Cle } ->
+    comp_bint_primitive bi "lessequal_unsigned_unboxed" args
+  | Pbintcomp { size = bi; signed = false; comp = Cge } ->
+    comp_bint_primitive bi "greaterqual_unsigned" args
+  | Punboxed_int_comp { size = bi; signed = false; comp = Cge } ->
+    comp_bint_primitive bi "greaterequal_unsigned_unboxed" args
   | Pbigarrayref(_, n, Pbigarray_float32_t, _) -> Kccall("caml_ba_float32_get_" ^ Int.to_string n, n + 1)
   | Pbigarrayset(_, n, Pbigarray_float32_t, _) -> Kccall("caml_ba_float32_set_" ^ Int.to_string n, n + 2)
   | Pbigarrayref(_, n, _, _) -> Kccall("caml_ba_get_" ^ Int.to_string n, n + 1)
@@ -860,8 +902,8 @@ let rec comp_expr stack_info env exp sz cont =
   | Lprim (Pduparray _, _, _) ->
       Misc.fatal_error "Bytegen.comp_expr: Pduparray takes exactly one arg"
 (* Integer first for enabling further optimization (cf. emitcode.ml)  *)
-  | Lprim (Pintcomp c, [arg ; (Lconst _ as k)], _) ->
-      let p = Pintcomp (swap_integer_comparison c)
+  | Lprim (Pintcomp { comp=c; signed }, [arg ; (Lconst _ as k)], _) ->
+      let p = Pintcomp { comp = (swap_integer_comparison c); signed }
       and args = [k ; arg] in
       let nargs = List.length args - 1 in
       comp_args stack_info env args sz

--- a/ocaml/lambda/lambda.ml
+++ b/ocaml/lambda/lambda.ml
@@ -178,10 +178,10 @@ type primitive =
   | Pdivint of is_safe | Pmodint of is_safe
   | Pandint | Porint | Pxorint
   | Plslint | Plsrint | Pasrint
-  | Pintcomp of integer_comparison
-  | Pcompare_ints
+  | Pintcomp of { comp : integer_comparison; signed : bool }
+  | Pcompare_ints of { signed : bool }
   | Pcompare_floats of boxed_float
-  | Pcompare_bints of boxed_integer
+  | Pcompare_bints of { size : boxed_integer ; signed : bool }
   | Poffsetint of int
   | Poffsetref of int
   (* Float operations *)
@@ -229,8 +229,10 @@ type primitive =
   | Plslbint of boxed_integer * alloc_mode
   | Plsrbint of boxed_integer * alloc_mode
   | Pasrbint of boxed_integer * alloc_mode
-  | Pbintcomp of boxed_integer * integer_comparison
-  | Punboxed_int_comp of unboxed_integer * integer_comparison
+  | Pbintcomp of { size : boxed_integer; comp : integer_comparison;
+                   signed : bool }
+  | Punboxed_int_comp of { size : unboxed_integer; comp : integer_comparison;
+                           signed : bool }
   (* Operations on Bigarrays: (unsafe, #dimensions, kind, layout) *)
   | Pbigarrayref of bool * int * bigarray_kind * bigarray_layout
   | Pbigarrayset of bool * int * bigarray_kind * bigarray_layout
@@ -1715,7 +1717,7 @@ let primitive_may_allocate : primitive -> alloc_mode option = function
   | Pandint | Porint | Pxorint
   | Plslint | Plsrint | Pasrint
   | Pintcomp _
-  | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _
+  | Pcompare_ints _ | Pcompare_floats _ | Pcompare_bints _
   | Poffsetint _
   | Poffsetref _ -> None
   | Pintoffloat _ -> None
@@ -1917,7 +1919,7 @@ let primitive_result_layout (p : primitive) =
   | Pandint | Porint | Pxorint
   | Plslint | Plsrint | Pasrint
   | Pintcomp _
-  | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _
+  | Pcompare_ints _ | Pcompare_floats _ | Pcompare_bints _
   | Poffsetint _ | Pintoffloat _
   | Pfloatcomp (_, _) | Punboxed_float_comp (_, _)
   | Pstringlength | Pstringrefu | Pstringrefs

--- a/ocaml/lambda/lambda.mli
+++ b/ocaml/lambda/lambda.mli
@@ -159,11 +159,11 @@ type primitive =
   | Pdivint of is_safe | Pmodint of is_safe
   | Pandint | Porint | Pxorint
   | Plslint | Plsrint | Pasrint
-  | Pintcomp of integer_comparison
+  | Pintcomp of { comp : integer_comparison; signed : bool }
   (* Comparisons that return int (not bool like above) for ordering *)
-  | Pcompare_ints
+  | Pcompare_ints of { signed : bool }
   | Pcompare_floats of boxed_float
-  | Pcompare_bints of boxed_integer
+  | Pcompare_bints of { size : boxed_integer; signed : bool }
   | Poffsetint of int
   | Poffsetref of int
   (* Float operations *)
@@ -214,8 +214,10 @@ type primitive =
   | Plslbint of boxed_integer * alloc_mode
   | Plsrbint of boxed_integer * alloc_mode
   | Pasrbint of boxed_integer * alloc_mode
-  | Pbintcomp of boxed_integer * integer_comparison
-  | Punboxed_int_comp of unboxed_integer * integer_comparison
+  | Pbintcomp of { size : boxed_integer; comp : integer_comparison;
+                   signed : bool }
+  | Punboxed_int_comp of { size : unboxed_integer; comp : integer_comparison;
+                           signed : bool }
   (* Operations on Bigarrays: (unsafe, #dimensions, kind, layout) *)
   | Pbigarrayref of bool * int * bigarray_kind * bigarray_layout
   | Pbigarrayset of bool * int * bigarray_kind * bigarray_layout

--- a/ocaml/lambda/tmc.ml
+++ b/ocaml/lambda/tmc.ml
@@ -899,7 +899,7 @@ let rec choice ctx t =
     | Parraylength _ | Parrayrefu _ | Parraysetu _ | Parrayrefs _ | Parraysets _
     | Pisint _ | Pisout
     | Pignore
-    | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _
+    | Pcompare_ints _ | Pcompare_floats _ | Pcompare_bints _
     | Preinterpret_tagged_int63_as_unboxed_int64
     | Preinterpret_unboxed_int64_as_tagged_int63
 

--- a/ocaml/lambda/transl_comprehension_utils.ml
+++ b/ocaml/lambda/transl_comprehension_utils.ml
@@ -122,17 +122,17 @@ module Lambda_utils = struct
 
       let ( / ) = binop (Pdivint Unsafe)
 
-      let ( = ) = binop (Pintcomp Ceq)
+      let ( = ) = binop (Pintcomp { comp = Ceq; signed = true } )
 
-      let ( <> ) = binop (Pintcomp Cne)
+      let ( <> ) = binop (Pintcomp { comp = Cne; signed = true })
 
-      let ( < ) = binop (Pintcomp Clt)
+      let ( < ) = binop (Pintcomp { comp = Clt; signed = true })
 
-      let ( > ) = binop (Pintcomp Cgt)
+      let ( > ) = binop (Pintcomp { comp = Cgt; signed = true })
 
-      let ( <= ) = binop (Pintcomp Cle)
+      let ( <= ) = binop (Pintcomp { comp = Cle; signed = true })
 
-      let ( >= ) = binop (Pintcomp Cge)
+      let ( >= ) = binop (Pintcomp { comp = Cge; signed = true })
 
       let ( && ) = binop Psequor
 

--- a/ocaml/lambda/translprim.mli
+++ b/ocaml/lambda/translprim.mli
@@ -64,6 +64,7 @@ type error =
   | Unknown_builtin_primitive of string
   | Wrong_arity_builtin_primitive of string
   | Invalid_floatarray_glb
+  | Unsigned_primitive_not_supported of string
 
 exception Error of Location.t * error
 

--- a/ocaml/lambda/value_rec_compiler.ml
+++ b/ocaml/lambda/value_rec_compiler.ml
@@ -293,7 +293,7 @@ let compute_static_size lam =
     | Pandint | Porint | Pxorint
     | Plslint | Plsrint | Pasrint
     | Pintcomp _
-    | Pcompare_ints | Pcompare_floats _ | Pcompare_bints _
+    | Pcompare_ints _ | Pcompare_floats _ | Pcompare_bints _
     | Pintoffloat _ | Pfloatofint _
     | Pnegfloat _ | Pabsfloat _
     | Paddfloat _ | Psubfloat _ | Pmulfloat _ | Pdivfloat _
@@ -375,7 +375,7 @@ let compute_static_size lam =
     | Pufloatfield (_, _)
     | Punboxed_product_field (_, _)
     | Punboxed_float_comp (_, _)
-    | Punboxed_int_comp (_, _)
+    | Punboxed_int_comp _
     | Pstring_load_128 _
     | Pbytes_load_128 _
     | Pbigstring_load_128 _

--- a/ocaml/runtime/ints.c
+++ b/ocaml/runtime/ints.c
@@ -134,6 +134,11 @@ CAMLprim value caml_int_compare(value v1, value v2)
   return Val_long(COMPARE_INT(v1, v2));
 }
 
+CAMLprim value caml_int_compare_unsigned(value v1, value v2)
+{
+  return Val_long(COMPARE_INT((uintnat)v1, (uintnat)v2));
+}
+
 CAMLprim value caml_int_of_string(value s)
 {
     return Val_long(parse_intnat(s, 8 * sizeof(value) - 1, INT_ERRMSG));
@@ -325,6 +330,17 @@ CAMLprim value caml_int32_compare(value v1, value v2)
 {
   return Val_int(caml_int32_compare_unboxed(Int32_val(v1),Int32_val(v2)));
 }
+
+intnat caml_int32_compare_unsigned_unboxed(int32_t i1, int32_t i2)
+{
+  return COMPARE_INT((uint32_t)i1, (uint32_t)i2);
+}
+
+CAMLprim value caml_int32_compare_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int32_compare_unsigned_unboxed(Int32_val(v1),Int32_val(v2)));
+}
+
 
 CAMLprim value caml_int32_format(value fmt, value arg)
 {
@@ -577,6 +593,16 @@ intnat caml_int64_compare_unboxed(int64_t i1, int64_t i2)
 CAMLprim value caml_int64_compare(value v1, value v2)
 {
   return Val_int(caml_int64_compare_unboxed(Int64_val(v1),Int64_val(v2)));
+}
+
+intnat caml_int64_compare_unsigned_unboxed(int64_t i1, int64_t i2)
+{
+  return COMPARE_INT((uint64_t)i1, (uint64_t)i2);
+}
+
+CAMLprim value caml_int64_compare_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int64_compare_unsigned_unboxed(Int64_val(v1),Int64_val(v2)));
 }
 
 CAMLprim value caml_int64_format(value fmt, value arg)
@@ -847,6 +873,17 @@ CAMLprim value caml_nativeint_compare(value v1, value v2)
                                                 Nativeint_val(v2)));
 }
 
+intnat caml_nativeint_compare_unsigned_unboxed(intnat i1, intnat i2)
+{
+  return COMPARE_INT((uintnat)i1, (uintnat)i2);
+}
+
+CAMLprim value caml_nativeint_compare_unsigned(value v1, value v2)
+{
+  return Val_int(caml_nativeint_compare_unsigned_unboxed(Nativeint_val(v1),
+                                                Nativeint_val(v2)));
+}
+
 CAMLprim value caml_nativeint_format(value fmt, value arg)
 {
   char format_string[FORMAT_BUFFER_SIZE];
@@ -884,4 +921,160 @@ CAMLprim value caml_reinterpret_unboxed_int64_as_tagged_int63(value i)
   CAMLassert(Is_block(i));
   CAMLassert(Tag_val(i) == Custom_tag);
   return (value) (Int64_val(i) | 1L);
+}
+
+CAMLprim value caml_int_lessthan_unsigned(value v1, value v2)
+{
+  intnat res = COMPARE_INT((uintnat)v1, (uintnat)v2);
+  return Val_int(res < 0);
+}
+
+CAMLprim value caml_int_lessequal_unsigned(value v1, value v2)
+{
+  intnat res = COMPARE_INT((uintnat)v1, (uintnat)v2);
+  return Val_int(res <= 0);
+}
+
+CAMLprim value caml_greaterthan_unsigned(value v1, value v2)
+{
+  intnat res = COMPARE_INT((uintnat)v1, (uintnat)v2);
+  return Val_int(res > 0);
+}
+
+CAMLprim value caml_greaterequal_unsigned(value v1, value v2)
+{
+  intnat res = COMPARE_INT((uintnat)v1, (uintnat)v2);
+  return Val_int(res >= 0);
+}
+
+intnat caml_int64_lessthan_unsigned_unboxed(int64_t i1, int64_t i2)
+{
+  intnat res = caml_int64_compare_unsigned_unboxed((uint64_t)i1, (uint64_t)i2);
+  return Val_int(res < 0);
+}
+
+intnat caml_int64_lessequal_unsigned_unboxed(int64_t i1, int64_t i2)
+{
+  intnat res = caml_int64_compare_unsigned_unboxed((uint64_t)i1, (uint64_t)i2);
+  return Val_int(res <= 0);
+}
+
+intnat caml_int64_greaterthan_unsigned_unboxed(int64_t i1, int64_t i2)
+{
+  intnat res = caml_int64_compare_unsigned_unboxed((uint64_t)i1, (uint64_t)i2);
+  return Val_int(res > 0);
+}
+
+intnat caml_int64_greaterequal_unsigned_unboxed(int64_t i1, int64_t i2)
+{
+  intnat res = caml_int64_compare_unsigned_unboxed((uint64_t)i1, (uint64_t)i2);
+  return Val_int(res >= 0);
+}
+
+CAMLprim value caml_int64_lessthan_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int64_lessthan_unsigned_unboxed(Int64_val(v1),Int64_val(v2)));
+}
+
+CAMLprim value caml_int64_lessequal_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int64_lessequal_unsigned_unboxed(Int64_val(v1),Int64_val(v2)));
+}
+
+CAMLprim value caml_int64_greaterthan_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int64_greaterthan_unsigned_unboxed(Int64_val(v1),Int64_val(v2)));
+}
+
+CAMLprim value caml_int64_greaterequal_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int64_greaterequal_unsigned_unboxed(Int64_val(v1),Int64_val(v2)));
+}
+
+intnat caml_int32_lessthan_unsigned_unboxed(int32_t i1, int32_t i2)
+{
+  intnat res = caml_int32_compare_unsigned_unboxed((uint32_t)i1, (uint32_t)i2);
+  return Val_int(res < 0);
+}
+
+intnat caml_int32_lessequal_unsigned_unboxed(int32_t i1, int32_t i2)
+{
+  intnat res = caml_int32_compare_unsigned_unboxed((uint32_t)i1, (uint32_t)i2);
+  return Val_int(res <= 0);
+}
+
+intnat caml_int32_greaterthan_unsigned_unboxed(int32_t i1, int32_t i2)
+{
+  intnat res = caml_int32_compare_unsigned_unboxed((uint32_t)i1, (uint32_t)i2);
+  return Val_int(res > 0);
+}
+
+intnat caml_int32_greaterequal_unsigned_unboxed(int32_t i1, int32_t i2)
+{
+  intnat res = caml_int32_compare_unsigned_unboxed((uint32_t)i1, (uint32_t)i2);
+  return Val_int(res >= 0);
+}
+
+CAMLprim value caml_int32_lessthan_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int32_lessthan_unsigned_unboxed(Int32_val(v1),Int32_val(v2)));
+}
+
+CAMLprim value caml_int32_lessequal_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int32_lessequal_unsigned_unboxed(Int32_val(v1),Int32_val(v2)));
+}
+
+CAMLprim value caml_int32_greaterthan_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int32_greaterthan_unsigned_unboxed(Int32_val(v1),Int32_val(v2)));
+}
+
+CAMLprim value caml_int32_greaterequal_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int32_greaterequal_unsigned_unboxed(Int32_val(v1),Int32_val(v2)));
+}
+
+intnat caml_nativeint_lessthan_unsigned_unboxed(intnat i1, intnat i2)
+{
+  intnat res = caml_nativeint_compare_unsigned_unboxed((uintnat)i1, (uintnat)i2);
+  return Val_int(res < 0);
+}
+
+intnat caml_nativeint_lessequal_unsigned_unboxed(intnat i1, intnat i2)
+{
+  intnat res = caml_nativeint_compare_unsigned_unboxed((uintnat)i1, (uintnat)i2);
+  return Val_int(res <= 0);
+}
+
+intnat caml_nativeint_greaterthan_unsigned_unboxed(intnat i1, intnat i2)
+{
+  intnat res = caml_nativeint_compare_unsigned_unboxed((uintnat)i1, (uintnat)i2);
+  return Val_int(res > 0);
+}
+
+intnat caml_nativeint_greaterequal_unsigned_unboxed(intnat i1, intnat i2)
+{
+  intnat res = caml_nativeint_compare_unsigned_unboxed((uintnat)i1, (uintnat)i2);
+  return Val_int(res >= 0);
+}
+
+CAMLprim value caml_nativeint_lessthan_unsigned(value v1, value v2)
+{
+  return Val_int(caml_nativeint_lessthan_unsigned_unboxed(Nativeint_val(v1),Nativeint_val(v2)));
+}
+
+CAMLprim value caml_nativeint_lessequal_unsigned(value v1, value v2)
+{
+  return Val_int(caml_nativeint_lessequal_unsigned_unboxed(Nativeint_val(v1),Nativeint_val(v2)));
+}
+
+CAMLprim value caml_nativeint_greaterthan_unsigned(value v1, value v2)
+{
+  return Val_int(caml_nativeint_greaterthan_unsigned_unboxed(Nativeint_val(v1),Nativeint_val(v2)));
+}
+
+CAMLprim value caml_nativeint_greaterequal_unsigned(value v1, value v2)
+{
+  return Val_int(caml_nativeint_greaterequal_unsigned_unboxed(Nativeint_val(v1),Nativeint_val(v2)));
 }

--- a/ocaml/runtime4/ints.c
+++ b/ocaml/runtime4/ints.c
@@ -134,6 +134,11 @@ CAMLprim value caml_int_compare(value v1, value v2)
   return Val_long(COMPARE_INT(v1, v2));
 }
 
+CAMLprim value caml_int_compare_unsigned(value v1, value v2)
+{
+  return Val_long(COMPARE_INT((uintnat)v1, (uintnat)v2));
+}
+
 CAMLprim value caml_int_of_string(value s)
 {
     return Val_long(parse_intnat(s, 8 * sizeof(value) - 1, INT_ERRMSG));
@@ -325,6 +330,17 @@ CAMLprim value caml_int32_compare(value v1, value v2)
 {
   return Val_int(caml_int32_compare_unboxed(Int32_val(v1),Int32_val(v2)));
 }
+
+intnat caml_int32_compare_unsigned_unboxed(int32_t i1, int32_t i2)
+{
+  return COMPARE_INT((uint32_t)i1, (uint32_t)i2);
+}
+
+CAMLprim value caml_int32_compare_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int32_compare_unsigned_unboxed(Int32_val(v1),Int32_val(v2)));
+}
+
 
 CAMLprim value caml_int32_format(value fmt, value arg)
 {
@@ -577,6 +593,16 @@ intnat caml_int64_compare_unboxed(int64_t i1, int64_t i2)
 CAMLprim value caml_int64_compare(value v1, value v2)
 {
   return Val_int(caml_int64_compare_unboxed(Int64_val(v1),Int64_val(v2)));
+}
+
+intnat caml_int64_compare_unsigned_unboxed(int64_t i1, int64_t i2)
+{
+  return COMPARE_INT((uint64_t)i1, (uint64_t)i2);
+}
+
+CAMLprim value caml_int64_compare_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int64_compare_unsigned_unboxed(Int64_val(v1),Int64_val(v2)));
 }
 
 CAMLprim value caml_int64_format(value fmt, value arg)
@@ -847,6 +873,17 @@ CAMLprim value caml_nativeint_compare(value v1, value v2)
                                                 Nativeint_val(v2)));
 }
 
+intnat caml_nativeint_compare_unsigned_unboxed(intnat i1, intnat i2)
+{
+  return COMPARE_INT((uintnat)i1, (uintnat)i2);
+}
+
+CAMLprim value caml_nativeint_compare_unsigned(value v1, value v2)
+{
+  return Val_int(caml_nativeint_compare_unsigned_unboxed(Nativeint_val(v1),
+                                                Nativeint_val(v2)));
+}
+
 CAMLprim value caml_nativeint_format(value fmt, value arg)
 {
   char format_string[FORMAT_BUFFER_SIZE];
@@ -884,4 +921,160 @@ CAMLprim value caml_reinterpret_unboxed_int64_as_tagged_int63(value i)
   CAMLassert(Is_block(i));
   CAMLassert(Tag_val(i) == Custom_tag);
   return (value) (Int64_val(i) | 1L);
+}
+
+CAMLprim value caml_int_lessthan_unsigned(value v1, value v2)
+{
+  intnat res = COMPARE_INT((uintnat)v1, (uintnat)v2);
+  return Val_int(res < 0);
+}
+
+CAMLprim value caml_int_lessequal_unsigned(value v1, value v2)
+{
+  intnat res = COMPARE_INT((uintnat)v1, (uintnat)v2);
+  return Val_int(res <= 0);
+}
+
+CAMLprim value caml_greaterthan_unsigned(value v1, value v2)
+{
+  intnat res = COMPARE_INT((uintnat)v1, (uintnat)v2);
+  return Val_int(res > 0);
+}
+
+CAMLprim value caml_greaterequal_unsigned(value v1, value v2)
+{
+  intnat res = COMPARE_INT((uintnat)v1, (uintnat)v2);
+  return Val_int(res >= 0);
+}
+
+intnat caml_int64_lessthan_unsigned_unboxed(int64_t i1, int64_t i2)
+{
+  intnat res = caml_int64_compare_unsigned_unboxed((uint64_t)i1, (uint64_t)i2);
+  return Val_int(res < 0);
+}
+
+intnat caml_int64_lessequal_unsigned_unboxed(int64_t i1, int64_t i2)
+{
+  intnat res = caml_int64_compare_unsigned_unboxed((uint64_t)i1, (uint64_t)i2);
+  return Val_int(res <= 0);
+}
+
+intnat caml_int64_greaterthan_unsigned_unboxed(int64_t i1, int64_t i2)
+{
+  intnat res = caml_int64_compare_unsigned_unboxed((uint64_t)i1, (uint64_t)i2);
+  return Val_int(res > 0);
+}
+
+intnat caml_int64_greaterequal_unsigned_unboxed(int64_t i1, int64_t i2)
+{
+  intnat res = caml_int64_compare_unsigned_unboxed((uint64_t)i1, (uint64_t)i2);
+  return Val_int(res >= 0);
+}
+
+CAMLprim value caml_int64_lessthan_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int64_lessthan_unsigned_unboxed(Int64_val(v1),Int64_val(v2)));
+}
+
+CAMLprim value caml_int64_lessequal_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int64_lessequal_unsigned_unboxed(Int64_val(v1),Int64_val(v2)));
+}
+
+CAMLprim value caml_int64_greaterthan_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int64_greaterthan_unsigned_unboxed(Int64_val(v1),Int64_val(v2)));
+}
+
+CAMLprim value caml_int64_greaterequal_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int64_greaterequal_unsigned_unboxed(Int64_val(v1),Int64_val(v2)));
+}
+
+intnat caml_int32_lessthan_unsigned_unboxed(int32_t i1, int32_t i2)
+{
+  intnat res = caml_int32_compare_unsigned_unboxed((uint32_t)i1, (uint32_t)i2);
+  return Val_int(res < 0);
+}
+
+intnat caml_int32_lessequal_unsigned_unboxed(int32_t i1, int32_t i2)
+{
+  intnat res = caml_int32_compare_unsigned_unboxed((uint32_t)i1, (uint32_t)i2);
+  return Val_int(res <= 0);
+}
+
+intnat caml_int32_greaterthan_unsigned_unboxed(int32_t i1, int32_t i2)
+{
+  intnat res = caml_int32_compare_unsigned_unboxed((uint32_t)i1, (uint32_t)i2);
+  return Val_int(res > 0);
+}
+
+intnat caml_int32_greaterequal_unsigned_unboxed(int32_t i1, int32_t i2)
+{
+  intnat res = caml_int32_compare_unsigned_unboxed((uint32_t)i1, (uint32_t)i2);
+  return Val_int(res >= 0);
+}
+
+CAMLprim value caml_int32_lessthan_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int32_lessthan_unsigned_unboxed(Int32_val(v1),Int32_val(v2)));
+}
+
+CAMLprim value caml_int32_lessequal_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int32_lessequal_unsigned_unboxed(Int32_val(v1),Int32_val(v2)));
+}
+
+CAMLprim value caml_int32_greaterthan_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int32_greaterthan_unsigned_unboxed(Int32_val(v1),Int32_val(v2)));
+}
+
+CAMLprim value caml_int32_greaterequal_unsigned(value v1, value v2)
+{
+  return Val_int(caml_int32_greaterequal_unsigned_unboxed(Int32_val(v1),Int32_val(v2)));
+}
+
+intnat caml_nativeint_lessthan_unsigned_unboxed(intnat i1, intnat i2)
+{
+  intnat res = caml_nativeint_compare_unsigned_unboxed((uintnat)i1, (uintnat)i2);
+  return Val_int(res < 0);
+}
+
+intnat caml_nativeint_lessequal_unsigned_unboxed(intnat i1, intnat i2)
+{
+  intnat res = caml_nativeint_compare_unsigned_unboxed((uintnat)i1, (uintnat)i2);
+  return Val_int(res <= 0);
+}
+
+intnat caml_nativeint_greaterthan_unsigned_unboxed(intnat i1, intnat i2)
+{
+  intnat res = caml_nativeint_compare_unsigned_unboxed((uintnat)i1, (uintnat)i2);
+  return Val_int(res > 0);
+}
+
+intnat caml_nativeint_greaterequal_unsigned_unboxed(intnat i1, intnat i2)
+{
+  intnat res = caml_nativeint_compare_unsigned_unboxed((uintnat)i1, (uintnat)i2);
+  return Val_int(res >= 0);
+}
+
+CAMLprim value caml_nativeint_lessthan_unsigned(value v1, value v2)
+{
+  return Val_int(caml_nativeint_lessthan_unsigned_unboxed(Nativeint_val(v1),Nativeint_val(v2)));
+}
+
+CAMLprim value caml_nativeint_lessequal_unsigned(value v1, value v2)
+{
+  return Val_int(caml_nativeint_lessequal_unsigned_unboxed(Nativeint_val(v1),Nativeint_val(v2)));
+}
+
+CAMLprim value caml_nativeint_greaterthan_unsigned(value v1, value v2)
+{
+  return Val_int(caml_nativeint_greaterthan_unsigned_unboxed(Nativeint_val(v1),Nativeint_val(v2)));
+}
+
+CAMLprim value caml_nativeint_greaterequal_unsigned(value v1, value v2)
+{
+  return Val_int(caml_nativeint_greaterequal_unsigned_unboxed(Nativeint_val(v1),Nativeint_val(v2)));
 }


### PR DESCRIPTION
The middle-end/backend can already emit unsigned comparisons. This PR exposes them as the following new builtins to the users: `%lessequal_unsigned` `%lessthan_unsigned` `%greaterequal_unsigned` `%greaterthan_unsigned` and `compare_unsigned` for int and boxed/unboxed int32/int64/nativeint, reusing the existing typed-based translation of compare primitives. 

The main changes are in `Lambda` and `Translprim`. The rest of the PR is refactoring to propagate the signed/unsigned information to the middle end.

This is a draft because it's completely untested.