### PR TITLE
Revert "Don't install `VERSION`"

### DIFF
--- a/dune
+++ b/dune
@@ -400,7 +400,8 @@
  (files
   Makefile.build_config
   Makefile.config_if_required
-  Makefile.config)
+  Makefile.config
+  VERSION)
  (section lib)
  (package ocaml))
 


### PR DESCRIPTION
Reverting this for a while, as we need to make some build rule changes first.

Reverts oxcaml/oxcaml#4127