### PR TITLE
Better errors for illegal recursive modules (backport ocaml/ocaml#13646)

### DIFF
--- a/testsuite/tests/typing-modules/strengthening.ml
+++ b/testsuite/tests/typing-modules/strengthening.ml
@@ -349,5 +349,8 @@ end
 Line 2, characters 30-31:
 2 |   module rec M : sig end with N = N
                                   ^
-Error: Illegal recursive module reference
+Error: This module type is recursive. This use of the recursive module "N"
+       within the definition of the module "M"
+       makes the module type of "M" depend on the module type of "N".
+       Such recursive definitions of module types are not allowed.
 |}]

--- a/testsuite/tests/typing-recmod/gpr1626.ml
+++ b/testsuite/tests/typing-recmod/gpr1626.ml
@@ -12,5 +12,18 @@ module rec M : S with module M := M = M;;
 Line 1, characters 34-35:
 1 | module rec M : S with module M := M = M;;
                                       ^
-Error: Illegal recursive module reference
+Error: This module type is recursive. This use of the recursive module "M"
+       within its own definition makes the module type of "M" depend on itself.
+       Such recursive definitions of module types are not allowed.
+|}];;
+
+module rec M : S = M and P : S with module M := M = P;;
+[%%expect{|
+Line 1, characters 48-49:
+1 | module rec M : S = M and P : S with module M := M = P;;
+                                                    ^
+Error: This module type is recursive. This use of the recursive module "M"
+       within the definition of the module "P"
+       makes the module type of "P" depend on the module type of "M".
+       Such recursive definitions of module types are not allowed.
 |}];;

--- a/testsuite/tests/typing-recmod/pr6491.ml
+++ b/testsuite/tests/typing-recmod/pr6491.ml
@@ -9,7 +9,25 @@ and Baz : sig class type c = object inherit Bar.c end end = Baz;;
 Line 2, characters 44-49:
 2 | and Bar : sig class type c = object inherit Foo.c end end = Bar
                                                 ^^^^^
-Error: Illegal recursive module reference
+Error: This class type is recursive. This use of the class type "Foo.c"
+       from the recursive module "Foo" within the definition of
+       the class type "c" in the recursive module "Bar"
+       makes the module type of "Bar" depend on the module type of "Foo".
+       Such recursive definitions of class types within recursive modules
+       are not allowed.
+|}]
+
+module rec Foo : sig class type c = object inherit Foo.c end end = Foo;;
+[%%expect {|
+Line 1, characters 51-56:
+1 | module rec Foo : sig class type c = object inherit Foo.c end end = Foo;;
+                                                       ^^^^^
+Error: This class type is recursive. This use of the class type "Foo.c"
+       from the recursive module "Foo" within the definition of
+       the class type "c" in the recursive module "Foo"
+       makes the module type of "Foo" depend on itself.
+       Such recursive definitions of class types within recursive modules
+       are not allowed.
 |}]
 
 module rec Foo : sig class type c = object method x : int end end = Foo
@@ -23,7 +41,12 @@ let baz (x : Baz.c) = x#x;;
 Line 2, characters 29-34:
 2 | and Bar : sig class type c = Foo.c end = Bar
                                  ^^^^^
-Error: Illegal recursive module reference
+Error: This class type is recursive. This use of the class type "Foo.c"
+       from the recursive module "Foo" within the definition of
+       the class type "c" in the recursive module "Bar"
+       makes the module type of "Bar" depend on the module type of "Foo".
+       Such recursive definitions of class types within recursive modules
+       are not allowed.
 |}]
 
 (* #12480 *)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -137,7 +137,8 @@ type value_unbound_reason =
   | Val_unbound_ghost_recursive of Location.t
 
 type module_unbound_reason =
-  | Mod_unbound_illegal_recursion
+  | Mod_unbound_illegal_recursion of
+      { container : string option; unbound : string }
 
 type summary =
     Env_empty
@@ -793,7 +794,14 @@ type lookup_error =
   | Functor_used_as_structure of Longident.t * structure_components_reason
   | Abstract_used_as_structure of Longident.t * Path.t * structure_components_reason
   | Generative_used_as_applicative of Longident.t
-  | Illegal_reference_to_recursive_module
+  | Illegal_reference_to_recursive_module of
+      { container: string option; unbound : string }
+  | Illegal_reference_to_recursive_class_type of
+      { container : string option;
+        unbound : string;
+        unbound_class_type : Longident.t;
+        container_class_type : string;
+      }
   | Cannot_scrape_alias of Longident.t * Path.t
   | Local_value_escaping of lock_item * Longident.t * escaping_context
   | Once_value_used_in of lock_item * Longident.t * shared_context
@@ -3054,9 +3062,10 @@ let may_lookup_error report_errors loc env err =
 
 let report_module_unbound ~errors ~loc env reason =
   match reason with
-  | Mod_unbound_illegal_recursion ->
+  | Mod_unbound_illegal_recursion { container; unbound } ->
       (* see #5965 *)
-    may_lookup_error errors loc env Illegal_reference_to_recursive_module
+      may_lookup_error errors loc env
+        (Illegal_reference_to_recursive_module { container; unbound })
 
 let report_value_unbound ~errors ~loc env reason lid =
   match reason with
@@ -4608,8 +4617,46 @@ let report_lookup_error _loc env ppf = function
         "The ancestor variable %a@ \
          cannot be accessed from the definition of an instance variable"
        (Style.as_inline_code !print_longident) lid
-  | Illegal_reference_to_recursive_module ->
-     fprintf ppf "Illegal recursive module reference"
+  | Illegal_reference_to_recursive_module { container; unbound } ->
+      let container = Option.value ~default:"_" container in
+      let self_or_definition, self_or_unbound =
+        if String.equal container unbound
+        then dprintf "its own definition", dprintf "itself"
+        else
+          dprintf "the definition of the module %a" Style.inline_code container,
+          dprintf "the module type of %a" Style.inline_code unbound
+      in
+      fprintf ppf
+        "@[<hov>This module type is recursive.@ \
+         This use of the recursive module %a@ \
+         within %t@ \
+         makes the module type of %a depend on@ %t.@ \
+         Such recursive definitions of module types are not allowed.@]"
+        Style.inline_code unbound
+        self_or_definition
+        Style.inline_code container
+        self_or_unbound
+  | Illegal_reference_to_recursive_class_type
+      { container; unbound; unbound_class_type; container_class_type } ->
+      let container = Option.value ~default:"_" container in
+      let self_or_unbound =
+        if String.equal container unbound
+        then dprintf "itself"
+        else dprintf "the module type of %a" Style.inline_code unbound
+      in
+      fprintf ppf
+        "@[<hov>This class type is recursive.@ This use of the class type %a@ \
+         from the recursive module %a@ within the definition of@ \
+         the class type %a@ in the recursive module %a@ \
+         makes the module type of %a@ depend on %t.@ \
+         Such recursive definitions of@ class types within recursive modules@ \
+         are not allowed.@]"
+        (Style.as_inline_code !print_longident) unbound_class_type
+        Style.inline_code unbound
+        Style.inline_code container_class_type
+        Style.inline_code container
+        Style.inline_code container
+        self_or_unbound
   | Structure_used_as_functor lid ->
       fprintf ppf "@[The module %a is a structure, it cannot be applied@]"
       (Style.as_inline_code !print_longident) lid

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -25,7 +25,8 @@ type value_unbound_reason =
   | Val_unbound_ghost_recursive of Location.t
 
 type module_unbound_reason =
-  | Mod_unbound_illegal_recursion
+  | Mod_unbound_illegal_recursion of
+      { container : string option; unbound: string }
 
 type summary =
     Env_empty
@@ -246,7 +247,14 @@ type lookup_error =
   | Functor_used_as_structure of Longident.t * structure_components_reason
   | Abstract_used_as_structure of Longident.t * Path.t * structure_components_reason
   | Generative_used_as_applicative of Longident.t
-  | Illegal_reference_to_recursive_module
+  | Illegal_reference_to_recursive_module of
+      { container : string option; unbound : string }
+  | Illegal_reference_to_recursive_class_type of
+      { container : string option;
+        unbound : string;
+        unbound_class_type : Longident.t;
+        container_class_type : string
+      }
   | Cannot_scrape_alias of Longident.t * Path.t
   | Local_value_escaping of lock_item * Longident.t * escaping_context
   | Once_value_used_in of lock_item * Longident.t * shared_context

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -2109,30 +2109,45 @@ let () =
 (*******************************)
 
 (* Check that there is no references through recursive modules (GPR#6491) *)
-let rec check_recmod_class_type env cty =
+let rec check_recmod_class_type env name cty =
   match cty.pcty_desc with
   | Pcty_constr(lid, _) ->
-      ignore (Env.lookup_cltype ~use:false ~loc:lid.loc lid.txt env)
+      begin try
+        ignore (Env.lookup_cltype ~use:false ~loc:lid.loc lid.txt env)
+      with
+      | Env.Error
+          (Lookup_error
+             (location, env,
+              Illegal_reference_to_recursive_module { container; unbound; })) ->
+          Env.lookup_error
+            location env
+            (Illegal_reference_to_recursive_class_type
+               { container;
+                 unbound;
+                 unbound_class_type = lid.txt;
+                 container_class_type = name.txt;
+               })
+      end
   | Pcty_extension _ -> ()
   | Pcty_arrow(_, _, cty) ->
-      check_recmod_class_type env cty
+      check_recmod_class_type env name cty
   | Pcty_open(od, cty) ->
       let _, env = !type_open_descr env od in
-      check_recmod_class_type env cty
+      check_recmod_class_type env name cty
   | Pcty_signature csig ->
-      check_recmod_class_sig env csig
+      check_recmod_class_sig env name csig
 
-and check_recmod_class_sig env csig =
+and check_recmod_class_sig env name csig =
   List.iter
     (fun ctf ->
        match ctf.pctf_desc with
-       | Pctf_inherit cty -> check_recmod_class_type env cty
+       | Pctf_inherit cty -> check_recmod_class_type env name cty
        | Pctf_val _ | Pctf_method _
        | Pctf_constraint _ | Pctf_attribute _ | Pctf_extension _ -> ())
     csig.pcsig_fields
 
 let check_recmod_decl env sdecl =
-  check_recmod_class_type env sdecl.pci_expr
+  check_recmod_class_type env sdecl.pci_name sdecl.pci_expr
 
 (* Approximate the class declaration as class ['params] id = object end *)
 let approx_class sdecl =

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2131,12 +2131,14 @@ and transl_recmodule_modtypes env sig_modalities sdecls =
     List.map (fun x -> Option.map (Ident.create_scoped ~scope) x.pmd_name.txt)
       sdecls
   in
-  let approx_env =
+  let approx_env container =
     List.fold_left
       (fun env ->
          Option.fold ~none:env ~some:(fun id -> (* cf #5965 *)
            Env.enter_unbound_module (Ident.name id)
-             Mod_unbound_illegal_recursion env
+             (Mod_unbound_illegal_recursion
+                { container; unbound = Ident.name id })
+             env
          ))
       env ids
   in
@@ -2145,7 +2147,7 @@ and transl_recmodule_modtypes env sig_modalities sdecls =
       (fun id pmd ->
          let md_uid = Uid.mk ~current_unit:(Env.get_unit_name ()) in
          let md_type =
-          approx_modtype approx_env pmd.pmd_type
+          approx_modtype (approx_env pmd.pmd_name.txt) pmd.pmd_type
           |> apply_pmd_modalities env sig_modalities pmd.pmd_modalities
          in
          let md =


### PR DESCRIPTION
Backports https://github.com/ocaml/ocaml/pull/13646.

### Stack
1. https://github.com/oxcaml/oxcaml/pull/4224
2. https://github.com/oxcaml/oxcaml/pull/4240
3. https://github.com/oxcaml/oxcaml/pull/4241
4. https://github.com/oxcaml/oxcaml/pull/4246