### PR TITLE
Restore unboxing of closures in the reaper

### DIFF
--- a/middle_end/flambda2/reaper/dep_solver.ml
+++ b/middle_end/flambda2/reaper/dep_solver.ml
@@ -802,25 +802,60 @@ type usages = Usages of unit Code_id_or_name.Map.t [@@unboxed]
     where the input variables flow with live accessor.
     
     Function slots are considered as aliases for this analysis. *)
-let get_all_usages : Datalog.database -> unit Code_id_or_name.Map.t -> usages =
+let get_all_usages :
+    for_unboxing:bool ->
+    Datalog.database ->
+    unit Code_id_or_name.Map.t ->
+    usages =
   (* CR-someday ncourant: once the datalog API supports something cleaner, use
      it. *)
   let out_tbl, out = rel1_r "out" Cols.[n] in
   let in_tbl, in_ = rel1_r "in_" Cols.[n] in
   let open! Syntax in
   let open! Global_flow_graph in
-  let rs =
-    [ (let$ [x; y] = ["x"; "y"] in
-       [in_ x; usages_rel x y] ==> out y);
-      (let$ [x; field; y; z] = ["x"; "field"; "y"; "z"] in
+  let base, for_closures, function_slots =
+    ( (let$ [x; y] = ["x"; "y"] in
+       [in_ x; usages_rel x y] ==> out y),
+      (let$ [ x;
+              indirect_call_witness;
+              indirect;
+              code_id_of_witness;
+              code_id;
+              my_closure_of_code_id;
+              y ] =
+         [ "x";
+           "indirect_call_witness";
+           "indirect";
+           "code_id_of_witness";
+           "code_id";
+           "my_closure_of_code_id";
+           "y" ]
+       in
        [ out x;
-         field_usages_rel x field y;
-         filter_field is_function_slot field;
-         usages_rel y z ]
-       ==> out z) ]
+         rev_accessor_rel x
+           (Term.constant (Field.encode Code_of_closure))
+           indirect_call_witness;
+         sources_rel indirect_call_witness indirect;
+         constructor_rel indirect code_id_of_witness code_id;
+         (* CR ncourant: this only works because this can only correspond to a
+            full application, otherwise we wouldn't have unboxed! *)
+         code_id_my_closure_rel code_id my_closure_of_code_id;
+         usages_rel my_closure_of_code_id y ]
+       ==> out y),
+      let$ [x; field; y; z] = ["x"; "field"; "y"; "z"] in
+      [ out x;
+        field_usages_rel x field y;
+        filter_field is_function_slot field;
+        usages_rel y z ]
+      ==> out z )
   in
-  fun db s ->
+  fun ~for_unboxing db s ->
     let db = Datalog.set_table in_tbl s db in
+    let rs =
+      if for_unboxing
+      then [base; for_closures; function_slots]
+      else [base; function_slots]
+    in
     let db = Datalog.Schedule.run (Datalog.Schedule.saturate rs) db in
     Usages (Datalog.get_table out_tbl db)
 
@@ -1008,11 +1043,9 @@ let to_change_representation = rel1 "to_change_representation" Cols.[n]
 let datalog_rules =
   let open! Syntax in
   let open! Global_flow_graph in
-  let field_cannot_be_destructured (i : Field.t) =
-    match[@ocaml.warning "-4"] i with
-    | Code_of_closure | Apply _ | Code_id_of_call_witness _ -> true
-    | _ -> false
-  in
+  (* let field_cannot_be_destructured (i : Field.t) = match[@ocaml.warning "-4"]
+     i with | Code_of_closure | Apply _ | Code_id_of_call_witness _ -> true | _
+     -> false in *)
   let real_field (i : Field.t) =
     match[@ocaml.warning "-4"] i with
     | Code_of_closure | Apply _ | Code_id_of_call_witness _ -> false
@@ -1293,9 +1326,16 @@ let datalog_rules =
      [cannot_change_representation1 x] ==> cannot_unbox0 x);
     (let$ [x] = ["x"] in
      [any_usage_pred x] ==> cannot_unbox0 x);
-    (let$ [x; field] = ["x"; "field"] in
-     [ field_of_constructor_is_used x field;
-       filter_field field_cannot_be_destructured field ]
+    (* (let$ [x; field] = ["x"; "field"] in [ field_of_constructor_is_used x
+       field; filter_field field_cannot_be_destructured field ] ==>
+       cannot_unbox0 x); *)
+    (let$ [x; coderel; call_witness; code_id_of_witness; codeid] =
+       ["x"; "coderel"; "call_witness"; "code_id_of_witness"; "codeid"]
+     in
+     [ constructor_rel x coderel call_witness;
+       filter_field is_code_field coderel;
+       constructor_rel call_witness code_id_of_witness codeid;
+       cannot_change_calling_convention codeid ]
      ==> cannot_unbox0 x);
     (let$ [ alias;
             allocation_id;
@@ -1455,7 +1495,9 @@ let rec rewrite_kind_with_subkind_not_top_not_bottom db flow_to kind =
     erase kind
   | Variant { consts; non_consts } ->
     (* CR ncourant: we should make sure poison is in the consts! *)
-    let usages = get_all_usages db flow_to in
+    (* We don't need to follow indirect code pointers for usage, since functions
+       never appear in value_kinds *)
+    let usages = get_all_usages ~for_unboxing:false db flow_to in
     let fields = get_fields db usages in
     let non_consts =
       Tag.Scannable.Map.map
@@ -1523,7 +1565,7 @@ let rec mk_unboxed_fields ~has_to_be_unboxed ~mk db usages name_prefix =
             Some
               (Unboxed
                  (mk_unboxed_fields ~has_to_be_unboxed ~mk db
-                    (get_all_usages db flow_to)
+                    (get_all_usages ~for_unboxing:true db flow_to)
                     new_name))
           else if Code_id_or_name.Map.exists
                     (fun k () -> has_to_be_unboxed k)
@@ -1605,7 +1647,8 @@ let fixpoint (graph : Global_flow_graph.graph) =
             mk_unboxed_fields ~has_to_be_unboxed
               ~mk:(fun _kind name -> Variable.create name)
               db
-              (get_all_usages db (Code_id_or_name.Map.singleton to_patch ()))
+              (get_all_usages ~for_unboxing:true db
+                 (Code_id_or_name.Map.singleton to_patch ()))
               new_name
           in
           unboxed := Code_id_or_name.Map.add to_patch fields !unboxed)
@@ -1651,7 +1694,8 @@ let fixpoint (graph : Global_flow_graph.graph) =
                   }) )
           in
           let uses =
-            get_all_usages db (Code_id_or_name.Map.singleton code_id_or_name ())
+            get_all_usages ~for_unboxing:false db
+              (Code_id_or_name.Map.singleton code_id_or_name ())
           in
           let repr = mk_unboxed_fields ~has_to_be_unboxed ~mk db uses "" in
           add_to_s (Block_representation (repr, !r + 1)) code_id_or_name
@@ -1662,7 +1706,7 @@ let fixpoint (graph : Global_flow_graph.graph) =
               ~name ~is_always_immediate:false kind
           in
           let uses =
-            get_all_usages db
+            get_all_usages ~for_unboxing:false db
               (List.fold_left
                  (fun acc (_, x) -> Code_id_or_name.Map.add x () acc)
                  Code_id_or_name.Map.empty l)

--- a/middle_end/flambda2/reaper/global_flow_graph.ml
+++ b/middle_end/flambda2/reaper/global_flow_graph.ml
@@ -226,6 +226,8 @@ module CoConstructor_rel =
   Datalog.Schema.Relation3 (Code_id_or_name) (CoFieldC) (Code_id_or_name)
 module Any_usage_pred = Datalog.Schema.Relation1 (Code_id_or_name)
 module Any_source_pred = Datalog.Schema.Relation1 (Code_id_or_name)
+module Code_id_my_closure_rel =
+  Datalog.Schema.Relation2 (Code_id_or_name) (Code_id_or_name)
 
 type graph =
   { mutable alias_rel : Alias_rel.t;
@@ -236,7 +238,8 @@ type graph =
     mutable coconstructor_rel : CoConstructor_rel.t;
     mutable propagate_rel : Propagate_rel.t;
     mutable any_usage_pred : Any_usage_pred.t;
-    mutable any_source_pred : Any_source_pred.t
+    mutable any_source_pred : Any_source_pred.t;
+    mutable code_id_my_closure_rel : Code_id_my_closure_rel.t
   }
 
 let print_iter_edges ~print_edge graph =
@@ -285,6 +288,9 @@ let any_usage_pred = Any_usage_pred.create ~name:"any_usage"
 
 let any_source_pred = Any_source_pred.create ~name:"any_source"
 
+let code_id_my_closure_rel =
+  Code_id_my_closure_rel.create ~name:"code_id_my_closure"
+
 let to_datalog graph =
   Datalog.set_table alias_rel graph.alias_rel
   @@ Datalog.set_table use_rel graph.use_rel
@@ -295,6 +301,7 @@ let to_datalog graph =
   @@ Datalog.set_table propagate_rel graph.propagate_rel
   @@ Datalog.set_table any_usage_pred graph.any_usage_pred
   @@ Datalog.set_table any_source_pred graph.any_source_pred
+  @@ Datalog.set_table code_id_my_closure_rel graph.code_id_my_closure_rel
   @@ Datalog.empty
 
 type 'a rel0 = [> `Atom of Datalog.atom] as 'a
@@ -335,6 +342,9 @@ let any_usage_pred var = Datalog.atom any_usage_pred [var]
 
 let any_source_pred var = Datalog.atom any_source_pred [var]
 
+let code_id_my_closure_rel code_id var =
+  Datalog.atom code_id_my_closure_rel [code_id; var]
+
 let create () =
   { alias_rel = Alias_rel.empty;
     use_rel = Use_rel.empty;
@@ -344,7 +354,8 @@ let create () =
     coconstructor_rel = CoConstructor_rel.empty;
     propagate_rel = Propagate_rel.empty;
     any_usage_pred = Any_usage_pred.empty;
-    any_source_pred = Any_source_pred.empty
+    any_source_pred = Any_source_pred.empty;
+    code_id_my_closure_rel = Code_id_my_closure_rel.empty
   }
 
 let add_alias t ~to_ ~from =
@@ -400,3 +411,9 @@ let add_use t (var : Code_id_or_name.t) =
 
 let add_any_source t (var : Code_id_or_name.t) =
   t.any_source_pred <- Any_source_pred.add_or_replace [var] () t.any_source_pred
+
+let add_code_id_my_closure t code_id my_closure =
+  t.code_id_my_closure_rel
+    <- Code_id_my_closure_rel.add_or_replace
+         [Code_id_or_name.code_id code_id; Code_id_or_name.var my_closure]
+         () t.code_id_my_closure_rel

--- a/middle_end/flambda2/reaper/global_flow_graph.mli
+++ b/middle_end/flambda2/reaper/global_flow_graph.mli
@@ -95,6 +95,8 @@ val any_usage_pred : (Code_id_or_name.t, _) rel1
 
 val any_source_pred : (Code_id_or_name.t, _) rel1
 
+val code_id_my_closure_rel : (Code_id_or_name.t, Code_id_or_name.t, _) rel2
+
 val create : unit -> graph
 
 val add_opaque_let_dependency :
@@ -127,6 +129,8 @@ val add_coaccessor_dep :
 
 val add_coconstructor_dep :
   graph -> base:Code_id_or_name.t -> CoField.t -> from:Code_id_or_name.t -> unit
+
+val add_code_id_my_closure : graph -> Code_id.t -> Variable.t -> unit
 
 val print_iter_edges :
   print_edge:(Code_id_or_name.t * Code_id_or_name.t * string -> unit) ->

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -724,6 +724,7 @@ and traverse_function_params_and_body acc code_id code ~return_continuation
      mark the code as escaping. *)
   let is_opaque = Code_metadata.is_opaque code_metadata in
   let code_dep = Acc.find_code acc code_id in
+  Graph.add_code_id_my_closure (Acc.graph acc) code_id my_closure;
   let maybe_opaque var = if is_opaque then Variable.rename var else var in
   let return = List.map maybe_opaque code_dep.return in
   let exn = maybe_opaque code_dep.exn in


### PR DESCRIPTION
This was removed from the unbox-fv-closures PR to have a minimum working version of it. Now that the reaper is merged, we can look at this separately. However, it currently doesn't pass the testsuite, that looks to be caused by a problem with SIMD vectors passed on the stack.