### PR TITLE
Arm64: fix and re-enable one more SIMD test

### DIFF
--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -540,11 +540,11 @@ end = struct
     | Maxq_u8 | Mvnq_s8 | Orrq_s8 | Andq_s8 | Eorq_s8 | Negq_s8 | Cntq_u8
     | Shlq_u8 | Shlq_s8 | Cmp_s8 _ | Cmpz_s8 _ | Shlq_n_u8 _ | Shrq_n_u8 _
     | Shrq_n_s8 _ | Getq_lane_s8 _ | Setq_lane_s8 _ | Dupq_lane_s8 _ | Extq_u8 _
-    | Qmovn_high_s32 | Qmovn_s32 | Qmovn_high_u32 | Qmovn_u32 | Qmovn_high_s16
-    | Qmovn_s16 | Qmovn_high_u16 | Qmovn_u16 | Movn_high_s64 | Movn_high_s32
-    | Movn_s32 | Movn_high_s16 | Movn_s16 | Mullq_s16 | Mullq_u16
-    | Mullq_high_s16 | Mullq_high_u16 | Movl_s16 | Movl_u16 | Movl_s8 | Movl_u8
-      ->
+    | Qmovn_high_s64 | Qmovn_s64 | Qmovn_high_s32 | Qmovn_s32 | Qmovn_high_u32
+    | Qmovn_u32 | Qmovn_high_s16 | Qmovn_s16 | Qmovn_high_u16 | Qmovn_u16
+    | Movn_high_s64 | Movn_high_s32 | Movn_s32 | Movn_high_s16 | Movn_s16
+    | Mullq_s16 | Mullq_u16 | Mullq_high_s16 | Mullq_high_u16 | Movl_s16
+    | Movl_u16 | Movl_s8 | Movl_u8 ->
       1
 
   let emit_rounding_mode (rm : Simd.Rounding_mode.t) : I.Rounding_mode.t =
@@ -676,8 +676,8 @@ end = struct
     | Qsubq_u16 | Qsubq_u8 -> ins I.UQSUB operands
     | Cntq_u16 | Cntq_u8 -> ins I.CNT operands
     | Extq_u8 n -> ins I.EXT (Array.append operands [| imm n |])
-    | Qmovn_high_s32 | Qmovn_high_s16 -> ins I.SQXTN2 operands
-    | Qmovn_s32 | Qmovn_s16 -> ins I.SQXTN operands
+    | Qmovn_high_s64 | Qmovn_high_s32 | Qmovn_high_s16 -> ins I.SQXTN2 operands
+    | Qmovn_s64 | Qmovn_s32 | Qmovn_s16 -> ins I.SQXTN operands
     | Qmovn_high_u32 | Qmovn_high_u16 -> ins I.UQXTN2 operands
     | Qmovn_u32 | Qmovn_u16 -> ins I.UQXTN operands
     | Movn_s64 | Movn_s32 | Movn_s16 -> ins I.XTN operands

--- a/backend/arm64/simd.ml
+++ b/backend/arm64/simd.ml
@@ -283,6 +283,8 @@ type operation =
       { src_lane : int;
         dst_lane : int
       }
+  | Qmovn_high_s64
+  | Qmovn_s64
   | Qmovn_high_s32
   | Qmovn_s32
   | Qmovn_high_u32
@@ -464,6 +466,8 @@ let print_name op =
   | Dupq_lane_s8 { lane } -> "Setq_lane_s8_" ^ Int.to_string lane
   | Copyq_laneq_s64 { src_lane; dst_lane } ->
     Printf.sprintf "Copyq_laneq_s64_%d_to_%d" src_lane dst_lane
+  | Qmovn_high_s64 -> "Qmovn_high_s64"
+  | Qmovn_s64 -> "Qmovn_s64"
   | Qmovn_high_s32 -> "Qmovn_high_s32"
   | Qmovn_s32 -> "Qmovn_s32"
   | Qmovn_high_u32 -> "Qmovn_high_u32"
@@ -613,6 +617,8 @@ let equal_operation op1 op2 =
   | Cntq_u8, Cntq_u8
   | Shlq_u8, Shlq_u8
   | Shlq_s8, Shlq_s8
+  | Qmovn_high_s64, Qmovn_high_s64
+  | Qmovn_s64, Qmovn_s64
   | Qmovn_high_s32, Qmovn_high_s32
   | Qmovn_s32, Qmovn_s32
   | Qmovn_high_u32, Qmovn_high_u32
@@ -704,11 +710,11 @@ let equal_operation op1 op2 =
       | Maxq_s8 | Minq_u8 | Maxq_u8 | Mvnq_s8 | Orrq_s8 | Andq_s8 | Eorq_s8
       | Negq_s8 | Cntq_u8 | Shlq_u8 | Shlq_s8 | Cmp_s8 _ | Cmpz_s8 _
       | Shlq_n_u8 _ | Shrq_n_u8 _ | Shrq_n_s8 _ | Getq_lane_s8 _
-      | Setq_lane_s8 _ | Dupq_lane_s8 _ | Copyq_laneq_s64 _ | Qmovn_high_s32
-      | Qmovn_s32 | Qmovn_high_u32 | Qmovn_u32 | Qmovn_high_s16 | Qmovn_s16
-      | Qmovn_high_u16 | Qmovn_u16 | Movn_high_s64 | Movn_s64 | Movn_high_s32
-      | Movn_s32 | Movn_high_s16 | Movn_s16 | Mullq_s16 | Mullq_u16
-      | Mullq_high_s16 | Mullq_high_u16 ),
+      | Setq_lane_s8 _ | Dupq_lane_s8 _ | Copyq_laneq_s64 _ | Qmovn_high_s64
+      | Qmovn_s64 | Qmovn_high_s32 | Qmovn_s32 | Qmovn_high_u32 | Qmovn_u32
+      | Qmovn_high_s16 | Qmovn_s16 | Qmovn_high_u16 | Qmovn_u16 | Movn_high_s64
+      | Movn_s64 | Movn_high_s32 | Movn_s32 | Movn_high_s16 | Movn_s16
+      | Mullq_s16 | Mullq_u16 | Mullq_high_s16 | Mullq_high_u16 ),
       _ ) ->
     false
 
@@ -740,11 +746,11 @@ let class_of_operation op =
   | Minq_s8 | Maxq_s8 | Minq_u8 | Maxq_u8 | Mvnq_s8 | Orrq_s8 | Andq_s8
   | Eorq_s8 | Negq_s8 | Cntq_u8 | Shlq_u8 | Shlq_s8 | Cmp_s8 _ | Cmpz_s8 _
   | Shlq_n_u8 _ | Shrq_n_u8 _ | Shrq_n_s8 _ | Getq_lane_s8 _ | Setq_lane_s8 _
-  | Dupq_lane_s8 _ | Copyq_laneq_s64 _ | Qmovn_high_s32 | Qmovn_s32
-  | Qmovn_high_u32 | Qmovn_u32 | Qmovn_high_s16 | Qmovn_s16 | Qmovn_high_u16
-  | Qmovn_u16 | Movn_high_s64 | Movn_s64 | Movn_high_s32 | Movn_s32
-  | Movn_high_s16 | Movn_s16 | Mullq_s16 | Mullq_u16 | Mullq_high_s16
-  | Mullq_high_u16 ->
+  | Dupq_lane_s8 _ | Copyq_laneq_s64 _ | Qmovn_high_s64 | Qmovn_s64
+  | Qmovn_high_s32 | Qmovn_s32 | Qmovn_high_u32 | Qmovn_u32 | Qmovn_high_s16
+  | Qmovn_s16 | Qmovn_high_u16 | Qmovn_u16 | Movn_high_s64 | Movn_s64
+  | Movn_high_s32 | Movn_s32 | Movn_high_s16 | Movn_s16 | Mullq_s16 | Mullq_u16
+  | Mullq_high_s16 | Mullq_high_u16 ->
     Pure
 
 let operation_is_pure op = match class_of_operation op with Pure -> true

--- a/backend/arm64/simd_proc.ml
+++ b/backend/arm64/simd_proc.ml
@@ -128,11 +128,11 @@ let register_behavior (op : Simd.operation) =
     Rs32x2_to_Rs64x2
   | Movl_s16 | Movl_u16 -> Rs16x4_to_Rs32x4
   | Movl_s8 | Movl_u8 -> Rs8x8_to_Rs16x8
-  | Movn_s64 ->
+  | Movn_s64 | Qmovn_s64 ->
     (* Output should be in Vec128 register but only the bottom s32x2 is used by
        this instruction. *)
     Rs64x2_to_Rs32x2
-  | Movn_high_s64 -> Rs32x4_Rs64x2_to_First
+  | Movn_high_s64 | Qmovn_high_s64 -> Rs32x4_Rs64x2_to_First
   | Qmovn_u32 | Qmovn_s32 | Movn_s32 -> Rs32x4_to_Rs16x4
   | Qmovn_high_s32 | Qmovn_high_u32 | Movn_high_s32 -> Rs16x8_Rs32x4_to_First
   | Qmovn_u16 | Qmovn_s16 | Movn_s16 -> Rs16x8_to_Rs8x8

--- a/backend/arm64/simd_selection.ml
+++ b/backend/arm64/simd_selection.ml
@@ -158,6 +158,9 @@ let select_simd_instr op args dbg =
   | "caml_neon_int16x8_mul_high_long" -> Some (Mullq_high_s16, args)
   | "caml_neon_int16x8_mul_low_long_unsigned" -> Some (Mullq_u16, args)
   | "caml_neon_int16x8_mul_high_long_unsigned" -> Some (Mullq_high_u16, args)
+  | "caml_neon_cvt_int64x2_to_int32x4_high_saturating" ->
+    Some (Qmovn_high_s64, args)
+  | "caml_neon_cvt_int64x2_to_int32x4_low_saturating" -> Some (Qmovn_s64, args)
   | "caml_neon_cvt_int32x4_to_int16x8_high_saturating" ->
     Some (Qmovn_high_s32, args)
   | "caml_neon_cvt_int32x4_to_int16x8_low_saturating" -> Some (Qmovn_s32, args)

--- a/oxcaml/tests/simd/amd64/sse_other_ops.ml
+++ b/oxcaml/tests/simd/amd64/sse_other_ops.ml
@@ -97,28 +97,6 @@ module Float64x2 = struct
         let result = dp 0b0011_0001 fv0 fv1 in
         let expect = to_float64x2 ((f0 *. f1) +. (f1 *. f0)) 0.0 in
         eq_float64x2 ~result ~expect)
-
-  let () =
-    (* CR gyorsh: Fix arm64 implementation of [Float64x2.cvt_int32x4] and
-       re-enable this tests on arm64. Current arm64 implementation returns a
-       slightly different result. Which arm64 coversion instruction should be
-       used? *)
-    Float64.check_floats (fun f0 f1 ->
-        (failmsg := fun () -> Printf.printf "cvti32 %g | %g\n%!" f0 f1);
-        let i0 =
-          Int32.of_float (Float64.c_round f0)
-          |> Int64.of_int32 |> Int64.logand 0xffffffffL
-        in
-        let i1 =
-          Int32.of_float (Float.round f1)
-          |> Int64.of_int32 |> Int64.logand 0xffffffffL
-        in
-        let ii = Int64.(logor (shift_left i1 32) i0) in
-        let iv = int32x4_of_int64s ii 0L in
-        let fv = to_float64x2 f0 f1 in
-        let res = cvt_int32x4 fv in
-        eq (int32x4_low_int64 res) (int32x4_high_int64 res)
-          (int32x4_low_int64 iv) (int32x4_high_int64 iv))
 end
 
 module Int64 = struct

--- a/oxcaml/tests/simd/arm64/builtins.ml
+++ b/oxcaml/tests/simd/arm64/builtins.ml
@@ -133,6 +133,15 @@ module Int64x2 = struct
     = "caml_vec128_unreachable" "caml_neon_cvt_int64x2_to_int32x4"
     [@@noalloc] [@@unboxed] [@@builtin]
 
+  external cvt_int32x4_saturating : t -> int32x4
+    = "caml_vec128_unreachable" "caml_neon_cvt_int64x2_to_int32x4_low_saturating"
+    [@@noalloc] [@@unboxed] [@@builtin]
+
+  (* preserves low bits *)
+  external to_int16x8_high_saturating : int32x4 -> t -> int32x4
+    = "caml_vec128_unreachable" "caml_neon_cvt_int64x2_to_int32x4_high_saturating"
+    [@@noalloc] [@@unboxed] [@@builtin]
+
   external ushl : t -> t -> t
     = "caml_vec128_unreachable" "caml_neon_int64x2_ushl"
     [@@noalloc] [@@unboxed] [@@builtin]
@@ -536,19 +545,14 @@ module Float64x2 = struct
     = "caml_vec128_unreachable" "caml_neon_float64x2_round_near"
     [@@noalloc] [@@builtin]
 
-  (* CR gyorsh: which coversion function should be used? *)
+  external round_current : (t[@unboxed]) -> (t[@unboxed])
+    = "caml_vec128_unreachable" "caml_neon_float64x2_round_current"
+    [@@noalloc] [@@builtin]
 
   let cvt_int32x4 : t -> int32x4 =
-   fun t -> t |> round_near |> cvt_int64x2 |> Int64x2.cvt_int32x4
-
-  (* let cvt_int32x4 : t -> int32x4 = *)
-  (* fun t -> t |> cvt_float32x4 |> Float32x4.cvt_int32x4 *)
-
-  (* let cvt_int32x4 : t -> int32x4 = *)
-  (*  fun t -> t |> cvt_int64x2 |> Int64x2.cvt_int32x4 *)
-
-  (* let cvt_int32x4 : t -> int32x4 = *)
-  (*  fun t -> t |> round_near |> cvt_float32x4 |> Float32x4.cvt_int32x4 *)
+   (* Use saturating narrowing conversion here to match SSE intrinsics and C
+      stubs behavior. *)
+   fun t -> t |> round_current |> cvt_int64x2 |> Int64x2.cvt_int32x4_saturating
 end
 
 module Int16x8 = struct

--- a/oxcaml/tests/simd/arm64/stub_builtins.c
+++ b/oxcaml/tests/simd/arm64/stub_builtins.c
@@ -11,6 +11,7 @@ BUILTIN(caml_neon_float64_min);
 BUILTIN(caml_neon_float64_sqrt);
 BUILTIN(caml_neon_float64_round_near);
 
+
 BUILTIN(caml_neon_float32x4_cmeq);
 BUILTIN(caml_neon_float32x4_cmgt);
 BUILTIN(caml_neon_float32x4_cmge);
@@ -229,6 +230,7 @@ BUILTIN(caml_neon_float64x2_cmgt)
 BUILTIN(caml_neon_float64x2_cmle)
 BUILTIN(caml_neon_float64x2_cmlt)
 BUILTIN(caml_neon_float64x2_round_near)
+BUILTIN(caml_neon_float64x2_round_current)
 BUILTIN(caml_neon_int16x8_neg)
 BUILTIN(caml_neon_int16x8_sshl)
 BUILTIN(caml_neon_int16x8_ushl)
@@ -258,7 +260,8 @@ BUILTIN(caml_neon_int8x16_bitwise_or)
 BUILTIN(caml_neon_int8x16_bitwise_xor)
 BUILTIN(caml_neon_int8x16_ext)
 
-
+BUILTIN(caml_neon_cvt_int64x2_to_int32x4_high_saturating)
+BUILTIN(caml_neon_cvt_int64x2_to_int32x4_low_saturating)
 BUILTIN(caml_neon_cvt_int32x4_to_int16x8_high_saturating);
 BUILTIN(caml_neon_cvt_int32x4_to_int16x8_high_saturating_unsigned);
 BUILTIN(caml_neon_cvt_int32x4_to_int16x8_low_saturating);

--- a/oxcaml/tests/simd/ops_float64x2.ml
+++ b/oxcaml/tests/simd/ops_float64x2.ml
@@ -132,3 +132,21 @@ let () =
       let result = round_near fv in
       let expect = to_float64x2 (Float64.c_round f0) (Float64.c_round f1) in
       eq_float64x2 ~result ~expect)
+
+let () =
+  Float64.check_floats (fun f0 f1 ->
+      (failmsg := fun () -> Printf.printf "cvti32 %g | %g\n%!" f0 f1);
+      let i0 =
+        Int32.of_float (Float64.c_round f0)
+        |> Int64.of_int32 |> Int64.logand 0xffffffffL
+      in
+      let i1 =
+        Int32.of_float (Float.round f1)
+        |> Int64.of_int32 |> Int64.logand 0xffffffffL
+      in
+      let ii = Int64.(logor (shift_left i1 32) i0) in
+      let iv = int32x4_of_int64s ii 0L in
+      let fv = to_float64x2 f0 f1 in
+      let res = cvt_int32x4 fv in
+      eq (int32x4_low_int64 res) (int32x4_high_int64 res) (int32x4_low_int64 iv)
+        (int32x4_high_int64 iv))


### PR DESCRIPTION
Use saturating coversion from `int64x2` to `int32x4` in `Float64x2.cvt_int32x4` on arm64 and re-enable the corresponding test on arm64.