### PR TITLE
Move symbol initialization up in `to_cmm`

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -260,6 +260,8 @@ val add_alias :
   num_normal_occurrences_of_bound_vars:Num_occurrences.t Variable.Map.t ->
   t * To_cmm_result.t
 
+val add_symbol_init : t -> Backend_var.t -> Cmm.expression -> t
+
 (** Try and inline an Flambda variable using the delayed let-bindings. *)
 val inline_variable :
   ?consider_inlining_effectful_expressions:bool ->

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -420,7 +420,7 @@ end
 
 let make_update env res dbg ({ kind; stride } : Update_kind.t) ~symbol var
     ~index ~prev_updates =
-  let To_cmm_env.{ env; res; expr = { cmm; free_vars; effs } } =
+  let To_cmm_env.{ env; res; expr = { cmm = field_value; free_vars; effs } } =
     To_cmm_env.inline_variable env res var
   in
   let cmm =
@@ -446,7 +446,8 @@ let make_update env res dbg ({ kind; stride } : Update_kind.t) ~symbol var
     match must_use_setfield with
     | Some imm_or_ptr ->
       assert (stride = Arch.size_addr);
-      Cmm_helpers.setfield index imm_or_ptr Root_initialization symbol cmm dbg
+      Cmm_helpers.setfield index imm_or_ptr Root_initialization symbol
+        field_value dbg
     | None ->
       let memory_chunk : Cmm.memory_chunk =
         match kind with
@@ -471,18 +472,33 @@ let make_update env res dbg ({ kind; stride } : Update_kind.t) ~symbol var
         | Naked_vec512 -> Fivetwelve_unaligned
       in
       let addr = strided_field_address symbol ~stride ~index dbg in
-      store ~dbg memory_chunk Initialization ~addr ~new_value:cmm
+      store ~dbg memory_chunk Initialization ~addr ~new_value:field_value
   in
-  let update =
-    match prev_updates with
-    | None -> To_cmm_env.{ cmm; free_vars; effs }
-    | Some (prev : To_cmm_env.expr_with_info) ->
-      let cmm = sequence prev.cmm cmm in
-      let free_vars = Backend_var.Set.union prev.free_vars free_vars in
-      let effs = Ece.join prev.effs effs in
-      To_cmm_env.{ cmm; free_vars; effs }
+  (* We dont need the `return_unit` part of the assignment/initialization
+
+     CR gury: we could instead add this simplification in `Cmm_helpers.sequence`
+     to remove unnecessary unit returns in between expressions that are
+     sequenced. *)
+  let cmm =
+    match[@warning "-4"] cmm with
+    | Csequence (cmm, Cconst_int (1, _)) -> cmm
+    | _ -> cmm
   in
-  env, res, Some update
+  match[@warning "-4"] field_value with
+  | Cvar v ->
+    let env = To_cmm_env.add_symbol_init env v cmm in
+    env, res, prev_updates
+  | _ ->
+    let update =
+      match prev_updates with
+      | None -> To_cmm_env.{ cmm; free_vars; effs }
+      | Some (prev : To_cmm_env.expr_with_info) ->
+        let cmm = sequence prev.cmm cmm in
+        let free_vars = Backend_var.Set.union prev.free_vars free_vars in
+        let effs = Ece.join prev.effs effs in
+        To_cmm_env.{ cmm; free_vars; effs }
+    in
+    env, res, Some update
 
 let check_arity arity args =
   Flambda_arity.cardinal_unarized arity = List.length args

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -474,16 +474,6 @@ let make_update env res dbg ({ kind; stride } : Update_kind.t) ~symbol var
       let addr = strided_field_address symbol ~stride ~index dbg in
       store ~dbg memory_chunk Initialization ~addr ~new_value:field_value
   in
-  (* We dont need the `return_unit` part of the assignment/initialization
-
-     CR gury: we could instead add this simplification in `Cmm_helpers.sequence`
-     to remove unnecessary unit returns in between expressions that are
-     sequenced. *)
-  let cmm =
-    match[@warning "-4"] cmm with
-    | Csequence (cmm, Cconst_int (1, _)) -> cmm
-    | _ -> cmm
-  in
   match[@warning "-4"] field_value with
   | Cvar v ->
     let env = To_cmm_env.add_symbol_init env v cmm in


### PR DESCRIPTION
This PR adds to `to_cmm` code to lift/move some symbol initialization upwards. The intent of that move is to (as much as possible and reasonable) have symbol initializations right after the definitions for the variable/value that is written in the symbol field. This should reduce the lifetime of some of these values, which should reduce the pressure on the register allocator (and allow for less spilling).

This is particularly useful for symbols that have a lot of fields that are not static (i.e. whose value is computed during module initialization), which is often the case in classic mode for most modules (where the lifting and static allocation is limited), but can also occur even with `Simplify` depending on the shape of the code.

Let's consider the following code:
```ocaml
let[@inline never] foo () = 42

let field1 = foo ()
let field2 = foo ()
let field3 = foo ()
let field4 = foo ()
```

Before this PR (i.e. on current `main`), this is the cmm code generated for the module initialization in classic mode:
```
(function no_cse reduce_code_size linscan camlFoo__entry ()
 (catch
   (let
     (field1/295 (app{../flambda2/foo.ml:4,13-19} G:"camlFoo__foo_0_0" 1 int)
      field2/296 (app{../flambda2/foo.ml:5,13-19} G:"camlFoo__foo_0_0" 1 int)
      field3/297 (app{../flambda2/foo.ml:6,13-19} G:"camlFoo__foo_0_0" 1 int)
      field4/298 (app{../flambda2/foo.ml:7,13-19} G:"camlFoo__foo_0_0" 1 int))
     (extcall "caml_initialize" (+a L:"camlFoo__s1" 8) field1/295 ->unit) 1
     (extcall "caml_initialize" (+a L:"camlFoo__s1" 16) field2/296 ->unit) 1
     (extcall "caml_initialize" (+a L:"camlFoo__s1" 24) field3/297 ->unit) 1
     (extcall "caml_initialize" (+a L:"camlFoo__s1" 32) field4/298 ->unit) 1
     (extcall "caml_initialize" G:"camlFoo" G:"camlFoo__s0" ->unit) 1
     (extcall "caml_initialize" (+a G:"camlFoo" 8)
       (load val (+a L:"camlFoo__s1" 8)) ->unit)
     1
     (extcall "caml_initialize" (+a G:"camlFoo" 16)
       (load val (+a L:"camlFoo__s1" 16)) ->unit)
     1
     (extcall "caml_initialize" (+a G:"camlFoo" 24)
       (load val (+a L:"camlFoo__s1" 24)) ->unit)
     1
     (extcall "caml_initialize" (+a G:"camlFoo" 32)
       (load val (+a L:"camlFoo__s1" 32)) ->unit)
     1 (exit 1 G:"camlFoo"))
 with(1 *ret*/292: val) 1))
```

After this PR, we now generate the following:
```
(function no_cse reduce_code_size linscan camlFoo__entry ()
 (catch
   (let field1/295 (app{foo.ml:4,13-19} G:"camlFoo__foo_0_0" 1 int)
     (extcall "caml_initialize" (+a L:"camlFoo__s1" 8) field1/295 ->unit)
     (let field2/296 (app{foo.ml:5,13-19} G:"camlFoo__foo_0_0" 1 int)
       (extcall "caml_initialize" (+a L:"camlFoo__s1" 16) field2/296 ->unit)
       (let field3/297 (app{foo.ml:6,13-19} G:"camlFoo__foo_0_0" 1 int)
         (extcall "caml_initialize" (+a L:"camlFoo__s1" 24) field3/297
           ->unit)
         (let field4/298 (app{foo.ml:7,13-19} G:"camlFoo__foo_0_0" 1 int)
           (extcall "caml_initialize" (+a L:"camlFoo__s1" 32) field4/298
             ->unit)
           (extcall "caml_initialize" G:"camlFoo" G:"camlFoo__s0" ->unit)
           (extcall "caml_initialize" (+a G:"camlFoo" 8)
             (load val (+a L:"camlFoo__s1" 8)) ->unit)
           (extcall "caml_initialize" (+a G:"camlFoo" 16)
             (load val (+a L:"camlFoo__s1" 16)) ->unit)
           (extcall "caml_initialize" (+a G:"camlFoo" 24)
             (load val (+a L:"camlFoo__s1" 24)) ->unit)
           (extcall "caml_initialize" (+a G:"camlFoo" 32)
             (load val (+a L:"camlFoo__s1" 32)) ->unit)
           (exit 1 G:"camlFoo")))))
 with(1 *ret*/292: val) 1))
```

Notice how the calls to `caml_initialize` are now spread out and occur immediately after the loads or function calls that create the value to be used, instead of all bunched up. This makes it so that the lifetime of the field values are now much shorter.

Finally, this effect of moving symbol initializations up is limited by the current implement, which only allows to move them up to the closest environment flush (or in flambda2 terms, roughly a the top of the current continuation's handler), so code with complex control flow might now get as optimized (one solution for this would be to disallow inlining of functions at top-level, thus ensuring a simple workflow).