### PR TITLE
`switching` mode

### DIFF
--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -1183,7 +1183,7 @@ Error: The kind of type "t" is value
          because it instantiates an unannotated type parameter of t,
          chosen to have kind value.
        But the kind of type "t" must be a subkind of
-         immutable_data mod global aliased yielding
+         immutable_data mod global aliased switching
          because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this should be accepted *)

--- a/testsuite/tests/typing-modes/crossing.ml
+++ b/testsuite/tests/typing-modes/crossing.ml
@@ -111,7 +111,7 @@ type cross_once
 type cross_portable : value mod portable
 type cross_nonportable
 type cross_unyielding : value mod unyielding
-type cross_yielding
+type cross_yielding : value mod yielding
 type cross_aliased : value mod aliased
 type cross_unique
 type cross_contended : value mod contended

--- a/testsuite/tests/typing-modes/mutable.ml
+++ b/testsuite/tests/typing-modes/mutable.ml
@@ -46,12 +46,12 @@ type r = { mutable s : string @@ yielding; }
 
 type r = {mutable s : string @@ local yielding}
 [%%expect{|
-type r = { mutable s : string @@ local; }
+type r = { mutable s : string @@ local yielding; }
 |}]
 
 type r = {mutable s : string @@ yielding local}
 [%%expect{|
-type r = { mutable s : string @@ local; }
+type r = { mutable s : string @@ local yielding; }
 |}]
 
 type r = {mutable s : string @@ local unyielding}

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -147,16 +147,20 @@ let value_descriptions ~loc env name
      match vd2.val_kind with
      | Val_prim p2 -> begin
          let locality = [ Mode.Locality.global; Mode.Locality.local ] in
-         let yielding = [ Mode.Yielding.unyielding; Mode.Yielding.yielding ] in
+         let yielding =
+            [ Mode.Yielding.unyielding
+            ; Mode.Yielding.yielding
+            ; Mode.Yielding.switching ]
+         in
          List.iter (fun loc ->
            List.iter (fun yield ->
              let ty1, _, _, _ = Ctype.instance_prim p1 vd1.val_type in
              let ty2, mode_l2, mode_y2, _ = Ctype.instance_prim p2 vd2.val_type in
              Option.iter (Mode.Locality.equate_exn loc) mode_l2;
              Option.iter (Mode.Yielding.equate_exn yield) mode_y2;
-             try 
+             try
                Ctype.moregeneral env true ty1 ty2
-             with Ctype.Moregen err -> 
+             with Ctype.Moregen err ->
                raise (Dont_match (Type err))
            ) yielding
          ) locality;

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1658,15 +1658,19 @@ module Const = struct
       |> function
       | None -> None
       | Some modes ->
+        (* CR-soon dkalinichenko: there ought to be a better way to handle this. *)
         (* Handle all the mode implications *)
         let modes =
           match List.mem "global" modes, List.mem "unyielding" modes with
           | true, true ->
             (* [global] implies [unyielding], omit it. *)
             List.filter (fun m -> m <> "unyielding") modes
+          | true, false when List.mem "yielding" modes ->
+            (* Print nothing extra, [yielding] already present. *)
+            modes
           | true, false ->
-            (* Otherwise, print [mod global yielding] to indicate [yielding]. *)
-            modes @ ["yielding"]
+            (* Otherwise, print [mod global switching]. *)
+            modes @ ["switching"]
           | _, _ -> modes
         in
         let modes =
@@ -1680,10 +1684,12 @@ module Const = struct
         let modes =
           match List.mem "immutable" modes, List.mem "contended" modes with
           | true, true -> List.filter (fun m -> m <> "contended") modes
+          | true, false when List.mem "shared" modes -> modes
           | true, false -> modes @ ["contended"]
           | _, _ -> (
             match List.mem "read" modes, List.mem "shared" modes with
             | true, true -> List.filter (fun m -> m <> "shared") modes
+            | true, false when List.mem "contended" modes -> modes
             | true, false -> modes @ ["shared"]
             | _, _ -> modes)
         in

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -335,6 +335,7 @@ module Lattices = struct
 
   module Yielding = struct
     type t =
+      | Switching
       | Yielding
       | Unyielding
 
@@ -343,32 +344,32 @@ module Lattices = struct
 
       let min = Unyielding
 
-      let max = Yielding
+      let max = Switching
 
       let legacy = Unyielding
 
       let[@inline] le a b =
         match a, b with
-        | Unyielding, _ | _, Yielding -> true
-        | Yielding, Unyielding -> false
-
-      let[@inline] equal a b =
-        match a, b with
+        | Unyielding, _ | _, Switching -> true
+        | Switching, _ | _, Unyielding -> false
         | Yielding, Yielding -> true
-        | Unyielding, Unyielding -> true
-        | Yielding, Unyielding | Unyielding, Yielding -> false
+
+      let[@inline] equal a b = a = b
 
       let join a b =
         match a, b with
+        | Switching, _ | _, Switching -> Switching
         | Yielding, _ | _, Yielding -> Yielding
         | Unyielding, Unyielding -> Unyielding
 
       let meet a b =
         match a, b with
         | Unyielding, _ | _, Unyielding -> Unyielding
-        | Yielding, Yielding -> Yielding
+        | Yielding, _ | _, Yielding -> Yielding
+        | Switching, Switching -> Switching
 
       let print ppf = function
+        | Switching -> Format.fprintf ppf "switching"
         | Yielding -> Format.fprintf ppf "yielding"
         | Unyielding -> Format.fprintf ppf "unyielding"
     end)
@@ -2059,6 +2060,8 @@ module Yielding = struct
   end
 
   include Comonadic_gen (Obj)
+
+  let switching = of_const Switching
 
   let yielding = of_const Yielding
 

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -305,6 +305,7 @@ module type S = sig
   module Yielding : sig
     module Const : sig
       type t =
+        | Switching
         | Yielding
         | Unyielding
 
@@ -315,6 +316,8 @@ module type S = sig
       Common_axis
         with module Const := Const
          and type 'd t = (Const.t, 'd pos) mode
+
+    val switching : lr
 
     val yielding : lr
 

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1447,7 +1447,7 @@ let tree_of_modes (modes : Mode.Alloc.Const.t) =
   (* [yielding] has implied defaults depending on [areality]: *)
   let yielding =
     match modes.areality, modes.yielding with
-    | Local, Yielding | Global, Unyielding -> None
+    | Local, Switching | Global, Unyielding -> None
     | _, _ -> Some modes.yielding
   in
 

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -59,6 +59,8 @@ module Axis_pair = struct
     | "external64" ->
       Any_axis_pair (Nonmodal Externality, Externality.External64)
     | "external_" -> Any_axis_pair (Nonmodal Externality, Externality.External)
+    | "switching" ->
+      Any_axis_pair (Modal (Comonadic Yielding), Yielding.Const.Switching)
     | "yielding" ->
       Any_axis_pair (Modal (Comonadic Yielding), Yielding.Const.Yielding)
     | "unyielding" ->
@@ -292,7 +294,7 @@ let default_mode_annots (annots : Alloc.Const.Option.t) =
     match annots.yielding, annots.areality with
     | (Some _ as y), _ | y, None -> y
     | None, Some Locality.Const.Global -> Some Yielding.Const.Unyielding
-    | None, Some Locality.Const.Local -> Some Yielding.Const.Yielding
+    | None, Some Locality.Const.Local -> Some Yielding.Const.Switching
   in
   (* Likewise for [contention]. *)
   let contention =
@@ -349,7 +351,7 @@ let untransl_mode_annots (modes : Mode.Alloc.Const.Option.t) =
     (* Since [yielding] has non-standard defaults, we special-case
        whether we want to print it here. *)
     match modes.yielding, modes.areality with
-    | Some Yielding.Const.Yielding, Some Locality.Const.Local
+    | Some Yielding.Const.Switching, Some Locality.Const.Local
     | Some Yielding.Const.Unyielding, Some Locality.Const.Global ->
       None
     | _, _ -> print_to_string_opt Mode.Yielding.Const.print modes.yielding
@@ -442,6 +444,8 @@ let untransl_modality (a : Modality.t) : Parsetree.modality loc =
     | Atom (Monadic Contention, Join_with Contention.Const.Shared) -> "shared"
     | Atom (Monadic Contention, Join_with Contention.Const.Uncontended) ->
       "uncontended"
+    | Atom (Comonadic Yielding, Meet_with Yielding.Const.Switching) ->
+      "switching"
     | Atom (Comonadic Yielding, Meet_with Yielding.Const.Yielding) -> "yielding"
     | Atom (Comonadic Yielding, Meet_with Yielding.Const.Unyielding) ->
       "unyielding"
@@ -502,7 +506,7 @@ let implied_modalities (Atom (ax, a) : Modality.t) : Modality.t list =
     let b : Yielding.Const.t =
       match a with
       | Global -> Unyielding
-      | Local -> Yielding
+      | Local -> Switching
       | Regional -> assert false
     in
     [Atom (Comonadic Yielding, Meet_with b)]


### PR DESCRIPTION
Add the `switching` mode on the yielding axis, going `unyielding < yielding < switching`, to distinguish between functions that perform stack-switching and functions that merely need exclusive access to the stack. `local` now implies `switching`.

Also fix a minor issue in mod bounds printing with implications.