### PR TITLE
Add missing inlining annotations to Name.pattern_match

### DIFF
--- a/middle_end/flambda2/identifiers/code_id_or_name.ml
+++ b/middle_end/flambda2/identifiers/code_id_or_name.ml
@@ -17,5 +17,5 @@ include Int_ids.Code_id_or_name
 
 let pattern_match' t ~code_id ~name =
   pattern_match t ~code_id
-    ~var:(fun var -> name (Name.var var))
-    ~symbol:(fun symbol -> name (Name.symbol symbol))
+    ~var:(fun var -> (name [@inlined hint]) (Name.var var))
+    ~symbol:(fun symbol -> (name [@inlined hint]) (Name.symbol symbol))

--- a/middle_end/flambda2/identifiers/code_id_or_name.ml
+++ b/middle_end/flambda2/identifiers/code_id_or_name.ml
@@ -15,7 +15,7 @@
 
 include Int_ids.Code_id_or_name
 
-let pattern_match' t ~code_id ~name =
+let[@inline always] pattern_match' t ~code_id ~name =
   pattern_match t ~code_id
     ~var:(fun var -> (name [@inlined hint]) (Name.var var))
     ~symbol:(fun symbol -> (name [@inlined hint]) (Name.symbol symbol))

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -831,7 +831,7 @@ module Code_id_or_symbol = struct
 
   let create_symbol symbol = symbol
 
-  let pattern_match t ~code_id ~symbol =
+  let[@inline always] pattern_match t ~code_id ~symbol =
     let flags = Table_by_int_id.Id.flags t in
     if flags = Code_id_data.flags
     then (code_id [@inlined hint]) t
@@ -900,7 +900,7 @@ module Code_id_or_name = struct
 
   let symbol symbol = symbol
 
-  let pattern_match t ~code_id ~var ~symbol =
+  let[@inline always] pattern_match t ~code_id ~var ~symbol =
     let flags = Table_by_int_id.Id.flags t in
     if flags = Code_id_data.flags
     then (code_id [@inlined hint]) t

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -834,9 +834,9 @@ module Code_id_or_symbol = struct
   let pattern_match t ~code_id ~symbol =
     let flags = Table_by_int_id.Id.flags t in
     if flags = Code_id_data.flags
-    then code_id t
+    then (code_id[@inlined hint]) t
     else if flags = Symbol_data.flags
-    then symbol t
+    then (symbol[@inlined hint]) t
     else
       Misc.fatal_errorf "Code_id_or_symbol 0x%x with wrong flags 0x%x" t flags
 
@@ -903,11 +903,11 @@ module Code_id_or_name = struct
   let pattern_match t ~code_id ~var ~symbol =
     let flags = Table_by_int_id.Id.flags t in
     if flags = Code_id_data.flags
-    then code_id t
+    then (code_id[@inlined hint]) t
     else if flags = Symbol_data.flags
-    then symbol t
+    then (symbol[@inlined hint]) t
     else if flags = Variable_data.flags
-    then var t
+    then (var[@inlined hint]) t
     else
       Misc.fatal_errorf "Code_id_or_symbol 0x%x with wrong flags 0x%x" t flags
 

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -549,9 +549,9 @@ module Name = struct
   let[@inline always] pattern_match t ~var ~symbol =
     let flags = Id.flags t in
     if flags = var_flags
-    then var t
+    then (var[@inline hint]) t
     else if flags = symbol_flags
-    then symbol t
+    then (symbol[@inline hint]) t
     else assert false
 
   module T0 = struct

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -549,9 +549,9 @@ module Name = struct
   let[@inline always] pattern_match t ~var ~symbol =
     let flags = Id.flags t in
     if flags = var_flags
-    then (var[@inline hint]) t
+    then (var[@inlined hint]) t
     else if flags = symbol_flags
-    then (symbol[@inline hint]) t
+    then (symbol[@inlined hint]) t
     else assert false
 
   module T0 = struct

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -549,9 +549,9 @@ module Name = struct
   let[@inline always] pattern_match t ~var ~symbol =
     let flags = Id.flags t in
     if flags = var_flags
-    then (var[@inlined hint]) t
+    then (var [@inlined hint]) t
     else if flags = symbol_flags
-    then (symbol[@inlined hint]) t
+    then (symbol [@inlined hint]) t
     else assert false
 
   module T0 = struct
@@ -834,9 +834,9 @@ module Code_id_or_symbol = struct
   let pattern_match t ~code_id ~symbol =
     let flags = Table_by_int_id.Id.flags t in
     if flags = Code_id_data.flags
-    then (code_id[@inlined hint]) t
+    then (code_id [@inlined hint]) t
     else if flags = Symbol_data.flags
-    then (symbol[@inlined hint]) t
+    then (symbol [@inlined hint]) t
     else
       Misc.fatal_errorf "Code_id_or_symbol 0x%x with wrong flags 0x%x" t flags
 
@@ -903,11 +903,11 @@ module Code_id_or_name = struct
   let pattern_match t ~code_id ~var ~symbol =
     let flags = Table_by_int_id.Id.flags t in
     if flags = Code_id_data.flags
-    then (code_id[@inlined hint]) t
+    then (code_id [@inlined hint]) t
     else if flags = Symbol_data.flags
-    then (symbol[@inlined hint]) t
+    then (symbol [@inlined hint]) t
     else if flags = Variable_data.flags
-    then (var[@inlined hint]) t
+    then (var [@inlined hint]) t
     else
       Misc.fatal_errorf "Code_id_or_symbol 0x%x with wrong flags 0x%x" t flags
 

--- a/middle_end/flambda2/term_basics/simple.ml
+++ b/middle_end/flambda2/term_basics/simple.ml
@@ -62,7 +62,7 @@ let is_imported_or_constant t =
     ~const:(fun _ -> true)
     ~name:(fun name ~coercion:_ -> Name.is_imported name)
 
-let pattern_match' t ~var ~symbol ~const =
+let[@inline always] pattern_match' t ~var ~symbol ~const =
   pattern_match t ~const ~name:(fun name ->
       Name.pattern_match name ~var ~symbol)
 

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -133,11 +133,11 @@ module Simple_in_one_joined_env : sig
 end = struct
   include Thing_in_env (Simple) ()
 
-  let pattern_match (t : t) ~name:on_name ~const =
+  let[@inline always] pattern_match (t : t) ~name:on_name ~const =
     Simple.pattern_match
       (t :> Simple.t)
       ~name:(fun name ~coercion ->
-        on_name (Name_in_one_joined_env.create name) ~coercion)
+        (on_name [@inlined hint]) (Name_in_one_joined_env.create name) ~coercion)
       ~const
 end
 


### PR DESCRIPTION
We noticed some anonymous functions passed to `Name.pattern_match`  in perf profiles. This is likely not a big problem, but given the typical usage of `Name.pattern_match` it seems better to always inline.