### PR TITLE
Delete lbl_pos; rename lbl_num to lbl_pos

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -161,7 +161,7 @@ let all_record_args lbls =
             (mknoloc (Longident.Lident "?temp?"), lbl, Patterns.omega))
           lbl_all
       in
-      List.iter (fun ((_, lbl, _) as x) -> t.(lbl.lbl_num) <- x) lbls;
+      List.iter (fun ((_, lbl, _) as x) -> t.(lbl.lbl_pos) <- x) lbls;
       Array.to_list t
 
 let expand_record_head h =

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -677,7 +677,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           let shape =
             Lambda.transl_mixed_product_shape_for_read
               ~get_value_kind:(fun i ->
-                if i <> lbl.lbl_num then Lambda.generic_value
+                if i <> lbl.lbl_pos then Lambda.generic_value
                 else
                   let pointerness, nullable = maybe_pointer e in
                   let raw_kind = match pointerness with
@@ -686,7 +686,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                   in
                   Lambda.{ raw_kind; nullable })
               ~get_mode:(fun i ->
-                if i <> lbl.lbl_num then Lambda.alloc_heap
+                if i <> lbl.lbl_pos then Lambda.alloc_heap
                 else
                   match float with
                     | Boxing (mode, _) -> transl_alloc_mode mode
@@ -711,7 +711,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         (* erase singleton unboxed records before lambda *)
         targ
       else
-        Lprim (Punboxed_product_field (lbl.lbl_num, layouts), [targ],
+        Lprim (Punboxed_product_field (lbl.lbl_pos, layouts), [targ],
                of_location ~scopes e.exp_loc)
     end
   | Texp_setfield(arg, arg_mode, id, lbl, newval) ->
@@ -745,7 +745,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           let shape =
             Lambda.transl_mixed_product_shape
               ~get_value_kind:(fun i ->
-                if i <> lbl.lbl_num then Lambda.generic_value
+                if i <> lbl.lbl_pos then Lambda.generic_value
                 else
                   let pointerness, nullable =
                     maybe_pointer newval
@@ -1953,7 +1953,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                 let shape =
                   Lambda.transl_mixed_product_shape
                     ~get_value_kind:(fun i ->
-                      if i <> lbl.lbl_num then Lambda.generic_value
+                      if i <> lbl.lbl_pos then Lambda.generic_value
                       else
                         let pointerness, nullable =
                           maybe_pointer expr
@@ -2030,7 +2030,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                    let shape =
                      Lambda.transl_mixed_product_shape_for_read
                        ~get_value_kind:(fun i ->
-                         if i <> lbl.lbl_num then Lambda.generic_value
+                         if i <> lbl.lbl_pos then Lambda.generic_value
                          else
                            let pointerness, nullable =
                              maybe_pointer_type env typ

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -241,7 +241,7 @@ let dummy_label (type rep) (record_form : rep record_form)
   { lbl_name = ""; lbl_res = none; lbl_arg = none;
     lbl_mut = Immutable; lbl_modalities = Mode.Modality.Value.Const.id;
     lbl_sort = Jkind.Sort.Const.void;
-    lbl_num = -1; lbl_pos = -1; lbl_all = [||];
+    lbl_pos = -1; lbl_all = [||];
     lbl_repres = repres;
     lbl_private = Public;
     lbl_loc = Location.none;
@@ -251,10 +251,9 @@ let dummy_label (type rep) (record_form : rep record_form)
 
 let label_descrs record_form ty_res lbls repres priv =
   let all_labels = Array.make (List.length lbls) (dummy_label record_form) in
-  let rec describe_labels num pos = function
+  let rec describe_labels pos = function
       [] -> []
     | l :: rest ->
-        let is_void = Jkind.Sort.Const.(equal void l.ld_sort) in
         let lbl =
           { lbl_name = Ident.name l.ld_id;
             lbl_res = ty_res;
@@ -262,8 +261,7 @@ let label_descrs record_form ty_res lbls repres priv =
             lbl_mut = l.ld_mutable;
             lbl_modalities = l.ld_modalities;
             lbl_sort = l.ld_sort;
-            lbl_pos = if is_void then lbl_pos_void else pos;
-            lbl_num = num;
+            lbl_pos = pos;
             lbl_all = all_labels;
             lbl_repres = repres;
             lbl_private = priv;
@@ -271,10 +269,9 @@ let label_descrs record_form ty_res lbls repres priv =
             lbl_attributes = l.ld_attributes;
             lbl_uid = l.ld_uid;
           } in
-        all_labels.(num) <- lbl;
-        let pos = if is_void then pos else pos+1 in
-        (l.ld_id, lbl) :: describe_labels (num+1) pos rest in
-  describe_labels 0 0 lbls
+        all_labels.(pos) <- lbl;
+        (l.ld_id, lbl) :: describe_labels (pos+1) rest in
+  describe_labels 0 lbls
 
 exception Constr_not_found
 

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -312,9 +312,9 @@ let records_args l1 l2 =
   | [],(_,_,p2)::rem2 -> combine (omega::r1) (p2::r2) [] rem2
   | (_,_,p1)::rem1,[] -> combine (p1::r1) (omega::r2) rem1 []
   | (_,lbl1,p1)::rem1, ( _,lbl2,p2)::rem2 ->
-      if lbl1.lbl_num < lbl2.lbl_num then
+      if lbl1.lbl_pos < lbl2.lbl_pos then
         combine (p1::r1) (omega::r2) rem1 l2
-      else if lbl1.lbl_num > lbl2.lbl_num then
+      else if lbl1.lbl_pos > lbl2.lbl_pos then
         combine (omega::r1) (p2::r2) l1 rem2
       else (* same label on both sides *)
         combine (p1::r1) (p2::r2) rem1 rem2 in
@@ -466,11 +466,11 @@ let record_unboxed_product_arg ph =
 
 let extract_fields lbls arg =
   let get_field pos arg =
-    match List.find (fun (lbl,_) -> pos = lbl.lbl_num) arg with
+    match List.find (fun (lbl,_) -> pos = lbl.lbl_pos) arg with
     | _, p -> p
     | exception Not_found -> omega
   in
-  List.map (fun lbl -> get_field lbl.lbl_num arg) lbls
+  List.map (fun lbl -> get_field lbl.lbl_pos arg) lbls
 
 (* Build argument list when p2 >= p1, where p1 is a simple pattern *)
 let simple_match_args discr head args =
@@ -535,7 +535,7 @@ let discr_pat q pss =
     | ((head, _), _) :: rows ->
       let append_unique lbls lbls_unique =
         List.fold_right (fun lbl lbls_unique ->
-          if List.exists (fun l -> l.lbl_num = lbl.lbl_num) lbls_unique then
+          if List.exists (fun l -> l.lbl_pos = lbl.lbl_pos) lbls_unique then
             lbls_unique
           else
             lbl :: lbls_unique
@@ -1972,9 +1972,9 @@ and record_lubs l1 l2 =
   | [],_ -> l2
   | _,[] -> l1
   | (lid1, lbl1,p1)::rem1, (lid2, lbl2,p2)::rem2 ->
-      if lbl1.lbl_num < lbl2.lbl_num then
+      if lbl1.lbl_pos < lbl2.lbl_pos then
         (lid1, lbl1,p1)::lub_rec rem1 l2
-      else if lbl2.lbl_num < lbl1.lbl_num  then
+      else if lbl2.lbl_pos < lbl1.lbl_pos  then
         (lid2, lbl2,p2)::lub_rec l1 rem2
       else
         (lid1, lbl1,lub p1 p2)::lub_rec rem1 rem2 in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1425,15 +1425,15 @@ and build_as_type_aux (env : Env.t) p ~mode =
 
         RAE: why? It looks fine as-is. *)
     let ty = newvar (Jkind.Builtin.any ~why:Dummy_jkind) in
-    let ppl = List.map (fun (_, l, p) -> l.lbl_num, p) lpl in
+    let ppl = List.map (fun (_, l, p) -> l.lbl_pos, p) lpl in
     let do_label lbl =
       let _, ty_arg, ty_res = instance_label ~fixed:false lbl in
       unify_pat env {p with pat_type = ty} ty_res;
       let refinable =
-        lbl.lbl_mut = Immutable && List.mem_assoc lbl.lbl_num ppl &&
+        lbl.lbl_mut = Immutable && List.mem_assoc lbl.lbl_pos ppl &&
         match get_desc lbl.lbl_arg with Tpoly _ -> false | _ -> true in
       if refinable then begin
-        let arg = List.assoc lbl.lbl_num ppl in
+        let arg = List.assoc lbl.lbl_pos ppl in
         unify_pat env
           {arg with pat_type = build_as_type env arg} ty_arg
       end else begin
@@ -2407,7 +2407,7 @@ let disambiguate_sort_lid_a_list
       (Warnings.Name_out_of_scope (!w_scope_ty, warning)));
   (* Invariant: records are sorted in the typed tree *)
   List.sort
-    (fun (_,lbl1,_) (_,lbl2,_) -> compare lbl1.lbl_num lbl2.lbl_num)
+    (fun (_,lbl1,_) (_,lbl2,_) -> compare lbl1.lbl_pos lbl2.lbl_pos)
     lbl_a_list
 
 let map_fold_cont f xs k =
@@ -2424,9 +2424,9 @@ let check_recordpat_labels loc lbl_pat_list closed record_form =
       let all = label1.lbl_all in
       let defined = Array.make (Array.length all) false in
       let check_defined (_, label, _) =
-        if defined.(label.lbl_num)
+        if defined.(label.lbl_pos)
         then raise(Error(loc, Env.empty, Label_multiply_defined label.lbl_name))
-        else defined.(label.lbl_num) <- true in
+        else defined.(label.lbl_pos) <- true in
       List.iter check_defined lbl_pat_list;
       if closed = Closed
       && Warnings.is_active
@@ -5550,7 +5550,7 @@ and type_expect_
       (* note: check_duplicates would better be implemented in
          disambiguate_sort_lid_a_list directly *)
       let rec check_duplicates = function
-        | (_, lbl1, _) :: (_, lbl2, _) :: _ when lbl1.lbl_num = lbl2.lbl_num ->
+        | (_, lbl1, _) :: (_, lbl2, _) :: _ when lbl1.lbl_pos = lbl2.lbl_pos ->
           raise(Error(loc, env, Label_multiply_defined lbl1.lbl_name))
         | _ :: rem ->
             check_duplicates rem
@@ -5561,7 +5561,7 @@ and type_expect_
         let (_lid, lbl, _lbl_exp) = List.hd lbl_exp_list in
         let matching_label lbl =
           List.find
-            (fun (_, lbl',_) -> lbl'.lbl_num = lbl.lbl_num)
+            (fun (_, lbl',_) -> lbl'.lbl_pos = lbl.lbl_pos)
             lbl_exp_list
         in
         let unify_kept record_loc extended_expr_loc ty_exp mode lbl =
@@ -5598,7 +5598,7 @@ and type_expect_
                       Overridden (lid, lbl_exp)
                   | exception Not_found ->
                       let present_indices =
-                        List.map (fun (_, lbl, _) -> lbl.lbl_num) lbl_exp_list
+                        List.map (fun (_, lbl, _) -> lbl.lbl_pos) lbl_exp_list
                       in
                       let label_names =
                         extract_label_names record_form env ty_expected in
@@ -6112,7 +6112,7 @@ and type_expect_
           match label.lbl_repres with
           | Record_float -> true
           | Record_mixed mixed -> begin
-              match mixed.(label.lbl_num) with
+              match mixed.(label.lbl_pos) with
               | Float_boxed -> true
               | Float64 | Float32 | Value | Bits32 | Bits64 | Vec128 | Word
               | Product _ ->

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -1063,8 +1063,7 @@ type 'a gen_label_description =
     lbl_mut: mutability;                (* Is this a mutable field? *)
     lbl_modalities: Mode.Modality.Value.Const.t;(* Modalities on the field *)
     lbl_sort: Jkind_types.Sort.Const.t; (* Sort of the argument *)
-    lbl_pos: int;                       (* Position in block *)
-    lbl_num: int;                       (* Position in type *)
+    lbl_pos: int;                       (* Position in type *)
     lbl_all: 'a gen_label_description array;   (* All the labels in this type *)
     lbl_repres: 'a;                     (* Representation for outer record *)
     lbl_private: private_flag;          (* Read-only field? *)
@@ -1117,8 +1116,6 @@ let item_visibility = function
   | Sig_modtype (_, _, vis)
   | Sig_class (_, _, _, vis)
   | Sig_class_type (_, _, _, vis) -> vis
-
-let lbl_pos_void = -1
 
 let rec bound_value_identifiers = function
     [] -> []

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -1141,8 +1141,7 @@ type 'a gen_label_description =
     lbl_modalities: Mode.Modality.Value.Const.t;
                                         (* Modalities on the field *)
     lbl_sort: Jkind_types.Sort.Const.t; (* Sort of the argument *)
-    lbl_pos: int;                       (* Position in block *)
-    lbl_num: int;                       (* Position in the type *)
+    lbl_pos: int;                       (* Position in type *)
     lbl_all: 'a gen_label_description array;   (* All the labels in this type *)
     lbl_repres: 'a;  (* Representation for outer record *)
     lbl_private: private_flag;          (* Read-only field? *)
@@ -1171,14 +1170,6 @@ type record_form_packed =
   | P : _ record_form -> record_form_packed
 
 val record_form_to_string : _ record_form -> string
-
-(** The special value we assign to lbl_pos for label descriptions corresponding
-    to void types, because they can't sensibly be projected.
-
-    CR layouts v5: This should be removed once we have unarization, as it
-    will be up to a later stage of the compiler to erase void.
-*)
-val lbl_pos_void : int
 
 (** Extracts the list of "value" identifiers bound by a signature.
     "Value" identifiers are identifiers for signature components that

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -780,7 +780,7 @@ let rec expression : Typedtree.expression -> term_judg =
             | Kept _ -> empty
             | Overridden (_, e) -> expression e
           in
-          env << field_mode label.lbl_num
+          env << field_mode label.lbl_pos
         in
         join [
           array field es;


### PR DESCRIPTION
Currently, `lbl_pos` is the "physical" index (with special behavior for void) of a record field, and `lbl_num` is the logical index.

After this patch, only `lbl_pos` exists, and is the logical index. We prefer this name because it is the same one used by upstream.