### PR TITLE
Dedicated engine for Cmm Peephole optimisations

### DIFF
--- a/backend/cmm_peephole_engine.ml
+++ b/backend/cmm_peephole_engine.ml
@@ -1,0 +1,143 @@
+(* Variable kinds *)
+
+type _ pattern_kind =
+| Expr : Cmm.expression pattern_kind
+| Int : int pattern_kind
+| Natint : Nativeint.t pattern_kind
+
+type 'a pattern_var =
+{ id : int;
+  name : string;
+  kind : 'a pattern_kind;
+}
+
+let var_counter = ref 0
+
+let create_var kind name =
+  incr var_counter;
+  { id = !var_counter;
+    name;
+    kind;
+  }
+
+module IM = Numbers.Int.Map
+
+module Env : sig
+  type t
+  val empty : t
+  val add : t -> 'a pattern_var -> 'a -> t
+  val find_exn : t -> 'a pattern_var -> 'a
+end = struct
+  type t = {
+    exprs : Cmm.expression IM.t;
+    ints : int IM.t;
+    natints : Nativeint.t IM.t;
+  }
+  let empty = {
+    exprs = IM.empty;
+    ints = IM.empty;
+    natints = IM.empty;
+  }
+  let add (type a) env (var : a pattern_var) (expr : a) =
+    match var.kind with
+    | Expr ->
+        if IM.mem var.id env.exprs
+        then Misc.fatal_errorf "Duplicate binding for var %s" var.name
+        else { env with exprs = IM.add var.id expr env.exprs }
+    | Int ->
+        if IM.mem var.id env.ints
+        then Misc.fatal_errorf "Duplicate binding for var %s" var.name
+        else { env with ints = IM.add var.id expr env.ints }
+    | Natint ->
+        if IM.mem var.id env.natints
+        then Misc.fatal_errorf "Duplicate binding for var %s" var.name
+        else { env with natints = IM.add var.id expr env.natints }
+  let find_exn (type a) env (var : a pattern_var) : a =
+    match var.kind with
+    | Expr -> IM.find var.id env.exprs
+    | Int -> IM.find var.id env.ints
+    | Natint -> IM.find var.id env.natints
+end
+
+type cmm_pattern =
+  | Any
+  | Var of Cmm.expression pattern_var
+  | Const_int_fixed of int
+  | Const_int_var of int pattern_var
+  | Const_natint_fixed of Nativeint.t
+  | Const_natint_var of Nativeint.t pattern_var
+  | Add of cmm_pattern * cmm_pattern
+  | When of cmm_pattern * (Env.t -> bool)
+
+type 'a clause =
+  cmm_pattern * (Env.t -> 'a)
+
+let match_clauses_in_order clauses expr =
+  let rec match_one_pattern env pat (expr : Cmm.expression) =
+    match pat with
+    | Any -> Some env
+    | Var v -> Some (Env.add env v expr)
+    | Const_int_fixed n1 -> begin
+        match expr with
+        | Cconst_int (n2, _) -> if Int.equal n1 n2 then Some env else None
+        | _ -> None
+      end
+    | Const_int_var v -> begin
+        match expr with
+        | Cconst_int (n, _) -> Some (Env.add env v n)
+        | _ -> None
+      end
+    | Const_natint_fixed n1 -> begin
+        match expr with
+        | Cconst_natint (n2, _) -> if Nativeint.equal n1 n2 then Some env else None
+        | _ -> None
+      end
+    | Const_natint_var v -> begin
+        match expr with
+        | Cconst_natint (n, _) -> Some (Env.add env v n)
+        | _ -> None
+      end
+    | Add (pat1, pat2) ->begin
+        match expr with
+        | Cop (Caddi, [expr1; expr2], _) -> begin
+          match match_one_pattern env pat1 expr1 with
+          | Some env ->
+            match_one_pattern env pat2 expr2
+          | None -> None
+        end
+        | _ -> None
+      end
+    | When (pat, guard) -> begin
+        match match_one_pattern env pat expr with
+        | Some env -> if guard env then Some env else None
+        | None -> None
+      end
+  in
+  let rec find_matching_clause expr = function
+    | [] -> expr
+    | (pat, f) :: clauses -> begin
+        match match_one_pattern Env.empty pat expr with
+        | Some env -> f env
+        | None -> find_matching_clause expr clauses
+      end
+  in
+  find_matching_clause expr clauses
+
+let run expr clauses =
+  match_clauses_in_order clauses expr
+
+module Syntax = struct
+  let (#.) = Env.find_exn
+end
+
+module Default_variables = struct
+  let c = create_var Expr "c"
+  let c1 = create_var Expr "c1"
+  let c2 = create_var Expr "c2"
+  let i = create_var Int "i"
+  let i1 = create_var Int "i1"
+  let i2 = create_var Int "i2"
+  let n = create_var Natint "n"
+  let n1 = create_var Natint "n1"
+  let n2 = create_var Natint "n2"
+end

--- a/backend/cmm_peephole_engine.mli
+++ b/backend/cmm_peephole_engine.mli
@@ -1,0 +1,36 @@
+type 'a pattern_var
+
+module Env : sig
+  type t
+end
+
+type cmm_pattern =
+  | Any
+  | Var of Cmm.expression pattern_var
+  | Const_int_fixed of int
+  | Const_int_var of int pattern_var
+  | Const_natint_fixed of Nativeint.t
+  | Const_natint_var of Nativeint.t pattern_var
+  | Add of cmm_pattern * cmm_pattern
+  | When of cmm_pattern * (Env.t -> bool)
+
+type 'a clause =
+  cmm_pattern * (Env.t -> 'a)
+
+val run : Cmm.expression -> Cmm.expression clause list -> Cmm.expression
+
+module Syntax : sig
+  val (#.) : Env.t -> 'a pattern_var -> 'a
+end
+
+module Default_variables : sig
+  val c : Cmm.expression pattern_var
+  val c1 : Cmm.expression pattern_var
+  val c2 : Cmm.expression pattern_var
+  val i : int pattern_var
+  val i1 : int pattern_var
+  val i2 : int pattern_var
+  val n : Nativeint.t pattern_var
+  val n1 : Nativeint.t pattern_var
+  val n2 : Nativeint.t pattern_var
+end

--- a/dune
+++ b/dune
@@ -448,6 +448,7 @@
   cmm_helpers
   cmm_builtins
   cmm_invariants
+  cmm_peephole_engine
   cmm
   cmmgen_state
   CSE


### PR DESCRIPTION
This draft PR is a proposal for handling phantom lets (or debug info in general) in Cmm without interfering with the various existing peephole optimisations.

Here I propose to rewrite the existing optimisations using a dedicated DSL, provided by the `Cmm_peephole_engine` module, then in a second phase improve the engine itself to handle phantom lets (and maybe regular lets, if we want to).

Right now (at time of PR creation), the `add_int` Cmm helper function has been rewritten to use this engine.

I am going to wait for feedback before committing fully to this approach (as alternative proposals have also been put forward).