### PR TITLE
Take specialization into account in shortcuts

### DIFF
--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -753,27 +753,28 @@ let rewrite_exn_continuation = Apply_cont_rewrite.rewrite_exn_continuation
 let rewrite_fixed_arity_continuation0 uacc cont_or_apply_cont ~use_id arity :
     rewrite_fixed_arity_continuation0_result =
   let uenv = UA.uenv uacc in
-  let cont =
-    match cont_or_apply_cont with
-    | Continuation cont -> cont
-    | Apply_cont apply_cont -> Apply_cont.continuation apply_cont
+  let specialize_if_needed cont =
+    try Continuation_callsite_map.find cont use_id (UA.specialization_map uacc)
+    with Not_found -> cont
   in
-  let cont =
-    match
-      Continuation_callsite_map.find cont use_id (UA.specialization_map uacc)
-    with
-    | exception Not_found -> cont
-    | specialized -> specialized
+  let cont, cont_or_apply_cont =
+    match cont_or_apply_cont with
+    | Continuation cont ->
+      let cont = specialize_if_needed cont in
+      cont, Continuation cont
+    | Apply_cont apply_cont ->
+      let cont = specialize_if_needed (Apply_cont.continuation apply_cont) in
+      let apply_cont = Apply_cont.with_continuation apply_cont cont in
+      cont, Apply_cont apply_cont
   in
   let[@local] shortcut_this_continuation_if_possible () :
       rewrite_fixed_arity_continuation0_result =
     (* Apply the shortcut if we can, but not if we are rewriting a
        [Continuation] since we would need to introduce a new wrapper anyway. *)
     match cont_or_apply_cont with
-    (* We must be careful to use the specialized continuation *)
-    | Continuation _ -> This_continuation (apply_continuation_aliases uenv cont)
+    | Continuation cont ->
+      This_continuation (apply_continuation_aliases uenv cont)
     | Apply_cont apply_cont ->
-      let apply_cont = Apply_cont.with_continuation apply_cont cont in
       Apply_cont (apply_continuation_shortcuts uenv apply_cont)
   in
   match UE.find_apply_cont_rewrite uenv cont with


### PR DESCRIPTION
The shortcuting code "forgets" any specialization if/when it triggers and there are no rewrites (or an empty rewrite). This was unfortunately missed when i reviewed the shortcut PR, and this PR fixes that.