### PR TITLE
`cpu_relax` primitive

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,14 @@
                 "tmmintrin.h": "c",
                 "pmmintrin.h": "c",
                 "*.tbl": "c",
-                "platform.h": "c"
+                "platform.h": "c",
+                "optional": "c",
+                "system_error": "c",
+                "array": "c",
+                "functional": "c",
+                "tuple": "c",
+                "type_traits": "c",
+                "utility": "c"
         },
         "[ocaml]": {
                 "editor.defaultFormatter": "ocamllabs.ocaml-platform",

--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -55,7 +55,7 @@ let class_of_operation (op : Operation.t)
   | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
   | Stackoffset _ | Load _ | Store _ | Alloc _
   | Intop _ | Intop_imm _ | Intop_atomic _
-  | Name_for_debugger _ | Probe_is_enabled _ | Opaque
+  | Name_for_debugger _ | Probe_is_enabled _ | Opaque | Relax
   | Begin_region | End_region | Poll | Dls_get
     -> Use_default
 

--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -214,8 +214,8 @@ let pseudoregs_for_operation op arg res =
   | Const_float32 _ | Const_float _ | Const_vec128 _ | Const_vec256 _
   | Const_vec512 _ | Const_symbol _ | Stackoffset _ | Load _
   | Store (_, _, _)
-  | Alloc _ | Name_for_debugger _ | Probe_is_enabled _ | Opaque | Begin_region
-  | End_region | Poll | Dls_get ->
+  | Alloc _ | Name_for_debugger _ | Probe_is_enabled _ | Opaque | Relax
+  | Begin_region | End_region | Poll | Dls_get ->
     raise Use_default_exn
 
 let is_immediate (op : Operation.integer_operation) n :

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -1827,6 +1827,7 @@ let emit_instr ~first ~fallthrough i =
          }
          :: !call_gc_sites;
     D.define_label lbl_after_poll
+  | Lop Relax -> I.pause ()
   | Lop (Intop (Icomp cmp)) ->
     I.cmp (arg i 1) (arg i 0);
     I.set (cond cmp) al;

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -594,7 +594,7 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
        | Specific (Ilea _ | Ioffset_loc _ | Ibswap _
                   | Isextend32 | Izextend32 | Ipause
                   | Ilfence | Isfence | Imfence)
-       | Name_for_debugger _ | Dls_get)
+       | Name_for_debugger _ | Dls_get | Relax)
   | Poptrap _ | Prologue ->
     if fp then [| rbp |] else [||]
   | Stack_check _ ->
@@ -725,6 +725,7 @@ let operation_supported = function
   | Ctuple_field _
   | Cdls_get
   | Cpoll
+  | Crelax
     -> true
 
 let trap_size_in_bytes = 16

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -262,7 +262,7 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
       | Const_float _ | Const_float32 _ | Const_vec128 _ | Const_vec256 _
       | Const_vec512 _ | Stackoffset _ | Load _ | Store _ | Name_for_debugger _
       | Probe_is_enabled _ | Opaque | Begin_region | End_region | Dls_get | Poll
-      | Alloc _ )
+      | Relax | Alloc _ )
   | Op (Reinterpret_cast (Int_of_value | Value_of_int))
   | Op
       (Specific

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -722,7 +722,7 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
       | Reinterpret_cast _ | Static_cast _ | Spill | Reload | Const_float32 _
       | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
       | Const_vec512 _ | Stackoffset _ | Intop_atomic _ | Floatop _ | Csel _
-      | Probe_is_enabled _ | Opaque | Begin_region | End_region
+      | Probe_is_enabled _ | Opaque | Begin_region | End_region | Relax
       | Name_for_debugger _ | Dls_get | Poll ->
         assert false
     in
@@ -778,7 +778,7 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
       | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
       | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Intop_atomic _
       | Floatop _ | Csel _ | Probe_is_enabled _ | Opaque | Begin_region
-      | End_region | Name_for_debugger _ | Dls_get | Poll ->
+      | End_region | Name_for_debugger _ | Dls_get | Poll | Relax ->
         assert false
     in
     let consts = List.map extract_intop_imm_int cfg_ops in
@@ -819,7 +819,7 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
         | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
         | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Intop_atomic _
         | Floatop _ | Csel _ | Probe_is_enabled _ | Opaque | Begin_region
-        | End_region | Name_for_debugger _ | Dls_get | Poll ->
+        | End_region | Name_for_debugger _ | Dls_get | Poll | Relax ->
           assert false
       in
       let get_scale op =
@@ -947,7 +947,7 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
           | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
           | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Intop_atomic _
           | Floatop _ | Csel _ | Probe_is_enabled _ | Opaque | Begin_region
-          | End_region | Name_for_debugger _ | Dls_get | Poll ->
+          | End_region | Name_for_debugger _ | Dls_get | Poll | Relax ->
             assert false
         in
         let consts = List.map extract_store_int_imm cfg_ops in
@@ -1053,6 +1053,6 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
   | Alloc _ | Reinterpret_cast _ | Static_cast _ | Spill | Reload
   | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
   | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Intop_atomic _ | Floatop _
-  | Csel _ | Probe_is_enabled _ | Opaque | Begin_region | End_region
+  | Csel _ | Probe_is_enabled _ | Opaque | Relax | Begin_region | End_region
   | Name_for_debugger _ | Dls_get | Poll ->
     None

--- a/backend/arm64/CSE.ml
+++ b/backend/arm64/CSE.ml
@@ -54,7 +54,7 @@ let class_of_operation (op : Operation.t)
   | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
   | Stackoffset _ | Load _ | Store _ | Alloc _
   | Intop _ | Intop_imm _ | Intop_atomic _
-  | Name_for_debugger _ | Probe_is_enabled _ | Opaque
+  | Name_for_debugger _ | Probe_is_enabled _ | Opaque | Relax
   | Begin_region | End_region | Poll | Dls_get
     -> Use_default
 
@@ -72,6 +72,6 @@ let is_cheap_operation (op : Operation.t)
   | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
   | Stackoffset _ | Load _ | Store _ | Alloc _
   | Intop _ | Intop_imm _ | Intop_atomic _
-  | Name_for_debugger _ | Probe_is_enabled _ | Opaque
+  | Name_for_debugger _ | Probe_is_enabled _ | Opaque | Relax
   | Begin_region | End_region | Poll | Dls_get
     -> Cheap false

--- a/backend/arm64/cfg_selection.ml
+++ b/backend/arm64/cfg_selection.ml
@@ -243,8 +243,8 @@ let pseudoregs_for_operation op arg res =
       | Imulsubf | Inegmulsubf | Isqrtf | Imove32 | Ifar_alloc _
       | Ishiftarith (_, _)
       | Ibswap _ | Isignext _ )
-  | Move | Spill | Reload | Opaque | Begin_region | End_region | Dls_get | Poll
-  | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
+  | Move | Spill | Reload | Opaque | Relax | Begin_region | End_region | Dls_get
+  | Poll | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
   | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Load _
   | Store (_, _, _)
   | Intop _

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1062,9 +1062,9 @@ let num_call_gc_points instr =
           | Ishiftarith (_, _)
           | Ibswap _ | Isignext _ | Isimd _ ))
     | Lop
-        ( Move | Spill | Reload | Opaque | Begin_region | End_region | Dls_get
-        | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
-        | Const_vec128 _ | Stackoffset _ | Load _
+        ( Move | Spill | Reload | Opaque | Relax | Begin_region | End_region
+        | Dls_get | Const_int _ | Const_float32 _ | Const_float _
+        | Const_symbol _ | Const_vec128 _ | Stackoffset _ | Load _
         | Store (_, _, _)
         | Intop _
         | Intop_imm (_, _)
@@ -1131,7 +1131,7 @@ module BR = Branch_relaxation.Make (struct
       | Lcondbranch (Ioddtest, _) | Lcondbranch (Ieventest, _) -> Some TB
       | Lcondbranch3 _ -> Some Bcc
       | Lop
-          ( Specific _ | Move | Spill | Reload | Opaque | Begin_region
+          ( Specific _ | Move | Spill | Reload | Opaque | Begin_region | Relax
           | End_region | Dls_get | Const_int _ | Const_float32 _ | Const_float _
           | Const_symbol _ | Const_vec128 _ | Stackoffset _ | Load _
           | Store (_, _, _)
@@ -1226,6 +1226,7 @@ module BR = Branch_relaxation.Make (struct
     | Lop (Alloc { mode = Heap; _ }) when !fastcode_flag -> 5
     | Lop (Specific (Ifar_alloc _)) when !fastcode_flag -> 6
     | Lop Poll -> 3
+    | Lop Relax -> 1
     | Lop (Specific Ifar_poll) -> 4
     | Lop (Alloc { mode = Heap; bytes = num_bytes; _ })
     | Lop (Specific (Ifar_alloc { bytes = num_bytes; _ })) -> (
@@ -1913,6 +1914,7 @@ let emit_instr i =
          DSL.emit_addressing (Iindexed offset) reg_domain_state_ptr
       |]
   | Lop Poll -> assembly_code_for_poll i ~far:false ~return_label:None
+  | Lop Relax -> DSL.ins I.YIELD [||]
   | Lop (Specific Ifar_poll) ->
     assembly_code_for_poll i ~far:true ~return_label:None
   | Lop (Intop_imm (Iadd, n)) -> emit_addimm i.res.(0) i.arg.(0) n

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -335,7 +335,7 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
         | Const_symbol _ | Const_vec128 _
         | Stackoffset _
         | Intop_imm _ | Intop_atomic _
-        | Name_for_debugger _ | Probe_is_enabled _ | Opaque
+        | Name_for_debugger _ | Probe_is_enabled _ | Opaque | Relax
         | Begin_region | End_region | Dls_get)
   | Poptrap _ | Prologue
     -> [||]
@@ -466,7 +466,7 @@ let operation_supported : Cmm.operation -> bool = function
   | Ccmpf _
   | Ccsel _
   | Craise _
-  | Cprobe _ | Cprobe_is_enabled _ | Copaque
+  | Cprobe _ | Cprobe_is_enabled _ | Copaque | Crelax
   | Cbeginregion | Cendregion | Ctuple_field _
   | Cdls_get
   | Cpoll

--- a/backend/arm64/regalloc_stack_operands.ml
+++ b/backend/arm64/regalloc_stack_operands.ml
@@ -30,10 +30,10 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
         | Ishiftarith (_, _)
         | Ibswap _ | Isignext _ | Isimd _ ))
   | Op
-      ( Move | Spill | Reload | Opaque | Begin_region | End_region | Dls_get
-      | Poll | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
-      | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
-      | Load _
+      ( Move | Spill | Reload | Opaque | Relax | Begin_region | End_region
+      | Dls_get | Poll | Const_int _ | Const_float32 _ | Const_float _
+      | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
+      | Stackoffset _ | Load _
       | Store (_, _, _)
       | Intop _
       | Intop_imm (_, _)

--- a/backend/arm64_ast.ml
+++ b/backend/arm64_ast.ml
@@ -411,6 +411,7 @@ module Instruction_name = struct
     | ADRP
     | STP
     | RET
+    | YIELD
     (* neon *)
     | MOV
     | MOVI
@@ -549,6 +550,7 @@ module Instruction_name = struct
     | ADRP -> "adrp"
     | STP -> "stp"
     | RET -> "ret"
+    | YIELD -> "yield"
     (* neon *)
     | MOV -> "mov"
     | MOVI -> "movi"

--- a/backend/arm64_ast.mli
+++ b/backend/arm64_ast.mli
@@ -241,6 +241,7 @@ module Instruction_name : sig
     | ADRP
     | STP
     | RET
+    | YIELD
     (* neon *)
     | MOV
     | MOVI

--- a/backend/branch_relaxation.ml
+++ b/backend/branch_relaxation.ml
@@ -70,10 +70,10 @@ module Make (T : Branch_relaxation_intf.S) = struct
         || opt_branch_overflows map pc lbl1 max_branch_offset
         || opt_branch_overflows map pc lbl2 max_branch_offset
       | Lop
-          ( Move | Spill | Reload | Opaque | Begin_region | End_region | Dls_get
-          | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
-          | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
-          | Load _
+          ( Move | Spill | Reload | Opaque | Relax | Begin_region | End_region
+          | Dls_get | Const_int _ | Const_float32 _ | Const_float _
+          | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
+          | Stackoffset _ | Load _
           | Store (_, _, _)
           | Intop _
           | Intop_imm (_, _)
@@ -142,9 +142,9 @@ module Make (T : Branch_relaxation_intf.S) = struct
           | Lpoptrap _ | Lcall_op _ | Llabel _ | Lbranch _ | Lswitch _
           | Ladjust_stack_offset _ | Lpushtrap _ | Lraise _ | Lstackcheck _
           | Lop
-              ( Move | Spill | Reload | Opaque | Begin_region | End_region
-              | Dls_get | Const_int _ | Const_float32 _ | Const_float _
-              | Const_symbol _ | Const_vec128 _ | Const_vec256 _
+              ( Move | Spill | Reload | Opaque | Relax | Begin_region
+              | End_region | Dls_get | Const_int _ | Const_float32 _
+              | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
               | Const_vec512 _ | Stackoffset _ | Load _
               | Store (_, _, _)
               | Intop _

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -508,7 +508,7 @@ let is_noop_move instr =
       | Load _ | Store _ | Intop _ | Intop_imm _ | Intop_atomic _ | Floatop _
       | Opaque | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
       | Specific _ | Name_for_debugger _ | Begin_region | End_region | Dls_get
-      | Poll | Alloc _ )
+      | Poll | Alloc _ | Relax )
   | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ ->
     false
 
@@ -577,10 +577,10 @@ let is_poll (instr : basic instruction) =
   | Op Poll -> true
   | Reloadretaddr | Prologue | Pushtrap _ | Poptrap _ | Stack_check _
   | Op
-      ( Alloc _ | Move | Spill | Reload | Opaque | Begin_region | End_region
-      | Dls_get | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
-      | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
-      | Load _
+      ( Alloc _ | Move | Spill | Reload | Opaque | Relax | Begin_region
+      | End_region | Dls_get | Const_int _ | Const_float32 _ | Const_float _
+      | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
+      | Stackoffset _ | Load _
       | Store (_, _, _)
       | Intop _
       | Intop_imm (_, _)
@@ -596,9 +596,9 @@ let is_alloc (instr : basic instruction) =
   | Reloadretaddr | Prologue | Pushtrap _ | Poptrap _ | Stack_check _
   | Op
       ( Poll | Move | Spill | Reload | Opaque | Begin_region | End_region
-      | Dls_get | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
-      | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
-      | Load _
+      | Dls_get | Relax | Const_int _ | Const_float32 _ | Const_float _
+      | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
+      | Stackoffset _ | Load _
       | Store (_, _, _)
       | Intop _
       | Intop_imm (_, _)
@@ -614,7 +614,7 @@ let is_end_region (b : basic) =
   | Reloadretaddr | Prologue | Pushtrap _ | Poptrap _ | Stack_check _
   | Op
       ( Alloc _ | Poll | Move | Spill | Reload | Opaque | Begin_region | Dls_get
-      | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
+      | Relax | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
       | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
       | Load _
       | Store (_, _, _)
@@ -701,7 +701,7 @@ let remove_trap_instructions t removed_trap_handlers =
         | Load _ | Store _ | Intop _ | Intop_imm _ | Intop_atomic _ | Floatop _
         | Csel _ | Static_cast _ | Reinterpret_cast _ | Probe_is_enabled _
         | Opaque | Begin_region | End_region | Specific _ | Name_for_debugger _
-        | Dls_get | Poll | Alloc _ )
+        | Dls_get | Poll | Alloc _ | Relax )
     | Reloadretaddr | Prologue | Stack_check _ ->
       update_basic_next (DLL.Cursor.next cursor) ~stack_offset
   and update_body r ~stack_offset =

--- a/backend/cfg/cfg_available_regs.ml
+++ b/backend/cfg/cfg_available_regs.ml
@@ -307,7 +307,7 @@ module Transfer = struct
             | Load _ | Store _ | Intop _ | Intop_imm _ | Intop_atomic _
             | Floatop _ | Csel _ | Reinterpret_cast _ | Static_cast _
             | Probe_is_enabled _ | Opaque | Begin_region | End_region
-            | Specific _ | Dls_get | Poll | Alloc _ )
+            | Specific _ | Dls_get | Poll | Alloc _ | Relax )
         | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ ->
           let is_op_end_region = Cfg.is_end_region in
           common ~avail_before ~destroyed_at:Proc.destroyed_at_basic
@@ -378,9 +378,9 @@ let get_name_for_debugger_regs (b : Cfg.basic) =
   | Reloadretaddr | Prologue | Pushtrap _ | Poptrap _ | Stack_check _
   | Op
       ( Move | Spill | Reload | Opaque | Begin_region | End_region | Dls_get
-      | Poll | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
-      | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
-      | Load _
+      | Poll | Relax | Const_int _ | Const_float32 _ | Const_float _
+      | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
+      | Stackoffset _ | Load _
       | Store (_, _, _)
       | Intop _
       | Intop_imm (_, _)

--- a/backend/cfg/cfg_comballoc.ml
+++ b/backend/cfg/cfg_comballoc.ml
@@ -38,7 +38,8 @@ let rec find_next_allocation : cell option -> allocation option =
         | Stackoffset _ | Load _ | Store _ | Intop _ | Intop_imm _
         | Intop_atomic _ | Floatop _ | Csel _ | Reinterpret_cast _
         | Static_cast _ | Probe_is_enabled _ | Opaque | Begin_region
-        | End_region | Specific _ | Name_for_debugger _ | Dls_get | Poll )
+        | End_region | Specific _ | Name_for_debugger _ | Dls_get | Poll | Relax
+          )
     | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ ->
       find_next_allocation (DLL.next cell))
 
@@ -86,9 +87,9 @@ let find_compatible_allocations :
         { allocations = List.rev allocations; next_cell = Some cell }
       | Op
           ( Move | Spill | Reload | Floatop _ | Reinterpret_cast _ | Opaque
-          | Const_int _ | Const_float _ | Const_float32 _ | Const_vec128 _
-          | Const_vec256 _ | Const_vec512 _ | Const_symbol _ | Stackoffset _
-          | Load _
+          | Relax | Const_int _ | Const_float _ | Const_float32 _
+          | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Const_symbol _
+          | Stackoffset _ | Load _
           | Store (_, _, _)
           | Csel _ | Specific _ | Name_for_debugger _ | Probe_is_enabled _
           | Static_cast _ | Dls_get

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -307,7 +307,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
     | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
     | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ ->
       Op_pure
-    | Opaque -> assert false (* treated specially *)
+    | Opaque | Relax -> assert false (* treated specially *)
     | Stackoffset _ -> Op_other
     | Load { mutability; is_atomic; memory_chunk = _; addressing_mode = _ } ->
       (* #12173: disable CSE for atomic loads. *)
@@ -337,7 +337,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
     | Const_int _ -> true
     | Move | Spill | Reload | Const_float32 _ | Const_float _ | Const_symbol _
     | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Opaque | Stackoffset _
-    | Load _ | Store _ | Alloc _ | Poll | Intop _
+    | Load _ | Store _ | Alloc _ | Poll | Relax | Intop _
     | Intop_imm (_, _)
     | Intop_atomic _ | Floatop _ | Csel _ | Static_cast _ | Reinterpret_cast _
     | Specific _ | Name_for_debugger _ | Probe_is_enabled _ | Begin_region
@@ -357,8 +357,8 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
          the argument reg. *)
       let n1 = set_move n i.arg.(0) i.res.(0) in
       n1
-    | Op Opaque ->
-      (* Assume arbitrary side effects from Iopaque *)
+    | Op (Opaque | Relax) ->
+      (* Assume arbitrary side effects from Opaque / Relax *)
       empty_numbering
     | Op (Alloc _) | Op Poll ->
       (* For allocations, we must avoid extending the live range of a

--- a/backend/cfg/cfg_invariants.ml
+++ b/backend/cfg/cfg_invariants.ml
@@ -244,7 +244,7 @@ let check_stack_offset t label (block : Cfg.basic_block) =
             | Intop_atomic _ | Floatop _ | Csel _ | Static_cast _
             | Reinterpret_cast _ | Probe_is_enabled _ | Opaque | Begin_region
             | End_region | Specific _ | Name_for_debugger _ | Dls_get | Poll
-            | Alloc _ )
+            | Relax | Alloc _ )
         | Reloadretaddr | Prologue | Stack_check _ ->
           cur_stack_offset)
   in

--- a/backend/cfg/cfg_polling.ml
+++ b/backend/cfg/cfg_polling.ml
@@ -188,7 +188,7 @@ module Polls_before_prtc_transfer = struct
     | Op (Alloc _) -> Ok Always_polls
     | Op
         ( Move | Spill | Reload | Opaque | Begin_region | End_region | Dls_get
-        | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
+        | Relax | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
         | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
         | Load _
         | Store (_, _, _)
@@ -356,7 +356,7 @@ let add_poll_or_alloc_basic :
     | Stackoffset _ | Load _ | Store _ | Intop _ | Intop_imm _ | Intop_atomic _
     | Floatop _ | Csel _ | Reinterpret_cast _ | Static_cast _
     | Probe_is_enabled _ | Opaque | Begin_region | End_region | Specific _
-    | Name_for_debugger _ | Dls_get ->
+    | Name_for_debugger _ | Dls_get | Relax ->
       points
     | Poll -> (Poll, instr.dbg) :: points
     | Alloc _ -> (Alloc, instr.dbg) :: points)

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -134,9 +134,9 @@ let is_last_instruction_const_int (body : C.basic C.instruction Dll.t) :
           ( Reloadretaddr | Prologue | Pushtrap _ | Poptrap _ | Stack_check _
           | Op
               ( Const_int _ | Move | Spill | Reload | Opaque | Begin_region
-              | End_region | Dls_get | Poll | Const_float _ | Const_float32 _
-              | Const_symbol _ | Const_vec128 _ | Const_vec256 _
-              | Const_vec512 _ | Stackoffset _ | Load _
+              | End_region | Dls_get | Poll | Relax | Const_float _
+              | Const_float32 _ | Const_symbol _ | Const_vec128 _
+              | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Load _
               | Store (_, _, _)
               | Intop _
               | Intop_imm (_, _)

--- a/backend/cfg/vectorize.ml
+++ b/backend/cfg/vectorize.ml
@@ -311,6 +311,7 @@ end = struct
     | Static_cast _, _
     | Probe_is_enabled _, _
     | Opaque, _
+    | Relax, _
     | Begin_region, _
     | End_region, _
     | Specific _, _
@@ -799,7 +800,7 @@ end = struct
                         | Iasr | Ipopcnt | Imulh _ | Iclz _ | Ictz _ | Icomp _
                           ),
                         _ )
-                  | Opaque | Begin_region | End_region | Dls_get | Poll
+                  | Opaque | Begin_region | End_region | Dls_get | Poll | Relax
                   | Const_int _ | Const_float32 _ | Const_float _
                   | Const_symbol _ | Const_vec128 _ | Const_vec256 _
                   | Const_vec512 _ | Stackoffset _ | Load _
@@ -1035,8 +1036,8 @@ end = struct
           | Begin_region | End_region ->
             (* conservative, don't reorder around region begin/end. *)
             create Arbitrary
-          | Name_for_debugger _ | Dls_get | Poll | Opaque | Probe_is_enabled _
-            ->
+          | Name_for_debugger _ | Dls_get | Poll | Opaque | Relax
+          | Probe_is_enabled _ ->
             (* conservative, don't reorder around this instruction. *)
             (* CR-someday gyorsh: Poll insertion pass is after the vectorizer.
                Currently, it inserts instruction at the end of a block, so it
@@ -2302,8 +2303,8 @@ end = struct
         | Reload | Const_int _ | Const_float32 _ | Const_float _
         | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
         | Stackoffset _ | Intop _ | Intop_imm _ | Intop_atomic _ | Floatop _
-        | Csel _ | Probe_is_enabled _ | Opaque | Begin_region | End_region
-        | Name_for_debugger _ | Dls_get | Poll ->
+        | Csel _ | Probe_is_enabled _ | Opaque | Relax | Begin_region
+        | End_region | Name_for_debugger _ | Dls_get | Poll ->
           None)
 
     let from_block (block : Block.t) deps : t list =

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -61,7 +61,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         List.for_all is_simple_expr args
         (* The following may have side effects *)
       | Capply _ | Cextcall _ | Calloc _ | Cstore _ | Craise _ | Catomic _
-      | Cprobe _ | Cprobe_is_enabled _ | Copaque | Cpoll ->
+      | Cprobe _ | Cprobe_is_enabled _ | Copaque | Cpoll | Crelax ->
         false
       | Cprefetch _ | Cbeginregion | Cendregion ->
         false
@@ -110,7 +110,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         match op with
         | Cextcall { effects = e; coeffects = ce } ->
           EC.create (SU.select_effects e) (SU.select_coeffects ce)
-        | Capply _ | Cprobe _ | Copaque | Cpoll -> EC.arbitrary
+        | Capply _ | Cprobe _ | Copaque | Cpoll | Crelax -> EC.arbitrary
         | Calloc (Heap, _) -> EC.none
         | Calloc (Local, _) -> EC.coeffect_only Arbitrary
         | Cstore _ -> EC.effect_only Arbitrary
@@ -340,6 +340,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
              { bytes = 0; dbginfo = [placeholder_for_alloc_block_kind]; mode }),
         args )
     | Cpoll -> SU.basic_op Poll, args
+    | Crelax -> SU.basic_op Relax, args
     | Caddi -> select_arith_comm Iadd args
     | Csubi -> select_arith Isub args
     | Cmuli -> select_arith_comm Imul args

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -451,6 +451,7 @@ type operation =
   | Ctuple_field of int * machtype array
   | Cdls_get
   | Cpoll
+  | Crelax
 
 type is_global =
   | Global
@@ -612,7 +613,7 @@ let iter_shallow_tail f = function
   | Cop
       ( ( Calloc _ | Caddi | Csubi | Cmuli | Cdivi | Cmodi | Cand | Cor | Cxor
         | Clsl | Clsr | Casr | Cpopcnt | Caddv | Cadda | Cpackf32 | Copaque
-        | Cbeginregion | Cendregion | Cdls_get | Cpoll
+        | Cbeginregion | Cendregion | Cdls_get | Cpoll | Crelax
         | Capply (_, _)
         | Cextcall _ | Cload _
         | Cstore (_, _)
@@ -646,7 +647,7 @@ let map_shallow_tail f = function
     | Cop
         ( ( Calloc _ | Caddi | Csubi | Cmuli | Cdivi | Cmodi | Cand | Cor | Cxor
           | Clsl | Clsr | Casr | Cpopcnt | Caddv | Cadda | Cpackf32 | Copaque
-          | Cbeginregion | Cendregion | Cdls_get | Cpoll
+          | Cbeginregion | Cendregion | Cdls_get | Cpoll | Crelax
           | Capply (_, _)
           | Cextcall _ | Cload _
           | Cstore (_, _)

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -423,6 +423,7 @@ type operation =
     (* the [machtype array] refers to the whole tuple *)
   | Cdls_get
   | Cpoll
+  | Crelax
 
 type is_global =
   | Global

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4976,6 +4976,10 @@ let reperform ~dbg ~eff ~cont ~last_fiber =
 
 let poll ~dbg = return_unit dbg (Cop (Cpoll, [], dbg))
 
+let cpu_relax ~dbg =
+  let relax = return_unit dbg (Cop (Crelax, [], dbg)) in
+  if Config.poll_insertion then relax else sequence relax (poll ~dbg)
+
 module Scalar_type = struct
   module Float_width = struct
     type t = Cmm.float_width =

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1350,6 +1350,8 @@ val set_field_unboxed :
 
 val dls_get : dbg:Debuginfo.t -> expression
 
+val cpu_relax : dbg:Debuginfo.t -> expression
+
 val poll : dbg:Debuginfo.t -> expression
 
 (** This module defines the various kinds of scalars usable in Cmm. It also provides ways

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -528,8 +528,9 @@ let preproc_stack_check ~fun_body ~frame_size ~trap_size =
     | Lprologue
     | Lop
         ( Move | Spill | Reload | Opaque | Begin_region | End_region | Dls_get
-        | Poll | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
-        | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Load _
+        | Poll | Relax | Const_int _ | Const_float32 _ | Const_float _
+        | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
+        | Load _
         | Store (_, _, _)
         | Intop _
         | Intop_imm (_, _)

--- a/backend/operation.ml
+++ b/backend/operation.ml
@@ -315,6 +315,7 @@ type t =
       }
   | Dls_get
   | Poll
+  | Relax
   | Alloc of
       { bytes : int;
         dbginfo : Cmm.alloc_dbginfo;
@@ -356,6 +357,7 @@ let is_pure = function
   | Name_for_debugger _ -> false
   | Dls_get -> true
   | Poll -> false
+  | Relax -> false
   | Alloc _ -> false
 
 (* The next 2 functions are copied almost as is from asmcomp/printmach.ml
@@ -439,6 +441,7 @@ let dump ppf op =
   | Name_for_debugger _ -> Format.fprintf ppf "name_for_debugger"
   | Dls_get -> Format.fprintf ppf "dls_get"
   | Poll -> Format.fprintf ppf "poll"
+  | Relax -> Format.fprintf ppf "relax"
   | Alloc { bytes; dbginfo = _; mode = Heap } ->
     Format.fprintf ppf "alloc %i" bytes
   | Alloc { bytes; dbginfo = _; mode = Local } ->

--- a/backend/operation.mli
+++ b/backend/operation.mli
@@ -164,6 +164,7 @@ type t =
       }
   | Dls_get
   | Poll
+  | Relax
   | Alloc of
       { bytes : int;
         dbginfo : Cmm.alloc_dbginfo;

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -291,6 +291,7 @@ let operation d = function
   | Ctuple_field (field, _ty) -> to_string "tuple_field %i" field
   | Cdls_get -> "dls_get"
   | Cpoll -> "poll"
+  | Crelax -> "relax"
 
 let rec expr ppf = function
   | Cconst_int (n, _dbg) -> fprintf ppf "%i" n

--- a/backend/printoperation.ml
+++ b/backend/printoperation.ml
@@ -115,4 +115,5 @@ let operation ?(print_reg = Printreg.reg) (op : Operation.t) arg ppf res =
   | Specific op -> Arch.print_specific_operation reg op ppf arg
   | Dls_get -> fprintf ppf "dls_get"
   | Poll -> fprintf ppf "poll call"
+  | Relax -> fprintf ppf "relax"
   | Probe_is_enabled { name } -> fprintf ppf "probe_is_enabled \"%s\"" name

--- a/backend/regalloc/regalloc_invariants.ml
+++ b/backend/regalloc/regalloc_invariants.ml
@@ -20,7 +20,7 @@ let precondition : Cfg_with_layout.t -> unit =
       | Load _ | Store _ | Intop _ | Intop_imm _ | Intop_atomic _ | Floatop _
       | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
       | Opaque | Begin_region | End_region | Specific _ | Name_for_debugger _
-      | Dls_get | Poll | Alloc _ ->
+      | Dls_get | Poll | Relax | Alloc _ ->
         ())
     | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ -> ()
   in
@@ -99,7 +99,7 @@ let postcondition_layout : Cfg_with_layout.t -> unit =
             InstructionId.format id num_locals
       | Reloadretaddr | Prologue | Pushtrap _ | Poptrap _ | Stack_check _
       | Op
-          ( Move | Opaque | Begin_region | End_region | Dls_get | Poll
+          ( Move | Opaque | Begin_region | End_region | Dls_get | Poll | Relax
           | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
           | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
           | Load _

--- a/backend/regalloc/regalloc_irc_utils.ml
+++ b/backend/regalloc/regalloc_irc_utils.ml
@@ -171,6 +171,7 @@ let is_move_basic : Cfg.basic -> bool =
     | Name_for_debugger _ -> false
     | Dls_get -> false
     | Poll -> false
+    | Relax -> false
     | Alloc _ -> false)
   | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ -> false
 

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -87,7 +87,7 @@ let coalesce_temp_spills_and_reloads (block : Cfg.basic_block)
       | Some block_temp -> replace temp block_temp)
     | Reloadretaddr | Prologue | Pushtrap _ | Poptrap _ | Stack_check _
     | Op
-        ( Move | Opaque | Begin_region | End_region | Dls_get | Poll
+        ( Move | Opaque | Begin_region | End_region | Dls_get | Poll | Relax
         | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
         | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
         | Load _

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -223,7 +223,7 @@ let oper_result_type = function
   | Cprobe _ -> typ_void
   | Cprobe_is_enabled _ -> typ_int
   | Copaque -> typ_val
-  | Cpoll -> typ_void
+  | Cpoll | Crelax -> typ_void
   | Cbeginregion ->
     (* This must not be typ_val; the begin-region operation returns a naked
        pointer into the local allocation stack. *)
@@ -532,7 +532,7 @@ module Stack_offset_and_exn = struct
         | Load _ | Store _ | Intop _ | Intop_imm _ | Intop_atomic _ | Floatop _
         | Csel _ | Static_cast _ | Reinterpret_cast _ | Probe_is_enabled _
         | Opaque | Begin_region | End_region | Specific _ | Name_for_debugger _
-        | Dls_get | Poll | Alloc _ )
+        | Dls_get | Poll | Relax | Alloc _ )
     | Reloadretaddr | Prologue ->
       stack_offset, traps
     | Stack_check _ ->

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -2500,7 +2500,7 @@ end = struct
           next
         | Reinterpret_cast (Int_of_value | Value_of_int)
         | Name_for_debugger _ | Stackoffset _ | Probe_is_enabled _ | Opaque
-        | Begin_region | End_region | Intop_atomic _ | Store _ ->
+        | Begin_region | End_region | Intop_atomic _ | Store _ | Relax ->
           next
         | Poll ->
           (* Ignore poll points even though they may trigger an allocations,

--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -688,6 +688,7 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     | Patomic_lxor -> binary (Ccall "caml_atomic_lxor")
     | Pdls_get -> unary (Ccall "caml_domain_dls_get")
     | Ppoll -> unary (Ccall "caml_process_pending_actions_with_root")
+    | Pcpu_relax -> unary (Ccall "caml_ml_domain_cpu_relax")
     | Pisnull -> unary (Ccall "caml_is_null")
     | Pstring_load_128 _ | Pbytes_load_128 _ | Pbytes_set_128 _
     | Pbigstring_load_128 _ | Pbigstring_set_128 _ | Pfloatarray_load_128 _

--- a/chamelon/compat.mli
+++ b/chamelon/compat.mli
@@ -19,9 +19,9 @@ type texp_function_param = {
   param : Ident.t;
   partial : partial;
   optional_default : expression option;
-      (** The optional argument's default value. If [optional_default] is present,
-      [arg_label] must be [Optional], and [pattern] matches values of type [t]
-      if the parameter type is [t option]. *)
+      (** The optional argument's default value. If [optional_default] is
+          present, [arg_label] must be [Optional], and [pattern] matches values
+          of type [t] if the parameter type is [t option]. *)
   param_identifier : texp_function_param_identifier;
 }
 

--- a/chamelon/iterator.ml
+++ b/chamelon/iterator.ml
@@ -69,9 +69,9 @@ let step_minimizer c minimize cur_file map ~pos ~len =
   in
   r
 
-(** [apply_minimizer test map cur_file minimize c] applies [minimize] for [cur_file]
-     in the file set [mapi] for the command [c] as much as possible if (not !test),
-     only once otherwise *)
+(** [apply_minimizer test map cur_file minimize c] applies [minimize] for
+    [cur_file] in the file set [mapi] for the command [c] as much as possible if
+    (not !test), only once otherwise *)
 let dicho = true
 
 let apply_minimizer test map cur_file minimize (c : string) =

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -2072,8 +2072,7 @@ let primitive_may_allocate : primitive -> locality_mode option = function
   | Pbox_float (_, m) | Pbox_int (_, m) | Pbox_vector (_, m) -> Some m
   | Prunstack | Presume | Pperform | Preperform
     (* CR mshinwell: check *)
-  | Ppoll -> Some alloc_heap
-  | Pcpu_relax -> if Config.poll_insertion then None else Some alloc_heap
+  | Ppoll | Pcpu_relax -> Some alloc_heap
   | Patomic_load _
   | Patomic_set _
   | Patomic_exchange _

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -369,6 +369,8 @@ type primitive =
      handlers, finalizers, memprof callbacks, etc, as well as GCs and
      GC slices, so should not be moved or optimised away. *)
   | Ppoll
+  (* Arch-specific pause. Without poll insertion, also acts as a [Ppoll]. *)
+  | Pcpu_relax
 
 (** This is the same as [Primitive.native_repr] but with [Repr_poly]
     compiled away. *)

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -30,7 +30,7 @@ let unboxed_float = function
 
 let unboxed_vector = function
   | Unboxed_vec128 -> "unboxed_vec128"
-  | Unboxed_vec256 -> "unboxed_vec256" 
+  | Unboxed_vec256 -> "unboxed_vec256"
   | Unboxed_vec512 -> "unboxed_vec512"
 
 let boxed_integer = function
@@ -909,6 +909,7 @@ let primitive ppf = function
   | Popaque _ -> fprintf ppf "opaque"
   | Pdls_get -> fprintf ppf "dls_get"
   | Ppoll -> fprintf ppf "poll"
+  | Pcpu_relax -> fprintf ppf "cpu_relax"
   | Pprobe_is_enabled {name} -> fprintf ppf "probe_is_enabled[%s]" name
   | Pobj_dup -> fprintf ppf "obj_dup"
   | Pobj_magic _ -> fprintf ppf "obj_magic"
@@ -1108,6 +1109,7 @@ let name_of_primitive = function
   | Patomic_land -> "Patomic_land"
   | Patomic_lor -> "Patomic_lor"
   | Patomic_lxor -> "Patomic_lxor"
+  | Pcpu_relax -> "Pcpu_relax"
   | Popaque _ -> "Popaque"
   | Prunstack -> "Prunstack"
   | Presume -> "Presume"

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -916,6 +916,7 @@ let rec choice ctx t =
     | Patomic_compare_set _ | Patomic_fetch_add
     | Patomic_add | Patomic_sub | Patomic_land
     | Patomic_lor | Patomic_lxor | Patomic_load _ | Patomic_set _
+    | Pcpu_relax
     | Punbox_float _ | Pbox_float (_, _)
     | Punbox_int _ | Pbox_int _
     | Punbox_vector _ | Pbox_vector (_, _)

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -917,6 +917,7 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
     | "%atomic_land" -> Primitive (Patomic_land, 2)
     | "%atomic_lor" -> Primitive (Patomic_lor, 2)
     | "%atomic_lxor" -> Primitive (Patomic_lxor, 2)
+    | "%cpu_relax" -> Primitive (Pcpu_relax, 1)
     | "%runstack" ->
       if runtime5 then Primitive (Prunstack, 3) else Unsupported Prunstack
     | "%reperform" ->
@@ -1982,10 +1983,10 @@ let lambda_primitive_needs_event_after = function
   | Patomic_exchange _ | Patomic_compare_exchange _
   | Patomic_compare_set _ | Patomic_fetch_add | Patomic_add | Patomic_sub
   | Patomic_land | Patomic_lor | Patomic_lxor | Patomic_load _ | Patomic_set _
-  | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer _ | Popaque _
-  | Pdls_get
-  | Pobj_magic _ | Punbox_float _ | Punbox_int _ | Punbox_vector _
-  | Preinterpret_unboxed_int64_as_tagged_int63 | Ppeek _ | Ppoke _
+  | Pcpu_relax | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer _
+  | Popaque _ | Pdls_get | Pobj_magic _ | Punbox_float _ | Punbox_int _
+  | Punbox_vector _ | Preinterpret_unboxed_int64_as_tagged_int63
+  | Ppeek _ | Ppoke _
   (* These don't allocate in bytecode; they're just identity functions: *)
   | Pbox_float (_, _) | Pbox_int _ | Pbox_vector (_, _)
   | Punbox_unit

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -221,7 +221,8 @@ let compute_static_size lam =
     | Patomic_sub
     | Patomic_land
     | Patomic_lor
-    | Patomic_lxor ->
+    | Patomic_lxor
+    | Pcpu_relax ->
         (* Unit-returning primitives. Most of these are only generated from
            external declarations and not special-cased by [Value_rec_check],
            but it doesn't hurt to be consistent. *)

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1089,7 +1089,7 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Patomic_exchange _ | Patomic_compare_exchange _ | Patomic_compare_set _
       | Patomic_fetch_add | Patomic_add | Patomic_sub | Patomic_land
       | Patomic_lor | Patomic_lxor | Pdls_get | Ppoll | Patomic_load _
-      | Patomic_set _ | Preinterpret_tagged_int63_as_unboxed_int64
+      | Patomic_set _ | Pcpu_relax | Preinterpret_tagged_int63_as_unboxed_int64
       | Preinterpret_unboxed_int64_as_tagged_int63 | Ppeek _ | Ppoke _
       | Pmakelazyblock _ ->
         (* Inconsistent with outer match *)

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -2614,6 +2614,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
   | Patomic_land, [[atomic]; [i]] -> [Binary (Atomic_int_arith And, atomic, i)]
   | Patomic_lor, [[atomic]; [i]] -> [Binary (Atomic_int_arith Or, atomic, i)]
   | Patomic_lxor, [[atomic]; [i]] -> [Binary (Atomic_int_arith Xor, atomic, i)]
+  | Pcpu_relax, _ -> [Nullary Cpu_relax]
   | Pdls_get, _ -> [Nullary Dls_get]
   | Ppoll, _ -> [Nullary Poll]
   | Preinterpret_unboxed_int64_as_tagged_int63, [[i]] ->

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -537,7 +537,7 @@ let init_or_assign env (ia : Flambda_primitive.Init_or_assign.t) :
 let nullop _env (op : Flambda_primitive.nullary_primitive) : _ =
   match op with
   | Invalid _ | Optimised_out _ | Probe_is_enabled _ | Enter_inlined_apply _
-  | Dls_get | Poll ->
+  | Dls_get | Poll | Cpu_relax ->
     Misc.fatal_errorf "TODO: Nullary primitive: %a" Flambda_primitive.print
       (Flambda_primitive.Nullary op)
 

--- a/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
@@ -54,3 +54,8 @@ let simplify_nullary_primitive dacc original_prim (prim : P.nullary_primitive)
     let ty = T.this_tagged_immediate Targetint_31_63.zero in
     let dacc = DA.add_variable dacc result_var ty in
     Simplify_primitive_result.create named ~try_reify:false dacc
+  | Cpu_relax ->
+    let named = Named.create_prim original_prim dbg in
+    let ty = T.this_tagged_immediate Targetint_31_63.zero in
+    let dacc = DA.add_variable dacc result_var ty in
+    Simplify_primitive_result.create named ~try_reify:false dacc

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -333,7 +333,7 @@ let nullary_prim_size prim =
   | Probe_is_enabled { name = _ } -> 4
   | Enter_inlined_apply _ -> 0
   | Dls_get -> 1
-  | Poll -> alloc_size
+  | Poll | Cpu_relax -> alloc_size
 
 let unary_prim_size prim =
   match (prim : Flambda_primitive.unary_primitive) with

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -342,6 +342,9 @@ type nullary_primitive =
       (** Poll for runtime actions. May run pending actions such as signal
           handlers, finalizers, memprof callbacks, etc, as well as GCs and
           GC slices, so should not be moved or optimised away. *)
+  | Cpu_relax
+      (** Arch-specific pause. If poll insertion is disabled, also acts
+          as a polling point. *)
 
 (** Untagged binary integer arithmetic operations.
 

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -964,6 +964,7 @@ let nullary_primitive _env res dbg prim =
        correctly adjust the inlined debuginfo in the env."
   | Dls_get -> None, res, C.dls_get ~dbg
   | Poll -> None, res, C.poll ~dbg
+  | Cpu_relax -> None, res, C.cpu_relax ~dbg
 
 let imm_or_ptr : P.Block_access_field_kind.t -> Lambda.immediate_or_pointer =
  fun block_access_kind ->

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -2168,7 +2168,12 @@ CAMLprim value caml_ml_domain_cpu_relax(value t)
 {
   struct interruptor* self = &domain_self->interruptor;
   handle_incoming_otherwise_relax (self);
+
+#ifndef POLL_INSERTION
+  return caml_process_pending_actions_with_root(t);
+#else
   return Val_unit;
+#endif
 }
 
 CAMLprim value caml_domain_dls_set(value t)

--- a/runtime4/domain.c
+++ b/runtime4/domain.c
@@ -18,6 +18,8 @@
 
 #include "caml/domain_state.h"
 #include "caml/memory.h"
+#include "caml/fail.h"
+#include "caml/signals.h"
 
 CAMLexport caml_domain_state* Caml_state;
 
@@ -100,16 +102,14 @@ void caml_init_domain (void)
   #endif
 }
 
-#include "caml/fail.h"
+CAMLprim value caml_ml_domain_cpu_relax(value unit)
+{
+  return caml_process_pending_actions_with_root(unit);
+}
 
 /* Dummy implementations to enable [Stdlib.Domain] to link. */
 
 CAMLprim value caml_recommended_domain_count(void)
-{
-  caml_failwith("Domains not supported on runtime4");
-}
-
-CAMLprim value caml_ml_domain_cpu_relax(void)
 {
   caml_failwith("Domains not supported on runtime4");
 }

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -58,7 +58,7 @@ val get_id : 'a t -> id @@ portable
 val self : unit -> id @@ portable
 (** [self ()] is the identifier of the currently running domain *)
 
-val cpu_relax : unit -> unit @@ portable
+external cpu_relax : unit -> unit @@ portable = "%cpu_relax"
 (** If busy-waiting, calling cpu_relax () between iterations
     will improve performance on some CPU architectures *)
 

--- a/testsuite/tests/lib-domain/cpu_relax.ml
+++ b/testsuite/tests/lib-domain/cpu_relax.ml
@@ -1,0 +1,20 @@
+(* TEST
+   include systhreads;
+   hassysthreads;
+   { bytecode; }
+   { native; }
+*)
+
+let () =
+   let flag = Atomic.make false in
+   let thread = Thread.create (fun () ->
+      Atomic.set flag true;
+      while Atomic.get flag do
+         Domain.cpu_relax ()
+      done) ()
+   in
+   while not (Atomic.get flag) do
+     Domain.cpu_relax ();
+   done;
+   Atomic.set flag false;
+   Thread.join thread

--- a/testsuite/tests/lib-domain/cpu_relax_domain.ml
+++ b/testsuite/tests/lib-domain/cpu_relax_domain.ml
@@ -1,11 +1,17 @@
 (* TEST
+   flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
    include systhreads;
    hassysthreads;
+   multidomain;
    { bytecode; }
    { native; }
 *)
 
 let () =
+  (* create tick thread on initial domain *)
+  Thread.create (fun () -> ()) () |> Thread.join;
+  (* rely on ticks in another domain *)
+  Domain.spawn (fun () ->
    let flag = Atomic.make false in
    let thread = Thread.create (fun () ->
       Atomic.set flag true;
@@ -17,4 +23,5 @@ let () =
      Domain.cpu_relax ();
    done;
    Atomic.set flag false;
-   Thread.join thread
+   Thread.join thread)
+  |> Domain.join


### PR DESCRIPTION
Makes `Domain.cpu_relax` a primitive instead of a runtime call. 

- The lambda & flambda primitives imply an arch-specific pause instruction, and if poll insertion is disabled, also a polling point.
- In cmm, the primitive is translated to either `Crelax` or a sequence of `Crelax` and `Cpoll`, depending on `Config.poll_insertion`.
- In the rest of the backend, `Crelax` is treated like `Copaque` that returns void.
- In bytecode, the primitive is translated directly to a call to `caml_ml_domain_cpu_relax`, which now also checks pending actions if poll insertion is disabled.

This changes the behavior of `cpu_relax`, as `caml_ml_domain_cpu_relax` was previously implemented as a pause instruction plus a `interrupt_pending` check,  ignoring pending actions or external interrupts. As far as I can tell, the only way to set `interrupt_pending` also calls `interrupt_domain`, which will trigger the target domain's `young_limit` check upon the next poll point, so polling should be sufficient.

I've added tests that `cpu_relax` can be used for spin-blocking between systhreads in the initial domain and on another domain.
The assembly output for the following function is the same for runtime4, runtime5, and runtime5 with poll insertion:

```ocaml
fun () ->
  Atomic.set flag true;
  while Atomic.get flag do
     Domain.cpu_relax ()
  done
```

Runtime4
----------------------
```asm
000000000007f160 <camlCpu_relax__fn$5bcpu_relax.ml$3a10$2c30$2d$2d140$5d_0_1_code>:
   7f160:	48 83 ec 08          	sub    $0x8,%rsp
   7f164:	48 8d 05 fd bd 0e 00 	lea    0xebdfd(%rip),%rax        # 16af68 <camlCpu_relax+0x8>
   7f16b:	48 8b 58 10          	mov    0x10(%rax),%rbx
   7f16f:	b8 03 00 00 00       	mov    $0x3,%eax
   7f174:	48 87 03             	xchg   %rax,(%rbx)
   7f177:	48 8d 05 ea bd 0e 00 	lea    0xebdea(%rip),%rax        # 16af68 <camlCpu_relax+0x8>
   7f17e:	48 8b 40 10          	mov    0x10(%rax),%rax
   7f182:	48 8b 00             	mov    (%rax),%rax
   7f185:	48 83 f8 01          	cmp    $0x1,%rax
   7f189:	75 0d                	jne    7f198 <camlCpu_relax__fn$5bcpu_relax.ml$3a10$2c30$2d$2d140$5d_0_1_code+0x38>
   7f18b:	b8 01 00 00 00       	mov    $0x1,%eax
   7f190:	48 83 c4 08          	add    $0x8,%rsp
   7f194:	c3                   	ret
   7f195:	0f 1f 00             	nopl   (%rax)
   7f198:	f3 90                	pause
   7f19a:	4d 3b 3e             	cmp    (%r14),%r15
   7f19d:	76 02                	jbe    7f1a1 <camlCpu_relax__fn$5bcpu_relax.ml$3a10$2c30$2d$2d140$5d_0_1_code+0x41>
   7f19f:	eb d6                	jmp    7f177 <camlCpu_relax__fn$5bcpu_relax.ml$3a10$2c30$2d$2d140$5d_0_1_code+0x17>
   7f1a1:	e8 aa ff ff ff       	call   7f150 <camlCpu_relax__code_begin>
   7f1a6:	eb f7                	jmp    7f19f <camlCpu_relax__fn$5bcpu_relax.ml$3a10$2c30$2d$2d140$5d_0_1_code+0x3f>
   7f1a8:	0f 1f 84 00 00 00 00 	nopl   0x0(%rax,%rax,1)
   7f1af:	00
```

Runtime5 (without poll insertion)
-------------------------------
```asm
0000000000083060 <camlCpu_relax__fn$5bcpu_relax.ml$3a10$2c30$2d$2d140$5d_0_1_code>:
   83060:	48 83 ec 08          	sub    $0x8,%rsp
   83064:	48 8d 05 fd 6e 10 00 	lea    0x106efd(%rip),%rax        # 189f68 <camlCpu_relax+0x8>
   8306b:	48 8b 58 10          	mov    0x10(%rax),%rbx
   8306f:	b8 03 00 00 00       	mov    $0x3,%eax
   83074:	48 87 03             	xchg   %rax,(%rbx)
   83077:	48 8d 05 ea 6e 10 00 	lea    0x106eea(%rip),%rax        # 189f68 <camlCpu_relax+0x8>
   8307e:	48 8b 40 10          	mov    0x10(%rax),%rax
   83082:	48 8b 00             	mov    (%rax),%rax
   83085:	48 83 f8 01          	cmp    $0x1,%rax
   83089:	75 0d                	jne    83098 <camlCpu_relax__fn$5bcpu_relax.ml$3a10$2c30$2d$2d140$5d_0_1_code+0x38>
   8308b:	b8 01 00 00 00       	mov    $0x1,%eax
   83090:	48 83 c4 08          	add    $0x8,%rsp
   83094:	c3                   	ret
   83095:	0f 1f 00             	nopl   (%rax)
   83098:	f3 90                	pause
   8309a:	4d 3b 3e             	cmp    (%r14),%r15
   8309d:	76 02                	jbe    830a1 <camlCpu_relax__fn$5bcpu_relax.ml$3a10$2c30$2d$2d140$5d_0_1_code+0x41>
   8309f:	eb d6                	jmp    83077 <camlCpu_relax__fn$5bcpu_relax.ml$3a10$2c30$2d$2d140$5d_0_1_code+0x17>
   830a1:	e8 aa ff ff ff       	call   83050 <camlCpu_relax__code_begin>
   830a6:	eb f7                	jmp    8309f <camlCpu_relax__fn$5bcpu_relax.ml$3a10$2c30$2d$2d140$5d_0_1_code+0x3f>
   830a8:	0f 1f 84 00 00 00 00 	nopl   0x0(%rax,%rax,1)
   830af:	00
```

Runtime5 (with poll insertion)
-------------------------------
```asm
0000000000083080 <camlCpu_relax__fn$5bcpu_relax.ml$3a10$2c30$2d$2d140$5d_0_1_code>:
   83080:	48 83 ec 08          	sub    $0x8,%rsp
   83084:	48 8d 05 dd 9e 10 00 	lea    0x109edd(%rip),%rax        # 18cf68 <camlCpu_relax+0x8>
   8308b:	48 8b 58 10          	mov    0x10(%rax),%rbx
   8308f:	b8 03 00 00 00       	mov    $0x3,%eax
   83094:	48 87 03             	xchg   %rax,(%rbx)
   83097:	48 8d 05 ca 9e 10 00 	lea    0x109eca(%rip),%rax        # 18cf68 <camlCpu_relax+0x8>
   8309e:	48 8b 40 10          	mov    0x10(%rax),%rax
   830a2:	48 8b 00             	mov    (%rax),%rax
   830a5:	48 83 f8 01          	cmp    $0x1,%rax
   830a9:	75 0d                	jne    830b8 <camlCpu_relax__fn$5bcpu_relax.ml$3a10$2c30$2d$2d140$5d_0_1_code+0x38>
   830ab:	b8 01 00 00 00       	mov    $0x1,%eax
   830b0:	48 83 c4 08          	add    $0x8,%rsp
   830b4:	c3                   	ret
   830b5:	0f 1f 00             	nopl   (%rax)
   830b8:	f3 90                	pause
   830ba:	4d 3b 3e             	cmp    (%r14),%r15
   830bd:	76 02                	jbe    830c1 <camlCpu_relax__fn$5bcpu_relax.ml$3a10$2c30$2d$2d140$5d_0_1_code+0x41>
   830bf:	eb d6                	jmp    83097 <camlCpu_relax__fn$5bcpu_relax.ml$3a10$2c30$2d$2d140$5d_0_1_code+0x17>
   830c1:	e8 aa ff ff ff       	call   83070 <camlCpu_relax__code_begin>
   830c6:	eb f7                	jmp    830bf <camlCpu_relax__fn$5bcpu_relax.ml$3a10$2c30$2d$2d140$5d_0_1_code+0x3f>
   830c8:	0f 1f 84 00 00 00 00 	nopl   0x0(%rax,%rax,1)
   830cf:	00
```
