### PR TITLE
Optimize if-then-else when condition uses boolean operations

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -934,8 +934,8 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
   | Lifthenelse (cond, ifso, ifnot, kind) ->
     let loc = L.try_to_find_location cond in
     let lam =
-      Lambda_to_lambda_transforms.switch_for_if_then_else ~loc ~cond ~ifso ~ifnot
-        ~kind
+      Lambda_to_lambda_transforms.switch_for_if_then_else ~loc ~cond ~ifso
+        ~ifnot ~kind
     in
     cps acc env ccenv lam k k_exn
   | Lsequence (lam1, lam2) ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -932,8 +932,9 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
                       (get_unarized_vars body_result env)))
               ~handler:(handler k)))
   | Lifthenelse (cond, ifso, ifnot, kind) ->
+    let loc = L.try_to_find_location cond in
     let lam =
-      Lambda_to_lambda_transforms.switch_for_if_then_else ~cond ~ifso ~ifnot
+      Lambda_to_lambda_transforms.switch_for_if_then_else ~loc ~cond ~ifso ~ifnot
         ~kind
     in
     cps acc env ccenv lam k k_exn

--- a/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
@@ -49,34 +49,60 @@ let share_expr ~kind ~expr k =
     | _ -> false
   in
   match[@warning "-4"] (expr : L.lambda) with
+  | _ when is_simple_duplicable expr -> k expr
   | Lstaticraise (_, args) when List.for_all is_simple_duplicable args -> k expr
   | _ ->
     let cont = L.next_raise_count () in
     let jump = L.Lstaticraise (cont, []) in
     L.Lstaticcatch (k jump, (cont, []), expr, Same_region, kind)
 
-let optimize_boolean_sequop ~cond ~ifso ~ifnot ~kind =
-  let rec aux ~kind ~cond ~ifso ~ifnot =
+let switch_for_if_then_else ~loc ~cond ~ifso ~ifnot ~kind =
+  let rec aux ~loc ~kind ~cond ~ifso ~ifnot =
+    match[@warning "-4"] ifso, ifnot with
+    | L.Lconst (Const_base (Const_int 1)),
+      L.Lconst (Const_base (Const_int 0)) -> cond
+    | L.Lconst (Const_base (Const_int 0)),
+      L.Lconst (Const_base (Const_int 1)) ->
+        L.Lprim (Pnot, [cond], loc)
+    | _ -> begin
     match[@warning "-4"] cond with
+    | L.Lconst (Const_base (Const_int 1)) -> ifso
+    | L.Lconst (Const_base (Const_int 0)) -> ifnot
     (* CR gbury: should we try to use the locs here, or is it better to keep
        using the locs from each individual condition ? *)
-    | L.Lprim (Psequand, [a; b], _loc) ->
-      share_expr ~kind ~expr:(aux ~kind ~cond:b ~ifso ~ifnot) (fun ifso ->
-          aux ~kind ~cond:a ~ifso ~ifnot)
-    | L.Lprim (Psequor, [a; b], _loc) ->
-      share_expr ~kind ~expr:(aux ~kind ~cond:b ~ifso ~ifnot) (fun ifnot ->
-          aux ~kind ~cond:a ~ifso ~ifnot)
-    | L.Lprim (Pnot, [c], _loc) -> aux ~kind ~cond:c ~ifso:ifnot ~ifnot:ifso
+    | L.Lprim (Psequand, [a; b], loc)
+      ->
+      share_expr ~kind ~expr:(aux ~loc ~kind ~cond:b ~ifso ~ifnot) (fun ifso ->
+          aux ~loc ~kind ~cond:a ~ifso ~ifnot)
+    | L.Lifthenelse (a, b, Lconst (Const_base (Const_int 0)), _)
+      ->
+      share_expr ~kind ~expr:(aux ~loc ~kind ~cond:b ~ifso ~ifnot) (fun ifso ->
+          aux ~loc ~kind ~cond:a ~ifso ~ifnot)
+    | L.Lprim (Psequor, [a; b], loc)
+      ->
+      share_expr ~kind ~expr:(aux ~loc ~kind ~cond:b ~ifso ~ifnot) (fun ifnot ->
+          aux ~loc ~kind ~cond:a ~ifso ~ifnot)
+    | L.Lifthenelse (a, Lconst (Const_base (Const_int 1)), b, _)
+      ->
+      share_expr ~kind ~expr:(aux ~loc ~kind ~cond:b ~ifso ~ifnot) (fun ifnot ->
+          aux ~loc ~kind ~cond:a ~ifso ~ifnot)
+    | L.Lprim (Pnot, [c], loc) -> aux ~loc ~kind ~cond:c ~ifso:ifnot ~ifnot:ifso
+    | L.Lifthenelse (cond, inner_ifso, inner_ifnot, _) ->
+        share_expr ~kind ~expr:(aux ~loc ~kind ~cond:inner_ifso ~ifso ~ifnot) (fun new_ifso ->
+            share_expr ~kind ~expr:(aux ~loc ~kind ~cond:inner_ifnot ~ifso ~ifnot) (fun new_ifnot ->
+                aux ~loc ~kind ~cond ~ifso:new_ifso ~ifnot:new_ifnot))
     | _ -> mk_switch ~cond ~ifso ~ifnot ~kind
+  end
   in
-  share_expr ~kind ~expr:ifso (fun ifso ->
-      share_expr ~kind ~expr:ifnot (fun ifnot -> aux ~kind ~cond ~ifso ~ifnot))
-
-let switch_for_if_then_else ~cond ~ifso ~ifnot ~kind =
-  match[@warning "-4"] cond with
-  | L.Lprim ((Psequand | Psequor | Pnot), _, _) ->
-    optimize_boolean_sequop ~cond ~ifso ~ifnot ~kind
-  | _ -> mk_switch ~cond ~ifso ~ifnot ~kind
+  let res =
+    share_expr ~kind ~expr:ifso (fun ifso ->
+        share_expr ~kind ~expr:ifnot (fun ifnot -> aux ~loc ~kind ~cond ~ifso ~ifnot))
+      in
+  if Flambda_features.debug_flambda2 () then
+    Format.eprintf "SWITCH:@\n%a@\n->@\n%a@\n@."
+      Printlambda.lambda (L.Lifthenelse(cond,ifso,ifnot,kind))
+      Printlambda.lambda res;
+  res
 
 let rec_catch_for_while_loop env cond body =
   let cont = L.next_raise_count () in
@@ -668,12 +694,12 @@ let transform_primitive0 env (prim : L.primitive) args loc =
   | Psequor, [a; b] ->
     let const_true = L.Lconst (Const_base (Const_int 1)) in
     Transformed
-      (switch_for_if_then_else ~cond:a ~ifso:const_true ~ifnot:b
+      (switch_for_if_then_else ~loc ~cond:a ~ifso:const_true ~ifnot:b
          ~kind:Lambda.layout_int)
   | Psequand, [a; b] ->
     let const_false = L.Lconst (Const_base (Const_int 0)) in
     Transformed
-      (switch_for_if_then_else ~cond:a ~ifso:b ~ifnot:const_false
+      (switch_for_if_then_else ~loc ~cond:a ~ifso:b ~ifnot:const_false
          ~kind:Lambda.layout_int)
   | (Psequand | Psequor), _ ->
     Misc.fatal_error "Psequand / Psequor must have exactly two arguments"

--- a/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
@@ -43,7 +43,7 @@ let optimize_boolean_sequop ~cond ~ifso ~ifnot ~kind =
     (* CR gbury: should we try to use the locs here, or is it better to keep
        using the locs from each individual condition ? *)
     | L.Lprim (Psequand, [a; b], _loc) ->
-      aux ~cond:a ~ifnot ~ifso:(aux ~cond:b ~ifso ~ifnot)
+      aux ~cond:a ~ifso:(aux ~cond:b ~ifso ~ifnot) ~ifnot
     | L.Lprim (Psequor, [a; b], _loc) ->
       aux ~cond:a ~ifso ~ifnot:(aux ~cond:b ~ifso ~ifnot)
     | L.Lprim (Pnot, [c], _loc) -> aux ~cond:c ~ifso:ifnot ~ifnot:ifso

--- a/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
@@ -54,40 +54,38 @@ let share_expr ~kind ~expr k =
 
 let switch_for_if_then_else ~loc ~cond ~ifso ~ifnot ~kind =
   let rec aux ~loc ~kind ~cond ~ifso ~ifnot =
-    match[@warning "-4"] ifso, ifnot with
-    | L.Lconst (Const_base (Const_int 1)), L.Lconst (Const_base (Const_int 0))
-      ->
-      cond
-    | L.Lconst (Const_base (Const_int 0)), L.Lconst (Const_base (Const_int 1))
-      ->
-      L.Lprim (Pnot, [cond], loc)
+    match[@warning "-4"] cond with
+    | L.Lconst (Const_base (Const_int 1)) -> ifso
+    | L.Lconst (Const_base (Const_int 0)) -> ifnot
+    (* CR gbury: should we try to use the locs here, or is it better to keep
+       using the locs from each individual condition ? *)
+    | L.Lprim (Psequand, [a; b], loc) ->
+      share_expr ~kind ~expr:(aux ~loc ~kind ~cond:b ~ifso ~ifnot) (fun ifso ->
+          aux ~loc ~kind ~cond:a ~ifso ~ifnot)
+    | L.Lifthenelse (a, b, Lconst (Const_base (Const_int 0)), _) ->
+      share_expr ~kind ~expr:(aux ~loc ~kind ~cond:b ~ifso ~ifnot) (fun ifso ->
+          aux ~loc ~kind ~cond:a ~ifso ~ifnot)
+    | L.Lprim (Psequor, [a; b], loc) ->
+      share_expr ~kind ~expr:(aux ~loc ~kind ~cond:b ~ifso ~ifnot) (fun ifnot ->
+          aux ~loc ~kind ~cond:a ~ifso ~ifnot)
+    | L.Lifthenelse (a, Lconst (Const_base (Const_int 1)), b, _) ->
+      share_expr ~kind ~expr:(aux ~loc ~kind ~cond:b ~ifso ~ifnot) (fun ifnot ->
+          aux ~loc ~kind ~cond:a ~ifso ~ifnot)
+    | L.Lprim (Pnot, [c], loc) -> aux ~loc ~kind ~cond:c ~ifso:ifnot ~ifnot:ifso
+    | L.Lifthenelse (cond, inner_ifso, inner_ifnot, _) ->
+      share_expr ~kind ~expr:(aux ~loc ~kind ~cond:inner_ifso ~ifso ~ifnot)
+        (fun new_ifso ->
+          share_expr ~kind ~expr:(aux ~loc ~kind ~cond:inner_ifnot ~ifso ~ifnot)
+            (fun new_ifnot ->
+              aux ~loc ~kind ~cond ~ifso:new_ifso ~ifnot:new_ifnot))
     | _ -> (
-      match[@warning "-4"] cond with
-      | L.Lconst (Const_base (Const_int 1)) -> ifso
-      | L.Lconst (Const_base (Const_int 0)) -> ifnot
-      (* CR gbury: should we try to use the locs here, or is it better to keep
-         using the locs from each individual condition ? *)
-      | L.Lprim (Psequand, [a; b], loc) ->
-        share_expr ~kind ~expr:(aux ~loc ~kind ~cond:b ~ifso ~ifnot)
-          (fun ifso -> aux ~loc ~kind ~cond:a ~ifso ~ifnot)
-      | L.Lifthenelse (a, b, Lconst (Const_base (Const_int 0)), _) ->
-        share_expr ~kind ~expr:(aux ~loc ~kind ~cond:b ~ifso ~ifnot)
-          (fun ifso -> aux ~loc ~kind ~cond:a ~ifso ~ifnot)
-      | L.Lprim (Psequor, [a; b], loc) ->
-        share_expr ~kind ~expr:(aux ~loc ~kind ~cond:b ~ifso ~ifnot)
-          (fun ifnot -> aux ~loc ~kind ~cond:a ~ifso ~ifnot)
-      | L.Lifthenelse (a, Lconst (Const_base (Const_int 1)), b, _) ->
-        share_expr ~kind ~expr:(aux ~loc ~kind ~cond:b ~ifso ~ifnot)
-          (fun ifnot -> aux ~loc ~kind ~cond:a ~ifso ~ifnot)
-      | L.Lprim (Pnot, [c], loc) ->
-        aux ~loc ~kind ~cond:c ~ifso:ifnot ~ifnot:ifso
-      | L.Lifthenelse (cond, inner_ifso, inner_ifnot, _) ->
-        share_expr ~kind ~expr:(aux ~loc ~kind ~cond:inner_ifso ~ifso ~ifnot)
-          (fun new_ifso ->
-            share_expr ~kind
-              ~expr:(aux ~loc ~kind ~cond:inner_ifnot ~ifso ~ifnot)
-              (fun new_ifnot ->
-                aux ~loc ~kind ~cond ~ifso:new_ifso ~ifnot:new_ifnot))
+      match[@warning "-4"] ifso, ifnot with
+      | L.Lconst (Const_base (Const_int 1)), L.Lconst (Const_base (Const_int 0))
+        ->
+        cond
+      | L.Lconst (Const_base (Const_int 0)), L.Lconst (Const_base (Const_int 1))
+        ->
+        L.Lprim (Pnot, [cond], loc)
       | _ -> mk_switch ~cond ~ifso ~ifnot ~kind)
   in
   let res =

--- a/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
@@ -37,11 +37,7 @@ let mk_switch ~cond ~ifso ~ifnot ~kind =
    generated code. Currently, this is only used for if-then-else optimization,
    which guarantees that even if expressions are duplicated, they are still only
    evaluated once (but could have been duplicated among multiple code paths), so
-   this is for code size optimization mainly.
-
-   One could want to duplicate constants, however the backend does not
-   deduplicate them, especially when they are the return value of the function,
-   so for now constants returned are shared via a static catch/raise. *)
+   this is for code size optimization mainly. *)
 let share_expr ~kind ~expr k =
   let is_simple_duplicable expr =
     match[@warning "-4"] (expr : L.lambda) with

--- a/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
@@ -45,7 +45,7 @@ let mk_switch ~cond ~ifso ~ifnot ~kind =
 let bind_expr ~kind ~expr k =
   let is_simple_duplicable expr =
     match[@warning "-4"] (expr : L.lambda) with
-    | Lvar _ | Lmutvar _ | Lconst _ -> true
+    | Lvar _ | Lconst _ -> true
     | _ -> false
   in
   match[@warning "-4"] (expr : L.lambda) with
@@ -77,10 +77,7 @@ let optimize_boolean_sequop ~cond ~ifso ~ifnot ~kind =
 let switch_for_if_then_else ~cond ~ifso ~ifnot ~kind =
   match[@warning "-4"] cond with
   | L.Lprim ((Psequand | Psequor | Pnot), _, _) ->
-    let res = optimize_boolean_sequop ~cond ~ifso ~ifnot ~kind in
-    if Flambda_features.debug_flambda2 ()
-    then Format.eprintf "SWITCH: %a@\n@." Printlambda.lambda res;
-    res
+    optimize_boolean_sequop ~cond ~ifso ~ifnot ~kind
   | _ -> mk_switch ~cond ~ifso ~ifnot ~kind
 
 let rec_catch_for_while_loop env cond body =

--- a/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
@@ -666,7 +666,7 @@ let arrayblit env ~src_mutability ~(dst_array_set_kind : L.array_set_kind) args
 let transform_primitive0 env (prim : L.primitive) args loc =
   match prim, args with
   (* For Psequor and Psequand, earlier passes (notably for region handling)
-     assume that if [b] is in tail-position, so we must keep it so. *)
+     assume that [b] is in tail-position, so we must keep it so. *)
   | Psequor, [a; b] ->
     let const_true = L.Lconst (Const_base (Const_int 1)) in
     Transformed

--- a/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.mli
@@ -36,6 +36,7 @@ val rec_catch_for_for_loop :
   Lambda_to_flambda_env.t * Lambda.lambda
 
 val switch_for_if_then_else :
+  loc:Lambda.scoped_location ->
   cond:Lambda.lambda ->
   ifso:Lambda.lambda ->
   ifnot:Lambda.lambda ->


### PR DESCRIPTION
This PR optimizes the translation from lambda to flambda of if-then-elses whose condition is a sequential boolean operator.

This optimizes code such as the following:
```ocaml
let foo (x : int) (y : int) (z : int) =
  if x < y && y < z then 42 else 0
```