### PR TITLE
Change how extension level affects inferred modalities

### DIFF
--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -975,17 +975,17 @@ exception Odd
 val x : x:int * y:int = (~x:1, ~y:2)
 val x : x:int * y:int = (~x:1, ~y:2)
 - : x:int * int * z:int * punned:int = (~x:5, 2, ~z:4, ~punned:5)
-val x : x:int * y:int = (~x:1, ~y:2)
-val x : x:int * y:int = (~x:1, ~y:2)
+val x : x:int * y:int @@ stateless = (~x:1, ~y:2)
+val x : x:int * y:int @@ stateless = (~x:1, ~y:2)
 |}]
 
 let (~x:x0, ~s, ~(y:int), ..) : (x:int * s:string * y:int * string) =
    (~x: 1, ~s: "a", ~y: 2, "ignore me")
 
 [%%expect{|
-val x0 : int = 1
-val s : string = "a"
-val y : int = 2
+val x0 : int @@ stateless = 1
+val s : string @@ stateless = "a"
+val y : int @@ stateless = 2
 |}]
 
 module M : sig
@@ -1021,9 +1021,9 @@ let f ((~(x:int),y) : (x:int * int)) : int = x + y
 
 [%%expect{|
 val foo : 'a -> (unit -> 'b) -> (unit -> 'b) -> 'b = <fun>
-val x : int = 1
+val x : int @@ stateless = 1
 val y : int = 2
-val x : int = 1
+val x : int @@ stateless = 1
 val y : int = 2
 val f : (foo:int * bar:int) -> int = <fun>
 val f : (x:int * int) -> int = <fun>

--- a/testsuite/tests/typing-unique/rbtree.ml
+++ b/testsuite/tests/typing-unique/rbtree.ml
@@ -502,10 +502,10 @@ module Make_Okasaki :
     sig
       type 'a t = (Ord.t, 'a) tree
       val fold : ('a -> 'b -> 'c -> 'c) -> 'c -> ('a, 'b) tree -> 'c
-      val balance_left : ('a, 'b) tree -> ('a, 'b) tree
-      val balance_right : ('a, 'b) tree -> ('a, 'b) tree
+      val balance_left : ('a, 'b) tree -> ('a, 'b) tree @@ stateless
+      val balance_right : ('a, 'b) tree -> ('a, 'b) tree @@ stateless
       val ins : Ord.t -> 'a -> (Ord.t, 'a) tree -> (Ord.t, 'a) tree
-      val set_black : ('a, 'b) tree -> ('a, 'b) tree
+      val set_black : ('a, 'b) tree -> ('a, 'b) tree @@ stateless
       val insert : Ord.t -> 'a -> (Ord.t, 'a) tree -> (Ord.t, 'a) tree
     end
 Line 110, characters 16-52:

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5012,6 +5012,11 @@ let relevant_pairs pairs v =
   | Contravariant -> pairs.contravariant_pairs
   | Bivariant -> pairs.bivariant_pairs
 
+let zap_modalities_to_floor_if_at_least level =
+  if Language_extension.(is_at_least Mode level)
+    then Mode.Modality.Value.zap_to_floor
+    else Mode.Modality.Value.zap_to_id
+
 let crossing_of_jkind env jkind =
   let jkind_of_type = type_jkind_purely_if_principal env in
   Jkind.get_mode_crossing ~jkind_of_type jkind

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5012,7 +5012,7 @@ let relevant_pairs pairs v =
   | Contravariant -> pairs.contravariant_pairs
   | Bivariant -> pairs.bivariant_pairs
 
-let zap_modalities_to_floor_if_at_least level =
+let zap_modalities_to_floor_if_modes_enabled_at level =
   if Language_extension.(is_at_least Mode level)
     then Mode.Modality.Value.zap_to_floor
     else Mode.Modality.Value.zap_to_id

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -776,3 +776,9 @@ val cross_left_alloc :
   Types.type_expr ->
   Mode.Alloc.l ->
   Mode.Alloc.l
+
+(** Zap a modality to floor if maturity allows, zap to id otherwise. *)
+val zap_modalities_to_floor_if_at_least :
+  Language_extension.maturity ->
+  Mode.Modality.Value.t ->
+  Mode.Modality.Value.Const.t

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -777,8 +777,9 @@ val cross_left_alloc :
   Mode.Alloc.l ->
   Mode.Alloc.l
 
-(** Zap a modality to floor if maturity allows, zap to id otherwise. *)
-val zap_modalities_to_floor_if_at_least :
+(** Zap a modality to floor if the [modes] extension is enabled at a level more
+    immature than the given one. Zap to id otherwise. *)
+val zap_modalities_to_floor_if_modes_enabled_at :
   Language_extension.maturity ->
   Mode.Modality.Value.t ->
   Mode.Modality.Value.Const.t

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2230,7 +2230,9 @@ let tree_of_value_description id decl =
   (* Important: process the fvs *after* the type; tree_of_type_scheme
      resets the naming context *)
   let snap = Btype.snapshot () in
-  let moda = Mode.Modality.Value.zap_to_id decl.val_modalities in
+  let moda =
+    Ctype.zap_modalities_to_floor_if_at_least Alpha decl.val_modalities
+  in
   let qtvs = extract_qtvs [decl.val_type] in
   let apparent_arity =
     let rec count n typ =

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2231,7 +2231,7 @@ let tree_of_value_description id decl =
      resets the naming context *)
   let snap = Btype.snapshot () in
   let moda =
-    Ctype.zap_modalities_to_floor_if_at_least Alpha decl.val_modalities
+    Ctype.zap_modalities_to_floor_if_modes_enabled_at Alpha decl.val_modalities
   in
   let qtvs = extract_qtvs [decl.val_type] in
   let apparent_arity =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3555,9 +3555,9 @@ let type_module_type_of env smod =
   let mty = Mtype.scrape_for_type_of ~remove_aliases env tmty.mod_type in
   (* PR#5036: must not contain non-generalized type variables *)
   check_nongen_modtype env smod.pmod_loc mty;
+  let zap_modality = Ctype.zap_modalities_to_floor_if_modes_enabled_at Stable in
   let mty =
-    remove_modality_and_zero_alloc_variables_mty env
-      ~zap_modality:(Ctype.zap_modalities_to_floor_if_at_least Stable) mty
+    remove_modality_and_zero_alloc_variables_mty env ~zap_modality mty
   in
   tmty, mty
 
@@ -3799,11 +3799,13 @@ let type_implementation target modulename initial_env ast =
       let simple_sg = Signature_names.simplify finalenv names sg in
       if !Clflags.print_types then begin
         remove_mode_and_jkind_variables finalenv sg;
+        let zap_modality =
+          Ctype.zap_modalities_to_floor_if_modes_enabled_at Alpha
+        in
         let simple_sg =
           (* Printing [.mli] from [.ml], we zap to identity modality for legacy
              compatibility. *)
-          remove_modality_and_zero_alloc_variables_sg finalenv
-            ~zap_modality:(Ctype.zap_modalities_to_floor_if_at_least Alpha)
+          remove_modality_and_zero_alloc_variables_sg finalenv ~zap_modality
             simple_sg
         in
         Typecore.force_delayed_checks ();
@@ -3905,11 +3907,13 @@ let type_implementation target modulename initial_env ast =
                 sourcefile sg "(inferred signature)" simple_sg shape)
           in
           check_nongen_signature finalenv simple_sg;
+          let zap_modality =
+            Ctype.zap_modalities_to_floor_if_modes_enabled_at Stable
+          in
           let simple_sg =
             (* Generating [cmi] without [mli]. This [cmi] will only be on the
                LHS of inclusion check, so we zap to floor (strongest). *)
-            remove_modality_and_zero_alloc_variables_sg finalenv
-              ~zap_modality:(Ctype.zap_modalities_to_floor_if_at_least Stable)
+            remove_modality_and_zero_alloc_variables_sg finalenv ~zap_modality
               simple_sg
           in
           normalize_signature simple_sg;

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3908,11 +3908,12 @@ let type_implementation target modulename initial_env ast =
           in
           check_nongen_signature finalenv simple_sg;
           let zap_modality =
+            (* Generating [cmi] without [mli]. This [cmi] could be on the RHS of
+               inclusion check, so we zap to identity if mode extension is
+               disabled. Otherwise, zapping to floor (strongest) is better. *)
             Ctype.zap_modalities_to_floor_if_modes_enabled_at Stable
           in
           let simple_sg =
-            (* Generating [cmi] without [mli]. This [cmi] will only be on the
-               LHS of inclusion check, so we zap to floor (strongest). *)
             remove_modality_and_zero_alloc_variables_sg finalenv ~zap_modality
               simple_sg
           in


### PR DESCRIPTION
Currently, inferred modalities are fixed to be identity if `mode` extension is disabled. This causes some incompatibility between modules that has `mode` enabled and those not. For example, if we have `a.ml` that has `mode` enabled, and we have `b.ml` with `mode` disabled:
```
include A
```
and `b.mli`:
```
include module type of A
```
The later will have non-identity modalities while the former doesn't.

This is currently not testable, since with modules fixed at `legacy`, the type checker simply copies the modalities from `A` into `B` without infering new modalities. But #3759 will be affected.

The solution is to always infer modalties, but use extension level to control what the users can write and read.