### PR TITLE
datalog: Document read/write intent using types

### DIFF
--- a/middle_end/flambda2/algorithms/channel.ml
+++ b/middle_end/flambda2/algorithms/channel.ml
@@ -1,0 +1,40 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                        Basile Clément, OCamlPro                            *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 OCamlPro SAS                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+type 'a sender = 'a ref
+
+type 'a receiver = 'a ref
+
+let create v =
+  let r = ref v in
+  r, r
+
+external send : 'a sender -> 'a -> unit = "%setfield0"
+
+external recv : 'a receiver -> 'a = "%field0"

--- a/middle_end/flambda2/algorithms/channel.mli
+++ b/middle_end/flambda2/algorithms/channel.mli
@@ -1,0 +1,49 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                        Basile Clément, OCamlPro                            *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 OCamlPro SAS                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(** {1 Channels} *)
+
+(** A channel is really just a reference, but we use separate [sender] and
+     [receiver] types to indicate whether we expect to only write or only read to
+     a specific reference. *)
+
+type 'a sender
+
+external send : 'a sender -> 'a -> unit = "%setfield0"
+
+type 'a receiver
+
+external recv : 'a receiver -> 'a = "%field0"
+
+(** Create a pair [sender, receiver].
+
+    The value read (using [recv]) from the [receiver] is the last value that was
+    sent (using [send]) to the [sender], or the initial value provided to
+    [channel]. *)
+val create : 'a -> 'a sender * 'a receiver

--- a/middle_end/flambda2/algorithms/leapfrog.ml
+++ b/middle_end/flambda2/algorithms/leapfrog.ml
@@ -13,6 +13,18 @@
 (*                                                                        *)
 (**************************************************************************)
 
+type 'a sender = 'a ref
+
+type 'a receiver = 'a ref
+
+let channel v =
+  let r = ref v in
+  r, r
+
+external send : 'a sender -> 'a -> unit = "%setfield0"
+
+external recv : 'a receiver -> 'a = "%field0"
+
 module type Iterator = sig
   type 'a t
 
@@ -35,8 +47,8 @@ module Map (T : Container_types.S_plus_iterator) = struct
   type _ t =
     | Iterator :
         { mutable iterator : 'v T.Map.iterator;
-          map : 'v T.Map.t ref;
-          handler : 'v ref
+          map : 'v T.Map.t receiver;
+          handler : 'v sender
         }
         -> T.t t
 
@@ -56,12 +68,12 @@ module Map (T : Container_types.S_plus_iterator) = struct
     i.iterator <- T.Map.seek i.iterator k
 
   let init (type a) (Iterator i : a t) : unit =
-    i.iterator <- T.Map.iterator !(i.map)
+    i.iterator <- T.Map.iterator (recv i.map)
 
   let accept (type a) (Iterator i : a t) : unit =
     match T.Map.current i.iterator with
     | None -> invalid_arg "accept: iterator is exhausted"
-    | Some (_, value) -> i.handler := value
+    | Some (_, value) -> send i.handler value
 
   let create cell handler =
     Iterator { iterator = T.Map.iterator T.Map.empty; map = cell; handler }

--- a/middle_end/flambda2/algorithms/leapfrog.mli
+++ b/middle_end/flambda2/algorithms/leapfrog.mli
@@ -20,6 +20,29 @@
   (1) https://arxiv.org/pdf/1210.0481
 *)
 
+(** {2 Channels} *)
+
+(** A channel is really just a reference, but we use separate [sender] and
+    [receiver] types to indicate whether we expect to only write or only read to
+    a specific reference. *)
+
+type 'a sender
+
+external send : 'a sender -> 'a -> unit = "%setfield0"
+
+type 'a receiver
+
+external recv : 'a receiver -> 'a = "%field0"
+
+(** Create a pair [sender, receiver].
+
+    The value read (using [recv]) from the [receiver] is the last value that was
+    sent (using [send]) to the [sender], or the initial value provided to
+    [channel]. *)
+val channel : 'a -> 'a sender * 'a receiver
+
+(** {2 Iterators} *)
+
 module type Iterator = sig
   (** This module is really an interface for the trie iterators from "Leapfrog
       Triejoin: A Simple, Worst-Case Optimal Join Algorithm" by Todd L.
@@ -107,7 +130,7 @@ module Map (T : Container_types.S_plus_iterator) : sig
 
        - Calling [accept] will set the [handler] reference to the current value
          of the iterator. *)
-  val create : 'a T.Map.t ref -> 'a ref -> T.t t
+  val create : 'a T.Map.t receiver -> 'a sender -> T.t t
 end
 
 module Join (Iterator : Iterator) : sig

--- a/middle_end/flambda2/algorithms/leapfrog.mli
+++ b/middle_end/flambda2/algorithms/leapfrog.mli
@@ -20,27 +20,6 @@
   (1) https://arxiv.org/pdf/1210.0481
 *)
 
-(** {2 Channels} *)
-
-(** A channel is really just a reference, but we use separate [sender] and
-    [receiver] types to indicate whether we expect to only write or only read to
-    a specific reference. *)
-
-type 'a sender
-
-external send : 'a sender -> 'a -> unit = "%setfield0"
-
-type 'a receiver
-
-external recv : 'a receiver -> 'a = "%field0"
-
-(** Create a pair [sender, receiver].
-
-    The value read (using [recv]) from the [receiver] is the last value that was
-    sent (using [send]) to the [sender], or the initial value provided to
-    [channel]. *)
-val channel : 'a -> 'a sender * 'a receiver
-
 (** {2 Iterators} *)
 
 module type Iterator = sig
@@ -130,7 +109,7 @@ module Map (T : Container_types.S_plus_iterator) : sig
 
        - Calling [accept] will set the [handler] reference to the current value
          of the iterator. *)
-  val create : 'a T.Map.t receiver -> 'a sender -> T.t t
+  val create : 'a T.Map.t Channel.receiver -> 'a Channel.sender -> T.t t
 end
 
 module Join (Iterator : Iterator) : sig

--- a/middle_end/flambda2/datalog/cursor.ml
+++ b/middle_end/flambda2/datalog/cursor.ml
@@ -113,8 +113,7 @@ module Level = struct
       actions : actions;
       mutable iterators : 'a Trie.Iterator.t with_name list;
       mutable output :
-        ('a option Channel.sender * 'a option Channel.receiver) with_name
-        option
+        ('a option Channel.sender * 'a option Channel.receiver) with_name option
     }
 
   let print ppf { name; order; _ } =
@@ -360,9 +359,7 @@ let with_bound_cursor ?callback cursor db f =
 let evaluate = function
   | Unless (is_trie, cell, args, _cell_name, _args_names) ->
     if Option.is_some
-         (Trie.find_opt is_trie
-            (Option_receiver.recv args)
-            (Channel.recv cell))
+         (Trie.find_opt is_trie (Option_receiver.recv args) (Channel.recv cell))
     then Virtual_machine.Skip
     else Virtual_machine.Accept
   | Unless_eq (cell1, cell2, _cell1_name, _cell2_name, Int_repr) ->

--- a/middle_end/flambda2/datalog/cursor.ml
+++ b/middle_end/flambda2/datalog/cursor.ml
@@ -24,21 +24,25 @@ let int_repr = Int_repr
 type vm_action =
   | Unless :
       ('t, 'k, 'v) Trie.is_trie
-      * 't ref
-      * 'k Option_ref.hlist
+      * 't Leapfrog.receiver
+      * 'k Option_receiver.hlist
       * string
       * string list
       -> vm_action
   | Unless_eq :
-      'k option ref * 'k option ref * string * string * 'k value_repr
+      'k option Leapfrog.receiver
+      * 'k option Leapfrog.receiver
+      * string
+      * string
+      * 'k value_repr
       -> vm_action
   | Filter :
-      ('k Constant.hlist -> bool) * 'k Option_ref.hlist * string list
+      ('k Constant.hlist -> bool) * 'k Option_receiver.hlist * string list
       -> vm_action
 
 type action =
   | Bind_iterator :
-      'a option ref with_name * 'a Trie.Iterator.t with_name
+      'a option Leapfrog.receiver with_name * 'a Trie.Iterator.t with_name
       -> action
   | VM_action : vm_action -> action
 
@@ -54,7 +58,8 @@ let unless_eq repr cell1 cell2 =
 
 let filter f args = VM_action (Filter (f, args.values, args.names))
 
-type binder = Bind_table : ('t, 'k, 'v) Table.Id.t * 't ref -> binder
+type binder =
+  | Bind_table : ('t, 'k, 'v) Table.Id.t * 't Leapfrog.sender -> binder
 
 type actions = { mutable rev_actions : action list }
 
@@ -107,7 +112,9 @@ module Level = struct
       order : Order.t;
       actions : actions;
       mutable iterators : 'a Trie.Iterator.t with_name list;
-      mutable output : 'a option ref with_name option
+      mutable output :
+        ('a option Leapfrog.sender * 'a option Leapfrog.receiver) with_name
+        option
     }
 
   let print ppf { name; order; _ } =
@@ -119,10 +126,11 @@ module Level = struct
   let use_output level =
     match level.output with
     | None ->
-      let output = { value = ref None; name = level.name } in
+      let channel = Leapfrog.channel None in
+      let output = { value = channel; name = level.name } in
       level.output <- Some output;
-      output
-    | Some output -> output
+      { output with value = snd output.value }
+    | Some output -> { output with value = snd output.value }
 
   let actions { actions; _ } = actions
 
@@ -191,9 +199,11 @@ let add_iterator context id =
   iterators
 
 let add_naive_binder context id =
-  let handler = ref (Trie.empty (Table.Id.is_trie id)) in
-  add_binder context.naive_binders (Bind_table (id, handler));
-  handler
+  let send_trie, recv_trie =
+    Leapfrog.channel (Trie.empty (Table.Id.is_trie id))
+  in
+  add_binder context.naive_binders (Bind_table (id, send_trie));
+  recv_trie
 
 let initial_actions { actions; _ } = actions
 
@@ -254,8 +264,10 @@ let rec open_rev_vars :
         (* If we do not need the output (we usually do), write it to a dummy
            [ref] for simplicity. *)
         match var.output with
-        | Some output -> output
-        | None -> { value = ref None; name = "_" }
+        | Some output -> { output with value = fst output.value }
+        | None ->
+          let send, _recv = Leapfrog.channel None in
+          { value = send; name = "_" }
       in
       let iterators = List.map (fun it -> it.value) var.iterators in
       let iterator_names = List.map (fun it -> it.name) var.iterators in
@@ -284,7 +296,7 @@ type call =
   | Call :
       { func : 'a Constant.hlist -> unit;
         name : string;
-        args : 'a Option_ref.hlist with_names
+        args : 'a Option_receiver.hlist with_names
       }
       -> call
 
@@ -320,7 +332,7 @@ let create ?(calls = []) ?output context =
 
 let bind_table (Bind_table (id, handler)) database =
   let table = Table.Map.get id database in
-  handler := table;
+  Leapfrog.send handler table;
   not (Trie.is_empty (Table.Id.is_trie id) table)
 
 let bind_table_list binders database =
@@ -332,7 +344,7 @@ let bind_cursor cursor ?(callback = ignore) db =
   cursor.callback := callback
 
 let unbind_table (Bind_table (id, handler)) =
-  handler := Trie.empty (Table.Id.is_trie id)
+  Leapfrog.send handler (Trie.empty (Table.Id.is_trie id))
 
 let unbind_table_list binders = List.iter unbind_table binders
 
@@ -348,15 +360,19 @@ let with_bound_cursor ?callback cursor db f =
 let evaluate = function
   | Unless (is_trie, cell, args, _cell_name, _args_names) ->
     if Option.is_some
-         (Trie.find_opt is_trie (Option_ref.get args) cell.contents)
+         (Trie.find_opt is_trie
+            (Option_receiver.recv args)
+            (Leapfrog.recv cell))
     then Virtual_machine.Skip
     else Virtual_machine.Accept
   | Unless_eq (cell1, cell2, _cell1_name, _cell2_name, Int_repr) ->
-    if Int.equal (Option.get !cell1) (Option.get !cell2)
+    if Int.equal
+         (Option.get (Leapfrog.recv cell1))
+         (Option.get (Leapfrog.recv cell2))
     then Virtual_machine.Skip
     else Virtual_machine.Accept
   | Filter (f, args, _args_names) ->
-    if f (Option_ref.get args)
+    if f (Option_receiver.recv args)
     then Virtual_machine.Accept
     else Virtual_machine.Skip
 
@@ -387,7 +403,7 @@ let[@inline] seminaive_run cursor ~previous ~diff ~current =
 
 module With_parameters = struct
   type nonrec ('p, 'v) t =
-    { parameters : 'p Option_ref.hlist;
+    { parameters : 'p Option_sender.hlist;
       cursor : 'v t
     }
 
@@ -399,14 +415,14 @@ module With_parameters = struct
     { cursor = create ?calls ?output context; parameters }
 
   let naive_fold { parameters; cursor } ps db f acc =
-    Option_ref.set parameters ps;
+    Option_sender.send parameters ps;
     naive_fold cursor db f acc
 
   let naive_iter { parameters; cursor } ps db f =
-    Option_ref.set parameters ps;
+    Option_sender.send parameters ps;
     naive_iter cursor db f
 
   let seminaive_run { parameters; cursor } ps ~previous ~diff ~current =
-    Option_ref.set parameters ps;
+    Option_sender.send parameters ps;
     seminaive_run ~previous ~diff ~current cursor
 end

--- a/middle_end/flambda2/datalog/cursor.mli
+++ b/middle_end/flambda2/datalog/cursor.mli
@@ -22,16 +22,24 @@ val int_repr : int value_repr
 type action
 
 val bind_iterator :
-  'a option ref with_name -> 'a Trie.Iterator.t with_name -> action
+  'a option Leapfrog.receiver with_name ->
+  'a Trie.Iterator.t with_name ->
+  action
 
 val unless :
-  ('t, 'k, 'v) Table.Id.t -> 't ref -> 'k Option_ref.hlist with_names -> action
+  ('t, 'k, 'v) Table.Id.t ->
+  't Leapfrog.receiver ->
+  'k Option_receiver.hlist with_names ->
+  action
 
 val unless_eq :
-  'k value_repr -> 'k option ref with_name -> 'k option ref with_name -> action
+  'k value_repr ->
+  'k option Leapfrog.receiver with_name ->
+  'k option Leapfrog.receiver with_name ->
+  action
 
 val filter :
-  ('k Constant.hlist -> bool) -> 'k Option_ref.hlist with_names -> action
+  ('k Constant.hlist -> bool) -> 'k Option_receiver.hlist with_names -> action
 
 type actions
 
@@ -55,7 +63,7 @@ module Level : sig
       {b Note}: This reference is set to any new value found prior to executing
       the associated actions, if any, and can thus be used in actions for this
       level or levels of later orders. *)
-  val use_output : 'a t -> 'a option ref with_name
+  val use_output : 'a t -> 'a option Leapfrog.receiver with_name
 
   (** Actions to execute immediately after a value is found at this level. *)
   val actions : 'a t -> actions
@@ -77,7 +85,8 @@ val add_new_level : context -> string -> 'a Level.t
 val add_iterator :
   context -> ('t, 'k, 'v) Table.Id.t -> 'k Trie.Iterator.hlist with_names
 
-val add_naive_binder : context -> ('t, 'k, 'v) Table.Id.t -> 't ref
+val add_naive_binder :
+  context -> ('t, 'k, 'v) Table.Id.t -> 't Leapfrog.receiver
 
 (** Initial actions are always executed when iterating over a cursor, before
     opening the first level. *)
@@ -94,11 +103,14 @@ type call
 val create_call :
   ('a Constant.hlist -> unit) ->
   name:string ->
-  'a Option_ref.hlist with_names ->
+  'a Option_receiver.hlist with_names ->
   call
 
 val create :
-  ?calls:call list -> ?output:'v Option_ref.hlist with_names -> context -> 'v t
+  ?calls:call list ->
+  ?output:'v Option_receiver.hlist with_names ->
+  context ->
+  'v t
 
 val naive_fold :
   'v t -> Table.Map.t -> ('v Constant.hlist -> 'a -> 'a) -> 'a -> 'a
@@ -154,9 +166,9 @@ module With_parameters : sig
   val without_parameters : (nil, 'v) t -> 'v cursor
 
   val create :
-    parameters:'p Option_ref.hlist ->
+    parameters:'p Option_sender.hlist ->
     ?calls:call list ->
-    ?output:'v Option_ref.hlist with_names ->
+    ?output:'v Option_receiver.hlist with_names ->
     context ->
     ('p, 'v) t
 

--- a/middle_end/flambda2/datalog/cursor.mli
+++ b/middle_end/flambda2/datalog/cursor.mli
@@ -22,9 +22,7 @@ val int_repr : int value_repr
 type action
 
 val bind_iterator :
-  'a option Channel.receiver with_name ->
-  'a Trie.Iterator.t with_name ->
-  action
+  'a option Channel.receiver with_name -> 'a Trie.Iterator.t with_name -> action
 
 val unless :
   ('t, 'k, 'v) Table.Id.t ->
@@ -85,8 +83,7 @@ val add_new_level : context -> string -> 'a Level.t
 val add_iterator :
   context -> ('t, 'k, 'v) Table.Id.t -> 'k Trie.Iterator.hlist with_names
 
-val add_naive_binder :
-  context -> ('t, 'k, 'v) Table.Id.t -> 't Channel.receiver
+val add_naive_binder : context -> ('t, 'k, 'v) Table.Id.t -> 't Channel.receiver
 
 (** Initial actions are always executed when iterating over a cursor, before
     opening the first level. *)

--- a/middle_end/flambda2/datalog/cursor.mli
+++ b/middle_end/flambda2/datalog/cursor.mli
@@ -22,20 +22,20 @@ val int_repr : int value_repr
 type action
 
 val bind_iterator :
-  'a option Leapfrog.receiver with_name ->
+  'a option Channel.receiver with_name ->
   'a Trie.Iterator.t with_name ->
   action
 
 val unless :
   ('t, 'k, 'v) Table.Id.t ->
-  't Leapfrog.receiver ->
+  't Channel.receiver ->
   'k Option_receiver.hlist with_names ->
   action
 
 val unless_eq :
   'k value_repr ->
-  'k option Leapfrog.receiver with_name ->
-  'k option Leapfrog.receiver with_name ->
+  'k option Channel.receiver with_name ->
+  'k option Channel.receiver with_name ->
   action
 
 val filter :
@@ -63,7 +63,7 @@ module Level : sig
       {b Note}: This reference is set to any new value found prior to executing
       the associated actions, if any, and can thus be used in actions for this
       level or levels of later orders. *)
-  val use_output : 'a t -> 'a option Leapfrog.receiver with_name
+  val use_output : 'a t -> 'a option Channel.receiver with_name
 
   (** Actions to execute immediately after a value is found at this level. *)
   val actions : 'a t -> actions
@@ -86,7 +86,7 @@ val add_iterator :
   context -> ('t, 'k, 'v) Table.Id.t -> 'k Trie.Iterator.hlist with_names
 
 val add_naive_binder :
-  context -> ('t, 'k, 'v) Table.Id.t -> 't Leapfrog.receiver
+  context -> ('t, 'k, 'v) Table.Id.t -> 't Channel.receiver
 
 (** Initial actions are always executed when iterating over a cursor, before
     opening the first level. *)

--- a/middle_end/flambda2/datalog/datalog.ml
+++ b/middle_end/flambda2/datalog/datalog.ml
@@ -18,18 +18,21 @@ open Datalog_imports
 module Parameter = struct
   type 'a t =
     { name : string;
-      cell : 'a option ref
+      sender : 'a option Leapfrog.sender;
+      receiver : 'a option Leapfrog.receiver
     }
 
-  let create name = { name; cell = ref None }
+  let create name =
+    let sender, receiver = Leapfrog.channel None in
+    { name; sender; receiver }
 
   include Heterogenous_list.Make (struct
     type nonrec 'a t = 'a t
   end)
 
-  let rec to_refs : type a. a hlist -> a Option_ref.hlist = function
+  let rec to_senders : type a. a hlist -> a Option_sender.hlist = function
     | [] -> []
-    | p :: ps -> p.cell :: to_refs ps
+    | p :: ps -> p.sender :: to_senders ps
 end
 
 module Term = struct
@@ -108,14 +111,15 @@ let rec bind_atom :
     let this_iterator = { value = this_iterator; name = this_iterator_name } in
     match this_arg with
     | Constant cte ->
+      let _send, recv = Leapfrog.channel (Some cte) in
       bind_iterator post_level
-        { value = ref (Some cte); name = "<constant>" }
+        { value = recv; name = "<constant>" }
         this_iterator;
       bind_atom ~order post_level other_args other_iterators
         other_iterators_names
     | Parameter param ->
       bind_iterator post_level
-        { value = param.cell; name = param.name }
+        { value = param.receiver; name = param.name }
         this_iterator;
       bind_atom ~order post_level other_args other_iterators
         other_iterators_names
@@ -156,12 +160,15 @@ let rec find_last_binding0 : type a. order:_ -> _ -> a Term.hlist -> _ =
 let find_last_binding post_level args =
   find_last_binding0 ~order:Cursor.Order.parameters post_level args
 
-let compile_term : 'a Term.t -> 'a option ref with_name = function
-  | Constant cte -> { value = ref (Some cte); name = "<constant>" }
-  | Parameter param -> { value = param.cell; name = param.name }
+let compile_term : 'a Term.t -> 'a option Leapfrog.receiver with_name = function
+  | Constant cte ->
+    let _send, recv = Leapfrog.channel (Some cte) in
+    { value = recv; name = "<constant>" }
+  | Parameter param -> { value = param.receiver; name = param.name }
   | Variable var -> Cursor.Level.use_output var
 
-let rec compile_terms : type a. a Term.hlist -> a Option_ref.hlist with_names =
+let rec compile_terms :
+    type a. a Term.hlist -> a Option_receiver.hlist with_names =
  fun vars ->
   match vars with
   | [] -> { values = []; names = [] }
@@ -209,7 +216,7 @@ let create_callback func ~name args = Callback { func; name; args }
 let yield output (info : _ context) =
   let output = compile_terms output in
   Cursor.With_parameters.create
-    ~parameters:(Parameter.to_refs info.parameters)
+    ~parameters:(Parameter.to_senders info.parameters)
     info.context ~output
 
 let execute callbacks (info : _ context) =
@@ -220,5 +227,5 @@ let execute callbacks (info : _ context) =
       callbacks
   in
   Cursor.With_parameters.create ~calls
-    ~parameters:(Parameter.to_refs info.parameters)
+    ~parameters:(Parameter.to_senders info.parameters)
     info.context

--- a/middle_end/flambda2/datalog/datalog.ml
+++ b/middle_end/flambda2/datalog/datalog.ml
@@ -18,12 +18,12 @@ open Datalog_imports
 module Parameter = struct
   type 'a t =
     { name : string;
-      sender : 'a option Leapfrog.sender;
-      receiver : 'a option Leapfrog.receiver
+      sender : 'a option Channel.sender;
+      receiver : 'a option Channel.receiver
     }
 
   let create name =
-    let sender, receiver = Leapfrog.channel None in
+    let sender, receiver = Channel.create None in
     { name; sender; receiver }
 
   include Heterogenous_list.Make (struct
@@ -111,7 +111,7 @@ let rec bind_atom :
     let this_iterator = { value = this_iterator; name = this_iterator_name } in
     match this_arg with
     | Constant cte ->
-      let _send, recv = Leapfrog.channel (Some cte) in
+      let _send, recv = Channel.create (Some cte) in
       bind_iterator post_level
         { value = recv; name = "<constant>" }
         this_iterator;
@@ -160,9 +160,9 @@ let rec find_last_binding0 : type a. order:_ -> _ -> a Term.hlist -> _ =
 let find_last_binding post_level args =
   find_last_binding0 ~order:Cursor.Order.parameters post_level args
 
-let compile_term : 'a Term.t -> 'a option Leapfrog.receiver with_name = function
+let compile_term : 'a Term.t -> 'a option Channel.receiver with_name = function
   | Constant cte ->
-    let _send, recv = Leapfrog.channel (Some cte) in
+    let _send, recv = Channel.create (Some cte) in
     { value = recv; name = "<constant>" }
   | Parameter param -> { value = param.receiver; name = param.name }
   | Variable var -> Cursor.Level.use_output var

--- a/middle_end/flambda2/datalog/datalog_imports.ml
+++ b/middle_end/flambda2/datalog/datalog_imports.ml
@@ -42,3 +42,27 @@ module Option_ref = struct
       r.contents <- Some v;
       set rs vs
 end
+
+module Option_sender = struct
+  include Make (struct
+    type 'a t = 'a option Leapfrog.sender
+  end)
+
+  let rec send : type s. s hlist -> s Constant.hlist -> unit =
+   fun refs values ->
+    match refs, values with
+    | [], [] -> ()
+    | r :: rs, v :: vs ->
+      Leapfrog.send r (Some v);
+      send rs vs
+end
+
+module Option_receiver = struct
+  include Make (struct
+    type 'a t = 'a option Leapfrog.receiver
+  end)
+
+  let rec recv : type s. s hlist -> s Constant.hlist = function
+    | [] -> []
+    | r :: rs -> Option.get (Leapfrog.recv r) :: recv rs
+end

--- a/middle_end/flambda2/datalog/datalog_imports.ml
+++ b/middle_end/flambda2/datalog/datalog_imports.ml
@@ -25,24 +25,6 @@ type 'a with_names =
 
 include Heterogenous_list
 
-module Option_ref = struct
-  include Make (struct
-    type 'a t = 'a option ref
-  end)
-
-  let rec get : type s. s hlist -> s Constant.hlist = function
-    | [] -> []
-    | r :: rs -> Option.get r.contents :: get rs
-
-  let rec set : type s. s hlist -> s Constant.hlist -> unit =
-   fun refs values ->
-    match refs, values with
-    | [], [] -> ()
-    | r :: rs, v :: vs ->
-      r.contents <- Some v;
-      set rs vs
-end
-
 module Option_sender = struct
   include Make (struct
     type 'a t = 'a option Channel.sender

--- a/middle_end/flambda2/datalog/datalog_imports.ml
+++ b/middle_end/flambda2/datalog/datalog_imports.ml
@@ -45,7 +45,7 @@ end
 
 module Option_sender = struct
   include Make (struct
-    type 'a t = 'a option Leapfrog.sender
+    type 'a t = 'a option Channel.sender
   end)
 
   let rec send : type s. s hlist -> s Constant.hlist -> unit =
@@ -53,16 +53,16 @@ module Option_sender = struct
     match refs, values with
     | [], [] -> ()
     | r :: rs, v :: vs ->
-      Leapfrog.send r (Some v);
+      Channel.send r (Some v);
       send rs vs
 end
 
 module Option_receiver = struct
   include Make (struct
-    type 'a t = 'a option Leapfrog.receiver
+    type 'a t = 'a option Channel.receiver
   end)
 
   let rec recv : type s. s hlist -> s Constant.hlist = function
     | [] -> []
-    | r :: rs -> Option.get (Leapfrog.recv r) :: recv rs
+    | r :: rs -> Option.get (Channel.recv r) :: recv rs
 end

--- a/middle_end/flambda2/datalog/table.ml
+++ b/middle_end/flambda2/datalog/table.ml
@@ -103,9 +103,9 @@ module Id = struct
     | None -> Misc.fatal_error "Inconsistent type for uid."
 
   let create_iterator { is_trie; default_value; name; _ } =
-    let handler = ref (Trie.empty is_trie) in
-    let out = ref default_value in
-    let iterator = Trie.Iterator.create is_trie handler out in
+    let send_trie, recv_trie = Leapfrog.channel (Trie.empty is_trie) in
+    let send_value, recv_value = Leapfrog.channel default_value in
+    let iterator = Trie.Iterator.create is_trie recv_trie send_value in
     let rec get_names : type a. a Trie.Iterator.hlist -> int -> string list =
       fun (type a) (iterators : a Trie.Iterator.hlist) i : string list ->
        match iterators with
@@ -113,15 +113,15 @@ module Id = struct
        | _ :: iterators ->
          (name ^ "." ^ string_of_int i) :: get_names iterators (i + 1)
     in
-    handler, { values = iterator; names = get_names iterator 0 }, out
+    send_trie, { values = iterator; names = get_names iterator 0 }, recv_value
 end
 
 module VM = Virtual_machine.Make (Trie.Iterator)
 
 let iter id f table =
-  let input_ref, it, out_ref = Id.create_iterator id in
-  input_ref.contents <- table;
-  VM.iter (fun keys -> f keys out_ref.contents) (VM.iterator it)
+  let send_input, it, recv_output = Id.create_iterator id in
+  Leapfrog.send send_input table;
+  VM.iter (fun keys -> f keys (Leapfrog.recv recv_output)) (VM.iterator it)
 
 let print id ?(pp_sep = Format.pp_print_cut) pp_row ppf table =
   let first = ref true in

--- a/middle_end/flambda2/datalog/table.ml
+++ b/middle_end/flambda2/datalog/table.ml
@@ -103,8 +103,8 @@ module Id = struct
     | None -> Misc.fatal_error "Inconsistent type for uid."
 
   let create_iterator { is_trie; default_value; name; _ } =
-    let send_trie, recv_trie = Leapfrog.channel (Trie.empty is_trie) in
-    let send_value, recv_value = Leapfrog.channel default_value in
+    let send_trie, recv_trie = Channel.create (Trie.empty is_trie) in
+    let send_value, recv_value = Channel.create default_value in
     let iterator = Trie.Iterator.create is_trie recv_trie send_value in
     let rec get_names : type a. a Trie.Iterator.hlist -> int -> string list =
       fun (type a) (iterators : a Trie.Iterator.hlist) i : string list ->
@@ -120,8 +120,8 @@ module VM = Virtual_machine.Make (Trie.Iterator)
 
 let iter id f table =
   let send_input, it, recv_output = Id.create_iterator id in
-  Leapfrog.send send_input table;
-  VM.iter (fun keys -> f keys (Leapfrog.recv recv_output)) (VM.iterator it)
+  Channel.send send_input table;
+  VM.iter (fun keys -> f keys (Channel.recv recv_output)) (VM.iterator it)
 
 let print id ?(pp_sep = Format.pp_print_cut) pp_row ppf table =
   let first = ref true in

--- a/middle_end/flambda2/datalog/table.mli
+++ b/middle_end/flambda2/datalog/table.mli
@@ -58,7 +58,10 @@ module Id : sig
     ('t, 'k, 'v) t
 
   val create_iterator :
-    ('t, 'k, 'v) t -> 't ref * 'k Trie.Iterator.hlist with_names * 'v ref
+    ('t, 'k, 'v) t ->
+    't Leapfrog.sender
+    * 'k Trie.Iterator.hlist with_names
+    * 'v Leapfrog.receiver
 end
 
 module Map : sig

--- a/middle_end/flambda2/datalog/table.mli
+++ b/middle_end/flambda2/datalog/table.mli
@@ -59,9 +59,9 @@ module Id : sig
 
   val create_iterator :
     ('t, 'k, 'v) t ->
-    't Leapfrog.sender
+    't Channel.sender
     * 'k Trie.Iterator.hlist with_names
-    * 'v Leapfrog.receiver
+    * 'v Channel.receiver
 end
 
 module Map : sig

--- a/middle_end/flambda2/datalog/table.mli
+++ b/middle_end/flambda2/datalog/table.mli
@@ -59,9 +59,7 @@ module Id : sig
 
   val create_iterator :
     ('t, 'k, 'v) t ->
-    't Channel.sender
-    * 'k Trie.Iterator.hlist with_names
-    * 'v Channel.receiver
+    't Channel.sender * 'k Trie.Iterator.hlist with_names * 'v Channel.receiver
 end
 
 module Map : sig

--- a/middle_end/flambda2/datalog/trie.ml
+++ b/middle_end/flambda2/datalog/trie.ml
@@ -121,12 +121,12 @@ module Iterator = struct
 
   let rec create :
       type m k v.
-      (m, k, v) is_trie -> m Leapfrog.receiver -> v Leapfrog.sender -> k hlist =
+      (m, k, v) is_trie -> m Channel.receiver -> v Channel.sender -> k hlist =
    fun is_trie this_ref value_handler ->
     match is_trie with
     | Map_is_trie -> [create_iterator this_ref value_handler]
     | Nested_trie next_trie ->
-      let send_next, recv_next = Leapfrog.channel (empty next_trie) in
+      let send_next, recv_next = Channel.create (empty next_trie) in
       create_iterator this_ref send_next
       :: create next_trie recv_next value_handler
 

--- a/middle_end/flambda2/datalog/trie.ml
+++ b/middle_end/flambda2/datalog/trie.ml
@@ -119,14 +119,16 @@ module Iterator = struct
 
   let create_iterator = create
 
-  let rec create : type m k v. (m, k, v) is_trie -> m ref -> v ref -> k hlist =
+  let rec create :
+      type m k v.
+      (m, k, v) is_trie -> m Leapfrog.receiver -> v Leapfrog.sender -> k hlist =
    fun is_trie this_ref value_handler ->
     match is_trie with
     | Map_is_trie -> [create_iterator this_ref value_handler]
     | Nested_trie next_trie ->
-      let next_ref = ref (empty next_trie) in
-      create_iterator this_ref next_ref
-      :: create next_trie next_ref value_handler
+      let send_next, recv_next = Leapfrog.channel (empty next_trie) in
+      create_iterator this_ref send_next
+      :: create next_trie recv_next value_handler
 
   let create is_trie this_ref value_handler =
     create is_trie this_ref value_handler

--- a/middle_end/flambda2/datalog/trie.mli
+++ b/middle_end/flambda2/datalog/trie.mli
@@ -59,5 +59,9 @@ module Iterator : sig
       The [output] reference is set to the corresponding value when [accept] is
       called on the last iterator.
   *)
-  val create : ('m, 'k, 'v) is_trie -> 'm ref -> 'v ref -> 'k hlist
+  val create :
+    ('m, 'k, 'v) is_trie ->
+    'm Leapfrog.receiver ->
+    'v Leapfrog.sender ->
+    'k hlist
 end

--- a/middle_end/flambda2/datalog/trie.mli
+++ b/middle_end/flambda2/datalog/trie.mli
@@ -60,8 +60,5 @@ module Iterator : sig
       called on the last iterator.
   *)
   val create :
-    ('m, 'k, 'v) is_trie ->
-    'm Channel.receiver ->
-    'v Channel.sender ->
-    'k hlist
+    ('m, 'k, 'v) is_trie -> 'm Channel.receiver -> 'v Channel.sender -> 'k hlist
 end

--- a/middle_end/flambda2/datalog/trie.mli
+++ b/middle_end/flambda2/datalog/trie.mli
@@ -61,7 +61,7 @@ module Iterator : sig
   *)
   val create :
     ('m, 'k, 'v) is_trie ->
-    'm Leapfrog.receiver ->
-    'v Leapfrog.sender ->
+    'm Channel.receiver ->
+    'v Channel.sender ->
     'k hlist
 end

--- a/middle_end/flambda2/datalog/virtual_machine.ml
+++ b/middle_end/flambda2/datalog/virtual_machine.ml
@@ -28,7 +28,10 @@ struct
   type 's stack =
     | Stack_nil : nil stack
     | Stack_cons :
-        'a Iterator.t * 'a option ref * ('a -> 's) continuation * 's stack
+        'a Iterator.t
+        * 'a option Leapfrog.sender
+        * ('a -> 's) continuation
+        * 's stack
         -> ('a -> 's) stack
 
   and 's continuation = 's stack -> unit
@@ -38,11 +41,15 @@ struct
     | Up : ('x, 's) instruction -> ('x, 'a -> 's) instruction
     | Dispatch : ('a, 'b -> 's) instruction
     | Seek :
-        'b option ref * 'b Iterator.t * ('a, 's) instruction * string * string
+        'b option Leapfrog.receiver
+        * 'b Iterator.t
+        * ('a, 's) instruction
+        * string
+        * string
         -> ('a, 's) instruction
     | Open :
         'b Iterator.t
-        * 'b option ref
+        * 'b option Leapfrog.sender
         * ('a, 'b -> 's) instruction
         * ('a, 'b -> 's) instruction
         * string
@@ -51,7 +58,7 @@ struct
     | Action : 'a * ('a, 's) instruction -> ('a, 's) instruction
     | Call :
         ('b Constant.hlist -> unit)
-        * 'b Option_ref.hlist
+        * 'b Option_receiver.hlist
         * ('a, 's) instruction
         * string
         * string list
@@ -121,7 +128,7 @@ struct
     match Iterator.current iterator with
     | Some current_key ->
       Iterator.accept iterator;
-      cell.contents <- Some current_key;
+      Leapfrog.send cell (Some current_key);
       level stack
     | None -> advance next_stack
 
@@ -147,7 +154,7 @@ struct
         Iterator.init iterator;
         execute k (Stack_cons (iterator, cell, execute for_each, stack))
       | Seek (key_ref, iterator, k, _key_ref_name, _iterator_name) -> (
-        let key = Option.get !key_ref in
+        let key = Option.get (Leapfrog.recv key_ref) in
         Iterator.init iterator;
         Iterator.seek iterator key;
         match Iterator.current iterator with
@@ -161,7 +168,7 @@ struct
         | Accept -> execute k stack
         | Skip -> advance stack)
       | Call (f, rs, k, _name, _names) ->
-        f (Option_ref.get rs);
+        f (Option_receiver.recv rs);
         execute k stack
     in
     execute instruction
@@ -186,11 +193,17 @@ struct
 
   let call f ~name y k = Call (f, y.values, k, name, y.names)
 
-  let rec refs : type s. s Iterator.hlist -> s Option_ref.hlist = function
-    | [] -> []
-    | _ :: iterators -> ref None :: refs iterators
+  let rec channels :
+      type s.
+      s Iterator.hlist -> s Option_sender.hlist * s Option_receiver.hlist =
+    function
+    | [] -> [], []
+    | _ :: iterators ->
+      let send, recv = Leapfrog.channel None in
+      let senders, receivers = channels iterators in
+      send :: senders, recv :: receivers
 
-  type erev = Erev : 's Iterator.hlist * 's Option_ref.hlist -> erev
+  type erev = Erev : 's Iterator.hlist * 's Option_sender.hlist -> erev
 
   let iterate :
       type a.
@@ -201,7 +214,7 @@ struct
     let iterator_names = iterators.names in
     let iterators = iterators.values in
     let rec rev0 :
-        type s. s Iterator.hlist -> s Option_ref.hlist -> erev -> erev =
+        type s. s Iterator.hlist -> s Option_sender.hlist -> erev -> erev =
      fun iterators refs acc ->
       match iterators, refs with
       | [], [] -> acc
@@ -209,12 +222,14 @@ struct
         let (Erev (rev_iterators, rev_refs)) = acc in
         rev0 iterators refs (Erev (iterator :: rev_iterators, r :: rev_refs))
     in
-    let rs = refs iterators in
-    let (Erev (rev_iterators, rev_refs)) = rev0 iterators rs (Erev ([], [])) in
+    let senders, receivers = channels iterators in
+    let (Erev (rev_iterators, rev_refs)) =
+      rev0 iterators senders (Erev ([], []))
+    in
     let rec loop :
         type s a.
         (a -> s) Iterator.hlist ->
-        (a -> s) Option_ref.hlist ->
+        (a -> s) Option_sender.hlist ->
         (_, a -> s) instruction ->
         string list ->
         (_, nil) instruction =
@@ -236,7 +251,9 @@ struct
     | _ :: _ ->
       loop rev_iterators rev_refs
         (call f ~name:"yield"
-           { values = rs; names = List.map (fun _ -> "_") iterator_names }
+           { values = receivers;
+             names = List.map (fun _ -> "_") iterator_names
+           }
            advance)
         (List.rev iterator_names)
 

--- a/middle_end/flambda2/datalog/virtual_machine.ml
+++ b/middle_end/flambda2/datalog/virtual_machine.ml
@@ -29,7 +29,7 @@ struct
     | Stack_nil : nil stack
     | Stack_cons :
         'a Iterator.t
-        * 'a option Leapfrog.sender
+        * 'a option Channel.sender
         * ('a -> 's) continuation
         * 's stack
         -> ('a -> 's) stack
@@ -41,7 +41,7 @@ struct
     | Up : ('x, 's) instruction -> ('x, 'a -> 's) instruction
     | Dispatch : ('a, 'b -> 's) instruction
     | Seek :
-        'b option Leapfrog.receiver
+        'b option Channel.receiver
         * 'b Iterator.t
         * ('a, 's) instruction
         * string
@@ -49,7 +49,7 @@ struct
         -> ('a, 's) instruction
     | Open :
         'b Iterator.t
-        * 'b option Leapfrog.sender
+        * 'b option Channel.sender
         * ('a, 'b -> 's) instruction
         * ('a, 'b -> 's) instruction
         * string
@@ -128,7 +128,7 @@ struct
     match Iterator.current iterator with
     | Some current_key ->
       Iterator.accept iterator;
-      Leapfrog.send cell (Some current_key);
+      Channel.send cell (Some current_key);
       level stack
     | None -> advance next_stack
 
@@ -154,7 +154,7 @@ struct
         Iterator.init iterator;
         execute k (Stack_cons (iterator, cell, execute for_each, stack))
       | Seek (key_ref, iterator, k, _key_ref_name, _iterator_name) -> (
-        let key = Option.get (Leapfrog.recv key_ref) in
+        let key = Option.get (Channel.recv key_ref) in
         Iterator.init iterator;
         Iterator.seek iterator key;
         match Iterator.current iterator with
@@ -199,7 +199,7 @@ struct
     function
     | [] -> [], []
     | _ :: iterators ->
-      let send, recv = Leapfrog.channel None in
+      let send, recv = Channel.create None in
       let senders, receivers = channels iterators in
       send :: senders, recv :: receivers
 

--- a/middle_end/flambda2/datalog/virtual_machine.mli
+++ b/middle_end/flambda2/datalog/virtual_machine.mli
@@ -85,7 +85,7 @@ end) : sig
   val dispatch : ('a, _ -> 's) instruction
 
   val seek :
-    'a option Leapfrog.receiver with_name ->
+    'a option Channel.receiver with_name ->
     'a Iterator.t with_name ->
     ('b, 's) instruction ->
     ('b, 's) instruction
@@ -102,7 +102,7 @@ end) : sig
   *)
   val open_ :
     'i Iterator.t with_name ->
-    'i option Leapfrog.sender with_name ->
+    'i option Channel.sender with_name ->
     ('a, 'i -> 's) instruction ->
     ('a, 'i -> 's) instruction ->
     ('a, 's) instruction

--- a/middle_end/flambda2/datalog/virtual_machine.mli
+++ b/middle_end/flambda2/datalog/virtual_machine.mli
@@ -85,7 +85,7 @@ end) : sig
   val dispatch : ('a, _ -> 's) instruction
 
   val seek :
-    'a option ref with_name ->
+    'a option Leapfrog.receiver with_name ->
     'a Iterator.t with_name ->
     ('b, 's) instruction ->
     ('b, 's) instruction
@@ -102,7 +102,7 @@ end) : sig
   *)
   val open_ :
     'i Iterator.t with_name ->
-    'i option ref with_name ->
+    'i option Leapfrog.sender with_name ->
     ('a, 'i -> 's) instruction ->
     ('a, 'i -> 's) instruction ->
     ('a, 's) instruction
@@ -122,7 +122,7 @@ end) : sig
   val call :
     ('a Constant.hlist -> unit) ->
     name:string ->
-    'a Option_ref.hlist with_names ->
+    'a Option_receiver.hlist with_names ->
     ('x, 's) instruction ->
     ('x, 's) instruction
 


### PR DESCRIPTION
The datalog engine is using `ref`s to communicate values during iteration of a rule or query. These values are effectively used strictly as single-producer multi-consumer bounded channels: either we are computing the next value from an iterator, or we are using the current value in an expression.

This patch introduces distinct `sender` (can only be written to) and `receiver` (can only be read from) types that are both implemented by the same underlying reference, but documents (and enforces) whether a particular use is intended for writing or for reading.