### PR TITLE
Remove caml_get_header_val, as not needed.

### DIFF
--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -94,7 +94,6 @@ extern void caml_empty_minor_heaps_once(void); /* out STW */
 void caml_alloc_small_dispatch (caml_domain_state* domain,
                                 intnat wosize, int flags,
                                 int nallocs, unsigned char* encoded_alloc_lens);
-header_t caml_get_header_val(value v);
 void caml_alloc_table (struct caml_ref_table *tbl, asize_t sz, asize_t rsv);
 extern void caml_realloc_ref_table (struct caml_ref_table *);
 extern void caml_realloc_ephe_ref_table (struct caml_ephe_ref_table *);

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -243,7 +243,7 @@ static void generic_final_minor_update
   for (i = final->old; i < final->young; i++){
     CAMLassert (Is_block (final->table[i].val));
     if (Is_young(final->table[i].val) &&
-        !Is_promoted_hd(caml_get_header_val(final->table[i].val))) {
+        !Is_promoted_hd(Hd_val(final->table[i].val))) {
       ++ todo_count;
     }
   }
@@ -265,7 +265,7 @@ static void generic_final_minor_update
       CAMLassert (Is_block (final->table[i].val));
       CAMLassert (Tag_val (final->table[i].val) != Forward_tag);
       if (Is_young(final->table[i].val) &&
-          !Is_promoted_hd(caml_get_header_val(final->table[i].val))) {
+          !Is_promoted_hd(Hd_val(final->table[i].val))) {
         /** dead */
         fi->todo_tail->item[k] = final->table[i];
         /* The finalisation function is called with unit not with the value */
@@ -287,7 +287,7 @@ static void generic_final_minor_update
   for (i = final->old; i < final->young; i++) {
     CAMLassert (Is_block (final->table[i].val));
     if (Is_young(final->table[i].val)) {
-      CAMLassert (Is_promoted_hd(caml_get_header_val(final->table[i].val)));
+      CAMLassert (Is_promoted_hd(Hd_val(final->table[i].val)));
       final->table[i].val = Field(final->table[i].val, 0);
     }
   }

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -196,11 +196,6 @@ Caml_inline header_t get_header_val(value v) {
   return spin_on_header(v);
 }
 
-header_t caml_get_header_val(value v) {
-  return get_header_val(v);
-}
-
-
 static int try_update_object_header(value v, volatile value *p, value result,
                                     mlsize_t infix_offset) {
   int success = 0;
@@ -884,7 +879,7 @@ static void dependent_accounting_minor (caml_domain_state *domain)
     value *v = &elt->block;
     CAMLassert (Is_block (*v));
     if (Is_young(*v)) {
-      if (get_header_val(*v) == 0) { /* value copied to major heap */
+      if (Hd_val(*v) == 0) { /* value copied to major heap */
         /* inlined version of [caml_alloc_dependent_memory] */
         domain->allocated_dependent_bytes += elt->mem;
         domain->stat_promoted_dependent_bytes += elt->mem;


### PR DESCRIPTION
This arose during review of #3493 : `caml_get_header_val` only differs from `Hd_val` in that it will spin if it sees an in-progress header, i.e. if some domain is in the process of promoting the block. This can only happen between the barriers of a minor collection; there are very few places outside `minor_gc.c` where it might be possible, and certainly not while updating finalizer data structures after a minor GC.