### PR TITLE
Don't lie about the return layout of Patomic_set for bytecode

### DIFF
--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -675,8 +675,8 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     | Pget_header _ -> unary (Ccall "caml_get_header")
     | Pobj_dup -> unary (Ccall "caml_obj_dup")
     | Patomic_load _ -> unary (Ccall "caml_atomic_load")
-    | Patomic_set _ | Patomic_exchange _ ->
-      binary (Ccall "caml_atomic_exchange")
+    | Patomic_set _ -> binary (Ccall "caml_atomic_set")
+    | Patomic_exchange _ -> binary (Ccall "caml_atomic_exchange")
     | Patomic_compare_exchange _ ->
       ternary (Ccall "caml_atomic_compare_exchange")
     | Patomic_compare_set _ -> ternary (Ccall "caml_atomic_cas")

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -367,6 +367,12 @@ CAMLprim value caml_atomic_exchange (value ref, value v)
   return ret;
 }
 
+CAMLprim value caml_atomic_set (value ref, value v)
+{
+  caml_atomic_exchange(ref, v);
+  return Val_unit;
+}
+
 CAMLprim value caml_atomic_compare_exchange (value ref, value oldv, value newv)
 {
   if (caml_domain_alone()) {

--- a/runtime4/misc.c
+++ b/runtime4/misc.c
@@ -252,6 +252,12 @@ CAMLprim value caml_atomic_load(value ref)
   return Field(ref, 0);
 }
 
+CAMLprim value caml_atomic_set(value ref, value v)
+{
+  caml_modify_local(ref, 0, v);
+  return Val_unit;
+}
+
 CAMLprim value caml_atomic_compare_exchange(value ref, value oldv, value newv)
 {
   value* p = Op_val(ref);

--- a/testsuite/tests/lib-atomic/test_atomic.ml
+++ b/testsuite/tests/lib-atomic/test_atomic.ml
@@ -1,5 +1,10 @@
 (* TEST
  flags = "-alert -unsafe_multidomain";
+ {
+   bytecode;
+ }{
+   native;
+ }
 *)
 
 let r = Atomic.make 1


### PR DESCRIPTION
On bytecode, Patomic_set uses a c call of caml_atomic_exchange, which returns the old value - but the return layout of Patomic_set is annotated to be layout_unit. This doesn't seem to have caused any problems yet (and is fine in native code, since we add a return_unit in flambda2->cmm), but it's better hygiene (and might avoid issues) to not lie about the return layout. This does that by defining a caml_atomic_set C function which is only used in bytecode.