### PR TITLE
Always use a macro when checking for a promoted header

### DIFF
--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -76,10 +76,10 @@ struct caml_minor_tables {
 };
 
 /* Setting this to a different value can be useful for debugging
- * although may cause some slowdown. I suggest 0x200 (zero size,
- * non-zero colour). Compare with In_progress_update_val in
- * minor_gc.c. */
-#define Promoted_hd ((header_t)0x0)
+ * although may cause some slowdown. It must be a header value not
+ * otherwise found on the minor heap, not using Infix_tag, and not
+ * equal to In_progress_hd.  I suggest Make_header(0 ,0, 0x200). */
+#define Promoted_hd (Make_header(0, 0, 0))
 #define Is_promoted_hd(hd) ((hd) == Promoted_hd)
 
 CAMLextern void caml_minor_collection (void);

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -75,6 +75,13 @@ struct caml_minor_tables {
   struct caml_dependent_table dependent;
 };
 
+/* Setting this to a different value can be useful for debugging
+ * although may cause some slowdown. I suggest 0x200 (zero size,
+ * non-zero colour). Compare with In_progress_update_val in
+ * minor_gc.c. */
+#define Promoted_hd ((header_t)0x0)
+#define Is_promoted_hd(hd) ((hd) == Promoted_hd)
+
 CAMLextern void caml_minor_collection (void);
 
 #ifdef CAML_INTERNALS

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -243,7 +243,7 @@ static void generic_final_minor_update
   for (i = final->old; i < final->young; i++){
     CAMLassert (Is_block (final->table[i].val));
     if (Is_young(final->table[i].val) &&
-        caml_get_header_val(final->table[i].val) != 0){
+        !Is_promoted_hd(caml_get_header_val(final->table[i].val))) {
       ++ todo_count;
     }
   }
@@ -265,7 +265,7 @@ static void generic_final_minor_update
       CAMLassert (Is_block (final->table[i].val));
       CAMLassert (Tag_val (final->table[i].val) != Forward_tag);
       if (Is_young(final->table[i].val) &&
-          caml_get_header_val(final->table[i].val) != 0) {
+          !Is_promoted_hd(caml_get_header_val(final->table[i].val))) {
         /** dead */
         fi->todo_tail->item[k] = final->table[i];
         /* The finalisation function is called with unit not with the value */
@@ -287,7 +287,7 @@ static void generic_final_minor_update
   for (i = final->old; i < final->young; i++) {
     CAMLassert (Is_block (final->table[i].val));
     if (Is_young(final->table[i].val)) {
-      CAMLassert (caml_get_header_val(final->table[i].val) == 0);
+      CAMLassert (Is_promoted_hd(caml_get_header_val(final->table[i].val)));
       final->table[i].val = Field(final->table[i].val, 0);
     }
   }

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -1499,7 +1499,7 @@ static bool entry_update_after_minor_gc(entry_t e, void *data)
   CAMLassert(Is_block(e->block)
              || e->deleted || e->deallocated || e->offset);
   if (!e->offset && Is_block(e->block) && Is_young(e->block)) {
-    if (Hd_val(e->block) == 0) {
+    if (Is_promoted_hd(caml_get_header_val(e->block))) {
       /* Block has been promoted */
       e->block = Field(e->block, 0);
       e->promoted = true;

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -1499,7 +1499,7 @@ static bool entry_update_after_minor_gc(entry_t e, void *data)
   CAMLassert(Is_block(e->block)
              || e->deleted || e->deallocated || e->offset);
   if (!e->offset && Is_block(e->block) && Is_young(e->block)) {
-    if (Is_promoted_hd(caml_get_header_val(e->block))) {
+    if (Is_promoted_hd(Hd_val(e->block))) {
       /* Block has been promoted */
       e->block = Field(e->block, 0);
       e->promoted = true;

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -179,10 +179,11 @@ static value alloc_shared(caml_domain_state* d,
 #define In_progress_update_val ((header_t)0x100)
 #define Is_update_in_progress(hd) ((hd) == In_progress_update_val)
 
-static void spin_on_header(value v) {
+static header_t spin_on_header(value v) {
   SPIN_WAIT {
-    if (atomic_load(Hp_atomic_val(v)) == 0)
-      return;
+    header_t h = atomic_load(Hp_atomic_val(v));
+    if (Is_promoted_hd(h))
+      return h;
   }
 }
 
@@ -192,8 +193,7 @@ Caml_inline header_t get_header_val(value v) {
   if (!Is_update_in_progress(hd))
     return hd;
 
-  spin_on_header(v);
-  return 0;
+  return spin_on_header(v);
 }
 
 header_t caml_get_header_val(value v) {
@@ -206,19 +206,19 @@ static int try_update_object_header(value v, volatile value *p, value result,
   int success = 0;
 
   if( caml_domain_alone() ) {
-    *Hp_val (v) = 0;
+    *Hp_val (v) = Promoted_hd;
     Field(v, 0) = result;
     success = 1;
   } else {
     header_t hd = atomic_load(Hp_atomic_val(v));
-    if( hd == 0 ) {
+    if( Is_promoted_hd(hd) ) {
       /* in this case this has been updated by another domain, throw away result
          and return the one in the object */
       result = Field(v, 0);
     } else if( Is_update_in_progress(hd) ) {
       /* here we've caught a domain in the process of moving a minor heap object
          we need to wait for it to finish */
-      spin_on_header(v);
+      (void)spin_on_header(v);
       /* Also throw away result and use the one from the other domain */
       result = Field(v, 0);
     } else {
@@ -228,13 +228,13 @@ static int try_update_object_header(value v, volatile value *p, value result,
         /* Success. Now we can write the forwarding pointer. */
         atomic_store_relaxed(Op_atomic_val(v), result);
         /* And update header ('release' ensures after update of fwd pointer) */
-        atomic_store_release(Hp_atomic_val(v), 0);
+        atomic_store_release(Hp_atomic_val(v), Promoted_hd);
         /* Let the caller know we were responsible for the update */
         success = 1;
       } else {
         /* Updated by another domain. Spin for that update to complete and
            then throw away the result and use the one from the other domain. */
-        spin_on_header(v);
+        (void)spin_on_header(v);
         result = Field(v, 0);
       }
     }
@@ -269,7 +269,7 @@ static void oldify_one (void* st_v, value v, volatile value *p)
   infix_offset = 0;
   do {
     hd = get_header_val(v);
-    if (hd == 0) {
+    if (Is_promoted_hd(hd)) {
       /* already forwarded, another domain is likely working on this. */
       *p = Field(v, 0) + infix_offset;
       return;
@@ -403,7 +403,7 @@ static void oldify_one (void* st_v, value v, volatile value *p)
     ft = 0;
 
     if (Is_block (f)) {
-      ft = Tag_val (get_header_val(f) == 0 ? Field(f, 0) : f);
+      ft = Tag_val (Is_promoted_hd(get_header_val(f)) ? Field(f, 0) : f);
     }
 
     if (ft == Forward_tag || ft == Lazy_tag ||
@@ -455,7 +455,7 @@ again:
 
   while (st->todo_list != 0) {
     v = st->todo_list;                   /* Get the head. */
-    CAMLassert (get_header_val(v) == 0); /* It must be forwarded. */
+    CAMLassert (Is_promoted_hd(get_header_val(v))); /* It must be forwarded. */
     new_v = Field(v, 0);                 /* Follow forward pointer. */
     st->todo_list = Field (new_v, 1);    /* Remove from list. */
 
@@ -533,7 +533,7 @@ again:
           re->offset != CAML_EPHE_DATA_OFFSET && /* ephe key (not data)  */
           Is_block(v) &&                         /* a block              */
           young_start <= v && v < young_end &&   /* on *this* minor heap */
-          (hd = Hd_val(v)) != 0 &&               /* not already promoted */
+          !Is_promoted_hd(hd = Hd_val(v)) &&     /* not already promoted */
           Tag_hd(hd) != Infix_tag &&             /* not Infix_tag        */
           atomic_compare_exchange_strong(data, &v, caml_ephe_locked)) {
         /* locked, clean it later */
@@ -742,7 +742,7 @@ caml_empty_minor_heap_promote(caml_domain_state* domain,
        r < self_minor_tables->major_ref.ptr; r++) {
     value vnew = **r;
     CAMLassert (!Is_block(vnew)
-            || (get_header_val(vnew) != 0 && !Is_young(vnew)));
+            || (!Is_promoted_hd(get_header_val(vnew)) && !Is_young(vnew)));
   }
 #endif
 
@@ -844,7 +844,7 @@ static void ephe_clean_minor (caml_domain_state* domain)
       hd = Hd_val(v);
     }
     CAMLassert(Tag_hd(hd) != Infix_tag);
-    if (hd == 0) {
+    if (Is_promoted_hd(hd)) {
       /* promoted */
       v = Field(v, 0) + infix_offset;
     } else {
@@ -868,7 +868,7 @@ static void custom_finalize_minor (caml_domain_state * domain)
        elt < domain->minor_tables->custom.ptr; elt++) {
     value *v = &elt->block;
     if (Is_block(*v) && Is_young(*v)) {
-      if (get_header_val(*v) != 0) { /* value not copied to major heap */
+      if (!Is_promoted_hd(get_header_val(*v))) { /* value not copied to major heap */
         void (*final_fun)(value) = Custom_ops_val(*v)->finalize;
         if (final_fun != NULL) final_fun(*v);
       }


### PR DESCRIPTION
This introduces a macro `Is_promoted_hd` everywhere that checks a header is marking a promoted block. Every time we test for promotion, we do so using this predicate, so it could be broadened to allow (for instance) multiple promoted header values, rather than one single magic value. At present, it uses the constant value `Promoted_hd`, which can be zero (it is here, so this PR has no semantic effect at runtime) or non-zero (e.g. 0x200 - zero size, non-zero colour bits), which could be helpful for debugging.
This may be a small step towards using such named macros for other predicates, and also towards using distinct types for headers, tags, etc.
This was inspired by a hilarious bug in ocaml/ocaml#13643, see https://github.com/ocaml/ocaml/pull/13643#issuecomment-2602899055