### PR TITLE
Printing Support for Debugging UIDs Backend

### DIFF
--- a/middle_end/backend_var.ml
+++ b/middle_end/backend_var.ml
@@ -38,7 +38,12 @@ module Provenance = struct
     debug_uid : Flambda2_identifiers.Flambda_debug_uid.t
   }
 
-  let print ppf { module_path; location; original_ident; debug_uid = _ } =
+  let print_debug_uid ppf duid =
+    if !Clflags.dump_debug_uids then
+      Format.fprintf ppf "%@{%a}"
+        Flambda2_identifiers.Flambda_debug_uid.print duid
+
+  let print ppf { module_path; location; original_ident; debug_uid } =
     let printf fmt = Format.fprintf ppf fmt in
     printf "@[<hov 1>(";
     printf "@[<hov 1>(module_path@ %a)@]@ "
@@ -46,10 +51,9 @@ module Provenance = struct
     if !Clflags.locations then
       printf "@[<hov 1>(location@ %a)@]@ "
         Debuginfo.print_compact location;
-    printf "@[<hov 1>(original_ident@ %a)@]"
-      Ident.print original_ident;
-    (* CR sspies: Add printing support for the debugging UIDs here,
-       conditionally guarded by a flag. *)
+    printf "@[<hov 1>(original_ident@ %a%a)@]"
+      Ident.print original_ident
+      print_debug_uid debug_uid;
     printf ")@]"
 
   let create ~module_path ~location ~original_ident ~debug_uid =

--- a/middle_end/flambda2/bound_identifiers/bound_parameter.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_parameter.ml
@@ -42,11 +42,15 @@ include Container_types.Make (struct
         Flambda_kind.With_subkind.hash kind,
         Flambda_debug_uid.hash uid )
 
-  let [@ocamlformat "disable"] print ppf { param; kind; uid = _ } =
-    (* CR sspies: Add printing for debug uids, guarded by a flag. *)
-    Format.fprintf ppf "@[(%t%a%t @<1>\u{2237} %a)@]"
+  let print_debug_uid ppf duid =
+    if !Clflags.dump_debug_uids
+    then Format.fprintf ppf "%@{%a}" Flambda_debug_uid.print duid
+
+  let [@ocamlformat "disable"] print ppf { param; kind; uid } =
+    Format.fprintf ppf "@[(%t%a%a%t @<1>\u{2237} %a)@]"
       Flambda_colours.parameter
       Variable.print param
+      print_debug_uid uid
       Flambda_colours.pop
       Flambda_kind.With_subkind.print kind
 end)

--- a/middle_end/flambda2/bound_identifiers/bound_var.ml
+++ b/middle_end/flambda2/bound_identifiers/bound_var.ml
@@ -20,9 +20,12 @@ type t =
     name_mode : Name_mode.t
   }
 
-let [@ocamlformat "disable"] print ppf { var; debug_uid = _; name_mode = _; } =
-  Format.fprintf ppf "%a" Variable.print var
-(* CR sspies: Add printing for debug uids, guarded by a flag. *)
+let print_debug_uid ppf duid =
+  if !Clflags.dump_debug_uids
+  then Format.fprintf ppf "%@{%a}" Flambda_debug_uid.print duid
+
+let [@ocamlformat "disable"] print ppf { var; debug_uid; name_mode = _; } =
+  Format.fprintf ppf "%a%a" Variable.print var print_debug_uid debug_uid
 
 let create var debug_uid name_mode =
   (* Note that [name_mode] might be [In_types], e.g. when dealing with function


### PR DESCRIPTION
This PR builds on #4319. It adds printing support via the flag `-ddebug-uids` for debugging uids in the IRs after Lambda.