### PR TITLE
Fix building on OpenBSD

### DIFF
--- a/middle_end/flambda2/numbers/floats/float32_stubs.c
+++ b/middle_end/flambda2/numbers/floats/float32_stubs.c
@@ -40,6 +40,8 @@
 #ifndef strtof_l
 #define strtof_l _strtof_l
 #endif
+#elif defined(__OpenBSD__)
+#define strtof_l(b, e, l) strtof(b, e)
 #endif
 
 extern locale_t caml_locale;

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -17,7 +17,9 @@
 
 #include <unistd.h>
 #define __USE_GNU
+#if !defined(__OpenBSD__)
 #include <sys/ucontext.h>
+#endif
 
 /* Signal handling, code specific to the native-code compiler */
 


### PR DESCRIPTION
OpenBSD has neither `strtof_l` nor `<ucontext.h>`.

This PR doesn't fix the hard-coded `(run make ...)` found in some dune files. For now, this can be worked around by having the `make` in `$PATH` be `gmake`.