### PR TITLE
Add hint to challenging error message around kinds

### DIFF
--- a/testsuite/tests/typing-layouts/basics.ml
+++ b/testsuite/tests/typing-layouts/basics.ml
@@ -2916,9 +2916,9 @@ let g t = M.f t ~key:0
 [%%expect{|
 type ('v : immediate) t
 module M : sig val f : ('v : immediate). 'v t -> int -> 'v end
-Line 9, characters 10-13:
+Line 9, characters 10-15:
 9 | let g t = M.f t ~key:0
-              ^^^
+              ^^^^^
 Error: This expression is used as a function, but its type "'a"
        has kind "immediate", which cannot be the kind of a function.
        (Functions always have kind "value mod aliased immutable non_float".)

--- a/testsuite/tests/typing-layouts/basics.ml
+++ b/testsuite/tests/typing-layouts/basics.ml
@@ -2897,3 +2897,29 @@ let f (x : ('a : value mod uncontended)) = x ()
 val f : (unit -> 'a) -> 'a = <fun>
 val f : (unit -> 'a) -> 'a = <fun>
 |}]
+
+(***************************************)
+(* Test 47: Error message on bad label *)
+
+(* reduced from a test case in the wild *)
+
+type ('v : immediate) t
+
+module M : sig
+  val f : 'v t -> int -> 'v
+end = struct
+  let f _ _ = assert false
+end
+
+let g t = M.f t ~key:0
+
+[%%expect{|
+type ('v : immediate) t
+module M : sig val f : ('v : immediate). 'v t -> int -> 'v end
+Line 9, characters 10-13:
+9 | let g t = M.f t ~key:0
+              ^^^
+Error: This expression is used as a function, but its type "'a"
+       has kind "immediate", which cannot be the kind of a function.
+       (Functions always have kind "value mod aliased immutable non_float".)
+|}]

--- a/testsuite/tests/typing-layouts/basics.ml
+++ b/testsuite/tests/typing-layouts/basics.ml
@@ -2924,3 +2924,15 @@ Error: This expression is used as a function, but its type "'a"
        (Functions always have kind "value mod aliased immutable non_float".)
        Hint: Perhaps you have over-applied the function or used an incorrect label.
 |}]
+
+let h t = M.f ~key:0 t
+
+[%%expect{|
+Line 1, characters 10-22:
+1 | let h t = M.f ~key:0 t
+              ^^^^^^^^^^^^
+Error: This expression is used as a function, but its type "'a"
+       has kind "immediate", which cannot be the kind of a function.
+       (Functions always have kind "value mod aliased immutable non_float".)
+       Hint: Perhaps you have over-applied the function or used an incorrect label.
+|}]

--- a/testsuite/tests/typing-layouts/basics.ml
+++ b/testsuite/tests/typing-layouts/basics.ml
@@ -2922,4 +2922,5 @@ Line 9, characters 10-15:
 Error: This expression is used as a function, but its type "'a"
        has kind "immediate", which cannot be the kind of a function.
        (Functions always have kind "value mod aliased immutable non_float".)
+       Hint: Perhaps you have over-applied the function or used an incorrect label.
 |}]

--- a/testsuite/tests/typing-layouts/basics.ml
+++ b/testsuite/tests/typing-layouts/basics.ml
@@ -2871,22 +2871,24 @@ Error: This expression has type "float#" but an expression was expected of type
 let f (x : ('a : bits64)) = x ()
 
 [%%expect{|
-Line 1, characters 28-29:
+Line 1, characters 28-32:
 1 | let f (x : ('a : bits64)) = x ()
-                                ^
-Error: This expression is used as a function, but its type "'a"
-       has kind "bits64", which cannot be the kind of a function.
+                                ^^^^
+Error: This function application uses an expression with type "'a"
+       as a function, but that type has kind "bits64", which cannot
+       be the kind of a function.
        (Functions always have kind "value mod aliased immutable non_float".)
 |}]
 
 let f (x : ('a : value mod portable)) = x ()
 
 [%%expect{|
-Line 1, characters 40-41:
+Line 1, characters 40-44:
 1 | let f (x : ('a : value mod portable)) = x ()
-                                            ^
-Error: This expression is used as a function, but its type "'a"
-       has kind "value mod portable", which cannot be the kind of a function.
+                                            ^^^^
+Error: This function application uses an expression with type "'a"
+       as a function, but that type has kind "value mod portable", which cannot
+       be the kind of a function.
        (Functions always have kind "value mod aliased immutable non_float".)
 |}]
 
@@ -2916,11 +2918,12 @@ let g t = M.f t ~key:0
 [%%expect{|
 type ('v : immediate) t
 module M : sig val f : ('v : immediate). 'v t -> int -> 'v end
-Line 9, characters 10-15:
+Line 9, characters 10-22:
 9 | let g t = M.f t ~key:0
-              ^^^^^
-Error: This expression is used as a function, but its type "'a"
-       has kind "immediate", which cannot be the kind of a function.
+              ^^^^^^^^^^^^
+Error: This function application uses an expression with type "'a"
+       as a function, but that type has kind "immediate", which cannot
+       be the kind of a function.
        (Functions always have kind "value mod aliased immutable non_float".)
        Hint: Perhaps you have over-applied the function or used an incorrect label.
 |}]
@@ -2931,8 +2934,9 @@ let h t = M.f ~key:0 t
 Line 1, characters 10-22:
 1 | let h t = M.f ~key:0 t
               ^^^^^^^^^^^^
-Error: This expression is used as a function, but its type "'a"
-       has kind "immediate", which cannot be the kind of a function.
+Error: This function application uses an expression with type "'a"
+       as a function, but that type has kind "immediate", which cannot
+       be the kind of a function.
        (Functions always have kind "value mod aliased immutable non_float".)
        Hint: Perhaps you have over-applied the function or used an incorrect label.
 |}]

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -326,7 +326,8 @@ type error =
   | Cannot_stack_allocate of Env.locality_context option
   | Unsupported_stack_allocation of unsupported_stack_allocation
   | Not_allocation
-  | Impossible_function_jkind of type_expr * jkind_lr
+  | Impossible_function_jkind of
+      { some_args_ok : bool; ty_fun : type_expr; jkind : jkind_lr }
   | Overwrite_of_invalid_term
   | Unexpected_hole
 


### PR DESCRIPTION
As requested by a colleague.

The main body of the error message is actually accurate: if there were no kind annotation on the type involved, the code would be accepted (with a bizarre type that the user probably did not intend). But it is easy to detect this case and issue a hint, as I've done here.

Review: @rtjoa (pretty arbitrarily)

Recommend review by commits.