### PR TITLE
Zero alloc: improve error message for arch-specific

### DIFF
--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -293,6 +293,17 @@ let print_addressing printreg addr ppf arg =
       let idx = if n <> 0 then Printf.sprintf " + %i" n else "" in
       fprintf ppf "%a + %a * %i%s" printreg arg.(0) printreg arg.(1) scale idx
 
+let floatartith_name (width : float_width) op =
+  match width, op with
+  | Float64, Ifloatadd -> "+f"
+  | Float64, Ifloatsub -> "-f"
+  | Float64, Ifloatmul -> "*f"
+  | Float64, Ifloatdiv -> "/f"
+  | Float32, Ifloatadd -> "+f32"
+  | Float32, Ifloatsub -> "-f32"
+  | Float32, Ifloatmul -> "*f32"
+  | Float32, Ifloatdiv -> "/f32"
+
 let print_specific_operation printreg op ppf arg =
   match op with
   | Ilea addr -> print_addressing printreg addr ppf arg
@@ -303,15 +314,7 @@ let print_specific_operation printreg op ppf arg =
   | Ioffset_loc(n, addr) ->
       fprintf ppf "[%a] +:= %i" (print_addressing printreg addr) arg n
   | Ifloatarithmem(width, op, addr) ->
-      let op_name = match width, op with
-      | Float64, Ifloatadd -> "+f"
-      | Float64, Ifloatsub -> "-f"
-      | Float64, Ifloatmul -> "*f"
-      | Float64, Ifloatdiv -> "/f"
-      | Float32, Ifloatadd -> "+f32"
-      | Float32, Ifloatsub -> "-f32"
-      | Float32, Ifloatmul -> "*f32"
-      | Float32, Ifloatdiv -> "/f32" in
+      let op_name = floatartith_name width op in
       fprintf ppf "%a %s float64[%a]" printreg arg.(0) op_name
                    (print_addressing printreg addr)
                    (Array.sub arg 1 (Array.length arg - 1))
@@ -345,6 +348,28 @@ let print_specific_operation printreg op ppf arg =
       fprintf ppf "prefetch is_write=%b prefetch_temporal_locality_hint=%s %a"
         is_write (string_of_prefetch_temporal_locality_hint locality)
         printreg arg.(0)
+
+let specific_operation_name : specific_operation -> string = fun op ->
+  match op with
+  | Ilea _ -> "lea"
+  | Istore_int (n,_addr,_is_assign) -> "store_int "^ (Nativeint.to_string n)
+  | Ioffset_loc (n,_addr) -> "offset_loc "^(string_of_int n)
+  | Ifloatarithmem (width, op, _addr) -> floatartith_name width op
+  | Ibswap { bitwidth } ->
+      "bswap " ^ (bitwidth |> int_of_bswap_bitwidth |> string_of_int)
+  | Isextend32 -> "sextend32"
+  | Izextend32 -> "zextend32"
+  | Irdtsc -> "rdtsc"
+  | Ilfence -> "lfence"
+  | Isfence -> "sfence"
+  | Imfence -> "mfence"
+  | Irdpmc -> "rdpmc"
+  | Ipackf32 -> "packf32"
+  | Isimd _simd -> "simd"
+  | Isimd_mem (_simd,_addr) -> "simd_mem"
+  | Ipause -> "pause"
+  | Icldemote _ -> "cldemote"
+  | Iprefetch _ -> "prefetch"
 
 (* Are we using the Windows 64-bit ABI? *)
 let win64 =

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -142,6 +142,8 @@ val print_addressing :
   (Format.formatter -> 'a -> unit) -> addressing_mode ->
   Format.formatter -> 'a array -> unit
 
+val specific_operation_name : specific_operation -> string
+
 val print_specific_operation :
   (Format.formatter -> 'a -> unit) -> specific_operation ->
   Format.formatter -> 'a array -> unit

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -198,6 +198,25 @@ let print_specific_operation printreg op ppf arg =
   | Isimd op ->
     Simd.print_operation printreg op ppf arg
 
+let specific_operation_name : specific_operation -> string = fun op -<
+  match op with
+  | Ifar_poll -> "far poll"
+  | Ifar_alloc { bytes; dbginfo = _ } -> "far_alloc of %d bytes" bytes
+  | Ishiftarith (op, shift) ->
+  | Ishiftarith of arith_operation * int
+  | Imuladd -> "muladd"
+  | Imulsub -> "mulsub"
+  | Inegmulf -> "negmulf"
+  | Imuladdf -> "muladdf"
+  | Inegmuladdf -> "negmuladdf"
+  | Imulsubf -> "mulsubf"
+  | Inegmulsubf -> "negmulsubf"
+  | Isqrtf -> "sqrtf"
+  | Ibswap _ -> "bswap"
+  | Imove32 -> "move32"
+  | Isignext _ -> "signext"
+  | Isimd _ -> "simd"
+
 let equal_addressing_mode left right =
   match left, right with
   | Iindexed left_int, Iindexed right_int ->

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -198,12 +198,20 @@ let print_specific_operation printreg op ppf arg =
   | Isimd op ->
     Simd.print_operation printreg op ppf arg
 
-let specific_operation_name : specific_operation -> string = fun op -<
+let specific_operation_name : specific_operation -> string = fun op ->
   match op with
   | Ifar_poll -> "far poll"
-  | Ifar_alloc { bytes; dbginfo = _ } -> "far_alloc of %d bytes" bytes
+  | Ifar_alloc { bytes; dbginfo = _ } ->
+      Printf.sprintf "far alloc of %d bytes" bytes
   | Ishiftarith (op, shift) ->
-  | Ishiftarith of arith_operation * int
+      let op_name = function
+        | Ishiftadd -> "+"
+        | Ishiftsub -> "-" in
+      let shift_mark =
+        if shift >= 0
+        then sprintf "<< %i" shift
+        else sprintf ">> %i" (-shift) in
+      Printf.sprintf "%s %s" (op_name op) shift_mark
   | Imuladd -> "muladd"
   | Imulsub -> "mulsub"
   | Inegmulf -> "negmulf"

--- a/backend/arm64/arch.mli
+++ b/backend/arm64/arch.mli
@@ -103,6 +103,8 @@ val print_addressing :
   (Format.formatter -> 'a -> unit) -> addressing_mode ->
   Format.formatter -> 'a array -> unit
 
+val specific_operation_name : specific_operation -> string
+
 val print_specific_operation :
   (Format.formatter -> 'a -> unit) -> specific_operation ->
   Format.formatter -> 'a array -> unit

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -42,7 +42,7 @@ module Witness = struct
     | Direct_call of { callee : string }
     | Direct_tailcall of { callee : string }
     | Extcall of { callee : string }
-    | Arch_specific
+    | Arch_specific of Arch.specific_operation
     | Probe of
         { name : string;
           handler_code_sym : string
@@ -72,7 +72,9 @@ module Witness = struct
     | Direct_tailcall { callee : string } ->
       fprintf ppf "direct tailcall %s" callee
     | Extcall { callee } -> fprintf ppf "external call to %s" callee
-    | Arch_specific -> fprintf ppf "arch specific operation"
+    | Arch_specific op ->
+      fprintf ppf "architecture specific operation: %s"
+        (Arch.specific_operation_name op)
     | Probe { name; handler_code_sym } ->
       fprintf ppf "probe \"%s\" handler %s" name handler_code_sym
     | Widen -> fprintf ppf "widen"
@@ -1712,7 +1714,7 @@ end = struct
           ( Format.dprintf "called function may allocate%s (%a)" component_msg
               Witness.print_kind w.kind,
             [] )
-        | Arch_specific | Probe _ ->
+        | Arch_specific _ | Probe _ ->
           ( Format.dprintf "expression may allocate%s@ (%a)" component_msg
               Witness.print_kind w.kind,
             [] )
@@ -2216,7 +2218,7 @@ end = struct
     report t next ~msg:"transform_specific next" ~desc dbg;
     report t exn ~msg:"transform_specific exn" ~desc dbg;
     let effect =
-      let w = create_witnesses t Arch_specific dbg in
+      let w = create_witnesses t (Arch_specific s) dbg in
       match Metadata.assume_value dbg ~can_raise:false w with
       | Some v -> v
       | None ->

--- a/backend/zero_alloc_checker.mli
+++ b/backend/zero_alloc_checker.mli
@@ -54,7 +54,7 @@ module Witness : sig
     | Direct_call of { callee : string }
     | Direct_tailcall of { callee : string }
     | Extcall of { callee : string }
-    | Arch_specific
+    | Arch_specific of Arch.specific_operation
     | Probe of
         { name : string;
           handler_code_sym : string

--- a/oxcaml/tests/.ocamlformat-ignore
+++ b/oxcaml/tests/.ocamlformat-ignore
@@ -9,6 +9,7 @@ simd/unbox_types.ml
 simd/arrays.ml
 small_numbers/float32_u_lib.ml
 backend/zero_alloc_checker/fail27.ml
+backend/zero_alloc_checker/test_arch_specific_witness.ml
 intrinsics/select_float.ml
 backend/zero_alloc_checker/test_remove_inferred_assume.ml
 backend/zero_alloc_checker/test_remove_inferred_assume_workaround.ml

--- a/oxcaml/tests/backend/zero_alloc_checker/dune.inc
+++ b/oxcaml/tests/backend/zero_alloc_checker/dune.inc
@@ -1565,3 +1565,23 @@
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (deps test_custom_error_msg_sig.opt.output test_custom_error_msg_sig.opt.output.corrected)
  (action (diff test_custom_error_msg_sig.opt.output test_custom_error_msg_sig.opt.output.corrected)))
+
+(rule
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
+ (targets test_arch_specific_witness.output.corrected)
+ (deps (:ml test_arch_specific_witness.ml) filter.sh)
+ (action
+   (with-outputs-to test_arch_specific_witness.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 2
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -flambda2-expert-cont-specialization-budget 0
+          -zero-alloc-check default -zero-alloc-checker-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
+ (deps test_arch_specific_witness.output test_arch_specific_witness.output.corrected)
+ (action (diff test_arch_specific_witness.output test_arch_specific_witness.output.corrected)))

--- a/oxcaml/tests/backend/zero_alloc_checker/gen/gen_dune.ml
+++ b/oxcaml/tests/backend/zero_alloc_checker/gen/gen_dune.ml
@@ -288,4 +288,6 @@ let () =
     ~extra_dep:(Some "test_custom_error_msg_sig.mli")
     ~extra_flags:"-zero-alloc-check all" ~exit_code:2
     "test_custom_error_msg_sig";
+  print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None ~exit_code:2
+    "test_arch_specific_witness";
   ()

--- a/oxcaml/tests/backend/zero_alloc_checker/test_arch_specific_witness.ml
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_arch_specific_witness.ml
@@ -1,0 +1,12 @@
+module Float64 = struct
+  type t = float#
+
+  external max : t -> t -> t
+    = "caml_no_bytecode" "caml_simd_float64_max"
+  [@@noalloc] [@@builtin] [@@unboxed]
+
+end
+
+let[@zero_alloc] max f1 f2 = Float64.max f1 f2
+
+let[@zero_alloc strict] max_with_assume f1 f2 = (Float64.max[@zero_alloc assume]) f1 f2

--- a/oxcaml/tests/backend/zero_alloc_checker/test_arch_specific_witness.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_arch_specific_witness.output
@@ -1,0 +1,6 @@
+File "test_arch_specific_witness.ml", line 12, characters 5-15:
+Error: Annotation check for zero_alloc strict failed on function Test_arch_specific_witness.max_with_assume (camlTest_arch_specific_witness.max_with_assume_HIDE_STAMP).
+
+File "test_arch_specific_witness.ml", line 12, characters 48-87:
+Error: expression may allocate on a path to diverge
+       (architecture specific operation: simd)


### PR DESCRIPTION
This is a minor fix for an uncommon interaction between inlining and `assume` annotations. 
The test uses an external simd instruction for simplicity to get the same output on both amd64 and arm64. 