### PR TITLE
Fix Rec_info for imported classic mode approximations

### DIFF
--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -282,7 +282,8 @@ let exactly_this_closure function_slot ~all_function_slots_in_set:function_types
 let static_closure_with_this_code ~this_function_slot ~closure_symbol ~code_id =
   let function_types =
     let function_type =
-      TG.Function_type.create code_id ~rec_info:(unknown K.rec_info)
+      TG.Function_type.create code_id
+        ~rec_info:(TG.this_rec_info Rec_info_expr.initial)
     in
     Function_slot.Map.singleton this_function_slot
       (Or_unknown_or_bottom.Ok function_type)


### PR DESCRIPTION
Functions generated in classic mode are currently failing to inline at higher optimization levels unless there is an attribute at the call site.  This is because the rec-info expression that has to be constructed (in order to form a full Flambda 2 type) from the classic mode closure approximation is currently set to "unknown", which translates to "infinity", namely prevent all inlining.

@lukemaurer does this look correct to you?