### PR TITLE
Support module type inference for nested module types

### DIFF
--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -1529,18 +1529,9 @@ end = struct
   end
 end
 
-(* CR selee: Boundness check should catch this case *)
 [%%expect {|
-Lines 6-10, characters 6-3:
- 6 | ......struct
- 7 |   module B = struct
- 8 |     module type S = _
- 9 |   end
-10 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig module B : sig module type S = sig type u = t end end end
-       is not included in
-         sig type t module B : sig module type S = sig type u = t end end end
-       The type `t' is required but not provided
+Line 8, characters 4-21:
+8 |     module type S = _
+        ^^^^^^^^^^^^^^^^^
+Error: The inferred module type refers to type t, which is unbound here.
 |}]

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -1680,3 +1680,48 @@ end
 [%%expect {|
 module M : sig module type S = sig type t end module A : sig end end
 |}]
+
+module M : sig
+  module rec A : sig
+    type t
+    module rec B : sig
+      module rec C : sig
+        module type S = sig type u = t end
+      end
+    end
+  end
+end = struct
+  module rec A : sig
+    type t
+    module rec B : sig
+      module rec C : sig
+        module type S = sig type u = t end
+      end
+    end
+  end = struct
+    type t
+    module rec B : sig
+      module rec C : sig
+        module type S = sig type u = t end
+      end
+    end = struct
+      module rec C : sig
+        module type S = sig type u = t end
+      end = struct
+        module type S = _
+      end
+    end
+  end
+end
+
+[%%expect {|
+module M :
+  sig
+    module rec A :
+      sig
+        type t
+        module rec B :
+          sig module rec C : sig module type S = sig type u = t end end end
+      end
+  end
+|}]

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -1678,13 +1678,5 @@ end = struct
 end
 
 [%%expect {|
-Line 9, characters 4-35:
-9 |     module type S = sig type t' end
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This module type is incompatible with the corresponding
-       declaration in the signature.
-Line 2, characters 2-32:
-2 |   module type S = sig type t end
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Expected declaration here
+module M : sig module type S = sig type t end module A : sig end end
 |}]

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -1663,3 +1663,28 @@ Line 16, characters 8-25:
              ^^^^^^^^^^^^^^^^^
 Error: The inferred module type refers to type t, which is unbound here.
 |}]
+
+
+module M : sig
+  module type S = sig type t end
+
+  module A : sig end
+end = struct
+  module type S = sig type t end
+
+  module A = struct
+    module type S = sig type t' end
+  end
+end
+
+[%%expect {|
+Line 9, characters 4-35:
+9 |     module type S = sig type t' end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This module type is incompatible with the corresponding
+       declaration in the signature.
+Line 2, characters 2-32:
+2 |   module type S = sig type t end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Expected declaration here
+|}]

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -1517,3 +1517,30 @@ Line 2, characters 2-31:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Expected declaration here
 |}]
+
+module A : sig
+  type t
+  module B : sig
+    module type S = sig type u = t end
+  end
+end = struct
+  module B = struct
+    module type S = _
+  end
+end
+
+(* CR selee: Boundness check should catch this case *)
+[%%expect {|
+Lines 6-10, characters 6-3:
+ 6 | ......struct
+ 7 |   module B = struct
+ 8 |     module type S = _
+ 9 |   end
+10 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig module B : sig module type S = sig type u = t end end end
+       is not included in
+         sig type t module B : sig module type S = sig type u = t end end end
+       The type `t' is required but not provided
+|}]

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -1535,3 +1535,149 @@ Line 8, characters 4-21:
         ^^^^^^^^^^^^^^^^^
 Error: The inferred module type refers to type t, which is unbound here.
 |}]
+
+module A : sig
+  module B : sig
+    module C : sig
+      module D : sig
+        module type S = sig
+          type t
+        end
+      end
+    end
+  end
+end = struct
+  module B = struct
+    module C = struct
+      module D = struct
+        module type S = _
+      end
+    end
+  end
+end
+
+[%%expect {|
+module A :
+  sig
+    module B :
+      sig
+        module C : sig module D : sig module type S = sig type t end end end
+      end
+  end
+|}]
+
+module A : sig
+  module B : sig
+    type t
+    module C : sig
+      module D : sig
+        module type S = sig
+          val foo : t -> t
+        end
+      end
+    end
+  end
+end = struct
+  module B = struct
+    type t
+    module C = struct
+      module D = struct
+        module type S = _
+      end
+    end
+  end
+end
+
+[%%expect {|
+Line 17, characters 8-25:
+17 |         module type S = _
+             ^^^^^^^^^^^^^^^^^
+Error: The inferred module type refers to type t, which is unbound here.
+|}]
+
+module A : sig
+  module B : sig
+    type t
+    module C : sig
+      module D : sig
+        module type S = sig
+          val foo : t -> t
+        end
+      end
+    end
+  end
+end = struct
+  type t
+  module B = struct
+    type t
+    module C = struct
+      module D = struct
+        module type S = _
+      end
+    end
+  end
+end
+
+[%%expect {|
+Line 18, characters 8-25:
+18 |         module type S = _
+             ^^^^^^^^^^^^^^^^^
+Error: The inferred module type refers to type t, which is unbound here.
+|}]
+
+module A : sig
+  module B : sig
+    type t
+    module C : sig
+      module D : sig
+        module type S = sig
+          val foo : t -> t
+        end
+      end
+    end
+  end
+end = struct
+  type t
+  module B = struct
+    module C = struct
+      module D = struct
+        module type S = _
+      end
+    end
+  end
+end
+
+[%%expect {|
+Line 17, characters 8-25:
+17 |         module type S = _
+             ^^^^^^^^^^^^^^^^^
+Error: The inferred module type refers to type t, which is unbound here.
+|}]
+
+module A : sig
+  type t
+  module B : sig
+    module C : sig
+      module D : sig
+        module type S = sig
+          val foo : t -> t
+        end
+      end
+    end
+  end
+end = struct
+  module B = struct
+    module C = struct
+      module D = struct
+        module type S = _
+      end
+    end
+  end
+end
+
+[%%expect {|
+Line 16, characters 8-25:
+16 |         module type S = _
+             ^^^^^^^^^^^^^^^^^
+Error: The inferred module type refers to type t, which is unbound here.
+|}]

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -1027,12 +1027,8 @@ end = struct
   end
 end
 
-(* CR selee: We want to be able to infer this *)
 [%%expect {|
-Line 9, characters 4-21:
-9 |     module type S = _
-        ^^^^^^^^^^^^^^^^^
-Error: Cannot infer module type without a corresponding definition.
+module M : sig module N : sig module type S = sig type t end end end
 |}]
 
 module M : sig

--- a/ocaml/testsuite/tests/module-type-underscore/typing.ml
+++ b/ocaml/testsuite/tests/module-type-underscore/typing.ml
@@ -1589,10 +1589,15 @@ end = struct
 end
 
 [%%expect {|
-Line 17, characters 8-25:
-17 |         module type S = _
-             ^^^^^^^^^^^^^^^^^
-Error: The inferred module type refers to type t, which is unbound here.
+module A :
+  sig
+    module B :
+      sig
+        type t
+        module C :
+          sig module D : sig module type S = sig val foo : t -> t end end end
+      end
+  end
 |}]
 
 module A : sig
@@ -1619,39 +1624,15 @@ end = struct
 end
 
 [%%expect {|
-Line 18, characters 8-25:
-18 |         module type S = _
-             ^^^^^^^^^^^^^^^^^
-Error: The inferred module type refers to type t, which is unbound here.
-|}]
-
-module A : sig
-  module B : sig
-    type t
-    module C : sig
-      module D : sig
-        module type S = sig
-          val foo : t -> t
-        end
+module A :
+  sig
+    module B :
+      sig
+        type t
+        module C :
+          sig module D : sig module type S = sig val foo : t -> t end end end
       end
-    end
   end
-end = struct
-  type t
-  module B = struct
-    module C = struct
-      module D = struct
-        module type S = _
-      end
-    end
-  end
-end
-
-[%%expect {|
-Line 17, characters 8-25:
-17 |         module type S = _
-             ^^^^^^^^^^^^^^^^^
-Error: The inferred module type refers to type t, which is unbound here.
 |}]
 
 module A : sig
@@ -1673,6 +1654,7 @@ end = struct
       end
     end
   end
+  type t
 end
 
 [%%expect {|

--- a/ocaml/testsuite/tests/typing-modules/strengthening.ml
+++ b/ocaml/testsuite/tests/typing-modules/strengthening.ml
@@ -94,7 +94,7 @@ module Unaliasable = struct
     module F(X:S) = X
     module M = struct end
   end
-
+  
   module X = A.F(A.M)
 end
 [%%expect{|

--- a/ocaml/testsuite/tests/typing-modules/strengthening.ml
+++ b/ocaml/testsuite/tests/typing-modules/strengthening.ml
@@ -94,7 +94,7 @@ module Unaliasable = struct
     module F(X:S) = X
     module M = struct end
   end
-  
+
   module X = A.F(A.M)
 end
 [%%expect{|

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -3659,9 +3659,12 @@ and type_structure ?(toplevel = None)
                let modl, shape =
                  Builtin_attributes.warning_scope attrs
                    (fun () ->
+                      let expected_modtype =
+                        Some (Subst.modtype Keep subst mty.mty_type)
+                      in
                       type_module true funct_body (anchor_recmodule id) newenv
                         ~sig_env:newenv ~str_map:(Some str_map) ~sig_map
-                        smodl ~expected_modtype:(Some mty.mty_type)
+                        smodl ~expected_modtype
                    )
                in
                let mty' =

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -2793,7 +2793,7 @@ and type_module_aux
       let mty = transl_modtype env smty in
       let arg, arg_shape =
         type_module ~alias true funct_body anchor
-          env ~sig_env subst ~str_map ~sig_map sarg
+          env ~sig_env:env subst ~str_map:None ~sig_map:None sarg
           ~expected_modtype:(Some mty.mty_type)
       in
       let md, final_shape =

--- a/ocaml/typing/typemod.ml
+++ b/ocaml/typing/typemod.ml
@@ -117,10 +117,28 @@ exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
 (** Map of items in a signature (similar to an [Env.t] after [Env.add_signature]), but
-    only indexed by the item's name as a string. This avoids us having to iterate through
-    an [expected_sig] to find the declaration we are looking for in [type_str_item]. *)
+    only indexed by the item's name as a string.
+
+    We need [Sig_map] for two slightly conflicting purposes. Firstly, we can use it to
+    avoid having to iterate through an [expected_sig] to find the declaration we are
+    looking for in [type_str_item]. In this case, we only want a "shallow" map - i.e.
+    only the items in the current [expected_sig], and nothing else. This is necessary
+    because while a name can't occur in the same module twice, it could appear in an outer
+    module. We don't want to check for compatibility in the second case, but we can't tell
+    if all the symbols are in the map.
+
+    Secondly, we want it for boundness checking. In this case, we want a "deep" map,
+    because we want to be able to check for usages of paths pointing to things outside
+    the current sig or struct.
+
+    Because of this, [Sig_map] actually keeps track of two maps, corresponding to each
+    of these usages.
+
+    CR selee: [deep] could probably just be a set instead, since we only care about
+    whether a name exists. Either that, or this should be two separate structures?
+    In any case, this probably needs a refactor. *)
 module Sig_map = struct
-  type t = {
+  type map = {
     values: (Ident.t * value_description) String.Map.t;
     types: (Ident.t * type_declaration) String.Map.t;
     modules: (Ident.t * module_declaration) String.Map.t;
@@ -129,13 +147,23 @@ module Sig_map = struct
     class_types: (Ident.t * class_type_declaration) String.Map.t;
   }
 
-  let empty = {
+  type t = {
+    shallow : map;
+    deep : map;
+  }
+
+  let empty_map = {
     values = String.Map.empty;
     types = String.Map.empty;
     modules = String.Map.empty;
     module_types = String.Map.empty;
     classes = String.Map.empty;
     class_types = String.Map.empty;
+  }
+
+  let empty = {
+    shallow = empty_map;
+    deep = empty_map;
   }
 
   let add_value id value map =
@@ -156,6 +184,36 @@ module Sig_map = struct
   let add_class_type id clstype map =
     { map with class_types = String.Map.add (Ident.name id) (id, clstype) map.class_types }
 
+  let enter_value id value t = {
+    shallow = add_value id value t.shallow;
+    deep = add_value id value t.deep;
+  }
+
+  let enter_type id typ t = {
+    shallow = add_type id typ t.shallow;
+    deep = add_type id typ t.deep;
+  }
+
+  let enter_module id modl t = {
+    shallow = add_module id modl t.shallow;
+    deep = add_module id modl t.deep;
+  }
+
+  let enter_module_type id modtype t = {
+    shallow = add_module_type id modtype t.shallow;
+    deep = add_module_type id modtype t.deep;
+  }
+
+  let enter_class id cls t = {
+    shallow = add_class id cls t.shallow;
+    deep = add_class id cls t.deep;
+  }
+
+  let enter_class_type id clstype t = {
+    shallow = add_class_type id clstype t.shallow;
+    deep = add_class_type id clstype t.deep;
+  }
+
   let add_signature sg map =
     let add_item map = function
       | Sig_value (id, desc, _) -> add_value id desc map
@@ -168,12 +226,21 @@ module Sig_map = struct
     in
     List.fold_left add_item map sg
 
+  let enter_signature sg t = {
+    deep = add_signature sg t.deep;
+    shallow = add_signature sg empty_map
+  }
+
   let find_value name map = String.Map.find_opt name map.values
   let find_type name map = String.Map.find_opt name map.types
   let find_module name map = String.Map.find_opt name map.modules
   let find_module_type name map = String.Map.find_opt name map.module_types
   let find_class name map = String.Map.find_opt name map.classes
   let find_class_type name map = String.Map.find_opt name map.class_types
+
+  let find_type_shallow name t = find_type name t.shallow
+  let find_module_shallow name t = find_module name t.shallow
+  let find_module_type_shallow name t = find_module_type name t.shallow
 
   let has_value name map = Option.is_some (find_value name map)
   let has_type name map = Option.is_some (find_type name map)
@@ -182,6 +249,11 @@ module Sig_map = struct
   let has_class name map = Option.is_some (find_class name map)
   let has_class_type name map = Option.is_some (find_class_type name map)
 
+  let has_type_deep name t = has_type name t.deep
+  let has_module_deep name t = has_module name t.deep
+  let has_module_type_deep name t = has_module_type name t.deep
+  let has_class_type_deep name t = has_class_type name t.deep
+
   let subset ~sub ~super =
     String.Map.for_all (fun key _ -> has_value key super) sub.values
       && String.Map.for_all (fun key _ -> has_type key super) sub.types
@@ -189,6 +261,8 @@ module Sig_map = struct
       && String.Map.for_all (fun key _ -> has_module_type key super) sub.module_types
       && String.Map.for_all (fun key _ -> has_class key super) sub.classes
       && String.Map.for_all (fun key _ -> has_class_type key super) sub.class_types
+
+  let subset_shallow ~sub ~super = subset ~sub:sub.shallow ~super:super.shallow
 end
 
 type modtype_decl_expected = {
@@ -1669,8 +1743,8 @@ let check_no_unbound_paths env loc ~str_map ~sig_map mty =
     match path with
     | Pident id ->
         let name = Ident.name id in
-        let in_str = Sig_map.has_module name str_map in
-        let in_sig = Sig_map.has_module name sig_map in
+        let in_str = Sig_map.has_module_deep name str_map in
+        let in_sig = Sig_map.has_module_deep name sig_map in
         check_error initial_kind initial_path in_str in_sig
     | Pdot (p, _) | Pextra_ty (p, _) -> check_heads initial_kind initial_path p
     | Papply (p1, p2) ->
@@ -1688,19 +1762,19 @@ let check_no_unbound_paths env loc ~str_map ~sig_map mty =
                 | Path_value ->
                     Misc.fatal_error "Module type contains reference to a value"
                 | Path_type ->
-                    Sig_map.has_type name str_map,
-                    Sig_map.has_type name sig_map
+                    Sig_map.has_type_deep name str_map,
+                    Sig_map.has_type_deep name sig_map
                 | Path_module ->
-                    Sig_map.has_module name str_map,
-                    Sig_map.has_module name sig_map
+                    Sig_map.has_module_deep name str_map,
+                    Sig_map.has_module_deep name sig_map
                 | Path_modtype ->
-                    Sig_map.has_module_type name str_map,
-                    Sig_map.has_module_type name sig_map
+                    Sig_map.has_module_type_deep name str_map,
+                    Sig_map.has_module_type_deep name sig_map
                 | Path_class ->
                     Misc.fatal_error "Module type contains reference to a class"
                 | Path_classtype ->
-                    Sig_map.has_class_type name str_map,
-                    Sig_map.has_class_type name sig_map
+                    Sig_map.has_class_type_deep name str_map,
+                    Sig_map.has_class_type_deep name sig_map
                 | Path_class_lhs | Path_classtype_lhs ->
                     (true, true)
               end
@@ -3057,8 +3131,8 @@ and type_structure ?(toplevel = None)
     | None -> None
     | Some expected_sig ->
         begin match sig_map with
-          | None -> Some (Sig_map.add_signature expected_sig (Sig_map.empty))
-          | Some sig_map -> Some (Sig_map.add_signature expected_sig sig_map)
+          | None -> Some (Sig_map.enter_signature expected_sig (Sig_map.empty))
+          | Some sig_map -> Some (Sig_map.enter_signature expected_sig sig_map)
         end
   in
 
@@ -3092,12 +3166,12 @@ and type_structure ?(toplevel = None)
     let check_expected_sig actual expected =
       let env = Env.add_signature actual env in
       let sig_env = Env.add_signature expected sig_env in
-      let str_map = Sig_map.add_signature actual (Sig_map.empty) in
-      let sig_map = Sig_map.add_signature expected (Sig_map.empty) in
+      let str_map = Sig_map.enter_signature actual (Sig_map.empty) in
+      let sig_map = Sig_map.enter_signature expected (Sig_map.empty) in
       let is_subset =
         match direction with
-        | Covariant -> Sig_map.subset ~sub:sig_map ~super:str_map
-        | Contravariant -> Sig_map.subset ~sub:str_map ~super:sig_map
+        | Covariant -> Sig_map.subset_shallow ~sub:sig_map ~super:str_map
+        | Contravariant -> Sig_map.subset_shallow ~sub:str_map ~super:sig_map
       in
       if not is_subset then
         raise (Error (actual_loc, env, Incompatible_module_type (context, expected_loc)));
@@ -3209,7 +3283,7 @@ and type_structure ?(toplevel = None)
       | None -> subst
       | Some sig_map ->
           let add_to_subst subst (id, decl) =
-            match Sig_map.find_type (Ident.name id) sig_map with
+            match Sig_map.find_type_shallow (Ident.name id) sig_map with
             | None -> subst
             | Some (sig_ident, sig_decl) ->
                 check_expected_typedecl ~env ~sig_env id decl sig_decl;
@@ -3224,7 +3298,7 @@ and type_structure ?(toplevel = None)
       begin match ident with
         | None -> subst
         | Some ident ->
-            begin match Sig_map.find_module (Ident.name ident) sig_map with
+            begin match Sig_map.find_module_shallow (Ident.name ident) sig_map with
               | None -> subst
               | Some (sig_ident, sig_decl) ->
                   check_expected_modtype ~env ~sig_env From_module direction subst
@@ -3244,7 +3318,7 @@ and type_structure ?(toplevel = None)
     match sig_map with
     | None -> subst
     | Some sig_map ->
-        begin match Sig_map.find_module_type (Ident.name ident) sig_map with
+        begin match Sig_map.find_module_type_shallow (Ident.name ident) sig_map with
           | None -> subst
           | Some (sig_ident, sig_decl) ->
               check_expected_modtype ~env ~sig_env From_modtype direction subst
@@ -3298,7 +3372,7 @@ and type_structure ?(toplevel = None)
     new_env,
     (* CR selee: We currently don't support substitution for items in an include. *)
     subst,
-    Sig_map.add_signature sg str_map
+    Sig_map.enter_signature sg str_map
   in
 
   let type_str_include_functor ~loc env subst str_map shape_map ifincl sig_acc =
@@ -3395,7 +3469,7 @@ and type_structure ?(toplevel = None)
               in
               Sig_value(id, vd, Exported) :: acc,
               Shape.Map.add_value shape_map id vd.val_uid,
-              Sig_map.add_value id vd str_map
+              Sig_map.enter_value id vd str_map
             )
             ([], shape_map, str_map)
             (let_bound_idents_with_modes_sorts_and_checks defs)
@@ -3414,7 +3488,7 @@ and type_structure ?(toplevel = None)
         Shape.Map.add_value shape_map desc.val_id desc.val_val.val_uid,
         newenv,
         subst,
-        Sig_map.add_value desc.val_id desc.val_val str_map
+        Sig_map.enter_value desc.val_id desc.val_val str_map
     | Pstr_type (rec_flag, sdecls) ->
         let (decls, newenv, shapes) =
           Typedecl.transl_type_decl env rec_flag sdecls
@@ -3434,7 +3508,7 @@ and type_structure ?(toplevel = None)
           shapes
         in
         let str_map = List.fold_left
-          (fun map { typ_id; typ_type; _ } -> Sig_map.add_type typ_id typ_type map)
+          (fun map { typ_id; typ_type; _ } -> Sig_map.enter_type typ_id typ_type map)
           str_map decls
         in
         let ident_and_decls =
@@ -3489,16 +3563,18 @@ and type_structure ?(toplevel = None)
           match name.txt, sig_map with
           | None, _ | _, None -> None
           | Some name, Some sig_map ->
-              begin match Sig_map.find_module name sig_map with
+              begin match Sig_map.find_module_shallow name sig_map with
                 | None -> None
-                | Some (_, decl) -> Some decl.md_type
+                (* All references outside this new module shouldn't need to be checked
+                   anymore. *)
+                | Some (_, decl) -> Some (Subst.modtype Keep subst decl.md_type)
               end
         in
         let modl, md_shape =
           Builtin_attributes.warning_scope attrs
             (fun () ->
                type_module ~expected_modtype ~alias:true true funct_body
-                 (anchor_submodule name.txt anchor) env ~sig_env (Some subst)
+                 (anchor_submodule name.txt anchor) env ~sig_env:env (Some subst)
                  ~str_map:(Some str_map) ~sig_map smodl
             )
         in
@@ -3539,7 +3615,7 @@ and type_structure ?(toplevel = None)
           | None -> shape_map
         in
         let str_map = match id with
-          | Some id -> Sig_map.add_module id md str_map;
+          | Some id -> Sig_map.enter_module id md str_map;
           | None -> str_map
         in
         Tstr_module {mb_id=id; mb_name=name; mb_uid = md.md_uid;
@@ -3609,7 +3685,7 @@ and type_structure ?(toplevel = None)
                    in
                    Env.add_module_declaration ~check:true ~shape
                      id Mp_present mdecl env,
-                   Sig_map.add_module id mdecl map
+                   Sig_map.enter_module id mdecl map
             )
             (env, str_map) bindings1
         in
@@ -3653,7 +3729,7 @@ and type_structure ?(toplevel = None)
           match sig_map with
           | None -> In_structure None
           | Some sig_map ->
-            begin match Sig_map.find_module_type pmtd.pmtd_name.txt sig_map with
+            begin match Sig_map.find_module_type_shallow pmtd.pmtd_name.txt sig_map with
               | None -> In_structure None
               | Some (_, decl) ->
                   In_structure (Some ({
@@ -3673,7 +3749,7 @@ and type_structure ?(toplevel = None)
         map,
         newenv,
         add_expected_modtype_to_subst ~env ~sig_env sig_map Covariant id decl subst,
-        Sig_map.add_module_type id decl str_map
+        Sig_map.enter_module_type id decl str_map
     | Pstr_open sod ->
         let toplevel = Option.is_some toplevel in
         let (od, sg, newenv) =
@@ -3697,9 +3773,9 @@ and type_structure ?(toplevel = None)
         in
         let str_map = List.fold_left (fun map cls ->
             let open Typeclass in
-            Sig_map.add_class cls.cls_id cls.cls_decl map
-            |> Sig_map.add_class_type cls.cls_ty_id cls.cls_ty_decl
-            |> Sig_map.add_type cls.cls_obj_id cls.cls_obj_abbr
+            Sig_map.enter_class cls.cls_id cls.cls_decl map
+            |> Sig_map.enter_class_type cls.cls_ty_id cls.cls_ty_decl
+            |> Sig_map.enter_type cls.cls_obj_id cls.cls_obj_abbr
           ) str_map classes
         in
         let ty_ids_and_decls =
@@ -3738,8 +3814,8 @@ and type_structure ?(toplevel = None)
         in
         let str_map = List.fold_left (fun map decl ->
             let open Typeclass in
-            Sig_map.add_class_type decl.clsty_ty_id decl.clsty_ty_decl map
-            |> Sig_map.add_type decl.clsty_obj_id decl.clsty_obj_abbr
+            Sig_map.enter_class_type decl.clsty_ty_id decl.clsty_ty_decl map
+            |> Sig_map.enter_type decl.clsty_obj_id decl.clsty_obj_abbr
           ) str_map classes
         in
         let ty_ids_and_decls =

--- a/ocaml/typing/typemod.mli
+++ b/ocaml/typing/typemod.mli
@@ -34,12 +34,12 @@ end
 
 val type_module:
         expected_modtype:Types.module_type option ->
-        Env.t -> sig_env:Env.t -> Subst.t option ->
+        Env.t -> sig_env:Env.t ->
         str_map:Sig_map.t option -> sig_map:Sig_map.t option ->
         Parsetree.module_expr -> Typedtree.module_expr * Shape.t
 val type_structure:
   expected_sig:Types.signature option ->
-  Env.t -> sig_env:Env.t -> Subst.t option ->
+  Env.t -> sig_env:Env.t ->
   str_map:Sig_map.t option -> sig_map:Sig_map.t option -> Parsetree.structure ->
   Typedtree.structure * Types.signature * Signature_names.t * Shape.t *
   Env.t

--- a/ocaml/typing/typemod.mli
+++ b/ocaml/typing/typemod.mli
@@ -34,11 +34,13 @@ end
 
 val type_module:
         expected_modtype:Types.module_type option ->
-        Env.t -> sig_env:Env.t -> sig_map:Sig_map.t option ->
+        Env.t -> sig_env:Env.t -> Subst.t option ->
+        str_map:Sig_map.t option -> sig_map:Sig_map.t option ->
         Parsetree.module_expr -> Typedtree.module_expr * Shape.t
 val type_structure:
   expected_sig:Types.signature option ->
-  Env.t -> sig_env:Env.t -> sig_map:Sig_map.t option -> Parsetree.structure ->
+  Env.t -> sig_env:Env.t -> Subst.t option ->
+  str_map:Sig_map.t option -> sig_map:Sig_map.t option -> Parsetree.structure ->
   Typedtree.structure * Types.signature * Signature_names.t * Shape.t *
   Env.t
 val type_toplevel_phrase:

--- a/ocaml/typing/typemod.mli
+++ b/ocaml/typing/typemod.mli
@@ -28,13 +28,17 @@ module Signature_names : sig
   val simplify: Env.t -> t -> signature -> signature
 end
 
+module Sig_map : sig
+  type t
+end
+
 val type_module:
         expected_modtype:Types.module_type option ->
-        Env.t -> sig_env:Env.t ->
+        Env.t -> sig_env:Env.t -> sig_map:Sig_map.t option ->
         Parsetree.module_expr -> Typedtree.module_expr * Shape.t
 val type_structure:
   expected_sig:Types.signature option ->
-  Env.t -> sig_env:Env.t -> Parsetree.structure ->
+  Env.t -> sig_env:Env.t -> sig_map:Sig_map.t option -> Parsetree.structure ->
   Typedtree.structure * Types.signature * Signature_names.t * Shape.t *
   Env.t
 val type_toplevel_phrase:

--- a/ocaml/typing/typemod.mli
+++ b/ocaml/typing/typemod.mli
@@ -30,10 +30,11 @@ end
 
 val type_module:
         expected_modtype:Types.module_type option ->
-        Env.t -> Parsetree.module_expr -> Typedtree.module_expr * Shape.t
+        Env.t -> sig_env:Env.t ->
+        Parsetree.module_expr -> Typedtree.module_expr * Shape.t
 val type_structure:
   expected_sig:Types.signature option ->
-  Env.t -> Parsetree.structure ->
+  Env.t -> sig_env:Env.t -> Parsetree.structure ->
   Typedtree.structure * Types.signature * Signature_names.t * Shape.t *
   Env.t
 val type_toplevel_phrase:


### PR DESCRIPTION
This PR enables support for `module type S = _` syntax in module types nested within a module, e.g.
```ocaml
module M : sig
  module N : sig
    module type S = sig
      type t
    end
  end
end = struct
  module N = struct
    module type S = _
  end
end
```

This is a draft because I don't think it has been tested quite well enough, and also because it's not as tidy as I would like it to be. The crux of the problem is that we are using `Sig_map` for two slightly different purposes. Consider:
```ocaml
module M : sig
  module type S = sig type t end

  module A : sig end
end = struct
  module type S = sig type t end

  module A = struct
    module type S = sig type t' end
  end
end
```

If `sig_map` contains `S` at the point of checking `A`, then we don't know whether this `S` is from the `A` in the corresponding `sig`, or if it's from somewhere outside (as in this case). If we assume the former, then we'll be doing a compatibility check on two different `S`s, which would be wrong. This shows that `sig_map` should only contain the elements declared in the expected signature of the `struct` we are checking.

Now consider:
```ocaml
module A : sig
  type t
  module B : sig
    module type S = sig 
      val foo : t -> t
    end
  end
end = struct
  module B = struct
    module type S = _ 
  end
end
```

We also use `sig_map` to check for boundness in inferred module types: if an element shows up in `sig_map` but not in `str_map` we raise an error. But we are fine with an element not showing up in both `sig_map` and `str_map` - then we can just assume that they were declared somewhere outside, and therefore is accessible. However, this breaks in the above case when we are checking the inferred `S` if `sig_map` only contains elements in `B`. Then `sig_map` will be empty, so the error doesn't trigger. This demonstrates that our current use of `sig_map` conflicts with each other.

The solution I've decided to implement is somewhat messy and unsatisfying, and essentially turns `Sig_map` into two maps: `shallow` and `deep`. `shallow` contains elements that are only within the current sig (with `Sig_map.enter_signature` "refreshing" it before adding signature items), while `deep` accumulates. This has resulted in a significant amount of boilerplate for `Sig_map`, and more importantly, `deep` doesn't need to be a `map` at all because we only use it to check whether an element exists.

As I've had to rush this implementation, I haven't had much time to deeply think about how to refactor this. We could either separate out `Sig_map` into two data structures (`Sig_map` and `Sig_set`?) but this would require passing in more arguments to functions. We could also just turn `deep` into a set, but then `Sig_map` becomes a bit of a misnomer. I'm also not sure either solution will reduce the amount of boilerplate. It feels like there should be a cleaner third solution.
