### PR TITLE
Arm64: remove rosseta check

### DIFF
--- a/oxcaml/tests/simd/amd64/sse_other_ops.ml
+++ b/oxcaml/tests/simd/amd64/sse_other_ops.ml
@@ -39,7 +39,7 @@ module Float32x4 = struct
         else eq_float32x4 ~result ~expect)
 
   let () =
-    Test_helpers.run_if_not_under_rosetta2 ~f:(fun () ->
+
         Float32.check_floats (fun f0 f1 ->
             (failmsg
                := fun () ->
@@ -65,7 +65,7 @@ module Float32x4 = struct
               Float32.to_float32x4 (Float32.sub f0 f1) (Float32.sub f0 f1)
                 (Float32.sub f1 f0) (Float32.sub f1 f0)
             in
-            eq_float32x4 ~result ~expect))
+            eq_float32x4 ~result ~expect)
 end
 
 module Float64x2 = struct
@@ -73,7 +73,6 @@ module Float64x2 = struct
   include Builtins.Sse_other_builtins.Float64x2
 
   let () =
-    Test_helpers.run_if_not_under_rosetta2 ~f:(fun () ->
         Float64.check_floats (fun f0 f1 ->
             (failmsg := fun () -> Printf.printf "%f | %f\n%!" f0 f1);
             let fv0 = to_float64x2 f0 f0 in
@@ -87,7 +86,7 @@ module Float64x2 = struct
             let fv1 = to_float64x2 f1 f0 in
             let result = hsub fv0 fv1 in
             let expect = to_float64x2 (f0 -. f1) (f1 -. f0) in
-            eq_float64x2 ~result ~expect))
+            eq_float64x2 ~result ~expect)
 
   let () =
     Float64.check_floats (fun f0 f1 ->
@@ -127,11 +126,10 @@ module Int64 = struct
   let eq' x y = if x <> y then Printf.printf "%016Lx <> %016Lx\n" x y
 
   let () =
-    Test_helpers.run_if_not_under_rosetta2 ~f:(fun () ->
         eq' (bit_deposit 3L 4L) 0x4L;
         eq' (bit_deposit 235L 522L) 0xAL;
         eq' (bit_extract 3L 4L) 0x0L;
-        eq' (bit_extract 235L 522L) 0x3L)
+        eq' (bit_extract 235L 522L) 0x3L
 end
 
 module Int64x2 = struct

--- a/oxcaml/tests/simd/ops_float32x4.ml
+++ b/oxcaml/tests/simd/ops_float32x4.ml
@@ -117,20 +117,19 @@ let () =
       eq_float64x2 ~result:res ~expect:iv)
 
 let () =
-  Test_helpers.run_if_not_under_rosetta2 ~f:(fun () ->
-      Float32.check_floats (fun f0 f1 ->
-          (failmsg
-             := fun () ->
-                  Printf.printf "%f | %f\n%!" (Int32.float_of_bits f0)
-                    (Int32.float_of_bits f1));
-          let fv0 = Float32.to_float32x4 f0 f0 f1 f1 in
-          let fv1 = Float32.to_float32x4 f1 f1 f0 f0 in
-          let result = hadd fv0 fv1 in
-          let expect =
-            Float32.to_float32x4 (Float32.add f0 f0) (Float32.add f1 f1)
-              (Float32.add f1 f1) (Float32.add f0 f0)
-          in
-          eq_float32x4 ~result ~expect))
+  Float32.check_floats (fun f0 f1 ->
+      (failmsg
+         := fun () ->
+              Printf.printf "%f | %f\n%!" (Int32.float_of_bits f0)
+                (Int32.float_of_bits f1));
+      let fv0 = Float32.to_float32x4 f0 f0 f1 f1 in
+      let fv1 = Float32.to_float32x4 f1 f1 f0 f0 in
+      let result = hadd fv0 fv1 in
+      let expect =
+        Float32.to_float32x4 (Float32.add f0 f0) (Float32.add f1 f1)
+          (Float32.add f1 f1) (Float32.add f0 f0)
+      in
+      eq_float32x4 ~result ~expect)
 
 let () =
   Float32.check_floats (fun f0 f1 ->

--- a/oxcaml/tests/simd/scalar_ops.ml
+++ b/oxcaml/tests/simd/scalar_ops.ml
@@ -70,10 +70,9 @@ module Int = struct
   let rec popcnt i = if i = 0 then 0 else (i land 1) + popcnt (i lsr 1)
 
   let () =
-    Test_helpers.run_if_not_under_rosetta2 ~f:(fun () ->
-        check count_leading_zeros clz;
-        check count_leading_zeros2 clz;
-        check count_trailing_zeros ctz);
+    check count_leading_zeros clz;
+    check count_leading_zeros2 clz;
+    check count_trailing_zeros ctz;
     check count_set_bits popcnt;
     check count_set_bits2 popcnt
 end
@@ -139,11 +138,10 @@ module Int64 = struct
     else Int64.(logand i 1L |> to_int) + popcnt Int64.(shift_right_logical i 1)
 
   let () =
-    Test_helpers.run_if_not_under_rosetta2 ~f:(fun () ->
-        check count_leading_zeros clz;
-        check ~nonzero:true count_leading_zeros_nonzero_arg clz;
-        check count_trailing_zeros ctz;
-        check ~nonzero:true count_trailing_zeros_nonzero_arg ctz);
+    check count_leading_zeros clz;
+    check ~nonzero:true count_leading_zeros_nonzero_arg clz;
+    check count_trailing_zeros ctz;
+    check ~nonzero:true count_trailing_zeros_nonzero_arg ctz;
     check count_set_bits popcnt
 end
 
@@ -208,10 +206,9 @@ module Int32 = struct
     else Int32.(logand i 1l |> to_int) + popcnt Int32.(shift_right_logical i 1)
 
   let () =
-    Test_helpers.run_if_not_under_rosetta2 ~f:(fun () ->
-        check count_leading_zeros clz;
-        check ~nonzero:true count_leading_zeros_nonzero_arg clz;
-        check count_trailing_zeros ctz;
-        check ~nonzero:true count_trailing_zeros_nonzero_arg ctz);
+    check count_leading_zeros clz;
+    check ~nonzero:true count_leading_zeros_nonzero_arg clz;
+    check count_trailing_zeros ctz;
+    check ~nonzero:true count_trailing_zeros_nonzero_arg ctz;
     check count_set_bits popcnt
 end

--- a/oxcaml/tests/simd/test_helpers.mli
+++ b/oxcaml/tests/simd/test_helpers.mli
@@ -3,6 +3,4 @@ type rosetta2_status =
   | Off
   | On
 
-val get_rosetta2_status : unit -> rosetta2_status
-
 val run_if_not_under_rosetta2 : f:(unit -> unit) -> unit


### PR DESCRIPTION
`Test_helpers.run_if_not_under_rosetta2` doesn't do anything on amd64 (the check returns `Unknown` when I test it locally on an amd64 machine, and the checks don't run). Now that we have a separate arm64 implementation of these intrinsics, we can removed this check from  both shared and amd64-only tests.