### PR TITLE
Emit correct `FMOV` for arm64 popcnt sequence

### DIFF
--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1687,7 +1687,7 @@ let emit_instr i =
       DSL.ins I.FMOV [| Arm64_ast.DSL.reg_d tmp; DSL.emit_reg i.arg.(0) |];
       DSL.ins I.CNT [| tmp_v8b; tmp_v8b |];
       DSL.ins I.ADDV [| Arm64_ast.DSL.reg_b tmp; tmp_v8b |];
-      DSL.ins I.FMOV [| DSL.emit_reg i.res.(0); Arm64_ast.DSL.reg_s tmp |]
+      DSL.ins I.FMOV [| DSL.emit_reg i.res.(0); Arm64_ast.DSL.reg_d tmp |]
   | Lop (Intop (Ictz _)) ->
     (* [ctz Rd, Rn] is optionally supported from Armv8.7, but rbit and clz are
        supported in all ARMv8 CPUs. *)


### PR DESCRIPTION
`FMOV` doesn't strictly allow single-precision fp <-> 64-bit int register moves. Updates the instruction to copy double->int64 instead. (This caused ocaml_intrinsics_kernel to not build on macOS arm64)