### PR TITLE
Update version to `5.2.0+ox`

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
-5.2.0+jst
+5.2.0+ox
 
 # Starting with OCaml 4.14, although the version string that appears above is
 # still correct and this file can thus still be used to figure it out,

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@
 # Require Autoconf 2.71 for repeatability in CI
 AC_PREREQ([2.71])
 AC_INIT([The Flambda backend for OCaml],
-        5.2.0+jst,
+        5.2.0+ox,
         [mshinwell@janestreet.com],
         [flambda_backend],
         [http://github.com/ocaml-flambda/flambda_backend])

--- a/dune
+++ b/dune
@@ -400,8 +400,7 @@
  (files
   Makefile.build_config
   Makefile.config_if_required
-  Makefile.config
-  VERSION)
+  Makefile.config)
  (section lib)
  (package ocaml))
 


### PR DESCRIPTION
Title.

Also do not install the `VERSION` file -- it causes issues with C++ headers on MacOS. See https://github.com/ocaml/ocaml/pull/9895/files.