### PR TITLE
Refactor CI regalloc jobs.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,12 +60,6 @@ jobs:
             build_ocamlparam: ''
             ocamlparam: '_,O3=1'
 
-          - name: flambda2_o3_heap
-            config: --enable-middle-end=flambda2 --disable-stack-allocation
-            os: ubuntu-latest
-            build_ocamlparam: ''
-            ocamlparam: '_,O3=1'
-
           - name: flambda2_frame_pointers_oclassic_polling
             config: --enable-middle-end=flambda2 --enable-frame-pointers --enable-poll-insertion --enable-flambda-invariants
             os: ubuntu-latest


### PR DESCRIPTION
This pull request is refactoring the regalloc-related
CI jobs, to try and save some time.

Since we now have a `regalloc.exe` tool able to run
only the register allocation passes from artifacts, we
can factor out jobs testing IRC, Linscan, and Greedy
on a similar configuration. This is done through a
new optional CI step, which simply runs all 3 allocators
on the saved artifacts.

It is not the exact same thing as running a complete
build, because it will by definition not exercise the
consequences of register allocation on later passes.
However, it feels like a reasonable  compromise.
I have also not maintained a strict 1:1 of CI jobs
(in part because I think some were leftovers of a
debugging session). At the time of writing, the
refactoring deletes 6 CI jobs.

(Currently using the `-debug-output` only to manually
check that some work is indeed happening in the
new CI step.)