### PR TITLE
CI: update actions/cache to v4

### DIFF
--- a/.github/workflows/jane_ocaml5.yml
+++ b/.github/workflows/jane_ocaml5.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache OCaml 4.14, dune, and menhir
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache
         with:
           path: ${{ github.workspace }}/ocaml-414/_install


### PR DESCRIPTION
v2 appears to have just been deprecated