### PR TITLE
fix(flambda2): Deterministic order for lifted symbols

### DIFF
--- a/middle_end/flambda2/bound_identifiers/bound_static.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_static.ml
@@ -132,6 +132,10 @@ let check_pattern_list_invariant pattern_list =
       (Format.pp_print_list ~pp_sep:Format.pp_print_space Pattern.print)
       pattern_list
 
+let [@ocamlformat "disable"] print ppf t =
+  Format.fprintf ppf "@[<hov 1>(%a)@]"
+    (Format.pp_print_list ~pp_sep:Format.pp_print_space Pattern.print) t
+
 let create pattern_list =
   if Flambda_features.check_invariants ()
   then check_pattern_list_invariant pattern_list;
@@ -140,10 +144,6 @@ let create pattern_list =
 let singleton pattern = [pattern]
 
 let to_list t = t
-
-let [@ocamlformat "disable"] print ppf t =
-  Format.fprintf ppf "@[<hov 1>(%a)@]"
-    (Format.pp_print_list ~pp_sep:Format.pp_print_space Pattern.print) t
 
 let symbols_being_defined t =
   List.map Pattern.symbols_being_defined t |> Symbol.Set.union_list
@@ -158,6 +158,9 @@ let binds_symbols t = List.exists Pattern.binds_symbols t
 let everything_being_defined t =
   List.map Pattern.everything_being_defined t
   |> Code_id_or_symbol.Set.union_list
+
+let everything_being_defined_as_list t =
+  List.concat_map Pattern.everything_being_defined_as_list t
 
 let apply_renaming t renaming =
   List.map (fun pattern -> Pattern.apply_renaming pattern renaming) t

--- a/middle_end/flambda2/bound_identifiers/bound_static.mli
+++ b/middle_end/flambda2/bound_identifiers/bound_static.mli
@@ -63,6 +63,8 @@ val code_being_defined : t -> Code_id.Set.t
 
 val everything_being_defined : t -> Code_id_or_symbol.Set.t
 
+val everything_being_defined_as_list : t -> Code_id_or_symbol.t list
+
 val concat : t -> t -> t
 
 val gc_roots : t -> Symbol.t list

--- a/middle_end/flambda2/simplify/lifting/lifted_constant_state.ml
+++ b/middle_end/flambda2/simplify/lifting/lifted_constant_state.ml
@@ -213,14 +213,10 @@ let sort0 t =
        can just filter out external dependencies from the graph. *)
     remove_values_not_in_domain lifted_constants_dep_graph
   in
-  let lifted_constants_dep_numbered_graph =
-    SCC_lifted_constants.stable_number
-      (CIS.Lmap.bindings lifted_constants_dep_graph)
-  in
   let innermost_first =
-    lifted_constants_dep_numbered_graph
+    CIS.Lmap.bindings lifted_constants_dep_graph
     |> SCC_lifted_constants
-       .numbered_connected_components_sorted_from_roots_to_leaf
+       .stable_connected_components_sorted_from_roots_to_leaf
     |> ArrayLabels.map ~f:(fun (group : SCC_lifted_constants.component) ->
            let code_id_or_symbols =
              match group with

--- a/middle_end/flambda2/simplify/lifting/lifted_constant_state.ml
+++ b/middle_end/flambda2/simplify/lifting/lifted_constant_state.ml
@@ -134,7 +134,7 @@ module CIS = Code_id_or_symbol
 module SCC_lifted_constants = Strongly_connected_components.Make (CIS)
 
 let build_dep_graph t =
-  fold t ~init:(CIS.Map.empty, CIS.Map.empty)
+  fold t ~init:(CIS.Lmap.empty, CIS.Map.empty)
     ~f:(fun (dep_graph, code_id_or_symbol_to_const) lifted_constant ->
       ListLabels.fold_left (LC.definitions lifted_constant)
         ~init:(dep_graph, code_id_or_symbol_to_const)
@@ -165,26 +165,32 @@ let build_dep_graph t =
               (CIS.set_of_code_id_set free_code_ids)
           in
           let being_defined =
-            D.bound_static definition |> Bound_static.everything_being_defined
+            D.bound_static definition
+            |> Bound_static.everything_being_defined_as_list
           in
-          CIS.Set.fold
-            (fun being_defined (dep_graph, code_id_or_symbol_to_const) ->
-              let dep_graph = CIS.Map.add being_defined deps dep_graph in
+          List.fold_left
+            (fun (dep_graph, code_id_or_symbol_to_const) being_defined ->
+              let dep_graph = CIS.Lmap.add being_defined deps dep_graph in
               let code_id_or_symbol_to_const =
                 CIS.Map.add being_defined
                   (Lifted_constant.create_definition definition)
                   code_id_or_symbol_to_const
               in
               dep_graph, code_id_or_symbol_to_const)
-            being_defined
-            (dep_graph, code_id_or_symbol_to_const)))
+            (dep_graph, code_id_or_symbol_to_const)
+            being_defined))
 
-let remove_values_not_in_domain (m : CIS.Set.t CIS.Map.t) =
-  CIS.Map.map
+let remove_values_not_in_domain (m : CIS.Set.t CIS.Lmap.t) =
+  let domain =
+    CIS.Lmap.fold
+      (fun value _ domain -> CIS.Set.add value domain)
+      m CIS.Set.empty
+  in
+  CIS.Lmap.map
     (fun values ->
       (* CR lmaurer: This should use a map/set intersection function, which
          should be easy to define with the Patricia tree refactor *)
-      CIS.Set.filter (fun value -> CIS.Map.mem value m) values)
+      CIS.Set.filter (fun value -> CIS.Set.mem value domain) values)
     m
 
 type sort_result = { innermost_first : LC.t array }
@@ -207,9 +213,14 @@ let sort0 t =
        can just filter out external dependencies from the graph. *)
     remove_values_not_in_domain lifted_constants_dep_graph
   in
+  let lifted_constants_dep_numbered_graph =
+    SCC_lifted_constants.stable_number
+      (CIS.Lmap.bindings lifted_constants_dep_graph)
+  in
   let innermost_first =
-    lifted_constants_dep_graph
-    |> SCC_lifted_constants.connected_components_sorted_from_roots_to_leaf
+    lifted_constants_dep_numbered_graph
+    |> SCC_lifted_constants
+       .numbered_connected_components_sorted_from_roots_to_leaf
     |> ArrayLabels.map ~f:(fun (group : SCC_lifted_constants.component) ->
            let code_id_or_symbols =
              match group with

--- a/middle_end/flambda2/tests/mlexamples/inlined_rec.flt
+++ b/middle_end/flambda2/tests/mlexamples/inlined_rec.flt
@@ -48,7 +48,9 @@ let code inline(always) loopify(never) size(6) newer_version_of(apply_0)
   apply inlined(hint) f (i) -> k * k1
 in
 let $camlInlined_rec__apply_2 = closure apply_0_1 @`apply` in
-let code rec loopify(never) size(42) newer_version_of(fact_1)
+let $camlInlined_rec__fact_3 =
+  closure fact_1_1 @fact
+and code rec loopify(never) size(42) newer_version_of(fact_1)
       fact_1_1 (n : imm tagged)
         my_closure my_region my_ghost_region my_depth
         -> k * k1
@@ -62,25 +64,23 @@ let code rec loopify(never) size(42) newer_version_of(fact_1)
         let prim_1 = %phys_ne (Psubint, 0) in
         switch prim_1
           | 0 -> k2 (1)
-          | 1 -> k3
-          where k3 =
+          | 1 -> k2_1
+          where k2_1 =
             ((let Psubint_1 = Psubint - 1 in
               apply direct(fact_1_1) inlining_state(depth(12))
                 $camlInlined_rec__fact_3 ~ depth my_depth -> succ (unroll 1 (succ my_depth))
                   (Psubint_1)
-                  -> k3 * k1)
-               where k3 (apply_result : imm tagged) =
+                  -> k2_1 * k1)
+               where k2_1 (apply_result : imm tagged) =
                  let Pmulint = Psubint * apply_result in
                  cont k2 (Pmulint)))
          where k2 (apply_result : imm tagged) =
            let Pmulint = n * apply_result in
            cont k (Pmulint))
-and $camlInlined_rec__fact_3 =
-  closure fact_1_1 @fact
 in
 apply direct(fact_1_1)
-  ($camlInlined_rec__fact_3 : _ -> imm tagged) (1000000) -> k * error
-  where k (i : imm tagged) =
+  ($camlInlined_rec__fact_3 : _ -> imm tagged) (1000000) -> k1 * error
+  where k1 (i : imm tagged) =
     let $camlInlined_rec =
       Block 0 ($camlInlined_rec__apply_2, $camlInlined_rec__fact_3, i)
     in

--- a/middle_end/flambda2/tests/mlexamples/local.flt
+++ b/middle_end/flambda2/tests/mlexamples/local.flt
@@ -162,7 +162,7 @@ let code rec size(41)
   let rev_app = %project_value_slot spans.rev_app my_closure in
   let find_span = %project_function_slot (spans -> find_span) my_closure in
   let `region` = %begin_region in
-  let `ghost_region` = %begin_ghost_region in
+  let ghost_region = %begin_ghost_region in
   (let prim = %is_int l in
    let Pisint = %Tag_imm prim in
    (let untagged = %untag_imm Pisint in
@@ -170,7 +170,7 @@ let code rec size(41)
       | 0 -> k3
       | 1 -> k2 (0))
      where k3 =
-       (apply direct(find_span_6 &`region` &`ghost_region`)
+       (apply direct(find_span_6 &`region` &ghost_region)
           (find_span ~ depth my_depth -> next_depth
            : _ -> [ 0 of [ 0 | 0 of val * val ] * [ 0 | 0 of val * val ] ])
             (break_here, l, 0)
@@ -202,7 +202,7 @@ let code rec size(41)
                       cont k2 (Pmakeblock)))))
     where k2 (region_return : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
       let `unit` = %end_region `region` in
-      let `unit` = %end_ghost_region `ghost_region` in
+      let `unit` = %end_ghost_region ghost_region in
       cont k (region_return)
 in
 let code size(25)
@@ -240,8 +240,8 @@ in
           cont error pop(regular error) ($camlLocal__Pmakeblock55))
    where k1 (`*match*` : imm tagged) =
      ((let `region` = %begin_region in
-       let `ghost_region` = %begin_ghost_region in
-       apply direct(return_local_0 &`region` &`ghost_region`)
+       let ghost_region = %begin_ghost_region in
+       apply direct(return_local_0 &`region` &ghost_region)
          (return_local : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
            (0)
            -> k4 * error
@@ -259,12 +259,12 @@ in
                 cont error pop(regular error) ($camlLocal__Pmakeblock69))
          where k2 (region_return : imm tagged) =
            let `unit` = %end_region `region` in
-           let `unit` = %end_ghost_region `ghost_region` in
+           let `unit` = %end_ghost_region ghost_region in
            cont k1 (region_return))
         where k1 (`*match*_1` : imm tagged) =
           ((let `region` = %begin_region in
-            let `ghost_region` = %begin_ghost_region in
-            apply direct(return_local_0 &`region` &`ghost_region`)
+            let ghost_region = %begin_ghost_region in
+            apply direct(return_local_0 &`region` &ghost_region)
               (return_local : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                 (0)
                 -> k3 * error
@@ -273,7 +273,7 @@ in
                     closure `anon-fn[local.ml:24,27--43]_3`
                       @`anon-fn[local.ml:24,27--43]`
                   in
-                  apply direct(map_local_1 &`region` &`ghost_region`)
+                  apply direct(map_local_1 &`region` &ghost_region)
                     (map_local
                      : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                       (`anon-fn[local.ml:24,27--43]`, ns)
@@ -294,12 +294,12 @@ in
                                       ($camlLocal__Pmakeblock92))))
               where k2 (region_return : imm tagged) =
                 let `unit` = %end_region `region` in
-                let `unit` = %end_ghost_region `ghost_region` in
+                let `unit` = %end_ghost_region ghost_region in
                 cont k1 (region_return))
              where k1 (`*match*_2` : imm tagged) =
                let rev_app = closure rev_app_4 @rev_app in
-               let spans = closure spans_5 @spans
-               and find_span = closure find_span_6 @find_span
+               let find_span = closure find_span_6 @find_span
+               and spans = closure spans_5 @spans
                with { rev_app = rev_app }
                in
                let is_even = closure is_even_7 @is_even in
@@ -464,7 +464,7 @@ apply direct(length_2_1)
            | 1 -> k2
        where k2 =
          let `region` = %begin_region in
-         let `ghost_region` = %begin_ghost_region in
+         let ghost_region = %begin_ghost_region in
          ((let code loopify(never) size(3) newer_version_of(`anon-fn[local.ml:24,27--43]_3`)
                  `anon-fn[local.ml:24,27--43]_3_1` (i : imm tagged)
                    my_closure my_region my_ghost_region my_depth
@@ -477,7 +477,7 @@ apply direct(length_2_1)
              closure `anon-fn[local.ml:24,27--43]_3_1`
                @`anon-fn[local.ml:24,27--43]`
            in
-           apply direct(map_local_1_1 &`region` &`ghost_region`)
+           apply direct(map_local_1_1 &`region` &ghost_region)
              ($camlLocal__map_local_9
               : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                ($`camlLocal__anon-fn[local.ml:24,27--43]_11`,
@@ -495,7 +495,7 @@ apply direct(length_2_1)
                      | 1 -> k2)
             where k2 =
               let `unit` = %end_region `region` in
-              let `unit` = %end_ghost_region `ghost_region` in
+              let unit_1 = %end_ghost_region ghost_region in
               let code rec loopify(done) size(22) newer_version_of(rev_app_4)
                     rev_app_4_1
                       (l1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
@@ -520,7 +520,11 @@ apply direct(length_2_1)
                          cont self (Pfield_1, Pmakeblock))
               in
               let $camlLocal__rev_app_12 = closure rev_app_4_1 @rev_app in
-              let code rec loopify(never) size(36) newer_version_of(spans_5)
+              let $camlLocal__find_span_13 =
+                closure find_span_6_1 @find_span
+              and $camlLocal__spans_14 =
+                closure spans_5_1 @spans
+              and code rec loopify(never) size(36) newer_version_of(spans_5)
                     spans_5_1
                       (break_here,
                        l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
@@ -535,7 +539,7 @@ apply direct(length_2_1)
                    | 1 -> k2 (0)
                    where k3 =
                      (apply direct(find_span_6_1 &region_1 &ghost_region_1)
-                        ($camlLocal__find_span_14 ~ depth my_depth -> succ my_depth
+                        ($camlLocal__find_span_13 ~ depth my_depth -> succ my_depth
                          : _ ->
                            [ 0 of [ 0 | 0 of val * val ] *
                                [ 0 | 0 of val * val ] ]
@@ -548,7 +552,7 @@ apply direct(length_2_1)
                                        [ 0 | 0 of val * val ] ]) =
                           ((let Pfield = %block_load (1) `*match*` in
                             apply direct(spans_5_1)
-                              ($camlLocal__spans_13 ~ depth my_depth -> succ my_depth
+                              ($camlLocal__spans_14 ~ depth my_depth -> succ my_depth
                                : _ ->
                                  [ 0 | 0 of val * [ 0 | 0 of val * val ] ]
                                )
@@ -579,13 +583,9 @@ apply direct(length_2_1)
                   where k2
                           (region_return :
                              [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-                    let unit_1 = %end_region region_1 in
-                    let unit_2 = %end_ghost_region ghost_region_1 in
+                    let unit_2 = %end_region region_1 in
+                    let unit_3 = %end_ghost_region ghost_region_1 in
                     cont k (region_return)
-              and $camlLocal__spans_13 =
-                closure spans_5_1 @spans
-              and $camlLocal__find_span_14 =
-                closure find_span_6_1 @find_span
               and code rec loopify(never) size(58) newer_version_of(find_span_6)
                     find_span_6_1
                       (break_here,
@@ -621,8 +621,10 @@ apply direct(length_2_1)
                               in
                               cont k (Pmakeblock)
                             where k2 =
-                              apply direct(find_span_6_1 &my_region &my_ghost_region)
-                                ($camlLocal__find_span_14 ~ depth my_depth -> succ my_depth
+                              apply
+                                     direct(find_span_6_1
+                                     &my_region &my_ghost_region)
+                                ($camlLocal__find_span_13 ~ depth my_depth -> succ my_depth
                                  : _ ->
                                    [ 0 of [ 0 | 0 of val * val ] *
                                        [ 0 | 0 of val * val ] ]
@@ -642,7 +644,7 @@ apply direct(length_2_1)
               in
               let $camlLocal__is_even_15 = closure is_even_7_1 @is_even in
               (apply direct(spans_5_1)
-                 ($camlLocal__spans_13
+                 ($camlLocal__spans_14
                   : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                    ($camlLocal__is_even_15, $camlLocal__const_block169)
                    -> k2 * error
@@ -666,8 +668,8 @@ apply direct(length_2_1)
                               $camlLocal__map_local_9,
                               $camlLocal__length_10,
                               $camlLocal__rev_app_12,
-                              $camlLocal__spans_13,
-                              $camlLocal__find_span_14,
+                              $camlLocal__spans_14,
+                              $camlLocal__find_span_13,
                               $camlLocal__is_even_15)
                    in
                    cont done ($camlLocal))))

--- a/middle_end/flambda2/tests/mlexamples/tests5.flt
+++ b/middle_end/flambda2/tests/mlexamples/tests5.flt
@@ -48,7 +48,11 @@ in
     cont done ($camlTests5)
 ===>
 let code g_1 deleted and code f_0 deleted in
-let code rec loopify(never) size(18) newer_version_of(g_1)
+let $camlTests5__f_2 =
+  closure f_0_1 @f
+and $camlTests5__g_3 =
+  closure g_1_1 @g
+and code rec loopify(never) size(18) newer_version_of(g_1)
       g_1_1 (y : imm tagged)
         my_closure my_region my_ghost_region my_depth
         -> k * k1
@@ -64,10 +68,6 @@ let code rec loopify(never) size(18) newer_version_of(g_1)
          )
           (Psubint)
           -> k * k1
-and $camlTests5__f_2 =
-  closure f_0_1 @f
-and $camlTests5__g_3 =
-  closure g_1_1 @g
 and code rec loopify(never) size(18) newer_version_of(f_0)
       f_0_1 (x : imm tagged)
         my_closure my_region my_ghost_region my_depth

--- a/middle_end/flambda2/tests/mlexamples/unroll3.flt
+++ b/middle_end/flambda2/tests/mlexamples/unroll3.flt
@@ -55,22 +55,10 @@ in
     cont done ($camlUnroll3)
 ===>
 let code odd_1 deleted and code even_0 deleted in
-let code rec loopify(never) size(18) newer_version_of(even_0)
-      even_0_1 (n : imm tagged)
-        my_closure my_region my_ghost_region my_depth
-        -> k * k1
-        : imm tagged =
-  let prim = %phys_eq (n, 0) in
-  switch prim
-    | 0 -> k2
-    | 1 -> k (1)
-    where k2 =
-      let Psubint = n - 1 in
-      apply direct(odd_1_1)
-        ($camlUnroll3__odd_3 ~ depth my_depth -> succ my_depth
-         : _ -> imm tagged)
-          (Psubint)
-          -> k * k1
+let $camlUnroll3__even_2 =
+  closure even_0_1 @even
+and $camlUnroll3__odd_3 =
+  closure odd_1_1 @odd
 and code rec loopify(never) size(18) newer_version_of(odd_1)
       odd_1_1 (n : imm tagged)
         my_closure my_region my_ghost_region my_depth
@@ -87,10 +75,22 @@ and code rec loopify(never) size(18) newer_version_of(odd_1)
          : _ -> imm tagged)
           (Psubint)
           -> k * k1
-and $camlUnroll3__even_2 =
-  closure even_0_1 @even
-and $camlUnroll3__odd_3 =
-  closure odd_1_1 @odd
+and code rec loopify(never) size(18) newer_version_of(even_0)
+      even_0_1 (n : imm tagged)
+        my_closure my_region my_ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let prim = %phys_eq (n, 0) in
+  switch prim
+    | 0 -> k2
+    | 1 -> k (1)
+    where k2 =
+      let Psubint = n - 1 in
+      apply direct(odd_1_1)
+        ($camlUnroll3__odd_3 ~ depth my_depth -> succ my_depth
+         : _ -> imm tagged)
+          (Psubint)
+          -> k * k1
 in
 apply direct(odd_1_1) inlining_state(depth(20))
   ($camlUnroll3__odd_3 ~ depth unroll 1 1 -> unroll 0 2 : _ -> imm tagged)

--- a/middle_end/flambda2/tests/mlexamples/unroll4.flt
+++ b/middle_end/flambda2/tests/mlexamples/unroll4.flt
@@ -81,28 +81,12 @@ in
 let code odd_2 deleted and code even_1 deleted in
 let code parity_is_0 deleted in
 let code k_3 deleted in
-let code rec loopify(never) size(26) newer_version_of(even_1)
+let code rec loopify(never) size(26) newer_version_of(odd_2)
       even_1_1 (n : imm tagged)
         my_closure my_region my_ghost_region my_depth
         -> k * k1 =
   let k = %project_value_slot even.k my_closure in
-  let odd = %project_function_slot (even -> odd) my_closure in
-  let prim = %phys_eq (n, 0) in
-  switch prim
-    | 0 -> k2
-    | 1 -> k3
-    where k3 =
-      apply inlined(hint) k (1) -> k * k1
-    where k2 =
-      let Psubint = n - 1 in
-      apply direct(odd_2_1)
-        odd ~ depth my_depth -> succ my_depth (Psubint) -> k * k1
-and code rec loopify(never) size(26) newer_version_of(odd_2)
-      odd_2_1 (n : imm tagged)
-        my_closure my_region my_ghost_region my_depth
-        -> k * k1 =
-  let k = %project_value_slot odd.k my_closure in
-  let even = %project_function_slot (odd -> even) my_closure in
+  let even = %project_function_slot (even -> odd) my_closure in
   let prim = %phys_eq (n, 0) in
   switch prim
     | 0 -> k2
@@ -111,8 +95,24 @@ and code rec loopify(never) size(26) newer_version_of(odd_2)
       apply inlined(hint) k (0) -> k * k1
     where k2 =
       let Psubint = n - 1 in
-      apply direct(even_1_1)
+      apply direct(odd_2_1)
         even ~ depth my_depth -> succ my_depth (Psubint) -> k * k1
+and code rec loopify(never) size(26) newer_version_of(even_1)
+      odd_2_1 (n : imm tagged)
+        my_closure my_region my_ghost_region my_depth
+        -> k * k1 =
+  let k = %project_value_slot odd.k my_closure in
+  let odd = %project_function_slot (odd -> even) my_closure in
+  let prim = %phys_eq (n, 0) in
+  switch prim
+    | 0 -> k2
+    | 1 -> k3
+    where k3 =
+      apply inlined(hint) k (1) -> k * k1
+    where k2 =
+      let Psubint = n - 1 in
+      apply direct(even_1_1)
+        odd ~ depth my_depth -> succ my_depth (Psubint) -> k * k1
 in
 let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
       parity_is_0_1 (p : imm tagged, n : imm tagged, k)
@@ -129,39 +129,39 @@ let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
     where k3 =
       let prim = %phys_eq (n, 0) in
       (switch prim
-         | 0 -> k3
+         | 0 -> k2_1
          | 1 -> k4
          where k4 =
            apply inlined(hint) inlining_state(depth(10)) k (0) -> k * k1
-         where k3 =
+         where k2_1 =
            let Psubint = n - 1 in
            let prim_1 = %phys_eq (Psubint, 0) in
            (switch prim_1
-              | 0 -> k3
+              | 0 -> k2_1
               | 1 -> k4
               where k4 =
                 apply inlined(hint) inlining_state(depth(20)) k (1) -> k * k1
-              where k3 =
+              where k2_1 =
                 let Psubint_1 = Psubint - 1 in
                 let prim_2 = %phys_eq (Psubint_1, 0) in
                 (switch prim_2
-                   | 0 -> k3
+                   | 0 -> k2_1
                    | 1 -> k4
                    where k4 =
                      apply inlined(hint) inlining_state(depth(30))
                        k (0) -> k * k1
-                   where k3 =
+                   where k2_1 =
                      let Psubint_2 = Psubint_1 - 1 in
                      let prim_3 = %phys_eq (Psubint_2, 0) in
                      (switch prim_3
-                        | 0 -> k3
+                        | 0 -> k2_1
                         | 1 -> k4
                         where k4 =
                           apply inlined(hint) inlining_state(depth(40))
                             k (1) -> k * k1
-                        where k3 =
+                        where k2_1 =
                           let Psubint_3 = Psubint_2 - 1 in
-                          apply direct(odd_2_1) inlining_state(depth(40))
+                          apply direct(odd_2_1_1) inlining_state(depth(40))
                             odd ~ depth 0 -> unroll 0 4 (Psubint_3) -> k * k1))))
     where k2 =
       let prim = %phys_eq (n, 0) in
@@ -189,7 +189,7 @@ let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
                        k (1) -> k * k1
                    where k2 =
                      let Psubint_2 = Psubint_1 - 1 in
-                     apply direct(odd_2_1) inlining_state(depth(30))
+                     apply direct(odd_2_1_1) inlining_state(depth(30))
                        odd ~ depth 0 -> unroll 0 3 (Psubint_2) -> k * k1)))
 in
 let $camlUnroll4__parity_is_4 = closure parity_is_0_1 @parity_is in
@@ -199,45 +199,45 @@ let code inline(always) loopify(never) size(1) newer_version_of(k_3)
 in
 let $camlUnroll4__k_5 = closure k_3_1 @k in
 apply direct(k_3_1) inlined(hint) inlining_state(depth(21))
-  $camlUnroll4__k_5 (0) -> k * error
-  where k (one_is_even : imm tagged) =
-    ((let code rec loopify(never) size(18) newer_version_of(even_1_1)
-            even_1_2 (n : imm tagged)
+  $camlUnroll4__k_5 (0) -> k1 * error
+  where k1 (one_is_even : imm tagged) =
+    ((let $camlUnroll4__even_8 =
+        closure even_1_1_1 @even_1
+      and $camlUnroll4__odd_9 =
+        closure odd_2_2 @odd_1
+      and code rec loopify(never) size(18) newer_version_of(even_1_1)
+            odd_2_2 (n : imm tagged)
               my_closure my_region my_ghost_region my_depth
-              -> k1 * k2 =
+              -> k * k1_1 =
         let prim = %phys_eq (n, 0) in
         switch prim
-          | 0 -> k3
-          | 1 -> k1 (1)
-          where k3 =
+          | 0 -> k2
+          | 1 -> k (0)
+          where k2 =
+            let Psubint = n - 1 in
+            apply direct(even_1_1_1) inlining_state(depth(1))
+              $camlUnroll4__even_8 ~ depth my_depth -> succ my_depth
+                (Psubint)
+                -> k * k1_1
+      and code rec loopify(never) size(18) newer_version_of(odd_2_1)
+            even_1_1_1 (n : imm tagged)
+              my_closure my_region my_ghost_region my_depth
+              -> k * k1_1 =
+        let prim = %phys_eq (n, 0) in
+        switch prim
+          | 0 -> k2
+          | 1 -> k (1)
+          where k2 =
             let Psubint = n - 1 in
             apply direct(odd_2_2) inlining_state(depth(1))
               $camlUnroll4__odd_9 ~ depth my_depth -> succ my_depth
                 (Psubint)
-                -> k1 * k2
-      and code rec loopify(never) size(18) newer_version_of(odd_2_1)
-            odd_2_2 (n : imm tagged)
-              my_closure my_region my_ghost_region my_depth
-              -> k1 * k2 =
-        let prim = %phys_eq (n, 0) in
-        switch prim
-          | 0 -> k3
-          | 1 -> k1 (0)
-          where k3 =
-            let Psubint = n - 1 in
-            apply direct(even_1_2) inlining_state(depth(1))
-              $camlUnroll4__even_8 ~ depth my_depth -> succ my_depth
-                (Psubint)
-                -> k1 * k2
-      and $camlUnroll4__even_8 =
-        closure even_1_2 @even
-      and $camlUnroll4__odd_9 =
-        closure odd_2_2 @odd
-        with { k = $camlUnroll4__k_5 }
+                -> k * k1_1
+        with { k_1 = $camlUnroll4__k_5 }
       in
       apply direct(odd_2_2) inlining_state(depth(41))
-        $camlUnroll4__odd_9 ~ depth 0 -> unroll 0 4 (0) -> k * error)
-       where k (four_is_odd : imm tagged) =
+        $camlUnroll4__odd_9 ~ depth 0 -> unroll 0 4 (0) -> k1 * error)
+       where k1 (four_is_odd : imm tagged) =
          let $camlUnroll4 =
            Block 0 ($camlUnroll4__parity_is_4,
                     $camlUnroll4__k_5,

--- a/middle_end/flambda2/tests/mlexamples/unroll4.flt
+++ b/middle_end/flambda2/tests/mlexamples/unroll4.flt
@@ -82,11 +82,11 @@ let code odd_2 deleted and code even_1 deleted in
 let code parity_is_0 deleted in
 let code k_3 deleted in
 let code rec loopify(never) size(26) newer_version_of(odd_2)
-      even_1_1 (n : imm tagged)
+      odd_2_1 (n : imm tagged)
         my_closure my_region my_ghost_region my_depth
         -> k * k1 =
-  let k = %project_value_slot even.k my_closure in
-  let even = %project_function_slot (even -> odd) my_closure in
+  let k = %project_value_slot odd.k my_closure in
+  let even = %project_function_slot (odd -> even) my_closure in
   let prim = %phys_eq (n, 0) in
   switch prim
     | 0 -> k2
@@ -95,14 +95,14 @@ let code rec loopify(never) size(26) newer_version_of(odd_2)
       apply inlined(hint) k (0) -> k * k1
     where k2 =
       let Psubint = n - 1 in
-      apply direct(odd_2_1)
+      apply direct(even_1_1)
         even ~ depth my_depth -> succ my_depth (Psubint) -> k * k1
 and code rec loopify(never) size(26) newer_version_of(even_1)
-      odd_2_1 (n : imm tagged)
+      even_1_1 (n : imm tagged)
         my_closure my_region my_ghost_region my_depth
         -> k * k1 =
-  let k = %project_value_slot odd.k my_closure in
-  let odd = %project_function_slot (odd -> even) my_closure in
+  let k = %project_value_slot even.k my_closure in
+  let odd = %project_function_slot (even -> odd) my_closure in
   let prim = %phys_eq (n, 0) in
   switch prim
     | 0 -> k2
@@ -111,7 +111,7 @@ and code rec loopify(never) size(26) newer_version_of(even_1)
       apply inlined(hint) k (1) -> k * k1
     where k2 =
       let Psubint = n - 1 in
-      apply direct(even_1_1)
+      apply direct(odd_2_1)
         odd ~ depth my_depth -> succ my_depth (Psubint) -> k * k1
 in
 let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
@@ -130,24 +130,24 @@ let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
       let prim = %phys_eq (n, 0) in
       (switch prim
          | 0 -> k2_1
-         | 1 -> k4
-         where k4 =
+         | 1 -> k3
+         where k3 =
            apply inlined(hint) inlining_state(depth(10)) k (0) -> k * k1
          where k2_1 =
            let Psubint = n - 1 in
            let prim_1 = %phys_eq (Psubint, 0) in
            (switch prim_1
               | 0 -> k2_1
-              | 1 -> k4
-              where k4 =
+              | 1 -> k3
+              where k3 =
                 apply inlined(hint) inlining_state(depth(20)) k (1) -> k * k1
               where k2_1 =
                 let Psubint_1 = Psubint - 1 in
                 let prim_2 = %phys_eq (Psubint_1, 0) in
                 (switch prim_2
                    | 0 -> k2_1
-                   | 1 -> k4
-                   where k4 =
+                   | 1 -> k3
+                   where k3 =
                      apply inlined(hint) inlining_state(depth(30))
                        k (0) -> k * k1
                    where k2_1 =
@@ -155,13 +155,13 @@ let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
                      let prim_3 = %phys_eq (Psubint_2, 0) in
                      (switch prim_3
                         | 0 -> k2_1
-                        | 1 -> k4
-                        where k4 =
+                        | 1 -> k3
+                        where k3 =
                           apply inlined(hint) inlining_state(depth(40))
                             k (1) -> k * k1
                         where k2_1 =
                           let Psubint_3 = Psubint_2 - 1 in
-                          apply direct(odd_2_1_1) inlining_state(depth(40))
+                          apply direct(odd_2_1) inlining_state(depth(40))
                             odd ~ depth 0 -> unroll 0 4 (Psubint_3) -> k * k1))))
     where k2 =
       let prim = %phys_eq (n, 0) in
@@ -189,7 +189,7 @@ let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
                        k (1) -> k * k1
                    where k2 =
                      let Psubint_2 = Psubint_1 - 1 in
-                     apply direct(odd_2_1_1) inlining_state(depth(30))
+                     apply direct(odd_2_1) inlining_state(depth(30))
                        odd ~ depth 0 -> unroll 0 3 (Psubint_2) -> k * k1)))
 in
 let $camlUnroll4__parity_is_4 = closure parity_is_0_1 @parity_is in
@@ -202,10 +202,10 @@ apply direct(k_3_1) inlined(hint) inlining_state(depth(21))
   $camlUnroll4__k_5 (0) -> k1 * error
   where k1 (one_is_even : imm tagged) =
     ((let $camlUnroll4__even_8 =
-        closure even_1_1_1 @even_1
+        closure even_1_2 @even
       and $camlUnroll4__odd_9 =
-        closure odd_2_2 @odd_1
-      and code rec loopify(never) size(18) newer_version_of(even_1_1)
+        closure odd_2_2 @odd
+      and code rec loopify(never) size(18) newer_version_of(odd_2_1)
             odd_2_2 (n : imm tagged)
               my_closure my_region my_ghost_region my_depth
               -> k * k1_1 =
@@ -215,12 +215,12 @@ apply direct(k_3_1) inlined(hint) inlining_state(depth(21))
           | 1 -> k (0)
           where k2 =
             let Psubint = n - 1 in
-            apply direct(even_1_1_1) inlining_state(depth(1))
+            apply direct(even_1_2) inlining_state(depth(1))
               $camlUnroll4__even_8 ~ depth my_depth -> succ my_depth
                 (Psubint)
                 -> k * k1_1
-      and code rec loopify(never) size(18) newer_version_of(odd_2_1)
-            even_1_1_1 (n : imm tagged)
+      and code rec loopify(never) size(18) newer_version_of(even_1_1)
+            even_1_2 (n : imm tagged)
               my_closure my_region my_ghost_region my_depth
               -> k * k1_1 =
         let prim = %phys_eq (n, 0) in
@@ -233,7 +233,7 @@ apply direct(k_3_1) inlined(hint) inlining_state(depth(21))
               $camlUnroll4__odd_9 ~ depth my_depth -> succ my_depth
                 (Psubint)
                 -> k * k1_1
-        with { k_1 = $camlUnroll4__k_5 }
+        with { k = $camlUnroll4__k_5 }
       in
       apply direct(odd_2_2) inlining_state(depth(41))
         $camlUnroll4__odd_9 ~ depth 0 -> unroll 0 4 (0) -> k1 * error)

--- a/middle_end/flambda2/tests/mlexamples/unroll5.flt
+++ b/middle_end/flambda2/tests/mlexamples/unroll5.flt
@@ -57,7 +57,9 @@ let code foo_0 deleted in
 let code test1_1 deleted in
 let code test2_2 deleted in
 let code test3_3 deleted in
-let code rec loopify(never) size(80) newer_version_of(foo_0)
+let $camlUnroll5__foo_4 =
+  closure foo_0_1 @foo
+and code rec loopify(never) size(80) newer_version_of(foo_0)
       foo_0_1 (x : imm tagged)
         my_closure my_region my_ghost_region my_depth
         -> k * k1 =
@@ -71,41 +73,41 @@ let code rec loopify(never) size(80) newer_version_of(foo_0)
       let Popaque_1 = %Opaque 1 in
       ((let untagged = %untag_imm Popaque_1 in
         switch untagged
-          | 0 -> k3
-          | 1 -> k4)
-         where k4 =
+          | 0 -> k2_1
+          | 1 -> k3)
+         where k3 =
            let Paddint_1 = Paddint + 1 in
            let Popaque_2 = %Opaque 1 in
            ((let untagged = %untag_imm Popaque_2 in
              switch untagged
-               | 0 -> k4
-               | 1 -> k5)
-              where k5 =
+               | 0 -> k2_2
+               | 1 -> k3)
+              where k3 =
                 let Paddint_2 = Paddint_1 + 1 in
                 apply direct(foo_0_1) inlining_state(depth(20))
                   $camlUnroll5__foo_4 ~ depth my_depth -> succ (succ (unroll 2 (succ my_depth)))
                     (Paddint_2)
                     -> k * k1
-              where k4 =
+              where k2_2 =
                 let Psubint = Paddint_1 - 1 in
                 apply direct(foo_0_1) inlining_state(depth(20))
                   $camlUnroll5__foo_4 ~ depth my_depth -> succ (succ (unroll 2 (succ my_depth)))
                     (Psubint)
                     -> k * k1)
-         where k3 =
+         where k2_1 =
            let Psubint = Paddint - 1 in
            let Popaque_2 = %Opaque 1 in
            ((let untagged = %untag_imm Popaque_2 in
              switch untagged
-               | 0 -> k3
-               | 1 -> k4)
-              where k4 =
+               | 0 -> k2_1
+               | 1 -> k3)
+              where k3 =
                 let Paddint_1 = Psubint + 1 in
                 apply direct(foo_0_1) inlining_state(depth(20))
                   $camlUnroll5__foo_4 ~ depth my_depth -> succ (succ (unroll 2 (succ my_depth)))
                     (Paddint_1)
                     -> k * k1
-              where k3 =
+              where k2_1 =
                 let Psubint_1 = Psubint - 1 in
                 apply direct(foo_0_1) inlining_state(depth(20))
                   $camlUnroll5__foo_4 ~ depth my_depth -> succ (succ (unroll 2 (succ my_depth)))
@@ -117,8 +119,6 @@ let code rec loopify(never) size(80) newer_version_of(foo_0)
         $camlUnroll5__foo_4 ~ depth my_depth -> succ my_depth
           (Psubint)
           -> k * k1
-and $camlUnroll5__foo_4 =
-  closure foo_0_1 @foo
 in
 let code loopify(never) size(4) newer_version_of(test1_1)
       test1_1_1 (x : imm tagged)
@@ -141,41 +141,41 @@ let code loopify(never) size(80) newer_version_of(test2_2)
       let Popaque_1 = %Opaque 1 in
       ((let untagged = %untag_imm Popaque_1 in
         switch untagged
-          | 0 -> k3
-          | 1 -> k4)
-         where k4 =
+          | 0 -> k2_1
+          | 1 -> k3)
+         where k3 =
            let Paddint_1 = Paddint + 1 in
            let Popaque_2 = %Opaque 1 in
            ((let untagged = %untag_imm Popaque_2 in
              switch untagged
-               | 0 -> k4
-               | 1 -> k5)
-              where k5 =
+               | 0 -> k2_2
+               | 1 -> k3)
+              where k3 =
                 let Paddint_2 = Paddint_1 + 1 in
                 apply direct(foo_0_1) inlining_state(depth(30))
                   $camlUnroll5__foo_4 ~ depth unroll 1 0 -> unroll 0 3
                     (Paddint_2)
                     -> k * k1
-              where k4 =
+              where k2_2 =
                 let Psubint = Paddint_1 - 1 in
                 apply direct(foo_0_1) inlining_state(depth(30))
                   $camlUnroll5__foo_4 ~ depth unroll 1 0 -> unroll 0 3
                     (Psubint)
                     -> k * k1)
-         where k3 =
+         where k2_1 =
            let Psubint = Paddint - 1 in
            let Popaque_2 = %Opaque 1 in
            ((let untagged = %untag_imm Popaque_2 in
              switch untagged
-               | 0 -> k3
-               | 1 -> k4)
-              where k4 =
+               | 0 -> k2_1
+               | 1 -> k3)
+              where k3 =
                 let Paddint_1 = Psubint + 1 in
                 apply direct(foo_0_1) inlining_state(depth(30))
                   $camlUnroll5__foo_4 ~ depth unroll 1 0 -> unroll 0 3
                     (Paddint_1)
                     -> k * k1
-              where k3 =
+              where k2_1 =
                 let Psubint_1 = Psubint - 1 in
                 apply direct(foo_0_1) inlining_state(depth(30))
                   $camlUnroll5__foo_4 ~ depth unroll 1 0 -> unroll 0 3
@@ -203,41 +203,41 @@ let code loopify(never) size(232) newer_version_of(test3_3)
       let Popaque_1 = %Opaque 1 in
       ((let untagged = %untag_imm Popaque_1 in
         switch untagged
-          | 0 -> k3
-          | 1 -> k4)
-         where k4 =
+          | 0 -> k2_1
+          | 1 -> k3)
+         where k3 =
            let Paddint_1 = Paddint + 1 in
            let Popaque_2 = %Opaque 1 in
            ((let untagged = %untag_imm Popaque_2 in
              switch untagged
-               | 0 -> k4
-               | 1 -> k5)
-              where k5 =
+               | 0 -> k2_2
+               | 1 -> k3)
+              where k3 =
                 let Paddint_2 = Paddint_1 + 1 in
                 apply direct(foo_0_1) inlining_state(depth(30))
                   $camlUnroll5__foo_4 ~ depth unroll 3 0 -> unroll 0 3
                     (Paddint_2)
                     -> k * k1
-              where k4 =
+              where k2_2 =
                 let Psubint = Paddint_1 - 1 in
                 apply direct(foo_0_1) inlining_state(depth(30))
                   $camlUnroll5__foo_4 ~ depth unroll 3 0 -> unroll 0 3
                     (Psubint)
                     -> k * k1)
-         where k3 =
+         where k2_1 =
            let Psubint = Paddint - 1 in
            let Popaque_2 = %Opaque 1 in
            ((let untagged = %untag_imm Popaque_2 in
              switch untagged
-               | 0 -> k3
-               | 1 -> k4)
-              where k4 =
+               | 0 -> k2_1
+               | 1 -> k3)
+              where k3 =
                 let Paddint_1 = Psubint + 1 in
                 apply direct(foo_0_1) inlining_state(depth(30))
                   $camlUnroll5__foo_4 ~ depth unroll 3 0 -> unroll 0 3
                     (Paddint_1)
                     -> k * k1
-              where k3 =
+              where k2_1 =
                 let Psubint_1 = Psubint - 1 in
                 apply direct(foo_0_1) inlining_state(depth(30))
                   $camlUnroll5__foo_4 ~ depth unroll 3 0 -> unroll 0 3
@@ -255,41 +255,41 @@ let code loopify(never) size(232) newer_version_of(test3_3)
            let Popaque_2 = %Opaque 1 in
            ((let untagged = %untag_imm Popaque_2 in
              switch untagged
-               | 0 -> k3
-               | 1 -> k4)
-              where k4 =
+               | 0 -> k2_1
+               | 1 -> k3)
+              where k3 =
                 let Paddint_1 = Paddint + 1 in
                 let Popaque_3 = %Opaque 1 in
                 ((let untagged = %untag_imm Popaque_3 in
                   switch untagged
-                    | 0 -> k4
-                    | 1 -> k5)
-                   where k5 =
+                    | 0 -> k2_2
+                    | 1 -> k3)
+                   where k3 =
                      let Paddint_2 = Paddint_1 + 1 in
                      apply direct(foo_0_1) inlining_state(depth(40))
                        $camlUnroll5__foo_4 ~ depth unroll 2 1 -> unroll 0 4
                          (Paddint_2)
                          -> k * k1
-                   where k4 =
+                   where k2_2 =
                      let Psubint_1 = Paddint_1 - 1 in
                      apply direct(foo_0_1) inlining_state(depth(40))
                        $camlUnroll5__foo_4 ~ depth unroll 2 1 -> unroll 0 4
                          (Psubint_1)
                          -> k * k1)
-              where k3 =
+              where k2_1 =
                 let Psubint_1 = Paddint - 1 in
                 let Popaque_3 = %Opaque 1 in
                 ((let untagged = %untag_imm Popaque_3 in
                   switch untagged
-                    | 0 -> k3
-                    | 1 -> k4)
-                   where k4 =
+                    | 0 -> k2_1
+                    | 1 -> k3)
+                   where k3 =
                      let Paddint_1 = Psubint_1 + 1 in
                      apply direct(foo_0_1) inlining_state(depth(40))
                        $camlUnroll5__foo_4 ~ depth unroll 2 1 -> unroll 0 4
                          (Paddint_1)
                          -> k * k1
-                   where k3 =
+                   where k2_1 =
                      let Psubint_2 = Psubint_1 - 1 in
                      apply direct(foo_0_1) inlining_state(depth(40))
                        $camlUnroll5__foo_4 ~ depth unroll 2 1 -> unroll 0 4
@@ -307,41 +307,41 @@ let code loopify(never) size(232) newer_version_of(test3_3)
                 let Popaque_3 = %Opaque 1 in
                 ((let untagged = %untag_imm Popaque_3 in
                   switch untagged
-                    | 0 -> k3
-                    | 1 -> k4)
-                   where k4 =
+                    | 0 -> k2_1
+                    | 1 -> k3)
+                   where k3 =
                      let Paddint_1 = Paddint + 1 in
                      let Popaque_4 = %Opaque 1 in
                      ((let untagged = %untag_imm Popaque_4 in
                        switch untagged
-                         | 0 -> k4
-                         | 1 -> k5)
-                        where k5 =
+                         | 0 -> k2_2
+                         | 1 -> k3)
+                        where k3 =
                           let Paddint_2 = Paddint_1 + 1 in
                           apply direct(foo_0_1) inlining_state(depth(50))
                             $camlUnroll5__foo_4 ~ depth unroll 1 2 -> unroll 0 5
                               (Paddint_2)
                               -> k * k1
-                        where k4 =
+                        where k2_2 =
                           let Psubint_2 = Paddint_1 - 1 in
                           apply direct(foo_0_1) inlining_state(depth(50))
                             $camlUnroll5__foo_4 ~ depth unroll 1 2 -> unroll 0 5
                               (Psubint_2)
                               -> k * k1)
-                   where k3 =
+                   where k2_1 =
                      let Psubint_2 = Paddint - 1 in
                      let Popaque_4 = %Opaque 1 in
                      ((let untagged = %untag_imm Popaque_4 in
                        switch untagged
-                         | 0 -> k3
-                         | 1 -> k4)
-                        where k4 =
+                         | 0 -> k2_1
+                         | 1 -> k3)
+                        where k3 =
                           let Paddint_1 = Psubint_2 + 1 in
                           apply direct(foo_0_1) inlining_state(depth(50))
                             $camlUnroll5__foo_4 ~ depth unroll 1 2 -> unroll 0 5
                               (Paddint_1)
                               -> k * k1
-                        where k3 =
+                        where k2_1 =
                           let Psubint_3 = Psubint_2 - 1 in
                           apply direct(foo_0_1) inlining_state(depth(50))
                             $camlUnroll5__foo_4 ~ depth unroll 1 2 -> unroll 0 5

--- a/utils/strongly_connected_components.ml
+++ b/utils/strongly_connected_components.ml
@@ -156,16 +156,12 @@ module type S = sig
 
   type directed_graph = Id.Set.t Id.Map.t
 
-  type numbered_graph
-
   type component =
     | Has_loop of Id.t list
     | No_loop of Id.t
 
-  val stable_number : (Id.t * Id.Set.t) list -> numbered_graph
-
-  val numbered_connected_components_sorted_from_roots_to_leaf
-     : numbered_graph
+  val stable_connected_components_sorted_from_roots_to_leaf
+    : (Id.t * Id.Set.t) list
     -> component array
 
   val connected_components_sorted_from_roots_to_leaf
@@ -177,8 +173,6 @@ end
 
 module Make (Id : Id) = struct
   type directed_graph = Id.Set.t Id.Map.t
-
-  type numbered_graph = Id.t array * int list array
 
   type component =
     | Has_loop of Id.t list
@@ -197,7 +191,7 @@ module Make (Id : Id) = struct
           set)
       dependencies
 
-  let number_bindings ?(stable = false) (bindings : (Id.t * Id.Set.t) list) =
+  let number ?(stable = false) (bindings : (Id.t * Id.Set.t) list) =
     let size = List.length bindings in
     let a = Array.of_list bindings in
     let forth = Array.map fst a in
@@ -228,12 +222,6 @@ module Make (Id : Id) = struct
     in
     forth, integer_graph
 
-  let stable_number graph =
-    number_bindings ~stable:true graph
-
-  let number graph =
-    number_bindings (Id.Map.bindings graph)
-
   let rec int_list_mem x xs =
     match xs with
     | [] -> false
@@ -257,11 +245,14 @@ module Make (Id : Id) = struct
             component_edges.(component))
       sorted_connected_components
 
-  let numbered_connected_components_sorted_from_roots_to_leaf graph =
-    Array.map fst (numbered_component_graph graph)
+  let stable_component_graph graph =
+    numbered_component_graph (number ~stable:true graph)
+
+  let stable_connected_components_sorted_from_roots_to_leaf graph =
+    Array.map fst (stable_component_graph graph)
 
   let component_graph graph =
-    numbered_component_graph (number graph)
+    numbered_component_graph (number ~stable:false (Id.Map.bindings graph))
 
   let connected_components_sorted_from_roots_to_leaf graph =
     Array.map fst (component_graph graph)

--- a/utils/strongly_connected_components.mli
+++ b/utils/strongly_connected_components.mli
@@ -73,9 +73,17 @@ module type S = sig
       from [a] to every element of [set].  It is assumed that no edge
       points to a vertex not represented in the map. *)
 
+  type numbered_graph
+
   type component =
     | Has_loop of Id.t list
     | No_loop of Id.t
+
+  val stable_number : (Id.t * Id.Set.t) list -> numbered_graph
+
+  val numbered_connected_components_sorted_from_roots_to_leaf
+     : numbered_graph
+    -> component array
 
   val connected_components_sorted_from_roots_to_leaf
      : directed_graph

--- a/utils/strongly_connected_components.mli
+++ b/utils/strongly_connected_components.mli
@@ -73,16 +73,12 @@ module type S = sig
       from [a] to every element of [set].  It is assumed that no edge
       points to a vertex not represented in the map. *)
 
-  type numbered_graph
-
   type component =
     | Has_loop of Id.t list
     | No_loop of Id.t
 
-  val stable_number : (Id.t * Id.Set.t) list -> numbered_graph
-
-  val numbered_connected_components_sorted_from_roots_to_leaf
-     : numbered_graph
+  val stable_connected_components_sorted_from_roots_to_leaf
+    : (Id.t * Id.Set.t) list
     -> component array
 
   val connected_components_sorted_from_roots_to_leaf


### PR DESCRIPTION
Ensure that the order in which lifted constants are defined does not depend on the `Code_id_or_symbol` ordering by using an `Lmap` and sorting the connected components.

This helps making comparisons between different runs (e.g. with different options) using the `flambda2-compare` library.