### PR TITLE
Refactoring of Flambda 2 array types

### DIFF
--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -45,6 +45,22 @@ type typing_env = Typing_env.t
 type typing_env_extension = Typing_env_extension.t
 
 include Type_grammar
+
+module Array_contents = struct
+  type nonrec t = array_contents =
+    | Immutable of { fields : t array }
+    | Mutable
+end
+
+module Array_type = struct
+  type nonrec t = array_type =
+    { element_kind : Flambda_kind.With_subkind.t Or_unknown_or_bottom.t;
+      length : t;
+      contents : array_contents Or_unknown.t;
+      alloc_mode : Alloc_mode.For_types.t
+    }
+end
+
 include More_type_creators
 include Expand_head
 include Meet_and_join

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -654,21 +654,24 @@ val meet_is_naked_number_array :
 
 val prove_is_immediates_array : Typing_env.t -> t -> unit proof_of_property
 
-val meet_is_immutable_array :
-  Typing_env.t ->
-  t ->
-  (Flambda_kind.With_subkind.t Or_unknown_or_bottom.t
-  * t array
-  * Alloc_mode.For_types.t)
-  meet_shortcut
+module Array_contents : sig
+  type nonrec t = private
+    | Immutable of { fields : t array }
+    | Mutable
+end
 
-val prove_is_immutable_array :
-  Typing_env.t ->
-  t ->
-  (Flambda_kind.With_subkind.t Or_unknown_or_bottom.t
-  * t array
-  * Alloc_mode.For_types.t)
-  proof_of_property
+module Array_type : sig
+  type nonrec t = private
+    { element_kind : Flambda_kind.With_subkind.t Or_unknown_or_bottom.t;
+      length : t;
+      contents : Array_contents.t Or_unknown.t;
+      alloc_mode : Alloc_mode.For_types.t
+    }
+end
+
+val meet_is_array : Typing_env.t -> t -> Array_type.t meet_shortcut
+
+val prove_is_array : Typing_env.t -> t -> Array_type.t proof_of_property
 
 val meet_single_closures_entry :
   Typing_env.t ->

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -69,12 +69,7 @@ and head_of_kind_value =
         alloc_mode : Alloc_mode.For_types.t
       }
   | String of String_info.Set.t
-  | Array of
-      { element_kind : Flambda_kind.With_subkind.t Or_unknown_or_bottom.t;
-        length : t;
-        contents : array_contents Or_unknown.t;
-        alloc_mode : Alloc_mode.For_types.t
-      }
+  | Array of array_type
 
 (* CR someday vlaviron: comparison results are encoded as naked immediates, and
    in a few cases (physical equality mostly) some values of the boolean carry
@@ -193,6 +188,13 @@ and function_type =
 and array_contents =
   | Immutable of { fields : t array }
   | Mutable
+
+and array_type =
+  { element_kind : Flambda_kind.With_subkind.t Or_unknown_or_bottom.t;
+    length : t;
+    contents : array_contents Or_unknown.t;
+    alloc_mode : Alloc_mode.For_types.t
+  }
 
 and env_extension = { equations : t Name.Map.t } [@@unboxed]
 

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -60,12 +60,7 @@ and head_of_kind_value = private
         alloc_mode : Alloc_mode.For_types.t
       }
   | String of String_info.Set.t
-  | Array of
-      { element_kind : Flambda_kind.With_subkind.t Or_unknown_or_bottom.t;
-        length : t;
-        contents : array_contents Or_unknown.t;
-        alloc_mode : Alloc_mode.For_types.t
-      }
+  | Array of array_type
 
 and head_of_kind_naked_immediate = private
   | Naked_immediates of Targetint_31_63.Set.t
@@ -146,6 +141,13 @@ and function_type = private
 and array_contents =
   | Immutable of { fields : t array }
   | Mutable
+
+and array_type =
+  { element_kind : Flambda_kind.With_subkind.t Or_unknown_or_bottom.t;
+    length : t;
+    contents : array_contents Or_unknown.t;
+    alloc_mode : Alloc_mode.For_types.t
+  }
 
 and env_extension = private { equations : t Name.Map.t } [@@unboxed]
 

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -657,26 +657,20 @@ let prove_single_closures_entry_generic env t : _ generic_proof =
 let meet_single_closures_entry env t =
   as_meet_shortcut (prove_single_closures_entry_generic env t)
 
-let prove_is_immutable_array_generic env t : _ generic_proof =
+let prove_is_array_generic env t : _ generic_proof =
   match expand_head env t with
   | Value Unknown -> Unknown
   | Value Bottom -> Invalid
-  | Value (Ok (Array { element_kind; length = _; contents; alloc_mode })) -> (
-    match contents with
-    | Known (Immutable { fields }) -> Proved (element_kind, fields, alloc_mode)
-    | Known Mutable -> Invalid
-    | Unknown -> Unknown)
+  | Value (Ok (Array array_ty)) -> Proved array_ty
   | Value (Ok _)
   | Naked_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int32 _
   | Naked_int64 _ | Naked_vec128 _ | Naked_nativeint _ | Rec_info _ | Region _
     ->
     Invalid
 
-let meet_is_immutable_array env t =
-  as_meet_shortcut (prove_is_immutable_array_generic env t)
+let meet_is_array env t = as_meet_shortcut (prove_is_array_generic env t)
 
-let prove_is_immutable_array env t =
-  as_property (prove_is_immutable_array_generic env t)
+let prove_is_array env t = as_property (prove_is_array_generic env t)
 
 let prove_single_closures_entry env t =
   as_property (prove_single_closures_entry_generic env t)

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -141,21 +141,11 @@ val meet_is_naked_number_array :
   Flambda_kind.Naked_number_kind.t ->
   bool meet_shortcut
 
-val meet_is_immutable_array :
-  Typing_env.t ->
-  Type_grammar.t ->
-  (Flambda_kind.With_subkind.t Or_unknown_or_bottom.t
-  * Type_grammar.t array
-  * Alloc_mode.For_types.t)
-  meet_shortcut
+val meet_is_array :
+  Typing_env.t -> Type_grammar.t -> Type_grammar.array_type meet_shortcut
 
-val prove_is_immutable_array :
-  Typing_env.t ->
-  Type_grammar.t ->
-  (Flambda_kind.With_subkind.t Or_unknown_or_bottom.t
-  * Type_grammar.t array
-  * Alloc_mode.For_types.t)
-  proof_of_property
+val prove_is_array :
+  Typing_env.t -> Type_grammar.t -> Type_grammar.array_type proof_of_property
 
 val prove_is_immediates_array :
   Typing_env.t -> Type_grammar.t -> unit proof_of_property


### PR DESCRIPTION
This rearranges the representation of array types in the Flambda 2 type grammar a little.  It then exposes these directly through the provers rather than providing only a subset of information.  This will help to tighten up the array simplification functions to ensure that examples such as in https://github.com/ocaml-flambda/flambda-backend/pull/3129 produce `Invalid`.