### PR TITLE
Linscan: use skip lists (remove doubly-linked lists)

### DIFF
--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -144,7 +144,6 @@ let allocate_free_register : State.t -> Interval.t -> spilling_reg =
           then set_not_available r
         | Stack _ | Unknown -> ()
       in
-      DLL.iter intervals.active_dll ~f:set_not_available_if_valid_phys_reg;
       Interval.DescEndList.iter intervals.active_sl
         ~f:set_not_available_if_valid_phys_reg;
       let remove_bound_overlapping (itv : Interval.t) : unit =
@@ -156,9 +155,6 @@ let allocate_free_register : State.t -> Interval.t -> spilling_reg =
           then set_not_available r
         | Stack _ | Unknown -> ()
       in
-      DLL.iter intervals.inactive_dll ~f:remove_bound_overlapping;
-      DLL.iter intervals.fixed_dll ~f:remove_bound_overlapping;
-      (* note: already removed, for transition *)
       Interval.DescEndList.iter intervals.inactive_sl
         ~f:remove_bound_overlapping;
       Interval.DescEndList.iter intervals.fixed_sl ~f:remove_bound_overlapping;
@@ -168,7 +164,6 @@ let allocate_free_register : State.t -> Interval.t -> spilling_reg =
         else if available.(idx)
         then (
           reg.loc <- Reg (first_available + idx);
-          Interval.DLL.insert_sorted intervals.active_dll interval;
           Interval.DescEndList.insert intervals.active_sl interval;
           if debug
           then (
@@ -186,54 +181,25 @@ let allocate_blocked_register : State.t -> Interval.t -> spilling_reg =
   let reg = interval.reg in
   let reg_class = Reg_class.of_machtype reg.typ in
   let intervals = State.active state ~reg_class in
-  (* will change to `match Interval.DescEndList.hd intervals.active_sl with` *)
-  match DLL.hd_cell intervals.active_dll with
+  match Interval.DescEndList.hd_cell intervals.active_sl with
   | Some hd_cell ->
-    let hd_cell' = Interval.DescEndList.hd_cell intervals.active_sl in
-    if Option.is_none hd_cell'
-    then fatal "Regalloc_ls.allocate_blocked_register: missing skip list head";
-    let hd_cell' = Option.get hd_cell' in
-    let hd = DLL.value hd_cell in
-    let hd' = Interval.DescEndList.value hd_cell' in
-    if not (Interval.equal hd hd')
-    then
-      fatal
-        "Regalloc_ls.allocate_blocked_register: inconsistent heads (dll=%a vs \
-         sl=%a)"
-        Interval.print hd Interval.print hd';
+    let hd = Interval.DescEndList.value hd_cell in
     let chk r =
       assert (same_reg_class r.Interval.reg hd.Interval.reg);
       Reg.same_loc r.Interval.reg hd.Interval.reg && Interval.overlap r interval
     in
-    let dll_exists =
-      DLL.exists ~f:chk intervals.fixed_dll
-      || DLL.exists ~f:chk intervals.inactive_dll
-    in
-    let sl_exists =
-      Interval.DescEndList.exists ~f:chk intervals.fixed_sl
-      || Interval.DescEndList.exists ~f:chk intervals.inactive_sl
-    in
-    if not (Bool.equal dll_exists sl_exists)
-    then
-      fatal
-        "Regalloc_ls.allocate_blocked_register: inconsistent lists \
-         (dll_exists=%B sl_exists=%B)"
-        dll_exists sl_exists;
-    if hd.end_ > interval.end_ && not dll_exists
+    if hd.end_ > interval.end_
+       && not
+            (Interval.DescEndList.exists ~f:chk intervals.fixed_sl
+            || Interval.DescEndList.exists ~f:chk intervals.inactive_sl)
     then (
       (match hd.reg.loc with Reg _ -> () | Stack _ | Unknown -> assert false);
       interval.reg.loc <- hd.reg.loc;
-      DLL.delete_curr hd_cell;
-      Interval.DLL.insert_sorted intervals.active_dll interval;
-      Interval.DescEndList.delete_curr hd_cell';
+      Interval.DescEndList.delete_curr hd_cell;
       Interval.DescEndList.insert intervals.active_sl interval;
       allocate_stack_slot hd.reg)
     else allocate_stack_slot reg
-  | None ->
-    if Option.is_some (Interval.DescEndList.hd_cell intervals.active_sl)
-    then
-      fatal "Regalloc_ls.allocate_blocked_register: unexpected skip list head";
-    allocate_stack_slot reg
+  | None -> allocate_stack_slot reg
 
 let reg_reinit () =
   List.iter (Reg.all_relocatable_regs ()) ~f:(fun (reg : Reg.t) ->
@@ -254,11 +220,8 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
     log "main, round #%d" round;
     indent ());
   reg_reinit ();
-  State.check_consistency state "main/start";
   build_intervals state cfg_with_infos;
-  State.check_consistency state "main/after build_intervals";
   State.invariant_intervals state cfg_with_infos;
-  State.invariant_active state;
   if debug then snapshot_for_fatal := Some (State.for_fatal state);
   if debug
   then (
@@ -267,22 +230,17 @@ let rec main : round:int -> State.t -> Cfg_with_infos.t -> unit =
   let spilled =
     State.fold_intervals state ~init:Reg.Set.empty
       ~f:(fun acc (interval : Interval.t) ->
-        State.check_consistency state "main/before release";
         (* Equivalent to [walk_interval] in "backend/linscan.ml".*)
         let pos = interval.begin_ land lnot 1 in
         if debug
         then log_interval ~kind:(Printf.sprintf "<pos=%d>" pos) interval;
         State.release_expired_intervals state ~pos;
-        State.check_consistency state "main/after release";
         let spilled =
           match allocate_free_register state interval with
-          | spilled ->
-            State.check_consistency state "main/after allocate_free_register";
-            spilled
+          | spilled -> spilled
           | exception No_free_register ->
             allocate_blocked_register state interval
         in
-        State.check_consistency state "main/after allocation";
         match spilled with
         | Not_spilling -> acc
         | Spilling reg -> Reg.Set.add reg acc)
@@ -306,15 +264,12 @@ let run : Cfg_with_infos.t -> Cfg_with_infos.t =
       (module Utils)
       ~on_fatal_callback:(fun () ->
         Option.iter
-          (fun (intervals_dll, intervals_sl, active) ->
+          (fun (intervals_sl, active) ->
             Format.eprintf "Regalloc_ls.run (on_fatal):";
             Format.eprintf "\n\nactives:\n";
             Reg_class.Tbl.iter active ~f:(fun reg_class a ->
                 Format.eprintf "class %a:\n %a\n" Reg_class.print reg_class
                   ClassIntervals.print a);
-            Format.eprintf "\n\nintervals_dll:\n";
-            DLL.iter intervals_dll ~f:(fun i ->
-                Format.eprintf "- %a\n" Interval.print i);
             Format.eprintf "\n\nintervals_sl:\n";
             Interval.AscBeginList.iter intervals_sl ~f:(fun i ->
                 Format.eprintf "- %a\n" Interval.print i);

--- a/backend/regalloc/regalloc_ls_state.ml
+++ b/backend/regalloc/regalloc_ls_state.ml
@@ -6,39 +6,16 @@ open! Regalloc_ls_utils
 module DLL = Flambda_backend_utils.Doubly_linked_list
 
 type t =
-  { interval_dll : Interval.t DLL.t;
-    interval_sl : Interval.AscBeginList.t;
+  { interval_sl : Interval.AscBeginList.t;
     active : ClassIntervals.t Reg_class.Tbl.t;
     stack_slots : Regalloc_stack_slots.t
   }
 
-let print_intervals ppf (t : t) : unit =
-  Format.fprintf ppf "interval_dll(%d):\n" (DLL.length t.interval_dll);
-  DLL.iter t.interval_dll ~f:(fun i ->
-      Format.fprintf ppf " %a\n" Interval.print i);
-  Format.fprintf ppf "interval_sl(%d):\n"
-    (Interval.AscBeginList.length t.interval_sl);
-  Interval.AscBeginList.iter t.interval_sl ~f:(fun i ->
-      Format.fprintf ppf " %a\n" Interval.print i);
-  Format.fprintf ppf "\n%!"
-
-let check_consistency t msg : unit =
-  Reg_class.Tbl.iter t.active ~f:(fun reg_class ci ->
-      ClassIntervals.check_consistency ci
-        (Printf.sprintf "%s (reg_glass=%s)" msg (Reg_class.to_string reg_class)));
-  let consistent = equal_dll_asc_sl t.interval_dll t.interval_sl in
-  if not consistent
-  then (
-    print_intervals Format.err_formatter t;
-    Misc.fatal_errorf "Regalloc_ls_state.check_consistency")
-
 let for_fatal t =
-  ( DLL.map t.interval_dll ~f:Interval.copy,
-    Interval.AscBeginList.map t.interval_sl ~f:Interval.copy,
+  ( Interval.AscBeginList.map t.interval_sl ~f:Interval.copy,
     Reg_class.Tbl.map t.active ~f:ClassIntervals.copy )
 
 let[@inline] make ~stack_slots =
-  let interval_dll = DLL.make_empty () in
   (* CR xclerc for xclerc: review the parameters. *)
   let interval_sl =
     Interval.AscBeginList.make_empty ~max_skip_level:7 ~skip_factor:0.5 ()
@@ -46,85 +23,30 @@ let[@inline] make ~stack_slots =
   let active =
     Reg_class.Tbl.init ~f:(fun _reg_class -> ClassIntervals.make ())
   in
-  let res = { interval_dll; interval_sl; active; stack_slots } in
-  check_consistency res "State.make/end";
-  res
-
-(* CR-someday xclerc: consider using Dynarray *)
-type class_interval_array =
-  { mutable elements : Interval.t array;
-    mutable length : int
-  }
-
-let dummy_interval =
-  { Interval.reg = Reg.dummy;
-    begin_ = -1;
-    end_ = -1;
-    (* this list can be safely duplicated below, because the empty list is
-       stateless *)
-    ranges = DLL.make_empty ()
-  }
-
-let make_class_interval_array () =
-  { elements = Array.make 32 dummy_interval; length = 0 }
-
-let add_class_interval_array ci x =
-  if ci.length >= Array.length ci.elements
-  then (
-    let old = ci.elements in
-    let len = Array.length old in
-    ci.elements <- Array.make (Int.max ci.length (2 * len)) dummy_interval;
-    Array.blit ~src:old ~dst:ci.elements ~src_pos:0 ~dst_pos:0 ~len);
-  ci.elements.(ci.length) <- x;
-  ci.length <- succ ci.length
-
-let extract_class_interval_array ci : Interval.t array =
-  Array.sub ci.elements ~pos:0 ~len:ci.length
+  { interval_sl; active; stack_slots }
 
 let[@inline] update_intervals state map =
-  check_consistency state "State.update_intervals/begin";
   let active : ClassIntervals.t Reg_class.Tbl.t = state.active in
   Reg_class.Tbl.iter active ~f:(fun _regclass intervals ->
       ClassIntervals.clear intervals);
-  let active' : class_interval_array Reg_class.Tbl.t =
-    Reg_class.Tbl.init ~f:(fun _ -> make_class_interval_array ())
-  in
-  let class_intervals = make_class_interval_array () in
   Interval.AscBeginList.clear state.interval_sl;
   Reg.Tbl.iter
     (fun reg interval ->
       match reg.loc with
       | Reg _ ->
         let reg_class = Reg_class.of_machtype reg.typ in
-        add_class_interval_array (Reg_class.Tbl.find active' reg_class) interval;
         Interval.DescEndList.insert
           (Reg_class.Tbl.find state.active reg_class).fixed_sl interval
       | Stack _ | Unknown ->
-        add_class_interval_array class_intervals interval;
         Interval.AscBeginList.insert state.interval_sl interval)
     map;
-  let class_intervals = extract_class_interval_array class_intervals in
-  Array.sort ~cmp:Interval.compare_asc_begin class_intervals;
-  DLL.clear state.interval_dll;
-  DLL.add_array state.interval_dll class_intervals;
-  if debug then log_interval_dll ~kind:"regular" state.interval_dll;
-  Reg_class.Tbl.iter active'
-    ~f:(fun reg_class (intervals : class_interval_array) ->
-      let extracted = extract_class_interval_array intervals in
-      Array.sort extracted ~cmp:Interval.compare_desc_end;
-      DLL.clear (Reg_class.Tbl.find active reg_class).fixed_dll;
-      DLL.add_array (Reg_class.Tbl.find active reg_class).fixed_dll extracted);
-  if debug then log_interval_asc_sl ~kind:"regular" state.interval_sl;
-  check_consistency state "State.update_intervals/end"
+  if debug then log_interval_asc_sl ~kind:"regular" state.interval_sl
 
 let[@inline] iter_intervals state ~f =
-  (* will change to: Interval.AscBeginList.iter state.interval_sl ~f *)
-  DLL.iter state.interval_dll ~f
+  Interval.AscBeginList.iter state.interval_sl ~f
 
 let[@inline] fold_intervals state ~f ~init =
-  (* will change to: Interval.AscBeginList.fold_left state.interval_sl ~f
-     ~init *)
-  DLL.fold_left state.interval_dll ~f ~init
+  Interval.AscBeginList.fold_left state.interval_sl ~f ~init
 
 let[@inline] release_expired_intervals state ~pos =
   Reg_class.Tbl.iter state.active ~f:(fun _ x ->
@@ -147,7 +69,7 @@ let rec check_ranges (prev : Range.t) (cell : Range.t DLL.cell option) : int =
     then fatal "Regalloc_ls_state.check_ranges: prev.end_ >= hd.begin_";
     check_ranges value (DLL.next cell)
 
-let rec check_intervals (prev : Interval.t) (rest : Interval.t DLL.cell option)
+let rec _check_intervals (prev : Interval.t) (rest : Interval.t DLL.cell option)
     : unit =
   if prev.begin_ > prev.end_
   then fatal "Regalloc_ls_state.check_intervals: prev.begin_ > prev.end_";
@@ -166,91 +88,35 @@ let rec check_intervals (prev : Interval.t) (rest : Interval.t DLL.cell option)
     let hd = DLL.value hd_rest in
     if prev.begin_ > hd.begin_
     then fatal "Regalloc_ls_state.check_intervals: prev.begin_ > hd.begin_";
-    check_intervals hd (DLL.next hd_rest)
+    _check_intervals hd (DLL.next hd_rest)
 
-let rec is_in_a_range ls_order (cell : Range.t DLL.cell option) : bool =
+let rec _is_in_a_range ls_order (cell : Range.t DLL.cell option) : bool =
   match cell with
   | None -> false
   | Some cell ->
     let value = DLL.value cell in
     (ls_order >= value.begin_ && ls_order <= value.end_)
-    || is_in_a_range ls_order (DLL.next cell)
+    || _is_in_a_range ls_order (DLL.next cell)
 
-let[@inline] invariant_intervals state cfg_with_infos =
-  if debug && Lazy.force invariants
-  then (
-    (match DLL.hd_cell state.interval_dll with
-    | None -> ()
-    | Some hd_cell -> check_intervals (DLL.value hd_cell) (DLL.next hd_cell));
-    let interval_map : Interval.t Reg.Map.t =
-      fold_intervals state ~init:Reg.Map.empty ~f:(fun acc interval ->
-          Reg.Map.update interval.reg
-            (function
-              | None -> Some interval
-              | Some _reg ->
-                fatal
-                  "Regalloc_ls_state.invariant_intervals: state.intervals \
-                   duplicate register %a"
-                  Printreg.reg interval.reg)
-            acc)
-    in
-    let check_instr : type a. a Cfg.instruction -> unit =
-     fun instr ->
-      Reg.Set.iter
-        (fun reg ->
-          match Reg.Map.find_opt reg interval_map with
-          | None ->
-            fatal
-              "Regalloc_ls_state.invariant_intervals: register %a is not in \
-               interval_map"
-              Printreg.reg reg
-          | Some interval ->
-            if instr.ls_order < interval.begin_
-            then
-              fatal
-                "Regalloc_ls_state.invariant_intervals: instr.ls_order < \
-                 interval.begin_";
-            if instr.ls_order > interval.end_
-            then
-              fatal
-                "Regalloc_ls_state.invariant_intervals: instr.ls_order > \
-                 interval.end_";
-            if not (is_in_a_range instr.ls_order (DLL.hd_cell interval.ranges))
-            then
-              fatal
-                "Regalloc_ls_state.invariant_intervals: not (is_in_a_range \
-                 instr.ls_order interval.ranges)")
-        instr.live
-    in
-    Cfg_with_layout.iter_instructions
-      (Cfg_with_infos.cfg_with_layout cfg_with_infos)
-      ~instruction:check_instr ~terminator:check_instr)
-
-let invariant_field_dll (reg_class : Reg_class.t) (field_name : string)
-    (l : Interval.t DLL.t) =
-  let rec is prev curr =
-    match curr with
-    | None -> ()
-    | Some cell ->
-      let value = DLL.value cell in
-      if value.Interval.end_ > prev.Interval.end_
-      then
-        fatal
-          "Regalloc_ls_state.invariant_field_dll: active.(%a).%s is not sorted"
-          Reg_class.print reg_class field_name
-      else is value (DLL.next cell)
-  in
-  match DLL.hd_cell l with
-  | None -> ()
-  | Some cell -> is (DLL.value cell) (DLL.next cell)
-
-let[@inline] invariant_active state =
-  if debug && Lazy.force invariants
-  then
-    Reg_class.Tbl.iter state.active ~f:(fun reg_class intervals ->
-        invariant_field_dll reg_class "fixed "
-          intervals.ClassIntervals.fixed_dll;
-        invariant_field_dll reg_class "active "
-          intervals.ClassIntervals.active_dll;
-        invariant_field_dll reg_class "inactive "
-          intervals.ClassIntervals.inactive_dll)
+let[@inline] invariant_intervals _state _cfg_with_infos =
+  (* TODO *)
+  (* if debug && Lazy.force invariants then ( (match DLL.hd_cell
+     state.interval_dll with | None -> () | Some hd_cell -> check_intervals
+     (DLL.value hd_cell) (DLL.next hd_cell)); let interval_map : Interval.t
+     Reg.Map.t = fold_intervals state ~init:Reg.Map.empty ~f:(fun acc interval
+     -> Reg.Map.update interval.reg (function | None -> Some interval | Some
+     _reg -> fatal "Regalloc_ls_state.invariant_intervals: state.intervals \
+     duplicate register %a" Printreg.reg interval.reg) acc) in let check_instr :
+     type a. a Cfg.instruction -> unit = fun instr -> Reg.Set.iter (fun reg ->
+     match Reg.Map.find_opt reg interval_map with | None -> fatal
+     "Regalloc_ls_state.invariant_intervals: register %a is not in \
+     interval_map" Printreg.reg reg | Some interval -> if instr.ls_order <
+     interval.begin_ then fatal "Regalloc_ls_state.invariant_intervals:
+     instr.ls_order < \ interval.begin_"; if instr.ls_order > interval.end_ then
+     fatal "Regalloc_ls_state.invariant_intervals: instr.ls_order > \
+     interval.end_"; if not (is_in_a_range instr.ls_order (DLL.hd_cell
+     interval.ranges)) then fatal "Regalloc_ls_state.invariant_intervals: not
+     (is_in_a_range \ instr.ls_order interval.ranges)") instr.live in
+     Cfg_with_layout.iter_instructions (Cfg_with_infos.cfg_with_layout
+     cfg_with_infos) ~instruction:check_instr ~terminator:check_instr) *)
+  ()

--- a/backend/regalloc/regalloc_ls_state.mli
+++ b/backend/regalloc/regalloc_ls_state.mli
@@ -5,11 +5,7 @@ module DLL = Flambda_backend_utils.Doubly_linked_list
 
 type t
 
-val for_fatal :
-  t ->
-  Interval.t DLL.t * Interval.AscBeginList.t * ClassIntervals.t Reg_class.Tbl.t
-
-val check_consistency : t -> string -> unit
+val for_fatal : t -> Interval.AscBeginList.t * ClassIntervals.t Reg_class.Tbl.t
 
 val make : stack_slots:Regalloc_stack_slots.t -> t
 
@@ -28,5 +24,3 @@ val active_classes : t -> ClassIntervals.t Reg_class.Tbl.t
 val stack_slots : t -> Regalloc_stack_slots.t
 
 val invariant_intervals : t -> Cfg_with_infos.t -> unit
-
-val invariant_active : t -> unit

--- a/backend/regalloc/regalloc_ls_utils.mli
+++ b/backend/regalloc/regalloc_ls_utils.mli
@@ -94,11 +94,8 @@ val equal_dll_desc_sl : Interval.t DLL.t -> Interval.DescEndList.t -> bool
 module ClassIntervals : sig
   (* Similar to [Linscan.class_intervals] (in "backend/linscan.ml"). *)
   type t =
-    { fixed_dll : Interval.t DLL.t;
-      fixed_sl : Interval.DescEndList.t;
-      active_dll : Interval.t DLL.t;
+    { fixed_sl : Interval.DescEndList.t;
       active_sl : Interval.DescEndList.t;
-      inactive_dll : Interval.t DLL.t;
       inactive_sl : Interval.DescEndList.t
     }
 
@@ -111,8 +108,6 @@ module ClassIntervals : sig
   val clear : t -> unit
 
   val release_expired_intervals : t -> pos:int -> unit
-
-  val check_consistency : t -> string -> unit
 end
 
 val log_interval : kind:string -> Interval.t -> unit

--- a/utils/dune
+++ b/utils/dune
@@ -63,16 +63,16 @@
     (flambda_backend_utils.cma as compiler-libs/flambda_backend_utils.cma)
     (flambda_backend_utils.cmxa as compiler-libs/flambda_backend_utils.cmxa)
     (.flambda_backend_utils.objs/byte/flambda_backend_utils.cmi as compiler-libs/flambda_backend_utils.cmi)
-   (doubly_linked_list.mli as compiler-libs/doubly_linked_list.ml)
-   (.flambda_backend_utils.objs/byte/flambda_backend_utils__Doubly_linked_list.cmi
+    (doubly_linked_list.mli as compiler-libs/doubly_linked_list.ml)
+    (.flambda_backend_utils.objs/byte/flambda_backend_utils__Doubly_linked_list.cmi
      as compiler-libs/flambda_backend_utils__Doubly_linked_list.cmi)
-   (.flambda_backend_utils.objs/byte/flambda_backend_utils__Doubly_linked_list.cmti
+    (.flambda_backend_utils.objs/byte/flambda_backend_utils__Doubly_linked_list.cmti
      as compiler-libs/flambda_backend_utils__Doubly_linked_list.cmti)
-   (.flambda_backend_utils.objs/byte/flambda_backend_utils__Doubly_linked_list.cmt
+    (.flambda_backend_utils.objs/byte/flambda_backend_utils__Doubly_linked_list.cmt
      as compiler-libs/flambda_backend_utils__Doubly_linked_list.cmt)
-   (.flambda_backend_utils.objs/native/flambda_backend_utils__Doubly_linked_list.cmx
+    (.flambda_backend_utils.objs/native/flambda_backend_utils__Doubly_linked_list.cmx
      as compiler-libs/flambda_backend_utils__Doubly_linked_list.cmx)
-   (.flambda_backend_utils.objs/native/flambda_backend_utils__Doubly_linked_list.o
+    (.flambda_backend_utils.objs/native/flambda_backend_utils__Doubly_linked_list.o
      as compiler-libs/flambda_backend_utils__Doubly_linked_list.o)
    (.flambda_backend_utils.objs/byte/flambda_backend_utils__Skip_list.cmi
      as compiler-libs/flambda_backend_utils__Skip_list.cmi)


### PR DESCRIPTION
This pull request is a follow-up to #4048,
simply removing the old representation to
only keep the skip lists for the interval lists.