### PR TITLE
Revert "Revert "`exn` crosses portable and contended (#4062)""

### DIFF
--- a/stdlib/effect.ml
+++ b/stdlib/effect.ml
@@ -27,7 +27,9 @@ let () =
         Some msg
     | _ -> None
   in
-  Printexc.Safe.register_printer printer
+  (* need magic because jkind doesn't know [t] crosses portability and
+    contention  *)
+  Printexc.Safe.register_printer (Obj.magic_portable printer)
 
 (* Register the exceptions so that the runtime can access it *)
 type _ t += Should_not_see_this__ : unit t

--- a/testsuite/tests/backtrace/backtrace_effects.reference
+++ b/testsuite/tests/backtrace/backtrace_effects.reference
@@ -1,7 +1,7 @@
 (** get_callstack **)
 Raised by primitive operation at Backtrace_effects.bar in file "backtrace_effects.ml", line 20, characters 13-39
 Called from Backtrace_effects.foo in file "backtrace_effects.ml", line 27, characters 12-17
-Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 80, characters 4-47
+Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 82, characters 4-47
 Called from Backtrace_effects.baz in file "backtrace_effects.ml" (inlined), lines 31-41, characters 2-401
 Called from Backtrace_effects in file "backtrace_effects.ml", line 43, characters 8-14
 (** get_continuation_callstack **)
@@ -11,6 +11,6 @@ Called from Backtrace_effects.foo in file "backtrace_effects.ml", line 27, chara
 Fatal error: exception Stdlib.Exit
 Raised at Backtrace_effects.bar in file "backtrace_effects.ml", line 17, characters 4-14
 Re-raised at Backtrace_effects.baz.(fun) in file "backtrace_effects.ml", line 33, characters 21-28
-Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 80, characters 4-47
+Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 82, characters 4-47
 Called from Backtrace_effects.baz in file "backtrace_effects.ml" (inlined), lines 31-41, characters 2-401
 Called from Backtrace_effects in file "backtrace_effects.ml", line 43, characters 8-14

--- a/testsuite/tests/backtrace/backtrace_effects_nested.flambda.reference
+++ b/testsuite/tests/backtrace/backtrace_effects_nested.flambda.reference
@@ -1,5 +1,5 @@
 Raised by primitive operation at Backtrace_effects_nested.blorp in file "backtrace_effects_nested.ml", line 24, characters 2-11
-Called from Stdlib__Effect.Deep.continue in file "stdlib/effect.ml" (inlined), line 99, characters 21-64
+Called from Stdlib__Effect.Deep.continue in file "stdlib/effect.ml" (inlined), line 101, characters 21-64
 Called from Backtrace_effects_nested.baz.(fun) in file "backtrace_effects_nested.ml", line 32, characters 16-29
-Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 80, characters 4-47
+Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 82, characters 4-47
 43

--- a/testsuite/tests/effects/backtrace.byte.reference
+++ b/testsuite/tests/effects/backtrace.byte.reference
@@ -2,5 +2,5 @@ Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace.foo in file "backtrace.ml", line 14, characters 11-27
 Called from Backtrace.bar in file "backtrace.ml", line 22, characters 4-9
 Called from Backtrace.task1 in file "backtrace.ml", line 31, characters 4-10
-Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 104, characters 44-78
+Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 106, characters 44-78
 Called from Backtrace.task2 in file "backtrace.ml", line 38, characters 4-16

--- a/testsuite/tests/effects/backtrace.reference
+++ b/testsuite/tests/effects/backtrace.reference
@@ -2,5 +2,5 @@ Raised at Stdlib.failwith in file "stdlib.ml" (inlined), line 39, characters 17-
 Called from Backtrace.foo in file "backtrace.ml", line 14, characters 11-27
 Called from Backtrace.bar in file "backtrace.ml", line 22, characters 4-9
 Called from Backtrace.task1 in file "backtrace.ml", line 31, characters 4-10
-Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 104, characters 44-78
+Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 106, characters 44-78
 Called from Backtrace.task2 in file "backtrace.ml", line 38, characters 4-16

--- a/testsuite/tests/typing-modes/exn.ml
+++ b/testsuite/tests/typing-modes/exn.ml
@@ -1,0 +1,295 @@
+(* TEST
+   expect;
+*)
+
+(* [exn] currently crosses portability. To make it safe, exception constructors
+are portable iff all its arguments are portable. *)
+
+exception Nonportable of (unit -> unit)
+exception Portable of unit
+exception Portable' of (unit -> unit) @@ portable
+
+[%%expect{|
+exception Nonportable of (unit -> unit)
+exception Portable of unit
+exception Portable' of (unit -> unit) @@ portable
+|}]
+
+let x : exn = Nonportable (fun x -> x)
+[%%expect{|
+val x : exn = Nonportable <fun>
+|}]
+
+let (foo @ portable) () =
+    match x with
+    | Nonportable g -> ()
+    | _ -> ()
+[%%expect{|
+Line 3, characters 6-17:
+3 |     | Nonportable g -> ()
+          ^^^^^^^^^^^
+Error: The constructor "Nonportable" is nonportable, so cannot be used inside a function that is portable.
+|}]
+
+let (foo @ portable) () =
+    try () with
+    | Nonportable g -> ()
+    | _ -> ()
+[%%expect{|
+Line 3, characters 6-17:
+3 |     | Nonportable g -> ()
+          ^^^^^^^^^^^
+Error: The constructor "Nonportable" is nonportable, so cannot be used inside a function that is portable.
+|}]
+
+let (foo @ portable) () =
+    match () with
+    | exception Nonportable g -> ()
+    | _ -> ()
+[%%expect{|
+Line 3, characters 16-27:
+3 |     | exception Nonportable g -> ()
+                    ^^^^^^^^^^^
+Error: The constructor "Nonportable" is nonportable, so cannot be used inside a function that is portable.
+|}]
+
+(* below we will only use [match] to test *)
+
+let (foo @ portable) () =
+    match x with
+    | Portable g -> ()
+    | _ -> ()
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+let (foo @ portable) () =
+    match x with
+    | Portable' g -> ()
+    | _ -> ()
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+let (foo @ portable) () =
+    raise (Nonportable (fun () -> ()))
+[%%expect{|
+Line 2, characters 11-22:
+2 |     raise (Nonportable (fun () -> ()))
+               ^^^^^^^^^^^
+Error: The constructor "Nonportable" is nonportable, so cannot be used inside a function that is portable.
+|}]
+
+let (foo @ portable) () =
+    raise (Portable ())
+[%%expect{|
+val foo : unit -> 'a = <fun>
+|}]
+
+let (foo @ portable) () =
+    raise (Portable' (fun () -> ()))
+[%%expect{|
+val foo : unit -> 'a = <fun>
+|}]
+
+(* rebinding counts as usage *)
+let (foo @ portable) () =
+    let module M = struct
+        exception Nonportable' = Nonportable
+    end in
+    ()
+[%%expect{|
+Line 3, characters 33-44:
+3 |         exception Nonportable' = Nonportable
+                                     ^^^^^^^^^^^
+Error: The constructor "Nonportable" is nonportable, so cannot be used inside a function that is portable.
+|}]
+
+
+(* CR zqian: the following should be allowed, but requires a completely different
+approach (coportable). *)
+exception SemiPortable of string * (unit -> unit)
+
+let (foo @ portable) () =
+    try () with
+    SemiPortable (s, _) -> print_endline s
+[%%expect{|
+exception SemiPortable of string * (unit -> unit)
+Line 5, characters 4-16:
+5 |     SemiPortable (s, _) -> print_endline s
+        ^^^^^^^^^^^^
+Error: The constructor "SemiPortable" is nonportable, so cannot be used inside a function that is portable.
+|}]
+
+(* [exn] also crosses contention. To make it safe, exception constructors
+are uncontended iff all its arguments are uncontended. *)
+exception Uncontended of unit
+exception Uncontended' of int ref @@ contended
+exception Contended of int ref
+[%%expect{|
+exception Uncontended of unit
+exception Uncontended' of int ref @@ contended
+exception Contended of int ref
+|}]
+
+let (foo @ portable) () =
+    match x with
+    | Uncontended () -> ()
+    | _ -> ()
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+let (foo @ portable) () =
+    match x with
+    | Uncontended' _ -> ()
+    | _ -> ()
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+let (foo @ portable) () =
+    match x with
+    | Contended _ -> ()
+    | _ -> ()
+[%%expect{|
+Line 3, characters 6-15:
+3 |     | Contended _ -> ()
+          ^^^^^^^^^
+Error: The constructor "Contended" is nonportable, so cannot be used inside a function that is portable.
+|}]
+
+let (foo @ portable) () =
+    raise (Uncontended ())
+[%%expect{|
+val foo : unit -> 'a = <fun>
+|}]
+
+let (foo @ portable) () =
+    raise (Uncontended' (ref 42))
+[%%expect{|
+val foo : unit -> 'a = <fun>
+|}]
+
+let (foo @ portable) () =
+    raise (Contended (ref 42))
+[%%expect{|
+Line 2, characters 11-20:
+2 |     raise (Contended (ref 42))
+               ^^^^^^^^^
+Error: The constructor "Contended" is nonportable, so cannot be used inside a function that is portable.
+|}]
+
+(* rebinding counts as usage *)
+let (foo @ portable) () =
+    let module M = struct
+        exception Contended' = Contended
+    end in
+    ()
+[%%expect{|
+Line 3, characters 31-40:
+3 |         exception Contended' = Contended
+                                   ^^^^^^^^^
+Error: The constructor "Contended" is nonportable, so cannot be used inside a function that is portable.
+|}]
+
+(* defining exception inside a portable function is fine *)
+let (foo @ portable) () =
+    let module M = struct
+        exception Bad of int ref * (unit -> unit)
+    end in
+    raise (M.Bad (ref 42, fun () -> ()))
+[%%expect{|
+val foo : unit -> 'a = <fun>
+|}]
+
+let (foo @ portable) () =
+    let exception Bad of int ref * (unit -> unit) in
+    raise (Bad (ref 42, fun () -> ()))
+[%%expect{|
+val foo : unit -> 'a = <fun>
+|}]
+
+
+exception Fields : { x : int } -> exn
+exception MutFields : { mutable x : string } -> exn
+exception MutFields': { mutable z : int ref @@ contended } -> exn
+[%%expect{|
+exception Fields : { x : int; } -> exn
+exception MutFields : { mutable x : string; } -> exn
+exception MutFields' : { mutable z : int ref @@ contended; } -> exn
+|}]
+
+let (foo @ portable) () =
+    match x with
+    | Fields _ -> ()
+    | _ -> ()
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+let (foo @ portable) () =
+    match x with
+    | MutFields _ -> ()
+    | _ -> ()
+[%%expect{|
+Line 3, characters 6-15:
+3 |     | MutFields _ -> ()
+          ^^^^^^^^^
+Error: The constructor "MutFields" is nonportable, so cannot be used inside a function that is portable.
+|}]
+
+let (foo @ portable) () =
+    match x with
+    | MutFields' _ -> ()
+    | _ -> ()
+[%%expect{|
+Line 3, characters 6-16:
+3 |     | MutFields' _ -> ()
+          ^^^^^^^^^^
+Error: The constructor "MutFields'" is nonportable, so cannot be used inside a function that is portable.
+|}]
+
+(* built-in exceptions can be raised arbitrarily inside portable functions - we
+show that's safe. *)
+let (foo @ portable) () =
+    match x with
+    | Exit
+    | Match_failure _
+    | Assert_failure _
+    | Invalid_argument _
+    | Failure _
+    | Not_found
+    | Out_of_memory
+    | Stack_overflow
+    | Sys_error _
+    | End_of_file
+    | Division_by_zero
+    | Sys_blocked_io
+    | Undefined_recursive_module _
+    | _ -> ()
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+
+(* other extensible types are not affected *)
+(* CR zqian: support other extensible types. *)
+type t = ..
+
+type t += Foo of int
+
+let x : t = Foo 42
+
+let (foo @ portable) () =
+    ignore (x : _ @ portable)
+
+[%%expect{|
+type t = ..
+type t += Foo of int
+val x : t = Foo 42
+Line 8, characters 12-13:
+8 |     ignore (x : _ @ portable)
+                ^
+Error: The value "x" is nonportable, so cannot be used inside a function that is portable.
+|}]

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -489,7 +489,7 @@ let () =
    * that are not also exception types. *)
   reg_show_prim "show_constructor"
     (fun env loc id lid ->
-       let desc = Env.lookup_constructor ~loc Env.Positive lid env in
+       let desc, _ = Env.lookup_constructor ~loc Env.Positive lid env in
        if is_exception_constructor env desc.cstr_res then
          raise Not_found;
        let path = Btype.cstr_type_path desc in
@@ -525,7 +525,7 @@ let () =
 let () =
   reg_show_prim "show_exception"
     (fun env loc id lid ->
-       let desc = Env.lookup_constructor ~loc Env.Positive lid env in
+       let desc, _ = Env.lookup_constructor ~loc Env.Positive lid env in
        if not (is_exception_constructor env desc.cstr_res) then
          raise Not_found;
        let ret_type =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -7229,3 +7229,38 @@ let constrain_decl_jkind env decl jkind =
         match decl.type_manifest with
         | None -> err
         | Some ty -> constrain_type_jkind env ty jkind
+
+let check_constructor_crossing env tag ~res args held_locks =
+  match tag with
+  | Ordinary _ | Null -> ()
+  | Extension _ ->
+      match get_desc (expand_head env res) with
+      | Tconstr (p, _, _) when Path.same Predef.path_exn p ->
+          (* CR zqian: handle other extensible variant types as well *)
+          let mode_crossings =
+            List.map (
+              fun ({ca_type; ca_modalities; _} : Types.constructor_argument) ->
+              crossing_of_ty env ~modalities:ca_modalities ca_type
+            ) args
+          in
+          let mode_crossing =
+            List.fold_left Mode.Crossing.join Mode.Crossing.bot mode_crossings
+          in
+          (* We only check portability and contention, since [exn] doesn't
+               cross other axes anyway. *)
+          let monadic =
+            Mode.Value.max_with (Monadic Contention) Mode.Contention.min
+            |> Mode.Crossing.apply_right mode_crossing
+          in
+          let comonadic =
+            Mode.Value.min_with (Comonadic Portability) Mode.Portability.max
+            |> Mode.Crossing.apply_left mode_crossing
+          in
+          let mode = {
+            monadic = monadic.monadic;
+            comonadic = comonadic.comonadic;
+          }
+          |> Mode.Value.close_over
+          in
+          ignore (Env.walk_locks ~env ~item:Constructor mode None held_locks)
+      | _ -> ()

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -776,3 +776,10 @@ val cross_left_alloc :
   Types.type_expr ->
   Mode.Alloc.l ->
   Mode.Alloc.l
+
+(** Currently [exn] crosses portability and contention. To make that safe,
+usages of constructors are constrained according to the mode crossing of
+constructor arguments. *)
+val check_constructor_crossing : Env.t ->
+  tag -> res:type_expr -> constructor_argument list ->
+  Env.held_locks -> unit

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -282,16 +282,17 @@ let find_constr ~constant tag cstrs =
   try
     List.find
       (function
-        | ({cstr_tag=Ordinary {runtime_tag=tag'}; cstr_constant},_) ->
+        | (({cstr_tag=Ordinary {runtime_tag=tag'}; cstr_constant},_),_) ->
           tag' = tag && cstr_constant = constant
-        | ({cstr_tag=Null; cstr_constant}, _) -> tag = -1 && cstr_constant = constant
-        | ({cstr_tag=Extension _},_) -> false)
+        | (({cstr_tag=Null; cstr_constant}, _),_) ->
+          tag = -1 && cstr_constant = constant
+        | (({cstr_tag=Extension _},_),_) -> false)
       cstrs
   with
   | Not_found -> raise Constr_not_found
 
 let find_constr_by_tag ~constant tag cstrlist =
-  fst (find_constr ~constant tag cstrlist)
+  fst (fst (find_constr ~constant tag cstrlist))
 
 let constructors_of_type ~current_unit ty_path decl =
   match decl.type_kind with

--- a/typing/datarepr.mli
+++ b/typing/datarepr.mli
@@ -36,7 +36,7 @@ val constructors_of_type:
 exception Constr_not_found
 
 val find_constr_by_tag:
-  constant:bool -> int -> (constructor_description*'a) list ->
+  constant:bool -> int -> ((constructor_description * 'a) * 'b) list ->
     constructor_description
 
 val constructor_existentials :

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -224,6 +224,7 @@ type lock_item =
   | Value
   | Module
   | Class
+  | Constructor
 
 type structure_components_reason =
   | Project
@@ -317,14 +318,14 @@ val lookup_module_instance_path:
 
 val lookup_constructor:
   ?use:bool -> loc:Location.t -> constructor_usage -> Longident.t -> t ->
-  constructor_description
+  constructor_description * locks
 val lookup_all_constructors:
   ?use:bool -> loc:Location.t -> constructor_usage -> Longident.t -> t ->
-  ((constructor_description * (unit -> unit)) list,
+  (((constructor_description * locks) * (unit -> unit)) list,
    Location.t * t * lookup_error) result
 val lookup_all_constructors_from_type:
   ?use:bool -> loc:Location.t -> constructor_usage -> Path.t -> t ->
-  (constructor_description * (unit -> unit)) list
+  ((constructor_description * locks) * (unit -> unit)) list
 
 val lookup_label:
   ?use:bool -> record_form:'rcd record_form -> loc:Location.t -> label_usage -> Longident.t -> t ->

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2678,6 +2678,21 @@ let for_float ident =
     ~annotation:None ~why:(Primitive ident)
   |> mark_best
 
+let for_exn ident =
+  let mod_bounds =
+    (* the mode crossing is safe by [Ctype.check_constructor_crossing] *)
+    Mod_bounds.create ~locality:Locality.Const.max
+      ~linearity:Linearity.Const.max ~portability:Portability.Const.min
+      ~yielding:Yielding.Const.max ~uniqueness:Uniqueness.Const_op.max
+      ~contention:Contention.Const_op.min ~statefulness:Statefulness.Const.max
+      ~visibility:Visibility.Const_op.max ~externality:Externality.max
+      ~nullability:Nullability.Non_null ~separability:Separability.Non_float
+  in
+  fresh_jkind
+    { layout = Sort (Base Value); mod_bounds; with_bounds = No_with_bounds }
+    ~annotation:None ~why:(Primitive ident)
+  |> mark_best
+
 (******************************)
 (* elimination and defaulting *)
 

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -524,6 +524,9 @@ val for_arrow : Types.jkind_l
 (** The jkind of an object type.  *)
 val for_object : Types.jkind_l
 
+(** The jkind for [exn] *)
+val for_exn : Ident.t -> Types.jkind_l
+
 (** The jkind of a float. *)
 val for_float : Ident.t -> Types.jkind_l
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3405,6 +3405,14 @@ module Crossing = struct
     let top : t = Join_const Mode.Const.min
 
     let bot : t = Join_const Mode.Const.max
+
+    let join (t0 : t) (t1 : t) : t =
+      match t0, t1 with
+      | Join_const c0, Join_const c1 -> Join_const (Mode.Const.meet c0 c1)
+
+    let meet (t0 : t) (t1 : t) : t =
+      match t0, t1 with
+      | Join_const c0, Join_const c1 -> Join_const (Mode.Const.join c0 c1)
   end
 
   module Comonadic = struct
@@ -3434,6 +3442,14 @@ module Crossing = struct
     let top : t = Meet_const Mode.Const.max
 
     let bot : t = Meet_const Mode.Const.min
+
+    let join (t0 : t) (t1 : t) : t =
+      match t0, t1 with
+      | Meet_const c0, Meet_const c1 -> Meet_const (Mode.Const.join c0 c1)
+
+    let meet (t0 : t) (t1 : t) : t =
+      match t0, t1 with
+      | Meet_const c0, Meet_const c1 -> Meet_const (Mode.Const.meet c0 c1)
   end
 
   type t = (Monadic.t, Comonadic.t) monadic_comonadic
@@ -3493,6 +3509,16 @@ module Crossing = struct
   let top = { monadic = Monadic.top; comonadic = Comonadic.top }
 
   let bot = { monadic = Monadic.bot; comonadic = Comonadic.bot }
+
+  let join t0 t1 =
+    { monadic = Monadic.join t0.monadic t1.monadic;
+      comonadic = Comonadic.join t0.comonadic t1.comonadic
+    }
+
+  let meet t0 t1 =
+    { monadic = Monadic.meet t0.monadic t1.monadic;
+      comonadic = Comonadic.meet t0.comonadic t1.comonadic
+    }
 
   let print ppf t =
     let print_atom ppf = function

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -755,8 +755,6 @@ module type S = sig
     programs mode-check. The adjustment is called mode crossing. *)
     type t
 
-    (* CR zqian: Complete the lattice structure of mode crossing. *)
-
     (* CR zqian: jkind modal bounds should just be our [t]. In particular, jkind
        should infer the modal bounds of a type in the form of [Value] instead of
        [Alloc]. For example, a type could have [regional] modality, in which case
@@ -802,6 +800,12 @@ module type S = sig
 
     (** The mode crossing that crosses everything. *)
     val bot : t
+
+    (** The mode crossing that's weaker than both inputs *)
+    val join : t -> t -> t
+
+    (** The mode crossing that's stronger than both inputs *)
+    val meet : t -> t -> t
 
     (** Print the mode crossing by axis. Omit axes that do not cross. *)
     val print : Format.formatter -> t -> unit

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -409,7 +409,7 @@ let build_initial_env add_type add_extension empty_env =
        ~jkind:Jkind.Const.Builtin.immediate
   |> add_type ident_char ~jkind:Jkind.Const.Builtin.immediate
   |> add_type_with_jkind ident_exn ~kind:Type_open
-    ~jkind:(Jkind.for_non_float ~why:(Primitive ident_exn))
+       ~jkind:(Jkind.for_exn ident_exn)
   |> add_type ident_extension_constructor ~jkind:Jkind.Const.Builtin.immutable_data
   |> add_type_with_jkind ident_float ~jkind:(Jkind.for_float ident_float)
       ~unboxed_jkind:Jkind.Const.Builtin.kind_of_unboxed_float

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1723,20 +1723,19 @@ let solve_Ppat_construct ~refine tps penv loc constr no_existentials
     unify_pat_types_return_equated_pairs ~refine loc penv ty_res expected_ty
   in
 
-  let ty_args_ty, ty_args_gf, equated_types, existential_ctyp =
+  let ty_args, equated_types, existential_ctyp =
     with_local_level_iter ~post: generalize_structure begin fun () ->
       let expected_ty = instance expected_ty in
-      let ty_args_ty, ty_args_gf, ty_res, equated_types, existential_ctyp =
+      let ty_args, ty_args_ty, ty_res, equated_types, existential_ctyp =
         match existential_styp with
           None ->
             let ty_args, ty_res, _ =
               instance_constructor (Make_existentials_abstract penv) constr
             in
-            let ty_args_ty, ty_args_gf =
-              List.split
-                (List.map (fun ca -> ca.Types.ca_type, ca.Types.ca_modalities) ty_args)
+            let ty_args_ty =
+              List.map (fun ca -> ca.Types.ca_type) ty_args
             in
-            ty_args_ty, ty_args_gf, ty_res, unify_res ty_res expected_ty, None
+            ty_args, ty_args_ty, ty_res, unify_res ty_res expected_ty, None
         | Some (name_list, sty) ->
             let existential_treatment =
               if name_list = [] then
@@ -1750,19 +1749,20 @@ let solve_Ppat_construct ~refine tps penv loc constr no_existentials
               instance_constructor existential_treatment constr
             in
             let equated_types = unify_res ty_res expected_ty in
-            let ty_args_ty, ty_args_gf =
-              List.split
-                (List.map (fun ca -> ca.Types.ca_type, ca.Types.ca_modalities) ty_args)
-            in
+            let ty_args_ty = List.map (fun ca -> ca.Types.ca_type) ty_args in
             let ty_args_ty, existential_ctyp =
               solve_constructor_annotation tps penv name_list sty ty_args_ty
                 ty_ex
             in
-            ty_args_ty, ty_args_gf, ty_res, equated_types, existential_ctyp
+            let ty_args =
+              List.map2 (fun arg ca_type -> {arg with Types.ca_type}) ty_args
+                ty_args_ty
+            in
+            ty_args, ty_args_ty, ty_res, equated_types, existential_ctyp
       in
       if constr.cstr_existentials <> [] then
         lower_variables_only !!penv penv.Pattern_env.equations_scope ty_res;
-      ((ty_args_ty, ty_args_gf, equated_types, existential_ctyp),
+      ((ty_args, equated_types, existential_ctyp),
        expected_ty :: ty_res :: ty_args_ty)
     end
   in
@@ -1788,7 +1788,7 @@ let solve_Ppat_construct ~refine tps penv loc constr no_existentials
         equated_types
     with Warn_only_once -> ()
   end;
-  (ty_args_ty, ty_args_gf, existential_ctyp)
+  (ty_args, existential_ctyp)
 
 let solve_Ppat_record_field ~refine loc penv label label_lid record_ty
       record_form =
@@ -2459,11 +2459,11 @@ let check_recordpat_labels loc lbl_pat_list closed record_form =
 (* Constructors *)
 
 module Constructor = NameChoice (struct
-  type t = constructor_description
+  type t = constructor_description * Env.locks
   type usage = Env.constructor_usage
   let kind = Datatype_kind.Variant
-  let get_name cstr = cstr.cstr_name
-  let get_type cstr = cstr.cstr_res
+  let get_name (cstr, _) = cstr.cstr_name
+  let get_type (cstr, _) = cstr.cstr_res
   let lookup_all_from_type loc usage path env =
     match Env.lookup_all_constructors_from_type ~loc usage path env with
     | _ :: _ as x -> x
@@ -2477,7 +2477,9 @@ module Constructor = NameChoice (struct
             let filter lbl =
               compare_type_path env
                 path (get_constr_type_path @@ get_type lbl) in
-            let add_valid x acc = if filter x then (x,ignore)::acc else acc in
+            let add_valid x acc =
+              let x = (x, Env.locks_empty) in
+              if filter x then (x, ignore)::acc else acc in
             Env.fold_constructors add_valid None env []
         | _ -> []
   let in_env _ = true
@@ -2915,7 +2917,7 @@ and type_pat_aux
             let error = Wrong_expected_kind(srt, Pattern, expected_ty) in
             raise (Error (loc, !!penv, error))
       in
-      let constr =
+      let constr, locks =
         let candidates =
           Env.lookup_all_constructors Env.Pattern ~loc:lid.loc lid.txt !!penv in
         wrap_disambiguate "This variant pattern is expected to have"
@@ -2923,6 +2925,7 @@ and type_pat_aux
           (Constructor.disambiguate Env.Pattern lid !!penv expected_type)
           candidates
       in
+      let held_locks = (locks, lid.txt, lid.loc) in
       begin match no_existentials, constr.cstr_existentials with
       | None, _ | _, [] -> ()
       | Some r, (_ :: _) ->
@@ -2972,10 +2975,12 @@ and type_pat_aux
         raise(Error(loc, !!penv, Constructor_arity_mismatch(lid.txt,
                                      constr.cstr_arity, List.length sargs)));
 
-      let (ty_args_ty, ty_args_gf, existential_ctyp) =
+      let (args, existential_ctyp) =
         solve_Ppat_construct ~refine:false tps penv loc constr no_existentials
           existential_styp expected_ty
       in
+      Ctype.check_constructor_crossing !!penv constr.cstr_tag ~res:expected_ty
+        args held_locks;
 
       let rec check_non_escaping p =
         match p.ppat_desc with
@@ -2996,11 +3001,13 @@ and type_pat_aux
 
       let args =
         List.map2
-          (fun p (ty, gf) ->
-             let alloc_mode = Modality.Value.Const.apply gf alloc_mode.mode in
+          (fun p (arg : Types.constructor_argument) ->
+             let alloc_mode =
+              Modality.Value.Const.apply arg.ca_modalities alloc_mode.mode
+             in
              let alloc_mode = simple_pat_mode alloc_mode in
-             type_pat ~alloc_mode tps Value p ty)
-          sargs (List.combine ty_args_ty ty_args_gf)
+             type_pat ~alloc_mode tps Value p arg.ca_type)
+          sargs args
       in
       rvp { pat_desc=Tpat_construct(lid, constr, args, existential_ctyp);
             pat_loc = loc; pat_extra=[];
@@ -3555,12 +3562,12 @@ let rec check_counter_example_pat
   | Tpat_construct(cstr_lid, constr, targs, _) ->
       if constr.cstr_generalized && must_backtrack_on_gadt then
         raise Need_backtrack;
-      let (ty_args, _, existential_ctyp) =
+      let (ty_args, existential_ctyp) =
         solve_Ppat_construct ~refine type_pat_state penv loc constr None None
           expected_ty
       in
       map_fold_cont
-        (fun (p,t) -> check_rec p t)
+        (fun (p,t) -> check_rec p t.Types.ca_type)
         (List.combine targs ty_args)
         (fun args ->
           mkp k (Tpat_construct(cstr_lid, constr, args, existential_ctyp)))
@@ -6799,9 +6806,11 @@ and type_expect_
                    Pstr_eval ({ pexp_desc = Pexp_construct (lid, None); _ }, _)
                } ] ->
           let path =
-            let cd =
+            let cd, held_locks =
               Env.lookup_constructor Env.Positive ~loc:lid.loc lid.txt env
             in
+            (* no argument and thus crossing portability *)
+            ignore held_locks;
             match cd.cstr_tag with
             | Extension path -> path
             | _ -> raise (Error (lid.loc, env, Not_an_extension_constructor))
@@ -8513,11 +8522,12 @@ and type_construct ~overwrite env (expected_mode : expected_mode) loc lid sarg
   let constrs =
     Env.lookup_all_constructors ~loc:lid.loc Env.Positive lid.txt env
   in
-  let constr =
+  let constr, locks =
     wrap_disambiguate "This variant expression is expected to have"
       ty_expected_explained
       (Constructor.disambiguate Env.Positive lid env expected_type) constrs
   in
+  let held_locks = (locks, lid.txt, lid.loc) in
   let sargs =
     match sarg with
     | None -> []
@@ -8567,6 +8577,8 @@ and type_construct ~overwrite env (expected_mode : expected_mode) loc lid sarg
         List.iter (fun {Types.ca_type=ty; _} -> generalize_structure ty) ty_args)
   in
   let ty_args, ty_res, texp = unify_as_construct ty_expected in
+  Ctype.check_constructor_crossing env constr.cstr_tag ~res:ty_res ty_args
+    held_locks;
   let ty_args0, ty_res =
     match instance_list (ty_res :: (List.map (fun ca -> ca.Types.ca_type) ty_args)) with
       t :: tl -> tl, t

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2990,7 +2990,10 @@ let transl_extension_constructor ~scope env type_path type_params
         let usage : Env.constructor_usage =
           if priv = Public then Env.Exported else Env.Exported_private
         in
-        let cdescr = Env.lookup_constructor ~loc:lid.loc usage lid.txt env in
+        let cdescr, locks =
+          Env.lookup_constructor ~loc:lid.loc usage lid.txt env
+        in
+        let held_locks = (locks, lid.txt, lid.loc) in
         let (args, cstr_res, _ex) =
           Ctype.instance_constructor Keep_existentials_flexible cdescr
         in
@@ -3024,6 +3027,8 @@ let transl_extension_constructor ~scope env type_path type_params
               | _ -> ())
             typext_params
         end;
+        Ctype.check_constructor_crossing env cdescr.cstr_tag ~res:cstr_res args
+          held_locks;
         (* Ensure that constructor's type matches the type being extended *)
         let cstr_type_path = Btype.cstr_type_path cdescr in
         let cstr_type_params = (Env.find_type cstr_type_path env).type_params in


### PR DESCRIPTION
Reverts oxcaml/oxcaml#4068
Re-applies https://github.com/oxcaml/oxcaml/pull/4062