### PR TITLE
Deterministic order for `lets_to_introduce`

### DIFF
--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -458,6 +458,7 @@ module Variable = struct
 
   module Set = Tree.Set
   module Map = Tree.Map
+  module Lmap = Lmap.Make (T)
 
   let export t = find_data t
 

--- a/middle_end/flambda2/identifiers/int_ids.mli
+++ b/middle_end/flambda2/identifiers/int_ids.mli
@@ -101,6 +101,8 @@ module Variable : sig
 
   include Container_types.S with type t := t
 
+  module Lmap : Lmap.S with type key := t
+
   val create : ?user_visible:unit -> string -> t
 
   val compilation_unit : t -> Compilation_unit.t

--- a/middle_end/flambda2/simplify/flow/control_flow_graph.ml
+++ b/middle_end/flambda2/simplify/flow/control_flow_graph.ml
@@ -256,9 +256,9 @@ let minimize_extra_args_for_one_continuation ~(source_info : T.Acc.t)
   in
   let lets_to_introduce =
     match exception_handler_first_param_aliased with
-    | None -> Variable.Map.empty
+    | None -> Variable.Lmap.empty
     | Some (alias, exception_param) ->
-      Variable.Map.singleton alias exception_param
+      Variable.Lmap.singleton alias exception_param
   in
   let removed_aliased_params_and_extra_params, lets_to_introduce =
     List.fold_left
@@ -268,7 +268,7 @@ let minimize_extra_args_for_one_continuation ~(source_info : T.Acc.t)
           let lets_to_introduce =
             if Variable.Set.mem alias unboxed_blocks
             then lets_to_introduce
-            else Variable.Map.add param alias lets_to_introduce
+            else Variable.Lmap.add param alias lets_to_introduce
           in
           removed, lets_to_introduce
         in

--- a/middle_end/flambda2/simplify/flow/flow_types.ml
+++ b/middle_end/flambda2/simplify/flow/flow_types.ml
@@ -267,7 +267,7 @@ module Continuation_param_aliases = struct
 
   type t =
     { removed_aliased_params_and_extra_params : Variable.Set.t;
-      lets_to_introduce : Variable.t Variable.Map.t;
+      lets_to_introduce : Variable.t Variable.Lmap.t;
       extra_args_for_aliases : Variable.Set.t;
       recursive_continuation_wrapper : recursive_continuation_wrapper
     }
@@ -288,7 +288,7 @@ module Continuation_param_aliases = struct
         %a\
        )@]"
       Variable.Set.print removed_aliased_params_and_extra_params
-      (Variable.Map.print Variable.print) lets_to_introduce
+      (Variable.Lmap.print Variable.print) lets_to_introduce
       Variable.Set.print extra_args_for_aliases
       pp_wrapper recursive_continuation_wrapper
 end

--- a/middle_end/flambda2/simplify/flow/flow_types.mli
+++ b/middle_end/flambda2/simplify/flow/flow_types.mli
@@ -157,7 +157,7 @@ module Continuation_param_aliases : sig
 
   type t =
     { removed_aliased_params_and_extra_params : Variable.Set.t;
-      lets_to_introduce : Variable.t Variable.Map.t;
+      lets_to_introduce : Variable.t Variable.Lmap.t;
       extra_args_for_aliases : Variable.Set.t;
       recursive_continuation_wrapper : recursive_continuation_wrapper
     }

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -553,7 +553,7 @@ let add_lets_around_handler cont at_unit_toplevel uacc handler =
         Continuation.print cont
   in
   let handler, uacc =
-    Variable.Map.fold
+    Variable.Lmap.fold
       (fun var bound_to (handler, uacc) ->
         let bound_pattern =
           Bound_pattern.singleton (Bound_var.create var Name_mode.normal)


### PR DESCRIPTION
This patch uses a `Variable.Lmap` instead of a `Variable.Map` to record de-duplicated continuation parameters, ensuring a deterministic (i.e. independent of `Int_ids` hasing) order of the `let` expressions introduced to replace them.

This helps making comparisons between different runs (e.g. with different options) using the `flambda2-compare` library.