### PR TITLE
`('a : value mod non_float) or_null` is `non_float`

### DIFF
--- a/otherlibs/stdlib_stable/or_null.ml
+++ b/otherlibs/stdlib_stable/or_null.ml
@@ -12,7 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type 'a t : immediate_or_null with 'a = 'a or_null [@@or_null_reexport]
+type 'a t : value_or_null = 'a or_null [@@or_null_reexport]
 
 let null = Null
 let this v = This v

--- a/otherlibs/stdlib_stable/or_null.mli
+++ b/otherlibs/stdlib_stable/or_null.mli
@@ -24,9 +24,9 @@
 (* CR layouts: enable ocamlformat for this module when it starts supporting
    jkind annotations. *)
 
-type 'a t : immediate_or_null with 'a = 'a or_null [@@or_null_reexport]
+type 'a t : value_or_null = 'a or_null [@@or_null_reexport]
       (** The type of nullable values. Either [Null] or a value [This v].
-          ['a or_null] has a non-standard [immediate_or_null with 'a] layout,
+          ['a or_null] has a non-standard [value_or_null] layout,
           preventing the type constructor from being nested. *)
 
 val null : 'a t

--- a/otherlibs/stdlib_stable/or_null.mli
+++ b/otherlibs/stdlib_stable/or_null.mli
@@ -26,8 +26,8 @@
 
 type 'a t : value_or_null = 'a or_null [@@or_null_reexport]
       (** The type of nullable values. Either [Null] or a value [This v].
-          ['a or_null] has a non-standard [value_or_null] layout,
-          preventing the type constructor from being nested. *)
+          ['a or_null] accepts arguments of kind [value] while itself
+          having kind [value_or_null], forbidding [_ or_null or_null]. *)
 
 val null : 'a t
 (** [null] is [Null]. *)

--- a/testsuite/tests/typing-layouts-or-null/containers.ml
+++ b/testsuite/tests/typing-layouts-or-null/containers.ml
@@ -63,8 +63,8 @@ Line 1, characters 21-25:
                          ^^^^
 Error: This expression has type "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a or_null is immediate_or_null with 'a
-         because it is the primitive immediate_or_null type or_null.
+       The kind of 'a or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of 'a or_null must be a subkind of value
          because it's the type of an array element,
          chosen to have kind value.
@@ -129,8 +129,8 @@ Line 1, characters 28-32:
                                 ^^^^
 Error: This expression has type "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a or_null is immediate_or_null with 'a
-         because it is the primitive immediate_or_null type or_null.
+       The kind of 'a or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of 'a or_null must be a subkind of value
          because it's the type of an array element,
          chosen to have kind value.
@@ -260,7 +260,8 @@ let should_work_option3 = None
 
 [%%expect{|
 val should_work_option1 : float or_null option = Some (This 3.4)
-val should_work_option2 : 'a or_null option = Some Null
+val should_work_option2 :
+  ('a : value_or_null mod non_null). 'a or_null option = Some Null
 val should_work_option3 : 'a option = None
 |}]
 

--- a/testsuite/tests/typing-layouts-or-null/immediate.ml
+++ b/testsuite/tests/typing-layouts-or-null/immediate.ml
@@ -85,21 +85,9 @@ type should_work = int_or_null accept_immediate_or_null
 type should_work = int_or_null accept_immediate_or_null
 |}]
 
-(* CR layouts v2.8: this is a bug in principal inference with with-kinds. *)
-
 type should_work = int or_null accept_immediate_or_null
 [%%expect{|
 type should_work = int or_null accept_immediate_or_null
-|}, Principal{|
-Line 1, characters 19-30:
-1 | type should_work = int or_null accept_immediate_or_null
-                       ^^^^^^^^^^^
-Error: This type "int or_null" should be an instance of type
-         "('a : immediate_or_null)"
-       The kind of int or_null is immediate_or_null mod non_float with int
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of int or_null must be a subkind of immediate_or_null
-         because of the definition of accept_immediate_or_null at line 1, characters 0-54.
 |}]
 
 (* Values. *)
@@ -118,8 +106,6 @@ external write_imm : ('a : immediate_or_null). 'a myref -> 'a -> unit
 external equal : ('a : immediate_or_null). 'a -> 'a -> bool = "%equal"
 |}]
 
-(* CR layouts v2.8: this is a bug in principal inference with with-kinds. *)
-
 let () =
   let r = { v = (Null : int or_null) } in
   let x = read_imm r in
@@ -129,14 +115,4 @@ let () =
 ;;
 
 [%%expect{|
-|}, Principal{|
-Line 2, characters 16-36:
-2 |   let r = { v = (Null : int or_null) } in
-                    ^^^^^^^^^^^^^^^^^^^^
-Error: This expression has type "int or_null"
-       but an expression was expected of type "('a : immediate_or_null)"
-       The kind of int or_null is immediate_or_null mod non_float with int
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of int or_null must be a subkind of immediate_or_null
-         because of the definition of myref at line 1, characters 0-56.
 |}]

--- a/testsuite/tests/typing-layouts-or-null/immediate.ml
+++ b/testsuite/tests/typing-layouts-or-null/immediate.ml
@@ -116,3 +116,14 @@ let () =
 
 [%%expect{|
 |}]
+
+(* [immediate_or_null] is [non_float]: *)
+
+type ('a : value_or_null mod non_float) accepts_nonfloat
+
+type succeeds = t_immediate_or_null accepts_nonfloat
+
+[%%expect{|
+type ('a : value_or_null mod non_float) accepts_nonfloat
+type succeeds = t_immediate_or_null accepts_nonfloat
+|}]

--- a/testsuite/tests/typing-layouts-or-null/immediate.ml
+++ b/testsuite/tests/typing-layouts-or-null/immediate.ml
@@ -96,7 +96,7 @@ Line 1, characters 19-30:
                        ^^^^^^^^^^^
 Error: This type "int or_null" should be an instance of type
          "('a : immediate_or_null)"
-       The kind of int or_null is immediate_or_null with int
+       The kind of int or_null is immediate_or_null mod non_float with int
          because it is the primitive immediate_or_null type or_null.
        But the kind of int or_null must be a subkind of immediate_or_null
          because of the definition of accept_immediate_or_null at line 1, characters 0-54.
@@ -135,7 +135,7 @@ Line 2, characters 16-36:
                     ^^^^^^^^^^^^^^^^^^^^
 Error: This expression has type "int or_null"
        but an expression was expected of type "('a : immediate_or_null)"
-       The kind of int or_null is immediate_or_null with int
+       The kind of int or_null is immediate_or_null mod non_float with int
          because it is the primitive immediate_or_null type or_null.
        But the kind of int or_null must be a subkind of immediate_or_null
          because of the definition of myref at line 1, characters 0-56.

--- a/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -18,6 +18,7 @@ Error: This variant or record definition does not match that of type
          "'a or_null"
        Their internal representations differ:
        the original definition has a null constructor.
+       Hint: add [@@or_null_reexport].
 |}]
 
 module Or_null = struct

--- a/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -160,7 +160,7 @@ Error: This expression has type "'a Or_null.t" = "'a or_null"
        The kind of 'a Or_null.t is value_or_null
          because it is the primitive value_or_null type or_null.
        But the kind of 'a Or_null.t must be a subkind of
-         value_or_null mod non_null
+           value_or_null mod non_null
          because of the definition of t at line 2, characters 2-63.
 |}]
 

--- a/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -5,23 +5,23 @@
 (* CR layouts v3.5: ['a or_null] can't be re-exported normally,
    because users can't define their own [Null]-like constructors. *)
 module Or_null = struct
-  type ('a : value) t : immediate_or_null with 'a = 'a or_null =
+  type ('a : value) t : value_or_null = 'a or_null =
     | Null
     | This of 'a
 end
 [%%expect{|
 Lines 2-4, characters 2-16:
-2 | ..type ('a : value) t : immediate_or_null with 'a = 'a or_null =
+2 | ..type ('a : value) t : value_or_null = 'a or_null =
 3 |     | Null
 4 |     | This of 'a
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of immediate_or_null with 'a
-         because of the annotation on the declaration of the type t.
+Error: This variant or record definition does not match that of type
+         "'a or_null"
+       Their internal representations differ:
+       the original definition has a null constructor.
 |}]
 
 module Or_null = struct
-  type ('a : value) t : immediate_or_null with 'a = 'a or_null
+  type ('a : value) t : value_or_null = 'a or_null
 end
 [%%expect{|
 module Or_null : sig type 'a t = 'a or_null end
@@ -50,7 +50,7 @@ Error: Unbound constructor "Or_null.This"
 (* [@@or_null_reexport] re-exports those constructors. *)
 
 module Or_null = struct
-  type ('a : value) t : immediate_or_null with 'a = 'a or_null [@@or_null_reexport]
+  type ('a : value) t : value_or_null with 'a = 'a or_null [@@or_null_reexport]
 end
 let n = Or_null.Null
 let t v = Or_null.This v
@@ -70,10 +70,10 @@ Line 1, characters 24-40:
                             ^^^^^^^^^^^^^^^^
 Error: This expression has type "'a Or_null.t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a Or_null.t is immediate_or_null with 'a
-         because it is the primitive immediate_or_null type or_null.
+       The kind of 'a Or_null.t is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of 'a Or_null.t must be a subkind of value
-         because of the definition of t at line 2, characters 2-83.
+         because of the definition of t at line 2, characters 2-79.
 |}]
 
 (* Type annotations are not required. *)
@@ -91,8 +91,8 @@ Line 4, characters 24-40:
                             ^^^^^^^^^^^^^^^^
 Error: This expression has type "'a Or_null.t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a Or_null.t is immediate_or_null with 'a
-         because it is the primitive immediate_or_null type or_null.
+       The kind of 'a Or_null.t is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of 'a Or_null.t must be a subkind of value
          because of the definition of t at line 2, characters 2-45.
 |}]
@@ -105,8 +105,8 @@ type 'a t : value = 'a or_null [@@or_null_reexport]
 Line 1, characters 0-51:
 1 | type 'a t : value = 'a or_null [@@or_null_reexport]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a or_null" is immediate_or_null with 'a
-         because it is the primitive immediate_or_null type or_null.
+Error: The kind of type "'a or_null" is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of type "'a or_null" must be a subkind of value
          because of the definition of t at line 1, characters 0-51.
 |}]
@@ -118,7 +118,7 @@ Line 1, characters 0-53:
 1 | type 'a t : float64 = 'a or_null [@@or_null_reexport]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type "'a or_null" is value
-         because it is the primitive immediate_or_null type or_null.
+         because it is the primitive value_or_null type or_null.
        But the layout of type "'a or_null" must be a sublayout of float64
          because of the definition of t at line 1, characters 0-53.
 |}]
@@ -129,7 +129,8 @@ type ('a : float64) t = 'a or_null [@@or_null_reexport]
 Line 1, characters 24-26:
 1 | type ('a : float64) t = 'a or_null [@@or_null_reexport]
                             ^^
-Error: This type "('a : float64)" should be an instance of type "('b : value)"
+Error: This type "('a : float64)" should be an instance of type
+         "('b : value_or_null mod non_null)"
        The layout of 'a is float64
          because of the annotation on 'a in the declaration of the type t.
        But the layout of 'a must overlap with value
@@ -146,15 +147,19 @@ let fail = Or_null.This (Or_null.This 5)
 
 [%%expect{|
 module Or_null :
-  sig type 'a t = 'a or_null = Null | This of 'a [@@or_null_reexport] end
+  sig
+    type ('a : value_or_null mod non_null) t = 'a or_null = Null | This of 'a [@@or_null_reexport]
+  end
 Line 4, characters 24-40:
 4 | let fail = Or_null.This (Or_null.This 5)
                             ^^^^^^^^^^^^^^^^
 Error: This expression has type "'a Or_null.t" = "'a or_null"
-       but an expression was expected of type "('b : value)"
-       The kind of 'a Or_null.t is immediate_or_null with 'a
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of 'a Or_null.t must be a subkind of value
+       but an expression was expected of type
+         "('b : value_or_null mod non_null)"
+       The kind of 'a Or_null.t is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of 'a Or_null.t must be a subkind of
+         value_or_null mod non_null
          because of the definition of t at line 2, characters 2-63.
 |}]
 

--- a/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -17,7 +17,7 @@ Lines 2-4, characters 2-16:
 Error: This variant or record definition does not match that of type
          "'a or_null"
        Their internal representations differ:
-       the original definition has a null constructor.
+       the original definition has a constructor represented as a null pointer.
        Hint: add [@@or_null_reexport].
 |}]
 

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -467,57 +467,70 @@ type succeeds = t2 accepts_nonfloat
 
 (* [or_null] and separability. *)
 
-(* ['a or_null] is not separable: *)
+(* ['a] must be [non_float] for ['a or_null] to be [non_float] or [separable].  *)
 
-type 'a fails = 'a or_null accepts_nonfloat
+type 'a narrowed = 'a or_null accepts_nonfloat
 
 [%%expect{|
-Line 1, characters 16-26:
-1 | type 'a fails = 'a or_null accepts_nonfloat
-                    ^^^^^^^^^^
-Error: This type "'a or_null" should be an instance of type
-         "('b : any mod non_float)"
-       The kind of 'a or_null is immediate_or_null with 'a
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of 'a or_null must be a subkind of any mod non_float
-         because of the definition of accepts_nonfloat at line 3, characters 0-46.
+type ('a : value mod non_float) narrowed = 'a or_null accepts_nonfloat
 |}]
 
-type 'a fails = 'a or_null accepts_sep
+type 'a narrowed = 'a or_null accepts_sep
 
 [%%expect{|
-Line 1, characters 16-26:
-1 | type 'a fails = 'a or_null accepts_sep
-                    ^^^^^^^^^^
-Error: This type "'a or_null" should be an instance of type
-         "('b : any mod separable)"
-       The kind of 'a or_null is immediate_or_null with 'a
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of 'a or_null must be a subkind of any mod separable
+type ('a : value mod non_float) narrowed = 'a or_null accepts_sep
+|}]
+
+type 'a succeds = 'a or_null accepts_maybesep
+
+[%%expect{|
+type 'a succeds = 'a or_null accepts_maybesep
+|}]
+
+type t_val_nonfloat : value mod non_float
+
+type succeeds = t_val_nonfloat or_null accepts_nonfloat
+
+[%%expect{|
+type t_val_nonfloat : value mod non_float
+type succeeds = t_val_nonfloat or_null accepts_nonfloat
+|}]
+
+type fails = t_val or_null accepts_sep
+
+[%%expect{|
+Line 1, characters 13-26:
+1 | type fails = t_val or_null accepts_sep
+                 ^^^^^^^^^^^^^
+Error: This type "t_val or_null" should be an instance of type
+         "('a : any mod separable)"
+       The kind of t_val or_null is value
+         because of the definition of t_val at line 1, characters 0-18.
+       But the kind of t_val or_null must be a subkind of
+         any_non_null mod non_float
          because of the definition of accepts_sep at line 2, characters 0-41.
 |}]
 
-type 'a succeds = 'a or_null accepts_maybesep
+type fails = t_b64 or_null accepts_maybesep
 
 [%%expect{|
-type 'a succeds = 'a or_null accepts_maybesep
+Line 1, characters 13-18:
+1 | type fails = t_b64 or_null accepts_maybesep
+                 ^^^^^
+Error: This type "t_b64" should be an instance of type
+         "('a : value_or_null mod non_null)"
+       The layout of t_b64 is bits64
+         because of the definition of t_b64 at line 1, characters 0-19.
+       But the layout of t_b64 must be a sublayout of value
+         because the type argument of or_null has layout value.
 |}]
 
-(* CR layouts v3.4: [or_null] should be able accept maybe-separable values? *)
-
 type t_maybesep_val : value_or_null mod non_null
-type fails = t_maybesep_val or_null
+type succeeds = t_maybesep_val or_null
 
 [%%expect{|
 type t_maybesep_val : value_or_null mod non_null
-Line 2, characters 13-27:
-2 | type fails = t_maybesep_val or_null
-                 ^^^^^^^^^^^^^^
-Error: This type "t_maybesep_val" should be an instance of type "('a : value)"
-       The kind of t_maybesep_val is value_or_null mod non_null
-         because of the definition of t_maybesep_val at line 1, characters 0-48.
-       But the kind of t_maybesep_val must be a subkind of value
-         because the type argument of or_null has kind value.
+type succeeds = t_maybesep_val or_null
 |}]
 
 type ('a : value mod non_float) succeeds = 'a or_null accepts_nonfloat
@@ -537,7 +550,6 @@ type ('a : value mod non_float) succeeds = 'a or_null accepts_maybesep
 type ('a : value mod non_float) succeeds = 'a or_null accepts_maybesep
 |}]
 
-(* CR layouts v2.8: fix error reporting difference. *)
 (* [float or_null] is not separable: *)
 
 type fails = float or_null accepts_sep
@@ -549,19 +561,10 @@ Line 1, characters 13-26:
 Error: This type "float or_null" should be an instance of type
          "('a : any mod separable)"
        The kind of float or_null is
-           value_or_null mod many unyielding stateless immutable
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of float or_null must be a subkind of any mod separable
-         because of the definition of accepts_sep at line 2, characters 0-41.
-|}, Principal{|
-Line 1, characters 13-26:
-1 | type fails = float or_null accepts_sep
-                 ^^^^^^^^^^^^^
-Error: This type "float or_null" should be an instance of type
-         "('a : any mod separable)"
-       The kind of float or_null is immediate_or_null with float
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of float or_null must be a subkind of any mod separable
+           value mod many unyielding stateless immutable
+         because it is the primitive type float.
+       But the kind of float or_null must be a subkind of
+         any_non_null mod non_float
          because of the definition of accepts_sep at line 2, characters 0-41.
 |}]
 
@@ -600,18 +603,8 @@ Line 1, characters 22-33:
                           ^^^^^^^^^^^
 Error: This type "int or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of int or_null is immediate_or_null mod non_float
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of int or_null must be a subkind of any_non_null
-         because it's the type argument to the array type.
-|}, Principal{|
-Line 1, characters 22-33:
-1 | type should_succeed = int or_null array
-                          ^^^^^^^^^^^
-Error: This type "int or_null" should be an instance of type
-         "('a : any_non_null)"
-       The kind of int or_null is immediate_or_null mod non_float with int
-         because it is the primitive immediate_or_null type or_null.
+       The kind of int or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of int or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
 |}]
@@ -624,20 +617,8 @@ Line 1, characters 22-36:
                           ^^^^^^^^^^^^^^
 Error: This type "string or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of string or_null is
-           value_or_null mod many unyielding stateless immutable non_float
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of string or_null must be a subkind of any_non_null
-         because it's the type argument to the array type.
-|}, Principal{|
-Line 1, characters 22-36:
-1 | type should_succeed = string or_null array
-                          ^^^^^^^^^^^^^^
-Error: This type "string or_null" should be an instance of type
-         "('a : any_non_null)"
-       The kind of string or_null is immediate_or_null mod non_float
-         with string
-         because it is the primitive immediate_or_null type or_null.
+       The kind of string or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of string or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
 |}]
@@ -652,19 +633,8 @@ Line 1, characters 13-26:
                  ^^^^^^^^^^^^^
 Error: This type "float or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of float or_null is
-           value_or_null mod many unyielding stateless immutable
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of float or_null must be a subkind of any_non_null
-         because it's the type argument to the array type.
-|}, Principal{|
-Line 1, characters 13-26:
-1 | type fails = float or_null array
-                 ^^^^^^^^^^^^^
-Error: This type "float or_null" should be an instance of type
-         "('a : any_non_null)"
-       The kind of float or_null is immediate_or_null with float
-         because it is the primitive immediate_or_null type or_null.
+       The kind of float or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of float or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
 |}]
@@ -679,20 +649,8 @@ Line 1, characters 22-36:
                           ^^^^^^^^^^^^^^
 Error: This type "string or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of string or_null is
-           value_or_null mod many unyielding stateless immutable non_float
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of string or_null must be a subkind of any_non_null
-         because it's the type argument to the array type.
-|}, Principal{|
-Line 1, characters 22-36:
-1 | type should_succeed = string or_null array
-                          ^^^^^^^^^^^^^^
-Error: This type "string or_null" should be an instance of type
-         "('a : any_non_null)"
-       The kind of string or_null is immediate_or_null mod non_float
-         with string
-         because it is the primitive immediate_or_null type or_null.
+       The kind of string or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of string or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
 |}]
@@ -705,18 +663,8 @@ Line 1, characters 22-33:
                           ^^^^^^^^^^^
 Error: This type "int or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of int or_null is immediate_or_null mod non_float
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of int or_null must be a subkind of any_non_null
-         because it's the type argument to the array type.
-|}, Principal{|
-Line 1, characters 22-33:
-1 | type should_succeed = int or_null array
-                          ^^^^^^^^^^^
-Error: This type "int or_null" should be an instance of type
-         "('a : any_non_null)"
-       The kind of int or_null is immediate_or_null mod non_float with int
-         because it is the primitive immediate_or_null type or_null.
+       The kind of int or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of int or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
 |}]
@@ -736,14 +684,22 @@ type ('a : value_or_null) smth : immediate with 'a
 
 type ('a : immediate) bounded
 
-(* CR layouts v2.8: broken mode crossing with [-principal]. *)
+(* CR layouts v2.8: with-bounds don't peek through unboxed-like types. *)
 
 type works = int or_null smth bounded
 
 [%%expect{|
 type 'a smth : immediate with 'a
 type ('a : immediate) bounded
-type works = int or_null smth bounded
+Line 7, characters 13-29:
+7 | type works = int or_null smth bounded
+                 ^^^^^^^^^^^^^^^^
+Error: This type "int or_null smth" should be an instance of type
+         "('a : immediate)"
+       The kind of int or_null smth is value mod non_float
+         because of the definition of smth at line 1, characters 0-50.
+       But the kind of int or_null smth must be a subkind of immediate
+         because of the definition of bounded at line 3, characters 0-29.
 |}, Principal{|
 type 'a smth : immediate with 'a
 type ('a : immediate) bounded
@@ -833,36 +789,19 @@ end
 
 (* Generic ['a or_null] re-export is still maybe-separable. *)
 
-type 'a fails = 'a Or_null_reexport.t accepts_nonfloat
+type 'a narrowed = 'a Or_null_reexport.t accepts_nonfloat
 
 [%%expect{|
 module Or_null_reexport :
   sig type 'a t = 'a or_null = Null | This of 'a [@@or_null_reexport] end
-Line 7, characters 16-37:
-7 | type 'a fails = 'a Or_null_reexport.t accepts_nonfloat
-                    ^^^^^^^^^^^^^^^^^^^^^
-Error: This type "'a Or_null_reexport.t" = "'a or_null"
-       should be an instance of type "('b : any mod non_float)"
-       The kind of 'a Or_null_reexport.t is immediate_or_null with 'a
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of 'a Or_null_reexport.t must be a subkind of
-         any mod non_float
-         because of the definition of accepts_nonfloat at line 3, characters 0-46.
+type ('a : value mod non_float) narrowed =
+    'a Or_null_reexport.t accepts_nonfloat
 |}]
 
-type 'a fails = 'a Or_null_reexport.t accepts_sep
+type 'a narrowed = 'a Or_null_reexport.t accepts_sep
 
 [%%expect{|
-Line 1, characters 16-37:
-1 | type 'a fails = 'a Or_null_reexport.t accepts_sep
-                    ^^^^^^^^^^^^^^^^^^^^^
-Error: This type "'a Or_null_reexport.t" = "'a or_null"
-       should be an instance of type "('b : any mod separable)"
-       The kind of 'a Or_null_reexport.t is immediate_or_null with 'a
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of 'a Or_null_reexport.t must be a subkind of
-         any mod separable
-         because of the definition of accepts_sep at line 2, characters 0-41.
+type ('a : value mod non_float) narrowed = 'a Or_null_reexport.t accepts_sep
 |}]
 
 type 'a succeeds = 'a Or_null_reexport.t accepts_maybesep
@@ -897,21 +836,10 @@ Line 1, characters 13-37:
 Error: This type "float Or_null_reexport.t" = "float or_null"
        should be an instance of type "('a : any mod non_float)"
        The kind of float Or_null_reexport.t is
-         value_or_null mod many unyielding stateless immutable
-         because it is the primitive immediate_or_null type or_null.
+         value mod many unyielding stateless immutable
+         because it is the primitive type float.
        But the kind of float Or_null_reexport.t must be a subkind of
-         any mod non_float
-         because of the definition of accepts_nonfloat at line 3, characters 0-46.
-|}, Principal{|
-Line 1, characters 13-37:
-1 | type fails = float Or_null_reexport.t accepts_nonfloat
-                 ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type "float Or_null_reexport.t" = "float or_null"
-       should be an instance of type "('a : any mod non_float)"
-       The kind of float Or_null_reexport.t is immediate_or_null with float
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of float Or_null_reexport.t must be a subkind of
-         any mod non_float
+         any_non_null mod non_float
          because of the definition of accepts_nonfloat at line 3, characters 0-46.
 |}]
 
@@ -924,20 +852,41 @@ Line 1, characters 13-37:
 Error: This type "float Or_null_reexport.t" = "float or_null"
        should be an instance of type "('a : any mod separable)"
        The kind of float Or_null_reexport.t is
-         value_or_null mod many unyielding stateless immutable
-         because it is the primitive immediate_or_null type or_null.
+         value mod many unyielding stateless immutable
+         because it is the primitive type float.
        But the kind of float Or_null_reexport.t must be a subkind of
-         any mod separable
+         any_non_null mod non_float
          because of the definition of accepts_sep at line 2, characters 0-41.
-|}, Principal{|
-Line 1, characters 13-37:
-1 | type fails = float Or_null_reexport.t accepts_sep
-                 ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type "float Or_null_reexport.t" = "float or_null"
-       should be an instance of type "('a : any mod separable)"
-       The kind of float Or_null_reexport.t is immediate_or_null with float
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of float Or_null_reexport.t must be a subkind of
-         any mod separable
+|}]
+
+(* Peeking through unboxed types *)
+
+(* CR or-null: test [('a : value_or_null) unbx] when it's allowed. *)
+
+type 'a unbx : value = Box of 'a [@@unboxed]
+
+[%%expect{|
+type 'a unbx = Box of 'a [@@unboxed]
+|}]
+
+type succeeds = string unbx or_null accepts_nonfloat
+
+[%%expect{|
+type succeeds = string unbx or_null accepts_nonfloat
+|}]
+
+type fails = float unbx or_null accepts_sep
+
+[%%expect{|
+Line 1, characters 13-31:
+1 | type fails = float unbx or_null accepts_sep
+                 ^^^^^^^^^^^^^^^^^^
+Error: This type "float unbx or_null" should be an instance of type
+         "('a : any mod separable)"
+       The kind of float unbx or_null is
+         value mod many unyielding stateless immutable
+         because it is the primitive type float.
+       But the kind of float unbx or_null must be a subkind of
+         any_non_null mod non_float
          because of the definition of accepts_sep at line 2, characters 0-41.
 |}]

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -835,7 +835,7 @@ Error: This type "float Or_null_reexport.t" = "float or_null"
        The kind of float Or_null_reexport.t is value_or_null
          because it is the primitive value_or_null type or_null.
        But the kind of float Or_null_reexport.t must be a subkind of
-         any mod non_float
+           any mod non_float
          because of the definition of accepts_nonfloat at line 3, characters 0-46.
 |}]
 
@@ -850,7 +850,7 @@ Error: This type "float Or_null_reexport.t" = "float or_null"
        The kind of float Or_null_reexport.t is value_or_null
          because it is the primitive value_or_null type or_null.
        But the kind of float Or_null_reexport.t must be a subkind of
-         any mod separable
+           any mod separable
          because of the definition of accepts_sep at line 2, characters 0-41.
 |}]
 
@@ -881,6 +881,6 @@ Error: This type "float unbx or_null" should be an instance of type
        The kind of float unbx or_null is value_or_null
          because it is the primitive value_or_null type or_null.
        But the kind of float unbx or_null must be a subkind of
-         any mod separable
+           any mod separable
          because of the definition of accepts_sep at line 2, characters 0-41.
 |}]

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -504,10 +504,9 @@ Line 1, characters 13-26:
                  ^^^^^^^^^^^^^
 Error: This type "t_val or_null" should be an instance of type
          "('a : any mod separable)"
-       The kind of t_val or_null is value
-         because of the definition of t_val at line 1, characters 0-18.
-       But the kind of t_val or_null must be a subkind of
-         any_non_null mod non_float
+       The kind of t_val or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of t_val or_null must be a subkind of any mod separable
          because of the definition of accepts_sep at line 2, characters 0-41.
 |}]
 
@@ -560,11 +559,9 @@ Line 1, characters 13-26:
                  ^^^^^^^^^^^^^
 Error: This type "float or_null" should be an instance of type
          "('a : any mod separable)"
-       The kind of float or_null is
-           value mod many unyielding stateless immutable
-         because it is the primitive type float.
-       But the kind of float or_null must be a subkind of
-         any_non_null mod non_float
+       The kind of float or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of float or_null must be a subkind of any mod separable
          because of the definition of accepts_sep at line 2, characters 0-41.
 |}]
 
@@ -835,11 +832,10 @@ Line 1, characters 13-37:
                  ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type "float Or_null_reexport.t" = "float or_null"
        should be an instance of type "('a : any mod non_float)"
-       The kind of float Or_null_reexport.t is
-         value mod many unyielding stateless immutable
-         because it is the primitive type float.
+       The kind of float Or_null_reexport.t is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of float Or_null_reexport.t must be a subkind of
-         any_non_null mod non_float
+         any mod non_float
          because of the definition of accepts_nonfloat at line 3, characters 0-46.
 |}]
 
@@ -851,11 +847,10 @@ Line 1, characters 13-37:
                  ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type "float Or_null_reexport.t" = "float or_null"
        should be an instance of type "('a : any mod separable)"
-       The kind of float Or_null_reexport.t is
-         value mod many unyielding stateless immutable
-         because it is the primitive type float.
+       The kind of float Or_null_reexport.t is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of float Or_null_reexport.t must be a subkind of
-         any_non_null mod non_float
+         any mod separable
          because of the definition of accepts_sep at line 2, characters 0-41.
 |}]
 
@@ -883,10 +878,9 @@ Line 1, characters 13-31:
                  ^^^^^^^^^^^^^^^^^^
 Error: This type "float unbx or_null" should be an instance of type
          "('a : any mod separable)"
-       The kind of float unbx or_null is
-         value mod many unyielding stateless immutable
-         because it is the primitive type float.
+       The kind of float unbx or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of float unbx or_null must be a subkind of
-         any_non_null mod non_float
+         any mod separable
          because of the definition of accepts_sep at line 2, characters 0-41.
 |}]

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -520,33 +520,15 @@ Error: This type "t_maybesep_val" should be an instance of type "('a : value)"
          because the type argument of or_null has kind value.
 |}]
 
-(* CR layouts v3.4: ['a or_null] where 'a is non-float should be non-float. *)
-
-type ('a : value mod non_float) should_succeed = 'a or_null accepts_nonfloat
+type ('a : value mod non_float) succeeds = 'a or_null accepts_nonfloat
 
 [%%expect{|
-Line 1, characters 49-59:
-1 | type ('a : value mod non_float) should_succeed = 'a or_null accepts_nonfloat
-                                                     ^^^^^^^^^^
-Error: This type "'a or_null" should be an instance of type
-         "('b : any mod non_float)"
-       The kind of 'a or_null is immediate_or_null with 'a
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of 'a or_null must be a subkind of any mod non_float
-         because of the definition of accepts_nonfloat at line 3, characters 0-46.
+type ('a : value mod non_float) succeeds = 'a or_null accepts_nonfloat
 |}]
 
-type ('a : value mod non_float) should_succeed = 'a or_null accepts_sep
+type ('a : value mod non_float) succeeds = 'a or_null accepts_sep
 [%%expect{|
-Line 1, characters 49-59:
-1 | type ('a : value mod non_float) should_succeed = 'a or_null accepts_sep
-                                                     ^^^^^^^^^^
-Error: This type "'a or_null" should be an instance of type
-         "('b : any mod separable)"
-       The kind of 'a or_null is immediate_or_null with 'a
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of 'a or_null must be a subkind of any mod separable
-         because of the definition of accepts_sep at line 2, characters 0-41.
+type ('a : value mod non_float) succeeds = 'a or_null accepts_sep
 |}]
 
 type ('a : value mod non_float) succeeds = 'a or_null accepts_maybesep
@@ -618,7 +600,7 @@ Line 1, characters 22-33:
                           ^^^^^^^^^^^
 Error: This type "int or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of int or_null is immediate_or_null
+       The kind of int or_null is immediate_or_null mod non_float
          because it is the primitive immediate_or_null type or_null.
        But the kind of int or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
@@ -628,7 +610,7 @@ Line 1, characters 22-33:
                           ^^^^^^^^^^^
 Error: This type "int or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of int or_null is immediate_or_null with int
+       The kind of int or_null is immediate_or_null mod non_float with int
          because it is the primitive immediate_or_null type or_null.
        But the kind of int or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
@@ -643,7 +625,7 @@ Line 1, characters 22-36:
 Error: This type "string or_null" should be an instance of type
          "('a : any_non_null)"
        The kind of string or_null is
-           value_or_null mod many unyielding stateless immutable
+           value_or_null mod many unyielding stateless immutable non_float
          because it is the primitive immediate_or_null type or_null.
        But the kind of string or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
@@ -653,7 +635,8 @@ Line 1, characters 22-36:
                           ^^^^^^^^^^^^^^
 Error: This type "string or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of string or_null is immediate_or_null with string
+       The kind of string or_null is immediate_or_null mod non_float
+         with string
          because it is the primitive immediate_or_null type or_null.
        But the kind of string or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
@@ -697,7 +680,7 @@ Line 1, characters 22-36:
 Error: This type "string or_null" should be an instance of type
          "('a : any_non_null)"
        The kind of string or_null is
-           value_or_null mod many unyielding stateless immutable
+           value_or_null mod many unyielding stateless immutable non_float
          because it is the primitive immediate_or_null type or_null.
        But the kind of string or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
@@ -707,7 +690,8 @@ Line 1, characters 22-36:
                           ^^^^^^^^^^^^^^
 Error: This type "string or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of string or_null is immediate_or_null with string
+       The kind of string or_null is immediate_or_null mod non_float
+         with string
          because it is the primitive immediate_or_null type or_null.
        But the kind of string or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
@@ -721,7 +705,7 @@ Line 1, characters 22-33:
                           ^^^^^^^^^^^
 Error: This type "int or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of int or_null is immediate_or_null
+       The kind of int or_null is immediate_or_null mod non_float
          because it is the primitive immediate_or_null type or_null.
        But the kind of int or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
@@ -731,7 +715,7 @@ Line 1, characters 22-33:
                           ^^^^^^^^^^^
 Error: This type "int or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of int or_null is immediate_or_null with int
+       The kind of int or_null is immediate_or_null mod non_float with int
          because it is the primitive immediate_or_null type or_null.
        But the kind of int or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
@@ -837,4 +821,123 @@ type ('c : value & value & float64 mod non_null non_float) fails = unit constrai
 [%%expect{|
 type c = #(float * float or_null * float#)
 type 'a fails = unit constraint 'a = c
+|}]
+
+(* Separability and [@@or_null_reexport]. *)
+
+(* Re-exported [or_null] types preserve separability behavior. *)
+
+module Or_null_reexport = struct
+  type 'a t = 'a or_null [@@or_null_reexport]
+end
+
+(* Generic ['a or_null] re-export is still maybe-separable. *)
+
+type 'a fails = 'a Or_null_reexport.t accepts_nonfloat
+
+[%%expect{|
+module Or_null_reexport :
+  sig type 'a t = 'a or_null = Null | This of 'a [@@or_null_reexport] end
+Line 7, characters 16-37:
+7 | type 'a fails = 'a Or_null_reexport.t accepts_nonfloat
+                    ^^^^^^^^^^^^^^^^^^^^^
+Error: This type "'a Or_null_reexport.t" = "'a or_null"
+       should be an instance of type "('b : any mod non_float)"
+       The kind of 'a Or_null_reexport.t is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of 'a Or_null_reexport.t must be a subkind of
+         any mod non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-46.
+|}]
+
+type 'a fails = 'a Or_null_reexport.t accepts_sep
+
+[%%expect{|
+Line 1, characters 16-37:
+1 | type 'a fails = 'a Or_null_reexport.t accepts_sep
+                    ^^^^^^^^^^^^^^^^^^^^^
+Error: This type "'a Or_null_reexport.t" = "'a or_null"
+       should be an instance of type "('b : any mod separable)"
+       The kind of 'a Or_null_reexport.t is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of 'a Or_null_reexport.t must be a subkind of
+         any mod separable
+         because of the definition of accepts_sep at line 2, characters 0-41.
+|}]
+
+type 'a succeeds = 'a Or_null_reexport.t accepts_maybesep
+
+[%%expect{|
+type 'a succeeds = 'a Or_null_reexport.t accepts_maybesep
+|}]
+
+(* Non-float constraints are preserved through re-export. *)
+
+type ('a : value mod non_float) succeeds = 'a Or_null_reexport.t accepts_nonfloat
+
+[%%expect{|
+type ('a : value mod non_float) succeeds =
+    'a Or_null_reexport.t accepts_nonfloat
+|}]
+
+(* Specific type instances preserve their separability. *)
+
+type succeeds = int Or_null_reexport.t accepts_nonfloat
+
+[%%expect{|
+type succeeds = int Or_null_reexport.t accepts_nonfloat
+|}]
+
+type fails = float Or_null_reexport.t accepts_nonfloat
+
+[%%expect{|
+Line 1, characters 13-37:
+1 | type fails = float Or_null_reexport.t accepts_nonfloat
+                 ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type "float Or_null_reexport.t" = "float or_null"
+       should be an instance of type "('a : any mod non_float)"
+       The kind of float Or_null_reexport.t is
+         value_or_null mod many unyielding stateless immutable
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of float Or_null_reexport.t must be a subkind of
+         any mod non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-46.
+|}, Principal{|
+Line 1, characters 13-37:
+1 | type fails = float Or_null_reexport.t accepts_nonfloat
+                 ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type "float Or_null_reexport.t" = "float or_null"
+       should be an instance of type "('a : any mod non_float)"
+       The kind of float Or_null_reexport.t is immediate_or_null with float
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of float Or_null_reexport.t must be a subkind of
+         any mod non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-46.
+|}]
+
+type fails = float Or_null_reexport.t accepts_sep
+
+[%%expect{|
+Line 1, characters 13-37:
+1 | type fails = float Or_null_reexport.t accepts_sep
+                 ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type "float Or_null_reexport.t" = "float or_null"
+       should be an instance of type "('a : any mod separable)"
+       The kind of float Or_null_reexport.t is
+         value_or_null mod many unyielding stateless immutable
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of float Or_null_reexport.t must be a subkind of
+         any mod separable
+         because of the definition of accepts_sep at line 2, characters 0-41.
+|}, Principal{|
+Line 1, characters 13-37:
+1 | type fails = float Or_null_reexport.t accepts_sep
+                 ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type "float Or_null_reexport.t" = "float or_null"
+       should be an instance of type "('a : any mod separable)"
+       The kind of float Or_null_reexport.t is immediate_or_null with float
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of float Or_null_reexport.t must be a subkind of
+         any mod separable
+         because of the definition of accepts_sep at line 2, characters 0-41.
 |}]

--- a/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -102,7 +102,7 @@ Error: This type "int or_null" should be an instance of type
        The kind of int or_null is value_or_null
          because it is the primitive value_or_null type or_null.
        But the kind of int or_null must be a subkind of
-         value_or_null mod non_null
+           value_or_null mod non_null
          because the type argument of or_null has kind value.
 |}]
 
@@ -352,8 +352,8 @@ Line 1, characters 45-55:
 1 | type (_, _) fail = Fail : 'a or_null -> ('a, 'a or_null) fail [@@unboxed]
                                                  ^^^^^^^^^^
 Error: This type "'a or_null" should be an instance of type "('b : value)"
-       The kind of 'a or_null is immediate_or_null with 'a
-         because it is the primitive immediate_or_null type or_null.
+       The kind of 'a or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of 'a or_null must be a subkind of value
          because it instantiates an unannotated type parameter of fail,
          chosen to have kind value.
@@ -392,10 +392,10 @@ Line 1, characters 35-51:
                                        ^^^^^^^^^^^^^^^^
 Error: This expression has type "unboxed_rec"
        but an expression was expected of type "('a : value)"
-       The kind of unboxed_rec is immediate_or_null
-         because it is the primitive immediate_or_null type or_null.
+       The kind of unboxed_rec is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of unboxed_rec must be a subkind of value
-         because of the definition of t at line 1, characters 0-81.
+         because of the definition of t at line 1, characters 0-69.
 |}]
 
 let should_fail_unboxed_var = This (Wrap Null)
@@ -406,10 +406,10 @@ Line 1, characters 35-46:
                                        ^^^^^^^^^^^
 Error: This expression has type "unboxed_var"
        but an expression was expected of type "('a : value)"
-       The kind of unboxed_var is immediate_or_null
-         because it is the primitive immediate_or_null type or_null.
+       The kind of unboxed_var is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of unboxed_var must be a subkind of value
-         because of the definition of t at line 1, characters 0-81.
+         because of the definition of t at line 1, characters 0-69.
 |}]
 
 let should_fail_unboxed_gadt = This (Gadt Null)
@@ -420,8 +420,8 @@ Line 1, characters 36-47:
                                         ^^^^^^^^^^^
 Error: This expression has type "('a, 'a or_null) gadt"
        but an expression was expected of type "('b : value)"
-       The kind of ('a, 'a or_null) gadt is immediate_or_null with 'a
-         because it is the primitive immediate_or_null type or_null.
+       The kind of ('a, 'a or_null) gadt is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of ('a, 'a or_null) gadt must be a subkind of value
-         because of the definition of t at line 1, characters 0-81.
+         because of the definition of t at line 1, characters 0-69.
 |}]

--- a/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -2,7 +2,7 @@
  expect;
 *)
 
-type ('a : value) t : immediate_or_null with 'a = 'a or_null [@@or_null_reexport]
+type ('a : value) t : value_or_null = 'a or_null [@@or_null_reexport]
 
 [%%expect{|
 type 'a t = 'a or_null = Null | This of 'a [@@or_null_reexport]
@@ -97,19 +97,12 @@ type nested = int or_null or_null
 Line 1, characters 14-25:
 1 | type nested = int or_null or_null
                   ^^^^^^^^^^^
-Error: This type "int or_null" should be an instance of type "('a : value)"
-       The kind of int or_null is immediate_or_null mod non_float
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of int or_null must be a subkind of value
-         because the type argument of or_null has kind value.
-|}, Principal{|
-Line 1, characters 14-25:
-1 | type nested = int or_null or_null
-                  ^^^^^^^^^^^
-Error: This type "int or_null" should be an instance of type "('a : value)"
-       The kind of int or_null is immediate_or_null mod non_float with int
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of int or_null must be a subkind of value
+Error: This type "int or_null" should be an instance of type
+         "('a : value_or_null mod non_null)"
+       The kind of int or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
+       But the kind of int or_null must be a subkind of
+         value_or_null mod non_null
          because the type argument of or_null has kind value.
 |}]
 
@@ -121,10 +114,10 @@ Line 1, characters 23-31:
                            ^^^^^^^^
 Error: This expression has type "'a t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a t is immediate_or_null with 'a
-         because it is the primitive immediate_or_null type or_null.
+       The kind of 'a t is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of 'a t must be a subkind of value
-         because of the definition of t at line 1, characters 0-81.
+         because of the definition of t at line 1, characters 0-69.
 |}]
 
 let should_also_fail = This Null
@@ -135,10 +128,10 @@ Line 1, characters 28-32:
                                 ^^^^
 Error: This expression has type "'a t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a t is immediate_or_null with 'a
-         because it is the primitive immediate_or_null type or_null.
+       The kind of 'a t is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of 'a t must be a subkind of value
-         because of the definition of t at line 1, characters 0-81.
+         because of the definition of t at line 1, characters 0-69.
 |}]
 
 let mk' n = `Foo (This n)
@@ -200,8 +193,8 @@ Line 1, characters 21-25:
                          ^^^^
 Error: This expression has type "'a t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a t is immediate_or_null with 'a
-         because it is the primitive immediate_or_null type or_null.
+       The kind of 'a t is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of 'a t must be a subkind of value
          because it's the type of an array element,
          chosen to have kind value.
@@ -215,19 +208,8 @@ Line 1, characters 19-32:
                        ^^^^^^^^^^^^^
 Error: This type "float or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of float or_null is
-           value_or_null mod many unyielding stateless immutable
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of float or_null must be a subkind of any_non_null
-         because it's the type argument to the array type.
-|}, Principal{|
-Line 1, characters 19-32:
-1 | type should_fail = float or_null array
-                       ^^^^^^^^^^^^^
-Error: This type "float or_null" should be an instance of type
-         "('a : any_non_null)"
-       The kind of float or_null is immediate_or_null with float
-         because it is the primitive immediate_or_null type or_null.
+       The kind of float or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of float or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
 |}]
@@ -254,8 +236,8 @@ Line 1, characters 21-25:
                          ^^^^
 Error: This expression has type "'a t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a t is immediate_or_null with 'a
-         because it is the primitive immediate_or_null type or_null.
+       The kind of 'a t is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of 'a t must be a subkind of value
          because it's the type of an array element,
          chosen to have kind value.
@@ -269,19 +251,8 @@ Line 1, characters 19-32:
                        ^^^^^^^^^^^^^
 Error: This type "float or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of float or_null is
-           value_or_null mod many unyielding stateless immutable
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of float or_null must be a subkind of any_non_null
-         because it's the type argument to the array type.
-|}, Principal{|
-Line 1, characters 19-32:
-1 | type should_fail = float or_null array
-                       ^^^^^^^^^^^^^
-Error: This type "float or_null" should be an instance of type
-         "('a : any_non_null)"
-       The kind of float or_null is immediate_or_null with float
-         because it is the primitive immediate_or_null type or_null.
+       The kind of float or_null is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of float or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
 |}]
@@ -294,17 +265,8 @@ Line 1, characters 26-42:
 1 | type object_with_null = < x : int or_null; .. >
                               ^^^^^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The kind of "int or_null" is immediate_or_null mod non_float
-         because it is the primitive immediate_or_null type or_null.
-       But the kind of "int or_null" must be a subkind of value
-         because it's the type of an object field.
-|}, Principal{|
-Line 1, characters 26-42:
-1 | type object_with_null = < x : int or_null; .. >
-                              ^^^^^^^^^^^^^^^^
-Error: Object field types must have layout value.
-       The kind of "int or_null" is immediate_or_null mod non_float with int
-         because it is the primitive immediate_or_null type or_null.
+       The kind of "int or_null" is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of "int or_null" must be a subkind of value
          because it's the type of an object field.
 |}]
@@ -320,8 +282,8 @@ Line 3, characters 8-9:
 3 |     val x = Null
             ^
 Error: Variables bound in a class must have layout value.
-       The kind of x is immediate_or_null with 'a
-         because it is the primitive immediate_or_null type or_null.
+       The kind of x is value_or_null
+         because it is the primitive value_or_null type or_null.
        But the kind of x must be a subkind of value
          because it's the type of a class field.
 |}]

--- a/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -98,7 +98,7 @@ Line 1, characters 14-25:
 1 | type nested = int or_null or_null
                   ^^^^^^^^^^^
 Error: This type "int or_null" should be an instance of type "('a : value)"
-       The kind of int or_null is immediate_or_null
+       The kind of int or_null is immediate_or_null mod non_float
          because it is the primitive immediate_or_null type or_null.
        But the kind of int or_null must be a subkind of value
          because the type argument of or_null has kind value.
@@ -107,7 +107,7 @@ Line 1, characters 14-25:
 1 | type nested = int or_null or_null
                   ^^^^^^^^^^^
 Error: This type "int or_null" should be an instance of type "('a : value)"
-       The kind of int or_null is immediate_or_null with int
+       The kind of int or_null is immediate_or_null mod non_float with int
          because it is the primitive immediate_or_null type or_null.
        But the kind of int or_null must be a subkind of value
          because the type argument of or_null has kind value.
@@ -294,7 +294,7 @@ Line 1, characters 26-42:
 1 | type object_with_null = < x : int or_null; .. >
                               ^^^^^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The kind of "int or_null" is immediate_or_null
+       The kind of "int or_null" is immediate_or_null mod non_float
          because it is the primitive immediate_or_null type or_null.
        But the kind of "int or_null" must be a subkind of value
          because it's the type of an object field.
@@ -303,7 +303,7 @@ Line 1, characters 26-42:
 1 | type object_with_null = < x : int or_null; .. >
                               ^^^^^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The kind of "int or_null" is immediate_or_null with int
+       The kind of "int or_null" is immediate_or_null mod non_float with int
          because it is the primitive immediate_or_null type or_null.
        But the kind of "int or_null" must be a subkind of value
          because it's the type of an object field.

--- a/testsuite/tests/typing-modal-kinds/everything.ml
+++ b/testsuite/tests/typing-modal-kinds/everything.ml
@@ -11,7 +11,7 @@ type t_float64 : float64
 type t_float64_mod_e : float64 mod everything
 [%%expect{|
 type t_value
-type t_value_mod_e : immediate_or_null mod non_null separable
+type t_value_mod_e : value_or_null mod everything mod non_null separable
 type t_float64 : float64
 type t_float64_mod_e : float64 mod everything
 |}]
@@ -257,11 +257,11 @@ type t : value_or_null mod everything
 type bad : value = t
 
 [%%expect{|
-type t : immediate_or_null
+type t : value_or_null mod everything
 Line 2, characters 0-20:
 2 | type bad : value = t
     ^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immediate_or_null
+Error: The kind of type "t" is value_or_null mod everything
          because of the definition of t at line 1, characters 0-37.
        But the kind of type "t" must be a subkind of value
          because of the definition of bad at line 2, characters 0-20.
@@ -295,15 +295,15 @@ type t : immediate & immediate
 type t : value & float64 mod everything
 [%%expect{|
 type t
-  : immediate_or_null mod non_null separable
+  : value_or_null mod everything mod non_null separable
     & float64 mod global aliased many stateless immutable external_
 |}]
 
 type t : value & (immediate & bits64) & float32 mod everything
 [%%expect{|
 type t
-  : immediate_or_null mod non_null separable
-    & (immediate_or_null mod non_null separable
+  : value_or_null mod everything mod non_null separable
+    & (value_or_null mod everything mod non_null separable
       & bits64 mod global aliased many stateless immutable external_)
     & float32 mod global aliased many stateless immutable external_
 |}]

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -656,7 +656,7 @@ let report_type_mismatch first second decl env ppf err =
   | With_null_representation ord ->
       pr "Their internal representations differ:@ %s %s %s."
          (choose ord first second) decl
-         "has a null constructor";
+         "has a constructor represented as a null pointer";
       pr "@ Hint: add [%@%@or_null_reexport]."
   | Jkind v ->
       Jkind.Violation.report_with_name ~name:first ppf v

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -154,9 +154,9 @@ let value_descriptions ~loc env name
              let ty2, mode_l2, mode_y2, _ = Ctype.instance_prim p2 vd2.val_type in
              Option.iter (Mode.Locality.equate_exn loc) mode_l2;
              Option.iter (Mode.Yielding.equate_exn yield) mode_y2;
-             try 
+             try
                Ctype.moregeneral env true ty1 ty2
-             with Ctype.Moregen err -> 
+             with Ctype.Moregen err ->
                raise (Dont_match (Type err))
            ) yielding
          ) locality;
@@ -656,7 +656,8 @@ let report_type_mismatch first second decl env ppf err =
   | With_null_representation ord ->
       pr "Their internal representations differ:@ %s %s %s."
          (choose ord first second) decl
-         "has a null constructor"
+         "has a null constructor";
+      pr "@ Hint: add [%@%@or_null_reexport]."
   | Jkind v ->
       Jkind.Violation.report_with_name ~name:first ppf v
   | Unsafe_mode_crossing mismatch ->

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1444,7 +1444,7 @@ module Const = struct
     let immediate_or_null =
       { jkind =
           mk_jkind (Base Value) ~mode_crossing:true ~nullability:Maybe_null
-            ~separability:Maybe_separable;
+            ~separability:Non_float;
         name = "immediate_or_null"
       }
 

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2423,6 +2423,20 @@ let for_non_float ~(why : History.value_creation_reason) =
     { layout = Sort (Base Value); mod_bounds; with_bounds = No_with_bounds }
     ~annotation:None ~why:(Value_creation why)
 
+let for_or_null_argument ~(why : History.value_creation_reason) =
+  let mod_bounds =
+    Mod_bounds.create ~locality:Locality.Const.max
+      ~linearity:Linearity.Const.max ~portability:Portability.Const.max
+      ~yielding:Yielding.Const.max ~uniqueness:Uniqueness.Const_op.max
+      ~contention:Contention.Const_op.max ~statefulness:Statefulness.Const.max
+      ~visibility:Visibility.Const_op.max ~externality:Externality.max
+      ~nullability:Nullability.Non_null
+      ~separability:Separability.Maybe_separable
+  in
+  fresh_jkind
+    { layout = Sort (Base Value); mod_bounds; with_bounds = No_with_bounds }
+    ~annotation:None ~why:(Value_creation why)
+
 let for_abbreviation ~type_jkind_purely ~modality ty =
   (* CR layouts v2.8: This should really use layout_of *)
   let jkind = type_jkind_purely ty in

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2423,7 +2423,11 @@ let for_non_float ~(why : History.value_creation_reason) =
     { layout = Sort (Base Value); mod_bounds; with_bounds = No_with_bounds }
     ~annotation:None ~why:(Value_creation why)
 
-let for_or_null_argument ~(why : History.value_creation_reason) =
+let for_or_null_argument ident =
+  let why =
+    History.Type_argument
+      { parent_path = Path.Pident ident; position = 1; arity = 1 }
+  in
   let mod_bounds =
     Mod_bounds.create ~locality:Locality.Const.max
       ~linearity:Linearity.Const.max ~portability:Portability.Const.max

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -634,7 +634,13 @@ val set_nullability_upper_bound :
 (** Computes a jkind that is the same as the input but with an updated maximum
     mode for the separability axis *)
 val set_separability_upper_bound :
-  Types.jkind_r -> Jkind_axis.Separability.t -> Types.jkind_r
+  'd Types.jkind -> Jkind_axis.Separability.t -> 'd Types.jkind
+
+(** Gets the separability from a jkind *)
+val get_separability :
+  jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
+  'd Types.jkind ->
+  Jkind_axis.Separability.t
 
 (** Sets the layout in a jkind. *)
 val set_layout : 'd Types.jkind -> Sort.t Layout.t -> 'd Types.jkind

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -626,7 +626,7 @@ val set_externality_upper_bound :
 (** Gets the nullability from a jkind. *)
 val get_nullability :
   jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
-  'd Types.jkind ->
+  Types.jkind_l ->
   Jkind_axis.Nullability.t
 
 (** Computes a jkind that is the same as the input but with an updated maximum
@@ -638,12 +638,6 @@ val set_nullability_upper_bound :
     mode for the separability axis *)
 val set_separability_upper_bound :
   Types.jkind_r -> Jkind_axis.Separability.t -> Types.jkind_r
-
-(** Gets the separability from a jkind *)
-val get_separability :
-  jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
-  'd Types.jkind ->
-  Jkind_axis.Separability.t
 
 (** Sets the layout in a jkind. *)
 val set_layout : 'd Types.jkind -> Sort.t Layout.t -> 'd Types.jkind
@@ -660,6 +654,12 @@ val apply_modality_l :
     will all be top. The with-bounds are left unchanged. *)
 val apply_modality_r :
   Mode.Modality.Value.Const.t -> ('l * allowed) Types.jkind -> Types.jkind_r
+
+(** Change a jkind to be appropriate for an expectation of a type passed to
+    the [or_null] constructor. Adjusts nullability to be [Non_null], and
+    separability to be [Non_float] if it is demanded to be [Separable].
+    If the jkind is already [Non_null], fails. *)
+val apply_or_null : Types.jkind_r -> (Types.jkind_r, unit) result
 
 (** Extract out component jkinds from the product. Because there are no product
     jkinds, this is a bit of a lie: instead, this decomposes the layout but just

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -634,7 +634,7 @@ val set_nullability_upper_bound :
 (** Computes a jkind that is the same as the input but with an updated maximum
     mode for the separability axis *)
 val set_separability_upper_bound :
-  'd Types.jkind -> Jkind_axis.Separability.t -> 'd Types.jkind
+  Types.jkind_r -> Jkind_axis.Separability.t -> Types.jkind_r
 
 (** Gets the separability from a jkind *)
 val get_separability :

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -530,6 +530,9 @@ val for_float : Ident.t -> Types.jkind_l
 (** The jkind for values that are not floats. *)
 val for_non_float : why:History.value_creation_reason -> 'd Types.jkind
 
+(** The jkind for [or_null] type arguments. *)
+val for_or_null_argument : why:History.value_creation_reason -> 'd Types.jkind
+
 (** The jkind for an abbreviation declaration. This implements the design
     in rule FIND_ABBREV in kind-inference.md, where we consider a definition
 

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -531,7 +531,7 @@ val for_float : Ident.t -> Types.jkind_l
 val for_non_float : why:History.value_creation_reason -> 'd Types.jkind
 
 (** The jkind for [or_null] type arguments. *)
-val for_or_null_argument : why:History.value_creation_reason -> 'd Types.jkind
+val for_or_null_argument : Ident.t -> 'd Types.jkind
 
 (** The jkind for an abbreviation declaration. This implements the design
     in rule FIND_ABBREV in kind-inference.md, where we consider a definition

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -695,12 +695,7 @@ let add_or_null add_type env =
      the most argument types, and forbid arrays from accepting [or_null]s.
      In the future, we will track separability in the jkind system. *)
   ~kind:or_null_kind
-  ~param_jkind:(Jkind.for_or_null_argument ~why:(
-    Type_argument {
-      parent_path = Path.Pident ident_or_null;
-      position = 1;
-      arity = 1}
-  ))
+  ~param_jkind:(Jkind.for_or_null_argument ident_or_null)
   ~jkind:or_null_jkind
 
 let builtin_values =

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -678,12 +678,8 @@ let or_null_kind tvar =
   in
   Type_variant (cstrs, Variant_with_null, None)
 
-let or_null_jkind param =
-  Jkind.Builtin.immediate_or_null ~why:(Primitive ident_or_null) |>
-  Jkind.add_with_bounds
-    ~modality:Mode.Modality.Value.Const.id
-    ~type_expr:param |>
-  Jkind.mark_best
+let or_null_jkind _ =
+  Jkind.Builtin.value_or_null ~why:(Primitive ident_or_null)
 
 let add_or_null add_type env =
   let add_type1 = mk_add_type1 add_type in

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -695,6 +695,12 @@ let add_or_null add_type env =
      the most argument types, and forbid arrays from accepting [or_null]s.
      In the future, we will track separability in the jkind system. *)
   ~kind:or_null_kind
+  ~param_jkind:(Jkind.for_or_null_argument ~why:(
+    Type_argument {
+      parent_path = Path.Pident ident_or_null;
+      position = 1;
+      arity = 1}
+  ))
   ~jkind:or_null_jkind
 
 let builtin_values =


### PR DESCRIPTION
Change `or_null` to be `non_float` when its type argument is itself `non_float`. We can't express this behavior with
mod-bounds, so hardcode it in `estimate_type_jkind` for `or_null` itself and types marked as re-exporting `or_null` through the magic `[@@or_null_reexport]` attribute.

This change has no risk on its own, since `'a or_null` can't be put into arrays regardless. However, a subsequent PR will allow `'a or_null array`.