### PR TITLE
Default to non-hugepage fiber stacks.

### DIFF
--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -66,7 +66,7 @@ uintnat caml_init_main_stack_wsz = 0;   /* -Xmain_stack_size= */
 uintnat caml_init_thread_stack_wsz = 0; /* -Xthread_stack_size= */
 uintnat caml_init_fiber_stack_wsz = 0;  /* -Xfiber_stack_size= */
 
-uintnat caml_nohugepage_stacks = 0;
+uintnat caml_nohugepage_stacks = 1;
 
 uintnat caml_get_init_stack_wsize (int context)
 {


### PR DESCRIPTION
This flips the default of the switch introduced by #4001, on the basis that call stacks are mostly small so hugepage stacks are unnecessary, and bloat the RSS of small processes especially. Anyone who really wants hugepage stacks can still get them with `OCAMLRUNPARAM=Xnohugepage_stacks=0`.