### PR TITLE
Fix test order for inlining conditions

### DIFF
--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -147,7 +147,9 @@ let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr
     Code_or_metadata.code_metadata code_or_metadata
     |> Code_metadata.inlining_decision
   in
-  if Function_decl_inlining_decision_type.must_be_inlined decision
+  if env_prohibits_inlining
+  then Environment_says_never_inline
+  else if Function_decl_inlining_decision_type.must_be_inlined decision
   then
     Definition_says_inline
       { was_inline_always =
@@ -155,8 +157,6 @@ let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr
       }
   else if Function_decl_inlining_decision_type.cannot_be_inlined decision
   then Definition_says_not_to_inline
-  else if env_prohibits_inlining
-  then Environment_says_never_inline
   else if not (argument_types_useful dacc apply)
   then Argument_types_not_useful
   else


### PR DESCRIPTION
This prevents any option from overriding the main environment condition.

This made inlining possible when simplifying stub function which is a massive compilation performance problem.