### PR TITLE
Implement compatibility check for module type inference

### DIFF
--- a/ocaml/testsuite/tests/module-type-underscore/file_level_success.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/file_level_success.ml
@@ -6,9 +6,9 @@
 
   module type S = _
 
-  include List
+  (* include List
 
-  module type T = _
+  module type T = _ *)  (* CR selee: For nowe, we don't support includes *)
 
   module M = List
 

--- a/ocaml/testsuite/tests/module-type-underscore/file_level_success.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/file_level_success.ml
@@ -8,7 +8,7 @@
 
   (* include List
 
-  module type T = _ *)  (* CR selee: For nowe, we don't support includes *)
+  module type T = _ *)  (* CR selee: For now, we don't support includes *)
 
   module M = List
 

--- a/ocaml/testsuite/tests/module-type-underscore/file_level_success.mli
+++ b/ocaml/testsuite/tests/module-type-underscore/file_level_success.mli
@@ -1,10 +1,10 @@
 module type S = module type of List
 
-type 'a t = [] | ( :: ) of 'a * 'a t
+(* type 'a t = [] | ( :: ) of 'a * 'a t
 
 module type T = sig
     type nonrec t = int t
-end
+end *)
 
 module M = List
 

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -1475,7 +1475,7 @@ end
 Line 5, characters 2-23:
 5 |   module A = struct end
       ^^^^^^^^^^^^^^^^^^^^^
-Error: This functor declaration is incompatible with the corresponding
+Error: This module is incompatible with the corresponding
        declaration in the signature.
 Line 2, characters 2-27:
 2 |   module A : sig type t end

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -777,6 +777,10 @@ Line 8, characters 2-14:
       ^^^^^^^^^^^^
 Error: This type declaration is incompatible with the corresponding
        declaration in the signature: expected type 'a t.
+Line 2, characters 2-11:
+2 |   type 'a t
+      ^^^^^^^^^
+  Expected declaration here
 |}]
 
 module M : sig
@@ -805,6 +809,10 @@ Line 11, characters 4-16:
          ^^^^^^^^^^^^
 Error: This type declaration is incompatible with the corresponding
        declaration in the signature: expected type 'a t.
+Line 3, characters 4-13:
+3 |     type 'a t
+        ^^^^^^^^^
+  Expected declaration here
 |}]
 
 module M : sig
@@ -845,6 +853,10 @@ Line 20, characters 10-22:
                ^^^^^^^^^^^^
 Error: This type declaration is incompatible with the corresponding
        declaration in the signature: expected type 'a t.
+Line 6, characters 10-19:
+6 |           type 'a t
+              ^^^^^^^^^
+  Expected declaration here
 |}]
 
 module M : sig
@@ -891,6 +903,10 @@ Line 26, characters 10-23:
                ^^^^^^^^^^^^^
 Error: This type declaration is incompatible with the corresponding
        declaration in the signature: expected type 'a td = (ta, tb) tc.
+Line 9, characters 10-34:
+9 |           type 'a td = (ta, tb) tc
+              ^^^^^^^^^^^^^^^^^^^^^^^^
+  Expected declaration here
 |}]
 
 module M : sig
@@ -1045,6 +1061,10 @@ Line 13, characters 4-16:
          ^^^^^^^^^^^^
 Error: This type declaration is incompatible with the corresponding
        declaration in the signature: expected type 'a t.
+Line 3, characters 4-13:
+3 |     type 'a t
+        ^^^^^^^^^
+  Expected declaration here
 |}]
 
 module A = struct
@@ -1148,6 +1168,10 @@ Line 3, characters 4-13:
         ^^^^^^^^^
 Error: This type declaration is incompatible with the corresponding
        declaration in the signature: expected type t.
+Line 11, characters 4-10:
+11 |     type t
+         ^^^^^^
+  Expected declaration here
 |}]
 
 module A = struct
@@ -1407,4 +1431,25 @@ Error: Signature mismatch:
        Modules do not match: sig end is not included in sig type t end
        In module A:
        The type `t' is required but not provided
+|}]
+
+module type S = sig type t end
+
+module M : sig
+  module N : S
+
+  type 'a t
+
+  val foo : N.t -> N.t
+end = struct
+  module N = struct type t end
+
+  type 'a t
+
+  let foo x = x
+end
+
+[%%expect{|
+module type S = sig type t end
+module M : sig module N : S type 'a t val foo : N.t -> N.t end
 |}]

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -745,10 +745,12 @@ end = struct
   end
 end
 
-(* CR selee: This needs to be fixed *)
 [%%expect {|
-Uncaught exception: Invalid_argument("List.iter2")
-
+Line 8, characters 2-14:
+8 |   type t = int
+      ^^^^^^^^^^^^
+Error: This type declaration is incompatible with the corresponding
+       declaration in the signature: expected type 'a t.
 |}]
 
 module M : sig
@@ -771,10 +773,12 @@ end = struct
   end
 end
 
-(* CR selee: This needs to be fixed *)
 [%%expect{|
-Uncaught exception: Invalid_argument("List.iter2")
-
+Line 11, characters 4-16:
+11 |     type t = int
+         ^^^^^^^^^^^^
+Error: This type declaration is incompatible with the corresponding
+       declaration in the signature: expected type 'a t.
 |}]
 
 module M : sig

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -1503,3 +1503,21 @@ end
 module type S = sig type t end
 module M : sig module N : S type 'a t val foo : N.t -> N.t end
 |}]
+
+module M : sig
+  module F(X:sig end) : sig end
+end = struct
+  module F(X:sig type t end) = struct end
+end
+
+[%%expect {|
+Line 4, characters 2-41:
+4 |   module F(X:sig type t end) = struct end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This module is incompatible with the corresponding
+       declaration in the signature.
+Line 2, characters 2-31:
+2 |   module F(X:sig end) : sig end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Expected declaration here
+|}]

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -1122,6 +1122,35 @@ module M :
 |}]
 
 module A = struct
+  module type D = sig
+    type 'a t
+  end
+
+  module type B = D
+end
+
+module M : sig
+  module type B = sig
+    type t
+  end
+
+  module type C = B
+end = struct
+  include A
+
+  module type C = _
+end
+
+[%%expect {|
+module A : sig module type D = sig type 'a t end module type B = D end
+Line 3, characters 4-13:
+3 |     type 'a t
+        ^^^^^^^^^
+Error: This type declaration is incompatible with the corresponding
+       declaration in the signature: expected type t.
+|}]
+
+module A = struct
   module type B = sig
     type t = int
   end

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -1113,6 +1113,8 @@ end = struct
   module type C = _
 end
 
+(* CR selee: For now, we don't support includes. *)
+
 [%%expect {|
 module A :
   sig
@@ -1127,20 +1129,44 @@ module A :
         class type f1 = d
       end
   end
-module M :
-  sig
-    class c : object val mutable v : int end
-    class type d = object val mutable v : int end
-    module type B =
-      sig
-        type t = c -> int
-        class e : c
-        class type e1 = c
-        class f : d
-        class type f1 = d
-      end
-    module type C = B
-  end
+Lines 39-43, characters 6-3:
+39 | ......struct
+40 |   include A
+41 |
+42 |   module type C = _
+43 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           class c : object val mutable v : int end
+           class type d = object val mutable v : int end
+           module type B = A.B
+           module type C = B/2
+         end
+       is not included in
+         sig
+           class c : object val mutable v : int end
+           class type d = object val mutable v : int end
+           module type B =
+             sig
+               type t = c -> int
+               class e : c
+               class type e1 = c
+               class f : d
+               class type f1 = d
+               ...
+             end
+           module type C = B
+         end
+       Module type declarations do not match:
+         module type C = B/2
+       does not match
+         module type C = B/1
+       At position module type C = <here>
+       Module types do not match: B/2 is not equal to B/1
+
+       Lines 10-17, characters 2-5:
+         Definition of module type B/1
 |}]
 
 module A = struct
@@ -1163,17 +1189,32 @@ end = struct
   module type C = _
 end
 
+(* CR selee: For now, we don't support includes. *)
+
 [%%expect {|
 module A : sig module type D = sig type 'a t end module type B = D end
-Line 3, characters 4-13:
-3 |     type 'a t
-        ^^^^^^^^^
-Error: This type declaration is incompatible with the corresponding
-       declaration in the signature: expected type t.
-Line 11, characters 4-10:
-11 |     type t
-         ^^^^^^
-  Expected declaration here
+Lines 15-19, characters 6-3:
+15 | ......struct
+16 |   include A
+17 |
+18 |   module type C = _
+19 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig module type D = A.D module type B = A.B module type C = B/2 end
+       is not included in
+         sig module type B = sig type t end module type C = B end
+       Module type declarations do not match:
+         module type B = A.B
+       does not match
+         module type B = sig type t end
+       At position module type B = <here>
+       Module types do not match: A.B is not equal to sig type t end
+       At position module type B = <here>
+       Type declarations do not match: type 'a t is not included in type t
+       They have different arities.
+       Line 6, characters 2-19:
+         Definition of module type B/1
 |}]
 
 module A = struct
@@ -1192,9 +1233,30 @@ end = struct
   module type C = _
 end
 
+(* CR selee: For now, we don't support includes. *)
+
 [%%expect {|
 module A : sig module type B = sig type t = int end end
-module M : sig module type B = sig type t = int end module type C = B end
+Lines 11-15, characters 6-3:
+11 | ......struct
+12 |   include A
+13 |
+14 |   module type C = _
+15 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig module type B = A.B module type C = B/2 end
+       is not included in
+         sig module type B = sig type t = int end module type C = B end
+       Module type declarations do not match:
+         module type C = B/2
+       does not match
+         module type C = B/1
+       At position module type C = <here>
+       Module types do not match: B/2 is not equal to B/1
+
+       Lines 2-4, characters 2-5:
+         Definition of module type B/1
 |}]
 
 module M : sig
@@ -1409,30 +1471,16 @@ end = struct
   module type S = _
 end
 
-(* CR selee: Currently our boundness check relies on the compatibility check.
-   As this branch doesn't have the compatibility check, it doesn't error properly
-   in this case. This should error properly before inclusion checking *)
 [%%expect {|
-Lines 4-7, characters 6-3:
-4 | ......struct
+Line 5, characters 2-23:
 5 |   module A = struct end
-6 |   module type S = _
-7 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           module A : sig end
-           module type S = sig type t = A.t -> A.t end
-         end
-       is not included in
-         sig
-           module A : sig type t end
-           module type S = sig type t = A.t -> A.t end
-         end
-       In module A:
-       Modules do not match: sig end is not included in sig type t end
-       In module A:
-       The type `t' is required but not provided
+      ^^^^^^^^^^^^^^^^^^^^^
+Error: This functor declaration is incompatible with the corresponding
+       declaration in the signature.
+Line 2, characters 2-27:
+2 |   module A : sig type t end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
+  Expected declaration here
 |}]
 
 module type S = sig type t end

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -548,7 +548,6 @@ end
 module M : sig module type A module type B = A end
 |}]
 
-
 module M : sig
   type t
 
@@ -567,6 +566,8 @@ module M : sig
     class type e1 = c
     class f : d
     class type f1 = d
+
+    val foo : c -> c
   end
 end = struct
   type t = int
@@ -595,6 +596,7 @@ module M :
         class type e1 = c
         class f : d
         class type f1 = d
+        val foo : c -> c
       end
   end
 |}]

--- a/ocaml/testsuite/tests/shape-index/index_constrs_records.reference
+++ b/ocaml/testsuite/tests/shape-index/index_constrs_records.reference
@@ -1,35 +1,35 @@
 Indexed shapes:
-Resolved: Index_constrs_records.34 :
+Resolved: Index_constrs_records.35 :
   l_exn (File "index_constrs_records.ml", line 40, characters 21-26)
-Resolved: Index_constrs_records.30 :
+Resolved: Index_constrs_records.31 :
   l_exn (File "index_constrs_records.ml", line 40, characters 10-15)
-Resolved: Index_constrs_records.31 :
+Resolved: Index_constrs_records.32 :
   Exn (File "index_constrs_records.ml", line 40, characters 4-7)
-Resolved: Index_constrs_records.33 :
+Resolved: Index_constrs_records.34 :
   e (File "index_constrs_records.ml", line 39, characters 14-15)
-Resolved: Index_constrs_records.30 :
-  l_exn (File "index_constrs_records.ml", line 38, characters 14-19)
 Resolved: Index_constrs_records.31 :
+  l_exn (File "index_constrs_records.ml", line 38, characters 14-19)
+Resolved: Index_constrs_records.32 :
   Exn (File "index_constrs_records.ml", line 38, characters 8-11)
-Resolved: Index_constrs_records.29 :
+Resolved: Index_constrs_records.30 :
   l_ext (File "index_constrs_records.ml", line 33, characters 21-26)
-Resolved: Index_constrs_records.24 :
-  l_ext (File "index_constrs_records.ml", line 33, characters 10-15)
 Resolved: Index_constrs_records.25 :
+  l_ext (File "index_constrs_records.ml", line 33, characters 10-15)
+Resolved: Index_constrs_records.26 :
   Ext (File "index_constrs_records.ml", line 33, characters 4-7)
-Resolved: Index_constrs_records.28 :
+Resolved: Index_constrs_records.29 :
   x (File "index_constrs_records.ml", line 32, characters 22-23)
-Resolved: Index_constrs_records.23 :
+Resolved: Index_constrs_records.24 :
   u (File "index_constrs_records.ml", line 32, characters 11-12)
-Resolved: Index_constrs_records.23 :
+Resolved: Index_constrs_records.24 :
   u (File "index_constrs_records.ml", line 30, characters 5-6)
-Resolved: Index_constrs_records.22 :
+Resolved: Index_constrs_records.23 :
   l (File "index_constrs_records.ml", line 27, characters 47-48)
 Resolved: Index_constrs_records.1 :
   lbl (File "index_constrs_records.ml", line 27, characters 49-52)
-Resolved: Index_constrs_records.21 :
+Resolved: Index_constrs_records.22 :
   lbl (File "index_constrs_records.ml", line 27, characters 41-44)
-Resolved: Index_constrs_records.20 :
+Resolved: Index_constrs_records.21 :
   l_c (File "index_constrs_records.ml", line 27, characters 35-38)
 Unresolved: CU Stdlib . "+"[value]  :
   (+) (File "index_constrs_records.ml", line 27, characters 39-40)
@@ -37,57 +37,57 @@ Unresolved: CU Stdlib . "+"[value]  :
   (+) (File "index_constrs_records.ml", line 27, characters 45-46)
 Resolved: Index_constrs_records.1 :
   lbl (File "index_constrs_records.ml", line 27, characters 21-24)
-Resolved: Index_constrs_records.10 :
+Resolved: Index_constrs_records.11 :
   l_c (File "index_constrs_records.ml", line 27, characters 11-14)
-Resolved: Index_constrs_records.11 :
+Resolved: Index_constrs_records.12 :
   A (File "index_constrs_records.ml", line 27, characters 7-8)
-Resolved: Index_constrs_records.10 :
+Resolved: Index_constrs_records.11 :
   l_c (File "index_constrs_records.ml", line 26, characters 12-15)
-Resolved: Index_constrs_records.11 :
+Resolved: Index_constrs_records.12 :
   A (File "index_constrs_records.ml", line 26, characters 8-9)
-Resolved: Index_constrs_records.17 :
+Resolved: Index_constrs_records.18 :
   M (File "index_constrs_records.ml", line 24, characters 5-6)
-Resolved: Index_constrs_records.10 :
+Resolved: Index_constrs_records.11 :
   l_c (File "index_constrs_records.ml", line 22, characters 14-17)
-Resolved: Index_constrs_records.11 :
+Resolved: Index_constrs_records.12 :
   M.A (File "index_constrs_records.ml", line 22, characters 8-11)
-Resolved: Index_constrs_records.10 :
-  l_c (File "index_constrs_records.ml", line 19, characters 14-17)
 Resolved: Index_constrs_records.11 :
+  l_c (File "index_constrs_records.ml", line 19, characters 14-17)
+Resolved: Index_constrs_records.12 :
   A (File "index_constrs_records.ml", line 19, characters 10-11)
 
 Uid of decls:
-Index_constrs_records.19:
-  f (File "index_constrs_records.ml", line 27, characters 4-5)
 Index_constrs_records.4:
   A (File "index_constrs_records.ml", line 16, characters 11-12)
-Index_constrs_records.33:
-  e (File "index_constrs_records.ml", line 38, characters 4-5)
+Index_constrs_records.12:
+  A (File "index_constrs_records.ml", line 18, characters 11-12)
 Index_constrs_records.2:
   t (File "index_constrs_records.ml", line 16, characters 7-8)
 Index_constrs_records.10:
-  l_c (File "index_constrs_records.ml", line 18, characters 18-21)
+  t (File "index_constrs_records.ml", line 18, characters 7-8)
+Index_constrs_records.34:
+  e (File "index_constrs_records.ml", line 38, characters 4-5)
 Index_constrs_records.25:
-  Ext (File "index_constrs_records.ml", line 30, characters 10-13)
-Index_constrs_records.24:
   l_ext (File "index_constrs_records.ml", line 30, characters 19-24)
+Index_constrs_records.24:
+  u (File "index_constrs_records.ml", line 29, characters 5-6)
+Index_constrs_records.20:
+  f (File "index_constrs_records.ml", line 27, characters 4-5)
 Index_constrs_records.3:
   l_c (File "index_constrs_records.ml", line 16, characters 18-21)
-Index_constrs_records.30:
-  l_exn (File "index_constrs_records.ml", line 36, characters 18-23)
-Index_constrs_records.17:
+Index_constrs_records.26:
+  Ext (File "index_constrs_records.ml", line 30, characters 10-13)
+Index_constrs_records.18:
   M (File "index_constrs_records.ml", line 15, characters 7-8)
 Index_constrs_records.31:
-  Exn (File "index_constrs_records.ml", line 36, characters 10-13)
+  l_exn (File "index_constrs_records.ml", line 36, characters 18-23)
 Index_constrs_records.11:
-  A (File "index_constrs_records.ml", line 18, characters 11-12)
-Index_constrs_records.27:
+  l_c (File "index_constrs_records.ml", line 18, characters 18-21)
+Index_constrs_records.28:
   f (File "index_constrs_records.ml", line 32, characters 4-5)
-Index_constrs_records.9:
-  t (File "index_constrs_records.ml", line 18, characters 7-8)
 Index_constrs_records.0:
   l (File "index_constrs_records.ml", line 14, characters 5-6)
-Index_constrs_records.23:
-  u (File "index_constrs_records.ml", line 29, characters 5-6)
+Index_constrs_records.32:
+  Exn (File "index_constrs_records.ml", line 36, characters 10-13)
 Index_constrs_records.1:
   lbl (File "index_constrs_records.ml", line 14, characters 11-14)

--- a/ocaml/testsuite/tests/shapes/nested_types.ml
+++ b/ocaml/testsuite/tests/shapes/nested_types.ml
@@ -20,21 +20,21 @@ end
 [%%expect{|
 {
  "M"[module] ->
-   {<.35>
-    "Exn"[extension constructor] -> {<.17>
-                                     "lbl_exn"[label] -> <.16>;
+   {<.38>
+    "Exn"[extension constructor] -> {<.20>
+                                     "lbl_exn"[label] -> <.19>;
                                      };
-    "Ext"[extension constructor] -> {<.23>
-                                     "lbl_ext"[label] -> <.22>;
+    "Ext"[extension constructor] -> {<.26>
+                                     "lbl_ext"[label] -> <.25>;
                                      };
-    "ext"[type] -> <.21>;
-    "l"[type] -> {<.19>
-                  "lbl"[label] -> <.20>;
+    "ext"[type] -> <.24>;
+    "l"[type] -> {<.22>
+                  "lbl"[label] -> <.23>;
                   };
     "t"[type] ->
-      {<.25>
-       "C"[constructor] -> {<.27>
-                            "lbl_cstr"[label] -> <.26>;
+      {<.28>
+       "C"[constructor] -> {<.30>
+                            "lbl_cstr"[label] -> <.29>;
                             };
        };
     };

--- a/ocaml/testsuite/tests/typing-misc/distant_errors.ml
+++ b/ocaml/testsuite/tests/typing-misc/distant_errors.ml
@@ -16,19 +16,9 @@ end = struct
 end
 
 [%%expect{|
-Lines 9-12, characters 6-3:
- 9 | ......struct
+Line 10, characters 2-10:
 10 |   type _ t
-11 |   let f _ = ()
-12 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig type _ t val f : 'a -> unit end
-       is not included in
-         sig type (_, _) t val f : ('a, 'b) t -> unit end
-       Type declarations do not match:
-         type _ t
-       is not included in
-         type (_, _) t
-       They have different arities.
+       ^^^^^^^^
+Error: This type declaration is incompatible with the corresponding
+       declaration in the signature: expected type (_, _) t.
 |}]

--- a/ocaml/testsuite/tests/typing-misc/distant_errors.ml
+++ b/ocaml/testsuite/tests/typing-misc/distant_errors.ml
@@ -21,4 +21,8 @@ Line 10, characters 2-10:
        ^^^^^^^^
 Error: This type declaration is incompatible with the corresponding
        declaration in the signature: expected type (_, _) t.
+Line 7, characters 2-15:
+7 |   type (_, _) t
+      ^^^^^^^^^^^^^
+  Expected declaration here
 |}]

--- a/ocaml/testsuite/tests/typing-misc/includeclass_errors.ml
+++ b/ocaml/testsuite/tests/typing-misc/includeclass_errors.ml
@@ -71,20 +71,15 @@ end
 
 [%%expect{|
 class type ['a] ct = object val x : 'a end
-Lines 5-7, characters 6-3:
-5 | ......struct
+Line 6, characters 2-27:
 6 |   class type c = object end
-7 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig class type c = object  end end
-       is not included in
-         sig class type ['a] c = object  end end
-       Class type declarations do not match:
-         class type c = object  end
-       does not match
-         class type ['a] c = object  end
-       The classes do not have the same number of type parameters
+      ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type declaration is incompatible with the corresponding
+       declaration in the signature: expected type 'a c = <  >.
+Line 4, characters 2-32:
+4 |   class type ['a] c = object end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Expected declaration here
 |}]
 
 module M: sig

--- a/ocaml/testsuite/tests/typing-modules/functors.ml
+++ b/ocaml/testsuite/tests/typing-modules/functors.ml
@@ -167,26 +167,15 @@ end = struct
  module F(X:sig type y end) = struct end
 end
 [%%expect {|
-Lines 3-5, characters 6-3:
-3 | ......struct
+Line 4, characters 1-40:
 4 |  module F(X:sig type y end) = struct end
-5 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig module F : functor (X : sig type y end) -> sig end end
-       is not included in
-         sig
-           module F :
-             functor (X : sig type x end) (X : sig type y end) -> sig end
-         end
-       In module F:
-       Modules do not match:
-         functor (X : $S2) -> ...
-       is not included in
-         functor (X : $T1) (X : $T2) -> ...
-       1. An argument appears to be missing with module type
-              $T1 = sig type x end
-       2. Module types $S2 and $T2 match
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This functor declaration is incompatible with the corresponding
+       declaration in the signature.
+Line 2, characters 2-66:
+2 |   module F: functor(X:sig type x end)(X:sig type y end) -> sig end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Expected declaration here
 |}]
 
 
@@ -731,9 +720,8 @@ end = struct
   = struct end
 end
 [%%expect {|
-Lines 12-21, characters 6-3:
-12 | ......struct
-13 |   module F
+Lines 13-20, characters 2-14:
+13 | ..module F
 14 |       (X:
 15 |          functor (A: sig type xa end)(B:sig type xz end) -> sig end
 16 |       )
@@ -741,40 +729,20 @@ Lines 12-21, characters 6-3:
 18 |          functor (A: sig type ya end)(B:sig type yb end) -> sig end
 19 |       )
 20 |   = struct end
-21 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           module F :
-             functor
-               (X : functor (A : sig type xa end) (B : sig type xz end) ->
-                      sig end)
-               (Y : functor (A : sig type ya end) (B : sig type yb end) ->
-                      sig end)
-               -> sig end
-         end
-       is not included in
-         sig
-           module F :
-             functor
-               (X : functor (A : sig type xa end) (B : sig type xz end) ->
-                      sig end)
-               (Y : functor (A : sig type ya end) (B : sig type yb end) ->
-                      sig end)
-               (Z : functor (A : sig type za end) (B : sig type zb end) ->
-                      sig end)
-               -> sig end
-         end
-       In module F:
-       Modules do not match:
-         functor (X : $S1) (Y : $S2) -> ...
-       is not included in
-         functor (X : $T1) (Y : $T2) (Z : $T3) -> ...
-       1. Module types $S1 and $T1 match
-       2. Module types $S2 and $T2 match
-       3. An argument appears to be missing with module type
-              $T3 =
-              functor (A : sig type za end) (B : sig type zb end) -> sig end
+Error: This functor declaration is incompatible with the corresponding
+       declaration in the signature.
+Lines 2-11, characters 2-18:
+ 2 | ..module F: functor
+ 3 |       (X:
+ 4 |          functor(A: sig type xa end)(B:sig type xz end) -> sig end
+ 5 |       )
+ 6 |       (Y:
+ 7 |          functor(A: sig type ya end)(B:sig type yb end) -> sig end
+ 8 |       )
+ 9 |       (Z:
+10 |          functor(A: sig type za end)(B:sig type zb end) -> sig end
+11 |       ) -> sig end
+  Expected declaration here
 |}]
 
 module M: sig
@@ -905,99 +873,15 @@ end = struct
   end
 end
 [%%expect {|
-Lines 12-23, characters 6-3:
-12 | ......struct
-13 |   module B = struct
-14 |     module C = struct
-15 |       module D = struct
-16 |         module E = struct
-...
-20 |       end
-21 |     end
-22 |   end
-23 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           module B :
-             sig
-               module C : sig module D : sig module E : sig ... end end end
-             end
-         end
-       is not included in
-         sig
-           module B :
-             sig
-               module C : sig module D : sig module E : sig ... end end end
-             end
-         end
-       In module B:
-       Modules do not match:
-         sig module C = B.C end
-       is not included in
-         sig
-           module C :
-             sig
-               module D :
-                 sig
-                   module E :
-                     sig
-                       module F :
-                         sig ... end -> sig ... end -> sig ... end ->
-                           sig ... end -> sig end
-                     end
-                 end
-             end
-         end
-       In module B.C:
-       Modules do not match:
-         sig module D = B.C.D end
-       is not included in
-         sig
-           module D :
-             sig
-               module E :
-                 sig
-                   module F :
-                     sig type x end -> sig type y end -> sig type z end ->
-                       sig type w end -> sig end
-                 end
-             end
-         end
-       In module B.C.D:
-       Modules do not match:
-         sig module E = B.C.D.E end
-       is not included in
-         sig
-           module E :
-             sig
-               module F :
-                 sig type x end -> sig type y end -> sig type z end ->
-                   sig type w end -> sig end
-             end
-         end
-       In module B.C.D.E:
-       Modules do not match:
-         sig module F = B.C.D.E.F end
-       is not included in
-         sig
-           module F :
-             sig type x end -> sig type y end -> sig type z end ->
-               sig type w end -> sig end
-         end
-       In module B.C.D.E.F:
-       Modules do not match:
-         functor (X : $S1) (Y : $S3) (W : $S4) -> ...
-       is not included in
-         functor $T1 $T2 $T3 $T4 -> ...
-       1. Module types $S1 and $T1 match
-       2. An argument appears to be missing with module type
-              $T2 = sig type y end
-       3. Module types do not match:
-            $S3 = sig type y' end
-          does not include
-            $T3 = sig type z end
-       4. Module types $S4 and $T4 match
+Lines 17-18, characters 10-43:
+17 | ..........module F(X:sig type x end)(Y:sig type y' end)
+18 |             (W:sig type w end) = struct end
+Error: This functor declaration is incompatible with the corresponding
+       declaration in the signature.
+Lines 6-7, characters 10-56:
+6 | ..........module F: sig type x end -> sig type y end
+7 |           -> sig type z end -> sig type w end -> sig end
+  Expected declaration here
 |}]
 
 
@@ -1362,37 +1246,18 @@ end
   module F(X:sig type x end)(Z:sig type z end) = struct end
 end
 [%%expect {|
-Lines 14-16, characters 2-3:
-14 | ..struct
+Line 15, characters 2-59:
 15 |   module F(X:sig type x end)(Z:sig type z end) = struct end
-16 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           module F :
-             functor (X : sig type x end) (Z : sig type z end) -> sig end
-         end
-       is not included in
-         sig
-           module F :
-             functor
-               (X : sig
-                      type x
-                      module type t =
-                        functor (Y : sig type y end) (Z : sig type z end) ->
-                          sig end
-                    end)
-               -> X.t
-         end
-       In module F:
-       Modules do not match:
-         functor (X : $S1) (Z : $S3) -> ...
-       is not included in
-         functor (X : $T1) (Y : $T2) (Z : $T3) -> ...
-       1. Module types $S1 and $T1 match
-       2. An argument appears to be missing with module type
-              $T2 = sig type y end
-       3. Module types $S3 and $T3 match
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This functor declaration is incompatible with the corresponding
+       declaration in the signature.
+Lines 7-11, characters 15-29:
+ 7 | ...............module type t =
+ 8 |                  functor
+ 9 |                    (Y:sig type y end)
+10 |                    (Z:sig type z end)
+11 |                    -> sig end
+  Expected declaration here
 |}]
 
 

--- a/ocaml/testsuite/tests/typing-modules/functors.ml
+++ b/ocaml/testsuite/tests/typing-modules/functors.ml
@@ -91,25 +91,15 @@ module M : sig module F: functor (X:sig end) -> sig end end =
     module F(X:sig type t end) = struct end
   end
 [%%expect {|
-Lines 2-4, characters 2-5:
-2 | ..struct
+Line 3, characters 4-43:
 3 |     module F(X:sig type t end) = struct end
-4 |   end
-Error: Signature mismatch:
-       Modules do not match:
-         sig module F : functor (X : sig type t end) -> sig end end
-       is not included in
-         sig module F : functor (X : sig end) -> sig end end
-       In module F:
-       Modules do not match:
-         functor (X : $S1) -> ...
-       is not included in
-         functor (X : sig end) -> ...
-       Module types do not match:
-         $S1 = sig type t end
-       does not include
-         sig end
-       The type `t' is required but not provided
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This module is incompatible with the corresponding
+       declaration in the signature.
+Line 1, characters 15-55:
+1 | module M : sig module F: functor (X:sig end) -> sig end end =
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Expected declaration here
 |}]
 
 module F(X:sig type t end) = struct end
@@ -170,7 +160,7 @@ end
 Line 4, characters 1-40:
 4 |  module F(X:sig type y end) = struct end
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This functor declaration is incompatible with the corresponding
+Error: This module is incompatible with the corresponding
        declaration in the signature.
 Line 2, characters 2-66:
 2 |   module F: functor(X:sig type x end)(X:sig type y end) -> sig end
@@ -463,27 +453,15 @@ end = struct
   module type S = sig type t end
 end;;
   [%%expect {|
-Lines 3-5, characters 6-3:
-3 | ......struct
+Line 4, characters 2-32:
 4 |   module type S = sig type t end
-5 | end..
-Error: Signature mismatch:
-       Modules do not match:
-         sig module type S = sig type t end end
-       is not included in
-         sig module type S = sig type t type u end end
-       Module type declarations do not match:
-         module type S = sig type t end
-       does not match
-         module type S = sig type t type u end
-       The first module type is not included in the second
-       At position module type S = <here>
-       Module types do not match:
-         sig type t end
-       is not equal to
-         sig type t type u end
-       At position module type S = <here>
-       The type `u' is required but not provided
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This module type is incompatible with the corresponding
+       declaration in the signature.
+Line 2, characters 2-39:
+2 |   module type S = sig type t type u end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Expected declaration here
 |}]
 
 
@@ -627,74 +605,31 @@ end = struct
   = struct end
 end
 [%%expect {|
-Lines 15-27, characters 6-3:
-15 | ......struct
-16 |   module F
+Lines 16-26, characters 2-14:
+16 | ..module F
 17 |       (X:
 18 |          functor (A: sig type xa end)(B:sig type xz end) -> sig end
 19 |       )
+20 |       (Y:
 ...
+23 |       (Z:
 24 |          functor (A: sig type za end)(B:sig type zbb end) -> sig end
 25 |       )
 26 |   = struct end
-27 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           module F :
-             functor
-               (X : functor (A : sig type xa end) (B : sig type xz end) ->
-                      sig end)
-               (Y : functor (A : sig type ya end) (B : sig type ybb end) ->
-                      sig end)
-               (Z : functor (A : sig type za end) (B : sig type zbb end) ->
-                      sig end)
-               -> sig end
-         end
-       is not included in
-         sig
-           module F :
-             functor
-               (X : functor (A : sig type xa end) (B : sig type xz end) ->
-                      sig end)
-               (Y : functor (A : sig type ya end) (B : sig type yb end) ->
-                      sig end)
-               (Z : functor (A : sig type za end) (B : sig type zb end) ->
-                      sig end)
-               -> sig end
-         end
-       In module F:
-       Modules do not match:
-         functor (X : $S1) (Y : $S2) (Z : $S3) -> ...
-       is not included in
-         functor (X : $T1) (Y : $T2) (Z : $T3) -> ...
-       1. Module types $S1 and $T1 match
-       2. Module types do not match:
-            $S2 =
-            functor (A : sig type ya end) (B : sig type ybb end) -> sig end
-          does not include
-            $T2 =
-            functor (A : sig type ya end) (B : sig type yb end) -> sig end
-          Modules do not match:
-            functor (A : $S1) (B : $S2) -> ...
-          is not included in
-            functor (A : $T1) (B : $T2) -> ...
-          1. Module types $S1 and $T1 match
-          2. Module types do not match:
-               $S2 = sig type yb end
-             does not include
-               $T2 = sig type ybb end
-             The type `yb' is required but not provided
-       3. Module types do not match:
-            $S3 =
-            functor (A : sig type za end) (B : sig type zbb end) -> sig end
-          does not include
-            $T3 =
-            functor (A : sig type za end) (B : sig type zb end) -> sig end
-          Modules do not match:
-            functor (A : $S1) (B : $S2) -> ...
-          is not included in
-            functor (A : $T1) (B : $T2) -> ...
+Error: This module is incompatible with the corresponding
+       declaration in the signature.
+Lines 5-14, characters 2-18:
+ 5 | ..module F: functor
+ 6 |       (X:
+ 7 |          functor(A: sig type xa end)(B:sig type xz end) -> sig end
+ 8 |       )
+ 9 |       (Y:
+10 |          functor(A: sig type ya end)(B:sig type yb end) -> sig end
+11 |       )
+12 |       (Z:
+13 |          functor(A: sig type za end)(B:sig type zb end) -> sig end
+14 |       ) -> sig end
+  Expected declaration here
 |}]
 
 
@@ -770,83 +705,31 @@ end = struct
   = struct end
 end
 [%%expect {|
-Lines 12-24, characters 6-3:
-12 | ......struct
-13 |   module F
+Lines 13-23, characters 2-14:
+13 | ..module F
 14 |       (X:
 15 |          functor (A: sig type xaa end)(B:sig type xz end) -> sig end
 16 |       )
+17 |       (Y:
 ...
+20 |       (Z:
 21 |          functor (A: sig type za end)(B:sig type zbb end) -> sig end
 22 |       )
 23 |   = struct end
-24 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           module F :
-             functor
-               (X : functor (A : sig type xaa end) (B : sig type xz end) ->
-                      sig end)
-               (Y : functor (A : sig type ya end) (B : sig type ybb end) ->
-                      sig end)
-               (Z : functor (A : sig type za end) (B : sig type zbb end) ->
-                      sig end)
-               -> sig end
-         end
-       is not included in
-         sig
-           module F :
-             functor
-               (X : functor (A : sig type xa end) (B : sig type xz end) ->
-                      sig end)
-               (Y : functor (A : sig type ya end) (B : sig type yb end) ->
-                      sig end)
-               (Z : functor (A : sig type za end) (B : sig type zb end) ->
-                      sig end)
-               -> sig end
-         end
-       In module F:
-       Modules do not match:
-         functor (X : $S1) (Y : $S2) (Z : $S3) -> ...
-       is not included in
-         functor (X : $T1) (Y : $T2) (Z : $T3) -> ...
-       1. Module types do not match:
-            $S1 =
-            functor (A : sig type xaa end) (B : sig type xz end) -> sig end
-          does not include
-            $T1 =
-            functor (A : sig type xa end) (B : sig type xz end) -> sig end
-          Modules do not match:
-            functor (A : $S1) (B : $S2) -> ...
-          is not included in
-            functor (A : $T1) (B : $T2) -> ...
-          1. Module types do not match:
-               $S1 = sig type xa end
-             does not include
-               $T1 = sig type xaa end
-             The type `xa' is required but not provided
-          2. Module types $S2 and $T2 match
-       2. Module types do not match:
-            $S2 =
-            functor (A : sig type ya end) (B : sig type ybb end) -> sig end
-          does not include
-            $T2 =
-            functor (A : sig type ya end) (B : sig type yb end) -> sig end
-          Modules do not match:
-            functor (A : $S1) (B : $S2) -> ...
-          is not included in
-            functor (A : $T1) (B : $T2) -> ...
-       3. Module types do not match:
-            $S3 =
-            functor (A : sig type za end) (B : sig type zbb end) -> sig end
-          does not include
-            $T3 =
-            functor (A : sig type za end) (B : sig type zb end) -> sig end
-          Modules do not match:
-            functor (A : $S1) (B : $S2) -> ...
-          is not included in
-            functor (A : $T1) (B : $T2) -> ...
+Error: This module is incompatible with the corresponding
+       declaration in the signature.
+Lines 2-11, characters 2-18:
+ 2 | ..module F: functor
+ 3 |       (X:
+ 4 |          functor(A: sig type xa end)(B:sig type xz end) -> sig end
+ 5 |       )
+ 6 |       (Y:
+ 7 |          functor(A: sig type ya end)(B:sig type yb end) -> sig end
+ 8 |       )
+ 9 |       (Z:
+10 |          functor(A: sig type za end)(B:sig type zb end) -> sig end
+11 |       ) -> sig end
+  Expected declaration here
 |}]
 
 module A: sig
@@ -876,7 +759,7 @@ end
 Lines 17-18, characters 10-43:
 17 | ..........module F(X:sig type x end)(Y:sig type y' end)
 18 |             (W:sig type w end) = struct end
-Error: This functor declaration is incompatible with the corresponding
+Error: This module is incompatible with the corresponding
        declaration in the signature.
 Lines 6-7, characters 10-56:
 6 | ..........module F: sig type x end -> sig type y end
@@ -1249,7 +1132,7 @@ end
 Line 15, characters 2-59:
 15 |   module F(X:sig type x end)(Z:sig type z end) = struct end
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This functor declaration is incompatible with the corresponding
+Error: This module is incompatible with the corresponding
        declaration in the signature.
 Lines 7-11, characters 15-29:
  7 | ...............module type t =
@@ -1276,42 +1159,22 @@ end = struct
        end)  = (X.M : X.t)
 end
 [%%expect {|
-Lines 8-14, characters 6-3:
- 8 | ......struct
- 9 |   module F (Wrong: sig type wrong end)
+Lines 9-13, characters 2-26:
+ 9 | ..module F (Wrong: sig type wrong end)
 10 |       (X: sig
 11 |          module type t
 12 |          module M: t
 13 |        end)  = (X.M : X.t)
-14 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           module F :
-             functor (Wrong : sig type wrong end)
-               (X : sig module type t module M : t end) -> X.t
-         end
-       is not included in
-         sig
-           module F :
-             functor
-               (X : sig
-                      module type T
-                      module type t = T -> T -> T
-                      module M : t
-                    end)
-               -> X.T -> X.T -> X.T
-         end
-       In module F:
-       Modules do not match:
-         functor (Wrong : $S1) (X : $S2) X.T X.T -> ...
-       is not included in
-         functor (X : $T2) X.T X.T -> ...
-       1. An extra argument is provided of module type
-              $S1 = sig type wrong end
-       2. Module types $S2 and $T2 match
-       3. Module types X/3.T and X/2.T match
-       4. Module types X/3.T and X/2.T match
+Error: This module is incompatible with the corresponding
+       declaration in the signature.
+Lines 2-7, characters 2-30:
+2 | ..module F(X: sig
+3 |       module type T
+4 |       module type t = T -> T -> T
+5 |       module M: t
+6 |     end
+7 |           )(_:X.T)(_:X.T): X.T
+  Expected declaration here
 |}]
 
 
@@ -1337,56 +1200,24 @@ end = struct
           )(Res: X.T)(Res: X.T)(Res: X.T) = Res
 end
 [%%expect {|
-Lines 17-21, characters 6-3:
-17 | ......struct
-18 |   module F(_:sig type wrong end) (X:
+Lines 18-20, characters 2-47:
+18 | ..module F(_:sig type wrong end) (X:
 19 |              sig  module type T end
 20 |           )(Res: X.T)(Res: X.T)(Res: X.T) = Res
-21 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig
-           module F :
-             sig type wrong end ->
-               functor (X : sig module type T end) (Res : X.T) (Res :
-                 X.T) (Res : X.T)
-               -> (X.T with Res)
-         end
-       is not included in
-         sig
-           module F :
-             sig end ->
-               functor
-                 (X : sig
-                        module type T
-                        module type inner =
-                          sig module type t module M : t end
-                        module F :
-                          functor (X : inner) -> (T -> T -> T) ->
-                            sig module type res = X.t end
-                        module Y :
-                          sig
-                            module type t = T -> T -> T
-                            module M : functor (X : T) (Y : T) -> T
-                          end
-                      end)
-               -> X.F(X.Y)(X.Y.M).res
-         end
-       In module F:
-       Modules do not match:
-         functor (Arg : $S1) (X : $S2) (Res : X.T) (Res : X.T) (Res :
-         X.T) -> ...
-       is not included in
-         functor (sig end) (X : $T2) X.T X.T -> ...
-       1. Module types do not match:
-            $S1 = sig type wrong end
-          does not include
-            sig end
-          The type `wrong' is required but not provided
-       2. Module types $S2 and $T2 match
-       3. An extra argument is provided of module type X/2.T
-       4. Module types X/2.T and X/2.T match
-       5. Module types X/2.T and X/2.T match
+Error: This module is incompatible with the corresponding
+       declaration in the signature.
+Lines 2-16, characters 2-23:
+ 2 | ..module F(_:sig end)(X:
+ 3 |            sig
+ 4 |              module type T
+ 5 |              module type inner = sig
+ 6 |                module type t
+...
+13 |                module M(X:T)(Y:T): T
+14 |              end
+15 |            end):
+16 |     X.F(X.Y)(X.Y.M).res
+  Expected declaration here
 |}]
 
 

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -3137,7 +3137,12 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
                   ~actual_loc ~expected_loc ~context
             | Mty_functor (Named (actual_id, mt1), mt2),
               Mty_functor (Named (expected_id, mt3), mt4) ->
-                check_expected_modtype ~env ~sig_env subst (Some mt1) (Some mt3)
+                (* Swap the two positions, because this position is contravariant and
+                   we'll be checking if the names in [expected] is a subset of the
+                   names in [actual]. *)
+                (* CR selee: Because [subst] is directional, I think we'll lose the
+                   shortcircuiting in this case. *)
+                check_expected_modtype ~env:sig_env ~sig_env:env subst (Some mt3) (Some mt1)
                   ~actual_loc ~expected_loc ~context;
                 let env =
                   match actual_id with

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -3130,7 +3130,8 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
   and add_expected_rec_modules_to_subst sig_env env expected_sig ident_and_decls subst =
     List.fold_left
       (fun acc (ident, decl) ->
-        add_expected_module_to_subst sig_env env expected_sig ident decl acc) subst ident_and_decls
+        add_expected_module_to_subst sig_env env expected_sig ident decl acc)
+      subst ident_and_decls
 
   and add_expected_modtype_to_subst sig_env env sig_map ident decl subst =
     (* CR selee: we are currently duplicating some work because we need the expected modtype decl

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -3177,10 +3177,10 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
             end
       end
 
-  and add_expected_rec_modules_to_subst ~env ~sig_env expected_sig ident_and_decls subst =
+  and add_expected_rec_modules_to_subst ~env ~sig_env sig_map ident_and_decls subst =
     List.fold_left
       (fun acc (ident, decl) ->
-        add_expected_module_to_subst ~env ~sig_env expected_sig ident decl acc)
+        add_expected_module_to_subst ~env ~sig_env sig_map ident decl acc)
       subst ident_and_decls
 
   and add_expected_modtype_to_subst ~env ~sig_env sig_map ident decl subst =

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -3229,8 +3229,8 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
         let sg, incl_kind =
           extract_sig_functor_open funct_body env smodl.pmod_loc
             modl.mod_type sig_acc
-        in
-        incl_kind, sg
+          in
+          incl_kind, sg
       else
         Tincl_structure, extract_sig_open env smodl.pmod_loc modl.mod_type
     in

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -174,8 +174,8 @@ end
 
 type modtype_decl_expected = {
   expected: modtype_declaration;
-  sig_map: Sig_map.t;
   str_map: Sig_map.t;
+  sig_map: Sig_map.t;
 }
 
 type modtype_decl_context =
@@ -1634,8 +1634,8 @@ let mksig desc env loc =
     current structure, then all is well; if it doesn't appear in the signature, then it
     was declared somewhere outside so it can't be unbound. This way, we avoid expensive
     [Env.t] queries.*)
-let check_no_unbound_paths env loc sig_map str_map mty =
-  let check_error path_kind path in_sig in_str =
+let check_no_unbound_paths env loc ~str_map ~sig_map mty =
+  let check_error path_kind path in_str in_sig =
     if in_sig && (not in_str) then
       raise (Error (loc, env, Unbound_path_in_inferred_type (path_kind, path)))
   in
@@ -1643,9 +1643,9 @@ let check_no_unbound_paths env loc sig_map str_map mty =
     match path with
     | Pident id ->
         let name = Ident.name id in
-        let in_sig = Sig_map.has_module name sig_map in
         let in_str = Sig_map.has_module name str_map in
-        check_error initial_kind initial_path in_sig in_str
+        let in_sig = Sig_map.has_module name sig_map in
+        check_error initial_kind initial_path in_str in_sig
     | Pdot (p, _) | Pextra_ty (p, _) -> check_heads initial_kind initial_path p
     | Papply (p1, p2) ->
         check_heads initial_kind initial_path p1;
@@ -1657,29 +1657,29 @@ let check_no_unbound_paths env loc sig_map str_map mty =
         match path with
         | Pident id ->
             let name = Ident.name id in
-            let (in_sig, in_str) =
+            let (in_str, in_sig) =
               begin match path_kind with
                 | Path_value ->
                     Misc.fatal_error "Module type contains reference to a value"
                 | Path_type ->
-                    Sig_map.has_type name sig_map,
-                    Sig_map.has_type name str_map
+                    Sig_map.has_type name str_map,
+                    Sig_map.has_type name sig_map
                 | Path_module ->
-                    Sig_map.has_module name sig_map,
-                    Sig_map.has_module name str_map
+                    Sig_map.has_module name str_map,
+                    Sig_map.has_module name sig_map
                 | Path_modtype ->
-                    Sig_map.has_module_type name sig_map,
-                    Sig_map.has_module_type name str_map
+                    Sig_map.has_module_type name str_map,
+                    Sig_map.has_module_type name sig_map
                 | Path_class ->
                     Misc.fatal_error "Module type contains reference to a class"
                 | Path_classtype ->
-                    Sig_map.has_class_type name sig_map,
-                    Sig_map.has_class_type name str_map
+                    Sig_map.has_class_type name str_map,
+                    Sig_map.has_class_type name sig_map
                 | Path_class_lhs | Path_classtype_lhs ->
                     (true, true)
               end
             in
-            check_error path_kind path in_sig in_str;
+            check_error path_kind path in_str in_sig;
         | Pdot (p, _) | Pextra_ty (p, _) -> check_heads path_kind path p
         | Papply (p1, p2) ->
             check_heads path_kind path p1;
@@ -2168,8 +2168,8 @@ and transl_modtype_decl_aux ~context env
       begin match context with
         | In_signature -> raise (Error (pmtd_loc, env, Underscore_not_allowed_in_signature))
         | In_structure None -> raise (Error (pmtd_loc, env, Cannot_infer_module_type))
-        | In_structure Some ({ expected = mtd; sig_map; str_map }) ->
-            check_no_unbound_paths env pmtd_loc sig_map str_map mtd.Types.mtd_type;
+        | In_structure Some ({ expected = mtd; str_map; sig_map }) ->
+            check_no_unbound_paths env pmtd_loc ~str_map ~sig_map mtd.Types.mtd_type;
             Tmtd_underscore, mtd.Types.mtd_type
       end
   in

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -3077,7 +3077,7 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
         end
     in
 
-    let same_path_after_subst p1 p2 =
+    let same_modtype_path_after_subst p1 p2 =
       (* When we see two [Path.t]s, first try applying [subst] to the expected path.
          If the two paths are the same after substitution, we don't need to look into
          the paths to tell that they're the same. *)
@@ -3087,9 +3087,18 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
       with Fatal_error -> false
     in
 
+    let same_module_path_after_subst p1 p2 =
+      try
+        let p1_after_subst = Subst.module_path subst p1 in
+        Path.same p1_after_subst p2
+      with Fatal_error -> false
+    in
+
     match expected_modtype, actual_modtype with
       | Some (Mty_ident p1), Some (Mty_ident p2)
-          when same_path_after_subst p1 p2 -> ()
+          when same_modtype_path_after_subst p1 p2 -> ()
+      | Some (Mty_alias p1), Some (Mty_alias p2)
+          when same_module_path_after_subst p1 p2 -> ()
       | _ ->
           let s1 = extract_signature sig_env expected_modtype in
           let s2 = extract_signature env actual_modtype in

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -3169,14 +3169,7 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
           in
         List.fold_left add_to_subst subst clty_ids
 
-  and add_expected_include_to_subst sig_env env sig_map expected_sig actual_sig subst =
-    let (sig_env, sig_map) =
-      match expected_sig with
-      | None -> sig_env, sig_map
-      | Some expected_sig ->
-          Env.add_signature expected_sig sig_env,
-          Option.map (fun map -> Sig_map.add_signature expected_sig map) sig_map
-    in
+  and add_expected_include_to_subst sig_env env sig_map actual_sig subst =
     let env = Env.add_signature actual_sig env in
 
     let add_item subst = function
@@ -3233,7 +3226,7 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
     sg,
     shape,
     new_env,
-    add_expected_include_to_subst sig_env env sig_map expected_sig sg subst,
+    add_expected_include_to_subst sig_env env sig_map sg subst,
     Sig_map.add_signature sg str_map
   in
 

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -3169,22 +3169,25 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
           in
         List.fold_left add_to_subst subst clty_ids
 
-  and add_expected_include_to_subst sig_env env expected_sig actual_sig subst =
-    let sig_env = match expected_sig with
-      | None -> sig_env
-      | Some expected_sig -> Env.add_signature expected_sig sig_env
+  and add_expected_include_to_subst sig_env env sig_map expected_sig actual_sig subst =
+    let (sig_env, sig_map) =
+      match expected_sig with
+      | None -> sig_env, sig_map
+      | Some expected_sig ->
+          Env.add_signature expected_sig sig_env,
+          Option.map (fun map -> Sig_map.add_signature expected_sig map) sig_map
     in
     let env = Env.add_signature actual_sig env in
 
     let add_item subst = function
       | Sig_type (id, decl, _, _) ->
-          add_expected_type_to_subst sig_env env expected_sig [id, decl] subst
+          add_expected_type_to_subst sig_env env sig_map [id, decl] subst
       | Sig_module (id, _, decl, _, _) ->
-          add_expected_module_to_subst sig_env env expected_sig (Some id) decl subst
+          add_expected_module_to_subst sig_env env sig_map (Some id) decl subst
       | Sig_modtype (id, decl, _) ->
-          add_expected_modtype_to_subst sig_env env expected_sig id decl subst
+          add_expected_modtype_to_subst sig_env env sig_map id decl subst
       | Sig_class_type (id, _, _, _) ->
-          add_expected_class_type_to_subst sig_env env expected_sig [id] [] subst
+          add_expected_class_type_to_subst sig_env env sig_map [id] [] subst
       | Sig_value _ | Sig_typext _ | Sig_class _ -> subst
     in
     List.fold_left add_item subst actual_sig
@@ -3230,7 +3233,7 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
     sg,
     shape,
     new_env,
-    add_expected_include_to_subst sig_env env sig_map sg subst,
+    add_expected_include_to_subst sig_env env sig_map expected_sig sg subst,
     Sig_map.add_signature sg str_map
   in
 

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -4653,11 +4653,11 @@ let report_error ~loc _env = function
         (Mode.Value.Const.print_axis ax) left
         (Mode.Value.Const.print_axis ax) right
   | Underscore_not_allowed_in_signature ->
-      Location.errorf ~loc
-        "Inference of module types is not allowed within a signature."
+    Location.errorf ~loc
+      "Inference of module types is not allowed within a signature."
   | Cannot_infer_module_type ->
-      Location.errorf ~loc
-        "Cannot infer module type without a corresponding definition."
+    Location.errorf ~loc
+      "Cannot infer module type without a corresponding definition."
   | Unbound_path_in_inferred_type (k, p) ->
       Location.errorf ~loc
         "The inferred module type refers to %a %a, which is unbound here."

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -3161,6 +3161,12 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
         List.fold_left add_to_subst subst clty_ids
 
   and add_expected_include_to_subst sig_env env expected_sig actual_sig subst =
+    let sig_env = match expected_sig with
+      | None -> sig_env
+      | Some expected_sig -> Env.add_signature expected_sig sig_env
+    in
+    let env = Env.add_signature actual_sig env in
+
     let add_item subst = function
       | Sig_type (id, decl, _, _) ->
           add_expected_type_to_subst sig_env env expected_sig [id, decl] subst

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -164,10 +164,12 @@ module Sig_map = struct
   let find_type name map = String.Map.find_opt name map.types
   let find_module name map = String.Map.find_opt name map.modules
   let find_module_type name map = String.Map.find_opt name map.module_types
+  let find_class_type name map = String.Map.find_opt name map.class_types
 
   let has_type name map = Option.is_some (find_type name map)
   let has_module name map = Option.is_some (find_module name map)
   let has_module_type name map = Option.is_some (find_module_type name map)
+  let has_class_type name map = Option.is_some (find_class_type name map)
 end
 
 type modtype_decl_expected = {
@@ -3607,13 +3609,13 @@ and type_structure ?(toplevel = None) ~expected_sig funct_body anchor env sstr =
         let context =
           match sig_map with
           | None -> In_structure None
-          | Some expected_sig ->
+          | Some sig_map ->
             begin match Sig_map.find_module_type pmtd.pmtd_name.txt sig_map with
               | None -> In_structure None
               | Some (_, decl) ->
                   In_structure (Some ({
                     expected = Subst.modtype_declaration Keep subst decl;
-                    sig_map = expected_sig;
+                    sig_map;
                     str_map;
                   }))
             end

--- a/ocaml/typing/typemod.mli
+++ b/ocaml/typing/typemod.mli
@@ -167,6 +167,7 @@ type error =
   | Underscore_not_allowed_in_signature
   | Cannot_infer_module_type
   | Unbound_path_in_inferred_type of Btype.path_kind * Path.t
+  | Incompatible_type_declaration of Ident.t * type_declaration
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error

--- a/ocaml/typing/typemod.mli
+++ b/ocaml/typing/typemod.mli
@@ -168,6 +168,7 @@ type error =
   | Cannot_infer_module_type
   | Unbound_path_in_inferred_type of Btype.path_kind * Path.t
   | Incompatible_type_declaration of Ident.t * type_declaration
+  | Incompatible_functor_declaration of Location.t
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error

--- a/ocaml/typing/typemod.mli
+++ b/ocaml/typing/typemod.mli
@@ -112,6 +112,12 @@ type functor_dependency_error =
     Functor_applied
   | Functor_included
 
+type modtype_context =
+  | From_module
+    (** The module type originated from a module declaration. *)
+  | From_modtype
+  (** The module type originated from a module type declaration. *)
+
 type error =
     Cannot_apply of module_type
   | Not_included of Includemod.explanation
@@ -169,6 +175,7 @@ type error =
   | Unbound_path_in_inferred_type of Btype.path_kind * Path.t
   | Incompatible_type_declaration of Ident.t * type_declaration
   | Incompatible_functor_declaration of Location.t
+  | Incompatible_module_type of modtype_context * Location.t
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error


### PR DESCRIPTION
This PR implements a compatibility check before adding a module/module type/type into the substitution for module type inference. For the module and module type, the check is simply that all of its elements are also compatible; for the type, we check for now that their arities are the same. This prevents certain invariants in the typechecker breaking after substitution:

```ocaml
module M : sig
  type 'a t

  module type S = sig
    val foo : int t -> int t
  end
end = struct
  type t = int

  module type S = _
  (* invariants inside type checker are messed up from this point onwards:
     the type checker will see Tconstr (int, [int]) *)

  module F(X:S) = struct
    let _ = X.foo 42
  end
end

(* Uncaught exception: Invalid_argument("List.iter2") *)
```

The check is rough for now because we only need to make the type checker not explode - there is a proper inclusion check later on that should catch everything else.