### PR TITLE
Deterministic order for CSE parameters based on binding times

### DIFF
--- a/middle_end/flambda2/simplify/common_subexpression_elimination.ml
+++ b/middle_end/flambda2/simplify/common_subexpression_elimination.ml
@@ -244,6 +244,11 @@ let cse_with_eligible_lhs ~typing_env_at_fork ~cse_at_each_use ~params prev_cse
                   EP.Map.add prim map eligible))))
         cse eligible)
 
+type extra_binding =
+  { extra_param : BP.t;
+    extra_args : EA.t RI.Map.t
+  }
+
 let join_one_cse_equation ~cse_at_each_use prim bound_to_map
     (cse, extra_bindings, env_extension, allowed) =
   let has_value_on_all_paths =
@@ -268,10 +273,7 @@ let join_one_cse_equation ~cse_at_each_use prim bound_to_map
       let extra_args =
         RI.Map.map (fun simple : EA.t -> Already_in_scope simple) bound_to
       in
-      let extra_bindings =
-        EPA.add extra_bindings ~extra_param ~extra_args
-          ~invalids:Apply_cont_rewrite_id.Set.empty
-      in
+      let extra_binding = { extra_param; extra_args } in
       let env_extension =
         (* For the primitives Is_int and Get_tag, they're strongly linked to
            their argument: additional information on the cse parameter should
@@ -290,7 +292,7 @@ let join_one_cse_equation ~cse_at_each_use prim bound_to_map
       let allowed =
         Name_occurrences.add_name allowed (Name.var var) NM.normal
       in
-      cse, extra_bindings, env_extension, allowed
+      cse, (prim, extra_binding) :: extra_bindings, env_extension, allowed
 
 let cut_cse_environment ({ by_scope; _ } as t) ~scope_at_fork =
   (* This extracts those CSE equations that arose between the fork point and
@@ -324,6 +326,39 @@ module Join_result = struct
     }
 end
 
+let stable_compare_primitives tenv (prim1 : P.t) (prim2 : P.t) =
+  match prim1, prim2 with
+  | Nullary prim1, Nullary prim2 -> P.compare_nullary_primitive prim1 prim2
+  | Nullary _, (Unary _ | Binary _ | Ternary _ | Variadic _) -> -1
+  | (Unary _ | Binary _ | Ternary _ | Variadic _), Nullary _ -> 1
+  | Unary (prim1, x1), Unary (prim2, x2) ->
+    let c = P.compare_unary_primitive prim1 prim2 in
+    if c <> 0 then c else TE.stable_compare_simples tenv x1 x2
+  | Unary _, (Binary _ | Ternary _ | Variadic _) -> -1
+  | (Binary _ | Ternary _ | Variadic _), Unary _ -> 1
+  | Binary (prim1, x1, y1), Binary (prim2, x2, y2) ->
+    let c = P.compare_binary_primitive prim1 prim2 in
+    if c <> 0
+    then c
+    else List.compare ~cmp:(TE.stable_compare_simples tenv) [x1; y1] [x2; y2]
+  | Binary _, (Ternary _ | Variadic _) -> -1
+  | (Ternary _ | Variadic _), Binary _ -> 1
+  | Ternary (prim1, x1, y1, z1), Ternary (prim2, x2, y2, z2) ->
+    let c = P.compare_ternary_primitive prim1 prim2 in
+    if c <> 0
+    then c
+    else
+      List.compare
+        ~cmp:(TE.stable_compare_simples tenv)
+        [x1; y1; z1] [x2; y2; z2]
+  | Ternary _, Variadic _ -> -1
+  | Variadic _, Ternary _ -> 1
+  | Variadic (prim1, xs1), Variadic (prim2, xs2) ->
+    let c = P.compare_variadic_primitive prim1 prim2 in
+    if c <> 0
+    then c
+    else List.compare ~cmp:(TE.stable_compare_simples tenv) xs1 xs2
+
 let join0 ~typing_env_at_fork ~cse_at_fork ~cse_at_each_use ~params
     ~scope_at_fork =
   let params = Bound_parameters.to_list params in
@@ -335,7 +370,8 @@ let join0 ~typing_env_at_fork ~cse_at_fork ~cse_at_each_use ~params
      defined at the fork point, having canonicalised such name, cannot be
      propagated. This step also canonicalises the right-hand sides of the CSE
      equations. *)
-  let compute_cse_one_round prev_cse extra_params env_extension ~allowed =
+  let compute_cse_one_round prev_cse extra_params typing_env_with_extra_params
+      env_extension ~allowed =
     let new_cse =
       cse_with_eligible_lhs ~typing_env_at_fork ~cse_at_each_use ~params
         prev_cse extra_params env_extension
@@ -346,11 +382,36 @@ let join0 ~typing_env_at_fork ~cse_at_fork ~cse_at_each_use ~params
        this. Sometimes we can force an equation to satisfy the property by
        explicitly passing the value of the right-hand side as an extra parameter
        to the continuation at the join point. *)
-    let cse', extra_params', env_extension', allowed =
+    let cse', extra_bindings, env_extension', allowed =
       EP.Map.fold
         (join_one_cse_equation ~cse_at_each_use)
         new_cse
-        (EP.Map.empty, EPA.empty, TEE.empty, allowed)
+        (EP.Map.empty, [], TEE.empty, allowed)
+    in
+    let sorted_extra_bindings =
+      List.sort extra_bindings ~cmp:(fun (prim1, _) (prim2, _) ->
+          stable_compare_primitives typing_env_with_extra_params
+            (EP.to_primitive prim1) (EP.to_primitive prim2))
+    in
+    let extra_params', typing_env_with_extra_params' =
+      List.fold_left sorted_extra_bindings
+        ~init:(EPA.empty, typing_env_with_extra_params)
+        ~f:(fun
+             (extra_bindings, typing_env_with_extra_params)
+             (_, { extra_param; extra_args })
+           ->
+          let extra_bindings =
+            EPA.add extra_bindings ~extra_param ~extra_args
+              ~invalids:Apply_cont_rewrite_id.Set.empty
+          in
+          (* We need to add the new variable to the typing env in order to be
+             able to compute binding times for the following rounds. *)
+          let typing_env_with_extra_params =
+            TE.add_definition typing_env_with_extra_params
+              (Bound_name.create (BP.name extra_param) Name_mode.normal)
+              (K.With_subkind.kind (BP.kind extra_param))
+          in
+          extra_bindings, typing_env_with_extra_params)
     in
     let need_other_round =
       (* If we introduce new parameters, then CSE equations involving the
@@ -363,15 +424,29 @@ let join0 ~typing_env_at_fork ~cse_at_fork ~cse_at_each_use ~params
        scope are used as extra arguments. *)
     let extra_params = EPA.concat ~outer:extra_params' ~inner:extra_params in
     let env_extension = TEE.disjoint_union env_extension env_extension' in
-    cse, extra_params, env_extension, allowed, need_other_round
+    ( cse,
+      extra_params,
+      typing_env_with_extra_params',
+      env_extension,
+      allowed,
+      need_other_round )
   in
   let cse, extra_params, env_extension, allowed =
-    let rec do_rounds current_round cse extra_params env_extension allowed =
-      let cse, extra_params, env_extension, allowed, need_other_round =
-        compute_cse_one_round cse extra_params env_extension ~allowed
+    let rec do_rounds current_round cse extra_params
+        typing_env_with_extra_params env_extension allowed =
+      let ( cse,
+            extra_params,
+            typing_env_with_extra_params,
+            env_extension,
+            allowed,
+            need_other_round ) =
+        compute_cse_one_round cse extra_params typing_env_with_extra_params
+          env_extension ~allowed
       in
       if need_other_round && current_round < Flambda_features.cse_depth ()
-      then do_rounds (succ current_round) cse extra_params env_extension allowed
+      then
+        do_rounds (succ current_round) cse extra_params
+          typing_env_with_extra_params env_extension allowed
       else
         ( (* Either a fixpoint has been reached or we've already explored far
              enough *)
@@ -380,7 +455,8 @@ let join0 ~typing_env_at_fork ~cse_at_fork ~cse_at_each_use ~params
           env_extension,
           allowed )
     in
-    do_rounds 1 EP.Map.empty EPA.empty TEE.empty Name_occurrences.empty
+    do_rounds 1 EP.Map.empty EPA.empty typing_env_at_fork TEE.empty
+      Name_occurrences.empty
   in
   let have_propagated_something = ref false in
   let cse_at_join_point =

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -2258,49 +2258,52 @@ let classify_for_printing t =
   | Ternary (prim, _, _, _) -> ternary_classify_for_printing prim
   | Variadic (prim, _) -> variadic_classify_for_printing prim
 
+let compare_primitive_application ~compare_simple t1 t2 =
+  if t1 == t2
+  then 0
+  else
+    let numbering t =
+      match t with
+      | Nullary _ -> 0
+      | Unary _ -> 1
+      | Binary _ -> 2
+      | Ternary _ -> 3
+      | Variadic _ -> 4
+    in
+    match t1, t2 with
+    | Nullary p, Nullary p' -> compare_nullary_primitive p p'
+    | Unary (p, s1), Unary (p', s1') ->
+      let c = compare_unary_primitive p p' in
+      if c <> 0 then c else compare_simple s1 s1'
+    | Binary (p, s1, s2), Binary (p', s1', s2') ->
+      let c = compare_binary_primitive p p' in
+      if c <> 0
+      then c
+      else
+        let c = compare_simple s1 s1' in
+        if c <> 0 then c else compare_simple s2 s2'
+    | Ternary (p, s1, s2, s3), Ternary (p', s1', s2', s3') ->
+      let c = compare_ternary_primitive p p' in
+      if c <> 0
+      then c
+      else
+        let c = compare_simple s1 s1' in
+        if c <> 0
+        then c
+        else
+          let c = compare_simple s2 s2' in
+          if c <> 0 then c else compare_simple s3 s3'
+    | Variadic (p, s), Variadic (p', s') ->
+      let c = compare_variadic_primitive p p' in
+      if c <> 0 then c else List.compare compare_simple s s'
+    | (Nullary _ | Unary _ | Binary _ | Ternary _ | Variadic _), _ ->
+      Stdlib.compare (numbering t1) (numbering t2)
+
 include Container_types.Make (struct
   type nonrec t = t
 
   let compare t1 t2 =
-    if t1 == t2
-    then 0
-    else
-      let numbering t =
-        match t with
-        | Nullary _ -> 0
-        | Unary _ -> 1
-        | Binary _ -> 2
-        | Ternary _ -> 3
-        | Variadic _ -> 4
-      in
-      match t1, t2 with
-      | Nullary p, Nullary p' -> compare_nullary_primitive p p'
-      | Unary (p, s1), Unary (p', s1') ->
-        let c = compare_unary_primitive p p' in
-        if c <> 0 then c else Simple.compare s1 s1'
-      | Binary (p, s1, s2), Binary (p', s1', s2') ->
-        let c = compare_binary_primitive p p' in
-        if c <> 0
-        then c
-        else
-          let c = Simple.compare s1 s1' in
-          if c <> 0 then c else Simple.compare s2 s2'
-      | Ternary (p, s1, s2, s3), Ternary (p', s1', s2', s3') ->
-        let c = compare_ternary_primitive p p' in
-        if c <> 0
-        then c
-        else
-          let c = Simple.compare s1 s1' in
-          if c <> 0
-          then c
-          else
-            let c = Simple.compare s2 s2' in
-            if c <> 0 then c else Simple.compare s3 s3'
-      | Variadic (p, s), Variadic (p', s') ->
-        let c = compare_variadic_primitive p p' in
-        if c <> 0 then c else Simple.List.compare s s'
-      | (Nullary _ | Unary _ | Binary _ | Ternary _ | Variadic _), _ ->
-        Stdlib.compare (numbering t1) (numbering t2)
+    compare_primitive_application ~compare_simple:Simple.compare t1 t2
 
   let equal t1 t2 = compare t1 t2 = 0
 

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -703,6 +703,18 @@ val equal_ternary_primitive : ternary_primitive -> ternary_primitive -> bool
 
 val equal_variadic_primitive : variadic_primitive -> variadic_primitive -> bool
 
+val compare : t -> t -> int
+
+val compare_nullary_primitive : nullary_primitive -> nullary_primitive -> int
+
+val compare_unary_primitive : unary_primitive -> unary_primitive -> int
+
+val compare_binary_primitive : binary_primitive -> binary_primitive -> int
+
+val compare_ternary_primitive : ternary_primitive -> ternary_primitive -> int
+
+val compare_variadic_primitive : variadic_primitive -> variadic_primitive -> int
+
 val is_begin_or_end_region : t -> bool
 
 val is_begin_region : t -> bool

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -703,17 +703,8 @@ val equal_ternary_primitive : ternary_primitive -> ternary_primitive -> bool
 
 val equal_variadic_primitive : variadic_primitive -> variadic_primitive -> bool
 
-val compare : t -> t -> int
-
-val compare_nullary_primitive : nullary_primitive -> nullary_primitive -> int
-
-val compare_unary_primitive : unary_primitive -> unary_primitive -> int
-
-val compare_binary_primitive : binary_primitive -> binary_primitive -> int
-
-val compare_ternary_primitive : ternary_primitive -> ternary_primitive -> int
-
-val compare_variadic_primitive : variadic_primitive -> variadic_primitive -> int
+val compare_primitive_application :
+  compare_simple:(Simple.t -> Simple.t -> int) -> t -> t -> int
 
 val is_begin_or_end_region : t -> bool
 

--- a/middle_end/flambda2/types/env/typing_env.mli
+++ b/middle_end/flambda2/types/env/typing_env.mli
@@ -151,6 +151,10 @@ val mem_simple : ?min_name_mode:Name_mode.t -> t -> Simple.t -> bool
 val alias_is_bound_strictly_earlier :
   t -> bound_name:Name.t -> alias:Simple.t -> bool
 
+(** [stable_compare_simples t simple1 simple2] is a total extension of the
+    binding time order that does not depend on [Int_ids] hashing. *)
+val stable_compare_simples : t -> Simple.t -> Simple.t -> int
+
 (* CR vlaviron: If the underlying level in the extension defines several
    variables, then there is no guarantee that the binding order in the result
    will match the binding order used to create the level. If they don't match,

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -241,6 +241,8 @@ module Typing_env : sig
 
   val bump_current_level_scope : t -> t
 
+  val stable_compare_simples : t -> Simple.t -> Simple.t -> int
+
   module Alias_set : sig
     type t
 


### PR DESCRIPTION
This patch ensures that the `cse_param` variables introduced by the CSE pass are introduced in a stable order that does not depend on the `Int_ids` assigned to variables.

This helps making comparisons between different runs (e.g. with different options) using the `flambda2-compare` library.

The order is determined lexicographically depending on the primitive under consideration and its arguments, which are guaranteed to be in scope in the target environment (see `cse_with_eligible_lhs`). The order for the argument uses the new `stable_compare_simples` function which is a total order on `Simple.t` values defined in a given typing environment, which coincides with the binding time order and does not depend on `Int_ids` hashing.