### PR TITLE
Make `cpu_relax` a poll point

### DIFF
--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -167,7 +167,12 @@ module Runtime_5 = struct
       = "caml_recommended_domain_count" [@@noalloc]
   end
 
-  let cpu_relax () = Raw.cpu_relax ()
+  (* When poll insertion is disabled, [cpu_relax] also needs to act as a polling
+     point to allow systhread preemption. *)
+  (* CR-soon mslater: make cpu_relax a primitive *)
+  let cpu_relax () =
+    Raw.cpu_relax ();
+    Sys.poll_actions ()
 
   type id = Raw.t
 


### PR DESCRIPTION
`Domain.cpu_relax` may be used to implement spin-wait loops, but it relies on poll insertion for systhread preemption. This is a temporary fix that makes `cpu_relax` also call `%poll`. I then plan to make `cpu_relax` a single primitive that will only poll when the compiler is configured without poll insertion.