### PR TITLE
Optionally disable hugepages for stacks

### DIFF
--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -58,6 +58,7 @@ extern uintnat caml_pool_min_chunk_bsz;  /* see shared_heap.c */
 extern uintnat caml_percent_sweep_per_mark; /* see major_gc.c */
 extern uintnat caml_gc_pacing_policy;       /* see major_gc.c */
 extern uintnat caml_gc_overhead_adjustment; /* see major_gc.c */
+extern uintnat caml_nohugepage_stacks;    /* see fiber.c */
 
 CAMLprim value caml_gc_quick_stat(value v)
 {
@@ -443,6 +444,7 @@ static struct gc_tweak gc_tweaks[] = {
   { "percent_sweep_per_mark", &caml_percent_sweep_per_mark, 0 },
   { "gc_pacing_policy", &caml_gc_pacing_policy, 0 },
   { "gc_overhead_adjustment", &caml_gc_overhead_adjustment, 0 },
+  { "nohugepage_stacks", &caml_nohugepage_stacks, 0 },
 };
 
 enum {N_GC_TWEAKS = sizeof(gc_tweaks)/sizeof(gc_tweaks[0])};


### PR DESCRIPTION
Hugepages are not necessarily a good idea for stacks: they mean that every stack takes 2MB of RAM, even though most programs confine themselves to a few k of stacks. This patch adds a new GC tweak to optionally disable hugepages for stacks (`Xnohugepage_stacks=1`), by passing `MADV_NOHUGEPAGE` to `madvise`.

On this program:
```
let n = Atomic.make 0
let () =
  let _ = List.init 100 (fun _ -> Thread.create (fun () -> Atomic.incr n; Unix.sleep 100) ()) in
  while Atomic.get n < 100 do Thread.yield () done;
  ()
```

the new flag makes the memory consumption go from 400 MB to 200 MB. (I think the remaining 2MB per thread is the glibc pthread stack).