### PR TITLE
Exploit sharing in patricia tree combine operations

### DIFF
--- a/middle_end/flambda2/algorithms/container_types.ml
+++ b/middle_end/flambda2/algorithms/container_types.ml
@@ -86,6 +86,95 @@ module Make_map (T : Thing) (Set : Set_plus_stdlib with type elt = T.t) = struct
         | Some datum1, Some datum2 -> Some (f key datum1 datum2))
       t1 t2
 
+  let union_sharing f t1 t2 =
+    let changed = ref false in
+    let t =
+      union
+        (fun key datum1 datum2 ->
+          match f key datum1 datum2 with
+          | None ->
+            changed := true;
+            None
+          | Some datum ->
+            if not (datum == datum1) then changed := true;
+            Some datum)
+        t1 t2
+    in
+    if !changed then t else t1
+
+  let union_shared f t1 t2 =
+    let changed = ref false in
+    let t =
+      union
+        (fun key datum1 datum2 ->
+          if datum1 == datum2
+          then Some datum1
+          else
+            match f key datum1 datum2 with
+            | None ->
+              changed := true;
+              None
+            | Some datum ->
+              if not (datum == datum1) then changed := true;
+              Some datum)
+        t1 t2
+    in
+    if !changed then t else t1
+
+  let diff f t1 t2 =
+    merge
+      (fun key datum1_opt datum2_opt ->
+        match datum1_opt, datum2_opt with
+        | None, None | None, Some _ -> None
+        | Some datum1, None -> Some datum1
+        | Some datum1, Some datum2 -> f key datum1 datum2)
+      t1 t2
+
+  let diff_sharing f t1 t2 =
+    let changed = ref false in
+    let t =
+      merge
+        (fun key datum1_opt datum2_opt ->
+          match datum1_opt, datum2_opt with
+          | None, None | None, Some _ -> None
+          | Some datum1, None -> Some datum1
+          | Some datum1, Some datum2 -> (
+            match f key datum1 datum2 with
+            | None ->
+              changed := true;
+              None
+            | Some datum ->
+              if not (datum == datum1) then changed := true;
+              Some datum))
+        t1 t2
+    in
+    if not !changed then t1 else t
+
+  let diff_shared f t1 t2 =
+    let changed = ref false in
+    let t =
+      merge
+        (fun key datum1_opt datum2_opt ->
+          match datum1_opt, datum2_opt with
+          | None, None | None, Some _ -> None
+          | Some datum1, None -> Some datum1
+          | Some datum1, Some datum2 -> (
+            if datum1 == datum2
+            then (
+              changed := true;
+              None)
+            else
+              match f key datum1 datum2 with
+              | None ->
+                changed := true;
+                None
+              | Some datum ->
+                if not (datum == datum1) then changed := true;
+                Some datum))
+        t1 t2
+    in
+    if not !changed then t1 else t
+
   exception Found_common_element
 
   let inter_domain_is_non_empty t1 t2 =
@@ -175,6 +264,14 @@ struct
   let rec union_list ts =
     match ts with [] -> empty | t :: ts -> union t (union_list ts)
 
+  let union_sharing = union
+
+  let union_shared s1 s2 = if s1 == s2 then s1 else union s1 s2
+
+  let diff_sharing = diff
+
+  let diff_shared s1 s2 = if s1 == s2 then empty else diff_sharing s1 s2
+
   exception More_than_one_element
 
   let get_singleton t =
@@ -211,4 +308,86 @@ module Make_pair (T1 : S) (T2 : S) = struct
       (fun t1 result ->
         T2.Set.fold (fun t2 result -> Set.add (t1, t2) result) t2_set result)
       t1_set Set.empty
+end
+
+module Shared_set (T : S) = struct
+  type t = T.Set.t
+
+  type elt = T.t
+
+  let create t = t
+
+  let print = T.Set.print
+
+  let empty = T.Set.empty
+
+  let is_empty = T.Set.is_empty
+
+  let singleton = T.Set.singleton
+
+  let add k t =
+    (* Note: [Set.add] is not guaranteed to preserve sharing in depth. *)
+    T.Set.union_sharing t (T.Set.singleton k)
+
+  let remove k t =
+    (* Note: [Set.remove] is not guaranteed to preserve sharing in depth. *)
+    T.Set.diff_sharing t (T.Set.singleton k)
+
+  let mem = T.Set.mem
+
+  let diff = T.Set.diff_shared
+
+  let diff_set = T.Set.diff_sharing
+
+  let union = T.Set.union_shared
+
+  let union_set = T.Set.union_sharing
+
+  let fold = T.Set.fold
+
+  let iter = T.Set.iter
+
+  let map_unshare = T.Set.map
+end
+
+module Shared_map (T : S) = struct
+  type 'a t = 'a T.Map.t
+
+  type key = T.t
+
+  let create m = m
+
+  let print = T.Map.print
+
+  let empty = T.Map.empty
+
+  let is_empty = T.Map.is_empty
+
+  let singleton = T.Map.singleton
+
+  let add k v t =
+    (* Note: [M.add] is not guaranteed to preserve sharing in depth. *)
+    T.Map.union_sharing (fun _k _v0 v1 -> Some v1) t (T.Map.singleton k v)
+
+  let remove k t =
+    (* Note: [M.remove] is not guaranteed to preserve sharing in depth. *)
+    T.Map.diff_sharing (fun _k _v0 () -> None) t (T.Map.singleton k ())
+
+  let find_opt = T.Map.find_opt
+
+  let diff = T.Map.diff_shared
+
+  let diff_map = T.Map.diff_sharing
+
+  let union = T.Map.union_shared
+
+  let union_map = T.Map.union_sharing
+
+  let fold = T.Map.fold
+
+  let iter = T.Map.iter
+
+  let map_unshare = T.Map.map
+
+  let map_keys_unshare = T.Map.map_keys
 end

--- a/middle_end/flambda2/algorithms/container_types.mli
+++ b/middle_end/flambda2/algorithms/container_types.mli
@@ -48,3 +48,138 @@ module Make_pair (T1 : S) (T2 : S) : sig
 
   val create_from_cross_product : T1.Set.t -> T2.Set.t -> Set.t
 end
+
+module Shared_set (T : S) : sig
+  type t = private T.Set.t
+
+  type elt = T.t
+
+  val create : T.Set.t -> t
+
+  val print : Format.formatter -> t -> unit
+
+  val empty : t
+
+  val is_empty : t -> bool
+
+  val singleton : elt -> t
+
+  val add : elt -> t -> t
+
+  val remove : elt -> t -> t
+
+  val mem : elt -> t -> bool
+
+  (** [diff ss1 ss2] computes the difference of the shared sets [ss1] and [ss2].
+
+      {b Sharing}: Sharing is guaranteed with sub-trees of [ss1] that are
+      disjoint from [ss2].
+
+      {b Complexity}: The complexity of [diff (union ss1 ss2) ss1] is linear
+      in the size of [ss2]. The complexity of [diff (add k ss) ss] is the
+      same as that of [mem k (add k ss)]. *)
+  val diff : t -> t -> t
+
+  (** [diff_set ss s] returns a shared set that is identical to [ss], with the
+      keys from [s] removed.
+
+      {b Sharing}: Sharing is guaranteed for sub-trees of [ss] that are
+      disjoint from [s]. *)
+  val diff_set : t -> T.Set.t -> t
+
+  (** [union ss1 ss2] computes the union of the shared sets [ss1] and [ss2].
+
+      {b Sharing}: Sharing is guaranteed with sub-trees of [ss1] that are
+      disjoint from [ss2].
+
+      {b Complexity}: The complexity of [union (diff ss1 ss2) ss1] is linear in
+      the size of [ss2]. The complexity of [union (remove k ss) ss] is the same
+      as that of [add k (remove k ss)]. *)
+  val union : t -> t -> t
+
+  (** [union_set ss s] adds all the keys of set [s] to the shared set [ss].
+
+      {b Sharing}: Sharing is guaranteed with sub-trees of [ss] that are
+      disjoint from [s]. *)
+  val union_set : t -> T.Set.t -> t
+
+  val fold : (elt -> 'a -> 'a) -> t -> 'a -> 'a
+
+  val iter : (elt -> unit) -> t -> unit
+
+  (** {2 Unsharing functions}
+
+      The following functions construct a new shared set but do not
+      necessarily preserve sharing with their input. They are marked with the
+      [_unshare] suffix to make this stand out.
+  *)
+
+  val map_unshare : (elt -> elt) -> t -> t
+end
+
+module Shared_map (T : S) : sig
+  type 'a t = private 'a T.Map.t
+
+  type key = T.t
+
+  val create : 'a T.Map.t -> 'a t
+
+  val print :
+    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
+
+  val empty : 'a t
+
+  val is_empty : 'a t -> bool
+
+  val singleton : key -> 'a -> 'a t
+
+  val add : key -> 'a -> 'a t -> 'a t
+
+  val remove : key -> 'a t -> 'a t
+
+  val find_opt : key -> 'a t -> 'a option
+
+  (** [diff f sm1 sm2] returns a shared map that is identical to [sm1], except
+      that bindings in [sm1] with a key [k] that also appears in [sm2] are
+      updated according to [f].
+
+      [diff] assumes that [f] always returns [None] when called with physically
+      equal arguments, and will never call [f] with physically equal arguments.
+
+      {b Sharing}: Sharing is guaranteed for sub-trees of [sm1] for which all
+      call to [f] return the first value unchanged. In particular, sharing is
+      guaranteed for all sub-trees of [sm1] that are disjoint from [sm2].
+
+      {b Complexity}: The complexity of [diff f (union g sm1 sm2) sm1] is linear
+      in the size of [sm2]. The complexity of [diff f (add sm k v) sm] is the
+      same as that of [find k (add sm k v)]. *)
+  val diff : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
+
+  (** [diff_map f sm m] returns a shared map that is identical to [sm], except
+      that bindings in [sm] with a key [k] that also appear in [m] are updated
+      according to [f].
+
+      {b Sharing}: Sharing is guaranteed for sub-trees of [sm] for which all
+      call to [f] return the first value unchanged. In particular, sharing is
+      guaranteed for all sub-trees of [sm] that are disjoint from [m]. *)
+  val diff_map : (key -> 'a -> 'b -> 'a option) -> 'a t -> 'b T.Map.t -> 'a t
+
+  val union : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
+
+  val union_map : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a T.Map.t -> 'a t
+
+  val fold : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
+
+  val iter : (key -> 'a -> unit) -> 'a t -> unit
+
+  (** {2 Unsharing functions}
+
+      The following functions construct a new {!Shared_map.t} but do not
+      necessarily preserve sharing with their input. They are marked with the
+      [_unshare] suffix to make this stand out.
+  *)
+
+  val map_unshare : ('a -> 'b) -> 'a t -> 'b t
+
+  val map_keys_unshare : (key -> key) -> 'a t -> 'a t
+end


### PR DESCRIPTION
This patch introduces a new `union`-like function to the patricia tree (and containers) interface, `diff`. It also provides `_shared` and `_sharing` variants of both `diff` and `union` to exploit internal sharing, and a typed interface to help ensure sharing is not accidentally lost.

The `diff` function is an `union`-like generalization of the existing `diff_domains`. `diff f m1 m2` is similar to `merge f m1 m2` with `f None (Some _) = None` and `f (Some v) None = Some v`.

The `_shared` variants (`diff_shared`, really) are the main motivation for this patch, and have a transformative impact on performance: `diff_shared` and `union_shared` exploit physical equality to simplify `diff_shared f m m = empty` and `union_shared f m m = m` in constant time. They also ensure maximal sharing of the result with their first argument.

The `_sharing` variants do not perform this optimisation but still ensure maximal sharing of the result with their first argument. They are useful to add or remove entries into a map while preserving sharing.

The `Shared_set` and `Shared_map` are thin wrapper modules that only expose sharing-preserving functions to avoid accidental loss of sharing.

These functions are currently unused, but will be used in the implementation #3219 and for the match-in-match heuristic (see #926), as discussed offline with @chambart and @lthls.