### PR TITLE
Add support for a new [%atomic.loc r.field] construct

### DIFF
--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -219,6 +219,8 @@ let iter_on_occurrences
           add_label ~namespace:Label exp_env lid label_desc
       | Texp_unboxed_field (_, _, lid, label_desc, _) ->
           add_label ~namespace:Unboxed_label exp_env lid label_desc
+      | Texp_atomic_loc (_, _, lid, label_desc, _) ->
+          add_label ~namespace:Label exp_env lid label_desc
       | Texp_new (path, lid, _, _) ->
           f ~namespace:Class exp_env path lid
       | Texp_record { fields; _ } ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -643,6 +643,19 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         {fields; representation; extended_expression } ->
       transl_record_unboxed_product ~scopes e.exp_loc e.exp_env
         fields representation extended_expression
+  | Texp_atomic_loc (arg, arg_sort, id, lbl, alloc_mode) ->
+      let shape =
+        Some
+          [ Typeopt.value_kind arg.exp_env arg.exp_loc arg.exp_type;
+            { raw_kind = Pintval; nullable = Non_nullable }
+          ]
+      in
+      let arg_sort = Jkind.Sort.default_for_transl_and_get arg_sort in
+      check_record_field_sort id.loc lbl.lbl_sort;
+      let (arg, lbl) = transl_atomic_loc ~scopes arg arg_sort lbl in
+      let loc = of_location ~scopes e.exp_loc in
+      Lprim (Pmakeblock (0, Immutable, shape, transl_alloc_mode alloc_mode),
+             [arg; lbl], loc)
   | Texp_field(arg, arg_sort, id, lbl, float, ubr) ->
       let arg_sort = Jkind.Sort.default_for_transl_and_get arg_sort in
       let targ = transl_exp ~scopes arg_sort arg in
@@ -2210,6 +2223,11 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
         Llet(Strict, Lambda.layout_block, init_id, init_id_duid,
              transl_exp ~scopes init_expr_sort init_expr, lam)
     end
+
+and transl_atomic_loc ~scopes arg arg_sort lbl =
+  let arg = transl_exp ~scopes arg_sort arg in
+  let lbl = Lconst (Const_base (Const_int (lbl.lbl_pos))) in
+  (arg, lbl)
 
 and transl_record_unboxed_product ~scopes loc env fields repres opt_init_expr =
   match repres with

--- a/testsuite/tests/typing-local/atomic_loc.ml
+++ b/testsuite/tests/typing-local/atomic_loc.ml
@@ -1,0 +1,27 @@
+(* TEST
+   expect;
+*)
+
+type 'a atomic = { mutable contents : 'a [@atomic] }
+
+[%%expect{|
+type 'a atomic = { mutable(<non-legacy>) contents : 'a; }
+|}]
+
+let contents_loc t = [%atomic.loc t.contents]
+[%%expect{|
+val contents_loc : 'a atomic -> 'a atomic_loc = <fun>
+|}]
+
+let contents_loc_local (t @ local) = exclave_ [%atomic.loc t.contents]
+[%%expect{|
+val contents_loc_local : local_ 'a atomic -> local_ 'a atomic_loc = <fun>
+|}]
+
+let contents_loc_escape (t @ local) = [%atomic.loc t.contents]
+[%%expect{|
+Line 1, characters 38-62:
+1 | let contents_loc_escape (t @ local) = [%atomic.loc t.contents]
+                                          ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value escapes its region.
+|}]

--- a/testsuite/tests/typing-modes/atomic_loc.ml
+++ b/testsuite/tests/typing-modes/atomic_loc.ml
@@ -1,0 +1,30 @@
+(* TEST
+   expect;
+   flags += "-no-mutable-implied-modalities";
+*)
+
+type 'a atomic = { mutable contents : 'a [@atomic] }
+[%%expect{|
+type 'a atomic = { mutable(<non-legacy>) contents : 'a; }
+|}]
+
+let atomic_loc_contended (t @ contended) = [%atomic.loc t.contents]
+[%%expect{|
+val atomic_loc_contended : 'a atomic @ contended -> 'a atomic_loc @ contended =
+  <fun>
+|}]
+
+let atomic_loc_portable (t @ portable) : _ @ portable = [%atomic.loc t.contents]
+[%%expect{|
+val atomic_loc_portable : 'a atomic @ portable -> 'a atomic_loc @ portable =
+  <fun>
+|}]
+
+let uses_unique (t @ unique) : _ @ unique =
+  [%atomic.loc t.contents], [%atomic.loc t.contents]
+[%%expect{|
+Line 2, characters 2-26:
+2 |   [%atomic.loc t.contents], [%atomic.loc t.contents]
+      ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "aliased" but expected to be "unique".
+|}]

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -2991,18 +2991,18 @@ let mark_type_path_used env path =
   | decl -> mark_type_used decl.type_uid
   | exception Not_found -> ()
 
-let mark_constructor_used usage cd =
-  match Types.Uid.Tbl.find !used_constructors cd.cd_uid with
+let mark_constructor_used usage uid =
+  match Types.Uid.Tbl.find !used_constructors uid with
   | mark -> mark usage
   | exception Not_found -> ()
 
-let mark_extension_used usage ext =
-  match Types.Uid.Tbl.find !used_constructors ext.ext_uid with
+let mark_extension_used usage uid =
+  match Types.Uid.Tbl.find !used_constructors uid with
   | mark -> mark usage
   | exception Not_found -> ()
 
-let mark_label_used usage ld =
-  match Types.Uid.Tbl.find !used_labels ld.ld_uid with
+let mark_label_used usage uid =
+  match Types.Uid.Tbl.find !used_labels uid with
   | mark -> mark usage
   | exception Not_found -> ()
 

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -164,14 +164,14 @@ val mark_type_used: Uid.t -> unit
 
 type constructor_usage = Positive | Pattern | Exported_private | Exported
 val mark_constructor_used:
-    constructor_usage -> constructor_declaration -> unit
+    constructor_usage -> Uid.t -> unit
 val mark_extension_used:
-    constructor_usage -> extension_constructor -> unit
+    constructor_usage -> Uid.t -> unit
 
 type label_usage =
     Projection | Mutation | Construct | Exported_private | Exported
 val mark_label_used:
-    label_usage -> label_declaration -> unit
+    label_usage -> Uid.t -> unit
 
 (* Lookup by long identifiers *)
 

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -1375,7 +1375,7 @@ let type_declarations ?(equality = false) ~loc env ~mark name
   let mark_and_compare_records record_form labels1 rep1 labels2 rep2 =
     if mark then begin
       let mark usage lbls =
-        List.iter (Env.mark_label_used usage) lbls
+        List.iter (fun lbl -> Env.mark_label_used usage lbl.Types.ld_uid) lbls
       in
       let usage : Env.label_usage =
         if decl2.type_private = Public then Env.Exported
@@ -1409,7 +1409,9 @@ let type_declarations ?(equality = false) ~loc env ~mark name
     | (Type_variant (cstrs1, rep1, umc1), Type_variant (cstrs2, rep2, umc2)) -> begin
         if mark then begin
           let mark usage cstrs =
-            List.iter (Env.mark_constructor_used usage) cstrs
+            List.iter (fun cstr ->
+              Env.mark_constructor_used usage cstr.Types.cd_uid
+            ) cstrs
           in
           let usage : Env.constructor_usage =
             if decl2.type_private = Public then Env.Exported
@@ -1488,7 +1490,7 @@ let extension_constructors ~loc env ~mark id ext1 ext2 =
       if ext2.ext_private = Public then Env.Exported
       else Env.Exported_private
     in
-    Env.mark_extension_used usage ext1
+    Env.mark_extension_used usage ext1.ext_uid
   end;
   let ty1 =
     Btype.newgenty (Tconstr(ext1.ext_type_path, ext1.ext_type_params, ref Mnil))

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -50,6 +50,7 @@ and ident_string = ident_create "string"
 and ident_extension_constructor = ident_create "extension_constructor"
 and ident_floatarray = ident_create "floatarray"
 and ident_lexing_position = ident_create "lexing_position"
+and ident_atomic_loc = ident_create "atomic_loc"
 
 and ident_or_null = ident_create "or_null"
 
@@ -94,6 +95,7 @@ and path_string = Pident ident_string
 and path_extension_constructor = Pident ident_extension_constructor
 and path_floatarray = Pident ident_floatarray
 and path_lexing_position = Pident ident_lexing_position
+and path_atomic_loc = Pident ident_atomic_loc
 
 and path_or_null = Pident ident_or_null
 
@@ -164,6 +166,7 @@ and type_extension_constructor =
       newgenty (Tconstr(path_extension_constructor, [], ref Mnil))
 and type_floatarray = newgenty (Tconstr(path_floatarray, [], ref Mnil))
 and type_lexing_position = newgenty (Tconstr(path_lexing_position, [], ref Mnil))
+and type_atomic_loc t = newgenty (Tconstr(path_atomic_loc, [t], ref Mnil))
 
 and type_unboxed_float = newgenty (Tconstr(path_unboxed_float, [], ref Mnil))
 and type_unboxed_float32 = newgenty (Tconstr(path_unboxed_float32, [], ref Mnil))
@@ -568,6 +571,15 @@ let build_initial_env add_type add_extension empty_env =
          add_with_bounds ~modality:Mode.Modality.Value.Const.id ~type_expr:type_int |>
          add_with_bounds ~modality:Mode.Modality.Value.Const.id ~type_expr:type_int |>
          add_with_bounds ~modality:Mode.Modality.Value.Const.id ~type_expr:type_string)
+  |> add_type1 ident_atomic_loc
+       ~variance:Variance.full
+       ~separability:Separability.Ind
+       ~param_jkind:(Jkind.Builtin.value_or_null ~why:(Primitive ident_atomic_loc))
+       ~jkind:(fun param ->
+         Jkind.Builtin.mutable_data ~why:(Primitive ident_atomic_loc) |>
+         Jkind.add_with_bounds
+           ~modality:Mode.Modality.Value.Const.id
+           ~type_expr:param)
   |> add_type ident_string ~jkind:Jkind.Const.Builtin.immutable_data
   |> add_type ident_bytes ~jkind:Jkind.Const.Builtin.mutable_data
   |> add_type ident_unit

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -39,6 +39,7 @@ val type_lazy_t: type_expr -> type_expr
 val type_extension_constructor:type_expr
 val type_floatarray:type_expr
 val type_lexing_position:type_expr
+val type_atomic_loc:type_expr -> type_expr
 val type_unboxed_float:type_expr
 val type_unboxed_float32:type_expr
 val type_unboxed_nativeint:type_expr

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -583,6 +583,12 @@ and expression i ppf x =
       line i ppf "%a\n" Jkind.Sort.format sort;
       alloc_mode i ppf amode;
       list i expression ppf l;
+  | Texp_atomic_loc (e, sort, li, _, amode) ->
+      line i ppf "Texp_atomic_loc\n";
+      expression i ppf e;
+      line i ppf "%a\n" Jkind.Sort.format sort;
+      longident i ppf li;
+      alloc_mode i ppf amode
   | Texp_list_comprehension comp ->
       line i ppf "Texp_list_comprehension\n";
       comprehension i ppf comp

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -401,6 +401,9 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
           | Texp_comp_when exp ->
             sub.expr sub exp)
         comp_clauses
+  | Texp_atomic_loc (exp, _, lid, _, _) ->
+      iter_loc sub lid;
+      sub.expr sub exp
   | Texp_ifthenelse (exp1, exp2, expo) ->
       sub.expr sub exp1;
       sub.expr sub exp2;

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -530,6 +530,9 @@ let expr sub x =
           ld,
           sub.expr sub exp2
         )
+    | Texp_atomic_loc (exp, sort, lid, ld, alloc_mode) ->
+        Texp_atomic_loc
+          (sub.expr sub exp, sort, map_loc sub lid, ld, alloc_mode)
     | Texp_array (amut, sort, list, alloc_mode) ->
         Texp_array (amut, sort, List.map (sub.expr sub) list, alloc_mode)
     | Texp_list_comprehension comp ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -244,6 +244,8 @@ type error =
   | Probe_name_undefined of string
   | Probe_is_enabled_format
   | Extension_not_enabled : _ Language_extension.t -> error
+  | Invalid_atomic_loc_payload
+  | Label_not_atomic of Longident.t
   | Literal_overflow of string
   | Unknown_literal of string * char
   | Float32_literal of string
@@ -4348,6 +4350,7 @@ let rec is_nonexpansive exp =
            | Kept _ -> true)
         fields
       && is_nonexpansive_opt (Option.map fst extended_expression)
+  | Texp_atomic_loc(exp, _, _, _, _) -> is_nonexpansive exp
   | Texp_field(exp, _, _, _, _, _) -> is_nonexpansive exp
   | Texp_unboxed_field(exp, _, _, _, _) -> is_nonexpansive exp
   | Texp_ifthenelse(_cond, ifso, ifnot) ->
@@ -4849,6 +4852,7 @@ let check_partial_application ~statement exp =
             | Texp_ident _ | Texp_constant _ | Texp_tuple _
             | Texp_unboxed_tuple _
             | Texp_construct _ | Texp_variant _ | Texp_record _
+            | Texp_atomic_loc _
             | Texp_record_unboxed_product _ | Texp_unboxed_field _
             | Texp_overwrite _ | Texp_hole _
             | Texp_field _ | Texp_setfield _ | Texp_array _
@@ -7015,6 +7019,41 @@ and type_expect_
     end
   | Pexp_extension ({ txt = "src_pos"; _ }, _) ->
       rue (src_pos loc sexp.pexp_attributes env)
+  | Pexp_extension ({ txt = ("ocaml.atomic.loc"
+                             |"atomic.loc"); _ },
+                    payload) ->
+      begin match payload with
+      | PStr [ { pstr_desc =
+                  Pstr_eval (
+                    { pexp_desc = Pexp_field (srecord, lid); _ } as sexp, _
+                  )
+               } ] ->
+          let (record, record_sort, rmode, label, _) =
+            type_label_access Legacy env srecord Env.Mutation lid
+          in
+          Env.mark_label_used Env.Projection label.lbl_uid;
+          begin match (Types.atomic label.lbl_mut) with
+          | Nonatomic -> raise (Error (loc, env, Label_not_atomic lid.txt))
+          | Atomic -> ()
+          end;
+          let (_, ty_arg, ty_res) = instance_label ~fixed:false label in
+          unify_exp env record ty_res;
+          let alloc_mode, argument_mode = register_allocation expected_mode in
+          let mode = Modality.Value.Const.apply label.lbl_modalities rmode in
+          let mode = cross_left env ty_arg mode in
+          submode ~loc ~env mode argument_mode;
+          (* let uu = unique_use ~loc ~env mode (as_single_mode expected_mode) In *)
+          rue {
+            exp_desc =
+              Texp_atomic_loc
+                (record, record_sort, lid, label, alloc_mode);
+            exp_loc = loc; exp_extra = [];
+            exp_type = instance (Predef.type_atomic_loc ty_arg);
+            exp_attributes = sexp.pexp_attributes;
+            exp_env = env }
+      | _ ->
+          raise (Error (loc, env, Invalid_atomic_loc_payload))
+      end
   | Pexp_extension ext ->
     raise (Error_forward (Builtin_attributes.error_of_extension ext))
 
@@ -11064,6 +11103,13 @@ let report_error ~loc env =
     let name = Language_extension.to_string ext in
     Location.errorf ~loc
         "Extension %s must be enabled to use this feature." name
+  | Invalid_atomic_loc_payload ->
+      Location.errorf ~loc
+        "Invalid %a payload, a record field access is expected."
+        Style.inline_code "[%atomic.loc]"
+  | Label_not_atomic lid ->
+      Location.errorf ~loc "The record field %a is not atomic"
+        (Style.as_inline_code longident) lid
   | Literal_overflow ty ->
       Location.errorf ~loc
         "Integer literal exceeds the range of representable integers of type %a"

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -291,6 +291,8 @@ type error =
   (* CR-soon mshinwell: Use an inlined record *)
   | Probe_is_enabled_format
   | Extension_not_enabled : _ Language_extension.t -> error
+  | Invalid_atomic_loc_payload
+  | Label_not_atomic of Longident.t
   | Literal_overflow of string
   | Unknown_literal of string * char
   | Float32_literal of string

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -246,6 +246,9 @@ and expression_desc =
       representation : Types.record_unboxed_product_representation;
       extended_expression : (expression * Jkind.sort) option;
     }
+  | Texp_atomic_loc of
+      expression * Jkind.sort * Longident.t loc * label_description *
+      alloc_mode
   | Texp_field of
       expression * Jkind.sort * Longident.t loc * label_description *
         texp_field_boxing * Unique_barrier.t

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -446,6 +446,9 @@ and expression_desc =
               { fields = [| l1, Kept t1; l2 Override P2 |]; representation;
                 extended_expression = Some E0 }
           *)
+  | Texp_atomic_loc of
+      expression * Jkind.sort * Longident.t loc * Types.label_description *
+      alloc_mode
   | Texp_field of expression * Jkind.sort * Longident.t loc *
       Types.label_description * texp_field_boxing * Unique_barrier.t
     (** - The sort is the sort of the whole record (which may be non-value if

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -2294,6 +2294,11 @@ let rec check_uniqueness_exp ~overwrite (ienv : Ienv.t) exp : UF.t =
     let uf_write = Value.mark_implicit_borrow_memory_address Write value in
     let uf_tag = Value.invalidate_tag value in
     UF.pars [uf_rcd; uf_arg; uf_write; uf_tag]
+  | Texp_atomic_loc (rcd, _, _, _, _) ->
+    let value, uf_rcd = check_uniqueness_exp_as_value ienv rcd in
+    let uf_write = Value.mark_implicit_borrow_memory_address Write value in
+    let uf_tag = Value.invalidate_tag value in
+    UF.pars [uf_rcd; uf_write; uf_tag]
   | Texp_array (_, _, es, _) ->
     UF.pars (List.map (fun e -> check_uniqueness_exp ~overwrite:None ienv e) es)
   | Texp_ifthenelse (if_, then_, else_opt) ->

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -599,6 +599,13 @@ let expression sub exp =
         Pexp_record_unboxed_product
           (list,
            Option.map (fun (exp, _) -> sub.expr sub exp) extended_expression)
+    | Texp_atomic_loc (exp, _, lid, _label, _) ->
+        Pexp_extension ({ txt = "ocaml.atomic.loc"; loc },
+                        PStr [ Str.eval ~loc
+                                 (Exp.field ~loc
+                                    (sub.expr sub exp)
+                                    (map_loc sub lid))
+                             ])
     | Texp_field (exp, _sort, lid, _label, _, _) ->
         Pexp_field (sub.expr sub exp, map_loc sub lid)
     | Texp_unboxed_field (exp, _, lid, _label, _) ->

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -194,6 +194,7 @@ let classify_expression : Typedtree.expression -> sd =
 
     | Texp_variant _
     | Texp_tuple _
+    | Texp_atomic_loc _
     | Texp_extension_constructor _
     | Texp_constant _
     | Texp_src_pos ->
@@ -734,6 +735,8 @@ let rec expression : Typedtree.expression -> term_judg =
       list expression (List.map snd exprs) << Guard
     | Texp_unboxed_tuple exprs ->
       list expression (List.map (fun (_, e, _) -> e) exprs) << Return
+    | Texp_atomic_loc (expr, _, _, _, _) ->
+      expression expr << Guard
     | Texp_array (_, elt_sort, exprs, _) ->
       let elt_sort = Jkind.Sort.default_for_transl_and_get elt_sort in
       list expression exprs << array_mode exp elt_sort


### PR DESCRIPTION
Add support for a new [%atomic.lock r.field] contstruct, which gets typed into a
new Texp_atomic_loc typedtree expression node, which in turn turns into a block
allocation containing the record `r`, and the field index of the field `field`
in that record, with type `'a atomic_loc`, where `'a'` is the type of that
field:

```
Γ ⊢ e₁ : τ₁ @ m,
     τ₁ = { ... f : τ₂ ... }
——————————————————————————————————————————– ATOMIC_LOC
Γ ⊢ [%atomic.loc e₁.f] : τ₂ atomic_loc @ m
```