### PR TITLE
added type-directed disambiguation of integer literals

### DIFF
--- a/jane/doc/extensions/_11-miscellaneous-extensions/type-directed-disambiguation.md
+++ b/jane/doc/extensions/_11-miscellaneous-extensions/type-directed-disambiguation.md
@@ -1,0 +1,33 @@
+---
+layout: documentation-page
+collectionName: Miscellaneous extensions
+title: Type-directed disambiguation
+---
+
+# Type-directed disambiguation
+
+OCaml already has some type-directed disambiguation. For example, array literals
+are disambiguated among `array`s, `iarray`s, and `floatarray`s. More
+disambiguation can be enabled with `-extension type_directed_disambiguation`.
+
+## Type-directed disambiguation of integer literals
+
+Integer literals with no suffix and no `#` prefix can be disambiguated if their
+type can be inferred exactly. Consider the following two expressions:
+```
+let four = Int32.add 2 2;;
+let my_array = [| #10L; 20; 30 |];;
+```
+Both of them are accepted, but `my_array` will emit warnings with `-principal`.
+
+A typical pitfall of non-principal type-inference applies: Whether a bare
+integer literal is disambiguated or inferred to be `int` can depend on the order
+of type-inference.
+```
+# let my_array = [| 10; #20L; 30 |];;
+                        ^^^^
+Error: This constant has type "int64#" but an expression was expected of type
+         "int"
+```
+
+Disambiguation also works in patterns.

--- a/parsing/language_extension.ml
+++ b/parsing/language_extension.ml
@@ -75,6 +75,7 @@ let get_level_ops : type a. a t -> (module Extension_level with type t = a) =
   | Let_mutable -> (module Unit)
   | Layout_poly -> (module Maturity)
   | Runtime_metaprogramming -> (module Unit)
+  | Type_directed_disambiguation -> (module Unit)
 
 (* We'll do this in a more principled way later. *)
 (* CR layouts: Note that layouts is only "mostly" erasable, because of annoying
@@ -88,7 +89,7 @@ let is_erasable : type a. a t -> bool = function
   | Mode | Unique | Overwriting | Layouts | Layout_poly -> true
   | Comprehensions | Include_functor | Polymorphic_parameters | Immutable_arrays
   | Module_strengthening | SIMD | Small_numbers | Instances | Let_mutable
-  | Runtime_metaprogramming ->
+  | Runtime_metaprogramming | Type_directed_disambiguation ->
     false
 
 let maturity_of_unique_for_drf = Stable
@@ -114,6 +115,7 @@ module Exist_pair = struct
     | Pair (Let_mutable, ()) -> Stable
     | Pair (Layout_poly, m) -> m
     | Pair (Runtime_metaprogramming, ()) -> Beta
+    | Pair (Type_directed_disambiguation, ()) -> Stable
 
   let is_erasable : t -> bool = function Pair (ext, _) -> is_erasable ext
 
@@ -129,7 +131,8 @@ module Exist_pair = struct
     | Pair
         ( (( Comprehensions | Include_functor | Polymorphic_parameters
            | Immutable_arrays | Module_strengthening | Instances | Overwriting
-           | Let_mutable | Runtime_metaprogramming ) as ext),
+           | Let_mutable | Runtime_metaprogramming
+           | Type_directed_disambiguation ) as ext),
           _ ) ->
       to_string ext
 
@@ -165,6 +168,8 @@ module Exist_pair = struct
     | "layout_poly_alpha" -> Some (Pair (Layout_poly, Alpha))
     | "layout_poly_beta" -> Some (Pair (Layout_poly, Beta))
     | "runtime_metaprogramming" -> Some (Pair (Runtime_metaprogramming, ()))
+    | "type_directed_disambiguation" ->
+      Some (Pair (Type_directed_disambiguation, ()))
     | _ -> None
 end
 
@@ -187,7 +192,8 @@ let all_extensions =
     Pack Instances;
     Pack Let_mutable;
     Pack Layout_poly;
-    Pack Runtime_metaprogramming ]
+    Pack Runtime_metaprogramming;
+    Pack Type_directed_disambiguation ]
 
 (**********************************)
 (* string conversions *)
@@ -228,10 +234,11 @@ let equal_t (type a b) (a : a t) (b : b t) : (a, b) Misc.eq option =
   | Let_mutable, Let_mutable -> Some Refl
   | Layout_poly, Layout_poly -> Some Refl
   | Runtime_metaprogramming, Runtime_metaprogramming -> Some Refl
+  | Type_directed_disambiguation, Type_directed_disambiguation -> Some Refl
   | ( ( Comprehensions | Mode | Unique | Overwriting | Include_functor
       | Polymorphic_parameters | Immutable_arrays | Module_strengthening
       | Layouts | SIMD | Small_numbers | Instances | Let_mutable | Layout_poly
-      | Runtime_metaprogramming ),
+      | Runtime_metaprogramming | Type_directed_disambiguation ),
       _ ) ->
     None
 

--- a/parsing/language_extension.mli
+++ b/parsing/language_extension.mli
@@ -32,6 +32,7 @@ type 'a t = 'a Language_extension_kernel.t =
   | Let_mutable : unit t
   | Layout_poly : maturity t
   | Runtime_metaprogramming : unit t
+  | Type_directed_disambiguation : unit t
 
 (** Require that an extension is enabled for at least the provided level, or
     else throw an exception at the provided location saying otherwise. *)

--- a/testsuite/tests/typing-core-bugs/const_int_hint.ml
+++ b/testsuite/tests/typing-core-bugs/const_int_hint.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags = "-no-extension type_directed_disambiguation";
  expect;
 *)
 

--- a/testsuite/tests/typing-core-bugs/const_int_hint_with_tydi.ml
+++ b/testsuite/tests/typing-core-bugs/const_int_hint_with_tydi.ml
@@ -1,0 +1,104 @@
+(* TEST
+ flags = "-extension type_directed_disambiguation";
+ expect;
+*)
+
+let _ = Int32.(add 1 2);;
+[%%expect{|
+- : int32 = 3l
+|}]
+
+let _ : int32 * nativeint = 42l, 43;;
+[%%expect{|
+- : int32 * nativeint = (42l, 43n)
+|}]
+
+let _ = min 6L 7m;;
+[%%expect{|
+Line 1, characters 15-17:
+1 | let _ = min 6L 7m;;
+                   ^^
+Error: The constant "7m" has type "int" but an expression was expected of type
+         "int64"
+Hint: Did you mean "7L"?
+|}]
+
+let _ = min 6L 7;;
+[%%expect{|
+- : int64 = 6L
+|}, Principal{|
+Line 1, characters 15-16:
+1 | let _ = min 6L 7;;
+                   ^
+Warning 18 [not-principal]: this coercion to int64 is not principal.
+
+- : int64 = 6L
+|}]
+
+(* pattern *)
+let _ : int32 -> int32 = function
+  | 0m -> 0l
+  | x -> x
+[%%expect{|
+Line 2, characters 4-6:
+2 |   | 0m -> 0l
+        ^^
+Error: This pattern matches values of type "int"
+       but a pattern was expected which matches values of type "int32"
+Hint: Did you mean "0l"?
+|}]
+
+let _ : int32 -> int32 = function
+  | 0 -> 0l
+  | x -> x
+[%%expect{|
+- : int32 -> int32 = <fun>
+|}]
+
+let _ : int64 -> int64 = function
+  | 1L | 2m -> 3L
+  | x -> x;;
+[%%expect{|
+Line 2, characters 9-11:
+2 |   | 1L | 2m -> 3L
+             ^^
+Error: This pattern matches values of type "int"
+       but a pattern was expected which matches values of type "int64"
+Hint: Did you mean "2L"?
+|}]
+
+let _ : int64 -> int64 = function
+  | 1L | 2 -> 3L
+  | x -> x;;
+[%%expect{|
+- : int64 -> int64 = <fun>
+|}]
+
+let _ : nativeint -> nativeint = function
+  | 12 -> 0n
+  | x -> x;;
+[%%expect{|
+- : nativeint -> nativeint = <fun>
+|}]
+
+let _ = function
+  | 1L | 2 -> 3L
+  | x -> x;;
+[%%expect{|
+- : int64 -> int64 = <fun>
+|}, Principal{|
+Line 2, characters 9-10:
+2 |   | 1L | 2 -> 3L
+             ^
+Warning 18 [not-principal]: this coercion to int64 is not principal.
+
+- : int64 -> int64 = <fun>
+|}]
+
+let _ : int8 = 129;;
+[%%expect{|
+Line 1, characters 15-18:
+1 | let _ : int8 = 129;;
+                   ^^^
+Error: Integer literal exceeds the range of representable integers of type "int8"
+|}]

--- a/testsuite/tests/typing-layouts/literals.ml
+++ b/testsuite/tests/typing-layouts/literals.ml
@@ -221,6 +221,17 @@ let () = test_char "untagged decimal char" #'\222'
 untagged decimal char: '\222'
 |}]
 
+let () = test_int32 "type_directed_int32" 0
+let () = test_int64 "type_directed_int64" 100
+let () = test_nativeint "type_directed_nativeint" (-42)
+let () = test_int "type_directed_int" 0xFF
+[%%expect{|
+type_directed_int32: 0
+type_directed_int64: 100
+type_directed_nativeint: -42
+type_directed_int: 255
+|}]
+
 (*****************************************)
 (* Patterns *)
 
@@ -235,6 +246,21 @@ f #4L;;
 [%%expect {|
 val f : int64# -> [> `Five | `Four | `Other ] = <fun>
 - : [> `Five | `Four | `Other ] = `Four
+|}];;
+
+let f_tydi (x : nativeint#) =
+  match x with
+  | 4 -> `Four
+  | 5 -> `Five
+  | _ -> `Other
+;;
+
+f_tydi 5;;
+f_tydi 6;;
+[%%expect {|
+val f_tydi : nativeint# -> [> `Five | `Four | `Other ] = <fun>
+- : [> `Five | `Four | `Other ] = `Five
+- : [> `Five | `Four | `Other ] = `Other
 |}];;
 
 let f x =

--- a/testsuite/tests/typing-small-numbers/test_enabled.ml
+++ b/testsuite/tests/typing-small-numbers/test_enabled.ml
@@ -210,6 +210,11 @@ let _ : int8 = 128s
 - : int8 = -128s
 |}]
 
+let _ : int8 = 12
+[%%expect{|
+- : int8 = 12s
+|}]
+
 let _ : int8 = 129s
 [%%expect{|
 Line 1, characters 15-19:
@@ -344,6 +349,16 @@ let _ : int =
 - : int = 2
 |}]
 
+let _ : int =
+  match (12 : int8) with
+  | 12 -> 0
+  | 11s -> 1
+  | _ -> 2
+;;
+[%%expect{|
+- : int = 0
+|}]
+
 (* Partial match *)
 let _ : int =
   match 1s with
@@ -409,6 +424,11 @@ let _ : int16 = 32768S
 - : int16 = 32767S
 - : int16 = -32768S
 - : int16 = -32768S
+|}]
+
+let _ : int16 = 300
+[%%expect{|
+- : int16 = 300S
 |}]
 
 let _ : int16 = 32769S
@@ -543,6 +563,16 @@ let _ : int =
 ;;
 [%%expect{|
 - : int = 2
+|}]
+
+let _ : int =
+  match (300 : int16) with
+  | 300 -> 0
+  | 200S -> 1
+  | _ -> 2
+;;
+[%%expect{|
+- : int = 0
 |}]
 
 (* Partial match *)
@@ -764,6 +794,16 @@ let _ : int =
 - : int = 2
 |}]
 
+let _ : int =
+  match (12 : int8#) with
+  | 12 -> 0
+  | #11s -> 1
+  | _ -> 2
+;;
+[%%expect{|
+- : int = 0
+|}]
+
 (* Partial match *)
 let _ : int =
   match #1s with
@@ -893,6 +933,16 @@ let _ : int =
 ;;
 [%%expect{|
 - : int = 2
+|}]
+
+let _ : int =
+  match (300 : int16#) with
+  | 300 -> 0
+  | #200S -> 1
+  | _ -> 2
+;;
+[%%expect{|
+- : int = 0
 |}]
 
 (* Partial match *)

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -419,6 +419,21 @@ and path_unboxed_float16x32 = Path.unboxed_version path_float16x32
 and path_unboxed_float32x16 = Path.unboxed_version path_float32x16
 and path_unboxed_float64x8 = Path.unboxed_version path_float64x8
 
+let path_of_scalar (scalar : 'a Scalar.t) =
+  let value : _ Scalar.Width.t -> Path.t = function
+    | Integral (Taggable Int8) -> path_int8
+    | Integral (Taggable Int16) -> path_int16
+    | Integral (Taggable Int) -> path_int
+    | Integral (Boxable (Int32 _)) -> path_int32
+    | Integral (Boxable (Int64 _)) -> path_int64
+    | Integral (Boxable (Nativeint _)) -> path_nativeint
+    | Floating (Float32 _) -> path_float32
+    | Floating (Float64 _) -> path_float
+  in
+  match scalar with
+  | Value width -> value width
+  | Naked width -> Path.unboxed_version (value width)
+
 let path_of_type_constr typ =
   Pident (ident_of_type_constr typ)
 

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -232,6 +232,9 @@ val path_uint8_u: Path.t
 val path_uint16_u: Path.t
 val path_uint32_u: Path.t
 val path_uint64_u: Path.t
+
+val path_of_scalar: 'a Scalar.t -> Path.t
+
 val path_or_null: Path.t
 val path_idx_imm: Path.t
 val path_idx_mut: Path.t

--- a/typing/scalar.ml
+++ b/typing/scalar.ml
@@ -52,6 +52,8 @@ module Maybe_naked = struct
       | Value m -> M.to_string m
       | Naked m -> M.to_string m ^ "#"
 
+    let pp ppf t = Format_doc.pp_print_string ppf (to_string t)
+
     let ignore_locality = map ~f:ignore_locality
 
     let all = List.concat_map (fun m -> [Value m; Naked m]) M.all

--- a/typing/scalar.mli
+++ b/typing/scalar.mli
@@ -94,6 +94,9 @@
     fixed to any_locality_mode when the corresponding function is expecting a
     simple sum type (e.g., [to_string]). *)
 
+(* CR-someday jvanburen: for brevity, rename all of the [type 'a t =...]s to
+   [type 'a t1 = ...], and make [type t = any_locality_mode t1] *)
+
 type any_locality_mode = Any_locality_mode
 
 val equal_any_locality_mode : any_locality_mode -> any_locality_mode -> bool
@@ -123,6 +126,8 @@ module type S := sig
   val width : _ t -> any_locality_mode width
 
   val to_string : any_locality_mode t -> string
+
+  val pp : any_locality_mode t Format_doc.printer
 
   val sort : any_locality_mode t -> Jkind_types.Sort.Const.t
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -267,7 +267,7 @@ type error =
   | Probe_is_enabled_format
   | Extension_not_enabled : _ Language_extension.t -> error
   | Modalities_on_atomic_field of Longident.t
-  | Literal_overflow of string
+  | Literal_overflow of Scalar.any_locality_mode Scalar.Integral.t
   | Unknown_literal of string * char
   | Float32_literal of string
   | Int8_literal of string
@@ -936,86 +936,69 @@ let type_constant: Typedtree.constant -> type_expr = function
   | Const_unboxed_int64 _ -> instance Predef.type_unboxed_int64
   | Const_unboxed_nativeint _ -> instance Predef.type_unboxed_nativeint
 
-type constant_integer_result =
-  | Int8 of int
-  | Int16 of int
-  | Int32 of int32
-  | Int64 of int64
-  | Nativeint of nativeint
-  | Int of int
+let parse_integer (scalar : 'a Scalar.Integral.t) i : _ result =
+  let module I = Misc.Int_literal_converter in
+  let literal () =
+    match scalar with
+    | Value _ -> i
+    | Naked _ -> Misc.format_as_unboxed_literal i
+  in
+  try
+    match scalar with
+    | Value (Taggable Int8) | Naked (Taggable Int8)
+      when not (Language_extension.is_enabled Small_numbers) ->
+      Error (Int8_literal (literal ()))
+    | Value (Taggable Int16) | Naked (Taggable Int16)
+      when not (Language_extension.is_enabled Small_numbers) ->
+      Error (Int16_literal (literal ()))
+    | Value (Taggable Int8) -> Ok (Const_int8 (I.int8 i))
+    | Naked (Taggable Int8) -> Ok (Const_untagged_int8 (I.int8 i))
+    | Value (Taggable Int16) -> Ok (Const_int16 (I.int16 i))
+    | Naked (Taggable Int16) -> Ok (Const_untagged_int16 (I.int16 i))
+    | Value (Taggable Int) -> Ok (Const_int (I.int i))
+    | Naked (Taggable Int) -> Ok (Const_untagged_int (I.int i))
+    | Value (Boxable (Int32 _)) -> Ok (Const_int32 (I.int32 i))
+    | Naked (Boxable (Int32 _)) -> Ok (Const_unboxed_int32 (I.int32 i))
+    | Value (Boxable (Int64 _)) -> Ok (Const_int64 (I.int64 i))
+    | Naked (Boxable (Int64 _)) -> Ok (Const_unboxed_int64 (I.int64 i))
+    | Value (Boxable (Nativeint _)) -> Ok (Const_nativeint (I.nativeint i))
+    | Naked (Boxable (Nativeint _)) ->
+      Ok (Const_unboxed_nativeint (I.nativeint i))
+  with
+  | Failure _ -> Error (Literal_overflow scalar)
 
-type constant_integer_error =
-  | Int8_literal_not_enabled
-  | Int16_literal_not_enabled
-  | Int8_literal_overflow
-  | Int16_literal_overflow
-  | Int32_literal_overflow
-  | Int64_literal_overflow
-  | Nativeint_literal_overflow
-  | Int_literal_overflow
-  | Unknown_constant_literal of char
+type naked_flag =
+  | Naked
+  | Value
 
-let constant_integer i ~suffix :
-    (constant_integer_result, constant_integer_error) result =
+let parse_integer_with_suffix naked i ~suffix : _ result =
+  let parse_as width =
+    let scalar : _ Scalar.Maybe_naked.t =
+      match naked with
+      | Naked -> Naked width
+      | Value -> Value width
+    in
+    parse_integer scalar i
+  in
   match suffix with
-  | Some 's' ->
-    if Language_extension.is_enabled Small_numbers then
-    begin
-      try Ok (Int8 (Misc.Int_literal_converter.int8 i))
-      with Failure _ -> Error Int8_literal_overflow
-    end
-    else Error (Int8_literal_not_enabled)
-  | Some 'S' ->
-    if Language_extension.is_enabled Small_numbers then
-    begin
-      try Ok (Int16 (Misc.Int_literal_converter.int16 i))
-      with Failure _ -> Error Int16_literal_overflow
-    end
-    else Error (Int16_literal_not_enabled)
-  | Some 'l' ->
-    begin
-      try Ok (Int32 (Misc.Int_literal_converter.int32 i))
-      with Failure _ -> Error Int32_literal_overflow
-    end
-  | Some 'L' ->
-    begin
-      try Ok (Int64 (Misc.Int_literal_converter.int64 i))
-      with Failure _ -> Error Int64_literal_overflow
-    end
-  | Some 'n' ->
-    begin
-      try Ok (Nativeint (Misc.Int_literal_converter.nativeint i))
-      with Failure _ -> Error Nativeint_literal_overflow
-    end
-  | Some 'm' | None ->
-    begin
-      try Ok (Int (Misc.Int_literal_converter.int i))
-      with Failure _ -> Error Int_literal_overflow
-    end
-  | Some suffix -> Error (Unknown_constant_literal suffix)
+  | Some 's' -> parse_as (Taggable Int8)
+  | Some 'S' -> parse_as (Taggable Int16)
+  | Some 'm' | None -> parse_as (Taggable Int)
+  | Some 'l' -> parse_as (Boxable (Int32 Any_locality_mode))
+  | Some 'L' -> parse_as (Boxable (Int64 Any_locality_mode))
+  | Some 'n' -> parse_as (Boxable (Nativeint Any_locality_mode))
+  | Some suffix ->
+    let literal =
+      match naked with
+      | Value -> i
+      | Naked -> Misc.format_as_unboxed_literal i
+    in
+    Error (Unknown_literal (literal, suffix))
 
 let constant_desc
   : Parsetree.constant_desc -> (Typedtree.constant, error) result =
   function
-  | Pconst_integer (i, suffix) ->
-    begin match constant_integer i ~suffix with
-      | Ok (Int8 v) -> Ok (Const_int8 v)
-      | Ok (Int16 v) -> Ok (Const_int16 v)
-      | Ok (Int32 v) -> Ok (Const_int32 v)
-      | Ok (Int64 v) -> Ok (Const_int64 v)
-      | Ok (Nativeint v) -> Ok (Const_nativeint v)
-      | Ok (Int v) -> Ok (Const_int v)
-      | Error Int8_literal_not_enabled -> Error (Int8_literal i)
-      | Error Int16_literal_not_enabled -> Error (Int16_literal i)
-      | Error Int8_literal_overflow -> Error (Literal_overflow "int8")
-      | Error Int16_literal_overflow -> Error (Literal_overflow "int16")
-      | Error Int32_literal_overflow -> Error (Literal_overflow "int32")
-      | Error Int64_literal_overflow -> Error (Literal_overflow "int64")
-      | Error Nativeint_literal_overflow -> Error (Literal_overflow "nativeint")
-      | Error Int_literal_overflow -> Error (Literal_overflow "int")
-      | Error Unknown_constant_literal suffix ->
-        Error (Unknown_literal (i, suffix))
-    end
+  | Pconst_integer (i, suffix) -> parse_integer_with_suffix Value i ~suffix
   | Pconst_char c -> Ok (Const_char c)
   | Pconst_untagged_char c ->
       if Language_extension.is_enabled Small_numbers
@@ -1035,31 +1018,12 @@ let constant_desc
   | Pconst_unboxed_float (x, Some c) ->
       Error (Unknown_literal (Misc.format_as_unboxed_literal x, c))
   | Pconst_unboxed_integer (i, suffix) ->
-      begin match constant_integer i ~suffix:(Some suffix) with
-      | Ok (Int8 v) -> Ok (Const_untagged_int8 v)
-      | Ok (Int16 v) -> Ok (Const_untagged_int16 v)
-      | Ok (Int32 v) -> Ok (Const_unboxed_int32 v)
-      | Ok (Int64 v) -> Ok (Const_unboxed_int64 v)
-      | Ok (Nativeint v) -> Ok (Const_unboxed_nativeint v)
-      | Ok (Int v) -> Ok (Const_untagged_int v)
-      | Error Int8_literal_not_enabled ->
-        Error (Int8_literal (Misc.format_as_unboxed_literal i))
-      | Error Int16_literal_not_enabled ->
-        Error (Int16_literal (Misc.format_as_unboxed_literal i))
-      | Error Int8_literal_overflow -> Error (Literal_overflow "int8#")
-      | Error Int16_literal_overflow -> Error (Literal_overflow "int16#")
-      | Error Int32_literal_overflow -> Error (Literal_overflow "int32#")
-      | Error Int64_literal_overflow -> Error (Literal_overflow "int64#")
-      | Error Nativeint_literal_overflow -> Error (Literal_overflow "nativeint#")
-      | Error Int_literal_overflow -> Error (Literal_overflow "int#")
-      | Error Unknown_constant_literal suffix ->
-          Error (Unknown_literal (Misc.format_as_unboxed_literal i, suffix))
-      end
+    parse_integer_with_suffix Naked i ~suffix:(Some suffix)
 
 let constant const = constant_desc const.pconst_desc
 
-let constant_or_raise env loc cst =
-  match constant cst with
+let constant_result_or_raise env loc (result : _ result) =
+  match result with
   | Ok c ->
       (match c with
        | Const_untagged_char _
@@ -1079,6 +1043,9 @@ let constant_or_raise env loc cst =
            ());
       c
   | Error err -> raise (Error (loc, env, err))
+
+let constant_or_raise env loc cst =
+  constant_result_or_raise env loc (constant cst)
 
 (* Specific version of type_option, using newty rather than newgenty *)
 
@@ -1380,6 +1347,38 @@ let disambiguate_array_literal ~loc env expected_ty =
     return None Immutable
   else
     { ty_elt = None; mut = Mutable }
+
+let disambiguate_integer_literal ~loc env ty_expected i =
+  if not (Language_extension.is_enabled Type_directed_disambiguation)
+  then None
+  else
+    let ty_expected = expand_head env (protect_expansion env ty_expected) in
+    match get_desc ty_expected with
+    | Tconstr (ty_expected_path, _, _)
+      when not (Path.same ty_expected_path Predef.path_int) ->
+      List.find_map
+        (fun (scalar : _ Scalar.Integral.t) ->
+          let candidate = Predef.path_of_scalar (Scalar.integral scalar) in
+          if Path.same ty_expected_path candidate then (
+            if not (is_principal ty_expected)
+            then
+              Location.prerr_warning loc
+                (not_principal "this coercion to %s" (Path.name candidate));
+            Some (constant_result_or_raise env loc (parse_integer scalar i)))
+          else None)
+        Scalar.Integral.all
+    | _ -> None
+
+let disambiguated_constant_or_raise env loc cst ~ty_expected =
+  let disambiguated =
+    match cst.pconst_desc with
+    | Pconst_integer (i, None) ->
+      disambiguate_integer_literal ~loc env ty_expected i
+    | _ -> None
+  in
+  match disambiguated with
+  | Some constant -> constant
+  | None -> constant_or_raise env loc cst
 
 (* Typing of patterns *)
 
@@ -3634,7 +3633,9 @@ and type_pat_aux
         pat_env = !!penv;
         pat_unique_barrier = Unique_barrier.not_computed () }
   | Ppat_constant cst ->
-      let cst = constant_or_raise !!penv loc cst in
+      let cst =
+        disambiguated_constant_or_raise !!penv loc cst ~ty_expected:expected_ty
+      in
       rvp @@ solve_expected {
         pat_desc = Tpat_constant cst;
         pat_loc = loc; pat_extra=[];
@@ -7027,7 +7028,7 @@ and type_expect_
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_constant cst ->
-      let cst = constant_or_raise env loc cst in
+      let cst = disambiguated_constant_or_raise env loc cst ~ty_expected in
       rue {
         exp_desc = Texp_constant cst;
         exp_loc = loc; exp_extra = [];
@@ -13042,7 +13043,7 @@ let report_error ~loc env =
   | Literal_overflow ty ->
       Location.errorf ~loc
         "Integer literal exceeds the range of representable integers of type %a"
-        Style.inline_code ty
+        (Style.as_inline_code Scalar.Integral.pp) ty
   | Unknown_literal (n, m) ->
       let pp_lit ppf (n,m) = fprintf ppf "%s%c" n m in
       Location.errorf ~loc "Unknown modifier %a for literal %a"

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -312,7 +312,7 @@ type error =
   | Probe_is_enabled_format
   | Extension_not_enabled : _ Language_extension.t -> error
   | Modalities_on_atomic_field of Longident.t
-  | Literal_overflow of string
+  | Literal_overflow of Scalar.any_locality_mode Scalar.Integral.t
   | Unknown_literal of string * char
   | Float32_literal of string
   | Int8_literal of string

--- a/utils/language_extension_kernel.ml
+++ b/utils/language_extension_kernel.ml
@@ -20,6 +20,7 @@ type _ t =
   | Let_mutable : unit t
   | Layout_poly : maturity t
   | Runtime_metaprogramming : unit t
+  | Type_directed_disambiguation : unit t
 
 (* When you update this, update [pair_of_string] below too. *)
 let to_string : type a. a t -> string = function
@@ -38,3 +39,4 @@ let to_string : type a. a t -> string = function
   | Let_mutable -> "let_mutable"
   | Layout_poly -> "layout_poly"
   | Runtime_metaprogramming -> "runtime_metaprogramming"
+  | Type_directed_disambiguation -> "type_directed_disambiguation"

--- a/utils/language_extension_kernel.mli
+++ b/utils/language_extension_kernel.mli
@@ -31,6 +31,7 @@ type _ t =
   | Let_mutable : unit t
   | Layout_poly : maturity t
   | Runtime_metaprogramming : unit t
+  | Type_directed_disambiguation : unit t
 
 (** Print and parse language extensions; parsing is case-insensitive *)
 val to_string : _ t -> string

--- a/utils/profile_counters_functions.ml
+++ b/utils/profile_counters_functions.ml
@@ -12,7 +12,7 @@ let count_language_extensions typing_input =
       Language_extension_kernel.to_string lang_ext
     | Mode | Unique | Polymorphic_parameters | Layouts | SIMD | Small_numbers
     | Instances | Overwriting | Let_mutable | Layout_poly
-    | Runtime_metaprogramming ->
+    | Runtime_metaprogramming | Type_directed_disambiguation ->
       let error_msg =
         Format.sprintf "No counters supported for language extension : %s."
           (Language_extension_kernel.to_string lang_ext)


### PR DESCRIPTION
People have complained about the verbosity of unboxed types. This is a quick example attempt at fixing it by using type annotations.