### PR TITLE
Compiler Compare Script

### DIFF
--- a/tools/diff_compiler_versions.sh
+++ b/tools/diff_compiler_versions.sh
@@ -65,3 +65,10 @@ sed -i.bak "s/runtime-stdlib: boot-compiler/runtime-stdlib: _build\/_bootinstall
 make install
 cp -R -f _install/ "$TARGETDIR/base-compiler-revision/_install/"
 cp -R -f _build/ "$TARGETDIR/base-compiler-revision/_build/"
+
+
+# recommended versions to compare the output
+#   compare the binaries:
+#       diff <(objdump -dr "$TARGETDIR_REL_ABS/base-compiler-original/_install/bin/ocamlopt.opt") <(objdump -dr "$TARGETDIR_REL_ABS/base-compiler-revision/_install/bin/ocamlopt.opt")
+#   compare the assembly files:
+#       (cd $TARGETDIR_REL_ABS/base-compiler-original && (for i in $(find _build/ -name "*.s"); do diff -u -p  "$i" "../base-compiler-revision/$i"; done))


### PR DESCRIPTION
This PR provides a script that allows one to compare the binaries of the compiler *built on the same code* but with two different versions of the compiler. Concretely, it takes a base commit and a revision commit, and then it builds the *code of the base commit compiler* both with the base commit compiler and the revision commit compiler.