### PR TITLE
Runtime events should never be conditional on debug log level

### DIFF
--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -936,12 +936,9 @@ int caml_do_opportunistic_major_slice
 {
   int work_available = caml_opportunistic_major_work_available(domain_state);
   if (work_available) {
-    /* NB: need to put guard around the ev logs to prevent spam when we poll */
-    uintnat log_events =
-        atomic_load_relaxed(&caml_verb_gc) & CAML_GC_MSG_SLICE;
-    if (log_events) CAML_EV_BEGIN(EV_MAJOR_MARK_OPPORTUNISTIC);
+    CAML_EV_BEGIN(EV_MAJOR_MARK_OPPORTUNISTIC);
     caml_opportunistic_major_collection_slice(Major_slice_work_min);
-    if (log_events) CAML_EV_END(EV_MAJOR_MARK_OPPORTUNISTIC);
+    CAML_EV_END(EV_MAJOR_MARK_OPPORTUNISTIC);
   }
   return work_available;
 }


### PR DESCRIPTION
While working on making the runtime events system more useful, I discovered that major GC cycle runtime event recording is conditional on (among other things) the GC log level. This can't be right.
Digging into git history I find that the runtime events used to be [string-based and very slow](https://github.com/ocaml-flambda/flambda-backend/blob/2897e91b5fc6758a2ff5d35d916ea5e635016f14/byterun/eventlog.c#L225-L229). Now they are very whizzy.