### PR TITLE
Added a generalize function to mode solver

### DIFF
--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -1876,6 +1876,11 @@ module Common (Obj : Obj) = struct
 
   let update_level i a = with_log (Solver.update_level i obj a)
 
+  let generalize ~current_level ~generic_level a ~traversed =
+    let log' = ref S.empty_changes in
+    let log = Some log' in
+    Solver.generalize ~current_level ~generic_level obj a ~traversed ~log
+
   let join l = Solver.join obj l
 
   let meet l = Solver.meet obj l
@@ -2528,6 +2533,11 @@ module Value_with (Areality : Areality) = struct
   let update_level i { monadic = monadic0; comonadic = comonadic0 } =
     Monadic.update_level i monadic0;
     Comonadic.update_level i comonadic0
+
+  let generalize ~current_level ~generic_level
+      { monadic = monadic0; comonadic = comonadic0} ~traversed =
+    Monadic.generalize ~current_level ~generic_level monadic0 ~traversed;
+    Comonadic.generalize ~current_level ~generic_level comonadic0 ~traversed
 
   let equate a b = try_with_log (equate_from_submode submode_log a b)
 

--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -1876,10 +1876,15 @@ module Common (Obj : Obj) = struct
 
   let update_level i a = with_log (Solver.update_level i obj a)
 
-  let generalize ~current_level ~generic_level a ~traversed =
+  let generalize ~current_level ~generic_level a =
     let log' = ref S.empty_changes in
     let log = Some log' in
-    Solver.generalize ~current_level ~generic_level obj a ~traversed ~log
+    Solver.generalize ~current_level ~generic_level obj a ~log
+
+  let generalize_structure ~current_level ~generic_level a =
+    let log' = ref S.empty_changes in
+    let log = Some log' in
+    Solver.generalize_structure ~current_level ~generic_level obj a ~log
 
   let join l = Solver.join obj l
 
@@ -2535,9 +2540,14 @@ module Value_with (Areality : Areality) = struct
     Comonadic.update_level i comonadic0
 
   let generalize ~current_level ~generic_level
-      { monadic = monadic0; comonadic = comonadic0} ~traversed =
-    Monadic.generalize ~current_level ~generic_level monadic0 ~traversed;
-    Comonadic.generalize ~current_level ~generic_level comonadic0 ~traversed
+      { monadic = monadic0; comonadic = comonadic0} =
+    Monadic.generalize ~current_level ~generic_level monadic0;
+    Comonadic.generalize ~current_level ~generic_level comonadic0
+
+  let generalize_structure ~current_level ~generic_level
+      { monadic = monadic0; comonadic = comonadic0} =
+    Monadic.generalize_structure ~current_level ~generic_level monadic0;
+    Comonadic.generalize_structure ~current_level ~generic_level comonadic0
 
   let equate a b = try_with_log (equate_from_submode submode_log a b)
 

--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -1877,14 +1877,10 @@ module Common (Obj : Obj) = struct
   let update_level i a = with_log (Solver.update_level i obj a)
 
   let generalize ~current_level ~generic_level a =
-    let log' = ref S.empty_changes in
-    let log = Some log' in
-    Solver.generalize ~current_level ~generic_level obj a ~log
+    with_log (Solver.generalize ~current_level ~generic_level obj a)
 
   let generalize_structure ~current_level ~generic_level a =
-    let log' = ref S.empty_changes in
-    let log = Some log' in
-    Solver.generalize_structure ~current_level ~generic_level obj a ~log
+    with_log (Solver.generalize_structure ~current_level ~generic_level obj a)
 
   let join l = Solver.join obj l
 

--- a/ocaml/typing/mode_intf.mli
+++ b/ocaml/typing/mode_intf.mli
@@ -80,7 +80,12 @@ module type Common = sig
     current_level:int ->
     generic_level:int ->
     ('l * 'r) t ->
-    traversed:(int,unit) Hashtbl.t ->
+    unit
+
+  val generalize_structure :
+    current_level:int ->
+    generic_level:int ->
+    ('l * 'r) t ->
     unit
 
   val equate : lr -> lr -> (unit, equate_error) result

--- a/ocaml/typing/mode_intf.mli
+++ b/ocaml/typing/mode_intf.mli
@@ -76,6 +76,13 @@ module type Common = sig
 
   val update_level : int -> ('l * 'r) t -> unit
 
+  val generalize :
+    current_level:int ->
+    generic_level:int ->
+    ('l * 'r) t ->
+    traversed:(int,unit) Hashtbl.t ->
+    unit
+
   val equate : lr -> lr -> (unit, equate_error) result
 
   val submode_exn : (allowed * 'r) t -> ('l * allowed) t -> unit

--- a/ocaml/typing/solver.ml
+++ b/ocaml/typing/solver.ml
@@ -661,7 +661,6 @@ module Solver_mono (C : Lattices_mono) = struct
   let fresh ?upper ?lower ?vlower ?vupper ?level obj =
     let id = !cnt_id in
     cnt_id := id + 1;
-    (* For now, pick the levels at random *)
     let level = Option.value level ~default:0 in
     let upper = Option.value upper ~default:(C.max obj) in
     let lower = Option.value lower ~default:(C.min obj) in
@@ -711,9 +710,9 @@ module Solver_mono (C : Lattices_mono) = struct
           let copy = fresh ~upper:u.upper ~lower:u.lower ~level:u.level dst in
           let ok1 = submode_mvmv ~log dst (Amorphvar (copy, C.id)) (Amorphvar (u, C.id)) in
           let ok2 = submode_mvmv ~log dst (Amorphvar (u, C.id)) (Amorphvar (copy, C.id)) in
-          assert (Result.is_ok ok1 && Result.is_ok ok2)
-        end;
-        update_level_v ~log dst current_level u
+          assert (Result.is_ok ok1 && Result.is_ok ok2);
+          update_level_v ~log dst current_level copy
+        end
       end
 
   let generalize_v

--- a/ocaml/typing/solver.ml
+++ b/ocaml/typing/solver.ml
@@ -724,7 +724,8 @@ module Solver_mono (C : Lattices_mono) = struct
 
   (* generalize_structure has three cases:
     (1) if bounds are tight, the var is moved to generic_level
-    (2) if bounds are fully open, do nothing
+    (2) if bounds are fully open, do nothing --- we consider only the case where bounds
+        are precise by virtue of having no vupper/vlower
     (3) if bounds are non-trivial (neither tight nor fully open) we make a copy, move the
         original var to generic_level, and mark the two variables as equivalent by adding
         constraint arrows via [add_vlower] and [add_vupper]
@@ -739,7 +740,8 @@ module Solver_mono (C : Lattices_mono) = struct
         update_level_v ~log dst generic_level u
       end else if
         C.le dst (C.max dst) u.upper &&
-        C.le dst u.lower (C.min dst) then
+        C.le dst u.lower (C.min dst) &&
+        u.vlower = [] && u.vupper = [] then
         (* the bounds are fully open *)
         update_level_v ~log dst current_level u
       else begin

--- a/ocaml/typing/solver.ml
+++ b/ocaml/typing/solver.ml
@@ -765,9 +765,10 @@ module Solver_mono (C : Lattices_mono) = struct
         generalize_topology ~log dst ~current_level ~generic_level u;
         update_level_v ~log dst generic_level u
       end else if
-        u.vupper = [] && u.vlower = [] then
+        C.le dst (C.max dst) u.upper &&
+        C.le dst u.lower (C.min dst) then
         (* the bounds are fully open *)
-        ()
+        update_level_v ~log dst current_level u
       else begin
         (* the bounds are non-trivial *)
         let cond = { b = fun v -> v.level > current_level } in

--- a/ocaml/typing/solver_intf.mli
+++ b/ocaml/typing/solver_intf.mli
@@ -285,16 +285,24 @@ module type Solver_polarized = sig
     unit
 
   (** Generalizes all reachable variables whose level is above [current_level],
-      by putting their level to [generic_level]. [traversed] tracks all the variables that
-      have already been generalized *)
+      by putting their level to [generic_level]. *)
   val generalize :
     current_level:int ->
     generic_level:int ->
     'a obj ->
     ('a, 'l * 'r) mode ->
-    traversed:(int,unit) Hashtbl.t ->
     log:changes ref option ->
     unit
+
+  (** Generalizes all reachable variables whose level is above [current_level], and whose
+      value can be determined (equal bounds), by putting their level to [generic_level].*)
+      val generalize_structure :
+      current_level:int ->
+      generic_level:int ->
+      'a obj ->
+      ('a, 'l * 'r) mode ->
+      log:changes ref option ->
+      unit
 
   (** Creates a new mode variable above the given mode and returns [true]. In
         the speical case where the given mode is top, returns the constant top

--- a/ocaml/typing/solver_intf.mli
+++ b/ocaml/typing/solver_intf.mli
@@ -294,8 +294,8 @@ module type Solver_polarized = sig
     log:changes ref option ->
     unit
 
-  (** Generalizes all reachable variables whose level is above [current_level], and whose
-      value can be determined (equal bounds), by putting their level to [generic_level].*)
+  (** Generalizes all reachable variables whose level is above [current_level],
+      whose value is fully determined, by putting their level to [generic_level].*)
       val generalize_structure :
       current_level:int ->
       generic_level:int ->

--- a/ocaml/typing/solver_intf.mli
+++ b/ocaml/typing/solver_intf.mli
@@ -284,6 +284,18 @@ module type Solver_polarized = sig
     log:changes ref option ->
     unit
 
+  (** Generalizes all reachable variables whose level is above [current_level],
+      by putting their level to [generic_level]. [traversed] tracks all the variables that
+      have already been generalized *)
+  val generalize :
+    current_level:int ->
+    generic_level:int ->
+    'a obj ->
+    ('a, 'l * 'r) mode ->
+    traversed:(int,unit) Hashtbl.t ->
+    log:changes ref option ->
+    unit
+
   (** Creates a new mode variable above the given mode and returns [true]. In
         the speical case where the given mode is top, returns the constant top
         and [false]. *)


### PR DESCRIPTION
Added the `generalize` operation, which takes all mode variables above the current level and sets them to the general level. `update_level` is called to maintain mode variable invariants whenever multiple levels are generalized