### PR TITLE
Flambda2: Store kind on variables

### DIFF
--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -1358,8 +1358,12 @@ and cont_handlers env handler1 handler2 =
 let flambda_units u1 u2 =
   let ret_cont = Continuation.create ~sort:Toplevel_return () in
   let exn_cont = Continuation.create () in
-  let toplevel_my_region = Variable.create "toplevel_my_region" in
-  let toplevel_my_ghost_region = Variable.create "toplevel_my_ghost_region" in
+  let toplevel_my_region =
+    Variable.create "toplevel_my_region" Flambda_kind.region
+  in
+  let toplevel_my_ghost_region =
+    Variable.create "toplevel_my_ghost_region" Flambda_kind.region
+  in
   let mk_renaming u =
     let renaming = Renaming.empty in
     let renaming =

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -238,7 +238,10 @@ module Env = struct
       | Not_user_visible -> None
       | User_visible -> Some ()
     in
-    let var = Variable.create_with_same_name_as_ident ?user_visible id in
+    let var =
+      Variable.create_with_same_name_as_ident ?user_visible id
+        (Flambda_kind.With_subkind.kind kind)
+    in
     add_var t id var kind, var
 
   let add_vars_like t ids =
@@ -250,7 +253,9 @@ module Env = struct
             | Not_user_visible -> None
             | User_visible -> Some ()
           in
-          Variable.create_with_same_name_as_ident ?user_visible id, kind)
+          ( Variable.create_with_same_name_as_ident ?user_visible id
+              (Flambda_kind.With_subkind.kind kind),
+            kind ))
         ids
     in
     add_vars t (List.map (fun (id, _, _, _) -> id) ids) vars, List.map fst vars

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -228,25 +228,29 @@ module Variable_data = struct
     { compilation_unit : Compilation_unit.t;
       name : string;
       name_stamp : int;
+      kind : Flambda_kind.t;
       user_visible : bool
     }
 
   let flags = var_flags
 
   let [@ocamlformat "disable"] print ppf { compilation_unit; name; name_stamp;
-                                           user_visible; } =
+                                           kind; user_visible; } =
     Format.fprintf ppf "@[<hov 1>(\
         @[<hov 1>(compilation_unit@ %a)@]@ \
         @[<hov 1>(name@ %s)@]@ \
         @[<hov 1>(name_stamp@ %d)@]@ \
+        @[<hov 1>(kind@ %a)@]@ \
         @[<hov 1>(user_visible@ %b)@]\
         )@]"
       Compilation_unit.print_debug compilation_unit
       name
       name_stamp
+      Flambda_kind.print kind
       user_visible
 
-  let hash { compilation_unit; name = _; name_stamp; user_visible = _ } =
+  let hash
+      { compilation_unit; name = _; name_stamp; kind = _; user_visible = _ } =
     hash2 (Compilation_unit.hash compilation_unit) (Hashtbl.hash name_stamp)
 
   let equal t1 t2 =
@@ -256,6 +260,7 @@ module Variable_data = struct
       let { compilation_unit = compilation_unit1;
             name = _;
             name_stamp = name_stamp1;
+            kind = _;
             user_visible = _
           } =
         t1
@@ -263,6 +268,7 @@ module Variable_data = struct
       let { compilation_unit = compilation_unit2;
             name = _;
             name_stamp = name_stamp2;
+            kind = _;
             user_visible = _
           } =
         t2
@@ -435,11 +441,13 @@ module Variable = struct
 
   let name_stamp t = (find_data t).name_stamp
 
+  let kind t = (find_data t).kind
+
   let user_visible t = (find_data t).user_visible
 
   let previous_name_stamp = ref (-1)
 
-  let create ?user_visible name =
+  let create ?user_visible name kind =
     let name_stamp =
       (* CR mshinwell: check for overflow on 32 bit *)
       incr previous_name_stamp;
@@ -449,6 +457,7 @@ module Variable = struct
       { compilation_unit = Compilation_unit.get_current_exn ();
         name;
         name_stamp;
+        kind;
         user_visible = Option.is_some user_visible
       }
     in

--- a/middle_end/flambda2/identifiers/int_ids.mli
+++ b/middle_end/flambda2/identifiers/int_ids.mli
@@ -109,13 +109,15 @@ module Variable : sig
 
   module Lmap : Lmap.S with type key := t
 
-  val create : ?user_visible:unit -> string -> t
+  val create : ?user_visible:unit -> string -> Flambda_kind.t -> t
 
   val compilation_unit : t -> Compilation_unit.t
 
   val name : t -> string
 
   val name_stamp : t -> int
+
+  val kind : t -> Flambda_kind.t
 
   val user_visible : t -> bool
 

--- a/middle_end/flambda2/identifiers/variable.ml
+++ b/middle_end/flambda2/identifiers/variable.ml
@@ -16,13 +16,13 @@
 
 include Int_ids.Variable
 
-let create_with_same_name_as_ident ?user_visible ident : t =
-  create ?user_visible (Ident.name ident)
+let create_with_same_name_as_ident ?user_visible ident kind : t =
+  create ?user_visible (Ident.name ident) kind
 
 let rename ?append t =
   let name = match append with None -> name t | Some s -> name t ^ s in
   let user_visible = if user_visible t then Some () else None in
-  create ?user_visible name
+  create ?user_visible name (kind t)
 
 let is_renamed_version_of t t' =
   (* We only keep track of variables renamed with an empty {append} parameter *)

--- a/middle_end/flambda2/identifiers/variable.mli
+++ b/middle_end/flambda2/identifiers/variable.mli
@@ -18,7 +18,8 @@ include module type of struct
   include Int_ids.Variable
 end
 
-val create_with_same_name_as_ident : ?user_visible:unit -> Ident.t -> t
+val create_with_same_name_as_ident :
+  ?user_visible:unit -> Ident.t -> Flambda_kind.t -> t
 
 (** [rename] always returns a variable with a compilation unit set to that of
     the current unit, not the unit of the variable passed in. *)

--- a/middle_end/flambda2/reaper/dep_solver.ml
+++ b/middle_end/flambda2/reaper/dep_solver.ml
@@ -1603,7 +1603,7 @@ let fixpoint (graph : Global_flow_graph.graph) =
           in
           let fields =
             mk_unboxed_fields ~has_to_be_unboxed
-              ~mk:(fun _kind name -> Variable.create name)
+              ~mk:(fun kind name -> Variable.create name kind)
               db
               (get_all_usages db (Code_id_or_name.Map.singleton to_patch ()))
               new_name

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -929,7 +929,8 @@ let rebuild_apply env apply =
     in
     let func_decisions =
       List.map
-        (fun kind -> Keep (Variable.create "function_return", kind))
+        (fun kind ->
+          Keep (Variable.create "function_return" (KS.kind kind), kind))
         (Flambda_arity.unarized_components return_arity)
     in
     make_apply_wrapper env make_apply (Apply.continuation apply) func_decisions

--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -237,7 +237,7 @@ let record_set_of_closure_deps ~get_code_metadata ~le_monde_exterieur t =
           List.length
             (Flambda_arity.unarize (Code_metadata.params_arity code_metadata))
         in
-        let always_used = Variable.create "always_used" in
+        let always_used = Variable.create "always_used" Flambda_kind.value in
         Graph.add_use t.deps (Code_id_or_name.var always_used);
         for i = 0 to num_direct_params - 1 do
           Graph.add_coconstructor_dep t.deps
@@ -291,7 +291,7 @@ let record_set_of_closure_deps ~get_code_metadata ~le_monde_exterieur t =
             code_dep.return;
           Graph.add_constructor_dep t.deps ~from:call_witness Code_of_closure
             ~base:(Code_id_or_name.name name);
-          let untuple_var = Variable.create "untuple_var" in
+          let untuple_var = Variable.create "untuple_var" Flambda_kind.value in
           Graph.add_coconstructor_dep t.deps
             ~from:(Code_id_or_name.var untuple_var)
             (Param (Indirect_code_pointer, 0))
@@ -329,7 +329,7 @@ let record_set_of_closure_deps ~get_code_metadata ~le_monde_exterieur t =
                       ~base:func)
                   code_dep.return
               | _ :: _ ->
-                let v = Variable.create "partial_apply" in
+                let v = Variable.create "partial_apply" Flambda_kind.value in
                 Graph.add_constructor_dep t.deps ~from:(Code_id_or_name.var v)
                   (Apply (Indirect_code_pointer, Normal 0))
                   ~base:func;

--- a/middle_end/flambda2/simplify/common_subexpression_elimination.ml
+++ b/middle_end/flambda2/simplify/common_subexpression_elimination.ml
@@ -264,7 +264,7 @@ let join_one_cse_equation ~cse_at_each_use prim bound_to_map
       EP.Map.add prim bound_to cse, extra_bindings, env_extension, allowed
     | None | Some (Rhs_kind.Needs_extra_binding { bound_to = _ }) ->
       let prim_result_kind = P.result_kind' (EP.to_primitive prim) in
-      let var = Variable.create "cse_param" in
+      let var = Variable.create "cse_param" prim_result_kind in
       let var_duid = Flambda_debug_uid.none in
       let extra_param =
         BP.create var (K.With_subkind.anything prim_result_kind) var_duid

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -262,7 +262,7 @@ let create_coerced_singleton_let uacc var defining_expr
     | Prim _ | Set_of_closures _ | Static_consts _ | Rec_info _ -> (
       let uncoerced_var =
         let name = "uncoerced_" ^ Variable.unique_name (VB.var var) in
-        Variable.create name
+        Variable.create name (Variable.kind (VB.var var))
       in
       let uncoerced_var_duid = Flambda_debug_uid.none in
       (* CR sspies: In the future, try propagating the debugging UID information
@@ -822,7 +822,9 @@ let rewrite_fixed_arity_continuation0 uacc cont_or_apply_cont ~use_id arity :
       let params =
         List.map
           (fun kind ->
-            let param_var = Variable.create "param" in
+            let param_var =
+              Variable.create "param" (Flambda_kind.With_subkind.kind kind)
+            in
             let param_var_duid = Flambda_debug_uid.none in
             BP.create param_var kind param_var_duid)
           (Flambda_arity.unarized_components arity)

--- a/middle_end/flambda2/simplify/flow/mutable_unboxing.ml
+++ b/middle_end/flambda2/simplify/flow/mutable_unboxing.ml
@@ -483,7 +483,11 @@ module Fold_prims = struct
                       Misc.fatal_errorf
                         "[Mutable Unboxing] Cannot unbox constants")
                 in
-                let var = Variable.create (Printf.sprintf "%s_%i" name i) in
+                let var =
+                  Variable.create
+                    (Printf.sprintf "%s_%i" name i)
+                    (Flambda_kind.With_subkind.kind kind)
+                in
                 let var_duid = Flambda_debug_uid.none in
                 (* CR sspies: Improve the debug UID here in the future. *)
                 Bound_parameter.create var kind var_duid)

--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -355,9 +355,9 @@ module Group = struct
          ~exn_continuation:(Continuation.create ()) Bound_parameters.empty
          ~body:(Expr.create_invalid Code_not_rebuilt)
          ~free_names_of_body:Unknown
-         ~my_closure:(Variable.create "my_closure")
+         ~my_closure:(Variable.create "my_closure" Flambda_kind.value)
          ~my_region:None ~my_ghost_region:None
-         ~my_depth:(Variable.create "my_depth"))
+         ~my_depth:(Variable.create "my_depth" Flambda_kind.rec_info))
 
   let pieces_of_code_including_those_not_rebuilt t =
     ListLabels.filter_map t.consts ~f:(fun const ->

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -123,7 +123,7 @@ let simplify_direct_tuple_application ~simplify_expr dacc apply
   (* Create the list of variables and projections *)
   let vars_and_fields =
     List.init tuple_size (fun field ->
-        ( Variable.create "tuple_field",
+        ( Variable.create "tuple_field" K.value,
           Flambda_debug_uid.none,
           (* This internally created variable does not get a
              [Flambda_debug_uid.t]. *)
@@ -427,7 +427,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
       args
       (Flambda_arity.unarize param_arity)
   in
-  let wrapper_var = Variable.create "partial_app" in
+  let wrapper_var = Variable.create "partial_app" K.value in
   let wrapper_var_duid = Flambda_debug_uid.none in
   let compilation_unit = Compilation_unit.get_current_exn () in
   let wrapper_function_slot =
@@ -484,7 +484,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
         let remaining_params =
           List.map
             (fun kind ->
-              let param = Variable.create "param" in
+              let param = Variable.create "param" (KS.kind kind) in
               let param_duid = Flambda_debug_uid.none in
               Bound_parameter.create param kind param_duid)
             (Flambda_arity.unarize remaining_param_arity)
@@ -534,7 +534,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
               if Coercion.is_id coercion
               then Symbol symbol
               else
-                let var = Variable.create "symbol" in
+                let var = Variable.create "symbol" K.value in
                 if not (K.equal (K.With_subkind.kind kind) K.value)
                 then
                   Misc.fatal_errorf
@@ -561,18 +561,18 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
         let contains_no_escaping_local_allocs =
           match result_mode with Alloc_heap -> true | Alloc_local -> false
         in
-        let my_closure = Variable.create "my_closure" in
+        let my_closure = Variable.create "my_closure" K.value in
         let my_region =
           if contains_no_escaping_local_allocs
           then None
-          else Some (Variable.create "my_region")
+          else Some (Variable.create "my_region" K.region)
         in
         let my_ghost_region =
           if contains_no_escaping_local_allocs
           then None
-          else Some (Variable.create "my_ghost_region")
+          else Some (Variable.create "my_ghost_region" K.region)
         in
-        let my_depth = Variable.create "my_depth" in
+        let my_depth = Variable.create "my_depth" K.rec_info in
         let exn_continuation =
           Apply.exn_continuation apply |> Exn_continuation.without_extra_args
         in

--- a/middle_end/flambda2/simplify/simplify_extcall.ml
+++ b/middle_end/flambda2/simplify/simplify_extcall.ml
@@ -57,9 +57,9 @@ let let_prim ~dbg v v_duid prim (free_names, body) =
 (* ******************************** *)
 
 let simplify_comparison_of_tagged_immediates ~dbg dacc ~cmp_prim cont a b =
-  let v_comp = Variable.create "comp" in
+  let v_comp = Variable.create "comp" K.naked_immediate in
   let v_comp_duid = Flambda_debug_uid.none in
-  let tagged = Variable.create "tagged" in
+  let tagged = Variable.create "tagged" K.value in
   let tagged_duid = Flambda_debug_uid.none in
   let _free_names, res =
     let_prim ~dbg v_comp v_comp_duid (P.Binary (cmp_prim, a, b))
@@ -70,13 +70,17 @@ let simplify_comparison_of_tagged_immediates ~dbg dacc ~cmp_prim cont a b =
   Specialised (dacc, res, RO.specialized_poly_compare)
 
 let simplify_comparison_of_boxed_numbers ~dbg dacc ~kind ~cmp_prim cont a b =
-  let a_naked = Variable.create "unboxed" in
+  let a_naked =
+    Variable.create "unboxed" (K.Boxable_number.unboxed_kind kind)
+  in
   let a_naked_duid = Flambda_debug_uid.none in
-  let b_naked = Variable.create "unboxed" in
+  let b_naked =
+    Variable.create "unboxed" (K.Boxable_number.unboxed_kind kind)
+  in
   let b_naked_duid = Flambda_debug_uid.none in
-  let v_comp = Variable.create "comp" in
+  let v_comp = Variable.create "comp" K.naked_immediate in
   let v_comp_duid = Flambda_debug_uid.none in
-  let tagged = Variable.create "tagged" in
+  let tagged = Variable.create "tagged" K.value in
   let tagged_duid = Flambda_debug_uid.none in
   let _free_names, res =
     (* XXX try to remove @@ *)

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -388,7 +388,11 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
   let return_cont_params =
     List.mapi
       (fun i kind_with_subkind ->
-        let result_var = Variable.create ("result" ^ string_of_int i) in
+        let result_var =
+          Variable.create
+            ("result" ^ string_of_int i)
+            (KS.kind kind_with_subkind)
+        in
         let result_var_duid = Flambda_debug_uid.none in
         BP.create result_var kind_with_subkind result_var_duid)
       (Flambda_arity.unarized_components result_arity)

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -293,7 +293,7 @@ let rebuild_switch_with_single_arg_to_same_destination uacc ~dacc_before_switch
     dbg =
   let rebuilding = UA.are_rebuilding_terms uacc in
   let block_sym =
-    let var = Variable.create "switch_block" in
+    let var = Variable.create "switch_block" K.value in
     Symbol.create
       (Compilation_unit.get_current_exn ())
       (Linkage_name.of_string (Variable.unique_name var))
@@ -327,13 +327,13 @@ let rebuild_switch_with_single_arg_to_same_destination uacc ~dacc_before_switch
     Binary (Array_load (Values, Values, Immutable), block, tagged_scrutinee)
   in
   let load_from_block = Named.create_prim load_from_block_prim dbg in
-  let arg_var = Variable.create "arg" in
+  let arg_var = Variable.create "arg" K.value in
   let arg_var_duid = Flambda_debug_uid.none in
   let arg = Simple.var arg_var in
   let final_arg_var, final_arg_var_duid, final_arg =
     match must_untag_lookup_table_result with
     | Must_untag ->
-      let final_arg_var = Variable.create "final_arg" in
+      let final_arg_var = Variable.create "final_arg" K.naked_immediate in
       let final_arg_var_duid = Flambda_debug_uid.none in
       final_arg_var, final_arg_var_duid, Simple.var final_arg_var
     | Leave_as_tagged_immediate -> arg_var, arg_var_duid, arg
@@ -514,7 +514,7 @@ let rebuild_switch ~original ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
             let uacc =
               UA.notify_removed ~operation:Removed_operations.branch uacc
             in
-            let not_scrutinee = Variable.create "not_scrutinee" in
+            let not_scrutinee = Variable.create "not_scrutinee" K.value in
             let not_scrutinee_duid = Flambda_debug_uid.none in
             let not_scrutinee' = Simple.var not_scrutinee in
             let tagging_prim : P.t = Unary (Tag_immediate, scrutinee) in
@@ -703,7 +703,7 @@ let simplify_switch0 dacc switch ~down_to_up =
 
 let simplify_switch ~simplify_let_with_bound_pattern ~simplify_function_body
     dacc switch ~down_to_up =
-  let tagged_scrutinee = Variable.create "tagged_scrutinee" in
+  let tagged_scrutinee = Variable.create "tagged_scrutinee" K.value in
   let tagged_scrutinee_duid = Flambda_debug_uid.none in
   let tagging_prim =
     Named.create_prim

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -745,7 +745,9 @@ let simplify_obj_dup dbg dacc ~original_term ~arg ~arg_ty ~result_var =
            can become unused. This might have the effect of moving a projection
            earlier in the event that it already exists later, but this is
            probably fine: this operation isn't that common. *)
-        let contents_var = Variable.create "obj_dup_contents" in
+        let contents_var =
+          Variable.create "obj_dup_contents" (T.kind contents_ty)
+        in
         let contents_var_duid = Flambda_debug_uid.none in
         let contents_expr =
           Named.create_prim (Unary (Unbox_number boxable_number, arg)) dbg

--- a/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
+++ b/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
@@ -33,10 +33,11 @@ let unbox_closures = true
 let make_optimistic_const_ctor () : U.const_ctors_decision =
   let is_int =
     Extra_param_and_args.create ~name:"is_int" ~debug_uid:Flambda_debug_uid.none
+      K.naked_immediate
   in
   let unboxed_const_ctor =
     Extra_param_and_args.create ~name:"unboxed_const_ctor"
-      ~debug_uid:Flambda_debug_uid.none
+      ~debug_uid:Flambda_debug_uid.none K.naked_immediate
   in
   let ctor = U.Unbox (Number (Naked_immediate, unboxed_const_ctor)) in
   At_least_one { is_int; ctor }
@@ -48,6 +49,7 @@ let make_optimistic_number_decision tenv param_type
     let naked_number =
       Extra_param_and_args.create ~name:decider.param_name
         ~debug_uid:Flambda_debug_uid.none
+        (K.naked_number decider.kind)
     in
     Some (Unbox (Number (decider.kind, naked_number)))
   | Unknown -> None
@@ -107,7 +109,7 @@ let rec make_optimistic_decision ~depth ~recursive tenv ~param_type : U.decision
             when unbox_variants && not recursive -> (
             let tag =
               Extra_param_and_args.create ~name:"tag"
-                ~debug_uid:Flambda_debug_uid.none
+                ~debug_uid:Flambda_debug_uid.none K.naked_immediate
             in
             let const_ctors : U.const_ctors_decision =
               match const_ctors with
@@ -163,7 +165,8 @@ and make_optimistic_fields ~add_tag_to_name ~depth ~recursive tenv param_type
   let field_vars =
     List.init (Targetint_31_63.to_int size) (fun i ->
         Extra_param_and_args.create ~name:(field_name i)
-          ~debug_uid:Flambda_debug_uid.none)
+          ~debug_uid:Flambda_debug_uid.none
+          (K.Block_shape.element_kind shape i))
   in
   let type_of_var index (epa : Extra_param_and_args.t) =
     T.alias_type_of
@@ -211,6 +214,7 @@ and make_optimistic_vars_within_closure ~depth ~recursive tenv closures_entry =
         Extra_param_and_args.create
           ~name:(Value_slot.to_string value_slot)
           ~debug_uid:Flambda_debug_uid.none
+          (Value_slot.kind value_slot)
       in
       let decision =
         make_optimistic_decision ~depth:(depth + 1) ~recursive tenv

--- a/middle_end/flambda2/simplify/unboxing/unboxers.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.ml
@@ -24,6 +24,7 @@ type number_decider =
 
 type unboxer =
   { var_name : string;
+    var_kind : Flambda_kind.t;
     poison_const : Const.t;
     unboxing_prim : Simple.t -> P.t;
     prove_simple :
@@ -49,6 +50,7 @@ module Immediate = struct
 
   let unboxer =
     { var_name = "naked_immediate";
+      var_kind = K.naked_immediate;
       poison_const = Const.naked_immediate (Targetint_31_63.of_int 0xabcd);
       unboxing_prim;
       prove_simple = T.meet_tagging_of_simple
@@ -66,6 +68,7 @@ module Float32 = struct
 
   let unboxer =
     { var_name = "unboxed_float32";
+      var_kind = K.naked_float32;
       poison_const =
         Const.naked_float32 Numeric_types.Float32_by_bit_pattern.zero;
       unboxing_prim;
@@ -84,6 +87,7 @@ module Float = struct
 
   let unboxer =
     { var_name = "unboxed_float";
+      var_kind = K.naked_float;
       poison_const = Const.naked_float Numeric_types.Float_by_bit_pattern.zero;
       unboxing_prim;
       prove_simple = T.meet_boxed_float_containing_simple
@@ -101,6 +105,7 @@ module Int32 = struct
 
   let unboxer =
     { var_name = "unboxed_int32";
+      var_kind = K.naked_int32;
       poison_const = Const.naked_int32 Int32.(div 0xabcd0l 2l);
       unboxing_prim;
       prove_simple = T.meet_boxed_int32_containing_simple
@@ -118,6 +123,7 @@ module Int64 = struct
 
   let unboxer =
     { var_name = "unboxed_int64";
+      var_kind = K.naked_int64;
       poison_const = Const.naked_int64 Int64.(div 0xdcba0L 2L);
       unboxing_prim;
       prove_simple = T.meet_boxed_int64_containing_simple
@@ -135,6 +141,7 @@ module Nativeint = struct
 
   let unboxer =
     { var_name = "unboxed_nativeint";
+      var_kind = K.naked_nativeint;
       poison_const = Const.naked_nativeint Targetint_32_64.zero;
       unboxing_prim;
       prove_simple = T.meet_boxed_nativeint_containing_simple
@@ -152,6 +159,7 @@ module Vec128 = struct
 
   let unboxer =
     { var_name = "unboxed_vec128";
+      var_kind = K.naked_vec128;
       poison_const = Const.naked_vec128 Vector_types.Vec128.Bit_pattern.zero;
       unboxing_prim;
       prove_simple = T.meet_boxed_vec128_containing_simple
@@ -169,6 +177,7 @@ module Vec256 = struct
 
   let unboxer =
     { var_name = "unboxed_vec256";
+      var_kind = K.naked_vec256;
       poison_const = Const.naked_vec256 Vector_types.Vec256.Bit_pattern.zero;
       unboxing_prim;
       prove_simple = T.meet_boxed_vec256_containing_simple
@@ -186,6 +195,7 @@ module Vec512 = struct
 
   let unboxer =
     { var_name = "unboxed_vec512";
+      var_kind = K.naked_vec512;
       poison_const = Const.naked_vec512 Vector_types.Vec512.Bit_pattern.zero;
       unboxing_prim;
       prove_simple = T.meet_boxed_vec512_containing_simple
@@ -198,6 +208,7 @@ module Field = struct
 
   let unboxer ~poison_const bak ~index =
     { var_name = "field_at_use";
+      var_kind = P.Block_access_kind.element_kind_for_load bak;
       poison_const;
       unboxing_prim = (fun block -> unboxing_prim bak ~block ~index);
       prove_simple =
@@ -215,6 +226,7 @@ module Closure_field = struct
 
   let unboxer function_slot value_slot =
     { var_name = "closure_field_at_use";
+      var_kind = Value_slot.kind value_slot;
       poison_const = Const.of_int_of_kind (Value_slot.kind value_slot) 0;
       unboxing_prim =
         (fun closure -> unboxing_prim function_slot ~closure value_slot);

--- a/middle_end/flambda2/simplify/unboxing/unboxers.mli
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.mli
@@ -24,6 +24,7 @@ type number_decider =
 
 type unboxer =
   { var_name : string;
+    var_kind : Flambda_kind.t;
     poison_const : Const.t;
     unboxing_prim : Simple.t -> P.t;
     prove_simple :

--- a/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
@@ -62,18 +62,18 @@ let unbox_arg (unboxer : Unboxers.unboxer) ~typing_env_at_use arg_being_unboxed
     | Known_result simple ->
       EPA.Extra_arg.Already_in_scope simple, Available simple
     | Need_meet ->
-      let var = Variable.create unboxer.var_name in
+      let var = Variable.create unboxer.var_name unboxer.var_kind in
       let prim = unboxer.unboxing_prim arg_at_use in
       let extra_arg = EPA.Extra_arg.New_let_binding (var, prim) in
       extra_arg, Generated var)
   | Generated var ->
     let arg_at_use = Simple.var var in
-    let var = Variable.create unboxer.var_name in
+    let var = Variable.create unboxer.var_name unboxer.var_kind in
     let prim = unboxer.unboxing_prim arg_at_use in
     let extra_arg = EPA.Extra_arg.New_let_binding (var, prim) in
     extra_arg, Generated var
   | Added_by_wrapper_at_rewrite_use { nth_arg } ->
-    let var = Variable.create "unboxed_field" in
+    let var = Variable.create "unboxed_field" unboxer.var_kind in
     ( EPA.Extra_arg.New_let_binding_with_named_args
         ( var,
           fun args ->

--- a/middle_end/flambda2/simplify/unboxing/unboxing_types.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_types.ml
@@ -35,8 +35,8 @@ module Extra_param_and_args = struct
       args : EPA.Extra_arg.t Apply_cont_rewrite_id.Map.t
     }
 
-  let create ~name ~debug_uid =
-    { param = Variable.create name;
+  let create ~name ~debug_uid kind =
+    { param = Variable.create name kind;
       param_debug_uid = debug_uid;
       args = Apply_cont_rewrite_id.Map.empty
     }

--- a/middle_end/flambda2/simplify/unboxing/unboxing_types.mli
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_types.mli
@@ -35,7 +35,8 @@ module Extra_param_and_args : sig
       args : EPA.Extra_arg.t Apply_cont_rewrite_id.Map.t
     }
 
-  val create : name:string -> debug_uid:Flambda_debug_uid.t -> t
+  val create :
+    name:string -> debug_uid:Flambda_debug_uid.t -> Flambda_kind.t -> t
 
   val update_param_args : t -> Apply_cont_rewrite_id.t -> EPA.Extra_arg.t -> t
 end

--- a/middle_end/flambda2/simplify_shared/inlining_helpers.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_helpers.ml
@@ -90,7 +90,10 @@ let wrap_inlined_body_for_exn_extra_args acc ~extra_args ~apply_exn_continuation
       let kinded_params =
         List.map
           (fun k ->
-            let wrapper_return = Variable.create "wrapper_return" in
+            let wrapper_return =
+              Variable.create "wrapper_return"
+                (Flambda_kind.With_subkind.kind k)
+            in
             let wrapper_return_duid = Flambda_debug_uid.none in
             Bound_parameter.create wrapper_return k wrapper_return_duid)
           (Flambda_arity.unarized_components result_arity)
@@ -107,7 +110,7 @@ let wrap_inlined_body_for_exn_extra_args acc ~extra_args ~apply_exn_continuation
         ~handler_params:(Bound_parameters.create kinded_params)
         ~handler ~body ~is_exn_handler:false ~is_cold:false
   in
-  let param = Variable.create "exn" in
+  let param = Variable.create "exn" Flambda_kind.value in
   let param_duid = Flambda_debug_uid.none in
   let wrapper_handler_params =
     [Bound_parameter.create param Flambda_kind.With_subkind.any_value param_duid]

--- a/middle_end/flambda2/term_basics/simple.ml
+++ b/middle_end/flambda2/term_basics/simple.ml
@@ -124,6 +124,11 @@ let free_names_in_types t = free_names_with_mode t Name_mode.in_types
 
 let apply_renaming t renaming = Renaming.apply_simple renaming t
 
+let kind t =
+  pattern_match' t ~const:Reg_width_const.kind
+    ~symbol:(fun _sym ~coercion:_ -> Flambda_kind.value)
+    ~var:(fun var ~coercion:_ -> Variable.kind var)
+
 module List = struct
   type nonrec t = t list
 

--- a/middle_end/flambda2/term_basics/simple.mli
+++ b/middle_end/flambda2/term_basics/simple.mli
@@ -91,6 +91,8 @@ val pattern_match' :
   const:(Reg_width_const.t -> 'a) ->
   'a
 
+val kind : t -> Flambda_kind.t
+
 module List : sig
   type nonrec t = t list
 

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -1428,6 +1428,14 @@ module Named = struct
     in
     Simple simple
 
+  let kind t =
+    match t with
+    | Simple s -> Simple.kind s
+    | Prim (p, _dbg) -> Flambda_primitive.result_kind' p
+    | Rec_info _ -> K.rec_info
+    | Set_of_closures _ | Static_consts _ ->
+      Misc.fatal_errorf "No valid kind for non-singleton named %a" print t
+
   let is_dynamically_allocated_set_of_closures t =
     match t with
     | Set_of_closures _ -> true

--- a/middle_end/flambda2/terms/flambda.mli
+++ b/middle_end/flambda2/terms/flambda.mli
@@ -187,6 +187,10 @@ module Named : sig
       necessarily type-correct, at the given kind. *)
   val dummy_value : Flambda_kind.t -> t
 
+  (** Return the kind of the expression. Must only be used on expressions
+      bound to a singleton pattern (everything except sets of closures and static consts). *)
+  val kind : t -> Flambda_kind.t
+
   (** Returns [true] iff the given expression is a set of closures that will be
       allocated on the OCaml heap during execution (i.e. not a
       statically-allocated set of closures). *)

--- a/middle_end/flambda2/tests/api_tests/extension_meet.ml
+++ b/middle_end/flambda2/tests/api_tests/extension_meet.ml
@@ -13,10 +13,10 @@ let _test_recursive_meet () =
       ~resolver:(fun _ -> None)
       ~get_imported_names:(fun () -> Name.Set.empty)
   in
-  let var_x = Variable.create "x" in
-  let var_y = Variable.create "y" in
-  let var_z = Variable.create "z" in
-  let var_v = Variable.create "v" in
+  let var_x = Variable.create "x" Flambda_kind.value in
+  let var_y = Variable.create "y" Flambda_kind.value in
+  let var_z = Variable.create "z" Flambda_kind.value in
+  let var_v = Variable.create "v" Flambda_kind.value in
   let n_x = Name.var var_x in
   let n_y = Name.var var_y in
   let n_z = Name.var var_z in
@@ -64,7 +64,7 @@ let _test_bottom_detection () =
       ~resolver:(fun _ -> None)
       ~get_imported_names:(fun () -> Name.Set.empty)
   in
-  let var_x = Variable.create "x" in
+  let var_x = Variable.create "x" Flambda_kind.value in
   let n_x = Name.var var_x in
   let nb_x = Bound_name.create n_x Name_mode.normal in
   let env = TE.add_definition env nb_x Flambda_kind.value in
@@ -98,7 +98,7 @@ let _test_bottom_recursive () =
       ~resolver:(fun _ -> None)
       ~get_imported_names:(fun () -> Name.Set.empty)
   in
-  let var_x = Variable.create "x" in
+  let var_x = Variable.create "x" Flambda_kind.value in
   let n_x = Name.var var_x in
   let nb_x = Bound_name.create n_x Name_mode.normal in
   let env = TE.add_definition env nb_x Flambda_kind.value in
@@ -142,9 +142,9 @@ let test_double_recursion () =
       ~resolver:(fun _ -> None)
       ~get_imported_names:(fun () -> Name.Set.empty)
   in
-  let var_x = Variable.create "x" in
-  let var_y = Variable.create "y" in
-  let var_z = Variable.create "z" in
+  let var_x = Variable.create "x" Flambda_kind.value in
+  let var_y = Variable.create "y" Flambda_kind.value in
+  let var_z = Variable.create "z" Flambda_kind.value in
   let n_x = Name.var var_x in
   let n_y = Name.var var_y in
   let n_z = Name.var var_z in

--- a/middle_end/flambda2/tests/api_tests/import_test.ml
+++ b/middle_end/flambda2/tests/api_tests/import_test.ml
@@ -4,9 +4,9 @@ let test () =
      However, importing will map var to var_bad so if for some reason importing
      is done twice then one of the output simples will be printed as "bad"
      instead of "ok". *)
-  let var_ext = Variable.create "ext" in
-  let var_ok = Variable.create "ok" in
-  let var_bad = Variable.create "bad" in
+  let var_ext = Variable.create "ext" Flambda_kind.value in
+  let var_ok = Variable.create "ok" Flambda_kind.value in
+  let var_bad = Variable.create "bad" Flambda_kind.value in
   let variables =
     Variable.Map.add var_ok var_bad (Variable.Map.singleton var_ext var_ok)
   in

--- a/middle_end/flambda2/tests/meet_test.ml
+++ b/middle_end/flambda2/tests/meet_test.ml
@@ -15,7 +15,7 @@ let create_env () =
 
 let test_meet_chains_two_vars () =
   let env = create_env () in
-  let var1 = Variable.create "var1" in
+  let var1 = Variable.create "var1" K.value in
   let var1' = Bound_var.create var1 Flambda_debug_uid.none Name_mode.normal in
   let env = TE.add_definition env (Bound_name.create_var var1') K.value in
   let env =
@@ -24,7 +24,7 @@ let test_meet_chains_two_vars () =
          ~shape:(K.Block_shape.Scannable Value_only) Alloc_mode.For_types.heap
          ~fields:[T.any_tagged_immediate])
   in
-  let var2 = Variable.create "var2" in
+  let var2 = Variable.create "var2" K.value in
   let var2' = Bound_var.create var2 Flambda_debug_uid.none Name_mode.normal in
   let env = TE.add_definition env (Bound_name.create_var var2') K.value in
   let first_type_for_var2 = T.alias_type_of K.value (Simple.var var1) in
@@ -48,7 +48,7 @@ let test_meet_chains_two_vars () =
 
 let test_meet_chains_three_vars () =
   let env = create_env () in
-  let var1 = Variable.create "var1" in
+  let var1 = Variable.create "var1" K.value in
   let var1' = Bound_var.create var1 Flambda_debug_uid.none Name_mode.normal in
   let env = TE.add_definition env (Bound_name.create_var var1') K.value in
   let env =
@@ -57,12 +57,12 @@ let test_meet_chains_three_vars () =
          ~shape:(K.Block_shape.Scannable Value_only) Alloc_mode.For_types.heap
          ~fields:[T.any_tagged_immediate])
   in
-  let var2 = Variable.create "var2" in
+  let var2 = Variable.create "var2" K.value in
   let var2' = Bound_var.create var2 Flambda_debug_uid.none Name_mode.normal in
   let env = TE.add_definition env (Bound_name.create_var var2') K.value in
   let first_type_for_var2 = T.alias_type_of K.value (Simple.var var1) in
   let env = TE.add_equation env (Name.var var2) first_type_for_var2 in
-  let var3 = Variable.create "var3" in
+  let var3 = Variable.create "var3" K.value in
   let var3' = Bound_var.create var3 Flambda_debug_uid.none Name_mode.normal in
   let env = TE.add_definition env (Bound_name.create_var var3') K.value in
   let first_type_for_var3 = T.alias_type_of K.value (Simple.var var2) in
@@ -91,11 +91,11 @@ let meet_variants_don't_lose_aliases () =
     TE.add_definition env (Bound_name.create_var v') K.value
   in
   let defines env l = List.fold_left define env l in
-  let vx = Variable.create "x" in
-  let vy = Variable.create "y" in
-  let va = Variable.create "a" in
-  let vb = Variable.create "b" in
-  let v_variant = Variable.create "variant" in
+  let vx = Variable.create "x" K.value in
+  let vy = Variable.create "y" K.value in
+  let va = Variable.create "a" K.value in
+  let vb = Variable.create "b" K.value in
+  let v_variant = Variable.create "variant" K.value in
   let env = defines env [vx; vy; va; vb; v_variant] in
   let const_ctors = T.bottom K.naked_immediate in
   let ty1 =
@@ -129,7 +129,7 @@ let meet_variants_don't_lose_aliases () =
       T.print ty2 T.print meet_ty TE.print env;
     (* Env extension should be empty *)
     let env = TE.add_equation env (Name.var v_variant) meet_ty in
-    let v_naked = Variable.create "naked" in
+    let v_naked = Variable.create "naked" K.naked_immediate in
     let bv_naked =
       Bound_var.create v_naked Flambda_debug_uid.none Name_mode.normal
     in
@@ -164,10 +164,10 @@ let test_join_with_extensions () =
     TE.add_definition env (Bound_name.create_var v') kind
   in
   let env = create_env () in
-  let y = Variable.create "y" in
-  let x = Variable.create "x" in
-  let a = Variable.create "a" in
-  let b = Variable.create "b" in
+  let y = Variable.create "y" K.value in
+  let x = Variable.create "x" K.value in
+  let a = Variable.create "a" K.naked_immediate in
+  let b = Variable.create "b" K.naked_immediate in
   let env = define env y in
   let env = define env x in
   let env = define ~kind:K.naked_immediate env a in
@@ -220,14 +220,14 @@ let test_join_with_complex_extensions () =
     TE.add_definition env (Bound_name.create_var v') kind
   in
   let env = create_env () in
-  let y = Variable.create "y" in
-  let x = Variable.create "x" in
-  let w = Variable.create "w" in
-  let z = Variable.create "z" in
-  let a = Variable.create "a" in
-  let b = Variable.create "b" in
-  let c = Variable.create "c" in
-  let d = Variable.create "d" in
+  let y = Variable.create "y" K.value in
+  let x = Variable.create "x" K.value in
+  let w = Variable.create "w" K.value in
+  let z = Variable.create "z" K.value in
+  let a = Variable.create "a" K.naked_immediate in
+  let b = Variable.create "b" K.naked_immediate in
+  let c = Variable.create "c" K.naked_immediate in
+  let d = Variable.create "d" K.naked_immediate in
   let env = define env z in
   let env = define env x in
   let env = define env y in
@@ -312,10 +312,10 @@ let test_meet_two_blocks () =
   in
   let defines env l = List.fold_left define env l in
   let env = create_env () in
-  let block1 = Variable.create "block1" in
-  let field1 = Variable.create "field1" in
-  let block2 = Variable.create "block2" in
-  let field2 = Variable.create "field2" in
+  let block1 = Variable.create "block1" K.value in
+  let field1 = Variable.create "field1" K.value in
+  let block2 = Variable.create "block2" K.value in
+  let field2 = Variable.create "field2" K.value in
   let env = defines env [block1; block2; field1; field2] in
   let env =
     TE.add_equation env (Name.var block1)
@@ -372,7 +372,7 @@ let test_meet_recover_alias () =
     TE.add_definition env (Bound_name.create_var v') K.value
   in
   let env = create_env () in
-  let x = Variable.create "x" in
+  let x = Variable.create "x" K.value in
   let env = define env x in
   let existing_ty =
     T.variant Alloc_mode.For_types.heap
@@ -410,7 +410,7 @@ let test_meet_bottom_after_alias () =
     TE.add_definition env (Bound_name.create_var v') K.value
   in
   let env = create_env () in
-  let x = Variable.create "x" in
+  let x = Variable.create "x" K.value in
   let env = define env x in
   let existing_ty =
     T.these_tagged_immediates Targetint_31_63.zero_one_and_minus_one

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -75,7 +75,7 @@ let unit0 ~offsets ~all_code ~reachable_names flambda_unit =
       ~return_continuation_arity:[] ~trans_prim:To_cmm_primitive.trans_prim
       ~exn_continuation:(Flambda_unit.exn_continuation flambda_unit)
   in
-  let ret_var = Variable.create "*ret*" in
+  let ret_var = Variable.create "*ret*" Flambda_kind.value in
   let ret_var_duid = Flambda_debug_uid.none in
   let _env, return_cont_params =
     (* The environment is dropped because the handler for the dummy continuation

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -679,7 +679,12 @@ and split_in_env env res var binding =
     let env, res =
       List.fold_left
         (fun (env, res) new_binding ->
-          let flambda_var = Variable.create "to_cmm_tmp" in
+          let flambda_var =
+            (* CR vlaviron/gbury: The kind is wrong, but it should never be
+               actually used. We could enforce this by using a dedicated invalid
+               kind, but for now we just use Value arbitrarily. *)
+            Variable.create "to_cmm_tmp" Flambda_kind.value
+          in
           add_binding_to_env env res flambda_var new_binding)
         (env, res) new_bindings
     in

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -742,7 +742,7 @@ let let_dynamic_set_of_closures0 env res ~body ~bound_vars set
       ~mode:(C.alloc_mode_for_allocations_to_cmm closure_alloc_mode)
       dbg ~tag l memory_chunks
   in
-  let soc_var = Variable.create "*set_of_closures*" in
+  let soc_var = Variable.create "*set_of_closures*" Flambda_kind.value in
   let soc_var_duid = Flambda_debug_uid.none in
   let soc_var = Bound_var.create soc_var soc_var_duid Name_mode.normal in
   let defining_expr = Env.simple csoc free_vars in

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -345,7 +345,8 @@ let invalid res ~message =
         Symbol.create
           (Compilation_unit.get_current_exn ())
           (Linkage_name.of_string
-             (Variable.unique_name (Variable.create "invalid")))
+             (Variable.unique_name
+                (Variable.create "invalid" Flambda_kind.value)))
       in
       let res =
         Cmm_helpers.emit_string_constant

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -188,6 +188,8 @@ module Simples_in_joined_envs : sig
 
   val raw_name : t -> string
 
+  val kind : t -> Flambda_kind.t
+
   val add : Index.t -> Simple_in_one_joined_env.t -> t -> t
 
   val of_list : (Index.t * Simple.t) list -> t
@@ -267,6 +269,11 @@ end = struct
       with Not_found -> None
     in
     match shared_name with Some raw_name -> raw_name | None -> "join_var"
+
+  let kind (t : t) =
+    match Index.Map.choose_opt (t :> Simple.t Index.Map.t) with
+    | Some (_, s) -> Simple.kind s
+    | None -> Misc.fatal_error "Simple_in_joined_envs.kind: No binding"
 
   let of_list list =
     List.fold_left
@@ -576,7 +583,8 @@ end = struct
        record it so that it can be found by [find] if we encounter the same set
        of values later. *)
     let raw_name = Simples_in_joined_envs.raw_name simples in
-    let var = Variable.create raw_name in
+    let kind = Simples_in_joined_envs.kind simples in
+    let var = Variable.create raw_name kind in
     let var_as_name = Name_in_target_env.create (Name.var var) in
     let joined_simples =
       Simples_in_joined_envs.Map.add simples var_as_name t.joined_simples


### PR DESCRIPTION
This PR updates the data associated to each Flambda2 variable to also include the kind (but not the subkind).
The rationale for this PR is that several parts of Flambda2 need to know the kinds of the variables (or simples), and tracking this independently requires some work (typically, the typing env stores the kind for every variable).
This is particularly problematic in the case where a cmx might be missing: currently we can load a cmx containing occurrences of a variable coming from another compilation unit, whose cmx is now unavailable, and in this case we cannot know the kind of the variable (at least not directly). This happens in practice with the new n-way join, and #4212 is a workaround for this issue.
With this PR, the variable would have its kind stored in all cmx files where it occurs, so even with a missing cmx we would be able to access the kind.
Currently the PR doesn't change the existing code to make use of the stored kinds, but a follow-up PR could clean the typing environment to avoid storing kinds completely.