### PR TITLE
Disable the "for all or none" check for variable quantification

### DIFF
--- a/testsuite/tests/typing-misc/optbinders.ml
+++ b/testsuite/tests/typing-misc/optbinders.ml
@@ -58,10 +58,7 @@ module type F2 = sig
   val four : 'a 'b 'd . 'a -> 'b -> 'c -> 'd -> 'a * 'b * 'c * 'd
 end
 [%%expect{|
-Line 2, characters 36-38:
-2 |   val four : 'a 'b 'd . 'a -> 'b -> 'c -> 'd -> 'a * 'b * 'c * 'd
-                                        ^^
-Error: The type variable "'c" is unbound in this type declaration.
+module type F2 = sig val four : 'a -> 'b -> 'c -> 'd -> 'a * 'b * 'c * 'd end
 |}]
 
 

--- a/testsuite/tests/typing-misc/variable_quantification_check.ml
+++ b/testsuite/tests/typing-misc/variable_quantification_check.ml
@@ -1,0 +1,19 @@
+(* TEST
+ expect;
+*)
+
+module type Test1 = sig
+    val unbound_variable : 'a . 'a -> 'b
+end
+
+[%%expect{|
+module type Test1 = sig val unbound_variable : 'a -> 'b end
+|}]
+
+module type Test2 = sig
+    val wildcard : 'a . _ option -> 'a
+end
+
+[%%expect{|
+module type Test2 = sig val wildcard : 'b option -> 'a end
+|}]

--- a/testsuite/tests/typing-misc/variable_quantification_check_upstream.ml
+++ b/testsuite/tests/typing-misc/variable_quantification_check_upstream.ml
@@ -25,4 +25,6 @@ Line 2, characters 24-25:
 2 |     val wildcard : 'a . _ option -> 'a
                             ^
 Error: A type wildcard "_" is not allowed in this type declaration.
+Hint: Explicit quantification requires quantifying all type variables for compatibility with upstream OCaml.
+Enable non-erasable extensions to disable this check.
 |}]

--- a/testsuite/tests/typing-misc/variable_quantification_check_upstream.ml
+++ b/testsuite/tests/typing-misc/variable_quantification_check_upstream.ml
@@ -1,0 +1,28 @@
+(* TEST
+ flags = "-extension-universe upstream_compatible";
+ expect;
+*)
+
+module type Test1 = sig
+    val unbound_variable : 'a . 'a -> 'b
+end
+
+[%%expect{|
+Line 2, characters 38-40:
+2 |     val unbound_variable : 'a . 'a -> 'b
+                                          ^^
+Error: The type variable "'b" is unbound in this type declaration.
+Hint: Explicit quantification requires quantifying all type variables for compatibility with upstream OCaml.
+Enable non-erasable extensions to disable this check.
+|}]
+
+module type Test2 = sig
+    val wildcard : 'a . _ option -> 'a
+end
+
+[%%expect{|
+Line 2, characters 24-25:
+2 |     val wildcard : 'a . _ option -> 'a
+                            ^
+Error: A type wildcard "_" is not allowed in this type declaration.
+|}]

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1019,7 +1019,8 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
       end;
       let name = !name in
       let make_row more =
-        create_row ~fields ~more ~closed:(closed = Asttypes.Closed) ~fixed:None ~name
+        create_row ~fields ~more ~closed:(closed = Asttypes.Closed)
+          ~fixed:None ~name
       in
       let more =
         if Btype.static_row
@@ -1313,7 +1314,8 @@ and transl_fields env ~policy ~row_context o fields =
   let ty_init =
      match o with
      | Asttypes.Closed -> newty Tnil
-     | Asttypes.Open -> TyVarEnv.new_var (Jkind.Builtin.value ~why:Row_variable) policy
+     | Asttypes.Open ->
+        TyVarEnv.new_var (Jkind.Builtin.value ~why:Row_variable) policy
   in
   let ty = List.fold_left (fun ty (s, ty') ->
       newty (Tfield (s, field_public, ty', ty))) ty_init fields in
@@ -1419,7 +1421,8 @@ let transl_type_scheme_poly env attrs loc vars inner_type =
       let typ =
         if Language_extension.erasable_extensions_only () then
           transl_simple_type_impl ~new_var_jkind:Sort env ~univars
-            ~policy:Closed_for_upstream_compatibility Alloc.Const.legacy inner_type
+            ~policy:Closed_for_upstream_compatibility Alloc.Const.legacy
+            inner_type
         else
           transl_simple_type_impl ~new_var_jkind:Sort env ~univars ~policy:Open
             Alloc.Const.legacy inner_type
@@ -1452,8 +1455,8 @@ let pp_tag ppf t = Format.fprintf ppf "`%s" t
 
 let report_unbound_variable_reason ppf = function
   | Some Upstream_compatibility ->
-      fprintf ppf "@.Hint: Explicit quantification requires quantifying all type \
-                   variables for compatibility with upstream OCaml.\n\
+      fprintf ppf "@.Hint: Explicit quantification requires quantifying all \
+                   type variables for compatibility with upstream OCaml.\n\
                    Enable non-erasable extensions to disable this check."
   | None -> ()
 

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -27,6 +27,13 @@ open Ctype
 
 exception Already_bound
 
+type unbound_variable_policy =
+  | Open (* common case *)
+  | Closed (* no wildcards or unqunatified variables allowed *)
+  | Closed_for_upstream_compatibility (* same as above, extra error hint *)
+
+type unbound_variable_reason = | Upstream_compatibility
+
 (* A way to specify what jkind should be used for new type variables:
 
    [Sort] means to initialize variables with representable jkinds (sort
@@ -60,8 +67,9 @@ type jkind_info =
   }
 
 type error =
-  | Unbound_type_variable of string * string list * string option
-  | No_type_wildcards of string option
+  | Unbound_type_variable of
+    string * string list * unbound_variable_reason option
+  | No_type_wildcards of unbound_variable_reason option
   | Undefined_type_constructor of Path.t
   | Type_arity_mismatch of Longident.t * int * int
   | Bound_type_variable of string
@@ -177,11 +185,8 @@ module TyVarEnv : sig
   (* see mli file *)
 
   type policy
-  val make_fixed_policy :
-    ?hint_for_unbound_variables:string -> jkind_initialization_choice -> policy
-    (* no wildcards allowed *)
-  val make_extensible_policy : jkind_initialization_choice -> policy
-    (* common case *)
+  val make_policy :
+    unbound_variable_policy -> jkind_initialization_choice -> policy
   val univars_policy : policy
     (* fresh variables are univars (in methods), with representable jkinds *)
   val new_any_var : Location.t -> Env.t -> jkind_lr -> policy -> type_expr
@@ -446,33 +451,22 @@ end = struct
 
 
   type flavor = Unification | Universal
-  type extensibility = Extensible | Fixed
   type policy = {
     flavor : flavor;
-    extensibility : extensibility;
+    unbound_variable_policy : unbound_variable_policy;
     jkind_initialization: jkind_initialization_choice;
-    hint_for_unbound_variables : string option;
   }
 
-  let make_fixed_policy ?hint_for_unbound_variables jkind_initialization = {
+  let make_policy unbound_variable_policy jkind_initialization = {
     flavor = Unification;
-    extensibility = Fixed;
+    unbound_variable_policy;
     jkind_initialization;
-    hint_for_unbound_variables;
-  }
-
-  let make_extensible_policy jkind_initialization = {
-    flavor = Unification;
-    extensibility = Extensible;
-    jkind_initialization;
-    hint_for_unbound_variables = None;
   }
 
   let univars_policy = {
     flavor = Universal;
-    extensibility = Extensible;
+    unbound_variable_policy = Open;
     jkind_initialization = Sort;
-    hint_for_unbound_variables = None;
   }
 
   let add_pre_univar tv = function
@@ -502,12 +496,14 @@ end = struct
     | Sort -> Jkind.of_new_legacy_sort ~why:(if is_named then Unification_var else Wildcard)
 
   let new_any_var loc env jkind = function
-    | { extensibility = Fixed; hint_for_unbound_variables; _ } ->
-      raise(Error(loc, env, No_type_wildcards hint_for_unbound_variables))
+    | { unbound_variable_policy = Closed; _ } ->
+      raise(Error(loc, env, No_type_wildcards None))
+    | { unbound_variable_policy = Closed_for_upstream_compatibility; _ } ->
+      raise(Error(loc, env, No_type_wildcards (Some Upstream_compatibility)))
     | policy -> new_var jkind policy
 
   let globalize_used_variables
-      { flavor; extensibility; hint_for_unbound_variables; _ } env =
+      { flavor; unbound_variable_policy; _ } env =
     let r = ref [] in
     TyVarMap.iter
       (fun name (ty, loc) ->
@@ -518,15 +514,22 @@ end = struct
           then try
             r := (loc, v, lookup_global name) :: !r
           with Not_found ->
-            if extensibility = Fixed && Btype.is_Tvar ty then
+            match unbound_variable_policy, Btype.is_Tvar ty with
+            | Open, _ | (Closed | Closed_for_upstream_compatibility), false ->
+              let jkind = Jkind.Builtin.any ~why:Dummy_jkind in
+              let v2 = new_global_var jkind in
+              r := (loc, v, v2) :: !r;
+              add name v2 jkind
+            | Closed, true ->
               raise(Error(loc, env,
                           Unbound_type_variable (Pprintast.tyvar_of_name name,
                                                  get_in_scope_names (),
-                                                 hint_for_unbound_variables)));
-            let jkind = Jkind.Builtin.any ~why:Dummy_jkind in
-            let v2 = new_global_var jkind in
-            r := (loc, v, v2) :: !r;
-            add name v2 jkind)
+                                                 None)))
+            | Closed_for_upstream_compatibility, true ->
+              raise(Error(loc, env,
+                          Unbound_type_variable (Pprintast.tyvar_of_name name,
+                                                 get_in_scope_names (),
+                                                 Some Upstream_compatibility))))
       !used_variables;
     used_variables := TyVarMap.empty;
     fun () ->
@@ -1016,7 +1019,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
       end;
       let name = !name in
       let make_row more =
-        create_row ~fields ~more ~closed:(closed = Closed) ~fixed:None ~name
+        create_row ~fields ~more ~closed:(closed = Asttypes.Closed) ~fixed:None ~name
       in
       let more =
         if Btype.static_row
@@ -1309,8 +1312,8 @@ and transl_fields env ~policy ~row_context o fields =
   let fields = Hashtbl.fold (fun s ty l -> (s, ty) :: l) hfields [] in
   let ty_init =
      match o with
-     | Closed -> newty Tnil
-     | Open -> TyVarEnv.new_var (Jkind.Builtin.value ~why:Row_variable) policy
+     | Asttypes.Closed -> newty Tnil
+     | Asttypes.Open -> TyVarEnv.new_var (Jkind.Builtin.value ~why:Row_variable) policy
   in
   let ty = List.fold_left (fun ty (s, ty') ->
       newty (Tfield (s, field_public, ty', ty))) ty_init fields in
@@ -1347,18 +1350,17 @@ let make_fixed_univars ty =
   make_fixed_univars ty;
   Btype.unmark_type ty
 
-let transl_simple_type env ~new_var_jkind ?univars ?hint_for_unbound_variables
-    ~closed mode styp =
+let transl_simple_type_impl env ~new_var_jkind ?univars ~policy mode styp =
   TyVarEnv.reset_locals ?univars ();
-  let policy =
-    if closed
-    then TyVarEnv.make_fixed_policy ?hint_for_unbound_variables new_var_jkind
-    else TyVarEnv.make_extensible_policy new_var_jkind
-  in
+  let policy = TyVarEnv.make_policy policy new_var_jkind in
   let typ = transl_type env policy mode styp in
   TyVarEnv.globalize_used_variables policy env ();
   make_fixed_univars typ.ctyp_type;
   typ
+
+let transl_simple_type env ~new_var_jkind ?univars ~closed mode styp =
+  let policy = if closed then Closed else Open in
+  transl_simple_type_impl env ~new_var_jkind ?univars ~policy mode styp
 
 let transl_simple_type_univars env styp =
   TyVarEnv.reset_locals ();
@@ -1379,7 +1381,7 @@ let transl_simple_type_delayed env mode styp =
   TyVarEnv.reset_locals ();
   let typ, force =
     with_local_level begin fun () ->
-      let policy = TyVarEnv.make_extensible_policy Any in
+      let policy = TyVarEnv.make_policy Open Any in
       let typ = transl_type env policy mode styp in
       make_fixed_univars typ.ctyp_type;
       (* This brings the used variables to the global level, but doesn't link
@@ -1416,14 +1418,10 @@ let transl_type_scheme_poly env attrs loc vars inner_type =
       let typed_vars = TyVarEnv.ttyp_poly_arg univars in
       let typ =
         if Language_extension.erasable_extensions_only () then
-          transl_simple_type ~new_var_jkind:Sort env ~univars
-            ~hint_for_unbound_variables:
-              "Hint: Explicit quantification requires quantifying all type \
-               variables for compatibility with upstream OCaml.\n\
-               Enable non-erasable extensions to disable this check."
-            ~closed:true Alloc.Const.legacy inner_type
+          transl_simple_type_impl ~new_var_jkind:Sort env ~univars
+            ~policy:Closed_for_upstream_compatibility Alloc.Const.legacy inner_type
         else
-          transl_simple_type ~new_var_jkind:Sort env ~univars ~closed:false
+          transl_simple_type_impl ~new_var_jkind:Sort env ~univars ~policy:Open
             Alloc.Const.legacy inner_type
       in
       (typed_vars, univars, typ)
@@ -1452,18 +1450,24 @@ open Printtyp
 module Style = Misc.Style
 let pp_tag ppf t = Format.fprintf ppf "`%s" t
 
+let report_unbound_variable_reason ppf = function
+  | Some Upstream_compatibility ->
+      fprintf ppf "@.Hint: Explicit quantification requires quantifying all type \
+                   variables for compatibility with upstream OCaml.\n\
+                   Enable non-erasable extensions to disable this check."
+  | None -> ()
 
 let report_error env ppf =
   function
-  | Unbound_type_variable (name, in_scope_names, hint) ->
+  | Unbound_type_variable (name, in_scope_names, reason) ->
     fprintf ppf "The type variable %a is unbound in this type declaration.@ %a"
       Style.inline_code name
       did_you_mean (fun () -> Misc.spellcheck in_scope_names name );
-    Option.iter (fprintf ppf "@.%s") hint
-  | No_type_wildcards hint ->
+    report_unbound_variable_reason ppf reason
+  | No_type_wildcards reason ->
       fprintf ppf "A type wildcard %a is not allowed in this type declaration."
         Style.inline_code "_";
-      Option.iter (fprintf ppf "@.%s") hint
+      report_unbound_variable_reason ppf reason
   | Undefined_type_constructor p ->
     fprintf ppf "The type constructor@ %a@ is not yet completely defined"
       (Style.as_inline_code path) p

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -114,7 +114,8 @@ val transl_label_from_expr :
    of a constraint is typed using [Any] while the right hand side uses [Sort]. *)
 val transl_simple_type:
         Env.t -> new_var_jkind:jkind_initialization_choice
-        -> ?univars:TyVarEnv.poly_univars -> closed:bool -> Alloc.Const.t
+        -> ?univars:TyVarEnv.poly_univars
+        -> ?hint_for_unbound_variables:string -> closed:bool -> Alloc.Const.t
         -> Parsetree.core_type -> Typedtree.core_type
 val transl_simple_type_univars:
         Env.t -> Parsetree.core_type -> Typedtree.core_type
@@ -148,7 +149,7 @@ type sort_loc =
 type cannot_quantify_reason
 type jkind_info
 type error =
-  | Unbound_type_variable of string * string list
+  | Unbound_type_variable of string * string list * string option
   | No_type_wildcards
   | Undefined_type_constructor of Path.t
   | Type_arity_mismatch of Longident.t * int * int

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -115,7 +115,7 @@ val transl_label_from_expr :
 val transl_simple_type:
         Env.t -> new_var_jkind:jkind_initialization_choice
         -> ?univars:TyVarEnv.poly_univars
-        -> ?hint_for_unbound_variables:string -> closed:bool -> Alloc.Const.t
+        -> closed:bool -> Alloc.Const.t
         -> Parsetree.core_type -> Typedtree.core_type
 val transl_simple_type_univars:
         Env.t -> Parsetree.core_type -> Typedtree.core_type
@@ -148,9 +148,10 @@ type sort_loc =
 
 type cannot_quantify_reason
 type jkind_info
+type unbound_variable_reason
 type error =
-  | Unbound_type_variable of string * string list * string option
-  | No_type_wildcards of string option
+  | Unbound_type_variable of string * string list * unbound_variable_reason option
+  | No_type_wildcards of unbound_variable_reason option
   | Undefined_type_constructor of Path.t
   | Type_arity_mismatch of Longident.t * int * int
   | Bound_type_variable of string

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -150,7 +150,7 @@ type cannot_quantify_reason
 type jkind_info
 type error =
   | Unbound_type_variable of string * string list * string option
-  | No_type_wildcards
+  | No_type_wildcards of string option
   | Undefined_type_constructor of Path.t
   | Type_arity_mismatch of Longident.t * int * int
   | Bound_type_variable of string

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -150,7 +150,8 @@ type cannot_quantify_reason
 type jkind_info
 type unbound_variable_reason
 type error =
-  | Unbound_type_variable of string * string list * unbound_variable_reason option
+  | Unbound_type_variable of
+    string * string list * unbound_variable_reason option
   | No_type_wildcards of unbound_variable_reason option
   | Undefined_type_constructor of Path.t
   | Type_arity_mismatch of Longident.t * int * int


### PR DESCRIPTION
Title. To maintain compatibility with upstream OCaml, accept unbound type variables after quantification only if the extension universe is `stable` or higher. If the extension universe is `upstream_compatible`, emit an error and a hint instead.