### PR TITLE
Avoid clearing 2K prefetch buffer every time we do_some_marking

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1136,9 +1136,13 @@ value volatile_load_uninstrumented(volatile value* p) {
 }
 
 Caml_noinline static intnat do_some_marking(struct mark_stack* stk,
-                                            intnat budget) {
-  prefetch_buffer_t pb = { .enqueued = 0, .dequeued = 0,
-                           .waterline = PREFETCH_BUFFER_MIN };
+                                            intnat budget)
+{
+  prefetch_buffer_t pb;
+  /* Not a struct initializer, which would force clearing the .buffer */
+  pb.enqueued = 0;
+  pb.dequeued = 0;
+  pb.waterline = PREFETCH_BUFFER_MIN;
   mark_entry me;
   /* These global values are cached in locals,
      so that they can be stored in registers */


### PR DESCRIPTION
Initialize the struct members of `prefetch_buffer_t` separately, because the struct initialiizer implicitly zeroes the (2 KiB) actual buffer, which in fact we don't care about.

Before:
```
cs push %r15
mov    %rdi,%rdx
mov    $0x103,%ecx
xor    %eax,%eax
push   %r14
mov    $0x40,%r15d
xor    %r14d,%r14d
push   %r13
push   %r12
xor    %r12d,%r12d
push   %rbp
mov    %rsi,%rbp
push   %rbx
sub    $0x848,%rsp
mov    0x5860f6(%rip),%rsi <caml_global_heap_state+8>
lea    0x20(%rsp),%rdi
rep stos %rax,%es:(%rdi)
```
After:
```
push   %r15
mov    %rdi,%rdx
mov    $0x40,%r15d
xor    %ecx,%ecx
push   %r14
xor    %r14d,%r14d
push   %r13
push   %r12
xor    %r12d,%r12d
push   %rbp
mov    %rsi,%rbp
push   %rbx
sub    $0x848,%rsp
mov    0x5840fc(%rip),%rsi        <caml_global_heap_state+8>
```
(Note the loss of the `rep stos`).