### PR TITLE
fix(flambda2): Only check for unbound names in invariant

### DIFF
--- a/middle_end/flambda2/nominal/name_occurrences.ml
+++ b/middle_end/flambda2/nominal/name_occurrences.ml
@@ -951,6 +951,9 @@ let with_only_variables { names; _ } =
   let names = For_names.filter names ~f:Name.is_var in
   { empty with names }
 
+let with_only_names { names; _ } =
+  { empty with names }
+
 let with_only_names_and_code_ids_promoting_newer_version_of
     { names; code_ids; newer_version_of_code_ids; _ } =
   let code_ids = For_code_ids.union code_ids newer_version_of_code_ids in

--- a/middle_end/flambda2/nominal/name_occurrences.ml
+++ b/middle_end/flambda2/nominal/name_occurrences.ml
@@ -951,8 +951,7 @@ let with_only_variables { names; _ } =
   let names = For_names.filter names ~f:Name.is_var in
   { empty with names }
 
-let with_only_names { names; _ } =
-  { empty with names }
+let with_only_names { names; _ } = { empty with names }
 
 let with_only_names_and_code_ids_promoting_newer_version_of
     { names; code_ids; newer_version_of_code_ids; _ } =

--- a/middle_end/flambda2/nominal/name_occurrences.mli
+++ b/middle_end/flambda2/nominal/name_occurrences.mli
@@ -148,6 +148,8 @@ val without_code_ids : t -> t
 
 val with_only_variables : t -> t
 
+val with_only_names : t -> t
+
 (** The value returned by this function only records occurrences in two fields:
 
     - names, as per the input

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -713,7 +713,7 @@ let invariant_for_new_equation (t : t) name ty =
         (Name.Set.union (name_domain t) (t.get_imported_names ()))
         Name_mode.in_types
     in
-    let free_names = Name_occurrences.without_code_ids (TG.free_names ty) in
+    let free_names = Name_occurrences.with_only_names (TG.free_names ty) in
     if not (Name_occurrences.subset_domain free_names defined_names)
     then
       let unbound_names =


### PR DESCRIPTION
The `invariant_for_new_equation` in the typing env is supposed to check that the type we are adding only contains bound names, but it also includes checks for function slots and value slots that are never "bound" per se.

Fix the check to only consider names instead.

(This makes the "heavy" invariants check not fail immediately when we add an equation with a closure type)