### PR TITLE
chore: Use `kind_checks` for fallible kind-related invariant

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1456,9 +1456,9 @@ let close_let acc env let_bound_ids_with_kinds user_visible defining_expr
           | Not_a_block ->
             if Flambda_features.kind_checks ()
             then
-              (* CR keryan: This is hidden behind kind checks because it
-                 can appear on correct code using Lazy or GADT. It might
-                 warrant a proper warning at some point. *)
+              (* CR keryan: This is hidden behind kind checks because it can
+                 appear on correct code using Lazy or GADT. It might warrant a
+                 proper warning at some point. *)
               Misc.fatal_errorf
                 "Unexpected approximation found when block approximation was \
                  expected in [Closure_conversion]: %a"

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1454,11 +1454,11 @@ let close_let acc env let_bound_ids_with_kinds user_visible defining_expr
           match simplify_block_load acc body_env ~block ~field with
           | Unknown -> bind acc body_env
           | Not_a_block ->
-            if Flambda_features.check_invariants ()
+            if Flambda_features.kind_checks ()
             then
-              (* CR keryan: This is hidden behind invariants check because it
-                 can appear on correct code using Lazy or GADT. It might warrant
-                 a proper warning at some point. *)
+              (* CR keryan: This is hidden behind kind checks because it
+                 can appear on correct code using Lazy or GADT. It might
+                 warrant a proper warning at some point. *)
               Misc.fatal_errorf
                 "Unexpected approximation found when block approximation was \
                  expected in [Closure_conversion]: %a"


### PR DESCRIPTION
The invariant in `closure_conversion` that asserts that we are not trying to call the `Block_load` primitive on something that is not a block can fail in the presence of lazy values or GADTs, as noted by a CR. In fact, it *does* fail when compiling `parser.mly`.

Move this invariant to the newly introduced `kind_checks` instead, since it is (sub)kind-related and the `kind_checks` already contain many fallible checks, whereas invariants should always hold.