### PR TITLE
Add `-o` option to ocamldep

### DIFF
--- a/testsuite/tests/tool-ocamldep-shadowing/a.ml
+++ b/testsuite/tests/tool-ocamldep-shadowing/a.ml
@@ -2,9 +2,18 @@
  subdirectories = "dir1 dir2";
  setup-ocamlc.byte-build-env;
  commandline = "-depend -slash -I dir1 -I dir2 a.ml";
- ocamlc.byte;
  compiler_reference = "${test_source_directory}/a.reference";
- check-ocamlc.byte-output;
+ {
+   ocamlc.byte;
+   check-ocamlc.byte-output;
+ }
+ {
+   commandline += " -o a.output";
+   ocamlc.byte;
+   output = "a.output";
+   reference = "${compiler_reference}";
+   check-program-output;
+ }
 *)
 
 include B


### PR DESCRIPTION
Let `ocamldep` output to a file rather than standard output. This makes life easier for build rules.