### PR TITLE
Remove patch application from CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,7 +241,6 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       working-directory: ocaml-414
       run: |
-        patch -p1 < $GITHUB_WORKSPACE/oxcaml/arm64-issue-debug-upstream.patch
         ./configure --prefix=$GITHUB_WORKSPACE/ocaml-414/_install
         make -j $J world.opt
         make install


### PR DESCRIPTION
In https://github.com/oxcaml/oxcaml/pull/4114, I removed the patch file,
but forgot to remove its application
from the CI job.