### PR TITLE
Allow `float32` kind without the `small_numbers` extension.

### DIFF
--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -965,8 +965,7 @@ let[@inline always] rec layout_of_const_sort_generic ~value_kind ~error
     Lambda.Punboxed_int Unboxed_int32
   | Base Bits64 when Language_extension.(is_at_least Layouts Stable) ->
     Lambda.Punboxed_int Unboxed_int64
-  | Base Float32 when Language_extension.(is_at_least Layouts Stable) &&
-                      Language_extension.(is_enabled Small_numbers) ->
+  | Base Float32 when Language_extension.(is_at_least Layouts Stable) ->
     Lambda.Punboxed_float Unboxed_float32
   | Base Vec128 when Language_extension.(is_at_least Layouts Stable) &&
                      Language_extension.(is_at_least SIMD Stable) ->


### PR DESCRIPTION
Kinds are erasable, so it's ok to refer to the `float32` kind without losing upstream compatibility. This makes library integration easier.

The `small_numbers` extension is still required to use `float32` types and literals, so no code referring to float32 can exist after erasure.