### PR TITLE
Move Capply to Cmm.expression and harmonise with Cfg

### DIFF
--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -125,7 +125,7 @@ let is_immediate_natint n =
   Nativeint.compare n 0x7FFF_FFFFn <= 0
   && Nativeint.compare n (-0x8000_0000n) >= 0
 
-let specific x : Cfg.basic_or_terminator = Basic (Op (Specific x))
+let specific x : Cfg.basic = Op (Specific x)
 
 let pseudoregs_for_operation op arg res =
   match (op : Operation.t) with

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -710,7 +710,7 @@ let precolored_regs () =
 let operation_supported = function
   | Cpopcnt -> Arch.Extension.enabled POPCNT
   | Cprefetch _ | Catomic _
-  | Capply _ | Cextcall _ | Cload _ | Calloc _ | Cstore _
+  | Cextcall _ | Cload _ | Calloc _ | Cstore _
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
   | Ccsel _

--- a/backend/arm64/CSE.ml
+++ b/backend/arm64/CSE.ml
@@ -55,7 +55,7 @@ let class_of_operation (op : Operation.t)
   | Stackoffset _ | Load _ | Store _ | Alloc _
   | Intop _ | Intop_imm _ | Intop_atomic _
   | Name_for_debugger _ | Probe_is_enabled _ | Opaque
-  | Begin_region | End_region | Poll | Dls_get
+  | Begin_region | End_region | Poll | Dls_get | Extcall _
     -> Use_default
 
 let is_cheap_operation (op : Operation.t)
@@ -73,5 +73,5 @@ let is_cheap_operation (op : Operation.t)
   | Stackoffset _ | Load _ | Store _ | Alloc _
   | Intop _ | Intop_imm _ | Intop_atomic _
   | Name_for_debugger _ | Probe_is_enabled _ | Opaque
-  | Begin_region | End_region | Poll | Dls_get
+  | Begin_region | End_region | Poll | Dls_get | Extcall _
     -> Cheap false

--- a/backend/arm64/CSE.ml
+++ b/backend/arm64/CSE.ml
@@ -55,7 +55,7 @@ let class_of_operation (op : Operation.t)
   | Stackoffset _ | Load _ | Store _ | Alloc _
   | Intop _ | Intop_imm _ | Intop_atomic _
   | Name_for_debugger _ | Probe_is_enabled _ | Opaque
-  | Begin_region | End_region | Poll | Dls_get | Extcall _
+  | Begin_region | End_region | Poll | Dls_get | External _
     -> Use_default
 
 let is_cheap_operation (op : Operation.t)
@@ -73,5 +73,5 @@ let is_cheap_operation (op : Operation.t)
   | Stackoffset _ | Load _ | Store _ | Alloc _
   | Intop _ | Intop_imm _ | Intop_atomic _
   | Name_for_debugger _ | Probe_is_enabled _ | Opaque
-  | Begin_region | End_region | Poll | Dls_get | Extcall _
+  | Begin_region | End_region | Poll | Dls_get | External _
     -> Cheap false

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -859,7 +859,7 @@ let num_call_gc_points instr =
         | Intop_atomic _
         | Floatop (_, _)
         | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-        | Name_for_debugger _ | Extcall _ )
+        | Name_for_debugger _ | External _ )
     | Lprologue | Lreloadretaddr | Lreturn | Lentertrap | Lpoptrap | Lcall_op _
     | Llabel _ | Lbranch _
     | Lcondbranch (_, _)
@@ -926,7 +926,7 @@ module BR = Branch_relaxation.Make (struct
           | Intop_atomic _
           | Floatop (_, _)
           | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-          | Name_for_debugger _ | Extcall _ )
+          | Name_for_debugger _ | External _ )
       | Lprologue | Lend | Lreloadretaddr | Lreturn | Lentertrap | Lpoptrap
       | Lcall_op _ | Llabel _ | Lbranch _ | Lswitch _ | Ladjust_stack_offset _
       | Lpushtrap _ | Lraise _ | Lstackcheck _ ->
@@ -972,7 +972,7 @@ module BR = Branch_relaxation.Make (struct
           { alloc; stack_ofs; func = _; ty_res = _; ty_args = _; returns = _ })
       ->
       if Config.runtime5 && stack_ofs > 0 then 5 else if alloc then 3 else 5
-    | Lop (Extcall _) ->
+    | Lop (External _) ->
       (* Never allocates *)
       5
     | Lop (Stackoffset _) -> 2
@@ -1514,7 +1514,7 @@ let emit_instr i =
   | Lcall_op (Lextcall { func; alloc; stack_ofs; _ }) ->
     emit_extcall i ~func ~alloc ~stack_ofs
   | Lop
-      (Extcall
+      (External
         { func_symbol = func;
           effects = _;
           ty_args = _;

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -354,7 +354,7 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
   | Op Poll -> destroyed_at_alloc_or_poll
   | Op (Alloc _) ->
     destroyed_at_alloc_or_poll
-  | Op (Extcall { stack_ofs; _ }) ->
+  | Op (External { stack_ofs; _ }) ->
     if stack_ofs > 0 then all_phys_regs else destroyed_at_c_noalloc_call
   | Op(Load {memory_chunk = Single { reg = Float64 }; _ }
       | Store(Single { reg = Float64 }, _, _))

--- a/backend/arm64/regalloc_stack_operands.ml
+++ b/backend/arm64/regalloc_stack_operands.ml
@@ -39,7 +39,7 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
       | Intop_atomic _
       | Floatop (_, _)
       | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-      | Name_for_debugger _ | Alloc _ | Extcall _ )
+      | Name_for_debugger _ | Alloc _ | External _ )
   | Reloadretaddr | Prologue | Pushtrap _ | Poptrap _ | Stack_check _ ->
     (* no rewrite *)
     May_still_have_spilled_registers

--- a/backend/arm64/regalloc_stack_operands.ml
+++ b/backend/arm64/regalloc_stack_operands.ml
@@ -39,17 +39,16 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
       | Intop_atomic _
       | Floatop (_, _)
       | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-      | Name_for_debugger _ | Alloc _ )
+      | Name_for_debugger _ | Alloc _ | Extcall _ )
   | Reloadretaddr | Prologue | Pushtrap _ | Poptrap _ | Stack_check _ ->
     (* no rewrite *)
     May_still_have_spilled_registers
 
 let terminator (map : spilled_map) (term : Cfg.terminator Cfg.instruction) =
   match term.desc with
-  | Prim { op = Probe _; _ } -> may_use_stack_operands_everywhere map term
-  | Prim { op = External _; _ }
+  | Call (Probe _) -> may_use_stack_operands_everywhere map term
   | Never | Return | Always _ | Parity_test _ | Truth_test _ | Float_test _
   | Int_test _ | Switch _ | Raise _ | Tailcall_self _ | Tailcall_func _
-  | Call_no_return _ | Call _ ->
+  | Call (OCaml _ | External _) ->
     (* no rewrite *)
     May_still_have_spilled_registers

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -564,7 +564,7 @@ let is_noop_move instr =
       | Const_vec128 _ | Stackoffset _ | Load _ | Store _ | Intop _
       | Intop_imm _ | Intop_atomic _ | Floatop _ | Opaque | Reinterpret_cast _
       | Static_cast _ | Probe_is_enabled _ | Specific _ | Name_for_debugger _
-      | Begin_region | End_region | Dls_get | Poll | Alloc _ | Extcall _ )
+      | Begin_region | End_region | Dls_get | Poll | Alloc _ | External _ )
   | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ ->
     false
 
@@ -655,7 +655,7 @@ let is_poll (instr : basic instruction) =
       | Intop_atomic _
       | Floatop (_, _)
       | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-      | Specific _ | Name_for_debugger _ | Extcall _ ) ->
+      | Specific _ | Name_for_debugger _ | External _ ) ->
     false
 
 let is_alloc (instr : basic instruction) =
@@ -672,7 +672,7 @@ let is_alloc (instr : basic instruction) =
       | Intop_atomic _
       | Floatop (_, _)
       | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-      | Specific _ | Name_for_debugger _ | Extcall _ ) ->
+      | Specific _ | Name_for_debugger _ | External _ ) ->
     false
 
 let is_end_region (b : basic) =
@@ -689,7 +689,7 @@ let is_end_region (b : basic) =
       | Intop_atomic _
       | Floatop (_, _)
       | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-      | Specific _ | Name_for_debugger _ | Extcall _ ) ->
+      | Specific _ | Name_for_debugger _ | External _ ) ->
     false
 
 let basic_block_contains_calls block =
@@ -711,7 +711,7 @@ let basic_block_contains_calls block =
      | Call _ -> true)
   || DLL.exists block.body ~f:(fun (instr : basic instruction) ->
          match instr.desc with
-         | Op (Alloc _ | Poll | Extcall _) -> true
+         | Op (Alloc _ | Poll | External _) -> true
          | Op
              ( Move | Spill | Reload | Const_int _ | Const_float32 _
              | Const_float _ | Const_symbol _ | Const_vec128 _ | Stackoffset _

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -247,3 +247,5 @@ val basic_block_contains_calls : basic_block -> bool
 val max_instr_id : t -> InstructionId.t
 
 val equal_irc_work_list : irc_work_list -> irc_work_list -> bool
+
+val print_block : Format.formatter -> basic_block -> unit

--- a/backend/cfg/cfg_available_regs.ml
+++ b/backend/cfg/cfg_available_regs.ml
@@ -308,7 +308,7 @@ module Transfer = struct
             | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _
             | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _ | Opaque
             | Begin_region | End_region | Specific _ | Dls_get | Poll | Alloc _
-            | Extcall _ )
+            | External _ )
         | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ ->
           let is_op_end_region = Cfg.is_end_region in
           common ~avail_before ~destroyed_at:Proc.destroyed_at_basic
@@ -386,7 +386,7 @@ let get_name_for_debugger_regs (b : Cfg.basic) =
       | Intop_atomic _
       | Floatop (_, _)
       | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-      | Specific _ | Alloc _ | Extcall _ ) ->
+      | Specific _ | Alloc _ | External _ ) ->
     None
 
 let compute_all_regs_that_might_be_named : Cfg.t -> Reg.Set.t =

--- a/backend/cfg/cfg_comballoc.ml
+++ b/backend/cfg/cfg_comballoc.ml
@@ -38,7 +38,7 @@ let rec find_next_allocation : cell option -> allocation option =
         | Intop _ | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _
         | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _ | Opaque
         | Begin_region | End_region | Specific _ | Name_for_debugger _ | Dls_get
-        | Poll | Extcall _ )
+        | Poll | External _ )
     | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ ->
       find_next_allocation (DLL.next cell))
 
@@ -98,7 +98,7 @@ let find_compatible_allocations :
               ( ( Iadd | Isub | Imul | Idiv | Imod | Iand | Ior | Ixor | Ilsl
                 | Ilsr | Iasr | Ipopcnt | Imulh _ | Iclz _ | Ictz _ | Icomp _ ),
                 _ )
-          | Intop_atomic _ | Extcall _ ) ->
+          | Intop_atomic _ | External _ ) ->
         loop allocations (DLL.next cell) ~curr_mode ~curr_size)
   in
   loop [] cell ~curr_mode ~curr_size

--- a/backend/cfg/cfg_comballoc.ml
+++ b/backend/cfg/cfg_comballoc.ml
@@ -38,7 +38,7 @@ let rec find_next_allocation : cell option -> allocation option =
         | Intop _ | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _
         | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _ | Opaque
         | Begin_region | End_region | Specific _ | Name_for_debugger _ | Dls_get
-        | Poll )
+        | Poll | Extcall _ )
     | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ ->
       find_next_allocation (DLL.next cell))
 
@@ -98,7 +98,7 @@ let find_compatible_allocations :
               ( ( Iadd | Isub | Imul | Idiv | Imod | Iand | Ior | Ixor | Ilsl
                 | Ilsr | Iasr | Ipopcnt | Imulh _ | Iclz _ | Ictz _ | Icomp _ ),
                 _ )
-          | Intop_atomic _ ) ->
+          | Intop_atomic _ | Extcall _ ) ->
         loop allocations (DLL.next cell) ~curr_mode ~curr_size)
   in
   loop [] cell ~curr_mode ~curr_size

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -329,7 +329,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
     | Probe_is_enabled _ -> Op_other
     | Begin_region | End_region -> Op_other
     | Dls_get -> Op_load Mutable
-    | Extcall _ -> assert false (* treated specially *)
+    | External _ -> assert false (* treated specially *)
 
   let class_of_operation op =
     match Target.class_of_operation op with
@@ -344,7 +344,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
     | Intop_imm (_, _)
     | Intop_atomic _ | Floatop _ | Csel _ | Static_cast _ | Reinterpret_cast _
     | Specific _ | Name_for_debugger _ | Probe_is_enabled _ | Begin_region
-    | End_region | Dls_get | Extcall _ ->
+    | End_region | Dls_get | External _ ->
       false
 
   let kill_loads (n : numbering) : numbering = remove_mutable_load_numbering n
@@ -363,7 +363,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
     | Op Opaque ->
       (* Assume arbitrary side effects from Iopaque *)
       empty_numbering
-    | Op (Extcall _) ->
+    | Op (External _) ->
       (* Likewise for external calls *)
       (* CR mshinwell: could do better with knowledge about effects *)
       empty_numbering

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -365,6 +365,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
       empty_numbering
     | Op (Extcall _) ->
       (* Likewise for external calls *)
+      (* CR mshinwell: could do better with knowledge about effects *)
       empty_numbering
     | Op (Alloc _) | Op Poll ->
       (* For allocations, we must avoid extending the live range of a

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -43,9 +43,10 @@ module S = struct
       returns : Label.t option;
           (** At least one of [alloc] and [returns] must be set.  Otherwise,
               use [Op]. *)
-      (* CR mshinwell: same comment as in cmm.mli about [effects], [alloc] and
-         [returns]. In addition this should apply to the [OCaml] case below e.g.
-         to know that an OCaml function doesn't return. *)
+      (* CR mshinwell: same comment as in cmm.mli (see the [External]
+         constructor) about [effects], [alloc] and [returns]. In addition this
+         should apply to the [OCaml] case below e.g. to know that an OCaml
+         function doesn't return. *)
       effects : Cmm.effects;
       ty_res : Cmm.machtype;
       ty_args : Cmm.exttype list;
@@ -56,6 +57,10 @@ module S = struct
     | OCaml of
         { op : func_call_operation;
           returns : Label.t
+              (* CR mshinwell: we should track [Rc_nontail] here: at the moment
+                 it is impossible to turn a non-tail call into a tail call in
+                 Cfg, because this information has been dropped in
+                 [Cfg_selectgen]. *)
         }
     | External of external_call_operation
     | Probe of

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -40,18 +40,29 @@ module S = struct
     { func_symbol : string;
       alloc : bool;
       (* CR mshinwell: rename [alloc] -> [needs_caml_c_call] *)
+      returns : Label.t option;
+          (** At least one of [alloc] and [returns] must be set.  Otherwise,
+              use [Op]. *)
+      (* CR mshinwell: same comment as in cmm.mli about [effects], [alloc] and
+         [returns]. In addition this should apply to the [OCaml] case below e.g.
+         to know that an OCaml function doesn't return. *)
       effects : Cmm.effects;
       ty_res : Cmm.machtype;
       ty_args : Cmm.exttype list;
       stack_ofs : int
     }
 
-  type prim_call_operation =
+  type call_operation =
+    | OCaml of
+        { op : func_call_operation;
+          returns : Label.t
+        }
     | External of external_call_operation
     | Probe of
         { name : string;
           handler_code_sym : string;
-          enabled_at_init : bool
+          enabled_at_init : bool;
+          returns : Label.t
         }
 
   type bool_test =
@@ -120,11 +131,6 @@ module S = struct
     | Prologue
     | Stack_check of { max_frame_size_bytes : int }
 
-  type 'a with_label_after =
-    { op : 'a;
-      label_after : Label.t
-    }
-
   (* Properties of the representation of successors:
    * - Tests of different types are not mixed. For example, a test that
    *   compares between variables of type int cannot be combined with a
@@ -149,16 +155,10 @@ module S = struct
     | Raise of Lambda.raise_kind
     | Tailcall_self of { destination : Label.t }
     | Tailcall_func of func_call_operation
-    | Call_no_return of external_call_operation
-    (* CR mshinwell: [Call_no_return] should have "external" in the name *)
     (* CR mshinwell: [Invalid] from flambda2 should have its own terminator, to
        avoid the hack in [can_raise_terminator] *)
-    | Call of func_call_operation with_label_after
-    | Prim of prim_call_operation with_label_after
-
-  type basic_or_terminator =
-    | Basic of basic
-    | Terminator of terminator
+    (* CR mshinwell: move [Tailcall_*] into [call_operation] *)
+    | Call of call_operation
 end
 
 (* CR-someday gyorsh: Switch can be translated to Branch. *)

--- a/backend/cfg/cfg_invariants.ml
+++ b/backend/cfg/cfg_invariants.ml
@@ -124,7 +124,7 @@ let check_call t _label block =
   | Call (External { alloc = false; returns = Some _; _ }) ->
     report t
       "[Call External] with alloc=false and returns=Some must be encoded as \
-       [Op Extcall]"
+       [Op External]"
   | _ -> ()
 
 let check_tailrec t _label block =

--- a/backend/cfg/cfg_invariants.ml
+++ b/backend/cfg/cfg_invariants.ml
@@ -119,6 +119,14 @@ let check_tailrec_position t =
            followingsuccessors:@.%a@."
           Label.print tailrec_label Label.Set.print successors
 
+let check_call t _label block =
+  match[@ocaml.warning "-fragile-match"] block.Cfg.terminator.desc with
+  | Call (External { alloc = false; returns = Some _; _ }) ->
+    report t
+      "[Call External] with alloc=false and returns=Some must be encoded as \
+       [Op Extcall]"
+  | _ -> ()
+
 let check_tailrec t _label block =
   (* check all Tailrec Self agree on the successor label *)
   match block.Cfg.terminator.desc with
@@ -130,9 +138,8 @@ let check_tailrec t _label block =
       then
         report t "Two self-tailcall terminators with different labels: %a %a"
           Label.print l Label.print destination)
-  | Call _ | Prim _ | Tailcall_func _ | Never | Always _ | Parity_test _
-  | Truth_test _ | Float_test _ | Int_test _ | Switch _ | Return | Raise _
-  | Call_no_return _ ->
+  | Call _ | Tailcall_func _ | Never | Always _ | Parity_test _ | Truth_test _
+  | Float_test _ | Int_test _ | Switch _ | Return | Raise _ ->
     ()
 
 let check_can_raise t label (block : Cfg.basic_block) =
@@ -154,6 +161,7 @@ let check_can_raise t label (block : Cfg.basic_block) =
       (Label.to_string label)
 
 let check_block t label (block : Cfg.basic_block) =
+  check_call t label block;
   check_tailrec t label block;
   check_can_raise t label block;
   (* exn and normal successors are disjoint *)

--- a/backend/cfg/cfg_liveness.ml
+++ b/backend/cfg/cfg_liveness.ml
@@ -88,8 +88,7 @@ module Transfer :
         ~can_raise:(Cfg.can_raise_terminator instr.desc)
         ~exn Domain.bot instr
     | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-    | Switch _ | Return | Raise _ | Tailcall_func _ | Call_no_return _ | Call _
-    | Prim _ ->
+    | Switch _ | Return | Raise _ | Tailcall_func _ | Call _ ->
       instruction
         ~can_raise:(Cfg.can_raise_terminator instr.desc)
         ~exn domain instr

--- a/backend/cfg/cfg_polling.ml
+++ b/backend/cfg/cfg_polling.ml
@@ -196,7 +196,7 @@ module Polls_before_prtc_transfer = struct
         | Intop_atomic _
         | Floatop (_, _)
         | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-        | Specific _ | Name_for_debugger _ | Extcall _ )
+        | Specific _ | Name_for_debugger _ | External _ )
     | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ ->
       Ok dom
 
@@ -360,7 +360,7 @@ let add_poll_or_alloc_basic :
     | Intop _ | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _
     | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _ | Opaque
     | Begin_region | End_region | Specific _ | Name_for_debugger _ | Dls_get
-    | Extcall _ ->
+    | External _ ->
       points
     | Poll -> (Poll, instr.dbg) :: points
     | Alloc _ -> (Alloc, instr.dbg) :: points)

--- a/backend/cfg/cfg_polling.ml
+++ b/backend/cfg/cfg_polling.ml
@@ -129,7 +129,7 @@ let is_safe_terminator : Cfg.terminator Cfg.instruction -> bool =
     false
   | Raise _ -> false
   | Tailcall_self _ | Tailcall_func _ | Return -> true
-  | Call_no_return _ | Call _ | Prim _ -> false
+  | Call _ -> false
 
 let is_safe_block : Cfg.basic_block -> bool =
  fun block ->
@@ -196,7 +196,7 @@ module Polls_before_prtc_transfer = struct
         | Intop_atomic _
         | Floatop (_, _)
         | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-        | Specific _ | Name_for_debugger _ )
+        | Specific _ | Name_for_debugger _ | Extcall _ )
     | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ ->
       Ok dom
 
@@ -220,7 +220,7 @@ module Polls_before_prtc_transfer = struct
       then Ok Might_not_poll
       else Ok Always_polls
     | Return -> Ok Always_polls
-    | Call_no_return _ | Call _ | Prim _ ->
+    | Call _ ->
       if Cfg.can_raise_terminator term.desc
       then Ok (Polls_before_prtc_domain.join dom exn)
       else Ok dom
@@ -359,7 +359,8 @@ let add_poll_or_alloc_basic :
     | Const_symbol _ | Const_vec128 _ | Stackoffset _ | Load _ | Store _
     | Intop _ | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _
     | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _ | Opaque
-    | Begin_region | End_region | Specific _ | Name_for_debugger _ | Dls_get ->
+    | Begin_region | End_region | Specific _ | Name_for_debugger _ | Dls_get
+    | Extcall _ ->
       points
     | Poll -> (Poll, instr.dbg) :: points
     | Alloc _ -> (Alloc, instr.dbg) :: points)
@@ -374,50 +375,10 @@ let add_calls_terminator :
   | Switch _ | Return | Raise _ ->
     points
   | Tailcall_self _ | Tailcall_func _ -> (Function_call, term.dbg) :: points
-  | Call _ -> (Function_call, term.dbg) :: points
-  | Call_no_return
-      { alloc = false;
-        func_symbol = _;
-        ty_res = _;
-        ty_args = _;
-        stack_ofs = _;
-        effects = _
-      }
-  | Prim
-      { op =
-          External
-            { alloc = false;
-              func_symbol = _;
-              ty_res = _;
-              ty_args = _;
-              stack_ofs = _;
-              effects = _
-            };
-        label_after = _
-      } ->
-    points
-  | Call_no_return
-      { alloc = true;
-        func_symbol = _;
-        ty_res = _;
-        ty_args = _;
-        stack_ofs = _;
-        effects = _
-      }
-  | Prim
-      { op =
-          External
-            { alloc = true;
-              func_symbol = _;
-              ty_res = _;
-              ty_args = _;
-              stack_ofs = _;
-              effects = _
-            };
-        label_after = _
-      } ->
-    (External_call, term.dbg) :: points
-  | Prim { op = Probe _; label_after = _ } -> points
+  | Call (OCaml _) -> (Function_call, term.dbg) :: points
+  | Call (External { alloc; _ }) ->
+    if alloc then (External_call, term.dbg) :: points else points
+  | Call (Probe _) -> points
 
 let find_poll_alloc_or_calls : Cfg.t -> polling_points =
  fun cfg ->

--- a/backend/cfg/cfg_stack_checks.ml
+++ b/backend/cfg/cfg_stack_checks.ml
@@ -37,9 +37,10 @@ let is_nontail_call : Cfg.terminator -> bool =
      well-defined enough to be moved to `Cfg` once the transitive checks are
      implemented. *)
   match term_desc with
-  | Call_no_return _ | Call _ -> true
+  | Call (External { returns = None; _ } | OCaml _) -> true
   | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-  | Switch _ | Return | Raise _ | Tailcall_self _ | Tailcall_func _ | Prim _ ->
+  | Switch _ | Return | Raise _ | Tailcall_self _ | Tailcall_func _
+  | Call (External { returns = Some _; _ } | Probe _) ->
     false
 
 (* Returns the stack check info, and the max of seen instruction ids. *)

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -122,22 +122,7 @@ let dump ppf t ~msg =
   let print_block label =
     let block = Label.Tbl.find t.cfg.blocks label in
     fprintf ppf "\n%a:\n" Label.format label;
-    let pp_with_id ppf ~pp (instr : _ Cfg.instruction) =
-      fprintf ppf "(id:%a) %a\n" InstructionId.format instr.id pp instr
-    in
-    DLL.iter ~f:(pp_with_id ppf ~pp:Cfg.print_basic) block.body;
-    pp_with_id ppf ~pp:Cfg.print_terminator block.terminator;
-    fprintf ppf "\npredecessors:";
-    Label.Set.iter (fprintf ppf " %a" Label.format) block.predecessors;
-    fprintf ppf "\nsuccessors:";
-    Label.Set.iter
-      (fprintf ppf " %a" Label.format)
-      (Cfg.successor_labels ~normal:true ~exn:false block);
-    fprintf ppf "\nexn-successors:";
-    Label.Set.iter
-      (fprintf ppf " %a" Label.format)
-      (Cfg.successor_labels ~normal:false ~exn:true block);
-    fprintf ppf "\n"
+    Cfg.print_block ppf block
   in
   DLL.iter ~f:print_block t.layout
 

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -121,7 +121,7 @@ let evaluate_terminator ~(reg : Reg.t) ~(const : nativeint)
     else None
   | Never -> assert false
   | Always _ | Float_test _ | Return | Raise _ | Tailcall_self _
-  | Tailcall_func _ | Call_no_return _ | Call _ | Prim _ ->
+  | Tailcall_func _ | Call _ ->
     None
 
 let is_last_instruction_const_int (body : C.basic C.instruction Dll.t) :
@@ -142,7 +142,7 @@ let is_last_instruction_const_int (body : C.basic C.instruction Dll.t) :
               | Intop_atomic _
               | Floatop (_, _)
               | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-              | Specific _ | Name_for_debugger _ | Alloc _ ) );
+              | Specific _ | Name_for_debugger _ | Alloc _ | Extcall _ ) );
         _
       } ->
     None
@@ -209,9 +209,7 @@ let block (cfg : C.t) (block : C.basic_block) : bool =
     else (
       simplify_switch block labels;
       false)
-  | Raise _ | Return | Tailcall_self _ | Tailcall_func _ | Call_no_return _
-  | Call _ | Prim _ ->
-    false
+  | Raise _ | Return | Tailcall_self _ | Tailcall_func _ | Call _ -> false
 
 let run cfg =
   let registration_needed =

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -142,7 +142,7 @@ let is_last_instruction_const_int (body : C.basic C.instruction Dll.t) :
               | Intop_atomic _
               | Floatop (_, _)
               | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-              | Specific _ | Name_for_debugger _ | Alloc _ | Extcall _ ) );
+              | Specific _ | Name_for_debugger _ | Alloc _ | External _ ) );
         _
       } ->
     None

--- a/backend/cfg/vectorize.ml
+++ b/backend/cfg/vectorize.ml
@@ -315,7 +315,8 @@ end = struct
     | Name_for_debugger _, _
     | Dls_get, _
     | Poll, _
-    | Alloc _, _ ->
+    | Alloc _, _
+    | Extcall _, _ ->
       false
 
   let have_isomorphic_op instruction1 instruction2 =
@@ -805,7 +806,7 @@ end = struct
                   | Floatop (_, _)
                   | Csel _ | Reinterpret_cast _ | Static_cast _
                   | Probe_is_enabled _ | Specific _ | Name_for_debugger _
-                  | Alloc _ ->
+                  | Alloc _ | Extcall _ ->
                     None))
               | _ -> None
             in
@@ -1052,7 +1053,7 @@ end = struct
           | Move | Reinterpret_cast _ | Static_cast _ | Const_int _
           | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
           | Stackoffset _ | Intop _ | Intop_imm _ | Floatop _ | Csel _ | Alloc _
-            ->
+          | Extcall _ ->
             None)
 
       let create (instruction : Instruction.t) reaching_definitions : t option =
@@ -2300,7 +2301,7 @@ end = struct
         | Const_symbol _ | Const_vec128 _ | Stackoffset _ | Intop _
         | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _ | Probe_is_enabled _
         | Opaque | Begin_region | End_region | Name_for_debugger _ | Dls_get
-        | Poll ->
+        | Poll | Extcall _ ->
           None)
 
     let from_block (block : Block.t) deps : t list =

--- a/backend/cfg/vectorize.ml
+++ b/backend/cfg/vectorize.ml
@@ -316,7 +316,7 @@ end = struct
     | Dls_get, _
     | Poll, _
     | Alloc _, _
-    | Extcall _, _ ->
+    | External _, _ ->
       false
 
   let have_isomorphic_op instruction1 instruction2 =
@@ -806,7 +806,7 @@ end = struct
                   | Floatop (_, _)
                   | Csel _ | Reinterpret_cast _ | Static_cast _
                   | Probe_is_enabled _ | Specific _ | Name_for_debugger _
-                  | Alloc _ | Extcall _ ->
+                  | Alloc _ | External _ ->
                     None))
               | _ -> None
             in
@@ -1053,7 +1053,7 @@ end = struct
           | Move | Reinterpret_cast _ | Static_cast _ | Const_int _
           | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
           | Stackoffset _ | Intop _ | Intop_imm _ | Floatop _ | Csel _ | Alloc _
-          | Extcall _ ->
+          | External _ ->
             None)
 
       let create (instruction : Instruction.t) reaching_definitions : t option =
@@ -2301,7 +2301,7 @@ end = struct
         | Const_symbol _ | Const_vec128 _ | Stackoffset _ | Intop _
         | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _ | Probe_is_enabled _
         | Opaque | Begin_region | End_region | Name_for_debugger _ | Dls_get
-        | Poll | Extcall _ ->
+        | Poll | External _ ->
           None)
 
     let from_block (block : Block.t) deps : t list =

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -276,7 +276,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         func ()
     | Cextcall { func; ty; ty_args; builtin = false; effects; _ } ->
       ( Op
-          (Extcall
+          (External
              { func_symbol = func;
                effects;
                ty_res = ty;
@@ -974,14 +974,15 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       let ty = SU.oper_result_type op in
       let new_op, new_args = select_operation op simple_args dbg in
       match new_op with
-      | Op (Extcall { func_symbol; effects; ty_res; ty_args; stack_ofs = _ }) ->
+      | Op (External { func_symbol; effects; ty_res; ty_args; stack_ofs = _ })
+        ->
         (* XXX is it correct that [stack_ofs] gets ignored? *)
         let* loc_arg, stack_ofs =
           emit_extcall_args env sub_cfg ty_args new_args dbg
         in
         let rd = SU.regs_for ty_res in
         let term : Cfg.basic =
-          Op (Extcall { func_symbol; effects; ty_res; ty_args; stack_ofs })
+          Op (External { func_symbol; effects; ty_res; ty_args; stack_ofs })
         in
         let loc_res = Proc.loc_external_results (Reg.typv rd) in
         insert_debug env sub_cfg term dbg loc_arg loc_res;

--- a/backend/cfg_selectgen_target_intf.ml
+++ b/backend/cfg_selectgen_target_intf.ml
@@ -41,16 +41,16 @@ type effects_of_result =
   | Use_default
 
 type select_operation_then_rewrite_result =
-  | Rewritten of Cfg.basic_or_terminator * Cmm.expression list
+  | Rewritten of Cfg.basic * Cmm.expression list
   | Use_default
 
 type select_operation_result =
-  | Rewritten of Cfg.basic_or_terminator * Cmm.expression list
+  | Rewritten of Cfg.basic * Cmm.expression list
   | Select_operation_then_rewrite of
       Cmm.operation
       * Cmm.expression list
       * Debuginfo.t
-      * (Cfg.basic_or_terminator ->
+      * (Cfg.basic ->
         args:Cmm.expression list ->
         select_operation_then_rewrite_result)
   | Use_default
@@ -85,15 +85,11 @@ module type S = sig
   val select_addressing :
     Cmm.memory_chunk -> Cmm.expression -> Arch.addressing_mode * Cmm.expression
 
-  (* CR-soon gyorsh: remove unused [label_after], maybe simplify
-     [select_operation_result] to return [Cfg.basic] instead of
-     [Cfg.basic_or_terminator]. *)
   val select_operation :
     generic_select_condition:(Cmm.expression -> Operation.test * Cmm.expression) ->
     Cmm.operation ->
     Cmm.expression list ->
     Debuginfo.t ->
-    label_after:Label.t ->
     select_operation_result
 
   val select_store :

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -470,10 +470,10 @@ and apply =
         returns : bool;
             (** At least one of [alloc] and [returns] must be [true].  Otherwise,
           use [Cop]. *)
-        (* CR mshinwell: improve description of effects/alloc/returns, including
-           ruling out impossible cases e.g. for extcalls treated as operations
-           where they are never allocated to allocate and should always
-           return. *)
+        (* CR mshinwell: improve description of effects/coeffects/alloc/returns,
+           including ruling out impossible cases e.g. for extcalls treated as
+           operations where they are never allocated to allocate and should
+           always return. *)
         effects : effects;
         coeffects : coeffects
       }

--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -805,19 +805,32 @@ let extcall ~dbg ~returns ~alloc ~is_c_builtin ~effects ~coeffects ~ty_args name
     assert (
       Misc.Stdlib.Array.equal Cmm.equal_machtype_component typ_res typ_void);
   let default =
-    Cop
-      ( Cextcall
-          { func = name;
-            ty = typ_res;
-            alloc;
-            ty_args;
-            returns;
-            builtin = is_c_builtin;
-            effects;
-            coeffects
-          },
-        args,
-        dbg )
+    if alloc || not returns
+    then
+      Capply
+        ( { args; dbg },
+          External
+            { func = name;
+              alloc;
+              returns;
+              ty = typ_res;
+              ty_args;
+              builtin = is_c_builtin;
+              effects;
+              coeffects
+            } )
+    else
+      Cop
+        ( Cextcall
+            { func = name;
+              ty = typ_res;
+              ty_args;
+              builtin = is_c_builtin;
+              effects;
+              coeffects
+            },
+          args,
+          dbg )
   in
   if is_c_builtin || builtin_even_if_not_annotated name
   then

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -442,10 +442,6 @@ type unary_primitive = expression -> Debuginfo.t -> expression
 (** Int_as_pointer primitive *)
 val int_as_pointer : unary_primitive
 
-(** Raise primitive *)
-val raise_prim :
-  Lambda.raise_kind -> extra_args:expression list -> unary_primitive
-
 (** Unary negation of an OCaml integer *)
 val negint : unary_primitive
 
@@ -654,6 +650,12 @@ val trywith :
 
 (** Opaque type for static handlers. *)
 type static_handler
+
+(* CR mshinwell: take a [static_handler] and implement like Flambda 2? *)
+
+(** Raise primitive *)
+val raise_prim :
+  Lambda.raise_kind -> extra_args:expression list -> unary_primitive
 
 (** [handler id vars body is_cold] creates a static handler for exit number [id],
     binding variables [vars] in [body]. *)

--- a/backend/operation.ml
+++ b/backend/operation.ml
@@ -318,6 +318,13 @@ type t =
         dbginfo : Cmm.alloc_dbginfo;
         mode : Cmm.Alloc_mode.t
       }
+  | Extcall of
+      { func_symbol : string;
+        effects : Cmm.effects;
+        ty_res : Cmm.machtype;
+        ty_args : Cmm.exttype list;
+        stack_ofs : int
+      }
 
 let is_pure = function
   | Move -> true
@@ -353,6 +360,9 @@ let is_pure = function
   | Dls_get -> true
   | Poll -> false
   | Alloc _ -> false
+  | Extcall _ ->
+    (* CR mshinwell/xclerc: refine this using [effects] *)
+    false
 
 (* The next 2 functions are copied almost as is from asmcomp/printmach.ml
    because there is no interface to call them. Eventually this won't be needed
@@ -432,3 +442,6 @@ let dump ppf op =
     Format.fprintf ppf "alloc %i" bytes
   | Alloc { bytes; dbginfo = _; mode = Local } ->
     Format.fprintf ppf "alloc_local %i" bytes
+  | Extcall { func_symbol; effects = _; ty_res = _; ty_args = _; stack_ofs = _ }
+    ->
+    Format.fprintf ppf "extcall %s" func_symbol

--- a/backend/operation.ml
+++ b/backend/operation.ml
@@ -318,7 +318,7 @@ type t =
         dbginfo : Cmm.alloc_dbginfo;
         mode : Cmm.Alloc_mode.t
       }
-  | Extcall of
+  | External of
       { func_symbol : string;
         effects : Cmm.effects;
         ty_res : Cmm.machtype;
@@ -360,7 +360,7 @@ let is_pure = function
   | Dls_get -> true
   | Poll -> false
   | Alloc _ -> false
-  | Extcall _ ->
+  | External _ ->
     (* CR mshinwell/xclerc: refine this using [effects] *)
     false
 
@@ -442,6 +442,6 @@ let dump ppf op =
     Format.fprintf ppf "alloc %i" bytes
   | Alloc { bytes; dbginfo = _; mode = Local } ->
     Format.fprintf ppf "alloc_local %i" bytes
-  | Extcall { func_symbol; effects = _; ty_res = _; ty_args = _; stack_ofs = _ }
-    ->
+  | External
+      { func_symbol; effects = _; ty_res = _; ty_args = _; stack_ofs = _ } ->
     Format.fprintf ppf "extcall %s" func_symbol

--- a/backend/operation.mli
+++ b/backend/operation.mli
@@ -167,6 +167,15 @@ type t =
         dbginfo : Cmm.alloc_dbginfo;
         mode : Cmm.Alloc_mode.t
       }
+  | Extcall of
+      { func_symbol : string;
+        effects : Cmm.effects;
+        ty_res : Cmm.machtype;
+        ty_args : Cmm.exttype list;
+        stack_ofs : int
+      }
+      (** [Extcalls] cannot require [caml_c_call] or diverge.  Use [Prim] for
+          such cases. *)
 
 val is_pure : t -> bool
 

--- a/backend/operation.mli
+++ b/backend/operation.mli
@@ -167,14 +167,14 @@ type t =
         dbginfo : Cmm.alloc_dbginfo;
         mode : Cmm.Alloc_mode.t
       }
-  | Extcall of
+  | External of
       { func_symbol : string;
         effects : Cmm.effects;
         ty_res : Cmm.machtype;
         ty_args : Cmm.exttype list;
         stack_ofs : int
       }
-      (** [Extcalls] cannot require [caml_c_call] or diverge.  Use [Prim] for
+      (** [Externals] cannot require [caml_c_call] or diverge.  Use [Prim] for
           such cases. *)
 
 val is_pure : t -> bool

--- a/backend/printoperation.ml
+++ b/backend/printoperation.ml
@@ -109,3 +109,6 @@ let operation ?(print_reg = Printreg.reg) (op : Operation.t) arg ppf res =
   | Dls_get -> fprintf ppf "dls_get"
   | Poll -> fprintf ppf "poll call"
   | Probe_is_enabled { name } -> fprintf ppf "probe_is_enabled \"%s\"" name
+  | Extcall { func_symbol; effects = _; ty_res = _; ty_args = _; stack_ofs = _ }
+    ->
+    fprintf ppf "extcall %s" func_symbol

--- a/backend/printoperation.ml
+++ b/backend/printoperation.ml
@@ -109,6 +109,6 @@ let operation ?(print_reg = Printreg.reg) (op : Operation.t) arg ppf res =
   | Dls_get -> fprintf ppf "dls_get"
   | Poll -> fprintf ppf "poll call"
   | Probe_is_enabled { name } -> fprintf ppf "probe_is_enabled \"%s\"" name
-  | Extcall { func_symbol; effects = _; ty_res = _; ty_args = _; stack_ofs = _ }
-    ->
+  | External
+      { func_symbol; effects = _; ty_res = _; ty_args = _; stack_ofs = _ } ->
     fprintf ppf "extcall %s" func_symbol

--- a/backend/regalloc/regalloc_invariants.ml
+++ b/backend/regalloc/regalloc_invariants.ml
@@ -19,7 +19,7 @@ let precondition : Cfg_with_layout.t -> unit =
       | Const_vec128 _ | Stackoffset _ | Load _ | Store _ | Intop _
       | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _ | Reinterpret_cast _
       | Static_cast _ | Probe_is_enabled _ | Opaque | Begin_region | End_region
-      | Specific _ | Name_for_debugger _ | Dls_get | Poll | Alloc _ | Extcall _
+      | Specific _ | Name_for_debugger _ | Dls_get | Poll | Alloc _ | External _
         ->
         ())
     | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ -> ()
@@ -108,7 +108,7 @@ let postcondition_layout : Cfg_with_layout.t -> unit =
           | Intop_atomic _
           | Floatop (_, _)
           | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-          | Specific _ | Name_for_debugger _ | Alloc _ | Extcall _ ) ->
+          | Specific _ | Name_for_debugger _ | Alloc _ | External _ ) ->
         ())
     | arch -> fatal "unsupported architecture %S" arch
   in

--- a/backend/regalloc/regalloc_invariants.ml
+++ b/backend/regalloc/regalloc_invariants.ml
@@ -19,7 +19,8 @@ let precondition : Cfg_with_layout.t -> unit =
       | Const_vec128 _ | Stackoffset _ | Load _ | Store _ | Intop _
       | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _ | Reinterpret_cast _
       | Static_cast _ | Probe_is_enabled _ | Opaque | Begin_region | End_region
-      | Specific _ | Name_for_debugger _ | Dls_get | Poll | Alloc _ ->
+      | Specific _ | Name_for_debugger _ | Dls_get | Poll | Alloc _ | Extcall _
+        ->
         ())
     | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ -> ()
   in
@@ -107,7 +108,7 @@ let postcondition_layout : Cfg_with_layout.t -> unit =
           | Intop_atomic _
           | Floatop (_, _)
           | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-          | Specific _ | Name_for_debugger _ | Alloc _ ) ->
+          | Specific _ | Name_for_debugger _ | Alloc _ | Extcall _ ) ->
         ())
     | arch -> fatal "unsupported architecture %S" arch
   in

--- a/backend/regalloc/regalloc_irc_utils.ml
+++ b/backend/regalloc/regalloc_irc_utils.ml
@@ -170,7 +170,8 @@ let is_move_basic : Cfg.basic -> bool =
     | Name_for_debugger _ -> false
     | Dls_get -> false
     | Poll -> false
-    | Alloc _ -> false)
+    | Alloc _ -> false
+    | Extcall _ -> false)
   | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ -> false
 
 let is_move_instruction : Cfg.basic Cfg.instruction -> bool =

--- a/backend/regalloc/regalloc_irc_utils.ml
+++ b/backend/regalloc/regalloc_irc_utils.ml
@@ -171,7 +171,7 @@ let is_move_basic : Cfg.basic -> bool =
     | Dls_get -> false
     | Poll -> false
     | Alloc _ -> false
-    | Extcall _ -> false)
+    | External _ -> false)
   | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ -> false
 
 let is_move_instruction : Cfg.basic Cfg.instruction -> bool =

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -98,7 +98,7 @@ let coalesce_temp_spills_and_reloads (block : Cfg.basic_block)
         | Intop_atomic _
         | Floatop (_, _)
         | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-        | Specific _ | Name_for_debugger _ | Alloc _ ) ->
+        | Specific _ | Name_for_debugger _ | Alloc _ | Extcall _ ) ->
       ()
   in
   DLL.iter_cell block.body ~f:update_info_using_inst;

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -98,7 +98,7 @@ let coalesce_temp_spills_and_reloads (block : Cfg.basic_block)
         | Intop_atomic _
         | Floatop (_, _)
         | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-        | Specific _ | Name_for_debugger _ | Alloc _ | Extcall _ ) ->
+        | Specific _ | Name_for_debugger _ | Alloc _ | External _ ) ->
       ()
   in
   DLL.iter_cell block.body ~f:update_info_using_inst;

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -389,14 +389,16 @@ let insert_phi_moves : State.t -> Cfg_with_infos.t -> Substitution.map -> bool =
             Cfg_with_infos.get_block_exn cfg_with_infos predecessor_label
           in
           match predecessor_block.terminator.desc with
-          | Return | Raise _ | Tailcall_func _ | Call_no_return _ | Never ->
+          | Return | Raise _ | Tailcall_func _
+          | Call (External { returns = None; _ })
+          | Never ->
             assert false
           | Tailcall_self _ -> ()
           | Always _ ->
             add_phi_moves_to_instr_list state ~before:predecessor_block
               ~phi:block substs to_unify predecessor_block.body
           | Switch _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-          | Call _ | Prim _ ->
+          | Call (OCaml _ | External { returns = Some _; _ } | Probe _) ->
             let instrs = DLL.make_empty () in
             add_phi_moves_to_instr_list state ~before:predecessor_block
               ~phi:block substs to_unify instrs;

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -351,8 +351,8 @@ let remove_prologue_if_not_required : Cfg_with_layout.t -> unit =
         let removed = remove_prologue block in
         assert removed
       | Never | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-      | Switch _ | Return | Raise _ | Tailcall_self _ | Tailcall_func _
-      | Call_no_return _ | Call _ | Prim _ ->
+      | Switch _ | Return | Raise _ | Tailcall_self _ | Tailcall_func _ | Call _
+        ->
         assert false
 
 let update_live_fields : Cfg_with_layout.t -> liveness -> unit =
@@ -440,11 +440,11 @@ module SpillCosts = struct
         DLL.iter ~f:(fun instr -> update_instr cost instr) block.body;
         (* Ignore probes *)
         match block.terminator.desc with
-        | Prim { op = Probe _; _ } -> ()
-        | Prim { op = External _; _ }
+        | Call (Probe _) -> ()
         | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
         | Int_test _ | Switch _ | Return | Raise _ | Tailcall_self _
-        | Tailcall_func _ | Call_no_return _ | Call _ ->
+        | Tailcall_func _
+        | Call (OCaml _ | External _) ->
           update_instr cost block.terminator);
     costs
 end

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -578,20 +578,10 @@ end = struct
     (* CR-someday azewierzejew: Avoid using polymorphic comparison. *)
       when Stdlib.compare call1 call2 = 0 ->
       ()
-    | Call_no_return call1, Call_no_return call2
+    | Call call1, Call call2
     (* CR-someday azewierzejew: Avoid using polymorphic comparison. *)
       when Stdlib.compare call1 call2 = 0 ->
       ()
-    | ( Call { op = call1; label_after = l1 },
-        Call { op = call2; label_after = l2 } )
-    (* CR-someday azewierzejew: Avoid using polymorphic comparison. *)
-      when Stdlib.compare call1 call2 = 0 ->
-      compare_label l1 l2
-    | ( Prim { op = prim1; label_after = l1 },
-        Prim { op = prim2; label_after = l2 } )
-    (* CR-someday azewierzejew: Avoid using polymorphic comparison. *)
-      when Stdlib.compare prim1 prim2 = 0 ->
-      compare_label l1 l2
     | _ ->
       Regalloc_utils.fatal
         "The desc of terminator with id %a changed, before: %a, after: %a."

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -524,8 +524,8 @@ module Stack_offset_and_exn = struct
         | Intop_imm _ | Intop_atomic _ | Floatop _ | Csel _ | Static_cast _
         | Reinterpret_cast _ | Probe_is_enabled _ | Opaque | Begin_region
         | End_region | Specific _ | Name_for_debugger _ | Dls_get | Poll
-        | Alloc _ | Extcall _ )
-    (* XXX do we need to do anything with [stack_ofs] in the [Extcall] case? *)
+        | Alloc _ | External _ )
+    (* XXX do we need to do anything with [stack_ofs] in the [External] case? *)
     | Reloadretaddr | Prologue ->
       stack_offset, traps
     | Stack_check _ ->

--- a/backend/select_utils.mli
+++ b/backend/select_utils.mli
@@ -242,8 +242,6 @@ val make_opaque : unit -> Operation.t
 
 val regs_for : Cmm.machtype -> Reg.t array
 
-val basic_op : Operation.t -> Cfg.basic_or_terminator
-
 val insert_debug :
   environment ->
   Sub_cfg.t ->
@@ -323,5 +321,3 @@ val join_array :
   (Reg.t array Or_never_returns.t * Sub_cfg.t) array ->
   bound_name:Backend_var.With_provenance.t option ->
   Reg.t array Or_never_returns.t
-
-val basic_op : Operation.t -> Cfg.basic_or_terminator

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -41,7 +41,7 @@ module Witness = struct
     | Indirect_tailcall
     | Direct_call of { callee : string }
     | Direct_tailcall of { callee : string }
-    | Extcall of { callee : string }
+    | External of { callee : string }
     | Arch_specific
     | Probe of
         { name : string;
@@ -71,7 +71,7 @@ module Witness = struct
     | Direct_call { callee } -> fprintf ppf "direct call %s" callee
     | Direct_tailcall { callee : string } ->
       fprintf ppf "direct tailcall %s" callee
-    | Extcall { callee } -> fprintf ppf "external call to %s" callee
+    | External { callee } -> fprintf ppf "external call to %s" callee
     | Arch_specific -> fprintf ppf "arch specific operation"
     | Probe { name; handler_code_sym } ->
       fprintf ppf "probe \"%s\" handler %s" name handler_code_sym
@@ -1704,7 +1704,7 @@ end = struct
                (widening applied in function %s%s)" t.fun_name component_msg,
             [] )
         | Indirect_call | Indirect_tailcall | Direct_call _ | Direct_tailcall _
-        | Extcall _ ->
+        | External _ ->
           ( Format.dprintf "called function may allocate%s (%a)" component_msg
               Witness.print_kind w.kind,
             [] )
@@ -2513,7 +2513,7 @@ end = struct
           transform t ~effect ~next ~exn:Value.bot "heap allocation" dbg
         | Specific s -> transform_specific t s ~next ~exn:Value.bot dbg
         | Dls_get -> next
-        | Extcall _ ->
+        | External _ ->
           (* This variety of external call operation cannot allocate. *)
           next
 
@@ -2563,13 +2563,13 @@ end = struct
           ->
           (* Sound to ignore [next] because the call never returns. *)
           (* CR gyorsh: we do not currently generate this, but may later. *)
-          let w = create_witnesses t (Extcall { callee = func }) dbg in
+          let w = create_witnesses t (External { callee = func }) dbg in
           transform_top t ~next:Value.bot ~exn w
             ("external call to " ^ func)
             dbg
         | Call (External { returns = _; alloc = true; func_symbol = func; _ })
           ->
-          let w = create_witnesses t (Extcall { callee = func }) dbg in
+          let w = create_witnesses t (External { callee = func }) dbg in
           transform_top t ~next ~exn w ("external call to " ^ func) dbg
         | Call (External { func_symbol; alloc = false; returns = Some _; _ }) ->
           Misc.fatal_errorf

--- a/backend/zero_alloc_checker.mli
+++ b/backend/zero_alloc_checker.mli
@@ -53,7 +53,7 @@ module Witness : sig
     | Indirect_tailcall
     | Direct_call of { callee : string }
     | Direct_tailcall of { callee : string }
-    | Extcall of { callee : string }
+    | External of { callee : string }
     | Arch_specific
     | Probe of
         { name : string;

--- a/flambda-backend/testsuite/tools/parsecmm.mly
+++ b/flambda-backend/testsuite/tools/parsecmm.mly
@@ -214,12 +214,17 @@ expr:
   | LBRACKET RBRACKET { Ctuple [] }
   | LPAREN LET letdef sequence RPAREN { make_letdef $3 $4 }
   | LPAREN APPLY location expr exprlist machtype RPAREN
-                { Cop(Capply ($6, Lambda.Rc_normal),
-                      $4 :: List.rev $5, debuginfo ?loc:$3 ()) }
+                { (Capply (
+                     { args = List.rev $5;
+                       dbg = debuginfo ?loc:$3 ();
+                     },
+                     OCaml { callee = $4;
+                       result_ty = $6;
+                       region_close = Lambda.Rc_normal;
+                     })) }
   | LPAREN EXTCALL STRING exprlist machtype RPAREN
-               {Cop(Cextcall {func=$3; ty=$5; alloc=false;
+               {Cop(Cextcall {func=$3; ty=$5;
                               builtin=false;
-                              returns=true;
                               effects=Arbitrary_effects;
                               coeffects=Has_coeffects;
                               ty_args=[];},
@@ -365,7 +370,6 @@ unaryop:
   | INTOFFLOAT                  { Cstatic_cast (Int_of_float Float64) }
   | VALUEOFINT                  { Creinterpret_cast Value_of_int }
   | INTOFVALUE                  { Creinterpret_cast Int_of_value }
-  | RAISE                       { Craise $1 }
   | ABSF                        { Cabsf Float64 }
 ;
 binaryop:

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -408,8 +408,8 @@ let is_cmm_simple cmm =
   | Cconst_int _ | Cconst_natint _ | Cconst_float32 _ | Cconst_float _
   | Cconst_vec128 _ | Cconst_symbol _ | Cvar _ ->
     true
-  | Clet _ | Cphantom_let _ | Ctuple _ | Cop _ | Csequence _ | Cifthenelse _
-  | Cswitch _ | Ccatch _ | Cexit _ ->
+  | Clet _ | Cphantom_let _ | Ctuple _ | Capply _ | Cop _ | Csequence _
+  | Cifthenelse _ | Cswitch _ | Ccatch _ | Cexit _ | Craise _ ->
     false
 
 (* Helper function to create bindings *)


### PR DESCRIPTION
This moves `Capply` from being a Cmm `operation` and makes it an `expression`, matching up with what happens in Flambda 2.  A further refinement is made: applications corresponding to extcalls which do not require `caml_c_call` and which always return remain as `operation`s (this is not yet reflected in Flambda 2 but we will probably change this at some point, by adding an extcall case to `Flambda_primitive`).

This simplifies various code and introduces a nice property: target-specific instruction selection cannot introduce control flow (this is seen by the removal of the `Cfg.basic_or_terminator` type).  This may become important for potential future changes/replacement of the Cmm language, e.g. by a representation taking some inspiration from the "sea of nodes" approaches.  In addition, after this PR and #3743, we are close to having the control flow constructs in Cmm match those of Flambda 2.

While matching this up with what is provided by `Cfg` (which also required a change to permit the above special case of extcalls to be an `Operation`) I found the existing type confusing, and have refactored it to match up with `Cmm`.  As noted in a CR I think we should also move the tailcall cases under the new `Call` terminator, which will then match up with `Linear`.  It is possible this part could be split into a separate PR but I'm unsure that it's worth the work and the risk of introducing bugs in instruction selection.

I haven't made the necessary changes for the x86-64 backend yet, pending a first pass of review.  (I will get in touch with potential reviewers directly.)