### PR TITLE
Adding support for runtime quotations

### DIFF
--- a/dune
+++ b/dune
@@ -261,6 +261,7 @@
   translmod
   translobj
   translprim
+  translquote
   ;; bytecomp/
   debug_event
   meta

--- a/dune
+++ b/dune
@@ -20,10 +20,10 @@
    (:standard -principal -w +a-4-9-40-41-42-44-45-48-66-67-70)))
  (main
   (flags
-   (:standard -principal -warn-error +A -w +a-4-9-40-41-42-44-45-48-66-67-70)))
+   (:standard -principal -warn-error -A -w +a-4-9-40-41-42-44-45-48-66-67-70)))
  (dev
   (flags
-   (:standard -principal -w +a-4-9-40-41-42-44-45-48-66-67-70 -warn-error +A))))
+   (:standard -principal -w +a-4-9-40-41-42-44-45-48-66-67-70 -warn-error -A))))
 
 (include dune.runtime_selection)
 
@@ -236,6 +236,7 @@
   typedecl_properties
   typedecl_separability
   cmt2annot
+  camlinternalQuote_bootstrap
   ; manual update: mli only files
   annot
   outcometree
@@ -282,6 +283,7 @@
   value_rec_types
   asttypes
   cmo_format
+  camlinternalQuote_bootstrap
   outcometree
   parsetree
   debug_event))

--- a/dune
+++ b/dune
@@ -20,10 +20,10 @@
    (:standard -principal -w +a-4-9-40-41-42-44-45-48-66-67-70)))
  (main
   (flags
-   (:standard -principal -warn-error -A -w +a-4-9-40-41-42-44-45-48-66-67-70)))
+   (:standard -principal -warn-error +A -w +a-4-9-40-41-42-44-45-48-66-67-70)))
  (dev
   (flags
-   (:standard -principal -w +a-4-9-40-41-42-44-45-48-66-67-70 -warn-error -A))))
+   (:standard -principal -w +a-4-9-40-41-42-44-45-48-66-67-70 -warn-error +A))))
 
 (include dune.runtime_selection)
 

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -247,7 +247,8 @@ let iter_on_occurrences
       | Texp_object _ | Texp_pack _ | Texp_letop _ | Texp_unreachable
       | Texp_list_comprehension _ | Texp_array_comprehension _ | Texp_probe _
       | Texp_probe_is_enabled _ | Texp_exclave _
-      | Texp_open _ | Texp_src_pos | Texp_overwrite _ | Texp_hole _ -> ());
+      | Texp_open _ | Texp_src_pos | Texp_overwrite _
+      | Texp_hole _ | Texp_quotation _ | Texp_antiquotation _ -> ());
       default_iterator.expr sub e);
 
   (* Remark: some types get iterated over twice due to how constraints are

--- a/lambda/.ocamlformat-enable
+++ b/lambda/.ocamlformat-enable
@@ -8,3 +8,5 @@ transl_list_comprehension.ml
 transl_list_comprehension.mli
 translmode.ml
 translmode.mli
+translquote.ml
+translquote.mli

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1241,9 +1241,9 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       Location.todo_overwrite_not_implemented ~kind:"Translcore" e.exp_loc
   | Texp_hole _ ->
       Location.todo_overwrite_not_implemented ~kind:"Translcore" e.exp_loc
-  | Texp_quotation _ -> transl_quote (transl_exp ~scopes sort) e
+  | Texp_quotation exp -> transl_quote (transl_exp ~scopes sort) exp e.exp_loc
+  (* TODO: update scopes *)
   | Texp_antiquotation _ -> failwith "Cannot unqoute outside of a quotation context."
-(* TODO: do the correct error reporting *)
 
 and pure_module m =
   match m.mod_desc with

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1240,6 +1240,8 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       Location.todo_overwrite_not_implemented ~kind:"Translcore" e.exp_loc
   | Texp_hole _ ->
       Location.todo_overwrite_not_implemented ~kind:"Translcore" e.exp_loc
+  | Texp_quotation _ -> failwith "Not implemented yet"
+  | Texp_antiquotation _ -> failwith "Not implemented yet"
 
 and pure_module m =
   match m.mod_desc with

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1242,7 +1242,8 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
   | Texp_hole _ ->
       Location.todo_overwrite_not_implemented ~kind:"Translcore" e.exp_loc
   | Texp_quotation _ -> transl_quote (transl_exp ~scopes sort) e
-  | Texp_antiquotation _ -> failwith "Not implemented yet" (* should fail *)
+  | Texp_antiquotation _ -> failwith "Cannot unqoute outside of a quotation context."
+(* TODO: do the correct error reporting *)
 
 and pure_module m =
   match m.mod_desc with

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -24,6 +24,7 @@ open Typedtree
 open Typeopt
 open Lambda
 open Translmode
+open Translquote
 open Debuginfo.Scoped_location
 
 type error =
@@ -1240,8 +1241,8 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       Location.todo_overwrite_not_implemented ~kind:"Translcore" e.exp_loc
   | Texp_hole _ ->
       Location.todo_overwrite_not_implemented ~kind:"Translcore" e.exp_loc
-  | Texp_quotation _ -> failwith "Not implemented yet"
-  | Texp_antiquotation _ -> failwith "Not implemented yet"
+  | Texp_quotation _ -> transl_quote (transl_exp ~scopes sort) e
+  | Texp_antiquotation _ -> failwith "Not implemented yet" (* should fail *)
 
 and pure_module m =
   match m.mod_desc with

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -1,0 +1,541 @@
+open Misc
+open Asttypes
+open Types
+open Typedtree
+open Lambda
+
+let camlinternalQuote =
+  lazy
+    (match Env.open_pers_signature
+             "CamlinternalQuote" Env.initial_safe_string with
+     | exception Not_found ->
+         fatal_error "Module CamlinternalQuote unavailable."
+     | env -> ident, env)
+
+let combinator modname field =
+  lazy
+    (let (ident, env) = Lazy.force camlinternalQuote in
+     let lid = Longident.Ldot(Longident.Lident modname, field) in
+     match Env.lookup_value lid env with
+     | (Path.Pdot(Path.Pdot(Pident ident, _, pos1), _, pos2), _) ->
+         Lprim(Pfield pos2,
+               [Lprim(Pfield pos1,
+                     [Lprim(Pgetglobal ident, [])])])
+     | _ ->
+         fatal_error
+           "Primitive CamlinternalQuote."^modname^"."^field^" not found."
+     | exception Not_found ->
+        fatal_error
+          "Primitive CamlinternalQuote."^modname^"."^field^" not found.")
+
+module Loc = struct
+  let none = combinator "Loc" "none"
+  let unmarshal = combinator "Loc" "unmarshal"
+end
+
+module Name = struct
+  let mk = combinator "Name" "mk"
+  let unmarshal = combinator "Name" "unmarshal"
+end
+
+module Var : sig
+  let name = combinator "Var" "name"
+end
+
+module Constant : sig
+  let unmarshal = combinator "Constant" "unmarshal"
+end
+
+module Ident : sig
+  let unmarshal = combinator "Ident" "unmarshal"
+end
+
+module Label : sig
+  let none = combinator "Label" "none"
+  let of_string = combinator "Label" "of_string"
+end
+
+module Variant : sig
+  let of_string = combinator "Variant" "of_string"
+end
+
+module Method : sig
+  let of_string = combinator "Method" "of_string"
+end
+
+module Pat : sig
+  let any = combinator "Pat" "any"
+  let var = combinator "Pat" "var"
+  let alias = combinator "Pat" "alias"
+  let constant = combinator "Pat" "constant"
+  let interval = combinator "Pat" "interval"
+  let tuple = combinator "Pat" "tuple"
+  let construct = combinator "Pat" "construct"
+  let variant = combinator "Pat" "variant"
+  let record = combinator "Pat" "record"
+  let array = combinator "Pat" "array"
+  let or_ = combinator "Pat" "or"
+  let type_ = combinator "Pat" "type"
+  let lazy_ = combinator "Pat" "lazy"
+  let exception_ = combinator "Pat" "exception"
+end
+
+module rec Case : sig
+  let nonbinding = combinator "Case" "nonbinding"
+  let simple = combinator "Case" "simple"
+  let pattern = combinator "Case" "pattern"
+  let guarded = combinator "Case" "guarded"
+end
+
+and Exp : sig
+  let var = combinator "Exp" "var"
+  let ident = combinator "Exp" "ident"
+  let constant = combinator "Exp" "constant"
+  let let_simple = combinator "Exp" "let_simple"
+  let let_rec_simple = combinator "Exp" "let_rec_simple"
+  let let_ = combinator "Exp" "let_"
+  let fun_nonbinding = combinator "Exp" "fun_nonbinding"
+  let fun_simple = combinator "Exp" "fun_simple"
+  let fun_ = combinator "Exp" "fun_"
+  let function_ = combinator "Exp" "function_"
+  let apply = combinator "Exp" "apply"
+  let match_ = combinator "Exp" "match_"
+  let try_ = combinator "Exp" "try_"
+  let tuple = combinator "Exp" "tuple"
+  let construct = combinator "Exp" "construct"
+  let variant = combinator "Exp" "variant"
+  let record = combinator "Exp" "record"
+  let field = combinator "Exp" "field"
+  let setfield = combinator "Exp" "setfield"
+  let array = combinator "Exp" "array"
+  let ifthenelse = combinator "Exp" "ifthenelse"
+  let sequence = combinator "Exp" "sequence"
+  let while_ = combinator "Exp" "while_"
+  let for_nonbinding = combinator "Exp" "for_nonbinding"
+  let for_simple = combinator "Exp" "for_simple"
+  let send = combinator "Exp" "send"
+  let assert_ = combinator "Exp" "assert_"
+  let lazy_ = combinator "Exp" "lazy_"
+  let open_ = combinator "Exp" "open_"
+  let quote = combinator "Exp" "quote"
+  let escape = combinator "Exp" "escape"
+end
+
+let use comb =
+  Lazy.force comb
+
+let apply loc comb args =
+  let comb = Lazy.force comb in
+    Lapply (comb, args, loc)
+
+let string s =
+  Lconst (Const_base (Const_string(s, None)))
+
+let marshal x =
+  let s = Marshal.to_string x in
+    string s
+
+let true_ = Lconst(Const_pointer 1)
+
+let false_ = Lconst(Const_pointer 0)
+
+let none =  Lconst(Const_pointer 0)
+
+let some x = Lprim(Pmakeblock(0, Immutable), [x])
+
+let option opt =
+  match opt with
+  | None -> none
+  | Some x -> some x
+
+let nil = Lconst(Const_pointer 0)
+
+let cons hd tl = Lprim(Pmakeblock(0, Immutable), [hd; tl])
+
+let rec list list =
+  match list with
+  | [] -> nil
+  | hd :: tl -> cons hd (list tl)
+
+let pair (x, y) =
+  Lprim(Pmakeblock(0, Immutable), [x; y])
+
+let triple (x, y, z) =
+  Lprim(Pmakeblock(0, Immutable), [x; y; z])
+
+let func ids body =
+  Lfunction(Curried, ids, body)
+
+let bind id def body =
+  Llet(Strict, id, def, body)
+
+let quote_loc (loc : Location.t) =
+  if loc = Location.none then use Loc.none
+  else apply Location.none Loc.unmarshal [marshal loc]
+
+let quote_constant loc (const : Asttypes.constant) =
+  apply loc Const.unmarshal [marshal const]
+
+let quote_name loc (str : string loc) =
+  apply loc Name.unmarshal [marshal str]
+
+let quote_variant loc (variant : label) =
+  apply loc Variant.of_string [string variant]
+
+let quote_method loc (meth : Typedtree.meth) =
+  let name =
+    match meth with
+    | Tmeth_name name -> name
+    | Tmeth_val id -> Ident.name id
+  in
+  apply loc Method.of_string [string name]
+
+let quote_label loc lbl =
+  if lbl = "" then use Label.none
+  else apply loc Label.of_string [string lbl]
+
+let lid_of_path p =
+  let rec loop = function
+    | Pident id ->
+      if Ident.global id then Lid (Ident.name id)
+      else raise Exit
+    | Pdot(p, s, _) -> Ldot(loop p, s)
+    | Papply _ -> raise Exit
+  in
+    match loop p with
+    | lid -> Some lid
+    | exception Exit -> None
+
+let lid_of_type_path env ty =
+  let desc =
+    (Ctype.repr (Ctype.expand_head_opt env (Ctype.correct_levels ty))).desc
+  in
+  match desc with
+  | Tconstr(p, _, _) -> lid_of_path p
+  | _ -> None
+
+let quote_variant_constructor env loc constr =
+  let lid =
+    match lid_of_type_path env constr.cstr_res with
+    | None -> fatal_error "No global path for variant constructor"
+    | Some (Lident _) -> Lident constr.cstr_name
+    | Some (Ldot(lid, _)) -> Ldot(lid, constr.cstr_name)
+  in
+  apply loc Ident.unmarshall [marshall lid]
+
+let quote_record_label env loc lbl =
+  let lid =
+    match lid_of_type_path env lbl.lbl_res with
+    | None -> fatal_error "No global path for record label"
+    | Some (Lident _) -> Lident constr.lbl_name
+    | Some (Ldot(lid, _)) -> Ldot(lid, constr.lbl_name)
+  in
+  apply loc Ident.unmarshall [marshall lid]
+
+let rec quote_pattern p =
+  let env = p.pat_env in
+  let loc = p.pat_loc in
+  match p.pat_desc with
+  | Tpat_any -> apply loc Pat.any [quote_loc loc]
+  | Tpat_var(id, _) -> apply loc Pat.var [quote_loc loc; Lvar id]
+  | Tpat_alias(pat, id, _) ->
+      let pat = quote_pattern pat in
+      apply loc Pat.alias [quote_loc loc; pat; Lvar id]
+  | Tpat_constant const ->
+      let const = quote_constant loc const in
+      apply loc Pat.const [quote_loc loc; const]
+  | Tpat_tuple pats ->
+      let pats = List.map quote_pattern pats in
+      apply loc Pat.tuple [quote_loc loc; list pats]
+  | Tpat_construct(lid, constr, args) ->
+      let constr = quote_constructor env lid.loc constr in
+      let args =
+        match args with
+        | [] -> None
+        | _ :: _ ->
+            let args = List.map quote_pattern args in
+            Some (apply loc Pat.tuple [quote_loc loc; list args])
+      in
+      apply loc Pat.construct [quote_loc loc; constr; option args]
+  | Tpat_variant(variant, argo, _) ->
+      let variant = quote_variant loc variant in
+      let argo = Utils.may_map quote_pattern argo in
+      apply loc Pat.variant [quote_loc loc; variant; option argo]
+  | Tpat_record(lbl_pats, closed) ->
+      let lbl_pats =
+        List.map
+          (fun (lid, lbl, pat) ->
+            let lbl = quote_record_label env lid.loc lbl in
+            let pat = quote_pattern pat in
+            pair (lbl, pat))
+          lbl_pats
+      in
+      let closed =
+        match closed with
+        | Asttypes.Closed -> true_
+        | Asttypes.Open -> false_
+      in
+      apply loc Pat.record [quote_loc loc; list lbl_pats; closed]
+  | Tpat_array pats ->
+      let pats = List.map quote_pattern pats in
+      apply loc Pat.array [quote_loc loc; list pats]
+  | Tpat_or(pat1, pat2, _) ->
+      let pat1 = quote_pattern pat1 in
+      let pat2 = quote_pattern pat2 in
+      apply loc Pat.or_ [quote_loc loc; pat1; pat2]
+  | Tpat_lazy pat ->
+      let pat = quote_pattern pat in
+      apply loc Pat.lazy_ [quote_loc loc; pat]
+
+type case_binding =
+  | Non_binding of lambda * lambda
+  | Simple of lambda * lambda
+  | Pattern of lambda * lambda
+  | Guarded of lambda * lambda
+
+let rec case_binding exn transl stage cases =
+  match cases.c_guard with
+  | None -> begin
+      match case.c_lhs, exn with
+      | Tpat_var(id, name), false ->
+          let name = quote_name name.loc name in
+          let body = quote_expression transl stage case.c_rhs in
+          Simple(name, func [id] body)
+      | pat, _ ->
+          match pat_bound_idents pat with
+          | [] ->
+              let pat = quote_pattern pat in
+              let pat =
+                if exn then
+                  apply pat.pat_loc Pat.exception_ [quote_loc loc; pat]
+                else
+                  pat
+              in
+              let exp = quote_expression transl stage case.c_rhs in
+              Non_binding(pat, exp)
+          | id_names ->
+              let ids = List.map fst id_names in
+              let names =
+                List.map (fun (_, name) -> quote_name name.loc name) id_names
+              in
+              let pat = quote_pattern pat in
+              let pat =
+                if exn then
+                  apply pat.pat_loc Pat.exception_ [quote_loc loc; pat]
+                else
+                  pat
+              in
+              let exp = quote_expression transl stage case.c_rhs in
+              let pat_id = Ident.create "pattern" in
+              let exp_id = Ident.create "expression" in
+              let body =
+                bind pat_id pat
+                  (bind exp_id exp
+                    (pair (Lvar pat_id, Lvar exp_id)))
+              in
+              Pattern(list names, func ids body)
+    end
+  | Some guard ->
+      let id_names = pat_bound_idents case.c_lhs in
+      let ids = List.map fst id_names in
+      let names =
+        List.map (fun (_, name) -> quote_name name.loc name) id_names
+      in
+      let pat = quote_pattern case.c_lhs in
+      let pat =
+        if exn then apply pat.pat_loc Pat.exception_ [quote_loc loc; pat]
+        else pat
+      in
+      let guard = quote_expression transl stage guard in
+      let exp = quote_expression transl stage case.c_rhs in
+      let pat_id = Ident.create "pattern" in
+      let guard_id = Ident.create "guard" in
+      let exp_id = Ident.create "expression" in
+      let body =
+        bind pat_id pat
+          (bind guard_id guard
+            (bind exp_id exp
+              (triple (Lvar pat_id, Lvar guard_id, Lvar exp_id)))
+      in
+      Guarded(list names, func ids body)
+
+and quote_case_binding loc cb =
+  match cb with
+  | Non_binding(pat, exp) ->
+      apply loc Case.nonbinding [quote_loc loc; pat; exp]
+  | Simple(name, body) ->
+      apply loc Case.simple [quote_loc loc; name; body]
+  | Pattern(names, body) ->
+      apply loc Case.pattern [quote_loc loc; names; body]
+  | Guarded(names, body) ->
+      apply loc Case.guarded [quote_loc loc; names; body]
+
+and quote_case exn transl stage loc case =
+  quote_case_binding loc (case_binding exn transl stage case)
+
+and quote_expression_extra transl stage extra lambda =
+  match extra with
+  | _ -> failwith "Not implemented"
+
+and quote_expression transl stage e =
+  let env = e.exp_env in
+  let loc = e.exp_loc in
+  let body =
+    match e.exp_desc with
+    | Texp_ident(path, _, _) -> begin
+        match lid_of_path path with
+        | Some lid ->
+            let lid = apply loc Ident.unmarshall [marshall lid] in
+            apply loc Exp.ident [quote_loc loc; lid]
+        | None ->
+            match path with
+            | Pident id ->
+                (* TODO: properly check stage *)
+                apply loc Exp.var [quote_loc loc; Lvar id]
+            | Pdot _ | Papply _ ->
+                fatal_error "No global path for identifier"
+      end
+    | Texp_constant const ->
+        let const = quote_constant loc const in
+        apply loc Exp.constant [quote_loc loc; const]
+    | Texp_let of rec_flag * value_binding list * expression
+    | Texp_function(label, cases, _) -> begin
+        let cbs = List.map (case_binding transl stage) cases in
+        match cbs with
+        | [Non_binding(pat, exp)] ->
+            let label = quote_label label in
+            apply loc Exp.fun_nonbinding [quote_loc loc; label; pat; exp]
+        | [Simple(name, body)] ->
+            let label = quote_label label in
+            apply loc Exp.fun_simple [quote_loc loc; name; label; body]
+        | [Pattern(names, body)] ->
+            let label = quote_label label in
+            apply loc Exp.fun_ [quote_loc loc; names; label; body]
+        | cases ->
+            let cases = List.map (quote_case_binding loc) cases in
+            apply loc Exp.function_ [quote_loc loc; list cases]
+      end
+    | Texp_apply(fn, args) ->
+        let fn = quote_expression transl stage fn in
+        let args = List.filter (fun (_, exp, _) -> exp <> None) args in
+        let args =
+          List.map
+            (fun (lbl, exp, _) ->
+              match exp with
+              | None -> assert false
+              | Some exp ->
+                  let lbl = quote_label loc lbl in
+                  let exp = quote_expression transl stage exp in
+                  pair (lbl, exp))
+            args
+        in
+        apply loc Exp.apply [quote_loc loc; fn; list args]
+    | Texp_match(exp, cases, exn_cases, _) ->
+        let exp = quote_expression transl stage exp in
+        let cases = List.map (quote_case false transl stage loc) cases in
+        let exn_cases = List.map (quote_case true transl stage loc) exn_cases in
+        apply loc Exp.match_ [quote_loc loc; exp; list (cases @ exn_cases)]
+    | Texp_try(exp, cases) ->
+        let exp = quote_expression transl stage exp in
+        let cases = List.map (quote_case false transl stage loc) cases in
+        apply loc Exp.try_ [quote_loc loc; exp; list cases]
+    | Texp_tuple exps ->
+        let exps = List.map (quote_expression transl stage) exps in
+        apply loc Exp.tuple [quote_loc loc; list exps]
+    | Texp_construct(lid, constr, args) ->
+        let constr = quote_constructor env lid.loc constr in
+        let args =
+          match args with
+          | [] -> None
+          | _ :: _ ->
+              let args = List.map (quote_expression transl stage) args in
+              Some (apply loc Pat.tuple [quote_loc loc; list args])
+        in
+        apply loc Exp.construct [quote_loc loc; constr; option args]
+    | Texp_variant(variant, argo) ->
+        let variant = quote_variant loc variant in
+        let argo = Utils.may_map (quote_expression transl stage) argo in
+        apply loc Exp.variant [quote_loc loc; variant; option argo]
+    | Texp_record(lbl_exps, base) ->
+        let lbl_exps =
+          List.map
+            (fun (lid, lbl, exp) ->
+              let lbl = quote_record_label env lid.loc lbl in
+              let exp = quote_expression transl stage exp in
+              pair (lbl, exp))
+            lbl_exps
+        in
+        let base = Misc.may_map quote_expression base in
+        apply loc Exp.record [quote_loc loc; list lbl_exps; option base]
+    | Texp_field(rcd, lid, lbl) ->
+        let rcd = quote_expression transl stage rcd in
+        let lbl = quote_record_label env lid.loc lbl in
+        apply loc Exp.field [quote_loc loc; rcd; lbl]
+    | Texp_setfield(rcd, lid, lbl, exp) ->
+        let rcd = quote_expression transl stage rcd in
+        let lbl = quote_record_label env lid.loc lbl in
+        let exp = quote_expression transl stage exp in
+        apply loc Exp.setfield [quote_loc loc; rcd; lbl; exp]
+    | Texp_array exps ->
+        let exps = List.map (quote_expression transl stage) exps in
+        apply loc Exp.array [quote_loc loc; list exps]
+    | Texp_ifthenelse(cond, then_, else_) ->
+        let cond = quote_expression transl stage cond in
+        let then_ = quote_expression transl stage then_ in
+        let else_ = Utils.may_map (quote_expression transl stage) else_ in
+        apply loc Exp.ifthenelse [quote_loc loc; cond; then_; option else_]
+    | Texp_sequence(exp1, exp2) ->
+        let exp1 = quote_expression transl stage exp1 in
+        let exp2 = quote_expression transl stage exp2 in
+        apply loc Exp.sequence [quote_loc loc; exp1; exp2]
+    | Texp_while(cond, body) ->
+        let cond = quote_expression transl stage cond in
+        let body = quote_expression transl stage body in
+        apply loc Exp.while_ [quote_loc loc; cond; body]
+    | Texp_for(_, pat, low, high, dir, body) -> begin
+        let low = quote_expression transl stage low in
+        let high = quote_expression transl stage high in
+        let dir =
+          match dir with
+          | Asttype.Upto -> true_
+          | Astype.Downto -> false_
+        in
+        match pat with
+        | Tpat_var(id, name) ->
+            let name = quote_name name.loc name in
+            let body = quote_expression transl stage case.c_rhs in
+            apply loc Exp.for_simple
+              [quote_loc loc; name; low; high; dir; func [id] body]
+        | pat ->
+            let pat = quote_pattern pat in
+            let body = quote_expression transl stage body in
+            apply loc Exp.for_nonbinding
+              [quote_loc loc; pat; low; high; dir; body]
+      end
+    | Texp_send(obj, meth, _) ->
+        let obj = quote_expression transl stage obj in
+        let meth = quote_method meth in
+        apply loc Exp.send [quote_loc loc; obj; meth]
+    | Texp_assert exp ->
+        let exp = quote_expression transl stage exp in
+        apply loc Exp.assert_ [quote_loc loc; exp]
+    | Texp_lazy exp ->
+        let exp = quote_expression transl stage exp in
+        apply loc Exp.lazy_ [quote_loc loc; exp]
+    | Texp_quote exp ->
+        let exp = quote_expression (stage + 1) exp in
+        apply loc Exp.quote_ [quote_loc loc; exp]
+    | Texp_escape exp ->
+        if stage > 0 then begin
+            let exp = quote_expression (stage + 1) exp in
+            apply loc Exp.escape_ [quote_loc loc; exp]
+          end else transl exp
+    | Texp_new _ | Texp_instvar _ | Texp_setinstvar _ | Texp_override _
+      | Texp_letmodule _ | Texp_object _ | Texp_pack _ ->
+        fatal_error "Expression cannot be quoted"
+  in
+  List.fold_right
+    (quote_expression_extra transl stage)
+    e.exp_extra body
+
+let transl_quote =

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -5,6 +5,58 @@ open Typedtree
 open Types
 open Debuginfo.Scoped_location
 open Longident
+module Var_env = Map.Make (String)
+
+type fv_env = lambda Var_env.t
+
+type var_env =
+  { env_vals : fv_env;
+    env_tys : fv_env;
+    env_mod : fv_env
+  }
+
+let rec print_path = function
+  | Path.Pident id -> Ident.name id
+  | Path.Pdot (p, s) -> print_path p ^ "." ^ s
+  | Path.Papply (p1, p2) -> print_path p1 ^ "(" ^ print_path p2 ^ ")"
+  | Path.Pextra_ty (p, _) -> print_path p ^ "[extra]"
+
+let with_new_value var_env name val_ =
+  { var_env with env_vals = Var_env.add name val_ var_env.env_vals }
+
+let with_new_type var_env name ty =
+  { var_env with env_vals = Var_env.add name ty var_env.env_tys }
+
+let with_new_module var_env name mod_ =
+  { var_env with env_mod = Var_env.add name mod_ var_env.env_mod }
+
+let with_new_values var_env name_vals =
+  List.fold_left
+    (fun var_env (name, val_) -> with_new_value var_env name val_)
+    var_env name_vals
+
+let with_new_modules var_env name_mods =
+  List.fold_left
+    (fun var_env (name, mod_) -> with_new_module var_env name mod_)
+    var_env name_mods
+
+let with_new_idents_values var_env idents =
+  List.fold_left
+    (fun var_env id -> with_new_value var_env (Ident.name id) (Lvar id))
+    var_env idents
+
+let with_new_idents_types var_env idents =
+  List.fold_left
+    (fun var_env id -> with_new_type var_env (Ident.name id) (Lvar id))
+    var_env idents
+
+let with_new_idents_modules var_env idents =
+  List.fold_left
+    (fun var_env id -> with_new_module var_env (Ident.name id) (Lvar id))
+    var_env idents
+
+let new_env =
+  { env_vals = Var_env.empty; env_tys = Var_env.empty; env_mod = Var_env.empty }
 
 let camlinternalQuote =
   lazy
@@ -14,7 +66,11 @@ let camlinternalQuote =
     | exception Not_found -> fatal_error "Module CamlinternalQuote unavailable."
     | path, env -> path, env)
 
-let combinator modname field =
+let rec get_arity = function
+  | Tarrow (_, _, ty, _) -> 1 + get_arity (get_desc ty)
+  | _ -> 0
+
+let combinator modname field arity =
   lazy
     (let _, env = Lazy.force camlinternalQuote in
      let lid =
@@ -23,247 +79,457 @@ let combinator modname field =
        | Some lid -> Ldot (lid, field)
      in
      match Env.find_value_by_name lid env with
-     | p, _ -> transl_value_path Loc_unknown env p
+     | p, value_desc ->
+       let ty_ar = get_arity (get_desc value_desc.val_type) in
+       if ty_ar = arity
+       then transl_value_path Loc_unknown env p
+       else
+         fatal_error
+           ("Primitive CamlinternalQuote." ^ modname ^ "." ^ field
+          ^ " expects arity " ^ string_of_int arity ^ ", but it is "
+          ^ string_of_int ty_ar ^ ".")
      | exception Not_found ->
        fatal_error
          ("Primitive CamlinternalQuote." ^ modname ^ "." ^ field ^ " not found."))
 
 module Loc = struct
-  let unknown = combinator "Loc" "unknown"
+  let unknown = combinator "Loc" "unknown" 0
 
-  let known = combinator "Loc" "known"
+  let known = combinator "Loc" "known" 5
 end
 
 module Name = struct
-  let mk = combinator "Name" "mk"
+  let mk = combinator "Name" "mk" 1
 end
 
 module Constant = struct
-  let int = combinator "Constant" "int"
+  let int = combinator "Constant" "int" 1
 
-  let char = combinator "Constant" "char"
+  let char = combinator "Constant" "char" 1
 
-  let string = combinator "Constant" "string"
+  let string = combinator "Constant" "string" 2
 
-  let float = combinator "Constant" "float"
+  let float = combinator "Constant" "float" 1
 
-  let int32 = combinator "Constant" "int32"
+  let float32 = combinator "Constant" "float32" 1
 
-  let int64 = combinator "Constant" "int64"
+  let int32 = combinator "Constant" "int32" 1
 
-  let nativeint = combinator "Constant" "nativeint"
+  let int64 = combinator "Constant" "int64" 1
+
+  let nativeint = combinator "Constant" "nativeint" 1
+
+  let unboxed_float = combinator "Constant" "unboxed_float" 1
+
+  let unboxed_float32 = combinator "Constant" "unboxed_float32" 1
+
+  let unboxed_int32 = combinator "Constant" "unboxed_int32" 1
+
+  let unboxed_int64 = combinator "Constant" "unboxed_int64" 1
+
+  let unboxed_nativeint = combinator "Constant" "unboxed_nativeint" 1
 end
 
 module Label = struct
   module Nonoptional = struct
-    let no_label = combinator "Label.Nonoptional" "no_label"
+    let no_label = combinator "Label.Nonoptional" "no_label" 0
 
-    let labelled = combinator "Label.Nonoptional" "labelled"
+    let labelled = combinator "Label.Nonoptional" "labelled" 1
   end
 
-  let no_label = combinator "Label" "no_label"
+  let no_label = combinator "Label" "no_label" 0
 
-  let labelled = combinator "Label" "labelled"
+  let labelled = combinator "Label" "labelled" 1
 
-  let optional = combinator "Label" "optional"
+  let optional = combinator "Label" "optional" 1
 end
 
 module Identifier = struct
   module Module = struct
-    let compilation_unit = combinator "Identifier.Module" "compilation_unit"
+    let compilation_unit = combinator "Identifier.Module" "compilation_unit" 1
 
-    let dot = combinator "Identifier.Module" "dot"
+    let dot = combinator "Identifier.Module" "dot" 2
+
+    let var = combinator "Identifier.Module" "var" 2
   end
 
   module Value = struct
-    let dot = combinator "Identifier.Value" "dot"
+    let dot = combinator "Identifier.Value" "dot" 2
 
-    let var = combinator "Identifier.Value" "var"
+    let var = combinator "Identifier.Value" "var" 2
+  end
+
+  module Type = struct
+    let dot = combinator "Identifier.Type" "dot" 2
+
+    let var = combinator "Identifier.Type" "var" 2
+
+    let int = combinator "Identifier.Type" "int" 0
+
+    let char = combinator "Identifier.Type" "char" 0
+
+    let string = combinator "Identifier.Type" "string" 0
+
+    let bytes = combinator "Identifier.Type" "bytes" 0
+
+    let float = combinator "Identifier.Type" "float" 0
+
+    let float32 = combinator "Identifier.Type" "float32" 0
+
+    let bool = combinator "Identifier.Type" "bool" 0
+
+    let unit = combinator "Identifier.Type" "unit" 0
+
+    let exn = combinator "Identifier.Type" "exn" 0
+
+    let array = combinator "Identifier.Type" "array" 0
+
+    let iarray = combinator "Identifier.Type" "iarray" 0
+
+    let list = combinator "Identifier.Type" "list" 0
+
+    let option = combinator "Identifier.Type" "option" 0
+
+    let nativeint = combinator "Identifier.Type" "nativeint" 0
+
+    let int32 = combinator "Identifier.Type" "int32" 0
+
+    let int64 = combinator "Identifier.Type" "int64" 0
+
+    let lazy_t = combinator "Identifier.Type" "lazy_t" 0
+
+    let extension_constructor =
+      combinator "Identifier.Type" "extension_constructor" 0
+
+    let floatarray = combinator "Identifier.Type" "floatarray" 0
+
+    let lexing_position = combinator "Identifier.Type" "lexing_position" 0
+
+    let code = combinator "Identifier.Type" "code" 0
+
+    let unboxed_float = combinator "Identifier.Type" "unboxed_float" 0
+
+    let unboxed_nativeint = combinator "Identifier.Type" "unboxed_nativeint" 0
+
+    let unboxed_int32 = combinator "Identifier.Type" "unboxed_int32" 0
+
+    let unboxed_int64 = combinator "Identifier.Type" "unboxed_int64" 0
+
+    let int8x16 = combinator "Identifier.Type" "int8x16" 0
+
+    let int16x8 = combinator "Identifier.Type" "int16x8" 0
+
+    let int32x4 = combinator "Identifier.Type" "int32x4" 0
+
+    let int64x2 = combinator "Identifier.Type" "int64x2" 0
+
+    let float32x4 = combinator "Identifier.Type" "float32x4" 0
+
+    let float64x2 = combinator "Identifier.Type" "float64x2" 0
+  end
+
+  module Module_type = struct
+    let dot = combinator "Identifier.Module_type" "dot" 2
   end
 
   module Constructor = struct
-    let dot = combinator "Identifier.Constructor" "dot"
+    let dot = combinator "Identifier.Constructor" "dot" 2
 
-    let false_ = combinator "Identifier.Constructor" "false_"
+    let false_ = combinator "Identifier.Constructor" "false_" 0
 
-    let true_ = combinator "Identifier.Constructor" "true_"
+    let true_ = combinator "Identifier.Constructor" "true_" 0
 
-    let void = combinator "Identifier.Constructor" "void"
+    let void = combinator "Identifier.Constructor" "void" 0
 
-    let nil = combinator "Identifier.Constructor" "nil"
+    let nil = combinator "Identifier.Constructor" "nil" 0
 
-    let cons = combinator "Identifier.Constructor" "cons"
+    let cons = combinator "Identifier.Constructor" "cons" 0
 
-    let none = combinator "Identifier.Constructor" "none"
+    let none = combinator "Identifier.Constructor" "none" 0
 
-    let some = combinator "Identifier.Constructor" "some"
+    let some = combinator "Identifier.Constructor" "some" 0
+
+    let match_failure = combinator "Identifier.Constructor" "match_failure" 0
+
+    let out_of_memory = combinator "Identifier.Constructor" "out_of_memory" 0
+
+    let invalid_argument =
+      combinator "Identifier.Constructor" "invalid_argument" 0
+
+    let failure = combinator "Identifier.Constructor" "failure" 0
+
+    let not_found = combinator "Identifier.Constructor" "not_found" 0
+
+    let sys_error = combinator "Identifier.Constructor" "sys_error" 0
+
+    let end_of_file = combinator "Identifier.Constructor" "end_of_file" 0
+
+    let division_by_zero =
+      combinator "Identifier.Constructor" "division_by_zero" 0
+
+    let stack_overflow = combinator "Identifier.Constructor" "stack_overflow" 0
+
+    let sys_blocked_io = combinator "Identifier.Constructor" "sys_blocked_io" 0
+
+    let assert_failure = combinator "Identifier.Constructor" "assert_failure" 0
+
+    let undefined_recursive_module =
+      combinator "Identifier.Constructor" "undefined_recursive_module" 0
   end
 
   module Field = struct
-    let dot = combinator "Identifier.Field" "dot"
+    let dot = combinator "Identifier.Field" "dot" 2
   end
+end
+
+module Variant_type = struct
+  module Variant_form = struct
+    let fixed = combinator "Variant_type.Variant_form" "fixed" 0
+
+    let open_ = combinator "Variant_type.Variant_form" "open_" 0
+
+    let closed = combinator "Variant_type.Variant_form" "closed" 1
+  end
+
+  module Row_field = struct
+    let inherit_ = combinator "Variant_type.Row_field" "inherit_row_field" 1
+
+    let tag = combinator "Variant_type.Row_field" "tag_row_field" 3
+  end
+
+  let of_row_fields_list = combinator "Variant_type" "of_row_fields_list" 2
+end
+
+module Module_type = struct
+  let of_string = combinator "Module_type" "of_string" 1
+
+  let ident = combinator "Module_type" "ident" 1
+end
+
+module Fragment = struct
+  let name = combinator "Fragment" "name" 1
+
+  let dot = combinator "Fragment" "dot" 2
+end
+
+module Type = struct
+  let var = combinator "Type" "var" 1
+
+  let arrow = combinator "Type" "arrow" 3
+
+  let tuple = combinator "Type" "tuple" 1
+
+  let unboxed_tuple = combinator "Type" "unboxed_tuple" 1
+
+  let constr = combinator "Type" "constr" 2
+
+  let alias = combinator "Type" "alias" 2
+
+  let variant = combinator "Type" "variant" 1
+
+  let poly = combinator "Type" "poly" 3
+
+  let package = combinator "Type" "package" 2
+
+  let object_ = combinator "Type" "object_" 2
+
+  let class_ = combinator "Type" "class_" 2
+
+  let call_pos = combinator "Type" "call_pos" 0
 end
 
 module Variant = struct
-  let of_string = combinator "Variant" "of_string"
+  let of_string = combinator "Variant" "of_string" 1
+end
+
+module Constructor = struct
+  let ident = combinator "Constructor" "ident" 1
+
+  let of_string = combinator "Constructor" "of_string" 1
+end
+
+module Field = struct
+  let ident = combinator "Field" "ident" 1
+
+  let of_string = combinator "Field" "of_string" 1
 end
 
 module Method = struct
-  let of_string = combinator "Method" "of_string"
+  let of_string = combinator "Method" "of_string" 1
 end
 
 module Pat = struct
-  let any = combinator "Pat" "any"
+  let any = combinator "Pat" "any" 0
 
-  let var = combinator "Pat" "var"
+  let var = combinator "Pat" "var" 1
 
-  let alias = combinator "Pat" "alias"
+  let alias = combinator "Pat" "alias" 2
 
-  let constant = combinator "Pat" "constant"
+  let constant = combinator "Pat" "constant" 1
 
-  let tuple = combinator "Pat" "tuple"
+  let tuple = combinator "Pat" "tuple" 1
 
-  let construct = combinator "Pat" "construct"
+  let unboxed_tuple = combinator "Pat" "unboxed_tuple" 1
 
-  let variant = combinator "Pat" "variant"
+  let construct = combinator "Pat" "construct" 2
 
-  let record = combinator "Pat" "record"
+  let variant = combinator "Pat" "variant" 2
 
-  let array = combinator "Pat" "array"
+  let record = combinator "Pat" "record" 2
 
-  let or_ = combinator "Pat" "or_"
+  let unboxed_record = combinator "Pat" "unboxed_record" 2
 
-  let lazy_ = combinator "Pat" "lazy_"
+  let array = combinator "Pat" "array" 1
 
-  let exception_ = combinator "Pat" "exception_"
+  let or_ = combinator "Pat" "or_" 1
+
+  let lazy_ = combinator "Pat" "lazy_" 1
+
+  let unpack = combinator "Pat" "unpack" 1
+
+  let exception_ = combinator "Pat" "exception_" 1
+
+  let constraint_ = combinator "Pat" "constraint_" 2
 end
 
 module Case = struct
-  let nonbinding = combinator "Case" "nonbinding"
+  let nonbinding = combinator "Case" "nonbinding" 3
 
-  let simple = combinator "Case" "simple"
+  let simple = combinator "Case" "simple" 3
 
-  let pattern = combinator "Case" "pattern"
+  let pattern = combinator "Case" "pattern" 4
 
-  let guarded = combinator "Case" "guarded"
+  let guarded = combinator "Case" "guarded" 4
 
-  let refutation = combinator "Case" "refutation"
+  let refutation = combinator "Case" "refutation" 4
 end
 
 module Function = struct
-  let body = combinator "Function" "body"
+  let body = combinator "Function" "body" 2
 
-  let cases = combinator "Function" "cases"
+  let cases = combinator "Function" "cases" 2
 
-  let param = combinator "Function" "param"
+  let param = combinator "Function" "param" 5
 
-  let newtype = combinator "Function" "newtype"
+  let newtype = combinator "Function" "newtype" 3
 end
 
 module Module = struct
-  let ident = combinator "Module" "ident"
+  let ident = combinator "Module" "ident" 1
 
-  let apply = combinator "Module" "apply"
+  let apply = combinator "Module" "apply" 2
 
-  let apply_unit = combinator "Module" "apply_unit"
+  let apply_unit = combinator "Module" "apply_unit" 1
 end
 
 module Comprehension = struct
-  module ClauseBinding = struct
-    let range = combinator "Comprehension.ClauseBinding" "range"
+  let body = combinator "Comprehension" "body" 1
 
-    let in_ = combinator "Comprehension.ClauseBinding" "in_"
-  end
+  let when_clause = combinator "Comprehension" "when_clause" 2
 
-  let body = combinator "Comprehension" "body"
+  let for_range = combinator "Comprehension" "for_range" 6
 
-  let add_when_clause = combinator "Comprehension" "add_when_clause"
+  let for_in = combinator "Comprehension" "for_in" 4
+end
 
-  let add_for_clause = combinator "Comprehension" "add_for_clause"
+module Type_constraint = struct
+  let constraint_ = combinator "Type_constraint" "constraint_" 1
+
+  let coercion = combinator "Type_constraint" "coercion" 2
 end
 
 module Exp = struct
-  let ident = combinator "Exp" "ident"
+  let ident = combinator "Exp" "ident" 1
 
-  let constant = combinator "Exp" "constant"
+  let constant = combinator "Exp" "constant" 1
 
-  let let_rec_simple = combinator "Exp" "let_rec_simple"
+  let let_rec_simple = combinator "Exp" "let_rec_simple" 3
 
-  let let_ = combinator "Exp" "let_"
+  let let_ = combinator "Exp" "let_" 5
 
-  let function_ = combinator "Exp" "function_"
+  let function_ = combinator "Exp" "function_" 1
 
-  let apply = combinator "Exp" "apply"
+  let apply = combinator "Exp" "apply" 2
 
-  let match_ = combinator "Exp" "match_"
+  let match_ = combinator "Exp" "match_" 2
 
-  let try_ = combinator "Exp" "try_"
+  let try_ = combinator "Exp" "try_" 2
 
-  let tuple = combinator "Exp" "tuple"
+  let tuple = combinator "Exp" "tuple" 1
 
-  let construct = combinator "Exp" "construct"
+  let construct = combinator "Exp" "construct" 2
 
-  let variant = combinator "Exp" "variant"
+  let variant = combinator "Exp" "variant" 2
 
-  let record = combinator "Exp" "record"
+  let record = combinator "Exp" "record" 2
 
-  let field = combinator "Exp" "field"
+  let field = combinator "Exp" "field" 2
 
-  let setfield = combinator "Exp" "setfield"
+  let setfield = combinator "Exp" "setfield" 3
 
-  let array = combinator "Exp" "array"
+  let array = combinator "Exp" "array" 1
 
-  let ifthenelse = combinator "Exp" "ifthenelse"
+  let ifthenelse = combinator "Exp" "ifthenelse" 3
 
-  let sequence = combinator "Exp" "sequence"
+  let sequence = combinator "Exp" "sequence" 2
 
-  let while_ = combinator "Exp" "while_"
+  let while_ = combinator "Exp" "while_" 2
 
-  let for_simple = combinator "Exp" "for_simple"
+  let for_simple = combinator "Exp" "for_simple" 6
 
-  let unboxed_tuple = combinator "Exp" "unboxed_tuple"
+  let unboxed_tuple = combinator "Exp" "unboxed_tuple" 1
 
-  let unboxed_record_product = combinator "Exp" "unboxed_record_product"
+  let unboxed_record_product = combinator "Exp" "unboxed_record_product" 2
 
-  let unboxed_field = combinator "Exp" "unboxed_field"
+  let unboxed_field = combinator "Exp" "unboxed_field" 2
 
-  let pack = combinator "Exp" "pack"
+  let pack = combinator "Exp" "pack" 1
 
-  let unreachable = combinator "Exp" "unreachable"
+  let unreachable = combinator "Exp" "unreachable" 0
 
-  let src_pos = combinator "Exp" "src_pos"
+  let src_pos = combinator "Exp" "src_pos" 0
 
-  let exclave = combinator "Exp" "exclave"
+  let exclave = combinator "Exp" "exclave" 1
 
-  let extension_constructor = combinator "Exp" "extension_constructor"
+  let extension_constructor = combinator "Exp" "extension_constructor" 1
 
-  let probe = combinator "Exp" "probe"
+  let list_comprehension = combinator "Exp" "list_comprehension" 1
 
-  let probe_is_enabled = combinator "Exp" "probe_is_enabled"
+  let array_comprehension = combinator "Exp" "array_comprehension" 1
 
-  let list_comprehension = combinator "Exp" "list_comprehension"
+  let let_exception = combinator "Exp" "let_exception" 2
 
-  let array_comprehension = combinator "Exp" "array_comprehension"
+  let let_op = combinator "Exp" "let_op" 3
 
-  let let_exception = combinator "Exp" "let_exception"
+  let new_ = combinator "Exp" "new_" 1
 
-  let let_op = combinator "Exp" "let_op"
+  let send = combinator "Exp" "send" 2
 
-  let new_ = combinator "Exp" "new_"
+  let assert_ = combinator "Exp" "assert_" 1
 
-  let send = combinator "Exp" "send"
+  let stack = combinator "Exp" "stack" 1
 
-  let assert_ = combinator "Exp" "assert_"
+  let lazy_ = combinator "Exp" "lazy_" 1
 
-  let lazy_ = combinator "Exp" "lazy_"
+  let letmodule_nonbinding = combinator "Exp" "letmodule_nonbinding" 3
 
-  let letmodule = combinator "Exp" "letmodule"
+  let letmodule = combinator "Exp" "letmodule" 4
 
-  let open_ = combinator "Exp" "open_"
+  let constraint_ = combinator "Exp" "constraint_" 2
 
-  let quote = combinator "Exp" "quote"
+  let quote = combinator "Exp" "quote" 1
 
-  let antiquote = combinator "Exp" "antiquote"
+  let antiquote = combinator "Exp" "antiquote" 1
+
+  let splice = combinator "Exp" "splice" 1
+end
+
+module Code = struct
+  let to_exp = combinator "Code" "to_exp" 1
+
+  let of_exp = combinator "Code" "of_exp" 2
+
+  let of_exp_with_type_vars = combinator "Code" "of_exp_with_type_vars" 3
 end
 
 let use comb = Lazy.force comb
@@ -343,14 +609,31 @@ let quote_constant loc (const : Typedtree.constant) =
     apply loc Constant.string
       [Lconst (Const_base (Const_string (x, loc, None))); comp_opt]
   | Const_float x ->
-    apply loc Constant.float [Lconst (Const_base (Const_float x))]
+    apply loc Constant.float [Lconst (Const_base (Const_string (x, loc, None)))]
+  | Const_float32 x ->
+    apply loc Constant.float32
+      [Lconst (Const_base (Const_string (x, loc, None)))]
   | Const_int32 x ->
     apply loc Constant.int32 [Lconst (Const_base (Const_int32 x))]
   | Const_int64 x ->
     apply loc Constant.int64 [Lconst (Const_base (Const_int64 x))]
   | Const_nativeint x ->
     apply loc Constant.nativeint [Lconst (Const_base (Const_nativeint x))]
-  | _ -> fatal_error "Unsupported constant type detected."
+  | Const_unboxed_float x ->
+    apply loc Constant.unboxed_float
+      [Lconst (Const_base (Const_string (x, loc, None)))]
+  | Const_unboxed_float32 x ->
+    apply loc Constant.unboxed_float32
+      [Lconst (Const_base (Const_string (x, loc, None)))]
+  | Const_unboxed_int32 x ->
+    apply loc Constant.unboxed_int32
+      [Lconst (Const_base (Const_unboxed_int32 x))]
+  | Const_unboxed_int64 x ->
+    apply loc Constant.unboxed_int64
+      [Lconst (Const_base (Const_unboxed_int64 x))]
+  | Const_unboxed_nativeint x ->
+    apply loc Constant.unboxed_nativeint
+      [Lconst (Const_base (Const_unboxed_nativeint x))]
 
 let quote_loc (loc : Location.t) =
   if loc = Location.none
@@ -384,17 +667,73 @@ let quote_arg_label loc = function
       "No support for any types of labels other than Labelled, Nolabel and \
        Optional"
 
-let rec module_for_path loc = function
-  | Path.Pident id ->
-    if Ident.is_global id
-    then
-      apply loc Identifier.Module.compilation_unit [string loc (Ident.name id)]
-    else raise Exit
+let rec module_for_path var_env loc = function
+  | Path.Pident id -> (
+      match Var_env.find_opt (Ident.name id) var_env.env_mod with
+      | Some m -> apply loc Identifier.Module.var [m; quote_loc loc]
+      | None ->
+        if Ident.is_global id
+        then
+          apply loc Identifier.Module.compilation_unit [string loc (Ident.name id)]
+        else raise Exit)
   | Path.Pdot (p, s) ->
-    apply loc Identifier.Module.dot [module_for_path loc p; string loc s]
+    apply loc Identifier.Module.dot [module_for_path var_env loc p; string loc s]
   | _ -> raise Exit
 
-let value_for_path loc = function
+let module_type_for_path var_env loc = function
+  | Path.Pident id -> apply loc Module_type.of_string [string loc (Ident.name id)]
+  | Path.Pdot (p, s) ->
+    apply loc Module_type.ident
+      [apply loc Identifier.Module_type.dot [module_for_path var_env loc p; string loc s]]
+  | _ -> raise Exit
+
+let type_for_path var_env loc = function
+  | Path.Pident id -> (
+    match Var_env.find_opt (Ident.name id) var_env.env_tys with
+    | Some t -> apply loc Identifier.Type.var [t; quote_loc loc]
+    | None ->
+      if Ident.is_global id
+      then
+        match Ident.name id with
+        | "int" -> Lazy.force Identifier.Type.int
+        | "char" -> Lazy.force Identifier.Type.char
+        | "string" -> Lazy.force Identifier.Type.string
+        | "bytes" -> Lazy.force Identifier.Type.bytes
+        | "float" -> Lazy.force Identifier.Type.float
+        | "float32" -> Lazy.force Identifier.Type.float32
+        | "bool" -> Lazy.force Identifier.Type.bool
+        | "unit" -> Lazy.force Identifier.Type.unit
+        | "exn" -> Lazy.force Identifier.Type.exn
+        | "array" -> Lazy.force Identifier.Type.array
+        | "iarray" -> Lazy.force Identifier.Type.iarray
+        | "list" -> Lazy.force Identifier.Type.list
+        | "option" -> Lazy.force Identifier.Type.option
+        | "nativeint" -> Lazy.force Identifier.Type.nativeint
+        | "int32" -> Lazy.force Identifier.Type.int32
+        | "int64" -> Lazy.force Identifier.Type.int64
+        | "lazy_t" -> Lazy.force Identifier.Type.lazy_t
+        | "extension_constructor" ->
+          Lazy.force Identifier.Type.extension_constructor
+        | "floatarray" -> Lazy.force Identifier.Type.floatarray
+        | "lexing_position" -> Lazy.force Identifier.Type.lexing_position
+        | "code" -> Lazy.force Identifier.Type.code
+        | "unboxed_float" -> Lazy.force Identifier.Type.unboxed_float
+        | "unboxed_nativeint" -> Lazy.force Identifier.Type.unboxed_nativeint
+        | "unboxed_int32" -> Lazy.force Identifier.Type.unboxed_int32
+        | "unboxed_int64" -> Lazy.force Identifier.Type.unboxed_int64
+        | "int8x16" -> Lazy.force Identifier.Type.int8x16
+        | "int16x8" -> Lazy.force Identifier.Type.int16x8
+        | "int32x4" -> Lazy.force Identifier.Type.int32x4
+        | "int64x2" -> Lazy.force Identifier.Type.int64x2
+        | "float32x4" -> Lazy.force Identifier.Type.float32x4
+        | "float62x2" -> Lazy.force Identifier.Type.float64x2
+        | name -> fatal_error ("Unknown type: " ^ name)
+      else raise Exit)
+  | Path.Pdot (p, s) ->
+    apply loc Identifier.Type.dot [module_for_path var_env loc p; string loc s]
+  | _ -> raise Exit
+
+let value_for_path var_env loc = function
   | Path.Pident id ->
     if Ident.is_global id
     then
@@ -403,11 +742,28 @@ let value_for_path loc = function
           string loc (Ident.name id) ]
     else raise Exit
   | Path.Pdot (p, s) ->
-    apply loc Identifier.Value.dot [module_for_path loc p; string loc s]
+    apply loc Identifier.Value.dot [module_for_path var_env loc p; string loc s]
   | _ -> raise Exit
 
-let value_for_path_opt loc p =
-  match value_for_path loc p with res -> Some res | exception Exit -> None
+let value_for_path_opt var_env loc p =
+  match value_for_path var_env loc p with
+  | res -> Some res
+  | exception Exit -> None
+
+let quote_value_ident_path var_env loc path =
+  match value_for_path_opt var_env loc path with
+  | Some ident_val -> ident_val
+  | None -> (
+      match path with
+      | Pident id ->
+        if Var_env.mem (Ident.name id) var_env.env_vals
+        then apply loc Identifier.Value.var [Lvar id; quote_loc loc]
+        else fatal_error ("Cannot quote free variable " ^ Ident.name id)
+      | _ -> fatal_error ("No global path for identifier " ^ print_path path))
+
+let quote_value_ident_path_as_exp var_env loc path =
+  apply loc Exp.ident [quote_value_ident_path var_env loc path]
+
 
 let type_path env ty =
   let desc =
@@ -415,48 +771,86 @@ let type_path env ty =
   in
   match desc with Tconstr (p, _, _) -> Some p | _ -> None
 
-let quote_record_field env loc lbl_desc =
+let create_list_param_binding idents body =
+  let fun_body, t_opt =
+    List.fold_right
+      (fun id (body, t_opt) ->
+        let new_t = Ident.create_local "t" in
+        let let_t =
+          match t_opt with
+          | None -> body
+          | Some t -> bind t (tl (Lvar new_t)) body
+        in
+        bind id (hd (Lvar new_t)) let_t, Some new_t)
+      idents (body, None)
+  in
+  let list_arg =
+    match t_opt with None -> Ident.create_local "t" | Some t -> t
+  in
+  func [list_arg] fun_body
+
+let quote_record_field env var_env loc lbl_desc =
   match type_path env lbl_desc.lbl_res with
   | None -> fatal_error "No global path for record field"
   | Some (Path.Pident _) ->
-    apply loc Identifier.Field.dot
-      [ apply loc Identifier.Module.compilation_unit [string loc ""];
-        string loc lbl_desc.lbl_name ]
+    apply loc Field.of_string [string loc lbl_desc.lbl_name]
   | Some (Path.Pdot (p, _)) ->
-    apply loc Identifier.Field.dot
-      [module_for_path loc p; string loc lbl_desc.lbl_name]
+    apply loc Field.ident
+      [apply loc Identifier.Field.dot
+         [module_for_path var_env loc p; string loc lbl_desc.lbl_name]]
   | _ -> fatal_error "Unsupported constructor type detected."
 
-let quote_constructor env loc constr =
+let quote_constructor env var_env loc constr =
   match type_path env constr.cstr_res with
   | None -> fatal_error "No global path for constructor"
   | Some (Path.Pident _) -> (
-      match constr.cstr_name with
-      | "false" -> Lazy.force Identifier.Constructor.false_
-      | "true" -> Lazy.force Identifier.Constructor.true_
-      | "()" -> Lazy.force Identifier.Constructor.void
-      | "[]" -> Lazy.force Identifier.Constructor.nil
-      | "::" -> Lazy.force Identifier.Constructor.cons
-      | "None" -> Lazy.force Identifier.Constructor.none
-      | "Some" -> Lazy.force Identifier.Constructor.some
-      | _ ->
-        apply loc Identifier.Constructor.dot
-          [ apply loc Identifier.Module.compilation_unit [string loc ""];
-            string loc constr.cstr_name ])
+    match constr.cstr_name with
+    | "false" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.false_]
+    | "true" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.true_]
+    | "()" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.void]
+    | "[]" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.nil]
+    | "::" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.cons]
+    | "None" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.none]
+    | "Some" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.some]
+    | "Match_failure" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.match_failure]
+    | "Out_of_memory" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.out_of_memory]
+    | "Invalid_argument" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.invalid_argument]
+    | "Failure" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.failure]
+    | "Not_found" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.not_found]
+    | "Sys_error" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.sys_error]
+    | "End_of_file" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.end_of_file]
+    | "Division_by_zero" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.division_by_zero]
+    | "Stack_overflow" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.stack_overflow]
+    | "Sys_blocked_io" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.sys_blocked_io]
+    | "Assert_failure" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.assert_failure]
+    | "Undefined_recursive_module" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.undefined_recursive_module]
+    | name -> apply loc Constructor.of_string [string loc name])
   | Some (Path.Pdot (p, _)) ->
-    apply loc Identifier.Constructor.dot
-      [module_for_path loc p; string loc constr.cstr_name]
+    apply loc Constructor.ident
+      [apply loc Identifier.Constructor.dot
+         [module_for_path var_env loc p; string loc constr.cstr_name]]
   | _ -> fatal_error "Unsupported constructor type detected."
 
-let quote_ext_constructor loc = function
-  | Path.Pident id -> (
-      apply loc Identifier.Constructor.dot
-        [ apply loc Identifier.Module.compilation_unit [string loc ""];
-          string loc (Ident.name id) ])
+let quote_ext_constructor var_env loc = function
+  | Path.Pident id ->
+    apply loc Constructor.of_string [string loc (Ident.name id)]
   | Path.Pdot (p, s) ->
-    apply loc Identifier.Constructor.dot
-      [module_for_path loc p; string loc s]
+    apply loc Constructor.ident
+      [apply loc Identifier.Constructor.dot
+         [module_for_path var_env loc p; string loc s]]
   | _ -> fatal_error "Unsupported constructor type detected."
+
+let rec quote_fragment_of_lid loc = function
+  | Lident id -> apply loc Fragment.name [string loc id]
+  | Ldot (p, s) ->
+    apply loc Fragment.dot [quote_fragment_of_lid loc p; string loc s]
+  | _ -> fatal_error "Unsupported fragment type detected."
+
+let rec quote_fragment loc = function
+  | Path.Pident id -> apply loc Fragment.name [string loc (Ident.name id)]
+  | Path.Pdot (p, s) ->
+    apply loc Fragment.dot [quote_fragment loc p; string loc s]
+  | _ -> fatal_error "Unsupported fragment type detected."
 
 let quote_variant loc name = apply loc Variant.of_string [string loc name]
 
@@ -465,86 +859,60 @@ let quote_nonopt loc (lbl : string option) =
   | None -> Lazy.force Label.Nonoptional.no_label
   | Some s -> apply loc Label.Nonoptional.labelled [string loc s]
 
-let rec quote_value_pattern p =
-  let env = p.pat_env in
-  let loc = p.pat_loc in
-  match p.pat_desc with
-  | Tpat_any -> Lazy.force Pat.any
-  | Tpat_var (id, _, _, _) -> apply loc Pat.var [Lvar id]
+let is_module pat =
+  List.mem Tpat_unpack (List.map (fun (extra, _, _) -> extra) pat.pat_extra)
+
+let rec with_new_idents_pat pat var_env =
+  match pat.pat_desc with
+  | Tpat_any -> var_env
+  | Tpat_var (id, _, _, _) ->
+    if is_module pat then
+      with_new_module var_env (Ident.name id) (Lambda.Lvar id)
+    else
+      with_new_value var_env (Ident.name id) (Lambda.Lvar id)
   | Tpat_alias (pat, id, _, _, _) ->
-    let pat = quote_value_pattern pat in
-    apply loc Pat.alias [pat; Lvar id]
-  | Tpat_constant const ->
-    let const = quote_constant loc const in
-    apply loc Pat.constant [const]
-  | Tpat_tuple pats ->
-    let pats =
-      List.map
-        (fun (lbl, p) -> pair (quote_nonopt loc lbl, quote_value_pattern p))
-        pats
-    in
-    apply loc Pat.tuple [mk_list pats]
-  | Tpat_construct (lid, constr, args, _) ->
-    let constr = quote_constructor env lid.loc constr in
-    let args =
-      match args with
-      | [] -> None
-      | _ :: _ ->
-        let args = List.map quote_value_pattern args in
-        let with_labels =
-          List.map
-            (fun a -> pair (Lazy.force Label.Nonoptional.no_label, a))
-            args
-        in
-        let as_tuple = apply loc Pat.tuple [mk_list with_labels] in
-        Some as_tuple
-    in
-    apply loc Pat.construct [constr; option args]
-  | Tpat_variant (variant, argo, _) ->
-    let variant = quote_variant loc variant in
-    let argo = Option.map quote_value_pattern argo in
-    apply loc Pat.variant [variant; option argo]
-  | Tpat_record (lbl_pats, closed) ->
-    let lbl_pats =
-      List.map
-        (fun (lid, lbl_desc, pat) ->
-          let lbl = quote_record_field env Asttypes.(lid.loc) lbl_desc in
-          let pat = quote_value_pattern pat in
-          pair (lbl, pat))
-        lbl_pats
-    in
-    let closed =
-      match closed with Asttypes.Closed -> true_ | Asttypes.Open -> false_
-    in
-    apply loc Pat.record [mk_list lbl_pats; closed]
+    let with_alias = with_new_value var_env (Ident.name id) (Lambda.Lvar id) in
+    with_new_idents_pat pat with_alias
+  | Tpat_constant const -> var_env
+  | Tpat_tuple args ->
+    List.fold_left
+      (fun var_env (_, pat) -> with_new_idents_pat pat var_env)
+      var_env args
+  | Tpat_construct (_, _, args, _) ->
+    List.fold_left
+      (fun var_env pat -> with_new_idents_pat pat var_env)
+      var_env args
+  | Tpat_variant (_, argo, _) -> (
+      match argo with
+      | None -> var_env
+      | Some pat -> with_new_idents_pat pat var_env)
+  | Tpat_record (lbl_pats, _) ->
+    List.fold_left
+      (fun var_env (_, _, pat) -> with_new_idents_pat pat var_env)
+      var_env lbl_pats
   | Tpat_array (_, _, pats) ->
-    let pats = List.map quote_value_pattern pats in
-    apply loc Pat.array [mk_list pats]
+    List.fold_left
+      (fun var_env pat -> with_new_idents_pat pat var_env)
+      var_env pats
   | Tpat_or (pat1, pat2, _) ->
-    let pat1 = quote_value_pattern pat1 in
-    let pat2 = quote_value_pattern pat2 in
-    apply loc Pat.or_ [pat1; pat2]
-  | Tpat_lazy pat ->
-    let pat = quote_value_pattern pat in
-    apply loc Pat.lazy_ [pat]
-  | _ -> fatal_error "Unsupported pattern type (unboxed stuff)"
+    with_new_idents_pat pat1 (with_new_idents_pat pat2 var_env)
+  | Tpat_unboxed_tuple args ->
+    List.fold_left
+      (fun var_env (_, pat, _) -> with_new_idents_pat pat var_env)
+      var_env args
+  | Tpat_record_unboxed_product (lbl_pats, _) ->
+    List.fold_left
+      (fun var_env (_, _, pat) -> with_new_idents_pat pat var_env)
+      var_env lbl_pats
+  | Tpat_lazy pat -> with_new_idents_pat pat var_env
 
-let rec quote_module_path loc = function
-  | Path.Pident s ->
-    apply loc Identifier.Module.compilation_unit [string loc (Ident.name s)]
-  | Path.Pdot (p, s) ->
-    apply loc Identifier.Module.dot [quote_module_path loc p; string loc s]
-  | _ -> fatal_error "No support for Papply in quoting modules"
-
-let rec quote_computation_pattern p =
-  let loc = p.pat_loc in
-  match p.pat_desc with
-  | Tpat_value pat -> quote_value_pattern (pat :> value general_pattern)
-  | Tpat_exception pat -> apply loc Pat.exception_ [quote_value_pattern pat]
-  | Tpat_or (pat1, pat2, _) ->
-    let pat1 = quote_computation_pattern pat1 in
-    let pat2 = quote_computation_pattern pat2 in
-    apply loc Pat.exception_ [pat1; pat2]
+let with_new_param var_env fp =
+  let pat_of_param =
+    match fp.fp_kind with
+    | Tparam_pat pat -> pat
+    | Tparam_optional_default (pat, _, _) -> pat
+  in
+  with_new_idents_pat pat_of_param var_env
 
 type case_binding =
   | Non_binding of lambda * lambda
@@ -553,24 +921,228 @@ type case_binding =
   | Guarded of lambda * lambda * lambda
   | Refutation of lambda * lambda * lambda
 
-let rec case_binding transl stage case =
+let rec quote_module_path loc = function
+  | Path.Pident s ->
+    apply loc Identifier.Module.compilation_unit [string loc (Ident.name s)]
+  | Path.Pdot (p, s) ->
+    apply loc Identifier.Module.dot [quote_module_path loc p; string loc s]
+  | _ -> fatal_error "No support for Papply in quoting modules"
+
+let rec quote_computation_pattern var_env p =
+  let loc = p.pat_loc in
+  match p.pat_desc with
+  | Tpat_value pat -> quote_value_pattern var_env (pat :> value general_pattern)
+  | Tpat_exception pat ->
+    apply loc Pat.exception_ [quote_value_pattern var_env pat]
+  | Tpat_or (pat1, pat2, _) ->
+    let pat1 = quote_computation_pattern var_env pat1 in
+    let pat2 = quote_computation_pattern var_env pat2 in
+    apply loc Pat.exception_ [pat1; pat2]
+
+and quote_pat_extra var_env loc pat extra =
+  let (extra, _, _) = extra in
+  match extra with
+  | Tpat_constraint ty ->
+    apply loc Pat.constraint_ [pat; quote_core_type var_env ty]
+  | Tpat_unpack ->
+    apply loc Pat.unpack [pat]
+  | Tpat_type _ -> pat (* TODO: consider adding support for #tconst *)
+  | Tpat_open _ -> fatal_error "No support for open patterns."
+
+and quote_value_pattern var_env p =
+  let env = p.pat_env in
+  let loc = p.pat_loc in
+  let pat_quoted =
+    match p.pat_desc with
+    | Tpat_any -> Lazy.force Pat.any
+    | Tpat_var (id, _, _, _) -> apply loc Pat.var [Lvar id]
+    | Tpat_alias (pat, id, _, _, _) ->
+      let pat = quote_value_pattern var_env pat in
+      apply loc Pat.alias [pat; Lvar id]
+    | Tpat_constant const ->
+      let const = quote_constant loc const in
+      apply loc Pat.constant [const]
+    | Tpat_tuple pats ->
+      let pats =
+        List.map
+          (fun (lbl, p) ->
+             pair (quote_nonopt loc lbl, quote_value_pattern var_env p))
+          pats
+      in
+      apply loc Pat.tuple [mk_list pats]
+    | Tpat_construct (lid, constr, args, _) ->
+      let constr = quote_constructor env var_env lid.loc constr in
+      let args =
+        match args with
+        | [] -> None
+        | _ :: _ ->
+          let args = List.map (quote_value_pattern var_env) args in
+          let with_labels =
+            List.map
+              (fun a -> pair (Lazy.force Label.Nonoptional.no_label, a))
+              args
+          in
+          let as_tuple = apply loc Pat.tuple [mk_list with_labels] in
+          Some as_tuple
+      in
+      apply loc Pat.construct [constr; option args]
+    | Tpat_variant (variant, argo, _) ->
+      let variant = quote_variant loc variant in
+      let argo = Option.map (quote_value_pattern var_env) argo in
+      apply loc Pat.variant [variant; option argo]
+    | Tpat_record (lbl_pats, closed) ->
+      let lbl_pats =
+        List.map
+          (fun (lid, lbl_desc, pat) ->
+             let lbl =
+               quote_record_field env var_env Asttypes.(lid.loc) lbl_desc
+             in
+             let pat = quote_value_pattern var_env pat in
+             pair (lbl, pat))
+          lbl_pats
+      in
+      let closed =
+        match closed with Asttypes.Closed -> true_ | Asttypes.Open -> false_
+      in
+      apply loc Pat.record [mk_list lbl_pats; closed]
+    | Tpat_array (_, _, pats) ->
+      let pats = List.map (quote_value_pattern var_env) pats in
+      apply loc Pat.array [mk_list pats]
+    | Tpat_or (pat1, pat2, _) ->
+      let pat1 = quote_value_pattern var_env pat1 in
+      let pat2 = quote_value_pattern var_env pat2 in
+      apply loc Pat.or_ [pat1; pat2]
+    | Tpat_unboxed_tuple pats ->
+      let pats =
+        List.map
+          (fun (lbl, p, _) ->
+             pair (quote_nonopt loc lbl, quote_value_pattern var_env p))
+          pats
+      in
+      apply loc Pat.unboxed_tuple [mk_list pats]
+    | Tpat_record_unboxed_product (lbl_pats, closed) ->
+      let lbl_pats =
+        List.map
+          (fun (lid, lbl_desc, pat) ->
+             let lbl =
+               quote_record_field env var_env Asttypes.(lid.loc) lbl_desc
+             in
+             let pat = quote_value_pattern var_env pat in
+             pair (lbl, pat))
+          lbl_pats
+      in
+      let closed =
+        match closed with Asttypes.Closed -> true_ | Asttypes.Open -> false_
+      in
+      apply loc Pat.unboxed_record [mk_list lbl_pats; closed]
+    | Tpat_lazy pat ->
+      let pat = quote_value_pattern var_env pat in
+      apply loc Pat.lazy_ [pat]
+  in
+  List.fold_right
+    (fun extra p -> quote_pat_extra var_env loc p extra)
+    p.pat_extra
+    pat_quoted
+
+and quote_core_type var_env ty =
+  let loc = ty.ctyp_loc in
+  match ty.ctyp_desc with
+  | Ttyp_var (id, _) ->
+    let id = Option.map (fun s -> Var_env.find s var_env.env_tys) id in
+    apply loc Type.var [option id]
+  | Ttyp_arrow (arg_lab, ty1, ty2) ->
+    let lab = quote_arg_label loc arg_lab
+    and ty1 = quote_core_type var_env ty1
+    and ty2 = quote_core_type var_env ty2 in
+    apply loc Type.arrow [lab; ty1; ty2]
+  | Ttyp_tuple ts ->
+    let tups =
+      List.map
+        (fun (s_opt, ty) ->
+          pair (quote_nonopt loc s_opt, quote_core_type var_env ty))
+        ts
+    in
+    apply loc Type.tuple [mk_list tups]
+  | Ttyp_unboxed_tuple ts ->
+    let tups =
+      List.map
+        (fun (s_opt, ty) ->
+          pair (quote_nonopt loc s_opt, quote_core_type var_env ty))
+        ts
+    in
+    apply loc Type.unboxed_tuple [mk_list tups]
+  | Ttyp_constr (path, _, tys) ->
+    let ident = type_for_path var_env loc path
+    and tys = List.map (quote_core_type var_env) tys in
+    apply loc Type.constr [ident; mk_list tys]
+  | Ttyp_object (fields, flag) -> fatal_error "Still not implemented."
+  | Ttyp_class (path, lident, tys) -> fatal_error "Still not implemented."
+  | Ttyp_alias (ty, alias_opt, _) -> fatal_error "Still not implemented."
+  | Ttyp_variant (row_fields, closed_flag, labels) ->
+    let row_fields =
+      List.map
+        (fun rf ->
+          match rf.rf_desc with
+          | Tinherit ty ->
+            apply rf.rf_loc Variant_type.Row_field.inherit_
+              [quote_core_type var_env ty]
+          | Ttag (tag, b, tys) ->
+            let variant =
+              apply tag.loc Variant.of_string [string tag.loc tag.txt]
+            in
+            apply rf.rf_loc Variant_type.Row_field.tag
+              [ variant;
+                quote_bool b;
+                mk_list (List.map (quote_core_type var_env) tys) ])
+        row_fields
+    and variant_form =
+      match closed_flag, labels with
+      | Open, None -> Lazy.force Variant_type.Variant_form.open_
+      | Closed, None -> Lazy.force Variant_type.Variant_form.fixed
+      | _, Some labs ->
+        apply loc Variant_type.Variant_form.closed
+          [mk_list (List.map (string loc) labs)]
+    in
+    apply loc Variant_type.of_row_fields_list [mk_list row_fields; variant_form]
+  | Ttyp_poly (tvs, ty) ->
+    let names =
+      List.map (fun (name, _) -> apply loc Name.mk [string loc name]) tvs
+    and ids = List.map (fun (name, _) -> Ident.create_local name) tvs in
+    let new_var_env = with_new_idents_types var_env ids in
+    let body = create_list_param_binding ids (quote_core_type new_var_env ty) in
+    apply loc Type.poly [quote_loc loc; mk_list names; body]
+  | Ttyp_package package ->
+    let {pack_path; pack_fields; pack_type; pack_txt} = package in
+    let mod_type = module_type_for_path var_env loc pack_path
+    and with_types =
+      List.map
+        (fun (lid, ty) ->
+           pair (quote_fragment_of_lid Asttypes.(lid.loc) lid.txt, quote_core_type var_env ty))
+        pack_fields
+    in
+    apply loc Type.package [mod_type; mk_list with_types]
+  | Ttyp_open (path, lident, ty) -> fatal_error "Still not implemented."
+  | Ttyp_call_pos -> fatal_error "Still not implemented."
+
+let rec case_binding var_env transl stage case =
   let pat = case.c_lhs in
   match case.c_guard with
   | None -> (
     let binding_with_computation_pat () =
       match pat_bound_idents pat with
       | [] ->
-        let exp = quote_expression transl stage case.c_rhs in
-        let pat = quote_computation_pattern pat in
+        let pat = quote_computation_pattern var_env pat in
+        let exp = quote_expression var_env transl stage case.c_rhs in
         Non_binding (pat, exp)
       | ids -> (
         let names =
           List.map (fun id -> string pat.pat_loc (Ident.name id)) ids
         in
-        let pat = quote_computation_pattern pat in
-        let exp = quote_expression transl stage case.c_rhs in
-        let pat_id = Ident.create_local "pattern" in
-        let exp_id = Ident.create_local "expression" in
+        let new_var_env = with_new_idents_values var_env ids in
+        let pat = quote_computation_pattern var_env pat
+        and exp = quote_expression new_var_env transl stage case.c_rhs
+        and pat_id = Ident.create_local "pattern"
+        and exp_id = Ident.create_local "expression" in
         let body =
           bind pat_id pat (bind exp_id exp (pair (Lvar pat_id, Lvar exp_id)))
         in
@@ -592,20 +1164,22 @@ let rec case_binding transl stage case =
     | Tpat_value pat -> (
       match (pat :> value general_pattern).pat_desc with
       | Tpat_var (id, name, _, _) ->
-        let name = quote_name name in
-        let body = quote_expression transl stage case.c_rhs in
-        Simple (name, func [id] body)
+        let new_var_env = with_new_idents_values var_env [id] in
+        let name = quote_name name
+        and exp = quote_expression new_var_env transl stage case.c_rhs in
+        Simple (name, func [id] exp)
       | _ -> binding_with_computation_pat ())
     | _ -> binding_with_computation_pat ())
   | Some guard ->
     let ids = pat_bound_idents case.c_lhs in
     let names = List.map (fun id -> string pat.pat_loc (Ident.name id)) ids in
-    let pat = quote_computation_pattern case.c_lhs in
-    let guard = quote_expression transl stage guard in
-    let exp = quote_expression transl stage case.c_rhs in
-    let pat_id = Ident.create_local "pattern" in
-    let guard_id = Ident.create_local "guard" in
-    let exp_id = Ident.create_local "expression" in
+    let pat = quote_computation_pattern var_env case.c_lhs in
+    let new_var_env = with_new_idents_values var_env ids in
+    let exp = quote_expression new_var_env transl stage case.c_rhs in
+    let guard = quote_expression new_var_env transl stage guard in
+    let pat_id = Ident.create_local "pattern"
+    and guard_id = Ident.create_local "guard"
+    and exp_id = Ident.create_local "expression" in
     let body =
       bind pat_id pat
         (bind guard_id guard
@@ -616,8 +1190,8 @@ let rec case_binding transl stage case =
         mk_list [],
         create_list_param_binding ids (create_list_param_binding [] body) )
 
-and case_value_pattern_binding transl stage case =
-  case_binding transl stage
+and case_value_pattern_binding var_env transl stage case =
+  case_binding var_env transl stage
     { case with c_lhs = as_computation_pattern case.c_lhs }
 
 and quote_case_binding loc cb =
@@ -631,34 +1205,16 @@ and quote_case_binding loc cb =
   | Refutation (names_vals, names_mods, body) ->
     apply loc Case.refutation [quote_loc loc; names_vals; names_mods; body]
 
-and quote_case transl stage loc case =
-  quote_case_binding loc (case_binding transl stage case)
+and quote_case var_env transl stage loc case =
+  quote_case_binding loc (case_binding var_env transl stage case)
 
-and quote_value_pattern_case transl stage loc case =
-  quote_case_binding loc (case_value_pattern_binding transl stage case)
+and quote_value_pattern_case var_env transl stage loc case =
+  quote_case_binding loc (case_value_pattern_binding var_env transl stage case)
 
 and quote_newtype loc ident sloc rest =
   apply loc Function.newtype [quote_loc loc; quote_name sloc; func [ident] rest]
 
-and create_list_param_binding idents body =
-  let fun_body, t_opt =
-    List.fold_right
-      (fun id (body, t_opt) ->
-        let new_t = Ident.create_local "t" in
-        let let_t =
-          match t_opt with
-          | None -> body
-          | Some t -> bind t (tl (Lvar new_t)) body
-        in
-        bind id (hd (Lvar new_t)) let_t, Some new_t)
-      idents (body, None)
-  in
-  let list_arg =
-    match t_opt with None -> Ident.create_local "t" | Some t -> t
-  in
-  func [list_arg] fun_body
-
-and fun_param_binding transl stage loc param frest =
+and fun_param_binding var_env transl stage loc param frest =
   let with_newtypes =
     List.fold_right
       (fun (ident, sloc, _, _) rest -> quote_newtype loc ident sloc rest)
@@ -668,7 +1224,7 @@ and fun_param_binding transl stage loc param frest =
     match param.fp_kind with
     | Tparam_pat pat -> pat, None
     | Tparam_optional_default (pat, exp, _) ->
-      pat, Some (quote_expression transl stage exp)
+      pat, Some (quote_expression var_env transl stage exp)
   in
   let idents = pat_bound_idents pat in
   let names =
@@ -676,7 +1232,7 @@ and fun_param_binding transl stage loc param frest =
   in
   let fun_rem =
     create_list_param_binding idents
-      (pair (quote_value_pattern pat, with_newtypes))
+      (pair (quote_value_pattern var_env pat, with_newtypes))
   in
   apply loc Function.param
     [ quote_arg_label loc param.fp_arg_label;
@@ -685,98 +1241,123 @@ and fun_param_binding transl stage loc param frest =
       mk_list names;
       fun_rem ]
 
-and quote_function transl stage loc fn =
+and quote_function var_env transl stage loc fn =
   match fn with
   | Texp_function fn ->
+    let body_env = List.fold_left with_new_param var_env fn.params in
     let fn_body =
       match fn.body with
       | Tfunction_body exp ->
-        apply loc Function.body [quote_expression transl stage exp]
+        apply loc Function.body
+          [quote_expression body_env transl stage exp; none]
       | Tfunction_cases cases ->
         apply loc Function.cases
           [ mk_list
               (List.map
                  (fun fc ->
                    quote_case_binding fc.c_lhs.pat_loc
-                     (case_value_pattern_binding transl stage fc))
-                 cases.fc_cases) ]
+                     (case_value_pattern_binding
+                        (with_new_idents_pat fc.c_lhs body_env)
+                        transl stage fc))
+                 cases.fc_cases);
+            none ]
     in
-    List.fold_right (fun_param_binding transl stage loc) fn.params fn_body
+    List.fold_right
+      (fun_param_binding body_env transl stage loc)
+      fn.params fn_body
   | _ -> fatal_error "Unexpected usage of quote_function."
 
-and quote_module_exp transl stage loc mod_exp =
+and quote_module_exp var_env transl stage loc mod_exp =
   match mod_exp.mod_desc with
   | Tmod_ident (path, _) ->
     let m = quote_module_path loc path in
     apply loc Module.ident [m]
   | Tmod_apply (funct, arg, _) ->
-    let transl_funct = quote_module_exp transl stage loc funct in
-    let transl_arg = quote_module_exp transl stage loc arg in
+    let transl_funct = quote_module_exp var_env transl stage loc funct in
+    let transl_arg = quote_module_exp var_env transl stage loc arg in
     apply loc Module.apply [transl_funct; transl_arg]
   | Tmod_apply_unit funct ->
-    let transl_funct = quote_module_exp transl stage loc funct in
+    let transl_funct = quote_module_exp var_env transl stage loc funct in
     apply loc Module.apply_unit [transl_funct]
   | Tmod_constraint (mod_exp, _, _, _) ->
-    quote_module_exp transl stage loc mod_exp
-  | Tmod_structure _ | Tmod_functor _ -> fatal_error "Cannot quote struct..end blocks"
+    quote_module_exp var_env transl stage loc mod_exp
+  | Tmod_structure _ | Tmod_functor _ ->
+    fatal_error "Cannot quote struct..end blocks"
   | Tmod_unpack _ -> fatal_error "No support for unpacking first-class modules"
 
-and quote_comprehension transl stage loc {comp_body; comp_clauses} =
+and quote_comprehension var_env transl stage loc { comp_body; comp_clauses } =
   let add_clause body = function
     | Texp_comp_when exp ->
-      let exp = quote_expression transl stage exp in
-      apply loc Comprehension.add_when_clause [body; exp]
+      let exp = quote_expression var_env transl stage exp in
+      apply loc Comprehension.when_clause [body; exp]
     | Texp_comp_for clause_bindings ->
-      let bindings =
-        List.map
-          (fun clb -> match clb.comp_cb_iterator with
-             | Texp_comp_range rcd ->
-               let start = quote_expression transl stage rcd.start
-               and stop = quote_expression transl stage rcd.stop
-               and direction = match rcd.direction with | Upto -> true | Downto -> false
-               in
-               apply loc Comprehension.ClauseBinding.range
-                 [quote_loc loc; quote_name (mkloc (Ident.name rcd.ident) loc);
-                  start; stop; quote_bool direction]
-             | Texp_comp_in {pattern; sequence} ->
-               let exp = quote_expression transl stage sequence in
-               apply loc Comprehension.ClauseBinding.in_
-                 [quote_loc loc; quote_value_pattern pattern; exp])
-          clause_bindings
-      in
-      apply loc Comprehension.add_for_clause [body; mk_list bindings]
+      List.fold_left
+        (fun body clb ->
+          match clb.comp_cb_iterator with
+          | Texp_comp_range rcd ->
+            let start = quote_expression var_env transl stage rcd.start
+            and stop = quote_expression var_env transl stage rcd.stop
+            and direction =
+              match rcd.direction with Upto -> true | Downto -> false
+            in
+            apply loc Comprehension.for_range
+              [ quote_loc loc;
+                quote_name (mkloc (Ident.name rcd.ident) loc);
+                start;
+                stop;
+                quote_bool direction ]
+          | Texp_comp_in { pattern; sequence } ->
+            let exp = quote_expression var_env transl stage sequence in
+            apply loc Comprehension.for_in
+              [quote_loc loc; quote_value_pattern var_env pattern; exp])
+        body clause_bindings
   in
-  let body = apply loc Comprehension.body [quote_expression transl stage comp_body] in
+  let body =
+    apply loc Comprehension.body
+      [quote_expression var_env transl stage comp_body]
+  in
   List.fold_left (fun body clause -> add_clause body clause) body comp_clauses
 
-and quote_expression_extra _ _ extra lambda =
+and quote_expression_extra var_env _ _ extra lambda =
   let extra, loc, _ = extra in
   match extra with
   | Texp_newtype (id, sloc, _, _) -> quote_newtype loc id sloc lambda
-  | _ ->
-    failwith "Not implemented yet" (* TODO: type constraints and the rest *)
+  | Texp_constraint ty ->
+    let constr_ =
+      apply loc Type_constraint.constraint_ [quote_core_type var_env ty]
+    in
+    apply loc Exp.constraint_ [lambda; constr_]
+  | Texp_coerce (ty_opt, ty) ->
+    let coerce =
+      apply loc Type_constraint.coercion
+        [ option (Option.map (quote_core_type var_env) ty_opt);
+          quote_core_type var_env ty ]
+    in
+    apply loc Exp.constraint_ [lambda; coerce]
+  | Texp_stack -> apply loc Exp.stack [lambda]
+  | Texp_poly ty_opt -> fatal_error "No support for Texp_poly yet"
+  | Texp_mode alloc_opt -> fatal_error "No support for modes yet"
 
-and quote_value_ident_path loc path =
-  match value_for_path_opt loc path with
-  | Some ident_val ->
-    (Format.printf "I AM HERE: %a\n" Printlambda.lambda ident_val;
-     apply loc Exp.ident [ident_val])
-  | None ->
-    match path with
-    | Pident id ->
-      let v = apply loc Identifier.Value.var [Lvar id; quote_loc loc] in
-      apply loc Exp.ident [v]
-    | p ->
-      Format.printf "    [%a]\n\n" Path.print p;
-      fatal_error "No global path for identifier"
+and update_env_with_extra var_env extra =
+  let extra, loc, _ = extra in
+  match extra with
+  | Texp_newtype (id, _, _, _) -> with_new_type var_env (Ident.name id) (Lvar id)
+  | Texp_constraint _ | Texp_coerce _ | Texp_stack _ -> var_env
+  | Texp_poly ty_opt -> fatal_error "No support for Texp_poly yet"
+  | Texp_mode _ -> fatal_error "No support for modes yet"
 
-and quote_expression transl stage e =
+and quote_expression var_env transl stage e =
   let env = e.exp_env in
   let loc = e.exp_loc in
+  let var_env =
+    List.fold_left
+      (fun var_env extra -> update_env_with_extra var_env extra)
+      var_env
+      e.exp_extra
+  in
   let body =
     match e.exp_desc with
-    | Texp_ident (path, _, _, _, _) ->
-      quote_value_ident_path loc path
+    | Texp_ident (path, _, _, _, _) -> quote_value_ident_path_as_exp var_env loc path
     | Texp_constant const ->
       let const = quote_constant loc const in
       apply loc Exp.constant [const]
@@ -796,36 +1377,53 @@ and quote_expression transl stage e =
           List.map
             (fun s -> apply loc Name.mk [string loc (Ident.name s)])
             idents
-        in
-        let defs_lam = List.map (quote_expression transl stage) defs in
+        and body_env = with_new_idents_values var_env idents in
+        let defs_lam = List.map (quote_expression body_env transl stage) defs in
         let frest =
           create_list_param_binding idents
-            (pair (mk_list defs_lam, quote_expression transl stage exp))
+            (pair
+               (mk_list defs_lam, quote_expression body_env transl stage exp))
         in
         apply loc Exp.let_rec_simple [quote_loc loc; mk_list names_lam; frest]
       | Nonrecursive ->
-        List.fold_right
-          (fun vb lexp ->
-            let pat = vb.vb_pat in
-            let idents = pat_bound_idents pat in
-            let names_lam =
-              List.map
-                (fun s -> apply loc Name.mk [string loc (Ident.name s)])
-                idents
-            in
-            let def = quote_expression transl stage vb.vb_expr in
-            let frest =
-              create_list_param_binding idents
-                (pair (quote_value_pattern pat, lexp))
-            in
-            apply loc Exp.let_ [quote_loc loc; mk_list names_lam; def; frest])
-          vbs
-          (quote_expression transl stage exp))
+        let body_env, val_l, mod_l, pats, defs =
+          List.fold_left
+            (fun (body_env, val_l, mod_loc, pats, defs) vb ->
+              let pat = vb.vb_pat in
+              let idents = pat_bound_idents pat in
+              let def = quote_expression var_env transl stage vb.vb_expr
+              and body_env = with_new_idents_values body_env idents in
+              body_env, idents @ val_l, [], pat :: pats, def :: defs)
+            (var_env, [], [], [], []) (List.rev vbs)
+        in
+        let def_pat =
+          apply loc Pat.tuple
+            [ mk_list
+                (List.map
+                   (fun pat ->
+                     pair
+                       ( Lazy.force Label.Nonoptional.no_label,
+                         quote_value_pattern var_env pat ))
+                   pats) ]
+        in
+        let names_lam =
+          List.map
+            (fun s -> apply loc Name.mk [string loc (Ident.name s)])
+            val_l
+        and frest =
+          create_list_param_binding val_l
+            (create_list_param_binding []
+               (pair (def_pat, quote_expression body_env transl stage exp)))
+        in
+        apply loc Exp.let_
+          [quote_loc loc; mk_list names_lam; nil; mk_list defs; frest])
     | Texp_function fun_spec ->
-      let fn = quote_function transl stage loc (Texp_function fun_spec) in
+      let fn =
+        quote_function var_env transl stage loc (Texp_function fun_spec)
+      in
       apply loc Exp.function_ [fn]
     | Texp_apply (fn, args, _, _, _) ->
-      let fn = quote_expression transl stage fn in
+      let fn = quote_expression var_env transl stage fn in
       let args =
         List.filter
           (fun (_, exp) -> match exp with Omitted _ -> false | _ -> true)
@@ -838,34 +1436,38 @@ and quote_expression transl stage e =
             | Omitted _ -> assert false
             | Arg (exp, _) ->
               let lbl = quote_arg_label loc lbl in
-              let exp = quote_expression transl stage exp in
+              let exp = quote_expression var_env transl stage exp in
               pair (lbl, exp))
           args
       in
       apply loc Exp.apply [fn; mk_list args]
     | Texp_match (exp, _, cases, _) ->
-      let exp = quote_expression transl stage exp in
-      let cases = List.map (quote_case transl stage loc) cases in
+      let exp = quote_expression var_env transl stage exp in
+      let cases = List.map (quote_case var_env transl stage loc) cases in
       apply loc Exp.match_ [exp; mk_list cases]
     | Texp_try (exp, cases) ->
-      let exp = quote_expression transl stage exp in
-      let cases = List.map (quote_value_pattern_case transl stage loc) cases in
+      let exp = quote_expression var_env transl stage exp
+      and cases =
+        List.map (quote_value_pattern_case var_env transl stage loc) cases
+      in
       apply loc Exp.try_ [exp; mk_list cases]
     | Texp_tuple (exps, _) ->
       let exps =
         List.map
           (fun (lab, exp) ->
-            pair (string_option loc lab, quote_expression transl stage exp))
+            pair
+              (string_option loc lab, quote_expression var_env transl stage exp))
           exps
       in
       apply loc Exp.tuple [mk_list exps]
     | Texp_construct (lid, constr, args, _) ->
-      let constr = quote_constructor env lid.loc constr in
+      let constr = quote_constructor env var_env lid.loc constr in
       let args =
         match args with
         | [] -> None
+        | [arg] -> Some (quote_expression var_env transl stage arg)
         | _ :: _ ->
-          let args = List.map (quote_expression transl stage) args in
+          let args = List.map (quote_expression var_env transl stage) args in
           let with_labels =
             List.map
               (fun a -> pair (Lazy.force Label.Nonoptional.no_label, a))
@@ -876,19 +1478,21 @@ and quote_expression transl stage e =
       in
       apply loc Exp.construct [constr; option args]
     | Texp_variant (variant, argo) ->
-      let variant = quote_variant loc variant in
-      let argo =
-        Option.map (fun (arg, _) -> quote_expression transl stage arg) argo
+      let variant = quote_variant loc variant
+      and argo =
+        Option.map
+          (fun (arg, _) -> quote_expression var_env transl stage arg)
+          argo
       in
       apply loc Exp.variant [variant; option argo]
     | Texp_record record ->
       let lbl_exps =
         Array.map
           (fun (lbl, def) ->
-            let lbl = quote_record_field env loc lbl in
+            let lbl = quote_record_field env var_env loc lbl in
             let exp =
               match def with
-              | Overridden (_, exp) -> quote_expression transl stage exp
+              | Overridden (_, exp) -> quote_expression var_env transl stage exp
               | Kept _ ->
                 fatal_error "No support for record update syntax in quotations"
             in
@@ -897,97 +1501,101 @@ and quote_expression transl stage e =
       in
       let base =
         Option.map
-          (fun (e, _) -> quote_expression transl stage e)
+          (fun (e, _) -> quote_expression var_env transl stage e)
           record.extended_expression
       in
       apply loc Exp.record [mk_list (Array.to_list lbl_exps); option base]
     | Texp_field (rcd, lid, lbl, _, _) ->
-      let rcd = quote_expression transl stage rcd in
-      let lbl = quote_record_field env lid.loc lbl in
+      let rcd = quote_expression var_env transl stage rcd in
+      let lbl = quote_record_field env var_env lid.loc lbl in
       apply loc Exp.field [rcd; lbl]
     | Texp_setfield (rcd, _, lid, lbl, exp) ->
-      let rcd = quote_expression transl stage rcd in
-      let lbl = quote_record_field env lid.loc lbl in
-      let exp = quote_expression transl stage exp in
+      let rcd = quote_expression var_env transl stage rcd in
+      let lbl = quote_record_field env var_env lid.loc lbl in
+      let exp = quote_expression var_env transl stage exp in
       apply loc Exp.setfield [rcd; lbl; exp]
     | Texp_array (_, _, exps, _) ->
-      let exps = List.map (quote_expression transl stage) exps in
+      let exps = List.map (quote_expression var_env transl stage) exps in
       apply loc Exp.array [mk_list exps]
     | Texp_ifthenelse (cond, then_, else_) ->
-      let cond = quote_expression transl stage cond in
-      let then_ = quote_expression transl stage then_ in
-      let else_ = Option.map (quote_expression transl stage) else_ in
+      let cond = quote_expression var_env transl stage cond in
+      let then_ = quote_expression var_env transl stage then_ in
+      let else_ = Option.map (quote_expression var_env transl stage) else_ in
       apply loc Exp.ifthenelse [cond; then_; option else_]
     | Texp_sequence (exp1, _, exp2) ->
-      let exp1 = quote_expression transl stage exp1 in
-      let exp2 = quote_expression transl stage exp2 in
+      let exp1 = quote_expression var_env transl stage exp1 in
+      let exp2 = quote_expression var_env transl stage exp2 in
       apply loc Exp.sequence [exp1; exp2]
     | Texp_while wh ->
-      let cond = quote_expression transl stage wh.wh_cond in
-      let body = quote_expression transl stage wh.wh_body in
+      let cond = quote_expression var_env transl stage wh.wh_cond in
+      let body = quote_expression var_env transl stage wh.wh_body in
       apply loc Exp.while_ [cond; body]
     | Texp_for floop ->
-      let low = quote_expression transl stage floop.for_from in
-      let high = quote_expression transl stage floop.for_to in
-      let dir =
+      let low = quote_expression var_env transl stage floop.for_from
+      and high = quote_expression var_env transl stage floop.for_to
+      and dir =
         match floop.for_dir with
         | Asttypes.Upto -> true_
         | Asttypes.Downto -> false_
-      in
-      let name = mkloc (Ident.name floop.for_id) loc in
-      let name = quote_name name in
-      let body = quote_expression transl stage floop.for_body in
+      and body_env =
+        with_new_value var_env (Ident.name floop.for_id) (Lvar floop.for_id)
+      and name = quote_name (mkloc (Ident.name floop.for_id) loc) in
+      let body = quote_expression body_env transl stage floop.for_body in
       apply loc Exp.for_simple
         [quote_loc loc; name; low; high; dir; func [floop.for_id] body]
     | Texp_send (obj, meth, _) ->
-      let obj = quote_expression transl stage obj in
+      let obj = quote_expression var_env transl stage obj in
       let meth = quote_method loc meth in
       apply loc Exp.send [obj; meth]
     | Texp_open (open_decl, exp) ->
-      let override =
-        match open_decl.open_override with Override -> true | Fresh -> false
-      in
-      let module_exp = quote_module_exp transl stage loc open_decl.open_expr in
-      let exp = quote_expression transl stage exp in
-      fatal_error "No support for opening modules yet. Will be translated to letmodule."
-    | Texp_letmodule(ident, _, _, mod_exp, body) ->
-      let name = Option.map (fun id -> quote_name (mkloc (Ident.name id) loc)) ident in
-      let mod_exp = quote_module_exp transl stage loc mod_exp in
-      let body = quote_expression transl stage body in
-      apply loc Exp.letmodule [option name; mod_exp; body]
+      fatal_error "No support for opening modules yet."
+    | Texp_letmodule (ident, _, _, mod_exp, body) -> (
+      let mod_exp = quote_module_exp var_env transl stage loc mod_exp in
+      match ident with
+      | None ->
+        apply loc Exp.letmodule_nonbinding
+          [mod_exp; quote_expression var_env transl stage body]
+      | Some ident ->
+        let name = quote_name (mkloc (Ident.name ident) loc)
+        and body_env =
+          with_new_module var_env (Ident.name ident) (Lvar ident)
+        in
+        let body = quote_expression body_env transl stage body in
+        apply loc Exp.letmodule [quote_loc loc; name; mod_exp; func [ident] body]
+      )
     | Texp_assert (exp, _) ->
-      let exp = quote_expression transl stage exp in
+      let exp = quote_expression var_env transl stage exp in
       apply loc Exp.assert_ [exp]
     | Texp_lazy exp ->
-      let exp = quote_expression transl stage exp in
+      let exp = quote_expression var_env transl stage exp in
       apply loc Exp.lazy_ [exp]
     | Texp_quotation exp ->
-      let exp = quote_expression transl (stage + 1) exp in
+      let exp = quote_expression var_env transl (stage + 1) exp in
       apply loc Exp.quote [exp]
     | Texp_antiquotation exp ->
-      if stage > 0
-      then
-        let exp = quote_expression transl (stage + 1) exp in
+      if stage > 0 then
+        let exp = quote_expression var_env transl stage exp in
         apply loc Exp.antiquote [exp]
-      else transl exp
+      else
+        apply loc Exp.splice [transl exp]
     | Texp_new (path, _, _, _) ->
-      apply loc Exp.new_ [quote_value_ident_path loc path]
+      apply loc Exp.new_ [quote_value_ident_path var_env loc path]
     | Texp_pack m ->
-      apply loc Exp.pack [quote_module_exp transl stage loc m]
-    | Texp_unreachable ->
-      Lazy.force Exp.unreachable
-    | Texp_src_pos ->
-      Lazy.force Exp.src_pos
+      apply loc Exp.pack [quote_module_exp var_env transl stage loc m]
+    | Texp_unreachable -> Lazy.force Exp.unreachable
+    | Texp_src_pos -> Lazy.force Exp.src_pos
     | Texp_exclave e ->
-      apply loc Exp.exclave [quote_expression transl stage e]
+      apply loc Exp.exclave [quote_expression var_env transl stage e]
     | Texp_extension_constructor (lid, path) ->
       apply loc Exp.extension_constructor
-        [quote_loc lid.loc; quote_ext_constructor loc path]
+        [quote_loc lid.loc; quote_ext_constructor var_env loc path]
     | Texp_unboxed_tuple ts ->
       let tups =
         List.map
-          (fun (lab_opt, exp, _)
-            -> pair (quote_nonopt loc lab_opt, quote_expression transl stage exp))
+          (fun (lab_opt, exp, _) ->
+            pair
+              ( quote_nonopt loc lab_opt,
+                quote_expression var_env transl stage exp ))
           ts
       in
       apply loc Exp.unboxed_tuple [mk_list tups]
@@ -995,61 +1603,61 @@ and quote_expression transl stage e =
       let lbl_exps =
         Array.map
           (fun (lbl, def) ->
-             let lbl = quote_record_field env loc lbl in
-             let exp =
-               match def with
-               | Overridden (_, exp) -> quote_expression transl stage exp
-               | Kept _ ->
-                 fatal_error "No support for record update syntax in quotations"
-             in
-             pair (lbl, exp))
+            let lbl = quote_record_field env var_env loc lbl in
+            let exp =
+              match def with
+              | Overridden (_, exp) -> quote_expression var_env transl stage exp
+              | Kept _ ->
+                fatal_error "No support for record update syntax in quotations."
+            in
+            pair (lbl, exp))
           record.fields
       in
       let base =
         Option.map
-          (fun (e, _) -> quote_expression transl stage e)
+          (fun (e, _) -> quote_expression var_env transl stage e)
           record.extended_expression
       in
-      apply loc Exp.unboxed_record_product [mk_list (Array.to_list lbl_exps); option base]
+      apply loc Exp.unboxed_record_product
+        [mk_list (Array.to_list lbl_exps); option base]
     | Texp_unboxed_field (rcd, _, lid, lbl, _) ->
-      let rcd = quote_expression transl stage rcd in
-      let lbl = quote_record_field env lid.loc lbl in
+      let rcd = quote_expression var_env transl stage rcd in
+      let lbl = quote_record_field env var_env lid.loc lbl in
       apply loc Exp.unboxed_field [rcd; lbl]
     | Texp_letexception (ext_const, exp) ->
-      let exp = quote_expression transl stage exp in
+      let exp = quote_expression var_env transl stage exp in
       apply loc Exp.let_exception [quote_name ext_const.ext_name; exp]
     | Texp_letop rcd ->
-      let let_l = value_for_path rcd.let_.bop_loc rcd.let_.bop_op_path
-      and ands_l = List.map (fun bop -> value_for_path bop.bop_loc bop.bop_op_path) rcd.ands
-      in
-      let let_ands = mk_list (let_l :: ands_l)
-      and idents = pat_bound_idents rcd.body.c_lhs
-      in
-      let names_lam =
+      let let_l =
+        quote_value_ident_path var_env rcd.let_.bop_loc rcd.let_.bop_op_path
+      and ands_l =
         List.map
-          (fun s -> apply loc Name.mk [string loc (Ident.name s)])
-          idents
-      in
-      let pat = rcd.body.c_lhs in
-      let body =
-        create_list_param_binding idents
-          (pair (quote_value_pattern pat, quote_expression transl stage rcd.body.c_rhs))
-      in apply loc Exp.let_op [quote_loc loc; let_ands; mk_list names_lam; body]
+          (fun bop ->
+            quote_value_ident_path var_env bop.bop_loc bop.bop_op_path)
+          rcd.ands
+      and defs =
+        quote_expression var_env transl stage rcd.let_.bop_exp
+        :: List.map
+             (fun d -> quote_expression var_env transl stage d.bop_exp)
+             rcd.ands
+      and body = quote_value_pattern_case var_env transl stage loc rcd.body in
+      apply loc Exp.let_op [mk_list (let_l :: ands_l); mk_list defs; body]
     | Texp_list_comprehension compr ->
-      apply loc Exp.list_comprehension [quote_comprehension transl stage loc compr]
+      apply loc Exp.list_comprehension
+        [quote_comprehension var_env transl stage loc compr]
     | Texp_array_comprehension (_, _, compr) ->
-      apply loc Exp.array_comprehension [quote_comprehension transl stage loc compr]
-    | Texp_overwrite _ ->
-      fatal_error "Not implemented yet"
-    | Texp_hole _ ->
-      fatal_error "No support for typed holes inside quotations."
+      apply loc Exp.array_comprehension
+        [quote_comprehension var_env transl stage loc compr]
+    | Texp_overwrite _ -> fatal_error "Not implemented yet"
+    | Texp_hole _ -> fatal_error "No support for typed holes inside quotations."
     | Texp_instvar _ | Texp_setinstvar _ | Texp_override _ ->
       fatal_error "Should not encounter OOP syntax in quotes."
-    | Texp_object _ ->
-      fatal_error "Cannot quote object construction."
+    | Texp_object _ -> fatal_error "Cannot quote object construction."
     | Texp_probe _ | Texp_probe_is_enabled _ ->
       fatal_error "Cannot quote probing constructs."
   in
-  List.fold_right (quote_expression_extra transl stage) e.exp_extra body
+  List.fold_right (quote_expression_extra var_env transl stage) e.exp_extra body
 
-let transl_quote transl exp = quote_expression transl 0 exp
+let transl_quote transl exp loc =
+  let expr = quote_expression new_env transl 0 exp in
+  apply loc Code.of_exp [expr; quote_loc loc]

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -1,291 +1,418 @@
-open Misc
 open Asttypes
-open Types
-open Typedtree
 open Lambda
+open Misc
+open Typedtree
+open Types
+open Debuginfo.Scoped_location
+open Longident
 
 let camlinternalQuote =
   lazy
-    (match Env.open_pers_signature
-             "CamlinternalQuote" Env.initial_safe_string with
-     | exception Not_found ->
-         fatal_error "Module CamlinternalQuote unavailable."
-     | env -> ident, env)
+    (match
+       Env.open_pers_signature "CamlinternalQuote" (Lazy.force Env.initial)
+     with
+    | exception Not_found -> fatal_error "Module CamlinternalQuote unavailable."
+    | path, env -> path, env)
 
 let combinator modname field =
   lazy
-    (let (ident, env) = Lazy.force camlinternalQuote in
-     let lid = Longident.Ldot(Longident.Lident modname, field) in
-     match Env.lookup_value lid env with
-     | (Path.Pdot(Path.Pdot(Pident ident, _, pos1), _, pos2), _) ->
-         Lprim(Pfield pos2,
-               [Lprim(Pfield pos1,
-                     [Lprim(Pgetglobal ident, [])])])
+    (let _, env = Lazy.force camlinternalQuote in
+     let lid = Ldot (Lident modname, field) in
+     match Env.lookup_value ~loc:Location.none lid env with
+     | Path.Pdot (Path.Pdot (Path.Pident ident, lab1), lab2), _, _ ->
+       transl_module_path Loc_unknown env
+         (Path.Pdot (Path.Pdot (Path.Pident ident, lab1), lab2))
      | _ ->
-         fatal_error
-           "Primitive CamlinternalQuote."^modname^"."^field^" not found."
+       fatal_error
+         ("Primitive CamlinternalQuote." ^ modname ^ "." ^ field ^ " not found.")
      | exception Not_found ->
-        fatal_error
-          "Primitive CamlinternalQuote."^modname^"."^field^" not found.")
+       fatal_error
+         ("Primitive CamlinternalQuote." ^ modname ^ "." ^ field ^ " not found."))
 
 module Loc = struct
-  let none = combinator "Loc" "none"
-  let unmarshal = combinator "Loc" "unmarshal"
+  let unknown = combinator "Loc" "unknown"
+
+  let known = combinator "Loc" "known"
 end
 
 module Name = struct
   let mk = combinator "Name" "mk"
-  let unmarshal = combinator "Name" "unmarshal"
 end
 
-module Var : sig
-  let name = combinator "Var" "name"
+module Constant = struct
+  let int = combinator "Constant" "int"
+
+  let char = combinator "Constant" "char"
+
+  let string = combinator "Constant" "string"
+
+  let float = combinator "Constant" "float"
+
+  let int32 = combinator "Constant" "int32"
+
+  let int64 = combinator "Constant" "int64"
+
+  let nativeint = combinator "Constant" "nativeint"
 end
 
-module Constant : sig
-  let unmarshal = combinator "Constant" "unmarshal"
+module Label = struct
+  module Nonoptional = struct
+    let no_label = combinator "Label.Nonoptional" "no_label"
+
+    let labelled = combinator "Label.Nonoptional" "labelled"
+  end
+
+  let no_label = combinator "Label" "no_label"
+
+  let labelled = combinator "Label" "labelled"
+
+  let optional = combinator "Label" "optional"
 end
 
-module Ident : sig
-  let unmarshal = combinator "Ident" "unmarshal"
+module Identifier = struct
+  let name = combinator "Ident" "name"
 end
 
-module Label : sig
-  let none = combinator "Label" "none"
-  let of_string = combinator "Label" "of_string"
-end
-
-module Variant : sig
+module Variant = struct
   let of_string = combinator "Variant" "of_string"
 end
 
-module Method : sig
+module Method = struct
   let of_string = combinator "Method" "of_string"
 end
 
-module Pat : sig
+module Pat = struct
   let any = combinator "Pat" "any"
+
   let var = combinator "Pat" "var"
+
   let alias = combinator "Pat" "alias"
+
   let constant = combinator "Pat" "constant"
-  let interval = combinator "Pat" "interval"
+
   let tuple = combinator "Pat" "tuple"
+
   let construct = combinator "Pat" "construct"
+
   let variant = combinator "Pat" "variant"
+
   let record = combinator "Pat" "record"
+
   let array = combinator "Pat" "array"
-  let or_ = combinator "Pat" "or"
-  let type_ = combinator "Pat" "type"
-  let lazy_ = combinator "Pat" "lazy"
-  let exception_ = combinator "Pat" "exception"
+
+  let or_ = combinator "Pat" "or_"
+
+  let lazy_ = combinator "Pat" "lazy_"
+
+  let exception_ = combinator "Pat" "exception_"
 end
 
-module rec Case : sig
+module Case = struct
   let nonbinding = combinator "Case" "nonbinding"
+
   let simple = combinator "Case" "simple"
+
   let pattern = combinator "Case" "pattern"
+
   let guarded = combinator "Case" "guarded"
+
+  let refutation = combinator "Case" "refutation"
 end
 
-and Exp : sig
+module Function = struct
+  let body = combinator "Function" "body"
+
+  let cases = combinator "Function" "cases"
+
+  let param = combinator "Function" "param_simple"
+
+  let newtype = combinator "Function" "newtype"
+end
+
+module Exp = struct
   let var = combinator "Exp" "var"
+
   let ident = combinator "Exp" "ident"
+
   let constant = combinator "Exp" "constant"
-  let let_simple = combinator "Exp" "let_simple"
+
   let let_rec_simple = combinator "Exp" "let_rec_simple"
+
   let let_ = combinator "Exp" "let_"
-  let fun_nonbinding = combinator "Exp" "fun_nonbinding"
-  let fun_simple = combinator "Exp" "fun_simple"
-  let fun_ = combinator "Exp" "fun_"
+
   let function_ = combinator "Exp" "function_"
+
   let apply = combinator "Exp" "apply"
+
   let match_ = combinator "Exp" "match_"
+
   let try_ = combinator "Exp" "try_"
+
   let tuple = combinator "Exp" "tuple"
+
   let construct = combinator "Exp" "construct"
+
   let variant = combinator "Exp" "variant"
+
   let record = combinator "Exp" "record"
+
   let field = combinator "Exp" "field"
+
   let setfield = combinator "Exp" "setfield"
+
   let array = combinator "Exp" "array"
+
   let ifthenelse = combinator "Exp" "ifthenelse"
+
   let sequence = combinator "Exp" "sequence"
+
   let while_ = combinator "Exp" "while_"
+
   let for_nonbinding = combinator "Exp" "for_nonbinding"
+
   let for_simple = combinator "Exp" "for_simple"
+
   let send = combinator "Exp" "send"
+
   let assert_ = combinator "Exp" "assert_"
+
   let lazy_ = combinator "Exp" "lazy_"
+
   let open_ = combinator "Exp" "open_"
+
+  let constraint_ = combinator "Exp" "constraint_"
+
   let quote = combinator "Exp" "quote"
-  let escape = combinator "Exp" "escape"
+
+  let antiquote = combinator "Exp" "antiquote"
 end
 
-let use comb =
-  Lazy.force comb
+let use comb = Lazy.force comb
 
 let apply loc comb args =
   let comb = Lazy.force comb in
-    Lapply (comb, args, loc)
+  Lambda.Lapply
+    { ap_func = comb;
+      ap_args = args;
+      ap_probe = None;
+      ap_loc = of_location ~scopes:empty_scopes loc;
+      ap_result_layout = Ptop;
+      ap_region_close = Rc_normal;
+      ap_mode = alloc_heap;
+      ap_tailcall = Default_tailcall;
+      ap_inlined = Default_inlined;
+      ap_specialised = Default_specialise
+    }
 
-let string s =
-  Lconst (Const_base (Const_string(s, None)))
+let string loc s = Lconst (Const_base (Const_string (s, loc, None)))
 
-let marshal x =
-  let s = Marshal.to_string x in
-    string s
+let marshal loc x =
+  let s = Marshal.to_string x [] in
+  string loc s
 
-let true_ = Lconst(Const_pointer 1)
+let true_ = Lconst (Const_base (Const_int 1))
 
-let false_ = Lconst(Const_pointer 0)
+let false_ = Lconst (Const_base (Const_int 0))
 
-let none =  Lconst(Const_pointer 0)
+let quote_bool b = if b then true_ else false_
 
-let some x = Lprim(Pmakeblock(0, Immutable), [x])
+let none = Lconst (Const_base (Const_int 0))
 
-let option opt =
-  match opt with
-  | None -> none
-  | Some x -> some x
+let some x =
+  Lprim (Pmakeblock (0, Immutable, None, alloc_heap), [x], Loc_unknown)
 
-let nil = Lconst(Const_pointer 0)
+let option opt = match opt with None -> none | Some x -> some x
 
-let cons hd tl = Lprim(Pmakeblock(0, Immutable), [hd; tl])
+let string_option loc s = option (Option.map (string loc) s)
 
-let rec list list =
-  match list with
-  | [] -> nil
-  | hd :: tl -> cons hd (list tl)
+let nil = Lconst (Const_base (Const_int 0))
+
+let cons hd tl =
+  Lprim (Pmakeblock (0, Immutable, None, alloc_heap), [hd; tl], Loc_unknown)
+
+let rec mk_list list =
+  match list with [] -> nil | hd :: tl -> cons hd (mk_list tl)
 
 let pair (x, y) =
-  Lprim(Pmakeblock(0, Immutable), [x; y])
+  Lprim (Pmakeblock (0, Immutable, None, alloc_heap), [x; y], Loc_unknown)
 
 let triple (x, y, z) =
-  Lprim(Pmakeblock(0, Immutable), [x; y; z])
+  Lprim (Pmakeblock (0, Immutable, None, alloc_heap), [x; y; z], Loc_unknown)
 
 let func ids body =
-  Lfunction(Curried, ids, body)
+  let param_from_name name =
+    { name;
+      layout = Ptop;
+      attributes = { unbox_param = false };
+      mode = alloc_heap
+    }
+  in
+  lfunction
+    ~kind:(Curried { nlocal = List.length ids })
+    ~params:(List.map param_from_name ids)
+    ~return:Ptop ~attr:default_function_attribute ~body ~loc:Loc_unknown
+    ~mode:alloc_heap ~ret_mode:alloc_heap ~region:false
 
-let bind id def body =
-  Llet(Strict, id, def, body)
+let bind id def body = Llet (Strict, Ptop, id, def, body)
 
 let quote_loc (loc : Location.t) =
-  if loc = Location.none then use Loc.none
-  else apply Location.none Loc.unmarshal [marshal loc]
+  if loc = Location.none
+  then use Loc.unknown
+  else apply loc Loc.known [marshal loc loc]
 
-let quote_constant loc (const : Asttypes.constant) =
-  apply loc Const.unmarshal [marshal const]
+let quote_constant loc (const : Typedtree.constant) =
+  match const with
+  | Const_int x -> apply loc Constant.int [Lconst (Const_base (Const_int x))]
+  | Const_char x -> apply loc Constant.char [Lconst (Const_base (Const_char x))]
+  | Const_string (x, loc, lopt) ->
+    let comp_opt = string_option loc lopt in
+    apply loc Constant.string
+      [Lconst (Const_base (Const_string (x, loc, None))); comp_opt]
+  | Const_float x ->
+    apply loc Constant.float [Lconst (Const_base (Const_float x))]
+  | Const_int32 x ->
+    apply loc Constant.int32 [Lconst (Const_base (Const_int32 x))]
+  | Const_int64 x ->
+    apply loc Constant.int64 [Lconst (Const_base (Const_int64 x))]
+  | Const_nativeint x ->
+    apply loc Constant.nativeint [Lconst (Const_base (Const_nativeint x))]
+  | _ -> fatal_error "Unsupported constant type detected."
 
-let quote_name loc (str : string loc) =
-  apply loc Name.unmarshal [marshal str]
-
-let quote_variant loc (variant : label) =
-  apply loc Variant.of_string [string variant]
+let quote_name (str : string loc) =
+  apply str.loc Name.mk [string str.loc str.txt]
 
 let quote_method loc (meth : Typedtree.meth) =
   let name =
     match meth with
     | Tmeth_name name -> name
     | Tmeth_val id -> Ident.name id
+    | Tmeth_ancestor (id, path) -> Path.name path ^ "#" ^ Ident.name id
   in
-  apply loc Method.of_string [string name]
+  apply loc Method.of_string [string loc name]
 
 let quote_label loc lbl =
-  if lbl = "" then use Label.none
-  else apply loc Label.of_string [string lbl]
+  if lbl = ""
+  then use Label.no_label
+  else apply loc Label.labelled [string loc lbl]
+
+let quote_arg_label loc = function
+  | Labelled s -> apply loc Label.labelled [string loc s]
+  | Optional s -> apply loc Label.optional [string loc s]
+  | Nolabel -> apply loc Label.no_label []
+  | _ ->
+    fatal_error
+      "No support for any types of labels other than Labelled, Nolabel and \
+       Optional"
 
 let lid_of_path p =
   let rec loop = function
-    | Pident id ->
-      if Ident.global id then Lid (Ident.name id)
-      else raise Exit
-    | Pdot(p, s, _) -> Ldot(loop p, s)
-    | Papply _ -> raise Exit
+    | Path.Pident id ->
+      if Ident.is_global id then Lident (Ident.name id) else raise Exit
+    | Path.Pdot (p, s) -> Ldot (loop p, s)
+    | _ -> raise Exit
   in
-    match loop p with
-    | lid -> Some lid
-    | exception Exit -> None
+  match loop p with lid -> Some lid | exception Exit -> None
 
 let lid_of_type_path env ty =
   let desc =
-    (Ctype.repr (Ctype.expand_head_opt env (Ctype.correct_levels ty))).desc
+    Types.get_desc (Ctype.expand_head_opt env (Ctype.correct_levels ty))
   in
-  match desc with
-  | Tconstr(p, _, _) -> lid_of_path p
-  | _ -> None
+  match desc with Tconstr (p, _, _) -> lid_of_path p | _ -> None
 
-let quote_variant_constructor env loc constr =
+let quote_constructor env loc constr =
   let lid =
     match lid_of_type_path env constr.cstr_res with
     | None -> fatal_error "No global path for variant constructor"
     | Some (Lident _) -> Lident constr.cstr_name
-    | Some (Ldot(lid, _)) -> Ldot(lid, constr.cstr_name)
+    | Some (Ldot (lid, _)) -> Ldot (lid, constr.cstr_name)
+    | _ -> fatal_error "Unsupported variant constructor type detected."
   in
-  apply loc Ident.unmarshall [marshall lid]
+  apply loc Identifier.name [marshal loc lid]
+
+let quote_variant loc name = apply loc Variant.of_string [string loc name]
 
 let quote_record_label env loc lbl =
   let lid =
     match lid_of_type_path env lbl.lbl_res with
     | None -> fatal_error "No global path for record label"
-    | Some (Lident _) -> Lident constr.lbl_name
-    | Some (Ldot(lid, _)) -> Ldot(lid, constr.lbl_name)
+    | Some (Lident _) -> Lident lbl.lbl_name
+    | Some (Ldot (lid, _)) -> Ldot (lid, lbl.lbl_name)
+    | _ -> fatal_error "Unsupported record label detected."
   in
-  apply loc Ident.unmarshall [marshall lid]
+  apply loc Identifier.name [marshal loc lid]
 
-let rec quote_pattern p =
+let quote_nonopt loc (lbl : string option) =
+  match lbl with
+  | None -> apply loc Label.Nonoptional.no_label []
+  | Some s -> apply loc Label.Nonoptional.labelled [string loc s]
+
+let rec quote_value_pattern p =
   let env = p.pat_env in
   let loc = p.pat_loc in
   match p.pat_desc with
-  | Tpat_any -> apply loc Pat.any [quote_loc loc]
-  | Tpat_var(id, _) -> apply loc Pat.var [quote_loc loc; Lvar id]
-  | Tpat_alias(pat, id, _) ->
-      let pat = quote_pattern pat in
-      apply loc Pat.alias [quote_loc loc; pat; Lvar id]
+  | Tpat_any -> apply loc Pat.any []
+  | Tpat_var (id, _, _, _) -> apply loc Pat.var [Lvar id]
+  | Tpat_alias (pat, id, _, _, _) ->
+    let pat = quote_value_pattern pat in
+    apply loc Pat.alias [pat; Lvar id]
   | Tpat_constant const ->
-      let const = quote_constant loc const in
-      apply loc Pat.const [quote_loc loc; const]
+    let const = quote_constant loc const in
+    apply loc Pat.constant [const]
   | Tpat_tuple pats ->
-      let pats = List.map quote_pattern pats in
-      apply loc Pat.tuple [quote_loc loc; list pats]
-  | Tpat_construct(lid, constr, args) ->
-      let constr = quote_constructor env lid.loc constr in
-      let args =
-        match args with
-        | [] -> None
-        | _ :: _ ->
-            let args = List.map quote_pattern args in
-            Some (apply loc Pat.tuple [quote_loc loc; list args])
-      in
-      apply loc Pat.construct [quote_loc loc; constr; option args]
-  | Tpat_variant(variant, argo, _) ->
-      let variant = quote_variant loc variant in
-      let argo = Utils.may_map quote_pattern argo in
-      apply loc Pat.variant [quote_loc loc; variant; option argo]
-  | Tpat_record(lbl_pats, closed) ->
-      let lbl_pats =
-        List.map
-          (fun (lid, lbl, pat) ->
-            let lbl = quote_record_label env lid.loc lbl in
-            let pat = quote_pattern pat in
-            pair (lbl, pat))
-          lbl_pats
-      in
-      let closed =
-        match closed with
-        | Asttypes.Closed -> true_
-        | Asttypes.Open -> false_
-      in
-      apply loc Pat.record [quote_loc loc; list lbl_pats; closed]
-  | Tpat_array pats ->
-      let pats = List.map quote_pattern pats in
-      apply loc Pat.array [quote_loc loc; list pats]
-  | Tpat_or(pat1, pat2, _) ->
-      let pat1 = quote_pattern pat1 in
-      let pat2 = quote_pattern pat2 in
-      apply loc Pat.or_ [quote_loc loc; pat1; pat2]
+    let pats =
+      List.map
+        (fun (lbl, p) -> pair (quote_nonopt loc lbl, quote_value_pattern p))
+        pats
+    in
+    apply loc Pat.tuple [mk_list pats]
+  | Tpat_construct (lid, constr, args, _) ->
+    let constr = quote_constructor env lid.loc constr in
+    let args =
+      match args with
+      | [] -> None
+      | _ :: _ ->
+        let args = List.map quote_value_pattern args in
+        Some (apply loc Pat.tuple [mk_list args])
+    in
+    apply loc Pat.construct [constr; option args]
+  | Tpat_variant (variant, argo, _) ->
+    let variant = quote_variant loc variant in
+    let argo = Option.map quote_value_pattern argo in
+    apply loc Pat.variant [variant; option argo]
+  | Tpat_record (lbl_pats, closed) ->
+    let lbl_pats =
+      List.map
+        (fun (lid, lbl_desc, pat) ->
+          let lbl = quote_record_label env Asttypes.(lid.loc) lbl_desc in
+          let pat = quote_value_pattern pat in
+          pair (lbl, pat))
+        lbl_pats
+    in
+    let closed =
+      match closed with Asttypes.Closed -> true_ | Asttypes.Open -> false_
+    in
+    apply loc Pat.record [mk_list lbl_pats; closed]
+  | Tpat_array (_, _, pats) ->
+    let pats = List.map quote_value_pattern pats in
+    apply loc Pat.array [mk_list pats]
+  | Tpat_or (pat1, pat2, _) ->
+    let pat1 = quote_value_pattern pat1 in
+    let pat2 = quote_value_pattern pat2 in
+    apply loc Pat.or_ [pat1; pat2]
   | Tpat_lazy pat ->
-      let pat = quote_pattern pat in
-      apply loc Pat.lazy_ [quote_loc loc; pat]
+    let pat = quote_value_pattern pat in
+    apply loc Pat.lazy_ [pat]
+  | _ -> fatal_error "Unsupported pattern type (unboxed stuff)"
+
+let rec quote_computation_pattern p =
+  let loc = p.pat_loc in
+  match p.pat_desc with
+  | Tpat_value pat -> quote_value_pattern (pat :> value general_pattern)
+  | Tpat_exception pat -> apply loc Pat.exception_ [quote_value_pattern pat]
+  | Tpat_or (pat1, pat2, _) ->
+    let pat1 = quote_computation_pattern pat1 in
+    let pat2 = quote_computation_pattern pat2 in
+    apply loc Pat.exception_ [pat1; pat2]
 
 type case_binding =
   | Non_binding of lambda * lambda
@@ -293,249 +420,330 @@ type case_binding =
   | Pattern of lambda * lambda
   | Guarded of lambda * lambda
 
-let rec case_binding exn transl stage cases =
-  match cases.c_guard with
-  | None -> begin
-      match case.c_lhs, exn with
-      | Tpat_var(id, name), false ->
-          let name = quote_name name.loc name in
-          let body = quote_expression transl stage case.c_rhs in
-          Simple(name, func [id] body)
-      | pat, _ ->
-          match pat_bound_idents pat with
-          | [] ->
-              let pat = quote_pattern pat in
-              let pat =
-                if exn then
-                  apply pat.pat_loc Pat.exception_ [quote_loc loc; pat]
-                else
-                  pat
-              in
-              let exp = quote_expression transl stage case.c_rhs in
-              Non_binding(pat, exp)
-          | id_names ->
-              let ids = List.map fst id_names in
-              let names =
-                List.map (fun (_, name) -> quote_name name.loc name) id_names
-              in
-              let pat = quote_pattern pat in
-              let pat =
-                if exn then
-                  apply pat.pat_loc Pat.exception_ [quote_loc loc; pat]
-                else
-                  pat
-              in
-              let exp = quote_expression transl stage case.c_rhs in
-              let pat_id = Ident.create "pattern" in
-              let exp_id = Ident.create "expression" in
-              let body =
-                bind pat_id pat
-                  (bind exp_id exp
-                    (pair (Lvar pat_id, Lvar exp_id)))
-              in
-              Pattern(list names, func ids body)
-    end
+let rec case_binding transl stage case =
+  let pat = case.c_lhs in
+  match case.c_guard with
+  | None -> (
+    let binding_with_computation_pat () =
+      match pat_bound_idents pat with
+      | [] ->
+        let pat = quote_computation_pattern pat in
+        let exp = quote_expression transl stage case.c_rhs in
+        Non_binding (pat, exp)
+      | ids ->
+        let names =
+          List.map (fun id -> string pat.pat_loc (Ident.name id)) ids
+        in
+        let pat = quote_computation_pattern pat in
+        let exp = quote_expression transl stage case.c_rhs in
+        let pat_id = Ident.create_local "pattern" in
+        let exp_id = Ident.create_local "expression" in
+        let body =
+          bind pat_id pat (bind exp_id exp (pair (Lvar pat_id, Lvar exp_id)))
+        in
+        Pattern (mk_list names, func ids body)
+    in
+    match pat.pat_desc with
+    | Tpat_value pat -> (
+      match (pat :> value general_pattern).pat_desc with
+      | Tpat_var (id, name, _, _) ->
+        let name = quote_name name in
+        let body = quote_expression transl stage case.c_rhs in
+        Simple (name, func [id] body)
+      | _ -> binding_with_computation_pat ())
+    | _ -> binding_with_computation_pat ())
   | Some guard ->
-      let id_names = pat_bound_idents case.c_lhs in
-      let ids = List.map fst id_names in
-      let names =
-        List.map (fun (_, name) -> quote_name name.loc name) id_names
-      in
-      let pat = quote_pattern case.c_lhs in
-      let pat =
-        if exn then apply pat.pat_loc Pat.exception_ [quote_loc loc; pat]
-        else pat
-      in
-      let guard = quote_expression transl stage guard in
-      let exp = quote_expression transl stage case.c_rhs in
-      let pat_id = Ident.create "pattern" in
-      let guard_id = Ident.create "guard" in
-      let exp_id = Ident.create "expression" in
-      let body =
-        bind pat_id pat
-          (bind guard_id guard
-            (bind exp_id exp
-              (triple (Lvar pat_id, Lvar guard_id, Lvar exp_id)))
-      in
-      Guarded(list names, func ids body)
+    let ids = pat_bound_idents case.c_lhs in
+    let names = List.map (fun id -> string pat.pat_loc (Ident.name id)) ids in
+    let pat = quote_computation_pattern case.c_lhs in
+    let guard = quote_expression transl stage guard in
+    let exp = quote_expression transl stage case.c_rhs in
+    let pat_id = Ident.create_local "pattern" in
+    let guard_id = Ident.create_local "guard" in
+    let exp_id = Ident.create_local "expression" in
+    let body =
+      bind pat_id pat
+        (bind guard_id guard
+           (bind exp_id exp (triple (Lvar pat_id, Lvar guard_id, Lvar exp_id))))
+    in
+    Guarded (mk_list names, func ids body)
+
+and case_value_pattern_binding transl stage case =
+  case_binding transl stage
+    { case with c_lhs = as_computation_pattern case.c_lhs }
 
 and quote_case_binding loc cb =
   match cb with
-  | Non_binding(pat, exp) ->
-      apply loc Case.nonbinding [quote_loc loc; pat; exp]
-  | Simple(name, body) ->
-      apply loc Case.simple [quote_loc loc; name; body]
-  | Pattern(names, body) ->
-      apply loc Case.pattern [quote_loc loc; names; body]
-  | Guarded(names, body) ->
-      apply loc Case.guarded [quote_loc loc; names; body]
+  | Non_binding (pat, exp) -> apply loc Case.nonbinding [quote_loc loc; pat; exp]
+  | Simple (name, body) -> apply loc Case.simple [quote_loc loc; name; body]
+  | Pattern (names, body) -> apply loc Case.pattern [quote_loc loc; names; body]
+  | Guarded (names, body) -> apply loc Case.guarded [quote_loc loc; names; body]
 
-and quote_case exn transl stage loc case =
-  quote_case_binding loc (case_binding exn transl stage case)
+and quote_case transl stage loc case =
+  quote_case_binding loc (case_binding transl stage case)
+
+and quote_value_pattern_case transl stage loc case =
+  quote_case_binding loc (case_value_pattern_binding transl stage case)
+
+and quote_newtype loc ident sloc rest =
+  apply loc Function.newtype [quote_loc loc; quote_name sloc; func [ident] rest]
+
+and fun_param_binding transl stage loc param frest =
+  let with_newtypes =
+    List.fold_right
+      (fun (ident, sloc, _, _) rest -> quote_newtype loc ident sloc rest)
+      param.fp_newtypes frest
+  in
+  let pat, opt_exp =
+    match param.fp_kind with
+    | Tparam_pat pat -> pat, None
+    | Tparam_optional_default (pat, exp, _) ->
+      pat, Some (quote_expression transl stage exp)
+  in
+  let idents = pat_bound_idents pat in
+  let names =
+    List.map (fun s -> apply loc Name.mk [string loc (Ident.name s)]) idents
+  in
+  let fun_rem = func idents (pair (quote_value_pattern pat, with_newtypes)) in
+  apply loc Function.param
+    [ quote_arg_label loc param.fp_arg_label;
+      option opt_exp;
+      quote_loc loc;
+      mk_list names;
+      fun_rem ]
+
+and quote_function transl stage loc fn =
+  match fn with
+  | Texp_function fn ->
+    let fn_body =
+      match fn.body with
+      | Tfunction_body exp ->
+        apply loc Function.body [quote_expression transl stage exp]
+      | Tfunction_cases cases ->
+        apply loc Function.cases
+          [ mk_list
+              (List.map
+                 (fun fc ->
+                   quote_case_binding fc.c_lhs.pat_loc
+                     (case_value_pattern_binding transl stage fc))
+                 cases.fc_cases) ]
+    in
+    List.fold_right (fun_param_binding transl stage loc) fn.params fn_body
+  | _ -> fatal_error "Unexpected usage of quote_function."
 
 and quote_expression_extra transl stage extra lambda =
+  let extra, loc, _ = extra in
   match extra with
-  | _ -> failwith "Not implemented"
+  | Texp_newtype (id, sloc, _, _) -> quote_newtype loc id sloc lambda
+  | _ ->
+    failwith "Not implemented yet" (* TODO: type constraints and the rest *)
 
 and quote_expression transl stage e =
   let env = e.exp_env in
   let loc = e.exp_loc in
   let body =
     match e.exp_desc with
-    | Texp_ident(path, _, _) -> begin
-        match lid_of_path path with
-        | Some lid ->
-            let lid = apply loc Ident.unmarshall [marshall lid] in
-            apply loc Exp.ident [quote_loc loc; lid]
-        | None ->
-            match path with
-            | Pident id ->
-                (* TODO: properly check stage *)
-                apply loc Exp.var [quote_loc loc; Lvar id]
-            | Pdot _ | Papply _ ->
-                fatal_error "No global path for identifier"
-      end
+    | Texp_ident (path, _, _, _, _) -> (
+      match lid_of_path path with
+      | Some lid ->
+        let lid = apply loc Identifier.name [marshal loc lid] in
+        apply loc Exp.ident [lid]
+      | None -> (
+        match path with
+        | Pident id ->
+          (* TODO: properly check stage *)
+          apply loc Exp.var [Lvar id]
+        | _ -> fatal_error "No global path for identifier"))
     | Texp_constant const ->
-        let const = quote_constant loc const in
-        apply loc Exp.constant [quote_loc loc; const]
-    | Texp_let of rec_flag * value_binding list * expression
-    | Texp_function(label, cases, _) -> begin
-        let cbs = List.map (case_binding transl stage) cases in
-        match cbs with
-        | [Non_binding(pat, exp)] ->
-            let label = quote_label label in
-            apply loc Exp.fun_nonbinding [quote_loc loc; label; pat; exp]
-        | [Simple(name, body)] ->
-            let label = quote_label label in
-            apply loc Exp.fun_simple [quote_loc loc; name; label; body]
-        | [Pattern(names, body)] ->
-            let label = quote_label label in
-            apply loc Exp.fun_ [quote_loc loc; names; label; body]
-        | cases ->
-            let cases = List.map (quote_case_binding loc) cases in
-            apply loc Exp.function_ [quote_loc loc; list cases]
-      end
-    | Texp_apply(fn, args) ->
-        let fn = quote_expression transl stage fn in
-        let args = List.filter (fun (_, exp, _) -> exp <> None) args in
-        let args =
+      let const = quote_constant loc const in
+      apply loc Exp.constant [const]
+    | Texp_let (rec_flag, vbs, exp) -> (
+      match rec_flag with
+      | Recursive ->
+        let names_defs =
           List.map
-            (fun (lbl, exp, _) ->
-              match exp with
-              | None -> assert false
-              | Some exp ->
-                  let lbl = quote_label loc lbl in
-                  let exp = quote_expression transl stage exp in
-                  pair (lbl, exp))
-            args
+            (fun vb ->
+              match vb.vb_pat.pat_desc with
+              | Tpat_var (ident, _, _, _) -> ident, vb.vb_expr
+              | _ -> assert false)
+            vbs
         in
-        apply loc Exp.apply [quote_loc loc; fn; list args]
-    | Texp_match(exp, cases, exn_cases, _) ->
-        let exp = quote_expression transl stage exp in
-        let cases = List.map (quote_case false transl stage loc) cases in
-        let exn_cases = List.map (quote_case true transl stage loc) exn_cases in
-        apply loc Exp.match_ [quote_loc loc; exp; list (cases @ exn_cases)]
-    | Texp_try(exp, cases) ->
-        let exp = quote_expression transl stage exp in
-        let cases = List.map (quote_case false transl stage loc) cases in
-        apply loc Exp.try_ [quote_loc loc; exp; list cases]
-    | Texp_tuple exps ->
-        let exps = List.map (quote_expression transl stage) exps in
-        apply loc Exp.tuple [quote_loc loc; list exps]
-    | Texp_construct(lid, constr, args) ->
-        let constr = quote_constructor env lid.loc constr in
-        let args =
-          match args with
-          | [] -> None
-          | _ :: _ ->
-              let args = List.map (quote_expression transl stage) args in
-              Some (apply loc Pat.tuple [quote_loc loc; list args])
-        in
-        apply loc Exp.construct [quote_loc loc; constr; option args]
-    | Texp_variant(variant, argo) ->
-        let variant = quote_variant loc variant in
-        let argo = Utils.may_map (quote_expression transl stage) argo in
-        apply loc Exp.variant [quote_loc loc; variant; option argo]
-    | Texp_record(lbl_exps, base) ->
-        let lbl_exps =
+        let idents, defs = List.split names_defs in
+        let names_lam =
           List.map
-            (fun (lid, lbl, exp) ->
-              let lbl = quote_record_label env lid.loc lbl in
+            (fun s -> apply loc Name.mk [string loc (Ident.name s)])
+            idents
+        in
+        let defs_lam = List.map (quote_expression transl stage) defs in
+        let frest =
+          func idents
+            (pair (mk_list defs_lam, quote_expression transl stage exp))
+        in
+        apply loc Exp.let_rec_simple [quote_loc loc; mk_list names_lam; frest]
+      | Nonrecursive ->
+        List.fold_right
+          (fun vb lexp ->
+            let pat = vb.vb_pat in
+            let idents = pat_bound_idents pat in
+            let names_lam =
+              List.map
+                (fun s -> apply loc Name.mk [string loc (Ident.name s)])
+                idents
+            in
+            let def = quote_expression transl stage vb.vb_expr in
+            let frest = func idents (pair (quote_value_pattern pat, lexp)) in
+            apply loc Exp.let_ [quote_loc loc; mk_list names_lam; def; frest])
+          vbs
+          (quote_expression transl stage exp))
+    | Texp_function fun_spec ->
+      let fn = quote_function transl stage loc (Texp_function fun_spec) in
+      apply loc Exp.function_ [fn]
+    | Texp_apply (fn, args, _, _, _) ->
+      let fn = quote_expression transl stage fn in
+      let args =
+        List.filter
+          (fun (_, exp) -> match exp with Omitted _ -> false | _ -> true)
+          args
+      in
+      let args =
+        List.map
+          (fun (lbl, exp) ->
+            match exp with
+            | Omitted _ -> assert false
+            | Arg (exp, _) ->
+              let lbl = quote_arg_label loc lbl in
               let exp = quote_expression transl stage exp in
               pair (lbl, exp))
-            lbl_exps
+          args
+      in
+      apply loc Exp.apply [fn; mk_list args]
+    | Texp_match (exp, _, cases, _) ->
+      let exp = quote_expression transl stage exp in
+      let cases = List.map (quote_case transl stage loc) cases in
+      apply loc Exp.match_ [exp; mk_list cases]
+    | Texp_try (exp, cases) ->
+      let exp = quote_expression transl stage exp in
+      let cases = List.map (quote_value_pattern_case transl stage loc) cases in
+      apply loc Exp.try_ [exp; mk_list cases]
+    | Texp_tuple (exps, _) ->
+      let exps =
+        List.map
+          (fun (lab, exp) ->
+            pair (string_option loc lab, quote_expression transl stage exp))
+          exps
+      in
+      apply loc Exp.tuple [mk_list exps]
+    | Texp_construct (lid, constr, args, _) ->
+      let constr = quote_constructor env lid.loc constr in
+      let args =
+        match args with
+        | [] -> None
+        | _ :: _ ->
+          let args = List.map (quote_expression transl stage) args in
+          Some (apply loc Pat.tuple [mk_list args])
+      in
+      apply loc Exp.construct [constr; option args]
+    | Texp_variant (variant, argo) ->
+      let variant = quote_variant loc variant in
+      let argo =
+        Option.map (fun (arg, _) -> quote_expression transl stage arg) argo
+      in
+      apply loc Exp.variant [variant; option argo]
+    | Texp_record record ->
+      let lbl_exps =
+        Array.map
+          (fun (lbl, def) ->
+            let lbl = quote_record_label env loc lbl in
+            let exp =
+              match def with
+              | Overridden (_, exp) -> quote_expression transl stage exp
+              | Kept _ ->
+                fatal_error "No support for record update syntax in quotations"
+            in
+            pair (lbl, exp))
+          record.fields
+      in
+      let base =
+        Option.map
+          (fun (e, _) -> quote_expression transl stage e)
+          record.extended_expression
+      in
+      apply loc Exp.record [mk_list (Array.to_list lbl_exps); option base]
+    | Texp_field (rcd, lid, lbl, _, _) ->
+      let rcd = quote_expression transl stage rcd in
+      let lbl = quote_record_label env lid.loc lbl in
+      apply loc Exp.field [rcd; lbl]
+    | Texp_setfield (rcd, _, lid, lbl, exp) ->
+      let rcd = quote_expression transl stage rcd in
+      let lbl = quote_record_label env lid.loc lbl in
+      let exp = quote_expression transl stage exp in
+      apply loc Exp.setfield [rcd; lbl; exp]
+    | Texp_array (_, _, exps, _) ->
+      let exps = List.map (quote_expression transl stage) exps in
+      apply loc Exp.array [mk_list exps]
+    | Texp_ifthenelse (cond, then_, else_) ->
+      let cond = quote_expression transl stage cond in
+      let then_ = quote_expression transl stage then_ in
+      let else_ = Option.map (quote_expression transl stage) else_ in
+      apply loc Exp.ifthenelse [cond; then_; option else_]
+    | Texp_sequence (exp1, _, exp2) ->
+      let exp1 = quote_expression transl stage exp1 in
+      let exp2 = quote_expression transl stage exp2 in
+      apply loc Exp.sequence [exp1; exp2]
+    | Texp_while wh ->
+      let cond = quote_expression transl stage wh.wh_cond in
+      let body = quote_expression transl stage wh.wh_body in
+      apply loc Exp.while_ [cond; body]
+    | Texp_for floop ->
+      let low = quote_expression transl stage floop.for_from in
+      let high = quote_expression transl stage floop.for_to in
+      let dir =
+        match floop.for_dir with
+        | Asttypes.Upto -> true_
+        | Asttypes.Downto -> false_
+      in
+      let name = mkloc (Ident.name floop.for_id) loc in
+      let name = quote_name name in
+      let body = quote_expression transl stage floop.for_body in
+      apply loc Exp.for_simple [name; low; high; dir; func [floop.for_id] body]
+    | Texp_send (obj, meth, _) ->
+      let obj = quote_expression transl stage obj in
+      let meth = quote_method loc meth in
+      apply loc Exp.send [obj; meth]
+    | Texp_open (open_decl, exp) -> (
+      match open_decl.open_expr.mod_desc with
+      | Tmod_ident (_, lid) ->
+        let override =
+          match open_decl.open_override with Override -> true | Fresh -> false
         in
-        let base = Misc.may_map quote_expression base in
-        apply loc Exp.record [quote_loc loc; list lbl_exps; option base]
-    | Texp_field(rcd, lid, lbl) ->
-        let rcd = quote_expression transl stage rcd in
-        let lbl = quote_record_label env lid.loc lbl in
-        apply loc Exp.field [quote_loc loc; rcd; lbl]
-    | Texp_setfield(rcd, lid, lbl, exp) ->
-        let rcd = quote_expression transl stage rcd in
-        let lbl = quote_record_label env lid.loc lbl in
         let exp = quote_expression transl stage exp in
-        apply loc Exp.setfield [quote_loc loc; rcd; lbl; exp]
-    | Texp_array exps ->
-        let exps = List.map (quote_expression transl stage) exps in
-        apply loc Exp.array [quote_loc loc; list exps]
-    | Texp_ifthenelse(cond, then_, else_) ->
-        let cond = quote_expression transl stage cond in
-        let then_ = quote_expression transl stage then_ in
-        let else_ = Utils.may_map (quote_expression transl stage) else_ in
-        apply loc Exp.ifthenelse [quote_loc loc; cond; then_; option else_]
-    | Texp_sequence(exp1, exp2) ->
-        let exp1 = quote_expression transl stage exp1 in
-        let exp2 = quote_expression transl stage exp2 in
-        apply loc Exp.sequence [quote_loc loc; exp1; exp2]
-    | Texp_while(cond, body) ->
-        let cond = quote_expression transl stage cond in
-        let body = quote_expression transl stage body in
-        apply loc Exp.while_ [quote_loc loc; cond; body]
-    | Texp_for(_, pat, low, high, dir, body) -> begin
-        let low = quote_expression transl stage low in
-        let high = quote_expression transl stage high in
-        let dir =
-          match dir with
-          | Asttype.Upto -> true_
-          | Astype.Downto -> false_
-        in
-        match pat with
-        | Tpat_var(id, name) ->
-            let name = quote_name name.loc name in
-            let body = quote_expression transl stage case.c_rhs in
-            apply loc Exp.for_simple
-              [quote_loc loc; name; low; high; dir; func [id] body]
-        | pat ->
-            let pat = quote_pattern pat in
-            let body = quote_expression transl stage body in
-            apply loc Exp.for_nonbinding
-              [quote_loc loc; pat; low; high; dir; body]
-      end
-    | Texp_send(obj, meth, _) ->
-        let obj = quote_expression transl stage obj in
-        let meth = quote_method meth in
-        apply loc Exp.send [quote_loc loc; obj; meth]
-    | Texp_assert exp ->
-        let exp = quote_expression transl stage exp in
-        apply loc Exp.assert_ [quote_loc loc; exp]
+        let lid = apply loc Identifier.name [marshal loc lid] in
+        apply loc Exp.open_ [quote_bool override; lid; exp]
+      | _ -> fatal_error "Unsupported module open syntax" (* TODO *))
+    | Texp_assert (exp, _) ->
+      let exp = quote_expression transl stage exp in
+      apply loc Exp.assert_ [exp]
     | Texp_lazy exp ->
-        let exp = quote_expression transl stage exp in
-        apply loc Exp.lazy_ [quote_loc loc; exp]
-    | Texp_quote exp ->
-        let exp = quote_expression (stage + 1) exp in
-        apply loc Exp.quote_ [quote_loc loc; exp]
-    | Texp_escape exp ->
-        if stage > 0 then begin
-            let exp = quote_expression (stage + 1) exp in
-            apply loc Exp.escape_ [quote_loc loc; exp]
-          end else transl exp
+      let exp = quote_expression transl stage exp in
+      apply loc Exp.lazy_ [exp]
+    | Texp_quotation exp ->
+      let exp = quote_expression transl (stage + 1) exp in
+      apply loc Exp.quote [exp]
+    | Texp_antiquotation exp ->
+      if stage > 0
+      then
+        let exp = quote_expression transl (stage + 1) exp in
+        apply loc Exp.antiquote [exp]
+      else transl exp
     | Texp_new _ | Texp_instvar _ | Texp_setinstvar _ | Texp_override _
-      | Texp_letmodule _ | Texp_object _ | Texp_pack _ ->
-        fatal_error "Expression cannot be quoted"
+    | Texp_letmodule _ | Texp_object _ | Texp_pack _ | Texp_unreachable
+    | Texp_src_pos | Texp_unboxed_tuple _ | Texp_record_unboxed_product _
+    | Texp_unboxed_field _ | Texp_list_comprehension _
+    | Texp_array_comprehension _ | Texp_letexception _ | Texp_letop _
+    | Texp_extension_constructor _ | Texp_probe _ | Texp_probe_is_enabled _
+    | Texp_exclave _ | Texp_overwrite _ | Texp_hole _ ->
+      fatal_error "Expression cannot be quoted"
   in
-  List.fold_right
-    (quote_expression_extra transl stage)
-    e.exp_extra body
+  List.fold_right (quote_expression_extra transl stage) e.exp_extra body
 
-let transl_quote =
+let transl_quote transl exp = quote_expression transl 0 exp

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -651,17 +651,17 @@ let mk_exp_noattr loc desc = apply loc Exp.mk [desc; nil]
 let quote_attributes e =
   let quoted_attr (attr : Typedtree.attribute) =
     match attr.attr_name.txt with
-    | "Inline" -> use Exp_attribute.inline
-    | "Inlined" -> use Exp_attribute.inlined
-    | "Specialise" -> use Exp_attribute.specialise
-    | "Specialised" -> use Exp_attribute.specialised
-    | "Unrolled" -> use Exp_attribute.unrolled
-    | "Nontail" -> use Exp_attribute.nontail
-    | "Tail" -> use Exp_attribute.tail
-    | "Poll" -> use Exp_attribute.poll
-    | "Loop" -> use Exp_attribute.loop
-    | "Tail_mod_cons" -> use Exp_attribute.tail_mod_cons
-    | "Quotation" -> use Exp_attribute.quotation
+    | "inline" -> use Exp_attribute.inline
+    | "inlined" -> use Exp_attribute.inlined
+    | "specialise" -> use Exp_attribute.specialise
+    | "specialised" -> use Exp_attribute.specialised
+    | "unrolled" -> use Exp_attribute.unrolled
+    | "nontail" -> use Exp_attribute.nontail
+    | "tail" -> use Exp_attribute.tail
+    | "poll" -> use Exp_attribute.poll
+    | "loop" -> use Exp_attribute.loop
+    | "tail_mod_cons" -> use Exp_attribute.tail_mod_cons
+    | "quotation" -> use Exp_attribute.quotation
     | _ -> fatal_error "Unknown attribute"
   in
   mk_list (List.map quoted_attr e.exp_attributes)

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -6,7 +6,7 @@ open Types
 open Debuginfo.Scoped_location
 open Longident
 
-type fv_env = (Ident.t, lambda) Hashtbl.t  (* maps identifiers to lambda *)
+type fv_env = (Ident.t, lambda) Hashtbl.t (* maps identifiers to lambda *)
 
 (* maps names of poly type variables to lambda *)
 type ptv_env = (string, Ident.t * lambda) Hashtbl.t
@@ -15,14 +15,14 @@ type var_env =
   { env_vals : fv_env;
     env_tys : fv_env;
     env_mod : fv_env;
-    env_poly : ptv_env;
+    env_poly : ptv_env
   }
 
 let vars_env =
-  {env_vals = Hashtbl.create 64;
-   env_tys = Hashtbl.create 64;
-   env_mod = Hashtbl.create 64;
-   env_poly = Hashtbl.create 64;
+  { env_vals = Hashtbl.create 64;
+    env_tys = Hashtbl.create 64;
+    env_mod = Hashtbl.create 64;
+    env_poly = Hashtbl.create 64
   }
 
 let rec print_path = function
@@ -32,24 +32,27 @@ let rec print_path = function
   | Path.Pextra_ty (p, _) -> print_path p ^ "[extra]"
 
 let with_new_value name val_ = Hashtbl.add vars_env.env_vals name val_
+
 let with_new_type name ty = Hashtbl.add vars_env.env_tys name ty
+
 let with_new_module name mod_ = Hashtbl.add vars_env.env_mod name mod_
 
-let with_new_idents_values =
-  List.iter (fun id -> with_new_value id (Lvar id))
+let with_new_idents_values = List.iter (fun id -> with_new_value id (Lvar id))
 
-let with_new_idents_types =
-  List.iter (fun id -> with_new_type id (Lvar id))
+let with_new_idents_types = List.iter (fun id -> with_new_type id (Lvar id))
 
-let with_new_idents_modules =
-  List.iter (fun id -> with_new_module id (Lvar id))
+let with_new_idents_modules = List.iter (fun id -> with_new_module id (Lvar id))
 
 let without_value name = Hashtbl.remove vars_env.env_vals name
+
 let without_type name = Hashtbl.remove vars_env.env_tys name
+
 let without_module name = Hashtbl.remove vars_env.env_mod name
 
 let without_idents_values = List.iter without_value
+
 let without_idents_types = List.iter without_type
+
 let without_idents_modules = List.iter without_module
 
 let with_poly_type name =
@@ -57,11 +60,14 @@ let with_poly_type name =
   Hashtbl.add vars_env.env_poly name (id, Lvar id)
 
 let without_poly_type name = Hashtbl.remove vars_env.env_poly name
+
 let with_new_idents_poly = List.iter with_poly_type
+
 let without_idents_poly = List.iter without_poly_type
 
 let ident_for_poly_name name =
-  let (ident, _) = Hashtbl.find vars_env.env_poly name in ident
+  let ident, _ = Hashtbl.find vars_env.env_poly name in
+  ident
 
 let camlinternalQuote =
   lazy
@@ -418,7 +424,8 @@ module Function = struct
 
   let param = combinator "Function" "param" 5
 
-  let param_module_nonbinding = combinator "Function" "param_module_nonbinding" 4
+  let param_module_nonbinding =
+    combinator "Function" "param_module_nonbinding" 4
 
   let param_module = combinator "Function" "param_module" 4
 
@@ -449,90 +456,118 @@ module Type_constraint = struct
   let coercion = combinator "Type_constraint" "coercion" 2
 end
 
+module Exp_desc = struct
+  let ident = combinator "Exp_desc" "ident" 1
+
+  let constant = combinator "Exp_desc" "constant" 1
+
+  let let_rec_simple = combinator "Exp_desc" "let_rec_simple" 3
+
+  let let_ = combinator "Exp_desc" "let_" 5
+
+  let function_ = combinator "Exp_desc" "function_" 1
+
+  let apply = combinator "Exp_desc" "apply" 2
+
+  let match_ = combinator "Exp_desc" "match_" 2
+
+  let try_ = combinator "Exp_desc" "try_" 2
+
+  let tuple = combinator "Exp_desc" "tuple" 1
+
+  let construct = combinator "Exp_desc" "construct" 2
+
+  let variant = combinator "Exp_desc" "variant" 2
+
+  let record = combinator "Exp_desc" "record" 2
+
+  let field = combinator "Exp_desc" "field" 2
+
+  let setfield = combinator "Exp_desc" "setfield" 3
+
+  let array = combinator "Exp_desc" "array" 1
+
+  let ifthenelse = combinator "Exp_desc" "ifthenelse" 3
+
+  let sequence = combinator "Exp_desc" "sequence" 2
+
+  let while_ = combinator "Exp_desc" "while_" 2
+
+  let for_simple = combinator "Exp_desc" "for_simple" 6
+
+  let unboxed_tuple = combinator "Exp_desc" "unboxed_tuple" 1
+
+  let unboxed_record_product = combinator "Exp_desc" "unboxed_record_product" 2
+
+  let unboxed_field = combinator "Exp_desc" "unboxed_field" 2
+
+  let pack = combinator "Exp_desc" "pack" 1
+
+  let unreachable = combinator "Exp_desc" "unreachable" 0
+
+  let src_pos = combinator "Exp_desc" "src_pos" 0
+
+  let exclave = combinator "Exp_desc" "exclave" 1
+
+  let extension_constructor = combinator "Exp_desc" "extension_constructor" 1
+
+  let list_comprehension = combinator "Exp_desc" "list_comprehension" 1
+
+  let array_comprehension = combinator "Exp_desc" "array_comprehension" 1
+
+  let let_exception = combinator "Exp_desc" "let_exception" 2
+
+  let let_op = combinator "Exp_desc" "let_op" 3
+
+  let new_ = combinator "Exp_desc" "new_" 1
+
+  let send = combinator "Exp_desc" "send" 2
+
+  let assert_ = combinator "Exp_desc" "assert_" 1
+
+  let stack = combinator "Exp_desc" "stack" 1
+
+  let lazy_ = combinator "Exp_desc" "lazy_" 1
+
+  let letmodule_nonbinding = combinator "Exp_desc" "letmodule_nonbinding" 3
+
+  let letmodule = combinator "Exp_desc" "letmodule" 4
+
+  let constraint_ = combinator "Exp_desc" "constraint_" 2
+
+  let quote = combinator "Exp_desc" "quote" 1
+
+  let antiquote = combinator "Exp_desc" "antiquote" 1
+
+  let splice = combinator "Exp_desc" "splice" 1
+end
+
+module Exp_attribute = struct
+  let inline = combinator "Exp_attribute" "inline" 0
+
+  let inlined = combinator "Exp_attribute" "inlined" 0
+
+  let specialise = combinator "Exp_attribute" "specialise" 0
+
+  let specialised = combinator "Exp_attribute" "specialised" 0
+
+  let unrolled = combinator "Exp_attribute" "unrolled" 0
+
+  let nontail = combinator "Exp_attribute" "nontail" 0
+
+  let tail = combinator "Exp_attribute" "tail" 0
+
+  let poll = combinator "Exp_attribute" "poll" 0
+
+  let loop = combinator "Exp_attribute" "loop" 0
+
+  let tail_mod_cons = combinator "Exp_attribute" "tail_mod_cons" 0
+
+  let quotation = combinator "Exp_attribute" "quotation" 0
+end
+
 module Exp = struct
-  let ident = combinator "Exp" "ident" 1
-
-  let constant = combinator "Exp" "constant" 1
-
-  let let_rec_simple = combinator "Exp" "let_rec_simple" 3
-
-  let let_ = combinator "Exp" "let_" 5
-
-  let function_ = combinator "Exp" "function_" 1
-
-  let apply = combinator "Exp" "apply" 2
-
-  let match_ = combinator "Exp" "match_" 2
-
-  let try_ = combinator "Exp" "try_" 2
-
-  let tuple = combinator "Exp" "tuple" 1
-
-  let construct = combinator "Exp" "construct" 2
-
-  let variant = combinator "Exp" "variant" 2
-
-  let record = combinator "Exp" "record" 2
-
-  let field = combinator "Exp" "field" 2
-
-  let setfield = combinator "Exp" "setfield" 3
-
-  let array = combinator "Exp" "array" 1
-
-  let ifthenelse = combinator "Exp" "ifthenelse" 3
-
-  let sequence = combinator "Exp" "sequence" 2
-
-  let while_ = combinator "Exp" "while_" 2
-
-  let for_simple = combinator "Exp" "for_simple" 6
-
-  let unboxed_tuple = combinator "Exp" "unboxed_tuple" 1
-
-  let unboxed_record_product = combinator "Exp" "unboxed_record_product" 2
-
-  let unboxed_field = combinator "Exp" "unboxed_field" 2
-
-  let pack = combinator "Exp" "pack" 1
-
-  let unreachable = combinator "Exp" "unreachable" 0
-
-  let src_pos = combinator "Exp" "src_pos" 0
-
-  let exclave = combinator "Exp" "exclave" 1
-
-  let extension_constructor = combinator "Exp" "extension_constructor" 1
-
-  let list_comprehension = combinator "Exp" "list_comprehension" 1
-
-  let array_comprehension = combinator "Exp" "array_comprehension" 1
-
-  let let_exception = combinator "Exp" "let_exception" 2
-
-  let let_op = combinator "Exp" "let_op" 3
-
-  let new_ = combinator "Exp" "new_" 1
-
-  let send = combinator "Exp" "send" 2
-
-  let assert_ = combinator "Exp" "assert_" 1
-
-  let stack = combinator "Exp" "stack" 1
-
-  let lazy_ = combinator "Exp" "lazy_" 1
-
-  let letmodule_nonbinding = combinator "Exp" "letmodule_nonbinding" 3
-
-  let letmodule = combinator "Exp" "letmodule" 4
-
-  let constraint_ = combinator "Exp" "constraint_" 2
-
-  let quote = combinator "Exp" "quote" 1
-
-  let antiquote = combinator "Exp" "antiquote" 1
-
-  let splice = combinator "Exp" "splice" 1
+  let mk = combinator "Exp" "mk" 2
 end
 
 module Code = struct
@@ -546,7 +581,7 @@ end
 let use comb = Lazy.force comb
 
 let apply loc comb args =
-  let comb = Lazy.force comb in
+  let comb = use comb in
   Lambda.Lapply
     { ap_func = comb;
       ap_args = args;
@@ -611,6 +646,26 @@ let func ids body =
 
 let bind id def body = Llet (Strict, Ptop, id, def, body)
 
+let mk_exp_noattr loc desc = apply loc Exp.mk [desc; nil]
+
+let quote_attributes e =
+  let quoted_attr (attr : Typedtree.attribute) =
+    match attr.attr_name.txt with
+    | "Inline" -> use Exp_attribute.inline
+    | "Inlined" -> use Exp_attribute.inlined
+    | "Specialise" -> use Exp_attribute.specialise
+    | "Specialised" -> use Exp_attribute.specialised
+    | "Unrolled" -> use Exp_attribute.unrolled
+    | "Nontail" -> use Exp_attribute.nontail
+    | "Tail" -> use Exp_attribute.tail
+    | "Poll" -> use Exp_attribute.poll
+    | "Loop" -> use Exp_attribute.loop
+    | "Tail_mod_cons" -> use Exp_attribute.tail_mod_cons
+    | "Quotation" -> use Exp_attribute.quotation
+    | _ -> fatal_error "Unknown attribute"
+  in
+  mk_list (List.map quoted_attr e.exp_attributes)
+
 let quote_constant loc (const : Typedtree.constant) =
   match const with
   | Const_int x -> apply loc Constant.int [Lconst (Const_base (Const_int x))]
@@ -672,7 +727,7 @@ let quote_method loc (meth : Typedtree.meth) =
 let quote_arg_label loc = function
   | Labelled s -> apply loc Label.labelled [string loc s]
   | Optional s -> apply loc Label.optional [string loc s]
-  | Nolabel -> Lazy.force Label.no_label
+  | Nolabel -> use Label.no_label
   | _ ->
     fatal_error
       "No support for any types of labels other than Labelled, Nolabel and \
@@ -680,64 +735,64 @@ let quote_arg_label loc = function
 
 let rec module_for_path loc = function
   | Path.Pident id -> (
-      match Hashtbl.find_opt vars_env.env_mod id with
-      | Some m -> apply loc Identifier.Module.var [m; quote_loc loc]
-      | None ->
-        if Ident.is_global id
-        then
-          apply loc Identifier.Module.compilation_unit [string loc (Ident.name id)]
-        else raise Exit)
+    match Hashtbl.find_opt vars_env.env_mod id with
+    | Some m -> apply loc Identifier.Module.var [m; quote_loc loc]
+    | None ->
+      if Ident.is_global id
+      then
+        apply loc Identifier.Module.compilation_unit [string loc (Ident.name id)]
+      else raise Exit)
   | Path.Pdot (p, s) ->
     apply loc Identifier.Module.dot [module_for_path loc p; string loc s]
   | _ -> raise Exit
 
 let module_type_for_path loc = function
-  | Path.Pident id -> apply loc Module_type.of_string [string loc (Ident.name id)]
+  | Path.Pident id ->
+    apply loc Module_type.of_string [string loc (Ident.name id)]
   | Path.Pdot (p, s) ->
     apply loc Module_type.ident
-      [apply loc Identifier.Module_type.dot [module_for_path loc p; string loc s]]
+      [ apply loc Identifier.Module_type.dot
+          [module_for_path loc p; string loc s] ]
   | _ -> raise Exit
 
-let type_for_path loc =
-  function
+let type_for_path loc = function
   | Path.Pident id -> (
-      match Hashtbl.find_opt vars_env.env_tys id with
+    match Hashtbl.find_opt vars_env.env_tys id with
     | Some t -> apply loc Identifier.Type.var [t; quote_loc loc]
-    | None ->
-        match Ident.name id with
-        | "int" -> Lazy.force Identifier.Type.int
-        | "char" -> Lazy.force Identifier.Type.char
-        | "string" -> Lazy.force Identifier.Type.string
-        | "bytes" -> Lazy.force Identifier.Type.bytes
-        | "float" -> Lazy.force Identifier.Type.float
-        | "float32" -> Lazy.force Identifier.Type.float32
-        | "bool" -> Lazy.force Identifier.Type.bool
-        | "unit" -> Lazy.force Identifier.Type.unit
-        | "exn" -> Lazy.force Identifier.Type.exn
-        | "array" -> Lazy.force Identifier.Type.array
-        | "iarray" -> Lazy.force Identifier.Type.iarray
-        | "list" -> Lazy.force Identifier.Type.list
-        | "option" -> Lazy.force Identifier.Type.option
-        | "nativeint" -> Lazy.force Identifier.Type.nativeint
-        | "int32" -> Lazy.force Identifier.Type.int32
-        | "int64" -> Lazy.force Identifier.Type.int64
-        | "lazy_t" -> Lazy.force Identifier.Type.lazy_t
-        | "extension_constructor" ->
-          Lazy.force Identifier.Type.extension_constructor
-        | "floatarray" -> Lazy.force Identifier.Type.floatarray
-        | "lexing_position" -> Lazy.force Identifier.Type.lexing_position
-        | "code" -> Lazy.force Identifier.Type.code
-        | "unboxed_float" -> Lazy.force Identifier.Type.unboxed_float
-        | "unboxed_nativeint" -> Lazy.force Identifier.Type.unboxed_nativeint
-        | "unboxed_int32" -> Lazy.force Identifier.Type.unboxed_int32
-        | "unboxed_int64" -> Lazy.force Identifier.Type.unboxed_int64
-        | "int8x16" -> Lazy.force Identifier.Type.int8x16
-        | "int16x8" -> Lazy.force Identifier.Type.int16x8
-        | "int32x4" -> Lazy.force Identifier.Type.int32x4
-        | "int64x2" -> Lazy.force Identifier.Type.int64x2
-        | "float32x4" -> Lazy.force Identifier.Type.float32x4
-        | "float62x2" -> Lazy.force Identifier.Type.float64x2
-        | _ -> raise Exit)
+    | None -> (
+      match Ident.name id with
+      | "int" -> use Identifier.Type.int
+      | "char" -> use Identifier.Type.char
+      | "string" -> use Identifier.Type.string
+      | "bytes" -> use Identifier.Type.bytes
+      | "float" -> use Identifier.Type.float
+      | "float32" -> use Identifier.Type.float32
+      | "bool" -> use Identifier.Type.bool
+      | "unit" -> use Identifier.Type.unit
+      | "exn" -> use Identifier.Type.exn
+      | "array" -> use Identifier.Type.array
+      | "iarray" -> use Identifier.Type.iarray
+      | "list" -> use Identifier.Type.list
+      | "option" -> use Identifier.Type.option
+      | "nativeint" -> use Identifier.Type.nativeint
+      | "int32" -> use Identifier.Type.int32
+      | "int64" -> use Identifier.Type.int64
+      | "lazy_t" -> use Identifier.Type.lazy_t
+      | "extension_constructor" -> use Identifier.Type.extension_constructor
+      | "floatarray" -> use Identifier.Type.floatarray
+      | "lexing_position" -> use Identifier.Type.lexing_position
+      | "code" -> use Identifier.Type.code
+      | "unboxed_float" -> use Identifier.Type.unboxed_float
+      | "unboxed_nativeint" -> use Identifier.Type.unboxed_nativeint
+      | "unboxed_int32" -> use Identifier.Type.unboxed_int32
+      | "unboxed_int64" -> use Identifier.Type.unboxed_int64
+      | "int8x16" -> use Identifier.Type.int8x16
+      | "int16x8" -> use Identifier.Type.int16x8
+      | "int32x4" -> use Identifier.Type.int32x4
+      | "int64x2" -> use Identifier.Type.int64x2
+      | "float32x4" -> use Identifier.Type.float32x4
+      | "float62x2" -> use Identifier.Type.float64x2
+      | _ -> raise Exit))
   | Path.Pdot (p, s) ->
     apply loc Identifier.Type.dot [module_for_path loc p; string loc s]
   | _ -> raise Exit
@@ -748,24 +803,22 @@ let value_for_path loc = function
   | _ -> raise Exit
 
 let value_for_path_opt loc p =
-  match value_for_path loc p with
-  | res -> Some res
-  | exception Exit -> None
+  match value_for_path loc p with res -> Some res | exception Exit -> None
 
 let quote_value_ident_path loc path =
   match value_for_path_opt loc path with
   | Some ident_val -> ident_val
   | None -> (
-      match path with
-      | Path.Pident id ->
-        if Hashtbl.mem vars_env.env_vals id
-        then apply loc Identifier.Value.var [Lvar id; quote_loc loc]
-        else fatal_error ("Cannot quote free variable " ^ Ident.name id)
-      | Path.Pdot _ | Path.Papply _ | Path.Pextra_ty _  ->
-        fatal_error ("No global path for identifier " ^ print_path path))
+    match path with
+    | Path.Pident id ->
+      if Hashtbl.mem vars_env.env_vals id
+      then apply loc Identifier.Value.var [Lvar id; quote_loc loc]
+      else fatal_error ("Cannot quote free variable " ^ Ident.name id)
+    | Path.Pdot _ | Path.Papply _ | Path.Pextra_ty _ ->
+      fatal_error ("No global path for identifier " ^ print_path path))
 
 let quote_value_ident_path_as_exp loc path =
-  apply loc Exp.ident [quote_value_ident_path loc path]
+  apply loc Exp_desc.ident [quote_value_ident_path loc path]
 
 let type_path env ty =
   let desc =
@@ -798,8 +851,8 @@ let quote_record_field env loc lbl_desc =
     apply loc Field.of_string [string loc lbl_desc.lbl_name]
   | Some (Path.Pdot (p, _)) ->
     apply loc Field.ident
-      [apply loc Identifier.Field.dot
-         [module_for_path loc p; string loc lbl_desc.lbl_name]]
+      [ apply loc Identifier.Field.dot
+          [module_for_path loc p; string loc lbl_desc.lbl_name] ]
   | _ -> fatal_error "Unsupported constructor type detected."
 
 let quote_constructor env loc constr =
@@ -807,30 +860,43 @@ let quote_constructor env loc constr =
   | None -> fatal_error "No global path for constructor"
   | Some (Path.Pident _) -> (
     match constr.cstr_name with
-    | "false" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.false_]
-    | "true" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.true_]
-    | "()" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.void]
-    | "[]" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.nil]
-    | "::" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.cons]
-    | "None" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.none]
-    | "Some" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.some]
-    | "Match_failure" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.match_failure]
-    | "Out_of_memory" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.out_of_memory]
-    | "Invalid_argument" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.invalid_argument]
-    | "Failure" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.failure]
-    | "Not_found" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.not_found]
-    | "Sys_error" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.sys_error]
-    | "End_of_file" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.end_of_file]
-    | "Division_by_zero" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.division_by_zero]
-    | "Stack_overflow" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.stack_overflow]
-    | "Sys_blocked_io" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.sys_blocked_io]
-    | "Assert_failure" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.assert_failure]
-    | "Undefined_recursive_module" -> apply loc Constructor.ident [Lazy.force Identifier.Constructor.undefined_recursive_module]
+    | "false" -> apply loc Constructor.ident [use Identifier.Constructor.false_]
+    | "true" -> apply loc Constructor.ident [use Identifier.Constructor.true_]
+    | "()" -> apply loc Constructor.ident [use Identifier.Constructor.void]
+    | "[]" -> apply loc Constructor.ident [use Identifier.Constructor.nil]
+    | "::" -> apply loc Constructor.ident [use Identifier.Constructor.cons]
+    | "None" -> apply loc Constructor.ident [use Identifier.Constructor.none]
+    | "Some" -> apply loc Constructor.ident [use Identifier.Constructor.some]
+    | "Match_failure" ->
+      apply loc Constructor.ident [use Identifier.Constructor.match_failure]
+    | "Out_of_memory" ->
+      apply loc Constructor.ident [use Identifier.Constructor.out_of_memory]
+    | "Invalid_argument" ->
+      apply loc Constructor.ident [use Identifier.Constructor.invalid_argument]
+    | "Failure" ->
+      apply loc Constructor.ident [use Identifier.Constructor.failure]
+    | "Not_found" ->
+      apply loc Constructor.ident [use Identifier.Constructor.not_found]
+    | "Sys_error" ->
+      apply loc Constructor.ident [use Identifier.Constructor.sys_error]
+    | "End_of_file" ->
+      apply loc Constructor.ident [use Identifier.Constructor.end_of_file]
+    | "Division_by_zero" ->
+      apply loc Constructor.ident [use Identifier.Constructor.division_by_zero]
+    | "Stack_overflow" ->
+      apply loc Constructor.ident [use Identifier.Constructor.stack_overflow]
+    | "Sys_blocked_io" ->
+      apply loc Constructor.ident [use Identifier.Constructor.sys_blocked_io]
+    | "Assert_failure" ->
+      apply loc Constructor.ident [use Identifier.Constructor.assert_failure]
+    | "Undefined_recursive_module" ->
+      apply loc Constructor.ident
+        [use Identifier.Constructor.undefined_recursive_module]
     | name -> apply loc Constructor.of_string [string loc name])
   | Some (Path.Pdot (p, _)) ->
     apply loc Constructor.ident
-      [apply loc Identifier.Constructor.dot
-         [module_for_path loc p; string loc constr.cstr_name]]
+      [ apply loc Identifier.Constructor.dot
+          [module_for_path loc p; string loc constr.cstr_name] ]
   | _ -> fatal_error "Unsupported constructor type detected."
 
 let quote_ext_constructor loc = function
@@ -838,8 +904,8 @@ let quote_ext_constructor loc = function
     apply loc Constructor.of_string [string loc (Ident.name id)]
   | Path.Pdot (p, s) ->
     apply loc Constructor.ident
-      [apply loc Identifier.Constructor.dot
-         [module_for_path loc p; string loc s]]
+      [ apply loc Identifier.Constructor.dot
+          [module_for_path loc p; string loc s] ]
   | _ -> fatal_error "Unsupported constructor type detected."
 
 let rec quote_fragment_of_lid loc = function
@@ -852,7 +918,7 @@ let quote_variant loc name = apply loc Variant.of_string [string loc name]
 
 let quote_nonopt loc (lbl : string option) =
   match lbl with
-  | None -> Lazy.force Label.Nonoptional.no_label
+  | None -> use Label.Nonoptional.no_label
   | Some s -> apply loc Label.Nonoptional.labelled [string loc s]
 
 let is_module pat =
@@ -862,90 +928,58 @@ let rec with_new_idents_pat pat =
   match pat.pat_desc with
   | Tpat_any -> ()
   | Tpat_var (id, _, _, _) ->
-    if is_module pat then
-      with_new_idents_modules [id]
-    else
-      with_new_idents_values [id]
+    if is_module pat
+    then with_new_idents_modules [id]
+    else with_new_idents_values [id]
   | Tpat_alias (pat, id, _, _, _) ->
     with_new_idents_values [id];
     with_new_idents_pat pat
   | Tpat_constant _ -> ()
-  | Tpat_tuple args ->
-    List.iter
-      (fun (_, pat) -> with_new_idents_pat pat)
-      args
+  | Tpat_tuple args -> List.iter (fun (_, pat) -> with_new_idents_pat pat) args
   | Tpat_construct (_, _, args, _) ->
-    List.iter
-      (fun pat -> with_new_idents_pat pat)
-      args
+    List.iter (fun pat -> with_new_idents_pat pat) args
   | Tpat_variant (_, argo, _) -> (
-      match argo with
-      | None -> ()
-      | Some pat -> with_new_idents_pat pat)
+    match argo with None -> () | Some pat -> with_new_idents_pat pat)
   | Tpat_record (lbl_pats, _) ->
-    List.iter
-      (fun (_, _, pat) -> with_new_idents_pat pat)
-      lbl_pats
+    List.iter (fun (_, _, pat) -> with_new_idents_pat pat) lbl_pats
   | Tpat_array (_, _, pats) ->
-    List.iter
-      (fun pat -> with_new_idents_pat pat)
-      pats
+    List.iter (fun pat -> with_new_idents_pat pat) pats
   | Tpat_or (pat1, pat2, _) ->
     with_new_idents_pat pat1;
     with_new_idents_pat pat2
   | Tpat_unboxed_tuple args ->
-    List.iter
-      (fun (_, pat, _) -> with_new_idents_pat pat)
-      args
+    List.iter (fun (_, pat, _) -> with_new_idents_pat pat) args
   | Tpat_record_unboxed_product (lbl_pats, _) ->
-    List.iter
-      (fun (_, _, pat) -> with_new_idents_pat pat)
-      lbl_pats
+    List.iter (fun (_, _, pat) -> with_new_idents_pat pat) lbl_pats
   | Tpat_lazy pat -> with_new_idents_pat pat
 
 let rec without_idents_pat pat =
   match pat.pat_desc with
   | Tpat_any -> ()
   | Tpat_var (id, _, _, _) ->
-    if is_module pat then
-      without_idents_modules [id]
-    else
-      without_idents_values [id]
+    if is_module pat
+    then without_idents_modules [id]
+    else without_idents_values [id]
   | Tpat_alias (pat, id, _, _, _) ->
     without_idents_values [id];
     without_idents_pat pat
   | Tpat_constant _ -> ()
-  | Tpat_tuple args ->
-    List.iter
-      (fun (_, pat) -> without_idents_pat pat)
-      args
+  | Tpat_tuple args -> List.iter (fun (_, pat) -> without_idents_pat pat) args
   | Tpat_construct (_, _, args, _) ->
-    List.iter
-      (fun pat -> without_idents_pat pat)
-      args
+    List.iter (fun pat -> without_idents_pat pat) args
   | Tpat_variant (_, argo, _) -> (
-      match argo with
-      | None -> ()
-      | Some pat -> without_idents_pat pat)
+    match argo with None -> () | Some pat -> without_idents_pat pat)
   | Tpat_record (lbl_pats, _) ->
-    List.iter
-      (fun (_, _, pat) -> without_idents_pat pat)
-      lbl_pats
+    List.iter (fun (_, _, pat) -> without_idents_pat pat) lbl_pats
   | Tpat_array (_, _, pats) ->
-    List.iter
-      (fun pat -> without_idents_pat pat)
-      pats
+    List.iter (fun pat -> without_idents_pat pat) pats
   | Tpat_or (pat1, pat2, _) ->
     without_idents_pat pat1;
     without_idents_pat pat2
   | Tpat_unboxed_tuple args ->
-    List.iter
-      (fun (_, pat, _) -> without_idents_pat pat)
-      args
+    List.iter (fun (_, pat, _) -> without_idents_pat pat) args
   | Tpat_record_unboxed_product (lbl_pats, _) ->
-    List.iter
-      (fun (_, _, pat) -> without_idents_pat pat)
-      lbl_pats
+    List.iter (fun (_, _, pat) -> without_idents_pat pat) lbl_pats
   | Tpat_lazy pat -> without_idents_pat pat
 
 let with_new_param fp =
@@ -984,34 +1018,29 @@ let rec quote_computation_pattern p =
   let loc = p.pat_loc in
   match p.pat_desc with
   | Tpat_value pat -> quote_value_pattern (pat :> value general_pattern)
-  | Tpat_exception pat ->
-    apply loc Pat.exception_ [quote_value_pattern pat]
+  | Tpat_exception pat -> apply loc Pat.exception_ [quote_value_pattern pat]
   | Tpat_or (pat1, pat2, _) ->
     let pat1 = quote_computation_pattern pat1 in
     let pat2 = quote_computation_pattern pat2 in
     apply loc Pat.exception_ [pat1; pat2]
 
 and quote_pat_extra loc pat_lam extra =
-  let (extra, _, _) = extra in
+  let extra, _, _ = extra in
   match extra with
-  | Tpat_constraint ty ->
-    apply loc Pat.constraint_ [pat_lam; quote_core_type ty]
+  | Tpat_constraint ty -> apply loc Pat.constraint_ [pat_lam; quote_core_type ty]
   | Tpat_unpack -> pat_lam (* handled elsewhere *)
   | Tpat_type _ -> pat_lam (* TODO: consider adding support for #tconst *)
   | Tpat_open _ -> fatal_error "No support for open patterns."
 
 and quote_value_pattern p =
-  let env = p.pat_env
-  and loc = p.pat_loc in
+  let env = p.pat_env and loc = p.pat_loc in
   let pat_quoted =
     match p.pat_desc with
-    | Tpat_any ->
-      if is_module p then Lazy.force Pat.any_module else Lazy.force Pat.any
+    | Tpat_any -> if is_module p then use Pat.any_module else use Pat.any
     | Tpat_var (id, _, _, _) ->
-      if is_module p then
-        apply loc Pat.unpack [Lvar id]
-      else
-        apply loc Pat.var [Lvar id]
+      if is_module p
+      then apply loc Pat.unpack [Lvar id]
+      else apply loc Pat.var [Lvar id]
     | Tpat_alias (pat, id, _, _, _) ->
       let pat = quote_value_pattern pat in
       apply loc Pat.alias [pat; Lvar id]
@@ -1021,8 +1050,7 @@ and quote_value_pattern p =
     | Tpat_tuple pats ->
       let pats =
         List.map
-          (fun (lbl, p) ->
-             pair (quote_nonopt loc lbl, quote_value_pattern p))
+          (fun (lbl, p) -> pair (quote_nonopt loc lbl, quote_value_pattern p))
           pats
       in
       apply loc Pat.tuple [mk_list pats]
@@ -1032,11 +1060,9 @@ and quote_value_pattern p =
         match args with
         | [] -> None
         | _ :: _ ->
-          let args = List.map (quote_value_pattern) args in
+          let args = List.map quote_value_pattern args in
           let with_labels =
-            List.map
-              (fun a -> pair (Lazy.force Label.Nonoptional.no_label, a))
-              args
+            List.map (fun a -> pair (use Label.Nonoptional.no_label, a)) args
           in
           let as_tuple = apply loc Pat.tuple [mk_list with_labels] in
           Some as_tuple
@@ -1044,17 +1070,15 @@ and quote_value_pattern p =
       apply loc Pat.construct [constr; option args]
     | Tpat_variant (variant, argo, _) ->
       let variant = quote_variant loc variant in
-      let argo = Option.map (quote_value_pattern) argo in
+      let argo = Option.map quote_value_pattern argo in
       apply loc Pat.variant [variant; option argo]
     | Tpat_record (lbl_pats, closed) ->
       let lbl_pats =
         List.map
           (fun (lid, lbl_desc, pat) ->
-             let lbl =
-               quote_record_field env Asttypes.(lid.loc) lbl_desc
-             in
-             let pat = quote_value_pattern pat in
-             pair (lbl, pat))
+            let lbl = quote_record_field env Asttypes.(lid.loc) lbl_desc in
+            let pat = quote_value_pattern pat in
+            pair (lbl, pat))
           lbl_pats
       in
       let closed =
@@ -1062,7 +1086,7 @@ and quote_value_pattern p =
       in
       apply loc Pat.record [mk_list lbl_pats; closed]
     | Tpat_array (_, _, pats) ->
-      let pats = List.map (quote_value_pattern) pats in
+      let pats = List.map quote_value_pattern pats in
       apply loc Pat.array [mk_list pats]
     | Tpat_or (pat1, pat2, _) ->
       let pat1 = quote_value_pattern pat1 in
@@ -1072,7 +1096,7 @@ and quote_value_pattern p =
       let pats =
         List.map
           (fun (lbl, p, _) ->
-             pair (quote_nonopt loc lbl, quote_value_pattern p))
+            pair (quote_nonopt loc lbl, quote_value_pattern p))
           pats
       in
       apply loc Pat.unboxed_tuple [mk_list pats]
@@ -1080,11 +1104,9 @@ and quote_value_pattern p =
       let lbl_pats =
         List.map
           (fun (lid, lbl_desc, pat) ->
-             let lbl =
-               quote_record_field env Asttypes.(lid.loc) lbl_desc
-             in
-             let pat = quote_value_pattern pat in
-             pair (lbl, pat))
+            let lbl = quote_record_field env Asttypes.(lid.loc) lbl_desc in
+            let pat = quote_value_pattern pat in
+            pair (lbl, pat))
           lbl_pats
       in
       let closed =
@@ -1097,8 +1119,7 @@ and quote_value_pattern p =
   in
   List.fold_right
     (fun extra p -> quote_pat_extra loc p extra)
-    p.pat_extra
-    pat_quoted
+    p.pat_extra pat_quoted
 
 and quote_core_type ty =
   let loc = ty.ctyp_loc in
@@ -1106,7 +1127,9 @@ and quote_core_type ty =
   | Ttyp_var (name, _) ->
     let id =
       Option.map
-        (fun n -> let (_, ty) = Hashtbl.find vars_env.env_poly n in ty)
+        (fun n ->
+          let _, ty = Hashtbl.find vars_env.env_poly n in
+          ty)
         name
     in
     apply loc Type.var [option id]
@@ -1118,30 +1141,28 @@ and quote_core_type ty =
   | Ttyp_tuple ts ->
     let tups =
       List.map
-        (fun (s_opt, ty) ->
-          pair (quote_nonopt loc s_opt, quote_core_type ty))
+        (fun (s_opt, ty) -> pair (quote_nonopt loc s_opt, quote_core_type ty))
         ts
     in
     apply loc Type.tuple [mk_list tups]
   | Ttyp_unboxed_tuple ts ->
     let tups =
       List.map
-        (fun (s_opt, ty) ->
-          pair (quote_nonopt loc s_opt, quote_core_type ty))
+        (fun (s_opt, ty) -> pair (quote_nonopt loc s_opt, quote_core_type ty))
         ts
     in
     apply loc Type.unboxed_tuple [mk_list tups]
   | Ttyp_constr (path, _, tys) ->
-    let ident = type_for_path loc path
-    and tys = List.map (quote_core_type) tys in
+    let ident = type_for_path loc path and tys = List.map quote_core_type tys in
     apply loc Type.constr [ident; mk_list tys]
   | Ttyp_object (_, _) -> fatal_error "Still not implemented."
   | Ttyp_class (_, _, _) -> fatal_error "Still not implemented."
   | Ttyp_alias (ty, alias_opt, _) ->
     let ty = quote_core_type ty
-    and alias_opt = match alias_opt with
+    and alias_opt =
+      match alias_opt with
       | None -> None
-      | Some {txt; loc} -> Some (string loc txt)
+      | Some { txt; loc } -> Some (string loc txt)
     in
     let alias_opt = option alias_opt in
     apply loc Type.alias [ty; alias_opt]
@@ -1151,30 +1172,30 @@ and quote_core_type ty =
         (fun rf ->
           match rf.rf_desc with
           | Tinherit ty ->
-            apply rf.rf_loc Variant_type.Row_field.inherit_
-              [quote_core_type ty]
+            apply rf.rf_loc Variant_type.Row_field.inherit_ [quote_core_type ty]
           | Ttag (tag, b, tys) ->
             let variant =
               apply tag.loc Variant.of_string [string tag.loc tag.txt]
             in
             apply rf.rf_loc Variant_type.Row_field.tag
-              [ variant;
-                quote_bool b;
-                mk_list (List.map quote_core_type tys) ])
+              [variant; quote_bool b; mk_list (List.map quote_core_type tys)])
         row_fields
     and variant_form =
       match closed_flag, labels with
-      | Open, None -> Lazy.force Variant_type.Variant_form.open_
-      | Closed, None -> Lazy.force Variant_type.Variant_form.fixed
+      | Open, None -> use Variant_type.Variant_form.open_
+      | Closed, None -> use Variant_type.Variant_form.fixed
       | _, Some labs ->
         apply loc Variant_type.Variant_form.closed
           [mk_list (List.map (string loc) labs)]
     in
     apply loc Type.variant
-      [apply loc Variant_type.of_row_fields_list [mk_list row_fields; variant_form]]
+      [ apply loc Variant_type.of_row_fields_list
+          [mk_list row_fields; variant_form] ]
   | Ttyp_poly (tvs, ty) ->
     let names = List.map (fun (name, _) -> name) tvs in
-    let names_lam = List.map (fun name -> apply loc Name.mk [string loc name]) names in
+    let names_lam =
+      List.map (fun name -> apply loc Name.mk [string loc name]) names
+    in
     with_new_idents_poly names;
     let body =
       create_list_param_binding
@@ -1184,13 +1205,14 @@ and quote_core_type ty =
     without_idents_poly names;
     apply loc Type.poly [quote_loc loc; mk_list names_lam; body]
   | Ttyp_package package ->
-    let {pack_path; pack_fields; pack_type = _; pack_txt = _} = package in
+    let { pack_path; pack_fields; pack_type = _; pack_txt = _ } = package in
     let mod_type = module_type_for_path loc pack_path
     and with_types =
       List.map
         (fun (lid, ty) ->
-           pair (quote_fragment_of_lid Asttypes.(lid.loc) lid.txt,
-                 quote_core_type ty))
+          pair
+            ( quote_fragment_of_lid Asttypes.(lid.loc) lid.txt,
+              quote_core_type ty ))
         pack_fields
     in
     apply loc Type.package [mod_type; mk_list with_types]
@@ -1207,7 +1229,7 @@ let rec case_binding transl stage case =
         let pat = quote_computation_pattern pat in
         let exp = quote_expression transl stage case.c_rhs in
         Non_binding (pat, exp)
-      | ids -> (
+      | ids ->
         let names =
           List.map (fun id -> string pat.pat_loc (Ident.name id)) ids
         in
@@ -1220,23 +1242,22 @@ let rec case_binding transl stage case =
           bind pat_id pat (bind exp_id exp (pair (Lvar pat_id, Lvar exp_id)))
         in
         let res =
-        match case.c_rhs.exp_desc with
-        | Texp_unreachable ->
-          Refutation
-            ( mk_list names,
-              mk_list [],
-              create_list_param_binding ids (create_list_param_binding [] body)
-            )
-        | _ ->
-          Pattern
-            ( mk_list names,
-              mk_list [],
-              create_list_param_binding ids (create_list_param_binding [] body)
-            )
+          match case.c_rhs.exp_desc with
+          | Texp_unreachable ->
+            Refutation
+              ( mk_list names,
+                mk_list [],
+                create_list_param_binding ids
+                  (create_list_param_binding [] body) )
+          | _ ->
+            Pattern
+              ( mk_list names,
+                mk_list [],
+                create_list_param_binding ids
+                  (create_list_param_binding [] body) )
         in
         without_idents_values ids;
         res
-      )
     in
     match pat.pat_desc with
     | Tpat_value pat -> (
@@ -1266,10 +1287,10 @@ let rec case_binding transl stage case =
            (bind exp_id exp (triple (Lvar pat_id, Lvar guard_id, Lvar exp_id))))
     in
     let res =
-    Guarded
-      ( mk_list names,
-        mk_list [],
-        create_list_param_binding ids (create_list_param_binding [] body) )
+      Guarded
+        ( mk_list names,
+          mk_list [],
+          create_list_param_binding ids (create_list_param_binding [] body) )
     in
     without_idents_values ids;
     res
@@ -1314,14 +1335,15 @@ and fun_param_binding transl stage loc param frest =
   let names =
     List.map (fun s -> apply loc Name.mk [string loc (Ident.name s)]) idents
   in
-  if is_module pat then
+  if is_module pat
+  then
     match names with
     | [] ->
       apply loc Function.param_module_nonbinding
-        [quote_arg_label loc param.fp_arg_label;
-         quote_loc loc;
-         quote_value_pattern pat;
-         with_newtypes]
+        [ quote_arg_label loc param.fp_arg_label;
+          quote_loc loc;
+          quote_value_pattern pat;
+          with_newtypes ]
     | [name] ->
       let fun_rem =
         func idents (pair (quote_value_pattern pat, with_newtypes))
@@ -1348,8 +1370,7 @@ and quote_function transl stage loc fn extras =
     let fn_body =
       match fn.body with
       | Tfunction_body exp ->
-        apply loc Function.body
-          [quote_expression transl stage exp; none]
+        apply loc Function.body [quote_expression transl stage exp; none]
       | Tfunction_cases cases ->
         apply loc Function.cases
           [ mk_list
@@ -1361,20 +1382,17 @@ and quote_function transl stage loc fn extras =
             none ]
     in
     let fn_def =
-      List.fold_right
-        (fun_param_binding transl stage loc)
-        fn.params fn_body
+      List.fold_right (fun_param_binding transl stage loc) fn.params fn_body
     in
     List.iter without_param fn.params;
     List.fold_right
       (fun (extra, loc, _) fn ->
-         match extra with
-         | Texp_newtype (id, sloc, _, _) ->
-           apply loc Function.newtype
-             [quote_loc sloc.loc; string loc sloc.txt; func [id] fn]
-         | _ -> fn)
-      extras
-      fn_def
+        match extra with
+        | Texp_newtype (id, sloc, _, _) ->
+          apply loc Function.newtype
+            [quote_loc sloc.loc; string loc sloc.txt; func [id] fn]
+        | _ -> fn)
+      extras fn_def
   | _ -> fatal_error "Unexpected usage of quote_function."
 
 and quote_module_exp transl stage loc mod_exp =
@@ -1422,8 +1440,7 @@ and quote_comprehension transl stage loc { comp_body; comp_clauses } =
         body clause_bindings
   in
   let body =
-    apply loc Comprehension.body
-      [quote_expression transl stage comp_body]
+    apply loc Comprehension.body [quote_expression transl stage comp_body]
   in
   List.fold_left (fun body clause -> add_clause body clause) body comp_clauses
 
@@ -1433,26 +1450,22 @@ and quote_expression_extra _ _ extra lambda =
   | Texp_newtype _ -> lambda
   (* Texp_newtype only relevant for functions, handled elsewhere *)
   | Texp_constraint ty ->
-    let constr_ =
-      apply loc Type_constraint.constraint_ [quote_core_type ty]
-    in
-    apply loc Exp.constraint_ [lambda; constr_]
+    let constr_ = apply loc Type_constraint.constraint_ [quote_core_type ty] in
+    apply loc Exp_desc.constraint_ [mk_exp_noattr loc lambda; constr_]
   | Texp_coerce (ty_opt, ty) ->
     let coerce =
       apply loc Type_constraint.coercion
-        [ option (Option.map (quote_core_type) ty_opt);
-          quote_core_type ty ]
+        [option (Option.map quote_core_type ty_opt); quote_core_type ty]
     in
-    apply loc Exp.constraint_ [lambda; coerce]
-  | Texp_stack -> apply loc Exp.stack [lambda]
+    apply loc Exp_desc.constraint_ [mk_exp_noattr loc lambda; coerce]
+  | Texp_stack -> apply loc Exp_desc.stack [mk_exp_noattr loc lambda]
   | Texp_poly _ -> fatal_error "No support for Texp_poly yet"
   | Texp_mode _ -> fatal_error "No support for modes yet"
 
 and update_env_with_extra extra =
   let extra, _, _ = extra in
   match extra with
-  | Texp_newtype (id, _, _, _) ->
-    with_new_idents_types [id]
+  | Texp_newtype (id, _, _, _) -> with_new_idents_types [id]
   | Texp_constraint _ | Texp_coerce _ | Texp_stack -> ()
   | Texp_poly _ -> fatal_error "No support for Texp_poly yet"
   | Texp_mode _ -> fatal_error "No support for modes yet"
@@ -1460,13 +1473,12 @@ and update_env_with_extra extra =
 and update_env_without_extra extra =
   let extra, _, _ = extra in
   match extra with
-  | Texp_newtype (id, _, _, _) ->
-    without_idents_types [id]
+  | Texp_newtype (id, _, _, _) -> without_idents_types [id]
   | Texp_constraint _ | Texp_coerce _ | Texp_stack -> ()
   | Texp_poly _ -> fatal_error "No support for Texp_poly yet"
   | Texp_mode _ -> fatal_error "No support for modes yet"
 
-and quote_expression transl stage e =
+and quote_expression_desc transl stage e =
   let env = e.exp_env in
   let loc = e.exp_loc in
   List.iter update_env_with_extra e.exp_extra;
@@ -1475,7 +1487,7 @@ and quote_expression transl stage e =
     | Texp_ident (path, _, _, _, _) -> quote_value_ident_path_as_exp loc path
     | Texp_constant const ->
       let const = quote_constant loc const in
-      apply loc Exp.constant [const]
+      apply loc Exp_desc.constant [const]
     | Texp_let (rec_flag, vbs, exp) -> (
       match rec_flag with
       | Recursive ->
@@ -1497,11 +1509,11 @@ and quote_expression transl stage e =
         let defs_lam = List.map (quote_expression transl stage) defs in
         let frest =
           create_list_param_binding idents
-            (pair
-               (mk_list defs_lam, quote_expression transl stage exp))
+            (pair (mk_list defs_lam, quote_expression transl stage exp))
         in
         without_idents_values idents;
-        apply loc Exp.let_rec_simple [quote_loc loc; mk_list names_lam; frest]
+        apply loc Exp_desc.let_rec_simple
+          [quote_loc loc; mk_list names_lam; frest]
       | Nonrecursive ->
         let val_l, _, pats, defs =
           List.fold_left
@@ -1519,8 +1531,7 @@ and quote_expression transl stage e =
                 (List.map
                    (fun pat ->
                      pair
-                       ( Lazy.force Label.Nonoptional.no_label,
-                         quote_value_pattern pat ))
+                       (use Label.Nonoptional.no_label, quote_value_pattern pat))
                    pats) ]
         in
         let names_lam =
@@ -1532,14 +1543,16 @@ and quote_expression transl stage e =
             (create_list_param_binding []
                (pair (def_pat, quote_expression transl stage exp)))
         in
-        List.iter (fun vb -> without_idents_values (pat_bound_idents vb.vb_pat)) vbs;
-        apply loc Exp.let_
+        List.iter
+          (fun vb -> without_idents_values (pat_bound_idents vb.vb_pat))
+          vbs;
+        apply loc Exp_desc.let_
           [quote_loc loc; mk_list names_lam; nil; mk_list defs; frest])
     | Texp_function fun_spec ->
       let fn =
         quote_function transl stage loc (Texp_function fun_spec) e.exp_extra
       in
-      apply loc Exp.function_ [fn]
+      apply loc Exp_desc.function_ [fn]
     | Texp_apply (fn, args, _, _, _) ->
       let fn = quote_expression transl stage fn in
       let args =
@@ -1558,26 +1571,23 @@ and quote_expression transl stage e =
               pair (lbl, exp))
           args
       in
-      apply loc Exp.apply [fn; mk_list args]
+      apply loc Exp_desc.apply [fn; mk_list args]
     | Texp_match (exp, _, cases, _) ->
       let exp = quote_expression transl stage exp in
       let cases = List.map (quote_case transl stage loc) cases in
-      apply loc Exp.match_ [exp; mk_list cases]
+      apply loc Exp_desc.match_ [exp; mk_list cases]
     | Texp_try (exp, cases) ->
       let exp = quote_expression transl stage exp
-      and cases =
-        List.map (quote_value_pattern_case transl stage loc) cases
-      in
-      apply loc Exp.try_ [exp; mk_list cases]
+      and cases = List.map (quote_value_pattern_case transl stage loc) cases in
+      apply loc Exp_desc.try_ [exp; mk_list cases]
     | Texp_tuple (exps, _) ->
       let exps =
         List.map
           (fun (lab, exp) ->
-            pair
-              (string_option loc lab, quote_expression transl stage exp))
+            pair (string_option loc lab, quote_expression transl stage exp))
           exps
       in
-      apply loc Exp.tuple [mk_list exps]
+      apply loc Exp_desc.tuple [mk_list exps]
     | Texp_construct (lid, constr, args, _) ->
       let constr = quote_constructor env lid.loc constr in
       let args =
@@ -1587,22 +1597,18 @@ and quote_expression transl stage e =
         | _ :: _ ->
           let args = List.map (quote_expression transl stage) args in
           let with_labels =
-            List.map
-              (fun a -> pair (Lazy.force Label.Nonoptional.no_label, a))
-              args
+            List.map (fun a -> pair (use Label.Nonoptional.no_label, a)) args
           in
-          let as_tuple = apply loc Exp.tuple [mk_list with_labels] in
-          Some as_tuple
+          let as_tuple = apply loc Exp_desc.tuple [mk_list with_labels] in
+          Some (apply loc Exp.mk [as_tuple; nil])
       in
-      apply loc Exp.construct [constr; option args]
+      apply loc Exp_desc.construct [constr; option args]
     | Texp_variant (variant, argo) ->
       let variant = quote_variant loc variant
       and argo =
-        Option.map
-          (fun (arg, _) -> quote_expression transl stage arg)
-          argo
+        Option.map (fun (arg, _) -> quote_expression transl stage arg) argo
       in
-      apply loc Exp.variant [variant; option argo]
+      apply loc Exp_desc.variant [variant; option argo]
     | Texp_record record ->
       let lbl_exps =
         Array.map
@@ -1622,32 +1628,32 @@ and quote_expression transl stage e =
           (fun (e, _) -> quote_expression transl stage e)
           record.extended_expression
       in
-      apply loc Exp.record [mk_list (Array.to_list lbl_exps); option base]
+      apply loc Exp_desc.record [mk_list (Array.to_list lbl_exps); option base]
     | Texp_field (rcd, lid, lbl, _, _) ->
       let rcd = quote_expression transl stage rcd in
       let lbl = quote_record_field env lid.loc lbl in
-      apply loc Exp.field [rcd; lbl]
+      apply loc Exp_desc.field [rcd; lbl]
     | Texp_setfield (rcd, _, lid, lbl, exp) ->
       let rcd = quote_expression transl stage rcd in
       let lbl = quote_record_field env lid.loc lbl in
       let exp = quote_expression transl stage exp in
-      apply loc Exp.setfield [rcd; lbl; exp]
+      apply loc Exp_desc.setfield [rcd; lbl; exp]
     | Texp_array (_, _, exps, _) ->
       let exps = List.map (quote_expression transl stage) exps in
-      apply loc Exp.array [mk_list exps]
+      apply loc Exp_desc.array [mk_list exps]
     | Texp_ifthenelse (cond, then_, else_) ->
       let cond = quote_expression transl stage cond in
       let then_ = quote_expression transl stage then_ in
       let else_ = Option.map (quote_expression transl stage) else_ in
-      apply loc Exp.ifthenelse [cond; then_; option else_]
+      apply loc Exp_desc.ifthenelse [cond; then_; option else_]
     | Texp_sequence (exp1, _, exp2) ->
       let exp1 = quote_expression transl stage exp1 in
       let exp2 = quote_expression transl stage exp2 in
-      apply loc Exp.sequence [exp1; exp2]
+      apply loc Exp_desc.sequence [exp1; exp2]
     | Texp_while wh ->
       let cond = quote_expression transl stage wh.wh_cond in
       let body = quote_expression transl stage wh.wh_body in
-      apply loc Exp.while_ [cond; body]
+      apply loc Exp_desc.while_ [cond; body]
     | Texp_for floop ->
       let low = quote_expression transl stage floop.for_from
       and high = quote_expression transl stage floop.for_to
@@ -1659,63 +1665,60 @@ and quote_expression transl stage e =
       with_new_idents_values [floop.for_id];
       let body = quote_expression transl stage floop.for_body in
       without_idents_values [floop.for_id];
-      apply loc Exp.for_simple
+      apply loc Exp_desc.for_simple
         [quote_loc loc; name; low; high; dir; func [floop.for_id] body]
     | Texp_send (obj, meth, _) ->
       let obj = quote_expression transl stage obj in
       let meth = quote_method loc meth in
-      apply loc Exp.send [obj; meth]
-    | Texp_open _ ->
-      fatal_error "No support for opening modules yet."
+      apply loc Exp_desc.send [obj; meth]
+    | Texp_open _ -> fatal_error "No support for opening modules yet."
     | Texp_letmodule (ident, _, _, mod_exp, body) -> (
       let mod_exp = quote_module_exp transl stage loc mod_exp in
       match ident with
       | None ->
-        apply loc Exp.letmodule_nonbinding
+        apply loc Exp_desc.letmodule_nonbinding
           [mod_exp; quote_expression transl stage body]
       | Some ident ->
         let name = quote_name (mkloc (Ident.name ident) loc) in
         with_new_idents_modules [ident];
         let body = quote_expression transl stage body in
         without_idents_modules [ident];
-        apply loc Exp.letmodule [quote_loc loc; name; mod_exp; func [ident] body]
-      )
+        apply loc Exp_desc.letmodule
+          [quote_loc loc; name; mod_exp; func [ident] body])
     | Texp_assert (exp, _) ->
       let exp = quote_expression transl stage exp in
-      apply loc Exp.assert_ [exp]
+      apply loc Exp_desc.assert_ [exp]
     | Texp_lazy exp ->
       let exp = quote_expression transl stage exp in
-      apply loc Exp.lazy_ [exp]
+      apply loc Exp_desc.lazy_ [exp]
     | Texp_quotation exp ->
       let exp = quote_expression transl (stage + 1) exp in
-      apply loc Exp.quote [exp]
+      apply loc Exp_desc.quote [exp]
     | Texp_antiquotation exp ->
-      if stage > 0 then
+      if stage > 0
+      then
         let exp = quote_expression transl stage exp in
-        apply loc Exp.antiquote [exp]
-      else
-        apply loc Exp.splice [transl exp]
+        apply loc Exp_desc.antiquote [exp]
+      else apply loc Exp_desc.splice [transl exp]
     | Texp_new (path, _, _, _) ->
-      apply loc Exp.new_ [quote_value_ident_path loc path]
+      apply loc Exp_desc.new_ [quote_value_ident_path loc path]
     | Texp_pack m ->
-      apply loc Exp.pack [quote_module_exp transl stage loc m]
-    | Texp_unreachable -> Lazy.force Exp.unreachable
-    | Texp_src_pos -> Lazy.force Exp.src_pos
+      apply loc Exp_desc.pack [quote_module_exp transl stage loc m]
+    | Texp_unreachable -> use Exp_desc.unreachable
+    | Texp_src_pos -> use Exp_desc.src_pos
     | Texp_exclave e ->
-      apply loc Exp.exclave [quote_expression transl stage e]
+      apply loc Exp_desc.exclave [quote_expression transl stage e]
     | Texp_extension_constructor (lid, path) ->
-      apply loc Exp.extension_constructor
+      apply loc Exp_desc.extension_constructor
         [quote_loc lid.loc; quote_ext_constructor loc path]
     | Texp_unboxed_tuple ts ->
       let tups =
         List.map
           (fun (lab_opt, exp, _) ->
-            pair
-              ( quote_nonopt loc lab_opt,
-                quote_expression transl stage exp ))
+            pair (quote_nonopt loc lab_opt, quote_expression transl stage exp))
           ts
       in
-      apply loc Exp.unboxed_tuple [mk_list tups]
+      apply loc Exp_desc.unboxed_tuple [mk_list tups]
     | Texp_record_unboxed_product record ->
       let lbl_exps =
         Array.map
@@ -1735,35 +1738,31 @@ and quote_expression transl stage e =
           (fun (e, _) -> quote_expression transl stage e)
           record.extended_expression
       in
-      apply loc Exp.unboxed_record_product
+      apply loc Exp_desc.unboxed_record_product
         [mk_list (Array.to_list lbl_exps); option base]
     | Texp_unboxed_field (rcd, _, lid, lbl, _) ->
       let rcd = quote_expression transl stage rcd in
       let lbl = quote_record_field env lid.loc lbl in
-      apply loc Exp.unboxed_field [rcd; lbl]
+      apply loc Exp_desc.unboxed_field [rcd; lbl]
     | Texp_letexception (ext_const, exp) ->
       let exp = quote_expression transl stage exp in
-      apply loc Exp.let_exception [quote_name ext_const.ext_name; exp]
+      apply loc Exp_desc.let_exception [quote_name ext_const.ext_name; exp]
     | Texp_letop rcd ->
-      let let_l =
-        quote_value_ident_path rcd.let_.bop_loc rcd.let_.bop_op_path
+      let let_l = quote_value_ident_path rcd.let_.bop_loc rcd.let_.bop_op_path
       and ands_l =
         List.map
-          (fun bop ->
-            quote_value_ident_path bop.bop_loc bop.bop_op_path)
+          (fun bop -> quote_value_ident_path bop.bop_loc bop.bop_op_path)
           rcd.ands
       and defs =
         quote_expression transl stage rcd.let_.bop_exp
-        :: List.map
-             (fun d -> quote_expression transl stage d.bop_exp)
-             rcd.ands
+        :: List.map (fun d -> quote_expression transl stage d.bop_exp) rcd.ands
       and body = quote_value_pattern_case transl stage loc rcd.body in
-      apply loc Exp.let_op [mk_list (let_l :: ands_l); mk_list defs; body]
+      apply loc Exp_desc.let_op [mk_list (let_l :: ands_l); mk_list defs; body]
     | Texp_list_comprehension compr ->
-      apply loc Exp.list_comprehension
+      apply loc Exp_desc.list_comprehension
         [quote_comprehension transl stage loc compr]
     | Texp_array_comprehension (_, _, compr) ->
-      apply loc Exp.array_comprehension
+      apply loc Exp_desc.array_comprehension
         [quote_comprehension transl stage loc compr]
     | Texp_overwrite _ -> fatal_error "Not implemented yet"
     | Texp_hole _ -> fatal_error "No support for typed holes inside quotations."
@@ -1776,16 +1775,12 @@ and quote_expression transl stage e =
   List.iter update_env_without_extra e.exp_extra;
   List.fold_right (quote_expression_extra transl stage) e.exp_extra body
 
+and quote_expression transl stage e =
+  let desc = quote_expression_desc transl stage e
+  and attributes = quote_attributes e
+  and loc = e.exp_loc in
+  apply loc Exp.mk [desc; attributes]
+
 let transl_quote transl exp loc =
-  let v = Hashtbl.length vars_env.env_vals
-  and m = Hashtbl.length vars_env.env_mod
-  and t = Hashtbl.length vars_env.env_tys
-  in
   let expr = quote_expression transl 0 exp in
-  Hashtbl.iter
-    (fun x y -> Format.printf "%s: %a\n" (Ident.name x) Printlambda.lambda y)
-    vars_env.env_tys;
-  assert (v = Hashtbl.length vars_env.env_vals);
-  assert (m = Hashtbl.length vars_env.env_mod);
-  assert (t = Hashtbl.length vars_env.env_tys);
   apply loc Code.of_exp [expr; quote_loc loc]

--- a/lambda/translquote.mli
+++ b/lambda/translquote.mli
@@ -1,0 +1,3 @@
+
+val transl_quote :
+  (Typedtree.expression -> Lambda.t) -> Typedtree.expression -> Lambda.t

--- a/lambda/translquote.mli
+++ b/lambda/translquote.mli
@@ -1,3 +1,2 @@
-
 val transl_quote :
-  (Typedtree.expression -> Lambda.t) -> Typedtree.expression -> Lambda.t
+  (Typedtree.expression -> Lambda.lambda) -> Typedtree.expression -> Lambda.lambda

--- a/lambda/translquote.mli
+++ b/lambda/translquote.mli
@@ -1,2 +1,2 @@
 val transl_quote :
-  (Typedtree.expression -> Lambda.lambda) -> Typedtree.expression -> Lambda.lambda
+  (Typedtree.expression -> Lambda.lambda) -> Typedtree.expression -> Location.t -> Lambda.lambda

--- a/otherlibs/dynlink/dune
+++ b/otherlibs/dynlink/dune
@@ -150,6 +150,7 @@
   asttypes
   parsetree
   typedtree
+  camlinternalQuote_bootstrap
   outcometree
   cmo_format
   cmxs_format
@@ -179,6 +180,12 @@
 ;  (package ocaml))
 
 ;; .ml:
+
+(rule
+ (action
+   (progn
+     (copy# ../../stdlib/camlinternalQuote.ml camlinternalQuote_bootstrap.ml)
+     (copy# ../../stdlib/camlinternalQuote.mli camlinternalQuote_bootstrap.mli))))
 
 (copy_files ../../utils/runtimetags.ml)
 

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -142,6 +142,13 @@ camlinternalComprehension.cmx : \
     stdlib.cmx \
     camlinternalComprehension.cmi
 camlinternalComprehension.cmi :
+camlinternalQuote.cmo : \
+    stdlib.cmi \
+    camlinternalQuote.cmi
+camlinternalQuote.cmx : \
+    stdlib.cmx \
+    camlinternalQuote.cmi
+camlinternalQuote.cmi :
 camlinternalFormat.cmo : \
     stdlib__Sys.cmi \
     stdlib__String.cmi \

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -103,7 +103,8 @@ STDLIB_MODULE_BASENAMES = \
   moreLabels \
   stdLabels \
   effect \
-  camlinternalComprehension
+  camlinternalComprehension \
+  camlinternalQuote
 
 STDLIB_PREFIXED_MODULES = \
   $(filter-out stdlib camlinternal%, $(STDLIB_MODULE_BASENAMES))

--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -1,0 +1,1697 @@
+# 2 "../home/lpw25/Repositories/flambda-backend/stdlib/camlinternalQuote.ml"
+let fold_map_option f acc o =
+  match o with
+  | None -> (acc, None)
+  | Some x ->
+      let acc, x = f acc x in
+        (acc, Some x)
+
+let rec fold_left_map_alist f acc l =
+  match l with
+  | [] -> (acc, [])
+  | (k, x) :: rest ->
+      let acc, x = f acc x in
+      let acc, rest = fold_left_map_alist f acc rest in
+        (acc, (k, x) :: rest)
+
+module Stamp : sig
+
+  type t
+  (** [t] is the type of stamps. Stamps have no structure, only a notion
+      of identity. *)
+
+  val fresh : unit -> t
+  (** [fresh ()] creates a fresh stamp, unequal to any other. *)
+
+  val compare : t -> t -> int
+  (** [compare] is a total ordering on stamps. *)
+
+  val to_string : t -> string
+  (** [to_string] prints a representation of the stamp. Each stamp
+      has a different representation. *)
+
+end = struct
+
+  type t = int
+
+  external fresh : unit -> int = "caml_fresh_oo_id" [@@noalloc]
+
+  let compare = Int.compare
+
+  let to_string = string_of_int
+
+end
+
+module Loc = struct
+
+  type t =
+    | Unknown
+    | Known of
+        { file: string;
+          start_line:int;
+          start_col:int;
+          end_line:int;
+          end_col:int; }
+
+  let unknown = Unknown
+
+  let known ~file ~start_line ~start_col ~end_line ~end_col =
+    Known { file; start_line; start_col; end_line; end_col; }
+
+end
+
+module Level : sig
+
+  type t
+  (** [t] is the type of binding levels. All variable bindings have an
+      associated level and all bindings of the same level have the same
+      scope. Each level is associated with a point on the call
+      stack. Each level has a location attached for error messages. *)
+
+  val with_fresh : Loc.t -> (t -> 'a) -> 'a
+  (** [with_fresh loc f] creates a fresh level not equal to any others,
+      associated with the current point in the call stack, with [loc] as
+      the attached location. *)
+
+  val check : t -> bool
+  (** [check t] is [true] if the point on the call stack associated with
+      [t] is still present, otherwise it is [false]. *)
+
+  val compare : t -> t -> int
+  (** [compare] is a total order on levels. *)
+
+  val loc : t -> Loc.t
+  (** [loc t] is the location attached to [t]. *)
+
+end = struct
+
+  type t =
+    { stamp : Stamp.t;
+      mutable valid : bool;
+      loc : Loc.t; }
+
+  let fresh loc =
+    let stamp = Stamp.fresh () in
+    let valid = true in
+    { stamp; valid; loc }
+
+  let with_fresh loc f =
+    let level = fresh loc in
+    try
+      let r = f level in
+      level.valid <- false;
+      r
+    with e ->
+      level.valid <- false;
+      raise e
+
+  let check t = t.valid
+
+  let compare t1 t2 = Stamp.compare t1.stamp t2.stamp
+
+  let loc t = t.loc
+
+end
+
+module Name = struct
+
+  type t = string
+
+  let mk t = t
+
+end
+
+module Var : sig
+
+  type t
+  (** [t] is the type of variables of any sort *)
+
+  type var := t
+
+  module Module : sig
+
+    type t
+    (** [t] is the type of module variables *)
+
+    val generate : Level.t -> Name.t -> t
+    (** [generate lv n] creates a fresh module variable bound at [lv]
+        whose name is [n]. *)
+
+    val generic : t -> var
+    (** [generic t] is [t] as a generic variable *)
+
+    val name : t -> Name.t
+    (** [name t] is the name of [t]. *)
+
+  end
+
+  module Value : sig
+
+    type t
+    (** [t] is the type of ordinary variables *)
+
+    val generate : Level.t -> Name.t -> t
+    (** [generate lv n] creates a fresh variable bound at [lv] whose
+        name is [n]. *)
+
+    val generic : t -> var
+    (** [generic t] is [t] as a generic variable *)
+
+    val name : t -> Name.t
+    (** [name t] is the name of [t]. *)
+
+  end
+
+  module Type : sig
+
+    type t
+    (** [t] is the type of type constructor variables *)
+
+    val generate : Level.t -> Name.t -> t
+    (** [generate lv n] creates a fresh type constructor variable
+        bound at [lv] whose name is [n]. *)
+
+    val generic : t -> var
+    (** [generic t] is [t] as a generic variable *)
+
+    val name : t -> Name.t
+    (** [name t] is the name of [t]. *)
+
+  end
+
+  val name : t -> Name.t
+  (** [name t] is the name of [t]. *)
+
+  val level : t -> Level.t
+  (** [level t] is the level of [t]. *)
+
+  val loc : t -> Loc.t
+  (** [loc t] is [Level.loc (level t)]. *)
+
+  val valid : t -> bool
+  (** [valid t] is [true] if [t]'s binding is still open, and [false] otherwise. Once [t]'s binding has
+      been closed there is no valid way to use [t]. *)
+
+  module Set : sig
+
+    type t
+    (** [t] is the type of sets of variables. *)
+
+    val empty : t
+    (** [empty] is the empty set. *)
+
+    val singleton : var -> t
+    (** [singleton v] is the set containing just [v]. *)
+
+    val add : var -> t -> t
+    (** [add v t] is the set containing [v] and the elements of [t]. *)
+
+    val union : shared:(var -> unit) -> t -> t -> t
+    (** [union ~shared t1 t2] is the union of [t1] and [t2]. [shared] is run on all
+        the variables that are in both [t1] and [t2]. *)
+
+    val inter : left_only:(var -> unit) -> right_only:(var -> unit) -> t -> t -> t
+    (** [inter ~left_only ~right_only t1 t2] is the intersection of [t1]
+        and [t2]. [left_only] is run on all the variables that are in
+        [t1] and not in [t2]. [right_only] is run on all the variables
+        that are in [t2] and not in [t1]. *)
+
+    val iter : (var -> unit) -> t -> unit
+    (** [iter f t] runs [f] on every variable in [t]. *)
+
+    val choose : t -> var option
+    (** [choose t] is [None] if [t] is equal to [empty] and [Some v],
+        where [v] is an element of [t], otherwise. *)
+
+    val differences :
+      left_only:(var -> unit) -> right_only:(var -> unit) -> t -> t -> unit
+    (** [differences ~left_only ~right_only t1 t2] runs [left_only] on every element of [t1]
+        that is not an element of [t2] and [right_only] on every element of [t2] that is
+        not an element of [t1]. *)
+
+  end
+
+  module Map : sig
+
+    type 'a t
+    (** ['a t] is the type of maps from variables to ['a] values. *)
+
+    val empty : 'a t
+    (** [empty] is the empty set. *)
+
+    val singleton : var -> 'a -> 'a t
+    (** [singleton v data] is the map containing just a binding of [v] to [data]. *)
+
+    val add : var -> 'a -> 'a t -> 'a t
+    (** [add v data t] is the map containing the same bindings as [t]
+        plus a binding of [v] to [data]. *)
+
+    val union : (var -> 'a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+    (** [union ~join t1 t2] is the union of [t1] and [t2]. [join] is run on all
+        the variables that are in both [t1] and [t2]. *)
+
+    val remove_level : Level.t -> 'a t -> 'a t
+    (** [remove_level l t] is the map containing the bindings of [t] whose
+        variables's level is not [l]. *)
+
+    val iter : (var -> 'a -> unit) -> 'a t -> unit
+    (** [iter f t] runs [f] on every variable in [t]. *)
+
+    val choose : 'a t -> (var * 'a) option
+    (** [choose t] is [None] if [t] is equal to [empty] and [Some (v, data)],
+        where [v] is bound to [data] in [t], otherwise. *)
+
+  end
+
+end = struct
+
+  type t =
+    { name : string;
+      stamp : Stamp.t;
+      level : Level.t; }
+
+  module Set = struct
+
+    type var = t
+
+    module Stamp_map = Map.Make(Stamp)
+
+    type t = var Stamp_map.t
+
+    let empty = Stamp_map.empty
+
+    let singleton v =
+      Stamp_map.singleton v.stamp v
+
+    let add v t =
+      Stamp_map.add v.stamp v t
+
+    let union ~shared t1 t2 =
+      Stamp_map.union
+        (fun x v1 v2 ->
+          shared v2;
+          Some v1)
+        t1 t2
+
+    let inter ~left_only ~right_only t1 t2 =
+      Stamp_map.merge
+        (fun _ v1 v2 ->
+          match v1, v2 with
+          | None, None -> None
+          | Some v1, None -> left_only v1; None
+          | None, Some v2 -> right_only v2; None
+          | Some v1, Some _  -> Some v1)
+        t1 t2
+
+    let choose t =
+      match Stamp_map.choose_opt t with
+      | None -> None
+      | Some (_, v) -> Some v
+
+    let iter f t =
+      Stamp_map.iter (fun _ v -> f v) t
+
+    let differences ~left_only ~right_only t1 t2 =
+      ignore
+        (Stamp_map.merge
+           (fun _ v1 v2 ->
+             match v1, v2 with
+             | None, None -> None
+             | Some v, None -> left_only v; None
+             | None, Some v -> right_only v; None
+             | Some v, Some _  -> None)
+           t1 t2);
+
+  end
+
+  module Map = struct
+
+    type var = t
+
+    module Var_map = Map.Make(struct
+        type t = var
+        let compare t1 t2 = Stamp.compare t1.stamp t2.stamp
+      end)
+
+    module Level_map = Map.Make(Level)
+
+    type 'a t = 'a Var_map.t Level_map.t
+
+    let empty = Level_map.empty
+
+    let singleton v data =
+      Level_map.singleton v.level
+        (Var_map.singleton v data)
+
+    let add v data t =
+      let update prev =
+        let prev =
+          match prev with
+          | None -> Var_map.empty
+          | Some prev -> prev
+        in
+        let next = Var_map.add v data prev in
+        Some next
+      in
+      Level_map.update v.level update t
+
+    let remove_level = Level_map.remove
+
+    let union combine t1 t2 =
+      Level_map.union
+        (fun x m1 m2 ->
+          let m =
+            Var_map.union
+              (fun v data1 data2 ->
+                let data = combine v data1 data2 in
+                Some data)
+              m1 m2
+          in
+          Some m)
+        t1 t2
+
+    let rec choose t =
+      match Level_map.choose_opt t with
+      | None -> None
+      | Some (l, m) ->
+          match Var_map.choose_opt m with
+          | None -> choose (Level_map.remove l t)
+          | Some _ as res -> res
+
+    let iter f t =
+      Level_map.iter
+        (fun _ m -> Var_map.iter (fun v data -> f v data) m)
+        t
+
+  end
+
+  let generate level name =
+    let stamp = Stamp.fresh () in
+    let name = name ^ "_" ^ (Stamp.to_string stamp) in
+    { name; stamp; level }
+
+  let name t = t.name
+
+  let loc t = Level.loc t.level
+
+  let level t = t.level
+
+  let valid t = Level.check t.level
+
+  module Module = struct
+
+    type var = t
+
+    type t = var
+
+    let generate = generate
+
+    let generic t = t
+
+    let name = name
+
+  end
+
+  module Value = struct
+
+    type var = t
+
+    type t = var
+
+    let generate = generate
+
+    let generic t = t
+
+    let name = name
+
+  end
+
+  module Type = struct
+
+    type var = t
+
+    type t = var
+
+    let generate = generate
+
+    let generic t = t
+
+    let name = name
+
+  end
+
+end
+
+module With_bound_vars : sig
+
+  type 'a t
+  (** ['a t] is the type of ['a]s paired with a set of variables that
+      are bound by the ['a]. *)
+
+  val mk : Var.Set.t -> 'a -> 'a t
+  (** [mk vars x] is [x] paired with [vars]. *)
+
+  val return : 'a -> 'a t
+  (** [return x] is [mk Var.Set.empty x]. *)
+
+  val var : Var.t -> Var.t t
+  (** [var v] is [mk (Var.Set.singleton v) v]. *)
+
+  val value_var : Var.Value.t -> Var.Value.t t
+  (** [value_var v] is [mk (Var.Set.singleton (Var.Value.generic v)) v]. *)
+
+  val module_var : Var.Module.t -> Var.Module.t t
+  (** [module_var v] is [mk (Var.Set.singleton (Var.Module.generic v)) v]. *)
+
+  val map : ('a -> 'b) -> 'a t -> 'b t
+  (** [map f t] is [f v], where [v] is the value of [t], paired with the
+      same variables as [t]. *)
+
+  val meet : 
+    duplicated:(Var.t -> unit)
+    -> 'a t
+    -> 'b t
+    -> ('a * 'b)t
+  (** [meet t1 t2] is [(v1, v2)], where [v1] and [v2] are the values of
+      [t1] and [t2] respectively, paired with the union of the variables
+      from [t1] and [t2] which are expected to be disjoint. If [t1] and
+      [t2] share any variables then [duplicated] will be run on the
+      shared variables.*)
+
+  val join :
+    left_only:(Var.t -> unit)
+    -> right_only:(Var.t -> unit)
+    -> 'a t -> 'b t -> ('a * 'b) t
+  (** [join ~left_only ~right_only t1 t2] is [(v1, v2)], where [v1] and
+      [v2] are the values of [t1] and [t2] respectively, paired with the
+      intersection of the variables from [t1] and [t2] which are
+      expected to be equal. If any variables in [t1] are missing from
+      [t2] then [left_only] with be run on them. If any variables in
+      [t2] are missing from [t1] then [right_only] will be run on
+      them. *)
+
+  val meet_all :
+    duplicated:(Var.t -> unit)
+    -> 'a t list    
+    -> 'a list t
+  (** [meet_all ~duplicated [t1; t2; ...]] is [[v1; v2; ...]], where
+      each [vn] is the value of [tn], paired with the union of the
+      variables from all the [ts] which are expected to be disjoint. If
+      the [ts] share any variables then [duplicated] will be run on the
+      shared variables. *)
+
+  val optional : 'a t option -> 'a option t
+  (** [optional tm] is [Some v], where [v] is the value of [t], paired
+      with the variables from [t] if [tm] is [Some t]. It is [return
+      None] if [tm] is [None]. *)
+
+  val value :
+    extra:(Var.t -> unit)
+    -> missing:(Var.t -> unit)
+    -> 'a t
+    -> Var.t list
+    -> 'a
+  (** [value ~extra ~missing t vs] is [t]'s value. [t] is expected to
+      bind exactly the variables [vs]. [extra] is run on any additional
+      variables that are bound. [missing] is run on any variables that
+      are missing. *)
+
+  val value_nonbinding :
+    extra:(Var.t -> unit)
+    -> 'a t
+    -> 'a
+  (** [value_nonbinding ~extra t] is [t]'s value. [t] is expected to
+      bind no variables. [extra] is run on any additional variables that
+      are bound. *)
+
+end = struct
+
+  type 'a t =
+    { vars : Var.Set.t;
+      v : 'a; }
+
+  let mk vars v = { vars; v }
+
+  let return v = mk Var.Set.empty v
+
+  let var v = mk (Var.Set.singleton v) v
+
+  let value_var v = mk (Var.Set.singleton (Var.Value.generic v)) v
+
+  let module_var v = mk (Var.Set.singleton (Var.Module.generic v)) v
+
+  let map f { vars; v } =
+    let v = f v in
+    { vars; v }
+
+  let meet ~duplicated {vars = vars1; v = v1} {vars = vars2; v = v2} =
+    let vars = Var.Set.union ~shared:duplicated vars1 vars2 in
+    let v = v1, v2 in
+    { vars; v }
+
+  let join ~left_only ~right_only {vars = vars1; v = v1} {vars = vars2; v = v2} =
+    let vars = Var.Set.inter ~left_only ~right_only vars1 vars2 in
+    let v = v1, v2 in
+    { vars; v }
+
+  let meet_all ~duplicated l =
+    let vars, v =
+      List.fold_left_map
+        (fun acc {vars; v} ->
+          let acc = Var.Set.union ~shared:duplicated acc vars in
+          (acc, v))
+        Var.Set.empty l
+    in
+    { vars; v }
+
+  let optional = function
+    | None -> return None
+    | Some t -> map Option.some t
+
+  let value ~extra ~missing t vs =
+    let expected = List.fold_left (fun acc v -> Var.Set.add v acc) Var.Set.empty vs in
+    Var.Set.differences ~left_only:extra ~right_only:missing t.vars expected;
+    t.v
+
+  let value_nonbinding ~extra t =
+    Var.Set.iter extra t.vars;
+    t.v
+end
+
+module With_free_vars : sig
+
+  type 'a t
+  (** ['a t] is the type of ['a]s paired with a set of variables that
+      are free in the ['a] along with their associated locations. *)
+
+  val mk : Loc.t Var.Map.t -> 'a -> 'a t
+  (** [mk vars x] is [x] paired with [vars]. *)
+
+  val return : 'a -> 'a t
+  (** [return x] is [mk Var.Map.empty x]. *)
+
+  val map : ('a -> 'b) -> 'a t -> 'b t
+  (** [map f t] is [f v], where [v] is the value of [t], paired with the
+      same variables as [t]. *)
+
+  val both : 'a t -> 'b t -> ('a * 'b) t
+  (** [both t1 t2] is [(v1, v2)], where [v1] and [v2] are the values of
+      [t1] and [t2] respectively, paired with the union of the variables
+      from [t1] and [t2]. *)
+
+  val all : 'a t list -> 'a list t
+  (** [all [t1; t2; ...]] is [[v1; v2; ...]], where each [vn] is the
+      value of [tn], paired with the union of the variables from all the
+      [ts]. *)
+
+  val optional : 'a t option -> 'a option t
+  (** [optional tm] is [Some t], where [v] is the value of [t], paired
+      with the variables from [t] if [tm] is [Some t]. It is [return
+      None] if [tm] is [None]. *)
+
+  val check : invalid:(Var.t -> Loc.t -> unit) -> 'a t -> unit
+  (** [check ~invalid t] runs [invalid] on any variables paired with [t]
+      that are not valid. *)
+
+  val value : free:(Var.t -> Loc.t -> unit) -> 'a t -> 'a
+  (** [value ~free t] is the value of [t]. [t] is expected to have no
+      free variables. [free] is run on any variables paired with [t]. *)
+
+  val value_binding :
+    Loc.t -> Name.t -> (Var.Value.t -> 'a t) -> 'a t
+
+  val module_binding :
+    Loc.t -> Name.t -> (Var.Module.t -> 'a t) -> 'a t
+
+  val value_bindings :
+    Loc.t -> Name.t list -> (Var.Value.t list -> 'a t) -> 'a t
+
+  val complex_bindings :
+    Loc.t
+    -> extra:(Var.t -> unit)
+    -> missing:(Var.t -> unit)
+    -> bound_values:Name.t list
+    -> bound_modules:Name.t list
+    -> (Var.Value.t list -> Var.Module.t list -> 'a With_bound_vars.t t * 'b t)
+    -> ('a * 'b) t
+
+end  = struct
+
+  type 'a t =
+    { vars : Loc.t Var.Map.t;
+      v : 'a; }
+
+  let mk vars v = { vars; v }
+
+  let return v = mk Var.Map.empty v
+
+  let map f { vars; v } =
+    let v = f v in
+    { vars; v }
+
+  let both f {vars = vars1; v = v1} {vars = vars2; v = v2} =
+    let vars = Var.Map.union (fun _ loc1 _ -> loc1) vars1 vars2 in
+    let v = v1, v2 in
+    { vars; v }
+
+  let all ts =
+    let vars, v =
+      List.fold_left_map
+        (fun acc {vars; v} ->
+          let acc = Var.Map.union (fun _ loc1 _ -> loc1) acc vars in
+          (acc, v))
+        Var.Map.empty ts
+    in
+    { vars; v }
+
+  let optional = function
+    | None -> return None
+    | Some t -> map Option.some t
+
+  let check ~invalid { vars; v } =
+    Var.Map.iter
+      (fun var loc -> if not (Var.valid var) then invalid var loc)
+      vars
+
+  let value = ()
+
+  let value_binding loc name f =
+    Level.with_fresh loc
+      (fun level ->
+        let fresh_var = Var.Value.generate level name in
+        let { vars; v } = f fresh_var in
+        let vars = Var.Map.remove_level level vars in
+        { vars; v })
+
+  let module_binding loc name f =
+    Level.with_fresh loc
+      (fun level ->
+        let fresh_var = Var.Module.generate level name in
+        let { vars; v } = f fresh_var in
+        let vars = Var.Map.remove_level level vars in
+        { vars; v })
+
+  let value_bindings loc names f =
+    Level.with_fresh loc
+      (fun level ->
+        let fresh_vars =
+          List.map
+            (fun name -> Var.Value.generate level name)
+            names
+        in
+        let { vars; v } = f fresh_vars in
+        let vars = Var.Map.remove_level level vars in
+        { vars; v })
+
+  let complex_bindings loc ~extra ~missing ~bound_values ~bound_modules f =
+    Level.with_fresh loc
+      (fun level ->
+        let fresh_value_vars =
+          List.map (Var.Value.generate level) bound_values
+        in
+        let fresh_module_vars =
+          List.map (Var.Module.generate level) bound_modules
+        in
+        let { vars = bindings_vars; v = bindings}, { vars; v } =
+          f fresh_value_vars fresh_module_vars
+        in
+        let fresh_vars =
+          List.map Var.Module.generic fresh_module_vars
+          @ List.map Var.Value.generic fresh_value_vars
+        in
+        let bindings =
+          With_bound_vars.value ~extra ~missing bindings fresh_vars
+        in
+        let vars = Var.Map.remove_level level vars in
+        let vars = Var.Map.union (fun _ loc1 _ -> loc1) bindings_vars vars in
+        let v = bindings, v in
+        { vars; v })
+
+end
+
+module With_free_and_bound_vars = struct
+
+  type 'a t = 'a With_bound_vars.t With_free_vars.t
+
+  let return p =
+    With_free_vars.return
+      (With_bound_vars.return p)
+
+  let with_no_free_vars v =
+    With_free_vars.return v
+
+  let with_no_bound_vars v =
+    With_free_vars.map With_bound_vars.return v
+
+  let bound_value_var v =
+    with_no_free_vars (With_bound_vars.value_var v)
+
+  let bound_module_var v =
+    with_no_free_vars (With_bound_vars.module_var v)
+
+  let map f t =
+    With_free_vars.map
+      (With_bound_vars.map f)
+      t
+
+  let meet ~dupicated t1 t2 =
+    With_free_vars.map
+      (fun (t1, t2) -> With_bound_vars.meet ~duplicated t1 t2)
+      (With_free_vars.both t1 t2)
+
+  let join ~left_only ~right_only t1 t2 =
+    With_free_vars.map
+      (fun (t1, t2) -> With_bound_vars.join ~left_only ~right_only t1 t2)
+      (With_free_vars.both t1 t2)
+
+  let meet_all ~duplicated ts =
+    With_free_vars.map
+      (With_bound_vars.all ~duplicated)
+      (With_free_vars.all ts)
+
+  let optional ts =
+    With_free_vars.map
+      With_bound_vars.optional
+      (With_free_vars.optional ts)
+
+end
+
+module Ident = struct
+
+  module Module : sig
+
+    type t
+
+    val compilation_unit : string -> t
+
+    val dot : t -> string -> t
+
+    val var : Var.Module.t -> Loc.t -> t
+
+    val with_free_vars : t -> t With_free_vars.t
+
+  end = struct
+
+    type t =
+      | Compilation_unit of string
+      | Dot of t * string
+      | Var of Var.Module.t * Loc.t
+
+    let compilation_unit s = Compilation_unit s
+    let dot t s = Dot(t, s)
+    let var v loc = Var(v, loc)
+
+    let rec free_vars = function
+      | Compilation_unit _ -> Var.Map.empty
+      | Dot(t, _) -> free_vars t
+      | Var(v, loc) -> Var.Map.singleton (Var.generic v) loc
+
+    let with_free_vars t =
+      With_free_vars.mk (free_vars t) t
+
+  end
+
+  module Value : sig
+
+    type t
+
+    val dot : Module.t -> string -> t
+
+    val var : Var.Value.t -> Loc.t -> t
+
+    val with_free_vars : t -> t With_free_vars.t
+
+  end = struct
+    type t =
+      | Dot of Module.t * string
+      | Var of Var.Value.t * Loc.t
+
+    let dot t s = Dot(v, s)
+    let var v = Var v
+    let free_vars = function
+      | Dot(t, _) -> Module.free_vars t
+      | Var(v, loc) -> Var.Map.singleton (Var.Value.generic v) loc
+
+    let with_free_vars t =
+      With_free_vars.mk (free_vars t) t
+
+  end
+
+  module Type : sig
+
+    type t
+
+    val dot : Module.t -> string -> t
+
+    val var : Var.Value.t -> Loc.t -> t
+
+    val with_free_vars : t -> t With_free_vars.t
+
+    val int: t
+    val char: t
+    val string: t
+    val bytes: t
+    val float: t
+    val float32: t
+    val bool: t
+    val unit: t
+    val exn: t
+    val array: t -> t
+    val iarray: t -> t
+    val list: t -> t
+    val option: t -> t
+    val nativeint: t
+    val int32: t
+    val int64: t
+    val lazy_t: t -> t
+    val extension_constructor:t
+    val floatarray:t
+    val lexing_position:t
+    val code: t -> t
+    val unboxed_float:t
+    val unboxed_nativeint:t
+    val unboxed_int32:t
+    val unboxed_int64:t
+    val int8x16: t
+    val int16x8: t
+    val int32x4: t
+    val int64x2: t
+    val float32x4: t
+    val float64x2: t
+
+  end = struct
+
+    type t =
+      | Dot of Module.t * string
+      | Var of Var.Type.t * Loc.t
+      | Builtin of string
+
+    let dot t s = Dot(v, s)
+    let var v = Var v
+    let free_vars = function
+      | Dot(t, _) -> Module.free_vars t
+      | Var(v, loc) -> Var.Map.singleton (Var.Type.generic v) loc
+
+    let with_free_vars t =
+      With_free_vars.mk (free_vars t) t
+
+    let int = Builtin "int"
+    let char = Builtin "char"
+    let string = Builtin "string"
+    let bytes = Builtin "bytes"
+    let float = Builtin "float"
+    let float32 = Builtin "float32"
+    let bool = Builtin "bool"
+    let unit = Builtin "unit"
+    let exn = Builtin "exn"
+    let array = Builtin "array"
+    let iarray = Builtin "iarray"
+    let list = Builtin "list"
+    let option = Builtin "option"
+    let nativeint = Builtin "nativeint"
+    let int32 = Builtin "int32"
+    let int64 = Builtin "int64"
+    let lazy_t = Builtin "lazy_t"
+    let extension_constructor = Builtin "extension_constructor"
+    let floatarray = Builtin "floatarray"
+    let lexing_position = Builtin "lexing_position"
+    let code = Builtin "code"
+    let unboxed_float = Builtin "float#"
+    let unboxed_nativeint = Builtin "nativeint#"
+    let unboxed_int32 = Builtin "int32#"
+    let unboxed_int64 = Builtin "int64#"
+    let int8x16 = Builtin "int8x16"
+    let int16x8 = Builtin "int16x8"
+    let int32x4 = Builtin "int32x4"
+    let int64x2 = Builtin "int64x2"
+    let float32x4 = Builtin "float32x4"
+    let float64x2 = Builtin "float64x2"
+
+  end
+
+  module Module_type : sig
+
+    type t
+
+    val dot : t -> string -> t
+
+    val with_free_vars : t -> t With_free_vars.t
+
+  end = struct
+
+    type t =
+      | Dot of t * string
+
+    let dot t s = Dot(t, s)
+
+    let free_vars = function
+      | Dot(t, _) -> Module.free_vars t
+
+    let with_free_vars t =
+      With_free_vars.mk (free_vars t) t
+
+  end
+
+  module Constructor : sig
+
+    type t
+
+    val dot : Module.t -> string -> t
+
+    val with_free_vars : t -> t With_free_vars.t
+
+    val with_free_and_bound_vars : t -> t With_free_and_bound_vars.t
+
+    val false_ : t
+    val true_ : t
+    val void : t
+    val nil : t
+    val cons : t
+    val none : t
+    val some : t
+    val match_failure : t
+    val out_of_memory : t
+    val invalid_argument : t
+    val failure : t
+    val not_found : t
+    val sys_error : t
+    val end_of_file : t
+    val division_by_zero : t
+    val stack_overflow : t
+    val sys_blocked_io : t
+    val assert_failure : t
+    val undefined_recursive_module : t
+
+  end = struct
+    type t =
+      | Dot of Module.t * string
+      | Builtin of string
+
+    let dot t s = Dot(t, s)
+
+    let free_vars = function
+      | Dot(t, _) -> Module.free_vars t
+
+    let with_free_vars t =
+      With_free_vars.mk (free_vars t) t
+
+    let with_free_and_bound_vars t =
+      With_free_and_bound_vars.no_bound_vars (with_free_vars t)
+
+    let false_ = Builtin "false"
+    let true_ = Builtin "true"
+    let void = Builtin "()"
+    let nil = Builtin "[]"
+    let cons = Builtin "(::)"
+    let none = Builtin "None"
+    let some = Builtin "Some"
+    let match_failure = Builtin "Match_failure"
+    let out_of_memory = Builtin "Out_of_memory"
+    let invalid_argument = Builtin "Invalid_argument"
+    let failure = Builtin "Failure"
+    let not_found = Builtin "Not_found"
+    let sys_error = Builtin "Sys_error"
+    let end_of_file = Builtin "End_of_file"
+    let division_by_zero = Builtin "Division_by_zero"
+    let stack_overflow = Builtin "Stack_overflow"
+    let sys_blocked_io = Builtin "Sys_blocked_io"
+    let assert_failure = Builtin "Assert_failure"
+    let undefined_recursive_module = Builtin "Undefined_recursive_module"
+
+  end
+
+  module Field : sig
+
+    type t
+
+    val dot : Module.t -> string -> t
+
+    val with_free_vars : t -> t With_free_vars.t
+
+    val with_free_and_bound_vars : t -> t With_free_and_bound_vars.t
+
+  end = struct
+
+    type t =
+      | Dot of Module.t * string
+
+    let dot t s = Dot(t, s)
+
+    let free_vars = function
+      | Dot(t, _) -> Module.free_vars t
+
+    let with_free_vars t =
+      With_free_vars.mk (free_vars t) t
+
+    let with_free_and_bound_vars t =
+      With_free_and_bound_vars.no_bound_vars (with_free_vars t)
+
+  end
+
+end
+
+module Ast = struct
+
+  type constant =
+    | Int of int
+    | Char of char
+    | String of string * string option
+    | Float of string
+    | Int32 of int32
+    | Int64 of int64
+    | Nativeint of nativeint
+
+  type rec_flag = Nonrecursive | Recursive
+
+  type direction_flag = Upto | Downto
+
+  type override_flag = Override | Fresh
+
+  type closed_flag = Closed | Open
+
+  type arg_label =
+    | Nolabel
+    | Labelled of string
+    | Optional of string
+
+  type tuple_label =
+    | Nolabel
+    | Labelled of label
+
+  type core_type =
+    | Any
+    | Var of Name.t
+    | Arrow of arg_label * core_type * core_type
+    | Tuple of (tuple_label * core_type) list
+    | Constr of Ident.Type.t * core_type list
+    | Alias of core_type * Name.t
+    | Variant of row_field list * closed_flag * string list option
+    | Poly of Name.t list * core_type
+    | Package of package_type
+
+  and row_field =
+    | Tag of string * bool * core_type list
+    | Inherit of core_type
+
+  and package_type = Ident.Module_type.t * (fragment * core_type) list
+
+  and fragment =
+    | Name of Name.t
+    | Dot of fragment * Name.t
+
+  type type_constraint =
+    | Constraint of core_type
+    | Coerce of core_type option * core_type
+
+  type pattern =
+    | Any
+    | Var of Var.Value.t
+    | Alias of pattern * Var.Value.t
+    | Constant of constant
+    | Interval of constant * constant
+    | Tuple of pattern list
+    | Construct of Ident.Constructor.t * pattern option
+    | Variant of string * pattern option
+    | Record of (Ident.Field.t * pattern) list * closed_flag
+    | Array of pattern list
+    | Or of pattern * pattern
+    | Constraint of pattern * core_type
+    | Lazy of pattern
+    | Unpack of Var.Module.t
+    | Exception of pattern
+
+  type expression_attribute =
+    | Inline
+    | Inlined
+    | Specialise
+    | Specialised
+    | Unrolled
+    | Nontail
+    | Tail
+    | Poll
+    | Loop
+    | Tail_mod_cons
+    | Quotation
+
+  type expression =
+    {
+      desc: expression_desc;
+      attributes: expression_attribute list;
+    }
+
+  and expression_desc =
+    | Ident of Ident.Value.t
+    | Constant of constant
+    | Let of rec_flag * value_binding list * expression
+    | Fun of function_
+    | Apply of expression * (arg_label * expression) list
+    | Match of expression * case list
+    | Try of expression * case list
+    | Tuple of (tuple_label * expression) list
+    | Construct of Ident.Constructor.t * expression option
+    | Variant of string * expression option
+    | Record of (Ident.Field.t * expression) list * expression option
+    | Field of expression * Ident.Field.t
+    | Setfield of expression * Ident.Field.t * expression
+    | Array of expression list
+    | Ifthenelse of expression * expression * expression option
+    | Sequence of expression * expression
+    | While of expression * expression
+    | For of
+        pattern * expression
+        * expression * direction_flag
+        * expression
+    | Constraint of expression * core_type
+    | Coerce of expression * core_type option * core_type
+    | Letmodule of Var.Module.t * module_expr * expression
+    | Assert of expression
+    | Lazy of expression
+    | Pack of module_expr
+    | Open of override_flag * Ident.Module.t * expression
+    | Quote of expression
+    | Escape of expression
+    | Splice of expression * Loc.t
+
+  and case =
+    {
+      lhs: pattern;
+      guard: expression option;
+      rhs: expression option;
+    }
+
+  and value_binding =
+    {
+      pat: pattern;
+      expr: expression;
+    }
+
+  and function_body =
+    | Pfunction_body of expression
+    | Pfunction_cases of case list
+
+  and function_param =
+    | Pparam_val of arg_label * expression option * pattern
+    | Pparam_newtype of Var.Type.t
+
+  and function_ =
+    { params : function_param list;
+      constraint_ : type_constraint option;
+      body : function_body; }
+
+  and module_expr =
+    | Ident of Ident.Module.t
+    | Apply of module_expr * module_expr
+    | Apply_unit of module_expr
+    | Unpack of expression
+
+end
+
+module Constant = struct
+
+  type t = Ast.constant
+
+  let int i = Int i
+  let char c = Char c
+  let string s = String s
+  let float f = Float f
+  let int32 i = Int32 i
+  let int64 i = Int64 i
+  let nativeint i = Nativeint i
+
+end
+
+module Label = struct
+
+  type t = arg_label
+
+  let no_label = Nolabel
+  let labelled s = Labelled s
+  let optional s = Optional s
+
+end
+
+module Variant = struct
+
+  type t = string
+
+  let of_string (s : string) : t = s
+
+end
+
+module Pat = struct
+
+  open With_free_and_bound_vars
+
+  type t = Ast.pattern With_free_and_bound_vars.t
+
+  let duplicate_binding_error var =
+    let msg =
+      Format.asprintf
+        "Duplicate bindings detected for the identifier %s at %a"
+        (Var.name var) Loc.print (Var.loc var)
+    in
+    failwith msg
+
+  let mismatch_binding_error var =
+    let msg =
+      Format.asprintf Format.str_formatter
+        "Mismatched bindings detected for the identifier %s at %a"
+        (Var.name var) Loc.print (Var.loc var)
+    in
+    failwith msg
+
+  let (let+) = map
+  let (and+) t1 t2 =
+    meet ~dupicated:duplicate_binding_error t1 t2
+  let all ~duplicated ts =
+    meet_all ~duplicated:duplicate_binding_error ts
+
+  let join t1 t2 =
+    join
+      ~left_only:mismatch_binding_error
+      ~right_only:mismatch_binding_error
+      t1 t2
+
+  let any = return Any
+
+  let var v =
+    let+ v = bound_value_var v in
+    Var v
+
+  let alias t v =
+    let+ p = t
+    and+ v = bound_value_var v in
+    Alias(p, v)
+
+  let constant const =
+    return (Constant const)
+
+  let interval const1 const2 =
+    return (Interval(const1, const2))
+
+  let tuple ts =
+    let+ ps = all ts in
+    Tuple ps
+
+  let construct lid tm =
+    let+ pm = optional tm
+    and+ lid = Ident.Constructor.with_free_and_bound_vars lid in
+    Construct(lid, pm)
+
+  let variant label tm =
+    let+ pm = optional tm in
+    Variant(label, pm)
+
+  let record fields closed =
+    let closed = if closed then AST.Closed else AST.Open in
+    let ts =
+      List.map
+        (fun (lbl, t) ->
+          let+ lbl = Ident.Field.with_free_and_bound_vars lid
+          and+ p = t in
+          lbl, t)
+        fields
+    in
+    let+ ps = all ts in
+    Record(ps, closed)
+
+  let array ts =
+    let+ ps = all ts in
+    Array ps
+
+  let or_ t1 t2 =
+    let+ (p1, p2) = join t1 t2 in
+    Or(pat1, pat2)
+
+  let lazy_ t =
+    let+ p = t in
+    Lazy p
+
+  let module_ v =
+    let+ v = bound_module_var v in
+    Module v
+
+  let exception_ t =
+    let+ p = t in
+    Exception p
+
+end
+
+module Case = struct
+
+  type t = Ast.case With_free_vars.t
+
+  let unexpected_binding_error loc var =
+    let msg =
+      Format.asprintf Format.str_formatter
+        "Unexpected binding detected for the identifier %s from %a at %a"
+        (Var.name var) Loc.print (Var.loc var) Loc.print loc
+    in
+    failwith msg
+
+  let missing_binding_error var =
+    let msg =
+      Format.asprintf Format.str_formatter
+        "Missing binding for the identifier %s at %a"
+        (Var.name var) Loc.print (Var.loc var)
+    in
+    failwith msg
+
+  let mk lhs guard rhs =
+    { lhs; guard; rhs; }
+
+  let (let+) = With_free_vars.map
+  let (and+) = With_free_vars.both
+
+  let nonbinding loc lhs rhs =
+    let+ lhs = value_nonbinding ~extra:(unexpected_binding_error loc) lhs
+    and+ rhs = rhs in
+    mk lhs None (Some rhs)
+
+  let simple loc name f =
+    With_free_vars.binding loc name
+      (fun var ->
+        let+ rhs = f var in
+        mk (Var var) None (Some rhs))
+
+  let pattern loc ~bound_vars ~bound_modules f =
+    let+ lhs, rhs =
+      With_free_vars.complex_bindings loc
+        ~extra:(unexpected_binding_error loc) ~missing:missing_binding_error
+        ~bound_vars ~bound_modules f
+    in
+    mk lhs None (Some rhs)
+
+  let guarded loc ~bound_vars ~bound_modules f =
+    let+ lhs, (guard, rhs) =
+      With_free_vars.complex_bindings loc
+        ~extra:(unexpected_binding_error loc) ~missing:missing_binding_error
+        ~bound_vars ~bound_modules
+        (fun value_vars module_vars ->
+            let lhs, guard, rhs = f value_vars module_vars in
+            lhs, both guard rhs)
+    in
+    mk lhs (Some guard) (Some rhs)
+
+  let refutation loc ~bound_vars ~bound_modules f =
+    let+ lhs =
+      With_free_vars.complex_bindings loc
+        ~extra:(unexpected_binding_error loc) ~missing:missing_binding_error
+        ~bound_vars ~bound_modules f
+    in
+    mk lhs None None
+
+end
+
+module Type_constraint = struct
+
+  type t = Ast.type_constraint With_free_vars.t
+
+  open With_free_vars
+
+  let (let+) = With_free_vars.map
+  let (and+) = With_free_vars.both
+
+  let constraint_ typ =
+    let+ typ = typ in
+    Constraint typ
+
+  let coercion typ1 typ2 =
+    let+ typ1 = typ1
+    and+ typ2 = typ2 in
+    Coercion(typ1, typ2)
+  
+end
+
+module Function_ = struct
+
+  type t = function_ With_free_vars.t
+
+  open With_free_vars
+
+  let (let+) = With_free_vars.map
+  let (and+) = With_free_vars.both
+
+  val body : Exp.t -> t
+
+  val cases : Case.t list -> t
+
+  val param_nonbinding : Label.t -> Exp.t option -> Pat.t -> t -> t
+
+  val param_simple :
+    Label.t
+    -> Exp.t option
+    -> Name.t
+    -> (Var.Value.t -> t)
+    -> t
+
+  val param :
+    Label.t
+    -> Exp.t option
+    -> Name.t list
+    -> (Var.Value.t list -> Pat.t * t)
+    -> t
+
+  val newtype : Name.t -> (Var.Type.t -> t) -> t
+
+end
+
+module Exp = struct
+
+  type t = Ast.expression With_free_vars.t
+
+  open With_free_vars
+
+  let unbound_var loc var use =
+    let msg =
+      Format.asprintf Format.str_formatter
+        "The quotation built at %a has unbound variables: \
+         variable %s used at %a is not bound."
+        Loc.print loc (Var.txt var)
+        Loc.print use
+    in
+    failwith msg
+
+  let unexpected_binding_error loc var =
+    let msg =
+      Format.asprintf Format.str_formatter
+        "Unexpected binding detected for the identifier %s from %a at %a"
+        (Var.name var) Loc.print (Var.loc var) Loc.print loc
+    in
+    failwith msg
+
+  let mk desc attributes : Ast.expression =
+    { desc; attributes; }
+
+  let (let+) = With_free_vars.map
+  let (and+) = With_free_vars.both
+
+  let mk_vb pat expr : Ast.value_binding =
+    {pat; expr}
+
+  let ident id =
+    let+ id = Ident.Value.with_free_vars id in
+    mk (Ident id) []
+
+  let constant const =
+    return (mk (Constant const) [])
+
+  let let_nonbinding loc pat def body =
+    let+ pat = pat
+    and+ def = def
+    and+ body = body in
+    let pat =
+      With_bound_vars.value_nonbinding ~extra:(unexpected_binding_error loc) pat
+    in
+    let vbs = [mk_vb pat def] in
+    mk (Let(Nonrec, vbs, body)) []
+
+  let let_simple loc name def f =
+    let+ def = def
+    and+ (pat, body) =
+      value_binding loc name
+        (fun var ->
+          let+ body = f var in
+          let pat = Var var in
+          pat, body)
+    in
+    let vbs = [mk_vb pat def] in
+    mk (Let(Nonrec, vbs, body)) []
+
+  let let_rec_simple loc names f =
+    value_bindings loc names
+      (fun vars ->
+        let defs, body = f vars in
+        let+ defs = defs
+        and+ body = body in
+        let vbs_rev =
+          List.rev_map2
+            (fun var def ->
+              let pat = Var var in
+              mk_vb pat def)
+            vars defs
+        in
+        let vbs = List.rev vbs_rev in
+        mk (Let(Rec, vbs, body))
+        vbs, body)
+
+  let let_ loc names def f =
+    let+ def = def
+    and+ (pat, body) = value_binding loc name f in
+    let vbs = [mk_vb pat def] in
+    mk (Let(Nonrec, vbs, body)) []
+
+  let fun_nonbinding loc params exp =
+    let+ params = params
+    and+ exp = exp in
+    let constraint_ = None in
+    let body = Pfunction_body exp in
+    let fn = { params; constraint_; body } in
+    mk (Fun fn)
+
+  let fun_simple loc name label default f =
+    let heap, pat, exp = Binding.simple loc name f in
+    let heap, default = fold_map_option merge loc heap default in
+      mk loc heap (Pexp_fun (label, default, pat, exp))
+
+  let fun_ loc names label default f =
+    let heap, pat, exp = Binding.pattern loc names f in
+    let heap, default = fold_map_option merge loc heap default in
+      mk loc heap (Pexp_fun(label, default, pat, exp))
+
+  let function_ loc cases =
+    let heap, cases = List.fold_left_map CaseRepr.merge loc Level_map.empty cases in
+      mk loc heap (Pexp_function cases)
+
+  let apply loc fn args =
+    let heap, fn = merge loc Level_map.empty fn in
+    let heap, args = fold_left_map_alist merge loc heap args in
+      mk loc heap (Pexp_apply (fn, args))
+
+  let match_ loc exp cases =
+    let heap, exp = merge loc Level_map.empty exp in
+    let heap, cases = List.fold_left_map CaseRepr.merge loc heap cases in
+      mk loc heap (Pexp_match(exp, cases))
+
+  let try_ loc exp cases =
+    let heap, exp = merge loc Level_map.empty exp in
+    let heap, cases = List.fold_left_map CaseRepr.merge loc heap cases in
+      mk loc heap (Pexp_try(exp, cases))
+
+  let tuple loc exps =
+    let heap, exps = List.fold_left_map merge loc Level_map.empty exps in
+      mk loc heap (Pexp_tuple exps)
+
+  let construct loc lid argo =
+    let heap, argo = fold_map_option merge loc Level_map.empty argo in
+      mk loc heap (Pexp_construct (lid, argo))
+
+  let variant loc label argo =
+    let heap, argo = fold_map_option merge loc Level_map.empty argo in
+      mk loc heap (Pexp_variant (label, argo))
+
+  let record loc defs orig =
+    let heap, defs = fold_left_map_alist merge loc Level_map.empty defs in
+    let heap, orig = fold_map_option merge loc heap orig in
+      mk loc heap (Pexp_record (defs, orig))
+
+  let field loc rcd lid =
+    let heap, rcd = merge loc Level_map.empty rcd in
+      mk loc heap (Pexp_field (rcd, lid))
+
+  let setfield loc rcd lid def =
+    let heap, rcd = merge loc Level_map.empty rcd in
+    let heap, def = merge loc heap def in
+      mk loc heap (Pexp_setfield (rcd, lid, def))
+
+  let array loc args =
+    let heap, args = List.fold_left_map merge loc Level_map.empty args in
+      mk loc heap (Pexp_array args)
+
+  let ifthenelse loc cond tr fs =
+    let heap, cond = merge loc Level_map.empty cond in
+    let heap, tr = merge loc heap tr in
+    let heap, fs = fold_map_option merge loc heap fs in
+      mk loc heap (Pexp_ifthenelse (cond, tr, fs))
+
+  let sequence loc exp1 exp2 =
+    let heap, exp1 = merge loc Level_map.empty exp1 in
+    let heap, exp2 = merge loc heap exp2 in
+      mk loc heap (Pexp_sequence(exp1, exp2))
+
+  let while_ loc cond body =
+    let heap, cond = merge loc Level_map.empty cond in
+    let heap, body = merge loc heap body in
+      mk loc heap (Pexp_while(cond, body))
+
+  let for_nonbinding loc pat low high dir body =
+    let dir = if dir then CamlinternalAST.Upto else CamlinternalAST.Downto in
+    let pat = PatRepr.nonbinding loc pat in
+    let heap, low = merge loc Level_map.empty low in
+    let heap, high = merge loc heap high in
+    let heap, body = merge loc heap body in
+      mk loc heap (Pexp_for (pat, low, high, dir, body))
+
+  let for_simple loc name low high dir f =
+    let dir = if dir then CamlinternalAST.Upto else CamlinternalAST.Downto in
+    let heap, pat, body = Binding.simple loc name f in
+    let heap, low = merge loc heap low in
+    let heap, high = merge loc heap high in
+      mk loc heap (Pexp_for (pat, low, high, dir, body))
+
+  let assert_ loc exp =
+    let heap, exp = merge loc Level_map.empty exp in
+      mk loc heap (Pexp_assert exp)
+
+  let lazy_ loc exp =
+    let heap, exp = merge loc Level_map.empty exp in
+      mk loc heap (Pexp_lazy exp)
+
+  let open_ loc ovr lid exp =
+    let ovr =
+      if ovr then CamlinternalAST.Override else CamlinternalAST.Fresh
+    in
+    let heap, exp = merge loc Level_map.empty exp in
+      mk loc heap (Pexp_open(ovr, lid, exp))
+
+  let quote loc exp =
+    let heap, exp = merge loc Level_map.empty exp in
+      mk loc heap (Pexp_quote exp)
+
+  let escape loc exp =
+    let heap, exp = merge loc Level_map.empty exp in
+      mk loc heap (Pexp_escape exp)
+
+end
+
+module Code = struct
+
+  module Closed = struct
+
+    type exp = t
+
+    type t = expression
+
+    let close_delay_check exp =
+        match Level_map.choose exp.heap with
+        | None -> (exp.exp, fun () -> ())
+        | Some var ->
+          (exp.exp, fun () ->
+            Format.fprintf Format.str_formatter
+            "The code built at %a is not closed: \
+             identifier %s bound at %a is free"
+            Loc.print exp.exp.pexp_loc (Var.txt var)
+            Loc.print (Var.loc var);
+            failwith (Format.flush_str_formatter ()))
+
+    let close exp =
+      let exp, check = close_delay_check exp in
+      check (); exp
+
+    let open_ exp =
+      let heap = Level_map.empty in
+        { heap; exp }
+
+  end
+
+end

--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -1,37 +1,33 @@
-# 2 "../home/lpw25/Repositories/flambda-backend/stdlib/camlinternalQuote.ml"
 let fold_map_option f acc o =
   match o with
-  | None -> (acc, None)
+  | None -> acc, None
   | Some x ->
-      let acc, x = f acc x in
-        (acc, Some x)
+    let acc, x = f acc x in
+    acc, Some x
 
 let rec fold_left_map_alist f acc l =
   match l with
-  | [] -> (acc, [])
+  | [] -> acc, []
   | (k, x) :: rest ->
-      let acc, x = f acc x in
-      let acc, rest = fold_left_map_alist f acc rest in
-        (acc, (k, x) :: rest)
+    let acc, x = f acc x in
+    let acc, rest = fold_left_map_alist f acc rest in
+    acc, (k, x) :: rest
 
 module Stamp : sig
-
-  type t
   (** [t] is the type of stamps. Stamps have no structure, only a notion
       of identity. *)
+  type t
 
-  val fresh : unit -> t
   (** [fresh ()] creates a fresh stamp, unequal to any other. *)
+  val fresh : unit -> t
 
-  val compare : t -> t -> int
   (** [compare] is a total ordering on stamps. *)
+  val compare : t -> t -> int
 
-  val to_string : t -> string
   (** [to_string] prints a representation of the stamp. Each stamp
       has a different representation. *)
-
+  val to_string : t -> string
 end = struct
-
   type t = int
 
   external fresh : unit -> int = "caml_fresh_oo_id" [@@noalloc]
@@ -39,56 +35,63 @@ end = struct
   let compare = Int.compare
 
   let to_string = string_of_int
-
 end
 
 module Loc = struct
-
   type t =
     | Unknown
     | Known of
-        { file: string;
-          start_line:int;
-          start_col:int;
-          end_line:int;
-          end_col:int; }
+        { file : string;
+          start_line : int;
+          start_col : int;
+          end_line : int;
+          end_col : int
+        }
 
   let unknown = Unknown
 
   let known ~file ~start_line ~start_col ~end_line ~end_col =
-    Known { file; start_line; start_col; end_line; end_col; }
+    Known { file; start_line; start_col; end_line; end_col }
 
+  let print fmt = function
+    | Unknown -> Format.printf "<unknown>"
+    | Known { file; start_line; start_col; end_line; end_col } ->
+      if start_line = end_line
+      then
+        Format.printf "File %s, line %d, characters %d-%d" file start_line
+          start_col end_col
+      else
+        Format.printf "File %s, lines %d-%d, characters %d-%d" file start_line
+          end_line start_col end_col
 end
 
 module Level : sig
-
-  type t
   (** [t] is the type of binding levels. All variable bindings have an
       associated level and all bindings of the same level have the same
       scope. Each level is associated with a point on the call
       stack. Each level has a location attached for error messages. *)
+  type t
 
-  val with_fresh : Loc.t -> (t -> 'a) -> 'a
   (** [with_fresh loc f] creates a fresh level not equal to any others,
       associated with the current point in the call stack, with [loc] as
       the attached location. *)
+  val with_fresh : Loc.t -> (t -> 'a) -> 'a
 
-  val check : t -> bool
   (** [check t] is [true] if the point on the call stack associated with
       [t] is still present, otherwise it is [false]. *)
+  val check : t -> bool
 
-  val compare : t -> t -> int
   (** [compare] is a total order on levels. *)
+  val compare : t -> t -> int
 
-  val loc : t -> Loc.t
   (** [loc t] is the location attached to [t]. *)
-
+  val loc : t -> Loc.t
 end = struct
-
   type t =
     { stamp : Stamp.t;
       mutable valid : bool;
-      loc : Loc.t; }
+      loc : Loc.t
+    }
 
   let fresh loc =
     let stamp = Stamp.fresh () in
@@ -110,181 +113,164 @@ end = struct
   let compare t1 t2 = Stamp.compare t1.stamp t2.stamp
 
   let loc t = t.loc
-
 end
 
 module Name = struct
-
   type t = string
 
   let mk t = t
-
 end
 
 module Var : sig
-
-  type t
   (** [t] is the type of variables of any sort *)
+  type t
 
   type var := t
 
   module Module : sig
-
-    type t
     (** [t] is the type of module variables *)
+    type t
 
-    val generate : Level.t -> Name.t -> t
     (** [generate lv n] creates a fresh module variable bound at [lv]
         whose name is [n]. *)
+    val generate : Level.t -> Name.t -> t
 
-    val generic : t -> var
     (** [generic t] is [t] as a generic variable *)
+    val generic : t -> var
 
-    val name : t -> Name.t
     (** [name t] is the name of [t]. *)
-
+    val name : t -> Name.t
   end
 
   module Value : sig
-
-    type t
     (** [t] is the type of ordinary variables *)
+    type t
 
-    val generate : Level.t -> Name.t -> t
     (** [generate lv n] creates a fresh variable bound at [lv] whose
         name is [n]. *)
+    val generate : Level.t -> Name.t -> t
 
-    val generic : t -> var
     (** [generic t] is [t] as a generic variable *)
+    val generic : t -> var
 
-    val name : t -> Name.t
     (** [name t] is the name of [t]. *)
-
+    val name : t -> Name.t
   end
 
   module Type : sig
-
-    type t
     (** [t] is the type of type constructor variables *)
+    type t
 
-    val generate : Level.t -> Name.t -> t
     (** [generate lv n] creates a fresh type constructor variable
         bound at [lv] whose name is [n]. *)
+    val generate : Level.t -> Name.t -> t
 
-    val generic : t -> var
     (** [generic t] is [t] as a generic variable *)
+    val generic : t -> var
 
-    val name : t -> Name.t
     (** [name t] is the name of [t]. *)
-
+    val name : t -> Name.t
   end
 
-  val name : t -> Name.t
   (** [name t] is the name of [t]. *)
+  val name : t -> Name.t
 
-  val level : t -> Level.t
   (** [level t] is the level of [t]. *)
+  val level : t -> Level.t
 
-  val loc : t -> Loc.t
   (** [loc t] is [Level.loc (level t)]. *)
+  val loc : t -> Loc.t
 
-  val valid : t -> bool
   (** [valid t] is [true] if [t]'s binding is still open, and [false] otherwise. Once [t]'s binding has
       been closed there is no valid way to use [t]. *)
+  val valid : t -> bool
 
   module Set : sig
-
-    type t
     (** [t] is the type of sets of variables. *)
+    type t
 
-    val empty : t
     (** [empty] is the empty set. *)
+    val empty : t
 
-    val singleton : var -> t
     (** [singleton v] is the set containing just [v]. *)
+    val singleton : var -> t
 
-    val add : var -> t -> t
     (** [add v t] is the set containing [v] and the elements of [t]. *)
+    val add : var -> t -> t
 
-    val union : shared:(var -> unit) -> t -> t -> t
     (** [union ~shared t1 t2] is the union of [t1] and [t2]. [shared] is run on all
         the variables that are in both [t1] and [t2]. *)
+    val union : shared:(var -> unit) -> t -> t -> t
 
-    val inter : left_only:(var -> unit) -> right_only:(var -> unit) -> t -> t -> t
     (** [inter ~left_only ~right_only t1 t2] is the intersection of [t1]
         and [t2]. [left_only] is run on all the variables that are in
         [t1] and not in [t2]. [right_only] is run on all the variables
         that are in [t2] and not in [t1]. *)
+    val inter :
+      left_only:(var -> unit) -> right_only:(var -> unit) -> t -> t -> t
 
-    val iter : (var -> unit) -> t -> unit
     (** [iter f t] runs [f] on every variable in [t]. *)
+    val iter : (var -> unit) -> t -> unit
 
-    val choose : t -> var option
     (** [choose t] is [None] if [t] is equal to [empty] and [Some v],
         where [v] is an element of [t], otherwise. *)
+    val choose : t -> var option
 
-    val differences :
-      left_only:(var -> unit) -> right_only:(var -> unit) -> t -> t -> unit
     (** [differences ~left_only ~right_only t1 t2] runs [left_only] on every element of [t1]
         that is not an element of [t2] and [right_only] on every element of [t2] that is
         not an element of [t1]. *)
-
+    val differences :
+      left_only:(var -> unit) -> right_only:(var -> unit) -> t -> t -> unit
   end
 
   module Map : sig
-
-    type 'a t
     (** ['a t] is the type of maps from variables to ['a] values. *)
+    type 'a t
 
-    val empty : 'a t
     (** [empty] is the empty set. *)
+    val empty : 'a t
 
-    val singleton : var -> 'a -> 'a t
     (** [singleton v data] is the map containing just a binding of [v] to [data]. *)
+    val singleton : var -> 'a -> 'a t
 
-    val add : var -> 'a -> 'a t -> 'a t
     (** [add v data t] is the map containing the same bindings as [t]
         plus a binding of [v] to [data]. *)
+    val add : var -> 'a -> 'a t -> 'a t
 
-    val union : (var -> 'a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
     (** [union ~join t1 t2] is the union of [t1] and [t2]. [join] is run on all
         the variables that are in both [t1] and [t2]. *)
+    val union : (var -> 'a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
 
-    val remove_level : Level.t -> 'a t -> 'a t
     (** [remove_level l t] is the map containing the bindings of [t] whose
         variables's level is not [l]. *)
+    val remove_level : Level.t -> 'a t -> 'a t
 
-    val iter : (var -> 'a -> unit) -> 'a t -> unit
     (** [iter f t] runs [f] on every variable in [t]. *)
+    val iter : (var -> 'a -> unit) -> 'a t -> unit
 
-    val choose : 'a t -> (var * 'a) option
     (** [choose t] is [None] if [t] is equal to [empty] and [Some (v, data)],
         where [v] is bound to [data] in [t], otherwise. *)
-
+    val choose : 'a t -> (var * 'a) option
   end
-
 end = struct
-
   type t =
     { name : string;
       stamp : Stamp.t;
-      level : Level.t; }
+      level : Level.t
+    }
 
   module Set = struct
-
     type var = t
 
-    module Stamp_map = Map.Make(Stamp)
+    module Stamp_map = Map.Make (Stamp)
 
     type t = var Stamp_map.t
 
     let empty = Stamp_map.empty
 
-    let singleton v =
-      Stamp_map.singleton v.stamp v
+    let singleton v = Stamp_map.singleton v.stamp v
 
-    let add v t =
-      Stamp_map.add v.stamp v t
+    let add v t = Stamp_map.add v.stamp v t
 
     let union ~shared t1 t2 =
       Stamp_map.union
@@ -298,18 +284,19 @@ end = struct
         (fun _ v1 v2 ->
           match v1, v2 with
           | None, None -> None
-          | Some v1, None -> left_only v1; None
-          | None, Some v2 -> right_only v2; None
-          | Some v1, Some _  -> Some v1)
+          | Some v1, None ->
+            left_only v1;
+            None
+          | None, Some v2 ->
+            right_only v2;
+            None
+          | Some v1, Some _ -> Some v1)
         t1 t2
 
     let choose t =
-      match Stamp_map.choose_opt t with
-      | None -> None
-      | Some (_, v) -> Some v
+      match Stamp_map.choose_opt t with None -> None | Some (_, v) -> Some v
 
-    let iter f t =
-      Stamp_map.iter (fun _ v -> f v) t
+    let iter f t = Stamp_map.iter (fun _ v -> f v) t
 
     let differences ~left_only ~right_only t1 t2 =
       ignore
@@ -317,38 +304,38 @@ end = struct
            (fun _ v1 v2 ->
              match v1, v2 with
              | None, None -> None
-             | Some v, None -> left_only v; None
-             | None, Some v -> right_only v; None
-             | Some v, Some _  -> None)
-           t1 t2);
-
+             | Some v, None ->
+               left_only v;
+               None
+             | None, Some v ->
+               right_only v;
+               None
+             | Some v, Some _ -> None)
+           t1 t2)
   end
 
   module Map = struct
-
     type var = t
 
-    module Var_map = Map.Make(struct
-        type t = var
-        let compare t1 t2 = Stamp.compare t1.stamp t2.stamp
-      end)
+    module Var_map = Map.Make (struct
+      type t = var
 
-    module Level_map = Map.Make(Level)
+      let compare t1 t2 = Stamp.compare t1.stamp t2.stamp
+    end)
+
+    module Level_map = Map.Make (Level)
 
     type 'a t = 'a Var_map.t Level_map.t
 
     let empty = Level_map.empty
 
     let singleton v data =
-      Level_map.singleton v.level
-        (Var_map.singleton v data)
+      Level_map.singleton v.level (Var_map.singleton v data)
 
     let add v data t =
       let update prev =
         let prev =
-          match prev with
-          | None -> Var_map.empty
-          | Some prev -> prev
+          match prev with None -> Var_map.empty | Some prev -> prev
         in
         let next = Var_map.add v data prev in
         Some next
@@ -373,21 +360,18 @@ end = struct
     let rec choose t =
       match Level_map.choose_opt t with
       | None -> None
-      | Some (l, m) ->
-          match Var_map.choose_opt m with
-          | None -> choose (Level_map.remove l t)
-          | Some _ as res -> res
+      | Some (l, m) -> (
+        match Var_map.choose_opt m with
+        | None -> choose (Level_map.remove l t)
+        | Some _ as res -> res)
 
     let iter f t =
-      Level_map.iter
-        (fun _ m -> Var_map.iter (fun v data -> f v data) m)
-        t
-
+      Level_map.iter (fun _ m -> Var_map.iter (fun v data -> f v data) m) t
   end
 
   let generate level name =
     let stamp = Stamp.fresh () in
-    let name = name ^ "_" ^ (Stamp.to_string stamp) in
+    let name = name ^ "_" ^ Stamp.to_string stamp in
     { name; stamp; level }
 
   let name t = t.name
@@ -399,7 +383,6 @@ end = struct
   let valid t = Level.check t.level
 
   module Module = struct
-
     type var = t
 
     type t = var
@@ -409,11 +392,9 @@ end = struct
     let generic t = t
 
     let name = name
-
   end
 
   module Value = struct
-
     type var = t
 
     type t = var
@@ -423,11 +404,9 @@ end = struct
     let generic t = t
 
     let name = name
-
   end
 
   module Type = struct
-
     type var = t
 
     type t = var
@@ -437,51 +416,40 @@ end = struct
     let generic t = t
 
     let name = name
-
   end
-
 end
 
 module With_bound_vars : sig
-
-  type 'a t
   (** ['a t] is the type of ['a]s paired with a set of variables that
       are bound by the ['a]. *)
+  type 'a t
 
-  val mk : Var.Set.t -> 'a -> 'a t
   (** [mk vars x] is [x] paired with [vars]. *)
+  val mk : Var.Set.t -> 'a -> 'a t
 
-  val return : 'a -> 'a t
   (** [return x] is [mk Var.Set.empty x]. *)
+  val return : 'a -> 'a t
 
-  val var : Var.t -> Var.t t
   (** [var v] is [mk (Var.Set.singleton v) v]. *)
+  val var : Var.t -> Var.t t
 
-  val value_var : Var.Value.t -> Var.Value.t t
   (** [value_var v] is [mk (Var.Set.singleton (Var.Value.generic v)) v]. *)
+  val value_var : Var.Value.t -> Var.Value.t t
 
-  val module_var : Var.Module.t -> Var.Module.t t
   (** [module_var v] is [mk (Var.Set.singleton (Var.Module.generic v)) v]. *)
+  val module_var : Var.Module.t -> Var.Module.t t
 
-  val map : ('a -> 'b) -> 'a t -> 'b t
   (** [map f t] is [f v], where [v] is the value of [t], paired with the
       same variables as [t]. *)
+  val map : ('a -> 'b) -> 'a t -> 'b t
 
-  val meet : 
-    duplicated:(Var.t -> unit)
-    -> 'a t
-    -> 'b t
-    -> ('a * 'b)t
   (** [meet t1 t2] is [(v1, v2)], where [v1] and [v2] are the values of
       [t1] and [t2] respectively, paired with the union of the variables
       from [t1] and [t2] which are expected to be disjoint. If [t1] and
       [t2] share any variables then [duplicated] will be run on the
       shared variables.*)
+  val meet : duplicated:(Var.t -> unit) -> 'a t -> 'b t -> ('a * 'b) t
 
-  val join :
-    left_only:(Var.t -> unit)
-    -> right_only:(Var.t -> unit)
-    -> 'a t -> 'b t -> ('a * 'b) t
   (** [join ~left_only ~right_only t1 t2] is [(v1, v2)], where [v1] and
       [v2] are the values of [t1] and [t2] respectively, paired with the
       intersection of the variables from [t1] and [t2] which are
@@ -489,46 +457,41 @@ module With_bound_vars : sig
       [t2] then [left_only] with be run on them. If any variables in
       [t2] are missing from [t1] then [right_only] will be run on
       them. *)
+  val join :
+    left_only:(Var.t -> unit) ->
+    right_only:(Var.t -> unit) ->
+    'a t ->
+    'b t ->
+    ('a * 'b) t
 
-  val meet_all :
-    duplicated:(Var.t -> unit)
-    -> 'a t list    
-    -> 'a list t
   (** [meet_all ~duplicated [t1; t2; ...]] is [[v1; v2; ...]], where
       each [vn] is the value of [tn], paired with the union of the
       variables from all the [ts] which are expected to be disjoint. If
       the [ts] share any variables then [duplicated] will be run on the
       shared variables. *)
+  val meet_all : duplicated:(Var.t -> unit) -> 'a t list -> 'a list t
 
-  val optional : 'a t option -> 'a option t
   (** [optional tm] is [Some v], where [v] is the value of [t], paired
       with the variables from [t] if [tm] is [Some t]. It is [return
       None] if [tm] is [None]. *)
+  val optional : 'a t option -> 'a option t
 
-  val value :
-    extra:(Var.t -> unit)
-    -> missing:(Var.t -> unit)
-    -> 'a t
-    -> Var.t list
-    -> 'a
   (** [value ~extra ~missing t vs] is [t]'s value. [t] is expected to
       bind exactly the variables [vs]. [extra] is run on any additional
       variables that are bound. [missing] is run on any variables that
       are missing. *)
+  val value :
+    extra:(Var.t -> unit) -> missing:(Var.t -> unit) -> 'a t -> Var.t list -> 'a
 
-  val value_nonbinding :
-    extra:(Var.t -> unit)
-    -> 'a t
-    -> 'a
   (** [value_nonbinding ~extra t] is [t]'s value. [t] is expected to
       bind no variables. [extra] is run on any additional variables that
       are bound. *)
-
+  val value_nonbinding : extra:(Var.t -> unit) -> 'a t -> 'a
 end = struct
-
   type 'a t =
     { vars : Var.Set.t;
-      v : 'a; }
+      v : 'a
+    }
 
   let mk vars v = { vars; v }
 
@@ -544,12 +507,13 @@ end = struct
     let v = f v in
     { vars; v }
 
-  let meet ~duplicated {vars = vars1; v = v1} {vars = vars2; v = v2} =
+  let meet ~duplicated { vars = vars1; v = v1 } { vars = vars2; v = v2 } =
     let vars = Var.Set.union ~shared:duplicated vars1 vars2 in
     let v = v1, v2 in
     { vars; v }
 
-  let join ~left_only ~right_only {vars = vars1; v = v1} {vars = vars2; v = v2} =
+  let join ~left_only ~right_only { vars = vars1; v = v1 }
+      { vars = vars2; v = v2 } =
     let vars = Var.Set.inter ~left_only ~right_only vars1 vars2 in
     let v = v1, v2 in
     { vars; v }
@@ -557,19 +521,19 @@ end = struct
   let meet_all ~duplicated l =
     let vars, v =
       List.fold_left_map
-        (fun acc {vars; v} ->
+        (fun acc { vars; v } ->
           let acc = Var.Set.union ~shared:duplicated acc vars in
-          (acc, v))
+          acc, v)
         Var.Set.empty l
     in
     { vars; v }
 
-  let optional = function
-    | None -> return None
-    | Some t -> map Option.some t
+  let optional = function None -> return None | Some t -> map Option.some t
 
   let value ~extra ~missing t vs =
-    let expected = List.fold_left (fun acc v -> Var.Set.add v acc) Var.Set.empty vs in
+    let expected =
+      List.fold_left (fun acc v -> Var.Set.add v acc) Var.Set.empty vs
+    in
     Var.Set.differences ~left_only:extra ~right_only:missing t.vars expected;
     t.v
 
@@ -579,67 +543,69 @@ end = struct
 end
 
 module With_free_vars : sig
-
-  type 'a t
   (** ['a t] is the type of ['a]s paired with a set of variables that
       are free in the ['a] along with their associated locations. *)
+  type 'a t
 
-  val mk : Loc.t Var.Map.t -> 'a -> 'a t
   (** [mk vars x] is [x] paired with [vars]. *)
+  val mk : Loc.t Var.Map.t -> 'a -> 'a t
 
-  val return : 'a -> 'a t
   (** [return x] is [mk Var.Map.empty x]. *)
+  val return : 'a -> 'a t
 
-  val map : ('a -> 'b) -> 'a t -> 'b t
   (** [map f t] is [f v], where [v] is the value of [t], paired with the
       same variables as [t]. *)
+  val map : ('a -> 'b) -> 'a t -> 'b t
 
-  val both : 'a t -> 'b t -> ('a * 'b) t
   (** [both t1 t2] is [(v1, v2)], where [v1] and [v2] are the values of
       [t1] and [t2] respectively, paired with the union of the variables
       from [t1] and [t2]. *)
+  val both : 'a t -> 'b t -> ('a * 'b) t
 
-  val all : 'a t list -> 'a list t
   (** [all [t1; t2; ...]] is [[v1; v2; ...]], where each [vn] is the
       value of [tn], paired with the union of the variables from all the
       [ts]. *)
+  val all : 'a t list -> 'a list t
 
-  val optional : 'a t option -> 'a option t
   (** [optional tm] is [Some t], where [v] is the value of [t], paired
       with the variables from [t] if [tm] is [Some t]. It is [return
       None] if [tm] is [None]. *)
+  val optional : 'a t option -> 'a option t
 
-  val check : invalid:(Var.t -> Loc.t -> unit) -> 'a t -> unit
   (** [check ~invalid t] runs [invalid] on any variables paired with [t]
       that are not valid. *)
+  val check : invalid:(Var.t -> Loc.t -> unit) -> 'a t -> unit
 
-  val value : free:(Var.t -> Loc.t -> unit) -> 'a t -> 'a
   (** [value ~free t] is the value of [t]. [t] is expected to have no
       free variables. [free] is run on any variables paired with [t]. *)
+  val value : free:(Var.t -> Loc.t -> unit) -> 'a t -> 'a
 
-  val value_binding :
-    Loc.t -> Name.t -> (Var.Value.t -> 'a t) -> 'a t
+  val value_nonbinding : extra:(Var.t -> Loc.t -> unit) -> 'a t -> 'a
 
-  val module_binding :
-    Loc.t -> Name.t -> (Var.Module.t -> 'a t) -> 'a t
+  val value_binding : Loc.t -> Name.t -> (Var.Value.t -> 'a t) -> 'a t
+
+  val type_binding : Loc.t -> Name.t -> (Var.Type.t -> 'a t) -> 'a t
+
+  val type_bindings : Loc.t -> Name.t list -> (Var.Type.t list -> 'a t) -> 'a t
+
+  val module_binding : Loc.t -> Name.t -> (Var.Module.t -> 'a t) -> 'a t
 
   val value_bindings :
     Loc.t -> Name.t list -> (Var.Value.t list -> 'a t) -> 'a t
 
   val complex_bindings :
-    Loc.t
-    -> extra:(Var.t -> unit)
-    -> missing:(Var.t -> unit)
-    -> bound_values:Name.t list
-    -> bound_modules:Name.t list
-    -> (Var.Value.t list -> Var.Module.t list -> 'a With_bound_vars.t t * 'b t)
-    -> ('a * 'b) t
-
-end  = struct
-
+    Loc.t ->
+    extra:(Var.t -> unit) ->
+    missing:(Var.t -> unit) ->
+    bound_values:Name.t list ->
+    bound_modules:Name.t list ->
+    (Var.Value.t list -> Var.Module.t list -> 'a With_bound_vars.t t * 'b t) ->
+    ('a * 'b) t
+end = struct
   type 'a t =
     { vars : Loc.t Var.Map.t;
-      v : 'a; }
+      v : 'a
+    }
 
   let mk vars v = { vars; v }
 
@@ -649,7 +615,7 @@ end  = struct
     let v = f v in
     { vars; v }
 
-  let both f {vars = vars1; v = v1} {vars = vars2; v = v2} =
+  let both { vars = vars1; v = v1 } { vars = vars2; v = v2 } =
     let vars = Var.Map.union (fun _ loc1 _ -> loc1) vars1 vars2 in
     let v = v1, v2 in
     { vars; v }
@@ -657,62 +623,76 @@ end  = struct
   let all ts =
     let vars, v =
       List.fold_left_map
-        (fun acc {vars; v} ->
+        (fun acc { vars; v } ->
           let acc = Var.Map.union (fun _ loc1 _ -> loc1) acc vars in
-          (acc, v))
+          acc, v)
         Var.Map.empty ts
     in
     { vars; v }
 
-  let optional = function
-    | None -> return None
-    | Some t -> map Option.some t
+  let optional = function None -> return None | Some t -> map Option.some t
 
   let check ~invalid { vars; v } =
     Var.Map.iter
       (fun var loc -> if not (Var.valid var) then invalid var loc)
       vars
 
-  let value = ()
+  let value ~free t =
+    Var.Map.iter free t.vars;
+    t.v
+
+  let value_nonbinding ~extra t =
+    Var.Map.iter extra t.vars;
+    t.v
 
   let value_binding loc name f =
-    Level.with_fresh loc
-      (fun level ->
+    Level.with_fresh loc (fun level ->
         let fresh_var = Var.Value.generate level name in
         let { vars; v } = f fresh_var in
         let vars = Var.Map.remove_level level vars in
         { vars; v })
 
+  let type_binding loc name f =
+    Level.with_fresh loc (fun level ->
+        let fresh_var = Var.Type.generate level name in
+        let { vars; v } = f fresh_var in
+        let vars = Var.Map.remove_level level vars in
+        { vars; v })
+
+  let type_bindings loc names f =
+    Level.with_fresh loc (fun level ->
+        let fresh_vars =
+          List.map (fun name -> Var.Type.generate level name) names
+        in
+        let { vars; v } = f fresh_vars in
+        let vars = Var.Map.remove_level level vars in
+        { vars; v })
+
   let module_binding loc name f =
-    Level.with_fresh loc
-      (fun level ->
+    Level.with_fresh loc (fun level ->
         let fresh_var = Var.Module.generate level name in
         let { vars; v } = f fresh_var in
         let vars = Var.Map.remove_level level vars in
         { vars; v })
 
   let value_bindings loc names f =
-    Level.with_fresh loc
-      (fun level ->
+    Level.with_fresh loc (fun level ->
         let fresh_vars =
-          List.map
-            (fun name -> Var.Value.generate level name)
-            names
+          List.map (fun name -> Var.Value.generate level name) names
         in
         let { vars; v } = f fresh_vars in
         let vars = Var.Map.remove_level level vars in
         { vars; v })
 
   let complex_bindings loc ~extra ~missing ~bound_values ~bound_modules f =
-    Level.with_fresh loc
-      (fun level ->
+    Level.with_fresh loc (fun level ->
         let fresh_value_vars =
           List.map (Var.Value.generate level) bound_values
         in
         let fresh_module_vars =
           List.map (Var.Module.generate level) bound_modules
         in
-        let { vars = bindings_vars; v = bindings}, { vars; v } =
+        let { vars = bindings_vars; v = bindings }, { vars; v } =
           f fresh_value_vars fresh_module_vars
         in
         let fresh_vars =
@@ -726,35 +706,24 @@ end  = struct
         let vars = Var.Map.union (fun _ loc1 _ -> loc1) bindings_vars vars in
         let v = bindings, v in
         { vars; v })
-
 end
 
 module With_free_and_bound_vars = struct
-
   type 'a t = 'a With_bound_vars.t With_free_vars.t
 
-  let return p =
-    With_free_vars.return
-      (With_bound_vars.return p)
+  let return p = With_free_vars.return (With_bound_vars.return p)
 
-  let with_no_free_vars v =
-    With_free_vars.return v
+  let with_no_free_vars v = With_free_vars.return v
 
-  let with_no_bound_vars v =
-    With_free_vars.map With_bound_vars.return v
+  let with_no_bound_vars v = With_free_vars.map With_bound_vars.return v
 
-  let bound_value_var v =
-    with_no_free_vars (With_bound_vars.value_var v)
+  let bound_value_var v = with_no_free_vars (With_bound_vars.value_var v)
 
-  let bound_module_var v =
-    with_no_free_vars (With_bound_vars.module_var v)
+  let bound_module_var v = with_no_free_vars (With_bound_vars.module_var v)
 
-  let map f t =
-    With_free_vars.map
-      (With_bound_vars.map f)
-      t
+  let map f t = With_free_vars.map (With_bound_vars.map f) t
 
-  let meet ~dupicated t1 t2 =
+  let meet ~duplicated t1 t2 =
     With_free_vars.map
       (fun (t1, t2) -> With_bound_vars.meet ~duplicated t1 t2)
       (With_free_vars.both t1 t2)
@@ -766,20 +735,15 @@ module With_free_and_bound_vars = struct
 
   let meet_all ~duplicated ts =
     With_free_vars.map
-      (With_bound_vars.all ~duplicated)
+      (With_bound_vars.meet_all ~duplicated)
       (With_free_vars.all ts)
 
   let optional ts =
-    With_free_vars.map
-      With_bound_vars.optional
-      (With_free_vars.optional ts)
-
+    With_free_vars.map With_bound_vars.optional (With_free_vars.optional ts)
 end
 
 module Ident = struct
-
   module Module : sig
-
     type t
 
     val compilation_unit : string -> t
@@ -788,31 +752,30 @@ module Ident = struct
 
     val var : Var.Module.t -> Loc.t -> t
 
+    val free_vars : t -> Loc.t Var.Map.t
+
     val with_free_vars : t -> t With_free_vars.t
-
   end = struct
-
     type t =
       | Compilation_unit of string
       | Dot of t * string
       | Var of Var.Module.t * Loc.t
 
     let compilation_unit s = Compilation_unit s
-    let dot t s = Dot(t, s)
-    let var v loc = Var(v, loc)
+
+    let dot t s = Dot (t, s)
+
+    let var v loc = Var (v, loc)
 
     let rec free_vars = function
       | Compilation_unit _ -> Var.Map.empty
-      | Dot(t, _) -> free_vars t
-      | Var(v, loc) -> Var.Map.singleton (Var.generic v) loc
+      | Dot (t, _) -> free_vars t
+      | Var (v, loc) -> Var.Map.singleton (Var.Module.generic v) loc
 
-    let with_free_vars t =
-      With_free_vars.mk (free_vars t) t
-
+    let with_free_vars t = With_free_vars.mk (free_vars t) t
   end
 
   module Value : sig
-
     type t
 
     val dot : Module.t -> string -> t
@@ -820,140 +783,189 @@ module Ident = struct
     val var : Var.Value.t -> Loc.t -> t
 
     val with_free_vars : t -> t With_free_vars.t
-
   end = struct
     type t =
       | Dot of Module.t * string
       | Var of Var.Value.t * Loc.t
 
-    let dot t s = Dot(v, s)
-    let var v = Var v
+    let dot t s = Dot (t, s)
+
+    let var v l = Var (v, l)
+
     let free_vars = function
-      | Dot(t, _) -> Module.free_vars t
-      | Var(v, loc) -> Var.Map.singleton (Var.Value.generic v) loc
+      | Dot (d, s) -> Module.free_vars d
+      | Var (v, loc) -> Var.Map.singleton (Var.Value.generic v) loc
 
-    let with_free_vars t =
-      With_free_vars.mk (free_vars t) t
-
+    let with_free_vars t = With_free_vars.mk (free_vars t) t
   end
 
   module Type : sig
-
     type t
 
     val dot : Module.t -> string -> t
 
-    val var : Var.Value.t -> Loc.t -> t
+    val var : Var.Type.t -> Loc.t -> t
 
     val with_free_vars : t -> t With_free_vars.t
 
-    val int: t
-    val char: t
-    val string: t
-    val bytes: t
-    val float: t
-    val float32: t
-    val bool: t
-    val unit: t
-    val exn: t
-    val array: t -> t
-    val iarray: t -> t
-    val list: t -> t
-    val option: t -> t
-    val nativeint: t
-    val int32: t
-    val int64: t
-    val lazy_t: t -> t
-    val extension_constructor:t
-    val floatarray:t
-    val lexing_position:t
-    val code: t -> t
-    val unboxed_float:t
-    val unboxed_nativeint:t
-    val unboxed_int32:t
-    val unboxed_int64:t
-    val int8x16: t
-    val int16x8: t
-    val int32x4: t
-    val int64x2: t
-    val float32x4: t
-    val float64x2: t
+    val int : t
 
+    val char : t
+
+    val string : t
+
+    val bytes : t
+
+    val float : t
+
+    val float32 : t
+
+    val bool : t
+
+    val unit : t
+
+    val exn : t
+
+    val array : t
+
+    val iarray : t
+
+    val list : t
+
+    val option : t
+
+    val nativeint : t
+
+    val int32 : t
+
+    val int64 : t
+
+    val lazy_t : t
+
+    val extension_constructor : t
+
+    val floatarray : t
+
+    val lexing_position : t
+
+    val code : t
+
+    val unboxed_float : t
+
+    val unboxed_nativeint : t
+
+    val unboxed_int32 : t
+
+    val unboxed_int64 : t
+
+    val int8x16 : t
+
+    val int16x8 : t
+
+    val int32x4 : t
+
+    val int64x2 : t
+
+    val float32x4 : t
+
+    val float64x2 : t
   end = struct
-
     type t =
       | Dot of Module.t * string
       | Var of Var.Type.t * Loc.t
       | Builtin of string
 
-    let dot t s = Dot(v, s)
-    let var v = Var v
-    let free_vars = function
-      | Dot(t, _) -> Module.free_vars t
-      | Var(v, loc) -> Var.Map.singleton (Var.Type.generic v) loc
+    let dot t s = Dot (t, s)
 
-    let with_free_vars t =
-      With_free_vars.mk (free_vars t) t
+    let var v l = Var (v, l)
+
+    let free_vars = function
+      | Dot (t, _) -> Module.free_vars t
+      | Var (v, loc) -> Var.Map.singleton (Var.Type.generic v) loc
+      | Builtin _ -> Var.Map.empty
+
+    let with_free_vars t = With_free_vars.mk (free_vars t) t
 
     let int = Builtin "int"
-    let char = Builtin "char"
-    let string = Builtin "string"
-    let bytes = Builtin "bytes"
-    let float = Builtin "float"
-    let float32 = Builtin "float32"
-    let bool = Builtin "bool"
-    let unit = Builtin "unit"
-    let exn = Builtin "exn"
-    let array = Builtin "array"
-    let iarray = Builtin "iarray"
-    let list = Builtin "list"
-    let option = Builtin "option"
-    let nativeint = Builtin "nativeint"
-    let int32 = Builtin "int32"
-    let int64 = Builtin "int64"
-    let lazy_t = Builtin "lazy_t"
-    let extension_constructor = Builtin "extension_constructor"
-    let floatarray = Builtin "floatarray"
-    let lexing_position = Builtin "lexing_position"
-    let code = Builtin "code"
-    let unboxed_float = Builtin "float#"
-    let unboxed_nativeint = Builtin "nativeint#"
-    let unboxed_int32 = Builtin "int32#"
-    let unboxed_int64 = Builtin "int64#"
-    let int8x16 = Builtin "int8x16"
-    let int16x8 = Builtin "int16x8"
-    let int32x4 = Builtin "int32x4"
-    let int64x2 = Builtin "int64x2"
-    let float32x4 = Builtin "float32x4"
-    let float64x2 = Builtin "float64x2"
 
+    let char = Builtin "char"
+
+    let string = Builtin "string"
+
+    let bytes = Builtin "bytes"
+
+    let float = Builtin "float"
+
+    let float32 = Builtin "float32"
+
+    let bool = Builtin "bool"
+
+    let unit = Builtin "unit"
+
+    let exn = Builtin "exn"
+
+    let array = Builtin "array"
+
+    let iarray = Builtin "iarray"
+
+    let list = Builtin "list"
+
+    let option = Builtin "option"
+
+    let nativeint = Builtin "nativeint"
+
+    let int32 = Builtin "int32"
+
+    let int64 = Builtin "int64"
+
+    let lazy_t = Builtin "lazy_t"
+
+    let extension_constructor = Builtin "extension_constructor"
+
+    let floatarray = Builtin "floatarray"
+
+    let lexing_position = Builtin "lexing_position"
+
+    let code = Builtin "code"
+
+    let unboxed_float = Builtin "float#"
+
+    let unboxed_nativeint = Builtin "nativeint#"
+
+    let unboxed_int32 = Builtin "int32#"
+
+    let unboxed_int64 = Builtin "int64#"
+
+    let int8x16 = Builtin "int8x16"
+
+    let int16x8 = Builtin "int16x8"
+
+    let int32x4 = Builtin "int32x4"
+
+    let int64x2 = Builtin "int64x2"
+
+    let float32x4 = Builtin "float32x4"
+
+    let float64x2 = Builtin "float64x2"
   end
 
   module Module_type : sig
-
     type t
 
-    val dot : t -> string -> t
+    val dot : Module.t -> string -> t
 
     val with_free_vars : t -> t With_free_vars.t
-
   end = struct
+    type t = Dot of Module.t * string
 
-    type t =
-      | Dot of t * string
+    let dot t s = Dot (t, s)
 
-    let dot t s = Dot(t, s)
+    let free_vars = function Dot (t, _) -> Module.free_vars t
 
-    let free_vars = function
-      | Dot(t, _) -> Module.free_vars t
-
-    let with_free_vars t =
-      With_free_vars.mk (free_vars t) t
-
+    let with_free_vars t = With_free_vars.mk (free_vars t) t
   end
 
   module Constructor : sig
-
     type t
 
     val dot : Module.t -> string -> t
@@ -963,65 +975,98 @@ module Ident = struct
     val with_free_and_bound_vars : t -> t With_free_and_bound_vars.t
 
     val false_ : t
-    val true_ : t
-    val void : t
-    val nil : t
-    val cons : t
-    val none : t
-    val some : t
-    val match_failure : t
-    val out_of_memory : t
-    val invalid_argument : t
-    val failure : t
-    val not_found : t
-    val sys_error : t
-    val end_of_file : t
-    val division_by_zero : t
-    val stack_overflow : t
-    val sys_blocked_io : t
-    val assert_failure : t
-    val undefined_recursive_module : t
 
+    val true_ : t
+
+    val void : t
+
+    val nil : t
+
+    val cons : t
+
+    val none : t
+
+    val some : t
+
+    val match_failure : t
+
+    val out_of_memory : t
+
+    val invalid_argument : t
+
+    val failure : t
+
+    val not_found : t
+
+    val sys_error : t
+
+    val end_of_file : t
+
+    val division_by_zero : t
+
+    val stack_overflow : t
+
+    val sys_blocked_io : t
+
+    val assert_failure : t
+
+    val undefined_recursive_module : t
   end = struct
     type t =
       | Dot of Module.t * string
       | Builtin of string
 
-    let dot t s = Dot(t, s)
+    let dot t s = Dot (t, s)
 
     let free_vars = function
-      | Dot(t, _) -> Module.free_vars t
+      | Dot (t, _) -> Module.free_vars t
+      | Builtin s -> Var.Map.empty
 
-    let with_free_vars t =
-      With_free_vars.mk (free_vars t) t
+    let with_free_vars t = With_free_vars.mk (free_vars t) t
 
     let with_free_and_bound_vars t =
-      With_free_and_bound_vars.no_bound_vars (with_free_vars t)
+      With_free_and_bound_vars.with_no_bound_vars (with_free_vars t)
 
     let false_ = Builtin "false"
-    let true_ = Builtin "true"
-    let void = Builtin "()"
-    let nil = Builtin "[]"
-    let cons = Builtin "(::)"
-    let none = Builtin "None"
-    let some = Builtin "Some"
-    let match_failure = Builtin "Match_failure"
-    let out_of_memory = Builtin "Out_of_memory"
-    let invalid_argument = Builtin "Invalid_argument"
-    let failure = Builtin "Failure"
-    let not_found = Builtin "Not_found"
-    let sys_error = Builtin "Sys_error"
-    let end_of_file = Builtin "End_of_file"
-    let division_by_zero = Builtin "Division_by_zero"
-    let stack_overflow = Builtin "Stack_overflow"
-    let sys_blocked_io = Builtin "Sys_blocked_io"
-    let assert_failure = Builtin "Assert_failure"
-    let undefined_recursive_module = Builtin "Undefined_recursive_module"
 
+    let true_ = Builtin "true"
+
+    let void = Builtin "()"
+
+    let nil = Builtin "[]"
+
+    let cons = Builtin "(::)"
+
+    let none = Builtin "None"
+
+    let some = Builtin "Some"
+
+    let match_failure = Builtin "Match_failure"
+
+    let out_of_memory = Builtin "Out_of_memory"
+
+    let invalid_argument = Builtin "Invalid_argument"
+
+    let failure = Builtin "Failure"
+
+    let not_found = Builtin "Not_found"
+
+    let sys_error = Builtin "Sys_error"
+
+    let end_of_file = Builtin "End_of_file"
+
+    let division_by_zero = Builtin "Division_by_zero"
+
+    let stack_overflow = Builtin "Stack_overflow"
+
+    let sys_blocked_io = Builtin "Sys_blocked_io"
+
+    let assert_failure = Builtin "Assert_failure"
+
+    let undefined_recursive_module = Builtin "Undefined_recursive_module"
   end
 
   module Field : sig
-
     type t
 
     val dot : Module.t -> string -> t
@@ -1029,29 +1074,21 @@ module Ident = struct
     val with_free_vars : t -> t With_free_vars.t
 
     val with_free_and_bound_vars : t -> t With_free_and_bound_vars.t
-
   end = struct
+    type t = Dot of Module.t * string
 
-    type t =
-      | Dot of Module.t * string
+    let dot t s = Dot (t, s)
 
-    let dot t s = Dot(t, s)
+    let free_vars = function Dot (t, _) -> Module.free_vars t
 
-    let free_vars = function
-      | Dot(t, _) -> Module.free_vars t
-
-    let with_free_vars t =
-      With_free_vars.mk (free_vars t) t
+    let with_free_vars t = With_free_vars.mk (free_vars t) t
 
     let with_free_and_bound_vars t =
-      With_free_and_bound_vars.no_bound_vars (with_free_vars t)
-
+      With_free_and_bound_vars.with_no_bound_vars (with_free_vars t)
   end
-
 end
 
 module Ast = struct
-
   type constant =
     | Int of int
     | Char of char
@@ -1061,13 +1098,26 @@ module Ast = struct
     | Int64 of int64
     | Nativeint of nativeint
 
-  type rec_flag = Nonrecursive | Recursive
+  type rec_flag =
+    | Nonrecursive
+    | Recursive
 
-  type direction_flag = Upto | Downto
+  type direction_flag =
+    | Upto
+    | Downto
 
-  type override_flag = Override | Fresh
+  type override_flag =
+    | Override
+    | Fresh
 
-  type closed_flag = Closed | Open
+  type record_flag =
+    | OpenRec
+    | ClosedRec
+
+  type variant_form =
+    | Fixed
+    | Open
+    | Closed of string list
 
   type arg_label =
     | Nolabel
@@ -1075,25 +1125,25 @@ module Ast = struct
     | Optional of string
 
   type tuple_label =
-    | Nolabel
-    | Labelled of label
+    | NolabelTup
+    | LabelledTup of string
 
   type core_type =
-    | Any
-    | Var of Name.t
+    | AnyType
+    | TypeVar of Var.Type.t
     | Arrow of arg_label * core_type * core_type
-    | Tuple of (tuple_label * core_type) list
-    | Constr of Ident.Type.t * core_type list
-    | Alias of core_type * Name.t
-    | Variant of row_field list * closed_flag * string list option
-    | Poly of Name.t list * core_type
+    | TupleType of (tuple_label * core_type) list
+    | Constr of Ident.Constructor.t * core_type list
+    | Alias of core_type * Var.Type.t
+    | VariantType of row_field list * variant_form
+    | Poly of Var.Type.t list * core_type
     | Package of package_type
 
   and row_field =
     | Tag of string * bool * core_type list
     | Inherit of core_type
 
-  and package_type = Ident.Module_type.t * (fragment * core_type) list
+  and package_type = Ident.Module.t * (fragment * core_type) list
 
   and fragment =
     | Name of Name.t
@@ -1106,18 +1156,18 @@ module Ast = struct
   type pattern =
     | Any
     | Var of Var.Value.t
-    | Alias of pattern * Var.Value.t
-    | Constant of constant
+    | AliasPat of pattern * Var.Value.t
+    | ConstantPat of constant
     | Interval of constant * constant
-    | Tuple of pattern list
-    | Construct of Ident.Constructor.t * pattern option
-    | Variant of string * pattern option
-    | Record of (Ident.Field.t * pattern) list * closed_flag
-    | Array of pattern list
+    | TuplePat of (tuple_label * pattern) list
+    | ConstructPat of Ident.Constructor.t * pattern option
+    | VariantPat of string * pattern option
+    | RecordPat of (Ident.Field.t * pattern) list * record_flag
+    | ArrayPat of pattern list
     | Or of pattern * pattern
-    | Constraint of pattern * core_type
-    | Lazy of pattern
-    | Unpack of Var.Module.t
+    | ConstraintPat of pattern * core_type
+    | LazyPat of pattern
+    | UnpackPat of Var.Module.t
     | Exception of pattern
 
   type expression_attribute =
@@ -1134,9 +1184,8 @@ module Ast = struct
     | Quotation
 
   type expression =
-    {
-      desc: expression_desc;
-      attributes: expression_attribute list;
+    { desc : expression_desc;
+      attributes : expression_attribute list
     }
 
   and expression_desc =
@@ -1157,32 +1206,27 @@ module Ast = struct
     | Ifthenelse of expression * expression * expression option
     | Sequence of expression * expression
     | While of expression * expression
-    | For of
-        pattern * expression
-        * expression * direction_flag
-        * expression
-    | Constraint of expression * core_type
-    | Coerce of expression * core_type option * core_type
+    | For of pattern * expression * expression * direction_flag * expression
+    | ConstraintExp of expression * core_type
+    | CoerceExp of expression * core_type option * core_type
     | Letmodule of Var.Module.t * module_expr * expression
     | Assert of expression
     | Lazy of expression
     | Pack of module_expr
-    | Open of override_flag * Ident.Module.t * expression
+    | OpenExp of override_flag * Ident.Module.t * expression
     | Quote of expression
     | Escape of expression
     | Splice of expression * Loc.t
 
   and case =
-    {
-      lhs: pattern;
-      guard: expression option;
-      rhs: expression option;
+    { lhs : pattern;
+      guard : expression option;
+      rhs : expression option
     }
 
   and value_binding =
-    {
-      pat: pattern;
-      expr: expression;
+    { pat : pattern;
+      expr : expression
     }
 
   and function_body =
@@ -1196,502 +1240,596 @@ module Ast = struct
   and function_ =
     { params : function_param list;
       constraint_ : type_constraint option;
-      body : function_body; }
+      body : function_body
+    }
 
   and module_expr =
-    | Ident of Ident.Module.t
-    | Apply of module_expr * module_expr
+    | ModuleIdent of Ident.Module.t
+    | ModuleApply of module_expr * module_expr
     | Apply_unit of module_expr
     | Unpack of expression
-
-end
-
-module Constant = struct
-
-  type t = Ast.constant
-
-  let int i = Int i
-  let char c = Char c
-  let string s = String s
-  let float f = Float f
-  let int32 i = Int32 i
-  let int64 i = Int64 i
-  let nativeint i = Nativeint i
-
 end
 
 module Label = struct
+  type t = Ast.arg_label
 
-  type t = arg_label
+  module Nonoptional = struct
+    type t = Ast.tuple_label
 
-  let no_label = Nolabel
-  let labelled s = Labelled s
-  let optional s = Optional s
+    let no_label = Ast.NolabelTup
 
+    let labelled s = Ast.LabelledTup s
+  end
+
+  let nonoptional = function
+    | Ast.NolabelTup -> Ast.Nolabel
+    | Ast.LabelledTup s -> Ast.Labelled s
+
+  let no_label = Ast.Nolabel
+
+  let labelled s = Ast.Labelled s
+
+  let optional s = Ast.Optional s
+end
+
+module Fragment = struct
+  type t = Ast.fragment
+end
+
+module Constant = struct
+  type t = Ast.constant
+
+  let int i = Ast.Int i
+
+  let char c = Ast.Char c
+
+  let string s id = Ast.String (s, id)
+
+  let float f = Ast.Float f
+
+  let int32 i = Ast.Int32 i
+
+  let int64 i = Ast.Int64 i
+
+  let nativeint i = Ast.Nativeint i
 end
 
 module Variant = struct
-
-  type t = string
-
-  let of_string (s : string) : t = s
-
+  type t = (Ast.row_field list * Ast.variant_form) With_free_vars.t
 end
 
-module Pat = struct
+module BindingError = struct
+  let unexpected_binding_error var loc : unit =
+    let msg =
+      Format.asprintf
+        "Unexpected binding detected for the identifier %s from %a at %a"
+        (Var.name var) Loc.print (Var.loc var) Loc.print loc
+    in
+    failwith msg
 
-  open With_free_and_bound_vars
+  let unexpected_binding_error_at_loc loc var : unit =
+    unexpected_binding_error var loc
 
-  type t = Ast.pattern With_free_and_bound_vars.t
+  let missing_binding_error var : unit =
+    let msg =
+      Format.asprintf "Missing binding for the identifier %s at %a"
+        (Var.name var) Loc.print (Var.loc var)
+    in
+    failwith msg
+
+  let unbound_var loc var use : unit =
+    let msg =
+      Format.asprintf
+        "The quotation built at %a has unbound variables: variable %s used at \
+         %a is not bound."
+        Loc.print loc (Var.name var) Loc.print use
+    in
+    failwith msg
 
   let duplicate_binding_error var =
     let msg =
-      Format.asprintf
-        "Duplicate bindings detected for the identifier %s at %a"
+      Format.asprintf "Duplicate bindings detected for the identifier %s at %a"
         (Var.name var) Loc.print (Var.loc var)
     in
     failwith msg
 
   let mismatch_binding_error var =
     let msg =
-      Format.asprintf Format.str_formatter
-        "Mismatched bindings detected for the identifier %s at %a"
+      Format.asprintf "Mismatched bindings detected for the identifier %s at %a"
         (Var.name var) Loc.print (Var.loc var)
     in
     failwith msg
+end
 
-  let (let+) = map
-  let (and+) t1 t2 =
-    meet ~dupicated:duplicate_binding_error t1 t2
-  let all ~duplicated ts =
-    meet_all ~duplicated:duplicate_binding_error ts
+module Pat = struct
+  open With_free_and_bound_vars
+
+  type t = Ast.pattern With_free_and_bound_vars.t
+
+  let ( let+ ) x f = map f x
+
+  let ( and+ ) t1 t2 =
+    meet ~duplicated:BindingError.duplicate_binding_error t1 t2
+
+  let all ts = meet_all ~duplicated:BindingError.duplicate_binding_error ts
 
   let join t1 t2 =
-    join
-      ~left_only:mismatch_binding_error
-      ~right_only:mismatch_binding_error
-      t1 t2
+    join ~left_only:BindingError.mismatch_binding_error
+      ~right_only:BindingError.mismatch_binding_error t1 t2
 
-  let any = return Any
+  let any = return Ast.Any
 
   let var v =
-    let+ v = bound_value_var v in
-    Var v
+    let+ var = bound_value_var v in
+    Ast.Var var
 
   let alias t v =
-    let+ p = t
-    and+ v = bound_value_var v in
-    Alias(p, v)
+    let+ p = t and+ v = bound_value_var v in
+    Ast.AliasPat (p, v)
 
-  let constant const =
-    return (Constant const)
+  let constant const = return (Ast.ConstantPat const)
 
-  let interval const1 const2 =
-    return (Interval(const1, const2))
+  let interval const1 const2 = return (Ast.Interval (const1, const2))
 
   let tuple ts =
-    let+ ps = all ts in
-    Tuple ps
+    let ps =
+      List.map
+        (fun (lab, e) ->
+          let+ v = e in
+          lab, v)
+        ts
+    in
+    let+ ps = all ps in
+    Ast.TuplePat ps
 
   let construct lid tm =
-    let+ pm = optional tm
-    and+ lid = Ident.Constructor.with_free_and_bound_vars lid in
-    Construct(lid, pm)
+    let+ pm = optional tm in
+    Ast.ConstructPat (lid, pm)
 
   let variant label tm =
     let+ pm = optional tm in
-    Variant(label, pm)
+    Ast.VariantPat (label, pm)
 
   let record fields closed =
-    let closed = if closed then AST.Closed else AST.Open in
+    let closed_ast = if closed then Ast.ClosedRec else Ast.OpenRec in
     let ts =
       List.map
-        (fun (lbl, t) ->
-          let+ lbl = Ident.Field.with_free_and_bound_vars lid
-          and+ p = t in
-          lbl, t)
+        (fun (lid, t) ->
+          let+ lbl = Ident.Field.with_free_and_bound_vars lid and+ p = t in
+          lbl, p)
         fields
     in
     let+ ps = all ts in
-    Record(ps, closed)
+    Ast.RecordPat (ps, closed_ast)
 
   let array ts =
     let+ ps = all ts in
-    Array ps
+    Ast.ArrayPat ps
 
   let or_ t1 t2 =
-    let+ (p1, p2) = join t1 t2 in
-    Or(pat1, pat2)
+    let+ p1, p2 = join t1 t2 in
+    Ast.Or (p1, p2)
 
   let lazy_ t =
     let+ p = t in
-    Lazy p
+    Ast.LazyPat p
 
-  let module_ v =
+  let unpack v =
     let+ v = bound_module_var v in
-    Module v
+    Ast.UnpackPat v
 
   let exception_ t =
     let+ p = t in
-    Exception p
+    Ast.Exception p
+end
 
+module Type = struct
+  type t = Ast.core_type With_free_vars.t
+
+  let ( let+ ) m f = With_free_vars.map f m
+
+  let ( and+ ) = With_free_vars.both
+
+  let all = With_free_vars.all
+
+  let any = With_free_vars.return Ast.AnyType
+
+  let var v = With_free_vars.return (Ast.TypeVar v)
+
+  let arrow lab lhs rhs =
+    let+ l = lhs and+ r = rhs in
+    Ast.Arrow (lab, l, r)
+
+  let tuple ts =
+    let w =
+      List.map
+        (fun (lab, t) ->
+          let+ t = t in
+          lab, t)
+        ts
+    in
+    let+ e = all w in
+    Ast.TupleType e
+
+  let constr cons typs =
+    let+ ts = all typs in
+    Ast.Constr (cons, ts)
+
+  let alias typ tv =
+    let+ t = typ in
+    Ast.Alias (t, tv)
+
+  let variant variant =
+    let+ row_fields, form = variant in
+    Ast.VariantType (row_fields, form)
+
+  let poly loc names f =
+    With_free_vars.type_bindings loc names (fun tvs ->
+        let+ t = f tvs in
+        Ast.Poly (tvs, t))
+
+  let package m spec =
+    let s =
+      List.map
+        (fun (frag, typ) ->
+          let+ t = typ in
+          frag, t)
+        spec
+    in
+    let+ specs = all s in
+    Ast.Package (m, specs)
 end
 
 module Case = struct
-
   type t = Ast.case With_free_vars.t
 
-  let unexpected_binding_error loc var =
-    let msg =
-      Format.asprintf Format.str_formatter
-        "Unexpected binding detected for the identifier %s from %a at %a"
-        (Var.name var) Loc.print (Var.loc var) Loc.print loc
+  let mk lhs guard rhs : Ast.case = { lhs; guard; rhs }
+
+  let ( let+ ) m f = With_free_vars.map f m
+
+  let ( and+ ) = With_free_vars.both
+
+  let nonbinding loc (pat : Pat.t) exp =
+    let+ pat = pat and+ rhs = exp in
+    let lhs =
+      With_bound_vars.value_nonbinding
+        ~extra:(BindingError.unexpected_binding_error_at_loc loc)
+        pat
     in
-    failwith msg
-
-  let missing_binding_error var =
-    let msg =
-      Format.asprintf Format.str_formatter
-        "Missing binding for the identifier %s at %a"
-        (Var.name var) Loc.print (Var.loc var)
-    in
-    failwith msg
-
-  let mk lhs guard rhs =
-    { lhs; guard; rhs; }
-
-  let (let+) = With_free_vars.map
-  let (and+) = With_free_vars.both
-
-  let nonbinding loc lhs rhs =
-    let+ lhs = value_nonbinding ~extra:(unexpected_binding_error loc) lhs
-    and+ rhs = rhs in
     mk lhs None (Some rhs)
 
   let simple loc name f =
-    With_free_vars.binding loc name
-      (fun var ->
+    With_free_vars.value_binding loc name (fun var ->
         let+ rhs = f var in
         mk (Var var) None (Some rhs))
 
-  let pattern loc ~bound_vars ~bound_modules f =
+  let pattern loc ~bound_values ~bound_modules f =
     let+ lhs, rhs =
       With_free_vars.complex_bindings loc
-        ~extra:(unexpected_binding_error loc) ~missing:missing_binding_error
-        ~bound_vars ~bound_modules f
+        ~extra:(BindingError.unexpected_binding_error_at_loc loc)
+        ~missing:BindingError.missing_binding_error ~bound_values ~bound_modules
+        f
     in
     mk lhs None (Some rhs)
 
-  let guarded loc ~bound_vars ~bound_modules f =
+  let guarded loc ~bound_values ~bound_modules f =
     let+ lhs, (guard, rhs) =
       With_free_vars.complex_bindings loc
-        ~extra:(unexpected_binding_error loc) ~missing:missing_binding_error
-        ~bound_vars ~bound_modules
+        ~extra:(BindingError.unexpected_binding_error_at_loc loc)
+        ~missing:BindingError.missing_binding_error ~bound_values ~bound_modules
         (fun value_vars module_vars ->
-            let lhs, guard, rhs = f value_vars module_vars in
-            lhs, both guard rhs)
+          let lhs, guard, rhs = f value_vars module_vars in
+          lhs, With_free_vars.both guard rhs)
     in
     mk lhs (Some guard) (Some rhs)
 
-  let refutation loc ~bound_vars ~bound_modules f =
-    let+ lhs =
+  let refutation loc ~bound_values ~bound_modules f =
+    let+ lhs, _ =
       With_free_vars.complex_bindings loc
-        ~extra:(unexpected_binding_error loc) ~missing:missing_binding_error
-        ~bound_vars ~bound_modules f
+        ~extra:(BindingError.unexpected_binding_error_at_loc loc)
+        ~missing:BindingError.missing_binding_error ~bound_values ~bound_modules
+        (fun v m -> f v m, With_free_vars.return ())
     in
     mk lhs None None
-
 end
 
 module Type_constraint = struct
-
   type t = Ast.type_constraint With_free_vars.t
 
-  open With_free_vars
+  let ( let+ ) m f = With_free_vars.map f m
 
-  let (let+) = With_free_vars.map
-  let (and+) = With_free_vars.both
+  let ( and+ ) = With_free_vars.both
 
   let constraint_ typ =
     let+ typ = typ in
-    Constraint typ
+    Ast.Constraint typ
 
   let coercion typ1 typ2 =
-    let+ typ1 = typ1
-    and+ typ2 = typ2 in
-    Coercion(typ1, typ2)
-  
+    let+ typ1 = With_free_vars.optional typ1 and+ typ2 = typ2 in
+    Ast.Coerce (typ1, typ2)
 end
 
-module Function_ = struct
+module Function = struct
+  type t = Ast.function_ With_free_vars.t
 
-  type t = function_ With_free_vars.t
+  let ( let+ ) m f = With_free_vars.map f m
 
-  open With_free_vars
+  let ( and+ ) = With_free_vars.both
 
-  let (let+) = With_free_vars.map
-  let (and+) = With_free_vars.both
+  let mk params constraint_ body : Ast.function_ = { params; constraint_; body }
 
-  val body : Exp.t -> t
+  let body e =
+    let+ b = e in
+    mk [] None (Ast.Pfunction_body b)
 
-  val cases : Case.t list -> t
+  let cases cl =
+    let+ c = With_free_vars.all cl in
+    mk [] None (Ast.Pfunction_cases c)
 
-  val param_nonbinding : Label.t -> Exp.t option -> Pat.t -> t -> t
+  let param_nonbinding loc lab exp pat rest =
+    let+ ({ params; constraint_; body } : Ast.function_) = rest
+    and+ pat = pat
+    and+ e = With_free_vars.optional exp in
+    let p =
+      With_bound_vars.value_nonbinding
+        ~extra:(BindingError.unexpected_binding_error_at_loc loc)
+        pat
+    in
+    let param = Ast.Pparam_val (Ast.Nolabel, e, p) in
+    mk (param :: params) constraint_ body
 
-  val param_simple :
-    Label.t
-    -> Exp.t option
-    -> Name.t
-    -> (Var.Value.t -> t)
-    -> t
+  let param_simple lab exp loc name rest =
+    With_free_vars.value_binding loc name (fun var ->
+        let+ ({ params; constraint_; body } : Ast.function_) = rest var
+        and+ e = With_free_vars.optional exp in
+        mk (Ast.Pparam_val (lab, e, Ast.Var var) :: params) constraint_ body)
 
-  val param :
-    Label.t
-    -> Exp.t option
-    -> Name.t list
-    -> (Var.Value.t list -> Pat.t * t)
-    -> t
+  let newtype loc name f =
+    With_free_vars.type_binding loc name (fun typ ->
+        let+ ({ params; constraint_; body } : Ast.function_) = f typ in
+        mk (Ast.Pparam_newtype typ :: params) constraint_ body)
+end
 
-  val newtype : Name.t -> (Var.Type.t -> t) -> t
+module Code = struct
+  type code_rep =
+    { exp : Ast.expression;
+      loc : Loc.t
+    }
 
+  type t = code_rep With_free_vars.t
+
+  let ( let+ ) m f = With_free_vars.map f m
+
+  let ( and+ ) = With_free_vars.both
+
+  let of_exp exp loc =
+    let+ exp = exp in
+    { exp; loc }
+
+  let of_exp_with_type_vars loc names body =
+    let+ exp = With_free_vars.type_bindings loc names body in
+    { exp; loc }
+
+  module Closed = struct
+    type exp = t
+
+    type t = code_rep
+
+    let close code =
+      With_free_vars.value
+        ~free:(fun var loc ->
+          let msg =
+            Format.asprintf
+              "The code built at %a is not closed: identifier %s bound at %a \
+               is free"
+              Loc.print loc (Var.name var) Loc.print (Var.loc var)
+          in
+          failwith (Format.flush_str_formatter ()))
+        code
+
+    let open_ = With_free_vars.return
+  end
 end
 
 module Exp = struct
-
   type t = Ast.expression With_free_vars.t
 
-  open With_free_vars
+  let ( let+ ) m f = With_free_vars.map f m
 
-  let unbound_var loc var use =
-    let msg =
-      Format.asprintf Format.str_formatter
-        "The quotation built at %a has unbound variables: \
-         variable %s used at %a is not bound."
-        Loc.print loc (Var.txt var)
-        Loc.print use
-    in
-    failwith msg
+  let ( and+ ) = With_free_vars.both
 
-  let unexpected_binding_error loc var =
-    let msg =
-      Format.asprintf Format.str_formatter
-        "Unexpected binding detected for the identifier %s from %a at %a"
-        (Var.name var) Loc.print (Var.loc var) Loc.print loc
-    in
-    failwith msg
+  let all = With_free_vars.all
 
-  let mk desc attributes : Ast.expression =
-    { desc; attributes; }
+  let optional = With_free_vars.optional
 
-  let (let+) = With_free_vars.map
-  let (and+) = With_free_vars.both
+  let return = With_free_vars.return
 
-  let mk_vb pat expr : Ast.value_binding =
-    {pat; expr}
+  let mk_vb pat expr : Ast.value_binding = { pat; expr }
+
+  let mk desc attributes : Ast.expression = { desc; attributes }
 
   let ident id =
     let+ id = Ident.Value.with_free_vars id in
     mk (Ident id) []
 
-  let constant const =
-    return (mk (Constant const) [])
+  let constant (const : Constant.t) = return (mk (Constant const) [])
 
   let let_nonbinding loc pat def body =
-    let+ pat = pat
-    and+ def = def
-    and+ body = body in
-    let pat =
-      With_bound_vars.value_nonbinding ~extra:(unexpected_binding_error loc) pat
+    let+ def = def and+ body = body and+ pat = pat in
+    let p =
+      With_bound_vars.value_nonbinding
+        ~extra:(BindingError.unexpected_binding_error_at_loc loc)
+        pat
     in
-    let vbs = [mk_vb pat def] in
-    mk (Let(Nonrec, vbs, body)) []
+    let vbs = [mk_vb p def] in
+    mk (Let (Nonrecursive, vbs, body)) []
 
   let let_simple loc name def f =
     let+ def = def
-    and+ (pat, body) =
-      value_binding loc name
-        (fun var ->
+    and+ pat, body =
+      With_free_vars.value_binding loc name (fun var ->
           let+ body = f var in
-          let pat = Var var in
+          let pat = Ast.Var var in
           pat, body)
     in
     let vbs = [mk_vb pat def] in
-    mk (Let(Nonrec, vbs, body)) []
+    mk (Let (Nonrecursive, vbs, body)) []
 
   let let_rec_simple loc names f =
-    value_bindings loc names
-      (fun vars ->
+    With_free_vars.value_bindings loc names (fun vars ->
         let defs, body = f vars in
-        let+ defs = defs
-        and+ body = body in
+        let+ defs = all defs and+ body = body in
         let vbs_rev =
           List.rev_map2
             (fun var def ->
-              let pat = Var var in
+              let pat = Ast.Var var in
               mk_vb pat def)
             vars defs
         in
         let vbs = List.rev vbs_rev in
-        mk (Let(Rec, vbs, body))
-        vbs, body)
+        mk (Let (Recursive, vbs, body)) [])
 
   let let_ loc names def f =
-    let+ def = def
-    and+ (pat, body) = value_binding loc name f in
-    let vbs = [mk_vb pat def] in
-    mk (Let(Nonrec, vbs, body)) []
+    With_free_vars.value_bindings loc names (fun vars ->
+        let pat, body = f vars in
+        let+ pat, body = With_free_vars.both pat body and+ def = def in
+        let pat =
+          With_bound_vars.value
+            ~extra:(BindingError.unexpected_binding_error_at_loc loc)
+            ~missing:BindingError.missing_binding_error pat
+            (List.map Var.Value.generic vars)
+        in
+        let vbs = [mk_vb pat def] in
+        mk (Let (Nonrecursive, vbs, body)) [])
 
-  let fun_nonbinding loc params exp =
-    let+ params = params
-    and+ exp = exp in
-    let constraint_ = None in
-    let body = Pfunction_body exp in
-    let fn = { params; constraint_; body } in
-    mk (Fun fn)
+  let function_ fn =
+    let+ fn = fn in
+    mk (Fun fn) []
 
-  let fun_simple loc name label default f =
-    let heap, pat, exp = Binding.simple loc name f in
-    let heap, default = fold_map_option merge loc heap default in
-      mk loc heap (Pexp_fun (label, default, pat, exp))
-
-  let fun_ loc names label default f =
-    let heap, pat, exp = Binding.pattern loc names f in
-    let heap, default = fold_map_option merge loc heap default in
-      mk loc heap (Pexp_fun(label, default, pat, exp))
-
-  let function_ loc cases =
-    let heap, cases = List.fold_left_map CaseRepr.merge loc Level_map.empty cases in
-      mk loc heap (Pexp_function cases)
-
-  let apply loc fn args =
-    let heap, fn = merge loc Level_map.empty fn in
-    let heap, args = fold_left_map_alist merge loc heap args in
-      mk loc heap (Pexp_apply (fn, args))
-
-  let match_ loc exp cases =
-    let heap, exp = merge loc Level_map.empty exp in
-    let heap, cases = List.fold_left_map CaseRepr.merge loc heap cases in
-      mk loc heap (Pexp_match(exp, cases))
-
-  let try_ loc exp cases =
-    let heap, exp = merge loc Level_map.empty exp in
-    let heap, cases = List.fold_left_map CaseRepr.merge loc heap cases in
-      mk loc heap (Pexp_try(exp, cases))
-
-  let tuple loc exps =
-    let heap, exps = List.fold_left_map merge loc Level_map.empty exps in
-      mk loc heap (Pexp_tuple exps)
-
-  let construct loc lid argo =
-    let heap, argo = fold_map_option merge loc Level_map.empty argo in
-      mk loc heap (Pexp_construct (lid, argo))
-
-  let variant loc label argo =
-    let heap, argo = fold_map_option merge loc Level_map.empty argo in
-      mk loc heap (Pexp_variant (label, argo))
-
-  let record loc defs orig =
-    let heap, defs = fold_left_map_alist merge loc Level_map.empty defs in
-    let heap, orig = fold_map_option merge loc heap orig in
-      mk loc heap (Pexp_record (defs, orig))
-
-  let field loc rcd lid =
-    let heap, rcd = merge loc Level_map.empty rcd in
-      mk loc heap (Pexp_field (rcd, lid))
-
-  let setfield loc rcd lid def =
-    let heap, rcd = merge loc Level_map.empty rcd in
-    let heap, def = merge loc heap def in
-      mk loc heap (Pexp_setfield (rcd, lid, def))
-
-  let array loc args =
-    let heap, args = List.fold_left_map merge loc Level_map.empty args in
-      mk loc heap (Pexp_array args)
-
-  let ifthenelse loc cond tr fs =
-    let heap, cond = merge loc Level_map.empty cond in
-    let heap, tr = merge loc heap tr in
-    let heap, fs = fold_map_option merge loc heap fs in
-      mk loc heap (Pexp_ifthenelse (cond, tr, fs))
-
-  let sequence loc exp1 exp2 =
-    let heap, exp1 = merge loc Level_map.empty exp1 in
-    let heap, exp2 = merge loc heap exp2 in
-      mk loc heap (Pexp_sequence(exp1, exp2))
-
-  let while_ loc cond body =
-    let heap, cond = merge loc Level_map.empty cond in
-    let heap, body = merge loc heap body in
-      mk loc heap (Pexp_while(cond, body))
-
-  let for_nonbinding loc pat low high dir body =
-    let dir = if dir then CamlinternalAST.Upto else CamlinternalAST.Downto in
-    let pat = PatRepr.nonbinding loc pat in
-    let heap, low = merge loc Level_map.empty low in
-    let heap, high = merge loc heap high in
-    let heap, body = merge loc heap body in
-      mk loc heap (Pexp_for (pat, low, high, dir, body))
-
-  let for_simple loc name low high dir f =
-    let dir = if dir then CamlinternalAST.Upto else CamlinternalAST.Downto in
-    let heap, pat, body = Binding.simple loc name f in
-    let heap, low = merge loc heap low in
-    let heap, high = merge loc heap high in
-      mk loc heap (Pexp_for (pat, low, high, dir, body))
-
-  let assert_ loc exp =
-    let heap, exp = merge loc Level_map.empty exp in
-      mk loc heap (Pexp_assert exp)
-
-  let lazy_ loc exp =
-    let heap, exp = merge loc Level_map.empty exp in
-      mk loc heap (Pexp_lazy exp)
-
-  let open_ loc ovr lid exp =
-    let ovr =
-      if ovr then CamlinternalAST.Override else CamlinternalAST.Fresh
+  let apply fn args =
+    let args =
+      List.map
+        (fun (lab, arg) ->
+          let+ exp = arg in
+          lab, exp)
+        args
     in
-    let heap, exp = merge loc Level_map.empty exp in
-      mk loc heap (Pexp_open(ovr, lid, exp))
+    let+ args = all args and+ fn = fn in
+    mk (Apply (fn, args)) []
 
-  let quote loc exp =
-    let heap, exp = merge loc Level_map.empty exp in
-      mk loc heap (Pexp_quote exp)
+  let match_ exp cases =
+    let+ cases = all cases and+ exp = exp in
+    mk (Match (exp, cases)) []
 
-  let escape loc exp =
-    let heap, exp = merge loc Level_map.empty exp in
-      mk loc heap (Pexp_escape exp)
+  let try_ exp cases =
+    let+ cases = all cases and+ exp = exp in
+    mk (Try (exp, cases)) []
 
-end
+  let tuple fs =
+    let entries =
+      List.map
+        (fun (lab, exp) ->
+          let+ exp = exp in
+          lab, exp)
+        fs
+    in
+    let+ entries = all entries in
+    mk (Tuple entries) []
 
-module Code = struct
+  let construct cons exp =
+    let+ exp = optional exp in
+    mk (Construct (cons, exp)) []
 
-  module Closed = struct
+  let variant v exp =
+    let+ exp = optional exp in
+    mk (Variant (v, exp)) []
 
-    type exp = t
+  let record entries exp =
+    let entries =
+      List.map
+        (fun (field, e) ->
+          let+ e = e in
+          field, e)
+        entries
+    in
+    let+ entries = all entries and+ exp = optional exp in
+    mk (Record (entries, exp)) []
 
-    type t = expression
+  let field exp field =
+    let+ exp = exp in
+    mk (Field (exp, field)) []
 
-    let close_delay_check exp =
-        match Level_map.choose exp.heap with
-        | None -> (exp.exp, fun () -> ())
-        | Some var ->
-          (exp.exp, fun () ->
-            Format.fprintf Format.str_formatter
-            "The code built at %a is not closed: \
-             identifier %s bound at %a is free"
-            Loc.print exp.exp.pexp_loc (Var.txt var)
-            Loc.print (Var.loc var);
-            failwith (Format.flush_str_formatter ()))
+  let setfield exp field value =
+    let+ exp = exp and+ value = value in
+    mk (Setfield (exp, field, value)) []
 
-    let close exp =
-      let exp, check = close_delay_check exp in
-      check (); exp
+  let array elements =
+    let+ elements = all elements in
+    mk (Array elements) []
 
-    let open_ exp =
-      let heap = Level_map.empty in
-        { heap; exp }
+  let ifthenelse cond then_ else_ =
+    let+ cond = cond and+ then_ = then_ and+ else_ = optional else_ in
+    mk (Ifthenelse (cond, then_, else_)) []
 
-  end
+  let sequence lhs rhs =
+    let+ lhs = lhs and+ rhs = rhs in
+    mk (Sequence (lhs, rhs)) []
 
+  let while_ cond body =
+    let+ cond = cond and+ body = body in
+    mk (While (cond, body)) [Loop]
+
+  let for_nonbinding loc pat begin_ end_ dir body =
+    let dir = if dir then Ast.Upto else Ast.Downto in
+    let+ body = body and+ pat = pat and+ begin_ = begin_ and+ end_ = end_ in
+    let pat =
+      With_bound_vars.value_nonbinding
+        ~extra:(BindingError.unexpected_binding_error_at_loc loc)
+        pat
+    in
+    mk (For (pat, begin_, end_, dir, body)) [Loop]
+
+  let for_simple loc name begin_ end_ dir body =
+    let dir = if dir then Ast.Upto else Ast.Downto in
+    let+ var, body =
+      With_free_vars.value_binding loc name (fun var ->
+          let+ body = body var in
+          var, body)
+    and+ begin_ = begin_
+    and+ end_ = end_ in
+    mk (For (Var var, begin_, end_, dir, body)) [Loop]
+
+  let constraint_ exp constr =
+    let+ exp = exp and+ constr = constr in
+    let desc =
+      match constr with
+      | Ast.Constraint typ -> Ast.ConstraintExp (exp, typ)
+      | Ast.Coerce (typ1, typ2) -> Ast.CoerceExp (exp, typ1, typ2)
+    in
+    mk desc []
+
+  let assert_ exp =
+    let+ exp = exp in
+    mk (Assert exp) []
+
+  let lazy_ exp =
+    let+ exp = exp in
+    mk (Lazy exp) []
+
+  let open_ override m rhs =
+    let flag = if override then Ast.Override else Ast.Fresh in
+    let+ exp = rhs in
+    mk (OpenExp (flag, m, exp)) []
+
+  let quote exp =
+    let+ exp = exp in
+    mk (Quote exp) [Quotation]
+
+  let escape exp =
+    let+ exp = exp in
+    mk (Escape exp) []
+
+  let splice code =
+    let+ ({ exp; loc } : Code.code_rep) = code in
+    mk (Splice (exp, loc)) []
 end

--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -8,18 +8,12 @@ module Stamp : sig
 
   (** [compare] is a total ordering on stamps. *)
   val compare : t -> t -> int
-
-  (** [to_string] prints a representation of the stamp. Each stamp
-      has a different representation. *)
-  val to_string : t -> string
 end = struct
   type t = int
 
   external fresh : unit -> int = "caml_fresh_oo_id" [@@noalloc]
 
   let compare = Int.compare
-
-  let to_string = string_of_int
 end
 
 module Loc = struct
@@ -100,13 +94,54 @@ end = struct
   let loc t = t.loc
 end
 
+let let_prefixes = ["let"; "and"]
+
 module Name = struct
   type t = string
 
   let mk t = t
 
+  let base_name s =
+    match String.index_opt s '_' with
+    | None ->
+      if List.for_all (fun p -> not (String.starts_with ~prefix:p s)) let_prefixes
+      then s
+      else "(" ^ s ^ ")"
+    | Some i -> String.sub s 0 i
+
   let print fmt s = Format.fprintf fmt "%s" s
 end
+
+type stamp_num = (Stamp.t, int) Hashtbl.t
+
+type name_counter = (string, int) Hashtbl.t
+
+type env_rec =
+  { value : name_counter;
+    type_var : name_counter;
+    type_constr : name_counter;
+    module_ : name_counter
+  }
+
+type env =
+  { stamps : stamp_num;
+    env : env_rec
+  }
+
+let new_env () =
+  { stamps = Hashtbl.create 32;
+    env =
+      { value = Hashtbl.create 32;
+        type_var = Hashtbl.create 32;
+        type_constr = Hashtbl.create 32;
+        module_ = Hashtbl.create 32
+      }
+  }
+
+let print_name_and_count fmt (name, count) =
+  if count > 0
+  then Format.fprintf fmt "%s__%d" name count
+  else Format.fprintf fmt "%s" name
 
 module Var : sig
   (** [t] is the type of variables of any sort *)
@@ -130,6 +165,10 @@ module Var : sig
 
     (** [name t] is the name of [t]. *)
     val name : t -> Name.t
+
+    (** [print env formatter t] prints [t] using [formatter], with [env] as the
+        naming environment. *)
+    val print : env -> Format.formatter -> t -> unit
   end
 
   module Value : sig
@@ -148,6 +187,10 @@ module Var : sig
 
     (** [name t] is the name of [t]. *)
     val name : t -> Name.t
+
+    (** [print env formatter t] prints [t] using [formatter], with [env] as the
+        naming environment. *)
+    val print : env -> Format.formatter -> t -> unit
   end
 
   module Type_var : sig
@@ -161,11 +204,15 @@ module Var : sig
     (** [generic t] is [t] as a generic variable *)
     val generic : t -> var
 
-    (** [generic t] is [t] as a list of generic variables *)
+    (** [generic_list t] is [t] as a list of generic variables *)
     val generic_list : t list -> var list
 
     (** [name t] is the name of [t]. *)
     val name : t -> Name.t
+
+    (** [print env formatter t] prints [t] using [formatter], with [env] as the
+        naming environment. *)
+    val print : env -> Format.formatter -> t -> unit
   end
 
   module Type_constr : sig
@@ -184,6 +231,10 @@ module Var : sig
 
     (** [name t] is the name of [t]. *)
     val name : t -> Name.t
+
+    (** [print env formatter t] prints [t] using [formatter], with [env] as the
+        naming environment. *)
+    val print : env -> Format.formatter -> t -> unit
   end
 
   (** [name t] is the name of [t]. *)
@@ -198,8 +249,6 @@ module Var : sig
   (** [valid t] is [true] if [t]'s binding is still open, and [false] otherwise. Once [t]'s binding has
       been closed there is no valid way to use [t]. *)
   val valid : t -> bool
-
-  val print : Format.formatter -> t -> unit
 
   module Set : sig
     (** [t] is the type of sets of variables. *)
@@ -387,7 +436,6 @@ end = struct
 
   let generate level name =
     let stamp = Stamp.fresh () in
-    let name = name ^ "_" ^ Stamp.to_string stamp in
     { name; stamp; level }
 
   let name t = t.name
@@ -398,8 +446,18 @@ end = struct
 
   let valid t = Level.check t.level
 
-  let print fmt t =
-    Format.fprintf fmt "%s @ %a" t.name Loc.print (Level.loc t.level)
+  let print_var_env stamp_env name_env fmt var =
+    match Hashtbl.find_opt stamp_env var.stamp with
+    | Some count -> print_name_and_count fmt (Name.base_name var.name, count)
+    | None -> (
+      let dict_update_and_print new_val =
+        Hashtbl.add stamp_env var.stamp new_val;
+        Hashtbl.add name_env (Name.base_name var.name) new_val;
+        print_name_and_count fmt (Name.base_name var.name, new_val)
+      in
+      match Hashtbl.find_opt name_env (Name.base_name var.name) with
+      | Some v -> dict_update_and_print (v + 1)
+      | None -> dict_update_and_print 0)
 
   module Module = struct
     type var = t
@@ -413,6 +471,9 @@ end = struct
     let generic_list = List.map generic
 
     let name = name
+
+    let print env fmt t =
+      Format.fprintf fmt "%a" (print_var_env env.stamps env.env.module_) t
   end
 
   module Value = struct
@@ -427,6 +488,9 @@ end = struct
     let generic_list = List.map generic
 
     let name = name
+
+    let print env fmt t =
+      Format.fprintf fmt "%a" (print_var_env env.stamps env.env.value) t
   end
 
   module Type_var = struct
@@ -441,6 +505,9 @@ end = struct
     let generic_list = List.map generic
 
     let name = name
+
+    let print env fmt t =
+      Format.fprintf fmt "%a" (print_var_env env.stamps env.env.type_var) t
   end
 
   module Type_constr = struct
@@ -455,6 +522,9 @@ end = struct
     let generic_list = List.map generic
 
     let name = name
+
+    let print env fmt t =
+      Format.fprintf fmt "%a" (print_var_env env.stamps env.env.type_constr) t
   end
 end
 
@@ -703,7 +773,7 @@ end = struct
 
   let optional = function None -> return None | Some t -> map Option.some t
 
-  let check ~invalid { vars; v } =
+  let check ~invalid { vars; _ } =
     Var.Map.iter
       (fun var loc -> if not (Var.valid var) then invalid var loc)
       vars
@@ -779,8 +849,8 @@ end = struct
           f fresh_value_vars fresh_module_vars
         in
         let fresh_vars =
-          List.map Var.Module.generic fresh_module_vars
-          @ List.map Var.Value.generic fresh_value_vars
+          Var.Module.generic_list fresh_module_vars
+          @ Var.Value.generic_list fresh_value_vars
         in
         let bindings =
           With_bound_vars.value ~extra ~missing bindings fresh_vars
@@ -847,29 +917,57 @@ type raw_ident_module_type_t = MtDot of raw_ident_module_t * string
 
 type raw_ident_field_t = FDot of raw_ident_module_t * string
 
-let rec print_raw_ident_module fmt = function
+let special_symbols =
+  [ '!';
+    '?';
+    '~';
+    '=';
+    '<';
+    '>';
+    '@';
+    '^';
+    '|';
+    '&';
+    '+';
+    '-';
+    '*';
+    '/';
+    '$';
+    '%';
+    '#' ]
+
+let special_infix_strings =
+  ["asr"; "land"; "lor"; "lsl"; "lsr"; "lxor"; "mod"; "or"; ":="; "!="; "::"]
+
+let print_op fmt s =
+  if List.mem s special_infix_strings || List.mem s.[0] special_symbols
+  then Format.fprintf fmt "( %s )" s
+  else Format.fprintf fmt "%s" s
+
+let rec print_raw_ident_module env fmt = function
   | Compilation_unit s -> Format.fprintf fmt "%s" s
-  | MDot (m, s) -> Format.fprintf fmt "%a.%s" print_raw_ident_module m s
-  | MVar (vm, l) -> Format.fprintf fmt "%a" Var.print (Var.Module.generic vm)
+  | MDot (m, s) -> Format.fprintf fmt "%a.%s" (print_raw_ident_module env) m s
+  | MVar (vm, _) -> Format.fprintf fmt "%a" (Var.Module.print env) vm
 
-let print_raw_ident_value fmt = function
-  | VDot (m, s) -> Format.fprintf fmt "%a.%s" print_raw_ident_module m s
-  | VVar (v, _) -> Var.print fmt (Var.Value.generic v)
+let print_raw_ident_value env fmt = function
+  | VDot (m, s) ->
+    Format.fprintf fmt "%a.%a" (print_raw_ident_module env) m print_op s
+  | VVar (v, _) -> Var.Value.print env fmt v
 
-let print_raw_ident_type fmt = function
-  | TDot (m, s) -> Format.fprintf fmt "%a.%s" print_raw_ident_module m s
-  | TVar (v, _) -> Var.print fmt (Var.Type_constr.generic v)
+let print_raw_ident_type env fmt = function
+  | TDot (m, s) -> Format.fprintf fmt "%a.%s" (print_raw_ident_module env) m s
+  | TVar (v, _) -> Var.Type_constr.print env fmt v
   | TBuiltin s -> Format.fprintf fmt "%s" s
 
-let print_raw_ident_constructor fmt = function
-  | CDot (m, s) -> Format.fprintf fmt "%a.%s" print_raw_ident_module m s
+let print_raw_ident_constructor env fmt = function
+  | CDot (m, s) -> Format.fprintf fmt "%a.%s" (print_raw_ident_module env) m s
   | CBuiltin s -> Format.fprintf fmt "%s" s
 
-let print_raw_ident_module_type fmt = function
-  | MtDot (m, s) -> Format.fprintf fmt "%a.%s" print_raw_ident_module m s
+let print_raw_ident_module_type env fmt = function
+  | MtDot (m, s) -> Format.fprintf fmt "%a.%s" (print_raw_ident_module env) m s
 
-let print_raw_ident_field fmt = function
-  | FDot (m, s) -> Format.fprintf fmt "%a.%s" print_raw_ident_module m s
+let print_raw_ident_field env fmt = function
+  | FDot (m, s) -> Format.fprintf fmt "%a.%s" (print_raw_ident_module env) m s
 
 let rec free_vars_module = function
   | Compilation_unit _ -> Var.Map.empty
@@ -1018,6 +1116,7 @@ module Identifier = struct
     let float64x2 = TBuiltin "float64x2" |> mk
   end
 
+
   module Module_type = struct
     type raw = raw_ident_module_type_t
 
@@ -1035,8 +1134,6 @@ module Identifier = struct
 
     type t = raw_ident_constructor_t With_free_vars.t
 
-    type t_with_bound = raw_ident_constructor_t With_free_and_bound_vars.t
-
     let ( let+ ) m f = With_free_vars.map f m
 
     let mk t = With_free_vars.mk (free_vars_constructor t) t
@@ -1044,10 +1141,6 @@ module Identifier = struct
     let dot t s =
       let+ t = t in
       CDot (t, s)
-
-    let with_bound_vars t =
-      let+ t = t in
-      With_bound_vars.return t
 
     let false_ = CBuiltin "false" |> mk
 
@@ -1104,7 +1197,7 @@ module Variant = struct
 
   let of_string s = s
 
-  let print fmt s = Format.fprintf fmt "%s" s
+  let print fmt s = Format.fprintf fmt "`%s" s
 end
 
 module Method = struct
@@ -1118,12 +1211,18 @@ end
 module Ast = struct
   type constant =
     | Int of int
-    | Char of char
-    | String of string * string option
-    | Float of string
     | Int32 of int32
     | Int64 of int64
     | Nativeint of nativeint
+    | Char of char
+    | String of string * string option
+    | Float of string
+    | Float32 of string
+    | UnboxedFloat of string
+    | UnboxedFloat32 of string
+    | UnboxedInt32 of int32
+    | UnboxedInt64 of int64
+    | UnboxedNativeint of nativeint
 
   type rec_flag =
     | Nonrecursive
@@ -1142,9 +1241,13 @@ module Ast = struct
     | ClosedRec
 
   type variant_form =
-    | Fixed
-    | Open
-    | Closed of string list
+    | VFixed
+    | VOpen
+    | VClosed of string list
+
+  type object_closed_flag =
+    | OClosed
+    | OOpen
 
   type arg_label =
     | Nolabel
@@ -1155,6 +1258,18 @@ module Ast = struct
     | NolabelTup
     | LabelledTup of string
 
+  type module_type =
+    | MTIdent of raw_ident_module_type_t
+    | MTBasic of string
+
+  type constr =
+    | CIdent of raw_ident_constructor_t
+    | CBasic of string
+
+  type record_field =
+    | FIdent of raw_ident_field_t
+    | FBasic of string
+
   type core_type =
     | TypeAny
     | TypeVar of Var.Type_var.t
@@ -1162,16 +1277,23 @@ module Ast = struct
     | TypeTuple of (tuple_label * core_type) list
     | TypeUnboxedTuple of (tuple_label * core_type) list
     | TypeConstr of raw_ident_type_t * core_type list
+    | TypeObject of object_field list * object_closed_flag
+    | TypeClass of Name.t * core_type list
     | TypeAlias of core_type * Name.t
     | TypeVariant of row_field list * variant_form
     | TypePoly of Name.t list * core_type
     | TypePackage of package_type
+    | TypeCallPos
+
+  and object_field =
+    | Otag of Name.t * core_type
+    | Oinherit of core_type
 
   and row_field =
-    | Tag of Variant.t * bool * core_type list
-    | Inherit of core_type
+    | Vtag of Variant.t * bool * core_type list
+    | Vinherit of core_type
 
-  and package_type = raw_ident_module_type_t * (fragment * core_type) list
+  and package_type = module_type * (fragment * core_type) list
 
   and fragment =
     | Name of Name.t
@@ -1187,9 +1309,11 @@ module Ast = struct
     | PatAlias of pattern * Var.Value.t
     | PatConstant of constant
     | PatTuple of (tuple_label * pattern) list
-    | PatConstruct of raw_ident_constructor_t * pattern option
+    | PatUnboxedTuple of (tuple_label * pattern) list
+    | PatConstruct of constr * pattern option
     | PatVariant of Variant.t * pattern option
-    | PatRecord of (raw_ident_field_t * pattern) list * record_flag
+    | PatRecord of (record_field * pattern) list * record_flag
+    | PatUnboxedRecord of (record_field * pattern) list * record_flag
     | PatArray of pattern list
     | PatOr of pattern * pattern
     | PatConstraint of pattern * core_type
@@ -1224,11 +1348,11 @@ module Ast = struct
     | Match of expression * case list
     | Try of expression * case list
     | Tuple of (tuple_label * expression) list
-    | Construct of raw_ident_constructor_t * expression option
+    | Construct of constr * expression option
     | Variant of string * expression option
-    | Record of (raw_ident_field_t * expression) list * expression option
-    | Field of expression * raw_ident_field_t
-    | Setfield of expression * raw_ident_field_t * expression
+    | Record of (record_field * expression) list * expression option
+    | Field of expression * record_field
+    | Setfield of expression * record_field * expression
     | Array of expression list
     | Ifthenelse of expression * expression * expression option
     | Sequence of expression * expression
@@ -1248,15 +1372,16 @@ module Ast = struct
     | Exclave of expression
     | Unboxed_tuple of (tuple_label * expression) list
     | Unboxed_record_product of
-        (raw_ident_field_t * expression) list * expression option
-    | Unboxed_field of expression * raw_ident_field_t
-    | Let_op of raw_ident_value_t list * value_binding list * expression
+        (record_field * expression) list * expression option
+    | Unboxed_field of expression * record_field
+    | Let_op of raw_ident_value_t list * expression list * case
     | Let_exception of Name.t * expression
-    | Extension_constructor of raw_ident_constructor_t
+    | Extension_constructor of Name.t
     | List_comprehension of comprehension
     | Array_comprehension of comprehension
     | Quote of expression
-    | Antiquote of expression * Loc.t
+    | Antiquote of expression
+    | Probe
 
   and case =
     { lhs : pattern;
@@ -1286,7 +1411,7 @@ module Ast = struct
   and module_expr =
     | ModuleIdent of raw_ident_module_t
     | ModuleApply of module_expr * module_expr
-    | Apply_unit of module_expr
+    | ModuleApply_unit of module_expr
 
   and comprehension_clause =
     | Range of Var.Value.t * expression * expression * direction_flag
@@ -1297,71 +1422,118 @@ module Ast = struct
     | When of comprehension * expression
     | ForComp of comprehension * comprehension_clause
 
-  let rec print_vb fmt ({ pat; expr } : value_binding) =
-    Format.fprintf fmt "%a = %a" print_pat pat print_exp expr
+  let print_tuple_like delim open_sym close_sym printer fmt entries =
+    Format.fprintf fmt "%s@[" open_sym;
+    (match entries with
+    | [] -> ()
+    | e :: es ->
+      printer fmt e;
+      List.iter (fun e -> Format.fprintf fmt "%s@ %a" delim printer e) es);
+    Format.fprintf fmt "@]%s" close_sym
+
+  let print_label_tup printer fmt (lab, entry) =
+    match lab with
+    | LabelledTup s -> Format.fprintf fmt "~%s:%a" s printer entry
+    | NolabelTup -> printer fmt entry
+
+  let print_array printer fmt entries =
+    print_tuple_like ";" "[|" "|]" printer fmt entries
+
+  let print_tuple printer fmt entries =
+    print_tuple_like "," "(" ")" (print_label_tup printer) fmt entries
+
+  let rec print_vb env fmt ({ pat; expr } : value_binding) =
+    Format.fprintf fmt "%a@ =@ @[%a@]" (print_pat env) pat
+      (print_exp_with_parens env)
+      expr
 
   and print_const fmt = function
     | Int n -> Format.fprintf fmt "%d" n
     | Char c -> Format.fprintf fmt "%c" c
     | String (s, id_opt) -> (
       match id_opt with
-      | None -> Format.fprintf fmt "%s" s
-      | Some id -> Format.fprintf fmt "{%s|@[<1>%s@]|%s}" id s id)
+      | None -> Format.fprintf fmt "\"%s\"" s
+      | Some id -> Format.fprintf fmt "{%s|@[%s@]|%s}" id s id)
     | Float s -> Format.fprintf fmt "%s" s
+    | Float32 s -> Format.fprintf fmt "%ss" s
     | Int32 n -> Format.fprintf fmt "%ld" n
     | Int64 n -> Format.fprintf fmt "%Ld" n
     | Nativeint n -> Format.fprintf fmt "%nd" n
+    | UnboxedFloat s -> Format.fprintf fmt "#%s" s
+    | UnboxedFloat32 s -> Format.fprintf fmt "#%ss" s
+    | UnboxedInt32 n -> Format.fprintf fmt "#%ldl" n
+    | UnboxedInt64 n -> Format.fprintf fmt "#%LdL" n
+    | UnboxedNativeint n -> Format.fprintf fmt "#%ndn" n
 
-  and print_pat fmt = function
+  and print_constr env fmt = function
+    | CBasic s -> Format.fprintf fmt "%s" s
+    | CIdent id -> print_raw_ident_constructor env fmt id
+
+  and print_module_type env fmt = function
+    | MTBasic s -> Format.fprintf fmt "%s" s
+    | MTIdent id -> print_raw_ident_module_type env fmt id
+
+  and print_field env fmt = function
+    | FBasic s -> Format.fprintf fmt "%s" s
+    | FIdent id -> print_raw_ident_field env fmt id
+
+  and print_pat env fmt = function
     | PatAny -> Format.fprintf fmt "_"
-    | PatVar v -> Var.print fmt (Var.Value.generic v)
+    | PatVar v -> Var.Value.print env fmt v
     | PatAlias (pat, v) ->
-      Format.fprintf fmt "%a@ as@ %a" print_pat pat Var.print
-        (Var.Value.generic v)
+      Format.fprintf fmt "%a@ as@ %a"
+        (print_pat env) pat (Var.Value.print env) v
     | PatConstant c -> print_const fmt c
-    | PatTuple ts ->
-      Format.fprintf fmt "(@[<1>";
-      List.iter
-        (fun (tlab, pat) ->
-          match tlab with
-          | NolabelTup -> Format.fprintf fmt "%a,@ " print_pat pat
-          | LabelledTup l -> Format.fprintf fmt "~%s:%a,@ " l print_pat pat)
-        ts;
-      Format.fprintf fmt "@])"
+    | PatTuple ts -> print_tuple (print_pat env) fmt ts
+    | PatUnboxedTuple ts ->
+      Format.fprintf fmt "#%a" (print_tuple (print_pat env)) ts
     | PatConstruct (ident, pat_opt) -> (
       match pat_opt with
-      | None -> print_raw_ident_constructor fmt ident
+      | None -> print_constr env fmt ident
       | Some pat ->
-        Format.fprintf fmt "%a %a" print_pat pat print_raw_ident_constructor
-          ident)
+        Format.fprintf fmt "%a@ %a" (print_constr env) ident (print_pat env) pat
+      )
     | PatVariant (variant, pat_opt) -> (
       match pat_opt with
       | None -> Variant.print fmt variant
       | Some pat ->
-        Format.fprintf fmt "%a %a" print_pat pat Variant.print variant)
+        Format.fprintf fmt "%a@ %a" Variant.print variant (print_pat env) pat)
     | PatRecord (entries, rec_flag) ->
-      Format.fprintf fmt "{@[<1>";
+      Format.fprintf fmt "{@[";
       List.iter
         (fun (field, pat) ->
-          Format.fprintf fmt "%a=%a;@ " print_raw_ident_field field print_pat
+           Format.fprintf fmt "%a=%a;@ " (print_field env) field (print_pat env)
+             pat)
+        entries;
+      if rec_flag = OpenRec then Format.fprintf fmt "_";
+      Format.fprintf fmt "@]}"
+    | PatUnboxedRecord (entries, rec_flag) ->
+      Format.fprintf fmt "#{@[";
+      List.iter
+        (fun (field, pat) ->
+          Format.fprintf fmt "%a=%a;@ " (print_field env) field (print_pat env)
             pat)
         entries;
       if rec_flag = OpenRec then Format.fprintf fmt "_";
       Format.fprintf fmt "@]}"
-    | PatArray pats ->
-      Format.fprintf fmt "[|@[<1>";
-      List.iter (fun pat -> Format.fprintf fmt "%a;@ " print_pat pat) pats;
-      Format.fprintf fmt "@]|]"
+    | PatArray pats -> print_array (print_pat env) fmt pats
     | PatOr (pat1, pat2) ->
-      Format.fprintf fmt "%a@ |@ %a" print_pat pat1 print_pat pat2
+      Format.fprintf fmt "%a@ |@ %a" (print_pat env) pat1 (print_pat env) pat2
     | PatConstraint (pat, ty) ->
-      Format.fprintf fmt "(%a@ :@ %a)" print_pat pat print_core_type ty
-    | PatLazy pat -> Format.fprintf fmt "lazy@ (%a)" print_pat pat
-    | PatUnpack v ->
-      Format.fprintf fmt "(module %a)" Var.print (Var.Module.generic v)
-    | PatException pat -> Format.fprintf fmt "(exception %a)" print_pat pat
+      Format.fprintf fmt "%a@ :@ %a" (print_pat env) pat (print_core_type env)
+        ty
+    | PatLazy pat -> Format.fprintf fmt "lazy@ (%a)" (print_pat env) pat
+    | PatUnpack v -> Format.fprintf fmt "module %a" (Var.Module.print env) v
+    | PatException pat ->
+      Format.fprintf fmt "(exception %a)" (print_pat env) pat
 
-  and print_exp_with_parens fmt exp =
+  and print_type_constraint env fmt = function
+    | Constraint ty ->
+      Format.fprintf fmt "%@ :@ @[%a@]" (print_core_type env) ty
+    | Coerce (opt_ty, ty) ->
+      Format.fprintf fmt "%@ :>@ @[%a@]" (print_core_type env) ty
+
+  and print_exp_with_parens env fmt exp =
     match exp.desc with
     | Ident _ | Constant _ | Tuple _
     | Construct (_, None)
@@ -1370,36 +1542,40 @@ module Ast = struct
     | Field _ | Array _ | Send _ | Unreachable | Src_pos | Unboxed_tuple _
     | Unboxed_record_product (_, None)
     | List_comprehension _ | Array_comprehension _ | Quote _ | Antiquote _ ->
-      Format.fprintf fmt "(@[<1>%a@])" print_exp exp
-    | _ -> print_exp fmt exp
+      (print_exp env) fmt exp
+    | _ -> Format.fprintf fmt "(@[%a@])" (print_exp env) exp
 
-  and print_case fmt { lhs; guard; rhs } =
-    Format.fprintf fmt " | %a" print_pat lhs;
+  and print_case env fmt { lhs; guard; rhs } =
+    Format.fprintf fmt " | %a" (print_pat env) lhs;
     (match guard with
     | None -> ()
-    | Some guard -> Format.fprintf fmt "@ with@ %a" print_exp_with_parens guard);
+    | Some guard ->
+      Format.fprintf fmt "@ with@ %a" (print_exp_with_parens env) guard);
     Format.fprintf fmt "@ ->@ ";
     match rhs with
     | None -> Format.fprintf fmt "."
-    | Some rhs -> print_exp fmt rhs
+    | Some rhs -> print_exp env fmt rhs
 
-  and print_row_field with_or fmt rf =
+  and print_row_field env with_or fmt rf =
     if with_or then Format.fprintf fmt "@ |@ ";
     match rf with
-    | Inherit ty -> print_core_type fmt ty
-    | Tag (variant, false, []) ->
+    | Vinherit ty -> print_core_type env fmt ty
+    | Vtag (variant, false, []) ->
       () (* fatal_error "Invalid polymorphic variant type" *)
-    | Tag (variant, true, []) -> Format.fprintf fmt "`%a" Variant.print variant
-    | Tag (variant, true, tys) ->
+    | Vtag (variant, true, []) -> Format.fprintf fmt "%a" Variant.print variant
+    | Vtag (variant, true, tys) ->
       Format.fprintf fmt "%a@ of" Variant.print variant;
       List.iter
-        (fun ty -> Format.fprintf fmt "@ &@ %a" print_core_type_with_arrow ty)
+        (fun ty ->
+          Format.fprintf fmt "@ &@ %a" (print_core_type_with_arrow env) ty)
         tys
-    | Tag (variant, false, ty :: tys) ->
+    | Vtag (variant, false, ty :: tys) ->
       Format.fprintf fmt "%a@ of@ %a" Variant.print variant
-        print_core_type_with_arrow ty;
+        (print_core_type_with_arrow env)
+        ty;
       List.iter
-        (fun ty -> Format.fprintf fmt "@ &@ %a" print_core_type_with_arrow ty)
+        (fun ty ->
+          Format.fprintf fmt "@ &@ %a" (print_core_type_with_arrow env) ty)
         tys
 
   and print_fragment fmt = function
@@ -1407,113 +1583,157 @@ module Ast = struct
     | Dot (frag, s) ->
       Format.fprintf fmt "%a.%a" print_fragment frag Name.print s
 
-  and print_module_with_clause is_first fmt (frag, ty) =
+  and print_module_with_clause env is_first fmt (frag, ty) =
     if is_first
     then
       Format.fprintf fmt "@ with@ type@ %a@ =@ %a" print_fragment frag
-        print_core_type ty
+        (print_core_type env) ty
     else
       Format.fprintf fmt "@ and@ type@ %a@ =@ %a" print_fragment frag
-        print_core_type ty
+        (print_core_type env) ty
 
-  and print_core_type_with_arrow fmt ty =
+  and print_core_type_with_arrow env fmt ty =
     match ty with
-    | TypeArrow _ -> Format.fprintf fmt "(@[<1>%a@])" print_core_type ty
-    | _ -> print_core_type fmt ty
+    | TypeArrow _ -> Format.fprintf fmt "(@[%a@])" (print_core_type env) ty
+    | _ -> print_core_type env fmt ty
 
-  and print_core_type_with_parens fmt ty =
+  and print_core_type_with_parens env fmt ty =
     match ty with
     | TypeArrow _ | TypeTuple _ | TypeConstr _ | TypeAlias _ | TypePoly _ ->
-      Format.fprintf fmt "(@[<1>%a@])" print_core_type ty
-    | _ -> print_core_type fmt ty
+      Format.fprintf fmt "(@[%a@])" (print_core_type env) ty
+    | _ -> print_core_type env fmt ty
 
-  and print_core_type fmt = function
+  and print_object_field env fmt = function
+    | Oinherit ty ->
+      Format.fprintf fmt "<inherit %a TODO>" (print_core_type env) ty
+    | Otag (name, ty) ->
+      Format.fprintf fmt "%a : %a" Name.print name (print_core_type env) ty
+
+  and print_module_exp env fmt = function
+    | ModuleIdent ident -> print_raw_ident_module env fmt ident
+    | ModuleApply (module_1, module_2) ->
+      Format.fprintf fmt "%a(@[%a@])" (print_module_exp env) module_1
+        (print_module_exp env) module_2
+    | ModuleApply_unit module_ ->
+      Format.fprintf fmt "%a()" (print_module_exp env) module_
+
+  and print_core_type env fmt = function
     | TypeAny -> Format.fprintf fmt "_"
-    | TypeVar v -> Var.print fmt (Var.Type_var.generic v)
+    | TypeVar v -> Var.Type_var.print env fmt v
     | TypeArrow (arg_label, ty1, ty2) ->
       Format.fprintf fmt "%a%a@ ->@ %a" print_arg_lab arg_label
-        print_core_type_with_arrow ty1 print_core_type ty2
+        (print_core_type_with_arrow env)
+        ty1 (print_core_type env) ty2
     | TypeTuple ((tl, ty) :: ts) ->
       (match tl with
       | LabelledTup l ->
-        Format.fprintf fmt "%s:%a" l print_core_type_with_parens ty
-      | NolabelTup -> print_core_type_with_parens fmt ty);
+        Format.fprintf fmt "%s:%a" l (print_core_type_with_parens env) ty
+      | NolabelTup -> print_core_type_with_parens env fmt ty);
       List.iter
         (fun (tl, ty) ->
           Format.fprintf fmt " * ";
           match tl with
           | LabelledTup l ->
-            Format.fprintf fmt "%s:%a" l print_core_type_with_parens ty
-          | NolabelTup -> print_core_type_with_parens fmt ty)
+            Format.fprintf fmt "%s:%a" l (print_core_type_with_parens env) ty
+          | NolabelTup -> print_core_type_with_parens env fmt ty)
         ts
     | TypeTuple [] -> () (* fatal_error "Invalid tuple type" *)
     | TypeUnboxedTuple ((tl, ty) :: ts) ->
       (match tl with
       | LabelledTup l ->
-        Format.fprintf fmt "%s:%a" l print_core_type_with_parens ty
-      | NolabelTup -> print_core_type_with_parens fmt ty);
+        Format.fprintf fmt "%s:%a" l (print_core_type_with_parens env) ty
+      | NolabelTup -> print_core_type_with_parens env fmt ty);
       List.iter
         (fun (tl, ty) ->
           Format.fprintf fmt " * ";
           match tl with
           | LabelledTup l ->
-            Format.fprintf fmt "%s:%a" l print_core_type_with_parens ty
-          | NolabelTup -> print_core_type_with_parens fmt ty)
+            Format.fprintf fmt "%s:%a" l (print_core_type_with_parens env) ty
+          | NolabelTup -> print_core_type_with_parens env fmt ty)
         ts (* possibly incorrect way of displaying unboxed tuples *)
     | TypeUnboxedTuple [] -> () (* fatal_error "Invalid unboxed tuple type" *)
-    | TypeConstr (ident, []) -> print_raw_ident_type fmt ident
+    | TypeConstr (ident, []) -> print_raw_ident_type env fmt ident
     | TypeConstr (ident, [ty]) ->
-      Format.fprintf fmt "%a@ %a" print_core_type_with_parens ty
-        print_raw_ident_type ident
+      Format.fprintf fmt "%a@ %a"
+        (print_core_type_with_parens env)
+        ty (print_raw_ident_type env) ident
     | TypeConstr (ident, ty :: tys) ->
-      Format.fprintf fmt "(%a" print_core_type ty;
-      List.iter (fun ty -> Format.fprintf fmt ", %a" print_core_type ty) tys;
-      Format.fprintf fmt ") %a" print_raw_ident_type ident
+      print_tuple_like "(" ")" "," (print_core_type env) fmt (ty :: tys);
+      Format.fprintf fmt "@ %a" (print_raw_ident_type env) ident
+    | TypeObject ([], closed_flag) -> Format.fprintf fmt "< >"
+    | TypeObject (f :: fs, closed_flag) ->
+      print_tuple_like "< " " >" "," (print_object_field env) fmt (f :: fs)
+    | TypeClass (name, []) -> Name.print fmt name
+    | TypeClass (name, [ty]) ->
+      Format.fprintf fmt "[%a]@ %a" (print_core_type env) ty Name.print name
+    | TypeClass (name, ty :: tys) ->
+      print_tuple_like "[" "]" "," (print_core_type env) fmt (ty :: tys);
+      Format.fprintf fmt "@ %a" Name.print name
     | TypeAlias (ty, tv) ->
-      Format.fprintf fmt "%a@ as@ %a" print_core_type ty Name.print tv
+      Format.fprintf fmt "%a@ as@ %a" (print_core_type env) ty Name.print tv
     | TypeVariant ([], _) -> () (* fatal_error "Invalid variant type" *)
     | TypeVariant (rf :: row_fields, variant_form) ->
       (match variant_form with
-      | Fixed -> Format.fprintf fmt "[ "
-      | Open -> Format.fprintf fmt "[> "
-      | Closed sl -> Format.fprintf fmt "[< ");
-      print_row_field false fmt rf;
-      List.iter (print_row_field true fmt) row_fields;
+      | VFixed -> Format.fprintf fmt "[ "
+      | VOpen -> Format.fprintf fmt "[> "
+      | VClosed sl -> Format.fprintf fmt "[< ");
+      print_row_field env false fmt rf;
+      List.iter (print_row_field env true fmt) row_fields;
       Format.fprintf fmt " ]"
     | TypePoly ([], _) -> () (* fatal_error "Invalid poly-type" *)
     | TypePoly (tv :: tvs, ty) ->
-      Format.fprintf fmt "'%a" Name.print tv;
-      List.iter (fun tv -> Format.fprintf fmt " '%a" Name.print tv) tvs;
-      Format.fprintf fmt ". %a" print_core_type ty
+      let print_tv fmt name = Format.fprintf fmt "'%s" name in
+      print_tuple_like "" "" " " print_tv fmt (tv :: tvs);
+      Format.fprintf fmt ".@ %a" (print_core_type env) ty
     | TypePackage (ident, []) ->
-      Format.fprintf fmt "(module %a)" print_raw_ident_module_type ident
-    | TypePackage (ident, with_clause :: wcs) ->
-      Format.fprintf fmt "(module %a" print_raw_ident_module_type ident;
-      print_module_with_clause true fmt with_clause;
-      List.iter (print_module_with_clause false fmt) wcs;
-      Format.fprintf fmt ")"
+      print_module_type env fmt ident
+    | TypePackage (ident, (fragment, core_type)::wcs) ->
+      Format.fprintf fmt "@[%a@ with@ type@ %a@ =@ %a"
+        (print_module_type env) ident
+        print_fragment fragment
+        (print_core_type env) core_type;
+      List.iter (fun (fragment, core_type) ->
+        Format.fprintf fmt "@ and@ type@ %a@ =@ %a"
+          print_fragment fragment
+          (print_core_type env) core_type)
+        wcs;
+      Format.fprintf fmt "@]"
+    | TypeCallPos -> Format.fprintf fmt "call_pos"
 
   and print_arg_lab fmt = function
     | Nolabel -> Format.fprintf fmt ""
     | Labelled s -> Format.fprintf fmt "~%s:" s
     | Optional s -> Format.fprintf fmt "?%s:" s
 
-  (* TODO: incorrect !! *)
-  and print_param fmt = function
+  (* TODO: incorrect !! -- add logic for (let+) *)
+  and print_param env fmt = function
     | Pparam_val (arg_lab, exp_opt, pat) ->
-      Format.fprintf fmt " %a%a" print_arg_lab arg_lab print_pat pat
+      Format.fprintf fmt "@ %a%a" print_arg_lab arg_lab (print_pat env) pat
     | Pparam_newtype ty ->
-      Format.fprintf fmt " (type %a)" Var.print (Var.Type_var.generic ty)
+      Format.fprintf fmt "@ (type %a)" (Var.Type_var.print env) ty
 
-  and print_exp fmt exp =
+  and print_record env fmt (fields, exp_opt) =
+    Format.fprintf fmt "{@[";
+    (match exp_opt with
+    | None -> ()
+    | Some exp -> Format.fprintf fmt "%a@ with@ " (print_exp env) exp);
+    List.iter
+      (fun (field, exp) ->
+        Format.fprintf fmt "%a = %a; " (print_field env) field (print_exp env)
+          exp)
+      fields;
+    Format.fprintf fmt "@]}"
+
+  and print_exp env fmt exp =
     match exp.desc with
-    | Ident id -> print_raw_ident_value fmt id
+    | Ident id -> print_raw_ident_value env fmt id
     | Constant c -> print_const fmt c
     | Apply (exp, args) ->
-      Format.fprintf fmt "%a@[<1>" print_exp exp;
+      Format.fprintf fmt "%a@[" (print_exp env) exp;
       List.iter
         (fun (arg_lab, exp) ->
-          Format.fprintf fmt "@ %a(@[<1>%a@])" print_arg_lab arg_lab print_exp
+          Format.fprintf fmt "@ %a@[%a@]" print_arg_lab arg_lab
+            (print_exp_with_parens env)
             exp)
         args;
       Format.fprintf fmt "@]"
@@ -1521,71 +1741,154 @@ module Ast = struct
       match body with
       | Pfunction_body exp ->
         Format.fprintf fmt "fun";
-        List.iter (print_param fmt) params;
-        Format.fprintf fmt "@ ->@ @[<1>%a@]" print_exp exp
+        List.iter (print_param env fmt) params;
+        Option.iter (print_type_constraint env fmt) constraint_;
+        Format.fprintf fmt "@ ->@ @[%a@]" (print_exp env) exp
       | Pfunction_cases cases ->
-        Format.fprintf fmt "function@ @[<1>";
-        List.iter (print_case fmt) cases;
+        Format.fprintf fmt "function@[";
+        List.iter (print_case env fmt) cases;
+        Option.iter (print_type_constraint env fmt) constraint_;
         Format.fprintf fmt "@]")
-    | Unreachable | Src_pos -> Format.fprintf fmt "."
-    | Exclave exp -> Format.fprintf fmt "exclave@ %a" print_exp exp
+    | Let (_, [], _) ->
+      failwith "Cannot create empty let-expressions. This should not happen."
+    | Let (rec_flag, vb :: vbs, body) ->
+      let prefix =
+        match rec_flag with Nonrecursive -> "let" | Recursive -> "let@ rec"
+      in
+      Format.fprintf fmt "@[@[%s@ @[%a@ @]@]" prefix (print_vb env) vb;
+      List.iter
+        (fun vb -> Format.fprintf fmt "@[and@ @[%a@ @]@]" (print_vb env) vb)
+        vbs;
+      Format.fprintf fmt "@]@[in@ @[%a@]@]" (print_exp env) body
+    | Let_op ([], _, _) ->
+      failwith "Cannot create empty let-expressions. This should not happen."
+    | Let_op (binders, defs, case) ->
+      let bind_lefts =
+        (match case.lhs with
+         | PatTuple l -> l
+         | pat -> [(NolabelTup, pat)]) in
+      let rec iter3 f xs ys zs =
+        match (xs, ys, zs) with
+        | ([], [], []) -> ()
+        | (x::xs, y::ys, z::zs) -> f x y z; iter3 f xs ys zs
+        | _ -> failwith "Lists should have equal length."
+      in
+      iter3
+        (fun binder (_, pat_bind) def ->
+           Format.fprintf fmt "@[%a@ %a@ =@ @[%a@]@]@ "
+             (print_raw_ident_value env) binder
+             (print_pat env) pat_bind
+             (print_exp env) def)
+        binders
+        bind_lefts
+        defs;
+      (match case.rhs with
+       | Some exp -> Format.fprintf fmt "@[in@ @[%a@]@]" (print_exp env) exp
+       | None -> Format.fprintf fmt ".")
+    | Exclave exp -> Format.fprintf fmt "exclave_@ %a" (print_exp env) exp
     | Construct (ident, exp_opt) -> (
       match exp_opt with
-      | None -> print_raw_ident_constructor fmt ident
+      | None -> print_constr env fmt ident
       | Some exp ->
-        Format.fprintf fmt "%a@ %a" print_raw_ident_constructor ident
-          print_exp_with_parens exp)
+        Format.fprintf fmt "%a@ %a" (print_constr env) ident
+          (print_exp_with_parens env)
+          exp)
     | Variant (s, exp_opt) -> (
       match exp_opt with
-      | None -> Format.fprintf fmt "%s" s
-      | Some exp -> Format.fprintf fmt "%s@ %a" s print_exp_with_parens exp)
-    | Record (fields, exp_opt) ->
-      Format.fprintf fmt "{@[<1>";
-      (match exp_opt with
-      | None -> ()
-      | Some exp -> Format.fprintf fmt "%a@ with@ " print_exp exp);
-      List.iter
-        (fun (field, exp) ->
-          Format.fprintf fmt "%a = %a; " print_raw_ident_field field print_exp
-            exp)
-        fields;
-      Format.fprintf fmt "@]}"
+      | None -> Format.fprintf fmt "`%s" s
+      | Some exp ->
+        Format.fprintf fmt "`%s@ %a" s (print_exp_with_parens env) exp)
+    | Record (fields, exp_opt) -> print_record env fmt (fields, exp_opt)
     | Field (exp, field) ->
-      Format.fprintf fmt "%a@ %a" print_exp_with_parens exp
-        print_raw_ident_field field
-    | Setfield (lhs, field, rhs) -> () (* !TODO! *)
-    | Array entries ->
-      Format.fprintf fmt "[|@[<1>";
-      List.iter
-        (fun entry -> Format.fprintf fmt "%a;@ " print_exp entry)
-        entries;
-      Format.fprintf fmt "@]|]"
+      Format.fprintf fmt "%a@ %a"
+        (print_exp_with_parens env)
+        exp (print_field env) field
+    | Array entries -> print_array (print_exp_with_parens env) fmt entries
+    | Tuple entries -> print_tuple (print_exp_with_parens env) fmt entries
     | Ifthenelse (cond, then_, else_) -> (
-      Format.fprintf fmt "if@ %a@ then@ %a" print_exp_with_parens cond print_exp
-        then_;
+      Format.fprintf fmt "if@ %a@ then@ %a"
+        (print_exp_with_parens env)
+        cond (print_exp env) then_;
       match else_ with
-      | Some else_ -> Format.fprintf fmt "@ else@ %a" print_exp else_
+      | Some else_ -> Format.fprintf fmt "@ else@ %a" (print_exp env) else_
       | None -> ())
     | Sequence (exp1, exp2) ->
-      Format.fprintf fmt "%a;@ %a" print_exp exp1 print_exp exp2
+      Format.fprintf fmt "%a;@ %a" (print_exp env) exp1 (print_exp env) exp2
     | While (cond, body) ->
-      Format.fprintf fmt "while@ %a@ do@ %a@ done" print_exp cond
-        print_exp_with_parens body
+      Format.fprintf fmt "while@ %a@ do@ %a@ done" (print_exp env) cond
+        (print_exp_with_parens env)
+        body
     | For (it, start, stop, dir, body) ->
       let dir = match dir with Upto -> "to" | Downto -> "downto" in
-      Format.fprintf fmt "for@ %a@ =@ %a@ %s@ %a@ do@ %a@ done" print_pat it
-        print_exp start dir print_exp stop print_exp_with_parens body
+      Format.fprintf fmt "for@ %a@ =@ %a@ %s@ %a@ do@ %a@ done" (print_pat env)
+        it (print_exp env) start dir (print_exp env) stop
+        (print_exp_with_parens env)
+        body
     | Send (exp, meth) ->
-      Format.fprintf fmt "%a#@[%a@]" print_exp_with_parens exp Method.print meth
+      Format.fprintf fmt "%a#@[%a@]"
+        (print_exp_with_parens env)
+        exp Method.print meth
     | ConstraintExp (exp, ty) ->
-      Format.fprintf fmt "%a@ :@ %a" print_exp exp print_core_type ty
+      Format.fprintf fmt "%a@ :@ %a" (print_exp env) exp (print_core_type env)
+        ty
+    | CoerceExp (exp, opt_ty, ty) ->
+      (match opt_ty with
+       | None ->
+         Format.fprintf fmt "%a@ :>@ %a" (print_exp env) exp (print_core_type env) ty
+       | Some ty_constr ->
+         Format.fprintf fmt "%a@ :@ %a@ :>@ %a"
+           (print_exp env) exp (print_core_type env) ty_constr (print_core_type env) ty)
     | Match (exp, cases) ->
-      Format.fprintf fmt "match@ @[<1>%a@]@ with@ @[<1>" print_exp exp;
-      List.iter (print_case fmt) cases;
+      Format.fprintf fmt "match@ @[%a@]@ with@[" (print_exp env) exp;
+      List.iter (print_case env fmt) cases;
       Format.fprintf fmt "@]"
-    | Quote exp -> Format.fprintf fmt "[%%quote@ @[<1>%a@]]" print_exp exp
-    | Antiquote (exp, _) -> Format.fprintf fmt "!#@ (@[<1>%a@])" print_exp exp
-    | _ -> Format.fprintf fmt "not yet printed"
+    | Probe -> Format.fprintf fmt "[%%probe]"
+    | Try (try_, with_) -> (
+      Format.fprintf fmt "try@ @[%a@]" (print_exp env) try_;
+      match with_ with
+      | [] -> ()
+      | with_ ->
+        Format.fprintf fmt "@ with@ @[";
+        List.iter
+          (fun case -> Format.fprintf fmt "%a" (print_case env) case)
+          with_;
+        Format.fprintf fmt "@]")
+    | Setfield (obj, field, exp) ->
+      Format.fprintf fmt "%a#%a <- %a"
+        (print_exp_with_parens env)
+        obj (print_field env) field (print_exp env) exp
+    | Letmodule (None, module_exp, exp) ->
+      Format.fprintf fmt "let@ module@ _@ =@ @[%a@]@ in@ @[%a@]"
+        (print_module_exp env) module_exp (print_exp env) exp
+    | Letmodule (Some modvar, module_exp, exp) ->
+      Format.fprintf fmt "let@ module@ %a@ =@ @[%a@]@ in@ @[%a@]"
+        (Var.Module.print env) modvar (print_module_exp env) module_exp
+        (print_exp env) exp
+    | Assert exp -> Format.fprintf fmt "assert@ @[%a@]" (print_exp env) exp
+    | Lazy exp -> Format.fprintf fmt "lazy@ @[%a@]" (print_exp env) exp
+    | Pack module_exp ->
+      Format.fprintf fmt "(module@ @[%a@])" (print_module_exp env) module_exp
+    | New ident ->
+      Format.fprintf fmt "new@ @[%a@]" (print_raw_ident_value env) ident
+    | Stack exp ->
+      Format.fprintf fmt "stack_@ @[%a@]" (print_exp_with_parens env) exp
+    | Let_exception (name, exp) ->
+      Format.fprintf fmt "let@ exception@ %s@ in@ @[%a@]" name
+        (print_exp env) exp
+    | Extension_constructor name -> Format.fprintf fmt "(* extension %s *)" name
+    | Unboxed_tuple ts ->
+      Format.fprintf fmt "#";
+      print_tuple (print_exp env) fmt ts
+    | Unboxed_record_product (ts, exp_opt) -> print_record env fmt (ts, exp_opt)
+    | Unboxed_field (exp, rec_field) ->
+      Format.fprintf fmt "#%a.%a" (print_exp env) exp (print_field env)
+        rec_field
+    | Quote exp -> Format.fprintf fmt "[%%quote@ @[%a@]]" (print_exp env) exp
+    | Antiquote exp ->
+      Format.fprintf fmt "!#@[%a@]" (print_exp_with_parens env) exp
+    | List_comprehension _ | Array_comprehension _ ->
+      Format.fprintf fmt "(* comprehension *)"
+    | Unreachable | Src_pos -> Format.fprintf fmt "."
 end
 
 module Label = struct
@@ -1608,16 +1911,14 @@ module Label = struct
   let labelled s = Ast.Labelled s
 
   let optional s = Ast.Optional s
-
-  let print = Ast.print_arg_lab
 end
 
 module Fragment = struct
   type t = Ast.fragment
 
-  let rec print fmt = function
-    | Ast.Name s -> Format.fprintf fmt "%s" s
-    | Ast.Dot (f, s) -> Format.fprintf fmt "%a.%s" print f s
+  let name s = Ast.Name s
+
+  let dot f s = Ast.Dot (f, s)
 end
 
 module Constant = struct
@@ -1631,23 +1932,23 @@ module Constant = struct
 
   let float f = Ast.Float f
 
+  let float32 f = Ast.Float32 f
+
   let int32 i = Ast.Int32 i
 
   let int64 i = Ast.Int64 i
 
   let nativeint i = Ast.Nativeint i
 
-  let print fmt = function
-    | Ast.Int i -> Format.fprintf fmt "%d" i
-    | Ast.Char c -> Format.fprintf fmt "%c" c
-    | Ast.String (s, o) -> (
-      match o with
-      | None -> Format.fprintf fmt "\"%s\"" s
-      | Some del -> Format.fprintf fmt "{%s|%s|%s}" del s del)
-    | Ast.Float s -> Format.fprintf fmt "%s" s
-    | Ast.Int32 i -> Format.fprintf fmt "%ld" i
-    | Ast.Int64 i -> Format.fprintf fmt "%Ld" i
-    | Ast.Nativeint i -> Format.fprintf fmt "%nd" i
+  let unboxed_int32 i = Ast.UnboxedInt32 i
+
+  let unboxed_int64 i = Ast.UnboxedInt64 i
+
+  let unboxed_nativeint i = Ast.UnboxedNativeint i
+
+  let unboxed_float f = Ast.UnboxedFloat f
+
+  let unboxed_float32 f = Ast.UnboxedFloat32 f
 end
 
 module Binding_error = struct
@@ -1700,6 +2001,61 @@ module Binding_error = struct
     failwith msg
 end
 
+module Module_type = struct
+  type t = Ast.module_type With_free_vars.t
+
+  let (let+) x f = With_free_vars.map f x
+
+  let return = With_free_vars.return
+
+  let ident id =
+    let+ id = id in Ast.MTIdent id
+
+  let of_string s = return (Ast.MTBasic s)
+end
+
+module Constructor = struct
+  type t = Ast.constr With_free_vars.t
+
+  let ( let+ ) m f = With_free_vars.map f m
+
+  let return = With_free_vars.return
+
+  let ident id =
+    let+ id = id in
+    Ast.CIdent id
+
+  let of_string s = return (Ast.CBasic s)
+end
+
+module Field = struct
+  type t = Ast.record_field With_free_vars.t
+
+  let ( let+ ) m f = With_free_vars.map f m
+
+  let return = With_free_vars.return
+
+  let ident id =
+    let+ id = id in
+    Ast.FIdent id
+
+  let of_string s = return (Ast.FBasic s)
+end
+
+module Object_field = struct
+  type t = Ast.object_field With_free_vars.t
+
+  let ( let+ ) m f = With_free_vars.map f m
+
+  let inherit_ ty =
+    let+ ty = ty in
+    Ast.Oinherit ty
+
+  let tag name ty =
+    let+ ty = ty in
+    Ast.Otag (name, ty)
+end
+
 module Pat = struct
   open With_free_and_bound_vars
 
@@ -1738,9 +2094,19 @@ module Pat = struct
     let+ ps = all ps in
     Ast.PatTuple ps
 
+  let unboxed_tuple ts =
+    let ps =
+      List.map
+        (fun (lab, e) ->
+          let+ v = e in
+          lab, v)
+        ts
+    in
+    let+ ps = all ps in
+    Ast.PatUnboxedTuple ps
+
   let construct lid tm =
-    let+ pm = optional tm
-    and+ id = Identifier.Constructor.with_bound_vars lid in
+    let+ pm = optional tm and+ id = with_no_bound_vars lid in
     Ast.PatConstruct (id, pm)
 
   let variant label tm =
@@ -1752,13 +2118,24 @@ module Pat = struct
     let ts =
       List.map
         (fun (lid, t) ->
-          let+ lbl = With_free_and_bound_vars.with_no_bound_vars lid
-          and+ p = t in
+          let+ lbl = with_no_bound_vars lid and+ p = t in
           lbl, p)
         fields
     in
     let+ ps = all ts in
     Ast.PatRecord (ps, closed_ast)
+
+  let unboxed_record fields closed =
+    let closed_ast = if closed then Ast.ClosedRec else Ast.OpenRec in
+    let ts =
+      List.map
+        (fun (lid, t) ->
+          let+ lbl = with_no_bound_vars lid and+ p = t in
+          lbl, p)
+        fields
+    in
+    let+ ps = all ts in
+    Ast.PatUnboxedRecord (ps, closed_ast)
 
   let array ts =
     let+ ps = all ts in
@@ -1779,6 +2156,10 @@ module Pat = struct
   let exception_ t =
     let+ p = t in
     Ast.PatException p
+
+  let constraint_ pat ty =
+    let+ pat = pat and+ ty = with_no_bound_vars ty in
+    Ast.PatConstraint (pat, ty)
 end
 
 module Variant_type = struct
@@ -1795,9 +2176,9 @@ module Variant_type = struct
     let closed s = Closed s
 
     let to_ast_variant_form = function
-      | Fixed -> Ast.Fixed
-      | Open -> Ast.Open
-      | Closed l -> Ast.Closed l
+      | Fixed -> Ast.VFixed
+      | Open -> Ast.VOpen
+      | Closed l -> Ast.VClosed l
   end
 
   module Row_field = struct
@@ -1807,11 +2188,11 @@ module Variant_type = struct
 
     let inherit_ ty =
       let+ ty = ty in
-      Ast.Inherit ty
+      Ast.Vinherit ty
 
     let tag variant has_empty types =
       let+ types = With_free_vars.all types in
-      Ast.Tag (variant, has_empty, types)
+      Ast.Vtag (variant, has_empty, types)
   end
 
   type t = Ast.row_field list With_free_vars.t * Ast.variant_form
@@ -1833,8 +2214,6 @@ module Type = struct
 
   let all = With_free_vars.all
 
-  let optional = With_free_vars.optional
-
   let var = function
     | None -> With_free_vars.return Ast.TypeAny
     | Some tv -> With_free_vars.return (Ast.TypeVar tv)
@@ -1854,9 +2233,29 @@ module Type = struct
     let+ e = all w in
     Ast.TypeTuple e
 
+  let unboxed_tuple ts =
+    let w =
+      List.map
+        (fun (lab, t) ->
+          let+ t = t in
+          lab, t)
+        ts
+    in
+    let+ e = all w in
+    Ast.TypeUnboxedTuple e
+
   let constr cons typs =
     let+ ts = all typs and+ cons = cons in
     Ast.TypeConstr (cons, ts)
+
+  let object_ object_fields is_closed =
+    let closed_flag = if is_closed then Ast.OClosed else Ast.OOpen in
+    let+ object_fields = all object_fields in
+    Ast.TypeObject (object_fields, closed_flag)
+
+  let class_ name tys =
+    let+ tys = all tys in
+    Ast.TypeClass (name, tys)
 
   let alias typ tv =
     let+ t = typ in
@@ -1882,6 +2281,8 @@ module Type = struct
     in
     let+ specs = all s and+ m = m in
     Ast.TypePackage (m, specs)
+
+  let call_pos = With_free_vars.return Ast.TypeCallPos
 end
 
 module Module = struct
@@ -1890,8 +2291,6 @@ module Module = struct
   let ( let+ ) m f = With_free_vars.map f m
 
   let ( and+ ) = With_free_vars.both
-
-  let return = With_free_vars.return
 
   let ident id =
     let+ id = id in
@@ -1903,7 +2302,7 @@ module Module = struct
 
   let apply_unit func =
     let+ func = func in
-    Ast.Apply_unit func
+    Ast.ModuleApply_unit func
 end
 
 module Case = struct
@@ -1972,8 +2371,6 @@ module Type_constraint = struct
   let coercion typ1 typ2 =
     let+ typ1 = With_free_vars.optional typ1 and+ typ2 = typ2 in
     Ast.Coerce (typ1, typ2)
-
-  let print _ = ""
 end
 
 module Function = struct
@@ -2004,7 +2401,7 @@ module Function = struct
           With_bound_vars.value
             ~extra:(Binding_error.unexpected_at_loc loc)
             ~missing:Binding_error.missing pat
-            (List.map Var.Value.generic vars)
+            (Var.Value.generic_list vars)
         in
         mk (Ast.Pparam_val (lab, e, pat) :: params) constraint_ body)
 
@@ -2043,7 +2440,7 @@ module Comprehension = struct
           With_bound_vars.value
             ~extra:(Binding_error.unexpected_at_loc loc)
             ~missing:Binding_error.missing pat
-            (List.map Var.Value.generic vars)
+            (Var.Value.generic_list vars)
         in
         Ast.ForComp (compr, Ast.In (p, exp)))
 end
@@ -2057,6 +2454,10 @@ module Code = struct
   type t = code_rep With_free_vars.t
 
   let ( let+ ) m f = With_free_vars.map f m
+
+  let to_exp code =
+    let+ {exp; _} = code
+    in exp
 
   let of_exp exp loc =
     let+ exp = exp in
@@ -2079,7 +2480,9 @@ module Code = struct
 
   let print fmt c =
     let ast_exp = With_free_vars.value ~free:(fun _ _ -> ()) c in
-    Format.fprintf fmt "[%%quote %a]" Ast.print_exp ast_exp.exp
+    Format.fprintf fmt "[%%quote@ @[%a@]]"
+      (Ast.print_exp (new_env ()))
+      ast_exp.exp
 end
 
 module Exp = struct
@@ -2119,15 +2522,18 @@ module Exp = struct
         let vbs = List.rev vbs_rev in
         mk (Let (Recursive, vbs, body)) [])
 
-  let let_ loc names_values names_modules def f =
-    let+ def = def
-    and+ pat, body =
+  let let_ loc names_values names_modules defs f =
+    let+ defs = all defs
+    and+ pats, body =
       With_free_vars.complex_bindings loc ~extra:Binding_error.duplicate
         ~missing:Binding_error.missing ~bound_values:names_values
         ~bound_modules:names_modules f
     in
-    let vbs = [mk_vb pat def] in
-    mk (Let (Nonrecursive, vbs, body)) []
+    match pats with
+    | Ast.PatTuple pats ->
+      let vbs = List.map2 (fun (_, pat) def -> mk_vb pat def) pats defs in
+      mk (Let (Nonrecursive, vbs, body)) []
+    | _ -> failwith "Cannot use non-tuple patterns in building let-expressions."
 
   let function_ fn =
     let+ fn = fn in
@@ -2247,19 +2653,18 @@ module Exp = struct
     let+ exp = exp in
     mk (Lazy exp) []
 
-  let letmodule loc name_opt mod_exp body =
+  let letmodule_nonbinding mod_exp body =
+    let+ mod_exp = mod_exp and+ body = body in
+    mk (Letmodule (None, mod_exp, body)) []
+
+  let letmodule loc name mod_exp body =
     let+ mod_exp = mod_exp
     and+ var, body =
-      match name_opt with
-      | None ->
-        let+ body = body None in
-        None, body
-      | Some name ->
-        With_free_vars.module_binding loc name (fun m ->
-            let+ body = body (Some m) in
-            Some m, body)
+      With_free_vars.module_binding loc name (fun m ->
+          let+ body = body m in
+          m, body)
     in
-    mk (Letmodule (var, mod_exp, body)) []
+    mk (Letmodule (Some var, mod_exp, body)) []
 
   let constraint_ exp constr =
     let+ exp = exp and+ constr = constr in
@@ -2317,24 +2722,16 @@ module Exp = struct
     let+ exp = exp and+ field = field in
     mk (Ast.Unboxed_field (exp, field)) []
 
-  let extension_constructor ident =
-    let+ ident = ident in
-    mk (Ast.Extension_constructor ident) []
+  let extension_constructor name =
+    return (mk (Ast.Extension_constructor name) [])
 
   let let_exception name exp =
     let+ exp = exp in
     mk (Ast.Let_exception (name, exp)) []
 
-  let let_op loc idents names_values names_modules def f =
-    let+ def = def
-    and+ idents = all idents
-    and+ pat, body =
-      With_free_vars.complex_bindings loc ~extra:Binding_error.duplicate
-        ~missing:Binding_error.missing ~bound_values:names_values
-        ~bound_modules:names_modules f
-    in
-    let vbs = [mk_vb pat def] in
-    mk (Ast.Let_op (idents, vbs, body)) []
+  let let_op idents defs case =
+    let+ idents = all idents and+ defs = all defs and+ case = case in
+    mk (Ast.Let_op (idents, defs, case)) []
 
   let stack exp =
     let+ exp = exp in
@@ -2344,11 +2741,14 @@ module Exp = struct
     let+ exp = exp in
     mk (Quote exp) [Quotation]
 
-  let antiquote code =
-    let+ ({ exp; loc } : Code.code_rep) = code in
-    mk (Antiquote (exp, loc)) []
+  let antiquote exp =
+    let+ exp = exp in
+    mk (Antiquote exp) []
+
+  let splice (code : Code.t) =
+    let+ code = code in code.exp
 
   let print fmt exp =
     let ast = With_free_vars.value ~free:(fun _ _ -> ()) exp in
-    Ast.print_exp fmt ast
+    Ast.print_exp (new_env ()) fmt ast
 end

--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -1777,7 +1777,7 @@ module Ast = struct
     | Unboxed_record_product (ts, exp_opt) -> print_record env fmt (ts, exp_opt)
     | Unboxed_field (exp, rec_field) ->
       pp fmt "#%a.%a" (print_exp env) exp (print_field env) rec_field
-    | Quote exp -> pp fmt "@[<2><<@ %a@ @]>>" (print_exp env) exp
+    | Quote exp -> pp fmt "@[<2><[@ %a@ @]]>" (print_exp env) exp
     | Antiquote exp -> pp fmt "@[<2>$@ %a@]" (print_exp_with_parens env) exp
     | List_comprehension _ | Array_comprehension _ ->
       pp fmt "(* comprehension *)"
@@ -2412,7 +2412,7 @@ module Code = struct
 
   let print fmt c =
     let ast_exp = With_free_vars.value ~free:(fun _ _ -> ()) c in
-    Format.fprintf fmt "@[<2><<@ %a@]@ >>"
+    Format.fprintf fmt "@[<2><[@ %a@]@ ]>"
       (Ast.print_exp (new_env ()))
       ast_exp.exp
 end

--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -98,7 +98,9 @@ module Name = struct
   let base_name s =
     match String.index_opt s '_' with
     | None ->
-      if List.for_all (fun p -> not (String.starts_with ~prefix:p s)) let_prefixes
+      if List.for_all
+           (fun p -> not (String.starts_with ~prefix:p s))
+           let_prefixes
       then s
       else "(" ^ s ^ ")"
     | Some i -> String.sub s 0 i
@@ -989,7 +991,6 @@ module Identifier = struct
     let float64x2 = TBuiltin "float64x2" |> mk
   end
 
-
   module Module_type = struct
     type t = raw_ident_module_type_t With_free_vars.t
 
@@ -1187,7 +1188,7 @@ module Ast = struct
     | PatUnpack of Var.Module.t
     | PatException of pattern
 
-  type _expression_attribute =
+  type expression_attribute =
     | Inline
     | Inlined
     | Specialise
@@ -1202,7 +1203,7 @@ module Ast = struct
 
   type expression =
     { desc : expression_desc;
-      _attributes : _expression_attribute list
+      _attributes : expression_attribute list
     }
 
   and expression_desc =
@@ -1309,9 +1310,7 @@ module Ast = struct
 
   let print_obj_closed fmt closed_flag =
     Format.fprintf fmt "%s"
-      (match closed_flag with
-           | OOpen -> ".."
-           | OClosed -> "")
+      (match closed_flag with OOpen -> ".." | OClosed -> "")
 
   let rec print_vb env fmt ({ pat; expr } : value_binding) =
     Format.fprintf fmt "%a@ =@ @[%a@]" (print_pat env) pat
@@ -1352,8 +1351,8 @@ module Ast = struct
     | PatAny -> Format.fprintf fmt "_"
     | PatVar v -> Var.Value.print env fmt v
     | PatAlias (pat, v) ->
-      Format.fprintf fmt "%a@ as@ %a"
-        (print_pat env) pat (Var.Value.print env) v
+      Format.fprintf fmt "%a@ as@ %a" (print_pat env) pat (Var.Value.print env)
+        v
     | PatConstant c -> print_const fmt c
     | PatTuple ts -> print_tuple (print_pat env) fmt ts
     | PatUnboxedTuple ts ->
@@ -1373,8 +1372,8 @@ module Ast = struct
       Format.fprintf fmt "{@[";
       List.iter
         (fun (field, pat) ->
-           Format.fprintf fmt "%a=%a;@ " (print_field env) field (print_pat env)
-             pat)
+          Format.fprintf fmt "%a=%a;@ " (print_field env) field (print_pat env)
+            pat)
         entries;
       if rec_flag = OpenRec then Format.fprintf fmt "_";
       Format.fprintf fmt "@]}"
@@ -1382,8 +1381,8 @@ module Ast = struct
       Format.fprintf fmt "#{@[";
       List.iter
         (fun (field, pat) ->
-           Format.fprintf fmt "@[%a@ =@ %a;@]@ "
-             (print_field env) field (print_pat env) pat)
+          Format.fprintf fmt "@[%a@ =@ %a;@]@ " (print_field env) field
+            (print_pat env) pat)
         entries;
       if rec_flag = OpenRec then Format.fprintf fmt "_";
       Format.fprintf fmt "@]}"
@@ -1405,8 +1404,8 @@ module Ast = struct
     | Coerce (None, ty) ->
       Format.fprintf fmt "%@ :>@ @[%a@]" (print_core_type env) ty
     | Coerce (Some ty_constr, ty) ->
-      Format.fprintf fmt "%@ :@ @[%a@]@ :>@ @[%a@]"
-        (print_core_type env) ty_constr (print_core_type env) ty
+      Format.fprintf fmt "%@ :@ @[%a@]@ :>@ @[%a@]" (print_core_type env)
+        ty_constr (print_core_type env) ty
 
   and print_exp_with_parens env fmt exp =
     match exp.desc with
@@ -1530,8 +1529,7 @@ module Ast = struct
       Format.fprintf fmt "< %a >" print_obj_closed closed_flag
     | TypeObject (f :: fs, closed_flag) ->
       Format.fprintf fmt "<@ @[";
-      print_tuple_like "" "" ","
-        (print_object_field env) fmt (f :: fs);
+      print_tuple_like "" "" "," (print_object_field env) fmt (f :: fs);
       print_obj_closed fmt closed_flag;
       Format.fprintf fmt "@]@ >"
     | TypeClass (name, []) -> Name.print fmt name
@@ -1556,17 +1554,14 @@ module Ast = struct
       let print_tv fmt name = Format.fprintf fmt "'%s" name in
       print_tuple_like "" "" " " print_tv fmt (tv :: tvs);
       Format.fprintf fmt ".@ %a" (print_core_type env) ty
-    | TypePackage (ident, []) ->
-      print_module_type env fmt ident
-    | TypePackage (ident, (fragment, core_type)::wcs) ->
-      Format.fprintf fmt "@[%a@ with@ type@ %a@ =@ %a"
-        (print_module_type env) ident
-        print_fragment fragment
-        (print_core_type env) core_type;
-      List.iter (fun (fragment, core_type) ->
-        Format.fprintf fmt "@ and@ type@ %a@ =@ %a"
-          print_fragment fragment
-          (print_core_type env) core_type)
+    | TypePackage (ident, []) -> print_module_type env fmt ident
+    | TypePackage (ident, (fragment, core_type) :: wcs) ->
+      Format.fprintf fmt "@[%a@ with@ type@ %a@ =@ %a" (print_module_type env)
+        ident print_fragment fragment (print_core_type env) core_type;
+      List.iter
+        (fun (fragment, core_type) ->
+          Format.fprintf fmt "@ and@ type@ %a@ =@ %a" print_fragment fragment
+            (print_core_type env) core_type)
         wcs;
       Format.fprintf fmt "@]"
     | TypeCallPos -> Format.fprintf fmt "call_pos"
@@ -1581,8 +1576,8 @@ module Ast = struct
     | Pparam_val (arg_lab, None, pat) ->
       Format.fprintf fmt "@ %a%a" print_arg_lab arg_lab (print_pat env) pat
     | Pparam_val (arg_lab, Some exp, pat) ->
-      Format.fprintf fmt "@ %a%a=(@[%a@])"
-        print_arg_lab arg_lab (print_pat env) pat (print_exp env) exp
+      Format.fprintf fmt "@ %a%a=(@[%a@])" print_arg_lab arg_lab (print_pat env)
+        pat (print_exp env) exp
     | Pparam_newtype ty ->
       Format.fprintf fmt "@ (type %a)" (Var.Type_var.print env) ty
 
@@ -1600,8 +1595,7 @@ module Ast = struct
 
   and print_exp env fmt exp =
     match exp.desc with
-    | Ident id ->
-      print_raw_ident_value env fmt id
+    | Ident id -> print_raw_ident_value env fmt id
     | Constant c -> print_const fmt c
     | Apply (exp, args) ->
       Format.fprintf fmt "%a@[<hov>" (print_exp env) exp;
@@ -1637,29 +1631,27 @@ module Ast = struct
       Format.fprintf fmt "@]in@ @[%a@]" (print_exp env) body
     | Let_op ([], _, _) ->
       failwith "Cannot create empty let-expressions. This should not happen."
-    | Let_op (binders, defs, case) ->
+    | Let_op (binders, defs, case) -> (
       let bind_lefts =
-        (match case.lhs with
-         | PatTuple l -> l
-         | pat -> [(NolabelTup, pat)]) in
+        match case.lhs with PatTuple l -> l | pat -> [NolabelTup, pat]
+      in
       let rec iter3 f xs ys zs =
-        match (xs, ys, zs) with
-        | ([], [], []) -> ()
-        | (x::xs, y::ys, z::zs) -> f x y z; iter3 f xs ys zs
+        match xs, ys, zs with
+        | [], [], [] -> ()
+        | x :: xs, y :: ys, z :: zs ->
+          f x y z;
+          iter3 f xs ys zs
         | _ -> failwith "Lists should have equal length."
       in
       iter3
         (fun binder (_, pat_bind) def ->
-           Format.fprintf fmt "@[%a@ %a@ =@ @[%a@]@]@ "
-             (print_raw_ident_value env) binder
-             (print_pat env) pat_bind
-             (print_exp env) def)
-        binders
-        bind_lefts
-        defs;
-      (match case.rhs with
-       | Some exp -> Format.fprintf fmt "@[in@ @[%a@]@]" (print_exp env) exp
-       | None -> Format.fprintf fmt ".")
+          Format.fprintf fmt "@[%a@ %a@ =@ @[%a@]@]@ "
+            (print_raw_ident_value env)
+            binder (print_pat env) pat_bind (print_exp env) def)
+        binders bind_lefts defs;
+      match case.rhs with
+      | Some exp -> Format.fprintf fmt "@[in@ @[%a@]@]" (print_exp env) exp
+      | None -> Format.fprintf fmt ".")
     | Exclave exp -> Format.fprintf fmt "exclave_@ %a" (print_exp env) exp
     | Construct (ident, exp_opt) -> (
       match exp_opt with
@@ -1681,22 +1673,24 @@ module Ast = struct
     | Array entries -> print_array (print_exp_with_parens env) fmt entries
     | Tuple entries -> print_tuple (print_exp_with_parens env) fmt entries
     | Ifthenelse (cond, then_, else_) -> (
-        Format.fprintf fmt "if@ %a@ then@ @;@[%a@]"
+      Format.fprintf fmt "if@ %a@ then@ @;@[%a@]"
         (print_exp_with_parens env)
         cond (print_exp env) then_;
       match else_ with
-      | Some else_ -> Format.fprintf fmt "@ @;else@ @;@[%a@]" (print_exp env) else_
+      | Some else_ ->
+        Format.fprintf fmt "@ @;else@ @;@[%a@]" (print_exp env) else_
       | None -> ())
     | Sequence (exp1, exp2) ->
       Format.fprintf fmt "%a;@ @,%a" (print_exp env) exp1 (print_exp env) exp2
     | While (cond, body) ->
-      Format.fprintf fmt "while@ %a@ do@ @,@[<2>%a@]@ @,done" (print_exp env) cond
+      Format.fprintf fmt "while@ %a@ do@ @,@[<2>%a@]@ @,done" (print_exp env)
+        cond
         (print_exp_with_parens env)
         body
     | For (it, start, stop, dir, body) ->
       let dir = match dir with Upto -> "to" | Downto -> "downto" in
-      Format.fprintf fmt "for@ %a@ =@ %a@ %s@ %a@ do@ @,@[<2>%a@]@ @,done" (print_pat env)
-        it (print_exp env) start dir (print_exp env) stop
+      Format.fprintf fmt "for@ %a@ =@ %a@ %s@ %a@ do@ @,@[<2>%a@]@ @,done"
+        (print_pat env) it (print_exp env) start dir (print_exp env) stop
         (print_exp_with_parens env)
         body
     | Send (exp, meth) ->
@@ -1706,13 +1700,14 @@ module Ast = struct
     | ConstraintExp (exp, ty) ->
       Format.fprintf fmt "%a@ :@ %a" (print_exp env) exp (print_core_type env)
         ty
-    | CoerceExp (exp, opt_ty, ty) ->
-      (match opt_ty with
-       | None ->
-         Format.fprintf fmt "%a@ :>@ %a" (print_exp env) exp (print_core_type env) ty
-       | Some ty_constr ->
-         Format.fprintf fmt "%a@ :@ %a@ :>@ %a"
-           (print_exp env) exp (print_core_type env) ty_constr (print_core_type env) ty)
+    | CoerceExp (exp, opt_ty, ty) -> (
+      match opt_ty with
+      | None ->
+        Format.fprintf fmt "%a@ :>@ %a" (print_exp env) exp
+          (print_core_type env) ty
+      | Some ty_constr ->
+        Format.fprintf fmt "%a@ :@ %a@ :>@ %a" (print_exp env) exp
+          (print_core_type env) ty_constr (print_core_type env) ty)
     | Match (exp, cases) ->
       Format.fprintf fmt "match@ @[%a@]@ with@[" (print_exp env) exp;
       List.iter (print_case env fmt) cases;
@@ -1747,8 +1742,8 @@ module Ast = struct
     | Stack exp ->
       Format.fprintf fmt "stack_@ @[%a@]" (print_exp_with_parens env) exp
     | Let_exception (name, exp) ->
-      Format.fprintf fmt "let@ exception@ %s@ in@ @[%a@]" name
-        (print_exp env) exp
+      Format.fprintf fmt "let@ exception@ %s@ in@ @[%a@]" name (print_exp env)
+        exp
     | Extension_constructor name -> Format.fprintf fmt "(* extension %s *)" name
     | Unboxed_tuple ts ->
       Format.fprintf fmt "#";
@@ -1869,12 +1864,13 @@ end
 module Module_type = struct
   type t = Ast.module_type With_free_vars.t
 
-  let (let+) x f = With_free_vars.map f x
+  let ( let+ ) x f = With_free_vars.map f x
 
   let return = With_free_vars.return
 
   let ident id =
-    let+ id = id in Ast.MTIdent id
+    let+ id = id in
+    Ast.MTIdent id
 
   let of_string s = return (Ast.MTBasic s)
 end
@@ -2027,6 +2023,32 @@ module Pat = struct
   let constraint_ pat ty =
     let+ pat = pat and+ ty = with_no_bound_vars ty in
     Ast.PatConstraint (pat, ty)
+end
+
+module Exp_attribute = struct
+  type t = Ast.expression_attribute
+
+  let inline = Ast.Inline
+
+  let inlined = Ast.Inlined
+
+  let specialise = Ast.Specialise
+
+  let specialised = Ast.Specialised
+
+  let unrolled = Ast.Unrolled
+
+  let nontail = Ast.Nontail
+
+  let tail = Ast.Tail
+
+  let poll = Ast.Poll
+
+  let loop = Ast.Loop
+
+  let tail_mod_cons = Ast.Tail_mod_cons
+
+  let quotation = Ast.Quotation
 end
 
 module Variant_type = struct
@@ -2269,25 +2291,26 @@ module Function = struct
         mk (Ast.Pparam_val (lab, e, pat) :: params) constraint_ body)
 
   let param_module_nonbinding lab loc pat fn =
-    let+ pat = pat
-    and+ ({params; constraint_; body} : Ast.function_) = fn in
+    let+ pat = pat and+ ({ params; constraint_; body } : Ast.function_) = fn in
     let pat =
-      With_bound_vars.value_nonbinding ~extra:(Binding_error.unexpected_at_loc loc) pat
+      With_bound_vars.value_nonbinding
+        ~extra:(Binding_error.unexpected_at_loc loc)
+        pat
     in
     mk (Ast.Pparam_val (lab, None, pat) :: params) constraint_ body
 
   let param_module lab loc name rest =
     With_free_vars.module_binding loc name (fun var ->
-      let pat, fn = rest var in
-      let+ ({ params; constraint_; body } : Ast.function_) = fn
-      and+ pat = pat in
-      let pat =
-        With_bound_vars.value
-          ~extra:(Binding_error.unexpected_at_loc loc)
-          ~missing:Binding_error.missing pat
-          [Var.Module.generic var]
-      in
-      mk (Ast.Pparam_val (lab, None, pat) :: params) constraint_ body)
+        let pat, fn = rest var in
+        let+ ({ params; constraint_; body } : Ast.function_) = fn
+        and+ pat = pat in
+        let pat =
+          With_bound_vars.value
+            ~extra:(Binding_error.unexpected_at_loc loc)
+            ~missing:Binding_error.missing pat
+            [Var.Module.generic var]
+        in
+        mk (Ast.Pparam_val (lab, None, pat) :: params) constraint_ body)
 
   let newtype loc name f =
     With_free_vars.type_var_binding loc name (fun typ ->
@@ -2340,8 +2363,8 @@ module Code = struct
   let ( let+ ) m f = With_free_vars.map f m
 
   let to_exp code =
-    let+ {exp; _} = code
-    in exp
+    let+ { exp; _ } = code in
+    exp
 
   let of_exp exp _loc =
     let+ exp = exp in
@@ -2369,8 +2392,8 @@ module Code = struct
       ast_exp.exp
 end
 
-module Exp = struct
-  type t = Ast.expression With_free_vars.t
+module Exp_desc = struct
+  type t = Ast.expression_desc With_free_vars.t
 
   let ( let+ ) m f = With_free_vars.map f m
 
@@ -2384,13 +2407,11 @@ module Exp = struct
 
   let mk_vb pat expr : Ast.value_binding = { pat; expr }
 
-  let mk desc _attributes : Ast.expression = { desc; _attributes }
-
   let ident id =
     let+ id = id in
-    mk (Ident id) []
+    Ast.Ident id
 
-  let constant (const : Constant.t) = return (mk (Constant const) [])
+  let constant (const : Constant.t) = return (Ast.Constant const)
 
   let let_rec_simple loc names f =
     With_free_vars.value_bindings loc names (fun vars ->
@@ -2404,7 +2425,7 @@ module Exp = struct
             vars defs
         in
         let vbs = List.rev vbs_rev in
-        mk (Let (Recursive, vbs, body)) [])
+        Ast.Let (Recursive, vbs, body))
 
   let let_ loc names_values names_modules defs f =
     let+ defs = all defs
@@ -2416,12 +2437,12 @@ module Exp = struct
     match pats with
     | Ast.PatTuple pats ->
       let vbs = List.map2 (fun (_, pat) def -> mk_vb pat def) pats defs in
-      mk (Let (Nonrecursive, vbs, body)) []
+      Ast.Let (Nonrecursive, vbs, body)
     | _ -> failwith "Cannot use non-tuple patterns in building let-expressions."
 
   let function_ fn =
     let+ fn = fn in
-    mk (Fun fn) []
+    Ast.Fun fn
 
   let apply fn args =
     let args =
@@ -2432,15 +2453,15 @@ module Exp = struct
         args
     in
     let+ args = all args and+ fn = fn in
-    mk (Apply (fn, args)) []
+    Ast.Apply (fn, args)
 
   let match_ exp cases =
     let+ cases = all cases and+ exp = exp in
-    mk (Match (exp, cases)) []
+    Ast.Match (exp, cases)
 
   let try_ exp cases =
     let+ cases = all cases and+ exp = exp in
-    mk (Try (exp, cases)) []
+    Ast.Try (exp, cases)
 
   let tuple fs =
     let entries =
@@ -2451,15 +2472,15 @@ module Exp = struct
         fs
     in
     let+ entries = all entries in
-    mk (Tuple entries) []
+    Ast.Tuple entries
 
   let construct cons exp =
     let+ exp = optional exp and+ cons = cons in
-    mk (Construct (cons, exp)) []
+    Ast.Construct (cons, exp)
 
   let variant v exp =
     let+ exp = optional exp in
-    mk (Variant (v, exp)) []
+    Ast.Variant (v, exp)
 
   let record entries exp =
     let entries =
@@ -2470,31 +2491,31 @@ module Exp = struct
         entries
     in
     let+ entries = all entries and+ exp = optional exp in
-    mk (Record (entries, exp)) []
+    Ast.Record (entries, exp)
 
   let field exp field =
     let+ exp = exp and+ field = field in
-    mk (Field (exp, field)) []
+    Ast.Field (exp, field)
 
   let setfield exp field value =
     let+ exp = exp and+ field = field and+ value = value in
-    mk (Setfield (exp, field, value)) []
+    Ast.Setfield (exp, field, value)
 
   let array elements =
     let+ elements = all elements in
-    mk (Array elements) []
+    Ast.Array elements
 
   let ifthenelse cond then_ else_ =
     let+ cond = cond and+ then_ = then_ and+ else_ = optional else_ in
-    mk (Ifthenelse (cond, then_, else_)) []
+    Ast.Ifthenelse (cond, then_, else_)
 
   let sequence lhs rhs =
     let+ lhs = lhs and+ rhs = rhs in
-    mk (Sequence (lhs, rhs)) []
+    Ast.Sequence (lhs, rhs)
 
   let while_ cond body =
     let+ cond = cond and+ body = body in
-    mk (While (cond, body)) [Loop]
+    Ast.While (cond, body)
 
   let for_nonbinding loc pat begin_ end_ dir body =
     let dir = if dir then Ast.Upto else Ast.Downto in
@@ -2504,7 +2525,7 @@ module Exp = struct
         ~extra:(Binding_error.unexpected_at_loc loc)
         pat
     in
-    mk (For (pat, begin_, end_, dir, body)) [Loop]
+    Ast.For (pat, begin_, end_, dir, body)
 
   let for_simple loc name begin_ end_ dir body =
     let dir = if dir then Ast.Upto else Ast.Downto in
@@ -2514,23 +2535,23 @@ module Exp = struct
           var, body)
     and+ begin_ = begin_
     and+ end_ = end_ in
-    mk (For (Ast.PatVar var, begin_, end_, dir, body)) [Loop]
+    Ast.For (Ast.PatVar var, begin_, end_, dir, body)
 
   let send exp meth =
     let+ exp = exp in
-    mk (Ast.Send (exp, meth)) []
+    Ast.Send (exp, meth)
 
   let assert_ exp =
     let+ exp = exp in
-    mk (Assert exp) []
+    Ast.Assert exp
 
   let lazy_ exp =
     let+ exp = exp in
-    mk (Lazy exp) []
+    Ast.Lazy exp
 
   let letmodule_nonbinding mod_exp body =
     let+ mod_exp = mod_exp and+ body = body in
-    mk (Letmodule (None, mod_exp, body)) []
+    Ast.Letmodule (None, mod_exp, body)
 
   let letmodule loc name mod_exp body =
     let+ mod_exp = mod_exp
@@ -2539,37 +2560,37 @@ module Exp = struct
           let+ body = body m in
           m, body)
     in
-    mk (Letmodule (Some var, mod_exp, body)) []
+    Ast.Letmodule (Some var, mod_exp, body)
 
   let constraint_ exp constr =
     let+ exp = exp and+ constr = constr in
     match constr with
-    | Ast.Coerce (ty_opt, ty_to) -> mk (Ast.CoerceExp (exp, ty_opt, ty_to)) []
-    | Ast.Constraint ty -> mk (Ast.ConstraintExp (exp, ty)) []
+    | Ast.Coerce (ty_opt, ty_to) -> Ast.CoerceExp (exp, ty_opt, ty_to)
+    | Ast.Constraint ty -> Ast.ConstraintExp (exp, ty)
 
   let new_ class_id =
     let+ class_id = class_id in
-    mk (Ast.New class_id) []
+    Ast.New class_id
 
   let pack m =
     let+ m = m in
-    mk (Ast.Pack m) []
+    Ast.Pack m
 
-  let unreachable = return (mk Ast.Unreachable [])
+  let unreachable = return Ast.Unreachable
 
-  let src_pos = return (mk Ast.Src_pos [])
+  let src_pos = return Ast.Src_pos
 
   let exclave exp =
     let+ exp = exp in
-    mk (Ast.Exclave exp) []
+    Ast.Exclave exp
 
   let list_comprehension compr =
     let+ compr = compr in
-    mk (Ast.List_comprehension compr) []
+    Ast.List_comprehension compr
 
   let array_comprehension compr =
     let+ compr = compr in
-    mk (Ast.Array_comprehension compr) []
+    Ast.Array_comprehension compr
 
   let unboxed_tuple fs =
     let entries =
@@ -2580,7 +2601,7 @@ module Exp = struct
         fs
     in
     let+ entries = all entries in
-    mk (Ast.Unboxed_tuple entries) []
+    Ast.Unboxed_tuple entries
 
   let unboxed_record_product entries exp =
     let entries =
@@ -2591,39 +2612,49 @@ module Exp = struct
         entries
     in
     let+ entries = all entries and+ exp = optional exp in
-    mk (Ast.Unboxed_record_product (entries, exp)) []
+    Ast.Unboxed_record_product (entries, exp)
 
   let unboxed_field exp field =
     let+ exp = exp and+ field = field in
-    mk (Ast.Unboxed_field (exp, field)) []
+    Ast.Unboxed_field (exp, field)
 
-  let extension_constructor name =
-    return (mk (Ast.Extension_constructor name) [])
+  let extension_constructor name = return (Ast.Extension_constructor name)
 
   let let_exception name exp =
     let+ exp = exp in
-    mk (Ast.Let_exception (name, exp)) []
+    Ast.Let_exception (name, exp)
 
   let let_op idents defs case =
     let+ idents = all idents and+ defs = all defs and+ case = case in
-    mk (Ast.Let_op (idents, defs, case)) []
+    Ast.Let_op (idents, defs, case)
 
   let stack exp =
     let+ exp = exp in
-    mk (Stack exp) []
+    Ast.Stack exp
 
   let quote exp =
     let+ exp = exp in
-    mk (Quote exp) [Quotation]
+    Ast.Quote exp
 
   let antiquote exp =
     let+ exp = exp in
-    mk (Antiquote exp) []
+    Ast.Antiquote exp
 
   let splice code =
-    let+ exp = Code.to_exp code in exp
+    let+ exp = Code.to_exp code in
+    Ast.(exp.desc)
 
   let print fmt exp =
     let ast = With_free_vars.value ~free:(fun _ _ -> ()) exp in
     Ast.print_exp (new_env ()) fmt ast
+end
+
+module Exp = struct
+  type t = Ast.expression With_free_vars.t
+
+  let ( let+ ) x f = With_free_vars.map f x
+
+  let mk exp_desc _attributes =
+    let+ desc = exp_desc in
+    ({ desc; _attributes } : Ast.expression)
 end

--- a/stdlib/camlinternalQuote.mli
+++ b/stdlib/camlinternalQuote.mli
@@ -1,0 +1,443 @@
+# 2 "camlinternalQuote.mli"
+module Loc : sig
+
+  type t
+
+  val unknown : t
+
+  val known :
+    file:string
+    -> start_line:int
+    -> start_col:int
+    -> end_line:int
+    -> end_col:int
+    -> t
+
+end
+
+module Name : sig
+
+  type t
+
+  val mk : string -> t
+
+end
+
+module Var : sig
+
+  module Module : sig
+
+    type t
+
+    val name : t -> Name.t
+
+  end
+
+  module Value : sig
+
+    type t
+
+    val name : t -> Name.t
+
+  end
+
+  module Type_constr : sig
+
+    type t
+
+    val name : t -> Name.t
+
+  end
+
+  module Type_var : sig
+
+    type t
+
+    val name : t -> Name.t
+
+  end
+
+end
+
+module Constant : sig
+
+  type t
+
+  val int : int -> t
+  val char : char -> t
+  val string : string -> string option -> t
+  val float : string -> t
+  val int32 : int32 -> t
+  val int64 : int64 -> t
+  val nativeint : nativeint -> t
+
+end
+
+module Ident : sig
+
+  module Module : sig
+
+    type t
+
+    val compilation_unit : string -> t
+
+    val dot : t -> string -> t
+
+    val var : Loc.t -> Var.Module.t -> t
+
+  end
+
+  module Value : sig
+
+    type t
+
+    val dot : Module.t -> string -> t
+
+    val var : Loc.t -> Var.Value.t -> t
+
+  end
+
+  module Type : sig
+
+    type t
+
+    val dot : Module.t -> string -> t
+
+    val var : Loc.t -> Var.Type_constr.t -> t
+
+    val int : t
+    val char : t
+    val string : t
+    val bytes : t
+    val float : t
+    val float32 : t
+    val bool : t
+    val unit : t
+    val exn : t
+    val array : t -> t
+    val iarray : t -> t
+    val list : t -> t
+    val option : t -> t
+    val nativeint : t
+    val int32 : t
+    val int64 : t
+    val lazy_t : t -> t
+    val extension_constructor : t
+    val floatarray : t
+    val lexing_position : t
+    val code : t -> t
+    val unboxed_float : t
+    val unboxed_nativeint : t
+    val unboxed_int32 : t
+    val unboxed_int64 : t
+    val int8x16 : t
+    val int16x8 : t
+    val int32x4 : t
+    val int64x2 : t
+    val float32x4 : t
+    val float64x2 : t
+
+  end
+
+  module Constructor : sig
+
+    type t
+
+    val dot : Module.t -> string -> t
+
+    val false_ : t
+    val true_ : t
+    val void : t
+    val nil : t
+    val cons : t
+    val none : t
+    val some : t
+    val match_failure : t
+    val out_of_memory : t
+    val invalid_argument : t
+    val failure : t
+    val not_found : t
+    val sys_error : t
+    val end_of_file : t
+    val division_by_zero : t
+    val stack_overflow : t
+    val sys_blocked_io : t
+    val assert_failure : t
+    val undefined_recursive_module : t
+
+  end
+
+  module Field : sig
+
+    type t
+
+    val dot : Module.t -> string -> t
+
+  end
+
+end
+
+module Label : sig
+
+  type t
+
+  module Nonoptional : sig
+
+    type t
+
+    val no_label : t
+
+    val labelled : string -> t
+
+  end
+
+  val nonoptional : Nonoptional.t -> t
+
+  val no_label : t
+
+  val labelled : string -> t
+
+  val optional : string -> t
+
+end
+
+module Variant : sig
+
+  type t
+
+  val of_string : string -> t
+
+end
+
+module Package : sig
+
+  type t
+
+end
+
+module Type : sig
+
+  type t
+
+  val any : t
+
+  val var : Var.Type_var.t -> t
+
+  val arrow : Label.t -> t -> t -> t
+
+  val tuple : (Label.Nonoptional.t * t) list -> t
+
+  val constr : t list -> Ident.Type.t -> t
+
+  val alias : t -> Var.Type_var.t -> t
+
+  val variant : Variant.t -> t
+
+  val poly : Name.t list -> (Var.Type_var.t -> t) -> t
+
+  val package : Package.t -> t
+
+end
+
+module Pat : sig
+
+  type t
+
+  val any : t
+
+  val var : Var.Value.t -> t
+
+  val alias : t -> Var.Value.t -> t
+
+  val constant : Constant.t -> t
+
+  val interval : Constant.t -> Constant.t -> t
+
+  val tuple : t list -> t
+
+  val construct : Ident.Constructor.t -> t option -> t
+
+  val variant : Variant.t -> t option -> t
+
+  val record : (Ident.Field.t * t) list -> bool -> t
+
+  val array : t list -> t
+
+  val or_ : t -> t -> t
+
+  val constraint_ : t -> Type.t -> t
+
+  val lazy_ : t -> t
+
+  val unpack : Var.Module.t -> t -> t
+
+  val exception_ : t -> t
+
+end
+
+module rec Case : sig
+
+  type t
+
+  val nonbinding : Pat.t -> Exp.t -> t
+
+  val simple : Name.t -> (Var.Value.t -> Exp.t) -> t
+
+  val pattern :
+    bound_vars:Name.t list
+    -> bound_modules:Name.t list
+    -> (bound_vars:Var.Value.t list
+        -> bound_modules:Var.Value.t list
+        -> Pat.t * Exp.t)
+    -> t
+
+  val guarded :
+    bound_vars:Name.t list
+    -> bound_modules:Name.t list
+    -> (bound_vars:Var.Value.t list
+        -> bound_modules:Var.Value.t list
+        -> Pat.t * Exp.t * Exp.t)
+    -> t
+
+  val refutation :
+    bound_vars:Name.t list
+    -> bound_modules:Name.t list
+    -> (bound_vars:Var.Value.t list
+        -> bound_modules:Var.Value.t list
+        -> Pat.t)
+    -> t 
+
+end
+
+and Type_constraint : sig
+
+  type t
+
+  val constraint_ : Type.t -> t
+
+  val coercion : Type.t -> Type.t -> t
+
+end
+
+and Function : sig
+
+  type t
+
+  val body : Exp.t -> Type_constraint.t option -> t
+
+  val cases : Case.t list -> Type_constraint.t option -> t
+
+  val add_params_nonbinding : (Label.t * Pat.t) list -> t -> t
+
+  val add_params_simple :
+    (Label.t * Name.t) list
+    -> (Var.Value.t list -> t)
+    -> t
+
+  val add_params :
+    Name.t list
+    -> (Var.Value.t list -> (Label.t * Pat.t) list * t)
+    -> t
+
+  val add_param_optional :
+    Label.t
+    -> Exp.t option
+    -> Name.t list
+    -> (Var.Value.t list -> Pat.t * t)
+    -> t
+
+  val add_newtype : Name.t -> (Var.Type_constr.t -> t) -> t
+
+end
+
+and Exp : sig
+
+  type t
+
+  val ident : Ident.Value.t -> t
+
+  val constant : Constant.t -> t
+
+  val let_nonbinding : Pat.t -> t -> t -> t
+
+  val let_simple : Name.t -> t -> (Var.Value.t -> t) -> t
+
+  val let_rec_simple : Name.t list -> (Var.Value.t list -> t list * t) -> t
+
+  val let_ : Name.t list -> t -> (Var.Value.t list -> Pat.t * t) -> t
+
+  val function_ : Function.t -> t
+
+  val fun_nonbinding : (Label.t * Pat.t) list -> t -> t
+
+  val fun_simple : (Label.t * Name.t) list -> (Var.Value.t list -> t) -> t
+
+  val fun_ : Name.t list -> (Var.Value.t list -> (Label.t * Pat.t) list * t) -> t
+
+  val apply : t -> (Label.t * t) list -> t
+
+  val match_ : t -> Case.t list -> t
+
+  val try_ : t -> Case.t list -> t
+
+  val tuple : t list -> t
+
+  val construct : Ident.Constructor.t -> t option -> t
+
+  val variant : Variant.t -> t option -> t
+
+  val record : (Ident.Field.t * t) list -> t option -> t
+
+  val field : t -> Ident.Field.t -> t
+
+  val setfield : t -> Ident.Field.t -> t -> t
+
+  val array : t list -> t
+
+  val ifthenelse : t -> t -> t option -> t
+
+  val sequence : t -> t -> t
+
+  val while_ : t -> t -> t
+
+  val for_nonbinding : Pat.t -> t -> t -> bool -> t -> t
+
+  val for_simple : Name.t -> t -> t -> bool -> (Var.Value.t -> t) -> t
+
+  val assert_ : t -> t
+
+  val lazy_ : t -> t
+
+  val open_ : bool -> Ident.Module.t -> t -> t
+
+  val constraint_ : t -> Type_constraint.t -> t
+
+  val quote : t -> t
+
+  val escape : t -> t
+
+  val splice : Code.t -> t
+
+end
+
+and Code : sig
+
+  type t
+
+  val of_exp : Exp.t -> Loc.t -> t
+
+  val of_exp_with_type_vars : Name.t list -> (Var.Type_var.t list -> Exp.t) -> Loc.t -> t
+
+  module Closed : sig
+
+    type exp = t
+
+    type t
+
+    val close : exp -> t
+
+    val open_ : t -> exp
+
+  end
+
+end

--- a/stdlib/camlinternalQuote.mli
+++ b/stdlib/camlinternalQuote.mli
@@ -1,194 +1,220 @@
-# 2 "camlinternalQuote.mli"
 module Loc : sig
-
   type t
 
   val unknown : t
 
   val known :
-    file:string
-    -> start_line:int
-    -> start_col:int
-    -> end_line:int
-    -> end_col:int
-    -> t
-
+    file:string ->
+    start_line:int ->
+    start_col:int ->
+    end_line:int ->
+    end_col:int ->
+    t
 end
 
 module Name : sig
-
   type t
 
   val mk : string -> t
-
 end
 
 module Var : sig
-
   module Module : sig
-
     type t
 
     val name : t -> Name.t
-
   end
 
   module Value : sig
-
     type t
 
     val name : t -> Name.t
-
   end
 
-  module Type_constr : sig
-
+  module Type : sig
     type t
 
     val name : t -> Name.t
-
   end
-
-  module Type_var : sig
-
-    type t
-
-    val name : t -> Name.t
-
-  end
-
-end
-
-module Constant : sig
 
   type t
 
-  val int : int -> t
-  val char : char -> t
-  val string : string -> string option -> t
-  val float : string -> t
-  val int32 : int32 -> t
-  val int64 : int64 -> t
-  val nativeint : nativeint -> t
+  val name : t -> Name.t
+end
 
+module Constant : sig
+  type t
+
+  val int : int -> t
+
+  val char : char -> t
+
+  val string : string -> string option -> t
+
+  val float : string -> t
+
+  val int32 : int32 -> t
+
+  val int64 : int64 -> t
+
+  val nativeint : nativeint -> t
 end
 
 module Ident : sig
-
   module Module : sig
-
     type t
 
     val compilation_unit : string -> t
 
     val dot : t -> string -> t
 
-    val var : Loc.t -> Var.Module.t -> t
-
+    val var : Var.Module.t -> Loc.t -> t
   end
 
   module Value : sig
-
     type t
 
     val dot : Module.t -> string -> t
 
-    val var : Loc.t -> Var.Value.t -> t
-
+    val var : Var.Value.t -> Loc.t -> t
   end
 
   module Type : sig
-
     type t
 
     val dot : Module.t -> string -> t
 
-    val var : Loc.t -> Var.Type_constr.t -> t
+    val var : Var.Type.t -> Loc.t -> t
 
     val int : t
-    val char : t
-    val string : t
-    val bytes : t
-    val float : t
-    val float32 : t
-    val bool : t
-    val unit : t
-    val exn : t
-    val array : t -> t
-    val iarray : t -> t
-    val list : t -> t
-    val option : t -> t
-    val nativeint : t
-    val int32 : t
-    val int64 : t
-    val lazy_t : t -> t
-    val extension_constructor : t
-    val floatarray : t
-    val lexing_position : t
-    val code : t -> t
-    val unboxed_float : t
-    val unboxed_nativeint : t
-    val unboxed_int32 : t
-    val unboxed_int64 : t
-    val int8x16 : t
-    val int16x8 : t
-    val int32x4 : t
-    val int64x2 : t
-    val float32x4 : t
-    val float64x2 : t
 
+    val char : t
+
+    val string : t
+
+    val bytes : t
+
+    val float : t
+
+    val float32 : t
+
+    val bool : t
+
+    val unit : t
+
+    val exn : t
+
+    val array : t
+
+    val iarray : t
+
+    val list : t
+
+    val option : t
+
+    val nativeint : t
+
+    val int32 : t
+
+    val int64 : t
+
+    val lazy_t : t
+
+    val extension_constructor : t
+
+    val floatarray : t
+
+    val lexing_position : t
+
+    val code : t
+
+    val unboxed_float : t
+
+    val unboxed_nativeint : t
+
+    val unboxed_int32 : t
+
+    val unboxed_int64 : t
+
+    val int8x16 : t
+
+    val int16x8 : t
+
+    val int32x4 : t
+
+    val int64x2 : t
+
+    val float32x4 : t
+
+    val float64x2 : t
+  end
+
+  module Module_type : sig
+    type t
+
+    val dot : Module.t -> string -> t
   end
 
   module Constructor : sig
-
     type t
 
     val dot : Module.t -> string -> t
 
     val false_ : t
-    val true_ : t
-    val void : t
-    val nil : t
-    val cons : t
-    val none : t
-    val some : t
-    val match_failure : t
-    val out_of_memory : t
-    val invalid_argument : t
-    val failure : t
-    val not_found : t
-    val sys_error : t
-    val end_of_file : t
-    val division_by_zero : t
-    val stack_overflow : t
-    val sys_blocked_io : t
-    val assert_failure : t
-    val undefined_recursive_module : t
 
+    val true_ : t
+
+    val void : t
+
+    val nil : t
+
+    val cons : t
+
+    val none : t
+
+    val some : t
+
+    val match_failure : t
+
+    val out_of_memory : t
+
+    val invalid_argument : t
+
+    val failure : t
+
+    val not_found : t
+
+    val sys_error : t
+
+    val end_of_file : t
+
+    val division_by_zero : t
+
+    val stack_overflow : t
+
+    val sys_blocked_io : t
+
+    val assert_failure : t
+
+    val undefined_recursive_module : t
   end
 
   module Field : sig
-
     type t
 
     val dot : Module.t -> string -> t
-
   end
-
 end
 
 module Label : sig
-
   type t
 
   module Nonoptional : sig
-
     type t
 
     val no_label : t
 
     val labelled : string -> t
-
   end
 
   val nonoptional : Nonoptional.t -> t
@@ -198,49 +224,13 @@ module Label : sig
   val labelled : string -> t
 
   val optional : string -> t
-
 end
 
 module Variant : sig
-
   type t
-
-  val of_string : string -> t
-
-end
-
-module Package : sig
-
-  type t
-
-end
-
-module Type : sig
-
-  type t
-
-  val any : t
-
-  val var : Var.Type_var.t -> t
-
-  val arrow : Label.t -> t -> t -> t
-
-  val tuple : (Label.Nonoptional.t * t) list -> t
-
-  val constr : t list -> Ident.Type.t -> t
-
-  val alias : t -> Var.Type_var.t -> t
-
-  val variant : Variant.t -> t
-
-  val poly : Name.t list -> (Var.Type_var.t -> t) -> t
-
-  val package : Package.t -> t
-
 end
 
 module Pat : sig
-
   type t
 
   val any : t
@@ -253,11 +243,11 @@ module Pat : sig
 
   val interval : Constant.t -> Constant.t -> t
 
-  val tuple : t list -> t
+  val tuple : (Label.Nonoptional.t * t) list -> t
 
   val construct : Ident.Constructor.t -> t option -> t
 
-  val variant : Variant.t -> t option -> t
+  val variant : string -> t option -> t
 
   val record : (Ident.Field.t * t) list -> bool -> t
 
@@ -265,114 +255,108 @@ module Pat : sig
 
   val or_ : t -> t -> t
 
-  val constraint_ : t -> Type.t -> t
-
   val lazy_ : t -> t
 
-  val unpack : Var.Module.t -> t -> t
+  val unpack : Var.Module.t -> t
 
   val exception_ : t -> t
+end
 
+module Fragment : sig
+  type t
+end
+
+module Type : sig
+  type t
+
+  val any : t
+
+  val var : Var.Type.t -> t
+
+  val arrow : Label.t -> t -> t -> t
+
+  val tuple : (Label.Nonoptional.t * t) list -> t
+
+  val constr : Ident.Constructor.t -> t list -> t
+
+  val alias : t -> Var.Type.t -> t
+
+  val variant : Variant.t -> t
+
+  val poly : Loc.t -> Name.t list -> (Var.Type.t list -> t) -> t
+
+  val package : Ident.Module.t -> (Fragment.t * t) list -> t
 end
 
 module rec Case : sig
-
   type t
 
-  val nonbinding : Pat.t -> Exp.t -> t
+  val nonbinding : Loc.t -> Pat.t -> Exp.t -> t
 
-  val simple : Name.t -> (Var.Value.t -> Exp.t) -> t
+  val simple : Loc.t -> Name.t -> (Var.Value.t -> Exp.t) -> t
 
   val pattern :
-    bound_vars:Name.t list
-    -> bound_modules:Name.t list
-    -> (bound_vars:Var.Value.t list
-        -> bound_modules:Var.Value.t list
-        -> Pat.t * Exp.t)
-    -> t
+    Loc.t ->
+    bound_values:Name.t list ->
+    bound_modules:Name.t list ->
+    (Var.Value.t list -> Var.Module.t list -> Pat.t * Exp.t) ->
+    t
 
   val guarded :
-    bound_vars:Name.t list
-    -> bound_modules:Name.t list
-    -> (bound_vars:Var.Value.t list
-        -> bound_modules:Var.Value.t list
-        -> Pat.t * Exp.t * Exp.t)
-    -> t
+    Loc.t ->
+    bound_values:Name.t list ->
+    bound_modules:Name.t list ->
+    (Var.Value.t list -> Var.Module.t list -> Pat.t * Exp.t * Exp.t) ->
+    t
 
   val refutation :
-    bound_vars:Name.t list
-    -> bound_modules:Name.t list
-    -> (bound_vars:Var.Value.t list
-        -> bound_modules:Var.Value.t list
-        -> Pat.t)
-    -> t 
-
+    Loc.t ->
+    bound_values:Name.t list ->
+    bound_modules:Name.t list ->
+    (Var.Value.t list -> Var.Module.t list -> Pat.t) ->
+    t
 end
 
 and Type_constraint : sig
-
   type t
 
   val constraint_ : Type.t -> t
 
-  val coercion : Type.t -> Type.t -> t
-
+  val coercion : Type.t option -> Type.t -> t
 end
 
 and Function : sig
-
   type t
 
-  val body : Exp.t -> Type_constraint.t option -> t
+  val body : Exp.t -> t
 
-  val cases : Case.t list -> Type_constraint.t option -> t
+  val cases : Case.t list -> t
 
-  val add_params_nonbinding : (Label.t * Pat.t) list -> t -> t
+  val param_nonbinding : Loc.t -> Label.t -> Exp.t option -> Pat.t -> t -> t
 
-  val add_params_simple :
-    (Label.t * Name.t) list
-    -> (Var.Value.t list -> t)
-    -> t
+  val param_simple :
+    Label.t -> Exp.t option -> Loc.t -> Name.t -> (Var.Value.t -> t) -> t
 
-  val add_params :
-    Name.t list
-    -> (Var.Value.t list -> (Label.t * Pat.t) list * t)
-    -> t
-
-  val add_param_optional :
-    Label.t
-    -> Exp.t option
-    -> Name.t list
-    -> (Var.Value.t list -> Pat.t * t)
-    -> t
-
-  val add_newtype : Name.t -> (Var.Type_constr.t -> t) -> t
-
+  val newtype : Loc.t -> Name.t -> (Var.Type.t -> t) -> t
 end
 
 and Exp : sig
-
   type t
 
   val ident : Ident.Value.t -> t
 
   val constant : Constant.t -> t
 
-  val let_nonbinding : Pat.t -> t -> t -> t
+  val let_nonbinding : Loc.t -> Pat.t -> t -> t -> t
 
-  val let_simple : Name.t -> t -> (Var.Value.t -> t) -> t
+  val let_simple : Loc.t -> Name.t -> t -> (Var.Value.t -> t) -> t
 
-  val let_rec_simple : Name.t list -> (Var.Value.t list -> t list * t) -> t
+  val let_rec_simple :
+    Loc.t -> Name.t list -> (Var.Value.t list -> t list * t) -> t
 
-  val let_ : Name.t list -> t -> (Var.Value.t list -> Pat.t * t) -> t
+  val let_ : Loc.t -> Name.t list -> t -> (Var.Value.t list -> Pat.t * t) -> t
 
   val function_ : Function.t -> t
-
-  val fun_nonbinding : (Label.t * Pat.t) list -> t -> t
-
-  val fun_simple : (Label.t * Name.t) list -> (Var.Value.t list -> t) -> t
-
-  val fun_ : Name.t list -> (Var.Value.t list -> (Label.t * Pat.t) list * t) -> t
 
   val apply : t -> (Label.t * t) list -> t
 
@@ -380,11 +364,11 @@ and Exp : sig
 
   val try_ : t -> Case.t list -> t
 
-  val tuple : t list -> t
+  val tuple : (Label.Nonoptional.t * t) list -> t
 
   val construct : Ident.Constructor.t -> t option -> t
 
-  val variant : Variant.t -> t option -> t
+  val variant : Name.t -> t option -> t
 
   val record : (Ident.Field.t * t) list -> t option -> t
 
@@ -400,9 +384,9 @@ and Exp : sig
 
   val while_ : t -> t -> t
 
-  val for_nonbinding : Pat.t -> t -> t -> bool -> t -> t
+  val for_nonbinding : Loc.t -> Pat.t -> t -> t -> bool -> t -> t
 
-  val for_simple : Name.t -> t -> t -> bool -> (Var.Value.t -> t) -> t
+  val for_simple : Loc.t -> Name.t -> t -> t -> bool -> (Var.Value.t -> t) -> t
 
   val assert_ : t -> t
 
@@ -417,19 +401,17 @@ and Exp : sig
   val escape : t -> t
 
   val splice : Code.t -> t
-
 end
 
 and Code : sig
-
   type t
 
   val of_exp : Exp.t -> Loc.t -> t
 
-  val of_exp_with_type_vars : Name.t list -> (Var.Type_var.t list -> Exp.t) -> Loc.t -> t
+  val of_exp_with_type_vars :
+    Loc.t -> Name.t list -> (Var.Type.t list -> Exp.t) -> t
 
   module Closed : sig
-
     type exp = t
 
     type t
@@ -437,7 +419,5 @@ and Code : sig
     val close : exp -> t
 
     val open_ : t -> exp
-
   end
-
 end

--- a/stdlib/camlinternalQuote.mli
+++ b/stdlib/camlinternalQuote.mli
@@ -324,7 +324,16 @@ module Type : sig
   val package : Identifier.Module.t -> (Fragment.t * t) list -> t
 end
 
-(* 10 *)
+module Module : sig
+  type t
+
+  val ident : Identifier.Module.t -> t
+
+  val apply : t -> t -> t
+
+  val apply_unit : t -> t
+end
+
 module rec Case : sig
   type t
 
@@ -380,6 +389,18 @@ and Function : sig
   val newtype : Loc.t -> Name.t -> (Var.Type.t -> t) -> t
 end
 
+and Comprehension : sig
+  type t
+
+  val body : Exp.t -> t
+
+  val add_when_clause : Exp.t -> t -> t
+
+  val add_for_range : Loc.t -> Name.t -> Exp.t -> Exp.t -> bool -> (Var.Value.t -> t) -> t
+
+  val add_for_in : Loc.t -> Exp.t -> Name.t list -> (Var.Value.t list -> Pat.t * t) -> t
+end
+
 and Exp : sig
   type t
 
@@ -430,9 +451,37 @@ and Exp : sig
 
   val lazy_ : t -> t
 
-  val open_ : bool -> Identifier.Module.t -> t -> t
+  val open_ : bool -> Module.t -> t -> t
+
+  val letmodule : Loc.t -> Name.t option -> Module.t -> (Var.Module.t option -> t) -> t
 
   val constraint_ : t -> Type_constraint.t -> t
+
+  val new_ : Identifier.Value.t -> t
+
+  val pack : Module.t -> t
+
+  val unreachable : t
+
+  val src_pos : t
+
+  val extension_constructor : Identifier.Constructor.t -> t
+
+  val let_exception : Name.t -> t -> t
+
+  val let_op : Loc.t -> Identifier.Value.t list -> Name.t list -> t -> (Var.Value.t list -> Pat.t * t) -> t
+
+  val exclave : t -> t
+
+  val list_comprehension : Comprehension.t -> t
+
+  val array_comprehension : Comprehension.t -> t
+
+  val unboxed_tuple : (Label.Nonoptional.t * t) list -> t
+
+  val unboxed_record_product : (Identifier.Field.t * t) list -> t option -> t
+
+  val unboxed_field : t -> Identifier.Field.t -> t
 
   val quote : t -> t
 

--- a/stdlib/camlinternalQuote.mli
+++ b/stdlib/camlinternalQuote.mli
@@ -387,6 +387,8 @@ module Pat : sig
 
   val lazy_ : t -> t
 
+  val any_module : t
+
   val unpack : Var.Module.t -> t
 
   val exception_ : t -> t
@@ -444,6 +446,15 @@ and Function : sig
     Loc.t ->
     Name.t list ->
     (Var.Value.t list -> Pat.t * t) ->
+    t
+
+  val param_module_nonbinding : Label.t -> Loc.t -> Pat.t -> t -> t
+
+  val param_module :
+    Label.t ->
+    Loc.t ->
+    Name.t ->
+    (Var.Module.t -> Pat.t * t) ->
     t
 
   val newtype : Loc.t -> Name.t -> (Var.Type_var.t -> t) -> t

--- a/stdlib/camlinternalQuote.mli
+++ b/stdlib/camlinternalQuote.mli
@@ -257,6 +257,8 @@ module Pat : sig
 
   val lazy_ : t -> t
 
+  val unpack : Var.Module.t -> t
+
   val exception_ : t -> t
 end
 
@@ -334,10 +336,13 @@ and Function : sig
 
   val cases : Case.t list -> t
 
-  val param_nonbinding : Loc.t -> Label.t -> Exp.t option -> Pat.t -> t -> t
-
-  val param_simple :
-    Label.t -> Exp.t option -> Loc.t -> Name.t -> (Var.Value.t -> t) -> t
+  val param :
+    Label.t ->
+    Exp.t option ->
+    Loc.t ->
+    Name.t list ->
+    (Var.Value.t list -> Pat.t * t) ->
+    t
 
   val newtype : Loc.t -> Name.t -> (Var.Type.t -> t) -> t
 end

--- a/stdlib/camlinternalQuote.mli
+++ b/stdlib/camlinternalQuote.mli
@@ -16,6 +16,8 @@ module Name : sig
   type t
 
   val mk : string -> t
+
+  val print: Format.formatter -> t -> unit
 end
 
 module Var : sig
@@ -40,6 +42,8 @@ module Var : sig
   type t
 
   val name : t -> Name.t
+
+  val print: Format.formatter -> t -> unit
 end
 
 module Constant : sig
@@ -58,9 +62,11 @@ module Constant : sig
   val int64 : int64 -> t
 
   val nativeint : nativeint -> t
+
+  val print: Format.formatter -> t -> unit
 end
 
-module Ident : sig
+module Identifier : sig
   module Module : sig
     type t
 
@@ -69,6 +75,8 @@ module Ident : sig
     val dot : t -> string -> t
 
     val var : Var.Module.t -> Loc.t -> t
+
+    val print: Format.formatter -> t -> unit
   end
 
   module Value : sig
@@ -77,6 +85,8 @@ module Ident : sig
     val dot : Module.t -> string -> t
 
     val var : Var.Value.t -> Loc.t -> t
+
+    val print: Format.formatter -> t -> unit
   end
 
   module Type : sig
@@ -147,12 +157,16 @@ module Ident : sig
     val float32x4 : t
 
     val float64x2 : t
+
+    val print: Format.formatter -> t -> unit
   end
 
   module Module_type : sig
     type t
 
     val dot : Module.t -> string -> t
+
+    val print: Format.formatter -> t -> unit
   end
 
   module Constructor : sig
@@ -197,12 +211,16 @@ module Ident : sig
     val assert_failure : t
 
     val undefined_recursive_module : t
+
+    val print: Format.formatter -> t -> unit
   end
 
   module Field : sig
     type t
 
     val dot : Module.t -> string -> t
+
+    val print: Format.formatter -> t -> unit
   end
 end
 
@@ -224,12 +242,24 @@ module Label : sig
   val labelled : string -> t
 
   val optional : string -> t
+
+  val print: Format.formatter -> t -> unit
 end
 
 module Variant : sig
   type t
 
   val of_string : string -> t
+
+  val print: Format.formatter -> t -> unit
+end
+
+module Method : sig
+  type t
+
+  val of_string : string -> t
+
+  val print: Format.formatter -> t -> unit
 end
 
 module Pat : sig
@@ -245,11 +275,11 @@ module Pat : sig
 
   val tuple : (Label.Nonoptional.t * t) list -> t
 
-  val construct : Ident.Constructor.t -> t option -> t
+  val construct : Identifier.Constructor.t -> t option -> t
 
   val variant : string -> t option -> t
 
-  val record : (Ident.Field.t * t) list -> bool -> t
+  val record : (Identifier.Field.t * t) list -> bool -> t
 
   val array : t list -> t
 
@@ -264,6 +294,8 @@ end
 
 module Fragment : sig
   type t
+
+  val print: Format.formatter -> t -> unit
 end
 
 module Type : sig
@@ -281,7 +313,7 @@ module Type : sig
 
   val tuple : (Label.Nonoptional.t * t) list -> t
 
-  val constr : Ident.Constructor.t -> t list -> t
+  val constr : Identifier.Constructor.t -> t list -> t
 
   val alias : t -> Var.Type.t -> t
 
@@ -289,9 +321,10 @@ module Type : sig
 
   val poly : Loc.t -> Name.t list -> (Var.Type.t list -> t) -> t
 
-  val package : Ident.Module.t -> (Fragment.t * t) list -> t
+  val package : Identifier.Module.t -> (Fragment.t * t) list -> t
 end
 
+(* 10 *)
 module rec Case : sig
   type t
 
@@ -350,7 +383,7 @@ end
 and Exp : sig
   type t
 
-  val ident : Ident.Value.t -> t
+  val ident : Identifier.Value.t -> t
 
   val constant : Constant.t -> t
 
@@ -369,15 +402,15 @@ and Exp : sig
 
   val tuple : (Label.Nonoptional.t * t) list -> t
 
-  val construct : Ident.Constructor.t -> t option -> t
+  val construct : Identifier.Constructor.t -> t option -> t
 
   val variant : Name.t -> t option -> t
 
-  val record : (Ident.Field.t * t) list -> t option -> t
+  val record : (Identifier.Field.t * t) list -> t option -> t
 
-  val field : t -> Ident.Field.t -> t
+  val field : t -> Identifier.Field.t -> t
 
-  val setfield : t -> Ident.Field.t -> t -> t
+  val setfield : t -> Identifier.Field.t -> t -> t
 
   val array : t list -> t
 
@@ -391,17 +424,21 @@ and Exp : sig
 
   val for_simple : Loc.t -> Name.t -> t -> t -> bool -> (Var.Value.t -> t) -> t
 
+  val send : t -> Method.t -> t
+
   val assert_ : t -> t
 
   val lazy_ : t -> t
 
-  val open_ : bool -> Ident.Module.t -> t -> t
+  val open_ : bool -> Identifier.Module.t -> t -> t
 
   val constraint_ : t -> Type_constraint.t -> t
 
   val quote : t -> t
 
   val antiquote : Code.t -> t
+
+  val print: Format.formatter -> t -> unit
 end
 
 and Code : sig
@@ -421,4 +458,6 @@ and Code : sig
 
     val open_ : t -> exp
   end
+
+  val print: Format.formatter -> t -> unit
 end

--- a/stdlib/camlinternalQuote.mli
+++ b/stdlib/camlinternalQuote.mli
@@ -228,6 +228,8 @@ end
 
 module Variant : sig
   type t
+
+  val of_string : string -> t
 end
 
 module Pat : sig
@@ -240,8 +242,6 @@ module Pat : sig
   val alias : t -> Var.Value.t -> t
 
   val constant : Constant.t -> t
-
-  val interval : Constant.t -> Constant.t -> t
 
   val tuple : (Label.Nonoptional.t * t) list -> t
 
@@ -257,8 +257,6 @@ module Pat : sig
 
   val lazy_ : t -> t
 
-  val unpack : Var.Module.t -> t
-
   val exception_ : t -> t
 end
 
@@ -268,6 +266,10 @@ end
 
 module Type : sig
   type t
+
+  module Variant : sig
+    type t
+  end
 
   val any : t
 
@@ -347,10 +349,6 @@ and Exp : sig
 
   val constant : Constant.t -> t
 
-  val let_nonbinding : Loc.t -> Pat.t -> t -> t -> t
-
-  val let_simple : Loc.t -> Name.t -> t -> (Var.Value.t -> t) -> t
-
   val let_rec_simple :
     Loc.t -> Name.t list -> (Var.Value.t list -> t list * t) -> t
 
@@ -398,9 +396,7 @@ and Exp : sig
 
   val quote : t -> t
 
-  val escape : t -> t
-
-  val splice : Code.t -> t
+  val antiquote : Code.t -> t
 end
 
 and Code : sig

--- a/stdlib/camlinternalQuote.mli
+++ b/stdlib/camlinternalQuote.mli
@@ -396,6 +396,32 @@ module Pat : sig
   val constraint_ : t -> Type.t -> t
 end
 
+module Exp_attribute : sig
+  type t
+
+  val inline : t
+
+  val inlined : t
+
+  val specialise : t
+
+  val specialised : t
+
+  val unrolled : t
+
+  val nontail : t
+
+  val tail : t
+
+  val poll : t
+
+  val loop : t
+
+  val tail_mod_cons : t
+
+  val quotation : t
+end
+
 module rec Case : sig
   type t
 
@@ -451,11 +477,7 @@ and Function : sig
   val param_module_nonbinding : Label.t -> Loc.t -> Pat.t -> t -> t
 
   val param_module :
-    Label.t ->
-    Loc.t ->
-    Name.t ->
-    (Var.Module.t -> Pat.t * t) ->
-    t
+    Label.t -> Loc.t -> Name.t -> (Var.Module.t -> Pat.t * t) -> t
 
   val newtype : Loc.t -> Name.t -> (Var.Type_var.t -> t) -> t
 end
@@ -474,7 +496,7 @@ and Comprehension : sig
     Loc.t -> Exp.t -> Name.t list -> (Var.Value.t list -> Pat.t * t) -> t
 end
 
-and Exp : sig
+and Exp_desc : sig
   type t
 
   val ident : Identifier.Value.t -> t
@@ -482,59 +504,60 @@ and Exp : sig
   val constant : Constant.t -> t
 
   val let_rec_simple :
-    Loc.t -> Name.t list -> (Var.Value.t list -> t list * t) -> t
+    Loc.t -> Name.t list -> (Var.Value.t list -> Exp.t list * Exp.t) -> t
 
   val let_ :
     Loc.t ->
     Name.t list ->
     Name.t list ->
-    t list ->
-    (Var.Value.t list -> Var.Module.t list -> Pat.t * t) ->
+    Exp.t list ->
+    (Var.Value.t list -> Var.Module.t list -> Pat.t * Exp.t) ->
     t
 
   val function_ : Function.t -> t
 
-  val apply : t -> (Label.t * t) list -> t
+  val apply : Exp.t -> (Label.t * Exp.t) list -> t
 
-  val match_ : t -> Case.t list -> t
+  val match_ : Exp.t -> Case.t list -> t
 
-  val try_ : t -> Case.t list -> t
+  val try_ : Exp.t -> Case.t list -> t
 
-  val tuple : (Label.Nonoptional.t * t) list -> t
+  val tuple : (Label.Nonoptional.t * Exp.t) list -> t
 
-  val construct : Constructor.t -> t option -> t
+  val construct : Constructor.t -> Exp.t option -> t
 
-  val variant : Name.t -> t option -> t
+  val variant : Name.t -> Exp.t option -> t
 
-  val record : (Field.t * t) list -> t option -> t
+  val record : (Field.t * Exp.t) list -> Exp.t option -> t
 
-  val field : t -> Field.t -> t
+  val field : Exp.t -> Field.t -> t
 
-  val setfield : t -> Field.t -> t -> t
+  val setfield : Exp.t -> Field.t -> Exp.t -> t
 
-  val array : t list -> t
+  val array : Exp.t list -> t
 
-  val ifthenelse : t -> t -> t option -> t
+  val ifthenelse : Exp.t -> Exp.t -> Exp.t option -> t
 
-  val sequence : t -> t -> t
+  val sequence : Exp.t -> Exp.t -> t
 
-  val while_ : t -> t -> t
+  val while_ : Exp.t -> Exp.t -> t
 
-  val for_nonbinding : Loc.t -> Pat.t -> t -> t -> bool -> t -> t
+  val for_nonbinding : Loc.t -> Pat.t -> Exp.t -> Exp.t -> bool -> Exp.t -> t
 
-  val for_simple : Loc.t -> Name.t -> t -> t -> bool -> (Var.Value.t -> t) -> t
+  val for_simple :
+    Loc.t -> Name.t -> Exp.t -> Exp.t -> bool -> (Var.Value.t -> Exp.t) -> t
 
-  val send : t -> Method.t -> t
+  val send : Exp.t -> Method.t -> t
 
-  val assert_ : t -> t
+  val assert_ : Exp.t -> t
 
-  val lazy_ : t -> t
+  val lazy_ : Exp.t -> t
 
-  val letmodule_nonbinding : Module.t -> t -> t
+  val letmodule_nonbinding : Module.t -> Exp.t -> t
 
-  val letmodule : Loc.t -> Name.t -> Module.t -> (Var.Module.t -> t) -> t
+  val letmodule : Loc.t -> Name.t -> Module.t -> (Var.Module.t -> Exp.t) -> t
 
-  val constraint_ : t -> Type_constraint.t -> t
+  val constraint_ : Exp.t -> Type_constraint.t -> t
 
   val new_ : Identifier.Value.t -> t
 
@@ -544,33 +567,39 @@ and Exp : sig
 
   val src_pos : t
 
-  val stack : t -> t
+  val stack : Exp.t -> t
 
   val extension_constructor : Name.t -> t
 
-  val let_exception : Name.t -> t -> t
+  val let_exception : Name.t -> Exp.t -> t
 
-  val let_op : Identifier.Value.t list -> t list -> Case.t -> t
+  val let_op : Identifier.Value.t list -> Exp.t list -> Case.t -> t
 
-  val exclave : t -> t
+  val exclave : Exp.t -> t
 
   val list_comprehension : Comprehension.t -> t
 
   val array_comprehension : Comprehension.t -> t
 
-  val unboxed_tuple : (Label.Nonoptional.t * t) list -> t
+  val unboxed_tuple : (Label.Nonoptional.t * Exp.t) list -> t
 
-  val unboxed_record_product : (Field.t * t) list -> t option -> t
+  val unboxed_record_product : (Field.t * Exp.t) list -> Exp.t option -> t
 
-  val unboxed_field : t -> Field.t -> t
+  val unboxed_field : Exp.t -> Field.t -> t
 
-  val quote : t -> t
+  val quote : Exp.t -> t
 
-  val antiquote : t -> t
+  val antiquote : Exp.t -> t
 
   val splice : Code.t -> t
 
-  val print : Format.formatter -> t -> unit
+  val print : Format.formatter -> Exp.t -> unit
+end
+
+and Exp : sig
+  type t
+
+  val mk : Exp_desc.t -> Exp_attribute.t list -> t
 end
 
 and Code : sig

--- a/stdlib/dune
+++ b/stdlib/dune
@@ -101,6 +101,8 @@
   camlinternalMod.mli
   camlinternalOO.ml
   camlinternalOO.mli
+  camlinternalQuote.ml
+  camlinternalQuote.mli
   char.ml
   char.mli
   complex.ml
@@ -400,6 +402,7 @@
   .stdlib.objs/byte/camlinternalLazy.cmi
   .stdlib.objs/byte/camlinternalOO.cmi
   .stdlib.objs/byte/camlinternalFormat.cmi
+  .stdlib.objs/byte/camlinternalQuote.cmi
   .stdlib.objs/byte/camlinternalAtomic.cmt
   .stdlib.objs/byte/camlinternalComprehension.cmt
   .stdlib.objs/byte/camlinternalMod.cmt
@@ -407,6 +410,7 @@
   .stdlib.objs/byte/camlinternalLazy.cmt
   .stdlib.objs/byte/camlinternalOO.cmt
   .stdlib.objs/byte/camlinternalFormat.cmt
+  .stdlib.objs/byte/camlinternalQuote.cmt
   .stdlib.objs/byte/camlinternalAtomic.cmti
   .stdlib.objs/byte/camlinternalComprehension.cmti
   .stdlib.objs/byte/camlinternalMod.cmti
@@ -414,6 +418,7 @@
   .stdlib.objs/byte/camlinternalLazy.cmti
   .stdlib.objs/byte/camlinternalOO.cmti
   .stdlib.objs/byte/camlinternalFormat.cmti
+  .stdlib.objs/byte/camlinternalQuote.cmti
   .stdlib.objs/native/camlinternalAtomic.cmx
   .stdlib.objs/native/camlinternalComprehension.cmx
   .stdlib.objs/native/camlinternalMod.cmx
@@ -421,6 +426,7 @@
   .stdlib.objs/native/camlinternalLazy.cmx
   .stdlib.objs/native/camlinternalOO.cmx
   .stdlib.objs/native/camlinternalFormat.cmx
+  .stdlib.objs/native/camlinternalQuote.cmx
   .stdlib.objs/byte/std_exit.cmi
   .stdlib.objs/byte/std_exit.cmo
   .stdlib.objs/byte/std_exit.cmt

--- a/testsuite/tests/parsing/extension_operators.ml
+++ b/testsuite/tests/parsing/extension_operators.ml
@@ -12,10 +12,8 @@ Error: "##" is not a valid value identifier.
 
 let f x = !#x
 [%%expect {|
-Line 1, characters 10-12:
-1 | let f x = !#x
-              ^^
-Error: "!#" is not a valid value identifier.
+Uncaught exception: Failure("Cannot unqoute outside of a quotation context.")
+
 |}]
 
 let f x = ?#x

--- a/testsuite/tests/ppx-empty-cases/test.compilers.reference
+++ b/testsuite/tests/ppx-empty-cases/test.compilers.reference
@@ -3,35 +3,35 @@
     (empty_cases_returning_string/273 =
        (function {nlocal = 0} param/275
          (raise
-           (makeblock 0 (getpredef Match_failure/41!!) [0: "test.ml" 28 50])))
+           (makeblock 0 (getpredef Match_failure/42!!) [0: "test.ml" 28 50])))
      empty_cases_returning_float64/276 =
        (function {nlocal = 0} param/278 : unboxed_float
          (raise
-           (makeblock 0 (getpredef Match_failure/41!!) [0: "test.ml" 29 50])))
+           (makeblock 0 (getpredef Match_failure/42!!) [0: "test.ml" 29 50])))
      empty_cases_accepting_string/279 =
        (function {nlocal = 0} param/281
          (raise
-           (makeblock 0 (getpredef Match_failure/41!!) [0: "test.ml" 30 50])))
+           (makeblock 0 (getpredef Match_failure/42!!) [0: "test.ml" 30 50])))
      empty_cases_accepting_float64/282 =
        (function {nlocal = 0} param/284[unboxed_float]
          (raise
-           (makeblock 0 (getpredef Match_failure/41!!) [0: "test.ml" 31 50])))
+           (makeblock 0 (getpredef Match_failure/42!!) [0: "test.ml" 31 50])))
      non_empty_cases_returning_string/285 =
        (function {nlocal = 0} param/287
          (raise
-           (makeblock 0 (getpredef Assert_failure/51!!) [0: "test.ml" 32 68])))
+           (makeblock 0 (getpredef Assert_failure/52!!) [0: "test.ml" 32 68])))
      non_empty_cases_returning_float64/288 =
        (function {nlocal = 0} param/290 : unboxed_float
          (raise
-           (makeblock 0 (getpredef Assert_failure/51!!) [0: "test.ml" 33 68])))
+           (makeblock 0 (getpredef Assert_failure/52!!) [0: "test.ml" 33 68])))
      non_empty_cases_accepting_string/291 =
        (function {nlocal = 0} param/293
          (raise
-           (makeblock 0 (getpredef Assert_failure/51!!) [0: "test.ml" 34 68])))
+           (makeblock 0 (getpredef Assert_failure/52!!) [0: "test.ml" 34 68])))
      non_empty_cases_accepting_float64/294 =
        (function {nlocal = 0} param/296[unboxed_float]
          (raise
-           (makeblock 0 (getpredef Assert_failure/51!!) [0: "test.ml" 35 68]))))
+           (makeblock 0 (getpredef Assert_failure/52!!) [0: "test.ml" 35 68]))))
     (makeblock 0 empty_cases_returning_string/273
       empty_cases_returning_float64/276 empty_cases_accepting_string/279
       empty_cases_accepting_float64/282 non_empty_cases_returning_string/285

--- a/testsuite/tests/quotation/\
+++ b/testsuite/tests/quotation/\
@@ -1,0 +1,711 @@
+(* TEST
+ expect;
+*)
+
+[%quote 42];;
+[%%expect {|
+- : int code = [%quote 42]
+|}];;
+
+[%quote 3.14s];;
+[%%expect {|
+- : float32 code = [%quote 3.14s]
+|}];;
+
+[%quote 3.14];;
+[%%expect {|
+- : float code = [%quote 3.14]
+|}];;
+
+[%quote "foo"];;
+[%%expect {|
+- : string code = [%quote "foo"]
+|}];;
+
+[%quote {foo|bar|foo}];;
+[%%expect {|
+- : string code = [%quote {foo|bar|foo}]
+|}];;
+
+[%quote true];;
+[%%expect {|
+- : bool code = [%quote true]
+|}];;
+
+[%quote false];;
+[%%expect {|
+- : bool code = [%quote false]
+|}];;
+
+[%quote ()];;
+[%%expect {|
+- : unit code = [%quote ()]
+|}];;
+
+[%quote (1, 2)];;
+[%%expect {|
+- : (int * int) code = [%quote (1, 2)]
+|}];;
+
+[%quote (1, 2, 3)];;
+[%%expect {|
+- : (int * int * int) code = [%quote (1, 2, 3)]
+|}];;
+
+[%quote (~lab:"val", ~lab2:77, 30)];;
+[%%expect {|
+- : (lab:string * lab2:int * int) code = [%quote (~lab:"val", ~lab2:77, 30)]
+|}];;
+
+[%quote []];;
+[%%expect {|
+- : 'a list code = [%quote []]
+|}];;
+
+[%quote [1; 2; 3]];;
+[%%expect {|
+- : int list code = [%quote (::) (1, ((::) (2, ((::) (3, [])))))]
+|}];;
+
+[%quote [||]];;
+[%%expect {|
+- : '_weak1 array code = [%quote [||]]
+|}];;
+
+[%quote [| 1; 2; 3 |]];;
+[%%expect {|
+- : int array code = [%quote [|1; 2; 3|]]
+|}];;
+
+[%quote None];;
+[%%expect {|
+- : 'a option code = [%quote None]
+|}];;
+
+[%quote Some 111];;
+[%%expect {|
+- : int option code = [%quote Some 111]
+|}];;
+
+[%quote `A 42];;
+[%%expect {|
+- : [> `A of int ] code = [%quote `A 42]
+|}];;
+
+[%quote if true then `A 10 else `B ("foo", 42)];;
+[%%expect {|
+- : [> `A of int | `B of string * int ] code = [%quote
+if true then `A 10 else `B ("foo", 42)]
+|}];;
+
+[%quote function | `A x -> x | `B (_, foo) -> foo];;
+[%%expect {|
+- : (([< `A of '_weak3 | `B of '_weak4 * '_weak3 ] as '_weak2) -> '_weak3)
+    code
+= [%quote function | `A x -> x | `B (_, foo) -> foo]
+|}];;
+
+[%quote function | `A x -> x | `B (_, foo) -> foo | _ -> 42];;
+[%%expect {|
+- : (([> `A of int | `B of '_weak6 * int ] as '_weak5) -> int) code = [%quote
+function | `A x -> x | `B (_, foo) -> foo | _ -> 42]
+|}];;
+
+[%quote List.map];;
+[%%expect {|
+- : (('_weak7 -> '_weak8) -> '_weak7 list -> '_weak8 list) code = [%quote
+Stdlib.List.map]
+|}];;
+
+[%quote fun x -> 42];;
+[%%expect {|
+- : ('_weak9 -> int) code = [%quote fun x -> 42]
+|}];;
+
+[%quote fun _ -> 42];;
+[%%expect {|
+- : ('_weak10 -> int) code = [%quote fun _ -> 42]
+|}];;
+
+[%quote fun x y -> x];;
+[%%expect {|
+- : ('_weak11 -> '_weak12 -> '_weak11) code = [%quote fun x y -> x]
+|}];;
+
+[%quote fun f x y -> f ~a:y ~b:x];;
+[%%expect {|
+- : ((a:'_weak13 -> b:'_weak14 -> '_weak15) ->
+     '_weak14 -> '_weak13 -> '_weak15)
+    code
+= [%quote fun f x y -> f ~a:y ~b:x]
+|}];;
+
+[%quote fun f x y -> f ?a:y ?b:x];;
+[%%expect {|
+- : ((?a:'_weak16 -> ?b:'_weak17 -> '_weak18) ->
+     '_weak17 option -> '_weak16 option -> '_weak18)
+    code
+= [%quote fun f x y -> f ?a:y ?b:x]
+|}];;
+
+[%quote fun (x, y) -> x + y];;
+[%%expect {|
+- : (int * int -> int) code = [%quote fun (x, y) -> Stdlib.( + ) x y]
+|}];;
+
+[%quote function | _ -> 12];;
+[%%expect {|
+- : ('_weak19 -> int) code = [%quote function | _ -> 12]
+|}];;
+
+[%quote function | x -> x];;
+[%%expect {|
+- : ('_weak20 -> '_weak20) code = [%quote function | x -> x]
+|}];;
+
+[%quote function | 42 -> true | _ -> false];;
+[%%expect {|
+- : (int -> bool) code = [%quote function | 42 -> true | _ -> false]
+|}];;
+
+[%quote function | "foo" -> true | _ -> false];;
+[%%expect {|
+- : (string -> bool) code = [%quote function | "foo" -> true | _ -> false]
+|}];;
+
+[%quote function | (x, y) as z -> (x, y, z)];;
+[%%expect {|
+- : ('_weak21 * '_weak22 -> '_weak21 * '_weak22 * ('_weak21 * '_weak22)) code
+= [%quote function | (x, y) as z -> (x, y, z)]
+|}];;
+
+[%quote function | (x, y) -> x + y];;
+[%%expect {|
+- : (int * int -> int) code = [%quote function | (x, y) -> Stdlib.( + ) x y]
+|}];;
+
+[%quote function | (x, y, z) -> x + y - z];;
+[%%expect {|
+- : (int * int * int -> int) code = [%quote
+function | (x, y, z) -> Stdlib.( - ) (Stdlib.( + ) x y) z]
+|}];;
+
+[%quote function | `A -> true | `B -> false];;
+[%%expect {|
+- : (([< `A | `B ] as '_weak23) -> bool) code = [%quote
+function | `A -> true | `B -> false]
+|}];;
+
+[%quote function | `Foo x -> x | `Bar (y, z) -> y + z | `Baz -> 0];;
+[%%expect {|
+- : (([< `Bar of int * int | `Baz | `Foo of int ] as '_weak24) -> int) code =
+[%quote function | `Foo x -> x | `Bar (y, z) -> Stdlib.( + ) y z | `Baz -> 0]
+|}];;
+
+[%quote function | lazy x as l -> Lazy.force l];;
+[%%expect {|
+- : ('_weak25 Lazy.t -> '_weak25) code = [%quote
+function | lazy (x) as l -> Stdlib.Lazy.force l]
+|}];;
+
+[%quote fun f x d -> match f x with | res -> res | exception e -> d];;
+[%%expect {|
+- : (('_weak26 -> '_weak27) -> '_weak26 -> '_weak27 -> '_weak27) code =
+[%quote fun f x d -> match f x with | res -> res | (exception e) -> d]
+|}];;
+
+[%quote function | Some x -> x | None -> 0];;
+[%%expect {|
+- : (int option -> int) code = [%quote function | Some (x) -> x | None -> 0]
+|}];;
+
+[%quote function | [] -> false | x::xs -> true];;
+[%%expect {|
+- : ('_weak28 list -> bool) code = [%quote
+function | [] -> false | (::) (x, xs) -> true]
+|}];;
+
+[%quote fun x d -> match x with | Some y -> y | None -> d];;
+[%%expect {|
+- : ('_weak29 option -> '_weak29 -> '_weak29) code = [%quote
+fun x d -> match x with | Some (y) -> y | None -> d]
+|}];;
+
+[%quote fun l -> List.map (fun x -> 2 * x) l];;
+[%%expect {|
+- : (int list -> int list) code = [%quote
+fun l -> Stdlib.List.map (fun x -> Stdlib.( * ) 2 x) l]
+|}];;
+
+[%quote fun (type a) (f : a -> a) (x : a) -> f (f x)];;
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+
+[%quote fun x (type a) (f : a -> a * a) (g : int -> a) -> f (g x)];;
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+
+[%quote fun (f : 'a. 'a -> 'a) -> f f];;
+[%%expect {|
+Uncaught exception: Not_found
+
+|}];;
+
+[%quote fun x -> fun x -> fun x -> 42];;
+[%%expect {|
+- : ('_weak30 -> '_weak31 -> '_weak32 -> int) code = [%quote
+fun x -> fun x__1 -> fun x__2 -> 42]
+|}];;
+
+[%quote fun x -> fun x -> fun x__1 -> 42];;
+[%%expect {|
+- : ('_weak33 -> '_weak34 -> '_weak35 -> int) code = [%quote
+fun x -> fun x__1 -> fun x__2 -> 42]
+|}];;
+
+[%quote let z = 10 in z];;
+[%%expect {|
+- : int code = [%quote let z = 10 in z]
+|}];;
+
+[%quote let (x, y) = (42, 100) in x + y];;
+[%%expect {|
+- : int code = [%quote let (x, y) = (42, 100) in Stdlib.( + ) x y]
+|}];;
+
+[%quote let Some x = Some "foo" in x];;
+[%%expect {|
+Line 1, characters 8-36:
+1 | [%quote let Some x = Some "foo" in x];;
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+None
+
+- : string code = [%quote match Some "foo" with | Some (x) -> x]
+|}];;
+
+[%quote let x::xs = [1; 2; 3] in x];;
+[%%expect {|
+Line 1, characters 8-34:
+1 | [%quote let x::xs = [1; 2; 3] in x];;
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+[]
+
+- : int code = [%quote
+match (::) (1, ((::) (2, ((::) (3, []))))) with | (::) (x, xs) -> x]
+|}];;
+
+[%quote let x::xs = [1; 2; 3] in xs];;
+[%%expect {|
+Line 1, characters 8-35:
+1 | [%quote let x::xs = [1; 2; 3] in xs];;
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+[]
+
+- : int list code = [%quote
+match (::) (1, ((::) (2, ((::) (3, []))))) with | (::) (x, xs) -> xs]
+|}];;
+
+[%quote let foo x = (x, x) in foo 42];;
+[%%expect {|
+- : (int * int) code = [%quote let foo = (fun x -> (x, x)) in foo 42]
+|}];;
+
+[%quote let foo = 50 and bar = 15 in foo + bar];;
+[%%expect {|
+- : int code = [%quote let foo = 50 and bar = 15 in Stdlib.( + ) foo bar]
+|}];;
+
+[%quote let x = 42 in let x = x in x];;
+[%%expect {|
+- : int code = [%quote let x = 42 in let x__1 = x in x__1]
+|}];;
+
+[%quote
+  let (let+) x f = f x in
+  let+ a = 42 in a
+];;
+[%%expect {|
+- : int code = [%quote let (let+) = (fun x f -> f x) in (let+) a = 42 in a]
+|}];;
+
+[%quote
+  let (let+) x f = Option.map f x in
+  let+ a = Some 42
+  in a * 2
+];;
+[%%expect {|
+- : int option code = [%quote
+let (let+) = (fun x f -> Stdlib.Option.map f x) in
+                                                (let+) a = Some 42
+                                                in Stdlib.( * ) a 2]
+|}];;
+
+[%quote
+  let (let*) x f = List.map f x and (and*) = List.combine in
+  let* a = [1; 2; 3]
+  and* b = [10; 20; 30]
+  in a + b
+];;
+[%%expect {|
+- : int list code = [%quote
+let (let*) = (fun x f -> Stdlib.List.map f x) and
+                                              (and*) = Stdlib.List.combine
+in
+(let*) a = (::) (1, ((::) (2, ((::) (3, [])))))
+(and*) b = (::) (10, ((::) (20, ((::) (30, []))))) in Stdlib.( + ) a b]
+|}];;
+
+[%quote fun (f: int -> int) (x: int) -> f x]
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+
+[%quote let module M = Set.Make(Int) in M.singleton 100 |> M.elements];;
+[%%expect {|
+- : Int.t list code = [%quote
+let module M = Stdlib.Set.Make(Stdlib.Int) in M.elements (M.singleton 100)]
+|}];;
+
+[%quote ref 42];;
+[%%expect {|
+- : int ref code = [%quote Stdlib.ref 42]
+|}];;
+
+[%quote
+  let x = ref 0 in
+  for i = 0 to 10 do
+    x := !x + i
+  done;
+  !x
+];;
+[%%expect {|
+- : int code = [%quote
+let x = (Stdlib.ref 0) in
+                       for i = 0 to 10 do
+                       (Stdlib.( := ) x (Stdlib.( + ) (Stdlib.( ! ) x) i))
+                       done; Stdlib.( ! ) x]
+|}];;
+
+[%quote
+  let x = ref 0 in
+  for i = 10 downto 0 do
+    x := !x + i
+  done;
+  !x
+];;
+[%%expect {|
+- : int code = [%quote
+let x = (Stdlib.ref 0) in
+                       for i = 10 downto 0 do
+                       (Stdlib.( := ) x (Stdlib.( + ) (Stdlib.( ! ) x) i))
+                       done; Stdlib.( ! ) x]
+|}];;
+
+[%quote while true do () done];;
+[%%expect {|
+- : 'a code = [%quote while true do () done]
+|}];;
+
+[%quote
+  let f = ref 1 and i = ref 5 in
+  while !i > 0 do
+    f := !i * !f;
+    i := !i - 1
+  done;
+  !f
+];;
+[%%expect {|
+- : int code = [%quote
+let f = (Stdlib.ref 1) and i = (Stdlib.ref 5) in
+                                              while
+                                              Stdlib.( > ) (Stdlib.( ! ) i) 0
+                                              do
+                                              (Stdlib.( := ) f
+                                                            (Stdlib.( * )
+                                                              (Stdlib.( ! ) i)
+                                                             (Stdlib.( ! ) f));
+                                               Stdlib.( := ) i
+                                                            (Stdlib.( - )
+                                                              (Stdlib.( ! ) i)
+                                                             1))
+                                              done; Stdlib.( ! ) f]
+|}];;
+
+[%quote assert true];;
+[%%expect {|
+- : unit code = [%quote assert true]
+|}];;
+
+[%quote assert false];;
+[%%expect {|
+- : 'a code = [%quote assert false]
+|}];;
+
+[%quote lazy 42];;
+[%%expect {|
+- : int lazy_t code = [%quote lazy 42]
+|}];;
+
+[%quote fun () -> #25n];;
+[%%expect {|
+- : (unit -> nativeint#) code = [%quote fun () -> #25n]
+|}];;
+
+[%quote fun () -> #25l];;
+[%%expect {|
+- : (unit -> int32#) code = [%quote fun () -> #25l]
+|}];;
+
+[%quote fun () -> #25L];;
+[%%expect {|
+- : (unit -> int64#) code = [%quote fun () -> #25L]
+|}];;
+
+[%quote fun () -> #6.0];;
+[%%expect {|
+- : (unit -> float#) code = [%quote fun () -> #6.0]
+|}];;
+
+[%quote fun () -> #6.0s];;
+[%%expect {|
+- : (unit -> float32#) code = [%quote fun () -> #6.0s]
+|}];;
+
+[%quote fun () -> #(1, 2, 3)];;
+[%%expect {|
+- : (unit -> #(int * int * int)) code = [%quote fun () -> #(1, 2, 3)]
+|}];;
+
+type rcd = {x: int; y: string};;
+[%%expect {|
+type rcd = { x : int; y : string; }
+|}];;
+
+[%quote {x = 42; y = "foo"}];;
+[%%expect {|
+- : rcd code = [%quote {x = 42; y = "foo"; }]
+|}];;
+
+type rcd_u = #{xu: int; yu: string};;
+[%%expect {|
+type rcd_u = #{ xu : int; yu : string; }
+|}];;
+
+[%quote fun () -> #{xu = 42; yu = "foo"}];;
+[%%expect {|
+- : (unit -> rcd_u) code = [%quote fun () -> {xu = 42; yu = "foo"; }]
+|}];;
+
+[%quote fun r -> r.x];;
+[%%expect {|
+- : (rcd -> int) code = [%quote fun r -> r x]
+|}];;
+
+[%quote fun {x; y} -> x];;
+[%%expect {|
+- : (rcd -> int) code = [%quote fun {x=x; y=y; } -> x]
+|}];;
+
+[%quote raise (Match_failure ("foo", 42, 100))];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise (Match_failure ("foo", 42, 100))]
+|}];;
+
+[%quote raise Out_of_memory];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise Out_of_memory]
+|}];;
+
+[%quote raise (Invalid_argument "arg")];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise (Invalid_argument "arg")]
+|}];;
+
+[%quote raise (Failure "fail")];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise (Failure "fail")]
+|}];;
+
+[%quote raise Not_found];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise Not_found]
+|}];;
+
+[%quote raise (Sys_error "err")];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise (Sys_error "err")]
+|}];;
+
+[%quote raise End_of_file];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise End_of_file]
+|}];;
+
+[%quote raise Division_by_zero];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise Division_by_zero]
+|}];;
+
+[%quote raise Stack_overflow];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise Stack_overflow]
+|}];;
+
+[%quote raise Sys_blocked_io];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise Sys_blocked_io]
+|}];;
+
+[%quote raise (Assert_failure ("assert", 42, 100))];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise (Assert_failure ("assert", 42, 100))]
+|}];;
+
+[%quote raise (Undefined_recursive_module ("M", 42, 100))];;
+[%%expect {|
+- : 'a code = [%quote
+Stdlib.raise (Undefined_recursive_module ("M", 42, 100))]
+|}];;
+
+[%quote let exception E in ()];;
+[%%expect {|
+- : unit code = [%quote let exception E in ()]
+|}];;
+
+[%quote let exception E in raise E];;
+[%%expect {|
+- : 'a code = [%quote let exception E in Stdlib.raise E]
+|}];;
+
+[%quote let module M = Option in M.map];;
+[%%expect {|
+- : (('_weak36 -> '_weak37) -> '_weak36 option -> '_weak37 option) code =
+[%quote let module M = Stdlib.Option in M.map]
+|}];;
+
+[%quote let module M = Option in function | M.None -> false | M.Some x -> x];;
+[%%expect {|
+- : (bool option -> bool) code = [%quote
+let module M = Stdlib.Option in function | None -> false | Some (x) -> x]
+|}];;
+
+
+[%quote fun () -> exclave_ Some 42];;
+[%%expect {|
+- : (unit -> local_ int option) code = [%quote fun () -> exclave_ Some 42]
+|}];;
+
+[%quote fun () -> exclave_ stack_ (Some 42)];;
+[%%expect {|
+- : (unit -> local_ int option) code = [%quote
+fun () -> exclave_ stack_ (Some 42)]
+|}];;
+
+module type S = sig
+  type t
+  type t2
+  val a : t
+  val b : t -> int -> t
+  val c : t -> int
+end;;
+[%%expect {|
+module type S =
+  sig type t type t2 val a : t val b : t -> int -> t val c : t -> int end
+|}];;
+
+(* [%quote fun (module M : S) x -> M.c (M.b M.a x)];;
+ * [%%expect {|
+ * Uncaught exception: Stdlib.Exit
+ * 
+ * |}];;
+ * 
+ * [%quote fun (module M : S with type t = string) x -> M.c (M.b M.a x)];;
+ * [%%expect {|
+ * Uncaught exception: Stdlib.Exit
+ * 
+ * |}];;
+ * 
+ * [%quote fun (module M : S with type t = string and type t2 = int) x -> M.c (M.b M.a x)];;
+ * [%%expect {|
+ * Uncaught exception: Stdlib.Exit
+ * 
+ * |}];; *)
+
+
+[%quote let module M (N : S) = struct type t = N.t let x = N.a end in ()];;
+[%%expect {|
+Line 1, characters 26-27:
+1 | [%quote let module M (N : S) = struct type t = N.t let x = N.a end in ()];;
+                              ^
+Error: Unbound module type "S"
+|}];;
+
+[%quote let module M = struct type t = int let x = 42 end in M.x];;
+[%%expect {|
+>> Fatal error: Cannot quote struct..end blocks
+Uncaught exception: Misc.Fatal_error
+
+|}];;
+
+let x = 42 in [%quote x];;
+[%%expect {|
+>> Fatal error: Cannot quote free variable x
+Uncaught exception: Misc.Fatal_error
+
+|}];;
+
+[%quote let o = object method f = 1 end in o#f];;
+[%%expect {|
+>> Fatal error: Cannot quote object construction.
+Uncaught exception: Misc.Fatal_error
+
+|}];;
+
+let x = 123 in [%quote x];;
+[%%expect {|
+>> Fatal error: Cannot quote free variable x
+Uncaught exception: Misc.Fatal_error
+
+|}];;
+
+let x = [%quote 123] in [%quote !#(x)];;
+[%%expect {|
+- : int code = [%quote 123]
+|}];;
+
+[%quote !#[%quote "foo"]];;
+[%%expect {|
+- : string code = [%quote "foo"]
+|}];;
+
+(* [%quote fun x -> !#x];;
+ * [%%expect {|
+ * - : ('_weak39 code -> '_weak39) code = [%quote fun x -> !#x]
+ * |}];; *)
+
+[%quote [%quote !#[%quote 123]]];;
+[%%expect {|
+- : int code code = [%quote [%quote !#[%quote 123]]]
+|}];;
+
+let x = [%quote "foo"] and y = [%quote "bar"] in [%quote !#x ^ !#y];;
+[%%expect {|
+- : string code = [%quote Stdlib.( ^ ) "foo" "bar"]
+|}];;
+
+[%quote fun x -> [%quote [%quote !#x]]];;
+[%%expect {|
+- : ('_weak38 code -> '_weak38 code code) code = [%quote
+fun x -> [%quote [%quote !#x]]]
+|}];;

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -237,33 +237,33 @@ fun x d -> match x with | Some (y) -> y | None -> d]
 fun l -> Stdlib.List.map (fun x -> Stdlib.( * ) 2 x) l]
 |}];;
 
-(* [%quote fun (type a) (f : a -> a) (x : a) -> f (f x)];;
- * [%%expect {|
- * Uncaught exception: Stdlib.Exit
- *
- * |}];;
- *
- * [%quote fun x (type a) (f : a -> a * a) (g : int -> a) -> f (g x)];;
- * [%%expect {|
- * Uncaught exception: Stdlib.Exit
- *
- * |}];;
- *
- * [%quote fun (f : 'a. 'a -> 'a) -> f f];;
- * [%%expect {|
- * Uncaught exception: Not_found
- *
- * |}];; *)
+[%quote fun (type a) (f : a -> a) (x : a) -> f (f x)];;
+[%%expect {|
+- : (('_a -> '_a) -> '_a -> '_a) code = [%quote
+fun (type a) (f : a -> a) (x : a) -> f (f x)]
+|}];;
+
+[%quote fun x (type a) (f : a -> a * a) (g : int -> a) -> f (g x)];;
+[%%expect {|
+- : (int -> ('_a -> '_a * '_a) -> (int -> '_a) -> '_a * '_a) code = [%quote
+fun x (type a) (f : a -> (a) * (a)) (g : int -> a) -> f (g x)]
+|}];;
+
+[%quote fun (f : 'a. 'a -> 'a) -> f f];;
+[%%expect {|
+- : (('a. 'a -> 'a) -> '_weak30 -> '_weak30) code = [%quote
+fun (f : 'a . a -> a) -> f f]
+|}];;
 
 [%quote fun x -> fun x -> fun x -> 42];;
 [%%expect {|
-- : ('_weak30 -> '_weak31 -> '_weak32 -> int) code = [%quote
+- : ('_weak31 -> '_weak32 -> '_weak33 -> int) code = [%quote
 fun x -> fun x__1 -> fun x__2 -> 42]
 |}];;
 
 [%quote fun x -> fun x -> fun x__1 -> 42];;
 [%%expect {|
-- : ('_weak33 -> '_weak34 -> '_weak35 -> int) code = [%quote
+- : ('_weak34 -> '_weak35 -> '_weak36 -> int) code = [%quote
 fun x -> fun x__1 -> fun x__2 -> 42]
 |}];;
 
@@ -346,8 +346,7 @@ match (::) (1, ((::) (2, ((::) (3, []))))) with | (::) (x, xs) -> xs]
 [%%expect {|
 - : int option code = [%quote
 let (let+) = (fun x f -> Stdlib.Option.map f x) in
-                                                (let+) a = Some 42
-                                                in Stdlib.( * ) a 2]
+(let+) a = Some 42 in Stdlib.( * ) a 2]
 |}];;
 
 [%quote
@@ -359,16 +358,15 @@ let (let+) = (fun x f -> Stdlib.Option.map f x) in
 [%%expect {|
 - : int list code = [%quote
 let (let*) = (fun x f -> Stdlib.List.map f x) and
-                                              (and*) = Stdlib.List.combine
-in
+                                              (and*) = Stdlib.List.combine in
 (let*) a = (::) (1, ((::) (2, ((::) (3, [])))))
 (and*) b = (::) (10, ((::) (20, ((::) (30, []))))) in Stdlib.( + ) a b]
 |}];;
 
 [%quote fun (f: int -> int) (x: int) -> f x]
 [%%expect {|
-Uncaught exception: Stdlib.Exit
-
+- : ((int -> int) -> int -> int) code = [%quote
+fun (f : int -> int) (x : int) -> f x]
 |}];;
 
 [%quote let module M = Set.Make(Int) in M.singleton 100 |> M.elements];;
@@ -392,9 +390,8 @@ let module M = Stdlib.Set.Make(Stdlib.Int) in M.elements (M.singleton 100)]
 [%%expect {|
 - : int code = [%quote
 let x = (Stdlib.ref 0) in
-                       for i = 0 to 10 do
-                       (Stdlib.( := ) x (Stdlib.( + ) (Stdlib.( ! ) x) i))
-                       done; Stdlib.( ! ) x]
+for i = 0 to 10 do (Stdlib.( := ) x (Stdlib.( + ) (Stdlib.( ! ) x) i)) done;
+Stdlib.( ! ) x]
 |}];;
 
 [%quote
@@ -407,9 +404,8 @@ let x = (Stdlib.ref 0) in
 [%%expect {|
 - : int code = [%quote
 let x = (Stdlib.ref 0) in
-                       for i = 10 downto 0 do
-                       (Stdlib.( := ) x (Stdlib.( + ) (Stdlib.( ! ) x) i))
-                       done; Stdlib.( ! ) x]
+for i = 10 downto 0 do (Stdlib.( := ) x (Stdlib.( + ) (Stdlib.( ! ) x) i))
+done; Stdlib.( ! ) x]
 |}];;
 
 [%quote while true do () done];;
@@ -428,18 +424,10 @@ let x = (Stdlib.ref 0) in
 [%%expect {|
 - : int code = [%quote
 let f = (Stdlib.ref 1) and i = (Stdlib.ref 5) in
-                                              while
-                                              Stdlib.( > ) (Stdlib.( ! ) i) 0
-                                              do
-                                              (Stdlib.( := ) f
-                                                            (Stdlib.( * )
-                                                              (Stdlib.( ! ) i)
-                                                             (Stdlib.( ! ) f));
-                                               Stdlib.( := ) i
-                                                            (Stdlib.( - )
-                                                              (Stdlib.( ! ) i)
-                                                             1))
-                                              done; Stdlib.( ! ) f]
+while Stdlib.( > ) (Stdlib.( ! ) i) 0 do
+(Stdlib.( := ) f (Stdlib.( * ) (Stdlib.( ! ) i) (Stdlib.( ! ) f));
+ Stdlib.( := ) i (Stdlib.( - ) (Stdlib.( ! ) i) 1))
+done; Stdlib.( ! ) f]
 |}];;
 
 [%quote assert true];;
@@ -494,7 +482,7 @@ type rcd = { x : int; y : string; }
 
 [%quote {x = 42; y = "foo"}];;
 [%%expect {|
-- : rcd code = [%quote {x = 42; y = "foo"; }]
+- : rcd code = [%quote { x = 42; y = "foo"; }]
 |}];;
 
 type rcd_u = #{xu: int; yu: string};;
@@ -504,12 +492,12 @@ type rcd_u = #{ xu : int; yu : string; }
 
 [%quote fun () -> #{xu = 42; yu = "foo"}];;
 [%%expect {|
-- : (unit -> rcd_u) code = [%quote fun () -> {xu = 42; yu = "foo"; }]
+- : (unit -> rcd_u) code = [%quote fun () -> { xu = 42; yu = "foo"; }]
 |}];;
 
 [%quote fun r -> r.x];;
 [%%expect {|
-- : (rcd -> int) code = [%quote fun r -> r x]
+- : (rcd -> int) code = [%quote fun r -> r.x]
 |}];;
 
 [%quote fun {x; y} -> x];;
@@ -590,7 +578,7 @@ Stdlib.raise (Undefined_recursive_module ("M", 42, 100))]
 
 [%quote let module M = Option in M.map];;
 [%%expect {|
-- : (('_weak36 -> '_weak37) -> '_weak36 option -> '_weak37 option) code =
+- : (('_weak37 -> '_weak38) -> '_weak37 option -> '_weak38 option) code =
 [%quote let module M = Stdlib.Option in M.map]
 |}];;
 
@@ -599,7 +587,6 @@ Stdlib.raise (Undefined_recursive_module ("M", 42, 100))]
 - : (bool option -> bool) code = [%quote
 let module M = Stdlib.Option in function | None -> false | Some (x) -> x]
 |}];;
-
 
 [%quote fun () -> exclave_ Some 42];;
 [%%expect {|
@@ -624,24 +611,31 @@ module type S =
   sig type t type t2 val a : t val b : t -> int -> t val c : t -> int end
 |}];;
 
-(* [%quote fun (module M : S) x -> M.c (M.b M.a x)];;
- * [%%expect {|
- * Uncaught exception: Stdlib.Exit
- *
- * |}];;
- *
- * [%quote fun (module M : S with type t = string) x -> M.c (M.b M.a x)];;
- * [%%expect {|
- * Uncaught exception: Stdlib.Exit
- *
- * |}];;
- *
- * [%quote fun (module M : S with type t = string and type t2 = int) x -> M.c (M.b M.a x)];;
- * [%%expect {|
- * Uncaught exception: Stdlib.Exit
- *
- * |}];; *)
+[%quote fun (module _ : S) x -> 42];;
+[%%expect {|
+- : ((module S) -> '_weak39 -> int) code = [%quote
+fun (module _ : S) x -> 42]
+|}];;
 
+[%quote fun (module M : S) x -> M.c (M.b M.a x)];;
+[%%expect {|
+- : ((module S) -> int -> int) code = [%quote
+fun (module M : S) x -> M.c (M.b M.a x)]
+|}];;
+
+[%quote fun (module M : S with type t = string) x -> M.c (M.b M.a x)];;
+[%%expect {|
+- : ((module S with type t = string) -> int -> int) code = [%quote
+fun (module M : S with type t = string) x -> M.c (M.b M.a x)]
+|}];;
+
+[%quote fun (module M : S with type t = string and type t2 = int) x -> M.c (M.b M.a x)];;
+[%%expect {|
+- : ((module S with type t = string and type t2 = int) -> int -> int) code =
+[%quote
+fun (module M : S with type t = string and type t2 = int) x ->
+M.c (M.b M.a x)]
+|}];;
 
 [%quote let module M (N : S) = struct type t = N.t let x = N.a end in ()];;
 [%%expect {|
@@ -664,6 +658,11 @@ Uncaught exception: Misc.Fatal_error
 
 |}];;
 
+let x = [%quote 123] in [%quote !#(x)];;
+[%%expect {|
+- : int code = [%quote 123]
+|}];;
+
 [%quote let o = object method f = 1 end in o#f];;
 [%%expect {|
 >> Fatal error: Cannot quote object construction.
@@ -671,16 +670,14 @@ Uncaught exception: Misc.Fatal_error
 
 |}];;
 
-let x = 123 in [%quote x];;
+[%quote fun x -> !#[%quote x]];;
 [%%expect {|
->> Fatal error: Cannot quote free variable x
-Uncaught exception: Misc.Fatal_error
-
+- : ('_weak40 -> '_weak40) code = [%quote fun x -> x]
 |}];;
 
-let x = [%quote 123] in [%quote !#(x)];;
+[%quote !#[%quote 42]];;
 [%%expect {|
-- : int code = [%quote 123]
+- : int code = [%quote 42]
 |}];;
 
 [%quote !#[%quote "foo"]];;
@@ -688,10 +685,15 @@ let x = [%quote 123] in [%quote !#(x)];;
 - : string code = [%quote "foo"]
 |}];;
 
-(* [%quote fun x -> !#x];;
- * [%%expect {|
- * - : ('_weak39 code -> '_weak39) code = [%quote fun x -> !#x]
- * |}];; *)
+[%quote fun x -> !#((fun y -> [%quote !#y + !#y]) [%quote x])];;
+[%%expect {|
+- : (int -> int) code = [%quote fun x -> Stdlib.( + ) x x]
+|}];;
+
+[%quote !#((fun y -> [%quote !#y + !#y]) [%quote 2])];;
+[%%expect {|
+- : int code = [%quote Stdlib.( + ) 2 2]
+|}];;
 
 [%quote [%quote !#[%quote 123]]];;
 [%%expect {|
@@ -705,6 +707,6 @@ let x = [%quote "foo"] and y = [%quote "bar"] in [%quote !#x ^ !#y];;
 
 [%quote fun x -> [%quote [%quote !#x]]];;
 [%%expect {|
-- : ('_weak38 code -> '_weak38 code code) code = [%quote
+- : ('_weak41 code -> '_weak41 code code) code = [%quote
 fun x -> [%quote [%quote !#x]]]
 |}];;

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -1,0 +1,710 @@
+(* TEST
+ expect;
+*)
+
+[%quote 42];;
+[%%expect {|
+- : int code = [%quote 42]
+|}];;
+
+[%quote 3.14s];;
+[%%expect {|
+- : float32 code = [%quote 3.14s]
+|}];;
+
+[%quote 3.14];;
+[%%expect {|
+- : float code = [%quote 3.14]
+|}];;
+
+[%quote "foo"];;
+[%%expect {|
+- : string code = [%quote "foo"]
+|}];;
+
+[%quote {foo|bar|foo}];;
+[%%expect {|
+- : string code = [%quote {foo|bar|foo}]
+|}];;
+
+[%quote true];;
+[%%expect {|
+- : bool code = [%quote true]
+|}];;
+
+[%quote false];;
+[%%expect {|
+- : bool code = [%quote false]
+|}];;
+
+[%quote ()];;
+[%%expect {|
+- : unit code = [%quote ()]
+|}];;
+
+[%quote (1, 2)];;
+[%%expect {|
+- : (int * int) code = [%quote (1, 2)]
+|}];;
+
+[%quote (1, 2, 3)];;
+[%%expect {|
+- : (int * int * int) code = [%quote (1, 2, 3)]
+|}];;
+
+[%quote (~lab:"val", ~lab2:77, 30)];;
+[%%expect {|
+- : (lab:string * lab2:int * int) code = [%quote (~lab:"val", ~lab2:77, 30)]
+|}];;
+
+[%quote []];;
+[%%expect {|
+- : 'a list code = [%quote []]
+|}];;
+
+[%quote [1; 2; 3]];;
+[%%expect {|
+- : int list code = [%quote (::) (1, ((::) (2, ((::) (3, [])))))]
+|}];;
+
+[%quote [||]];;
+[%%expect {|
+- : '_weak1 array code = [%quote [||]]
+|}];;
+
+[%quote [| 1; 2; 3 |]];;
+[%%expect {|
+- : int array code = [%quote [|1; 2; 3|]]
+|}];;
+
+[%quote None];;
+[%%expect {|
+- : 'a option code = [%quote None]
+|}];;
+
+[%quote Some 111];;
+[%%expect {|
+- : int option code = [%quote Some 111]
+|}];;
+
+[%quote `A 42];;
+[%%expect {|
+- : [> `A of int ] code = [%quote `A 42]
+|}];;
+
+[%quote if true then `A 10 else `B ("foo", 42)];;
+[%%expect {|
+- : [> `A of int | `B of string * int ] code = [%quote
+if true then `A 10 else `B ("foo", 42)]
+|}];;
+
+[%quote function | `A x -> x | `B (_, foo) -> foo];;
+[%%expect {|
+- : (([< `A of '_weak3 | `B of '_weak4 * '_weak3 ] as '_weak2) -> '_weak3)
+    code
+= [%quote function | `A x -> x | `B (_, foo) -> foo]
+|}];;
+
+[%quote function | `A x -> x | `B (_, foo) -> foo | _ -> 42];;
+[%%expect {|
+- : (([> `A of int | `B of '_weak6 * int ] as '_weak5) -> int) code = [%quote
+function | `A x -> x | `B (_, foo) -> foo | _ -> 42]
+|}];;
+
+[%quote List.map];;
+[%%expect {|
+- : (('_weak7 -> '_weak8) -> '_weak7 list -> '_weak8 list) code = [%quote
+Stdlib.List.map]
+|}];;
+
+[%quote fun x -> 42];;
+[%%expect {|
+- : ('_weak9 -> int) code = [%quote fun x -> 42]
+|}];;
+
+[%quote fun _ -> 42];;
+[%%expect {|
+- : ('_weak10 -> int) code = [%quote fun _ -> 42]
+|}];;
+
+[%quote fun x y -> x];;
+[%%expect {|
+- : ('_weak11 -> '_weak12 -> '_weak11) code = [%quote fun x y -> x]
+|}];;
+
+[%quote fun f x y -> f ~a:y ~b:x];;
+[%%expect {|
+- : ((a:'_weak13 -> b:'_weak14 -> '_weak15) ->
+     '_weak14 -> '_weak13 -> '_weak15)
+    code
+= [%quote fun f x y -> f ~a:y ~b:x]
+|}];;
+
+[%quote fun f x y -> f ?a:y ?b:x];;
+[%%expect {|
+- : ((?a:'_weak16 -> ?b:'_weak17 -> '_weak18) ->
+     '_weak17 option -> '_weak16 option -> '_weak18)
+    code
+= [%quote fun f x y -> f ?a:y ?b:x]
+|}];;
+
+[%quote fun (x, y) -> x + y];;
+[%%expect {|
+- : (int * int -> int) code = [%quote fun (x, y) -> Stdlib.( + ) x y]
+|}];;
+
+[%quote function | _ -> 12];;
+[%%expect {|
+- : ('_weak19 -> int) code = [%quote function | _ -> 12]
+|}];;
+
+[%quote function | x -> x];;
+[%%expect {|
+- : ('_weak20 -> '_weak20) code = [%quote function | x -> x]
+|}];;
+
+[%quote function | 42 -> true | _ -> false];;
+[%%expect {|
+- : (int -> bool) code = [%quote function | 42 -> true | _ -> false]
+|}];;
+
+[%quote function | "foo" -> true | _ -> false];;
+[%%expect {|
+- : (string -> bool) code = [%quote function | "foo" -> true | _ -> false]
+|}];;
+
+[%quote function | (x, y) as z -> (x, y, z)];;
+[%%expect {|
+- : ('_weak21 * '_weak22 -> '_weak21 * '_weak22 * ('_weak21 * '_weak22)) code
+= [%quote function | (x, y) as z -> (x, y, z)]
+|}];;
+
+[%quote function | (x, y) -> x + y];;
+[%%expect {|
+- : (int * int -> int) code = [%quote function | (x, y) -> Stdlib.( + ) x y]
+|}];;
+
+[%quote function | (x, y, z) -> x + y - z];;
+[%%expect {|
+- : (int * int * int -> int) code = [%quote
+function | (x, y, z) -> Stdlib.( - ) (Stdlib.( + ) x y) z]
+|}];;
+
+[%quote function | `A -> true | `B -> false];;
+[%%expect {|
+- : (([< `A | `B ] as '_weak23) -> bool) code = [%quote
+function | `A -> true | `B -> false]
+|}];;
+
+[%quote function | `Foo x -> x | `Bar (y, z) -> y + z | `Baz -> 0];;
+[%%expect {|
+- : (([< `Bar of int * int | `Baz | `Foo of int ] as '_weak24) -> int) code =
+[%quote function | `Foo x -> x | `Bar (y, z) -> Stdlib.( + ) y z | `Baz -> 0]
+|}];;
+
+[%quote function | lazy x as l -> Lazy.force l];;
+[%%expect {|
+- : ('_weak25 Lazy.t -> '_weak25) code = [%quote
+function | lazy (x) as l -> Stdlib.Lazy.force l]
+|}];;
+
+[%quote fun f x d -> match f x with | res -> res | exception e -> d];;
+[%%expect {|
+- : (('_weak26 -> '_weak27) -> '_weak26 -> '_weak27 -> '_weak27) code =
+[%quote fun f x d -> match f x with | res -> res | (exception e) -> d]
+|}];;
+
+[%quote function | Some x -> x | None -> 0];;
+[%%expect {|
+- : (int option -> int) code = [%quote function | Some (x) -> x | None -> 0]
+|}];;
+
+[%quote function | [] -> false | x::xs -> true];;
+[%%expect {|
+- : ('_weak28 list -> bool) code = [%quote
+function | [] -> false | (::) (x, xs) -> true]
+|}];;
+
+[%quote fun x d -> match x with | Some y -> y | None -> d];;
+[%%expect {|
+- : ('_weak29 option -> '_weak29 -> '_weak29) code = [%quote
+fun x d -> match x with | Some (y) -> y | None -> d]
+|}];;
+
+[%quote fun l -> List.map (fun x -> 2 * x) l];;
+[%%expect {|
+- : (int list -> int list) code = [%quote
+fun l -> Stdlib.List.map (fun x -> Stdlib.( * ) 2 x) l]
+|}];;
+
+(* [%quote fun (type a) (f : a -> a) (x : a) -> f (f x)];;
+ * [%%expect {|
+ * Uncaught exception: Stdlib.Exit
+ *
+ * |}];;
+ *
+ * [%quote fun x (type a) (f : a -> a * a) (g : int -> a) -> f (g x)];;
+ * [%%expect {|
+ * Uncaught exception: Stdlib.Exit
+ *
+ * |}];;
+ *
+ * [%quote fun (f : 'a. 'a -> 'a) -> f f];;
+ * [%%expect {|
+ * Uncaught exception: Not_found
+ *
+ * |}];; *)
+
+[%quote fun x -> fun x -> fun x -> 42];;
+[%%expect {|
+- : ('_weak30 -> '_weak31 -> '_weak32 -> int) code = [%quote
+fun x -> fun x__1 -> fun x__2 -> 42]
+|}];;
+
+[%quote fun x -> fun x -> fun x__1 -> 42];;
+[%%expect {|
+- : ('_weak33 -> '_weak34 -> '_weak35 -> int) code = [%quote
+fun x -> fun x__1 -> fun x__2 -> 42]
+|}];;
+
+[%quote let z = 10 in z];;
+[%%expect {|
+- : int code = [%quote let z = 10 in z]
+|}];;
+
+[%quote let (x, y) = (42, 100) in x + y];;
+[%%expect {|
+- : int code = [%quote let (x, y) = (42, 100) in Stdlib.( + ) x y]
+|}];;
+
+[%quote let Some x = Some "foo" in x];;
+[%%expect {|
+Line 1, characters 8-36:
+1 | [%quote let Some x = Some "foo" in x];;
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+None
+
+- : string code = [%quote match Some "foo" with | Some (x) -> x]
+|}];;
+
+[%quote let x::xs = [1; 2; 3] in x];;
+[%%expect {|
+Line 1, characters 8-34:
+1 | [%quote let x::xs = [1; 2; 3] in x];;
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+[]
+
+- : int code = [%quote
+match (::) (1, ((::) (2, ((::) (3, []))))) with | (::) (x, xs) -> x]
+|}];;
+
+[%quote let x::xs = [1; 2; 3] in xs];;
+[%%expect {|
+Line 1, characters 8-35:
+1 | [%quote let x::xs = [1; 2; 3] in xs];;
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+Here is an example of a case that is not matched:
+[]
+
+- : int list code = [%quote
+match (::) (1, ((::) (2, ((::) (3, []))))) with | (::) (x, xs) -> xs]
+|}];;
+
+[%quote let foo x = (x, x) in foo 42];;
+[%%expect {|
+- : (int * int) code = [%quote let foo = (fun x -> (x, x)) in foo 42]
+|}];;
+
+[%quote let foo = 50 and bar = 15 in foo + bar];;
+[%%expect {|
+- : int code = [%quote let foo = 50 and bar = 15 in Stdlib.( + ) foo bar]
+|}];;
+
+[%quote let x = 42 in let x = x in x];;
+[%%expect {|
+- : int code = [%quote let x = 42 in let x__1 = x in x__1]
+|}];;
+
+[%quote
+  let (let+) x f = f x in
+  let+ a = 42 in a
+];;
+[%%expect {|
+- : int code = [%quote let (let+) = (fun x f -> f x) in (let+) a = 42 in a]
+|}];;
+
+[%quote
+  let (let+) x f = Option.map f x in
+  let+ a = Some 42
+  in a * 2
+];;
+[%%expect {|
+- : int option code = [%quote
+let (let+) = (fun x f -> Stdlib.Option.map f x) in
+                                                (let+) a = Some 42
+                                                in Stdlib.( * ) a 2]
+|}];;
+
+[%quote
+  let (let*) x f = List.map f x and (and*) = List.combine in
+  let* a = [1; 2; 3]
+  and* b = [10; 20; 30]
+  in a + b
+];;
+[%%expect {|
+- : int list code = [%quote
+let (let*) = (fun x f -> Stdlib.List.map f x) and
+                                              (and*) = Stdlib.List.combine
+in
+(let*) a = (::) (1, ((::) (2, ((::) (3, [])))))
+(and*) b = (::) (10, ((::) (20, ((::) (30, []))))) in Stdlib.( + ) a b]
+|}];;
+
+[%quote fun (f: int -> int) (x: int) -> f x]
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+
+[%quote let module M = Set.Make(Int) in M.singleton 100 |> M.elements];;
+[%%expect {|
+- : Int.t list code = [%quote
+let module M = Stdlib.Set.Make(Stdlib.Int) in M.elements (M.singleton 100)]
+|}];;
+
+[%quote ref 42];;
+[%%expect {|
+- : int ref code = [%quote Stdlib.ref 42]
+|}];;
+
+[%quote
+  let x = ref 0 in
+  for i = 0 to 10 do
+    x := !x + i
+  done;
+  !x
+];;
+[%%expect {|
+- : int code = [%quote
+let x = (Stdlib.ref 0) in
+                       for i = 0 to 10 do
+                       (Stdlib.( := ) x (Stdlib.( + ) (Stdlib.( ! ) x) i))
+                       done; Stdlib.( ! ) x]
+|}];;
+
+[%quote
+  let x = ref 0 in
+  for i = 10 downto 0 do
+    x := !x + i
+  done;
+  !x
+];;
+[%%expect {|
+- : int code = [%quote
+let x = (Stdlib.ref 0) in
+                       for i = 10 downto 0 do
+                       (Stdlib.( := ) x (Stdlib.( + ) (Stdlib.( ! ) x) i))
+                       done; Stdlib.( ! ) x]
+|}];;
+
+[%quote while true do () done];;
+[%%expect {|
+- : 'a code = [%quote while true do () done]
+|}];;
+
+[%quote
+  let f = ref 1 and i = ref 5 in
+  while !i > 0 do
+    f := !i * !f;
+    i := !i - 1
+  done;
+  !f
+];;
+[%%expect {|
+- : int code = [%quote
+let f = (Stdlib.ref 1) and i = (Stdlib.ref 5) in
+                                              while
+                                              Stdlib.( > ) (Stdlib.( ! ) i) 0
+                                              do
+                                              (Stdlib.( := ) f
+                                                            (Stdlib.( * )
+                                                              (Stdlib.( ! ) i)
+                                                             (Stdlib.( ! ) f));
+                                               Stdlib.( := ) i
+                                                            (Stdlib.( - )
+                                                              (Stdlib.( ! ) i)
+                                                             1))
+                                              done; Stdlib.( ! ) f]
+|}];;
+
+[%quote assert true];;
+[%%expect {|
+- : unit code = [%quote assert true]
+|}];;
+
+[%quote assert false];;
+[%%expect {|
+- : 'a code = [%quote assert false]
+|}];;
+
+[%quote lazy 42];;
+[%%expect {|
+- : int lazy_t code = [%quote lazy 42]
+|}];;
+
+[%quote fun () -> #25n];;
+[%%expect {|
+- : (unit -> nativeint#) code = [%quote fun () -> #25n]
+|}];;
+
+[%quote fun () -> #25l];;
+[%%expect {|
+- : (unit -> int32#) code = [%quote fun () -> #25l]
+|}];;
+
+[%quote fun () -> #25L];;
+[%%expect {|
+- : (unit -> int64#) code = [%quote fun () -> #25L]
+|}];;
+
+[%quote fun () -> #6.0];;
+[%%expect {|
+- : (unit -> float#) code = [%quote fun () -> #6.0]
+|}];;
+
+[%quote fun () -> #6.0s];;
+[%%expect {|
+- : (unit -> float32#) code = [%quote fun () -> #6.0s]
+|}];;
+
+[%quote fun () -> #(1, 2, 3)];;
+[%%expect {|
+- : (unit -> #(int * int * int)) code = [%quote fun () -> #(1, 2, 3)]
+|}];;
+
+type rcd = {x: int; y: string};;
+[%%expect {|
+type rcd = { x : int; y : string; }
+|}];;
+
+[%quote {x = 42; y = "foo"}];;
+[%%expect {|
+- : rcd code = [%quote {x = 42; y = "foo"; }]
+|}];;
+
+type rcd_u = #{xu: int; yu: string};;
+[%%expect {|
+type rcd_u = #{ xu : int; yu : string; }
+|}];;
+
+[%quote fun () -> #{xu = 42; yu = "foo"}];;
+[%%expect {|
+- : (unit -> rcd_u) code = [%quote fun () -> {xu = 42; yu = "foo"; }]
+|}];;
+
+[%quote fun r -> r.x];;
+[%%expect {|
+- : (rcd -> int) code = [%quote fun r -> r x]
+|}];;
+
+[%quote fun {x; y} -> x];;
+[%%expect {|
+- : (rcd -> int) code = [%quote fun {x=x; y=y; } -> x]
+|}];;
+
+[%quote raise (Match_failure ("foo", 42, 100))];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise (Match_failure ("foo", 42, 100))]
+|}];;
+
+[%quote raise Out_of_memory];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise Out_of_memory]
+|}];;
+
+[%quote raise (Invalid_argument "arg")];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise (Invalid_argument "arg")]
+|}];;
+
+[%quote raise (Failure "fail")];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise (Failure "fail")]
+|}];;
+
+[%quote raise Not_found];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise Not_found]
+|}];;
+
+[%quote raise (Sys_error "err")];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise (Sys_error "err")]
+|}];;
+
+[%quote raise End_of_file];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise End_of_file]
+|}];;
+
+[%quote raise Division_by_zero];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise Division_by_zero]
+|}];;
+
+[%quote raise Stack_overflow];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise Stack_overflow]
+|}];;
+
+[%quote raise Sys_blocked_io];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise Sys_blocked_io]
+|}];;
+
+[%quote raise (Assert_failure ("assert", 42, 100))];;
+[%%expect {|
+- : 'a code = [%quote Stdlib.raise (Assert_failure ("assert", 42, 100))]
+|}];;
+
+[%quote raise (Undefined_recursive_module ("M", 42, 100))];;
+[%%expect {|
+- : 'a code = [%quote
+Stdlib.raise (Undefined_recursive_module ("M", 42, 100))]
+|}];;
+
+[%quote let exception E in ()];;
+[%%expect {|
+- : unit code = [%quote let exception E in ()]
+|}];;
+
+[%quote let exception E in raise E];;
+[%%expect {|
+- : 'a code = [%quote let exception E in Stdlib.raise E]
+|}];;
+
+[%quote let module M = Option in M.map];;
+[%%expect {|
+- : (('_weak36 -> '_weak37) -> '_weak36 option -> '_weak37 option) code =
+[%quote let module M = Stdlib.Option in M.map]
+|}];;
+
+[%quote let module M = Option in function | M.None -> false | M.Some x -> x];;
+[%%expect {|
+- : (bool option -> bool) code = [%quote
+let module M = Stdlib.Option in function | None -> false | Some (x) -> x]
+|}];;
+
+
+[%quote fun () -> exclave_ Some 42];;
+[%%expect {|
+- : (unit -> local_ int option) code = [%quote fun () -> exclave_ Some 42]
+|}];;
+
+[%quote fun () -> exclave_ stack_ (Some 42)];;
+[%%expect {|
+- : (unit -> local_ int option) code = [%quote
+fun () -> exclave_ stack_ (Some 42)]
+|}];;
+
+module type S = sig
+  type t
+  type t2
+  val a : t
+  val b : t -> int -> t
+  val c : t -> int
+end;;
+[%%expect {|
+module type S =
+  sig type t type t2 val a : t val b : t -> int -> t val c : t -> int end
+|}];;
+
+(* [%quote fun (module M : S) x -> M.c (M.b M.a x)];;
+ * [%%expect {|
+ * Uncaught exception: Stdlib.Exit
+ *
+ * |}];;
+ *
+ * [%quote fun (module M : S with type t = string) x -> M.c (M.b M.a x)];;
+ * [%%expect {|
+ * Uncaught exception: Stdlib.Exit
+ *
+ * |}];;
+ *
+ * [%quote fun (module M : S with type t = string and type t2 = int) x -> M.c (M.b M.a x)];;
+ * [%%expect {|
+ * Uncaught exception: Stdlib.Exit
+ *
+ * |}];; *)
+
+
+[%quote let module M (N : S) = struct type t = N.t let x = N.a end in ()];;
+[%%expect {|
+>> Fatal error: Cannot quote struct..end blocks
+Uncaught exception: Misc.Fatal_error
+
+|}];;
+
+[%quote let module M = struct type t = int let x = 42 end in M.x];;
+[%%expect {|
+>> Fatal error: Cannot quote struct..end blocks
+Uncaught exception: Misc.Fatal_error
+
+|}];;
+
+let x = 42 in [%quote x];;
+[%%expect {|
+>> Fatal error: Cannot quote free variable x
+Uncaught exception: Misc.Fatal_error
+
+|}];;
+
+[%quote let o = object method f = 1 end in o#f];;
+[%%expect {|
+>> Fatal error: Cannot quote object construction.
+Uncaught exception: Misc.Fatal_error
+
+|}];;
+
+let x = 123 in [%quote x];;
+[%%expect {|
+>> Fatal error: Cannot quote free variable x
+Uncaught exception: Misc.Fatal_error
+
+|}];;
+
+let x = [%quote 123] in [%quote !#(x)];;
+[%%expect {|
+- : int code = [%quote 123]
+|}];;
+
+[%quote !#[%quote "foo"]];;
+[%%expect {|
+- : string code = [%quote "foo"]
+|}];;
+
+(* [%quote fun x -> !#x];;
+ * [%%expect {|
+ * - : ('_weak39 code -> '_weak39) code = [%quote fun x -> !#x]
+ * |}];; *)
+
+[%quote [%quote !#[%quote 123]]];;
+[%%expect {|
+- : int code code = [%quote [%quote !#[%quote 123]]]
+|}];;
+
+let x = [%quote "foo"] and y = [%quote "bar"] in [%quote !#x ^ !#y];;
+[%%expect {|
+- : string code = [%quote Stdlib.( ^ ) "foo" "bar"]
+|}];;
+
+[%quote fun x -> [%quote [%quote !#x]]];;
+[%%expect {|
+- : ('_weak38 code -> '_weak38 code code) code = [%quote
+fun x -> [%quote [%quote !#x]]]
+|}];;

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -4,139 +4,139 @@
 
 [%quote 42];;
 [%%expect {|
-- : int code = << 42 >>
+- : int expr = << 42 >>
 |}];;
 
 [%quote 3.14s];;
 [%%expect {|
-- : float32 code = << 3.14s >>
+- : float32 expr = << 3.14s >>
 |}];;
 
 [%quote 3.14];;
 [%%expect {|
-- : float code = << 3.14 >>
+- : float expr = << 3.14 >>
 |}];;
 
 [%quote "foo"];;
 [%%expect {|
-- : string code = << "foo" >>
+- : string expr = << "foo" >>
 |}];;
 
 [%quote {foo|bar|foo}];;
 [%%expect {|
-- : string code = << {foo|bar|foo} >>
+- : string expr = << {foo|bar|foo} >>
 |}];;
 
 [%quote true];;
 [%%expect {|
-- : bool code = << true >>
+- : bool expr = << true >>
 |}];;
 
 [%quote false];;
 [%%expect {|
-- : bool code = << false >>
+- : bool expr = << false >>
 |}];;
 
 [%quote ()];;
 [%%expect {|
-- : unit code = << () >>
+- : unit expr = << () >>
 |}];;
 
 [%quote (1, 2)];;
 [%%expect {|
-- : (int * int) code = << (1, 2) >>
+- : (int * int) expr = << (1, 2) >>
 |}];;
 
 [%quote (1, 2, 3)];;
 [%%expect {|
-- : (int * int * int) code = << (1, 2, 3) >>
+- : (int * int * int) expr = << (1, 2, 3) >>
 |}];;
 
 [%quote (~lab:"val", ~lab2:77, 30)];;
 [%%expect {|
-- : (lab:string * lab2:int * int) code = << (~lab:"val", ~lab2:77, 30) >>
+- : (lab:string * lab2:int * int) expr = << (~lab:"val", ~lab2:77, 30) >>
 |}];;
 
 [%quote []];;
 [%%expect {|
-- : 'a list code = << [] >>
+- : 'a list expr = << [] >>
 |}];;
 
 [%quote [1; 2; 3]];;
 [%%expect {|
-- : int list code = << (::) (1, ((::) (2, ((::) (3, []))))) >>
+- : int list expr = << (::) (1, ((::) (2, ((::) (3, []))))) >>
 |}];;
 
 [%quote [||]];;
 [%%expect {|
-- : '_weak1 array code = << [||] >>
+- : '_weak1 array expr = << [||] >>
 |}];;
 
 [%quote [| 1; 2; 3 |]];;
 [%%expect {|
-- : int array code = << [|1; 2; 3|] >>
+- : int array expr = << [|1; 2; 3|] >>
 |}];;
 
 [%quote None];;
 [%%expect {|
-- : 'a option code = << None >>
+- : 'a option expr = << None >>
 |}];;
 
 [%quote Some 111];;
 [%%expect {|
-- : int option code = << Some 111 >>
+- : int option expr = << Some 111 >>
 |}];;
 
 [%quote `A 42];;
 [%%expect {|
-- : [> `A of int ] code = << `A 42 >>
+- : [> `A of int ] expr = << `A 42 >>
 |}];;
 
 [%quote if true then `A 10 else `B ("foo", 42)];;
 [%%expect {|
-- : [> `A of int | `B of string * int ] code =
+- : [> `A of int | `B of string * int ] expr =
 << if true then `A 10 else `B ("foo", 42) >>
 |}];;
 
 [%quote function | `A x -> x | `B (_, foo) -> foo];;
 [%%expect {|
 - : (([< `A of '_weak3 | `B of '_weak4 * '_weak3 ] as '_weak2) -> '_weak3)
-    code
+    expr
 = << function | `A x -> x | `B (_, foo) -> foo >>
 |}];;
 
 [%quote function | `A x -> x | `B (_, foo) -> foo | _ -> 42];;
 [%%expect {|
-- : (([> `A of int | `B of '_weak6 * int ] as '_weak5) -> int) code =
+- : (([> `A of int | `B of '_weak6 * int ] as '_weak5) -> int) expr =
 << function | `A x -> x | `B (_, foo) -> foo | _ -> 42 >>
 |}];;
 
 [%quote List.map];;
 [%%expect {|
-- : (('_weak7 -> '_weak8) -> '_weak7 list -> '_weak8 list) code =
+- : (('_weak7 -> '_weak8) -> '_weak7 list -> '_weak8 list) expr =
 << Stdlib.List.map >>
 |}];;
 
 [%quote fun x -> 42];;
 [%%expect {|
-- : ('_weak9 -> int) code = << fun x -> 42 >>
+- : ('_weak9 -> int) expr = << fun x -> 42 >>
 |}];;
 
 [%quote fun _ -> 42];;
 [%%expect {|
-- : ('_weak10 -> int) code = << fun _ -> 42 >>
+- : ('_weak10 -> int) expr = << fun _ -> 42 >>
 |}];;
 
 [%quote fun x y -> x];;
 [%%expect {|
-- : ('_weak11 -> '_weak12 -> '_weak11) code = << fun x y -> x >>
+- : ('_weak11 -> '_weak12 -> '_weak11) expr = << fun x y -> x >>
 |}];;
 
 [%quote fun f x y -> f ~a:y ~b:x];;
 [%%expect {|
 - : ((a:'_weak13 -> b:'_weak14 -> '_weak15) ->
      '_weak14 -> '_weak13 -> '_weak15)
-    code
+    expr
 = << fun f x y -> f ~a:y ~b:x >>
 |}];;
 
@@ -144,136 +144,136 @@
 [%%expect {|
 - : ((?a:'_weak16 -> ?b:'_weak17 -> '_weak18) ->
      '_weak17 option -> '_weak16 option -> '_weak18)
-    code
+    expr
 = << fun f x y -> f ?a:y ?b:x >>
 |}];;
 
 [%quote fun (x, y) -> x + y];;
 [%%expect {|
-- : (int * int -> int) code = << fun (x, y) -> x + y >>
+- : (int * int -> int) expr = << fun (x, y) -> x + y >>
 |}];;
 
 [%quote function | _ -> 12];;
 [%%expect {|
-- : ('_weak19 -> int) code = << function | _ -> 12 >>
+- : ('_weak19 -> int) expr = << function | _ -> 12 >>
 |}];;
 
 [%quote function | x -> x];;
 [%%expect {|
-- : ('_weak20 -> '_weak20) code = << function | x -> x >>
+- : ('_weak20 -> '_weak20) expr = << function | x -> x >>
 |}];;
 
 [%quote function | 42 -> true | _ -> false];;
 [%%expect {|
-- : (int -> bool) code = << function | 42 -> true | _ -> false >>
+- : (int -> bool) expr = << function | 42 -> true | _ -> false >>
 |}];;
 
 [%quote function | "foo" -> true | _ -> false];;
 [%%expect {|
-- : (string -> bool) code = << function | "foo" -> true | _ -> false >>
+- : (string -> bool) expr = << function | "foo" -> true | _ -> false >>
 |}];;
 
 [%quote function | (x, y) as z -> (x, y, z)];;
 [%%expect {|
-- : ('_weak21 * '_weak22 -> '_weak21 * '_weak22 * ('_weak21 * '_weak22)) code
+- : ('_weak21 * '_weak22 -> '_weak21 * '_weak22 * ('_weak21 * '_weak22)) expr
 = << function | (x, y) as z -> (x, y, z) >>
 |}];;
 
 [%quote function | (x, y) -> x + y];;
 [%%expect {|
-- : (int * int -> int) code = << function | (x, y) -> x + y >>
+- : (int * int -> int) expr = << function | (x, y) -> x + y >>
 |}];;
 
 [%quote function | (x, y, z) -> x + y - z];;
 [%%expect {|
-- : (int * int * int -> int) code = << function | (x, y, z) -> (x + y) - z >>
+- : (int * int * int -> int) expr = << function | (x, y, z) -> (x + y) - z >>
 |}];;
 
 [%quote function | `A -> true | `B -> false];;
 [%%expect {|
-- : (([< `A | `B ] as '_weak23) -> bool) code =
+- : (([< `A | `B ] as '_weak23) -> bool) expr =
 << function | `A -> true | `B -> false >>
 |}];;
 
 [%quote function | `Foo x -> x | `Bar (y, z) -> y + z | `Baz -> 0];;
 [%%expect {|
-- : (([< `Bar of int * int | `Baz | `Foo of int ] as '_weak24) -> int) code =
+- : (([< `Bar of int * int | `Baz | `Foo of int ] as '_weak24) -> int) expr =
 << function | `Foo x -> x | `Bar (y, z) -> y + z | `Baz -> 0 >>
 |}];;
 
 [%quote function | lazy x as l -> Lazy.force l];;
 [%%expect {|
-- : ('_weak25 Lazy.t -> '_weak25) code =
+- : ('_weak25 Lazy.t -> '_weak25) expr =
 << function | lazy (x) as l -> Stdlib.Lazy.force l >>
 |}];;
 
 [%quote fun f x d -> match f x with | res -> res | exception e -> d];;
 [%%expect {|
-- : (('_weak26 -> '_weak27) -> '_weak26 -> '_weak27 -> '_weak27) code =
+- : (('_weak26 -> '_weak27) -> '_weak26 -> '_weak27 -> '_weak27) expr =
 << fun f x d -> match f x with | res -> res | (exception e) -> d >>
 |}];;
 
 [%quote function | Some x -> x | None -> 0];;
 [%%expect {|
-- : (int option -> int) code = << function | Some (x) -> x | None -> 0 >>
+- : (int option -> int) expr = << function | Some (x) -> x | None -> 0 >>
 |}];;
 
 [%quote function | [] -> false | x::xs -> true];;
 [%%expect {|
-- : ('_weak28 list -> bool) code =
+- : ('_weak28 list -> bool) expr =
 << function | [] -> false | (::) (x, xs) -> true >>
 |}];;
 
 [%quote fun x d -> match x with | Some y -> y | None -> d];;
 [%%expect {|
-- : ('_weak29 option -> '_weak29 -> '_weak29) code =
+- : ('_weak29 option -> '_weak29 -> '_weak29) expr =
 << fun x d -> match x with | Some (y) -> y | None -> d >>
 |}];;
 
 [%quote fun l -> List.map (fun x -> 2 * x) l];;
 [%%expect {|
-- : (int list -> int list) code =
+- : (int list -> int list) expr =
 << fun l -> Stdlib.List.map (fun x -> 2 * x) l >>
 |}];;
 
 [%quote fun (type a) (f : a -> a) (x : a) -> f (f x)];;
 [%%expect {|
-- : (('_a -> '_a) -> '_a -> '_a) code =
+- : (('_a -> '_a) -> '_a -> '_a) expr =
 << fun (type a) (f : a -> a) (x : a) -> f (f x) >>
 |}];;
 
 [%quote fun x (type a) (f : a -> a * a) (g : int -> a) -> f (g x)];;
 [%%expect {|
-- : (int -> ('_a -> '_a * '_a) -> (int -> '_a) -> '_a * '_a) code =
+- : (int -> ('_a -> '_a * '_a) -> (int -> '_a) -> '_a * '_a) expr =
 << fun x (type a) (f : a -> (a) * (a)) (g : int -> a) -> f (g x) >>
 |}];;
 
 [%quote fun (f : 'a. 'a -> 'a) -> f f];;
 [%%expect {|
-- : (('a. 'a -> 'a) -> '_weak30 -> '_weak30) code =
+- : (('a. 'a -> 'a) -> '_weak30 -> '_weak30) expr =
 << fun (f : 'a . a -> a) -> f f >>
 |}];;
 
 [%quote fun x -> fun x -> fun x -> 42];;
 [%%expect {|
-- : ('_weak31 -> '_weak32 -> '_weak33 -> int) code =
+- : ('_weak31 -> '_weak32 -> '_weak33 -> int) expr =
 << fun x -> fun x__1 -> fun x__2 -> 42 >>
 |}];;
 
 [%quote fun x -> fun x -> fun x__1 -> 42];;
 [%%expect {|
-- : ('_weak34 -> '_weak35 -> '_weak36 -> int) code =
+- : ('_weak34 -> '_weak35 -> '_weak36 -> int) expr =
 << fun x -> fun x__1 -> fun x__2 -> 42 >>
 |}];;
 
 [%quote let z = 10 in z];;
 [%%expect {|
-- : int code = << let z = 10 in z >>
+- : int expr = << let z = 10 in z >>
 |}];;
 
 [%quote let (x, y) = (42, 100) in x + y];;
 [%%expect {|
-- : int code = << let (x, y) = (42, 100) in x + y >>
+- : int expr = << let (x, y) = (42, 100) in x + y >>
 |}];;
 
 [%quote let Some x = Some "foo" in x];;
@@ -285,7 +285,7 @@ Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 None
 
-- : string code = << match Some "foo" with | Some (x) -> x >>
+- : string expr = << match Some "foo" with | Some (x) -> x >>
 |}];;
 
 [%quote let x::xs = [1; 2; 3] in x];;
@@ -297,7 +297,7 @@ Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 []
 
-- : int code =
+- : int expr =
 << match (::) (1, ((::) (2, ((::) (3, []))))) with | (::) (x, xs) -> x >>
 |}];;
 
@@ -310,23 +310,23 @@ Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 []
 
-- : int list code =
+- : int list expr =
 << match (::) (1, ((::) (2, ((::) (3, []))))) with | (::) (x, xs) -> xs >>
 |}];;
 
 [%quote let foo x = (x, x) in foo 42];;
 [%%expect {|
-- : (int * int) code = << let foo = (fun x -> (x, x)) in foo 42 >>
+- : (int * int) expr = << let foo = (fun x -> (x, x)) in foo 42 >>
 |}];;
 
 [%quote let foo = 50 and bar = 15 in foo + bar];;
 [%%expect {|
-- : int code = << let foo = 50 and bar = 15 in foo + bar >>
+- : int expr = << let foo = 50 and bar = 15 in foo + bar >>
 |}];;
 
 [%quote let x = 42 in let x = x in x];;
 [%%expect {|
-- : int code = << let x = 42 in let x__1 = x in x__1 >>
+- : int expr = << let x = 42 in let x__1 = x in x__1 >>
 |}];;
 
 [%quote
@@ -334,7 +334,7 @@ Here is an example of a case that is not matched:
   let+ a = 42 in a
 ];;
 [%%expect {|
-- : int code = << let (let+) = (fun x f -> f x) in let+ a = 42 in a >>
+- : int expr = << let (let+) = (fun x f -> f x) in let+ a = 42 in a >>
 |}];;
 
 [%quote
@@ -343,7 +343,7 @@ Here is an example of a case that is not matched:
   in a * 2
 ];;
 [%%expect {|
-- : int option code =
+- : int option expr =
 <<
   let (let+) = (fun x f -> Stdlib.Option.map f x) in
     let+ a = Some 42 in a * 2
@@ -357,7 +357,7 @@ Here is an example of a case that is not matched:
   in a + b
 ];;
 [%%expect {|
-- : int list code =
+- : int list expr =
 <<
   let (let*) = (fun x f -> Stdlib.List.map f x)
   and (and*) = Stdlib.List.combine in
@@ -367,20 +367,20 @@ Here is an example of a case that is not matched:
 
 [%quote fun (f: int -> int) (x: int) -> f x]
 [%%expect {|
-- : ((int -> int) -> int -> int) code =
+- : ((int -> int) -> int -> int) expr =
 << fun (f : int -> int) (x : int) -> f x >>
 |}];;
 
 [%quote let module M = Set.Make(Int) in M.singleton 100 |> M.elements];;
 [%%expect {|
-- : Int.t list code =
+- : Int.t list expr =
 << let module M = Stdlib.Set.Make(Stdlib.Int) in M.elements (M.singleton 100)
 >>
 |}];;
 
 [%quote ref 42];;
 [%%expect {|
-- : int ref code = << Stdlib.ref 42 >>
+- : int ref expr = << Stdlib.ref 42 >>
 |}];;
 
 [%quote
@@ -391,7 +391,7 @@ Here is an example of a case that is not matched:
   !x
 ];;
 [%%expect {|
-- : int code =
+- : int expr =
 << let x = (Stdlib.ref 0) in for i = 0 to 10 do (x := ((! x) + i)) done; ! x
 >>
 |}];;
@@ -404,7 +404,7 @@ Here is an example of a case that is not matched:
   !x
 ];;
 [%%expect {|
-- : int code =
+- : int expr =
 <<
   let x = (Stdlib.ref 0) in for i = 10 downto 0 do (x := ((! x) + i)) done;
     ! x
@@ -413,7 +413,7 @@ Here is an example of a case that is not matched:
 
 [%quote while true do () done];;
 [%%expect {|
-- : 'a code = << while true do  () done >>
+- : 'a expr = << while true do  () done >>
 |}];;
 
 [%quote
@@ -425,7 +425,7 @@ Here is an example of a case that is not matched:
   !f
 ];;
 [%%expect {|
-- : int code =
+- : int expr =
 <<
   let f = (Stdlib.ref 1) and i = (Stdlib.ref 5) in
     while (! i) > 0 do  (f := ((! i) * (! f)); i := ((! i) - 1)) done;
@@ -435,47 +435,47 @@ Here is an example of a case that is not matched:
 
 [%quote assert true];;
 [%%expect {|
-- : unit code = << assert true >>
+- : unit expr = << assert true >>
 |}];;
 
 [%quote assert false];;
 [%%expect {|
-- : 'a code = << assert false >>
+- : 'a expr = << assert false >>
 |}];;
 
 [%quote lazy 42];;
 [%%expect {|
-- : int lazy_t code = << lazy 42 >>
+- : int lazy_t expr = << lazy 42 >>
 |}];;
 
 [%quote fun () -> #25n];;
 [%%expect {|
-- : (unit -> nativeint#) code = << fun () -> #25n >>
+- : (unit -> nativeint#) expr = << fun () -> #25n >>
 |}];;
 
 [%quote fun () -> #25l];;
 [%%expect {|
-- : (unit -> int32#) code = << fun () -> #25l >>
+- : (unit -> int32#) expr = << fun () -> #25l >>
 |}];;
 
 [%quote fun () -> #25L];;
 [%%expect {|
-- : (unit -> int64#) code = << fun () -> #25L >>
+- : (unit -> int64#) expr = << fun () -> #25L >>
 |}];;
 
 [%quote fun () -> #6.0];;
 [%%expect {|
-- : (unit -> float#) code = << fun () -> #6.0 >>
+- : (unit -> float#) expr = << fun () -> #6.0 >>
 |}];;
 
 [%quote fun () -> #6.0s];;
 [%%expect {|
-- : (unit -> float32#) code = << fun () -> #6.0s >>
+- : (unit -> float32#) expr = << fun () -> #6.0s >>
 |}];;
 
 [%quote fun () -> #(1, 2, 3)];;
 [%%expect {|
-- : (unit -> #(int * int * int)) code = << fun () -> #(1, 2, 3) >>
+- : (unit -> #(int * int * int)) expr = << fun () -> #(1, 2, 3) >>
 |}];;
 
 type rcd = {x: int; y: string};;
@@ -485,7 +485,7 @@ type rcd = { x : int; y : string; }
 
 [%quote {x = 42; y = "foo"}];;
 [%%expect {|
-- : rcd code = << { x = 42; y = "foo"; } >>
+- : rcd expr = << { x = 42; y = "foo"; } >>
 |}];;
 
 type rcd_u = #{xu: int; yu: string};;
@@ -495,110 +495,110 @@ type rcd_u = #{ xu : int; yu : string; }
 
 [%quote fun () -> #{xu = 42; yu = "foo"}];;
 [%%expect {|
-- : (unit -> rcd_u) code = << fun () -> { xu = 42; yu = "foo"; } >>
+- : (unit -> rcd_u) expr = << fun () -> { xu = 42; yu = "foo"; } >>
 |}];;
 
 [%quote fun r -> r.x];;
 [%%expect {|
-- : (rcd -> int) code = << fun r -> r.x >>
+- : (rcd -> int) expr = << fun r -> r.x >>
 |}];;
 
 [%quote fun {x; y} -> x];;
 [%%expect {|
-- : (rcd -> int) code = << fun {x=x; y=y; } -> x >>
+- : (rcd -> int) expr = << fun {x=x; y=y; } -> x >>
 |}];;
 
 [%quote raise (Match_failure ("foo", 42, 100))];;
 [%%expect {|
-- : 'a code = << Stdlib.raise (Match_failure ("foo", 42, 100)) >>
+- : 'a expr = << Stdlib.raise (Match_failure ("foo", 42, 100)) >>
 |}];;
 
 [%quote raise Out_of_memory];;
 [%%expect {|
-- : 'a code = << Stdlib.raise Out_of_memory >>
+- : 'a expr = << Stdlib.raise Out_of_memory >>
 |}];;
 
 [%quote raise (Invalid_argument "arg")];;
 [%%expect {|
-- : 'a code = << Stdlib.raise (Invalid_argument "arg") >>
+- : 'a expr = << Stdlib.raise (Invalid_argument "arg") >>
 |}];;
 
 [%quote raise (Failure "fail")];;
 [%%expect {|
-- : 'a code = << Stdlib.raise (Failure "fail") >>
+- : 'a expr = << Stdlib.raise (Failure "fail") >>
 |}];;
 
 [%quote raise Not_found];;
 [%%expect {|
-- : 'a code = << Stdlib.raise Not_found >>
+- : 'a expr = << Stdlib.raise Not_found >>
 |}];;
 
 [%quote raise (Sys_error "err")];;
 [%%expect {|
-- : 'a code = << Stdlib.raise (Sys_error "err") >>
+- : 'a expr = << Stdlib.raise (Sys_error "err") >>
 |}];;
 
 [%quote raise End_of_file];;
 [%%expect {|
-- : 'a code = << Stdlib.raise End_of_file >>
+- : 'a expr = << Stdlib.raise End_of_file >>
 |}];;
 
 [%quote raise Division_by_zero];;
 [%%expect {|
-- : 'a code = << Stdlib.raise Division_by_zero >>
+- : 'a expr = << Stdlib.raise Division_by_zero >>
 |}];;
 
 [%quote raise Stack_overflow];;
 [%%expect {|
-- : 'a code = << Stdlib.raise Stack_overflow >>
+- : 'a expr = << Stdlib.raise Stack_overflow >>
 |}];;
 
 [%quote raise Sys_blocked_io];;
 [%%expect {|
-- : 'a code = << Stdlib.raise Sys_blocked_io >>
+- : 'a expr = << Stdlib.raise Sys_blocked_io >>
 |}];;
 
 [%quote raise (Assert_failure ("assert", 42, 100))];;
 [%%expect {|
-- : 'a code = << Stdlib.raise (Assert_failure ("assert", 42, 100)) >>
+- : 'a expr = << Stdlib.raise (Assert_failure ("assert", 42, 100)) >>
 |}];;
 
 [%quote raise (Undefined_recursive_module ("M", 42, 100))];;
 [%%expect {|
-- : 'a code = << Stdlib.raise (Undefined_recursive_module ("M", 42, 100)) >>
+- : 'a expr = << Stdlib.raise (Undefined_recursive_module ("M", 42, 100)) >>
 |}];;
 
 [%quote let exception E in ()];;
 [%%expect {|
-- : unit code = << let exception E in () >>
+- : unit expr = << let exception E in () >>
 |}];;
 
 [%quote let exception E in raise E];;
 [%%expect {|
-- : 'a code = << let exception E in Stdlib.raise E >>
+- : 'a expr = << let exception E in Stdlib.raise E >>
 |}];;
 
 [%quote let module M = Option in M.map];;
 [%%expect {|
-- : (('_weak37 -> '_weak38) -> '_weak37 option -> '_weak38 option) code =
+- : (('_weak37 -> '_weak38) -> '_weak37 option -> '_weak38 option) expr =
 << let module M = Stdlib.Option in M.map >>
 |}];;
 
 [%quote let module M = Option in function | M.None -> false | M.Some x -> x];;
 [%%expect {|
-- : (bool option -> bool) code =
+- : (bool option -> bool) expr =
 << let module M = Stdlib.Option in function | None -> false | Some (x) -> x
 >>
 |}];;
 
 [%quote fun () -> exclave_ Some 42];;
 [%%expect {|
-- : (unit -> local_ int option) code = << fun () -> exclave_ Some 42 >>
+- : (unit -> local_ int option) expr = << fun () -> exclave_ Some 42 >>
 |}];;
 
 [%quote fun () -> exclave_ stack_ (Some 42)];;
 [%%expect {|
-- : (unit -> local_ int option) code = << fun () -> exclave_ stack_ (Some 42)
+- : (unit -> local_ int option) expr = << fun () -> exclave_ stack_ (Some 42)
 >>
 |}];;
 
@@ -616,24 +616,24 @@ module type S =
 
 [%quote fun (module _ : S) x -> 42];;
 [%%expect {|
-- : ((module S) -> '_weak39 -> int) code = << fun (module _ : S) x -> 42 >>
+- : ((module S) -> '_weak39 -> int) expr = << fun (module _ : S) x -> 42 >>
 |}];;
 
 [%quote fun (module M : S) x -> M.c (M.b M.a x)];;
 [%%expect {|
-- : ((module S) -> int -> int) code =
+- : ((module S) -> int -> int) expr =
 << fun (module M : S) x -> M.c (M.b M.a x) >>
 |}];;
 
 [%quote fun (module M : S with type t = string) x -> M.c (M.b M.a x)];;
 [%%expect {|
-- : ((module S with type t = string) -> int -> int) code =
+- : ((module S with type t = string) -> int -> int) expr =
 << fun (module M : S with type t = string) x -> M.c (M.b M.a x) >>
 |}];;
 
 [%quote fun (module M : S with type t = string and type t2 = int) x -> M.c (M.b M.a x)];;
 [%%expect {|
-- : ((module S with type t = string and type t2 = int) -> int -> int) code =
+- : ((module S with type t = string and type t2 = int) -> int -> int) expr =
 <<
   fun (module M : S with type t = string and type t2 = int) x ->
     M.c (M.b M.a x)
@@ -663,7 +663,7 @@ Uncaught exception: Misc.Fatal_error
 
 let x = [%quote 123] in [%quote !#(x)];;
 [%%expect {|
-- : int code = << 123 >>
+- : int expr = << 123 >>
 |}];;
 
 [%quote let o = object method f = 1 end in o#f];;
@@ -675,104 +675,104 @@ Uncaught exception: Misc.Fatal_error
 
 [%quote fun x -> !#[%quote x]];;
 [%%expect {|
-- : ('_weak40 -> '_weak40) code = << fun x -> x >>
+- : ('_weak40 -> '_weak40) expr = << fun x -> x >>
 |}];;
 
 [%quote !#[%quote 42]];;
 [%%expect {|
-- : int code = << 42 >>
+- : int expr = << 42 >>
 |}];;
 
 [%quote !#[%quote "foo"]];;
 [%%expect {|
-- : string code = << "foo" >>
+- : string expr = << "foo" >>
 |}];;
 
 [%quote fun x -> !#((fun y -> [%quote !#y + !#y]) [%quote x])];;
 [%%expect {|
-- : (int -> int) code = << fun x -> x + x >>
+- : (int -> int) expr = << fun x -> x + x >>
 |}];;
 
 [%quote !#((fun y -> [%quote !#y + !#y]) [%quote 2])];;
 [%%expect {|
-- : int code = << 2 + 2 >>
+- : int expr = << 2 + 2 >>
 |}];;
 
 [%quote [%quote !#[%quote 123]]];;
 [%%expect {|
-- : int code code = << << $ << 123 >> >> >>
+- : int expr expr = << << $ << 123 >> >> >>
 |}];;
 
 let x = [%quote "foo"] and y = [%quote "bar"] in [%quote !#x ^ !#y];;
 [%%expect {|
-- : string code = << "foo" ^ "bar" >>
+- : string expr = << "foo" ^ "bar" >>
 |}];;
 
 [%quote fun x -> [%quote [%quote !#(!#x)]]];;
 [%%expect {|
-- : ('_weak41 code code -> '_weak41 code code) code =
+- : ('_weak41 expr expr -> '_weak41 expr expr) expr =
 << fun x -> << << $ ($ x) >> >> >>
 |}];;
 
 [%quote 42 [@inline]];;
 [%%expect {|
-- : int code = << 42 [@inline] >>
+- : int expr = << 42 [@inline] >>
 |}];;
 
 [%quote 42 [@inlined]];;
 [%%expect {|
-- : int code = << 42 [@inlined] >>
+- : int expr = << 42 [@inlined] >>
 |}];;
 
 [%quote 42 [@specialise]];;
 [%%expect {|
-- : int code = << 42 [@specialise] >>
+- : int expr = << 42 [@specialise] >>
 |}];;
 
 
 [%quote 42 [@specialised]];;
 [%%expect {|
-- : int code = << 42 [@specialised] >>
+- : int expr = << 42 [@specialised] >>
 |}];;
 
 
 [%quote 42 [@unrolled]];;
 [%%expect {|
-- : int code = << 42 [@unrolled] >>
+- : int expr = << 42 [@unrolled] >>
 |}];;
 
 
 [%quote 42 [@nontail]];;
 [%%expect {|
-- : int code = << 42 [@nontail] >>
+- : int expr = << 42 [@nontail] >>
 |}];;
 
 
 [%quote 42 [@tail]];;
 [%%expect {|
-- : int code = << 42 [@tail] >>
+- : int expr = << 42 [@tail] >>
 |}];;
 
 
 [%quote 42 [@poll]];;
 [%%expect {|
-- : int code = << 42 [@poll] >>
+- : int expr = << 42 [@poll] >>
 |}];;
 
 
 [%quote 42 [@loop]];;
 [%%expect {|
-- : int code = << 42 [@loop] >>
+- : int expr = << 42 [@loop] >>
 |}];;
 
 
 [%quote 42 [@tail_mod_cons]];;
 [%%expect {|
-- : int code = << 42 [@tail_mod_cons] >>
+- : int expr = << 42 [@tail_mod_cons] >>
 |}];;
 
 
 [%quote 42 [@quotation]];;
 [%%expect {|
-- : int code = << 42 [@quotation] >>
+- : int expr = << 42 [@quotation] >>
 |}];;

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -4,132 +4,132 @@
 
 [%quote 42];;
 [%%expect {|
-- : int code = [%quote 42]
+- : int code = << 42 >>
 |}];;
 
 [%quote 3.14s];;
 [%%expect {|
-- : float32 code = [%quote 3.14s]
+- : float32 code = << 3.14s >>
 |}];;
 
 [%quote 3.14];;
 [%%expect {|
-- : float code = [%quote 3.14]
+- : float code = << 3.14 >>
 |}];;
 
 [%quote "foo"];;
 [%%expect {|
-- : string code = [%quote "foo"]
+- : string code = << "foo" >>
 |}];;
 
 [%quote {foo|bar|foo}];;
 [%%expect {|
-- : string code = [%quote {foo|bar|foo}]
+- : string code = << {foo|bar|foo} >>
 |}];;
 
 [%quote true];;
 [%%expect {|
-- : bool code = [%quote true]
+- : bool code = << true >>
 |}];;
 
 [%quote false];;
 [%%expect {|
-- : bool code = [%quote false]
+- : bool code = << false >>
 |}];;
 
 [%quote ()];;
 [%%expect {|
-- : unit code = [%quote ()]
+- : unit code = << () >>
 |}];;
 
 [%quote (1, 2)];;
 [%%expect {|
-- : (int * int) code = [%quote (1, 2)]
+- : (int * int) code = << (1, 2) >>
 |}];;
 
 [%quote (1, 2, 3)];;
 [%%expect {|
-- : (int * int * int) code = [%quote (1, 2, 3)]
+- : (int * int * int) code = << (1, 2, 3) >>
 |}];;
 
 [%quote (~lab:"val", ~lab2:77, 30)];;
 [%%expect {|
-- : (lab:string * lab2:int * int) code = [%quote (~lab:"val", ~lab2:77, 30)]
+- : (lab:string * lab2:int * int) code = << (~lab:"val", ~lab2:77, 30) >>
 |}];;
 
 [%quote []];;
 [%%expect {|
-- : 'a list code = [%quote []]
+- : 'a list code = << [] >>
 |}];;
 
 [%quote [1; 2; 3]];;
 [%%expect {|
-- : int list code = [%quote (::) (1, ((::) (2, ((::) (3, [])))))]
+- : int list code = << (::) (1, ((::) (2, ((::) (3, []))))) >>
 |}];;
 
 [%quote [||]];;
 [%%expect {|
-- : '_weak1 array code = [%quote [||]]
+- : '_weak1 array code = << [||] >>
 |}];;
 
 [%quote [| 1; 2; 3 |]];;
 [%%expect {|
-- : int array code = [%quote [|1; 2; 3|]]
+- : int array code = << [|1; 2; 3|] >>
 |}];;
 
 [%quote None];;
 [%%expect {|
-- : 'a option code = [%quote None]
+- : 'a option code = << None >>
 |}];;
 
 [%quote Some 111];;
 [%%expect {|
-- : int option code = [%quote Some 111]
+- : int option code = << Some 111 >>
 |}];;
 
 [%quote `A 42];;
 [%%expect {|
-- : [> `A of int ] code = [%quote `A 42]
+- : [> `A of int ] code = << `A 42 >>
 |}];;
 
 [%quote if true then `A 10 else `B ("foo", 42)];;
 [%%expect {|
-- : [> `A of int | `B of string * int ] code = [%quote
-if true then  `A 10  else  `B ("foo", 42)]
+- : [> `A of int | `B of string * int ] code =
+<< if true then `A 10 else `B ("foo", 42) >>
 |}];;
 
 [%quote function | `A x -> x | `B (_, foo) -> foo];;
 [%%expect {|
 - : (([< `A of '_weak3 | `B of '_weak4 * '_weak3 ] as '_weak2) -> '_weak3)
     code
-= [%quote function | `A x -> x | `B (_, foo) -> foo]
+= << function | `A x -> x | `B (_, foo) -> foo >>
 |}];;
 
 [%quote function | `A x -> x | `B (_, foo) -> foo | _ -> 42];;
 [%%expect {|
-- : (([> `A of int | `B of '_weak6 * int ] as '_weak5) -> int) code = [%quote
-function | `A x -> x | `B (_, foo) -> foo | _ -> 42]
+- : (([> `A of int | `B of '_weak6 * int ] as '_weak5) -> int) code =
+<< function | `A x -> x | `B (_, foo) -> foo | _ -> 42 >>
 |}];;
 
 [%quote List.map];;
 [%%expect {|
-- : (('_weak7 -> '_weak8) -> '_weak7 list -> '_weak8 list) code = [%quote
-Stdlib.List.map]
+- : (('_weak7 -> '_weak8) -> '_weak7 list -> '_weak8 list) code =
+<< Stdlib.List.map >>
 |}];;
 
 [%quote fun x -> 42];;
 [%%expect {|
-- : ('_weak9 -> int) code = [%quote fun x -> 42]
+- : ('_weak9 -> int) code = << fun x -> 42 >>
 |}];;
 
 [%quote fun _ -> 42];;
 [%%expect {|
-- : ('_weak10 -> int) code = [%quote fun _ -> 42]
+- : ('_weak10 -> int) code = << fun _ -> 42 >>
 |}];;
 
 [%quote fun x y -> x];;
 [%%expect {|
-- : ('_weak11 -> '_weak12 -> '_weak11) code = [%quote fun x y -> x]
+- : ('_weak11 -> '_weak12 -> '_weak11) code = << fun x y -> x >>
 |}];;
 
 [%quote fun f x y -> f ~a:y ~b:x];;
@@ -137,7 +137,7 @@ Stdlib.List.map]
 - : ((a:'_weak13 -> b:'_weak14 -> '_weak15) ->
      '_weak14 -> '_weak13 -> '_weak15)
     code
-= [%quote fun f x y -> f ~a:y ~b:x]
+= << fun f x y -> f ~a:y ~b:x >>
 |}];;
 
 [%quote fun f x y -> f ?a:y ?b:x];;
@@ -145,136 +145,135 @@ Stdlib.List.map]
 - : ((?a:'_weak16 -> ?b:'_weak17 -> '_weak18) ->
      '_weak17 option -> '_weak16 option -> '_weak18)
     code
-= [%quote fun f x y -> f ?a:y ?b:x]
+= << fun f x y -> f ?a:y ?b:x >>
 |}];;
 
 [%quote fun (x, y) -> x + y];;
 [%%expect {|
-- : (int * int -> int) code = [%quote fun (x, y) -> Stdlib.( + ) x y]
+- : (int * int -> int) code = << fun (x, y) -> x + y >>
 |}];;
 
 [%quote function | _ -> 12];;
 [%%expect {|
-- : ('_weak19 -> int) code = [%quote function | _ -> 12]
+- : ('_weak19 -> int) code = << function | _ -> 12 >>
 |}];;
 
 [%quote function | x -> x];;
 [%%expect {|
-- : ('_weak20 -> '_weak20) code = [%quote function | x -> x]
+- : ('_weak20 -> '_weak20) code = << function | x -> x >>
 |}];;
 
 [%quote function | 42 -> true | _ -> false];;
 [%%expect {|
-- : (int -> bool) code = [%quote function | 42 -> true | _ -> false]
+- : (int -> bool) code = << function | 42 -> true | _ -> false >>
 |}];;
 
 [%quote function | "foo" -> true | _ -> false];;
 [%%expect {|
-- : (string -> bool) code = [%quote function | "foo" -> true | _ -> false]
+- : (string -> bool) code = << function | "foo" -> true | _ -> false >>
 |}];;
 
 [%quote function | (x, y) as z -> (x, y, z)];;
 [%%expect {|
 - : ('_weak21 * '_weak22 -> '_weak21 * '_weak22 * ('_weak21 * '_weak22)) code
-= [%quote function | (x, y) as z -> (x, y, z)]
+= << function | (x, y) as z -> (x, y, z) >>
 |}];;
 
 [%quote function | (x, y) -> x + y];;
 [%%expect {|
-- : (int * int -> int) code = [%quote function | (x, y) -> Stdlib.( + ) x y]
+- : (int * int -> int) code = << function | (x, y) -> x + y >>
 |}];;
 
 [%quote function | (x, y, z) -> x + y - z];;
 [%%expect {|
-- : (int * int * int -> int) code = [%quote
-function | (x, y, z) -> Stdlib.( - ) (Stdlib.( + ) x y) z]
+- : (int * int * int -> int) code = << function | (x, y, z) -> (x + y) - z >>
 |}];;
 
 [%quote function | `A -> true | `B -> false];;
 [%%expect {|
-- : (([< `A | `B ] as '_weak23) -> bool) code = [%quote
-function | `A -> true | `B -> false]
+- : (([< `A | `B ] as '_weak23) -> bool) code =
+<< function | `A -> true | `B -> false >>
 |}];;
 
 [%quote function | `Foo x -> x | `Bar (y, z) -> y + z | `Baz -> 0];;
 [%%expect {|
 - : (([< `Bar of int * int | `Baz | `Foo of int ] as '_weak24) -> int) code =
-[%quote function | `Foo x -> x | `Bar (y, z) -> Stdlib.( + ) y z | `Baz -> 0]
+<< function | `Foo x -> x | `Bar (y, z) -> y + z | `Baz -> 0 >>
 |}];;
 
 [%quote function | lazy x as l -> Lazy.force l];;
 [%%expect {|
-- : ('_weak25 Lazy.t -> '_weak25) code = [%quote
-function | lazy (x) as l -> Stdlib.Lazy.force l]
+- : ('_weak25 Lazy.t -> '_weak25) code =
+<< function | lazy (x) as l -> Stdlib.Lazy.force l >>
 |}];;
 
 [%quote fun f x d -> match f x with | res -> res | exception e -> d];;
 [%%expect {|
 - : (('_weak26 -> '_weak27) -> '_weak26 -> '_weak27 -> '_weak27) code =
-[%quote fun f x d -> match f x with | res -> res | (exception e) -> d]
+<< fun f x d -> match f x with | res -> res | (exception e) -> d >>
 |}];;
 
 [%quote function | Some x -> x | None -> 0];;
 [%%expect {|
-- : (int option -> int) code = [%quote function | Some (x) -> x | None -> 0]
+- : (int option -> int) code = << function | Some (x) -> x | None -> 0 >>
 |}];;
 
 [%quote function | [] -> false | x::xs -> true];;
 [%%expect {|
-- : ('_weak28 list -> bool) code = [%quote
-function | [] -> false | (::) (x, xs) -> true]
+- : ('_weak28 list -> bool) code =
+<< function | [] -> false | (::) (x, xs) -> true >>
 |}];;
 
 [%quote fun x d -> match x with | Some y -> y | None -> d];;
 [%%expect {|
-- : ('_weak29 option -> '_weak29 -> '_weak29) code = [%quote
-fun x d -> match x with | Some (y) -> y | None -> d]
+- : ('_weak29 option -> '_weak29 -> '_weak29) code =
+<< fun x d -> match x with | Some (y) -> y | None -> d >>
 |}];;
 
 [%quote fun l -> List.map (fun x -> 2 * x) l];;
 [%%expect {|
-- : (int list -> int list) code = [%quote
-fun l -> Stdlib.List.map (fun x -> Stdlib.( * ) 2 x) l]
+- : (int list -> int list) code =
+<< fun l -> Stdlib.List.map (fun x -> 2 * x) l >>
 |}];;
 
 [%quote fun (type a) (f : a -> a) (x : a) -> f (f x)];;
 [%%expect {|
-- : (('_a -> '_a) -> '_a -> '_a) code = [%quote
-fun (type a) (f : a -> a) (x : a) -> f (f x)]
+- : (('_a -> '_a) -> '_a -> '_a) code =
+<< fun (type a) (f : a -> a) (x : a) -> f (f x) >>
 |}];;
 
 [%quote fun x (type a) (f : a -> a * a) (g : int -> a) -> f (g x)];;
 [%%expect {|
-- : (int -> ('_a -> '_a * '_a) -> (int -> '_a) -> '_a * '_a) code = [%quote
-fun x (type a) (f : a -> (a) * (a)) (g : int -> a) -> f (g x)]
+- : (int -> ('_a -> '_a * '_a) -> (int -> '_a) -> '_a * '_a) code =
+<< fun x (type a) (f : a -> (a) * (a)) (g : int -> a) -> f (g x) >>
 |}];;
 
 [%quote fun (f : 'a. 'a -> 'a) -> f f];;
 [%%expect {|
-- : (('a. 'a -> 'a) -> '_weak30 -> '_weak30) code = [%quote
-fun (f : 'a . a -> a) -> f f]
+- : (('a. 'a -> 'a) -> '_weak30 -> '_weak30) code =
+<< fun (f : 'a . a -> a) -> f f >>
 |}];;
 
 [%quote fun x -> fun x -> fun x -> 42];;
 [%%expect {|
-- : ('_weak31 -> '_weak32 -> '_weak33 -> int) code = [%quote
-fun x -> fun x__1 -> fun x__2 -> 42]
+- : ('_weak31 -> '_weak32 -> '_weak33 -> int) code =
+<< fun x -> fun x__1 -> fun x__2 -> 42 >>
 |}];;
 
 [%quote fun x -> fun x -> fun x__1 -> 42];;
 [%%expect {|
-- : ('_weak34 -> '_weak35 -> '_weak36 -> int) code = [%quote
-fun x -> fun x__1 -> fun x__2 -> 42]
+- : ('_weak34 -> '_weak35 -> '_weak36 -> int) code =
+<< fun x -> fun x__1 -> fun x__2 -> 42 >>
 |}];;
 
 [%quote let z = 10 in z];;
 [%%expect {|
-- : int code = [%quote let z = 10 in z]
+- : int code = << let z = 10 in z >>
 |}];;
 
 [%quote let (x, y) = (42, 100) in x + y];;
 [%%expect {|
-- : int code = [%quote let (x, y) = (42, 100) in Stdlib.( + ) x y]
+- : int code = << let (x, y) = (42, 100) in x + y >>
 |}];;
 
 [%quote let Some x = Some "foo" in x];;
@@ -286,7 +285,7 @@ Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 None
 
-- : string code = [%quote match Some "foo" with | Some (x) -> x]
+- : string code = << match Some "foo" with | Some (x) -> x >>
 |}];;
 
 [%quote let x::xs = [1; 2; 3] in x];;
@@ -298,8 +297,8 @@ Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 []
 
-- : int code = [%quote
-match (::) (1, ((::) (2, ((::) (3, []))))) with | (::) (x, xs) -> x]
+- : int code =
+<< match (::) (1, ((::) (2, ((::) (3, []))))) with | (::) (x, xs) -> x >>
 |}];;
 
 [%quote let x::xs = [1; 2; 3] in xs];;
@@ -311,23 +310,23 @@ Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 []
 
-- : int list code = [%quote
-match (::) (1, ((::) (2, ((::) (3, []))))) with | (::) (x, xs) -> xs]
+- : int list code =
+<< match (::) (1, ((::) (2, ((::) (3, []))))) with | (::) (x, xs) -> xs >>
 |}];;
 
 [%quote let foo x = (x, x) in foo 42];;
 [%%expect {|
-- : (int * int) code = [%quote let foo = (fun x -> (x, x)) in foo 42]
+- : (int * int) code = << let foo = (fun x -> (x, x)) in foo 42 >>
 |}];;
 
 [%quote let foo = 50 and bar = 15 in foo + bar];;
 [%%expect {|
-- : int code = [%quote let foo = 50 and bar = 15 in Stdlib.( + ) foo bar]
+- : int code = << let foo = 50 and bar = 15 in foo + bar >>
 |}];;
 
 [%quote let x = 42 in let x = x in x];;
 [%%expect {|
-- : int code = [%quote let x = 42 in let x__1 = x in x__1]
+- : int code = << let x = 42 in let x__1 = x in x__1 >>
 |}];;
 
 [%quote
@@ -335,7 +334,7 @@ match (::) (1, ((::) (2, ((::) (3, []))))) with | (::) (x, xs) -> xs]
   let+ a = 42 in a
 ];;
 [%%expect {|
-- : int code = [%quote let (let+) = (fun x f -> f x) in (let+) a = 42 in a]
+- : int code = << let (let+) = (fun x f -> f x) in let+ a = 42 in a >>
 |}];;
 
 [%quote
@@ -344,9 +343,11 @@ match (::) (1, ((::) (2, ((::) (3, []))))) with | (::) (x, xs) -> xs]
   in a * 2
 ];;
 [%%expect {|
-- : int option code = [%quote
-let (let+) = (fun x f -> Stdlib.Option.map f x) in
-(let+) a = Some 42 in Stdlib.( * ) a 2]
+- : int option code =
+<<
+  let (let+) = (fun x f -> Stdlib.Option.map f x) in
+    let+ a = Some 42 in a * 2
+>>
 |}];;
 
 [%quote
@@ -356,28 +357,30 @@ let (let+) = (fun x f -> Stdlib.Option.map f x) in
   in a + b
 ];;
 [%%expect {|
-- : int list code = [%quote
-let (let*) = (fun x f -> Stdlib.List.map f x)
-and (and*) = Stdlib.List.combine in
-(let*) a = (::) (1, ((::) (2, ((::) (3, [])))))
-(and*) b = (::) (10, ((::) (20, ((::) (30, []))))) in Stdlib.( + ) a b]
+- : int list code =
+<<
+  let (let*) = (fun x f -> Stdlib.List.map f x)
+  and (and*) = Stdlib.List.combine in
+    let* a = (::) (1, ((::) (2, ((::) (3, [])))))
+    and* b = (::) (10, ((::) (20, ((::) (30, []))))) in a + b >>
 |}];;
 
 [%quote fun (f: int -> int) (x: int) -> f x]
 [%%expect {|
-- : ((int -> int) -> int -> int) code = [%quote
-fun (f : int -> int) (x : int) -> f x]
+- : ((int -> int) -> int -> int) code =
+<< fun (f : int -> int) (x : int) -> f x >>
 |}];;
 
 [%quote let module M = Set.Make(Int) in M.singleton 100 |> M.elements];;
 [%%expect {|
-- : Int.t list code = [%quote
-let module M = Stdlib.Set.Make(Stdlib.Int) in M.elements (M.singleton 100)]
+- : Int.t list code =
+<< let module M = Stdlib.Set.Make(Stdlib.Int) in M.elements (M.singleton 100)
+>>
 |}];;
 
 [%quote ref 42];;
 [%%expect {|
-- : int ref code = [%quote Stdlib.ref 42]
+- : int ref code = << Stdlib.ref 42 >>
 |}];;
 
 [%quote
@@ -388,10 +391,9 @@ let module M = Stdlib.Set.Make(Stdlib.Int) in M.elements (M.singleton 100)]
   !x
 ];;
 [%%expect {|
-- : int code = [%quote
-let x = (Stdlib.ref 0) in
-for i = 0 to 10 do (Stdlib.( := ) x (Stdlib.( + ) (Stdlib.( ! ) x) i)) done;
-Stdlib.( ! ) x]
+- : int code =
+<< let x = (Stdlib.ref 0) in for i = 0 to 10 do (x := ((! x) + i)) done; ! x
+>>
 |}];;
 
 [%quote
@@ -402,15 +404,16 @@ Stdlib.( ! ) x]
   !x
 ];;
 [%%expect {|
-- : int code = [%quote
-let x = (Stdlib.ref 0) in
-for i = 10 downto 0 do (Stdlib.( := ) x (Stdlib.( + ) (Stdlib.( ! ) x) i))
-done; Stdlib.( ! ) x]
+- : int code =
+<<
+  let x = (Stdlib.ref 0) in for i = 10 downto 0 do (x := ((! x) + i)) done;
+    ! x
+>>
 |}];;
 
 [%quote while true do () done];;
 [%%expect {|
-- : 'a code = [%quote while true do () done]
+- : 'a code = << while true do  () done >>
 |}];;
 
 [%quote
@@ -422,57 +425,57 @@ done; Stdlib.( ! ) x]
   !f
 ];;
 [%%expect {|
-- : int code = [%quote
-let f = (Stdlib.ref 1) and i = (Stdlib.ref 5) in
-while Stdlib.( > ) (Stdlib.( ! ) i) 0 do
-(Stdlib.( := ) f (Stdlib.( * ) (Stdlib.( ! ) i) (Stdlib.( ! ) f));
- Stdlib.( := ) i (Stdlib.( - ) (Stdlib.( ! ) i) 1))
-done; Stdlib.( ! ) f]
+- : int code =
+<<
+  let f = (Stdlib.ref 1) and i = (Stdlib.ref 5) in
+    while (! i) > 0 do  (f := ((! i) * (! f)); i := ((! i) - 1)) done;
+    ! f
+>>
 |}];;
 
 [%quote assert true];;
 [%%expect {|
-- : unit code = [%quote assert true]
+- : unit code = << assert true >>
 |}];;
 
 [%quote assert false];;
 [%%expect {|
-- : 'a code = [%quote assert false]
+- : 'a code = << assert false >>
 |}];;
 
 [%quote lazy 42];;
 [%%expect {|
-- : int lazy_t code = [%quote lazy 42]
+- : int lazy_t code = << lazy 42 >>
 |}];;
 
 [%quote fun () -> #25n];;
 [%%expect {|
-- : (unit -> nativeint#) code = [%quote fun () -> #25n]
+- : (unit -> nativeint#) code = << fun () -> #25n >>
 |}];;
 
 [%quote fun () -> #25l];;
 [%%expect {|
-- : (unit -> int32#) code = [%quote fun () -> #25l]
+- : (unit -> int32#) code = << fun () -> #25l >>
 |}];;
 
 [%quote fun () -> #25L];;
 [%%expect {|
-- : (unit -> int64#) code = [%quote fun () -> #25L]
+- : (unit -> int64#) code = << fun () -> #25L >>
 |}];;
 
 [%quote fun () -> #6.0];;
 [%%expect {|
-- : (unit -> float#) code = [%quote fun () -> #6.0]
+- : (unit -> float#) code = << fun () -> #6.0 >>
 |}];;
 
 [%quote fun () -> #6.0s];;
 [%%expect {|
-- : (unit -> float32#) code = [%quote fun () -> #6.0s]
+- : (unit -> float32#) code = << fun () -> #6.0s >>
 |}];;
 
 [%quote fun () -> #(1, 2, 3)];;
 [%%expect {|
-- : (unit -> #(int * int * int)) code = [%quote fun () -> #(1, 2, 3)]
+- : (unit -> #(int * int * int)) code = << fun () -> #(1, 2, 3) >>
 |}];;
 
 type rcd = {x: int; y: string};;
@@ -482,7 +485,7 @@ type rcd = { x : int; y : string; }
 
 [%quote {x = 42; y = "foo"}];;
 [%%expect {|
-- : rcd code = [%quote { x = 42; y = "foo"; }]
+- : rcd code = << { x = 42; y = "foo"; } >>
 |}];;
 
 type rcd_u = #{xu: int; yu: string};;
@@ -492,111 +495,111 @@ type rcd_u = #{ xu : int; yu : string; }
 
 [%quote fun () -> #{xu = 42; yu = "foo"}];;
 [%%expect {|
-- : (unit -> rcd_u) code = [%quote fun () -> { xu = 42; yu = "foo"; }]
+- : (unit -> rcd_u) code = << fun () -> { xu = 42; yu = "foo"; } >>
 |}];;
 
 [%quote fun r -> r.x];;
 [%%expect {|
-- : (rcd -> int) code = [%quote fun r -> r.x]
+- : (rcd -> int) code = << fun r -> r.x >>
 |}];;
 
 [%quote fun {x; y} -> x];;
 [%%expect {|
-- : (rcd -> int) code = [%quote fun {x=x; y=y; } -> x]
+- : (rcd -> int) code = << fun {x=x; y=y; } -> x >>
 |}];;
 
 [%quote raise (Match_failure ("foo", 42, 100))];;
 [%%expect {|
-- : 'a code = [%quote Stdlib.raise (Match_failure ("foo", 42, 100))]
+- : 'a code = << Stdlib.raise (Match_failure ("foo", 42, 100)) >>
 |}];;
 
 [%quote raise Out_of_memory];;
 [%%expect {|
-- : 'a code = [%quote Stdlib.raise Out_of_memory]
+- : 'a code = << Stdlib.raise Out_of_memory >>
 |}];;
 
 [%quote raise (Invalid_argument "arg")];;
 [%%expect {|
-- : 'a code = [%quote Stdlib.raise (Invalid_argument "arg")]
+- : 'a code = << Stdlib.raise (Invalid_argument "arg") >>
 |}];;
 
 [%quote raise (Failure "fail")];;
 [%%expect {|
-- : 'a code = [%quote Stdlib.raise (Failure "fail")]
+- : 'a code = << Stdlib.raise (Failure "fail") >>
 |}];;
 
 [%quote raise Not_found];;
 [%%expect {|
-- : 'a code = [%quote Stdlib.raise Not_found]
+- : 'a code = << Stdlib.raise Not_found >>
 |}];;
 
 [%quote raise (Sys_error "err")];;
 [%%expect {|
-- : 'a code = [%quote Stdlib.raise (Sys_error "err")]
+- : 'a code = << Stdlib.raise (Sys_error "err") >>
 |}];;
 
 [%quote raise End_of_file];;
 [%%expect {|
-- : 'a code = [%quote Stdlib.raise End_of_file]
+- : 'a code = << Stdlib.raise End_of_file >>
 |}];;
 
 [%quote raise Division_by_zero];;
 [%%expect {|
-- : 'a code = [%quote Stdlib.raise Division_by_zero]
+- : 'a code = << Stdlib.raise Division_by_zero >>
 |}];;
 
 [%quote raise Stack_overflow];;
 [%%expect {|
-- : 'a code = [%quote Stdlib.raise Stack_overflow]
+- : 'a code = << Stdlib.raise Stack_overflow >>
 |}];;
 
 [%quote raise Sys_blocked_io];;
 [%%expect {|
-- : 'a code = [%quote Stdlib.raise Sys_blocked_io]
+- : 'a code = << Stdlib.raise Sys_blocked_io >>
 |}];;
 
 [%quote raise (Assert_failure ("assert", 42, 100))];;
 [%%expect {|
-- : 'a code = [%quote Stdlib.raise (Assert_failure ("assert", 42, 100))]
+- : 'a code = << Stdlib.raise (Assert_failure ("assert", 42, 100)) >>
 |}];;
 
 [%quote raise (Undefined_recursive_module ("M", 42, 100))];;
 [%%expect {|
-- : 'a code = [%quote
-Stdlib.raise (Undefined_recursive_module ("M", 42, 100))]
+- : 'a code = << Stdlib.raise (Undefined_recursive_module ("M", 42, 100)) >>
 |}];;
 
 [%quote let exception E in ()];;
 [%%expect {|
-- : unit code = [%quote let exception E in ()]
+- : unit code = << let exception E in () >>
 |}];;
 
 [%quote let exception E in raise E];;
 [%%expect {|
-- : 'a code = [%quote let exception E in Stdlib.raise E]
+- : 'a code = << let exception E in Stdlib.raise E >>
 |}];;
 
 [%quote let module M = Option in M.map];;
 [%%expect {|
 - : (('_weak37 -> '_weak38) -> '_weak37 option -> '_weak38 option) code =
-[%quote let module M = Stdlib.Option in M.map]
+<< let module M = Stdlib.Option in M.map >>
 |}];;
 
 [%quote let module M = Option in function | M.None -> false | M.Some x -> x];;
 [%%expect {|
-- : (bool option -> bool) code = [%quote
-let module M = Stdlib.Option in function | None -> false | Some (x) -> x]
+- : (bool option -> bool) code =
+<< let module M = Stdlib.Option in function | None -> false | Some (x) -> x
+>>
 |}];;
 
 [%quote fun () -> exclave_ Some 42];;
 [%%expect {|
-- : (unit -> local_ int option) code = [%quote fun () -> exclave_ Some 42]
+- : (unit -> local_ int option) code = << fun () -> exclave_ Some 42 >>
 |}];;
 
 [%quote fun () -> exclave_ stack_ (Some 42)];;
 [%%expect {|
-- : (unit -> local_ int option) code = [%quote
-fun () -> exclave_ stack_ (Some 42)]
+- : (unit -> local_ int option) code = << fun () -> exclave_ stack_ (Some 42)
+>>
 |}];;
 
 module type S = sig
@@ -613,28 +616,28 @@ module type S =
 
 [%quote fun (module _ : S) x -> 42];;
 [%%expect {|
-- : ((module S) -> '_weak39 -> int) code = [%quote
-fun (module _ : S) x -> 42]
+- : ((module S) -> '_weak39 -> int) code = << fun (module _ : S) x -> 42 >>
 |}];;
 
 [%quote fun (module M : S) x -> M.c (M.b M.a x)];;
 [%%expect {|
-- : ((module S) -> int -> int) code = [%quote
-fun (module M : S) x -> M.c (M.b M.a x)]
+- : ((module S) -> int -> int) code =
+<< fun (module M : S) x -> M.c (M.b M.a x) >>
 |}];;
 
 [%quote fun (module M : S with type t = string) x -> M.c (M.b M.a x)];;
 [%%expect {|
-- : ((module S with type t = string) -> int -> int) code = [%quote
-fun (module M : S with type t = string) x -> M.c (M.b M.a x)]
+- : ((module S with type t = string) -> int -> int) code =
+<< fun (module M : S with type t = string) x -> M.c (M.b M.a x) >>
 |}];;
 
 [%quote fun (module M : S with type t = string and type t2 = int) x -> M.c (M.b M.a x)];;
 [%%expect {|
 - : ((module S with type t = string and type t2 = int) -> int -> int) code =
-[%quote
-fun (module M : S with type t = string and type t2 = int) x ->
-M.c (M.b M.a x)]
+<<
+  fun (module M : S with type t = string and type t2 = int) x ->
+    M.c (M.b M.a x)
+>>
 |}];;
 
 [%quote let module M (N : S) = struct type t = N.t let x = N.a end in ()];;
@@ -660,7 +663,7 @@ Uncaught exception: Misc.Fatal_error
 
 let x = [%quote 123] in [%quote !#(x)];;
 [%%expect {|
-- : int code = [%quote 123]
+- : int code = << 123 >>
 |}];;
 
 [%quote let o = object method f = 1 end in o#f];;
@@ -672,41 +675,104 @@ Uncaught exception: Misc.Fatal_error
 
 [%quote fun x -> !#[%quote x]];;
 [%%expect {|
-- : ('_weak40 -> '_weak40) code = [%quote fun x -> x]
+- : ('_weak40 -> '_weak40) code = << fun x -> x >>
 |}];;
 
 [%quote !#[%quote 42]];;
 [%%expect {|
-- : int code = [%quote 42]
+- : int code = << 42 >>
 |}];;
 
 [%quote !#[%quote "foo"]];;
 [%%expect {|
-- : string code = [%quote "foo"]
+- : string code = << "foo" >>
 |}];;
 
 [%quote fun x -> !#((fun y -> [%quote !#y + !#y]) [%quote x])];;
 [%%expect {|
-- : (int -> int) code = [%quote fun x -> Stdlib.( + ) x x]
+- : (int -> int) code = << fun x -> x + x >>
 |}];;
 
 [%quote !#((fun y -> [%quote !#y + !#y]) [%quote 2])];;
 [%%expect {|
-- : int code = [%quote Stdlib.( + ) 2 2]
+- : int code = << 2 + 2 >>
 |}];;
 
 [%quote [%quote !#[%quote 123]]];;
 [%%expect {|
-- : int code code = [%quote [%quote !#[%quote 123]]]
+- : int code code = << << $ << 123 >> >> >>
 |}];;
 
 let x = [%quote "foo"] and y = [%quote "bar"] in [%quote !#x ^ !#y];;
 [%%expect {|
-- : string code = [%quote Stdlib.( ^ ) "foo" "bar"]
+- : string code = << "foo" ^ "bar" >>
 |}];;
 
 [%quote fun x -> [%quote [%quote !#(!#x)]]];;
 [%%expect {|
-- : ('_weak41 code code -> '_weak41 code code) code = [%quote
-fun x -> [%quote [%quote !#!#x]]]
+- : ('_weak41 code code -> '_weak41 code code) code =
+<< fun x -> << << $ ($ x) >> >> >>
+|}];;
+
+[%quote 42 [@inline]];;
+[%%expect {|
+- : int code = << 42 [@inline] >>
+|}];;
+
+[%quote 42 [@inlined]];;
+[%%expect {|
+- : int code = << 42 [@inlined] >>
+|}];;
+
+[%quote 42 [@specialise]];;
+[%%expect {|
+- : int code = << 42 [@specialise] >>
+|}];;
+
+
+[%quote 42 [@specialised]];;
+[%%expect {|
+- : int code = << 42 [@specialised] >>
+|}];;
+
+
+[%quote 42 [@unrolled]];;
+[%%expect {|
+- : int code = << 42 [@unrolled] >>
+|}];;
+
+
+[%quote 42 [@nontail]];;
+[%%expect {|
+- : int code = << 42 [@nontail] >>
+|}];;
+
+
+[%quote 42 [@tail]];;
+[%%expect {|
+- : int code = << 42 [@tail] >>
+|}];;
+
+
+[%quote 42 [@poll]];;
+[%%expect {|
+- : int code = << 42 [@poll] >>
+|}];;
+
+
+[%quote 42 [@loop]];;
+[%%expect {|
+- : int code = << 42 [@loop] >>
+|}];;
+
+
+[%quote 42 [@tail_mod_cons]];;
+[%%expect {|
+- : int code = << 42 [@tail_mod_cons] >>
+|}];;
+
+
+[%quote 42 [@quotation]];;
+[%%expect {|
+- : int code = << 42 [@quotation] >>
 |}];;

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -95,7 +95,7 @@
 [%quote if true then `A 10 else `B ("foo", 42)];;
 [%%expect {|
 - : [> `A of int | `B of string * int ] code = [%quote
-if true then `A 10 else `B ("foo", 42)]
+if true then  `A 10  else  `B ("foo", 42)]
 |}];;
 
 [%quote function | `A x -> x | `B (_, foo) -> foo];;
@@ -357,8 +357,8 @@ let (let+) = (fun x f -> Stdlib.Option.map f x) in
 ];;
 [%%expect {|
 - : int list code = [%quote
-let (let*) = (fun x f -> Stdlib.List.map f x) and
-                                              (and*) = Stdlib.List.combine in
+let (let*) = (fun x f -> Stdlib.List.map f x)
+and (and*) = Stdlib.List.combine in
 (let*) a = (::) (1, ((::) (2, ((::) (3, [])))))
 (and*) b = (::) (10, ((::) (20, ((::) (30, []))))) in Stdlib.( + ) a b]
 |}];;

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -4,132 +4,132 @@
 
 [%quote 42];;
 [%%expect {|
-- : int expr = << 42 >>
+- : int expr = <[ 42 ]>
 |}];;
 
 [%quote 3.14s];;
 [%%expect {|
-- : float32 expr = << 3.14s >>
+- : float32 expr = <[ 3.14s ]>
 |}];;
 
 [%quote 3.14];;
 [%%expect {|
-- : float expr = << 3.14 >>
+- : float expr = <[ 3.14 ]>
 |}];;
 
 [%quote "foo"];;
 [%%expect {|
-- : string expr = << "foo" >>
+- : string expr = <[ "foo" ]>
 |}];;
 
 [%quote {foo|bar|foo}];;
 [%%expect {|
-- : string expr = << {foo|bar|foo} >>
+- : string expr = <[ {foo|bar|foo} ]>
 |}];;
 
 [%quote true];;
 [%%expect {|
-- : bool expr = << true >>
+- : bool expr = <[ true ]>
 |}];;
 
 [%quote false];;
 [%%expect {|
-- : bool expr = << false >>
+- : bool expr = <[ false ]>
 |}];;
 
 [%quote ()];;
 [%%expect {|
-- : unit expr = << () >>
+- : unit expr = <[ () ]>
 |}];;
 
 [%quote (1, 2)];;
 [%%expect {|
-- : (int * int) expr = << (1, 2) >>
+- : (int * int) expr = <[ (1, 2) ]>
 |}];;
 
 [%quote (1, 2, 3)];;
 [%%expect {|
-- : (int * int * int) expr = << (1, 2, 3) >>
+- : (int * int * int) expr = <[ (1, 2, 3) ]>
 |}];;
 
 [%quote (~lab:"val", ~lab2:77, 30)];;
 [%%expect {|
-- : (lab:string * lab2:int * int) expr = << (~lab:"val", ~lab2:77, 30) >>
+- : (lab:string * lab2:int * int) expr = <[ (~lab:"val", ~lab2:77, 30) ]>
 |}];;
 
 [%quote []];;
 [%%expect {|
-- : 'a list expr = << [] >>
+- : 'a list expr = <[ [] ]>
 |}];;
 
 [%quote [1; 2; 3]];;
 [%%expect {|
-- : int list expr = << (::) (1, ((::) (2, ((::) (3, []))))) >>
+- : int list expr = <[ (::) (1, ((::) (2, ((::) (3, []))))) ]>
 |}];;
 
 [%quote [||]];;
 [%%expect {|
-- : '_weak1 array expr = << [||] >>
+- : '_weak1 array expr = <[ [||] ]>
 |}];;
 
 [%quote [| 1; 2; 3 |]];;
 [%%expect {|
-- : int array expr = << [|1; 2; 3|] >>
+- : int array expr = <[ [|1; 2; 3|] ]>
 |}];;
 
 [%quote None];;
 [%%expect {|
-- : 'a option expr = << None >>
+- : 'a option expr = <[ None ]>
 |}];;
 
 [%quote Some 111];;
 [%%expect {|
-- : int option expr = << Some 111 >>
+- : int option expr = <[ Some 111 ]>
 |}];;
 
 [%quote `A 42];;
 [%%expect {|
-- : [> `A of int ] expr = << `A 42 >>
+- : [> `A of int ] expr = <[ `A 42 ]>
 |}];;
 
 [%quote if true then `A 10 else `B ("foo", 42)];;
 [%%expect {|
 - : [> `A of int | `B of string * int ] expr =
-<< if true then `A 10 else `B ("foo", 42) >>
+<[ if true then `A 10 else `B ("foo", 42) ]>
 |}];;
 
 [%quote function | `A x -> x | `B (_, foo) -> foo];;
 [%%expect {|
 - : (([< `A of '_weak3 | `B of '_weak4 * '_weak3 ] as '_weak2) -> '_weak3)
     expr
-= << function | `A x -> x | `B (_, foo) -> foo >>
+= <[ function | `A x -> x | `B (_, foo) -> foo ]>
 |}];;
 
 [%quote function | `A x -> x | `B (_, foo) -> foo | _ -> 42];;
 [%%expect {|
 - : (([> `A of int | `B of '_weak6 * int ] as '_weak5) -> int) expr =
-<< function | `A x -> x | `B (_, foo) -> foo | _ -> 42 >>
+<[ function | `A x -> x | `B (_, foo) -> foo | _ -> 42 ]>
 |}];;
 
 [%quote List.map];;
 [%%expect {|
 - : (('_weak7 -> '_weak8) -> '_weak7 list -> '_weak8 list) expr =
-<< Stdlib.List.map >>
+<[ Stdlib.List.map ]>
 |}];;
 
 [%quote fun x -> 42];;
 [%%expect {|
-- : ('_weak9 -> int) expr = << fun x -> 42 >>
+- : ('_weak9 -> int) expr = <[ fun x -> 42 ]>
 |}];;
 
 [%quote fun _ -> 42];;
 [%%expect {|
-- : ('_weak10 -> int) expr = << fun _ -> 42 >>
+- : ('_weak10 -> int) expr = <[ fun _ -> 42 ]>
 |}];;
 
 [%quote fun x y -> x];;
 [%%expect {|
-- : ('_weak11 -> '_weak12 -> '_weak11) expr = << fun x y -> x >>
+- : ('_weak11 -> '_weak12 -> '_weak11) expr = <[ fun x y -> x ]>
 |}];;
 
 [%quote fun f x y -> f ~a:y ~b:x];;
@@ -137,7 +137,7 @@
 - : ((a:'_weak13 -> b:'_weak14 -> '_weak15) ->
      '_weak14 -> '_weak13 -> '_weak15)
     expr
-= << fun f x y -> f ~a:y ~b:x >>
+= <[ fun f x y -> f ~a:y ~b:x ]>
 |}];;
 
 [%quote fun f x y -> f ?a:y ?b:x];;
@@ -145,135 +145,135 @@
 - : ((?a:'_weak16 -> ?b:'_weak17 -> '_weak18) ->
      '_weak17 option -> '_weak16 option -> '_weak18)
     expr
-= << fun f x y -> f ?a:y ?b:x >>
+= <[ fun f x y -> f ?a:y ?b:x ]>
 |}];;
 
 [%quote fun (x, y) -> x + y];;
 [%%expect {|
-- : (int * int -> int) expr = << fun (x, y) -> x + y >>
+- : (int * int -> int) expr = <[ fun (x, y) -> x + y ]>
 |}];;
 
 [%quote function | _ -> 12];;
 [%%expect {|
-- : ('_weak19 -> int) expr = << function | _ -> 12 >>
+- : ('_weak19 -> int) expr = <[ function | _ -> 12 ]>
 |}];;
 
 [%quote function | x -> x];;
 [%%expect {|
-- : ('_weak20 -> '_weak20) expr = << function | x -> x >>
+- : ('_weak20 -> '_weak20) expr = <[ function | x -> x ]>
 |}];;
 
 [%quote function | 42 -> true | _ -> false];;
 [%%expect {|
-- : (int -> bool) expr = << function | 42 -> true | _ -> false >>
+- : (int -> bool) expr = <[ function | 42 -> true | _ -> false ]>
 |}];;
 
 [%quote function | "foo" -> true | _ -> false];;
 [%%expect {|
-- : (string -> bool) expr = << function | "foo" -> true | _ -> false >>
+- : (string -> bool) expr = <[ function | "foo" -> true | _ -> false ]>
 |}];;
 
 [%quote function | (x, y) as z -> (x, y, z)];;
 [%%expect {|
 - : ('_weak21 * '_weak22 -> '_weak21 * '_weak22 * ('_weak21 * '_weak22)) expr
-= << function | (x, y) as z -> (x, y, z) >>
+= <[ function | (x, y) as z -> (x, y, z) ]>
 |}];;
 
 [%quote function | (x, y) -> x + y];;
 [%%expect {|
-- : (int * int -> int) expr = << function | (x, y) -> x + y >>
+- : (int * int -> int) expr = <[ function | (x, y) -> x + y ]>
 |}];;
 
 [%quote function | (x, y, z) -> x + y - z];;
 [%%expect {|
-- : (int * int * int -> int) expr = << function | (x, y, z) -> (x + y) - z >>
+- : (int * int * int -> int) expr = <[ function | (x, y, z) -> (x + y) - z ]>
 |}];;
 
 [%quote function | `A -> true | `B -> false];;
 [%%expect {|
 - : (([< `A | `B ] as '_weak23) -> bool) expr =
-<< function | `A -> true | `B -> false >>
+<[ function | `A -> true | `B -> false ]>
 |}];;
 
 [%quote function | `Foo x -> x | `Bar (y, z) -> y + z | `Baz -> 0];;
 [%%expect {|
 - : (([< `Bar of int * int | `Baz | `Foo of int ] as '_weak24) -> int) expr =
-<< function | `Foo x -> x | `Bar (y, z) -> y + z | `Baz -> 0 >>
+<[ function | `Foo x -> x | `Bar (y, z) -> y + z | `Baz -> 0 ]>
 |}];;
 
 [%quote function | lazy x as l -> Lazy.force l];;
 [%%expect {|
 - : ('_weak25 Lazy.t -> '_weak25) expr =
-<< function | lazy (x) as l -> Stdlib.Lazy.force l >>
+<[ function | lazy (x) as l -> Stdlib.Lazy.force l ]>
 |}];;
 
 [%quote fun f x d -> match f x with | res -> res | exception e -> d];;
 [%%expect {|
 - : (('_weak26 -> '_weak27) -> '_weak26 -> '_weak27 -> '_weak27) expr =
-<< fun f x d -> match f x with | res -> res | (exception e) -> d >>
+<[ fun f x d -> match f x with | res -> res | (exception e) -> d ]>
 |}];;
 
 [%quote function | Some x -> x | None -> 0];;
 [%%expect {|
-- : (int option -> int) expr = << function | Some (x) -> x | None -> 0 >>
+- : (int option -> int) expr = <[ function | Some (x) -> x | None -> 0 ]>
 |}];;
 
 [%quote function | [] -> false | x::xs -> true];;
 [%%expect {|
 - : ('_weak28 list -> bool) expr =
-<< function | [] -> false | (::) (x, xs) -> true >>
+<[ function | [] -> false | (::) (x, xs) -> true ]>
 |}];;
 
 [%quote fun x d -> match x with | Some y -> y | None -> d];;
 [%%expect {|
 - : ('_weak29 option -> '_weak29 -> '_weak29) expr =
-<< fun x d -> match x with | Some (y) -> y | None -> d >>
+<[ fun x d -> match x with | Some (y) -> y | None -> d ]>
 |}];;
 
 [%quote fun l -> List.map (fun x -> 2 * x) l];;
 [%%expect {|
 - : (int list -> int list) expr =
-<< fun l -> Stdlib.List.map (fun x -> 2 * x) l >>
+<[ fun l -> Stdlib.List.map (fun x -> 2 * x) l ]>
 |}];;
 
 [%quote fun (type a) (f : a -> a) (x : a) -> f (f x)];;
 [%%expect {|
 - : (('_a -> '_a) -> '_a -> '_a) expr =
-<< fun (type a) (f : a -> a) (x : a) -> f (f x) >>
+<[ fun (type a) (f : a -> a) (x : a) -> f (f x) ]>
 |}];;
 
 [%quote fun x (type a) (f : a -> a * a) (g : int -> a) -> f (g x)];;
 [%%expect {|
 - : (int -> ('_a -> '_a * '_a) -> (int -> '_a) -> '_a * '_a) expr =
-<< fun x (type a) (f : a -> (a) * (a)) (g : int -> a) -> f (g x) >>
+<[ fun x (type a) (f : a -> (a) * (a)) (g : int -> a) -> f (g x) ]>
 |}];;
 
 [%quote fun (f : 'a. 'a -> 'a) -> f f];;
 [%%expect {|
 - : (('a. 'a -> 'a) -> '_weak30 -> '_weak30) expr =
-<< fun (f : 'a . a -> a) -> f f >>
+<[ fun (f : 'a . a -> a) -> f f ]>
 |}];;
 
 [%quote fun x -> fun x -> fun x -> 42];;
 [%%expect {|
 - : ('_weak31 -> '_weak32 -> '_weak33 -> int) expr =
-<< fun x -> fun x__1 -> fun x__2 -> 42 >>
+<[ fun x -> fun x__1 -> fun x__2 -> 42 ]>
 |}];;
 
 [%quote fun x -> fun x -> fun x__1 -> 42];;
 [%%expect {|
 - : ('_weak34 -> '_weak35 -> '_weak36 -> int) expr =
-<< fun x -> fun x__1 -> fun x__2 -> 42 >>
+<[ fun x -> fun x__1 -> fun x__2 -> 42 ]>
 |}];;
 
 [%quote let z = 10 in z];;
 [%%expect {|
-- : int expr = << let z = 10 in z >>
+- : int expr = <[ let z = 10 in z ]>
 |}];;
 
 [%quote let (x, y) = (42, 100) in x + y];;
 [%%expect {|
-- : int expr = << let (x, y) = (42, 100) in x + y >>
+- : int expr = <[ let (x, y) = (42, 100) in x + y ]>
 |}];;
 
 [%quote let Some x = Some "foo" in x];;
@@ -285,7 +285,7 @@ Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 None
 
-- : string expr = << match Some "foo" with | Some (x) -> x >>
+- : string expr = <[ match Some "foo" with | Some (x) -> x ]>
 |}];;
 
 [%quote let x::xs = [1; 2; 3] in x];;
@@ -298,7 +298,7 @@ Here is an example of a case that is not matched:
 []
 
 - : int expr =
-<< match (::) (1, ((::) (2, ((::) (3, []))))) with | (::) (x, xs) -> x >>
+<[ match (::) (1, ((::) (2, ((::) (3, []))))) with | (::) (x, xs) -> x ]>
 |}];;
 
 [%quote let x::xs = [1; 2; 3] in xs];;
@@ -311,22 +311,22 @@ Here is an example of a case that is not matched:
 []
 
 - : int list expr =
-<< match (::) (1, ((::) (2, ((::) (3, []))))) with | (::) (x, xs) -> xs >>
+<[ match (::) (1, ((::) (2, ((::) (3, []))))) with | (::) (x, xs) -> xs ]>
 |}];;
 
 [%quote let foo x = (x, x) in foo 42];;
 [%%expect {|
-- : (int * int) expr = << let foo = (fun x -> (x, x)) in foo 42 >>
+- : (int * int) expr = <[ let foo = (fun x -> (x, x)) in foo 42 ]>
 |}];;
 
 [%quote let foo = 50 and bar = 15 in foo + bar];;
 [%%expect {|
-- : int expr = << let foo = 50 and bar = 15 in foo + bar >>
+- : int expr = <[ let foo = 50 and bar = 15 in foo + bar ]>
 |}];;
 
 [%quote let x = 42 in let x = x in x];;
 [%%expect {|
-- : int expr = << let x = 42 in let x__1 = x in x__1 >>
+- : int expr = <[ let x = 42 in let x__1 = x in x__1 ]>
 |}];;
 
 [%quote
@@ -334,7 +334,7 @@ Here is an example of a case that is not matched:
   let+ a = 42 in a
 ];;
 [%%expect {|
-- : int expr = << let (let+) = (fun x f -> f x) in let+ a = 42 in a >>
+- : int expr = <[ let (let+) = (fun x f -> f x) in let+ a = 42 in a ]>
 |}];;
 
 [%quote
@@ -344,10 +344,10 @@ Here is an example of a case that is not matched:
 ];;
 [%%expect {|
 - : int option expr =
-<<
+<[
   let (let+) = (fun x f -> Stdlib.Option.map f x) in
     let+ a = Some 42 in a * 2
->>
+]>
 |}];;
 
 [%quote
@@ -358,29 +358,29 @@ Here is an example of a case that is not matched:
 ];;
 [%%expect {|
 - : int list expr =
-<<
+<[
   let (let*) = (fun x f -> Stdlib.List.map f x)
   and (and*) = Stdlib.List.combine in
     let* a = (::) (1, ((::) (2, ((::) (3, [])))))
-    and* b = (::) (10, ((::) (20, ((::) (30, []))))) in a + b >>
+    and* b = (::) (10, ((::) (20, ((::) (30, []))))) in a + b ]>
 |}];;
 
 [%quote fun (f: int -> int) (x: int) -> f x]
 [%%expect {|
 - : ((int -> int) -> int -> int) expr =
-<< fun (f : int -> int) (x : int) -> f x >>
+<[ fun (f : int -> int) (x : int) -> f x ]>
 |}];;
 
 [%quote let module M = Set.Make(Int) in M.singleton 100 |> M.elements];;
 [%%expect {|
 - : Int.t list expr =
-<< let module M = Stdlib.Set.Make(Stdlib.Int) in M.elements (M.singleton 100)
->>
+<[ let module M = Stdlib.Set.Make(Stdlib.Int) in M.elements (M.singleton 100)
+]>
 |}];;
 
 [%quote ref 42];;
 [%%expect {|
-- : int ref expr = << Stdlib.ref 42 >>
+- : int ref expr = <[ Stdlib.ref 42 ]>
 |}];;
 
 [%quote
@@ -392,8 +392,8 @@ Here is an example of a case that is not matched:
 ];;
 [%%expect {|
 - : int expr =
-<< let x = (Stdlib.ref 0) in for i = 0 to 10 do (x := ((! x) + i)) done; ! x
->>
+<[ let x = (Stdlib.ref 0) in for i = 0 to 10 do (x := ((! x) + i)) done; ! x
+]>
 |}];;
 
 [%quote
@@ -405,15 +405,15 @@ Here is an example of a case that is not matched:
 ];;
 [%%expect {|
 - : int expr =
-<<
+<[
   let x = (Stdlib.ref 0) in for i = 10 downto 0 do (x := ((! x) + i)) done;
     ! x
->>
+]>
 |}];;
 
 [%quote while true do () done];;
 [%%expect {|
-- : 'a expr = << while true do  () done >>
+- : 'a expr = <[ while true do  () done ]>
 |}];;
 
 [%quote
@@ -426,56 +426,56 @@ Here is an example of a case that is not matched:
 ];;
 [%%expect {|
 - : int expr =
-<<
+<[
   let f = (Stdlib.ref 1) and i = (Stdlib.ref 5) in
     while (! i) > 0 do  (f := ((! i) * (! f)); i := ((! i) - 1)) done;
     ! f
->>
+]>
 |}];;
 
 [%quote assert true];;
 [%%expect {|
-- : unit expr = << assert true >>
+- : unit expr = <[ assert true ]>
 |}];;
 
 [%quote assert false];;
 [%%expect {|
-- : 'a expr = << assert false >>
+- : 'a expr = <[ assert false ]>
 |}];;
 
 [%quote lazy 42];;
 [%%expect {|
-- : int lazy_t expr = << lazy 42 >>
+- : int lazy_t expr = <[ lazy 42 ]>
 |}];;
 
 [%quote fun () -> #25n];;
 [%%expect {|
-- : (unit -> nativeint#) expr = << fun () -> #25n >>
+- : (unit -> nativeint#) expr = <[ fun () -> #25n ]>
 |}];;
 
 [%quote fun () -> #25l];;
 [%%expect {|
-- : (unit -> int32#) expr = << fun () -> #25l >>
+- : (unit -> int32#) expr = <[ fun () -> #25l ]>
 |}];;
 
 [%quote fun () -> #25L];;
 [%%expect {|
-- : (unit -> int64#) expr = << fun () -> #25L >>
+- : (unit -> int64#) expr = <[ fun () -> #25L ]>
 |}];;
 
 [%quote fun () -> #6.0];;
 [%%expect {|
-- : (unit -> float#) expr = << fun () -> #6.0 >>
+- : (unit -> float#) expr = <[ fun () -> #6.0 ]>
 |}];;
 
 [%quote fun () -> #6.0s];;
 [%%expect {|
-- : (unit -> float32#) expr = << fun () -> #6.0s >>
+- : (unit -> float32#) expr = <[ fun () -> #6.0s ]>
 |}];;
 
 [%quote fun () -> #(1, 2, 3)];;
 [%%expect {|
-- : (unit -> #(int * int * int)) expr = << fun () -> #(1, 2, 3) >>
+- : (unit -> #(int * int * int)) expr = <[ fun () -> #(1, 2, 3) ]>
 |}];;
 
 type rcd = {x: int; y: string};;
@@ -485,7 +485,7 @@ type rcd = { x : int; y : string; }
 
 [%quote {x = 42; y = "foo"}];;
 [%%expect {|
-- : rcd expr = << { x = 42; y = "foo"; } >>
+- : rcd expr = <[ { x = 42; y = "foo"; } ]>
 |}];;
 
 type rcd_u = #{xu: int; yu: string};;
@@ -495,111 +495,111 @@ type rcd_u = #{ xu : int; yu : string; }
 
 [%quote fun () -> #{xu = 42; yu = "foo"}];;
 [%%expect {|
-- : (unit -> rcd_u) expr = << fun () -> { xu = 42; yu = "foo"; } >>
+- : (unit -> rcd_u) expr = <[ fun () -> { xu = 42; yu = "foo"; } ]>
 |}];;
 
 [%quote fun r -> r.x];;
 [%%expect {|
-- : (rcd -> int) expr = << fun r -> r.x >>
+- : (rcd -> int) expr = <[ fun r -> r.x ]>
 |}];;
 
 [%quote fun {x; y} -> x];;
 [%%expect {|
-- : (rcd -> int) expr = << fun {x=x; y=y; } -> x >>
+- : (rcd -> int) expr = <[ fun {x=x; y=y; } -> x ]>
 |}];;
 
 [%quote raise (Match_failure ("foo", 42, 100))];;
 [%%expect {|
-- : 'a expr = << Stdlib.raise (Match_failure ("foo", 42, 100)) >>
+- : 'a expr = <[ Stdlib.raise (Match_failure ("foo", 42, 100)) ]>
 |}];;
 
 [%quote raise Out_of_memory];;
 [%%expect {|
-- : 'a expr = << Stdlib.raise Out_of_memory >>
+- : 'a expr = <[ Stdlib.raise Out_of_memory ]>
 |}];;
 
 [%quote raise (Invalid_argument "arg")];;
 [%%expect {|
-- : 'a expr = << Stdlib.raise (Invalid_argument "arg") >>
+- : 'a expr = <[ Stdlib.raise (Invalid_argument "arg") ]>
 |}];;
 
 [%quote raise (Failure "fail")];;
 [%%expect {|
-- : 'a expr = << Stdlib.raise (Failure "fail") >>
+- : 'a expr = <[ Stdlib.raise (Failure "fail") ]>
 |}];;
 
 [%quote raise Not_found];;
 [%%expect {|
-- : 'a expr = << Stdlib.raise Not_found >>
+- : 'a expr = <[ Stdlib.raise Not_found ]>
 |}];;
 
 [%quote raise (Sys_error "err")];;
 [%%expect {|
-- : 'a expr = << Stdlib.raise (Sys_error "err") >>
+- : 'a expr = <[ Stdlib.raise (Sys_error "err") ]>
 |}];;
 
 [%quote raise End_of_file];;
 [%%expect {|
-- : 'a expr = << Stdlib.raise End_of_file >>
+- : 'a expr = <[ Stdlib.raise End_of_file ]>
 |}];;
 
 [%quote raise Division_by_zero];;
 [%%expect {|
-- : 'a expr = << Stdlib.raise Division_by_zero >>
+- : 'a expr = <[ Stdlib.raise Division_by_zero ]>
 |}];;
 
 [%quote raise Stack_overflow];;
 [%%expect {|
-- : 'a expr = << Stdlib.raise Stack_overflow >>
+- : 'a expr = <[ Stdlib.raise Stack_overflow ]>
 |}];;
 
 [%quote raise Sys_blocked_io];;
 [%%expect {|
-- : 'a expr = << Stdlib.raise Sys_blocked_io >>
+- : 'a expr = <[ Stdlib.raise Sys_blocked_io ]>
 |}];;
 
 [%quote raise (Assert_failure ("assert", 42, 100))];;
 [%%expect {|
-- : 'a expr = << Stdlib.raise (Assert_failure ("assert", 42, 100)) >>
+- : 'a expr = <[ Stdlib.raise (Assert_failure ("assert", 42, 100)) ]>
 |}];;
 
 [%quote raise (Undefined_recursive_module ("M", 42, 100))];;
 [%%expect {|
-- : 'a expr = << Stdlib.raise (Undefined_recursive_module ("M", 42, 100)) >>
+- : 'a expr = <[ Stdlib.raise (Undefined_recursive_module ("M", 42, 100)) ]>
 |}];;
 
 [%quote let exception E in ()];;
 [%%expect {|
-- : unit expr = << let exception E in () >>
+- : unit expr = <[ let exception E in () ]>
 |}];;
 
 [%quote let exception E in raise E];;
 [%%expect {|
-- : 'a expr = << let exception E in Stdlib.raise E >>
+- : 'a expr = <[ let exception E in Stdlib.raise E ]>
 |}];;
 
 [%quote let module M = Option in M.map];;
 [%%expect {|
 - : (('_weak37 -> '_weak38) -> '_weak37 option -> '_weak38 option) expr =
-<< let module M = Stdlib.Option in M.map >>
+<[ let module M = Stdlib.Option in M.map ]>
 |}];;
 
 [%quote let module M = Option in function | M.None -> false | M.Some x -> x];;
 [%%expect {|
 - : (bool option -> bool) expr =
-<< let module M = Stdlib.Option in function | None -> false | Some (x) -> x
->>
+<[ let module M = Stdlib.Option in function | None -> false | Some (x) -> x
+]>
 |}];;
 
 [%quote fun () -> exclave_ Some 42];;
 [%%expect {|
-- : (unit -> local_ int option) expr = << fun () -> exclave_ Some 42 >>
+- : (unit -> local_ int option) expr = <[ fun () -> exclave_ Some 42 ]>
 |}];;
 
 [%quote fun () -> exclave_ stack_ (Some 42)];;
 [%%expect {|
-- : (unit -> local_ int option) expr = << fun () -> exclave_ stack_ (Some 42)
->>
+- : (unit -> local_ int option) expr = <[ fun () -> exclave_ stack_ (Some 42)
+]>
 |}];;
 
 module type S = sig
@@ -616,28 +616,28 @@ module type S =
 
 [%quote fun (module _ : S) x -> 42];;
 [%%expect {|
-- : ((module S) -> '_weak39 -> int) expr = << fun (module _ : S) x -> 42 >>
+- : ((module S) -> '_weak39 -> int) expr = <[ fun (module _ : S) x -> 42 ]>
 |}];;
 
 [%quote fun (module M : S) x -> M.c (M.b M.a x)];;
 [%%expect {|
 - : ((module S) -> int -> int) expr =
-<< fun (module M : S) x -> M.c (M.b M.a x) >>
+<[ fun (module M : S) x -> M.c (M.b M.a x) ]>
 |}];;
 
 [%quote fun (module M : S with type t = string) x -> M.c (M.b M.a x)];;
 [%%expect {|
 - : ((module S with type t = string) -> int -> int) expr =
-<< fun (module M : S with type t = string) x -> M.c (M.b M.a x) >>
+<[ fun (module M : S with type t = string) x -> M.c (M.b M.a x) ]>
 |}];;
 
 [%quote fun (module M : S with type t = string and type t2 = int) x -> M.c (M.b M.a x)];;
 [%%expect {|
 - : ((module S with type t = string and type t2 = int) -> int -> int) expr =
-<<
+<[
   fun (module M : S with type t = string and type t2 = int) x ->
     M.c (M.b M.a x)
->>
+]>
 |}];;
 
 [%quote let module M (N : S) = struct type t = N.t let x = N.a end in ()];;
@@ -663,7 +663,7 @@ Uncaught exception: Misc.Fatal_error
 
 let x = [%quote 123] in [%quote !#(x)];;
 [%%expect {|
-- : int expr = << 123 >>
+- : int expr = <[ 123 ]>
 |}];;
 
 [%quote let o = object method f = 1 end in o#f];;
@@ -675,104 +675,104 @@ Uncaught exception: Misc.Fatal_error
 
 [%quote fun x -> !#[%quote x]];;
 [%%expect {|
-- : ('_weak40 -> '_weak40) expr = << fun x -> x >>
+- : ('_weak40 -> '_weak40) expr = <[ fun x -> x ]>
 |}];;
 
 [%quote !#[%quote 42]];;
 [%%expect {|
-- : int expr = << 42 >>
+- : int expr = <[ 42 ]>
 |}];;
 
 [%quote !#[%quote "foo"]];;
 [%%expect {|
-- : string expr = << "foo" >>
+- : string expr = <[ "foo" ]>
 |}];;
 
 [%quote fun x -> !#((fun y -> [%quote !#y + !#y]) [%quote x])];;
 [%%expect {|
-- : (int -> int) expr = << fun x -> x + x >>
+- : (int -> int) expr = <[ fun x -> x + x ]>
 |}];;
 
 [%quote !#((fun y -> [%quote !#y + !#y]) [%quote 2])];;
 [%%expect {|
-- : int expr = << 2 + 2 >>
+- : int expr = <[ 2 + 2 ]>
 |}];;
 
 [%quote [%quote !#[%quote 123]]];;
 [%%expect {|
-- : int expr expr = << << $ << 123 >> >> >>
+- : int expr expr = <[ <[ $ <[ 123 ]> ]> ]>
 |}];;
 
 let x = [%quote "foo"] and y = [%quote "bar"] in [%quote !#x ^ !#y];;
 [%%expect {|
-- : string expr = << "foo" ^ "bar" >>
+- : string expr = <[ "foo" ^ "bar" ]>
 |}];;
 
 [%quote fun x -> [%quote [%quote !#(!#x)]]];;
 [%%expect {|
 - : ('_weak41 expr expr -> '_weak41 expr expr) expr =
-<< fun x -> << << $ ($ x) >> >> >>
+<[ fun x -> <[ <[ $ ($ x) ]> ]> ]>
 |}];;
 
 [%quote 42 [@inline]];;
 [%%expect {|
-- : int expr = << 42 [@inline] >>
+- : int expr = <[ 42 [@inline] ]>
 |}];;
 
 [%quote 42 [@inlined]];;
 [%%expect {|
-- : int expr = << 42 [@inlined] >>
+- : int expr = <[ 42 [@inlined] ]>
 |}];;
 
 [%quote 42 [@specialise]];;
 [%%expect {|
-- : int expr = << 42 [@specialise] >>
+- : int expr = <[ 42 [@specialise] ]>
 |}];;
 
 
 [%quote 42 [@specialised]];;
 [%%expect {|
-- : int expr = << 42 [@specialised] >>
+- : int expr = <[ 42 [@specialised] ]>
 |}];;
 
 
 [%quote 42 [@unrolled]];;
 [%%expect {|
-- : int expr = << 42 [@unrolled] >>
+- : int expr = <[ 42 [@unrolled] ]>
 |}];;
 
 
 [%quote 42 [@nontail]];;
 [%%expect {|
-- : int expr = << 42 [@nontail] >>
+- : int expr = <[ 42 [@nontail] ]>
 |}];;
 
 
 [%quote 42 [@tail]];;
 [%%expect {|
-- : int expr = << 42 [@tail] >>
+- : int expr = <[ 42 [@tail] ]>
 |}];;
 
 
 [%quote 42 [@poll]];;
 [%%expect {|
-- : int expr = << 42 [@poll] >>
+- : int expr = <[ 42 [@poll] ]>
 |}];;
 
 
 [%quote 42 [@loop]];;
 [%%expect {|
-- : int expr = << 42 [@loop] >>
+- : int expr = <[ 42 [@loop] ]>
 |}];;
 
 
 [%quote 42 [@tail_mod_cons]];;
 [%%expect {|
-- : int expr = << 42 [@tail_mod_cons] >>
+- : int expr = <[ 42 [@tail_mod_cons] ]>
 |}];;
 
 
 [%quote 42 [@quotation]];;
 [%%expect {|
-- : int expr = << 42 [@quotation] >>
+- : int expr = <[ 42 [@quotation] ]>
 |}];;

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -705,8 +705,8 @@ let x = [%quote "foo"] and y = [%quote "bar"] in [%quote !#x ^ !#y];;
 - : string code = [%quote Stdlib.( ^ ) "foo" "bar"]
 |}];;
 
-[%quote fun x -> [%quote [%quote !#x]]];;
+[%quote fun x -> [%quote [%quote !#(!#x)]]];;
 [%%expect {|
-- : ('_weak41 code -> '_weak41 code code) code = [%quote
-fun x -> [%quote [%quote !#x]]]
+- : ('_weak41 code code -> '_weak41 code code) code = [%quote
+fun x -> [%quote [%quote !#!#x]]]
 |}];;

--- a/testsuite/tests/quotation/imports.mli
+++ b/testsuite/tests/quotation/imports.mli
@@ -1,0 +1,1 @@
+type test_record = {field_a: int; field_b: string}

--- a/testsuite/tests/typing-unique/unique_analysis.ml
+++ b/testsuite/tests/typing-unique/unique_analysis.ml
@@ -503,7 +503,7 @@ Line 4, characters 12-13:
 4 |   unique_id r
                 ^
 Error: This value is used here as unique,
-       but it has already been read from in a closure that might be called later:
+       but it has already been read from in a lazy expression that might be forced later:
 Line 3, characters 17-18:
 3 |   let _l = lazy (r.z) in
                      ^

--- a/toplevel/byte/dune
+++ b/toplevel/byte/dune
@@ -43,6 +43,7 @@
                     camlinternalComprehension
                     camlinternalOO
                     camlinternalAtomic
+                    camlinternalQuote
                     stdlib__Char
                     stdlib__Complex
                     stdlib__Digest

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -404,9 +404,9 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                  Oval_lazy v
                end
 
-          | Tconstr (path, [ty_arg], _)
+          | Tconstr (path, [_], _)
             when Path.same path Predef.path_code ->
-            Oval_code
+            Oval_code (O.obj obj : CamlinternalQuote_bootstrap.Code.t)
 
           | Tconstr(path, ty_list, _) -> begin
               try

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -403,6 +403,11 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                  in
                  Oval_lazy v
                end
+
+          | Tconstr (path, [ty_arg], _)
+            when Path.same path Predef.path_code ->
+            Oval_code
+
           | Tconstr(path, ty_list, _) -> begin
               try
                 let decl = Env.find_type path env in

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -112,6 +112,7 @@ let pivot_level = 2 * lowest_level - 1
 
 let newgenty desc = newty2 ~level:generic_level desc
 let newgenvar ?name jkind = newgenty (Tvar { name; jkind })
+let newgenconstr path tyl = newgenty (Tconstr (path, tyl, ref Mnil))
 let newgenstub ~scope jkind =
   newty3 ~level:generic_level ~scope (Tvar { name=None; jkind })
 

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -61,6 +61,8 @@ val generic_level: int
 
 val newgenty: type_desc -> type_expr
         (* Create a generic type *)
+val newgenconstr: Path.t -> type_expr list -> type_expr
+        (* Create a generic type constructor *)
 val newgenvar: ?name:string -> jkind_lr -> type_expr
         (* Return a fresh generic variable *)
 val newgenstub: scope:int -> jkind_lr -> type_expr

--- a/typing/dune
+++ b/typing/dune
@@ -1,0 +1,5 @@
+(rule
+ (action
+   (progn
+     (copy ../stdlib/camlinternalQuote.ml camlinternalQuote_bootstrap.ml)
+     (copy ../stdlib/camlinternalQuote.mli camlinternalQuote_bootstrap.mli))))

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1478,6 +1478,7 @@ module Format_history = struct
       fprintf ppf
         "it's the type of the first argument to a function in a recursive \
          module"
+    | Quotation_result -> fprintf ppf "it's the result type of a quotation"
     | Unknown s ->
       fprintf ppf
         "unknown @[(please alert the Jane Street@;\
@@ -1972,6 +1973,7 @@ module Debug_printers = struct
     | Class_term_argument -> fprintf ppf "Class_term_argument"
     | Debug_printer_argument -> fprintf ppf "Debug_printer_argument"
     | Recmod_fun_arg -> fprintf ppf "Recmod_fun_arg"
+    | Quotation_result -> fprintf ppf "Quotation_result"
     | Unknown s -> fprintf ppf "Unknown %s" s
 
   let product_creation_reason ppf : History.product_creation_reason -> _ =

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1479,6 +1479,7 @@ module Format_history = struct
         "it's the type of the first argument to a function in a recursive \
          module"
     | Quotation_result -> fprintf ppf "it's the result type of a quotation"
+    | Antiquotation_result -> fprintf ppf "it's the result type of unquoting"
     | Unknown s ->
       fprintf ppf
         "unknown @[(please alert the Jane Street@;\
@@ -1974,6 +1975,7 @@ module Debug_printers = struct
     | Debug_printer_argument -> fprintf ppf "Debug_printer_argument"
     | Recmod_fun_arg -> fprintf ppf "Recmod_fun_arg"
     | Quotation_result -> fprintf ppf "Quotation_result"
+    | Antiquotation_result -> fprintf ppf "Antiquotation_result"
     | Unknown s -> fprintf ppf "Unknown %s" s
 
   let product_creation_reason ppf : History.product_creation_reason -> _ =

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -293,6 +293,7 @@ module History = struct
     | Debug_printer_argument
     | Recmod_fun_arg
     | Quotation_result
+    | Antiquotation_result
     | Unknown of string (* CR layouts: get rid of these *)
 
   type immediate_creation_reason =

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -292,6 +292,7 @@ module History = struct
     | Class_term_argument
     | Debug_printer_argument
     | Recmod_fun_arg
+    | Quotation_result
     | Unknown of string (* CR layouts: get rid of these *)
 
   type immediate_creation_reason =

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -287,6 +287,8 @@ let print_out_value ppf tree =
     | Oval_unboxed_tuple tree_list ->
         fprintf ppf "@[<1>#(%a)@]" (print_labeled_tree_list print_tree_1 ",")
           tree_list
+    | Oval_code ->
+        fprintf ppf "@[<1>code(%s)@]" "TODO"
     | tree -> fprintf ppf "@[<1>(%a)@]" (cautious print_tree_1) tree
   and print_fields first ppf =
     function

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -287,8 +287,7 @@ let print_out_value ppf tree =
     | Oval_unboxed_tuple tree_list ->
         fprintf ppf "@[<1>#(%a)@]" (print_labeled_tree_list print_tree_1 ",")
           tree_list
-    | Oval_code ->
-        fprintf ppf "@[<1>code(%s)@]" "TODO"
+    | Oval_code e -> CamlinternalQuote_bootstrap.Code.print ppf e
     | tree -> fprintf ppf "@[<1>(%a)@]" (cautious print_tree_1) tree
   and print_fields first ppf =
     function

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -59,6 +59,7 @@ type out_value =
   | Oval_unboxed_tuple of (string option * out_value) list
   | Oval_variant of string * out_value option
   | Oval_lazy of out_value
+  | Oval_code
 type out_modality_legacy = Ogf_global
 
 type out_modality_new = string

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -59,7 +59,8 @@ type out_value =
   | Oval_unboxed_tuple of (string option * out_value) list
   | Oval_variant of string * out_value option
   | Oval_lazy of out_value
-  | Oval_code
+  | Oval_code of CamlinternalQuote_bootstrap.Code.t
+
 type out_modality_legacy = Ogf_global
 
 type out_modality_new = string
@@ -71,8 +72,6 @@ type out_modality =
 type out_mutability =
   | Om_immutable
   | Om_mutable of string option
-
-
 
 (** This definition avoids a cyclic dependency between Outcometree and Types. *)
 type arg_label =

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -50,6 +50,7 @@ and ident_string = ident_create "string"
 and ident_extension_constructor = ident_create "extension_constructor"
 and ident_floatarray = ident_create "floatarray"
 and ident_lexing_position = ident_create "lexing_position"
+and ident_code = ident_create "code"
 
 and ident_unboxed_float = ident_create "float#"
 and ident_unboxed_float32 = ident_create "float32#"
@@ -93,6 +94,7 @@ and path_string = Pident ident_string
 and path_extension_constructor = Pident ident_extension_constructor
 and path_floatarray = Pident ident_floatarray
 and path_lexing_position = Pident ident_lexing_position
+and path_code = Pident ident_code
 
 and path_unboxed_float = Pident ident_unboxed_float
 and path_unboxed_float32 = Pident ident_unboxed_float32
@@ -137,6 +139,7 @@ and type_extension_constructor =
       newgenty (Tconstr(path_extension_constructor, [], ref Mnil))
 and type_floatarray = newgenty (Tconstr(path_floatarray, [], ref Mnil))
 and type_lexing_position = newgenty (Tconstr(path_lexing_position, [], ref Mnil))
+and type_code t = newgenty (Tconstr(path_code, [t], ref Mnil))
 
 and type_unboxed_float = newgenty (Tconstr(path_unboxed_float, [], ref Mnil))
 and type_unboxed_float32 = newgenty (Tconstr(path_unboxed_float32, [], ref Mnil))
@@ -418,6 +421,9 @@ let build_initial_env add_type add_extension empty_env =
        )
        ~jkind:Jkind.Const.Builtin.immutable_data
   |> add_type ident_string ~jkind:Jkind.Const.Builtin.immutable_data
+  |> add_type1 ident_code
+       ~variance:Variance.covariant
+       ~separability:Separability.Ind
   |> add_type ident_unboxed_float ~jkind:Jkind.Const.Builtin.float64
   |> add_type ident_unboxed_nativeint ~jkind:Jkind.Const.Builtin.word
   |> add_type ident_unboxed_int32 ~jkind:Jkind.Const.Builtin.bits32

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -50,7 +50,7 @@ and ident_string = ident_create "string"
 and ident_extension_constructor = ident_create "extension_constructor"
 and ident_floatarray = ident_create "floatarray"
 and ident_lexing_position = ident_create "lexing_position"
-and ident_code = ident_create "code"
+and ident_code = ident_create "expr"
 
 and ident_unboxed_float = ident_create "float#"
 and ident_unboxed_float32 = ident_create "float32#"

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -39,6 +39,7 @@ val type_lazy_t: type_expr -> type_expr
 val type_extension_constructor:type_expr
 val type_floatarray:type_expr
 val type_lexing_position:type_expr
+val type_code: type_expr -> type_expr
 val type_unboxed_float:type_expr
 val type_unboxed_float32:type_expr
 val type_unboxed_nativeint:type_expr
@@ -81,6 +82,7 @@ val path_lazy_t: Path.t
 val path_extension_constructor: Path.t
 val path_floatarray: Path.t
 val path_lexing_position: Path.t
+val path_code: Path.t
 
 val path_unboxed_float: Path.t
 val path_unboxed_float32: Path.t

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -659,6 +659,12 @@ and expression i ppf x =
     expression i ppf e2
   | Texp_hole _ ->
     line i ppf "Texp_hole"
+  | Texp_quotation e ->
+    line i ppf "Texp_quotation";
+      expression i ppf e
+  | Texp_antiquotation e ->
+    line i ppf "Texp_antiquotation";
+    expression i ppf e
 
 and value_description i ppf x =
   line i ppf "value_description %a %a\n" fmt_ident x.val_id fmt_location

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -444,7 +444,8 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
     sub.expr sub exp1;
     sub.expr sub exp2
   | Texp_hole _ -> ()
-
+  | Texp_quotation exp -> sub.expr sub exp
+  | Texp_antiquotation exp -> sub.expr sub exp
 
 let package_type sub {pack_fields; pack_txt; _} =
   List.iter (fun (lid, p) -> iter_loc sub lid; sub.typ sub p) pack_fields;

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -622,6 +622,10 @@ let expr sub x =
     | Texp_overwrite (exp1, exp2) ->
         Texp_overwrite (sub.expr sub exp1, sub.expr sub exp2)
     | Texp_hole use -> Texp_hole use
+    | Texp_quotation exp ->
+        Texp_quotation (sub.expr sub exp)
+    | Texp_antiquotation exp ->
+        Texp_antiquotation (sub.expr sub exp)
   in
   let exp_attributes = sub.attributes sub x.exp_attributes in
   {x with exp_loc; exp_extra; exp_desc; exp_env; exp_attributes}

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -274,6 +274,7 @@ type error =
   | Unrefuted_pattern of Typedtree.pattern
   | Invalid_extension_constructor_payload
   | Not_an_extension_constructor
+  | Invalid_quote_payload
   | Probe_format
   | Probe_name_format of string
   | Probe_name_undefined of string

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -301,6 +301,8 @@ and expression_desc =
   | Texp_src_pos
   | Texp_overwrite of expression * expression
   | Texp_hole of unique_use
+  | Texp_quotation of expression
+  | Texp_antiquotation of expression
 
 and ident_kind =
   | Id_value
@@ -1336,3 +1338,166 @@ let loc_of_decl ~uid =
   | Module_substitution msd -> msd.ms_name
   | Class cd -> cd.ci_id_name
   | Class_type ctd -> ctd.ci_id_name
+
+let rec fold_antiquote_exp f  acc exp =
+  match exp.exp_desc with
+  | Texp_ident _ | Texp_constant _ -> acc
+  | Texp_let (_, vbs, exp) ->
+      let acc = fold_antiquote_value_bindings f acc vbs in
+      fold_antiquote_exp f acc exp
+  | Texp_function { params; body; _ } ->
+      let acc = fold_antiquote_fun_params f acc params in
+      fold_antiquote_function_body f acc body
+  | Texp_apply (exp, list, _, _, _) ->
+      let acc = fold_antiquote_exp f acc exp in
+      fold_antiquote_args f acc list
+  | Texp_match (exp, _, cases, _) ->
+      let acc = fold_antiquote_exp f acc exp in
+      fold_antiquote_cases f acc cases
+  | Texp_try (exp, cases) ->
+      let acc = fold_antiquote_exp f acc exp in
+      fold_antiquote_cases f acc cases
+  | Texp_tuple (list, _) ->
+      List.fold_left (fun acc (_, e) -> fold_antiquote_exp f acc e) acc list
+  | Texp_unboxed_tuple list ->
+      List.fold_left (fun acc (_, e, _) -> fold_antiquote_exp f acc e) acc list
+  | Texp_construct (_, _, args, _) ->
+      fold_antiquote_exps f acc args
+  | Texp_variant (_, expo) ->
+      Option.fold
+        ~none:acc
+        ~some:(fun (e, _) -> fold_antiquote_exp f acc e)
+        expo
+  | Texp_record { fields; extended_expression; _} ->
+      let acc = Array.fold_left (fold_antiquote_field f) acc fields in
+      Option.fold
+        ~none:acc
+        ~some:(fun (e, _) -> fold_antiquote_exp f acc e)
+        extended_expression
+  | Texp_record_unboxed_product { fields; extended_expression; _} ->
+      let acc = Array.fold_left (fold_antiquote_field f) acc fields in
+      Option.fold
+        ~none:acc
+        ~some:(fun (e, _) -> fold_antiquote_exp f acc e)
+        extended_expression
+  | Texp_field (exp, _, _, _, _) ->
+      fold_antiquote_exp f acc exp
+  | Texp_unboxed_field (exp, _, _, _, _) ->
+      fold_antiquote_exp f acc exp
+  | Texp_setfield (exp1, _, _, _, exp2) ->
+      let acc = fold_antiquote_exp f acc exp1 in
+      fold_antiquote_exp f acc exp2
+  | Texp_array (_, _, list, _) ->
+      fold_antiquote_exps f acc list
+  | Texp_list_comprehension { comp_body; comp_clauses }
+  | Texp_array_comprehension (_, _, { comp_body; comp_clauses }) ->
+      let acc = fold_antiquote_exp f acc comp_body in
+      fold_antiquote_comprehension_clauses f acc comp_clauses
+  | Texp_ifthenelse (exp1, exp2, expo) ->
+      let acc = fold_antiquote_exp f acc exp1 in
+      let acc = fold_antiquote_exp f acc exp2 in
+      fold_antiquote_exp_opt f acc expo
+  | Texp_sequence (exp1, _, exp2) ->
+      let acc = fold_antiquote_exp f acc exp1 in
+      fold_antiquote_exp f acc exp2
+  | Texp_while { wh_cond; wh_body } ->
+      let acc = fold_antiquote_exp f acc wh_cond in
+      fold_antiquote_exp f acc wh_body
+  | Texp_for {for_from; for_to; for_body} ->
+      let acc = fold_antiquote_exp f acc for_from in
+      let acc = fold_antiquote_exp f acc for_to in
+      fold_antiquote_exp f acc for_body
+  | Texp_send (exp, _, _) -> fold_antiquote_exp f acc exp
+  | Texp_new (_, _, _, _) -> acc
+  | Texp_instvar (_, _, _) -> acc
+  | Texp_setinstvar (_, _, _, exp) -> fold_antiquote_exp f acc exp
+  | Texp_override (_, list) ->
+      List.fold_left (fun acc (_, _, e) -> fold_antiquote_exp f acc e) acc list
+  | Texp_letmodule (_, _, _, _, exp) -> fold_antiquote_exp f acc exp
+  | Texp_letexception (_, exp) -> fold_antiquote_exp f acc exp
+  | Texp_assert (exp, _) -> fold_antiquote_exp f acc exp
+  | Texp_lazy exp -> fold_antiquote_exp f acc exp
+  | Texp_object (_, _) -> acc
+  | Texp_pack _ -> acc
+  | Texp_letop {let_ = l; ands; body; _} ->
+      let acc = fold_antiquote_binding_op f acc l in
+      let acc = List.fold_left (fold_antiquote_binding_op f) acc ands in
+      fold_antiquote_case f acc body
+  | Texp_unreachable -> acc
+  | Texp_extension_constructor (_, _) -> acc
+  | Texp_open (_, e) -> fold_antiquote_exp f acc e
+  | Texp_probe {handler;_} -> fold_antiquote_exp f acc handler
+  | Texp_probe_is_enabled _ -> acc
+  | Texp_exclave exp -> fold_antiquote_exp f acc exp
+  | Texp_src_pos -> acc
+  | Texp_overwrite (exp1, exp2) ->
+      let acc = fold_antiquote_exp f acc exp1 in
+      fold_antiquote_exp f acc exp2
+  | Texp_hole _ -> acc
+  | Texp_quotation exp ->
+      fold_antiquote_exp (fold_antiquote_exp f) acc exp
+  | Texp_antiquotation exp -> f acc exp
+
+and fold_antiquote_exp_opt f acc = function
+  | None -> acc
+  | Some exp -> fold_antiquote_exp f acc exp
+
+and fold_antiquote_exps f acc exps =
+  List.fold_left (fold_antiquote_exp f) acc exps
+
+and fold_antiquote_value_bindings f acc vbs =
+  List.fold_left (fun acc vb -> fold_antiquote_exp f acc vb.vb_expr) acc vbs
+
+and fold_antiquote_fun_param f acc fp =
+  match fp.fp_kind with
+  | Tparam_pat _ -> acc
+  | Tparam_optional_default(_, exp, _) -> fold_antiquote_exp f acc exp
+
+and fold_antiquote_fun_params f acc fps =
+  List.fold_left (fold_antiquote_fun_param f) acc fps
+
+and fold_antiquote_function_body f acc = function
+  | Tfunction_body exp -> fold_antiquote_exp f acc exp
+  | Tfunction_cases fc -> fold_antiquote_cases f acc fc.fc_cases
+
+and fold_antiquote_case : 'k. _ -> _ -> 'k case -> _ =
+  fun f acc c ->
+    let acc = fold_antiquote_exp_opt f acc c.c_guard in
+    fold_antiquote_exp f acc c.c_rhs
+
+and fold_antiquote_cases : 'k. _ -> _ -> 'k case list -> _ =
+  fun f acc cases ->
+    List.fold_left (fold_antiquote_case f) acc cases
+
+and fold_antiquote_arg f acc (_, arg) =
+  match arg with
+  | Omitted _ -> acc
+  | Arg (exp, _) -> fold_antiquote_exp f acc exp
+
+and fold_antiquote_args f acc args =
+  List.fold_left (fold_antiquote_arg f) acc args
+
+and fold_antiquote_field : 'l. _ -> _ -> 'l * _ -> _ =
+  fun f acc -> function
+  | _, Kept _ -> acc
+  | _, Overridden (_, exp) -> fold_antiquote_exp f acc exp
+
+and fold_antiquote_comprehension_clause f acc = function
+  | Texp_comp_for bindings ->
+      List.fold_left
+        (fun acc { comp_cb_iterator; _ } ->
+          match comp_cb_iterator with
+          | Texp_comp_range { ident = _; start; stop; direction = _ } ->
+              let acc = fold_antiquote_exp f acc start in
+              fold_antiquote_exp f acc stop
+          | Texp_comp_in { pattern = _; sequence } ->
+              fold_antiquote_exp f acc sequence)
+        acc bindings
+  | Texp_comp_when exp ->
+      fold_antiquote_exp f acc exp
+
+and fold_antiquote_comprehension_clauses f acc ccs =
+  List.fold_left (fold_antiquote_comprehension_clause f) acc ccs
+
+and fold_antiquote_binding_op f acc op =
+  fold_antiquote_exp f acc op.bop_exp

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -505,6 +505,8 @@ and expression_desc =
        Position argument in function application *)
   | Texp_overwrite of expression * expression (** overwrite_ exp with exp *)
   | Texp_hole of unique_use (** _ *)
+  | Texp_quotation of expression
+  | Texp_antiquotation of expression
 
 and function_curry =
   | More_args of { partial_mode : Mode.Alloc.l }
@@ -1288,3 +1290,7 @@ val function_arity : function_param list -> function_body -> int
 
 (** Given a declaration, return the location of the bound identifier *)
 val loc_of_decl : uid:Shape.Uid.t -> item_declaration -> string Location.loc
+
+(** Fold over the antiquotations in an expression. This function defines the
+    evaluation order of antiquotations. *)
+val fold_antiquote_exp : ('a -> expression -> 'a) -> 'a -> expression -> 'a

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -2660,7 +2660,7 @@ let report_multi_use inner first_is_of_second =
             match lifter with
             | Closure -> " in a closure that might be called later"
             | Lazy_expr -> " in a lazy expression that might be forced later"
-            | Quotation -> " in a quotation that might be spliced in at a later point"
+            | Quotation -> " in a quotation that might be unquoted in at a later point"
           in
           access ^ lifter)
     | _ -> "used"

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -673,7 +673,7 @@ end = struct
     | Maybe_aliased ma -> fprintf ppf "Maybe_aliased(%a)" Maybe_aliased.print ma
     | Aliased a -> fprintf ppf "Aliased(%a)" Aliased.print a
     | Maybe_unique mu -> fprintf ppf "Maybe_unique(%a)" Maybe_unique.print mu
-    | Antiquote t -> fprintf ppf "Antiquote(%a)" print t  
+    | Antiquote t -> fprintf ppf "Antiquote(%a)" print t
 
 end
 

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -2660,7 +2660,7 @@ let report_multi_use inner first_is_of_second =
             match lifter with
             | Closure -> " in a closure that might be called later"
             | Lazy_expr -> " in a lazy expression that might be forced later"
-            | Quotation -> " in a quotation that might be unquoted in at a later point"
+            | Quotation -> " in a quotation that might be spliced in at a later point"
           in
           access ^ lifter)
     | _ -> "used"

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -711,6 +711,12 @@ let expression sub exp =
     | Texp_overwrite (exp1, exp2) ->
         Pexp_overwrite(sub.expr sub exp1, sub.expr sub exp2)
     | Texp_hole _ -> Pexp_hole
+    | Texp_quotation exp ->
+        Pexp_extension
+          ({ txt = "quotation"; loc} , PStr ([Str.eval ~loc (sub.expr sub exp)]))
+    | Texp_antiquotation exp ->
+        let op = Exp.ident ~loc (mkloc (Longident.Lident "!#") loc) in
+        Pexp_apply(op, [(Nolabel, sub.expr sub exp)])
   in
   List.fold_right (exp_extra sub) exp.exp_extra
     (Exp.mk ~loc ~attrs desc)

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -1037,7 +1037,7 @@ let rec expression : Typedtree.expression -> term_judg =
       ]
     | Texp_hole _ -> empty
     | Texp_quotation e ->
-        (* The quoted code may be antiquoted into a dereferencing context. *)
+        (* The quoted code may be spliced into a dereferencing context. *)
         expression e << Dereference
     | Texp_antiquotation e ->
         expression e << Dereference

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -1037,7 +1037,7 @@ let rec expression : Typedtree.expression -> term_judg =
       ]
     | Texp_hole _ -> empty
     | Texp_quotation e ->
-        (* The quoted code may be spliced into a dereferencing context. *)
+        (* The quoted code may be antiquoted into a dereferencing context. *)
         expression e << Dereference
     | Texp_antiquotation e ->
         expression e << Dereference

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -264,7 +264,9 @@ let classify_expression : Typedtree.expression -> sd =
     | Texp_assert _
     | Texp_try _
     | Texp_override _
-    | Texp_letop _ ->
+    | Texp_letop _
+    | Texp_quotation _
+    | Texp_antiquotation _ ->
         Dynamic
   and classify_value_bindings rec_flag env bindings =
     (* We use a non-recursive classification, classifying each
@@ -1034,6 +1036,11 @@ let rec expression : Typedtree.expression -> term_judg =
         expression exp2
       ]
     | Texp_hole _ -> empty
+    | Texp_quotation e ->
+        (* The quoted code may be spliced into a dereferencing context. *)
+        expression e << Dereference
+    | Texp_antiquotation e ->
+        expression e << Dereference
 
 (* Function bodies.
     G |-{body} b : m


### PR DESCRIPTION
Quoted expressions can be created using `[%quote ...]` extension point syntax. They can also be spliced using the `!#` operator.

The changes in this pull request do not guarantee type safety at this point. Not all kinds of expressions can be quoted (notably, locally opening modules).