### PR TITLE
Add Simplify_primitive_result.Resimplify

### DIFF
--- a/middle_end/flambda2/simplify/simplify_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_primitive.ml
@@ -91,7 +91,7 @@ let check_arg_kinds prim arg_tys_with_expected_kinds =
           T.print arg_ty K.print arg_kind K.print expected_kind P.print prim)
     arg_tys_with_expected_kinds
 
-let simplify_primitive dacc (prim : P.t) dbg ~result_var =
+let simplify_primitive0 dacc (prim : P.t) dbg ~result_var =
   let min_name_mode = Bound_var.name_mode result_var in
   match prim with
   | Nullary prim' ->
@@ -190,3 +190,8 @@ let simplify_primitive dacc (prim : P.t) dbg ~result_var =
     | Not_applied dacc ->
       Simplify_variadic_primitive.simplify_variadic_primitive dacc original_prim
         variadic_prim ~args_with_tys dbg ~result_var)
+
+let rec simplify_primitive dacc prim dbg ~result_var =
+  match simplify_primitive0 dacc prim dbg ~result_var with
+  | Simplified result -> result
+  | Resimplify { prim; dacc } -> simplify_primitive dacc prim dbg ~result_var

--- a/middle_end/flambda2/simplify/simplify_primitive.mli
+++ b/middle_end/flambda2/simplify/simplify_primitive.mli
@@ -21,4 +21,4 @@ val simplify_primitive :
   Flambda_primitive.t ->
   Debuginfo.t ->
   result_var:Bound_var.t ->
-  Simplify_primitive_result.t
+  Simplify_primitive_result.simplified

--- a/middle_end/flambda2/simplify/simplify_primitive_result.mli
+++ b/middle_end/flambda2/simplify/simplify_primitive_result.mli
@@ -16,12 +16,19 @@
 
 [@@@ocaml.warning "+a-30-40-41-42"]
 
-type t = private
+type simplified = private
   { simplified_named : Simplified_named.t Or_invalid.t;
     extra_bindings : Expr_builder.binding_to_place list;
     try_reify : bool;
     dacc : Downwards_acc.t
   }
+
+type t = private
+  | Simplified of simplified
+  | Resimplify of
+      { prim : Flambda_primitive.t;
+        dacc : Downwards_acc.t
+      }
 
 val create :
   ?extra_bindings:Expr_builder.binding_to_place list ->
@@ -48,4 +55,8 @@ val create_unknown :
   original_term:Flambda.Named.t ->
   t
 
+val create_resimplify : Downwards_acc.t -> Flambda_primitive.t -> t
+
 val with_dacc : t -> Downwards_acc.t -> t
+
+val dacc : t -> Downwards_acc.t

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -83,11 +83,12 @@ let simplify_project_value_slot function_slot value_slot ~min_name_mode dacc
                ~value_slot_var:(Bound_var.var result_var) ~value_slot_kind:kind)
           ~result_var ~result_kind:(K.With_subkind.kind kind)
       in
-      let dacc = DA.add_use_of_value_slot result.dacc value_slot in
+      let dacc = DA.add_use_of_value_slot (SPR.dacc result) value_slot in
       SPR.with_dacc result dacc
   in
   let dacc =
-    Simplify_common.add_symbol_projection result.dacc ~projected_from:closure
+    Simplify_common.add_symbol_projection (SPR.dacc result)
+      ~projected_from:closure
       (Symbol_projection.Projection.project_value_slot function_slot value_slot)
       ~projection_bound_to:result_var ~kind
   in
@@ -131,7 +132,7 @@ let simplify_unbox_number (boxable_number_kind : K.Boxable_number.t) dacc
       ~deconstructing:boxed_number_ty ~shape ~result_var ~result_kind
   in
   let dacc =
-    let dacc = result.dacc in
+    let dacc = SPR.dacc result in
     (* We can only add the inverse CSE equation if we know the alloc mode for
        certain and it is [Heap]. (As per [Flambda_primitive] we don't currently
        CSE local allocations.) *)
@@ -160,7 +161,7 @@ let simplify_untag_immediate dacc ~original_term ~arg ~arg_ty:boxed_number_ty
       ~deconstructing:boxed_number_ty ~shape ~result_var ~result_kind
   in
   let dacc =
-    DA.map_denv result.dacc ~f:(fun denv ->
+    DA.map_denv (SPR.dacc result) ~f:(fun denv ->
         DE.add_cse denv
           (P.Eligible_for_cse.create_exn
              (Unary (Tag_immediate, Simple.var result_var')))
@@ -813,14 +814,14 @@ let[@inline always] simplify_immutable_block_load0
              ~field_n_minus_one:result_var')
         ~result_var ~result_kind
     in
-    match result.simplified_named with
-    | Invalid -> result
-    | Ok _ -> (
+    match result with
+    | Simplified { simplified_named = Invalid; _ } -> result
+    | Simplified { dacc; simplified_named = Ok _; _ } | Resimplify { dacc; _ }
+      -> (
       (* If the type contains enough information to actually build a primitive
          to make the corresponding block, then we add a CSE equation, to try to
          avoid duplicate allocations in the future. This should help with cases
          such as "Some x -> Some x". *)
-      let dacc = result.dacc in
       match
         T.prove_unique_fully_constructed_immutable_heap_block
           (DA.typing_env dacc) block_ty
@@ -873,7 +874,7 @@ let simplify_immutable_block_load access_kind ~field ~min_name_mode dacc
   in
   let dacc' =
     let kind = P.Block_access_kind.element_subkind_for_load access_kind in
-    Simplify_common.add_symbol_projection result.dacc ~projected_from:arg
+    Simplify_common.add_symbol_projection (SPR.dacc result) ~projected_from:arg
       (Symbol_projection.Projection.block_load ~index:field)
       ~projection_bound_to:result_var ~kind
   in


### PR DESCRIPTION
This allows the primitive simplification code (in `Simplify`) to return a primitive which is then immediately subject to resimplification.  This will be used in a forthcoming PR for array reinterpret operations.