### PR TITLE
Accept `caml_simd` names for f64 min/max on amd64

### DIFF
--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -128,8 +128,8 @@ let select_operation_sse op args =
 let select_operation_sse2 op args =
   match op with
   | "caml_sse2_float64_sqrt" | "sqrt" -> instr sqrtsd args
-  | "caml_sse2_float64_max" -> instr maxsd args
-  | "caml_sse2_float64_min" -> instr minsd args
+  | "caml_simd_float64_max" | "caml_sse2_float64_max" -> instr maxsd args
+  | "caml_simd_float64_min" | "caml_sse2_float64_min" -> instr minsd args
   | "caml_sse2_cast_float64_int64" -> instr cvtsd2si_r64_Xm64 args
   | "caml_sse2_float64x2_sqrt" -> instr sqrtpd args
   | "caml_sse2_int8x16_add" -> instr paddb args


### PR DESCRIPTION
We need to update `ocaml_intrinsics_kernel` to use the non-platform-specific float64 min/max intrinsics, but the amd64 backend doesn't accept them.