### PR TITLE
arm64 - switch to C stack before raising stack overflow

### DIFF
--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -486,6 +486,8 @@ FUNCTION(caml_call_realloc_stack)
         ldp     x29, x30, [sp], 16
         ret
 1:  /* Restore the gc_regs bucket popped by SAVE_ALL_REGS */
+        ldr     TMP, Caml_state(gc_regs)
+        sub     TMP, TMP, #16
         ldr     TMP2, Caml_state(gc_regs_buckets)
         str     TMP2, [TMP, 0]  /* next ptr */
         str     TMP, Caml_state(gc_regs_buckets)

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -485,10 +485,14 @@ FUNCTION(caml_call_realloc_stack)
     /* Free stack space and return to caller */
         ldp     x29, x30, [sp], 16
         ret
-1:      RESTORE_ALL_REGS
+1:  /* Restore the gc_regs bucket popped by SAVE_ALL_REGS */
+        ldr     TMP2, Caml_state(gc_regs_buckets)
+        str     TMP2, [TMP, 0]  /* next ptr */
+        str     TMP, Caml_state(gc_regs_buckets)
     /* Raise the Stack_overflow exception */
         ldp     x29, x30, [sp], 16
         add     sp, sp, 16 /* pop argument */
+        SWITCH_OCAML_TO_C
         ADDRGLOBAL(x0, caml_exn_Stack_overflow)
         b       G(caml_raise_async)
         CFI_ENDPROC


### PR DESCRIPTION
Updates the arm64 version of `caml_call_realloc_stack` to be consistent with the amd64 version as of #4078 
- Switch back to the C stack before calling `caml_raise_async`
- Don't bother restoring all regs, just replace the gc_regs bucket