### PR TITLE
Do not include fail_if_called_indirectly in data section for shared outputs

### DIFF
--- a/backend/generic_fns.ml
+++ b/backend/generic_fns.ml
@@ -360,7 +360,7 @@ let compile ~shared tbl =
   List.concat_map H.curry_function curry_fun
   @ List.map H.send_function send_fun
   @ List.map H.apply_function apply_fun
-  @ H.fail_if_called_indirectly_function ()
+  @ if shared then [] else H.fail_if_called_indirectly_function ()
 
 let imported_units p =
   Partition.Set.to_seq p |> Seq.map Partition.to_cu |> List.of_seq


### PR DESCRIPTION
The current scheme always generates the `fail_if_called_indirectly` function, which makes the linker fail when some shared object includes it and is later linked with a binary that also includes it. This PR should ensure that we only generate the function once when we emit a binary (we may later want to see whether we can include it in the cache for `caml_apply` functions, which already does something along these lines).