### PR TITLE
arm64: fix reinterpret cast for Float/Float32

### DIFF
--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1552,13 +1552,13 @@ let emit_reinterpret_cast (cast : Cmm.reinterpret_cast) i =
     then (
       DSL.check_reg Float src;
       DSL.check_reg Float32 dst;
-      DSL.ins I.MOV [| DSL.emit_reg_d dst; DSL.emit_reg_d src |])
+      DSL.ins I.FMOV [| DSL.emit_reg_d dst; DSL.emit_reg_d src |])
   | Float_of_float32 ->
     if distinct
     then (
       DSL.check_reg Float32 src;
       DSL.check_reg Float dst;
-      DSL.ins I.MOV [| DSL.emit_reg_d dst; DSL.emit_reg_d src |])
+      DSL.ins I.FMOV [| DSL.emit_reg_d dst; DSL.emit_reg_d src |])
   | V128_of_v128 ->
     if distinct
     then (


### PR DESCRIPTION
Use FMOV instead of MOV. Fixes assembler error. 

Draft for the CI first, and still needs a test.