### PR TITLE
New design for portable exceptions

### DIFF
--- a/stdlib/effect.ml
+++ b/stdlib/effect.ml
@@ -27,7 +27,9 @@ let () =
         Some msg
     | _ -> None
   in
-  Printexc.Safe.register_printer printer
+  (* need magic because jkind doesn't know [t] crosses portability and
+    contention  *)
+  Printexc.Safe.register_printer (Obj.magic_portable printer)
 
 (* Register the exceptions so that the runtime can access it *)
 type _ t += Should_not_see_this__ : unit t

--- a/testsuite/tests/backtrace/backtrace_effects.reference
+++ b/testsuite/tests/backtrace/backtrace_effects.reference
@@ -1,7 +1,7 @@
 (** get_callstack **)
 Raised by primitive operation at Backtrace_effects.bar in file "backtrace_effects.ml", line 20, characters 13-39
 Called from Backtrace_effects.foo in file "backtrace_effects.ml", line 27, characters 12-17
-Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 81, characters 4-53
+Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 82, characters 4-47
 Called from Backtrace_effects.baz in file "backtrace_effects.ml" (inlined), lines 31-41, characters 2-401
 Called from Backtrace_effects in file "backtrace_effects.ml", line 43, characters 8-14
 (** get_continuation_callstack **)
@@ -11,6 +11,6 @@ Called from Backtrace_effects.foo in file "backtrace_effects.ml", line 27, chara
 Fatal error: exception Stdlib.Exit
 Raised at Backtrace_effects.bar in file "backtrace_effects.ml", line 17, characters 4-14
 Re-raised at Backtrace_effects.baz.(fun) in file "backtrace_effects.ml", line 33, characters 21-28
-Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 81, characters 4-53
+Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 82, characters 4-47
 Called from Backtrace_effects.baz in file "backtrace_effects.ml" (inlined), lines 31-41, characters 2-401
 Called from Backtrace_effects in file "backtrace_effects.ml", line 43, characters 8-14

--- a/testsuite/tests/backtrace/backtrace_effects.reference
+++ b/testsuite/tests/backtrace/backtrace_effects.reference
@@ -1,7 +1,7 @@
 (** get_callstack **)
 Raised by primitive operation at Backtrace_effects.bar in file "backtrace_effects.ml", line 20, characters 13-39
 Called from Backtrace_effects.foo in file "backtrace_effects.ml", line 27, characters 12-17
-Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 82, characters 4-47
+Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 83, characters 4-53
 Called from Backtrace_effects.baz in file "backtrace_effects.ml" (inlined), lines 31-41, characters 2-401
 Called from Backtrace_effects in file "backtrace_effects.ml", line 43, characters 8-14
 (** get_continuation_callstack **)
@@ -11,6 +11,6 @@ Called from Backtrace_effects.foo in file "backtrace_effects.ml", line 27, chara
 Fatal error: exception Stdlib.Exit
 Raised at Backtrace_effects.bar in file "backtrace_effects.ml", line 17, characters 4-14
 Re-raised at Backtrace_effects.baz.(fun) in file "backtrace_effects.ml", line 33, characters 21-28
-Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 82, characters 4-47
+Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 83, characters 4-53
 Called from Backtrace_effects.baz in file "backtrace_effects.ml" (inlined), lines 31-41, characters 2-401
 Called from Backtrace_effects in file "backtrace_effects.ml", line 43, characters 8-14

--- a/testsuite/tests/backtrace/backtrace_effects_nested.flambda.reference
+++ b/testsuite/tests/backtrace/backtrace_effects_nested.flambda.reference
@@ -1,5 +1,5 @@
 Raised by primitive operation at Backtrace_effects_nested.blorp in file "backtrace_effects_nested.ml", line 24, characters 2-11
-Called from Stdlib__Effect.Deep.continue in file "stdlib/effect.ml" (inlined), line 101, characters 21-64
+Called from Stdlib__Effect.Deep.continue in file "stdlib/effect.ml" (inlined), line 102, characters 21-64
 Called from Backtrace_effects_nested.baz.(fun) in file "backtrace_effects_nested.ml", line 32, characters 16-29
-Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 82, characters 4-47
+Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 83, characters 4-53
 43

--- a/testsuite/tests/backtrace/backtrace_effects_nested.flambda.reference
+++ b/testsuite/tests/backtrace/backtrace_effects_nested.flambda.reference
@@ -1,5 +1,5 @@
 Raised by primitive operation at Backtrace_effects_nested.blorp in file "backtrace_effects_nested.ml", line 24, characters 2-11
-Called from Stdlib__Effect.Deep.continue in file "stdlib/effect.ml" (inlined), line 100, characters 21-64
+Called from Stdlib__Effect.Deep.continue in file "stdlib/effect.ml" (inlined), line 101, characters 21-64
 Called from Backtrace_effects_nested.baz.(fun) in file "backtrace_effects_nested.ml", line 32, characters 16-29
-Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 81, characters 4-53
+Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 82, characters 4-47
 43

--- a/testsuite/tests/effects/backtrace.byte.reference
+++ b/testsuite/tests/effects/backtrace.byte.reference
@@ -2,5 +2,5 @@ Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace.foo in file "backtrace.ml", line 14, characters 11-27
 Called from Backtrace.bar in file "backtrace.ml", line 22, characters 4-9
 Called from Backtrace.task1 in file "backtrace.ml", line 31, characters 4-10
-Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 106, characters 44-78
+Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 107, characters 44-78
 Called from Backtrace.task2 in file "backtrace.ml", line 38, characters 4-16

--- a/testsuite/tests/effects/backtrace.byte.reference
+++ b/testsuite/tests/effects/backtrace.byte.reference
@@ -2,5 +2,5 @@ Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace.foo in file "backtrace.ml", line 14, characters 11-27
 Called from Backtrace.bar in file "backtrace.ml", line 22, characters 4-9
 Called from Backtrace.task1 in file "backtrace.ml", line 31, characters 4-10
-Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 105, characters 44-78
+Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 106, characters 44-78
 Called from Backtrace.task2 in file "backtrace.ml", line 38, characters 4-16

--- a/testsuite/tests/effects/backtrace.reference
+++ b/testsuite/tests/effects/backtrace.reference
@@ -2,5 +2,5 @@ Raised at Stdlib.failwith in file "stdlib.ml" (inlined), line 39, characters 17-
 Called from Backtrace.foo in file "backtrace.ml", line 14, characters 11-27
 Called from Backtrace.bar in file "backtrace.ml", line 22, characters 4-9
 Called from Backtrace.task1 in file "backtrace.ml", line 31, characters 4-10
-Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 105, characters 44-78
+Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 106, characters 44-78
 Called from Backtrace.task2 in file "backtrace.ml", line 38, characters 4-16

--- a/testsuite/tests/effects/backtrace.reference
+++ b/testsuite/tests/effects/backtrace.reference
@@ -2,5 +2,5 @@ Raised at Stdlib.failwith in file "stdlib.ml" (inlined), line 39, characters 17-
 Called from Backtrace.foo in file "backtrace.ml", line 14, characters 11-27
 Called from Backtrace.bar in file "backtrace.ml", line 22, characters 4-9
 Called from Backtrace.task1 in file "backtrace.ml", line 31, characters 4-10
-Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 106, characters 44-78
+Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 107, characters 44-78
 Called from Backtrace.task2 in file "backtrace.ml", line 38, characters 4-16

--- a/testsuite/tests/typing-modes/exn.ml
+++ b/testsuite/tests/typing-modes/exn.ml
@@ -1,0 +1,196 @@
+(* TEST
+   expect;
+*)
+
+(* [exn] currently crosses portability. To make it safe, exception constructors
+are portable iff all its arguments are portable. *)
+
+exception Nonportable of (unit -> unit)
+exception Portable of unit
+exception Portable' of (unit -> unit) @@ portable
+
+[%%expect{|
+exception Nonportable of (unit -> unit)
+exception Portable of unit
+exception Portable' of (unit -> unit) @@ portable
+|}]
+
+let x : exn = Nonportable (fun x -> x)
+[%%expect{|
+val x : exn = Nonportable <fun>
+|}]
+
+let (foo @ portable) () =
+    match x with
+    | Nonportable g -> ()
+    | _ -> ()
+[%%expect{|
+Line 3, characters 6-17:
+3 |     | Nonportable g -> ()
+          ^^^^^^^^^^^
+Error: The constructor "Nonportable" is nonportable, so cannot be used inside a function that is portable.
+|}]
+
+let (foo @ portable) () =
+    match x with
+    | Portable g -> ()
+    | _ -> ()
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+let (foo @ portable) () =
+    match x with
+    | Portable' g -> ()
+    | _ -> ()
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+let (foo @ portable) () =
+    raise (Nonportable (fun () -> ()))
+[%%expect{|
+Line 2, characters 11-22:
+2 |     raise (Nonportable (fun () -> ()))
+               ^^^^^^^^^^^
+Error: The constructor "Nonportable" is nonportable, so cannot be used inside a function that is portable.
+|}]
+
+let (foo @ portable) () =
+    raise (Portable ())
+[%%expect{|
+val foo : unit -> 'a = <fun>
+|}]
+
+let (foo @ portable) () =
+    raise (Portable' (fun () -> ()))
+[%%expect{|
+val foo : unit -> 'a = <fun>
+|}]
+
+(* rebinding counts as usage *)
+let (foo @ portable) () =
+    let module M = struct
+        exception Nonportable' = Nonportable
+    end in
+    ()
+[%%expect{|
+Line 3, characters 33-44:
+3 |         exception Nonportable' = Nonportable
+                                     ^^^^^^^^^^^
+Error: The constructor "Nonportable" is nonportable, so cannot be used inside a function that is portable.
+|}]
+
+
+(* CR zqian: the following should be allowed, but requires a completely different
+approach (coportable). *)
+exception SemiPortable of string * (unit -> unit)
+
+let (foo @ portable) () =
+    try () with
+    SemiPortable (s, _) -> print_endline s
+[%%expect{|
+exception SemiPortable of string * (unit -> unit)
+Line 5, characters 4-16:
+5 |     SemiPortable (s, _) -> print_endline s
+        ^^^^^^^^^^^^
+Error: The constructor "SemiPortable" is nonportable, so cannot be used inside a function that is portable.
+|}]
+
+(* [exn] also crosses contention. To make it safe, exception constructors
+are uncontended iff all its arguments are uncontended. *)
+exception Uncontended of unit
+exception Uncontended' of int ref @@ contended
+exception Contended of int ref
+[%%expect{|
+exception Uncontended of unit
+exception Uncontended' of int ref @@ contended
+exception Contended of int ref
+|}]
+
+let (foo @ portable) () =
+    match x with
+    | Uncontended () -> ()
+    | _ -> ()
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+let (foo @ portable) () =
+    match x with
+    | Uncontended' _ -> ()
+    | _ -> ()
+[%%expect{|
+val foo : unit -> unit = <fun>
+|}]
+
+let (foo @ portable) () =
+    match x with
+    | Contended _ -> ()
+    | _ -> ()
+[%%expect{|
+Line 3, characters 6-15:
+3 |     | Contended _ -> ()
+          ^^^^^^^^^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+let (foo @ portable) () =
+    raise (Uncontended ())
+[%%expect{|
+val foo : unit -> 'a = <fun>
+|}]
+
+let (foo @ portable) () =
+    raise (Uncontended' (ref 42))
+[%%expect{|
+val foo : unit -> 'a = <fun>
+|}]
+
+let (foo @ portable) () =
+    raise (Contended (ref 42))
+[%%expect{|
+Line 2, characters 11-20:
+2 |     raise (Contended (ref 42))
+               ^^^^^^^^^
+Error: This value is "contended" but expected to be "uncontended".
+|}]
+
+(* rebinding counts as usage *)
+let (foo @ portable) () =
+    let module M = struct
+        exception Contended' = Contended
+    end in
+    ()
+[%%expect{|
+Line 3, characters 31-40:
+3 |         exception Contended' = Contended
+                                   ^^^^^^^^^
+Error: This constructor is at mode "contended", but expected to be at mode "uncontended".
+|}, Principal{|
+Line 3, characters 31-40:
+3 |         exception Contended' = Contended
+                                   ^^^^^^^^^
+Error: The constructor "Contended" is nonportable, so cannot be used inside a function that is portable.
+|}]
+
+
+(* other extensible types are not affected *)
+type t = ..
+
+type t += Foo of int
+
+let x : t = Foo 42
+
+let (foo @ portable) () =
+    ignore (x : _ @ portable)
+
+[%%expect{|
+type t = ..
+type t += Foo of int
+val x : t = Foo 42
+Line 8, characters 12-13:
+8 |     ignore (x : _ @ portable)
+                ^
+Error: The value "x" is nonportable, so cannot be used inside a function that is portable.
+|}]

--- a/testsuite/tests/typing-modes/exn.ml
+++ b/testsuite/tests/typing-modes/exn.ml
@@ -96,6 +96,12 @@ Line 3, characters 33-44:
                                      ^^^^^^^^^^^
 Error: This constructor is at mode "nonportable", but expected to be at mode "portable".
        Hint: all argument types must mode-cross for rebinding to succeed.
+|}, Principal{|
+Line 3, characters 33-44:
+3 |         exception Nonportable' = Nonportable
+                                     ^^^^^^^^^^^
+Error: This constructor is at mode "contended", but expected to be at mode "uncontended".
+       Hint: all argument types must mode-cross for rebinding to succeed.
 |}]
 
 (* Rebinding with crossing types succeeds. *)
@@ -116,7 +122,7 @@ val cross : unit -> 'a = <fun>
 Line 3, characters 30-38:
 3 |         exception Crossing' = Crossing
                                   ^^^^^^^^
-Error: This constructor is at mode "nonportable", but expected to be at mode "portable".
+Error: This constructor is at mode "contended", but expected to be at mode "uncontended".
        Hint: all argument types must mode-cross for rebinding to succeed.
 |}]
 
@@ -215,12 +221,6 @@ Line 3, characters 31-40:
                                    ^^^^^^^^^
 Error: This constructor is at mode "contended", but expected to be at mode "uncontended".
        Hint: all argument types must mode-cross for rebinding to succeed.
-|}, Principal{|
-Line 3, characters 31-40:
-3 |         exception Contended' = Contended
-                                   ^^^^^^^^^
-Error: This constructor is at mode "nonportable", but expected to be at mode "portable".
-       Hint: all argument types must mode-cross for rebinding to succeed.
 |}]
 
 let (bar @ portable) () =
@@ -234,7 +234,7 @@ val bar : unit -> 'a = <fun>
 Line 3, characters 34-45:
 3 |         exception Uncontended'' = Uncontended
                                       ^^^^^^^^^^^
-Error: This constructor is at mode "nonportable", but expected to be at mode "portable".
+Error: This constructor is at mode "contended", but expected to be at mode "uncontended".
        Hint: all argument types must mode-cross for rebinding to succeed.
 |}]
 

--- a/testsuite/tests/typing-modes/exn.ml
+++ b/testsuite/tests/typing-modes/exn.ml
@@ -1,5 +1,4 @@
 (* TEST
-   flags = "-extension-universe alpha";
    expect;
 *)
 
@@ -26,7 +25,7 @@ exception Portable' of (unit -> unit) @@ portable
 
 let x : exn = Nonportable (fun x -> x)
 [%%expect{|
-val x : exn @@ portable = Nonportable <fun>
+val x : exn = Nonportable <fun>
 |}]
 
 let (foo @ portable) () =
@@ -269,19 +268,6 @@ module type S = sig exception Exn of string ref end
 
 (* CR dkalinichenko: fix. *)
 
-let fails : (unit -> (module S)) Modes.Portable.t =
-    let module M @ portable = struct
-        exception Exn of string ref
-    end
-    in
-    { portable = fun () -> (module M : S) }
-[%%expect{|
-Line 3, characters 8-35:
-3 |         exception Exn of string ref
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This is "nonportable", but expected to be "portable" because it is inside a "portable" structure.
-|}]
-
 let make_s : (unit -> (module S)) Modes.Portable.t =
     let module M = struct
         exception Exn of string ref
@@ -290,7 +276,7 @@ let make_s : (unit -> (module S)) Modes.Portable.t =
     { portable = fun () -> (module M : S) }
 
 [%%expect{|
-val make_s : (unit -> (module S)) Modes.Portable.t @@ portable =
+val make_s : (unit -> (module S)) Modes.Portable.t =
   {Modes.Portable.portable = <fun>}
 |}]
 

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -489,7 +489,7 @@ let () =
    * that are not also exception types. *)
   reg_show_prim "show_constructor"
     (fun env loc id lid ->
-       let desc = Env.lookup_constructor ~loc Env.Positive lid env in
+       let desc, _ = Env.lookup_constructor ~loc Env.Positive lid env in
        if is_exception_constructor env desc.cstr_res then
          raise Not_found;
        let path = Btype.cstr_type_path desc in
@@ -525,7 +525,7 @@ let () =
 let () =
   reg_show_prim "show_exception"
     (fun env loc id lid ->
-       let desc = Env.lookup_constructor ~loc Env.Positive lid env in
+       let desc, _ = Env.lookup_constructor ~loc Env.Positive lid env in
        if not (is_exception_constructor env desc.cstr_res) then
          raise Not_found;
        let ret_type =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -7371,7 +7371,7 @@ let exn_constructor_crossing env lid ~args locks =
       fun ({ca_type; ca_modalities; _} : Types.constructor_argument) ->
         crossing_of_ty env ~modalities:ca_modalities ca_type
     ) args
-    |> List.fold_left Mode.Crossing.join Mode.Crossing.bot
+    |> List.fold_left Mode.Crossing.join Mode.Crossing.min
   in
   let min_bound =
     { monadic;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -7357,10 +7357,10 @@ type 'res constructor_crossing_kind =
 
 let check_exn_constructor_crossing (type res)
    (kind : res constructor_crossing_kind)
-   env ~args held_locks : (res, Mode.Value.error) result =
+   env lid ~args locks : (res, Mode.Value.error) result =
   let vmode =
-    Env.walk_locks ~env ~item:Constructor
-      (Mode.Value.(disallow_right min)) None held_locks
+    Env.walk_locks ~env ~loc:lid.loc lid.txt ~item:Constructor
+      None ((Mode.Value.(disallow_right min)), locks)
   in
   (* Exceptions cross portability and contention, so we project those axes. *)
   let monadic =
@@ -7413,7 +7413,7 @@ let check_exn_constructor_crossing (type res)
 
 let check_constructor_crossing (type res)
    (kind : res constructor_crossing_kind)
-    env tag ~res ~args held_locks =
+    env lid tag ~res ~args held_locks =
   let no_check : res =
     match kind with
     | Creation -> Mode.Value.(disallow_left max)
@@ -7426,5 +7426,5 @@ let check_constructor_crossing (type res)
       match get_desc (expand_head env res) with
       | Tconstr (p, _, _) when Path.same Predef.path_exn p ->
           (* Currently, only [exn] is treated specially. *)
-          check_exn_constructor_crossing kind env ~args held_locks
+          check_exn_constructor_crossing kind env lid ~args held_locks
       | _ -> Ok no_check

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -7349,3 +7349,33 @@ let constrain_decl_jkind env decl jkind =
         match decl.type_manifest with
         | None -> err
         | Some ty -> constrain_type_jkind env ty jkind
+
+let check_constructor_crossing env tag ~res ~args held_locks =
+  match tag with
+  | Ordinary _ | Null -> Ok ()
+  | Extension _ ->
+      match get_desc (expand_head env res) with
+      | Tconstr (p, _, _) when Path.same Predef.path_exn p ->
+          (* Currently only [exn] is treated specially *)
+          let mode_crossings =
+            List.map (
+              fun ({ca_type; ca_modalities; _} : Types.constructor_argument) ->
+              crossing_of_ty env ~modalities:ca_modalities ca_type
+            ) args
+          in
+          let mode_crossing =
+            List.fold_left Mode.Crossing.join Mode.Crossing.bot mode_crossings
+          in
+          (* We only check portability and contention, since [exn] doesn't
+               cross other axes anyway. *)
+          let mode =
+            Mode.Value.min_with (Comonadic Portability) Mode.Portability.max
+            |> Mode.Crossing.apply_left mode_crossing
+          in
+          let vmode =
+            Env.walk_locks ~env ~item:Constructor mode None held_locks
+          in
+          let mode = vmode.mode |> Mode.Crossing.apply_left mode_crossing in
+          Mode.Value.submode mode
+            (Mode.Value.max_with (Monadic Contention) (Mode.Contention.min))
+      | _ -> Ok ()

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -799,6 +799,7 @@ type 'res constructor_crossing_kind =
   | Destruction : Mode.Value.l constructor_crossing_kind
   | Rebinding : unit constructor_crossing_kind
 
-val check_constructor_crossing : 'ok constructor_crossing_kind
-  -> Env.t -> tag -> res:type_expr -> args:constructor_argument list ->
-  Env.held_locks -> ('ok, Mode.Value.error) result
+val check_constructor_crossing :
+  'ok constructor_crossing_kind -> Env.t -> Longident.t loc
+  -> tag -> res:type_expr -> args:constructor_argument list
+  -> Env.locks -> ('ok, Mode.Value.error) result

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -794,12 +794,12 @@ val zap_modalities_to_floor_if_at_least :
   Mode.Modality.Value.t ->
   Mode.Modality.Value.Const.t
 
-type 'res constructor_crossing_kind =
-  | Creation : Mode.Value.r constructor_crossing_kind
-  | Destruction : Mode.Value.l constructor_crossing_kind
-  | Rebinding : unit constructor_crossing_kind
-
-val check_constructor_crossing :
-  'ok constructor_crossing_kind -> Env.t -> Longident.t loc
+val check_constructor_crossing_creation :
+  Env.t -> Longident.t loc
   -> tag -> res:type_expr -> args:constructor_argument list
-  -> Env.locks -> ('ok, Mode.Value.error) result
+  -> Env.locks -> (Mode.Value.r, Mode.Value.error) result
+
+val check_constructor_crossing_destruction :
+  Env.t -> Longident.t loc
+  -> tag -> res:type_expr -> args:constructor_argument list
+  -> Env.locks -> (Mode.Value.l, Mode.Value.error) result

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -794,6 +794,11 @@ val zap_modalities_to_floor_if_at_least :
   Mode.Modality.Value.t ->
   Mode.Modality.Value.Const.t
 
-val check_constructor_crossing : Env.t ->
-  tag -> res:type_expr -> args:constructor_argument list ->
-  Env.held_locks -> (unit, Mode.Value.error) result
+type 'res constructor_crossing_kind =
+  | Creation : Mode.Value.r constructor_crossing_kind
+  | Destruction : Mode.Value.l constructor_crossing_kind
+  | Rebinding : unit constructor_crossing_kind
+
+val check_constructor_crossing : 'ok constructor_crossing_kind
+  -> Env.t -> tag -> res:type_expr -> args:constructor_argument list ->
+  Env.held_locks -> ('ok, Mode.Value.error) result

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -793,3 +793,7 @@ val zap_modalities_to_floor_if_at_least :
   Language_extension.maturity ->
   Mode.Modality.Value.t ->
   Mode.Modality.Value.Const.t
+
+val check_constructor_crossing : Env.t ->
+  tag -> res:type_expr -> args:constructor_argument list ->
+  Env.held_locks -> (unit, Mode.Value.error) result

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -278,17 +278,17 @@ let find_constr ~constant tag cstrs =
   try
     List.find
       (function
-        | ({cstr_tag=Ordinary {runtime_tag=tag'}; cstr_constant},_) ->
+        | (({cstr_tag=Ordinary {runtime_tag=tag'}; cstr_constant},_),_) ->
           tag' = tag && cstr_constant = constant
-        | ({cstr_tag=Null; cstr_constant}, _) ->
+        | (({cstr_tag=Null; cstr_constant}, _),_) ->
           tag = -1 && cstr_constant = constant
-        | ({cstr_tag=Extension _},_) -> false)
+        | (({cstr_tag=Extension _},_),_) -> false)
       cstrs
   with
   | Not_found -> raise Constr_not_found
 
 let find_constr_by_tag ~constant tag cstrlist =
-  fst (find_constr ~constant tag cstrlist)
+  fst (fst (find_constr ~constant tag cstrlist))
 
 let constructors_of_type ~current_unit ty_path decl =
   match decl.type_kind with

--- a/typing/datarepr.mli
+++ b/typing/datarepr.mli
@@ -36,7 +36,7 @@ val constructors_of_type:
 exception Constr_not_found
 
 val find_constr_by_tag:
-  constant:bool -> int -> (constructor_description*'a) list ->
+  constant:bool -> int -> ((constructor_description * 'a) * 'b) list ->
     constructor_description
 
 val constructor_existentials :

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3769,7 +3769,7 @@ let lookup_all_dot_constructors ~errors ~use ~loc usage l s env =
       lookup_all_ident_constructors
         ~errors ~use ~loc usage s (Lazy.force initial)
   | _ ->
-      let (_, locks, comps) =
+      let (_, (_, locks), comps) =
         lookup_structure_components ~errors ~use ~loc l env
       in
       match NameMap.find s comps.comp_constrs with

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -224,38 +224,48 @@ module TycompTbl =
         and constructors).  We keep a representation of each nested
         "open" and the set of local bindings between each of them. *)
 
-    type 'a t = {
+    type ('lock, 'a) t = {
       current: 'a Ident.tbl;
       (** Local bindings since the last open. *)
 
-      opened: 'a opened option;
-      (** Symbolic representation of the last (innermost) open, if any. *)
+      layer: ('lock, 'a) layer;
+      (** Symbolic representation of the last (innermost) layer *)
     }
 
-    and 'a opened = {
-      components: ('a list) NameMap.t;
-      (** Components from the opened module. We keep a list of
-          bindings for each name, as in comp_labels and
-          comp_constrs. *)
+    and ('lock, 'a) layer =
+      | Open of {
+        components: ('a list) NameMap.t;
+        (** Components from the opened module. We keep a list of
+            bindings for each name, as in comp_labels and
+            comp_constrs. *)
 
-      root: Path.t;
-      (** Only used to check removal of open *)
+        root: Path.t;
+        (** Only used to check removal of open *)
 
-      using: (string -> ('a * 'a) option -> unit) option;
-      (** A callback to be applied when a component is used from this
-          "open".  This is used to detect unused "opens".  The
-          arguments are used to detect shadowing. *)
+        using: (string -> ('a * 'a) option -> unit) option;
+        (** A callback to be applied when a component is used from this
+            "open".  This is used to detect unused "opens".  The
+            arguments are used to detect shadowing. *)
 
-      next: 'a t;
-      (** The table before opening the module. *)
-    }
+        next: ('lock, 'a) t;
+        (** The table before opening the module. *)
 
-    let empty = { current = Ident.empty; opened = None }
+        locks: 'lock list;
+        (** List of locks from the definition of [root] to this [Open], in that
+            order *)
+      }
+      | Lock of {
+          lock : 'lock;
+          next : ('lock, 'a) t;
+      }
+      | Nothing
+
+    let empty = { current = Ident.empty; layer = Nothing }
 
     let add id x tbl =
       {tbl with current = Ident.add id x tbl.current}
 
-    let add_open slot wrap root components next =
+    let add_open slot wrap root components locks next =
       let using =
         match slot with
         | None -> None
@@ -263,12 +273,12 @@ module TycompTbl =
       in
       {
         current = Ident.empty;
-        opened = Some {using; components; root; next};
+        layer = Open {using; components; root; locks; next};
       }
 
     let remove_last_open rt tbl =
-      match tbl.opened with
-      | Some {root; next; _} when Path.same rt root ->
+      match tbl.layer with
+      | Open {root; next; _} when Path.same rt root ->
           { next with current =
             Ident.fold_all Ident.add tbl.current next.current }
       | _ ->
@@ -277,9 +287,10 @@ module TycompTbl =
     let rec find_same id tbl =
       try Ident.find_same id tbl.current
       with Not_found as exn ->
-        begin match tbl.opened with
-        | Some {next; _} -> find_same id next
-        | None -> raise exn
+        begin match tbl.layer with
+        | Open {next; _} -> find_same id next
+        | Lock {next; _} -> find_same id next
+        | Nothing -> raise exn
         end
 
     let nothing = fun () -> ()
@@ -296,9 +307,10 @@ module TycompTbl =
     let rec find_all ~mark name tbl =
       List.map (fun (_id, desc) -> desc, nothing)
         (Ident.find_all name tbl.current) @
-      match tbl.opened with
-      | None -> []
-      | Some {using; next; components; root = _} ->
+      match tbl.layer with
+      | Nothing -> []
+      | Lock {next; _} -> find_all ~mark name next
+      | Open {using; next; components; root = _} ->
           let rest = find_all ~mark name next in
           let using = if mark then using else None in
           match NameMap.find name components with
@@ -309,23 +321,50 @@ module TycompTbl =
                 opened
               @ rest
 
+    let add_lock lock next =
+      { current = Ident.empty; layer = Lock {lock; next} }
+
+    let rec find_all_and_locks ~mark name tbl acc =
+      List.map (fun (_id, desc) -> (desc, (acc, nothing)))
+        (Ident.find_all name tbl.current) @
+      match tbl.layer with
+      | Nothing -> []
+      | Lock {lock;next} ->
+          find_all_and_locks ~mark name next (lock :: acc)
+      | Open {using; next; components; locks; root = _} ->
+          let rest = find_all_and_locks ~mark name next acc in
+          let using = if mark then using else None in
+          match NameMap.find name components with
+          | exception Not_found -> rest
+          | opened ->
+              List.map
+                (fun desc -> desc,
+                  (locks @ acc, mk_callback rest name desc using))
+                opened
+              @ rest
+
+    let find_all_and_locks ~mark name tbl =
+      find_all_and_locks ~mark name tbl []
+
     let rec fold_name f tbl acc =
       let acc = Ident.fold_name (fun _id d -> f d) tbl.current acc in
-      match tbl.opened with
-      | Some {using = _; next; components; root = _} ->
+      match tbl.layer with
+      | Open {using = _; next; components; root = _} ->
           acc
           |> NameMap.fold
             (fun _name -> List.fold_right f)
             components
           |> fold_name f next
-      | None ->
+      | Lock {next; _} -> fold_name f next acc
+      | Nothing ->
           acc
 
     let rec local_keys tbl acc =
       let acc = Ident.fold_all (fun k _ accu -> k::accu) tbl.current acc in
-      match tbl.opened with
-      | Some o -> local_keys o.next acc
-      | None -> acc
+      match tbl.layer with
+      | Open o -> local_keys o.next acc
+      | Lock {next; _} -> local_keys next acc
+      | Nothing -> acc
 
     let diff_keys is_local tbl1 tbl2 =
       let keys2 = local_keys tbl2 [] in
@@ -351,6 +390,7 @@ type lock_item =
   | Value
   | Module
   | Class
+  | Constructor
 
 module IdTbl =
   struct
@@ -631,9 +671,9 @@ let in_signature_flag = 0x01
 
 type t = {
   values: (lock, value_entry, value_data) IdTbl.t;
-  constrs: constructor_data TycompTbl.t;
-  labels: label_data TycompTbl.t;
-  unboxed_labels: unboxed_label_description TycompTbl.t;
+  constrs: (lock, constructor_data) TycompTbl.t;
+  labels: (empty, label_data) TycompTbl.t;
+  unboxed_labels: (empty, unboxed_label_description) TycompTbl.t;
   types: (empty, type_data, type_data) IdTbl.t;
   modules: (lock, module_entry, module_data) IdTbl.t;
   modtypes: (empty, modtype_data, modtype_data) IdTbl.t;
@@ -844,7 +884,7 @@ let mode_default mode = {
 }
 
 let env_labels (type rep) (record_form : rep record_form) env
-    : rep gen_label_description TycompTbl.t  =
+    : (empty, rep gen_label_description) TycompTbl.t  =
   match record_form with
   | Legacy -> env.labels
   | Unboxed_product -> env.unboxed_labels
@@ -2797,6 +2837,7 @@ let add_lock lock env =
     values = IdTbl.add_lock lock env.values;
     modules = IdTbl.add_lock lock env.modules;
     classes = IdTbl.add_lock lock env.classes;
+    constrs = TycompTbl.add_lock lock env.constrs;
   }
 
 let add_escape_lock escaping_context env =
@@ -3512,16 +3553,16 @@ let lookup_all_ident_labels (type rep) ~(record_form : rep record_form) ~errors
     end
 
 let lookup_all_ident_constructors ~errors ~use ~loc usage s env =
-  match TycompTbl.find_all ~mark:use s env.constrs with
+  match TycompTbl.find_all_and_locks ~mark:use s env.constrs with
   | [] -> may_lookup_error errors loc env (Unbound_constructor (Lident s))
   | cstrs ->
       List.map
-        (fun (cda, use_fn) ->
+        (fun (cda, (locks, use_fn)) ->
            let use_fn () =
              use_constructor ~use ~loc usage env cda;
              use_fn ()
            in
-           (cda.cda_description, use_fn))
+           ((cda.cda_description, locks), use_fn))
         cstrs
 
 let rec lookup_module_components ~errors ~use ~loc lid env =
@@ -3728,7 +3769,7 @@ let lookup_all_dot_constructors ~errors ~use ~loc usage l s env =
       lookup_all_ident_constructors
         ~errors ~use ~loc usage s (Lazy.force initial)
   | _ ->
-      let (_, _, comps) = lookup_structure_components ~errors ~use ~loc l env in
+      let (_, locks, comps) = lookup_structure_components ~errors ~use ~loc l env in
       match NameMap.find s comps.comp_constrs with
       | [] | exception Not_found ->
           may_lookup_error errors loc env (Unbound_constructor (Ldot(l, s)))
@@ -3736,14 +3777,17 @@ let lookup_all_dot_constructors ~errors ~use ~loc usage l s env =
           List.map
             (fun cda ->
                let use_fun () = use_constructor ~use ~loc usage env cda in
-               (cda.cda_description, use_fun))
+               ((cda.cda_description, locks), use_fun))
             cstrs
 
 (* Open a signature path *)
 
 let add_components slot root env0 comps locks =
   let add_l w comps env0 =
-    TycompTbl.add_open slot w root comps env0
+    TycompTbl.add_open slot w root comps ([] : empty list) env0
+  in
+  let add_c w comps env0 =
+    TycompTbl.add_open slot w root comps locks env0
   in
   let add_v w comps env0 =
     IdTbl.add_open slot w root comps locks env0
@@ -3752,7 +3796,7 @@ let add_components slot root env0 comps locks =
     IdTbl.add_open slot w root comps ([] : empty list) env0
   in
   let constrs =
-    add_l (fun x -> `Constructor x) comps.comp_constrs env0.constrs
+    add_c (fun x -> `Constructor x) comps.comp_constrs env0.constrs
   in
   let labels =
     add_l (fun x -> `Label x) comps.comp_labels env0.labels
@@ -4069,7 +4113,7 @@ let lookup_all_constructors ~errors ~use ~loc usage lid env =
 let lookup_constructor ~errors ~use ~loc usage lid env =
   match lookup_all_constructors ~errors ~use ~loc usage lid env with
   | [] -> assert false
-  | (desc, use) :: _ -> use (); desc
+  | ((desc, locks), use) :: _ -> use (); desc, locks
 
 let lookup_all_constructors_from_type ~use ~loc usage ty_path env =
   match find_type_descrs ty_path env with
@@ -4082,7 +4126,7 @@ let lookup_all_constructors_from_type ~use ~loc usage ty_path env =
            let use_fun () =
              use_constructor_desc ~use ~loc usage env cstr
            in
-           (cstr, use_fun))
+           ((cstr, locks_empty), use_fun))
         cstrs
 
 (* Lookup functions that do not mark the item as used or
@@ -4119,6 +4163,7 @@ let find_cltype_by_name lid env =
 let find_constructor_by_name lid env =
   let loc = Location.(in_file !input_name) in
   lookup_constructor ~errors:false ~use:false ~loc Positive lid env
+  |> fst
 
 let find_label_by_name record_form lid env =
   let loc = Location.(in_file !input_name) in
@@ -4592,6 +4637,9 @@ let print_lock_item ppf (item, lid) =
         (Style.as_inline_code !print_longident) lid
   | Value ->
       fprintf ppf "The value %a is"
+        (Style.as_inline_code !print_longident) lid
+  | Constructor ->
+      fprintf ppf "The constructor %a is"
         (Style.as_inline_code !print_longident) lid
 
 module Style = Misc.Style

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3769,7 +3769,9 @@ let lookup_all_dot_constructors ~errors ~use ~loc usage l s env =
       lookup_all_ident_constructors
         ~errors ~use ~loc usage s (Lazy.force initial)
   | _ ->
-      let (_, locks, comps) = lookup_structure_components ~errors ~use ~loc l env in
+      let (_, locks, comps) =
+        lookup_structure_components ~errors ~use ~loc l env
+      in
       match NameMap.find s comps.comp_constrs with
       | [] | exception Not_found ->
           may_lookup_error errors loc env (Unbound_constructor (Ldot(l, s)))

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -236,6 +236,7 @@ type lock_item =
   | Value
   | Module
   | Class
+  | Constructor
 
 type structure_components_reason =
   | Project
@@ -339,14 +340,14 @@ val lookup_module_instance_path:
 
 val lookup_constructor:
   ?use:bool -> loc:Location.t -> constructor_usage -> Longident.t -> t ->
-  constructor_description
+  constructor_description * locks
 val lookup_all_constructors:
   ?use:bool -> loc:Location.t -> constructor_usage -> Longident.t -> t ->
-  ((constructor_description * (unit -> unit)) list,
+  (((constructor_description * locks) * (unit -> unit)) list,
    Location.t * t * lookup_error) result
 val lookup_all_constructors_from_type:
   ?use:bool -> loc:Location.t -> constructor_usage -> Path.t -> t ->
-  (constructor_description * (unit -> unit)) list
+  ((constructor_description * locks) * (unit -> unit)) list
 
 val lookup_label:
   ?use:bool -> record_form:'rcd record_form -> loc:Location.t -> label_usage -> Longident.t -> t ->

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1378,7 +1378,7 @@ module Const = struct
       { jkind =
           { layout = Base Value;
             mod_bounds =
-              Mod_bounds.create ~locality:Locality.Const.max
+              Mod_bounds.create ~areality:Regionality.Const.max
                 ~linearity:Linearity.Const.max
                 ~portability:Portability.Const.min ~yielding:Yielding.Const.max
                 ~uniqueness:Uniqueness.Const_op.max

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1374,6 +1374,24 @@ module Const = struct
         name = "immutable_data"
       }
 
+    let exn =
+      { jkind =
+          { layout = Base Value;
+            mod_bounds =
+              Mod_bounds.create ~locality:Locality.Const.max
+                ~linearity:Linearity.Const.max
+                ~portability:Portability.Const.min ~yielding:Yielding.Const.max
+                ~uniqueness:Uniqueness.Const_op.max
+                ~contention:Contention.Const_op.min
+                ~statefulness:Statefulness.Const.max
+                ~visibility:Visibility.Const_op.max ~externality:Externality.max
+                ~nullability:Nullability.Non_null
+                ~separability:Separability.Non_float;
+            with_bounds = No_with_bounds
+          };
+        name = "exn"
+      }
+
     let sync_data =
       { jkind =
           { layout = Base Value;

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -276,6 +276,9 @@ module Const : sig
     (** Immutable non-float values that don't contain functions. *)
     val immutable_data : t
 
+    (** Exceptions; only crossing portability *)
+    val exn : t
+
     (** Atomically mutable non-float values that don't contain functions. *)
     val sync_data : t
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2194,6 +2194,9 @@ module Monadic = struct
 
   let join_with ax c m = join_const (Const.min_with ax c) m
 
+  let min_with ax m =
+    Solver.apply Obj.obj (Max_with ax) (Solver.disallow_left m)
+
   let zap_to_legacy m : Const.t =
     let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy in
     let visibility = proj Visibility m |> Visibility.zap_to_legacy in

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2725,6 +2725,10 @@ module Value_with (Areality : Areality) = struct
   let monadic_to_comonadic_min m =
     S.apply Comonadic.Obj.obj Monadic_to_comonadic_min (Monadic.disallow_left m)
 
+  let monadic_to_comonadic_max m =
+    S.apply Comonadic.Obj.obj Monadic_to_comonadic_max
+      (Monadic.disallow_right m)
+
   let meet_const c { comonadic; monadic } =
     let comonadic = Comonadic.meet_const c comonadic in
     { monadic; comonadic }

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -409,29 +409,27 @@ module type S = sig
     module Areality : Common
 
     module Monadic : sig
-      type 'a axis := (monadic, 'a) Axis.t
-
       include
-        Common_product with type Const.t = monadic and type 'a Axis.t = 'a axis
+        Common_product
+          with type Const.t = monadic
+           and type 'a Axis.t = (monadic, 'a) Axis.t
 
       module Const_op : Lattice with type t = Const.t
 
-      val proj : 'a axis -> ('r * 'l) t -> ('a, 'l * 'r) mode
+      val proj : 'a Axis.t -> ('r * 'l) t -> ('a, 'l * 'r) mode
 
-      val min_with : 'a axis -> ('a, 'l * 'r) mode -> ('r * disallowed) t
+      val min_with : 'a Axis.t -> ('a, 'l * 'r) mode -> ('r * disallowed) t
     end
 
     module Comonadic : sig
-      type 'a axis := (Areality.Const.t comonadic_with, 'a) Axis.t
-
       include
         Common_product
           with type Const.t = Areality.Const.t comonadic_with
-           and type 'a Axis.t = 'a axis
+           and type 'a Axis.t = (Areality.Const.t comonadic_with, 'a) Axis.t
 
-      val proj : 'a axis -> ('l * 'r) t -> ('a, 'l * 'r) mode
+      val proj : 'a Axis.t -> ('l * 'r) t -> ('a, 'l * 'r) mode
 
-      val max_with : 'a axis -> ('a, 'l * 'r) mode -> (disallowed * 'r) t
+      val max_with : 'a Axis.t -> ('a, 'l * 'r) mode -> (disallowed * 'r) t
     end
 
     module Axis : sig

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -492,8 +492,7 @@ let build_initial_env add_type add_extension empty_env =
        ~kind:(variant [ cstr ident_false []; cstr ident_true []])
        ~jkind:Jkind.Const.Builtin.immediate
   |> add_type ident_char ~jkind:Jkind.Const.Builtin.immediate
-  |> add_type_with_jkind ident_exn ~kind:Type_open
-    ~jkind:(Jkind.for_non_float ~why:(Primitive ident_exn))
+  |> add_type ident_exn ~kind:Type_open ~jkind:Jkind.Const.Builtin.exn
   |> add_type ident_extension_constructor ~jkind:Jkind.Const.Builtin.immutable_data
   |> add_type_with_jkind ident_float ~jkind:(Jkind.for_float ident_float)
       ~unboxed_jkind:Jkind.Const.Builtin.kind_of_unboxed_float

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3016,7 +3016,6 @@ and type_pat_aux
           (Constructor.disambiguate Env.Pattern lid !!penv expected_type)
           candidates
       in
-      let held_locks = (locks, lid.txt, lid.loc) in
       begin match no_existentials, constr.cstr_existentials with
       | None, _ | _, [] -> ()
       | Some r, (_ :: _) ->
@@ -3090,7 +3089,7 @@ and type_pat_aux
 
       let constructor_mode =
         match Ctype.check_constructor_crossing Destruction !!penv
-          constr.cstr_tag ~res:expected_ty ~args held_locks with
+          lid constr.cstr_tag ~res:expected_ty ~args locks with
         | Ok mode -> mode
         | Error e -> raise (Error (lid.loc, !!penv,
           Submode_failed (e, Constructor lid.txt, None, None, None, None)))
@@ -8697,7 +8696,6 @@ and type_construct ~overwrite env (expected_mode : expected_mode) loc lid sarg
       ty_expected_explained
       (Constructor.disambiguate Env.Positive lid env expected_type) constrs
   in
-  let held_locks = (locks, lid.txt, lid.loc) in
   let sargs =
     match sarg with
     | None -> []
@@ -8770,8 +8768,8 @@ and type_construct ~overwrite env (expected_mode : expected_mode) loc lid sarg
       end
   in
   let constructor_mode =
-    match Ctype.check_constructor_crossing Creation env constr.cstr_tag
-      ~res:ty_res ~args:ty_args held_locks with
+    match Ctype.check_constructor_crossing Creation env lid
+      constr.cstr_tag ~res:ty_res ~args:ty_args locks with
     | Ok mode -> mode
     | Error e -> raise (Error (lid.loc, env,
         Submode_failed (e, Constructor lid.txt, None, None, None, None)))

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3088,7 +3088,7 @@ and type_pat_aux
       end;
 
       let constructor_mode =
-        match Ctype.check_constructor_crossing Destruction !!penv
+        match Ctype.check_constructor_crossing_destruction !!penv
           lid constr.cstr_tag ~res:expected_ty ~args locks with
         | Ok mode -> mode
         | Error e -> raise (Error (lid.loc, !!penv,
@@ -8768,7 +8768,7 @@ and type_construct ~overwrite env (expected_mode : expected_mode) loc lid sarg
       end
   in
   let constructor_mode =
-    match Ctype.check_constructor_crossing Creation env lid
+    match Ctype.check_constructor_crossing_creation env lid
       constr.cstr_tag ~res:ty_res ~args:ty_args locks with
     | Ok mode -> mode
     | Error e -> raise (Error (lid.loc, env,

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1750,21 +1750,20 @@ let solve_Ppat_construct ~refine tps penv loc constr no_existentials
     unify_pat_types_return_equated_pairs ~refine loc penv ty_res expected_ty
   in
 
-  let ty_args_ty, ty_args_gf, equated_types, existential_ctyp =
+  let ty_args, equated_types, existential_ctyp =
     with_local_level_iter ~post: generalize_structure begin fun () ->
       let expected_ty = instance expected_ty in
-      let ty_args_ty, ty_args_gf, ty_res, equated_types, existential_ctyp =
+      let ty_args, ty_args_ty, ty_res, equated_types, existential_ctyp =
         match existential_styp with
           None ->
             let ty_args, ty_res, _ =
               instance_constructor (Make_existentials_abstract penv) constr
             in
-            let ty_args_ty, ty_args_gf =
-              List.split
-                (List.map (fun ca ->
-                  ca.Types.ca_type, ca.Types.ca_modalities) ty_args)
+            let ty_args_ty =
+              List.map (fun ca ->
+                  ca.Types.ca_type) ty_args
             in
-            ty_args_ty, ty_args_gf, ty_res, unify_res ty_res expected_ty, None
+            ty_args, ty_args_ty, ty_res, unify_res ty_res expected_ty, None
         | Some (name_list, sty) ->
             let existential_treatment =
               if name_list = [] then
@@ -1778,20 +1777,21 @@ let solve_Ppat_construct ~refine tps penv loc constr no_existentials
               instance_constructor existential_treatment constr
             in
             let equated_types = unify_res ty_res expected_ty in
-            let ty_args_ty, ty_args_gf =
-              List.split
-                (List.map (fun ca ->
-                  ca.Types.ca_type, ca.Types.ca_modalities) ty_args)
-            in
+            let ty_args_ty = List.map (fun ca ->
+                  ca.Types.ca_type) ty_args in
             let ty_args_ty, existential_ctyp =
               solve_constructor_annotation tps penv name_list sty ty_args_ty
                 ty_ex
             in
-            ty_args_ty, ty_args_gf, ty_res, equated_types, existential_ctyp
+            let ty_args =
+              List.map2 (fun arg ca_type -> {arg with Types.ca_type}) ty_args
+                ty_args_ty
+            in
+            ty_args, ty_args_ty, ty_res, equated_types, existential_ctyp
       in
       if constr.cstr_existentials <> [] then
         lower_variables_only !!penv penv.Pattern_env.equations_scope ty_res;
-      ((ty_args_ty, ty_args_gf, equated_types, existential_ctyp),
+      ((ty_args, equated_types, existential_ctyp),
        expected_ty :: ty_res :: ty_args_ty)
     end
   in
@@ -1817,7 +1817,7 @@ let solve_Ppat_construct ~refine tps penv loc constr no_existentials
         equated_types
     with Warn_only_once -> ()
   end;
-  (ty_args_ty, ty_args_gf, existential_ctyp)
+  (ty_args, existential_ctyp)
 
 let solve_Ppat_record_field ~refine loc penv label label_lid record_ty
       record_form =
@@ -2511,11 +2511,11 @@ let check_recordpat_labels loc lbl_pat_list closed record_form =
 (* Constructors *)
 
 module Constructor = NameChoice (struct
-  type t = constructor_description
+  type t = constructor_description * Env.locks
   type usage = Env.constructor_usage
   let kind = Datatype_kind.Variant
-  let get_name cstr = cstr.cstr_name
-  let get_type cstr = cstr.cstr_res
+  let get_name (cstr, _) = cstr.cstr_name
+  let get_type (cstr, _) = cstr.cstr_res
   let lookup_all_from_type loc usage path env =
     match Env.lookup_all_constructors_from_type ~loc usage path env with
     | _ :: _ as x -> x
@@ -2529,7 +2529,9 @@ module Constructor = NameChoice (struct
             let filter lbl =
               compare_type_path env
                 path (get_constr_type_path @@ get_type lbl) in
-            let add_valid x acc = if filter x then (x,ignore)::acc else acc in
+            let add_valid x acc =
+              let x = (x, Env.locks_empty) in
+              if filter x then (x, ignore)::acc else acc in
             Env.fold_constructors add_valid None env []
         | _ -> []
   let in_env _ = true
@@ -3005,7 +3007,7 @@ and type_pat_aux
             let error = Wrong_expected_kind(srt, Pattern, expected_ty) in
             raise (Error (loc, !!penv, error))
       in
-      let constr =
+      let constr, locks =
         let candidates =
           Env.lookup_all_constructors Env.Pattern ~loc:lid.loc lid.txt !!penv in
         wrap_disambiguate "This variant pattern is expected to have"
@@ -3013,6 +3015,7 @@ and type_pat_aux
           (Constructor.disambiguate Env.Pattern lid !!penv expected_type)
           candidates
       in
+      let held_locks = (locks, lid.txt, lid.loc) in
       begin match no_existentials, constr.cstr_existentials with
       | None, _ | _, [] -> ()
       | Some r, (_ :: _) ->
@@ -3062,10 +3065,17 @@ and type_pat_aux
         raise(Error(loc, !!penv, Constructor_arity_mismatch(lid.txt,
                                      constr.cstr_arity, List.length sargs)));
 
-      let (ty_args_ty, ty_args_gf, existential_ctyp) =
+      let (args, existential_ctyp) =
         solve_Ppat_construct ~refine:false tps penv loc constr no_existentials
           existential_styp expected_ty
       in
+      begin match Ctype.check_constructor_crossing !!penv constr.cstr_tag
+        ~res:expected_ty ~args held_locks with
+      | Ok () -> ()
+      | Error e ->
+          raise (Error(lid.loc, !!penv,
+            Submode_failed(e, Other, None, None, None, None)))
+      end;
 
       let rec check_non_escaping p =
         match p.ppat_desc with
@@ -3086,11 +3096,13 @@ and type_pat_aux
 
       let args =
         List.map2
-          (fun p (ty, gf) ->
-             let alloc_mode = Modality.Value.Const.apply gf alloc_mode.mode in
+          (fun p (arg : Types.constructor_argument) ->
+             let alloc_mode =
+              Modality.Value.Const.apply arg.ca_modalities alloc_mode.mode
+             in
              let alloc_mode = simple_pat_mode alloc_mode in
-             type_pat ~alloc_mode tps Value p ty)
-          sargs (List.combine ty_args_ty ty_args_gf)
+             type_pat ~alloc_mode tps Value p arg.ca_type)
+          sargs args
       in
       rvp { pat_desc=Tpat_construct(lid, constr, args, existential_ctyp);
             pat_loc = loc; pat_extra=[];
@@ -3653,12 +3665,12 @@ let rec check_counter_example_pat
   | Tpat_construct(cstr_lid, constr, targs, _) ->
       if constr.cstr_generalized && must_backtrack_on_gadt then
         raise Need_backtrack;
-      let (ty_args, _, existential_ctyp) =
+      let (ty_args, existential_ctyp) =
         solve_Ppat_construct ~refine type_pat_state penv loc constr None None
           expected_ty
       in
       map_fold_cont
-        (fun (p,t) -> check_rec p t)
+        (fun (p,t) -> check_rec p t.Types.ca_type)
         (List.combine targs ty_args)
         (fun args ->
           mkp k (Tpat_construct(cstr_lid, constr, args, existential_ctyp)))
@@ -6959,9 +6971,11 @@ and type_expect_
                    Pstr_eval ({ pexp_desc = Pexp_construct (lid, None); _ }, _)
                } ] ->
           let path =
-            let cd =
+            let cd, held_locks =
               Env.lookup_constructor Env.Positive ~loc:lid.loc lid.txt env
             in
+            (* no argument and thus crossing portability *)
+            ignore held_locks;
             match cd.cstr_tag with
             | Extension path -> path
             | _ -> raise (Error (lid.loc, env, Not_an_extension_constructor))
@@ -8674,11 +8688,12 @@ and type_construct ~overwrite env (expected_mode : expected_mode) loc lid sarg
   let constrs =
     Env.lookup_all_constructors ~loc:lid.loc Env.Positive lid.txt env
   in
-  let constr =
+  let constr, locks =
     wrap_disambiguate "This variant expression is expected to have"
       ty_expected_explained
       (Constructor.disambiguate Env.Positive lid env expected_type) constrs
   in
+  let held_locks = (locks, lid.txt, lid.loc) in
   let sargs =
     match sarg with
     | None -> []
@@ -8728,6 +8743,13 @@ and type_construct ~overwrite env (expected_mode : expected_mode) loc lid sarg
         List.iter (fun {Types.ca_type=ty; _} -> generalize_structure ty) ty_args)
   in
   let ty_args, ty_res, texp = unify_as_construct ty_expected in
+  begin match Ctype.check_constructor_crossing env constr.cstr_tag
+    ~res:ty_res ~args:ty_args held_locks with
+  | Ok () -> ()
+  | Error e ->
+      raise (Error (lid.loc, env, Submode_failed(e, Other, None, None, None,
+        None)))
+  end;
   let ty_args0, ty_res =
     match instance_list (ty_res :: (List.map (fun ca -> ca.Types.ca_type) ty_args)) with
       t :: tl -> tl, t

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -184,7 +184,8 @@ type submode_reason =
   | Application of type_expr
       (* Check that the result of an application is a submode of the expected mode
          from the context *)
-
+  | Constructor of Longident.t
+      (* Check that this constructor is allowed in this context. *)
   | Other (* add more cases here for better hints *)
 
 val escape : loc:Location.t -> env:Env.t -> reason:submode_reason -> (Mode.allowed * 'r) Mode.Value.t -> unit

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -3086,9 +3086,14 @@ let transl_extension_constructor ~scope env type_path type_params
               | _ -> ())
             typext_params
         end;
-        (match Ctype.check_constructor_crossing Rebinding env lid
+        (* Rebinding is safe if constructor arguments mode-cross both ways. *)
+        (match Ctype.check_constructor_crossing_creation env lid
           cdescr.cstr_tag ~res:cstr_res ~args locks with
-        | Ok () -> ()
+        | Ok _ -> ()
+        | Error e -> raise (Error (lid.loc, Constructor_submode_failed e)));
+        (match Ctype.check_constructor_crossing_destruction env lid
+          cdescr.cstr_tag ~res:cstr_res ~args locks with
+        | Ok _ -> ()
         | Error e -> raise (Error (lid.loc, Constructor_submode_failed e)));
         (* Ensure that constructor's type matches the type being extended *)
         let cstr_type_path = Btype.cstr_type_path cdescr in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -142,6 +142,7 @@ type error =
   | Illegal_baggage of jkind_l
   | No_unboxed_version of Path.t
   | Atomic_field_must_be_mutable of string
+  | Constructor_submode_failed of Mode.Value.error
 
 open Typedtree
 
@@ -3049,7 +3050,10 @@ let transl_extension_constructor ~scope env type_path type_params
         let usage : Env.constructor_usage =
           if priv = Public then Env.Exported else Env.Exported_private
         in
-        let cdescr = Env.lookup_constructor ~loc:lid.loc usage lid.txt env in
+        let cdescr, locks =
+          Env.lookup_constructor ~loc:lid.loc usage lid.txt env
+        in
+        let held_locks = (locks, lid.txt, lid.loc) in
         let (args, cstr_res, _ex) =
           Ctype.instance_constructor Keep_existentials_flexible cdescr
         in
@@ -3082,6 +3086,11 @@ let transl_extension_constructor ~scope env type_path type_params
                 set_type_desc ty (Tvar { name = None; jkind })
               | _ -> ())
             typext_params
+        end;
+        begin match Ctype.check_constructor_crossing env cdescr.cstr_tag
+          ~res:cstr_res ~args held_locks with
+        | Ok () -> ()
+        | Error e -> raise (Error (lid.loc, Constructor_submode_failed e))
         end;
         (* Ensure that constructor's type matches the type being extended *)
         let cstr_type_path = Btype.cstr_type_path cdescr in
@@ -4780,6 +4789,11 @@ let report_error ppf = function
       fprintf ppf
         "@[The label %a must be mutable to be declared atomic.@]"
         Style.inline_code name
+  | Constructor_submode_failed (Error (ax, {left; right})) ->
+      fprintf ppf "@[This constructor is at mode %a, \
+        but expected to be at mode %a.@]"
+        (Style.as_inline_code (Mode.Value.Const.print_axis ax)) left
+        (Style.as_inline_code (Mode.Value.Const.print_axis ax)) right
 
 let () =
   Location.register_error_of_exn

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -3087,11 +3087,10 @@ let transl_extension_constructor ~scope env type_path type_params
               | _ -> ())
             typext_params
         end;
-        begin match Ctype.check_constructor_crossing env cdescr.cstr_tag
+        (match Ctype.check_constructor_crossing Rebinding env cdescr.cstr_tag
           ~res:cstr_res ~args held_locks with
         | Ok () -> ()
-        | Error e -> raise (Error (lid.loc, Constructor_submode_failed e))
-        end;
+        | Error e -> raise (Error (lid.loc, Constructor_submode_failed e)));
         (* Ensure that constructor's type matches the type being extended *)
         let cstr_type_path = Btype.cstr_type_path cdescr in
         let cstr_type_params = (Env.find_type cstr_type_path env).type_params in
@@ -4793,7 +4792,9 @@ let report_error ppf = function
       fprintf ppf "@[This constructor is at mode %a, \
         but expected to be at mode %a.@]"
         (Style.as_inline_code (Mode.Value.Const.print_axis ax)) left
-        (Style.as_inline_code (Mode.Value.Const.print_axis ax)) right
+        (Style.as_inline_code (Mode.Value.Const.print_axis ax)) right;
+      fprintf ppf "@[<hv>@[@{<hint>Hint@}: all argument types must \
+        mode-cross for rebinding to succeed.@]"
 
 let () =
   Location.register_error_of_exn

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -3053,7 +3053,6 @@ let transl_extension_constructor ~scope env type_path type_params
         let cdescr, locks =
           Env.lookup_constructor ~loc:lid.loc usage lid.txt env
         in
-        let held_locks = (locks, lid.txt, lid.loc) in
         let (args, cstr_res, _ex) =
           Ctype.instance_constructor Keep_existentials_flexible cdescr
         in
@@ -3087,8 +3086,8 @@ let transl_extension_constructor ~scope env type_path type_params
               | _ -> ())
             typext_params
         end;
-        (match Ctype.check_constructor_crossing Rebinding env cdescr.cstr_tag
-          ~res:cstr_res ~args held_locks with
+        (match Ctype.check_constructor_crossing Rebinding env lid
+          cdescr.cstr_tag ~res:cstr_res ~args locks with
         | Ok () -> ()
         | Error e -> raise (Error (lid.loc, Constructor_submode_failed e)));
         (* Ensure that constructor's type matches the type being extended *)

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -177,6 +177,7 @@ type error =
   | Illegal_baggage of jkind_l
   | No_unboxed_version of Path.t
   | Atomic_field_must_be_mutable of string
+  | Constructor_submode_failed of Mode.Value.error
 
 exception Error of Location.t * error
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3544,6 +3544,13 @@ and type_structure ?(toplevel = None) funct_body anchor env ?expected_mode
         let constructor = ext.tyexn_constructor in
         Signature_names.check_typext names constructor.ext_loc
           constructor.ext_id;
+        let nonportable_mode =
+          Value.min_with (Comonadic Portability) Portability.max in
+        begin match Value.submode nonportable_mode md_mode with
+          | Ok () -> ()
+          | Error e ->
+              raise (Error (loc, env, Item_weaker_than_structure e))
+        end;
         Tstr_exception ext,
         [Sig_typext(constructor.ext_id,
                     constructor.ext_type,

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3544,13 +3544,6 @@ and type_structure ?(toplevel = None) funct_body anchor env ?expected_mode
         let constructor = ext.tyexn_constructor in
         Signature_names.check_typext names constructor.ext_loc
           constructor.ext_id;
-        let nonportable_mode =
-          Value.min_with (Comonadic Portability) Portability.max in
-        begin match Value.submode nonportable_mode md_mode with
-          | Ok () -> ()
-          | Error e ->
-              raise (Error (loc, env, Item_weaker_than_structure e))
-        end;
         Tstr_exception ext,
         [Sig_typext(constructor.ext_id,
                     constructor.ext_type,


### PR DESCRIPTION
Update https://github.com/oxcaml/oxcaml/pull/4062 with the new design for portable exceptions.
Instead of always requiring the argument types to cross portability and contention, on creation under a contention lock, arguments are required to be portable and cross contention. Similarly, on pattern-matching under a contention lock, arguments must cross portability and are marked as contended. Rebinding still requires full mode-crossing.