### PR TITLE
Functional mode polymorphism

### DIFF
--- a/ocaml/lambda/translmode.ml
+++ b/ocaml/lambda/translmode.ml
@@ -20,12 +20,12 @@ let transl_locality_mode = function
   | Locality.Const.Local -> alloc_local
 
 let transl_locality_mode_l locality =
-  Locality.zap_to_floor locality |> transl_locality_mode
+  Locality.zap_to_floor_exn locality |> transl_locality_mode
 
 let transl_locality_mode_r locality =
   (* r mode are for allocations; [optimise_allocations] should have pushed it
      to ceil and determined; here we push it again just to get the constant. *)
-  Locality.zap_to_ceil locality |> transl_locality_mode
+  Locality.zap_to_ceil_exn locality |> transl_locality_mode
 
 let transl_alloc_mode_l mode =
   (* we only take the locality axis *)
@@ -39,6 +39,6 @@ let transl_alloc_mode (mode : Typedtree.alloc_mode) =
   transl_alloc_mode_r mode.mode
 
 let transl_modify_mode locality =
-  match Locality.zap_to_floor locality with
+  match Locality.zap_to_floor_exn locality with
   | Global -> modify_heap
   | Local -> modify_maybe_stack

--- a/ocaml/ocamldoc/odoc_env.ml
+++ b/ocaml/ocamldoc/odoc_env.ml
@@ -167,7 +167,7 @@ let subst_type env t =
   let rec iter t =
     if List.memq t !deja_vu then () else begin
       deja_vu := t :: !deja_vu;
-      Btype.iter_type_expr iter t;
+      Btype.iter_type_expr iter (Fun.const ()) t;
       let open Types in
       match get_desc t with
       | Tconstr (p, [_], _) when Path.same p Predef.path_option ->

--- a/ocaml/testsuite/tests/typing-local/local.ml
+++ b/ocaml/testsuite/tests/typing-local/local.ml
@@ -344,7 +344,7 @@ Line 1, characters 61-65:
 Error: This value escapes its region.
   Hint: Cannot return a local value without an "exclave_" annotation.
   Hint: This is a partial application
-        Adding 1 more argument will make the value non-local
+        Adding 1 more argument may make the value non-local
 |}]
 
 (* Optional argument elimination eta-expands and therefore allocates *)

--- a/ocaml/testsuite/tests/typing-modes/currying.ml
+++ b/ocaml/testsuite/tests/typing-modes/currying.ml
@@ -333,7 +333,7 @@ Line 2, characters 11-25:
                ^^^^^^^^^^^^^^
 Error: This value escapes its region.
   Hint: This is a partial application
-        Adding 1 more argument will make the value non-local
+        Adding 1 more argument may make the value non-local
 |}]
 
 (* The fixed version. Note that in the printed type, local returning is implicit

--- a/ocaml/testsuite/tests/typing-modes/levels.ml
+++ b/ocaml/testsuite/tests/typing-modes/levels.ml
@@ -1,0 +1,484 @@
+(* TEST
+ flags += "-extension mode_polymorphism_beta";
+ expect;
+*)
+
+(*
+ * This file tests that introducing levels and generalized
+ * structures does not interfere with typipng, and that it does not
+ * introduce mode polymorphism
+*)
+
+
+(* This test checks that no mode polymorphism has been introduced *)
+
+let () =
+  let foo x = x in
+  let x = ref 42 in
+  let x = foo x in
+  let (y @ contended) = ref !x in
+  let _ = foo y in
+  ()
+[%%expect{|
+Line 6, characters 14-15:
+6 |   let _ = foo y in
+                  ^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+
+(* The following tests are taken from modes.ml to check that typing is the same *)
+
+let local_ foo : string @@ unique = "hello"
+[%%expect{|
+Line 1, characters 4-43:
+1 | let local_ foo : string @@ unique = "hello"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value escapes its region.
+|}]
+
+let local_ foo @ unique = "hello"
+[%%expect{|
+Line 1, characters 4-33:
+1 | let local_ foo @ unique = "hello"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value escapes its region.
+|}]
+
+let local_ foo : 'a. 'a -> 'a @@ unique = fun x -> x
+[%%expect{|
+Line 1, characters 4-52:
+1 | let local_ foo : 'a. 'a -> 'a @@ unique = fun x -> x
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value escapes its region.
+|}]
+
+let foo : type a. a -> a @@ unique = fun x -> x
+[%%expect{|
+val foo : 'a -> 'a = <fun>
+|}]
+
+let (x, y) @ local unique = "hello", "world"
+[%%expect{|
+Line 1, characters 4-44:
+1 | let (x, y) @ local unique = "hello", "world"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value escapes its region.
+|}]
+
+let (x, y) : _ @@ local unique = "hello", "world"
+[%%expect{|
+Line 1, characters 4-49:
+1 | let (x, y) : _ @@ local unique = "hello", "world"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value escapes its region.
+|}]
+
+let foo @ foo = "hello"
+[%%expect{|
+Line 1, characters 10-13:
+1 | let foo @ foo = "hello"
+              ^^^
+Error: Unrecognized mode foo.
+|}]
+
+let foo () =
+  let bar @ local local = "hello" in
+  ()
+[%%expect{|
+Line 2, characters 18-23:
+2 |   let bar @ local local = "hello" in
+                      ^^^^^
+Error: The locality axis has already been specified.
+|}]
+
+(* Expressions *)
+let foo = ("hello" : _ @@ local)
+[%%expect{|
+Line 1, characters 10-32:
+1 | let foo = ("hello" : _ @@ local)
+              ^^^^^^^^^^^^^^^^^^^^^^
+Error: This value escapes its region.
+|}]
+
+(* this is not mode annotation *)
+let foo = ("hello" @ local)
+[%%expect{|
+Line 1, characters 11-18:
+1 | let foo = ("hello" @ local)
+               ^^^^^^^
+Error: This expression has type "string" but an expression was expected of type
+         "'a list"
+|}]
+
+(* arrow types *)
+type r = local_ string @ unique once -> unique_ string @ local once
+[%%expect{|
+type r = local_ once_ unique_ string -> local_ once_ unique_ string
+|}]
+
+type r = local_ string * y:string @ unique once -> local_ string * w:string @ once
+[%%expect{|
+type r =
+    local_ once_ unique_ string * y:string -> local_ once_ string * w:string
+|}]
+
+type r = x:local_ string * y:string @ unique once -> local_ string * w:string @ once
+[%%expect{|
+type r =
+    x:local_ once_ unique_ string * y:string -> local_ once_
+    string * w:string
+|}]
+
+
+type r = local_ string @ foo -> string
+[%%expect{|
+Line 1, characters 25-28:
+1 | type r = local_ string @ foo -> string
+                             ^^^
+Error: Unrecognized mode foo.
+|}]
+
+type r = local_ string @ local -> string
+[%%expect{|
+Line 1, characters 25-30:
+1 | type r = local_ string @ local -> string
+                             ^^^^^
+Error: The locality axis has already been specified.
+|}]
+
+(* Mixing legacy and new modes *)
+type r = local_ unique_ once_ string -> string
+[%%expect{|
+type r = local_ once_ unique_ string -> string
+|}]
+
+type r = local_ unique_ once_ string @ portable contended -> string
+[%%expect{|
+type r = local_ once_ unique_ string @ portable contended -> string
+|}]
+
+type r = string @ local unique once portable contended -> string
+[%%expect{|
+type r = local_ once_ unique_ string @ portable contended -> string
+|}]
+
+type r = string @ local unique once nonportable uncontended -> string
+[%%expect{|
+type r = local_ once_ unique_ string -> string
+|}]
+
+
+(* modality on constructor arguments and record fields *)
+
+type t = Foo of string @@ global * global_ string
+[%%expect{|
+type t = Foo of global_ string * global_ string
+|}]
+
+type t = Foo of string @@ foo
+[%%expect{|
+Line 1, characters 26-29:
+1 | type t = Foo of string @@ foo
+                              ^^^
+Error: Unrecognized modality foo.
+|}]
+
+type r = {
+  x : string @@ global
+}
+[%%expect{|
+type r = { global_ x : string; }
+|}]
+
+type r = {
+  x : string @@ foo
+}
+[%%expect{|
+Line 2, characters 16-19:
+2 |   x : string @@ foo
+                    ^^^
+Error: Unrecognized modality foo.
+|}]
+
+(* Modalities don't imply each other; this will change as we add borrowing. *)
+type r = {
+  global_ x : string @@ aliased
+}
+[%%expect{|
+type r = { global_ x : string @@ aliased; }
+|}]
+
+type r = {
+  x : string @@ aliased global many
+}
+[%%expect{|
+type r = { global_ x : string @@ many aliased; }
+|}]
+
+type r = Foo of string @@ global aliased many
+[%%expect{|
+type r = Foo of global_ string @@ many aliased
+|}]
+
+(* mutable implies global aliased many. No warnings are given since we imagine
+   that the coupling will be removed soon. *)
+type r = {
+  mutable x : string @@ global aliased many
+}
+[%%expect{|
+type r = { mutable x : string; }
+|}]
+
+
+(* patterns *)
+
+let foo ?(local_ x @ unique once = 42) () = ()
+[%%expect{|
+val foo : ?x:local_ once_ unique_ int -> unit -> unit = <fun>
+|}]
+
+let foo ?(local_ x : _ @@ unique once = 42) () = ()
+[%%expect{|
+val foo : ?x:local_ once_ unique_ int -> unit -> unit = <fun>
+|}]
+
+let foo ?(local_ x : 'a. 'a -> 'a @@ unique once) = ()
+[%%expect{|
+Line 1, characters 10-48:
+1 | let foo ?(local_ x : 'a. 'a -> 'a @@ unique once) = ()
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Optional parameters cannot be polymorphic
+|}]
+
+let foo ?x:(local_ (x,y) @ unique once = (42, 42)) () = ()
+[%%expect{|
+val foo : ?x:local_ once_ unique_ int * int -> unit -> unit = <fun>
+|}]
+
+let foo ?x:(local_ (x,y) : _ @@ unique once = (42, 42)) () = ()
+[%%expect{|
+val foo : ?x:local_ once_ unique_ int * int -> unit -> unit = <fun>
+|}]
+
+let foo ?x:(local_ (x,y) : 'a.'a->'a @@ unique once) () = ()
+[%%expect{|
+Line 1, characters 12-51:
+1 | let foo ?x:(local_ (x,y) : 'a.'a->'a @@ unique once) () = ()
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Optional parameters cannot be polymorphic
+|}]
+
+(* let-bound function *)
+(* by default, all strings following @ are parsed as modes, not argument *)
+let foo () =
+  let bar @ unique local once = () in
+  bar
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+let foo () =
+  let bar @ unique local foo = () in
+  bar
+[%%expect{|
+Line 2, characters 25-28:
+2 |   let bar @ unique local foo = () in
+                             ^^^
+Error: Unrecognized mode foo.
+|}]
+
+let foo () =
+  let (bar @ local) a b = () in
+  bar 42 24;
+  ()
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+(* modalities on normal values requires [-extension mode_alpha] *)
+module type S = sig
+  val x : string -> string @ local @@ foo bar
+end
+[%%expect{|
+Line 2, characters 38-41:
+2 |   val x : string -> string @ local @@ foo bar
+                                          ^^^
+Error: The extension "mode" is disabled and cannot be used
+|}]
+
+
+(*
+ * Modification of return modes in argument position
+ *)
+
+let use_local (f : _ -> _ -> _ @@ local) x y =
+  f x y
+let result = use_local (^) "hello" " world"
+[%%expect{|
+val use_local : local_ ('a -> 'b -> 'c) -> 'a -> 'b -> 'c = <fun>
+val result : string = "hello world"
+|}]
+
+let use_local_ret (f : _ -> _ @ local) x y =
+  let _ = f x in ()
+let global_ret : string -> string @ global = fun x -> x
+let result = use_local_ret global_ret "hello"
+[%%expect{|
+val use_local_ret : ('a -> local_ 'b) -> 'a -> 'c -> unit = <fun>
+val global_ret : string -> string = <fun>
+val result : '_weak1 -> unit = <fun>
+|}]
+
+let use_global_ret (f : _ -> _ @ global) x = lazy (f x)
+let local_ret a = exclave_ (Some a)
+let bad_use = use_global_ret local_ret "hello"
+[%%expect{|
+val use_global_ret : ('a -> 'b) -> 'a -> 'b lazy_t = <fun>
+val local_ret : 'a -> local_ 'a option = <fun>
+Line 3, characters 29-38:
+3 | let bad_use = use_global_ret local_ret "hello"
+                                 ^^^^^^^^^
+Error: This expression has type "'a -> local_ 'a option"
+       but an expression was expected of type "'b -> 'c"
+|}]
+
+let use_nonportable_ret (f : _ -> (_ -> _) @ nonportable) x y =
+  f x y
+let portable_ret : string -> (string -> string) @ portable =
+  fun x y -> y
+let result = use_nonportable_ret portable_ret "hello" " world"
+[%%expect{|
+val use_nonportable_ret : ('a -> 'b -> 'c) -> 'a -> 'b -> 'c = <fun>
+val portable_ret : string -> (string -> string) @ portable = <fun>
+val result : string = " world"
+|}]
+
+let use_portable_ret (f : _ -> (_ -> _) @ portable) x y =
+  lazy ((f x) y)
+let nonportable_ret : string -> (string -> string) @ nonportable =
+  fun x y -> x ^ y
+let bad_use = use_portable_ret nonportable_ret "hello" " world"
+[%%expect{|
+val use_portable_ret : ('a -> ('b -> 'c) @ portable) -> 'a -> 'b -> 'c lazy_t =
+  <fun>
+val nonportable_ret : string -> string -> string = <fun>
+Line 5, characters 31-46:
+5 | let bad_use = use_portable_ret nonportable_ret "hello" " world"
+                                   ^^^^^^^^^^^^^^^
+Error: This expression has type "string -> string -> string"
+       but an expression was expected of type "'a -> ('b -> 'c) @ portable"
+|}]
+
+let use_contended_ret (f : _ -> _ @ contended) x =
+  let _ = f x in ()
+let uncontended_ret : string -> string @ uncontended =
+  fun x -> x
+let result = use_contended_ret uncontended_ret "hello"
+[%%expect{|
+val use_contended_ret : ('a -> 'b @ contended) -> 'a -> unit = <fun>
+val uncontended_ret : string -> string = <fun>
+val result : unit = ()
+|}]
+
+let use_uncontended_ret (f : _ -> _ @ uncontended) x =
+  let _ = f x in ()
+let contended_ret : string -> string @ contended =
+  fun x -> x
+let bad_use = use_uncontended_ret contended_ret "hello"
+[%%expect{|
+val use_uncontended_ret : ('a -> 'b) -> 'a -> unit = <fun>
+val contended_ret : string -> string @ contended = <fun>
+Line 5, characters 34-47:
+5 | let bad_use = use_uncontended_ret contended_ret "hello"
+                                      ^^^^^^^^^^^^^
+Error: This expression has type "string -> string @ contended"
+       but an expression was expected of type "'a -> 'b"
+|}]
+
+(*
+ * Modification of parameter modes in argument position
+ *)
+
+let use_local (local_ f : _ -> _ -> _) x y =
+  f x y
+let use_global (f : _ -> _ -> _) x y = f x y
+
+let foo x y = x +. y
+let bar (local_ x) (local_ y) = let _ = x +. y in ()
+
+let result = use_local foo 1. 2.
+[%%expect{|
+val use_local : local_ ('a -> 'b -> 'c) -> 'a -> 'b -> 'c = <fun>
+val use_global : ('a -> 'b -> 'c) -> 'a -> 'b -> 'c = <fun>
+val foo : float -> float -> float = <fun>
+val bar : local_ float -> local_ float -> unit = <fun>
+val result : float = 3.
+|}]
+
+let result = use_local bar 1. 2.
+[%%expect{|
+val result : unit = ()
+|}]
+
+let result = use_global foo 1. 2.
+[%%expect{|
+val result : float = 3.
+|}]
+
+let result = use_global bar 1. 2.
+[%%expect{|
+Line 1, characters 24-27:
+1 | let result = use_global bar 1. 2.
+                            ^^^
+Error: This expression has type "local_ float -> local_ float -> unit"
+       but an expression was expected of type "local_ 'a -> ('b -> 'c)"
+|}]
+
+let use_portable_arg (f : (_ -> _) @ portable -> _) g = f g
+let nonportable_arg (f @ nonportable) = f ()
+let result = use_portable_arg nonportable_arg (fun () -> ())
+[%%expect{|
+val use_portable_arg :
+  ('a : any) ('b : any) 'c.
+    (('a -> 'b) @ portable -> 'c) -> ('a -> 'b) @ portable -> 'c =
+  <fun>
+val nonportable_arg : (unit -> 'a) -> 'a = <fun>
+val result : unit = ()
+|}]
+
+let use_nonportable_arg (f : (_ -> _) @ nonportable -> _) g = f g
+let portable_arg (f @ portable) = f ()
+let bad_use = use_nonportable_arg portable_arg (fun () -> ())
+[%%expect{|
+val use_nonportable_arg :
+  ('a : any) ('b : any) 'c. (('a -> 'b) -> 'c) -> ('a -> 'b) -> 'c = <fun>
+val portable_arg : (unit -> 'a) @ portable -> 'a = <fun>
+Line 3, characters 34-46:
+3 | let bad_use = use_nonportable_arg portable_arg (fun () -> ())
+                                      ^^^^^^^^^^^^
+Error: This expression has type "(unit -> 'a) @ portable -> 'a"
+       but an expression was expected of type "('b -> 'c) -> 'd"
+|}]
+
+let use_uncontended_arg (f : _ @ uncontended -> _) x = f x
+let contended_arg (x @ contended) = ()
+let result = use_uncontended_arg contended_arg ()
+[%%expect{|
+val use_uncontended_arg : ('a -> 'b) -> 'a -> 'b = <fun>
+val contended_arg : 'a @ contended -> unit = <fun>
+val result : unit = ()
+|}]
+
+let use_contended_arg (f : _ @ contended -> _) x = f x
+let uncontended_arg (x @ uncontended) = ()
+let bad_use = use_contended_arg uncontended_arg ()
+[%%expect{|
+val use_contended_arg : ('a @ contended -> 'b) -> 'a -> 'b = <fun>
+val uncontended_arg : 'a -> unit = <fun>
+Line 3, characters 32-47:
+3 | let bad_use = use_contended_arg uncontended_arg ()
+                                    ^^^^^^^^^^^^^^^
+Error: This expression has type "'a -> unit"
+       but an expression was expected of type "'b @ contended -> 'c"
+|}]

--- a/ocaml/testsuite/tests/typing-modes/mode_polymorphism_functionality.ml
+++ b/ocaml/testsuite/tests/typing-modes/mode_polymorphism_functionality.ml
@@ -1,0 +1,330 @@
+(* TEST
+ flags += "-extension unique -extension mode_polymorphism_alpha";
+ expect;
+*)
+
+(*
+ * This file tests that mode polymorphism works, without printing mode variables.
+ * The modes printed are not always representative of the underlying modes: they have
+ * been zapped to legacy
+*)
+
+(* BASIC POLYMORPHISM *)
+
+let foo =
+  let foo x = x in
+  let x = ref 42 in
+  let x = foo x in
+  let (y @ contended) = ref !x in
+  let _ = foo y in
+  foo
+[%%expect{|
+val foo : unique_ '_weak1 @ portable -> '_weak1 = <fun>
+|}]
+
+let id x = x
+[%%expect{|
+val id : 'a -> 'a = <fun>
+|}]
+
+let () =
+  let x = ref 42 in
+  let x = id x in
+  let (y @ contended) = ref !x in
+  let _ = id y in
+  ()
+[%%expect{|
+|}]
+
+let bar (unique_ c) (f : _ @ unique -> unit) =
+  f (id c)
+[%%expect{|
+val bar : unique_ 'a -> (unique_ 'a -> unit) -> unit = <fun>
+|}]
+
+let bar (local_ c) (f : _ @ local -> unit) =
+  let _ = f (id c) in
+  ()
+[%%expect{|
+val bar : local_ 'a -> (local_ 'a -> unit) -> unit = <fun>
+|}]
+
+let bar (x @ aliased) (f : _ @ unique -> unit) =
+  let x = id x in
+  let _ = f x in
+  ()
+[%%expect{|
+Line 3, characters 12-13:
+3 |   let _ = f x in
+                ^
+Error: This value is "aliased" but expected to be "unique".
+|}]
+
+(* mode variables used as portable imposes a portable bound on them *)
+let use_portable (_ @ portable) = ()
+let foo x = use_portable x
+[%%expect{|
+val use_portable : 'a @ portable -> unit = <fun>
+val foo : 'a @ portable -> unit = <fun>
+|}]
+
+let foo x =
+  let bar = fun () -> x in
+  use_portable bar
+[%%expect{|
+val foo : 'a @ portable -> unit = <fun>
+|}]
+
+(* REFERENCES *)
+
+(* references are not mode polymorphic *)
+let alloc x = ref x
+[%%expect{|
+val alloc : 'a -> 'a ref = <fun>
+|}]
+
+let foo (f : _ @ unique -> unit) =
+  f (alloc 42)
+[%%expect{|
+Line 2, characters 4-14:
+2 |   f (alloc 42)
+        ^^^^^^^^^^
+Error: This value is "aliased" but expected to be "unique".
+|}]
+
+let foo (f : _ @ uncontended -> unit) =
+  f (alloc 42)
+[%%expect{|
+val foo : (int ref -> unit) -> unit = <fun>
+|}]
+
+let foo x (f : _ @ unique -> unit) =
+  let y = ref x in
+  let x = !y in
+  f x
+[%%expect{|
+Line 4, characters 4-5:
+4 |   f x
+        ^
+Error: This value is "aliased" but expected to be "unique".
+|}]
+
+
+(* RECORDS AND MODALITIES *)
+
+type 'a myrec1 = { x : 'a }
+[%%expect{|
+type 'a myrec1 = { x : 'a; }
+|}]
+
+let foo =
+  let r = { x = fun x -> x } in
+  let _ = { x = local_ (fun x -> x) } in
+  r.x
+[%%expect{|
+val foo : 'a -> 'a = <fun>
+|}]
+
+type ('a, 'b) myrec2 = { i : 'a; p : 'b @@ portable }
+[%%expect{|
+type ('a, 'b) myrec2 = { i : 'a; p : 'b @@ portable; }
+|}]
+
+let foo =
+  let (c @ contended) = ref 42 in
+  let f = fun () -> () in
+  let _ = { i = c; p = f } in
+  let r = { i = ref 42; p = f } in
+  !(r.i)
+[%%expect{|
+val foo : int = 42
+|}]
+
+(* the p field is still polymorphic in the non-portability axes *)
+let () =
+    let r = { i = (); p = fun () -> () } in
+    let _ = { i = (); p = local_ (fun x -> x) } in
+    r.i
+[%%expect{|
+|}]
+
+(* mutable record fields are not polymorphic *)
+type 'a myrec3 = { mutable y : 'a }
+let foo =
+  let r = { y = fun x -> x } in
+  let _ = { y = local_ (fun x -> x) } in
+  r.y
+[%%expect{|
+type 'a myrec3 = { mutable y : 'a; }
+Line 4, characters 16-35:
+4 |   let _ = { y = local_ (fun x -> x) } in
+                    ^^^^^^^^^^^^^^^^^^^
+Error: This value escapes its region.
+|}]
+
+(* PRODUCTS *)
+
+(* currying has an effect on the following signature -- see [CURRYING] below *)
+let prod x y = (x, y)
+[%%expect{|
+val prod : 'a -> 'b -> 'a * 'b = <fun>
+|}]
+
+let dupl x = (x, x)
+[%%expect{|
+val dupl : 'a -> 'a * 'a = <fun>
+|}]
+
+let use_portable (_x @ portable contended) = ()
+[%%expect{|
+val use_portable : 'a @ portable contended -> unit = <fun>
+|}]
+
+(* CR ageorges: even without currying, products appear to enforce bounds on input/output *)
+let foo =
+    let p : unit -> int @@ portable = fun () -> 2 in
+    let x = dupl p in
+    let snd (_, a) = a in
+    use_portable (snd x)
+[%%expect{|
+Line 5, characters 17-24:
+5 |     use_portable (snd x)
+                     ^^^^^^^
+Error: This value is "nonportable" but expected to be "portable".
+|}]
+
+(* CURRYING *)
+
+let curry x y = x
+[%%expect{|
+val curry : 'a -> 'b -> 'a = <fun>
+|}]
+
+(* currying imposes bounds on the first polymorphic mode variable to be
+[< global many > aliased]. The following three tests display those bounds *)
+
+let () =
+  let c = local_ ref 42 in
+  curry c
+[%%expect{|
+Line 3, characters 8-9:
+3 |   curry c
+            ^
+Error: This value escapes its region.
+|}]
+
+let bar (once_ x) =
+  curry x
+[%%expect{|
+Line 2, characters 8-9:
+2 |   curry x
+            ^
+Error: This value is "once" but expected to be "many".
+|}]
+
+let bar (unique_ x) (f : _ @ unique -> unit) =
+  let x = curry x () in
+  f x
+[%%expect{|
+Line 3, characters 4-5:
+3 |   f x
+        ^
+Error: This value is "aliased" but expected to be "unique".
+|}]
+
+(* The returned closure is nonportable *)
+
+let () =
+  let c = ref 42 in
+  let f = fun () -> !c in
+  let bar1 = curry f in
+  let _ : unit -> unit @@ portable = fun () -> let _ = bar1 () in () in
+  ()
+[%%expect{|
+Line 5, characters 55-59:
+5 |   let _ : unit -> unit @@ portable = fun () -> let _ = bar1 () in () in
+                                                           ^^^^
+Error: The value "bar1" is nonportable, so cannot be used inside a function that is portable.
+|}]
+
+(* CLOSING OVER POLYMORPHIC MODE VARIABLES *)
+
+(* if [curry] is eta-expanded, we observe different bounds:
+  [< 'm & global many] -> (_ -> [> 'm | aliased]) [> nonportable]. *)
+
+let curry x = fun y -> x
+[%%expect{|
+val curry : 'a -> 'b -> 'a = <fun>
+|}]
+
+(* x is < global *)
+let () =
+  let c = local_ ref 42 in
+  curry c
+[%%expect{|
+Line 3, characters 8-9:
+3 |   curry c
+            ^
+Error: This value escapes its region.
+|}]
+
+(* x is < many *)
+let bar (once_ x) =
+  curry x
+[%%expect{|
+Line 2, characters 8-9:
+2 |   curry x
+            ^
+Error: This value is "once" but expected to be "many".
+|}]
+
+(* return value is > aliased *)
+let bar (unique_ x) (f : _ @ unique -> unit) =
+  let x = curry x () in
+  f x
+[%%expect{|
+Line 3, characters 4-5:
+3 |   f x
+        ^
+Error: This value is "aliased" but expected to be "unique".
+|}]
+
+(* returned value matches input portability *)
+let var (x @ portable) (f : _ @ portable -> unit) =
+  let x = curry x () in
+  f x
+[%%expect{|
+val var : 'a @ portable -> ('a @ portable -> unit) -> unit = <fun>
+|}]
+let var (x @ nonportable) =
+  curry x ()
+[%%expect{|
+val var : 'a -> 'a = <fun>
+|}]
+
+(* returned value matches input contention *)
+let var (x @ uncontended) (f : _ @ uncontended -> unit) =
+  let x = curry x () in
+  f x
+[%%expect{|
+val var : 'a -> ('a -> unit) -> unit = <fun>
+|}]
+let var (x @ contended) =
+  curry x ()
+[%%expect{|
+val var : 'a @ portable contended -> 'a @ contended = <fun>
+|}]
+
+(* The returned closure is nonportable *)
+let () =
+  let c = ref 42 in
+  let f = fun () -> !c in
+  let bar1 = curry f in
+  let _ : unit -> unit @@ portable = fun () -> let _ = bar1 () in () in
+  ()
+[%%expect{|
+Line 5, characters 55-59:
+5 |   let _ : unit -> unit @@ portable = fun () -> let _ = bar1 () in () in
+                                                           ^^^^
+Error: The value "bar1" is nonportable, so cannot be used inside a function that is portable.
+|}]

--- a/ocaml/typing/btype.ml
+++ b/ocaml/typing/btype.ml
@@ -101,7 +101,7 @@ let print_raw =
 
 (**** Type level management ****)
 
-let generic_level = Ident.highest_scope
+let generic_level = Mode.Alloc.generic_level
 
 (* Used to mark a type during a traversal. *)
 let lowest_level = Ident.lowest_scope
@@ -269,11 +269,13 @@ let fold_row f init row =
 let iter_row f row =
   fold_row (fun () v -> f v) () row
 
-let fold_type_expr f init ty =
+let fold_type_expr f fm init ty =
   match get_desc ty with
     Tvar _              -> init
-  | Tarrow (_, ty1, ty2, _) ->
-      let result = f init ty1 in
+  | Tarrow ((_, m1, m2), ty1, ty2, _) ->
+      let result = fm init m1 in
+      let result = fm result m2 in
+      let result = f result ty1 in
       f result ty2
   | Ttuple l            -> List.fold_left f init (List.map snd l)
   | Tunboxed_tuple l    -> List.fold_left f init (List.map snd l)
@@ -298,8 +300,8 @@ let fold_type_expr f init ty =
   | Tpackage (_, fl)  ->
     List.fold_left (fun result (_n, ty) -> f result ty) init fl
 
-let iter_type_expr f ty =
-  fold_type_expr (fun () v -> f v) () ty
+let iter_type_expr f fm ty =
+  fold_type_expr (fun () v -> f v) (fun () v -> fm v) () ty
 
 let rec iter_abbrev f = function
     Mnil                   -> ()
@@ -322,6 +324,8 @@ type type_iterators =
     it_type_kind: type_iterators -> type_decl_kind -> unit;
     it_do_type_expr: type_iterators -> type_expr -> unit;
     it_type_expr: type_iterators -> type_expr -> unit;
+    it_mode_expr: Mode.Alloc.lr -> unit;
+    it_modality: Mode.Modality.Value.t -> unit;
     it_path: Path.t -> unit; }
 
 let iter_type_expr_cstr_args f = function
@@ -360,7 +364,8 @@ let type_iterators =
     | Sig_class (_, cd, _, _)       -> it.it_class_declaration it cd
     | Sig_class_type (_, ctd, _, _) -> it.it_class_type_declaration it ctd
   and it_value_description it vd =
-    it.it_type_expr it vd.val_type
+    it.it_type_expr it vd.val_type;
+    it.it_modality vd.val_modalities
   and it_type_declaration it td =
     List.iter (it.it_type_expr it) td.type_params;
     Option.iter (it.it_type_expr it) td.type_manifest;
@@ -412,7 +417,7 @@ let type_iterators =
   and it_type_kind it kind =
     iter_type_expr_kind (it.it_type_expr it) kind
   and it_do_type_expr it ty =
-    iter_type_expr (it.it_type_expr it) ty;
+    iter_type_expr (it.it_type_expr it) it.it_mode_expr ty;
     match get_desc ty with
       Tconstr (p, _, _)
     | Tobject (_, {contents=Some (p, _)})
@@ -421,9 +426,11 @@ let type_iterators =
     | Tvariant row ->
         Option.iter (fun (p,_) -> it.it_path p) (row_name row)
     | _ -> ()
+  and it_mode_expr _m = ()
+  and it_modality _m = ()
   and it_path _p = ()
   in
-  { it_path; it_type_expr = it_do_type_expr; it_do_type_expr;
+  { it_path; it_type_expr = it_do_type_expr; it_do_type_expr; it_mode_expr; it_modality;
     it_type_kind; it_class_type; it_functor_param; it_module_type;
     it_signature; it_class_type_declaration; it_class_declaration;
     it_modtype_declaration; it_module_declaration; it_extension_constructor;
@@ -452,10 +459,10 @@ let copy_row f fixed row keep more =
 
 let copy_commu c = if is_commu_ok c then commu_ok else commu_var ()
 
-let rec copy_type_desc ?(keep_names=false) f = function
+let rec copy_type_desc ?(keep_names=false) f fm = function
     Tvar { jkind; _ } as tv ->
      if keep_names then tv else Tvar { name=None; jkind }
-  | Tarrow (p, ty1, ty2, c)-> Tarrow (p, f ty1, f ty2, copy_commu c)
+  | Tarrow ((p, m1, m2), ty1, ty2, c)-> Tarrow ((p, fm m1, fm m2), f ty1, f ty2, copy_commu c)
   | Ttuple l            -> Ttuple (List.map (fun (label, t) -> label, f t) l)
   | Tunboxed_tuple l    ->
     Tunboxed_tuple (List.map (fun (label, t) -> label, f t) l)
@@ -468,7 +475,7 @@ let rec copy_type_desc ?(keep_names=false) f = function
       Tfield (p, field_kind_internal_repr k, f ty1, f ty2)
       (* the kind is kept shared, with indirections removed for performance *)
   | Tnil                -> Tnil
-  | Tlink ty            -> copy_type_desc f (get_desc ty)
+  | Tlink ty            -> copy_type_desc f fm (get_desc ty)
   | Tsubst _            -> assert false
   | Tunivar _ as ty     -> ty (* always keep the name *)
   | Tpoly (ty, tyl)     ->
@@ -483,11 +490,18 @@ module For_copy : sig
 
   val redirect_desc: copy_scope -> type_expr -> type_desc -> unit
 
+  val mode_instantiate: copy_scope -> current_level:int -> Mode.Alloc.lr -> Mode.Alloc.lr
+
+  val mode_copy_generic: copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+
+  val mode_duplicate: copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
+
   val with_scope: (copy_scope -> 'a) -> 'a
 end = struct
   type copy_scope = {
     mutable saved_desc : (transient_expr * type_desc) list;
     (* Save association of generic nodes with their description. *)
+    saved_mode_changes : Mode.copy_scope;
   }
 
   let redirect_desc copy_scope ty desc =
@@ -495,15 +509,29 @@ end = struct
     copy_scope.saved_desc <- (ty, ty.desc) :: copy_scope.saved_desc;
     Transient_expr.set_desc ty desc
 
+  let mode_instantiate copy_scope ~current_level m =
+    let copy_scope = copy_scope.saved_mode_changes in
+    Mode.Alloc.instantiate ~copy_scope ~current_level m
+
+  let mode_copy_generic copy_scope m =
+    let copy_scope = copy_scope.saved_mode_changes in
+    Mode.Alloc.copy_generic ~copy_scope m
+
+  let mode_duplicate copy_scope m =
+    let copy_scope = copy_scope.saved_mode_changes in
+    Mode.Alloc.duplicate ~copy_scope m
+
   (* Restore type descriptions. *)
   let cleanup { saved_desc; _ } =
     List.iter (fun (ty, desc) -> Transient_expr.set_desc ty desc) saved_desc
 
   let with_scope f =
-    let scope = { saved_desc = [] } in
-    let res = f scope in
-    cleanup scope;
-    res
+    Mode.with_copy_scope (fun ms ->
+      let scope = { saved_desc = []; saved_mode_changes = ms } in
+      let res = f scope in
+      cleanup scope;
+      res)
+
 end
 
                   (*******************************************)
@@ -772,11 +800,11 @@ let try_logged_mark_node ty = not_marked_node ty && (logged_mark_node ty; true)
 let rec mark_type ty =
   if not_marked_node ty then begin
     flip_mark_node ty;
-    iter_type_expr mark_type ty
+    iter_type_expr mark_type (Fun.const ()) ty
   end
 
 let mark_type_params ty =
-  iter_type_expr mark_type ty
+  iter_type_expr mark_type (Fun.const ()) ty
 
 let type_iterators =
   let it_type_expr it ty =
@@ -790,7 +818,7 @@ let rec unmark_type ty =
   if get_level ty < lowest_level then begin
     (* flip back the marked level *)
     flip_mark_node ty;
-    iter_type_expr unmark_type ty
+    iter_type_expr unmark_type (Fun.const ()) ty
   end
 
 let unmark_iterators =

--- a/ocaml/typing/btype.mli
+++ b/ocaml/typing/btype.mli
@@ -198,7 +198,7 @@ module For_copy : sig
         (* Copies the generic parts of a mode variable without changing its level *)
 
   val mode_duplicate: copy_scope -> Mode.Alloc.lr -> Mode.Alloc.lr
-        (* Fupply duplicates a mode without changing its level *)
+        (* Copies a mode variable without changing its level *)
 
   val with_scope: (copy_scope -> 'a) -> 'a
         (* [with_scope f] calls [f] and restores saved type descriptions

--- a/ocaml/typing/ctype.ml
+++ b/ocaml/typing/ctype.ml
@@ -1666,11 +1666,6 @@ let curry_mode (type r) (alloc : (allowed * r) Alloc.Comonadic.t) (arg : Alloc.l
   Alloc.Comonadic.join
     [(Alloc.close_over arg).comonadic; (Alloc.Comonadic.disallow_right alloc)]
 
-(* let curry_mode_const alloc arg : Alloc.Comonadic.Const.t =
-  let arg = Alloc.Const.close_over arg in
-  let comonadic = (Alloc.Const.split arg).comonadic in
-    Alloc.Comonadic.Const.join comonadic alloc *)
-
 let curry_mode_const alloc arg : Alloc.Const.t =
   let acc =
     Alloc.Const.join

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -232,7 +232,11 @@ val instance_prim:
 (** Given (a @ m1 -> b -> c) @ m0, where [m0] and [m1] are modes expressed by
     user-syntax, [curry_mode m0 m1] gives the mode we implicitly interpret b->c
     to have. *)
-val curry_mode : Alloc.Const.t -> Alloc.Const.t -> Alloc.Const.t
+val curry_mode : (allowed * 'r) Alloc.Comonadic.t -> Alloc.lr -> Alloc.Comonadic.l
+
+(* val curry_mode_const : Alloc.Comonadic.Const.t -> Alloc.Const.t -> Alloc.Comonadic.Const.t *)
+val curry_mode_const : Alloc.Const.t -> Alloc.Const.t -> Alloc.Const.t
+
 
 val apply:
         ?use_current_level:bool ->
@@ -484,7 +488,7 @@ val nondep_cltype_declaration:
 val is_contractive: Env.t -> Path.t -> bool
 val normalize_type: type_expr -> unit
 
-val remove_mode_and_jkind_variables: type_expr -> unit
+val remove_mode_and_jkind_variables: zap_scope:Alloc.zap_scope -> type_expr -> unit
         (* Ensure mode and jkind variables are fully determined *)
 
 val nongen_vars_in_schema: Env.t -> type_expr -> Btype.TypeSet.t option
@@ -508,10 +512,10 @@ val free_variables: ?env:Env.t -> type_expr -> type_expr list
 val free_non_row_variables_of_list: type_expr list -> type_expr list
         (* gets only non-row variables *)
 
-val closed_type_decl: type_declaration -> type_expr option
-val closed_extension_constructor: extension_constructor -> type_expr option
+val closed_type_decl: zap_scope:Alloc.zap_scope -> type_declaration -> type_expr option
+val closed_extension_constructor: zap_scope:Alloc.zap_scope -> extension_constructor -> type_expr option
 val closed_class:
-        type_expr list -> class_signature ->
+        zap_scope:Alloc.zap_scope -> type_expr list -> class_signature ->
         closed_class_failure option
         (* Check whether all type variables are bound *)
 

--- a/ocaml/typing/ctype.mli
+++ b/ocaml/typing/ctype.mli
@@ -232,11 +232,11 @@ val instance_prim:
 (** Given (a @ m1 -> b -> c) @ m0, where [m0] and [m1] are modes expressed by
     user-syntax, [curry_mode m0 m1] gives the mode we implicitly interpret b->c
     to have. *)
-val curry_mode : (allowed * 'r) Alloc.Comonadic.t -> Alloc.lr -> Alloc.Comonadic.l
-
-(* val curry_mode_const : Alloc.Comonadic.Const.t -> Alloc.Const.t -> Alloc.Comonadic.Const.t *)
 val curry_mode_const : Alloc.Const.t -> Alloc.Const.t -> Alloc.Const.t
 
+(** Applies the same logic as [curry_mode_const] over the comonadic mode for [m0] and the
+    lr mode [m1] *)
+val curry_mode : (allowed * 'r) Alloc.Comonadic.t -> Alloc.lr -> Alloc.Comonadic.l
 
 val apply:
         ?use_current_level:bool ->

--- a/ocaml/typing/datarepr.ml
+++ b/ocaml/typing/datarepr.ml
@@ -37,7 +37,7 @@ let free_vars ?(param=false) ty =
           end
       (* XXX: What about Tobject ? *)
       | _ ->
-          iter_type_expr loop ty
+          iter_type_expr loop (Fun.const ()) ty
   in
   loop ty;
   unmark_type ty;

--- a/ocaml/typing/includecore.ml
+++ b/ocaml/typing/includecore.ml
@@ -138,6 +138,7 @@ let value_descriptions ~loc env name
         let ty1, mode1, sort1 = Ctype.instance_prim p1 vd1.val_type in
         (try Ctype.moregeneral env true ty1 vd2.val_type
          with Ctype.Moregen err -> raise (Dont_match (Type err)));
+        let mode1 = Option.map (Mode.Locality.newvar_above_if_nonzero) mode1 in
         let pc =
           {pc_desc = p1; pc_type = vd2.Types.val_type;
            pc_poly_mode = Option.map Mode.Locality.disallow_right mode1;

--- a/ocaml/typing/mode.ml
+++ b/ocaml/typing/mode.ml
@@ -1936,8 +1936,6 @@ module Common (Obj : Obj) = struct
 
   let of_const : type l r. const -> (l * r) t = fun a -> Solver.of_const obj a
 
-  let is_const a = Solver.is_const obj a
-
   let check_level a i = Solver.check_level a i
 
   let check_level_var a i = Solver.check_level_var a i
@@ -2906,9 +2904,6 @@ module Value_with (Areality : Areality) = struct
     let monadic1 = Monadic.duplicate ~copy_scope monadic0 in
     let comonadic1 = Comonadic.duplicate ~copy_scope comonadic0 in
     { monadic = monadic1; comonadic = comonadic1 }
-
-  let is_const { monadic = monadic0; comonadic = comonadic0 } =
-    Monadic.is_const monadic0 && Comonadic.is_const comonadic0
 
   let check_level { monadic = monadic0; comonadic = comonadic0 } i =
     Monadic.check_level monadic0 i &&

--- a/ocaml/typing/mode_intf.mli
+++ b/ocaml/typing/mode_intf.mli
@@ -70,7 +70,9 @@ module type Common = sig
 
   val legacy : lr
 
-  val newvar : unit -> ('l * 'r) t
+  val generic_level : int
+
+  val newvar : int -> ('l * 'r) t
 
   val submode : (allowed * 'r) t -> ('l * allowed) t -> (unit, error) result
 
@@ -78,13 +80,11 @@ module type Common = sig
 
   val generalize :
     current_level:int ->
-    generic_level:int ->
     ('l * 'r) t ->
     unit
 
   val generalize_structure :
     current_level:int ->
-    generic_level:int ->
     ('l * 'r) t ->
     unit
 
@@ -98,13 +98,21 @@ module type Common = sig
 
   val meet : ('l * allowed) t list -> right_only t
 
-  val newvar_above : (allowed * 'r) t -> ('l * 'r_) t * bool
+  val newvar_above : int -> (allowed * 'r) t -> ('l * 'r_) t * bool
 
-  val newvar_below : ('l * allowed) t -> ('l_ * 'r) t * bool
+  val newvar_below : int -> ('l * allowed) t -> ('l_ * 'r) t * bool
+
+  val newvar_above_if_nonzero : (allowed * 'r) t -> (allowed * 'r) t
 
   val print : ?verbose:bool -> unit -> Format.formatter -> ('l * 'r) t -> unit
 
   val of_const : Const.t -> ('l * 'r) t
+
+  val check_level : ('l * 'r) t -> int -> bool
+
+  val check_level_var : ('l * 'r) t -> int -> bool
+
+  val is_const : ('l * 'r) t -> bool
 end
 
 module type S = sig
@@ -154,9 +162,17 @@ module type S = sig
 
     val local : lr
 
-    val zap_to_floor : (allowed * 'r) t -> Const.t
+    val zap_to_floor : (allowed * 'r) t -> Const.t option
 
-    val zap_to_ceil : ('l * allowed) t -> Const.t
+    val zap_to_ceil : ('l * allowed) t -> Const.t option
+
+    val zap_to_floor_force : (allowed * 'r) t -> Const.t
+
+    val zap_to_ceil_force : ('l * allowed) t -> Const.t
+
+    val zap_to_floor_exn : (allowed * 'r) t -> Const.t
+
+    val zap_to_ceil_exn : ('l * allowed) t -> Const.t
 
     module Guts : sig
       (** This module exposes some functions that allow callers to inspect modes
@@ -381,6 +397,8 @@ module type S = sig
         val value : t -> default:some -> some
 
         val print : Format.formatter -> t -> unit
+
+        val partial_print : Format.formatter -> t -> unit
       end
 
       val split : t -> (Monadic.Const.t, Comonadic.Const.t) monadic_comonadic
@@ -404,6 +422,103 @@ module type S = sig
     type error = Error : ('m, 'a, 'd) axis * 'a Solver.error -> error
 
     type 'd t = ('d Monadic.t, 'd Comonadic.t) monadic_comonadic
+
+    type zap_scope
+
+    val with_zap_scope : (zap_scope:zap_scope -> 'a) -> 'a
+
+    (** Description types used for printing *)
+    module C : sig
+      type ('a, 'b, 'd) morph
+      type 'a obj
+
+      val le : 'a obj -> 'a -> 'a -> bool
+
+      val eq_obj : 'a obj -> 'b obj -> ('a, 'b) Misc.eq option
+
+      val src : 'b obj -> ('a, 'b, 'd) morph -> 'a obj
+
+      val id : ('a, 'a, 'd) morph
+
+      val compose :
+        'c obj -> ('b, 'c, 'd) morph -> ('a, 'b, 'd) morph -> ('a, 'c, 'd) morph
+
+      val eq_morph :
+        'b obj ->
+        ('a0, 'b, 'l0 * 'r0) morph ->
+        ('a1, 'b, 'l1 * 'r1) morph ->
+        ('a0, 'a1) Misc.eq option
+
+      val left_adjoint :
+        'b obj -> ('a, 'b, 'l * allowed) morph -> ('b, 'a, left_only) morph
+
+      val disallow_right : ('a, 'b, 'l * 'r) morph -> ('a, 'b, 'l * disallowed) morph
+
+      val apply : 'b obj -> ('a, 'b, 'd) morph -> 'a -> 'b
+
+      val print_morph : 'b obj -> Format.formatter -> ('a, 'b, 'd) morph -> unit
+
+    end
+
+    module Desc : sig
+
+      module Var : sig
+        type 'a t
+
+        type ('b, 'd) t_with_morph =
+        | Amorphvar : 'a t * ('a, 'b, 'd) C.morph -> ('b, 'd) t_with_morph
+
+        module Head : sig
+
+          type 'a t = {
+            desc_id : int;
+            desc_upper : 'a;
+            desc_lower : 'a;
+            desc_vlower : (('a,left_only) t_with_morph) list;
+            desc_level : int;
+          }
+
+          val equal : 'a t -> 'b t -> bool
+
+          val hash : 'a t -> int
+        end
+
+        val force : 'a C.obj -> 'a t -> 'a Head.t
+      end
+
+      type ('b, 'd) morphvar =
+      | Amorphvar : 'a Var.Head.t * ('a, 'b, 'd) C.morph -> ('b, 'd) morphvar
+
+      type ('a, 'd) t =
+      | Amode : 'a -> ('a, 'l * 'r) t
+      | Amodevar : ('a, 'd) morphvar -> ('a, 'd) t
+      | Amodejoin :
+          'a * ('a, 'l * disallowed) morphvar list
+          -> ('a, 'l * disallowed) t
+      | Amodemeet :
+         'a * ('a, disallowed * 'r) morphvar list
+         -> ('a, disallowed * 'r) t
+
+      val print : 'a C.obj -> Format.formatter -> ('a, ('l * 'r)) t -> unit
+    end
+
+    val obj_monadic : Monadic.Const.t C.obj
+
+    val obj_comonadic : Comonadic.Const.t C.obj
+
+    val get_comonadic_desc : 'd Comonadic.t -> (Comonadic.Const.t, 'd) Desc.t
+
+    val get_monadic_desc : ('l * 'r) Monadic.t -> (Monadic.Const.t, ('r * 'l)) Desc.t
+
+    val meet_const_morph : 'a -> ('a, 'a, allowed * disallowed) C.morph
+
+    val pretty_print_monadic_morph :
+      (Format.formatter -> 'a -> unit) -> 'a
+      -> Format.formatter -> ('d, Monadic.Const.t, 'f) C.morph -> unit
+
+    val pretty_print_comonadic_morph :
+      (Format.formatter -> 'a -> unit) -> 'a
+      -> Format.formatter -> ('d, Comonadic.Const.t, 'f) C.morph -> unit
 
     include
       Common
@@ -464,9 +579,34 @@ module type S = sig
       -> ('l * 'r) t
       -> ('l * disallowed) t
 
-    val zap_to_legacy : lr -> Const.t
+    (* val add_covariant_to_zap_scope :
+      (allowed * 'r) t
+      -> zap_scope
+      -> unit
 
-    val zap_to_ceil : ('l * allowed) t -> Const.t
+    val add_contravariant_to_zap_scope :
+      ('l * allowed) t
+      -> zap_scope
+      -> unit *)
+
+    val add_mode_to_zap_scope :
+      (allowed * allowed) t
+      -> zap_scope
+      -> unit
+
+    val zap_to_legacy_exn : lr -> Const.t
+
+    val zap_to_legacy : lr -> Const.t option
+
+    val zap_to_legacy_force : lr -> Const.t
+
+    val zap_to_ceil_exn : ('l * allowed) t -> Const.t
+
+    val zap_to_floor_exn : (allowed * 'r) t -> Const.t
+
+    val zap_to_ceil_force : ('l * allowed) t -> Const.t
+
+    val zap_to_floor_force : (allowed * 'r) t -> Const.t
 
     val comonadic_to_monadic : ('l * 'r) Comonadic.t -> ('r * 'l) Monadic.t
 
@@ -485,13 +625,11 @@ module type S = sig
     val instantiate :
       copy_scope:copy_scope ->
       current_level:int ->
-      generic_level:int ->
       ('l * 'r) t ->
       ('l * 'r) t
 
     val copy_generic :
       copy_scope:copy_scope ->
-      generic_level:int ->
       ('l * 'r) t ->
       ('l * 'r) t
 
@@ -499,6 +637,16 @@ module type S = sig
       copy_scope:copy_scope ->
       ('l * 'r) t ->
       ('l * 'r) t
+
+    module Guts : sig
+      val get_legacy : (allowed * allowed) t -> Const.t
+
+      val get_ceil : ('l * allowed) t -> Const.t
+
+      val check_const : (allowed * allowed) t -> Const.t option
+
+      val in_bounds : Const.t -> (allowed * allowed) t -> bool
+    end
   end
 
   (** The most general mode. Used in most type checking,
@@ -614,6 +762,9 @@ module type S = sig
           projection of [t0] on [ax], and [right] is the projection of [t1] on
           [ax]. *)
       val sub : t -> t -> (unit, error) Result.t
+
+      (** [update_level n t] updates the level of mode variables in [t] to [n] *)
+      val update_level : int -> t -> unit
 
       (** [equate t0 t1] checks that [t0 = t1].
           Definition: [t0 = t1] iff [t0 <= t1] and [t1 <= t0]. *)

--- a/ocaml/typing/mtype.ml
+++ b/ocaml/typing/mtype.ml
@@ -814,6 +814,8 @@ let lower_nongen nglev mty =
     | _ ->
         type_iterators.it_type_expr it ty
   in
-  let it = {type_iterators with it_type_expr} in
+  let it_mode_expr m = Mode.Alloc.update_level nglev m in
+  let it_modality m = Mode.Modality.Value.update_level nglev m in
+  let it = {type_iterators with it_type_expr; it_mode_expr; it_modality} in
   it.it_module_type it mty;
   it.it_module_type unmark_iterators mty

--- a/ocaml/typing/solver.ml
+++ b/ocaml/typing/solver.ml
@@ -351,22 +351,6 @@ module Solver_mono (C : Lattices_mono) = struct
       | Amodejoin (_, mvs) ->
         List.fold_left (fun acc mv -> acc && check_level_morphvar mv i) (mvs <> []) mvs
 
-  let is_const : type a l r. a C.obj -> (a, l * r) mode -> bool =
-    fun obj m ->
-      match m with
-      | Amode _ -> true
-      | Amodevar mv ->
-          check_level_morphvar mv generic_level &&
-          C.le obj (mupper obj mv) (mlower obj mv)
-      | Amodejoin (_, vs) ->
-        List.fold_left (fun acc mv ->
-          acc && check_level_morphvar mv generic_level &&
-          C.le obj (mupper obj mv) (mlower obj mv)) true vs
-      | Amodemeet (_, vs) ->
-        List.fold_left (fun acc mv ->
-          acc && check_level_morphvar mv generic_level &&
-          C.le obj (mupper obj mv) (mlower obj mv)) true vs
-
   let rec iter_covariant_morphvar :
       type a r. visited:(int, unit) Hashtbl.t -> a C.obj
       -> ((a, (allowed * disallowed)) mode -> unit) -> (a, allowed * r) morphvar -> unit =
@@ -1551,8 +1535,6 @@ module Solvers_polarized (C : Lattices_mono) = struct
 
     let of_const _ = S.of_const
 
-    let is_const = S.is_const
-
     let min = S.min
 
     let max = S.max
@@ -1643,8 +1625,6 @@ module Solvers_polarized (C : Lattices_mono) = struct
     let meet = S.join
 
     let of_const _ = S.of_const
-
-    let is_const = S.is_const
 
     let min = S.max
 

--- a/ocaml/typing/solver.ml
+++ b/ocaml/typing/solver.ml
@@ -163,6 +163,44 @@ module Solver_mono (C : Lattices_mono) = struct
         -> ('a, disallowed * 'r) mode
         (** [Amodemeet a [mv0, mv1, ..]] represents [a meet mv0 meet mv1 meet ..]. *)
 
+  (** Polymorphic iterator type *)
+  type mode_iterator = { iter : 'a. 'a C.obj -> ('a, (allowed * allowed)) mode -> unit } [@@unboxed]
+
+  (** Hashtables indexed by mode variables *)
+  type key =
+  | Key : 'a C.obj * 'a var -> key
+
+  module ModeTbl =
+    Hashtbl.Make (struct
+      type t = key
+      let equal (Key (_, v0)) (Key (_, v1)) = v0.id = v1.id
+      let hash (Key (_, v)) = Hashtbl.hash v.id
+    end)
+
+  let key_iter : key -> mode_iterator -> unit =
+    fun (Key (obj, v)) { iter } -> iter obj (Amodevar (Amorphvar (v, C.id)))
+
+  exception Invalid_key
+
+  let create_key_exn : type a l r. a C.obj -> (a, l * r) mode -> key =
+    fun dst m ->
+      match m with
+      | Amodevar (Amorphvar (v, f)) ->
+          let src = C.src dst f in
+          Key (src, v)
+      | _ -> raise Invalid_key
+
+  let create_key_opt : type a l r. a C.obj -> (a, l * r) mode -> key option =
+    fun dst m ->
+      match m with
+      | Amodevar (Amorphvar (v, f)) ->
+          let src = C.src dst f in
+          Some (Key (src, v))
+      | _ -> None
+
+  (** Levels *)
+  let generic_level = Ident.highest_scope
+
   (** Prints a mode variable, including the set of variables related to it
       (recursively). To handle cycles, [traversed] is the set of variables that
       we have already printed and will be skipped. An example of cycle:
@@ -289,6 +327,99 @@ module Solver_mono (C : Lattices_mono) = struct
   let max (type a) (obj : a C.obj) = Amode (C.max obj)
 
   let of_const a = Amode a
+
+  let check_level_morphvar : type a l r. (a, l * r) morphvar -> int -> bool =
+    fun (Amorphvar (v, _)) i -> v.level = i
+
+  let check_level : type a l r. (a, l * r) mode -> int -> bool =
+    fun m i ->
+      match m with
+      | Amode _ -> true
+      | Amodevar mv -> check_level_morphvar mv i
+      | Amodemeet (_, mvs) ->
+        List.fold_left (fun acc mv -> acc && check_level_morphvar mv i) true mvs
+      | Amodejoin (_, mvs) ->
+        List.fold_left (fun acc mv -> acc && check_level_morphvar mv i) true mvs
+
+  let check_level_var : type a l r. (a, l * r) mode -> int -> bool =
+    fun m i ->
+      match m with
+      | Amode _ -> false
+      | Amodevar mv -> check_level_morphvar mv i
+      | Amodemeet (_, mvs) ->
+        List.fold_left (fun acc mv -> acc && check_level_morphvar mv i) (mvs <> []) mvs
+      | Amodejoin (_, mvs) ->
+        List.fold_left (fun acc mv -> acc && check_level_morphvar mv i) (mvs <> []) mvs
+
+  let is_const : type a l r. a C.obj -> (a, l * r) mode -> bool =
+    fun obj m ->
+      match m with
+      | Amode _ -> true
+      | Amodevar mv ->
+          check_level_morphvar mv generic_level &&
+          C.le obj (mupper obj mv) (mlower obj mv)
+      | Amodejoin (_, vs) ->
+        List.fold_left (fun acc mv ->
+          acc && check_level_morphvar mv generic_level &&
+          C.le obj (mupper obj mv) (mlower obj mv)) true vs
+      | Amodemeet (_, vs) ->
+        List.fold_left (fun acc mv ->
+          acc && check_level_morphvar mv generic_level &&
+          C.le obj (mupper obj mv) (mlower obj mv)) true vs
+
+  let rec iter_covariant_morphvar :
+      type a r. visited:(int, unit) Hashtbl.t -> a C.obj
+      -> ((a, (allowed * disallowed)) mode -> unit) -> (a, allowed * r) morphvar -> unit =
+    fun ~visited dst iter (Amorphvar (v, f)) ->
+      if Hashtbl.mem visited v.id then () else begin
+        Hashtbl.add visited v.id ();
+        List.iter (fun (Amorphvar (u, g)) ->
+          let fg = C.compose dst (C.disallow_right f) g in
+          let mu = Amorphvar (u, fg) in
+          if u.level = 0 then
+            iter (Amodevar mu);
+          iter_covariant_morphvar ~visited dst iter mu) v.vlower
+      end
+
+  let iter_covariant :
+      type a r. a C.obj -> (a, allowed * r) mode
+      -> ((a, (allowed * disallowed)) mode -> unit) -> unit =
+    fun dst m iter ->
+      match m with
+      | Amode _ -> ()
+      | Amodevar mv ->
+        let visited = Hashtbl.create 17 in
+        iter_covariant_morphvar ~visited dst iter mv
+      | Amodejoin (_, mvs) ->
+        let visited = Hashtbl.create 17 in
+        List.iter (iter_covariant_morphvar ~visited dst iter) mvs
+
+  let rec iter_contravariant_morphvar :
+      type a l. visited:(int, unit) Hashtbl.t -> a C.obj
+      -> ((a, (disallowed * allowed)) mode -> unit) -> (a, l * allowed) morphvar -> unit =
+    fun ~visited dst iter (Amorphvar (v, f)) ->
+      if Hashtbl.mem visited v.id then () else begin
+        Hashtbl.add visited v.id ();
+        List.iter (fun (Amorphvar (u, g)) ->
+          let fg = C.compose dst (C.disallow_left f) g in
+          let mu = Amorphvar (u, fg) in
+          if u.level = 0 then
+            iter (Amodevar mu);
+          iter_contravariant_morphvar ~visited dst iter mu) v.vupper
+      end
+
+  let iter_contravariant :
+      type a l. a C.obj -> (a, l * allowed) mode
+      -> ((a, (disallowed * allowed)) mode -> unit) -> unit =
+    fun dst m iter ->
+      match m with
+      | Amode _ -> ()
+      | Amodevar mv ->
+        let visited = Hashtbl.create 17 in
+        iter_contravariant_morphvar ~visited dst iter mv
+      | Amodemeet (_, mvs) ->
+        let visited = Hashtbl.create 17 in
+        List.iter (iter_contravariant_morphvar ~visited dst iter) mvs
 
   let apply_morphvar dst morph (Amorphvar (var, morph')) =
     Amorphvar (var, C.compose dst morph morph')
@@ -679,7 +810,7 @@ module Solver_mono (C : Lattices_mono) = struct
         vupper_ge;
       (* optimization: if lower = upper, we can remove vuppers and vlowers since the
         information is as precise as it can get *)
-      if u.lower = u.upper then begin
+      if C.le dst u.upper u.lower then begin
         set_vlower ~log u [];
         set_vupper ~log u [];
       end
@@ -704,15 +835,15 @@ module Solver_mono (C : Lattices_mono) = struct
   [generic_level + (u.level - current_level)], preserving the exact topology *)
   let rec generalize_topology
       : type a. log:_ -> a C.obj -> current_level:int ->
-        generic_level:int -> a var -> unit =
-    fun ~log dst ~current_level ~generic_level u ->
+        a var -> unit =
+    fun ~log dst ~current_level u ->
       if u.level <= current_level || u.level >= generic_level then ()
       else begin
         let new_level = generic_level + (u.level - current_level) in
         set_level ~log u new_level;
         let do_gen (Amorphvar (v, f)) =
           let src = C.src dst f in
-          generalize_topology ~log src ~current_level ~generic_level v
+          generalize_topology ~log src ~current_level v
         in
         List.iter do_gen u.vupper;
         List.iter do_gen u.vlower
@@ -723,15 +854,15 @@ module Solver_mono (C : Lattices_mono) = struct
   to [current_level]. *)
   let rec generalize_topology_struct
       : type a. log:_ -> a C.obj -> current_level:int ->
-        generic_level:int -> a var -> unit =
-    fun ~log dst ~current_level ~generic_level u ->
+        a var -> unit =
+    fun ~log dst ~current_level u ->
       if u.level <= current_level || u.level >= generic_level then ()
       else begin
         let new_level = generic_level + (u.level - current_level) in
         set_level ~log u new_level;
         let do_gen (Amorphvar (v, f)) =
           let src = C.src dst f in
-          generalize_topology_struct ~log src ~current_level ~generic_level v
+          generalize_topology_struct ~log src ~current_level v
         in
         List.iter do_gen u.vupper;
         List.iter do_gen u.vlower;
@@ -747,9 +878,9 @@ module Solver_mono (C : Lattices_mono) = struct
 
   let generalize_v
       : type a. log:_ -> a C.obj -> current_level:int ->
-        generic_level:int -> a var -> unit =
-    fun ~log dst ~current_level ~generic_level u ->
-      generalize_topology ~log dst ~current_level ~generic_level u;
+        a var -> unit =
+    fun ~log dst ~current_level u ->
+      generalize_topology ~log dst ~current_level u;
       update_level_v ~log dst generic_level u
 
   (* generalize_structure has three cases:
@@ -762,11 +893,11 @@ module Solver_mono (C : Lattices_mono) = struct
   *)
   let generalize_structure_v
       : type a. log:_ -> a C.obj -> current_level:int ->
-        generic_level:int -> a var -> unit =
-    fun ~log dst ~current_level ~generic_level u ->
+        a var -> unit =
+    fun ~log dst ~current_level u ->
       if C.le dst u.upper u.lower then begin
         (* the bounds are tight *)
-        generalize_topology ~log dst ~current_level ~generic_level u;
+        generalize_topology ~log dst ~current_level u;
         update_level_v ~log dst generic_level u
       end else if
         C.le dst (C.max dst) u.upper &&
@@ -776,48 +907,48 @@ module Solver_mono (C : Lattices_mono) = struct
         update_level_v ~log dst current_level u
       else begin
         (* the bounds are non-trivial *)
-        generalize_topology_struct ~log dst ~current_level ~generic_level u;
+        generalize_topology_struct ~log dst ~current_level u;
         update_level_v ~log dst generic_level u
       end
 
-  let generalize (type a l r) ~current_level ~generic_level (obj : a C.obj)
+  let generalize (type a l r) ~current_level (obj : a C.obj)
       (a : (a, l * r) mode) ~log =
     match a with
     | Amodevar (Amorphvar (v, f)) ->
       let obj = C.src obj f in
-      generalize_v ~log obj ~current_level ~generic_level v
+      generalize_v ~log obj ~current_level v
     | Amode _ -> ()
     | Amodejoin (_, mvs) ->
       List.iter
         (fun (Amorphvar (v, f)) ->
           let obj = C.src obj f in
-          generalize_v ~log obj ~current_level ~generic_level v)
+          generalize_v ~log obj ~current_level v)
         mvs
     | Amodemeet (_, mvs) ->
       List.iter
         (fun (Amorphvar (v, f)) ->
           let obj = C.src obj f in
-          generalize_v ~log obj ~current_level ~generic_level v)
+          generalize_v ~log obj ~current_level v)
         mvs
 
-  let generalize_structure (type a l r) ~current_level ~generic_level (obj : a C.obj)
+  let generalize_structure (type a l r) ~current_level (obj : a C.obj)
       (a : (a, l * r) mode) ~log =
     match a with
     | Amodevar (Amorphvar (v, f)) ->
       let obj = C.src obj f in
-      generalize_structure_v ~log obj ~current_level ~generic_level v
+      generalize_structure_v ~log obj ~current_level v
     | Amode _ -> ()
     | Amodejoin (_, mvs) ->
       List.iter
         (fun (Amorphvar (v, f)) ->
           let obj = C.src obj f in
-          generalize_structure_v ~log obj ~current_level ~generic_level v)
+          generalize_structure_v ~log obj ~current_level v)
         mvs
     | Amodemeet (_, mvs) ->
       List.iter
         (fun (Amorphvar (v, f)) ->
           let obj = C.src obj f in
-          generalize_structure_v ~log obj ~current_level ~generic_level v)
+          generalize_structure_v ~log obj ~current_level v)
         mvs
 
   let copy_exists : type a. copy_to_level: int -> a C.obj -> a var -> (a var) option =
@@ -1043,7 +1174,7 @@ module Solver_mono (C : Lattices_mono) = struct
     | Amode a -> a
     | Amodevar mv -> mlower obj mv
     | Amodejoin (a, mvs) ->
-      List.fold_left (fun acc mv -> C.join obj acc (mupper obj mv)) a mvs
+      List.fold_left (fun acc mv -> C.join obj acc (mlower obj mv)) a mvs
     | Amodemeet (a, mvs) ->
       List.fold_left (fun acc mv -> C.meet obj acc (mlower obj mv)) a mvs
 
@@ -1183,6 +1314,105 @@ module Solver_mono (C : Lattices_mono) = struct
           C.meet obj acc (zap_to_ceil_morphvar obj mv ~commit:None))
         a mvs
 
+    (** Descriptions for typing *)
+  module Desc = struct
+
+    module Var = struct
+      type 'a t = 'a var
+
+      type ('b, 'd) t_with_morph = ('b, 'd) morphvar =
+      | Amorphvar : 'a t * ('a, 'b, 'd) C.morph -> ('b, 'd) t_with_morph
+
+      module Head = struct
+        type 'a t = {
+          desc_id : int;
+          desc_upper : 'a;
+          desc_lower : 'a;
+          desc_vlower : (('a,left_only) t_with_morph) list;
+          desc_level : int;
+        }
+
+        let equal v1 v2 = v1.desc_id = v2.desc_id
+
+        let hash v = Hashtbl.hash v.desc_id
+      end
+
+      let force : 'a C.obj -> 'a var -> 'a Head.t =
+        fun obj v ->
+          let desc_id = v.id in
+          let desc_lower = get_floor obj (Amodevar (Amorphvar (v, C.id))) in
+          let desc_upper = get_ceil obj (Amodevar (Amorphvar (v, C.id))) in
+          (* let desc_lower = v.lower in
+          let desc_upper = v.upper in *)
+          let desc_vlower = v.vlower in
+          let desc_level = v.level in
+          { desc_id; desc_lower; desc_upper; desc_vlower; desc_level }
+
+    end
+
+    type ('b, 'd) morphvar =
+    | Amorphvar : 'a Var.Head.t * ('a, 'b, 'd) C.morph -> ('b, 'd) morphvar
+
+    type ('a, 'd) t =
+    | Amode : 'a -> ('a, 'l * 'r) t
+    | Amodevar : ('a, 'd) morphvar -> ('a, 'd) t
+    | Amodejoin :
+        'a * ('a, 'l * disallowed) morphvar list
+        -> ('a, 'l * disallowed) t
+    | Amodemeet :
+       'a * ('a, disallowed * 'r) morphvar list
+       -> ('a, disallowed * 'r) t
+
+    let print_var :
+        type a. a C.obj -> Format.formatter -> a Var.Head.t -> unit =
+      fun obj ppf { desc_id; desc_upper; desc_lower; desc_level } ->
+        Format.fprintf ppf "%x<%d>[%a--%a]"
+          desc_id desc_level (C.print obj) desc_lower (C.print obj) desc_upper
+
+    let print_morphvar :
+        type a l r. a C.obj -> Format.formatter -> (a, l * r) morphvar -> unit =
+      fun dst ppf mv ->
+        let (Amorphvar (v, f)) = mv in
+        let src = C.src dst f in
+        Format.fprintf ppf "%a(%a)" (C.print_morph dst) f (print_var src) v
+
+    let print :
+        type a l r. a C.obj -> Format.formatter -> (a, l * r) t -> unit =
+      fun obj ppf m ->
+        match m with
+        | Amode a -> C.print obj ppf a
+        | Amodevar mv -> print_morphvar obj ppf mv
+        | Amodejoin (a, mvs) ->
+          Format.fprintf ppf "join(%a,%a)"
+            (C.print obj) a
+            (Format.pp_print_list
+              ~pp_sep:(fun ppf () -> Format.fprintf ppf ",")
+              (print_morphvar obj)) mvs
+        | Amodemeet (a, mvs) ->
+          Format.fprintf ppf "meet(%a,%a)"
+            (C.print obj) a
+            (Format.pp_print_list
+              ~pp_sep:(fun ppf () -> Format.fprintf ppf ",")
+              (print_morphvar obj)) mvs
+
+  end
+
+  let desc_morphvar : type a l r. a C.obj -> (a, (l * r)) morphvar -> (a, (l * r)) Desc.morphvar =
+    fun dst (Amorphvar (v, f)) ->
+      let src = C.src dst f in
+      let v = Desc.Var.force src v in
+      Desc.Amorphvar (v, f)
+
+  let desc : type a l r. a C.obj -> (a, (l * r)) mode -> (a, (l * r)) Desc.t =
+    fun dst m ->
+      match m with
+      | Amode a -> Desc.Amode a
+      | Amodevar mv -> Desc.Amodevar (desc_morphvar dst mv)
+      | Amodejoin (a, mvs) ->
+        Desc.Amodejoin (a, List.map (desc_morphvar dst) mvs)
+      | Amodemeet (a, mvs) ->
+        Desc.Amodemeet (a, List.map (desc_morphvar dst) mvs)
+
   let print :
       type a l r.
       ?verbose:bool -> a C.obj -> Format.formatter -> (a, l * r) mode -> unit =
@@ -1193,22 +1423,27 @@ module Solver_mono (C : Lattices_mono) = struct
     then C.print obj ppf ceil
     else print_raw ?verbose obj ppf m
 
-  let newvar obj = Amodevar (Amorphvar (fresh obj, C.id))
+  let newvar obj level =
+    let u = fresh ~level obj in
+    Amodevar (Amorphvar (u, C.id))
 
-  let newvar_above (type a r) (obj : a C.obj) (m : (a, allowed * r) mode) =
+  let newvar_above (type a r) (obj : a C.obj) (level : int) (m : (a, allowed * r) mode) =
     match disallow_right m with
     | Amode a ->
       if C.le obj (C.max obj) a
       then Amode a, false
-      else Amodevar (Amorphvar (fresh ~lower:a obj, C.id)), true
+      else begin
+        let u = fresh ~lower:a ~level obj in
+        Amodevar (Amorphvar (u, C.id)), true
+      end
     | Amodevar mv ->
-      let u = fresh obj in
+      let u = fresh ~level obj in
       let mu = Amorphvar (u, C.id) in
       let ok = submode_mvmv obj ~log:None mv mu in
       assert (Result.is_ok ok);
       allow_left (Amodevar mu), true
     | Amodejoin (a, mvs) ->
-      let u = fresh ~lower:a obj in
+      let u = fresh ~lower:a ~level obj in
       let mu = Amorphvar (u, C.id) in
       List.iter
         (fun mv ->
@@ -1217,20 +1452,23 @@ module Solver_mono (C : Lattices_mono) = struct
         mvs;
       allow_left (Amodevar mu), true
 
-  let newvar_below (type a l) (obj : a C.obj) (m : (a, l * allowed) mode) =
+  let newvar_below (type a l) (obj : a C.obj) (level : int) (m : (a, l * allowed) mode) =
     match disallow_left m with
     | Amode a ->
       if C.le obj a (C.min obj)
       then Amode a, false
-      else Amodevar (Amorphvar (fresh ~upper:a obj, C.id)), true
+      else begin
+        let u = fresh ~upper:a ~level obj in
+        Amodevar (Amorphvar (u, C.id)), true
+      end
     | Amodevar mv ->
-      let u = fresh obj in
+      let u = fresh ~level obj in
       let mu = Amorphvar (u, C.id) in
       let ok = submode_mvmv obj ~log:None mu mv in
       assert (Result.is_ok ok);
       allow_left (Amodevar mu), true
     | Amodemeet (a, mvs) ->
-      let u = fresh ~upper:a obj in
+      let u = fresh ~upper:a ~level obj in
       let mu = Amorphvar (u, C.id) in
       List.iter
         (fun mv ->
@@ -1254,6 +1492,12 @@ module Solvers_polarized (C : Lattices_mono) = struct
 
   let with_copy_scope = S.with_copy_scope
 
+  module Desc = S.Desc
+
+  type key = S.key
+
+  module ModeTbl = S.ModeTbl
+
   module type Solver_polarized =
     Solver_polarized
       with type ('a, 'b, 'd) morph := ('a, 'b, 'd) C.morph
@@ -1261,6 +1505,8 @@ module Solvers_polarized (C : Lattices_mono) = struct
        and type 'a error := 'a error
        and type changes := changes
        and type copy_scope := copy_scope
+       and type ('a, 'd) desc := ('a, 'd) S.Desc.t
+       and type key := key
 
   module rec Positive :
     (Solver_polarized
@@ -1272,7 +1518,20 @@ module Solvers_polarized (C : Lattices_mono) = struct
 
     type ('a, 'd) mode = ('a, 'd) S.mode constraint 'd = 'l * 'r
 
+    type mode_iterator = S.mode_iterator =
+      { iter : 'a. 'a C.obj -> ('a, (allowed * allowed)) S.mode -> unit } [@@unboxed]
+
     include Magic_allow_disallow (S)
+
+    let key_iter = S.key_iter
+
+    let create_key_exn = S.create_key_exn
+
+    let create_key_opt = S.create_key_opt
+
+    let desc = S.desc
+
+    let generic_level = S.generic_level
 
     let newvar = S.newvar
 
@@ -1291,6 +1550,8 @@ module Solvers_polarized (C : Lattices_mono) = struct
     let meet = S.meet
 
     let of_const _ = S.of_const
+
+    let is_const = S.is_const
 
     let min = S.min
 
@@ -1314,6 +1575,14 @@ module Solvers_polarized (C : Lattices_mono) = struct
 
     let print ?(verbose = false) = S.print ~verbose
 
+    let check_level = S.check_level
+
+    let check_level_var = S.check_level_var
+
+    let iter_covariant = S.iter_covariant
+
+    let iter_contravariant = S.iter_contravariant
+
     let via_monotone = S.apply
 
     let via_antitone = S.apply
@@ -1329,6 +1598,9 @@ module Solvers_polarized (C : Lattices_mono) = struct
 
     type ('a, 'd) mode = ('a, 'r * 'l) S.mode constraint 'd = 'l * 'r
 
+    type mode_iterator = S.mode_iterator =
+      { iter : 'a. 'a C.obj -> ('a, (allowed * allowed)) S.mode -> unit } [@@unboxed]
+
     include Magic_allow_disallow (struct
       type ('a, _, 'd) sided = ('a, 'd) mode
 
@@ -1340,6 +1612,16 @@ module Solvers_polarized (C : Lattices_mono) = struct
 
       let allow_left = S.allow_right
     end)
+
+    let key_iter = S.key_iter
+
+    let create_key_exn = S.create_key_exn
+
+    let create_key_opt = S.create_key_opt
+
+    let desc = S.desc
+
+    let generic_level = S.generic_level
 
     let newvar = S.newvar
 
@@ -1362,6 +1644,8 @@ module Solvers_polarized (C : Lattices_mono) = struct
 
     let of_const _ = S.of_const
 
+    let is_const = S.is_const
+
     let min = S.max
 
     let max = S.min
@@ -1383,6 +1667,14 @@ module Solvers_polarized (C : Lattices_mono) = struct
     let get_conservative_floor = S.get_conservative_ceil
 
     let print ?(verbose = false) = S.print ~verbose
+
+    let check_level = S.check_level
+
+    let check_level_var = S.check_level_var
+
+    let iter_covariant = S.iter_contravariant
+
+    let iter_contravariant = S.iter_covariant
 
     let via_monotone = S.apply
 

--- a/ocaml/typing/subst.ml
+++ b/ocaml/typing/subst.ml
@@ -313,7 +313,8 @@ let apply_type_function params args body =
           let t = newgenstub ~scope:(get_scope ty)
             (Jkind.Builtin.any ~why:Dummy_jkind) in
           For_copy.redirect_desc copy_scope ty (Tsubst (t, None));
-          let desc' = copy_type_desc copy desc in
+          let copy_mode m = For_copy.mode_copy_generic copy_scope m in
+          let desc' = copy_type_desc copy copy_mode desc in
           Transient_expr.set_stub_desc t desc';
           t
     in
@@ -437,7 +438,13 @@ let rec typexp copy_scope s ty =
           end
       | Tfield(_label, kind, _t1, t2) when field_kind_repr kind = Fabsent ->
           Tlink (typexp copy_scope s t2)
-      | _ -> copy_type_desc (typexp copy_scope s) desc
+      | _ ->
+        let copy_mode =
+          if should_duplicate_vars || get_id ty < 0
+          then (fun m -> For_copy.mode_duplicate copy_scope m)
+          else (fun m -> m)
+        in
+        copy_type_desc (typexp copy_scope s) copy_mode desc
     in
     Transient_expr.set_stub_desc ty' desc;
     ty'
@@ -458,7 +465,8 @@ let typexp copy_scope s loc ty =
 *)
 let type_expr s ty =
   let loc = Option.value s.loc ~default:Location.none in
-  For_copy.with_scope (fun copy_scope -> typexp copy_scope s loc ty)
+  For_copy.with_scope (fun copy_scope ->
+    typexp copy_scope s loc ty)
 
 let label_declaration copy_scope s l =
   {

--- a/ocaml/typing/typeclass.ml
+++ b/ocaml/typing/typeclass.ml
@@ -1906,7 +1906,7 @@ let final_decl env define_class
     );
 
   begin match
-    Ctype.closed_class clty.cty_params
+    Alloc.with_zap_scope Ctype.closed_class clty.cty_params
       (Btype.signature_of_class_type clty.cty_type)
   with
     None        -> ()

--- a/ocaml/typing/typecore.ml
+++ b/ocaml/typing/typecore.ml
@@ -647,7 +647,7 @@ let register_allocation_value_mode (mode : Value.r) : Alloc.r * Value.r =
   let alloc_mode, _ = Alloc.newvar_below 0 (value_to_alloc_r2g mode) in
   register_allocation_mode alloc_mode;
   let mode = alloc_as_value alloc_mode in
-  alloc_mode, mode (*make new var below mode and return that, new var at level 0*)
+  alloc_mode, mode
 
 (* Unlike most allocations which can be the highest mode allowed by
    [expected_mode] and their [alloc_mode] identical to [expected_mode] ,

--- a/ocaml/typing/typedecl_variance.ml
+++ b/ocaml/typing/typedecl_variance.ml
@@ -147,13 +147,13 @@ let compute_variance_type env ~check (required, loc) decl tyl =
             | Tconstr _ ->
                 let old = !visited in
                 begin try
-                  Btype.iter_type_expr check ty
+                  Btype.iter_type_expr check (Fun.const ()) ty
                 with Exit ->
                   visited := old;
                   let ty' = Ctype.expand_head_opt env ty in
                   if eq_type ty ty' then raise Exit else check ty'
                 end
-            | _ -> Btype.iter_type_expr check ty
+            | _ -> Btype.iter_type_expr check (Fun.const ()) ty
           end
         in
         try check ty; compute_variance env tvl injective ty
@@ -224,7 +224,7 @@ let compute_variance_type env ~check (required, loc) decl tyl =
                                     , (c1,n1,false)
                                     , (c2,n2,false))))
         | None ->
-            Btype.iter_type_expr check ty
+            Btype.iter_type_expr check (Fun.const ()) ty
       end
     in
     List.iter (fun (_,ty) -> check ty) tyl;

--- a/ocaml/typing/typetexp.ml
+++ b/ocaml/typing/typetexp.ml
@@ -685,7 +685,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
               ctyp Ttyp_call_pos (newconstr Predef.path_lexing_position [])
             else transl_type env ~policy ~row_context arg_mode arg
           in
-          let acc_mode = curry_mode acc_mode arg_mode in
+          let acc_mode = curry_mode_const acc_mode arg_mode in
           let ret_mode =
             match rest with
             | [] -> ret_mode
@@ -1288,7 +1288,7 @@ let rec make_fixed_univars ty =
                   ~fixed:(Some (Univar more))));
         Btype.iter_row make_fixed_univars row
     | _ ->
-        Btype.iter_type_expr make_fixed_univars ty
+        Btype.iter_type_expr make_fixed_univars (Fun.const ()) ty
     end
 
 let transl_type env policy mode styp =
@@ -1355,7 +1355,7 @@ let transl_type_scheme_mono env styp =
      declarations from having undefaulted jkind variables. Without
      this line, we might accidentally export a jkind-flexible definition
      from a compilation unit, which would lead to miscompilation. *)
-  remove_mode_and_jkind_variables typ.ctyp_type;
+  Alloc.with_zap_scope (remove_mode_and_jkind_variables typ.ctyp_type);
   typ
 
 let transl_type_scheme_poly env attrs loc vars inner_type =

--- a/ocaml/utils/language_extension.mli
+++ b/ocaml/utils/language_extension.mli
@@ -15,6 +15,7 @@ type 'a t = 'a Language_extension_kernel.t =
   | Comprehensions : unit t
   | Mode : maturity t
   | Unique : unit t
+  | Mode_polymorphism : maturity t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t

--- a/ocaml/utils/language_extension_kernel.ml
+++ b/ocaml/utils/language_extension_kernel.ml
@@ -5,6 +5,7 @@ type _ t =
   | Comprehensions : unit t
   | Mode : maturity t
   | Unique : unit t
+  | Mode_polymorphism : maturity t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t
@@ -23,6 +24,7 @@ module Exist = struct
     [ Pack Comprehensions
     ; Pack Mode
     ; Pack Unique
+    ; Pack Mode_polymorphism
     ; Pack Include_functor
     ; Pack Polymorphic_parameters
     ; Pack Immutable_arrays
@@ -43,6 +45,7 @@ let to_string : type a. a t -> string = function
   | Comprehensions -> "comprehensions"
   | Mode -> "mode"
   | Unique -> "unique"
+  | Mode_polymorphism -> "mode_polymorphism"
   | Include_functor -> "include_functor"
   | Polymorphic_parameters -> "polymorphic_parameters"
   | Immutable_arrays -> "immutable_arrays"
@@ -56,12 +59,16 @@ let to_string : type a. a t -> string = function
    an extension and its maturity. For extensions that don't take an
    argument, the conversion is just [Language_extension_kernel.of_string].
 *)
+(* CR ageorges: mode_polymorphism (stable) is currently not represented *)
 let pair_of_string extn_name : Exist_pair.t option =
   match String.lowercase_ascii extn_name with
   | "comprehensions" -> Some (Pair (Comprehensions, ()))
   | "mode" -> Some (Pair (Mode, Stable))
   | "mode_beta" -> Some (Pair (Mode, Beta))
   | "mode_alpha" -> Some (Pair (Mode, Alpha))
+  | "mode_polymorphism" -> Some (Pair (Mode_polymorphism, Stable))
+  | "mode_polymorphism_alpha" -> Some (Pair (Mode_polymorphism, Alpha))
+  | "mode_polymorphism_beta" -> Some (Pair (Mode_polymorphism, Beta))
   | "unique" -> Some (Pair (Unique, ()))
   | "include_functor" -> Some (Pair (Include_functor, ()))
   | "polymorphic_parameters" -> Some (Pair (Polymorphic_parameters, ()))
@@ -97,6 +104,7 @@ let of_string extn_name : Exist.t option =
 let is_erasable : type a. a t -> bool = function
   | Mode
   | Unique
+  | Mode_polymorphism
   | Layouts ->
       true
   | Comprehensions

--- a/ocaml/utils/language_extension_kernel.ml
+++ b/ocaml/utils/language_extension_kernel.ml
@@ -59,7 +59,6 @@ let to_string : type a. a t -> string = function
    an extension and its maturity. For extensions that don't take an
    argument, the conversion is just [Language_extension_kernel.of_string].
 *)
-(* CR ageorges: mode_polymorphism (stable) is currently not represented *)
 let pair_of_string extn_name : Exist_pair.t option =
   match String.lowercase_ascii extn_name with
   | "comprehensions" -> Some (Pair (Comprehensions, ()))

--- a/ocaml/utils/language_extension_kernel.mli
+++ b/ocaml/utils/language_extension_kernel.mli
@@ -14,6 +14,7 @@ type _ t =
   | Comprehensions : unit t
   | Mode : maturity t
   | Unique : unit t
+  | Mode_polymorphism : maturity t
   | Include_functor : unit t
   | Polymorphic_parameters : unit t
   | Immutable_arrays : unit t

--- a/ocaml/utils/profile_counters_functions.ml
+++ b/ocaml/utils/profile_counters_functions.ml
@@ -10,7 +10,8 @@ let count_language_extensions typing_input =
     | Comprehensions | Include_functor | Immutable_arrays | Module_strengthening
     | Labeled_tuples ->
       Language_extension_kernel.to_string lang_ext
-    | Mode | Unique | Polymorphic_parameters | Layouts | SIMD | Small_numbers ->
+    | Mode | Unique | Mode_polymorphism | Polymorphic_parameters | Layouts | SIMD
+    | Small_numbers ->
       let error_msg =
         Format.sprintf "No counters supported for language extension : %s."
           (Language_extension_kernel.to_string lang_ext)


### PR DESCRIPTION
This PR integrates mode levels into type checking, and implements mode polymorphism, and introduces a new flag that turns on various degrees of the feature: 

```-extension mode_polymorphism_alpha```

enables mode polymorphism, while

```-extension mode_polymorphism_beta```

enables levels, but applies `generalize_structure` rather than `generalize`, and therefore does not infer polymorphic modes.

The PR involves:
1. updating the level of mode whenever the level of a type is updating
2. generalizing a mode variable when a type is generalized
3. copying mode variables in the same manner as type variables are copied (this can be either an instantiation of a mode variable, a deep and exact copy, or an exact copy of the generic parts of a mode).

To implement copying, the existing copy scope in `btype.ml` is extended to include the mode copy scope.

Finally, new mode variables are allocated either at level 0 --- whenever a mode variable should not be generalized, such as allocation modes --- or at the current level.
NB: the curry mode of a function with multiple arguments (i.e. `m0` in `(a @ m1 -> b -> c) @ m0`) is set to level 0.

Some notable invariants: 
- modes in `typedtree.ml` should always be at level 0. To guarantee this invariant, `typecore.ml` allocates new mode variables above the inferred generic ones using `newvar_above_if_nonzero`.
- generic mode variables should (almost) never be mutated: that means regular calls to `zap_to_X` do nothing on generic mode variables. There are two exceptions: (1) if the mode_polymorphism_alpha extension is not turned on, generic modes are zapped during `remove_mode_and_jkind_variables`, and (2) polymorphic mode variables are printed as their zapped versions. To zap generic mode variables, use `zap_to_X_force`.

Since generic mode variables are no longer zapped, it is important to instead determine the level 0 modes they might point to. If a mode occurs only in covariant positions to other modes in the typed expression, it is zapped to floor, if it occurs only in contravariant positions to other modes in the typed expression, it is zapped to ceiling, and if it occurs in both, it is zapped to legacy.
