### PR TITLE
`Typeopt.array_type_kind`: when element is non-value or unknown, error instead of defaulting to `Pgenvalue`

### DIFF
--- a/lambda/transl_array_comprehension.ml
+++ b/lambda/transl_array_comprehension.ml
@@ -478,8 +478,8 @@ let iterator ~transl_exp ~scopes ~loc :
       (* CR layouts v4: [~elt_sort:None] here is not ideal and
          should be fixed. To do that, we will need to store a sort
          on [Texp_comp_in]. *)
-      Typeopt.array_type_kind ~elt_sort:None iter_arr_exp.exp_env
-        iter_arr_exp.exp_loc iter_arr_exp.exp_type
+      Typeopt.array_type_kind ~elt_sort:None ~elt_ty:(Some pattern.pat_type)
+        iter_arr_exp.exp_env iter_arr_exp.exp_loc iter_arr_exp.exp_type
     in
     let iter_arr_mut =
       Typeopt.array_type_mut iter_arr_exp.exp_env iter_arr_exp.exp_type

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -1273,7 +1273,8 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
          fixed. To do that, we will need more checking of primitives
          in the front end. *)
       let array_type =
-        glb_array_type loc t (array_type_kind ~elt_sort:None env loc p)
+        glb_array_type loc t
+          (array_type_kind ~elt_sort:None ~elt_ty:None env loc p)
       in
       if t = array_type then None
       else Some (Primitive (Parraylength array_type, arity))
@@ -1281,16 +1282,18 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
   | Primitive (Parrayrefu (rt, index_kind, mut), arity), p1 :: _ -> begin
       let loc = to_location loc in
       let array_ref_type =
-        glb_array_ref_type loc rt (array_type_kind ~elt_sort:None env loc p1)
+        glb_array_ref_type loc rt
+          (array_type_kind ~elt_sort:None ~elt_ty:(Some rest_ty) env loc p1)
       in
       let array_mut = array_type_mut env p1 in
       if rt = array_ref_type && mut = array_mut then None
       else Some (Primitive (Parrayrefu (array_ref_type, index_kind, array_mut), arity))
     end
-  | Primitive (Parraysetu (st, index_kind), arity), p1 :: _ -> begin
+  | Primitive (Parraysetu (st, index_kind), arity), p1 :: _ :: p3 :: _ -> begin
       let loc = to_location loc in
       let array_set_type =
-        glb_array_set_type loc st (array_type_kind ~elt_sort:None env loc p1)
+        glb_array_set_type loc st
+          (array_type_kind ~elt_sort:None ~elt_ty:(Some p3) env loc p1)
       in
       if st = array_set_type then None
       else Some (Primitive (Parraysetu (array_set_type, index_kind), arity))
@@ -1298,16 +1301,18 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
   | Primitive (Parrayrefs (rt, index_kind, mut), arity), p1 :: _ -> begin
       let loc = to_location loc in
       let array_ref_type =
-        glb_array_ref_type loc rt (array_type_kind ~elt_sort:None env loc p1)
+        glb_array_ref_type loc rt
+          (array_type_kind ~elt_sort:None ~elt_ty:(Some rest_ty) env loc p1)
       in
       let array_mut = array_type_mut env p1 in
       if rt = array_ref_type && mut = array_mut then None
       else Some (Primitive (Parrayrefs (array_ref_type, index_kind, array_mut), arity))
     end
-  | Primitive (Parraysets (st, index_kind), arity), p1 :: _ -> begin
+  | Primitive (Parraysets (st, index_kind), arity), p1 :: _ :: p3 :: _ -> begin
       let loc = to_location loc in
       let array_set_type =
-        glb_array_set_type loc st (array_type_kind ~elt_sort:None env loc p1)
+        glb_array_set_type loc st
+          (array_type_kind ~elt_sort:None ~elt_ty:(Some p3) env loc p1)
       in
       if st = array_set_type then None
       else Some (Primitive (Parraysets (array_set_type, index_kind), arity))
@@ -1330,7 +1335,7 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
     _ :: [] -> begin
       let loc = to_location loc in
       let new_array_kind =
-        array_type_kind ~elt_sort:None env loc rest_ty
+        array_type_kind ~elt_sort:None ~elt_ty:None env loc rest_ty
         |> glb_array_type loc array_kind
       in
       let array_mut = array_type_mut env rest_ty in
@@ -1353,7 +1358,7 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
        kind.  If you haven't, then taking the glb of both would be just as
        likely to compound your error (e.g., by treating a Pgenarray as a
        Pfloatarray) as to help you. *)
-    let array_kind = array_type_kind ~elt_sort:None env loc p2 in
+    let array_kind = array_type_kind ~elt_sort:None ~elt_ty:None env loc p2 in
     let new_dst_array_set_kind =
       glb_array_set_type loc dst_array_set_kind array_kind
     in
@@ -1362,7 +1367,7 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
       src_mutability; dst_array_set_kind = new_dst_array_set_kind }, arity))
   | Primitive (Parray_element_size_in_bytes _, arity), p1 :: _ -> (
       let array_kind =
-        array_type_kind ~elt_sort:None env (to_location loc) p1
+        array_type_kind ~elt_sort:None ~elt_ty:None env (to_location loc) p1
       in
       Some (Primitive (Parray_element_size_in_bytes array_kind, arity))
     )

--- a/testsuite/tests/typing-layouts-arrays/array_type_kind_errors.ml
+++ b/testsuite/tests/typing-layouts-arrays/array_type_kind_errors.ml
@@ -1,0 +1,185 @@
+(* TEST
+ include stdlib_upstream_compatible;
+ flambda2;
+ expect;
+*)
+
+type ('a : any_non_null) t
+
+external unsafe_get : ('a : any_non_null). 'a t -> int -> 'a
+  = "%array_unsafe_get"
+[@@layout_poly]
+external unsafe_set : ('a : any_non_null). 'a t -> int -> 'a -> unit
+  = "%array_unsafe_set"
+[@@layout_poly]
+external safe_get : ('a : any_non_null). 'a t -> int -> 'a
+  = "%array_safe_get"
+[@@layout_poly]
+external safe_set : ('a : any_non_null). 'a t -> int -> 'a -> unit
+  = "%array_safe_set"
+[@@layout_poly]
+external length : ('a : any_non_null). 'a t -> int
+  = "%array_length"
+[@@layout_poly]
+external size_in_bytes : ('a : any_non_null). 'a t -> int
+  = "%array_element_size_in_bytes"
+[@@layout_poly]
+[%%expect{|
+type ('a : any_non_null) t
+external unsafe_get : ('a : any_non_null). 'a t -> int -> 'a
+  = "%array_unsafe_get" [@@layout_poly]
+external unsafe_set : ('a : any_non_null). 'a t -> int -> 'a -> unit
+  = "%array_unsafe_set" [@@layout_poly]
+external safe_get : ('a : any_non_null). 'a t -> int -> 'a
+  = "%array_safe_get" [@@layout_poly]
+external safe_set : ('a : any_non_null). 'a t -> int -> 'a -> unit
+  = "%array_safe_set" [@@layout_poly]
+external length : ('a : any_non_null). 'a t -> int = "%array_length"
+  [@@layout_poly]
+external size_in_bytes : ('a : any_non_null). 'a t -> int
+  = "%array_element_size_in_bytes" [@@layout_poly]
+|}]
+
+(* Because [%array_unsafe_get] cannot see the array type kind from [a], its
+   return type must be value. So this is allowed: *)
+let f a i : string = unsafe_get a i
+[%%expect{|
+val f : string t -> int -> string = <fun>
+|}]
+
+(* But this is not: *)
+let bad a i : int64# = unsafe_get a i
+[%%expect{|
+Line 1, characters 23-37:
+1 | let bad a i : int64# = unsafe_get a i
+                           ^^^^^^^^^^^^^^
+Error: This array operation cannot tell whether int64# t is an array type,
+       possibly because it is abstract. In this case, the element type
+       int64# must be a value:
+
+       The layout of int64# is bits64
+         because it is the unboxed version of the primitive type int64.
+       But the layout of int64# must be a sublayout of value
+         because it's the element type for an array operation with an opaque
+         array type.
+|}]
+
+(* [%array_safe_get] is similiar *)
+let f a i : string = safe_get a i
+[%%expect{|
+val f : string t -> int -> string = <fun>
+|}]
+
+let bad a i : int64# = safe_get a i
+[%%expect{|
+Line 1, characters 23-35:
+1 | let bad a i : int64# = safe_get a i
+                           ^^^^^^^^^^^^
+Error: This array operation cannot tell whether int64# t is an array type,
+       possibly because it is abstract. In this case, the element type
+       int64# must be a value:
+
+       The layout of int64# is bits64
+         because it is the unboxed version of the primitive type int64.
+       But the layout of int64# must be a sublayout of value
+         because it's the element type for an array operation with an opaque
+         array type.
+|}]
+
+(* [%array_unsafe_set] looks at the third parameter type to determine the array
+   type kind *)
+let f a i (v : string) = unsafe_set a i v
+[%%expect{|
+val f : string t -> int -> string -> unit = <fun>
+|}]
+
+let bad a i (v : int64#) = unsafe_set a i v
+[%%expect{|
+Line 1, characters 27-43:
+1 | let bad a i (v : int64#) = unsafe_set a i v
+                               ^^^^^^^^^^^^^^^^
+Error: This array operation cannot tell whether int64# t is an array type,
+       possibly because it is abstract. In this case, the element type
+       int64# must be a value:
+
+       The layout of int64# is bits64
+         because it is the unboxed version of the primitive type int64.
+       But the layout of int64# must be a sublayout of value
+         because it's the element type for an array operation with an opaque
+         array type.
+|}]
+
+(* [%array_safe_set] is similiar *)
+let f a i (v : string) = safe_set a i v
+[%%expect{|
+val f : string t -> int -> string -> unit = <fun>
+|}]
+
+let bad a i (v : int64#) = safe_set a i v
+[%%expect{|
+Line 1, characters 27-41:
+1 | let bad a i (v : int64#) = safe_set a i v
+                               ^^^^^^^^^^^^^^
+Error: This array operation cannot tell whether int64# t is an array type,
+       possibly because it is abstract. In this case, the element type
+       int64# must be a value:
+
+       The layout of int64# is bits64
+         because it is the unboxed version of the primitive type int64.
+       But the layout of int64# must be a sublayout of value
+         because it's the element type for an array operation with an opaque
+         array type.
+|}]
+
+(* [%array_length] and [%array_element_size_in_bytes] require that the array
+   type be visible *)
+let bad a = length a
+[%%expect{|
+Line 1, characters 12-20:
+1 | let bad a = length a
+                ^^^^^^^^
+Error: This array operation expects an array type, but 'a t does not appear
+       to be one. (Hint: it is abstract?)
+|}]
+
+let bad a = size_in_bytes a
+[%%expect{|
+Line 1, characters 12-27:
+1 | let bad a = size_in_bytes a
+                ^^^^^^^^^^^^^^^
+Error: This array operation expects an array type, but 'a t does not appear
+       to be one. (Hint: it is abstract?)
+|}]
+
+(* Here is a more realistic failing example: *)
+module M : sig
+  type t
+  val t : t
+  external unsafe_get : t -> int -> int64# = "%array_unsafe_get"
+end = struct
+  type t = int64# array
+  let t = [| #0L |]
+  external unsafe_get : t -> int -> int64# = "%array_unsafe_get"
+end
+
+let get () : int -> int64# = M.unsafe_get M.t
+[%%expect{|
+module M :
+  sig
+    type t
+    val t : t
+    external unsafe_get : t -> int -> int64# = "%array_unsafe_get"
+  end
+Line 11, characters 29-41:
+11 | let get () : int -> int64# = M.unsafe_get M.t
+                                  ^^^^^^^^^^^^
+Error: This array operation cannot tell whether M.t is an array type,
+       possibly because it is abstract. In this case, the element type
+       int64# must be a value:
+
+       The layout of int64# is bits64
+         because it is the unboxed version of the primitive type int64.
+       But the layout of int64# must be a sublayout of value
+         because it's the element type for an array operation with an opaque
+         array type.
+|}]

--- a/testsuite/tests/typing-layouts-arrays/array_type_kind_errors.ml
+++ b/testsuite/tests/typing-layouts-arrays/array_type_kind_errors.ml
@@ -183,3 +183,30 @@ Error: This array operation cannot tell whether M.t is an array type,
          because it's the element type for an array operation with an opaque
          array type.
 |}]
+
+(* When part of the arrow type is behind an alias, it is disallowed by the
+   primitive arity check. *)
+type abstract_ufloat_array
+[%%expect{|
+type abstract_ufloat_array
+|}]
+
+type foo = int -> float#
+external array_get : abstract_ufloat_array -> foo = "%array_unsafe_get"
+[%%expect{|
+type foo = int -> float#
+Line 2, characters 0-71:
+2 | external array_get : abstract_ufloat_array -> foo = "%array_unsafe_get"
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Wrong arity for builtin primitive "%array_unsafe_get"
+|}]
+
+type foo = int -> float# -> unit
+external array_set : abstract_ufloat_array -> foo = "%array_unsafe_set"
+[%%expect{|
+type foo = int -> float# -> unit
+Line 2, characters 0-71:
+2 | external array_set : abstract_ufloat_array -> foo = "%array_unsafe_set"
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Wrong arity for builtin primitive "%array_unsafe_set"
+|}]

--- a/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/testsuite/tests/typing-layouts/layout_poly.ml
@@ -640,33 +640,34 @@ let f (): int32# M_any.t r = id (assert false : int32# M_any.t r) *)
 (********************************************)
 (* Some primitives require layout_poly to work *)
 
-type ('a : any) t
-external id : ('a : any). 'a t -> int = "%array_length"
+type ('a : any_non_null) t = 'a array
+external id : ('a : any_non_null). 'a t -> int = "%array_length"
 let id' x = id x
 
 [%%expect{|
-type ('a : any) t
-Line 2, characters 14-37:
-2 | external id : ('a : any). 'a t -> int = "%array_length"
-                  ^^^^^^^^^^^^^^^^^^^^^^^
+type ('a : any_non_null) t = 'a array
+Line 2, characters 14-46:
+2 | external id : ('a : any_non_null). 'a t -> int = "%array_length"
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The primitive "%array_length" doesn't work well with type variables of
        layout any. Consider using "[@layout_poly]".
 |}]
 
-external[@layout_poly] id : ('a : any). 'a t -> int = "%array_length"
+external[@layout_poly] id : ('a : any_non_null). 'a t -> int = "%array_length"
 let id' x = id x
 
 [%%expect{|
-external id : ('a : any). 'a t -> int = "%array_length" [@@layout_poly]
+external id : ('a : any_non_null). 'a t -> int = "%array_length"
+  [@@layout_poly]
 val id' : 'a t -> int = <fun>
 |}]
 
-external id : ('a : any). 'a t -> int = "%identity"
+external id : ('a : any_non_null). 'a t -> int = "%identity"
 let id' x = id x
 
 [%%expect{|
-external id : ('a : any). 'a t -> int = "%identity"
-val id' : ('a : any). 'a t -> int = <fun>
+external id : ('a : any_non_null). 'a t -> int = "%identity"
+val id' : 'a t -> int = <fun>
 |}]
 
 

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -3215,6 +3215,10 @@ module Format_history = struct
       fprintf ppf
         "unknown @[(please alert the Jane Street@;\
          compilers team with this message: %s)@]" s
+    | Array_type_kind ->
+      fprintf ppf
+        "it's the element type for an array operation with an opaque@ array \
+         type"
 
   let format_product_creation_reason ppf : History.product_creation_reason -> _
       = function
@@ -3957,6 +3961,7 @@ module Debug_printers = struct
     | Debug_printer_argument -> fprintf ppf "Debug_printer_argument"
     | Recmod_fun_arg -> fprintf ppf "Recmod_fun_arg"
     | Unknown s -> fprintf ppf "Unknown %s" s
+    | Array_type_kind -> fprintf ppf "Array_type_kind"
 
   let product_creation_reason ppf : History.product_creation_reason -> _ =
     function

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -304,6 +304,7 @@ module History = struct
     | Class_term_argument
     | Debug_printer_argument
     | Recmod_fun_arg
+    | Array_type_kind
     | Unknown of string (* CR layouts: get rid of these *)
 
   type immediate_creation_reason =

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -32,6 +32,9 @@ type error =
   | Unsupported_vector_in_product_array
   | Mixed_product_array of Jkind.Sort.Const.t * type_expr
   | Product_iarrays_unsupported
+  | Opaque_array_non_value of
+      { array_type: type_expr;
+        elt_kinding_failure: (type_expr * Jkind.Violation.t) option }
 
 exception Error of Location.t * error
 
@@ -279,7 +282,7 @@ let array_kind_of_elt ~elt_sort env loc ty =
   | Unboxed_vector v -> Punboxedvectorarray v
   | Product c -> c
 
-let array_type_kind ~elt_sort env loc ty =
+let array_type_kind ~elt_sort ~elt_ty env loc ty =
   match scrape_poly env ty with
   | Tconstr(p, [elt_ty], _) when Path.same p Predef.path_array ->
       array_kind_of_elt ~elt_sort env loc elt_ty
@@ -296,8 +299,33 @@ let array_type_kind ~elt_sort env loc ty =
   | Tconstr(p, [], _) when Path.same p Predef.path_floatarray ->
       Pfloatarray
   | _ ->
-      (* This can happen with e.g. Obj.field *)
-      Pgenarray
+    begin match elt_ty with
+    | Some elt_ty ->
+      let rhs = Jkind.Builtin.value ~why:Array_type_kind in
+      begin match Ctype.constrain_type_jkind env elt_ty rhs with
+      | Ok _ -> Pgenarray
+      | Error e ->
+        (* CR layouts v4: rather than constraining [elt_ty]'s jkind to be value,
+           we could instead use its jkind to determine a non-value array kind.
+
+           We are choosing to error in this case for now because it is safer,
+           and because it could be potentially confusing that there is a second
+           source of information used to determine array type kinds (in addition
+           to the type kind of the array parameter). See PR #4098.
+        *)
+        raise (Error(loc,
+          Opaque_array_non_value {
+            array_type = ty;
+            elt_kinding_failure = Some (elt_ty, e);
+          }))
+      end
+    | None ->
+      raise (Error(loc,
+        Opaque_array_non_value {
+          array_type = ty;
+          elt_kinding_failure = None;
+        }))
+    end
 
 let array_type_mut env ty =
   match scrape_poly env ty with
@@ -306,12 +334,12 @@ let array_type_mut env ty =
 
 let array_kind exp elt_sort =
   array_type_kind
-    ~elt_sort:(Some elt_sort)
+    ~elt_sort:(Some elt_sort) ~elt_ty:None
     exp.exp_env exp.exp_loc exp.exp_type
 
 let array_pattern_kind pat elt_sort =
   array_type_kind
-    ~elt_sort:(Some elt_sort)
+    ~elt_sort:(Some elt_sort) ~elt_ty:None
     pat.pat_env pat.pat_loc pat.pat_type
 
 let bigarray_decode_type env ty tbl dfl =
@@ -571,12 +599,13 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
     num_nodes_visited, non_nullable (Pboxedvectorval Boxed_vec512)
   | Tconstr(p, _, _) when Path.same p Predef.path_float64x8 ->
     num_nodes_visited, non_nullable (Pboxedvectorval Boxed_vec512)
-  | Tconstr(p, _, _)
+  | Tconstr(p, [arg], _)
     when (Path.same p Predef.path_array
           || Path.same p Predef.path_floatarray) ->
     (* CR layouts: [~elt_sort:None] here is bad for performance. To
        fix it, we need a place to store the sort on a [Tconstr]. *)
-    num_nodes_visited, non_nullable (Parrayval (array_type_kind ~elt_sort:None env loc ty))
+    let ak = array_type_kind ~elt_ty:(Some arg) ~elt_sort:None env loc ty in
+    num_nodes_visited, non_nullable (Parrayval ak)
   | Tconstr(p, _, _) -> begin
       (* CR layouts v2.8: The uses of [decl.type_jkind] here are suspect:
          with with-kinds, [decl.type_jkind] will mention variables bound
@@ -1192,6 +1221,23 @@ let report_error ppf = function
   | Product_iarrays_unsupported ->
       fprintf ppf
         "Immutable arrays of unboxed products are not yet supported."
+  | Opaque_array_non_value { array_type; elt_kinding_failure }  ->
+      begin match elt_kinding_failure with
+      | Some (ty, err) ->
+        fprintf ppf
+        "This array operation cannot tell whether %a is an array type,@ \
+         possibly because it is abstract. In this case, the element type@ \
+         %a must be a value:@ @\n@[%a@]"
+          Printtyp.type_expr array_type
+          Printtyp.type_expr ty
+          (Jkind.Violation.report_with_offender
+            ~offender:(fun ppf -> Printtyp.type_expr ppf ty)) err
+      | None ->
+        fprintf ppf
+          "This array operation expects an array type, but %a does not appear@ \
+           to be one.@ (Hint: it is abstract?)"
+          Printtyp.type_expr array_type;
+      end
 
 let () =
   Location.register_error_of_exn

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -312,6 +312,11 @@ let array_type_kind ~elt_sort ~elt_ty env loc ty =
            and because it could be potentially confusing that there is a second
            source of information used to determine array type kinds (in addition
            to the type kind of the array parameter). See PR #4098.
+
+           Using its jkind to determine a non-value array kind would also only
+           be useful for explicit user-written primitives. In other cases where
+           we compute an array kind (array matching, array comprehension),
+           [elt_ty] is [None].
         *)
         raise (Error(loc,
           Opaque_array_non_value {

--- a/typing/typeopt.mli
+++ b/typing/typeopt.mli
@@ -27,7 +27,7 @@ val maybe_pointer : Typedtree.expression
 (* Supplying [None] for [elt_sort] should be avoided when possible. It
    will result in a call to [Ctype.type_sort] which can be expensive. *)
 val array_type_kind :
-  elt_sort:(Jkind.Sort.Const.t option)
+  elt_sort:(Jkind.Sort.Const.t option) -> elt_ty:(Types.type_expr option)
   -> Env.t -> Location.t -> Types.type_expr -> Lambda.array_kind
 val array_type_mut : Env.t -> Types.type_expr -> Lambda.mutable_flag
 val array_kind_of_elt :


### PR DESCRIPTION
Since `5.1.1minus-12`, compiling this program with `ocamlopt` causes an flambda fatal error:
```ocaml
module M : sig
  type t
  val x : t
  external unsafe_get : t -> int -> int64# = "%array_unsafe_get"
end = struct
  type t = int64# array
  let x = [| #0L |]
  external unsafe_get : t -> int -> int64# = "%array_unsafe_get"
end

let get () : int -> int64# = M.unsafe_get M.x
```

The cause is that when `Typeopt.array_type_kind` calculates an array kind from an array type, if it's not visible that the type is an array type (e.g., it's abstract), it defaults the kind to `Pgenarray`, which is not safe for non-value arrays.

Two possible fixes:

1. Give an error when an array operation would otherwise default to `Pgenarray` but the element sort (for `get`, the element is the return type, for `set`, it's the third type parameter) is not actually `value`. (And always give an error if we can't tell the element sort from the typechecked application of the array operation.)
2. Don't default to `Pgenarray`, and choose a different array kind, based on the element jkind.

(1) is safer and good if we want to get this fix in soon, as it simply makes more programs error. (2) is probably more useful, as it makes more programs typecheck, but less safe. This PR implements (1). See the new tests in `testsuite/tests/typing-layouts-arrays/array_type_kind_errors.ml` for examples.

## Stack
1. https://github.com/ocaml-flambda/flambda-backend/pull/4101
2. https://github.com/ocaml-flambda/flambda-backend/pull/4098