### PR TITLE
Annotate Cmm.fundecl with only_kept_for_zero_alloc

### DIFF
--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -336,6 +336,7 @@ type fundecl =
     fun_codegen_options : codegen_option list;
     fun_poll: Lambda.poll_attribute;
     fun_dbg : Debuginfo.t;
+    fun_only_kept_for_zero_alloc : bool;
   }
 
 type data_item =

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -343,6 +343,7 @@ type fundecl =
     fun_codegen_options : codegen_option list;
     fun_poll: Lambda.poll_attribute;
     fun_dbg : Debuginfo.t;
+    fun_only_kept_for_zero_alloc : bool;
   }
 
 (** When data items that are less than 64 bits wide occur in blocks, whose

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2807,7 +2807,8 @@ let send_function (arity, result, mode) =
       fun_body = body;
       fun_codegen_options = [];
       fun_dbg;
-      fun_poll = Default_poll
+      fun_poll = Default_poll;
+      fun_only_kept_for_zero_alloc = false
     }
 
 let apply_function (arity, result, mode) =
@@ -2821,7 +2822,8 @@ let apply_function (arity, result, mode) =
       fun_body = body;
       fun_codegen_options = [];
       fun_dbg;
-      fun_poll = Default_poll
+      fun_poll = Default_poll;
+      fun_only_kept_for_zero_alloc = false
     }
 
 (* Generate tuplifying functions:
@@ -2859,7 +2861,8 @@ let tuplify_function arity return =
             dbg () );
       fun_codegen_options = [];
       fun_dbg;
-      fun_poll = Default_poll
+      fun_poll = Default_poll;
+      fun_only_kept_for_zero_alloc = false
     }
 
 (* Generate currying functions:
@@ -3011,7 +3014,8 @@ let final_curry_function nlocal arity result =
           last_clos (narity - 1);
       fun_codegen_options = [];
       fun_dbg;
-      fun_poll = Default_poll
+      fun_poll = Default_poll;
+      fun_only_kept_for_zero_alloc = false
     }
 
 let intermediate_curry_functions ~nlocal ~arity result =
@@ -3071,7 +3075,8 @@ let intermediate_curry_functions ~nlocal ~arity result =
                 dbg () );
           fun_codegen_options = [];
           fun_dbg;
-          fun_poll = Default_poll
+          fun_poll = Default_poll;
+          fun_only_kept_for_zero_alloc = false
         }
       ::
       (if has_nary
@@ -3102,7 +3107,8 @@ let intermediate_curry_functions ~nlocal ~arity result =
                   clos (num + 1);
               fun_codegen_options = [];
               fun_dbg;
-              fun_poll = Default_poll
+              fun_poll = Default_poll;
+              fun_only_kept_for_zero_alloc = false
             }
         in
         [cf]
@@ -3521,7 +3527,8 @@ let entry_point namelist =
         fun_body = Csequence (body, cconst_int 1);
         fun_codegen_options = [Reduce_code_size; Use_linscan_regalloc];
         fun_dbg;
-        fun_poll = Default_poll
+        fun_poll = Default_poll;
+        fun_only_kept_for_zero_alloc = false
       } ]
 
 (* Generate the table of globals *)
@@ -3939,8 +3946,16 @@ let cfunction decl = Cmm.Cfunction decl
 
 let cdata d = Cmm.Cdata d
 
-let fundecl fun_name fun_args fun_body fun_codegen_options fun_dbg fun_poll =
-  { Cmm.fun_name; fun_args; fun_body; fun_codegen_options; fun_dbg; fun_poll }
+let fundecl fun_name fun_args fun_body fun_codegen_options fun_dbg fun_poll
+    ~only_kept_for_zero_alloc =
+  { Cmm.fun_name;
+    fun_args;
+    fun_body;
+    fun_codegen_options;
+    fun_dbg;
+    fun_poll;
+    fun_only_kept_for_zero_alloc = only_kept_for_zero_alloc
+  }
 
 (* Gc root table *)
 

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -940,6 +940,7 @@ val fundecl :
   codegen_option list ->
   Debuginfo.t ->
   Lambda.poll_attribute ->
+  only_kept_for_zero_alloc:bool ->
   fundecl
 
 (** Create a cmm phrase for a function declaration. *)

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -427,8 +427,12 @@ let fundecl ppf f =
        fprintf ppf "%a: %a" VP.print id machtype ty)
      cases in
   with_location_mapping ~label:"Function" ~dbg:f.fun_dbg ppf (fun () ->
-  fprintf ppf "@[<1>(function%s%a@ %s@;<1 4>@[<1>(%a)@]@ @[%a@])@]@."
-         (location f.fun_dbg) print_codegen_options f.fun_codegen_options f.fun_name.sym_name
+  fprintf ppf "@[<1>(function%s%a@ %s%s@;<1 4>@[<1>(%a)@]@ @[%a@])@]@."
+         (location f.fun_dbg) print_codegen_options f.fun_codegen_options
+         (if f.fun_only_kept_for_zero_alloc
+          then "<only kept for zero-alloc> "
+          else "")
+         f.fun_name.sym_name
          print_cases f.fun_args sequence f.fun_body)
 
 let data_item ppf = function

--- a/middle_end/flambda2/simplify/env/upwards_acc.ml
+++ b/middle_end/flambda2/simplify/env/upwards_acc.ml
@@ -36,7 +36,8 @@ type t =
     demoted_exn_handlers : Continuation.Set.t;
     slot_offsets : Slot_offsets.t Or_unknown.t;
     flow_result : Flow_types.Flow_result.t;
-    resimplify : bool
+    resimplify : bool;
+    code_ids_kept_for_zero_alloc : Code_id.Set.t
   }
 
 let [@ocamlformat "disable"] print ppf
@@ -45,6 +46,7 @@ let [@ocamlformat "disable"] print ppf
         shareable_constants; cost_metrics; are_rebuilding_terms;
         generate_phantom_lets;
         demoted_exn_handlers; slot_offsets; flow_result; resimplify;
+        code_ids_kept_for_zero_alloc;
       } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(uenv@ %a)@]@ \
@@ -58,6 +60,7 @@ let [@ocamlformat "disable"] print ppf
       @[<hov 1>(generate_phantom_lets@ %b)@]@ \
       @[<hov 1>(demoted_exn_handlers@ %a)@]@ \
       @[<hov 1>(slot_offsets@ %a@)@]@ \
+      @[<hov 1>(code_ids_kept_for_zero_alloc@ %a)@]@ \
       @[<hov 1>(flow_result@ %a)@]\
       %a\
       )@]"
@@ -77,8 +80,10 @@ let [@ocamlformat "disable"] print ppf
        (fun ppf () -> Format.fprintf ppf "@ @[<hov 1>(should_resimplify)@]")
      else
        (fun _ppf () -> ())) ()
+    Code_id.Set.print code_ids_kept_for_zero_alloc
 
-let create ~flow_result ~compute_slot_offsets uenv dacc =
+let create ~flow_result ~compute_slot_offsets ~code_ids_kept_for_zero_alloc uenv
+    dacc =
   let are_rebuilding_terms = DE.are_rebuilding_terms (DA.denv dacc) in
   let generate_phantom_lets = DE.generate_phantom_lets (DA.denv dacc) in
   let slot_offsets : _ Or_unknown.t =
@@ -107,7 +112,8 @@ let create ~flow_result ~compute_slot_offsets uenv dacc =
     demoted_exn_handlers = DA.demoted_exn_handlers dacc;
     slot_offsets;
     flow_result;
-    resimplify = false
+    resimplify = false;
+    code_ids_kept_for_zero_alloc
   }
 
 let creation_dacc t = t.creation_dacc
@@ -213,3 +219,5 @@ let mutable_unboxing_result t = t.flow_result.mutable_unboxing_result
 let set_resimplify t = { t with resimplify = true }
 
 let resimplify t = t.resimplify
+
+let code_ids_kept_for_zero_alloc t = t.code_ids_kept_for_zero_alloc

--- a/middle_end/flambda2/simplify/env/upwards_acc.mli
+++ b/middle_end/flambda2/simplify/env/upwards_acc.mli
@@ -22,6 +22,7 @@ val print : Format.formatter -> t -> unit
 val create :
   flow_result:Flow_types.Flow_result.t ->
   compute_slot_offsets:bool ->
+  code_ids_kept_for_zero_alloc:Code_id.Set.t ->
   Upwards_env.t ->
   Downwards_acc.t ->
   t
@@ -113,3 +114,5 @@ val mutable_unboxing_result : t -> Flow_types.Mutable_unboxing_result.t
 val set_resimplify : t -> t
 
 val resimplify : t -> bool
+
+val code_ids_kept_for_zero_alloc : t -> Code_id.Set.t

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -119,7 +119,10 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
               return_arity
         in
         let uacc =
-          UA.create ~flow_result ~compute_slot_offsets:false uenv dacc
+          (* The value of [code_ids_kept_for_zero_alloc] will never be used
+             here. *)
+          UA.create ~flow_result ~compute_slot_offsets:false
+            ~code_ids_kept_for_zero_alloc:Code_id.Set.empty uenv dacc
         in
         rebuild uacc ~after_rebuild:(fun expr uacc -> expr, uacc))
   in

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -21,7 +21,8 @@ type simplify_result =
     unit : Flambda_unit.t;
     all_code : Exported_code.t;
     exported_offsets : Exported_offsets.t;
-    reachable_names : Name_occurrences.t
+    reachable_names : Name_occurrences.t;
+    code_ids_kept_for_zero_alloc : Code_id.Set.t
   }
 
 let run ~cmx_loader ~round ~code_slot_offsets unit =
@@ -106,4 +107,11 @@ let run ~cmx_loader ~round ~code_slot_offsets unit =
     FU.create ~return_continuation ~exn_continuation ~toplevel_my_region
       ~module_symbol ~body ~used_value_slots:(Known used_value_slots)
   in
-  { cmx; unit; all_code; exported_offsets; reachable_names }
+  let code_ids_kept_for_zero_alloc = UA.code_ids_kept_for_zero_alloc uacc in
+  { cmx;
+    unit;
+    all_code;
+    exported_offsets;
+    reachable_names;
+    code_ids_kept_for_zero_alloc
+  }

--- a/middle_end/flambda2/simplify/simplify.mli
+++ b/middle_end/flambda2/simplify/simplify.mli
@@ -25,7 +25,8 @@ type simplify_result = private
     unit : Flambda_unit.t;
     all_code : Exported_code.t;
     exported_offsets : Exported_offsets.t;
-    reachable_names : Name_occurrences.t
+    reachable_names : Name_occurrences.t;
+    code_ids_kept_for_zero_alloc : Code_id.Set.t
   }
 
 val run :

--- a/middle_end/flambda2/to_cmm/to_cmm.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm.mli
@@ -19,5 +19,6 @@ val unit :
   offsets:Exported_offsets.t ->
   all_code:Exported_code.t ->
   reachable_names:Name_occurrences.t ->
+  code_ids_kept_for_zero_alloc:Code_id.Set.t ->
   Flambda_unit.t ->
   Cmm.phrase list

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -82,6 +82,7 @@ val create :
   trans_prim:t trans_prim ->
   return_continuation:Continuation.t ->
   exn_continuation:Continuation.t ->
+  code_ids_kept_for_zero_alloc:Code_id.Set.t ->
   t
 
 (** Given an existing environment providing the "global" information (such as
@@ -357,3 +358,5 @@ val get_cmm_continuation : t -> Continuation.t -> Lambda.static_label
 (** print function *)
 val print_param_type :
   (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a param_type -> unit
+
+val code_ids_kept_for_zero_alloc : t -> Code_id.Set.t

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -449,7 +449,12 @@ let params_and_body0 env res code_id ~fun_dbg ~zero_alloc_attribute
     Env.get_code_metadata env code_id
     |> Code_metadata.poll_attribute |> Poll_attribute.to_lambda
   in
-  C.fundecl fun_sym fun_params fun_body fun_flags fun_dbg fun_poll, res
+  let only_kept_for_zero_alloc =
+    Code_id.Set.mem code_id (Env.code_ids_kept_for_zero_alloc env)
+  in
+  ( C.fundecl fun_sym fun_params fun_body fun_flags fun_dbg fun_poll
+      ~only_kept_for_zero_alloc,
+    res )
 
 let params_and_body env res code_id p ~fun_dbg ~zero_alloc_attribute
     ~translate_expr =


### PR DESCRIPTION
It should be the case that the flag is set iff:
- the function is unreachable; and
- the function is annotated with a zero-alloc `Check` attribute; and
- flambda2 would have deleted the function save for the presence of such attribute.

WIP for @gretay-js 