### PR TITLE
Fix missing check of illegal recursive module when using module type substitutions (backport ocaml/ocaml#13829)

### DIFF
--- a/testsuite/tests/typing-modules/module_type_substitution.ml
+++ b/testsuite/tests/typing-modules/module_type_substitution.ml
@@ -368,3 +368,225 @@ Error: The module type "t" is not a valid type for a packed module:
        it is defined as a local substitution (temporary name)
        for an anonymous module type. (see manual section 12.7.3)
 |}]
+
+(** Approximation and substitutions **)
+
+(* Approximating a signature with a constraint should merge the approximated
+   constraint (abstract, non destructive case) *)
+module type Test_Abstract = sig
+  module type S := sig
+    module type A
+    module X' : A
+  end
+
+  module rec X : (S with module type A = sig type t end)
+  and Y : sig type u = X.X'.t end
+end
+[%%expect {|
+module type Test_Abstract =
+  sig
+    module rec X : sig module type A = sig type t end module X' : A end
+    and Y : sig type u = X.X'.t end
+  end
+|}]
+
+
+(* Approximating a signature with a constraint should merge the approximated
+   constraint (abstract, destructive case) *)
+module type Test_Abstract_Destructive = sig
+  module type S := sig
+    module type A
+    module X' : A
+  end
+
+  module rec X : (S with module type A := sig type t end)
+  and Y : sig type u = X.X'.t end
+end
+[%%expect {|
+module type Test_Abstract_Destructive =
+  sig
+    module rec X : sig module X' : sig type t end end
+    and Y : sig type u = X.X'.t end
+  end
+|}]
+
+
+(* Approximating a signature with a constraint should merge the approximated
+   constraint (concrete, non destructive case) *)
+module type Test_Concrete = sig
+  module type S := sig
+    module type A = sig type t type u end
+    module X' : A
+  end
+
+  module rec X : (S with module type A = sig type u type t end)
+  and Y : sig type v = X.X'.t end
+end
+[%%expect {|
+module type Test_Concrete =
+  sig
+    module rec X :
+      sig module type A = sig type u type t end module X' : A end
+    and Y : sig type v = X.X'.t end
+  end
+|}]
+
+(* Approximating a signature with a constraint should merge the approximated
+   constraint (concrete, destructive case) *)
+module type Test_Concrete_Destructive = sig
+  module type S := sig
+    module type A = sig type t type u end
+    module X' : A
+  end
+
+  module rec X : (S with module type A := sig type u type t end)
+  and Y : sig type v = X.X'.t end
+end
+[%%expect {|
+module type Test_Concrete_Destructive =
+  sig
+    module rec X : sig module X' : sig type u type t end end
+    and Y : sig type v = X.X'.t end
+  end
+|}]
+
+
+(* Approximating a signature with a constraint should merge the approximated
+   constraint (deep, abstract, non destructive case) *)
+module type Test_Deep_Abstract = sig
+  module type S := sig
+    module M : sig
+      module type A
+      module X1 : A
+    end
+    module X2 : M.A
+  end
+
+  module rec X : (S with module type M.A = sig type t end)
+  and Y : sig type u = X.X2.t * X.M.X1.t end
+end
+[%%expect {|
+module type Test_Deep_Abstract =
+  sig
+    module rec X :
+      sig
+        module M : sig module type A = sig type t end module X1 : A end
+        module X2 : M.A
+      end
+    and Y : sig type u = X.X2.t * X.M.X1.t end
+  end
+|}]
+
+
+(* Approximating a signature with a constraint should merge the approximated
+   constraint (deep, abstract, destructive case) *)
+module type Test_Deep_Abstract_Destructive = sig
+  module type S := sig
+    module M : sig
+      module type A
+      module X1 : A
+    end
+    module X2 : M.A
+  end
+
+  module rec X : (S with module type M.A := sig type t end)
+  and Y : sig type u = X.X2.t * X.M.X1.t end
+end
+[%%expect {|
+module type Test_Deep_Abstract_Destructive =
+  sig
+    module rec X :
+      sig
+        module M : sig module X1 : sig type t end end
+        module X2 : sig type t end
+      end
+    and Y : sig type u = X.X2.t * X.M.X1.t end
+  end
+|}]
+
+
+(* Approximating a signature with a constraint should merge the approximated
+   constraint (deep, concrete, non destructive case) *)
+module type Test_Deep_Concrete = sig
+  module type S := sig
+    module M : sig
+      module type A = sig type t type u end
+      module X1 : A
+    end
+    module X2 : M.A
+  end
+
+  module rec X : (S with module type M.A = sig type u type t end)
+  and Y : sig type u = X.X2.t * X.M.X1.t end
+end
+[%%expect {|
+module type Test_Deep_Concrete =
+  sig
+    module rec X :
+      sig
+        module M :
+          sig module type A = sig type u type t end module X1 : A end
+        module X2 : M.A
+      end
+    and Y : sig type u = X.X2.t * X.M.X1.t end
+  end
+|}]
+
+
+(* Approximating a signature with a constraint should merge the approximated
+   constraint (deep, concrete, destructive case) *)
+module type Test_Deep_Concrete_Destructive = sig
+  module type S := sig
+    module M : sig
+      module type A = sig type t type u end
+      module X1 : A
+    end
+    module X2 : M.A
+  end
+
+  module rec X : (S with module type M.A := sig type u type t end)
+  and Y : sig type u = X.X2.t * X.M.X1.t end
+end
+[%%expect {|
+module type Test_Deep_Concrete_Destructive =
+  sig
+    module rec X :
+      sig
+        module M : sig module X1 : sig type u type t end end
+        module X2 : sig type u type t end
+      end
+    and Y : sig type u = X.X2.t * X.M.X1.t end
+  end
+|}]
+
+
+(* Invalid substitutions might be accepted during the approximation phase, but
+   should be rejected during typechecking of signatures (before typechecking of
+   module bodies) *)
+module type Test = sig
+  module rec X : (sig
+      module type A = sig type t = bool end
+      module X' : A
+    end with module type A = sig type t = int end)
+  and Y : sig type u = X.X'.t end
+end
+[%%expect {|
+Lines 2-5, characters 18-49:
+2 | ..................sig
+3 |       module type A = sig type t = bool end
+4 |       module X' : A
+5 |     end with module type A = sig type t = int end.
+Error: In this "with" constraint, the new definition of "A"
+       does not match its original definition in the constrained signature:
+       At position "module type A = <here>"
+       Module types do not match:
+         sig type t = bool end
+       is not equal to
+         sig type t = int end
+       At position "module type A = <here>"
+       Type declarations do not match:
+         type t = bool
+       is not included in
+         type t = int
+       The type "bool" is not equal to the type "int"
+|}]

--- a/testsuite/tests/typing-modules/recursive.ml
+++ b/testsuite/tests/typing-modules/recursive.ml
@@ -12,3 +12,27 @@ Line 1, characters 0-39:
 Error: The type abbreviation "T.t" is cyclic:
          "T.t" = "T.t"
 |}]
+
+(* Cyclic module type definitions should throw an error *)
+module rec X : (sig module type A = X.A end)
+  = struct module type A end
+[%%expect {|
+Line 1, characters 36-39:
+1 | module rec X : (sig module type A = X.A end)
+                                        ^^^
+Error: This module type is recursive. This use of the recursive module "X"
+       within its own definition makes the module type of "X" depend on itself.
+       Such recursive definitions of module types are not allowed.
+|}]
+
+(* Cyclic module type definitions should throw an error *)
+module rec X : (sig module type A := X.A end)
+  = struct end
+[%%expect {|
+Line 1, characters 37-40:
+1 | module rec X : (sig module type A := X.A end)
+                                         ^^^
+Error: This module type is recursive. This use of the recursive module "X"
+       within its own definition makes the module type of "X" depend on itself.
+       Such recursive definitions of module types are not allowed.
+|}]

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -624,7 +624,8 @@ and remove_modality_and_zero_alloc_variables_mty env ~zap_modality mty =
       in
       Mty_strengthen (mty, path, alias)
 
-type with_info =
+type merge_constraint =
+  (* Normal merging cases that returns a typed tree *)
   | With_type of Parsetree.type_declaration
   | With_typesubst of Parsetree.type_declaration
   | With_module of {
@@ -636,16 +637,38 @@ type with_info =
   | With_modsubst of Longident.t loc * Path.t * Types.module_declaration
   | With_modtype of Typedtree.module_type
   | With_modtypesubst of Typedtree.module_type
-  | With_type_package of Typedtree.core_type
-    (* Package with type constraints only use this last case.  Normal module
-       with constraints never use it. *)
 
-let merge_constraint initial_env loc sg lid constr =
+  (* Package with type constraints only use this last case. *)
+  | With_type_package of Typedtree.core_type
+
+  (* Merging of module types during signature approximation *)
+  | Approx_with_modtype      of Types.module_type
+  | Approx_with_modtypesubst of Types.module_type
+
+type merge_result = Path.t * merge_info * Types.signature
+and merge_info =
+  (* Result of normal merging *)
+  | Built_TypedTree of {
+      lid: Longident.t Asttypes.loc ;
+      constr : Typedtree.with_constraint
+    }
+  (* Result of merging a package_type or merging approximated module types
+     (without typedtree) *)
+  | No_TypedTree
+
+let merge_constraint_aux initial_env loc sg lid constr : merge_result =
   let destructive_substitution =
     match constr with
     | With_type _ | With_module _ | With_modtype _
+    | Approx_with_modtype _
     | With_type_package _ -> false
-    | With_typesubst _ | With_modsubst _ | With_modtypesubst _  -> true
+    | With_typesubst _ | With_modsubst _ | With_modtypesubst _
+    | Approx_with_modtypesubst _ -> true
+  in
+  let approx_substitution =
+    match constr with
+    | Approx_with_modtype _ | Approx_with_modtypesubst _ -> true
+    | _ -> false
   in
   let real_ids = ref [] in
   let split_row_id s ghosts =
@@ -672,6 +695,32 @@ let merge_constraint initial_env loc sg lid constr =
   let rec patch_item constr namelist outer_sig_env sg_for_env ~ghosts item =
     let return ?(ghosts=ghosts) ~replace_by info =
       Some (info, {Signature_group.ghosts; replace_by})
+    in
+    let patch_modtype_item
+        id (mtd: Types.modtype_declaration) priv mty  =
+      let sig_env = Env.add_signature sg_for_env outer_sig_env in
+      (* Check for equivalence if the previous module type was not empty. During
+         approximation, the equivalence check is ignored. *)
+      let () = match approx_substitution, mtd.mtd_type with
+        | false, Some previous_mty ->
+            Includemod.check_modtype_equiv ~loc sig_env
+              id previous_mty mty
+        | _ -> ()
+      in
+      if not destructive_substitution then
+        let mtd': modtype_declaration =
+          {
+            mtd_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
+            mtd_type = Some mty;
+            mtd_attributes = [];
+            mtd_loc = loc;
+          }
+        in Some(Sig_modtype(id, mtd', priv))
+      else begin
+        let path = Pident id in
+        real_ids := [path];
+        None
+      end
     in
     match item, namelist, constr with
     | Sig_type(id, decl, rs, priv), [s],
@@ -732,9 +781,9 @@ let merge_constraint initial_env loc sg lid constr =
         in
         return ~ghosts
           ~replace_by:(Some (Sig_type(id, newdecl, rs, priv)))
-          (Pident id, lid, Some (Twith_type tdecl))
+          (Pident id, Built_TypedTree {lid=lid; constr=Twith_type tdecl} )
     | Sig_type(id, sig_decl, rs, priv) , [s],
-       (With_type sdecl | With_typesubst sdecl as constr)
+       (With_type sdecl | With_typesubst sdecl)
       when Ident.name id = s ->
         let sig_env = Env.add_signature sg_for_env outer_sig_env in
         let tdecl =
@@ -745,15 +794,16 @@ let merge_constraint initial_env loc sg lid constr =
         let ghosts = List.rev_append before_ghosts after_ghosts in
         check_type_decl outer_sig_env sg_for_env loc
           id row_id newdecl sig_decl;
-        begin match constr with
-          With_type _ ->
-            return ~ghosts
-              ~replace_by:(Some(Sig_type(id, newdecl, rs, priv)))
-              (Pident id, lid, Some (Twith_type tdecl))
-        | (* With_typesubst *) _ ->
-            real_ids := [Pident id];
-            return ~ghosts ~replace_by:None
-              (Pident id, lid, Some (Twith_typesubst tdecl))
+        if not destructive_substitution then
+          return ~ghosts
+            ~replace_by:(Some(Sig_type(id, newdecl, rs, priv)))
+            (Pident id, Built_TypedTree {
+                  lid=lid; constr=(Twith_type tdecl)})
+        else begin
+          real_ids := [Pident id];
+          return ~ghosts ~replace_by:None
+            (Pident id, Built_TypedTree {
+                  lid=lid; constr=(Twith_typesubst tdecl)})
         end
     | Sig_type(id, sig_decl, rs, priv), [s], With_type_package cty
       when Ident.name id = s ->
@@ -778,35 +828,24 @@ let merge_constraint initial_env loc sg lid constr =
         check_type_decl outer_sig_env sg_for_env loc id None tdecl sig_decl;
         let tdecl = { tdecl with type_manifest = None } in
         return ~ghosts ~replace_by:(Some(Sig_type(id, tdecl, rs, priv)))
-          (Pident id, lid, None)
+          (Pident id, No_TypedTree)
     | Sig_modtype(id, mtd, priv), [s],
       (With_modtype mty | With_modtypesubst mty)
       when Ident.name id = s ->
-        let sig_env = Env.add_signature sg_for_env outer_sig_env in
-        let () = match mtd.mtd_type with
-          | None -> ()
-          | Some previous_mty ->
-              Includemod.check_modtype_equiv ~loc sig_env
-                id previous_mty mty.mty_type
+        let new_item = patch_modtype_item id mtd priv mty.mty_type in
+        let constr_tt =
+          if not destructive_substitution then
+            (Twith_modtype mty)
+          else
+            (Twith_modtypesubst mty)
         in
-        if not destructive_substitution then
-          let mtd': modtype_declaration =
-            {
-              mtd_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
-              mtd_type = Some mty.mty_type;
-              mtd_attributes = [];
-              mtd_loc = loc;
-            }
-          in
-          return
-            ~replace_by:(Some(Sig_modtype(id, mtd', priv)))
-            (Pident id, lid, Some (Twith_modtype mty))
-        else begin
-          let path = Pident id in
-          real_ids := [path];
-          return ~replace_by:None
-            (Pident id, lid, Some (Twith_modtypesubst mty))
-        end
+        return ~replace_by:new_item
+          (Pident id, Built_TypedTree {lid; constr=constr_tt})
+    | Sig_modtype(id, mtd, priv), [s],
+      (Approx_with_modtype mty | Approx_with_modtypesubst mty)
+      when Ident.name id = s ->
+        let new_item = patch_modtype_item id mtd priv mty in
+        return ~replace_by:new_item (Pident id, No_TypedTree)
     | Sig_module(id, pres, md, rs, priv), [s],
       With_module {lid=lid'; md=md'; path; remove_aliases}
       when Ident.name id = s ->
@@ -823,7 +862,8 @@ let merge_constraint initial_env loc sg lid constr =
           ~modes:(Legacy None) newmd.md_type md.md_type);
         return
           ~replace_by:(Some(Sig_module(id, pres, newmd, rs, priv)))
-          (Pident id, lid, Some (Twith_module (path, lid')))
+          (Pident id, Built_TypedTree {
+              lid=lid; constr=(Twith_module (path, lid'))})
     | Sig_module(id, _, md, _rs, _), [s], With_modsubst (lid',path,md')
       when Ident.name id = s ->
         let sig_env = Env.add_signature sg_for_env outer_sig_env in
@@ -833,12 +873,15 @@ let merge_constraint initial_env loc sg lid constr =
              ~aliasable sig_env ~mmodes:(Legacy None) md' path md);
         real_ids := [Pident id];
         return ~replace_by:None
-          (Pident id, lid, Some (Twith_modsubst (path, lid')))
-    | Sig_module(id, _, md, rs, priv) as item, s :: namelist, constr
+          (Pident id, Built_TypedTree {
+               lid=lid; constr=(Twith_modsubst (path, lid'))})
+
+    (* When the constraint affects a component of a submodule *)
+    | Sig_module(id, _, md, rs, priv) as current_item, s :: namelist, _
       when Ident.name id = s ->
         let sig_env = Env.add_signature sg_for_env outer_sig_env in
         let sg = extract_sig sig_env loc md.md_type in
-        let ((path, _, tcstr), newsg) = merge_signature sig_env sg namelist in
+        let subpath, merge_info, newsg = merge_signature sig_env sg namelist in
         let newsg =
           if destructive_substitution then
             remove_modality_and_zero_alloc_variables_sg sig_env
@@ -846,34 +889,43 @@ let merge_constraint initial_env loc sg lid constr =
           else
             newsg
         in
-        let path = path_concat id path in
-        real_ids := path :: !real_ids;
-        let item =
-          match md.md_type, constr with
-            Mty_alias _, (With_module _ | With_type _) ->
-              (* A module alias cannot be refined, so keep it
-                 and just check that the constraint is correct *)
-              item
-          | _ ->
-              let newmd = {md with md_type = Mty_signature newsg} in
-              Sig_module(id, Mp_present, newmd, rs, priv)
-        in
-        return ~replace_by:(Some item) (path, lid, tcstr)
+        let path = path_concat id subpath in
+        real_ids := path :: !real_ids ;
+        begin match md.md_type, merge_info with
+        (* A module alias cannot be refined, so keep it
+           and just check that the constraint is correct *)
+        | Mty_alias _, Built_TypedTree
+            { lid; constr = (Twith_module _
+                            | Twith_type _
+                            | Twith_modtype _) as tcstr } ->
+            return ~replace_by:(Some current_item)
+              (path, Built_TypedTree { lid; constr=tcstr} )
+        | _, Built_TypedTree { lid; constr } ->
+            let new_md = {md with md_type = Mty_signature newsg} in
+            let new_item = Sig_module(id, Mp_present, new_md, rs, priv) in
+            return ~replace_by:(Some new_item)
+              (path, Built_TypedTree {lid; constr})
+        | _, No_TypedTree ->
+            let new_md = {md with md_type = Mty_signature newsg} in
+            let new_item = Sig_module(id, Mp_present, new_md, rs, priv) in
+            return ~replace_by:(Some new_item) (path, No_TypedTree)
+        end
     | _ -> None
   and merge_signature env sg namelist =
     match
       Signature_group.replace_in_place (patch_item constr namelist env sg) sg
     with
-    | Some (x,sg) -> x, sg
+    | Some ((path, res), sg) -> path, res, sg
     | None -> raise(Error(loc, env, With_no_component lid.txt))
   in
   try
     let names = Longident.flatten lid.txt in
-    let (tcstr, sg) = merge_signature initial_env sg names in
+    let (path, merge_info, sg) = merge_signature initial_env sg names in
     if destructive_substitution then
       check_usage_after_substitution ~loc ~lid initial_env !real_ids sg;
-    let sub = match tcstr with
-      | (_, _, Some (Twith_typesubst tdecl)) ->
+    let sub =
+      match merge_info, constr with
+      | Built_TypedTree {constr=Twith_typesubst tdecl},_ ->
           let how_to_extend_subst =
             let sdecl =
               match constr with
@@ -900,7 +952,7 @@ let merge_constraint initial_env loc sg lid constr =
           let sub = Subst.change_locs Subst.identity loc in
           let sub = List.fold_left how_to_extend_subst sub !real_ids in
           Some sub
-      | (_, _, Some (Twith_modsubst (real_path, _))) ->
+      | Built_TypedTree {constr=Twith_modsubst (real_path, _)},_ ->
         let sub = Subst.change_locs Subst.identity loc in
         let sub =
           List.fold_left
@@ -909,8 +961,9 @@ let merge_constraint initial_env loc sg lid constr =
             !real_ids
         in
         Some sub
-      | (_, _, Some (Twith_modtypesubst tmty)) ->
-          let add s p = Subst.Unsafe.add_modtype_path p tmty.mty_type s in
+    | Built_TypedTree {constr=Twith_modtypesubst {mty_type=mty}}, _
+    | _, Approx_with_modtypesubst mty ->
+        let add s p = Subst.Unsafe.add_modtype_path p mty s in
           let sub = Subst.change_locs Subst.identity loc in
           let sub = List.fold_left add sub !real_ids in
           Some sub
@@ -929,13 +982,22 @@ let merge_constraint initial_env loc sg lid constr =
     in
     check_well_formed_module initial_env loc "this instantiated signature"
       (Mty_signature sg);
-    (tcstr, sg)
+    (path, merge_info, sg)
   with Includemod.Error explanation ->
     raise(Error(loc, initial_env, With_mismatch(lid.txt, explanation)))
 
-let merge_package_constraint initial_env loc sg lid cty =
-  let _, s = merge_constraint initial_env loc sg lid (With_type_package cty) in
-  s
+(* Normal merge function - build the typed tree *)
+let merge_constraint env loc sg lid cty =
+  match merge_constraint_aux env loc sg lid cty with
+  | path, Built_TypedTree { lid; constr }, newsg ->
+      (path, lid, constr, newsg)
+  | _, No_TypedTree, _ -> assert false
+
+(* Specialized merge function for package types *)
+let merge_package_constraint env loc sg lid cty =
+  match merge_constraint_aux env loc sg lid (With_type_package cty) with
+  | _, No_TypedTree, newsg -> newsg
+  | _, Built_TypedTree _, _ -> assert false
 
 let check_package_with_type_constraints loc env mty constraints =
   let sg = extract_sig env loc mty in
@@ -951,6 +1013,18 @@ let check_package_with_type_constraints loc env mty constraints =
 let () =
   Typetexp.check_package_with_type_constraints :=
     check_package_with_type_constraints
+
+(* Specialized merge function for merging during signature approximation *)
+let merge_constraint_approx env loc sg lid mty ~destructive =
+  let constr =
+    if not destructive then
+      Approx_with_modtype mty
+    else
+      Approx_with_modtypesubst mty
+  in
+  match merge_constraint_aux env loc sg lid constr with
+  | _, No_TypedTree, newsg -> newsg
+  | _, Built_TypedTree _, _ -> assert false
 
 (* Add recursion flags on declarations arising from a mutually recursive
    block. *)
@@ -1110,24 +1184,26 @@ let rec approx_modtype env smty =
       let res = approx_modtype newenv sres in
       Mty_functor(param, res)
   | Pmty_with(sbody, constraints) ->
-      let body = approx_modtype env sbody in
-      List.iter
-        (fun sdecl ->
-          match sdecl with
-          | Pwith_type _
-          | Pwith_typesubst _
-          | Pwith_modtype _
-          | Pwith_modtypesubst _  -> ()
-          | Pwith_module (_, lid') ->
-              (* Lookup the module to make sure that it is not recursive.
-                 (GPR#1626) *)
-              ignore (Env.lookup_module_path ~use:false ~load:false
-                        ~loc:lid'.loc lid'.txt env)
-          | Pwith_modsubst (_, lid') ->
-              ignore (Env.lookup_module_path ~use:false ~load:false
-                        ~loc:lid'.loc lid'.txt env))
-        constraints;
-      body
+      (* the module type body is approximated and resolved to a signature.*)
+      let approx_body = approx_modtype env sbody in
+      let initial_sig = extract_sig env sbody.pmty_loc approx_body in
+      (* then, the constraints are approximated and merged, instead of merged
+         and approximated. For (1) type constraints, (2) module constraints and
+         (3) module type constraints replacing an abstract module type, it
+         should be equivalent.
+
+         However, for module type constraints replacing a concrete module type,
+         approximating the constraint and the body before merging can interact
+         with the equivalence check that is done between the constraint and the
+         original definition. As approximation only tries to build a skeleton of
+         non-recursive module types that can be used as an under-approximation
+         of the name-spaces for the typechecking phase, the equivalence check is
+         disabled, allowing for ill-formed constraints to be merged. It is
+         should be harmless, because the ill-formedness is caught when
+         re-typechecking the module types (with the approximation in the
+         environment).  *)
+      Mty_signature (List.fold_left
+                       (approx_constraint env) initial_sig constraints)
   | Pmty_typeof smod ->
       let (_, mty) = !type_module_type_of_fwd env smod in
       mty
@@ -1282,6 +1358,29 @@ and approx_modtype_info env sinfo =
    mtd_loc = sinfo.pmtd_loc;
    mtd_uid = Uid.internal_not_actually_unique;
   }
+
+and approx_constraint env body constr =
+  match constr with
+  (* type substitutions are ignored *)
+  | Pwith_type _
+  | Pwith_typesubst _ -> body
+  (* module type substitutions are approximated then merged *)
+  | Pwith_modtype (id, smty)
+  | Pwith_modtypesubst (id, smty) ->
+      let destructive =
+        (match constr with | Pwith_modtypesubst _ -> true | _ -> false) in
+      let approx_smty = approx_modtype env smty in
+      merge_constraint_approx ~destructive
+        env smty.pmty_loc body id approx_smty
+  (* module substitutions are ignored, but checked for cyclicity *)
+  | Pwith_module (_, lid') ->
+      (* Lookup the module to make sure that it is not recursive.
+         (GPR#1626) *)
+      ignore (Env.lookup_module_path ~use:false ~load:false
+                ~loc:lid'.loc lid'.txt env) ; body
+  | Pwith_modsubst (_, lid') ->
+      ignore (Env.lookup_module_path ~use:false ~load:false
+                ~loc:lid'.loc lid'.txt env) ; body
 
 let approx_modtype env smty =
   Warnings.without_warnings
@@ -1715,10 +1814,8 @@ and transl_with ~loc env remove_aliases (rev_tcstrs,sg) constr =
         let mty = transl_modtype env smty in
         l, With_modtypesubst mty
   in
-  let ((path, lid, tcstr), sg) = merge_constraint env loc sg lid with_info in
-  (* Only package with constraints result in None here. *)
-  let tcstr = Option.get tcstr in
-  ((path, lid, tcstr) :: rev_tcstrs, sg)
+  let (path, lid, constr, sg) = merge_constraint env loc sg lid with_info in
+  ((path, lid, constr) :: rev_tcstrs, sg)
 
 and transl_signature env {psg_items; psg_modalities; psg_loc} =
   let names = Signature_names.create () in


### PR DESCRIPTION
Backports https://github.com/ocaml/ocaml/pull/13829.

### Stack
1. https://github.com/oxcaml/oxcaml/pull/4224
2. https://github.com/oxcaml/oxcaml/pull/4240
3. https://github.com/oxcaml/oxcaml/pull/4241
4. https://github.com/oxcaml/oxcaml/pull/4246
5. https://github.com/oxcaml/oxcaml/pull/4268