### PR TITLE
Lower `n` to 25k in the test `evenodd.ml`

### DIFF
--- a/testsuite/tests/effects/evenodd.ml
+++ b/testsuite/tests/effects/evenodd.ml
@@ -21,5 +21,5 @@ and odd n =
   else even (n-1)
 
 let _ =
-  let n = 100_000 in
+  let n = 25_000 in
   Printf.printf "even %d is %B\n%!" n (even n)

--- a/testsuite/tests/effects/evenodd.reference
+++ b/testsuite/tests/effects/evenodd.reference
@@ -1,1 +1,1 @@
-even 100000 is true
+even 25000 is true


### PR DESCRIPTION
`evenodd.ml` currently runs out of memory with asan, making it fail `address_sanitizer_runtime5` for everyone. The simplest way to fix this is to make the test allocate fewer stack frames by lowering `n`.