### PR TITLE
Allow `or_null` in `[@@unboxed]` types

### DIFF
--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -788,32 +788,14 @@ type test = float t req_non_float
 
 type unbx = { unbx : t_maybesep_val } [@@unboxed]
 
-(* CR layouts v3.4: non-separable unboxed records should be allowed. *)
-
 [%%expect{|
-Line 1, characters 0-49:
-1 | type unbx = { unbx : t_maybesep_val } [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "unbx" is value_or_null mod non_null
-         because of the definition of t_maybesep_val at line 1, characters 0-48.
-       But the kind of type "unbx" must be a subkind of value
-         because it's an [@@unboxed] type,
-         chosen to have kind value.
+type unbx = { unbx : t_maybesep_val; } [@@unboxed]
 |}]
-
-(* CR layouts v3.4: non-separable unboxed variants should be allowed. *)
 
 type ('a : value_or_null mod non_null) unbx' = Unbx of 'a [@@unboxed]
 
 [%%expect{|
-Line 1, characters 0-69:
-1 | type ('a : value_or_null mod non_null) unbx' = Unbx of 'a [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "unbx'" is value_or_null mod non_null
-         because of the annotation on 'a in the declaration of the type unbx'.
-       But the kind of type "unbx'" must be a subkind of value
-         because it's an [@@unboxed] type,
-         chosen to have kind value.
+type ('a : value_or_null mod non_null) unbx' = Unbx of 'a [@@unboxed]
 |}]
 
 (* Separability and unboxed records. *)

--- a/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -332,3 +332,134 @@ type t_any_non_null : any_non_null
 [%%expect{|
 type t_any_non_null : any_non_null
 |}]
+
+(* [or_null] in unboxed types *)
+
+type unboxed_rec = { field : int or_null } [@@unboxed]
+
+[%%expect{|
+type unboxed_rec = { field : int or_null; } [@@unboxed]
+|}]
+
+let unboxed_null = { field = Null }
+
+[%%expect{|
+val unboxed_null : unboxed_rec = {field = Null}
+|}]
+
+let unboxed_some = { field = This 42 }
+
+[%%expect{|
+val unboxed_some : unboxed_rec = {field = This 42}
+|}]
+
+let get_field (r : unboxed_rec) = r.field
+
+[%%expect{|
+val get_field : unboxed_rec -> int or_null = <fun>
+|}]
+
+type unboxed_var = Wrap of int or_null [@@unboxed]
+
+[%%expect{|
+type unboxed_var = Wrap of int or_null [@@unboxed]
+|}]
+
+let var_null = Wrap Null
+
+[%%expect{|
+val var_null : unboxed_var = <unknown constructor>
+|}]
+
+let var_some = Wrap (This 99)
+
+[%%expect{|
+val var_some : unboxed_var = <unknown constructor>
+|}]
+
+let unwrap = function
+  | Wrap x -> x
+
+[%%expect{|
+val unwrap : unboxed_var -> int or_null = <fun>
+|}]
+
+type (_, _) fail = Fail : 'a or_null -> ('a, 'a or_null) fail [@@unboxed]
+[%%expect{|
+Line 1, characters 45-55:
+1 | type (_, _) fail = Fail : 'a or_null -> ('a, 'a or_null) fail [@@unboxed]
+                                                 ^^^^^^^^^^
+Error: This type "'a or_null" should be an instance of type "('b : value)"
+       The kind of 'a or_null is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of 'a or_null must be a subkind of value
+         because it instantiates an unannotated type parameter of fail,
+         chosen to have kind value.
+|}]
+
+type (_, _ : value_or_null) gadt = Gadt : 'a or_null -> ('a, 'a or_null) gadt [@@unboxed]
+
+[%%expect{|
+type (_, _) gadt = Gadt : 'a or_null -> ('a, 'a or_null) gadt [@@unboxed]
+|}]
+
+let gadt_null = Gadt Null
+
+[%%expect{|
+val gadt_null : ('a, 'a or_null) gadt = <unknown constructor>
+|}]
+
+let gadt_some = Gadt (This 42)
+
+[%%expect{|
+val gadt_some : (int, int or_null) gadt = <unknown constructor>
+|}]
+
+let unwrap_gadt : type a. (a, a or_null) gadt -> a or_null = function
+  | Gadt x -> x
+
+[%%expect{|
+val unwrap_gadt : ('a, 'a or_null) gadt -> 'a or_null = <fun>
+|}]
+
+let should_fail_unboxed_rec = This { field = Null }
+
+[%%expect{|
+Line 1, characters 35-51:
+1 | let should_fail_unboxed_rec = This { field = Null }
+                                       ^^^^^^^^^^^^^^^^
+Error: This expression has type "unboxed_rec"
+       but an expression was expected of type "('a : value)"
+       The kind of unboxed_rec is immediate_or_null
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of unboxed_rec must be a subkind of value
+         because of the definition of t at line 1, characters 0-81.
+|}]
+
+let should_fail_unboxed_var = This (Wrap Null)
+
+[%%expect{|
+Line 1, characters 35-46:
+1 | let should_fail_unboxed_var = This (Wrap Null)
+                                       ^^^^^^^^^^^
+Error: This expression has type "unboxed_var"
+       but an expression was expected of type "('a : value)"
+       The kind of unboxed_var is immediate_or_null
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of unboxed_var must be a subkind of value
+         because of the definition of t at line 1, characters 0-81.
+|}]
+
+let should_fail_unboxed_gadt = This (Gadt Null)
+
+[%%expect{|
+Line 1, characters 36-47:
+1 | let should_fail_unboxed_gadt = This (Gadt Null)
+                                        ^^^^^^^^^^^
+Error: This expression has type "('a, 'a or_null) gadt"
+       but an expression was expected of type "('b : value)"
+       The kind of ('a, 'a or_null) gadt is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of ('a, 'a or_null) gadt must be a subkind of value
+         because of the definition of t at line 1, characters 0-81.
+|}]

--- a/testsuite/tests/typing-layouts-products/separability.ml
+++ b/testsuite/tests/typing-layouts-products/separability.ml
@@ -75,33 +75,33 @@ Error: This type cannot be unboxed because
        You should annotate it with "[@@ocaml.boxed]".
 |}]
 
-(* CR layouts v12: Once we allow products containing void in unboxed GADTs,
-   we'll have to make sure the below fails separability checking: *)
+(* #(value & void) and similar kinds are always considered separable,
+   since we don't apply the float array optimization for them. *)
 type t_void : void
 and 'a r = #{ a : 'a ; v : t_void }
-and bad = F : 'a r -> bad [@@unboxed]
+and ok = F : 'a r -> ok [@@unboxed]
 [%%expect{|
 type t_void : void
 and 'a r = #{ a : 'a; v : t_void; }
-and bad = F : 'a r -> bad [@@unboxed]
+and ok = F : 'a r -> ok [@@unboxed]
 |}]
 
 type t_void : void
 and 'a r = #{ a : 'a ; v : t_void }
-and bad = F : { x : 'a r } -> bad [@@unboxed]
+and ok = F : { x : 'a r } -> ok [@@unboxed]
 [%%expect{|
 type t_void : void
 and 'a r = #{ a : 'a; v : t_void; }
-and bad = F : { x : 'a r; } -> bad [@@unboxed]
+and ok = F : { x : 'a r; } -> ok [@@unboxed]
 |}]
 
 type t_void : void
 and ('a : value) r = #{ a : 'a ; v : t_void }
-and bad = F : 'a r -> bad [@@unboxed]
+and ok = F : 'a r -> ok [@@unboxed]
 [%%expect{|
 type t_void : void
 and 'a r = #{ a : 'a; v : t_void; }
-and bad = F : 'a r -> bad [@@unboxed]
+and ok = F : 'a r -> ok [@@unboxed]
 |}]
 
 (* CR layouts v12: Double-check this is safe when we add [void]. *)

--- a/testsuite/tests/typing-layouts-products/separability.ml
+++ b/testsuite/tests/typing-layouts-products/separability.ml
@@ -81,42 +81,27 @@ type t_void : void
 and 'a r = #{ a : 'a ; v : t_void }
 and bad = F : 'a r -> bad [@@unboxed]
 [%%expect{|
-Line 3, characters 0-37:
-3 | and bad = F : 'a r -> bad [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "bad" is value_or_null & void
-         because it is an unboxed record.
-       But the kind of type "bad" must be a subkind of value & void
-         because it's an [@@unboxed] type,
-         chosen to have kind value & void.
+type t_void : void
+and 'a r = #{ a : 'a; v : t_void; }
+and bad = F : 'a r -> bad [@@unboxed]
 |}]
 
 type t_void : void
 and 'a r = #{ a : 'a ; v : t_void }
 and bad = F : { x : 'a r } -> bad [@@unboxed]
 [%%expect{|
-Line 3, characters 0-45:
-3 | and bad = F : { x : 'a r } -> bad [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "bad" is value_or_null & void
-         because it is an unboxed record.
-       But the kind of type "bad" must be a subkind of value & void
-         because it's an [@@unboxed] type,
-         chosen to have kind value & void.
+type t_void : void
+and 'a r = #{ a : 'a; v : t_void; }
+and bad = F : { x : 'a r; } -> bad [@@unboxed]
 |}]
 
 type t_void : void
 and ('a : value) r = #{ a : 'a ; v : t_void }
 and bad = F : 'a r -> bad [@@unboxed]
 [%%expect{|
-Line 3, characters 0-37:
-3 | and bad = F : 'a r -> bad [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "bad" is value_or_null & void
-         because it is an unboxed record.
-       But the kind of type "bad" must be a subkind of value & void
-         because it's an [@@unboxed] type,
-         chosen to have kind value & void.
+type t_void : void
+and 'a r = #{ a : 'a; v : t_void; }
+and bad = F : 'a r -> bad [@@unboxed]
 |}]
 
 (* CR layouts v12: Double-check this is safe when we add [void]. *)

--- a/testsuite/tests/typing-layouts-products/separability_implicit_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/separability_implicit_unboxed_records.ml
@@ -82,26 +82,16 @@ type t_void : void
 and 'a r = { a : 'a ; v : t_void }
 and bad = F : 'a r# -> bad [@@unboxed]
 [%%expect{|
-Line 3, characters 0-38:
-3 | and bad = F : 'a r# -> bad [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "bad" is value_or_null & void
-         because it is an unboxed record.
-       But the kind of type "bad" must be a subkind of value & void
-         because it's an [@@unboxed] type,
-         chosen to have kind value & void.
+type t_void : void
+and 'a r = { a : 'a; v : t_void; }
+and bad = F : 'a r# -> bad [@@unboxed]
 |}]
 
 type t_void : void
 and 'a r = { a : 'a ; v : t_void }
 and bad = F : { x : 'a r# } -> bad [@@unboxed]
 [%%expect{|
-Line 3, characters 0-46:
-3 | and bad = F : { x : 'a r# } -> bad [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "bad" is value_or_null & void
-         because it is an unboxed record.
-       But the kind of type "bad" must be a subkind of value & void
-         because it's an [@@unboxed] type,
-         chosen to have kind value & void.
+type t_void : void
+and 'a r = { a : 'a; v : t_void; }
+and bad = F : { x : 'a r#; } -> bad [@@unboxed]
 |}]

--- a/testsuite/tests/typing-layouts-products/separability_implicit_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/separability_implicit_unboxed_records.ml
@@ -75,23 +75,22 @@ Error: This type cannot be unboxed because
        You should annotate it with "[@@ocaml.boxed]".
 |}]
 
-(* CR layouts v12: Once we allow products containing void in unboxed GADTs,
-   and boxed records containing void, we'll have to make sure the below fails
-   separability checking: *)
+(* #(value & void) and similar kinds are always considered separable,
+   since we don't apply the float array optimization for them. *)
 type t_void : void
 and 'a r = { a : 'a ; v : t_void }
-and bad = F : 'a r# -> bad [@@unboxed]
+and ok = F : 'a r# -> ok [@@unboxed]
 [%%expect{|
 type t_void : void
 and 'a r = { a : 'a; v : t_void; }
-and bad = F : 'a r# -> bad [@@unboxed]
+and ok = F : 'a r# -> ok [@@unboxed]
 |}]
 
 type t_void : void
 and 'a r = { a : 'a ; v : t_void }
-and bad = F : { x : 'a r# } -> bad [@@unboxed]
+and ok = F : { x : 'a r# } -> ok [@@unboxed]
 [%%expect{|
 type t_void : void
 and 'a r = { a : 'a; v : t_void; }
-and bad = F : { x : 'a r#; } -> bad [@@unboxed]
+and ok = F : { x : 'a r#; } -> ok [@@unboxed]
 |}]

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2879,6 +2879,7 @@ module Format_history = struct
       fprintf ppf "it's the type being used for a peek or poke primitive"
     | Mutable_var_assignment ->
       fprintf ppf "it's the type of a mutable variable used in an assignment"
+    | Old_style_unboxed_type -> fprintf ppf "it's an [@@@@unboxed] type"
 
   let format_concrete_legacy_creation_reason ppf :
       History.concrete_legacy_creation_reason -> unit = function
@@ -2888,7 +2889,6 @@ module Format_history = struct
     | Wildcard -> fprintf ppf "it's a _ in the type"
     | Unification_var -> fprintf ppf "it's a fresh unification variable"
     | Array_element -> fprintf ppf "it's the type of an array element"
-    | Old_style_unboxed_type -> fprintf ppf "it's an [@@@@unboxed] type"
 
   let rec format_annotation_context :
       type l r. _ -> (l * r) History.annotation_context -> unit =
@@ -3687,6 +3687,7 @@ module Debug_printers = struct
     | Unboxed_tuple_element -> fprintf ppf "Unboxed_tuple_element"
     | Peek_or_poke -> fprintf ppf "Peek_or_poke"
     | Mutable_var_assignment -> fprintf ppf "Mutable_var_assignment"
+    | Old_style_unboxed_type -> fprintf ppf "Old_style_unboxed_type"
 
   let concrete_legacy_creation_reason ppf :
       History.concrete_legacy_creation_reason -> unit = function
@@ -3695,7 +3696,6 @@ module Debug_printers = struct
     | Wildcard -> fprintf ppf "Wildcard"
     | Unification_var -> fprintf ppf "Unification_var"
     | Array_element -> fprintf ppf "Array_element"
-    | Old_style_unboxed_type -> fprintf ppf "Old_style_unboxed_type"
 
   let rec annotation_context :
       type l r. _ -> (l * r) History.annotation_context -> unit =

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -215,6 +215,7 @@ module History = struct
     | Unboxed_tuple_element
     | Peek_or_poke
     | Mutable_var_assignment
+    | Old_style_unboxed_type
 
   (* For sort variables that are in the "legacy" position
      on the jkind lattice, defaulting exactly to [value]. *)
@@ -225,7 +226,6 @@ module History = struct
     | Wildcard
     | Unification_var
     | Array_element
-    | Old_style_unboxed_type
 
   open Allowance
 

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -935,7 +935,7 @@ let transl_declaration env sdecl (id, uid) =
         let tcstrs, cstrs = List.split (List.map make_cstr scstrs) in
         let rep, jkind =
           if unbox then
-            Variant_unboxed, Jkind.of_new_legacy_sort ~why:Old_style_unboxed_type
+            Variant_unboxed, Jkind.of_new_sort ~why:Old_style_unboxed_type
           else
             (* We mark all arg sorts "void" here.  They are updated later,
                after the circular type checks make it safe to check sorts.
@@ -965,7 +965,7 @@ let transl_declaration env sdecl (id, uid) =
           let rep, jkind =
             if unbox then
               Record_unboxed,
-              Jkind.of_new_legacy_sort ~why:Old_style_unboxed_type
+              Jkind.of_new_sort ~why:Old_style_unboxed_type
             else
             (* Note this is inaccurate, using `Record_boxed` in cases where the
                correct representation is [Record_float], [Record_ufloat], or


### PR DESCRIPTION
There isn't any reason to disallow it, we just didn't get to allowing it before. Add tests.

@rtjoa could you double-check that the `void` tests are fine?