### PR TITLE
Fix soundness bug in `Stdlib.Atomic`

### DIFF
--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -42,19 +42,19 @@ let incr r = add r 1
 let decr r = sub r 1
 
 module Contended = struct
-  external get : ('a : value_or_null mod contended).
-    'a t @ contended local -> 'a @@ portable =
+  external get : ('a : value_or_null).
+    'a t @ contended local -> 'a @ contended @@ portable =
     "%atomic_load"
-  external set : ('a : value_or_null mod portable).
-    'a t @ contended local -> 'a -> unit @@ portable =
+  external set : ('a : value_or_null mod contended).
+    'a t @ contended local -> 'a @ portable -> unit @@ portable =
     "%atomic_set"
-  external exchange : ('a : value_or_null mod contended portable).
-    'a t @ contended local -> 'a -> 'a @@ portable =
+  external exchange : ('a : value_or_null mod contended).
+    'a t @ contended local -> 'a @ portable -> 'a @@ portable =
     "%atomic_exchange"
-  external compare_and_set : ('a : value_or_null mod portable).
-    'a t @ contended local -> 'a -> 'a -> bool @@ portable =
+  external compare_and_set : ('a : value_or_null mod contended).
+    'a t @ contended local -> 'a -> 'a @ portable -> bool @@ portable =
     "%atomic_cas"
-  external compare_exchange : ('a : value_or_null mod contended portable).
-    'a t @ contended local -> 'a -> 'a -> 'a @@ portable =
+  external compare_exchange : ('a : value_or_null mod contended).
+    'a t @ contended local -> 'a -> 'a @ portable -> 'a @ contended @@ portable =
     "%atomic_compare_exchange"
 end

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -102,28 +102,30 @@ val decr : int t @ contended local -> unit
     via modes. *)
 module Contended : sig
   (** Like {!get}, but can be called on an atomic that came from another domain. *)
-  val get : ('a : value_or_null mod contended).
-    'a t @ contended local -> 'a
+  external get : ('a : value_or_null).
+    'a t @ contended local -> 'a @ contended @@ portable =
+    "%atomic_load"
 
   (** Like {!set}, but can be called on an atomic that came from another domain. *)
   external set
-    : ('a : value_or_null mod portable).
-    'a t @ contended local -> 'a -> unit ="%atomic_set"
+    : ('a : value_or_null mod contended).
+    'a t @ contended local -> 'a @ portable -> unit = "%atomic_set"
 
   (** Like {!exchange}, but can be called on an atomic that came from another domain. *)
   external exchange :
-    ('a : value_or_null mod contended portable).
-    'a t @ contended local -> 'a -> 'a = "%atomic_exchange"
+    ('a : value_or_null mod contended).
+    'a t @ contended local -> 'a @ portable -> 'a = "%atomic_exchange"
 
   (** Like {!compare_and_set}, but can be called on an atomic that came from another domain. *)
   external compare_and_set
-    : ('a : value_or_null mod portable).
-    'a t @ contended local -> 'a -> 'a -> bool = "%atomic_cas"
+    : ('a : value_or_null mod contended).
+    'a t @ contended local -> 'a -> 'a @ portable -> bool = "%atomic_cas"
 
   (** Like {!compare_exchange}, but can be called on an atomic that came from another domain. *)
   external compare_exchange
-    : ('a : value_or_null mod contended portable).
-    'a t @ contended local -> 'a -> 'a -> 'a = "%atomic_compare_exchange"
+    : ('a : value_or_null mod contended).
+        'a t @ contended local -> 'a -> 'a @ portable -> 'a @ contended =
+    "%atomic_compare_exchange"
 end
 
 (** {1:examples Examples}

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -231,11 +231,10 @@ module Runtime_5 = struct
 
     let key_counter = Atomic.make 0
 
-    type key_initializer : immutable_data =
+    type key_initializer : value mod contended portable =
         KI: 'a key * ('a -> (Access.t -> 'a) @ portable) @@ portable -> key_initializer
-    [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
 
-    type key_initializer_list : immutable_data = key_initializer list
+    type key_initializer_list : value mod contended portable = key_initializer list
 
     let parent_keys = Atomic.make ([] : key_initializer_list)
 
@@ -330,12 +329,11 @@ module Runtime_5 = struct
 
     type key_value : value mod portable contended =
         KV : 'a key * (Access.t -> 'a) @@ portable -> key_value
-    [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
 
     let get_initial_keys access : key_value list =
       List.map
         (fun (KI (k, split)) -> KV (k, (split (get access k))))
-        (Atomic.Contended.get parent_keys)
+        (Atomic.Contended.get parent_keys : key_initializer_list)
 
     let set_initial_keys access (l: key_value list) =
       List.iter (fun (KV (k, v)) -> set access k (v access)) l


### PR DESCRIPTION
Argument for correctness: We consider an atomic to live in a capsule, and for that capsule to have uncontended access to it. If someone has the value `@ contended`, then they are either inside that capsule and just have a weakened reference to it, or are in another capsule and interacting across a capsule boundary.

For `Contended.get`, the contents of the atomic are crossing a capsule boundary, so we need to return it `@ contended`. (This is better than requiring `'a : value mod contended` since one can clearly implement the other but vice versa requires changing the type of the `'a` in `'a t` in a way that's not always desired.) We don't need to worry about portability here because the only way to get `'a` in another capsule is if `'a t` were in another capsule, and `'a t` is only portable if `'a` crosses portability.

For `Contended.set`, we are sending a value across a capsule boundary to the one that has the atomic, so the set value needs to be `@ portable`, but doesn't need to cross portability. It does need to cross contention, however, because after it crosses the capsule boundary, it needs to be `@ uncontended` to put it in the atomic.

The other types are derived from these, leaving out unnecessary `@ contended` annotations when `value mod contended` is required.