### PR TITLE
Better treatment of relations in flambda2 types 

### DIFF
--- a/driver/flambda_backend_args.ml
+++ b/driver/flambda_backend_args.ml
@@ -297,6 +297,18 @@ let mk_flambda2_join_algorithm f =
       debugging)."
 ;;
 
+let mk_flambda2_types_database f =
+  "-flambda2-types-database", Arg.Unit f,
+  Printf.sprintf " Enable the types database%s (Flambda 2 only)"
+    (format_default Flambda2.Default.types_database)
+;;
+
+let mk_no_flambda2_types_database f =
+  "-no-flambda2-types-database", Arg.Unit f,
+  Printf.sprintf " Disable the types database%s (Flambda 2 only)"
+    (format_not_default Flambda2.Default.types_database)
+;;
+
 let mk_flambda2_join_points f =
   "-flambda2-join-points", Arg.Unit f,
   Printf.sprintf " Propagate information from all incoming edges to a join\n\
@@ -814,6 +826,8 @@ module type Flambda_backend_options = sig
   val flambda2_basic_meet : unit -> unit
   val flambda2_advanced_meet : unit -> unit
   val flambda2_join_algorithm : string -> unit
+  val flambda2_types_database : unit -> unit
+  val no_flambda2_types_database : unit -> unit
   val flambda2_unbox_along_intra_function_control_flow : unit -> unit
   val no_flambda2_unbox_along_intra_function_control_flow : unit -> unit
   val flambda2_backend_cse_at_toplevel : unit -> unit
@@ -957,6 +971,8 @@ struct
     mk_flambda2_basic_meet F.flambda2_basic_meet;
     mk_flambda2_advanced_meet F.flambda2_advanced_meet;
     mk_flambda2_join_algorithm F.flambda2_join_algorithm;
+    mk_flambda2_types_database F.flambda2_types_database;
+    mk_no_flambda2_types_database F.no_flambda2_types_database;
     mk_flambda2_unbox_along_intra_function_control_flow
       F.flambda2_unbox_along_intra_function_control_flow;
     mk_no_flambda2_unbox_along_intra_function_control_flow
@@ -1193,6 +1209,8 @@ module Flambda_backend_options_impl = struct
   let flambda2_join_depth n = Flambda2.join_depth := Flambda_backend_flags.Set n
   let flambda2_reaper = set Flambda2.enable_reaper
   let no_flambda2_reaper = clear Flambda2.enable_reaper
+  let flambda2_types_database = set Flambda2.types_database
+  let no_flambda2_types_database = clear Flambda2.types_database
   let flambda2_expert_fallback_inlining_heuristic =
     set Flambda2.Expert.fallback_inlining_heuristic
   let no_flambda2_expert_fallback_inlining_heuristic =
@@ -1526,6 +1544,8 @@ module Extra_params = struct
       | _ ->
         Misc.fatal_error "Syntax: flambda2-join-algorithm=binary|n-way|checked");
       true
+    | "flambda2-types-database" ->
+      set Flambda2.types_database
     | "flambda2-unbox-along-intra-function-control-flow" ->
        set Flambda2.unbox_along_intra_function_control_flow
     | "flambda2-backend-cse-at-toplevel" ->

--- a/driver/flambda_backend_args.mli
+++ b/driver/flambda_backend_args.mli
@@ -94,6 +94,8 @@ module type Flambda_backend_options = sig
   val flambda2_basic_meet : unit -> unit
   val flambda2_advanced_meet : unit -> unit
   val flambda2_join_algorithm : string -> unit
+  val flambda2_types_database : unit -> unit
+  val no_flambda2_types_database : unit -> unit
   val flambda2_unbox_along_intra_function_control_flow : unit -> unit
   val no_flambda2_unbox_along_intra_function_control_flow : unit -> unit
   val flambda2_backend_cse_at_toplevel : unit -> unit

--- a/driver/flambda_backend_flags.ml
+++ b/driver/flambda_backend_flags.ml
@@ -135,6 +135,7 @@ module Flambda2 = struct
     let join_depth = 5
     let join_algorithm = Binary
     let function_result_types = Never
+    let types_database = false
     let enable_reaper = false
     let unicode = true
     let kind_checks = false
@@ -149,6 +150,7 @@ module Flambda2 = struct
     join_depth : int;
     join_algorithm : join_algorithm;
     function_result_types : function_result_types;
+    types_database : bool;
     enable_reaper : bool;
     unicode : bool;
     kind_checks : bool;
@@ -163,6 +165,7 @@ module Flambda2 = struct
     join_depth = Default.join_depth;
     join_algorithm = Default.join_algorithm;
     function_result_types = Default.function_result_types;
+    types_database = Default.types_database;
     enable_reaper = Default.enable_reaper;
     unicode = Default.unicode;
     kind_checks = Default.kind_checks;
@@ -199,6 +202,7 @@ module Flambda2 = struct
   let unicode = ref Default
   let kind_checks = ref Default
   let function_result_types = ref Default
+  let types_database = ref Default
   let enable_reaper = ref Default
 
   module Dump = struct

--- a/driver/flambda_backend_flags.mli
+++ b/driver/flambda_backend_flags.mli
@@ -115,6 +115,7 @@ module Flambda2 : sig
     val join_depth : int
     val join_algorithm : join_algorithm
     val function_result_types : function_result_types
+    val types_database : bool
     val enable_reaper : bool
     val unicode : bool
     val kind_checks : bool
@@ -132,6 +133,7 @@ module Flambda2 : sig
     join_depth : int;
     join_algorithm : join_algorithm;
     function_result_types : function_result_types;
+    types_database : bool;
     enable_reaper : bool;
     unicode : bool;
     kind_checks : bool;
@@ -148,6 +150,7 @@ module Flambda2 : sig
   val cse_depth : int or_default ref
   val join_depth : int or_default ref
   val join_algorithm : join_algorithm or_default ref
+  val types_database : bool or_default ref
   val enable_reaper : bool or_default ref
   val unicode : bool or_default ref
   val kind_checks : bool or_default ref

--- a/middle_end/flambda2/algorithms/container_types.ml
+++ b/middle_end/flambda2/algorithms/container_types.ml
@@ -387,6 +387,8 @@ module Shared_map (T : S) = struct
 
   let iter = T.Map.iter
 
+  let map = T.Map.map_sharing
+
   let map_unshare = T.Map.map
 
   let map_keys_unshare = T.Map.map_keys

--- a/middle_end/flambda2/algorithms/container_types.ml
+++ b/middle_end/flambda2/algorithms/container_types.ml
@@ -86,6 +86,95 @@ module Make_map (T : Thing) (Set : Set_plus_stdlib with type elt = T.t) = struct
         | Some datum1, Some datum2 -> Some (f key datum1 datum2))
       t1 t2
 
+  let union_sharing f t1 t2 =
+    let changed = ref false in
+    let t =
+      union
+        (fun key datum1 datum2 ->
+          match f key datum1 datum2 with
+          | None ->
+            changed := true;
+            None
+          | Some datum ->
+            if not (datum == datum1) then changed := true;
+            Some datum)
+        t1 t2
+    in
+    if !changed then t else t1
+
+  let union_shared f t1 t2 =
+    let changed = ref false in
+    let t =
+      union
+        (fun key datum1 datum2 ->
+          if datum1 == datum2
+          then Some datum1
+          else
+            match f key datum1 datum2 with
+            | None ->
+              changed := true;
+              None
+            | Some datum ->
+              if not (datum == datum1) then changed := true;
+              Some datum)
+        t1 t2
+    in
+    if !changed then t else t1
+
+  let diff f t1 t2 =
+    merge
+      (fun key datum1_opt datum2_opt ->
+        match datum1_opt, datum2_opt with
+        | None, None | None, Some _ -> None
+        | Some datum1, None -> Some datum1
+        | Some datum1, Some datum2 -> f key datum1 datum2)
+      t1 t2
+
+  let diff_sharing f t1 t2 =
+    let changed = ref false in
+    let t =
+      merge
+        (fun key datum1_opt datum2_opt ->
+          match datum1_opt, datum2_opt with
+          | None, None | None, Some _ -> None
+          | Some datum1, None -> Some datum1
+          | Some datum1, Some datum2 -> (
+            match f key datum1 datum2 with
+            | None ->
+              changed := true;
+              None
+            | Some datum ->
+              if not (datum == datum1) then changed := true;
+              Some datum))
+        t1 t2
+    in
+    if not !changed then t1 else t
+
+  let diff_shared f t1 t2 =
+    let changed = ref false in
+    let t =
+      merge
+        (fun key datum1_opt datum2_opt ->
+          match datum1_opt, datum2_opt with
+          | None, None | None, Some _ -> None
+          | Some datum1, None -> Some datum1
+          | Some datum1, Some datum2 -> (
+            if datum1 == datum2
+            then (
+              changed := true;
+              None)
+            else
+              match f key datum1 datum2 with
+              | None ->
+                changed := true;
+                None
+              | Some datum ->
+                if not (datum == datum1) then changed := true;
+                Some datum))
+        t1 t2
+    in
+    if not !changed then t1 else t
+
   exception Found_common_element
 
   let inter_domain_is_non_empty t1 t2 =
@@ -175,6 +264,14 @@ struct
   let rec union_list ts =
     match ts with [] -> empty | t :: ts -> union t (union_list ts)
 
+  let union_sharing = union
+
+  let union_shared s1 s2 = if s1 == s2 then s1 else union s1 s2
+
+  let diff_sharing = diff
+
+  let diff_shared s1 s2 = if s1 == s2 then empty else diff_sharing s1 s2
+
   exception More_than_one_element
 
   let get_singleton t =
@@ -211,4 +308,86 @@ module Make_pair (T1 : S) (T2 : S) = struct
       (fun t1 result ->
         T2.Set.fold (fun t2 result -> Set.add (t1, t2) result) t2_set result)
       t1_set Set.empty
+end
+
+module Shared_set (T : S) = struct
+  type t = T.Set.t
+
+  type elt = T.t
+
+  let create t = t
+
+  let print = T.Set.print
+
+  let empty = T.Set.empty
+
+  let is_empty = T.Set.is_empty
+
+  let singleton = T.Set.singleton
+
+  let add k t =
+    (* Note: [Set.add] is not guaranteed to preserve sharing in depth. *)
+    T.Set.union_sharing t (T.Set.singleton k)
+
+  let remove k t =
+    (* Note: [Set.remove] is not guaranteed to preserve sharing in depth. *)
+    T.Set.diff_sharing t (T.Set.singleton k)
+
+  let mem = T.Set.mem
+
+  let diff = T.Set.diff_shared
+
+  let diff_set = T.Set.diff_sharing
+
+  let union = T.Set.union_shared
+
+  let union_set = T.Set.union_sharing
+
+  let fold = T.Set.fold
+
+  let iter = T.Set.iter
+
+  let map_unshare = T.Set.map
+end
+
+module Shared_map (T : S) = struct
+  type 'a t = 'a T.Map.t
+
+  type key = T.t
+
+  let create m = m
+
+  let print = T.Map.print
+
+  let empty = T.Map.empty
+
+  let is_empty = T.Map.is_empty
+
+  let singleton = T.Map.singleton
+
+  let add k v t =
+    (* Note: [M.add] is not guaranteed to preserve sharing in depth. *)
+    T.Map.union_sharing (fun _k _v0 v1 -> Some v1) t (T.Map.singleton k v)
+
+  let remove k t =
+    (* Note: [M.remove] is not guaranteed to preserve sharing in depth. *)
+    T.Map.diff_sharing (fun _k _v0 () -> None) t (T.Map.singleton k ())
+
+  let find_opt = T.Map.find_opt
+
+  let diff = T.Map.diff_shared
+
+  let diff_map = T.Map.diff_sharing
+
+  let union = T.Map.union_shared
+
+  let union_map = T.Map.union_sharing
+
+  let fold = T.Map.fold
+
+  let iter = T.Map.iter
+
+  let map_unshare = T.Map.map
+
+  let map_keys_unshare = T.Map.map_keys
 end

--- a/middle_end/flambda2/algorithms/container_types.mli
+++ b/middle_end/flambda2/algorithms/container_types.mli
@@ -72,13 +72,10 @@ module Shared_set (T : S) : sig
 
   (** [diff ss1 ss2] computes the difference of the shared sets [ss1] and [ss2].
 
-      {b Sharing}: Sharing is guaranteed with sub-trees of [ss1] that are
-      disjoint from [ss2].
-
       {b Complexity}: The complexity of [diff (union ss1 ss2) ss1] is linear
       in the size of [ss2]. The complexity of [diff (add k ss) ss] is the
       same as that of [mem k (add k ss)]. *)
-  val diff : t -> t -> t
+  val diff : t -> t -> T.Set.t
 
   (** [diff_set ss s] returns a shared set that is identical to [ss], with the
       keys from [s] removed.
@@ -146,14 +143,10 @@ module Shared_map (T : S) : sig
       [diff] assumes that [f] always returns [None] when called with physically
       equal arguments, and will never call [f] with physically equal arguments.
 
-      {b Sharing}: Sharing is guaranteed for sub-trees of [sm1] for which all
-      call to [f] return the first value unchanged. In particular, sharing is
-      guaranteed for all sub-trees of [sm1] that are disjoint from [sm2].
-
       {b Complexity}: The complexity of [diff f (union g sm1 sm2) sm1] is linear
       in the size of [sm2]. The complexity of [diff f (add sm k v) sm] is the
       same as that of [find k (add sm k v)]. *)
-  val diff : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
+  val diff : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a T.Map.t
 
   (** [diff_map f sm m] returns a shared map that is identical to [sm], except
       that bindings in [sm] with a key [k] that also appear in [m] are updated
@@ -171,6 +164,8 @@ module Shared_map (T : S) : sig
   val fold : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
 
   val iter : (key -> 'a -> unit) -> 'a t -> unit
+
+  val map : ('a -> 'a) -> 'a t -> 'a t
 
   (** {2 Unsharing functions}
 

--- a/middle_end/flambda2/algorithms/container_types.mli
+++ b/middle_end/flambda2/algorithms/container_types.mli
@@ -48,3 +48,138 @@ module Make_pair (T1 : S) (T2 : S) : sig
 
   val create_from_cross_product : T1.Set.t -> T2.Set.t -> Set.t
 end
+
+module Shared_set (T : S) : sig
+  type t = private T.Set.t
+
+  type elt = T.t
+
+  val create : T.Set.t -> t
+
+  val print : Format.formatter -> t -> unit
+
+  val empty : t
+
+  val is_empty : t -> bool
+
+  val singleton : elt -> t
+
+  val add : elt -> t -> t
+
+  val remove : elt -> t -> t
+
+  val mem : elt -> t -> bool
+
+  (** [diff ss1 ss2] computes the difference of the shared sets [ss1] and [ss2].
+
+      {b Sharing}: Sharing is guaranteed with sub-trees of [ss1] that are
+      disjoint from [ss2].
+
+      {b Complexity}: The complexity of [diff (union ss1 ss2) ss1] is linear
+      in the size of [ss2]. The complexity of [diff (add k ss) ss] is the
+      same as that of [mem k (add k ss)]. *)
+  val diff : t -> t -> t
+
+  (** [diff_set ss s] returns a shared set that is identical to [ss], with the
+      keys from [s] removed.
+
+      {b Sharing}: Sharing is guaranteed for sub-trees of [ss] that are
+      disjoint from [s]. *)
+  val diff_set : t -> T.Set.t -> t
+
+  (** [union ss1 ss2] computes the union of the shared sets [ss1] and [ss2].
+
+      {b Sharing}: Sharing is guaranteed with sub-trees of [ss1] that are
+      disjoint from [ss2].
+
+      {b Complexity}: The complexity of [union (diff ss1 ss2) ss1] is linear in
+      the size of [ss2]. The complexity of [union (remove k ss) ss] is the same
+      as that of [add k (remove k ss)]. *)
+  val union : t -> t -> t
+
+  (** [union_set ss s] adds all the keys of set [s] to the shared set [ss].
+
+      {b Sharing}: Sharing is guaranteed with sub-trees of [ss] that are
+      disjoint from [s]. *)
+  val union_set : t -> T.Set.t -> t
+
+  val fold : (elt -> 'a -> 'a) -> t -> 'a -> 'a
+
+  val iter : (elt -> unit) -> t -> unit
+
+  (** {2 Unsharing functions}
+
+      The following functions construct a new shared set but do not
+      necessarily preserve sharing with their input. They are marked with the
+      [_unshare] suffix to make this stand out.
+  *)
+
+  val map_unshare : (elt -> elt) -> t -> t
+end
+
+module Shared_map (T : S) : sig
+  type 'a t = private 'a T.Map.t
+
+  type key = T.t
+
+  val create : 'a T.Map.t -> 'a t
+
+  val print :
+    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
+
+  val empty : 'a t
+
+  val is_empty : 'a t -> bool
+
+  val singleton : key -> 'a -> 'a t
+
+  val add : key -> 'a -> 'a t -> 'a t
+
+  val remove : key -> 'a t -> 'a t
+
+  val find_opt : key -> 'a t -> 'a option
+
+  (** [diff f sm1 sm2] returns a shared map that is identical to [sm1], except
+      that bindings in [sm1] with a key [k] that also appears in [sm2] are
+      updated according to [f].
+
+      [diff] assumes that [f] always returns [None] when called with physically
+      equal arguments, and will never call [f] with physically equal arguments.
+
+      {b Sharing}: Sharing is guaranteed for sub-trees of [sm1] for which all
+      call to [f] return the first value unchanged. In particular, sharing is
+      guaranteed for all sub-trees of [sm1] that are disjoint from [sm2].
+
+      {b Complexity}: The complexity of [diff f (union g sm1 sm2) sm1] is linear
+      in the size of [sm2]. The complexity of [diff f (add sm k v) sm] is the
+      same as that of [find k (add sm k v)]. *)
+  val diff : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
+
+  (** [diff_map f sm m] returns a shared map that is identical to [sm], except
+      that bindings in [sm] with a key [k] that also appear in [m] are updated
+      according to [f].
+
+      {b Sharing}: Sharing is guaranteed for sub-trees of [sm] for which all
+      call to [f] return the first value unchanged. In particular, sharing is
+      guaranteed for all sub-trees of [sm] that are disjoint from [m]. *)
+  val diff_map : (key -> 'a -> 'b -> 'a option) -> 'a t -> 'b T.Map.t -> 'a t
+
+  val union : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a t -> 'a t
+
+  val union_map : (key -> 'a -> 'a -> 'a option) -> 'a t -> 'a T.Map.t -> 'a t
+
+  val fold : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
+
+  val iter : (key -> 'a -> unit) -> 'a t -> unit
+
+  (** {2 Unsharing functions}
+
+      The following functions construct a new {!Shared_map.t} but do not
+      necessarily preserve sharing with their input. They are marked with the
+      [_unshare] suffix to make this stand out.
+  *)
+
+  val map_unshare : ('a -> 'b) -> 'a t -> 'b t
+
+  val map_keys_unshare : (key -> key) -> 'a t -> 'a t
+end

--- a/middle_end/flambda2/types/env/aliases.mli
+++ b/middle_end/flambda2/types/env/aliases.mli
@@ -142,6 +142,14 @@ val add_alias_set :
   Alias_set.t ->
   t
 
+(** [diff ~later ~earlier] returns a map recording the changes in canonical
+    element (ignoring name mode) between [earlier] and [later], which must be
+    derived from [earlier].
+
+    An entry [name -> (simple, coercion_to_simple)] in this maps indicates that
+    [coercion_to_simple(name)] was demoted to [simple]. *)
+val diff : later:t -> earlier:t -> (Simple.t * Coercion.t) Name.Map.t
+
 (** [get_aliases] always returns the supplied element in the result set. *)
 val get_aliases : t -> Simple.t -> Alias_set.t
 

--- a/middle_end/flambda2/types/env/cached_level.ml
+++ b/middle_end/flambda2/types/env/cached_level.ml
@@ -18,7 +18,9 @@ type t =
   { names_to_types :
       (Type_grammar.t * Binding_time.With_name_mode.t) Name.Map.t;
     aliases : Aliases.t;
-    symbol_projections : Symbol_projection.t Variable.Map.t
+    symbol_projections : Symbol_projection.t Variable.Map.t;
+    database : Database.t;
+    extensions : Typing_env_extension.t Database.Extension_id.Map.t
   }
 
 let print_kind_and_mode ~min_binding_time ppf (ty, binding_time_and_mode) =
@@ -40,7 +42,9 @@ let print_name_modes ~restrict_to ~min_binding_time ppf t =
 let empty =
   { names_to_types = Name.Map.empty;
     aliases = Aliases.empty;
-    symbol_projections = Variable.Map.empty
+    symbol_projections = Variable.Map.empty;
+    database = Database.empty;
+    extensions = Database.Extension_id.Map.empty
   }
 
 let names_to_types t = t.names_to_types
@@ -58,7 +62,9 @@ let add_or_replace_binding t (name : Name.t) ty binding_time name_mode =
   in
   { names_to_types;
     aliases = t.aliases;
-    symbol_projections = t.symbol_projections
+    symbol_projections = t.symbol_projections;
+    database = t.database;
+    extensions = t.extensions
   }
 
 let replace_variable_binding t var ty =
@@ -69,8 +75,26 @@ let replace_variable_binding t var ty =
   in
   { names_to_types;
     aliases = t.aliases;
-    symbol_projections = t.symbol_projections
+    symbol_projections = t.symbol_projections;
+    database = t.database;
+    extensions = t.extensions
   }
+
+let database t = t.database
+
+let extensions t = t.extensions
+
+let find_extension t extension_id =
+  Database.Extension_id.Map.find_opt extension_id t.extensions
+
+let add_or_replace_extension t extension_id extension =
+  let extensions =
+    Database.Extension_id.Map.add extension_id extension t.extensions
+  in
+  { t with extensions }
+
+let with_database_and_aliases t ~database ~aliases =
+  { t with database; aliases }
 
 let with_aliases t ~aliases = { t with aliases }
 
@@ -109,9 +133,12 @@ let clean_for_export t ~reachable_names =
       t.names_to_types
   in
   let aliases = Aliases.empty in
-  { t with names_to_types; aliases }
+  let database = Database.empty in
+  { t with names_to_types; aliases; database }
 
-let apply_renaming { names_to_types; aliases; symbol_projections } renaming =
+let apply_renaming
+    { names_to_types; aliases; symbol_projections; database; extensions }
+    renaming =
   let names_to_types =
     Name.Map.fold
       (fun name (ty, binding_time_and_mode) acc ->
@@ -131,7 +158,13 @@ let apply_renaming { names_to_types; aliases; symbol_projections } renaming =
           acc)
       symbol_projections Variable.Map.empty
   in
-  { names_to_types; aliases; symbol_projections }
+  let database = Database.apply_renaming database renaming in
+  let extensions =
+    Database.Extension_id.Map.map
+      (fun ext -> Typing_env_extension.apply_renaming ext renaming)
+      extensions
+  in
+  { names_to_types; aliases; symbol_projections; database; extensions }
 
 let merge t1 t2 =
   let names_to_types =
@@ -150,7 +183,9 @@ let merge t1 t2 =
             Symbol_projection.print proj2)
       t1.symbol_projections t2.symbol_projections
   in
-  { names_to_types; aliases; symbol_projections }
+  let database = Database.empty in
+  let extensions = Database.Extension_id.Map.empty in
+  { names_to_types; aliases; symbol_projections; database; extensions }
 
 let canonicalise t simple =
   Simple.pattern_match simple
@@ -161,7 +196,8 @@ let canonicalise t simple =
         coercion)
 
 let remove_unused_value_slots_and_shortcut_aliases
-    ({ names_to_types; aliases; symbol_projections } as t) ~used_value_slots =
+    ({ names_to_types; aliases; symbol_projections; database; extensions = _ }
+    as t) ~used_value_slots =
   let canonicalise = canonicalise t in
   let names_to_types =
     Name.Map.map_sharing
@@ -173,17 +209,31 @@ let remove_unused_value_slots_and_shortcut_aliases
         if ty == ty' then info else ty', binding_time_and_mode)
       names_to_types
   in
-  { names_to_types; aliases; symbol_projections }
+  let database = Database.shortcut_aliases ~canonicalise database in
+  let extensions = Database.Extension_id.Map.empty in
+  { names_to_types; aliases; symbol_projections; database; extensions }
 
 let free_function_slots_and_value_slots
-    { names_to_types; aliases = _; symbol_projections } =
-  let from_projections =
+    { names_to_types; aliases = _; symbol_projections; database; extensions } =
+  let from_database =
+    Name_occurrences.restrict_to_value_slots_and_function_slots
+      (Database.free_names database)
+  in
+  let from_database_and_extensions =
+    Database.Extension_id.Map.fold
+      (fun _extension_id extension free_names ->
+        Name_occurrences.union free_names
+          (Name_occurrences.restrict_to_value_slots_and_function_slots
+             (Typing_env_extension.free_names extension)))
+      extensions from_database
+  in
+  let from_projections_and_database =
     Variable.Map.fold
       (fun _var proj free_names ->
         Name_occurrences.union free_names
           (Name_occurrences.restrict_to_value_slots_and_function_slots
              (Symbol_projection.free_names proj)))
-      symbol_projections Name_occurrences.empty
+      symbol_projections from_database_and_extensions
   in
   Name.Map.fold
     (fun _name (ty, _binding_time) free_names ->
@@ -191,7 +241,7 @@ let free_function_slots_and_value_slots
       Name_occurrences.union free_names
         (Name_occurrences.restrict_to_value_slots_and_function_slots
            free_names_of_ty))
-    names_to_types from_projections
+    names_to_types from_projections_and_database
 
 let ids_for_export t =
   if not (Aliases.is_empty t.aliases)
@@ -199,9 +249,17 @@ let ids_for_export t =
     Misc.fatal_error
       "Aliases structure must be empty for export; did you forget to call \
        [clean_for_export]?";
-  Name.Map.fold
-    (fun name (typ, _binding_time_and_mode) ids ->
-      Ids_for_export.add_name
-        (Ids_for_export.union ids (Type_grammar.ids_for_export typ))
-        name)
-    (names_to_types t) Ids_for_export.empty
+  if not (Database.is_empty t.database)
+  then
+    Misc.fatal_error
+      "Database structure must be empty for export; did you forget to call \
+       [clean_for_export]?";
+  let ids_for_export =
+    Name.Map.fold
+      (fun name (typ, _binding_time_and_mode) ids ->
+        Ids_for_export.add_name
+          (Ids_for_export.union ids (Type_grammar.ids_for_export typ))
+          name)
+      (names_to_types t) Ids_for_export.empty
+  in
+  ids_for_export

--- a/middle_end/flambda2/types/env/cached_level.mli
+++ b/middle_end/flambda2/types/env/cached_level.mli
@@ -35,7 +35,20 @@ val add_or_replace_binding :
 
 val replace_variable_binding : t -> Variable.t -> Type_grammar.t -> t
 
+val database : t -> Database.t
+
+val extensions : t -> Typing_env_extension.t Database.Extension_id.Map.t
+
+val find_extension :
+  t -> Database.Extension_id.t -> Typing_env_extension.t option
+
+val add_or_replace_extension :
+  t -> Database.Extension_id.t -> Typing_env_extension.t -> t
+
 val with_aliases : t -> aliases:Aliases.t -> t
+
+val with_database_and_aliases :
+  t -> database:Database.t -> aliases:Aliases.t -> t
 
 val add_symbol_projection : t -> Variable.t -> Symbol_projection.t -> t
 

--- a/middle_end/flambda2/types/env/database.ml
+++ b/middle_end/flambda2/types/env/database.ml
@@ -1,0 +1,1186 @@
+module RWC = Reg_width_const
+
+(** {2 Meet}
+
+    We use a simplified version of [TE.meet_return_value] for the database: we
+    only care about whether the result of a [meet] is identical to the value
+    that was previously stored in the database, or if it needs to be updated.
+
+    We choose a left-biased approach: the existing value should always be passed
+    as the first argument of the [meet] function. *)
+
+type 'a left_meet_return_value =
+  | Left_input
+  | New_result of 'a
+
+let left_meet_return_value res left =
+  if res == left then Left_input else New_result res
+
+let extract_value res left =
+  match res with Left_input -> left | New_result value -> value
+
+(** {2 Row-like}
+
+    Generic row-like functor, used for disjunctions. *)
+
+module Row_like = struct
+  module Make (Branch : Container_types.S) = struct
+    type 'a t =
+      { known : 'a Branch.Map.t;
+        other : 'a Or_bottom.t
+      }
+
+    let create ?default known =
+      let other : _ Or_bottom.t =
+        match default with None -> Bottom | Some other -> Ok other
+      in
+      { known; other }
+
+    let print_known pp ppf known = Branch.Map.print pp ppf known
+
+    let print pp ppf { known; other } =
+      Format.fprintf ppf
+        "@[<hov 1>(@[<hov 1>(known@ %a)@]@ @[<hov 1>(other@ %a)@]@]"
+        (print_known pp) known (Or_bottom.print pp) other
+
+    let is_bottom { other; known } =
+      match other with Bottom -> Branch.Map.is_empty known | Ok _ -> false
+
+    let merge f { known = known1; other = other1 }
+        { known = known2; other = other2 } =
+      let known =
+        Branch.Map.merge
+          (fun _ case1 case2 ->
+            let case1 : _ Or_bottom.t =
+              match case1 with None -> other1 | Some case1 -> Ok case1
+            in
+            let case2 : _ Or_bottom.t =
+              match case2 with None -> other2 | Some case2 -> Ok case2
+            in
+            match (f case1 case2 : _ Or_bottom.t) with
+            | Bottom -> None
+            | Ok case -> Some case)
+          known1 known2
+      in
+      let other = f other1 other2 in
+      { known; other }
+
+    let left_meet ~meet t1 t2 : _ Or_bottom.t =
+      let result_is_left = ref true in
+      let t =
+        merge
+          (fun case1 case2 ->
+            match case1, case2 with
+            | Bottom, _ -> Bottom
+            | Ok _, Bottom ->
+              result_is_left := false;
+              Bottom
+            | Ok case1, Ok case2 -> (
+              match (meet case1 case2 : _ Or_bottom.t) with
+              | Ok Left_input -> Ok case1
+              | Ok (New_result case) ->
+                result_is_left := false;
+                Ok case
+              | Bottom -> Bottom))
+          t1 t2
+      in
+      if is_bottom t
+      then Bottom
+      else if !result_is_left
+      then Ok Left_input
+      else Ok (New_result t)
+
+    let find const { other; known } : _ Or_bottom.t =
+      match Branch.Map.find_opt const known with
+      | Some arm -> Ok arm
+      | None -> other
+  end
+
+  module For_const = Make (RWC)
+end
+
+(** {2 Extensions}
+
+    Extensions are treated as inert by the database (i.e. we can't learn new
+    aliases or new properties recursively when meeting extensions), so we can
+    implement basic extension-related functions without dependencies on the
+    database. *)
+
+module Extension_id : sig
+  include Container_types.S
+
+  val create : unit -> t
+end = struct
+  type t = int
+
+  let create =
+    let next_stamp = ref 0 in
+    fun () ->
+      incr next_stamp;
+      !next_stamp
+
+  module T0 = struct
+    let print ppf n = Format.fprintf ppf "ext%d" n
+
+    let equal = Int.equal
+
+    let compare = Int.compare
+
+    let hash (x : t) = Hashtbl.hash x
+  end
+
+  include T0
+
+  module T = struct
+    type nonrec t = t
+
+    include T0
+  end
+
+  module Tree = Patricia_tree.Make (struct
+    let print = print
+  end)
+
+  module Set = Tree.Set
+  module Map = Tree.Map
+end
+
+module Extension_set = Container_types.Shared_set (Extension_id)
+
+type switch = Extension_set.t Row_like.For_const.t
+
+let print_switch ppf switch =
+  Row_like.For_const.print Extension_set.print ppf switch
+
+let empty_switch =
+  Row_like.For_const.create ~default:Extension_set.empty RWC.Map.empty
+
+let is_empty_switch ({ other; known } : switch) =
+  match other with
+  | Bottom -> false
+  | Ok extension_ids ->
+    Extension_set.is_empty extension_ids
+    && RWC.Map.for_all
+         (fun _ extension_ids -> Extension_set.is_empty extension_ids)
+         known
+
+let left_meet_switch switch1 (switch2 : Extension_id.Set.t Row_like.For_const.t)
+    =
+  Row_like.For_const.left_meet
+    ~meet:(fun ext1 ext2 : _ Or_bottom.t ->
+      let ext = Extension_set.union_set ext1 ext2 in
+      Ok (left_meet_return_value ext ext1))
+    switch1 switch2
+
+(** {2 Relations} *)
+
+module Function : sig
+  type t
+
+  include Container_types.S_plus_iterator with type t := t
+
+  type descr =
+    | Is_null
+    | Is_int
+    | Get_tag
+    | Untag_imm
+    | Tag_imm
+
+  val descr : t -> descr
+
+  val is_null : t
+
+  val is_int : t
+
+  val get_tag : t
+
+  val untag_imm : t
+
+  val tag_imm : t
+
+  val inverse : t -> t option
+
+  val of_const : t -> RWC.t -> RWC.t Or_unknown_or_bottom.t
+end = struct
+  type t = int
+
+  module T0 = struct
+    let is_null = 0
+
+    let is_int = 1
+
+    let get_tag = 2
+
+    let untag_imm = 3
+
+    let tag_imm = 4
+
+    let equal = Int.equal
+
+    let compare = Int.compare
+
+    let hash (t : t) = Hashtbl.hash t
+
+    type descr =
+      | Is_null
+      | Is_int
+      | Get_tag
+      | Untag_imm
+      | Tag_imm
+
+    let grand_table_of_functions =
+      [| Is_null; Is_int; Get_tag; Untag_imm; Tag_imm |]
+
+    let descr fn = grand_table_of_functions.(fn)
+
+    let print ppf fn =
+      match descr fn with
+      | Is_null -> Format.fprintf ppf "is_null"
+      | Is_int -> Format.fprintf ppf "is_int"
+      | Get_tag -> Format.fprintf ppf "get_tag"
+      | Untag_imm -> Format.fprintf ppf "untag_int"
+      | Tag_imm -> Format.fprintf ppf "tag_imm"
+  end
+
+  include T0
+
+  module T = struct
+    type nonrec t = t
+
+    include T0
+  end
+
+  module Tree = Patricia_tree.Make (struct
+    let print = print
+  end)
+
+  module Set = Tree.Set
+  module Map = Tree.Map
+
+  let inverse fn =
+    match descr fn with
+    | Is_null | Is_int | Get_tag -> None
+    | Untag_imm -> Some tag_imm
+    | Tag_imm -> Some untag_imm
+
+  let of_const fn const : _ Or_unknown_or_bottom.t =
+    let[@inline] return b : _ Or_unknown_or_bottom.t =
+      if b then Ok RWC.untagged_const_true else Ok RWC.untagged_const_false
+    in
+    match descr fn, RWC.descr const with
+    (* is_null *)
+    | Is_null, Null -> return true
+    | Is_null, Tagged_immediate _ -> return false
+    | Is_null, Naked_immediate _ -> Bottom
+    (* is_int *)
+    | Is_int, Tagged_immediate _ -> return true
+    | Is_int, (Naked_immediate _ | Null) -> Bottom
+    (* get_tag *)
+    | Get_tag, _ -> Bottom
+    (* untag_imm *)
+    | Untag_imm, Tagged_immediate imm -> Ok (RWC.naked_immediate imm)
+    | Untag_imm, (Naked_immediate _ | Null) -> Bottom
+    (* tag_imm *)
+    | Tag_imm, Naked_immediate imm -> Ok (RWC.tagged_immediate imm)
+    | Tag_imm, (Tagged_immediate _ | Null) -> Bottom
+    (* others *)
+    | ( _,
+        ( Naked_float32 _ | Naked_float _ | Naked_int32 _ | Naked_int64 _
+        | Naked_nativeint _ | Naked_vec128 _ ) ) ->
+      Bottom
+end
+
+module Function_map = Container_types.Shared_map (Function)
+module Name_map = Container_types.Shared_map (Name)
+module Const_map = Container_types.Shared_map (RWC)
+
+let canonicalise aliases simple =
+  Simple.pattern_match simple
+    ~const:(fun _ -> simple)
+    ~name:(fun name ~coercion ->
+      Simple.apply_coercion_exn
+        (Aliases.get_canonical_ignoring_name_mode aliases name)
+        coercion)
+
+type simple_or_switch =
+  | Simple of Simple.t
+  | Switch of switch
+
+let print_simple_or_switch ppf = function
+  | Simple simple -> Simple.print ppf simple
+  | Switch switch -> print_switch ppf switch
+
+type properties_of_name =
+  { properties : simple_or_switch Function_map.t;
+        (** Maps unary properties on the name to their value.
+
+        Partial properties (i.e. properties that do not necessarily exist on all
+        names) are supported:
+
+          - If the value is a [Simple.t], the property exists.
+          - If the value is a switch, the property is not guaranteed to exist;
+            however, when it is added to the database (i.e. it is given a
+            [Simple.t] value), the switch will apply to its value. *)
+    inverses : Coercion.t Name_map.t Function_map.t;
+        (** Inverse map from property values to their arguments.
+
+            {b Note}: This map only contains {b non-inversible} properties. *)
+    switch : switch
+        (** Switches are the way we deal with disjunction in the database.
+
+            A switch on a name contains a mapping from possible values for that
+            name to extensions. When the name becomes equal to a value, the
+            corresponding extensions are activated. *)
+  }
+
+let print_properties_of_name ppf { properties; switch; _ } =
+  let needs_sep = ref false in
+  let print_sep ppf () =
+    if !needs_sep then Format.pp_print_space ppf ();
+    needs_sep := true
+  in
+  let print_properties ppf properties =
+    print_sep ppf ();
+    Format.fprintf ppf "@[<hov 1>(properties@ %a)@]"
+      (Function_map.print print_simple_or_switch)
+      properties
+  in
+  let print_switch ppf switch =
+    print_sep ppf ();
+    Format.fprintf ppf "@[<hov 1>(switch@ %a)@]" print_switch switch
+  in
+  Format.fprintf ppf "@[<hov 1>(";
+  if not (Function_map.is_empty properties) then print_properties ppf properties;
+  if not (is_empty_switch switch) then print_switch ppf switch;
+  Format.fprintf ppf ")@]"
+
+let properties_of_name ?(properties = Function_map.empty)
+    ?(inverses = Function_map.empty) ?(switch = empty_switch) () =
+  { properties; inverses; switch }
+
+let empty_properties_of_name =
+  { properties = Function_map.empty;
+    inverses = Function_map.empty;
+    switch = empty_switch
+  }
+
+let is_empty_properties_of_name { properties; inverses; switch } =
+  Function_map.is_empty properties
+  && Function_map.is_empty inverses
+  && is_empty_switch switch
+
+type t =
+  { properties_of_names : properties_of_name Name_map.t;
+    (* Map from names to their known properties.
+
+       {b Note}: The *keys* of this map is kept in canonical form, but not the
+       values. *)
+    inverses_of_consts : Name.Set.t Const_map.t Function_map.t;
+    active_extensions : Extension_set.t
+  }
+
+let print ppf t =
+  Format.fprintf ppf
+    "@[<hov 1>(@[<hov 1>(properties@ %a)@]@ @[<hov 1>(extensions@ %a)@])@]"
+    (Name_map.print print_properties_of_name)
+    t.properties_of_names Extension_set.print t.active_extensions
+
+let empty =
+  { properties_of_names = Name_map.empty;
+    inverses_of_consts = Function_map.empty;
+    active_extensions = Extension_set.empty
+  }
+
+let is_empty { properties_of_names; inverses_of_consts; active_extensions } =
+  Name_map.is_empty properties_of_names
+  && Function_map.is_empty inverses_of_consts
+  && Extension_set.is_empty active_extensions
+
+let active_extensions { active_extensions; _ } =
+  (active_extensions :> Extension_id.Set.t)
+
+let get name t =
+  match Name_map.find_opt name t.properties_of_names with
+  | None -> empty_properties_of_name
+  | Some properties_of_name -> properties_of_name
+
+let get_property property properties =
+  match Function_map.find_opt property properties with
+  | None -> Switch empty_switch
+  | Some simple_or_switch -> simple_or_switch
+
+let set name properties t =
+  let properties_of_names =
+    if is_empty_properties_of_name properties
+    then Name_map.remove name t.properties_of_names
+    else Name_map.add name properties t.properties_of_names
+  in
+  { t with properties_of_names }
+
+let activate_extensions t extension_ids =
+  let active_extensions =
+    Extension_set.union_set t.active_extensions extension_ids
+  in
+  { t with active_extensions }
+
+let add_alias ~binding_time_resolver ~binding_times_and_modes aliases canonical1
+    canonical2 : _ Or_bottom.t =
+  if Simple.equal canonical1 canonical2
+  then Ok aliases
+  else
+    match
+      Aliases.add ~binding_time_resolver aliases ~binding_times_and_modes
+        ~canonical_element1:canonical1 ~canonical_element2:canonical2
+    with
+    | Bottom -> Bottom
+    | Ok { demoted_name = _; canonical_element = _; t = aliases } -> Ok aliases
+
+module Meet_env = struct
+  type add_alias =
+    | Add_alias :
+        { binding_time_resolver : Name.t -> Binding_time.With_name_mode.t;
+          binding_times_and_modes :
+            ('a * Binding_time.With_name_mode.t) Name.Map.t
+        }
+        -> add_alias
+
+  type equation =
+    | Add_switch_on_name of Name.t * switch
+    | Activate_extensions of Extension_set.t
+
+  type t =
+    { add_alias : add_alias;
+      aliases : Aliases.t;
+      equations : equation list
+    }
+
+  let create ~binding_time_resolver ~binding_times_and_modes aliases =
+    let add_alias =
+      Add_alias { binding_time_resolver; binding_times_and_modes }
+    in
+    { add_alias; aliases; equations = [] }
+
+  let get_canonical env simple = canonicalise env.aliases simple
+
+  let add_alias_between_canonicals t canonical1 canonical2 : _ Or_bottom.t =
+    let (Add_alias { binding_time_resolver; binding_times_and_modes }) =
+      t.add_alias
+    in
+    match
+      add_alias ~binding_time_resolver ~binding_times_and_modes t.aliases
+        canonical1 canonical2
+    with
+    | Bottom -> Bottom
+    | Ok aliases -> Ok { t with aliases }
+
+  let add_alias t simple1 simple2 =
+    let canonical1 = get_canonical t simple1 in
+    let canonical2 = get_canonical t simple2 in
+    add_alias_between_canonicals t canonical1 canonical2
+
+  let add_equation t eqn = { t with equations = eqn :: t.equations }
+
+  let activate_extensions env extensions =
+    add_equation env (Activate_extensions extensions)
+
+  let add_switch env simple switch =
+    Simple.pattern_match simple
+      ~const:(fun const : _ Or_bottom.t ->
+        match Row_like.For_const.find const switch with
+        | Ok extensions -> Ok (activate_extensions env extensions)
+        | Bottom -> Bottom)
+      ~name:(fun name ~coercion : _ Or_bottom.t ->
+        assert (Coercion.is_id coercion);
+        Ok (add_equation env (Add_switch_on_name (name, switch))))
+
+  let rebuild ~add_switch ~activate_extensions
+      { aliases; equations; add_alias = _ } db : _ Or_bottom.t =
+    let exception Is_bottom in
+    let early_exit (db_ob : _ Or_bottom.t) =
+      match db_ob with Ok db -> db | Bottom -> raise Is_bottom
+    in
+    match
+      List.fold_left
+        (fun db eqn ->
+          match eqn with
+          | Add_switch_on_name (name, switch) ->
+            let canonical = canonicalise aliases (Simple.name name) in
+            early_exit
+              (add_switch db canonical
+                 (switch :> Extension_id.Set.t Row_like.For_const.t))
+          | Activate_extensions extension_ids ->
+            activate_extensions db (extension_ids :> Extension_id.Set.t))
+        db equations
+    with
+    | db -> Ok (db, aliases)
+    | exception Is_bottom -> Bottom
+end
+
+let left_meet_simple_or_switch env sos1 sos2 : _ Or_bottom.t =
+  let open Or_bottom.Let_syntax in
+  match sos1, sos2 with
+  | Simple simple1, Simple simple2 ->
+    let<+ env = Meet_env.add_alias env simple1 simple2 in
+    Left_input, env
+  | Simple simple, Switch switch ->
+    let<+ env = Meet_env.add_switch env simple switch in
+    Left_input, env
+  | Switch switch, Simple simple ->
+    let<+ env = Meet_env.add_switch env simple switch in
+    New_result (Simple simple), env
+  | Switch switch1, Switch switch2 -> (
+    match
+      left_meet_switch switch1
+        (switch2 :> Extension_id.Set.t Row_like.For_const.t)
+    with
+    | Ok Left_input -> Ok (Left_input, env)
+    | Ok (New_result switch) -> Ok (New_result (Switch switch), env)
+    | Bottom -> Bottom)
+
+let left_meet_properties env properties1 properties2 : _ Or_bottom.t =
+  let exception Is_bottom in
+  let env_ref = ref env in
+  let result_is_left = ref true in
+  match
+    Function_map.union
+      (fun _ sos1 sos2 ->
+        match left_meet_simple_or_switch !env_ref sos1 sos2 with
+        | Bottom -> raise Is_bottom
+        | Ok (meet_sos, env) -> (
+          env_ref := env;
+          match meet_sos with
+          | Left_input -> Some sos1
+          | New_result sos ->
+            result_is_left := false;
+            Some sos))
+      properties1 properties2
+  with
+  | properties ->
+    let properties =
+      if !result_is_left then Left_input else New_result properties
+    in
+    Ok (properties, !env_ref)
+  | exception Is_bottom -> Bottom
+
+let left_meet_inverses env inverses1 inverses2 : _ Or_bottom.t =
+  let inverses =
+    Function_map.union
+      (fun _ property_inverses1 property_inverses2 ->
+        let property_inverses =
+          Name_map.union
+            (fun _ coercion1 coercion2 ->
+              assert (Coercion.equal coercion1 coercion2);
+              Some coercion1)
+            property_inverses1 property_inverses2
+        in
+        Some property_inverses)
+      inverses1 inverses2
+  in
+  Ok (left_meet_return_value inverses inverses1, env)
+
+let left_meet_inverses_of_consts env ioc1 ioc2 : _ Or_bottom.t =
+  let ioc =
+    Function_map.union
+      (fun _ property_inverses1 property_inverses2 ->
+        let property_inverses =
+          Const_map.union
+            (fun _ set1 set2 -> Some (Name.Set.union set1 set2))
+            property_inverses1 property_inverses2
+        in
+        Some property_inverses)
+      ioc1 ioc2
+  in
+  Ok (left_meet_return_value ioc ioc1, env)
+
+let left_meet_properties_of_name env pn1 pn2 : _ Or_bottom.t =
+  let open Or_bottom.Let_syntax in
+  let<* properties, env =
+    left_meet_properties env pn1.properties pn2.properties
+  in
+  let<* inverses, env = left_meet_inverses env pn1.inverses pn2.inverses in
+  let<* switch =
+    left_meet_switch pn1.switch
+      (pn2.switch :> Extension_id.Set.t Row_like.For_const.t)
+  in
+  let meet_pn =
+    match properties, inverses, switch with
+    | Left_input, Left_input, Left_input -> Left_input
+    | (Left_input | New_result _), _, _ ->
+      let properties = extract_value properties pn1.properties in
+      let inverses = extract_value inverses pn1.inverses in
+      let switch = extract_value switch pn1.switch in
+      New_result { properties; inverses; switch }
+  in
+  Ok (meet_pn, env)
+
+let add_inverses_of_consts env inverses_of_consts t : _ Or_bottom.t =
+  match
+    left_meet_inverses_of_consts env t.inverses_of_consts inverses_of_consts
+  with
+  | Ok (Left_input, env) -> Ok (t, env)
+  | Ok (New_result inverses_of_consts, env) ->
+    Ok ({ t with inverses_of_consts }, env)
+  | Bottom -> Bottom
+
+let add_switch_on_const t const switch : _ Or_bottom.t =
+  match Row_like.For_const.find const switch with
+  | Ok extensions -> Ok (activate_extensions t extensions)
+  | Bottom -> Bottom
+
+let add_switch t simple switch =
+  Simple.pattern_match simple
+    ~const:(fun const -> add_switch_on_const t const switch)
+    ~name:(fun name ~coercion : _ Or_bottom.t ->
+      assert (Coercion.is_id coercion);
+      let pn = get name t in
+      match left_meet_switch pn.switch switch with
+      | Ok Left_input -> Ok t
+      | Ok (New_result switch) -> Ok (set name { pn with switch } t)
+      | Bottom -> Bottom)
+
+let add_properties_on_const env const properties_on_const t : _ Or_bottom.t =
+  let open Or_bottom.Let_syntax in
+  let exception Is_bottom in
+  let { properties; inverses; switch } = properties_on_const in
+  try
+    let t, env =
+      Function_map.fold
+        (fun property value (t, env) ->
+          let env_ob : _ Or_bottom.t =
+            match Function.of_const property const with
+            | Bottom -> Bottom
+            | Unknown -> Ok (t, env)
+            | Ok property_of_const -> (
+              match value with
+              | Switch switch ->
+                let<+ t =
+                  add_switch_on_const t property_of_const
+                    (switch :> Extension_id.Set.t Row_like.For_const.t)
+                in
+                t, env
+              | Simple value ->
+                let property_of_const = Simple.const property_of_const in
+                let<+ env = Meet_env.add_alias env property_of_const value in
+                t, env)
+          in
+          match env_ob with Bottom -> raise Is_bottom | Ok (t, env) -> t, env)
+        properties (t, env)
+    in
+    let t =
+      match
+        add_switch_on_const t const
+          (switch :> Extension_id.Set.t Row_like.For_const.t)
+      with
+      | Ok t -> t
+      | Bottom -> raise Is_bottom
+    in
+    let inverses =
+      Function_map.map_unshare
+        (fun (inverses_of_property : Coercion.t Name_map.t) ->
+          Const_map.singleton const
+            (Name.Map.keys (inverses_of_property :> Coercion.t Name.Map.t)))
+        inverses
+    in
+    add_inverses_of_consts env inverses t
+  with Is_bottom -> Bottom
+
+let add_properties_on_name env name properties_on_name t : _ Or_bottom.t =
+  match left_meet_properties_of_name env (get name t) properties_on_name with
+  | Bottom -> Bottom
+  | Ok (Left_input, env) -> Ok (t, env)
+  | Ok (New_result properties_of_name, env) ->
+    Ok (set name properties_of_name t, env)
+
+let add_properties env simple properties_on_simple t =
+  Simple.pattern_match simple
+    ~const:(fun const ->
+      add_properties_on_const env const properties_on_simple t)
+    ~name:(fun name ~coercion ->
+      assert (Coercion.is_id coercion);
+      add_properties_on_name env name properties_on_simple t)
+
+let add_inverse env property name value t : _ Or_bottom.t =
+  match Function.inverse property with
+  | Some inverse_property ->
+    add_properties env value
+      (properties_of_name
+         ~properties:
+           (Function_map.singleton inverse_property (Simple (Simple.name name)))
+         ())
+      t
+  | None ->
+    Simple.pattern_match value
+      ~const:(fun const ->
+        add_inverses_of_consts env
+          (Function_map.singleton property
+             (Const_map.singleton const (Name.Set.singleton name)))
+          t)
+      ~name:(fun value_name ~coercion : _ Or_bottom.t ->
+        assert (Coercion.is_id coercion);
+        add_properties_on_name env value_name
+          (properties_of_name
+             ~inverses:
+               (Function_map.singleton property
+                  (Name_map.singleton name coercion))
+             ())
+          t)
+
+let add_property ~binding_time_resolver ~binding_times_and_modes aliases t
+    property ~arg ~result =
+  let open Or_bottom.Let_syntax in
+  Simple.pattern_match (canonicalise aliases arg)
+    ~const:(fun const : _ Or_bottom.t ->
+      match Function.of_const property const with
+      | Bottom -> Bottom
+      | Unknown -> Ok (t, aliases)
+      | Ok property_of_const ->
+        let property_of_const = Simple.const property_of_const in
+        let<+ aliases =
+          add_alias ~binding_time_resolver ~binding_times_and_modes aliases
+            property_of_const result
+        in
+        t, aliases)
+    ~name:(fun name ~coercion ->
+      assert (Coercion.is_id coercion);
+      (* If there is already a [Simple] value for the property, we simply need
+         to add an alias to the existing [Simple.t].
+
+         Otherwise, this is the first time we learn that the property exists. We
+         need to add any pending switch onto the [result], and we also need to
+         record an inverse from [result] to [arg]. *)
+      let pn = get name t in
+      match get_property property pn.properties with
+      | Simple existing_value ->
+        let<+ aliases =
+          add_alias ~binding_time_resolver ~binding_times_and_modes aliases
+            (canonicalise aliases existing_value)
+            (canonicalise aliases result)
+        in
+        t, aliases
+      | Switch switch ->
+        let result = canonicalise aliases result in
+        let properties =
+          Function_map.add property (Simple result) pn.properties
+        in
+        let t = set name { pn with properties } t in
+        let<* t =
+          if is_empty_switch switch
+          then Ok t
+          else
+            add_switch t result
+              (switch :> Extension_id.Set.t Row_like.For_const.t)
+        in
+        let env =
+          Meet_env.create ~binding_time_resolver ~binding_times_and_modes
+            aliases
+        in
+        let<* t, env = add_inverse env property name result t in
+        Meet_env.rebuild ~add_switch ~activate_extensions env t)
+
+let find_property t simple property =
+  Simple.pattern_match simple
+    ~const:(fun const : _ Or_unknown_or_bottom.t ->
+      match Function.of_const property const with
+      | Bottom -> Bottom
+      | Unknown -> Unknown
+      | Ok property_of_const -> Ok (Simple.const property_of_const))
+    ~name:(fun name ~coercion : _ Or_unknown_or_bottom.t ->
+      let properties_of_name = get name t in
+      match get_property property properties_of_name.properties with
+      | Switch _ -> Unknown
+      | Simple value ->
+        (* simple <-- [coercion] name
+         *
+         * value <-- [property] name
+         *
+         * coercion(value) <-- [property] simple
+         *)
+        Ok (Simple.apply_coercion_exn value coercion))
+
+let rebuild ~binding_time_resolver ~binding_times_and_modes aliases t demotions
+    : _ Or_bottom.t =
+  let env =
+    Meet_env.create ~binding_time_resolver ~binding_times_and_modes aliases
+  in
+  let to_rebuild = ref [] in
+  let properties_of_names =
+    Name_map.diff_map
+      (fun _to_be_demoted properties_of_to_be_demoted
+           (canonical, coercion_to_canonical) ->
+        assert (Coercion.is_id coercion_to_canonical);
+        to_rebuild := (canonical, properties_of_to_be_demoted) :: !to_rebuild;
+        None)
+      t.properties_of_names demotions
+  in
+  let t = { t with properties_of_names } in
+  let exception Is_bottom in
+  match
+    List.fold_left
+      (fun (t, env) (simple, properties) ->
+        let canonical = Meet_env.get_canonical env simple in
+        match add_properties env canonical properties t with
+        | Ok (t, env) -> t, env
+        | Bottom -> raise Is_bottom)
+      (t, env) !to_rebuild
+  with
+  | t, env -> Meet_env.rebuild ~add_switch ~activate_extensions env t
+  | exception Is_bottom -> Bottom
+
+let shortcut_aliases ~canonicalise
+    { properties_of_names; inverses_of_consts; active_extensions } =
+  let properties_of_names =
+    Name_map.map
+      (fun pn ->
+        let properties =
+          Function_map.map
+            (function
+              | Simple simple -> Simple (canonicalise simple)
+              | Switch _ as sos -> sos)
+            pn.properties
+        in
+        let inverses =
+          Function_map.map
+            (fun inverses ->
+              Name_map.fold
+                (fun name coercion0 inverses ->
+                  let simple = canonicalise (Simple.name name) in
+                  Simple.pattern_match simple
+                    ~const:(fun _ -> inverses)
+                    ~name:(fun name ~coercion ->
+                      (* coercion0(coercion(name)) = fn(...) *)
+                      let coercion =
+                        Coercion.compose_exn coercion ~then_:coercion0
+                      in
+                      Name_map.add name coercion inverses))
+                inverses Name_map.empty)
+            pn.inverses
+        in
+        if properties == pn.properties && inverses == pn.inverses
+        then pn
+        else { properties; inverses; switch = pn.switch })
+      properties_of_names
+  in
+  let inverses_of_consts =
+    Function_map.map
+      (fun inv_fn_of_consts ->
+        Const_map.map
+          (fun inverses ->
+            Name.Set.filter_map
+              (fun name ->
+                let simple = canonicalise (Simple.name name) in
+                match Simple.must_be_name simple with
+                | Some (name, _) -> Some name
+                | None -> None)
+              inverses)
+          inv_fn_of_consts)
+      inverses_of_consts
+  in
+  { properties_of_names; inverses_of_consts; active_extensions }
+
+(** {2 Switches} *)
+
+let add_switch_on_canonical simple ?default ~arms t =
+  add_switch t simple (Row_like.For_const.create ?default arms)
+
+let add_switch_on_property_of_name ~aliases t property name switch :
+    _ Or_bottom.t =
+  let pn = get name t in
+  match get_property property pn.properties with
+  | Simple value -> add_switch t (canonicalise aliases value) switch
+  | Switch existing_switch -> (
+    match left_meet_switch existing_switch switch with
+    | Ok Left_input -> Ok t
+    | Ok (New_result switch) ->
+      let properties =
+        Function_map.add property (Switch switch) pn.properties
+      in
+      Ok (set name { pn with properties } t)
+    | Bottom -> Bottom)
+
+let add_switch_on_property property arg ?default ~arms t ~aliases =
+  let switch = Row_like.For_const.create ?default arms in
+  Simple.pattern_match arg
+    ~const:(fun const : _ Or_bottom.t ->
+      match Function.of_const property const with
+      | Bottom -> Bottom
+      | Unknown -> Ok t
+      | Ok property_of_const -> add_switch_on_const t property_of_const switch)
+    ~name:(fun name ~coercion : _ Or_bottom.t ->
+      assert (Coercion.is_id coercion);
+      add_switch_on_property_of_name ~aliases t property name switch)
+
+let switch_on_scrutinee t ~scrutinee =
+  Simple.pattern_match scrutinee
+    ~const:(fun const ->
+      RWC.Map.singleton const Extension_id.Set.empty, Or_bottom.Bottom)
+    ~name:(fun name ~coercion ->
+      assert (Coercion.is_id coercion);
+      let properties_of_name = get name t in
+      match properties_of_name.switch with
+      | { other; known } ->
+        ( (known :> Extension_id.Set.t RWC.Map.t),
+          (other :> Extension_id.Set.t Or_bottom.t) ))
+
+(** {2 Differential interface} *)
+
+type level =
+  { new_properties_of_names : properties_of_name Name.Map.t Lazy.t;
+    new_inverses_of_consts : Name.Set.t Const_map.t Function.Map.t Lazy.t;
+    new_active_extensions : Extension_id.Set.t Lazy.t
+  }
+
+let properties_of_name_opt ?properties ?inverses ?switch () =
+  let properties_of_name =
+    properties_of_name ?properties ?inverses ?switch ()
+  in
+  if is_empty_properties_of_name properties_of_name
+  then None
+  else Some properties_of_name
+
+let diff_properties_of_names t cut_after =
+  Name_map.diff
+    (fun _ properties cut_after_properties ->
+      let switch = properties.switch in
+      let cut_after_switch = cut_after_properties.switch in
+      let switch = if switch == cut_after_switch then None else Some switch in
+      let properties = properties.properties in
+      let cut_after_properties = cut_after_properties.properties in
+      let properties =
+        Function_map.diff
+          (fun _ value _ -> Some value)
+          properties cut_after_properties
+      in
+      let properties = Function_map.create properties in
+      properties_of_name_opt ~properties ?switch ())
+    t cut_after
+
+let diff_inverses_of_consts ic1 ic2 =
+  Function_map.diff
+    (fun _ property_inverses1 property_inverses2 ->
+      let property_inverses =
+        Const_map.diff
+          (fun _ inverses1 inverses2 ->
+            let inverses = Name.Set.diff inverses1 inverses2 in
+            if Name.Set.is_empty inverses then None else Some inverses)
+          property_inverses1 property_inverses2
+      in
+      if RWC.Map.is_empty property_inverses
+      then None
+      else Some (Const_map.create property_inverses))
+    ic1 ic2
+
+let cut t ~cut_after : level =
+  let properties_of_names = t.properties_of_names in
+  let old_properties_of_names = cut_after.properties_of_names in
+  let new_properties_of_names =
+    lazy (diff_properties_of_names properties_of_names old_properties_of_names)
+  in
+  let inverses_of_consts = t.inverses_of_consts in
+  let old_inverses_of_consts = cut_after.inverses_of_consts in
+  let new_inverses_of_consts =
+    lazy (diff_inverses_of_consts inverses_of_consts old_inverses_of_consts)
+  in
+  let active_extensions = t.active_extensions in
+  let old_active_extensions = cut_after.active_extensions in
+  let new_active_extensions =
+    lazy (Extension_set.diff active_extensions old_active_extensions)
+  in
+  { new_properties_of_names; new_inverses_of_consts; new_active_extensions }
+
+module Level = struct
+  type t = level
+
+  let print ppf { new_properties_of_names; _ } =
+    Name.Map.print print_properties_of_name ppf
+      (Lazy.force new_properties_of_names)
+
+  let empty =
+    { new_properties_of_names = lazy Name.Map.empty;
+      new_inverses_of_consts = lazy Function.Map.empty;
+      new_active_extensions = lazy Extension_id.Set.empty
+    }
+
+  let is_empty
+      { new_properties_of_names; new_inverses_of_consts; new_active_extensions }
+      =
+    Name.Map.is_empty (Lazy.force new_properties_of_names)
+    && Function.Map.is_empty (Lazy.force new_inverses_of_consts)
+    && Extension_id.Set.is_empty (Lazy.force new_active_extensions)
+
+  let fold_properties f { new_properties_of_names; _ } acc =
+    Name.Map.fold
+      (fun name { properties = properties_of_name; _ } acc ->
+        Function_map.fold
+          (fun property value acc ->
+            match value with
+            | Switch _ -> acc
+            | Simple value -> f property name value ~coercion:Coercion.id acc)
+          properties_of_name acc)
+      (Lazy.force new_properties_of_names)
+      acc
+
+  let fold_constant_properties f { new_inverses_of_consts; _ } acc =
+    let new_inverses_of_consts = Lazy.force new_inverses_of_consts in
+    Function.Map.fold
+      (fun property inverses_of_consts acc ->
+        Const_map.fold
+          (fun const inverses acc ->
+            Name.Set.fold
+              (fun inverse acc -> f property inverse const acc)
+              inverses acc)
+          inverses_of_consts acc)
+      new_inverses_of_consts acc
+
+  let activated_extensions { new_active_extensions; _ } =
+    (Lazy.force new_active_extensions :> Extension_id.Set.t)
+end
+
+type extension = Simple.t Function.Map.t Name.Map.t
+
+module Extension = struct
+  type t = extension
+
+  let fold f ext acc =
+    Name.Map.fold
+      (fun arg fns acc ->
+        Function.Map.fold (fun fn result acc -> f fn ~arg ~result acc) fns acc)
+      ext acc
+
+  let empty = Name.Map.empty
+
+  let is_empty = Name.Map.is_empty
+
+  let print ppf ext = Name.Map.print (Function.Map.print Simple.print) ppf ext
+
+  let union ext1 ext2 =
+    Name.Map.union
+      (fun _ fns1 fns2 -> Some (Function.Map.disjoint_union fns1 fns2))
+      ext1 ext2
+
+  let add_property ext property ~arg ~result =
+    union ext (Name.Map.singleton arg (Function.Map.singleton property result))
+
+  let free_names ext =
+    Name.Map.fold
+      (fun name fns free_names ->
+        let free_names =
+          Name_occurrences.add_name free_names name Name_mode.in_types
+        in
+        Function.Map.fold
+          (fun _ simple free_names ->
+            Name_occurrences.union free_names
+              (Simple.free_names_in_types simple))
+          fns free_names)
+      ext Name_occurrences.empty
+
+  let apply_renaming ext renaming =
+    let changed = ref false in
+    let ext' =
+      Name.Map.fold
+        (fun name fns acc ->
+          let fns' =
+            Function.Map.map_sharing (Renaming.apply_simple renaming) fns
+          in
+          let name' = Renaming.apply_name renaming name in
+          if not (fns' == fns && name == name') then changed := true;
+          Name.Map.add name' fns' acc)
+        ext Name.Map.empty
+    in
+    if !changed then ext' else ext
+
+  let project_variables_out ~to_project ext =
+    Name.Map.filter_map_sharing
+      (fun name fns ->
+        let keep_fns () =
+          let fns' =
+            Function.Map.filter_map_sharing
+              (fun _fn simple ->
+                match Simple.must_be_var simple with
+                | Some (var, _coercion) ->
+                  if Variable.Set.mem var to_project then None else Some simple
+                | None -> Some simple)
+              fns
+          in
+          if Function.Map.is_empty fns' then None else Some fns'
+        in
+        Name.pattern_match name
+          ~symbol:(fun _ -> keep_fns ())
+          ~var:(fun var ->
+            if Variable.Set.mem var to_project then None else keep_fns ()))
+      ext
+
+  let disjoint_union ext1 ext2 = Name.Map.disjoint_union ext1 ext2
+end
+
+(** {2 Contains names} *)
+
+let free_names_simple_or_switch = function
+  | Simple simple -> Simple.free_names_in_types simple
+  | Switch _ -> Name_occurrences.empty
+
+let free_names_properties properties =
+  Function_map.fold
+    (fun _ sos free_names ->
+      Name_occurrences.union free_names (free_names_simple_or_switch sos))
+    properties Name_occurrences.empty
+
+let free_names_inverses inverses =
+  Function_map.fold
+    (fun _ inverses free_names ->
+      Name_map.fold
+        (fun name _ free_names ->
+          Name_occurrences.add_name free_names name Name_mode.in_types)
+        inverses free_names)
+    inverses Name_occurrences.empty
+
+let free_names t =
+  let from_properties =
+    Name_map.fold
+      (fun name { properties; inverses; switch = _ } free_names ->
+        Name_occurrences.union_list
+          [ free_names_properties properties;
+            free_names_inverses inverses;
+            Name_occurrences.add_name free_names name Name_mode.in_types ])
+      t.properties_of_names Name_occurrences.empty
+  in
+  Function_map.fold
+    (fun _ inverses free_names ->
+      Const_map.fold
+        (fun _ inverses free_names ->
+          Name.Set.fold
+            (fun name free_names ->
+              Name_occurrences.add_name free_names name Name_mode.in_types)
+            inverses free_names)
+        inverses free_names)
+    t.inverses_of_consts from_properties
+
+let apply_renaming t renaming =
+  let rename_name = Renaming.apply_name renaming in
+  let rename_simple = Renaming.apply_simple renaming in
+  let rename_simple_or_switch = function
+    | Simple simple -> Simple (rename_simple simple)
+    | Switch _ as sos -> sos
+  in
+  let properties_of_names =
+    Name_map.fold
+      (fun name { properties; inverses; switch } properties_of_name ->
+        let properties =
+          Function_map.map_unshare rename_simple_or_switch properties
+        in
+        let inverses =
+          Function_map.map_unshare
+            (Name_map.map_keys_unshare rename_name)
+            inverses
+        in
+        Name_map.add (rename_name name)
+          { properties; inverses; switch }
+          properties_of_name)
+      t.properties_of_names Name_map.empty
+  in
+  let inverses_of_consts =
+    Function_map.map_unshare
+      (fun inverses ->
+        Const_map.map_unshare (Name.Set.map rename_name) inverses)
+      t.inverses_of_consts
+  in
+  { t with properties_of_names; inverses_of_consts }

--- a/middle_end/flambda2/types/env/database.mli
+++ b/middle_end/flambda2/types/env/database.mli
@@ -1,0 +1,322 @@
+(** {1 Database}
+
+  This module implements a database of relational {e facts} we know about
+  variables.
+
+  The database is able to represent relations such as [Pisint = Is_int(x)] and
+  [Pgettag = Get_tag(x)], and to accurately propagate them as we learn new
+  equalities.
+
+  Facilities are provided to:
+
+    - Record a relation [x = R(y)] ;
+    - Attach an extension that becomes available when the value of a variable
+      [x] becomes known ;
+    - Attach an extension that becomes available when the value of a relation
+      [R(x)] becomes known ;
+    - Find the value associated with [R(y)], if it exists ;
+    - Find all the [y] such that [R(y) = x] is in the database, for some [x] ;
+    - Find all the extensions that will become available when the value of a
+      variable [x] becomes known.
+
+  At the moment, only unary relations are supported.
+
+  Note that relations are partial. The database considers that a relation
+  [R(y)] holds as soon as an entry [R(y) = x] exists, but it is possible to
+  attach extensions to relations that do not (yet) hold. For instance, it is
+  possible to attach an extension to [Get_tag(y)] even if it is not known that
+  [y] is a block.
+
+  This module also provides an incremental/differential interface (levels)
+  to be able to efficiently inspect the changes between two states of the
+  database. *)
+
+type t
+
+include Contains_names.S with type t := t
+
+val print : Format.formatter -> t -> unit
+
+(** The empty database, containing no facts. *)
+val empty : t
+
+val is_empty : t -> bool
+
+(** {2 Relations} *)
+
+module Function : sig
+  type t
+
+  type descr =
+    | Is_null
+    | Is_int
+    | Get_tag
+    | Untag_imm
+    | Tag_imm
+
+  val descr : t -> descr
+
+  val is_null : t
+
+  val is_int : t
+
+  val get_tag : t
+
+  val untag_imm : t
+
+  val tag_imm : t
+
+  include Container_types.S_plus_iterator with type t := t
+
+  val of_const :
+    t -> Reg_width_const.t -> Reg_width_const.t Or_unknown_or_bottom.t
+end
+
+(** Record a new property [fn(arg) = result] in the database.
+
+    This may instead create new aliases if there was already an entry for
+    [fn(arg)] with a different value.
+
+    {b Warning}: Both [arg] and [result] {b must be canonical} in the [aliases]
+    structure. *)
+val add_property :
+  binding_time_resolver:(Name.t -> Binding_time.With_name_mode.t) ->
+  binding_times_and_modes:('a * Binding_time.With_name_mode.t) Name.Map.t ->
+  Aliases.t ->
+  t ->
+  Function.t ->
+  arg:Simple.t ->
+  result:Simple.t ->
+  (t * Aliases.t) Or_bottom.t
+
+(** Get the value associated with a property [fn(arg)].
+
+    If [find_property] returns [Ok simple], then the property definitely exists
+    and is equal to [simple] (for instance, if [find_property] returns [Ok] for
+    the [Get_tag] property, the argument is definitely a block).
+
+    If [find_property] returns [Bottom], then the property definitely does not
+    exist (for instance, [find_property] might return [Bottom] for the [Get_tag]
+    property on an argument that is known to be a tagged integer).
+
+    If [find_property] returns [Unknown], it is not known whether the property
+    exists (and what is value is) or does not exist.
+
+    {b Warning}: If a [simple] is returned, it is {b NOT} guaranteed to be
+    canonical. *)
+val find_property :
+  t -> Simple.t -> Function.t -> Simple.t Or_unknown_or_bottom.t
+
+(** {2 Canonicalization}
+
+    The database is intended to be kept canonical with respect to an [Aliases.t]
+    structure (and uses an [Aliases.t] structure to record learnt aliases).
+
+    Canonicalization ensures that properties that were known of a demoted name
+    apply to its new canonical instead.
+
+    The canonicalization process is {b delayed} and allows processing a batch of
+    demotions at once through the [rebuild] function. *)
+
+(** [rebuild aliases db demotions] applies the demotions in [demotions] to the
+    database [db], normalizing the database.
+
+    When new demotions occurs in the [aliases] structure, the database
+    should be notified through [rebuild].
+
+    Note that [rebuild] can itself introduce new aliases; for instance, if the
+    database has entries [P(x) = a] and [P(y) = b], then rebuilding after the
+    demotions [x -> y] will cause a new alias between [a] and [b] to be added by
+    [rebuild]. Such aliases introduced by rebuild are {b not} recursively
+    processed by [rebuild] and need to be handled by the caller.
+
+    {b Note}: Demotions are as computed by the [Aliases.diff] function, i.e.
+    an entry [name -> (simple, coercion)] means that [name] was demoted to
+    [coercion^-1(simple)] (or [coercion(name)] was demoted to [simple]). *)
+val rebuild :
+  binding_time_resolver:(Name.t -> Binding_time.With_name_mode.t) ->
+  binding_times_and_modes:('b * Binding_time.With_name_mode.t) Name.Map.t ->
+  Aliases.t ->
+  t ->
+  (Simple.t * Coercion.t) Name.Map.t ->
+  (t * Aliases.t) Or_bottom.t
+
+(** [shortcut_aliases ~canonicalise db] applies the canonicalisation function
+    [canonicalise] to the database [db].
+
+    Assumes that the database has been properly normalized through calls to
+    [rebuild] first.
+
+    {b Warning}: This function loses sharing. *)
+val shortcut_aliases : canonicalise:(Simple.t -> Simple.t) -> t -> t
+
+(** {2 Switches}
+
+    Switches are the mechanism by which we deal with (local) disjunction in the
+    database.
+
+    A switch can be recorded on a name or property. For each possible value of
+    the name or property, a set of extension identifiers are provided. When the
+    value for that name or property becomes known, the corresponding extension
+    identifiers are activated.
+
+    It is possible to peek at the state of the switches using the
+    [switch_on_scrutinee] function, which will return the current switch
+    associated with a name, encoding all the extensions that would become
+    active if the value of that name was known.
+
+    {b Note}: Switches can also function as a domain recording the possible
+    values of a name or property (by providing an empty set of extensions for
+    each possible value). *)
+
+module Extension_id : sig
+  include Container_types.S
+
+  val create : unit -> t
+end
+
+val active_extensions : t -> Extension_id.Set.t
+
+val add_switch_on_canonical :
+  Simple.t ->
+  ?default:Extension_id.Set.t ->
+  arms:Extension_id.Set.t Reg_width_const.Map.t ->
+  t ->
+  t Or_bottom.t
+
+val add_switch_on_property :
+  Function.t ->
+  Simple.t ->
+  ?default:Extension_id.Set.t ->
+  arms:Extension_id.Set.t Reg_width_const.Map.t ->
+  t ->
+  aliases:Aliases.t ->
+  t Or_bottom.t
+
+(** [switch_on_scrutinee db ~scrutinee] returns a pair [(known, other)] of
+    extensions associated with the switch.
+
+    If the value of the switch is in [known], the corresponding extension will
+    be activated.
+
+    If [other] is [Bottom], the value of the [scrutinee] is known to be one of
+    the constants in [known]. If [other] is not [Bottom], the extensions in
+    [other] will be activated if the value of [scrutinee] is not one of the
+    constants in [known]. *)
+val switch_on_scrutinee :
+  t ->
+  scrutinee:Simple.t ->
+  Extension_id.Set.t Reg_width_const.Map.t * Extension_id.Set.t Or_bottom.t
+
+(** {2 Extensions} *)
+
+type extension
+
+module Extension : sig
+  type t = extension
+
+  val fold :
+    (Function.t -> arg:Name.t -> result:Simple.t -> 'a -> 'a) -> t -> 'a -> 'a
+
+  val print : Format.formatter -> t -> unit
+
+  val empty : t
+
+  val is_empty : t -> bool
+
+  val add_property : t -> Function.t -> arg:Name.t -> result:Simple.t -> t
+
+  val free_names : t -> Name_occurrences.t
+
+  val apply_renaming : t -> Renaming.t -> t
+
+  val project_variables_out : to_project:Variable.Set.t -> t -> t
+
+  val disjoint_union : t -> t -> t
+end
+
+(** {2 Incremental interface}
+
+    The incremental interface allows to compute the {b difference} between two
+    databases as a [level].
+
+    {b Note}: The incremental interface makes use of physical equality to ensure
+    good performance when computing the difference with previous instance of the
+    same database. In particular, computing the difference between [db'] and
+    [db] where [db'] has been obtained by performing a sequence of database
+    operations on [db] is only linear on the size of the difference, and not
+    on the size of [db] and [db'] themselves.
+
+    The semantics of the incremental interface are however independent of the
+    physical representation of the database (but it will be less efficient when
+    sharing is not available). *)
+
+type level
+
+(** [cut target ~cut_after:source] constructs a new level starting in [source]
+    and ending in [target].
+
+    The [target] database must have been obtained by applying a sequence of
+    database operations on the [source] database. *)
+val cut : t -> cut_after:t -> level
+
+module Level : sig
+  (** A level represents the difference between a {e source} database (the start of the level) and a {e target}
+      database (the end of the level), where the target database has been obtained by performing a
+      sequence of operations on the source database. The level records the
+      effect of these operations.
+
+      A level on its own {b has no semantics}: it can only be understood in the
+      context of the transition from the start of the level to the end of the
+      level. *)
+
+  type t = level
+
+  val print : Format.formatter -> t -> unit
+
+  (** The empty level.
+
+      This is a special level that contains no change, and can represent a
+      transition from any database to itself. It is the only level that does not
+      have well-defined source and target databases. *)
+  val empty : t
+
+  (** [is_empty t] returns [true] iff [t] is an empty level.
+
+      An empty level is a level that starts and ends in the same database. *)
+  val is_empty : t -> bool
+
+  (** Fold over the new properties added in this level.
+
+      More precisely, and provided the database has been properly normalized, if
+      there is a property [P(x)] (where [x] is canonical at the end of the
+      level) that holds at the end of the level but did not hold at the start of
+      the level, then [fold_properties] is guaranteed to fold over exactly one
+      instance of a [P(x) = y] fact.
+
+      {b Note}: This includes not only properties that were effectively added
+      between the start and the end of the level, but also properties that held
+      for an alias of [x] at the start of the level, if this alias has been
+      demoted since the start of the level. *)
+  val fold_properties :
+    (Function.t -> Name.t -> Simple.t -> coercion:Coercion.t -> 'a -> 'a) ->
+    t ->
+    'a ->
+    'a
+
+  (** Fold over the properties that {b became constant} in this level.
+
+      More precisely, and provided the database has been properly normalized, if
+      there is a property [P(x)] whose value is constant at the end of the level
+      but it either did not hold or was not constant at the start of the level,
+      then [fold_constant_properties] is guaranteed to fold over {b at least
+      one} instance of a [P(x') = c] fact where the canonical of [x'] at the
+      end of the level is [x]. *)
+  val fold_constant_properties :
+    (Function.t -> Name.t -> Reg_width_const.t -> 'a -> 'a) -> t -> 'a -> 'a
+
+  (** Returns the set of extensions that were activated in this level, i.e.
+      extensions that are active at the end of the level but not at the start of
+      the level. *)
+  val activated_extensions : t -> Extension_id.Set.t
+end

--- a/middle_end/flambda2/types/env/typing_env.mli
+++ b/middle_end/flambda2/types/env/typing_env.mli
@@ -113,6 +113,19 @@ val add_definition : t -> Bound_name.t -> Flambda_kind.t -> t
 
 val add_equation : t -> Name.t -> Type_grammar.t -> meet_type:meet_type -> t
 
+val add_relation :
+  t -> Database.Function.t -> scrutinee:Simple.t -> Simple.t -> t
+
+val add_conditional_get_tag_relation :
+  t -> arg:Name.t -> result:Name.t -> meet_type:meet_type -> t
+
+val check_relation :
+  t -> Database.Function.t -> scrutinee:Simple.t -> Simple.t -> bool
+
+val reducer : t -> meet_type:meet_type -> t -> t
+
+val with_reduce : (t -> t) -> t -> meet_type:meet_type -> t
+
 val add_equation_strict :
   t -> Name.t -> Type_grammar.t -> meet_type:meet_type -> t Or_bottom.t
 
@@ -201,6 +214,9 @@ val code_age_relation : t -> Code_age_relation.t
 val with_code_age_relation : t -> Code_age_relation.t -> t
 
 val cut : t -> cut_after:Scope.t -> Typing_env_level.t
+
+val cut_with_database :
+  t -> cut_after:Scope.t -> Typing_env_level.t * Database.level
 
 val cut_as_extension : t -> cut_after:Scope.t -> Typing_env_extension.t
 

--- a/middle_end/flambda2/types/env/typing_env_extension.mli
+++ b/middle_end/flambda2/types/env/typing_env_extension.mli
@@ -18,7 +18,12 @@ type t = Type_grammar.Env_extension.t
 
 val print : Format.formatter -> t -> unit
 
-val fold : equation:(Name.t -> Type_grammar.t -> 'a -> 'a) -> t -> 'a -> 'a
+val fold :
+  equation:(Name.t -> Type_grammar.t -> 'a -> 'a) ->
+  relation:(Database.Function.t -> arg:Name.t -> result:Simple.t -> 'a -> 'a) ->
+  t ->
+  'a ->
+  'a
 
 val invariant : t -> unit
 
@@ -35,6 +40,9 @@ val has_equation : Name.t -> t -> bool
 val one_equation : Name.t -> Type_grammar.t -> t
 
 val add_or_replace_equation : t -> Name.t -> Type_grammar.t -> t
+
+val add_or_replace_relation :
+  t -> Database.Function.t -> arg:Name.t -> result:Simple.t -> t
 
 val replace_equation : t -> Name.t -> Type_grammar.t -> t
 

--- a/middle_end/flambda2/types/env/typing_env_level.ml
+++ b/middle_end/flambda2/types/env/typing_env_level.ml
@@ -207,4 +207,4 @@ let as_extension_without_bindings
       Misc.fatal_errorf
         "Typing_env_level.as_extension_without_bindings:@ level %a has bindings"
         print t;
-  TG.Env_extension.create ~equations
+  TG.Env_extension.create ~equations ~database:Database.Extension.empty

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -193,6 +193,8 @@ module Typing_env : sig
 
   val add_get_tag_relation : t -> Name.t -> scrutinee:Simple.t -> t
 
+  val add_conditional_get_tag_relation : t -> Name.t -> scrutinee:Name.t -> t
+
   val mem : ?min_name_mode:Name_mode.t -> t -> Name.t -> bool
 
   val mem_simple : ?min_name_mode:Name_mode.t -> t -> Simple.t -> bool

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -159,7 +159,10 @@ and array_contents =
   | Immutable of { fields : t array }
   | Mutable
 
-and env_extension = private { equations : t Name.Map.t } [@@unboxed]
+and env_extension = private
+  { equations : t Name.Map.t;
+    database : Database.Extension.t
+  }
 
 and variant_extensions =
   | No_extensions
@@ -571,7 +574,8 @@ module Env_extension : sig
 
   val empty : t
 
-  val create : equations:flambda_type Name.Map.t -> t
+  val create :
+    equations:flambda_type Name.Map.t -> database:Database.Extension.t -> t
 
   include Contains_ids.S with type t := t
 

--- a/middle_end/flambda2/types/join_levels.ml
+++ b/middle_end/flambda2/types/join_levels.ml
@@ -103,8 +103,10 @@ let cut_and_n_way_join definition_typing_env ts_and_use_ids ~params ~cut_after
        then
          List.iteri
            (fun i (t, _, _) ->
-             let level = TE.cut t ~cut_after in
-             Format.eprintf "@[<v 1>-- Level %d --@ %a@]@ " i TEL.print level)
+             let level, db_level = TE.cut_with_database t ~cut_after in
+             Format.eprintf "@[<v 1>-- Level %d --@ %a@]@ " i TEL.print level;
+             Format.eprintf "@[<v 1>-- Database %d --@ %a@]@ " i
+               Database.Level.print db_level)
            ts_and_use_ids;
        Format.eprintf "@[<v 1>-- Old join --@ %a@]@ " TEL.print old_joined_level;
        Format.eprintf "@[<v 1>-- New join --@ %a@]@ " TEL.print new_joined_level;

--- a/middle_end/flambda2/types/meet_and_n_way_join.ml
+++ b/middle_end/flambda2/types/meet_and_n_way_join.ml
@@ -2706,11 +2706,17 @@ let meet env ty1 ty2 : _ Or_bottom.t =
   if TE.is_bottom env
   then Bottom
   else
+    let reduce = TE.reducer env ~meet_type in
     match meet env ty1 ty2 with
     | Bottom _ -> Bottom
     | Ok (r, env) ->
+      let env = reduce env in
       let res_ty = extract_value r ty1 ty2 in
-      if TG.is_obviously_bottom res_ty then Bottom else Ok (res_ty, env)
+      (* Check [TE.is_bottom env] as we could discover a global inconsistency
+         while reducing the database. *)
+      if TG.is_obviously_bottom res_ty || TE.is_bottom env
+      then Bottom
+      else Ok (res_ty, env)
 
 let meet_shape env t ~shape : _ Or_bottom.t =
   if TE.is_bottom env

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -73,6 +73,10 @@ let use_n_way_join () =
     false
   | N_way -> true
 
+let types_database () =
+  !Flambda_backend_flags.Flambda2.types_database
+  |> with_default ~f:(fun d -> d.types_database)
+
 let enable_reaper () =
   !Flambda_backend_flags.Flambda2.enable_reaper
   |> with_default ~f:(fun d -> d.enable_reaper)

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -45,6 +45,8 @@ type join_algorithm = Flambda_backend_flags.join_algorithm =
 
 val join_algorithm : unit -> join_algorithm
 
+val types_database : unit -> bool
+
 val enable_reaper : unit -> bool
 
 val kind_checks : unit -> bool

--- a/otherlibs/str/dune
+++ b/otherlibs/str/dune
@@ -36,7 +36,6 @@
     (dllstr_stubs.so as stublibs/dllstr_stubs.so)
     (str.cmxa as str/str.cmxa)
     (str.a as str/str.a)
-    (str.cmxs as str/str.cmxs)
     (str.cma as str/str.cma)
     (str.mli as str/str.mli)
     (.str.objs/byte/str.cmi as str/str.cmi)

--- a/otherlibs/unix/dune
+++ b/otherlibs/unix/dune
@@ -152,7 +152,6 @@
     (.unix.objs/byte/unixLabels.cmi as unix/unixLabels.cmi)
     (.unix.objs/byte/unixLabels.cmt as unix/unixLabels.cmt)
     (.unix.objs/byte/unixLabels.cmti as unix/unixLabels.cmti)
-    (unix.cmxs as unix/unix.cmxs)
     (unix.mli as unix/unix.mli)
     (unixLabels.mli as unix/unixLabels.mli)
     (libunix_stubs.a as unix/libunix_stubs.a)


### PR DESCRIPTION
We currently deal with relational information through two (mostly,
because the CSE environment adds backwards information to the typing
environment) separate mechanisms:

 - The CSE environment keeps track of a map from arguments to values and
   effectively implements congruence closure over relations (i.e. it
   ensures that if `Get_tag(x) = y` and `Get_tag(x) = z` then `y = z`).

 - The typing env keeps track of a map from values to arguments though
   the relational types (if we have `Get_tag(x) = y` then `y` has type
   `(= Get_tag x)`)

This is not ideal, for at least two reasons: the CSE environment
and the canonicals in the typing env can get out of sync, causing missed
optimisation opportunities such as https://github.com/oxcaml/oxcaml/issues/3181; and the representation of
relational types is restrictive (see e.g. https://github.com/oxcaml/oxcaml/pull/2259, which this is can be
considered a rewrite of).

This patch introduces a new module in the flambda2 typing environment,
the "types database". This module is intended to provide a single and
principled source of relational informations between *canonical
elements* (or equivalently of non-alias relational information). The
design is loosely inspired from (a simplified version of) the
description in https://github.com/oxcaml/oxcaml/issues/3219. The types database internally maintains the same
maps that the CSE environment and the typing environment maintained
previously, except that it is wholly inside the typing environment now.
In particular, the typing environment can make sure that the canonicals
cannot get out of sync as with the CSE environment, and we also have
access to the more precise n-way join when computing the join of the
types database.

Having a single source of truth for relational information, instead of
it being distributed across the CSE environment and the typing
environment, also makes it easier to implement a robust heuristic for
match-in-match, which will come in a follow-up patch

More precisely, the current patch implements the following:

 - The types database itself, with support for `Is_int`, `Get_tag` and
   `Is_null` relations ;
 - Integration in the typing env in order to properly maintain
   canonicals ;
 - Join of databases with the new n-way join algorithm

Caveats:

 - This is currently gated behind the `-flambda2-types-database`
   command-line option or the `flambda2-types-database=1` OCAMLPARAM.
   This is done in order to facilitate testing, and we need to discuss
   during review whether to keep this flag or make it the default.

 - Enabling the types database currently enables the relational
   primitives but *does not* disable CSE for the corresponding
   primitives. This is because there are places (e.g. simplification of
   switch expressions) where we look up directly in the CSE environment,
   but these should be easy to replace with a lookup in the types
   database (it was not implemented in order to avoid multiplying the
   code paths, but will be implemented before merging).

 - Join is only implemented for the new n-way join algorithm.
   Implementing the join properly for the old binary join algorithm
   should not be complicated but requires a bit of thought and I'd like
   to wait until at least the first round of review first.

 - Support for env extension is currently partial. We discussed with
   @lthls on using identifiers for extensions in order to avoid
   potential infinite loops during meet, and this enables to store
   arbitrary information on extensions. Currently, the implementation is
   incorporating a database extension inside the `typing_env_extension`
   type, and allows attaching a full `typing_env_extension` to the
   database extension points. I believe that the first part is not
   necessary, and there are multiple places where database information
   is simply skipped in env extensions. Depending on the first round(s)
   of review, I'd be happy to either (a) keep things as is, or (b) more
   aggressively store database information in extensions (e.g. after
   a join) or (c) don't have database information in the
   `typing_env_extension` type at all (I personally favor (c); I believe
   this only has an effect on the join in practice and that we don't
   need to join such deep extensions).

 - Although the database supports `Untag_imm` and `Tag_imm` relations,
   they are not exposed through the typing env or used during
   simplification. This is in order to maintain feature parity with the
   existing implementation and facilitate comparisons; I plan on
   enabling them in a follow-up PR.

Note: The implementation relies heavily on the shared patricia tree
functions introduced in https://github.com/oxcaml/oxcaml/pull/4073, and is rebased on https://github.com/oxcaml/oxcaml/pull/4073; changes to the
`middle_end/flambda2/algorithms/` directory in this PR do not need to be
reviewed here.