### PR TITLE
Stop filtering ghost locations from cmt/cms files

### DIFF
--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -373,13 +373,14 @@ let index_occurrences binary_annots =
   let index : (Longident.t Location.loc * Shape_reduce.result) list ref =
     ref []
   in
-  let f ~namespace env path lid =
-    match Env.shape_of_path ~namespace env path with
-    | exception Not_found -> ()
-    | { uid = Some (Predef _); _ } -> ()
-    | path_shape ->
-      let result = Shape_reduce.local_reduce_for_uid env path_shape in
-      index := (lid, result) :: !index
+  let f ~namespace env path (lid : _ Location.loc) =
+    if not (Location.is_none lid.loc) then
+      match Env.shape_of_path ~namespace env path with
+      | exception Not_found -> ()
+      | { uid = Some (Predef _); _ } -> ()
+      | path_shape ->
+        let result = Shape_reduce.local_reduce_for_uid env path_shape in
+        index := (lid, result) :: !index
   in
   iter_on_annots (iter_on_occurrences ~f) binary_annots;
   Array.of_list !index


### PR DESCRIPTION
This PR changes cmt and cms files to include the locations of all identifier occurrences. This is different from before, where locations with `loc_ghost = true` are filtered out. The onus would then fall on Merlin to filter out occurrences of identifiers that shouldn't be displayed to users.

The immediate motivation for this change is to make project-wide occurrences work with punned let expressions. Currently, since the expression side of lets are marked ghost, they are filtered out from occurrences. One solution would be to continue filtering ghost locations, but add some sort of logic that special-cases the expression of a punned let. However, the solution that @ncik-roberts and I came up with is to instead filter locations that are not `Location.none`. Our reasoning is that user probably do actually want to see occurrences that are marked as ghost (for example, in ppx generated code) if there is a reasonable location in the source code to point to.

Regardless, I think filtering of locations should ultimately be handled by Merlin. If we want to iterate on what locations we choose to filter, it is much easier to change only Merlin rather than both Merlin and the compiler. This comes at a slight cost - cms/cmt files may be bloated with locations that we don't really care about, and the filtering will slow Merlin down slightly since that filtering is no longer done in a preprocessing step. But I think both of these costs are fairly small. With no evidence to back up my claim, I believe the number of ghost locations is likely small relative to non-ghost locations. And that Merlin slowdown it probably negligible compared to, say, serializing the locations after filtering.

This PR necessitates a corresponding change in Merlin because Merlin currently unconditionally includes all occurrences reported by the compiler via cms/cmt files. Thus, Merlin now needs to filter locations read from cms/cmt files. This is done in: https://github.com/janestreet/merlin-jst/pull/110