### PR TITLE
Even more moves of symbols initializations in to_cmm

### DIFF
--- a/bar.ml
+++ b/bar.ml
@@ -1,0 +1,8 @@
+
+let tail_call _ = true
+
+external opaque : 'a -> 'b = "%opaque"
+
+let f x =
+  let _unused_local = ref None in
+  opaque false && tail_call x

--- a/foo.ml
+++ b/foo.ml
@@ -1,7 +1,16 @@
 
 let[@inline never] foo () = 42
 
+let[@inline always] bar () =
+  if Sys.opaque_identity true then 13 else 42
+
+let[@inline always] loop () =
+  let r = ref 0 in
+  for i = 0 to Sys.opaque_identity 5 do
+    r := !r + i
+  done;
+  !r
+
 let field1 = foo ()
-let field2 = foo ()
-let field3 = foo ()
-let field4 = foo ()
+let field2 = bar ()
+let field3 = loop ()

--- a/foo.ml
+++ b/foo.ml
@@ -1,0 +1,7 @@
+
+let[@inline never] foo () = 42
+
+let field1 = foo ()
+let field2 = foo ()
+let field3 = foo ()
+let field4 = foo ()

--- a/foobar.ml
+++ b/foobar.ml
@@ -1,0 +1,18 @@
+(* TEST
+ ocamlopt_flags += " -O3 ";
+*)
+let r = ref None
+
+let f () =
+  match !r with
+  | Some l -> Lazy.force l
+  | None -> ()
+
+let l = Lazy.from_fun f
+
+let _ = r := Some l
+
+let _ =
+  try Lazy.force l
+  with Lazy.Undefined -> print_endline "Undefined"
+

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -100,8 +100,10 @@ let unit0 ~offsets ~all_code ~reachable_names flambda_unit =
   let body, body_free_vars, body_symbol_inits, res =
     To_cmm_expr.expr env r (Flambda_unit.body flambda_unit)
   in
-  if not (To_cmm_env.Symbol_inits.is_empty body_symbol_inits) then
-    Misc.fatal_errorf "Did not find where to place the following symbol initializations: %a"
+  if not (To_cmm_env.Symbol_inits.is_empty body_symbol_inits)
+  then
+    Misc.fatal_errorf
+      "Did not find where to place the following symbol initializations: %a"
       To_cmm_env.Symbol_inits.print body_symbol_inits;
   let free_vars =
     To_cmm_shared.remove_var_with_provenance body_free_vars toplevel_region_var

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -97,9 +97,10 @@ let unit0 ~offsets ~all_code ~reachable_names flambda_unit =
     R.create ~reachable_names
       ~module_symbol:(Flambda_unit.module_symbol flambda_unit)
   in
-  let body, body_free_vars, res =
+  let body, body_free_vars, body_symbol_inits, res =
     To_cmm_expr.expr env r (Flambda_unit.body flambda_unit)
   in
+  To_cmm_env.check_is_empty_symbol_inits body_symbol_inits;
   let free_vars =
     To_cmm_shared.remove_var_with_provenance body_free_vars toplevel_region_var
   in

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -100,7 +100,9 @@ let unit0 ~offsets ~all_code ~reachable_names flambda_unit =
   let body, body_free_vars, body_symbol_inits, res =
     To_cmm_expr.expr env r (Flambda_unit.body flambda_unit)
   in
-  To_cmm_env.check_is_empty_symbol_inits body_symbol_inits;
+  if not (To_cmm_env.Symbol_inits.is_empty body_symbol_inits) then
+    Misc.fatal_errorf "Did not find where to place the following symbol initializations: %a"
+      To_cmm_env.Symbol_inits.print body_symbol_inits;
   let free_vars =
     To_cmm_shared.remove_var_with_provenance body_free_vars toplevel_region_var
   in

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -18,9 +18,27 @@ module R = To_cmm_result
 module P = Flambda_primitive
 module Ece = Effects_and_coeffects
 
-type free_vars = Backend_var.Set.t
+(* Delayed symbol inits *)
+module Symbol_inits = struct
 
-type symbol_inits = Cmm.expression list Backend_var.Map.t
+  type t = Cmm.expression list Backend_var.Map.t
+
+  let empty : t = Backend_var.Map.empty
+
+  let is_empty t =
+    Backend_var.Map.is_empty t ||
+    Backend_var.Map.for_all (fun _ l -> Misc.Stdlib.List.is_empty l) t
+
+  let merge t t' =
+    Backend_var.Map.union_merge List.append t t'
+
+  let print ppf t =
+    let pp = Format.pp_print_list Printcmm.expression in
+    Backend_var.Map.print pp ppf t
+
+end
+
+type free_vars = Backend_var.Set.t
 
 type expr_with_info =
   { cmm : Cmm.expression;
@@ -73,17 +91,6 @@ type 'env trans_prim =
     variadic :
       ('env, P.variadic_primitive, Cmm.expression list -> prim_res) prim_helper
   }
-
-(* Delayed symbol inits *)
-let empty_symbol_inits : symbol_inits = Backend_var.Map.empty
-
-let check_is_empty_symbol_inits symbol_inits =
-  if not (Backend_var.Map.is_empty symbol_inits) then
-    assert false
-
-let merge_symbol_inits inits inits' =
-  Backend_var.Map.union_merge List.append inits inits'
-
 (* Delayed let-bindings (see the .mli) *)
 
 (* the binding kinds *)
@@ -169,7 +176,7 @@ type t =
     (* Maps for `Must_inline_once` variable that end up aliased. *)
     stages : stage list;
     (* Stages of let-bindings, most recent at the head. *)
-    symbol_inits : symbol_inits
+    symbol_inits : Symbol_inits.t
         (* Symbol initialization expressions, indexed by the variable used as
            value for the symbol field initialization. *)
   }
@@ -954,7 +961,7 @@ let flush_bindings order_map flushed_symbol_inits =
   fun e free_vars symbol_inits ->
   (* Merge the symbol inits from the env that was flushed, and those
      from the body (i.e. [e]) that we want to wrap *)
-  let symbol_inits = merge_symbol_inits flushed_symbol_inits symbol_inits in
+  let symbol_inits = Symbol_inits.merge flushed_symbol_inits symbol_inits in
   M.fold
     (fun _ (Binding b) (acc, acc_free_vars, symbol_inits) ->
        match b.bound_expr with

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -20,6 +20,8 @@ module Ece = Effects_and_coeffects
 
 type free_vars = Backend_var.Set.t
 
+type symbol_inits = Cmm.expression list Backend_var.Map.t
+
 type expr_with_info =
   { cmm : Cmm.expression;
     effs : Effects_and_coeffects.t;
@@ -71,6 +73,16 @@ type 'env trans_prim =
     variadic :
       ('env, P.variadic_primitive, Cmm.expression list -> prim_res) prim_helper
   }
+
+(* Delayed symbol inits *)
+let empty_symbol_inits : symbol_inits = Backend_var.Map.empty
+
+let check_is_empty_symbol_inits symbol_inits =
+  if not (Backend_var.Map.is_empty symbol_inits) then
+    assert false
+
+let merge_symbol_inits inits inits' =
+  Backend_var.Map.union_merge List.append inits inits'
 
 (* Delayed let-bindings (see the .mli) *)
 
@@ -157,7 +169,7 @@ type t =
     (* Maps for `Must_inline_once` variable that end up aliased. *)
     stages : stage list;
     (* Stages of let-bindings, most recent at the head. *)
-    symbol_inits : Cmm.expression list Backend_var.Map.t
+    symbol_inits : symbol_inits
         (* Symbol initialization expressions, indexed by the variable used as
            value for the symbol field initialization. *)
   }
@@ -916,52 +928,64 @@ let can_be_removed effs =
   | Arbitrary_effects, _, _ -> false
   | (Only_generative_effects _ | No_effects), _, _ -> true
 
+let pop_symbol_inits symbol_inits v =
+  match Backend_var.Map.find v symbol_inits with
+  | exception Not_found -> [], symbol_inits
+  | l -> l, Backend_var.Map.remove v symbol_inits
+
+(* Wrapper function to introduce delayed let-bindings. *)
+let place_symbol_inits ~params = fun e free_vars symbol_inits ->
+  List.fold_left (fun (acc, free_vars, symbol_inits) (v, _) ->
+      let v = Backend_var.With_provenance.var v in
+      let inits, symbol_inits = pop_symbol_inits symbol_inits v in
+      match inits with
+      | [] -> acc, free_vars, symbol_inits
+      | _ :: _ ->
+          let acc =
+            List.fold_left
+              (fun acc init -> Cmm_helpers.sequence init acc)
+              acc inits
+          in
+          let free_vars = Backend_var.Set.add v free_vars in
+          acc, free_vars, symbol_inits
+    ) (e, free_vars, symbol_inits) params
+
+let flush_bindings order_map flushed_symbol_inits =
+  fun e free_vars symbol_inits ->
+  (* Merge the symbol inits from the env that was flushed, and those
+     from the body (i.e. [e]) that we want to wrap *)
+  let symbol_inits = merge_symbol_inits flushed_symbol_inits symbol_inits in
+  M.fold
+    (fun _ (Binding b) (acc, acc_free_vars, symbol_inits) ->
+       match b.bound_expr with
+       | Splittable_prim _ ->
+           Misc.fatal_errorf
+             "Complex bindings should have been split prior to being flushed."
+       | Split { cmm_expr; free_vars } | Simple { cmm_expr; free_vars } ->
+           let v = Backend_var.With_provenance.var b.cmm_var in
+           let inits, symbol_inits = pop_symbol_inits symbol_inits v in
+           if can_be_removed b.effs
+           && Misc.Stdlib.List.is_empty inits
+           && not (Backend_var.Set.mem v acc_free_vars)
+           then acc, acc_free_vars, symbol_inits
+           else
+             let body =
+               List.fold_left
+                 (fun acc init -> Cmm_helpers.sequence init acc)
+                 acc inits
+             in
+             let expr =
+               Cmm_helpers.letin b.cmm_var ~defining_expr:cmm_expr ~body
+             in
+             let free_vars =
+               Backend_var.Set.union free_vars
+                 (Backend_var.Set.remove v acc_free_vars)
+             in
+             expr, free_vars, symbol_inits)
+      order_map
+      (e, free_vars, symbol_inits)
+
 let flush_delayed_lets ~mode env res =
-  (* Generate a wrapper function to introduce the delayed let-bindings. *)
-  let wrap_flush order_map e free_vars =
-    let expr, free_vars, symbol_inits =
-      M.fold
-        (fun _ (Binding b) (acc, acc_free_vars, symbol_inits) ->
-          match b.bound_expr with
-          | Splittable_prim _ ->
-            Misc.fatal_errorf
-              "Complex bindings should have been split prior to being flushed."
-          | Split { cmm_expr; free_vars } | Simple { cmm_expr; free_vars } ->
-            let v = Backend_var.With_provenance.var b.cmm_var in
-            let inits, symbol_inits =
-              match Backend_var.Map.find v symbol_inits with
-              | exception Not_found -> [], symbol_inits
-              | l -> l, Backend_var.Map.remove v symbol_inits
-            in
-            if can_be_removed b.effs
-               && Misc.Stdlib.List.is_empty inits
-               && not (Backend_var.Set.mem v acc_free_vars)
-            then acc, acc_free_vars, symbol_inits
-            else
-              let body =
-                List.fold_left
-                  (fun acc init -> Cmm_helpers.sequence init acc)
-                  acc inits
-              in
-              let expr =
-                Cmm_helpers.letin b.cmm_var ~defining_expr:cmm_expr ~body
-              in
-              let free_vars =
-                Backend_var.Set.union free_vars
-                  (Backend_var.Set.remove v acc_free_vars)
-              in
-              expr, free_vars, symbol_inits)
-        order_map
-        (e, free_vars, env.symbol_inits)
-    in
-    Backend_var.Map.fold
-      (fun v inits (acc, acc_free_vars) ->
-        ( List.fold_left
-            (fun acc init -> Cmm_helpers.sequence init acc)
-            acc inits,
-          Backend_var.Set.add v acc_free_vars ))
-      symbol_inits (expr, free_vars)
-  in
   (* CR-someday mshinwell: work out a criterion for allowing substitutions into
      loops. CR gbury: this is now done by creating a binding with the inline
      status `Must_inline_and_duplicate`, so the caller of `to_cmm_env` has to
@@ -1041,11 +1065,11 @@ let flush_delayed_lets ~mode env res =
             None))
       env.bindings
   in
-  let flush e = wrap_flush !bindings_to_flush e in
-  ( flush,
+  let flush = flush_bindings !bindings_to_flush env.symbol_inits in
+  let env =
     { env with
       stages = [];
       bindings = bindings_to_keep;
       symbol_inits = Backend_var.Map.empty
-    },
-    !res )
+    } in
+  ( flush, env, !res )

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -20,22 +20,19 @@ module Ece = Effects_and_coeffects
 
 (* Delayed symbol inits *)
 module Symbol_inits = struct
-
   type t = Cmm.expression list Backend_var.Map.t
 
   let empty : t = Backend_var.Map.empty
 
   let is_empty t =
-    Backend_var.Map.is_empty t ||
-    Backend_var.Map.for_all (fun _ l -> Misc.Stdlib.List.is_empty l) t
+    Backend_var.Map.is_empty t
+    || Backend_var.Map.for_all (fun _ l -> Misc.Stdlib.List.is_empty l) t
 
-  let merge t t' =
-    Backend_var.Map.union_merge List.append t t'
+  let merge t t' = Backend_var.Map.union_merge List.append t t'
 
   let print ppf t =
     let pp = Format.pp_print_list Printcmm.expression in
     Backend_var.Map.print pp ppf t
-
 end
 
 type free_vars = Backend_var.Set.t
@@ -941,56 +938,57 @@ let pop_symbol_inits symbol_inits v =
   | l -> l, Backend_var.Map.remove v symbol_inits
 
 (* Wrapper function to introduce delayed let-bindings. *)
-let place_symbol_inits ~params = fun e free_vars symbol_inits ->
-  List.fold_left (fun (acc, free_vars, symbol_inits) (v, _) ->
+let place_symbol_inits ~params e free_vars symbol_inits =
+  List.fold_left
+    (fun (acc, free_vars, symbol_inits) (v, _) ->
       let v = Backend_var.With_provenance.var v in
       let inits, symbol_inits = pop_symbol_inits symbol_inits v in
       match inits with
       | [] -> acc, free_vars, symbol_inits
       | _ :: _ ->
-          let acc =
+        let acc =
+          List.fold_left
+            (fun acc init -> Cmm_helpers.sequence init acc)
+            acc inits
+        in
+        let free_vars = Backend_var.Set.add v free_vars in
+        acc, free_vars, symbol_inits)
+    (e, free_vars, symbol_inits)
+    params
+
+let flush_bindings order_map flushed_symbol_inits e free_vars symbol_inits =
+  (* Merge the symbol inits from the env that was flushed, and those from the
+     body (i.e. [e]) that we want to wrap *)
+  let symbol_inits = Symbol_inits.merge flushed_symbol_inits symbol_inits in
+  M.fold
+    (fun _ (Binding b) (acc, acc_free_vars, symbol_inits) ->
+      match b.bound_expr with
+      | Splittable_prim _ ->
+        Misc.fatal_errorf
+          "Complex bindings should have been split prior to being flushed."
+      | Split { cmm_expr; free_vars } | Simple { cmm_expr; free_vars } ->
+        let v = Backend_var.With_provenance.var b.cmm_var in
+        let inits, symbol_inits = pop_symbol_inits symbol_inits v in
+        if can_be_removed b.effs
+           && Misc.Stdlib.List.is_empty inits
+           && not (Backend_var.Set.mem v acc_free_vars)
+        then acc, acc_free_vars, symbol_inits
+        else
+          let body =
             List.fold_left
               (fun acc init -> Cmm_helpers.sequence init acc)
               acc inits
           in
-          let free_vars = Backend_var.Set.add v free_vars in
-          acc, free_vars, symbol_inits
-    ) (e, free_vars, symbol_inits) params
-
-let flush_bindings order_map flushed_symbol_inits =
-  fun e free_vars symbol_inits ->
-  (* Merge the symbol inits from the env that was flushed, and those
-     from the body (i.e. [e]) that we want to wrap *)
-  let symbol_inits = Symbol_inits.merge flushed_symbol_inits symbol_inits in
-  M.fold
-    (fun _ (Binding b) (acc, acc_free_vars, symbol_inits) ->
-       match b.bound_expr with
-       | Splittable_prim _ ->
-           Misc.fatal_errorf
-             "Complex bindings should have been split prior to being flushed."
-       | Split { cmm_expr; free_vars } | Simple { cmm_expr; free_vars } ->
-           let v = Backend_var.With_provenance.var b.cmm_var in
-           let inits, symbol_inits = pop_symbol_inits symbol_inits v in
-           if can_be_removed b.effs
-           && Misc.Stdlib.List.is_empty inits
-           && not (Backend_var.Set.mem v acc_free_vars)
-           then acc, acc_free_vars, symbol_inits
-           else
-             let body =
-               List.fold_left
-                 (fun acc init -> Cmm_helpers.sequence init acc)
-                 acc inits
-             in
-             let expr =
-               Cmm_helpers.letin b.cmm_var ~defining_expr:cmm_expr ~body
-             in
-             let free_vars =
-               Backend_var.Set.union free_vars
-                 (Backend_var.Set.remove v acc_free_vars)
-             in
-             expr, free_vars, symbol_inits)
-      order_map
-      (e, free_vars, symbol_inits)
+          let expr =
+            Cmm_helpers.letin b.cmm_var ~defining_expr:cmm_expr ~body
+          in
+          let free_vars =
+            Backend_var.Set.union free_vars
+              (Backend_var.Set.remove v acc_free_vars)
+          in
+          expr, free_vars, symbol_inits)
+    order_map
+    (e, free_vars, symbol_inits)
 
 let flush_delayed_lets ~mode env res =
   (* CR-someday mshinwell: work out a criterion for allowing substitutions into
@@ -1078,5 +1076,6 @@ let flush_delayed_lets ~mode env res =
       stages = [];
       bindings = bindings_to_keep;
       symbol_inits = Backend_var.Map.empty
-    } in
-  ( flush, env, !res )
+    }
+  in
+  flush, env, !res

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -260,6 +260,8 @@ val add_alias :
   num_normal_occurrences_of_bound_vars:Num_occurrences.t Variable.Map.t ->
   t * To_cmm_result.t
 
+val add_symbol_init : t -> Backend_var.t -> Cmm.expression -> t
+
 (** Try and inline an Flambda variable using the delayed let-bindings. *)
 val inline_variable :
   ?consider_inlining_effectful_expressions:bool ->

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -22,13 +22,18 @@ type t
 type free_vars = Backend_var.Set.t
 
 (** Delayed symbol initializations *)
-type symbol_inits
+module Symbol_inits : sig
+  type t
 
-val empty_symbol_inits : symbol_inits
+  val empty : t
 
-val merge_symbol_inits : symbol_inits -> symbol_inits -> symbol_inits
+  val merge : t -> t -> t
 
-val check_is_empty_symbol_inits : symbol_inits -> unit
+  val is_empty : t -> bool
+
+  val print : Format.formatter -> t -> unit
+
+end
 
 (** A cmm expression along with extra information *)
 type expr_with_info =
@@ -290,13 +295,13 @@ val flush_delayed_lets :
   mode:flush_mode ->
   t ->
   To_cmm_result.t ->
-  (Cmm.expression -> free_vars -> symbol_inits -> Cmm.expression * free_vars * symbol_inits)
+  (Cmm.expression -> free_vars -> Symbol_inits.t -> Cmm.expression * free_vars * Symbol_inits.t)
   * t
   * To_cmm_result.t
 
 val place_symbol_inits :
   params:((Backend_var.With_provenance.t * _) list) ->
-  Cmm.expression -> free_vars -> symbol_inits -> Cmm.expression * free_vars * symbol_inits
+  Cmm.expression -> free_vars -> Symbol_inits.t -> Cmm.expression * free_vars * Symbol_inits.t
 
 (** Fetch the extra info for a Flambda variable (if any), specified as a
     [Simple]. *)

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -32,7 +32,6 @@ module Symbol_inits : sig
   val is_empty : t -> bool
 
   val print : Format.formatter -> t -> unit
-
 end
 
 (** A cmm expression along with extra information *)
@@ -295,13 +294,19 @@ val flush_delayed_lets :
   mode:flush_mode ->
   t ->
   To_cmm_result.t ->
-  (Cmm.expression -> free_vars -> Symbol_inits.t -> Cmm.expression * free_vars * Symbol_inits.t)
+  (Cmm.expression ->
+  free_vars ->
+  Symbol_inits.t ->
+  Cmm.expression * free_vars * Symbol_inits.t)
   * t
   * To_cmm_result.t
 
 val place_symbol_inits :
-  params:((Backend_var.With_provenance.t * _) list) ->
-  Cmm.expression -> free_vars -> Symbol_inits.t -> Cmm.expression * free_vars * Symbol_inits.t
+  params:(Backend_var.With_provenance.t * _) list ->
+  Cmm.expression ->
+  free_vars ->
+  Symbol_inits.t ->
+  Cmm.expression * free_vars * Symbol_inits.t
 
 (** Fetch the extra info for a Flambda variable (if any), specified as a
     [Simple]. *)

--- a/middle_end/flambda2/to_cmm/to_cmm_env.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.mli
@@ -21,6 +21,15 @@ type t
 (** Free names for cmm expressions *)
 type free_vars = Backend_var.Set.t
 
+(** Delayed symbol initializations *)
+type symbol_inits
+
+val empty_symbol_inits : symbol_inits
+
+val merge_symbol_inits : symbol_inits -> symbol_inits -> symbol_inits
+
+val check_is_empty_symbol_inits : symbol_inits -> unit
+
 (** A cmm expression along with extra information *)
 type expr_with_info =
   { cmm : Cmm.expression;
@@ -281,9 +290,13 @@ val flush_delayed_lets :
   mode:flush_mode ->
   t ->
   To_cmm_result.t ->
-  (Cmm.expression -> free_vars -> Cmm.expression * free_vars)
+  (Cmm.expression -> free_vars -> symbol_inits -> Cmm.expression * free_vars * symbol_inits)
   * t
   * To_cmm_result.t
+
+val place_symbol_inits :
+  params:((Backend_var.With_provenance.t * _) list) ->
+  Cmm.expression -> free_vars -> symbol_inits -> Cmm.expression * free_vars * symbol_inits
 
 (** Fetch the extra info for a Flambda variable (if any), specified as a
     [Simple]. *)

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -535,7 +535,7 @@ let translate_raise ~dbg_with_inlined:dbg env res apply exn_handler args =
     let free_vars = Backend_var.Set.union exn_free_vars extra_free_vars in
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
     let cmm = C.raise_prim raise_kind exn ~extra_args:extra dbg in
-    let cmm, free_vars, symbol_inits = wrap cmm free_vars Env.empty_symbol_inits in
+    let cmm, free_vars, symbol_inits = wrap cmm free_vars Env.Symbol_inits.empty in
     cmm, free_vars, symbol_inits, res
   | [] ->
     Misc.fatal_errorf "Exception continuation %a has no arguments:@ \n%a"
@@ -558,7 +558,7 @@ let translate_jump_to_continuation ~dbg_with_inlined:dbg env res apply types
     let args = C.remove_skipped_args args types in
     let args, free_vars, env, res, _ = C.simple_list ~dbg env res args in
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-    let cmm, free_vars, symbol_inits = wrap (C.cexit cont args trap_actions) free_vars Env.empty_symbol_inits in
+    let cmm, free_vars, symbol_inits = wrap (C.cexit cont args trap_actions) free_vars Env.Symbol_inits.empty in
     cmm, free_vars, symbol_inits, res
   else
     Misc.fatal_errorf "Types (%a) do not match arguments of@ %a"
@@ -579,12 +579,12 @@ let translate_jump_to_return_continuation ~dbg_with_inlined:dbg env res apply
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
     match Apply_cont.trap_action apply with
     | None ->
-      let cmm, free_vars, symbol_inits = wrap return_value free_vars Env.empty_symbol_inits in
+      let cmm, free_vars, symbol_inits = wrap return_value free_vars Env.Symbol_inits.empty in
       cmm, free_vars, symbol_inits, res
     | Some (Pop { exn_handler; _ }) ->
       let cont = Env.get_cmm_continuation env exn_handler in
       let cmm, free_vars, symbol_inits =
-        wrap (C.trap_return return_value [Cmm.Pop cont]) free_vars Env.empty_symbol_inits
+        wrap (C.trap_return return_value [Cmm.Pop cont]) free_vars Env.Symbol_inits.empty
       in
       cmm, free_vars, symbol_inits, res
     | Some (Push _) ->
@@ -602,12 +602,12 @@ let invalid env res ~message =
     Env.flush_delayed_lets ~mode:Branching_point env res
   in
   let cmm_invalid, res = C.invalid res ~message in
-  let cmm, free_vars, symbol_inits = wrap cmm_invalid Backend_var.Set.empty Env.empty_symbol_inits in
+  let cmm, free_vars, symbol_inits = wrap cmm_invalid Backend_var.Set.empty Env.Symbol_inits.empty in
   cmm, free_vars, symbol_inits, res
 
 (* The main set of translation functions for expressions *)
 
-let rec expr env res e : Cmm.expression * Backend_var.Set.t * Env.symbol_inits * To_cmm_result.t =
+let rec expr env res e : Cmm.expression * Backend_var.Set.t * Env.Symbol_inits.t * To_cmm_result.t =
   match Expr.descr e with
   | Let e' -> let_expr env res e'
   | Let_cont e' -> let_cont env res e'
@@ -802,7 +802,7 @@ and let_cont_not_inlined env res k handler body =
          Env.add_inlined_debuginfo to it *)
       let dbg = Debuginfo.none in
       let body, free_vars_of_body, body_symbol_inits, res = expr env res body in
-      let symbol_inits = Env.merge_symbol_inits handler_symbol_inits body_symbol_inits in
+      let symbol_inits = Env.Symbol_inits.merge handler_symbol_inits body_symbol_inits in
       let free_vars =
         Backend_var.Set.union free_vars_of_body
           (C.remove_vars_with_machtype free_vars_of_handler vars)
@@ -892,7 +892,9 @@ and let_cont_rec env res invariant_params conts body =
         in
         (* It should be an flambda2 invariant that symbols are bound at top-level,
            and the handler of a loop is clearly not top-level *)
-        Env.check_is_empty_symbol_inits symbol_inits;
+        if not (Env.Symbol_inits.is_empty symbol_inits) then
+          Format.eprintf "Found leftover symbol inits in the body of a loop: %a"
+            Env.Symbol_inits.print symbol_inits;
         ( Continuation.Map.add k
             (invariant_vars @ vars, handler, free_vars_of_handler)
             conts_to_handlers,
@@ -960,7 +962,7 @@ and apply_expr env res apply =
   | Never_returns ->
     (* Case 1 *)
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-    let cmm, free_vars, symbol_inits = wrap call free_vars Env.empty_symbol_inits in
+    let cmm, free_vars, symbol_inits = wrap call free_vars Env.Symbol_inits.empty in
     cmm, free_vars, symbol_inits, res
   | Return k -> (
     match Env.get_continuation env k with
@@ -974,7 +976,7 @@ and apply_expr env res apply =
         let wrap, _, res =
           Env.flush_delayed_lets ~mode:Branching_point env res
         in
-        let cmm, free_vars, symbol_inits = wrap call free_vars Env.empty_symbol_inits in
+        let cmm, free_vars, symbol_inits = wrap call free_vars Env.Symbol_inits.empty in
         cmm, free_vars, symbol_inits, res
       else
         Misc.fatal_errorf
@@ -984,7 +986,7 @@ and apply_expr env res apply =
     | Jump { param_types = _; cont } ->
       (* Case 2 *)
       let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-      let cmm, free_vars, symbol_inits = wrap (C.cexit cont [call] []) free_vars Env.empty_symbol_inits in
+      let cmm, free_vars, symbol_inits = wrap (C.cexit cont [call] []) free_vars Env.Symbol_inits.empty in
       cmm, free_vars, symbol_inits, res
     | Inline
         { handler_params;
@@ -1190,7 +1192,9 @@ and switch env res switch =
         Backend_var.Set.union scrutinee_free_vars
           (Backend_var.Set.union else_free_vars then_free_vars)
       in
-      let symbol_inits = Env.merge_symbol_inits then_inits else_inits in
+      (* CR gbury: technically, these symbol inits should be empty since neither of the branches
+         should be at top-level, but it should not hurt to do this. *)
+      let symbol_inits = Env.Symbol_inits.merge then_inits else_inits in
       let cmm, free_vars, symbol_inits =
         wrap (C.ite ~dbg scrutinee ~then_dbg ~then_ ~else_dbg ~else_) free_vars symbol_inits
       in
@@ -1209,7 +1213,9 @@ and switch env res switch =
           (C.eq ~dbg (C.int ~dbg x) scrutinee)
           ~then_dbg:if_x_dbg ~then_:if_x ~else_dbg:if_not_dbg ~else_:if_not
       in
-      let symbol_inits = Env.merge_symbol_inits if_x_symbol_inits if_not_symbol_inits in
+      (* CR gbury: technically, these symbol inits should be empty since neither of the branches
+         should be at top-level, but it should not hurt to do this. *)
+      let symbol_inits = Env.Symbol_inits.merge if_x_symbol_inits if_not_symbol_inits in
       let cmm, free_vars, symbol_inits = wrap expr free_vars symbol_inits in
       cmm, free_vars, symbol_inits, res)
   (* General case *)
@@ -1227,13 +1233,15 @@ and switch env res switch =
           let (d, cmm_action, action_free_vars, action_symbol_inits, _dbg), res =
             make_arm ~must_tag_discriminant env res (discriminant, action)
           in
-          let symbol_inits = Env.merge_symbol_inits symbol_inits action_symbol_inits in
+          (* CR gbury: technically, these symbol inits should be empty since neither of the branches
+             should be at top-level, but it should not hurt to do this. *)
+          let symbol_inits = Env.Symbol_inits.merge symbol_inits action_symbol_inits in
           let free_vars = Backend_var.Set.union free_vars action_free_vars in
           cases.(i) <- cmm_action;
           index.(d) <- i;
           i + 1, res, free_vars, symbol_inits)
         arms
-        (0, res, scrutinee_free_vars, Env.empty_symbol_inits)
+        (0, res, scrutinee_free_vars, Env.Symbol_inits.empty)
     in
     (* CR-someday poechsel: Put a more precise value kind here *)
     let expr = C.transl_switch_clambda dbg scrutinee index cases in

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -535,7 +535,9 @@ let translate_raise ~dbg_with_inlined:dbg env res apply exn_handler args =
     let free_vars = Backend_var.Set.union exn_free_vars extra_free_vars in
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
     let cmm = C.raise_prim raise_kind exn ~extra_args:extra dbg in
-    let cmm, free_vars, symbol_inits = wrap cmm free_vars Env.Symbol_inits.empty in
+    let cmm, free_vars, symbol_inits =
+      wrap cmm free_vars Env.Symbol_inits.empty
+    in
     cmm, free_vars, symbol_inits, res
   | [] ->
     Misc.fatal_errorf "Exception continuation %a has no arguments:@ \n%a"
@@ -558,7 +560,9 @@ let translate_jump_to_continuation ~dbg_with_inlined:dbg env res apply types
     let args = C.remove_skipped_args args types in
     let args, free_vars, env, res, _ = C.simple_list ~dbg env res args in
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-    let cmm, free_vars, symbol_inits = wrap (C.cexit cont args trap_actions) free_vars Env.Symbol_inits.empty in
+    let cmm, free_vars, symbol_inits =
+      wrap (C.cexit cont args trap_actions) free_vars Env.Symbol_inits.empty
+    in
     cmm, free_vars, symbol_inits, res
   else
     Misc.fatal_errorf "Types (%a) do not match arguments of@ %a"
@@ -579,12 +583,16 @@ let translate_jump_to_return_continuation ~dbg_with_inlined:dbg env res apply
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
     match Apply_cont.trap_action apply with
     | None ->
-      let cmm, free_vars, symbol_inits = wrap return_value free_vars Env.Symbol_inits.empty in
+      let cmm, free_vars, symbol_inits =
+        wrap return_value free_vars Env.Symbol_inits.empty
+      in
       cmm, free_vars, symbol_inits, res
     | Some (Pop { exn_handler; _ }) ->
       let cont = Env.get_cmm_continuation env exn_handler in
       let cmm, free_vars, symbol_inits =
-        wrap (C.trap_return return_value [Cmm.Pop cont]) free_vars Env.Symbol_inits.empty
+        wrap
+          (C.trap_return return_value [Cmm.Pop cont])
+          free_vars Env.Symbol_inits.empty
       in
       cmm, free_vars, symbol_inits, res
     | Some (Push _) ->
@@ -602,12 +610,15 @@ let invalid env res ~message =
     Env.flush_delayed_lets ~mode:Branching_point env res
   in
   let cmm_invalid, res = C.invalid res ~message in
-  let cmm, free_vars, symbol_inits = wrap cmm_invalid Backend_var.Set.empty Env.Symbol_inits.empty in
+  let cmm, free_vars, symbol_inits =
+    wrap cmm_invalid Backend_var.Set.empty Env.Symbol_inits.empty
+  in
   cmm, free_vars, symbol_inits, res
 
 (* The main set of translation functions for expressions *)
 
-let rec expr env res e : Cmm.expression * Backend_var.Set.t * Env.Symbol_inits.t * To_cmm_result.t =
+let rec expr env res e :
+    Cmm.expression * Backend_var.Set.t * Env.Symbol_inits.t * To_cmm_result.t =
   match Expr.descr e with
   | Let e' -> let_expr env res e'
   | Let_cont e' -> let_cont env res e'
@@ -719,7 +730,9 @@ and let_expr0 env res let_expr (bound_pattern : Bound_pattern.t)
       in
       let body, body_free_vars, symbol_inits, res = expr env res body in
       let free_vars = Backend_var.Set.union free_vars body_free_vars in
-      let cmm, free_vars, symbol_inits = wrap (C.sequence cmm body) free_vars symbol_inits in
+      let cmm, free_vars, symbol_inits =
+        wrap (C.sequence cmm body) free_vars symbol_inits
+      in
       cmm, free_vars, symbol_inits, res)
   | Singleton _, Rec_info _ -> expr env res body
   | Singleton _, (Set_of_closures _ | Static_consts _)
@@ -802,7 +815,9 @@ and let_cont_not_inlined env res k handler body =
          Env.add_inlined_debuginfo to it *)
       let dbg = Debuginfo.none in
       let body, free_vars_of_body, body_symbol_inits, res = expr env res body in
-      let symbol_inits = Env.Symbol_inits.merge handler_symbol_inits body_symbol_inits in
+      let symbol_inits =
+        Env.Symbol_inits.merge handler_symbol_inits body_symbol_inits
+      in
       let free_vars =
         Backend_var.Set.union free_vars_of_body
           (C.remove_vars_with_machtype free_vars_of_handler vars)
@@ -890,9 +905,10 @@ and let_cont_rec env res invariant_params conts body =
         let vars, _arity, handler, free_vars_of_handler, symbol_inits, res =
           continuation_handler env res handler
         in
-        (* It should be an flambda2 invariant that symbols are bound at top-level,
-           and the handler of a loop is clearly not top-level *)
-        if not (Env.Symbol_inits.is_empty symbol_inits) then
+        (* It should be an flambda2 invariant that symbols are bound at
+           top-level, and the handler of a loop is clearly not top-level *)
+        if not (Env.Symbol_inits.is_empty symbol_inits)
+        then
           Format.eprintf "Found leftover symbol inits in the body of a loop: %a"
             Env.Symbol_inits.print symbol_inits;
         ( Continuation.Map.add k
@@ -922,7 +938,7 @@ and let_cont_rec env res invariant_params conts body =
       conts_to_handlers ([], free_vars_of_body)
   in
   let cmm = C.create_ccatch ~rec_flag:true ~body ~handlers in
-  let cmm, free_vars, symbol_inits  = wrap cmm free_vars symbol_inits in
+  let cmm, free_vars, symbol_inits = wrap cmm free_vars symbol_inits in
   cmm, free_vars, symbol_inits, res
 
 and continuation_handler env res handler =
@@ -930,9 +946,12 @@ and continuation_handler env res handler =
     ~f:(fun params ~num_normal_occurrences_of_params:_ ~handler ->
       let arity = Bound_parameters.arity params in
       let env, vars = C.continuation_bound_parameters env params in
-      let expr, free_vars_of_handler, symbol_inits, res = expr env res handler in
+      let expr, free_vars_of_handler, symbol_inits, res =
+        expr env res handler
+      in
       let expr, free_vars_of_handler, symbol_inits =
-        Env.place_symbol_inits ~params:vars expr free_vars_of_handler symbol_inits
+        Env.place_symbol_inits ~params:vars expr free_vars_of_handler
+          symbol_inits
       in
       vars, arity, expr, free_vars_of_handler, symbol_inits, res)
 
@@ -962,7 +981,9 @@ and apply_expr env res apply =
   | Never_returns ->
     (* Case 1 *)
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-    let cmm, free_vars, symbol_inits = wrap call free_vars Env.Symbol_inits.empty in
+    let cmm, free_vars, symbol_inits =
+      wrap call free_vars Env.Symbol_inits.empty
+    in
     cmm, free_vars, symbol_inits, res
   | Return k -> (
     match Env.get_continuation env k with
@@ -976,7 +997,9 @@ and apply_expr env res apply =
         let wrap, _, res =
           Env.flush_delayed_lets ~mode:Branching_point env res
         in
-        let cmm, free_vars, symbol_inits = wrap call free_vars Env.Symbol_inits.empty in
+        let cmm, free_vars, symbol_inits =
+          wrap call free_vars Env.Symbol_inits.empty
+        in
         cmm, free_vars, symbol_inits, res
       else
         Misc.fatal_errorf
@@ -986,7 +1009,9 @@ and apply_expr env res apply =
     | Jump { param_types = _; cont } ->
       (* Case 2 *)
       let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-      let cmm, free_vars, symbol_inits = wrap (C.cexit cont [call] []) free_vars Env.Symbol_inits.empty in
+      let cmm, free_vars, symbol_inits =
+        wrap (C.cexit cont [call] []) free_vars Env.Symbol_inits.empty
+      in
       cmm, free_vars, symbol_inits, res
     | Inline
         { handler_params;
@@ -1029,9 +1054,12 @@ and apply_expr env res apply =
         let env =
           Env.set_inlined_debuginfo env handler_body_inlined_debuginfo
         in
-        let expr, free_vars_of_handler, handler_symbol_inits, res = expr env res body in
+        let expr, free_vars_of_handler, handler_symbol_inits, res =
+          expr env res body
+        in
         let expr, free_vars_of_handler, symbol_inits =
-          Env.place_symbol_inits ~params:params_with_machtype expr free_vars_of_handler handler_symbol_inits
+          Env.place_symbol_inits ~params:params_with_machtype expr
+            free_vars_of_handler handler_symbol_inits
         in
         (* we know the handler can't be cold, or it wouldn't have been
            inlined. *)
@@ -1165,7 +1193,9 @@ and switch env res switch =
   in
   let make_arm ~must_tag_discriminant env res (d, action) =
     let d = prepare_discriminant ~must_tag:must_tag_discriminant d in
-    let cmm_action, action_free_vars, action_symbol_inits, res = apply_cont env res action in
+    let cmm_action, action_free_vars, action_symbol_inits, res =
+      apply_cont env res action
+    in
     ( ( d,
         cmm_action,
         action_free_vars,
@@ -1185,18 +1215,22 @@ and switch env res switch =
        before creating an if-then-else, introducing an indirection that might
        prevent some optimizations performed by Selectgen/Emit when the condition
        is inlined in the if-then-else. Instead we use [C.ite]. *)
-    | (0, else_, else_free_vars, else_inits, else_dbg), (_, then_, then_free_vars, then_inits, then_dbg)
-    | (_, then_, then_free_vars, then_inits, then_dbg), (0, else_, else_free_vars, else_inits, else_dbg)
-      ->
+    | ( (0, else_, else_free_vars, else_inits, else_dbg),
+        (_, then_, then_free_vars, then_inits, then_dbg) )
+    | ( (_, then_, then_free_vars, then_inits, then_dbg),
+        (0, else_, else_free_vars, else_inits, else_dbg) ) ->
       let free_vars =
         Backend_var.Set.union scrutinee_free_vars
           (Backend_var.Set.union else_free_vars then_free_vars)
       in
-      (* CR gbury: technically, these symbol inits should be empty since neither of the branches
-         should be at top-level, but it should not hurt to do this. *)
+      (* CR gbury: technically, these symbol inits should be empty since neither
+         of the branches should be at top-level, but it should not hurt to do
+         this. *)
       let symbol_inits = Env.Symbol_inits.merge then_inits else_inits in
       let cmm, free_vars, symbol_inits =
-        wrap (C.ite ~dbg scrutinee ~then_dbg ~then_ ~else_dbg ~else_) free_vars symbol_inits
+        wrap
+          (C.ite ~dbg scrutinee ~then_dbg ~then_ ~else_dbg ~else_)
+          free_vars symbol_inits
       in
       cmm, free_vars, symbol_inits, res
     (* Similar case to the previous but none of the arms match 0, so we have to
@@ -1213,9 +1247,12 @@ and switch env res switch =
           (C.eq ~dbg (C.int ~dbg x) scrutinee)
           ~then_dbg:if_x_dbg ~then_:if_x ~else_dbg:if_not_dbg ~else_:if_not
       in
-      (* CR gbury: technically, these symbol inits should be empty since neither of the branches
-         should be at top-level, but it should not hurt to do this. *)
-      let symbol_inits = Env.Symbol_inits.merge if_x_symbol_inits if_not_symbol_inits in
+      (* CR gbury: technically, these symbol inits should be empty since neither
+         of the branches should be at top-level, but it should not hurt to do
+         this. *)
+      let symbol_inits =
+        Env.Symbol_inits.merge if_x_symbol_inits if_not_symbol_inits
+      in
       let cmm, free_vars, symbol_inits = wrap expr free_vars symbol_inits in
       cmm, free_vars, symbol_inits, res)
   (* General case *)
@@ -1230,12 +1267,16 @@ and switch env res switch =
     let _, res, free_vars, symbol_inits =
       Targetint_31_63.Map.fold
         (fun discriminant action (i, res, free_vars, symbol_inits) ->
-          let (d, cmm_action, action_free_vars, action_symbol_inits, _dbg), res =
+          let (d, cmm_action, action_free_vars, action_symbol_inits, _dbg), res
+              =
             make_arm ~must_tag_discriminant env res (discriminant, action)
           in
-          (* CR gbury: technically, these symbol inits should be empty since neither of the branches
-             should be at top-level, but it should not hurt to do this. *)
-          let symbol_inits = Env.Symbol_inits.merge symbol_inits action_symbol_inits in
+          (* CR gbury: technically, these symbol inits should be empty since
+             neither of the branches should be at top-level, but it should not
+             hurt to do this. *)
+          let symbol_inits =
+            Env.Symbol_inits.merge symbol_inits action_symbol_inits
+          in
           let free_vars = Backend_var.Set.union free_vars action_free_vars in
           cases.(i) <- cmm_action;
           index.(d) <- i;

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -535,8 +535,8 @@ let translate_raise ~dbg_with_inlined:dbg env res apply exn_handler args =
     let free_vars = Backend_var.Set.union exn_free_vars extra_free_vars in
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
     let cmm = C.raise_prim raise_kind exn ~extra_args:extra dbg in
-    let cmm, free_vars = wrap cmm free_vars in
-    cmm, free_vars, res
+    let cmm, free_vars, symbol_inits = wrap cmm free_vars Env.empty_symbol_inits in
+    cmm, free_vars, symbol_inits, res
   | [] ->
     Misc.fatal_errorf "Exception continuation %a has no arguments:@ \n%a"
       Continuation.print exn_handler Apply_cont.print apply
@@ -558,8 +558,8 @@ let translate_jump_to_continuation ~dbg_with_inlined:dbg env res apply types
     let args = C.remove_skipped_args args types in
     let args, free_vars, env, res, _ = C.simple_list ~dbg env res args in
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-    let cmm, free_vars = wrap (C.cexit cont args trap_actions) free_vars in
-    cmm, free_vars, res
+    let cmm, free_vars, symbol_inits = wrap (C.cexit cont args trap_actions) free_vars Env.empty_symbol_inits in
+    cmm, free_vars, symbol_inits, res
   else
     Misc.fatal_errorf "Types (%a) do not match arguments of@ %a"
       (Format.pp_print_list ~pp_sep:Format.pp_print_space
@@ -579,14 +579,14 @@ let translate_jump_to_return_continuation ~dbg_with_inlined:dbg env res apply
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
     match Apply_cont.trap_action apply with
     | None ->
-      let cmm, free_vars = wrap return_value free_vars in
-      cmm, free_vars, res
+      let cmm, free_vars, symbol_inits = wrap return_value free_vars Env.empty_symbol_inits in
+      cmm, free_vars, symbol_inits, res
     | Some (Pop { exn_handler; _ }) ->
       let cont = Env.get_cmm_continuation env exn_handler in
-      let cmm, free_vars =
-        wrap (C.trap_return return_value [Cmm.Pop cont]) free_vars
+      let cmm, free_vars, symbol_inits =
+        wrap (C.trap_return return_value [Cmm.Pop cont]) free_vars Env.empty_symbol_inits
       in
-      cmm, free_vars, res
+      cmm, free_vars, symbol_inits, res
     | Some (Push _) ->
       Misc.fatal_errorf
         "Return continuation %a should not be applied with a Push trap action"
@@ -602,12 +602,12 @@ let invalid env res ~message =
     Env.flush_delayed_lets ~mode:Branching_point env res
   in
   let cmm_invalid, res = C.invalid res ~message in
-  let cmm, free_vars = wrap cmm_invalid Backend_var.Set.empty in
-  cmm, free_vars, res
+  let cmm, free_vars, symbol_inits = wrap cmm_invalid Backend_var.Set.empty Env.empty_symbol_inits in
+  cmm, free_vars, symbol_inits, res
 
 (* The main set of translation functions for expressions *)
 
-let rec expr env res e : Cmm.expression * Backend_var.Set.t * To_cmm_result.t =
+let rec expr env res e : Cmm.expression * Backend_var.Set.t * Env.symbol_inits * To_cmm_result.t =
   match Expr.descr e with
   | Let e' -> let_expr env res e'
   | Let_cont e' -> let_cont env res e'
@@ -694,11 +694,11 @@ and let_expr0 env res let_expr (bound_pattern : Bound_pattern.t)
     let wrap, env, res =
       Env.flush_delayed_lets ~mode:Flush_everything env res
     in
-    let cmm, free_vars, res =
+    let cmm, free_vars, symbol_inits, res =
       let_prim env res ~num_normal_occurrences_of_bound_vars v p dbg body
     in
-    let cmm, free_vars = wrap cmm free_vars in
-    cmm, free_vars, res
+    let cmm, free_vars, symbol_inits = wrap cmm free_vars symbol_inits in
+    cmm, free_vars, symbol_inits, res
   | Singleton v, Prim (p, dbg) ->
     let_prim env res ~num_normal_occurrences_of_bound_vars v p dbg body
   | Set_of_closures bound_vars, Set_of_closures soc ->
@@ -717,10 +717,10 @@ and let_expr0 env res let_expr (bound_pattern : Bound_pattern.t)
       let wrap, env, res =
         Env.flush_delayed_lets ~mode:Branching_point env res
       in
-      let body, body_free_vars, res = expr env res body in
+      let body, body_free_vars, symbol_inits, res = expr env res body in
       let free_vars = Backend_var.Set.union free_vars body_free_vars in
-      let cmm, free_vars = wrap (C.sequence cmm body) free_vars in
-      cmm, free_vars, res)
+      let cmm, free_vars, symbol_inits = wrap (C.sequence cmm body) free_vars symbol_inits in
+      cmm, free_vars, symbol_inits, res)
   | Singleton _, Rec_info _ -> expr env res body
   | Singleton _, (Set_of_closures _ | Static_consts _)
   | Set_of_closures _, (Simple _ | Prim _ | Static_consts _ | Rec_info _)
@@ -782,13 +782,13 @@ and let_cont_not_inlined env res k handler body =
   let wrap, env, res = Env.flush_delayed_lets ~mode:Branching_point env res in
   let is_exn_handler = Continuation_handler.is_exn_handler handler in
   let is_cold = Continuation_handler.is_cold handler in
-  let vars, arity, handler, free_vars_of_handler, res =
+  let vars, arity, handler, free_vars_of_handler, handler_symbol_inits, res =
     continuation_handler env res handler
   in
   let catch_id, env =
     Env.add_jump_cont env k ~param_types:(List.map snd vars)
   in
-  let cmm, free_vars, res =
+  let cmm, free_vars, symbol_inits, res =
     (* Exception continuations are translated specially -- these will be reached
        via the raising of exceptions, whereas other continuations are reached
        using a normal jump. *)
@@ -801,7 +801,8 @@ and let_cont_not_inlined env res k handler body =
       (* CR gbury: once we get proper debuginfo here, remember to apply
          Env.add_inlined_debuginfo to it *)
       let dbg = Debuginfo.none in
-      let body, free_vars_of_body, res = expr env res body in
+      let body, free_vars_of_body, body_symbol_inits, res = expr env res body in
+      let symbol_inits = Env.merge_symbol_inits handler_symbol_inits body_symbol_inits in
       let free_vars =
         Backend_var.Set.union free_vars_of_body
           (C.remove_vars_with_machtype free_vars_of_handler vars)
@@ -812,10 +813,11 @@ and let_cont_not_inlined env res k handler body =
                 (C.remove_skipped_params vars)
                 handler is_cold ],
         free_vars,
+        symbol_inits,
         res )
   in
-  let cmm, free_vars = wrap cmm free_vars in
-  cmm, free_vars, res
+  let cmm, free_vars, symbol_inits = wrap cmm free_vars symbol_inits in
+  cmm, free_vars, symbol_inits, res
 
 (* Exception continuations are translated using delayed Ctrywith blocks. The
    exception handler parts of these blocks are identified by the [catch_id]s. *)
@@ -839,7 +841,7 @@ and let_cont_exn_handler env res k body vars handler free_vars_of_handler
       extra_params
   in
   let env_body = Env.add_exn_handler env k arity in
-  let body, free_vars_of_body, res = expr env_body res body in
+  let body, free_vars_of_body, symbol_inits, res = expr env_body res body in
   let free_vars =
     Backend_var.Set.union free_vars_of_body
       (C.remove_vars_with_machtype free_vars_of_handler vars)
@@ -851,6 +853,7 @@ and let_cont_exn_handler env res k body vars handler free_vars_of_handler
   ( C.trywith ~dbg ~body ~exn_var ~extra_args:extra_params
       ~handler_cont:catch_id ~handler (),
     free_vars,
+    symbol_inits,
     res )
 
 and let_cont_rec env res invariant_params conts body =
@@ -884,9 +887,12 @@ and let_cont_rec env res invariant_params conts body =
   let conts_to_handlers, res =
     Continuation.Lmap.fold
       (fun k handler (conts_to_handlers, res) ->
-        let vars, _arity, handler, free_vars_of_handler, res =
+        let vars, _arity, handler, free_vars_of_handler, symbol_inits, res =
           continuation_handler env res handler
         in
+        (* It should be an flambda2 invariant that symbols are bound at top-level,
+           and the handler of a loop is clearly not top-level *)
+        Env.check_is_empty_symbol_inits symbol_inits;
         ( Continuation.Map.add k
             (invariant_vars @ vars, handler, free_vars_of_handler)
             conts_to_handlers,
@@ -898,7 +904,7 @@ and let_cont_rec env res invariant_params conts body =
   (* CR gbury: once we get proper debuginfo here, remember to apply
      Env.add_inlined_debuginfo to it *)
   let dbg = Debuginfo.none in
-  let body, free_vars_of_body, res = expr env res body in
+  let body, free_vars_of_body, symbol_inits, res = expr env res body in
   (* Setup the Cmm handlers for the Ccatch *)
   let handlers, free_vars =
     Continuation.Map.fold
@@ -914,16 +920,19 @@ and let_cont_rec env res invariant_params conts body =
       conts_to_handlers ([], free_vars_of_body)
   in
   let cmm = C.create_ccatch ~rec_flag:true ~body ~handlers in
-  let cmm, free_vars = wrap cmm free_vars in
-  cmm, free_vars, res
+  let cmm, free_vars, symbol_inits  = wrap cmm free_vars symbol_inits in
+  cmm, free_vars, symbol_inits, res
 
 and continuation_handler env res handler =
   Continuation_handler.pattern_match' handler
     ~f:(fun params ~num_normal_occurrences_of_params:_ ~handler ->
       let arity = Bound_parameters.arity params in
       let env, vars = C.continuation_bound_parameters env params in
-      let expr, free_vars_of_handler, res = expr env res handler in
-      vars, arity, expr, free_vars_of_handler, res)
+      let expr, free_vars_of_handler, symbol_inits, res = expr env res handler in
+      let expr, free_vars_of_handler, symbol_inits =
+        Env.place_symbol_inits ~params:vars expr free_vars_of_handler symbol_inits
+      in
+      vars, arity, expr, free_vars_of_handler, symbol_inits, res)
 
 and apply_expr env res apply =
   let call, free_vars, env, res, effs = translate_apply env res apply in
@@ -951,8 +960,8 @@ and apply_expr env res apply =
   | Never_returns ->
     (* Case 1 *)
     let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-    let cmm, free_vars = wrap call free_vars in
-    cmm, free_vars, res
+    let cmm, free_vars, symbol_inits = wrap call free_vars Env.empty_symbol_inits in
+    cmm, free_vars, symbol_inits, res
   | Return k -> (
     match Env.get_continuation env k with
     | Return { param_types } ->
@@ -965,8 +974,8 @@ and apply_expr env res apply =
         let wrap, _, res =
           Env.flush_delayed_lets ~mode:Branching_point env res
         in
-        let cmm, free_vars = wrap call free_vars in
-        cmm, free_vars, res
+        let cmm, free_vars, symbol_inits = wrap call free_vars Env.empty_symbol_inits in
+        cmm, free_vars, symbol_inits, res
       else
         Misc.fatal_errorf
           "Types (%a) do not match arguments for the return cont of@ %a"
@@ -975,8 +984,8 @@ and apply_expr env res apply =
     | Jump { param_types = _; cont } ->
       (* Case 2 *)
       let wrap, _, res = Env.flush_delayed_lets ~mode:Branching_point env res in
-      let cmm, free_vars = wrap (C.cexit cont [call] []) free_vars in
-      cmm, free_vars, res
+      let cmm, free_vars, symbol_inits = wrap (C.cexit cont [call] []) free_vars Env.empty_symbol_inits in
+      cmm, free_vars, symbol_inits, res
     | Inline
         { handler_params;
           handler_body = body;
@@ -1018,7 +1027,10 @@ and apply_expr env res apply =
         let env =
           Env.set_inlined_debuginfo env handler_body_inlined_debuginfo
         in
-        let expr, free_vars_of_handler, res = expr env res body in
+        let expr, free_vars_of_handler, handler_symbol_inits, res = expr env res body in
+        let expr, free_vars_of_handler, symbol_inits =
+          Env.place_symbol_inits ~params:params_with_machtype expr free_vars_of_handler handler_symbol_inits
+        in
         (* we know the handler can't be cold, or it wouldn't have been
            inlined. *)
         let handler =
@@ -1033,8 +1045,8 @@ and apply_expr env res apply =
             (C.remove_vars_with_machtype free_vars_of_handler
                params_with_machtype)
         in
-        let cmm, free_vars = wrap expr free_vars in
-        cmm, free_vars, res))
+        let cmm, free_vars, symbol_inits = wrap expr free_vars symbol_inits in
+        cmm, free_vars, symbol_inits, res))
 
 and apply_cont env res apply_cont =
   let dbg_with_inlined =
@@ -1151,10 +1163,11 @@ and switch env res switch =
   in
   let make_arm ~must_tag_discriminant env res (d, action) =
     let d = prepare_discriminant ~must_tag:must_tag_discriminant d in
-    let cmm_action, action_free_vars, res = apply_cont env res action in
+    let cmm_action, action_free_vars, action_symbol_inits, res = apply_cont env res action in
     ( ( d,
         cmm_action,
         action_free_vars,
+        action_symbol_inits,
         Env.add_inlined_debuginfo env (Apply_cont.debuginfo action) ),
       res )
   in
@@ -1170,22 +1183,23 @@ and switch env res switch =
        before creating an if-then-else, introducing an indirection that might
        prevent some optimizations performed by Selectgen/Emit when the condition
        is inlined in the if-then-else. Instead we use [C.ite]. *)
-    | (0, else_, else_free_vars, else_dbg), (_, then_, then_free_vars, then_dbg)
-    | (_, then_, then_free_vars, then_dbg), (0, else_, else_free_vars, else_dbg)
+    | (0, else_, else_free_vars, else_inits, else_dbg), (_, then_, then_free_vars, then_inits, then_dbg)
+    | (_, then_, then_free_vars, then_inits, then_dbg), (0, else_, else_free_vars, else_inits, else_dbg)
       ->
       let free_vars =
         Backend_var.Set.union scrutinee_free_vars
           (Backend_var.Set.union else_free_vars then_free_vars)
       in
-      let cmm, free_vars =
-        wrap (C.ite ~dbg scrutinee ~then_dbg ~then_ ~else_dbg ~else_) free_vars
+      let symbol_inits = Env.merge_symbol_inits then_inits else_inits in
+      let cmm, free_vars, symbol_inits =
+        wrap (C.ite ~dbg scrutinee ~then_dbg ~then_ ~else_dbg ~else_) free_vars symbol_inits
       in
-      cmm, free_vars, res
+      cmm, free_vars, symbol_inits, res
     (* Similar case to the previous but none of the arms match 0, so we have to
        generate an equality test, and make sure it is inside the condition to
        ensure Selectgen and Emit can take advantage of it. *)
-    | ( (x, if_x, if_x_free_vars, if_x_dbg),
-        (_, if_not, if_not_free_vars, if_not_dbg) ) ->
+    | ( (x, if_x, if_x_free_vars, if_x_symbol_inits, if_x_dbg),
+        (_, if_not, if_not_free_vars, if_not_symbol_inits, if_not_dbg) ) ->
       let free_vars =
         Backend_var.Set.union scrutinee_free_vars
           (Backend_var.Set.union if_x_free_vars if_not_free_vars)
@@ -1195,8 +1209,9 @@ and switch env res switch =
           (C.eq ~dbg (C.int ~dbg x) scrutinee)
           ~then_dbg:if_x_dbg ~then_:if_x ~else_dbg:if_not_dbg ~else_:if_not
       in
-      let cmm, free_vars = wrap expr free_vars in
-      cmm, free_vars, res)
+      let symbol_inits = Env.merge_symbol_inits if_x_symbol_inits if_not_symbol_inits in
+      let cmm, free_vars, symbol_inits = wrap expr free_vars symbol_inits in
+      cmm, free_vars, symbol_inits, res)
   (* General case *)
   | n ->
     (* transl_switch_clambda expects an [index] array such that index.(d) is the
@@ -1206,20 +1221,21 @@ and switch env res switch =
     let unreachable, res = C.invalid res ~message:"unreachable switch case" in
     let cases = Array.make (n + 1) unreachable in
     let index = Array.make (m + 1) n in
-    let _, res, free_vars =
+    let _, res, free_vars, symbol_inits =
       Targetint_31_63.Map.fold
-        (fun discriminant action (i, res, free_vars) ->
-          let (d, cmm_action, action_free_vars, _dbg), res =
+        (fun discriminant action (i, res, free_vars, symbol_inits) ->
+          let (d, cmm_action, action_free_vars, action_symbol_inits, _dbg), res =
             make_arm ~must_tag_discriminant env res (discriminant, action)
           in
+          let symbol_inits = Env.merge_symbol_inits symbol_inits action_symbol_inits in
           let free_vars = Backend_var.Set.union free_vars action_free_vars in
           cases.(i) <- cmm_action;
           index.(d) <- i;
-          i + 1, res, free_vars)
+          i + 1, res, free_vars, symbol_inits)
         arms
-        (0, res, scrutinee_free_vars)
+        (0, res, scrutinee_free_vars, Env.empty_symbol_inits)
     in
     (* CR-someday poechsel: Put a more precise value kind here *)
     let expr = C.transl_switch_clambda dbg scrutinee index cases in
-    let cmm, free_vars = wrap expr free_vars in
-    cmm, free_vars, res
+    let cmm, free_vars, symbol_inits = wrap expr free_vars symbol_inits in
+    cmm, free_vars, symbol_inits, res

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.mli
@@ -18,4 +18,4 @@ val expr :
   To_cmm_env.t ->
   To_cmm_result.t ->
   Flambda.Expr.t ->
-  Cmm.expression * To_cmm_env.free_vars * To_cmm_result.t
+  Cmm.expression * To_cmm_env.free_vars * To_cmm_env.symbol_inits * To_cmm_result.t

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.mli
@@ -18,4 +18,4 @@ val expr :
   To_cmm_env.t ->
   To_cmm_result.t ->
   Flambda.Expr.t ->
-  Cmm.expression * To_cmm_env.free_vars * To_cmm_env.symbol_inits * To_cmm_result.t
+  Cmm.expression * To_cmm_env.free_vars * To_cmm_env.Symbol_inits.t * To_cmm_result.t

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.mli
@@ -18,4 +18,7 @@ val expr :
   To_cmm_env.t ->
   To_cmm_result.t ->
   Flambda.Expr.t ->
-  Cmm.expression * To_cmm_env.free_vars * To_cmm_env.Symbol_inits.t * To_cmm_result.t
+  Cmm.expression
+  * To_cmm_env.free_vars
+  * To_cmm_env.Symbol_inits.t
+  * To_cmm_result.t

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -28,7 +28,7 @@ type translate_expr =
   To_cmm_env.t ->
   To_cmm_result.t ->
   Expr.t ->
-  Cmm.expression * To_cmm_env.free_vars * To_cmm_result.t
+  Cmm.expression * To_cmm_env.free_vars * To_cmm_env.symbol_inits * To_cmm_result.t
 
 (* Filling of closure blocks *)
 
@@ -438,7 +438,7 @@ let transl_check_attrib : Zero_alloc_attribute.t -> Cmm.codegen_option list =
 let params_and_body0 env res code_id ~result_arity ~fun_dbg
     ~zero_alloc_attribute ~return_continuation ~exn_continuation params ~body
     ~my_closure ~(is_my_closure_used : _ Or_unknown.t) ~my_region
-    ~my_ghost_region ~translate_expr =
+    ~my_ghost_region ~(translate_expr : translate_expr) =
   let params =
     let is_my_closure_used =
       match is_my_closure_used with
@@ -486,7 +486,9 @@ let params_and_body0 env res code_id ~result_arity ~fun_dbg
   in
   (* Translate the arg list and body *)
   let env, fun_params = C.function_bound_parameters env params in
-  let fun_body, fun_body_free_vars, res = translate_expr env res body in
+  let fun_body, fun_body_free_vars, fun_body_symbol_inits, res = translate_expr env res body in
+  (* Symbol definitions should have been lifted at top-level *)
+  To_cmm_env.check_is_empty_symbol_inits fun_body_symbol_inits;
   let fun_free_vars =
     C.remove_vars_with_machtype
       (C.remove_var_opt_with_provenance
@@ -521,7 +523,7 @@ let params_and_body0 env res code_id ~result_arity ~fun_dbg
   C.fundecl fun_sym fun_params fun_body fun_flags fun_dbg fun_poll, res
 
 let params_and_body env res code_id p ~result_arity ~fun_dbg
-    ~zero_alloc_attribute ~translate_expr =
+    ~zero_alloc_attribute ~(translate_expr : translate_expr) =
   Function_params_and_body.pattern_match p
     ~f:(fun
          ~return_continuation
@@ -650,7 +652,7 @@ let let_static_set_of_closures env res closure_symbols set ~prev_updates =
  *   g
 
  *)
-let lift_set_of_closures env res ~body ~bound_vars layout set ~translate_expr
+let lift_set_of_closures env res ~body ~bound_vars layout set ~(translate_expr : translate_expr)
     ~num_normal_occurrences_of_bound_vars =
   (* Generate symbols for the set of closures, and each of the closures *)
   let comp_unit = Compilation_unit.get_current_exn () in
@@ -700,7 +702,7 @@ let lift_set_of_closures env res ~body ~bound_vars layout set ~translate_expr
 
 let let_dynamic_set_of_closures0 env res ~body ~bound_vars set
     (layout : Slot_offsets.Layout.t) ~num_normal_occurrences_of_bound_vars
-    ~(closure_alloc_mode : Alloc_mode.For_allocations.t) ~translate_expr =
+    ~(closure_alloc_mode : Alloc_mode.For_allocations.t) ~(translate_expr : translate_expr) =
   let fun_decls = Set_of_closures.function_decls set in
   let decls = Function_declarations.funs_in_order fun_decls in
   let value_slots = Set_of_closures.value_slots set in
@@ -779,7 +781,7 @@ let let_dynamic_set_of_closures0 env res ~body ~bound_vars set
   translate_expr env res body
 
 let let_dynamic_set_of_closures env res ~body ~bound_vars
-    ~num_normal_occurrences_of_bound_vars set ~translate_expr =
+    ~num_normal_occurrences_of_bound_vars set ~(translate_expr : translate_expr) =
   let layout = layout_for_set_of_closures env set in
   if layout.empty_env
   then

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -28,7 +28,10 @@ type translate_expr =
   To_cmm_env.t ->
   To_cmm_result.t ->
   Expr.t ->
-  Cmm.expression * To_cmm_env.free_vars * To_cmm_env.Symbol_inits.t * To_cmm_result.t
+  Cmm.expression
+  * To_cmm_env.free_vars
+  * To_cmm_env.Symbol_inits.t
+  * To_cmm_result.t
 
 (* Filling of closure blocks *)
 
@@ -486,10 +489,14 @@ let params_and_body0 env res code_id ~result_arity ~fun_dbg
   in
   (* Translate the arg list and body *)
   let env, fun_params = C.function_bound_parameters env params in
-  let fun_body, fun_body_free_vars, fun_body_symbol_inits, res = translate_expr env res body in
+  let fun_body, fun_body_free_vars, fun_body_symbol_inits, res =
+    translate_expr env res body
+  in
   (* Symbol definitions should have been lifted at top-level *)
-  if not (To_cmm_env.Symbol_inits.is_empty fun_body_symbol_inits) then
-    Misc.fatal_errorf "Found leftover symbol initializations statements in a function body: %a"
+  if not (To_cmm_env.Symbol_inits.is_empty fun_body_symbol_inits)
+  then
+    Misc.fatal_errorf
+      "Found leftover symbol initializations statements in a function body: %a"
       To_cmm_env.Symbol_inits.print fun_body_symbol_inits;
   let fun_free_vars =
     C.remove_vars_with_machtype
@@ -654,8 +661,8 @@ let let_static_set_of_closures env res closure_symbols set ~prev_updates =
  *   g
 
  *)
-let lift_set_of_closures env res ~body ~bound_vars layout set ~(translate_expr : translate_expr)
-    ~num_normal_occurrences_of_bound_vars =
+let lift_set_of_closures env res ~body ~bound_vars layout set
+    ~(translate_expr : translate_expr) ~num_normal_occurrences_of_bound_vars =
   (* Generate symbols for the set of closures, and each of the closures *)
   let comp_unit = Compilation_unit.get_current_exn () in
   let dbg = debuginfo_for_set_of_closures env set in
@@ -704,7 +711,8 @@ let lift_set_of_closures env res ~body ~bound_vars layout set ~(translate_expr :
 
 let let_dynamic_set_of_closures0 env res ~body ~bound_vars set
     (layout : Slot_offsets.Layout.t) ~num_normal_occurrences_of_bound_vars
-    ~(closure_alloc_mode : Alloc_mode.For_allocations.t) ~(translate_expr : translate_expr) =
+    ~(closure_alloc_mode : Alloc_mode.For_allocations.t)
+    ~(translate_expr : translate_expr) =
   let fun_decls = Set_of_closures.function_decls set in
   let decls = Function_declarations.funs_in_order fun_decls in
   let value_slots = Set_of_closures.value_slots set in
@@ -783,7 +791,8 @@ let let_dynamic_set_of_closures0 env res ~body ~bound_vars set
   translate_expr env res body
 
 let let_dynamic_set_of_closures env res ~body ~bound_vars
-    ~num_normal_occurrences_of_bound_vars set ~(translate_expr : translate_expr) =
+    ~num_normal_occurrences_of_bound_vars set ~(translate_expr : translate_expr)
+    =
   let layout = layout_for_set_of_closures env set in
   if layout.empty_env
   then

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -28,7 +28,7 @@ type translate_expr =
   To_cmm_env.t ->
   To_cmm_result.t ->
   Expr.t ->
-  Cmm.expression * To_cmm_env.free_vars * To_cmm_env.symbol_inits * To_cmm_result.t
+  Cmm.expression * To_cmm_env.free_vars * To_cmm_env.Symbol_inits.t * To_cmm_result.t
 
 (* Filling of closure blocks *)
 
@@ -488,7 +488,9 @@ let params_and_body0 env res code_id ~result_arity ~fun_dbg
   let env, fun_params = C.function_bound_parameters env params in
   let fun_body, fun_body_free_vars, fun_body_symbol_inits, res = translate_expr env res body in
   (* Symbol definitions should have been lifted at top-level *)
-  To_cmm_env.check_is_empty_symbol_inits fun_body_symbol_inits;
+  if not (To_cmm_env.Symbol_inits.is_empty fun_body_symbol_inits) then
+    Misc.fatal_errorf "Found leftover symbol initializations statements in a function body: %a"
+      To_cmm_env.Symbol_inits.print fun_body_symbol_inits;
   let fun_free_vars =
     C.remove_vars_with_machtype
       (C.remove_var_opt_with_provenance

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
@@ -20,7 +20,10 @@ type translate_expr =
   To_cmm_env.t ->
   To_cmm_result.t ->
   Expr.t ->
-  Cmm.expression * To_cmm_env.free_vars * To_cmm_env.Symbol_inits.t * To_cmm_result.t
+  Cmm.expression
+  * To_cmm_env.free_vars
+  * To_cmm_env.Symbol_inits.t
+  * To_cmm_result.t
 
 val let_static_set_of_closures :
   To_cmm_env.t ->
@@ -41,7 +44,10 @@ val let_dynamic_set_of_closures :
   num_normal_occurrences_of_bound_vars:Num_occurrences.t Variable.Map.t ->
   Set_of_closures.t ->
   translate_expr:translate_expr ->
-  Cmm.expression * To_cmm_env.free_vars * To_cmm_env.Symbol_inits.t * To_cmm_result.t
+  Cmm.expression
+  * To_cmm_env.free_vars
+  * To_cmm_env.Symbol_inits.t
+  * To_cmm_result.t
 
 val params_and_body :
   To_cmm_env.t ->

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
@@ -20,7 +20,7 @@ type translate_expr =
   To_cmm_env.t ->
   To_cmm_result.t ->
   Expr.t ->
-  Cmm.expression * To_cmm_env.free_vars * To_cmm_env.symbol_inits * To_cmm_result.t
+  Cmm.expression * To_cmm_env.free_vars * To_cmm_env.Symbol_inits.t * To_cmm_result.t
 
 val let_static_set_of_closures :
   To_cmm_env.t ->
@@ -41,7 +41,7 @@ val let_dynamic_set_of_closures :
   num_normal_occurrences_of_bound_vars:Num_occurrences.t Variable.Map.t ->
   Set_of_closures.t ->
   translate_expr:translate_expr ->
-  Cmm.expression * To_cmm_env.free_vars * To_cmm_env.symbol_inits * To_cmm_result.t
+  Cmm.expression * To_cmm_env.free_vars * To_cmm_env.Symbol_inits.t * To_cmm_result.t
 
 val params_and_body :
   To_cmm_env.t ->

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.mli
@@ -20,7 +20,7 @@ type translate_expr =
   To_cmm_env.t ->
   To_cmm_result.t ->
   Expr.t ->
-  Cmm.expression * To_cmm_env.free_vars * To_cmm_result.t
+  Cmm.expression * To_cmm_env.free_vars * To_cmm_env.symbol_inits * To_cmm_result.t
 
 val let_static_set_of_closures :
   To_cmm_env.t ->
@@ -41,7 +41,7 @@ val let_dynamic_set_of_closures :
   num_normal_occurrences_of_bound_vars:Num_occurrences.t Variable.Map.t ->
   Set_of_closures.t ->
   translate_expr:translate_expr ->
-  Cmm.expression * To_cmm_env.free_vars * To_cmm_result.t
+  Cmm.expression * To_cmm_env.free_vars * To_cmm_env.symbol_inits * To_cmm_result.t
 
 val params_and_body :
   To_cmm_env.t ->

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -420,7 +420,7 @@ end
 
 let make_update env res dbg ({ kind; stride } : Update_kind.t) ~symbol var
     ~index ~prev_updates =
-  let To_cmm_env.{ env; res; expr = { cmm; free_vars; effs } } =
+  let To_cmm_env.{ env; res; expr = { cmm = field_value; free_vars; effs } } =
     To_cmm_env.inline_variable env res var
   in
   let cmm =
@@ -446,7 +446,8 @@ let make_update env res dbg ({ kind; stride } : Update_kind.t) ~symbol var
     match must_use_setfield with
     | Some imm_or_ptr ->
       assert (stride = Arch.size_addr);
-      Cmm_helpers.setfield index imm_or_ptr Root_initialization symbol cmm dbg
+      Cmm_helpers.setfield index imm_or_ptr Root_initialization symbol
+        field_value dbg
     | None ->
       let memory_chunk : Cmm.memory_chunk =
         match kind with
@@ -471,18 +472,33 @@ let make_update env res dbg ({ kind; stride } : Update_kind.t) ~symbol var
         | Naked_vec512 -> Fivetwelve_unaligned
       in
       let addr = strided_field_address symbol ~stride ~index dbg in
-      store ~dbg memory_chunk Initialization ~addr ~new_value:cmm
+      store ~dbg memory_chunk Initialization ~addr ~new_value:field_value
   in
-  let update =
-    match prev_updates with
-    | None -> To_cmm_env.{ cmm; free_vars; effs }
-    | Some (prev : To_cmm_env.expr_with_info) ->
-      let cmm = sequence prev.cmm cmm in
-      let free_vars = Backend_var.Set.union prev.free_vars free_vars in
-      let effs = Ece.join prev.effs effs in
-      To_cmm_env.{ cmm; free_vars; effs }
+  (* We dont need the `return_unit` part of the assignment/initialization
+
+     CR gury: we could instead add this simplification in `Cmm_helpers.sequence`
+     to remove unnecessary unit returns in between expressions that are
+     sequenced. *)
+  let cmm =
+    match[@warning "-4"] cmm with
+    | Csequence (cmm, Cconst_int (1, _)) -> cmm
+    | _ -> cmm
   in
-  env, res, Some update
+  match[@warning "-4"] field_value with
+  | Cvar v ->
+    let env = To_cmm_env.add_symbol_init env v cmm in
+    env, res, prev_updates
+  | _ ->
+    let update =
+      match prev_updates with
+      | None -> To_cmm_env.{ cmm; free_vars; effs }
+      | Some (prev : To_cmm_env.expr_with_info) ->
+        let cmm = sequence prev.cmm cmm in
+        let free_vars = Backend_var.Set.union prev.free_vars free_vars in
+        let effs = Ece.join prev.effs effs in
+        To_cmm_env.{ cmm; free_vars; effs }
+    in
+    env, res, Some update
 
 let check_arity arity args =
   Flambda_arity.cardinal_unarized arity = List.length args


### PR DESCRIPTION
This builds upon #4238  and goes further to move symbol initializations, where the field value is a cmm variable `v`, up right after the binding for `v`. #4238 moves symbol inits up, but cannot cross points where the environment is flushed. This PR propagates symbol initializations (i.e. the map from cmm variables to cmm expressions that initializes symbols) up when rebuilding cmm terms, similarly to what is done for the free vars of generated cmm expressions, which allows symbols inits to cross environment flushes.

We can look at a more complex version of the example from #4238 , where we inline some functions with non-trivial control flow (i.e. functions whose body contain continuations that will not be inlined by to_cmm):
```ocaml
let[@inline never] foo () = 42

let[@inline always] bar () =
  if Sys.opaque_identity true then 13 else 42

let[@inline always] loop () =
  let r = ref 0 in
  for i = 0 to Sys.opaque_identity 5 do
    r := !r + i
  done;
  !r

let field1 = foo ()
let field2 = bar ()
let field3 = loop ()
```

With current main, we get the following cmm code for the module init code:
```
(function no_cse reduce_code_size linscan camlFoo__entry ()
 (catch
   (let field1/422 (app{foo.ml:14,13-19} G:"camlFoo__foo_0_3_code" 1 int)     [ call to `foo` (not inlined)
     (catch                                                                   ┌
       (let Popaque/432 (opaque 3)                                            │ inlined body of `bar`
         (if (== 1 Popaque/432) (exit 8 85) (exit 8 27)))                     │
     with(8 field2/423: int)                                                  └
       (catch                                                                 ┌
         (let for_stop/425 (opaque 11)                                        │ inlined body of `loop`
           (if (<= 1 for_stop/425)                                            │
             (catch rec (exit 7 1 1) with(7 i/427: int                        │
               r_365_unboxed0/428: int)                                       │
               (let Paddint/429 (+ (+ r_365_unboxed0/428 i/427) -1)           │
                 (if (!= i/427 for_stop/425) (exit 7 (+ i/427 2) Paddint/429) │
                   (exit 6 Paddint/429))))                                    │
             (exit 6 1)))                                                     │
       with(6 field3/424: int)                                                └
         (extcall "caml_initialize" (+a G:"camlFoo" 24) field1/422 ->unit) 1  [ init with the result of `foo`
         (extcall "caml_initialize" (+a G:"camlFoo" 32) field2/423 ->unit) 1  [ init with the result of `bar`
         (extcall "caml_initialize" (+a G:"camlFoo" 40) field3/424 ->unit) 1  [ init with the result of `loop`
         (exit 4 G:"camlFoo"))))
 with(4 *ret*/408: val) 1))
```
where we once again get the problem that the lifetime of `field1/422` and  `field2/423` are needlessly long.

With #4238, we get the same output, since the symbol inits cannot cross above the flush at the start of the cmm handler `6`.

With this PR we get
```
(function no_cse reduce_code_size linscan camlFoo__entry ()
 (catch
   (let field1/422 (app{foo.ml:14,13-19} G:"camlFoo__foo_0_3_code" 1 int)       [ call to `foo` (not inlined)
     (extcall "caml_initialize" (+a G:"camlFoo" 24) field1/422 ->unit)          [ init with the result of `foo`
     (catch                                                                     ┌
       (let Popaque/432 (opaque 3)                                              │ inlined body of `bar`
         (if (== 1 Popaque/432) (exit 8 85) (exit 8 27)))                       │
     with(8 field2/423: int)                                                    └
       (extcall "caml_initialize" (+a G:"camlFoo" 32) field2/423 ->unit)        [ init with the result of `bar`
       (catch                                                                   ┌
         (let for_stop/425 (opaque 11)                                          │ inlined body of `loop`
           (if (<= 1 for_stop/425)                                              │
             (catch rec (exit 7 1 1) with(7 i/427: int r/428: int)              │
               (let Paddint/429 (+ (+ r/428 i/427) -1)                          │
                 (if (!= i/427 for_stop/425) (exit 7 (+ i/427 2) Paddint/429)   │
                   (exit 6 Paddint/429))))                                      │
             (exit 6 1)))                                                       │
       with(6 field3/424: int)                                                  └
         (extcall "caml_initialize" (+a G:"camlFoo" 40) field3/424 ->unit)      [ init with the result of `loop`
         (exit 4 G:"camlFoo"))))
 with(4 *ret*/408: val) 1))
```
Resulting in an optimal placement of symbol initializations, and the shorted lifetimes for the values used in the initialization (this also applies in classic mode).

Note that while in this kind of simple examples, this PR achieves the best we can, it will not always apply: if the value used for the symbol initialization is not a cmm variable (but e.g. a substituted primitive), then nothing will change compared to main (though I'd expect a "sea of nodes" approach would be able to optimize this case), similarly if the variable used for symbol init is aliased, the process implemented in this PR may not move it up past the aliasing point (it may depends on some of the choices made by to_cmm).

Finally, while most of the changes may seem simple and mechanical, actually great care must be taken to correctly thread the symbol inits upwards, so all changes should be reviewed carefully to ensure that no symbol inits are dropped, and that they are propagated to the right places.