### PR TITLE
Remove with-bounds for GADTs

### DIFF
--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1265,10 +1265,17 @@ type 'a contended_with_int : immutable_data with 'a @@ contended
 type 'a abstract
 type existential_abstract : immutable_data with (type : value mod portable) abstract =
   | Mk : ('a : value mod portable) abstract -> existential_abstract
+(* CR layouts v2.8: This should be accepted *)
 [%%expect{|
 type 'a abstract
-type existential_abstract =
-    Mk : ('a : value mod portable). 'a abstract -> existential_abstract
+Lines 2-3, characters 0-67:
+2 | type existential_abstract : immutable_data with (type : value mod portable) abstract =
+3 |   | Mk : ('a : value mod portable) abstract -> existential_abstract
+Error: The kind of type "existential_abstract" is value mod non_float
+         because it's a boxed variant type.
+       But the kind of type "existential_abstract" must be a subkind of
+         immutable_data with (type : value mod portable) abstract
+         because of the annotation on the declaration of the type existential_abstract.
 |}]
 
 (* not yet supported *)

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1274,7 +1274,7 @@ Lines 2-3, characters 0-67:
 Error: The kind of type "existential_abstract" is value mod non_float
          because it's a boxed variant type.
        But the kind of type "existential_abstract" must be a subkind of
-         immutable_data with (type : value mod portable) abstract
+           immutable_data with (type : value mod portable) abstract
          because of the annotation on the declaration of the type existential_abstract.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/gadt.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt.ml
@@ -61,8 +61,12 @@ type t = Foo : ('a : immutable_data). 'a -> t
 |}]
 
 let foo (t : t @ contended) = use_uncontended t
+(* CR layouts v2.8: This should be accepted *)
 [%%expect {|
-val foo : t @ contended -> unit = <fun>
+Line 1, characters 46-47:
+1 | let foo (t : t @ contended) = use_uncontended t
+                                                  ^
+Error: This value is "contended" but expected to be "uncontended".
 |}]
 
 let foo (t : t @ local) = use_global t [@nontail]
@@ -81,8 +85,12 @@ type 'a t = Foo : 'a -> 'a t
 |}]
 
 let foo (t : int t @ once) = use_many t
+(* CR layouts v2.8: This should be accepted *)
 [%%expect {|
-val foo : int t @ once -> unit = <fun>
+Line 1, characters 38-39:
+1 | let foo (t : int t @ once) = use_many t
+                                          ^
+Error: This value is "once" but expected to be "many".
 |}]
 
 let foo (t : int t @ aliased) = use_unique t
@@ -104,7 +112,7 @@ Lines 1-3, characters 0-61:
 1 | type 'a t : value mod contended portable =
 2 |   | Shared : ('b : value mod contended portable). 'b  -> 'b t
 3 |   | Unshared : (unit -> 'c) @@ portable               -> 'c t
-Error: The kind of type "t" is value mod portable immutable non_float with 'a
+Error: The kind of type "t" is value mod non_float
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of
            value mod contended portable
@@ -176,8 +184,16 @@ type ('a, 'b) t = { inner : 'a; }
 type 'a u : immutable_data with 'a =
 | P1 : ('a1, 'b) t -> 'a1 u
 | P2 : ('a2, 'b) t -> 'a2 u
+(* CR layouts v2.8: This should be accepted *)
 [%%expect{|
-type 'a u = P1 : ('a1, 'b) t -> 'a1 u | P2 : ('a2, 'b) t -> 'a2 u
+Lines 1-3, characters 0-27:
+1 | type 'a u : immutable_data with 'a =
+2 | | P1 : ('a1, 'b) t -> 'a1 u
+3 | | P2 : ('a2, 'b) t -> 'a2 u
+Error: The kind of type "u" is value mod non_float
+         because it's a boxed variant type.
+       But the kind of type "u" must be a subkind of immutable_data with 'a
+         because of the annotation on the declaration of the type u.
 |}]
 
 (* Any existentials in the with-bounds turn into [(type : kind)] then get normalized away.
@@ -213,7 +229,15 @@ type ('x, 'y) t : immutable_data with 'x with 'y =
   | T : 'a -> ('a, 'a) t
   | U : 'c -> ('b,  'c) t
 [%%expect{|
-type ('x, 'y) t = T : 'a -> ('a, 'a) t | U : 'c -> ('b, 'c) t
+Lines 1-3, characters 0-25:
+1 | type ('x, 'y) t : immutable_data with 'x with 'y =
+2 |   | T : 'a -> ('a, 'a) t
+3 |   | U : 'c -> ('b,  'c) t
+Error: The kind of type "t" is value mod non_float
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of
+           immutable_data with 'x with 'y
+         because of the annotation on the declaration of the type t.
 |}]
 
 type 'a t : immediate =
@@ -230,8 +254,15 @@ Error: The kind of type "t" is value mod non_float
 
 type 'a t : immutable_data =
   | A : ('b : immutable_data). 'b -> 'b option t
+(* CR layouts v2.8: This should be accepted *)
 [%%expect{|
-type 'a t = A : ('b : immutable_data). 'b -> 'b option t
+Lines 1-2, characters 0-48:
+1 | type 'a t : immutable_data =
+2 |   | A : ('b : immutable_data). 'b -> 'b option t
+Error: The kind of type "t" is value mod non_float
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of immutable_data
+         because of the annotation on the declaration of the type t.
 |}]
 
 type 'a t : immediate =
@@ -240,7 +271,7 @@ type 'a t : immediate =
 Lines 1-2, characters 0-48:
 1 | type 'a t : immediate =
 2 |   | A : ('b : immutable_data). 'b -> 'b option t
-Error: The kind of type "t" is immutable_data
+Error: The kind of type "t" is value mod non_float
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immediate
          because of the annotation on the declaration of the type t.
@@ -249,19 +280,31 @@ Error: The kind of type "t" is immutable_data
 type 'a cell : mutable_data with 'a =
   | Nil : 'a cell
   | Cons of { value : 'a; mutable next: 'a cell }
+(* CR layouts v2.8: This should be accepted *)
 [%%expect{|
-type 'a cell =
-    Nil : 'a cell
-  | Cons of { value : 'a; mutable next : 'a cell; }
+Lines 1-3, characters 0-49:
+1 | type 'a cell : mutable_data with 'a =
+2 |   | Nil : 'a cell
+3 |   | Cons of { value : 'a; mutable next: 'a cell }
+Error: The kind of type "cell" is value mod non_float
+         because it's a boxed variant type.
+       But the kind of type "cell" must be a subkind of mutable_data with 'a
+         because of the annotation on the declaration of the type cell.
 |}]
 
 type 'a cell : mutable_data with 'a =
   | Nil
   | Cons : { value : 'b; mutable next: 'b cell } -> 'b cell
+(* CR layouts v2.8: This should be accepted *)
 [%%expect{|
-type 'a cell =
-    Nil
-  | Cons : { value : 'b; mutable next : 'b cell; } -> 'b cell
+Lines 1-3, characters 0-59:
+1 | type 'a cell : mutable_data with 'a =
+2 |   | Nil
+3 |   | Cons : { value : 'b; mutable next: 'b cell } -> 'b cell
+Error: The kind of type "cell" is value mod non_float
+         because it's a boxed variant type.
+       But the kind of type "cell" must be a subkind of mutable_data with 'a
+         because of the annotation on the declaration of the type cell.
 |}]
 
 (* Existentials that are the type arguments to abstract types should end up as [type :
@@ -277,8 +320,7 @@ type 'a abstract : value mod portable
 Lines 2-3, characters 0-70:
 2 | type existential_abstract : immediate =
 3 |   | P : ('a : value mod portable). 'a abstract -> existential_abstract
-Error: The kind of type "existential_abstract" is
-           immutable_data with (type : value mod portable) abstract
+Error: The kind of type "existential_abstract" is value mod non_float
          because it's a boxed variant type.
        But the kind of type "existential_abstract" must be a subkind of
            immediate
@@ -287,16 +329,30 @@ Error: The kind of type "existential_abstract" is
 
 type existential_abstract : immutable_data with (type : value mod portable) abstract =
   | P : ('a : value mod portable). 'a abstract -> existential_abstract
+(* CR layouts v2.8: This should be accepted *)
 [%%expect{|
-type existential_abstract =
-    P : ('a : value mod portable). 'a abstract -> existential_abstract
+Lines 1-2, characters 0-70:
+1 | type existential_abstract : immutable_data with (type : value mod portable) abstract =
+2 |   | P : ('a : value mod portable). 'a abstract -> existential_abstract
+Error: The kind of type "existential_abstract" is value mod non_float
+         because it's a boxed variant type.
+       But the kind of type "existential_abstract" must be a subkind of
+           immutable_data with (type : value mod portable) abstract
+         because of the annotation on the declaration of the type existential_abstract.
 |}]
 
 type existential_abstract : value mod portable =
   | P : ('a : value mod portable). 'a abstract -> existential_abstract
+(* CR layouts v2.8: This should be accepted *)
 [%%expect{|
-type existential_abstract =
-    P : ('a : value mod portable). 'a abstract -> existential_abstract
+Lines 1-2, characters 0-70:
+1 | type existential_abstract : value mod portable =
+2 |   | P : ('a : value mod portable). 'a abstract -> existential_abstract
+Error: The kind of type "existential_abstract" is value mod non_float
+         because it's a boxed variant type.
+       But the kind of type "existential_abstract" must be a subkind of
+           value mod portable
+         because of the annotation on the declaration of the type existential_abstract.
 |}]
 
 let foo (x : existential_abstract @ nonportable) =
@@ -307,10 +363,12 @@ module M : sig
 end = struct
   type t = P : ('a : value mod portable). 'a abstract -> t
 end
+(* CR layouts v2.8: This should be accepted *)
 [%%expect{|
-val foo : existential_abstract -> unit = <fun>
-module M :
-  sig type t : immutable_data with (type : value mod portable) abstract end
+Line 1, characters 13-33:
+1 | let foo (x : existential_abstract @ nonportable) =
+                 ^^^^^^^^^^^^^^^^^^^^
+Error: Unbound type constructor "existential_abstract"
 |}]
 
 module M : sig
@@ -336,8 +394,7 @@ Error: Signature mismatch:
          type t = P : ('a : immediate). 'a abstract -> t
        is not included in
          type t : immutable_data with (type : value) abstract
-       The kind of the first is
-           immutable_data with (type : immediate) abstract
+       The kind of the first is value mod non_float
          because of the definition of t at line 4, characters 2-49.
        But the kind of the first must be a subkind of
            immutable_data with (type : value) abstract
@@ -349,13 +406,16 @@ type existential_abstract : value mod portable with (type : value mod portable) 
   | P : ('a : value mod portable). 'a abstract t2 -> existential_abstract
 and 'a t2 = P : { contents : 'a; other : ('b : value mod portable) option } -> 'a t2
 and 'a abstract : value mod portable
+(* CR layouts v2.8: This should be accepted *)
 [%%expect{|
-type existential_abstract =
-    P : ('a : value mod portable). 'a abstract t2 -> existential_abstract
-and 'a t2 =
-    P : 'a ('b : value mod portable). { contents : 'a; other : 'b option;
-    } -> 'a t2
-and 'a abstract : value mod portable
+Lines 1-2, characters 0-73:
+1 | type existential_abstract : value mod portable with (type : value mod portable) abstract =
+2 |   | P : ('a : value mod portable). 'a abstract t2 -> existential_abstract
+Error: The kind of type "existential_abstract" is value mod non_float
+         because it's a boxed variant type.
+       But the kind of type "existential_abstract" must be a subkind of
+           value mod portable with (type : value mod portable) abstract/2
+         because of the annotation on the declaration of the type existential_abstract.
 |}]
 
 (* Actually mode crossing for [type : kind] *)
@@ -384,33 +444,30 @@ module F2(M : S with type 'a b = int) = struct
   let foo1 (x : M.t @ nonportable) = use_portable x
   let foo2 (x : M.t @ contended) = use_uncontended x
 end
+(* CR layouts v2.8: This should be accepted *)
 [%%expect{|
-module F2 :
-  functor
-    (M : sig
-           type 'a b = int
-           type t = P : ('a : value mod portable). 'a b -> t
-         end)
-    ->
-    sig
-      type t = M.t
-      val foo1 : M.t -> unit
-      val foo2 : M.t @ contended -> unit
-    end
+Line 2, characters 2-31:
+2 |   type t : immutable_data = M.t
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "M.t" is value mod non_float
+         because of the definition of t at line 3, characters 2-47.
+       But the kind of type "M.t" must be a subkind of immutable_data
+         because of the definition of t at line 2, characters 2-31.
 |}]
 
 module F3(M : S with type 'a b = 'a) = struct
   type t : value mod portable = M.t
   let foo (x : t @ nonportable) = use_portable x
 end
+(* CR layouts v2.8: This should be accepted *)
 [%%expect{|
-module F3 :
-  functor
-    (M : sig
-           type 'a b = 'a
-           type t = P : ('a : value mod portable). 'a b -> t
-         end)
-    -> sig type t = M.t val foo : t -> unit end
+Line 2, characters 2-35:
+2 |   type t : value mod portable = M.t
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "M/2.t" is value mod non_float
+         because of the definition of t at line 3, characters 2-47.
+       But the kind of type "M/2.t" must be a subkind of value mod portable
+         because of the definition of t at line 2, characters 2-35.
 |}]
 
 module F4(M : S with type 'a b = 'a) = struct
@@ -436,8 +493,12 @@ type _ box = Box : 'a -> 'a box
 |}]
 
 let foo (x : int box @ contended) = use_uncontended x
+(* CR layouts v2.8: This should be accepted *)
 [%%expect{|
-val foo : int box @ contended -> unit = <fun>
+Line 1, characters 52-53:
+1 | let foo (x : int box @ contended) = use_uncontended x
+                                                        ^
+Error: This value is "contended" but expected to be "uncontended".
 |}]
 
 let should_reject (x : int ref box @ contended) = use_uncontended x
@@ -455,8 +516,12 @@ type (_, _) box2 = Box2 : 'a -> ('a, 'a) box2
 |}]
 
 let foo (x : (int, int) box2 @ contended) = use_uncontended x
+(* CR layouts v2.8: This should be accepted *)
 [%%expect{|
-val foo : (int, int) box2 @ contended -> unit = <fun>
+Line 1, characters 60-61:
+1 | let foo (x : (int, int) box2 @ contended) = use_uncontended x
+                                                                ^
+Error: This value is "contended" but expected to be "uncontended".
 |}]
 
 let should_reject (x : (int ref, int ref) box2 @ contended) = use_uncontended x
@@ -472,7 +537,7 @@ type show_me_the_kind : immediate = (int ref, int ref) box2
 Line 1, characters 0-59:
 1 | type show_me_the_kind : immediate = (int ref, int ref) box2
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "(int ref, int ref) box2" is mutable_data
+Error: The kind of type "(int ref, int ref) box2" is value mod non_float
          because of the definition of box2 at line 1, characters 0-45.
        But the kind of type "(int ref, int ref) box2" must be a subkind of
            immediate
@@ -486,7 +551,7 @@ type _ box : immediate = Box : 'a -> 'a box
 Line 1, characters 0-43:
 1 | type _ box : immediate = Box : 'a -> 'a box
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "box" is immutable_data with _
+Error: The kind of type "box" is value mod non_float
          because it's a boxed variant type.
        But the kind of type "box" must be a subkind of immediate
          because of the annotation on the declaration of the type box.
@@ -495,8 +560,12 @@ Error: The kind of type "box" is immutable_data with _
 (* Only the first type parameter matters *)
 
 let crosses (x : (int, int ref) box2 @ contended) = use_uncontended x
+(* CR layouts v2.8: This should be accepted *)
 [%%expect{|
-val crosses : (int, int ref) box2 @ contended -> unit = <fun>
+Line 1, characters 68-69:
+1 | let crosses (x : (int, int ref) box2 @ contended) = use_uncontended x
+                                                                        ^
+Error: This value is "contended" but expected to be "uncontended".
 |}]
 
 let doesn't_cross (x : (int ref, int) box2 @ contended) = use_uncontended x
@@ -514,9 +583,17 @@ Error: This value is "contended" but expected to be "uncontended".
 type 'a t constraint 'a = 'b option
 type 'c t2 : immutable_data with (type : value) option t =
   | K : 'd t -> 'd t2
+(* CR layouts v2.8: This should be accepted *)
 [%%expect{|
 type 'a t constraint 'a = 'b option
-type 'c t2 = K : 'a option t -> 'a option t2
+Lines 2-3, characters 0-21:
+2 | type 'c t2 : immutable_data with (type : value) option t =
+3 |   | K : 'd t -> 'd t2
+Error: The kind of type "t2" is value mod non_float
+         because it's a boxed variant type.
+       But the kind of type "t2" must be a subkind of
+           immutable_data with (type : value) option t
+         because of the annotation on the declaration of the type t2.
 |}]
 
 type 'a t constraint 'a = 'b option
@@ -527,7 +604,7 @@ type 'a t constraint 'a = 'b option
 Lines 2-3, characters 0-21:
 2 | type 'c t2 : immediate =
 3 |   | K : 'd t -> 'd t2
-Error: The kind of type "t2" is immutable_data with (type : value) option t
+Error: The kind of type "t2" is value mod non_float
          because it's a boxed variant type.
        But the kind of type "t2" must be a subkind of immediate
          because of the annotation on the declaration of the type t2.
@@ -545,8 +622,7 @@ type show_me_the_kind : immediate = exist_row1
 Line 1, characters 0-46:
 1 | type show_me_the_kind : immediate = exist_row1
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "exist_row1" is
-           immutable_data with [< `A | `B of int ref ]
+Error: The kind of type "exist_row1" is value mod non_float
          because of the definition of exist_row1 at line 1, characters 0-67.
        But the kind of type "exist_row1" must be a subkind of immediate
          because of the definition of show_me_the_kind at line 1, characters 0-46.
@@ -579,8 +655,7 @@ type show_me_the_kind : immediate = exist_row2
 Line 1, characters 0-46:
 1 | type show_me_the_kind : immediate = exist_row2
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "exist_row2" is
-           immutable_data with [> `A | `B of int ref ]
+Error: The kind of type "exist_row2" is value mod non_float
          because of the definition of exist_row2 at line 1, characters 0-67.
        But the kind of type "exist_row2" must be a subkind of immediate
          because of the definition of show_me_the_kind at line 1, characters 0-46.
@@ -613,8 +688,7 @@ type 'a show_me_the_kind : immediate = 'a option exist_row3
 Line 1, characters 0-59:
 1 | type 'a show_me_the_kind : immediate = 'a option exist_row3
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a option exist_row3" is
-           immutable_data with [> `A | `B of int ref ]
+Error: The kind of type "'a option exist_row3" is value mod non_float
          because of the definition of exist_row3 at line 1, characters 0-80.
        But the kind of type "'a option exist_row3" must be a subkind of
            immediate

--- a/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/quality.ml
@@ -387,7 +387,7 @@ end = struct
 end
 [%%expect {|
 type gadt = Foo : int -> gadt
-module M : sig type t : value mod portable end
+module M : sig type t end
 |}]
 
 type gadt = Foo : int -> gadt
@@ -396,25 +396,10 @@ module M : sig
 end = struct
   type t
 end
+(* CR layouts v2.8: This should not be accepted *)
 [%%expect {|
 type gadt = Foo : int -> gadt
-Lines 4-6, characters 6-3:
-4 | ......struct
-5 |   type t
-6 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig type t end
-       is not included in
-         sig type t : value mod unyielding end
-       Type declarations do not match:
-         type t
-       is not included in
-         type t : value mod unyielding
-       The kind of the first is value
-         because of the definition of t at line 5, characters 2-8.
-       But the kind of the first must be a subkind of value mod unyielding
-         because of the definition of t at line 3, characters 2-37.
+module M : sig type t end
 |}]
 
 type gadt = Foo : int -> gadt [@@unboxed]

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2439,120 +2439,7 @@ let for_abbreviation ~type_jkind_purely ~modality ty =
     }
     ~annotation:None ~why:Abbreviation
 
-(* Note [With-bounds for GADTs]
-   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-   Inferring the with-bounds for a variant requires gathering bounds from each
-   constructor. We thus loop over each constructor:
-
-   A. If a constructor is not a GADT constructor, just add its fields and their
-   modalities as with-bounds.
-
-   B. If a constructor uses GADT syntax:
-
-   GADT constructors introduce their own local scope. That is, when we see
-
-   {[
-     type 'a t = K : 'b option -> 'b t
-   ]}
-
-   the ['b] in the constructor is distinct from the ['a] in the type header.
-   This would be true even if we wrote ['a] in the constructor: the variables
-   introduced in the type head never scope over GADT constructors.
-
-   So in order to get properly-scoped with-bounds, we must substitute.  But
-   what, exactly, do we substitute? The domain is the bare variables that appear
-   as arguments in the return type. The range is the corresponding variables in
-   the type head (even if those are written as [_]s; which are turned into
-   proper type variables by now).
-
-   We use [Ctype.apply] (passed in as [type_apply]) to perform the substitution.
-
-   We thus have
-
-   * STEP B1. Gather such variables from the result type, matching them with
-   their corresponding variables in the type head. We'll call these B1
-   variables.
-
-   We do not actually substitute quite yet.
-
-   There may still be other free type variables in the constructor type. Here
-   are some examples:
-
-   {[
-     type 'a t =
-       | K1 : 'o -> int t
-       | K2 : 'o -> 'o option t
-       | K3 : 'o -> 'b t
-   ]}
-
-   In each constructor, the type variable ['o] is not a B1 variable.  (The ['b]
-   in [K3] /is/ a B1 variable.) We call these variables /orphaned/. All
-   existential variables are orphans (as we see in [K1] and [K3]), but even
-   non-existential variables can be orphan (as we see in [K2]; note that ['o]
-   appears in the result).
-
-   We wish to replace each orphaned type variable with a [Tof_kind], holding
-   just its kind. Since [Tof_kind] has a *best* kind, they'll just get
-   normalized away during normalization, except in the case that they show up as
-   an argument to a type constructor representing an abstract type - in which
-   case, they still end up in the (fully normalized) with-bounds. For example,
-   the following type:
-
-   {[
-     type t : A : ('a : value mod portable). 'a abstract -> t
-   ]}
-
-   has kind:
-
-   {[
-     immutable_data with (type : value mod portable) abstract
-   ]}
-
-   This use of the [(type : <<kind>>)] construct is the reason we have
-   [Tof_kind] in the first place.
-
-   We thus have
-
-   * STEP B2. Gather the orphaned variables
-   * STEP B3. Build the [Tof_kind] types to use in the substitution
-   * STEP B4. Perform the substitution
-
-   There are wrinkles:
-
-   BW1. For repeated types on arguments, e.g. in the following type:
-
-   {[
-     type ('x, 'y) t = A : 'a -> ('a, 'a) t
-   ]}
-
-   we substitute only the *first* time we see an argument.  That means that in
-   the above type, we'll map all instances of ['a] to ['x] and infer a kind of
-   [immutable_data with 'x]. This is sound, but somewhat restrictive; in a
-   perfect world, we'd infer a kind of [immutable_data with ('x OR 'y)], but
-   that goes beyond what with-bounds can describe (which, if we implemented it,
-   would introduce a disjunction in type inference, requiring backtracking). At
-   some point in the future, we should at least change the subsumption algorithm
-   to accept either [immutable_data with 'x] or [immutable_data with 'y]
-   (* CR layouts v2.8: do that *)
-
-   BW2. All of the above applies for row variables. Here is an example:
-
-   {[
-     type t = K : [> `A] -> t
-   ]}
-
-   The row variable in the [ [> `A] ] is existential, and thus gets transformed
-   into a [(type : value)] when computing the kind of [t].
-
-   This fact has a few consequences:
-
-   * [Tof_kind] can appear as a [row_more].
-   * When [Tof_kind] is a [row_more], that row is considered fixed; it thus
-     needs a [fixed_explanation]. The [fixed_explanation] is [Existential], used
-     only for this purpose.
-*)
-let for_boxed_variant ~decl_params ~type_apply ~free_vars cstrs =
+let for_boxed_variant cstrs =
   let open Types in
   if List.for_all
        (* CR layouts v12: This code assumes that all voids mode-cross. I
@@ -2573,96 +2460,29 @@ let for_boxed_variant ~decl_params ~type_apply ~free_vars cstrs =
           | Cstr_record lbls -> has_mutable_label lbls)
         cstrs
     in
-    let base =
-      (if is_mutable then Builtin.mutable_data else Builtin.immutable_data)
-        ~why:Boxed_variant
-      |> mark_best
+    let has_gadt_constructor =
+      List.exists
+        (fun cstr -> match cstr.cd_res with None -> false | Some _ -> true)
+        cstrs
     in
-    let add_with_bounds_for_cstr jkind_so_far cstr =
-      let cstr_arg_tys, cstr_arg_modalities =
+    if has_gadt_constructor
+    then for_non_float ~why:Boxed_variant
+    else
+      let base =
+        (if is_mutable then Builtin.mutable_data else Builtin.immutable_data)
+          ~why:Boxed_variant
+        |> mark_best
+      in
+      let add_cstr_args cstr jkind =
         match cstr.cd_args with
         | Cstr_tuple args ->
-          List.fold_left
-            (fun (tys, ms) arg -> arg.ca_type :: tys, arg.ca_modalities :: ms)
-            ([], []) args
-        | Cstr_record lbls ->
-          List.fold_left
-            (fun (tys, ms) lbl -> lbl.ld_type :: tys, lbl.ld_modalities :: ms)
-            ([], []) lbls
+          List.fold_right
+            (fun arg ->
+              add_with_bounds ~modality:arg.ca_modalities ~type_expr:arg.ca_type)
+            args jkind
+        | Cstr_record lbls -> add_labels_as_with_bounds lbls jkind
       in
-      let cstr_arg_tys =
-        match cstr.cd_res with
-        | None -> cstr_arg_tys
-        | Some res ->
-          (* See Note [With-bounds for GADTs] for an overview *)
-          let apply_subst domain range tys =
-            if Misc.Stdlib.List.is_empty domain
-            then tys
-            else List.map (fun ty -> type_apply domain ty range) tys
-          in
-          (* STEP B1 from Note [With-bounds for GADTs]: *)
-          let res_args =
-            match Types.get_desc res with
-            | Tconstr (_, args, _) -> args
-            | _ -> Misc.fatal_error "cd_res must be Tconstr"
-          in
-          let domain, range, seen =
-            List.fold_left2
-              (fun ((domain, range, seen) as acc) arg param ->
-                if Btype.TypeSet.mem arg seen
-                then
-                  (* We've already seen this type parameter, so don't add it
-                     again.  See wrinkle BW1 from Note [With-bounds for GADTs]
-                  *)
-                  acc
-                else
-                  match Types.get_desc arg with
-                  | Tvar _ ->
-                    (* Only add types which are direct variables. Note that
-                       types which aren't variables might themselves /contain/
-                       variables; if those variables don't show up on another
-                       parameter, they're treated as orphaned. See example K2
-                       from Note [With-bounds for GADTs] *)
-                    arg :: domain, param :: range, Btype.TypeSet.add arg seen
-                  | _ -> acc)
-              ([], [], Btype.TypeSet.empty)
-              res_args decl_params
-          in
-          (* STEP B2 from Note [With-bounds for GADTs]: *)
-          let free_var_set = free_vars cstr_arg_tys in
-          let orphaned_type_var_set = Btype.TypeSet.diff free_var_set seen in
-          let orphaned_type_var_list =
-            Btype.TypeSet.elements orphaned_type_var_set
-          in
-          (* STEP B3 from Note [With-bounds for GADTs]: *)
-          let mk_type_of_kind ty =
-            match Types.get_desc ty with
-            (* use [newgenty] not [newty] here because we've already
-               generalized the decl and want to keep things at
-               generic_level *)
-            | Tvar { jkind; name = _ } -> Btype.newgenty (Tof_kind jkind)
-            | _ ->
-              Misc.fatal_error
-                "post-condition of [free_variable_set_of_list] violated"
-          in
-          let type_of_kind_list =
-            List.map mk_type_of_kind orphaned_type_var_list
-          in
-          (* STEP B4 from Note [With-bounds for GADTs]: *)
-          let cstr_arg_tys =
-            apply_subst
-              (orphaned_type_var_list @ domain)
-              (type_of_kind_list @ range)
-              cstr_arg_tys
-          in
-          cstr_arg_tys
-      in
-      List.fold_left2
-        (fun jkind type_expr modality ->
-          add_with_bounds ~modality ~type_expr jkind)
-        jkind_so_far cstr_arg_tys cstr_arg_modalities
-    in
-    List.fold_left add_with_bounds_for_cstr base cstrs
+      List.fold_right add_cstr_args cstrs base
 
 let for_boxed_tuple elts =
   List.fold_right

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -509,10 +509,7 @@ val for_boxed_record : Types.label_declaration list -> Types.jkind_l
 (** Choose an appropriate jkind for an unboxed record type. *)
 val for_unboxed_record : Types.label_declaration list -> Types.jkind_l
 
-(** Choose an appropriate jkind for a boxed variant type.
-
-    [decl_params] is the parameters in the head of the type declaration. [type_apply]
-    should be [Ctype.apply] partially applied to an [env]. *)
+(** Choose an appropriate jkind for a boxed variant type. *)
 val for_boxed_variant : Types.constructor_declaration list -> Types.jkind_l
 
 (** Choose an appropriate jkind for a boxed tuple type. *)

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -513,16 +513,7 @@ val for_unboxed_record : Types.label_declaration list -> Types.jkind_l
 
     [decl_params] is the parameters in the head of the type declaration. [type_apply]
     should be [Ctype.apply] partially applied to an [env]. *)
-val for_boxed_variant :
-  decl_params:Types.type_expr list ->
-  type_apply:
-    (Types.type_expr list ->
-    Types.type_expr ->
-    Types.type_expr list ->
-    Types.type_expr) ->
-  free_vars:(Types.type_expr list -> Btype.TypeSet.t) ->
-  Types.constructor_declaration list ->
-  Types.jkind_l
+val for_boxed_variant : Types.constructor_declaration list -> Types.jkind_l
 
 (** Choose an appropriate jkind for a boxed tuple type. *)
 val for_boxed_tuple : (string option * Types.type_expr) list -> Types.jkind_l

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1963,13 +1963,7 @@ let rec update_decl_jkind env dpath decl =
           (idx+1,cstr::cstrs)
         ) (0,[]) cstrs
       in
-      let jkind =
-        Jkind.for_boxed_variant
-          ~decl_params:decl.type_params
-          ~type_apply:(Ctype.apply env)
-          ~free_vars:(Ctype.free_variable_set_of_list env)
-          cstrs
-      in
+      let jkind = Jkind.for_boxed_variant cstrs in
       List.rev cstrs, rep, jkind
     | (([] | (_ :: _)), Variant_unboxed | _, Variant_extensible) ->
       assert false


### PR DESCRIPTION
This caused a major performance regression in some edge cases that we don't yet understand, so we're removing it temporarily until we can track down the issue.