### PR TITLE
Improved x86 code generation for Boolean not

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -734,14 +734,14 @@ let mk_not dbg cmm =
     | _ ->
       (* 0 -> 3, 1 -> 1 *)
       Cop
-        ( Csubi,
+        ( Cxor,
           [Cconst_int (3, dbg); Cop (Clsl, [c; Cconst_int (1, dbg)], dbg)],
           dbg ))
   | Cconst_int (3, _) -> Cconst_int (1, dbg)
   | Cconst_int (1, _) -> Cconst_int (3, dbg)
   | c ->
     (* 1 -> 3, 3 -> 1 *)
-    Cop (Csubi, [Cconst_int (4, dbg); c], dbg)
+    Cop (Cxor, [Cconst_int (2, dbg); c], dbg)
 
 let mk_compare_ints_untagged dbg a1 a2 =
   bind "int_cmp" a2 (fun a2 ->


### PR DESCRIPTION
We currently compile Boolean not (and equivalent `match` expressions) on tagged immediates as `4 - i` or, combined with tagging, as `3 - (i << 1)`. On x86 this generates

```
mov     rbx, rax
mov     eax, 4
sub     rax, rbx
```

for the (much more common) tagged-to-tagged case and

```
mov     rbx, rax
and     ebx, 1
shl     rbx
mov     eax, 3
sub     rax, rbx
```

for the untagged-to-tagged case. (These are the asm outputs for `not` and `Obj.is_block`, not counting the `ret`.)

This PR uses `2 xor i` for tagged-to-tagged and `3 xor (i << 1)` for untagged-to-tagged, giving

```
xor     2, rax
```

and

```
and     1, eax
sal     1, rax
xor     3, rax
```

respectively. Notably, gcc generates exactly the same single instruction for Boolean not (only it's `xor 1`, not 2, naturally).