### PR TITLE
Improve the inclusion check around identity abbreviations

### DIFF
--- a/jane/doc/proposals/kind-inference.md
+++ b/jane/doc/proposals/kind-inference.md
@@ -655,7 +655,7 @@ tconstr_jkind₁ = π [[ 'aᵢ : χ₁ᵢ ]]ₙ. κ₁₀
 TODO: More type_binding rules
 
 
-Γ ⊢includemod Γ₂ ≤ Γ₁  (* check whether Γ₁, covers Γ₂ *)
+Γ ⊢includemod Γ₂ ≤ Γ₁  (* check whether Γ₁ covers Γ₂ *)
 ============================
 
 -------------------- IM_EMPTY

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -1736,3 +1736,34 @@ end
 [%%expect{|
 module M : sig type t : value mod non_float end
 |}]
+
+(**************************)
+(* Test 18: identity type *)
+
+(* This tests a bug seen in practice *)
+module M : sig
+  type 'a t : value mod portable with 'a
+end = struct
+  type 'a t = 'a
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t = 'a
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = 'a end
+       is not included in
+         sig type 'a t : value mod portable with 'a end
+       Type declarations do not match:
+         type 'a t = 'a
+       is not included in
+         type 'a t : value mod portable with 'a
+       The kind of the first is value
+         because of the definition of t at line 2, characters 2-40.
+       But the kind of the first must be a subkind of value mod portable
+         with 'a
+         because of the definition of t at line 2, characters 2-40.
+|}]

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -1748,22 +1748,45 @@ end = struct
 end
 
 [%%expect{|
-Lines 3-5, characters 6-3:
-3 | ......struct
-4 |   type 'a t = 'a
-5 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig type 'a t = 'a end
-       is not included in
-         sig type 'a t : value mod portable with 'a end
-       Type declarations do not match:
-         type 'a t = 'a
-       is not included in
-         type 'a t : value mod portable with 'a
-       The kind of the first is value
-         because of the definition of t at line 2, characters 2-40.
-       But the kind of the first must be a subkind of value mod portable
-         with 'a
-         because of the definition of t at line 2, characters 2-40.
+module M : sig type 'a t : value mod portable with 'a end
+|}]
+
+module M : sig
+  type 'a t : value mod portable with 'a
+end = struct
+  type 'a t = { x : 'a } [@@unboxed]
+end
+
+[%%expect{|
+module M : sig type 'a t : value mod portable with 'a end
+|}]
+
+module M : sig
+  type 'a t : value mod portable with 'a
+end = struct
+  type 'a t = Mk of { x : 'a } [@@unboxed]
+end
+
+[%%expect{|
+module M : sig type 'a t : value mod portable with 'a end
+|}]
+
+module M : sig
+  type 'a t : value mod portable with 'a
+end = struct
+  type 'a t = Mk of 'a [@@unboxed]
+end
+
+[%%expect{|
+module M : sig type 'a t : value mod portable with 'a end
+|}]
+
+module M : sig
+  type 'a t : value mod portable with 'a
+end = struct
+  type 'a t = #{ x : 'a }
+end
+
+[%%expect{|
+module M : sig type 'a t : value mod portable with 'a end
 |}]

--- a/testsuite/tests/typing-jkind-bounds/row.ml
+++ b/testsuite/tests/typing-jkind-bounds/row.ml
@@ -111,12 +111,18 @@ module type S2 = S with type 'a abstract = 'a simple
 [%%expect{|
 type 'a test : immutable_data with 'a
 module type S = sig type 'a abstract : immutable_data with 'a test end
-Line 7, characters 24-52:
+Line 7, characters 17-52:
 7 | module type S2 = S with type 'a abstract = 'a simple
-                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a simple" is immutable_data with 'a
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this "with" constraint, the new definition of "abstract"
+       does not match its original definition in the constrained signature:
+       Type declarations do not match:
+         type 'a abstract = 'a simple
+       is not included in
+         type 'a abstract : immutable_data with 'a test
+       The kind of the first is immutable_data with 'a
          because of the definition of simple at line 1, characters 0-39.
-       But the kind of type "'a simple" must be a subkind of immutable_data
+       But the kind of the first must be a subkind of immutable_data
          with 'a test
          because of the definition of abstract at line 4, characters 2-48.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
@@ -142,13 +142,18 @@ module type T = S with type ('a, 'b) t = ('a, 'b) t
 [%%expect {|
 type ('a, 'b) t : immutable_data with 'a with 'b
 module type S = sig type ('a, 'b) t : immutable_data with 'a end
-Line 7, characters 23-51:
+Line 7, characters 16-51:
 7 | module type T = S with type ('a, 'b) t = ('a, 'b) t
-                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "('a, 'b) t" is immutable_data with 'a with 'b
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this "with" constraint, the new definition of "t"
+       does not match its original definition in the constrained signature:
+       Type declarations do not match:
+         type ('a, 'b) t = ('a, 'b) t
+       is not included in
+         type ('a, 'b) t : immutable_data with 'a
+       The kind of the first is immutable_data with 'a with 'b
          because of the definition of t at line 1, characters 0-48.
-       But the kind of type "('a, 'b) t" must be a subkind of immutable_data
-         with 'a
+       But the kind of the first must be a subkind of immutable_data with 'a
          because of the definition of t at line 4, characters 2-42.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
@@ -147,13 +147,18 @@ module type T = S with type ('a, 'b) t = ('a, 'b) t
 [%%expect {|
 type ('a, 'b) t : value mod portable with 'b
 module type S = sig type ('a, 'b) t : value mod portable end
-Line 7, characters 23-51:
+Line 7, characters 16-51:
 7 | module type T = S with type ('a, 'b) t = ('a, 'b) t
-                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "('a, 'b) t" is value mod portable with 'b
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this "with" constraint, the new definition of "t"
+       does not match its original definition in the constrained signature:
+       Type declarations do not match:
+         type ('a, 'b) t = ('a, 'b) t
+       is not included in
+         type ('a, 'b) t : value mod portable
+       The kind of the first is value mod portable with 'b
          because of the definition of t at line 1, characters 0-77.
-       But the kind of type "('a, 'b) t" must be a subkind of
-         value mod portable
+       But the kind of the first must be a subkind of value mod portable
          because of the definition of t at line 4, characters 2-38.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
@@ -113,12 +113,19 @@ module F (M : sig type t end) = struct
   module type T = S with type t = t
 end
 [%%expect {|
-Line 6, characters 25-35:
+Line 6, characters 18-35:
 6 |   module type T = S with type t = t
-                             ^^^^^^^^^^
-Error: The kind of type "t" is value
+                      ^^^^^^^^^^^^^^^^^
+Error: In this "with" constraint, the new definition of "t"
+       does not match its original definition in the constrained signature:
+       Type declarations do not match:
+         type t = t
+       is not included in
+         type t : value mod global with M.t
+       The kind of the first is value
          because of the definition of t at line 5, characters 2-8.
-       But the kind of type "t" must be a subkind of value mod global with M.t
+       But the kind of the first must be a subkind of value mod global
+         with M.t
          because of the definition of t at line 3, characters 4-38.
 |}]
 

--- a/testsuite/tests/typing-layouts/hash_types.ml
+++ b/testsuite/tests/typing-layouts/hash_types.ml
@@ -703,12 +703,19 @@ module type Bad = sig
   type t
 end with type t := float#
 [%%expect{|
-Line 3, characters 9-25:
+Lines 1-3, characters 18-25:
+1 | ..................sig
+2 |   type t
 3 | end with type t := float#
-             ^^^^^^^^^^^^^^^^
-Error: The layout of type "float#" is float64
+Error: In this "with" constraint, the new definition of "t"
+       does not match its original definition in the constrained signature:
+       Type declarations do not match:
+         type t = float#
+       is not included in
+         type t
+       The layout of the first is float64
          because it is the unboxed version of the primitive type float.
-       But the layout of type "float#" must be a sublayout of value
+       But the layout of the first must be a sublayout of value
          because of the definition of t at line 2, characters 2-8.
 |}]
 

--- a/testsuite/tests/typing-layouts/modules.ml
+++ b/testsuite/tests/typing-layouts/modules.ml
@@ -80,12 +80,18 @@ Error: The type constraints are not consistent.
 module type S1f'' = S1f with type s = t_float64;;
 
 [%%expect{|
-Line 1, characters 29-47:
+Line 1, characters 20-47:
 1 | module type S1f'' = S1f with type s = t_float64;;
-                                 ^^^^^^^^^^^^^^^^^^
-Error: The layout of type "t_float64" is float64
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this "with" constraint, the new definition of "s"
+       does not match its original definition in the constrained signature:
+       Type declarations do not match:
+         type s = t_float64
+       is not included in
+         type s
+       The layout of the first is float64
          because of the definition of t_float64 at line 4, characters 0-24.
-       But the layout of type "t_float64" must be a sublayout of value
+       But the layout of the first must be a sublayout of value
          because of the definition of s at line 3, characters 2-8.
 |}]
 
@@ -432,12 +438,18 @@ end
 module type S3_2' = S3_2 with type t := string;;
 [%%expect{|
 module type S3_2 = sig type t : immediate end
-Line 5, characters 30-46:
+Line 5, characters 20-46:
 5 | module type S3_2' = S3_2 with type t := string;;
-                                  ^^^^^^^^^^^^^^^^
-Error: The kind of type "string" is immutable_data
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this "with" constraint, the new definition of "t"
+       does not match its original definition in the constrained signature:
+       Type declarations do not match:
+         type t = string
+       is not included in
+         type t : immediate
+       The kind of the first is immutable_data
          because it is the primitive type string.
-       But the kind of type "string" must be a subkind of immediate
+       But the kind of the first must be a subkind of immediate
          because of the definition of t at line 2, characters 2-20.
 |}]
 

--- a/testsuite/tests/typing-layouts/modules_alpha.ml
+++ b/testsuite/tests/typing-layouts/modules_alpha.ml
@@ -47,12 +47,18 @@ Error: The type constraints are not consistent.
 module type S1'' = S1 with type s = t_void;;
 
 [%%expect{|
-Line 1, characters 27-42:
+Line 1, characters 19-42:
 1 | module type S1'' = S1 with type s = t_void;;
-                               ^^^^^^^^^^^^^^^
-Error: The layout of type "t_void" is void
+                       ^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this "with" constraint, the new definition of "s"
+       does not match its original definition in the constrained signature:
+       Type declarations do not match:
+         type s = t_void
+       is not included in
+         type s
+       The layout of the first is void
          because of the definition of t_void at line 5, characters 0-19.
-       But the layout of type "t_void" must be a sublayout of value
+       But the layout of the first must be a sublayout of value
          because of the definition of s at line 11, characters 2-8.
 |}]
 
@@ -373,12 +379,18 @@ end
 module type S3_2' = S3_2 with type t := string;;
 [%%expect{|
 module type S3_2 = sig type t : immediate end
-Line 5, characters 30-46:
+Line 5, characters 20-46:
 5 | module type S3_2' = S3_2 with type t := string;;
-                                  ^^^^^^^^^^^^^^^^
-Error: The kind of type "string" is immutable_data
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this "with" constraint, the new definition of "t"
+       does not match its original definition in the constrained signature:
+       Type declarations do not match:
+         type t = string
+       is not included in
+         type t : immediate
+       The kind of the first is immutable_data
          because it is the primitive type string.
-       But the kind of type "string" must be a subkind of immediate
+       But the kind of the first must be a subkind of immediate
          because of the definition of t at line 2, characters 2-20.
 |}]
 

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2423,6 +2423,20 @@ let for_non_float ~(why : History.value_creation_reason) =
     { layout = Sort (Base Value); mod_bounds; with_bounds = No_with_bounds }
     ~annotation:None ~why:(Value_creation why)
 
+let for_abbreviation ~type_jkind_purely ty =
+  (* CR layouts v2.8: This should really use layout_of *)
+  let jkind = type_jkind_purely ty in
+  let with_bounds_types =
+    let relevant_axes = Jkind_axis.Axis_set.all in
+    With_bounds_types.singleton ty { relevant_axes }
+  in
+  fresh_jkind_poly
+    { layout = jkind.jkind.layout;
+      mod_bounds = Mod_bounds.min;
+      with_bounds = With_bounds with_bounds_types
+    }
+    ~annotation:None ~why:Abbreviation
+
 (* Note [With-bounds for GADTs]
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -3245,6 +3259,7 @@ module Format_history = struct
       in
       fprintf ppf "of the definition%a at %a" format_id id
         Location.print_loc_in_lowercase loc
+    | Abbreviation -> fprintf ppf "it is the expansion of a type abbreviation"
 
   let format_interact_reason ppf : History.interact_reason -> _ = function
     | Gadt_equation name ->
@@ -3982,6 +3997,7 @@ module Debug_printers = struct
       fprintf ppf "Generalized (%s, %a)"
         (match id with Some id -> Ident.unique_name id | None -> "")
         Location.print_loc loc
+    | Abbreviation -> fprintf ppf "Abbreviation"
 
   let interact_reason ppf : History.interact_reason -> _ = function
     | Gadt_equation p -> fprintf ppf "Gadt_equation %a" Path.print p

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -542,6 +542,29 @@ val for_float : Ident.t -> Types.jkind_l
 (** The jkind for values that are not floats. *)
 val for_non_float : why:History.value_creation_reason -> 'd Types.jkind
 
+(** The jkind for an abbreviation declaration. This implements the design
+    in rule FIND_ABBREV in kind-inference.md, where we consider a definition
+
+    {[
+      type ... = rhs
+    ]}
+
+    to have the kind [<<layout of rhs>> mod everything with rhs]. This is
+    important to allow code like this to type-check:
+
+    {[
+      module M : sig
+        type 'a t : value mod portable with 'a
+      end = struct
+        type 'a t = 'a
+      end
+    ]}
+*)
+val for_abbreviation :
+  type_jkind_purely:(Types.type_expr -> Types.jkind_l) ->
+  Types.type_expr ->
+  Types.jkind_l
+
 (******************************)
 (* elimination and defaulting *)
 

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -356,6 +356,8 @@ module History = struct
         }
     (* [position] is 1-indexed *)
     | Generalized of Ident.t option * Location.t
+    (* See commentary on [Jkind.for_abbreviation] *)
+    | Abbreviation
 
   type interact_reason =
     | Gadt_equation of Path.t


### PR DESCRIPTION
This now accepts

```
module M : sig
  type 'a t : value mod portable with 'a
end = struct
  type 'a t = 'a
end
```

While I was in town, I also made this work for `[@@unboxed]` types, which has been requested (and I previously thought was impossible without `layout_of`).

Review: @riaqn. This choice is a combination of (other reviewers who have touched this code are all out) and (honestly, the correctness of this code is pretty hard to assess without doing proofs). So, instead, I invite @riaqn to check me for style and to observe that the test cases work out nicely.