### PR TITLE
Fix ignored signature constraints in approximation of recursive modules signatures (backport ocaml/ocaml#14100)

### DIFF
--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -751,7 +751,10 @@ end
 [%%expect{|
 module Empty : sig end
 module rec X :
-  sig module type T = sig end module F : (A : T) -> sig type t end end
+  sig
+    module type T = sig end
+    module F : functor (A : T) -> sig type t end
+  end
 and Y : sig type t = X.F(Empty).t end
 |}]
 

--- a/testsuite/tests/typing-modules/merge_constraint.ml
+++ b/testsuite/tests/typing-modules/merge_constraint.ml
@@ -520,3 +520,266 @@ Line 6, characters 32-34:
 Error: The type constraints are not consistent.
        Type "'a * 'b * 'c" is not compatible with type "'l * 'r"
 |}]
+
+(** Merging and approximation ***)
+(* The test are made inside module types, as they only focus on approximation
+   and typechecking of signatures of recursive modules, hence the
+   implementations are irrelevant. The tests for module type constraints can be
+   found in [module_type_substitution.ml] *)
+
+(** Module constraints during approximation **)
+
+(*  Merging modules constraints during the approximation phase of typechecking
+    recursive modules should result in the right approximated signature, with
+    the right set of visible fields. Concrete constraints (where a module that
+    is already an alias is replaced by an equivalent alias) are not tested as it
+    is unsupported (issue #13897) *)
+
+(* Approximating a signature with a module constraint should merge the module
+   (abstract, shallow, non destructive case) *)
+module type Module_Abstract_Shallow = sig
+  module X0 : sig type t end
+  module rec X : (sig module X1 : sig end end with module X1 = X0)
+     and Y : sig type u = X.X1.t end
+end
+[%%expect {|
+module type Module_Abstract_Shallow =
+  sig
+    module X0 : sig type t end
+    module rec X : sig module X1 : sig type t = X0.t end end
+    and Y : sig type u = X.X1.t end
+  end
+|}]
+
+(* Approximating a signature with a module constraint should merge the module
+   (abstract, shallow, destructive case). We use shadowing to test that the
+   destructed item has indeed been removed *)
+module type Module_Abstract_Shallow_Destructive = sig
+  module X0 : sig end
+  module type S = sig module X1 : sig end end
+  module rec X : (sig
+                   module X1 : sig type t end
+                   include (S with module X1 := X0)
+                 end)
+     and Y : sig type u = X.X1.t end
+end
+[%%expect {|
+module type Module_Abstract_Shallow_Destructive =
+  sig
+    module X0 : sig end
+    module type S = sig module X1 : sig end end
+    module rec X : sig module X1 : sig type t end end
+    and Y : sig type u = X.X1.t end
+  end
+|}]
+
+
+(* Approximating a signature with a module constraint should merge the module
+   (abstract, deep, non destructive case) *)
+module type Module_Abstract_Deep = sig
+  module X0 : sig type t end
+  module rec X : (sig
+                   module X1 : sig module X2 : sig end end
+                 end with module X1.X2 = X0)
+     and Y : sig type u = X.X1.X2.t end
+end
+[%%expect {|
+module type Module_Abstract_Deep =
+  sig
+    module X0 : sig type t end
+    module rec X :
+      sig module X1 : sig module X2 : sig type t = X0.t end end end
+    and Y : sig type u = X.X1.X2.t end
+  end
+|}]
+
+(* There is no test for (abstract, deep, destructive case). The shallow test
+   cannot be adapted, as the root module (X1) would still be shadowed *)
+
+(* Ill-formed module constraints (when the field does not exist) should be
+   caught during approximation.  *)
+module type IllFormed_Module_No_Field = sig
+  module X0 : sig end
+  module rec X : (sig
+                   module X1 : sig end
+
+                   (* invalid, but the error should not be here *)
+                   type 'a t
+                   type u = (int, bool) t
+                 end) with module X2 = X0
+end
+[%%expect {|
+Line 9, characters 39-41:
+9 |                  end) with module X2 = X0
+                                           ^^
+Error: The signature constrained by "with" has no component named "X2"
+|}]
+
+
+(* Ill-formed module constraints (when the field does not exist) should be
+   caught during approximation (destructive case).  *)
+module type IllFormed_Module_No_Field_Destructive = sig
+  module X0 : sig end
+  module rec X : (sig
+                   module X1 : sig module X1' : sig end end
+
+                   (* invalid, but the error should not be here *)
+                   type 'a t
+                   type u = (int, bool) t
+                 end) with module X1.X2 = X0
+end
+[%%expect {|
+Line 9, characters 42-44:
+9 |                  end) with module X1.X2 = X0
+                                              ^^
+Error: The signature constrained by "with" has no component named "X1.X2"
+|}]
+
+(* Other forms of ill-formed module constraints (when the field exists) should
+   be caught after approximation.  *)
+module type IllFormed_Module_Other = sig
+  module X0 : sig end
+  module rec X : (sig
+                   module X1 : sig type t end
+                 end) with module X1 = X0
+end
+[%%expect {|
+Lines 3-5, characters 17-41:
+3 | .................(sig
+4 |                    module X1 : sig type t end
+5 |                  end) with module X1 = X0
+Error: In this "with" constraint, the new definition of "X1"
+       does not match its original definition in the constrained signature:
+       Modules do not match: sig end is not included in sig type t end
+       The type "t" is required but not provided
+|}]
+
+(** Type constraints during approximation **)
+
+(*  Merging type constraints during the approximation phase of typechecking
+    recursive modules should result in the right approximated signature, with
+    the right set of visible fields. There is not much to check for non
+    destructive cases, as approximated constraints are abstract anyway *)
+
+(* Approximation a signature with a type constraint should merge the type
+   (abstract, shallow, destructive case). We use shadowing to test that the
+   type has indeed been removed *)
+module type Type_Abstract_Shallow_Destructive = sig
+  module rec X : (sig
+                   type 'a t
+                   include (sig type t end) with type t := int
+                 end)
+     and Y : sig type u = int X.t end
+end
+[%%expect {|
+module type Type_Abstract_Shallow_Destructive =
+  sig module rec X : sig type 'a t end and Y : sig type u = int X.t end end
+|}]
+
+
+(* Ill-formed type constraints (when the field does not exist) should be
+   caught during approximation.  *)
+module type IllFormed_Type_No_Field = sig
+  module rec X : (sig
+                   type t
+                   (* invalid, but the error should not be here *)
+                   type u = int t
+                 end) with type v = int
+end
+[%%expect {|
+Line 6, characters 27-39:
+6 |                  end) with type v = int
+                               ^^^^^^^^^^^^
+Error: The signature constrained by "with" has no component named "v"
+|}]
+
+
+(* Ill-formed type constraints (when the field does not exist) should be
+   caught during approximation (destructive case).  *)
+module type IllFormed_Type_No_Field_Destructive = sig
+  module rec X : (sig
+                   type t
+                   (* invalid, but the error should not be here *)
+                   type u = int t
+                 end) with type v := int
+end
+[%%expect {|
+Line 6, characters 27-40:
+6 |                  end) with type v := int
+                               ^^^^^^^^^^^^^
+Error: The signature constrained by "with" has no component named "v"
+|}]
+
+(* Other forms of ill-formed type constraints (when the field exists) should
+   be caught after approximation.  *)
+module type IllFormed_Module_Other = sig
+  module rec X : (sig
+                   type 'a t
+                 end) with type t = int
+end
+[%%expect {|
+Lines 2-4, characters 17-39:
+2 | .................(sig
+3 |                    type 'a t
+4 |                  end) with type t = int
+Error: In this "with" constraint, the new definition of "t"
+       does not match its original definition in the constrained signature:
+       Type declarations do not match:
+         type t = int
+       is not included in
+         type 'a t
+       They have different arities.
+|}]
+
+(** Type constraints on module types inside recursive signatures should be
+    properly typed. Here, if the [type t := int] constraint is ignored, the
+    functor application becomes invalid. As paths with functor application can
+    appear in signatures, it is crucial that the approximation phase get [T]
+    right, it would be too late in the typechecking phase *)
+module Empty = struct end
+module rec X: sig
+  module type T = sig type t end with type t := int
+  module F(A:T): sig type t end
+end = struct
+  module type T = sig end
+  module F(A:T) = struct type t end
+end
+and Y: sig type t = X.F(Empty).t end = struct
+   type t = X.F(Empty).t
+end
+
+[%%expect{|
+module Empty : sig end
+module rec X :
+  sig module type T = sig end module F : (A : T) -> sig type t end end
+and Y : sig type t = X.F(Empty).t end
+|}]
+
+
+(** Type constraints and ghost items **)
+
+(* Ghosts types (introduced by class definitions) should not be affected by type
+   constraints (normal mode) *)
+module type NoGhostTypeConstraintNormal = sig
+    class v : object end
+  end with type v = int
+[%%expect{|
+Lines 5-7, characters 42-23:
+5 | ..........................................sig
+6 |     class v : object end
+7 |   end with type v = int
+Error: The signature constrained by "with" has no component named "v"
+|}]
+
+(* Ghosts types (introduced by class definitions) should not be affected by type
+   constraints (approx mode) *)
+module type NoGhostTypeConstraintApprox = sig
+         module rec X : sig class v : object end
+                        end with type v = int
+       end
+[%%expect{|
+Line 3, characters 33-45:
+3 |                         end with type v = int
+                                     ^^^^^^^^^^^^
+Error: The signature constrained by "with" has no component named "v"
+|}]

--- a/testsuite/tests/typing-recmod/regression_destructive_subst.ml
+++ b/testsuite/tests/typing-recmod/regression_destructive_subst.ml
@@ -1,0 +1,96 @@
+(* TEST
+ expect;
+*)
+
+(* Regression test for https://github.com/oxcaml/oxcaml/pull/4121 *)
+
+module type Destructive_module_subst = sig
+  module type S = sig
+    module A : sig end
+  end
+
+  module rec M : sig
+    module A : sig type t end
+    include S with module A := A
+  end
+
+  and N : sig
+    type alias_MAt = M.A.t
+  end
+end
+[%%expect{|
+module type Destructive_module_subst =
+  sig
+    module type S = sig module A : sig end end
+    module rec M : sig module A : sig type t end end
+    and N : sig type alias_MAt = M.A.t end
+  end
+|}]
+
+module type Destructive_type_subst = sig
+  module type S = sig
+    type a
+  end
+
+  module rec M : sig
+    type a
+    include S with type a := a
+  end
+
+  and N : sig
+    type 'a require_value
+    type require_Ma_value = M.a require_value
+  end
+end
+[%%expect{|
+module type Destructive_type_subst =
+  sig
+    module type S = sig type a end
+    module rec M : sig type a end
+    and N :
+      sig type 'a require_value type require_Ma_value = M.a require_value end
+  end
+|}]
+
+(* Destructive module type substitution *)
+module type P = sig
+  module type T
+  module A:T
+end
+
+module rec X: P with module type T := sig type t end = struct
+  module A = struct type t end
+end
+and Y : sig type t = X.A.t end = struct
+   type t = X.A.t
+end
+[%%expect{|
+module type P = sig module type T module A : T end
+module rec X : sig module A : sig type t end end
+and Y : sig type t = X.A.t end
+|}]
+
+module type No_false_dangling_reference = sig
+  module type S = sig
+    module A : sig type t end
+    module C = A
+  end
+
+  module A2 : sig type t end
+
+  module rec M : sig
+    include S with module A := A2
+  end
+  and N : sig
+    type t = M.C.t
+  end
+end
+[%%expect{|
+module type No_false_dangling_reference =
+  sig
+    module type S = sig module A : sig type t end module C = A end
+    module A2 : sig type t end
+    module rec M : sig module C = A2 end
+    and N : sig type t = M.C.t end
+  end
+|}]

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -704,11 +704,12 @@ module Merge = struct
   (* After the item has been patched, post processing does the actual
      destructive substitution and checks wellformedness of the resulting
      signature *)
-  let post_process ~destructive loc lid env paths sg replace =
+  let post_process ~approx ~destructive loc lid env paths sg replace =
     let sg =
       if destructive then
         (* Check that the substitution will not make the signature ill-formed *)
-        let () = check_usage_after_substitution ~loc ~lid env paths sg in
+        let () = if not approx then
+                   check_usage_after_substitution ~loc ~lid env paths sg in
         (* Actually remove the identifiers *)
         let sub = Subst.change_locs Subst.identity loc in
         let sub = List.fold_left replace sub paths in
@@ -721,8 +722,9 @@ module Merge = struct
       else sg
     in
     (* check that the resulting signature is still wellformed *)
-    let () = check_well_formed_module env loc "this instantiated signature"
-        (Mty_signature sg) in
+    let () = if not approx then
+               check_well_formed_module env loc "this instantiated signature"
+                 (Mty_signature sg) in
     sg
 
   (* Main recursive knot to handle deep merges *)
@@ -898,15 +900,51 @@ module Merge = struct
       else
         fun s _ -> s
     in
-    let sg = post_process ~destructive loc lid env paths sg replace in
+    let sg =
+      post_process ~approx:false ~destructive loc lid env paths sg replace in
     (tdecl, (path, lid, sg))
+
+  (** Approximated type constraint [sg with type lid = _]
+
+      This function is separated from [merge_type] as its logic is much more
+      restricted (it does not need the right-hand side declaration).
+
+      - For destructive constraints, the field is removed to prevent incorrect
+      shadowing in the approximated signature.
+
+      - For non-destructive constraints, the normal merging infrastructure is
+      still used with an no-op identity patch. It is done to catch ill-formed
+      constraints on non-existing fields early, during the approximation phase
+      (rather than during signature typechecking) *)
+  let merge_type_approx ~destructive env loc sg lid =
+    let patch item s _sig_env _sg_for_env ~ghosts =
+      match item with
+      | Sig_type(id, _, _, _) when Ident.name id = s ->
+         let item_opt =
+           if destructive then None
+           else
+             (* An identity patch is applied *)
+             Some (item)
+         in
+         return ~ghosts ~replace_by:item_opt (Pident id)
+      | _ -> None
+    in
+    (* Merging *)
+    let _, paths, _, sg = merge ~patch ~destructive env sg loc lid in
+    (* Post processing *)
+    let replace = fun s _path -> s in
+    post_process ~approx:true ~destructive loc lid env paths sg replace
+
 
   (** Module constraint [sg with module lid = path]
 
       - [md'] is the module type of the module at [path], used for equivalence
       checks
+
+      - [~approx] is used to disable equivalence checking when merging inside
+      recursive module definitions
   *)
-  let merge_module ~destructive env loc sg lid
+  let merge_module ?(approx=false) ~destructive env loc sg lid
       (md': Types.module_declaration) path remove_aliases =
     let patch item s sig_env sg_for_env ~ghosts =
       match item with
@@ -916,9 +954,10 @@ module Merge = struct
           if destructive then
             let aliasable = not (Env.is_functor_arg path sig_env) in
             (* Inclusion check with the strengthened definition *)
-            let _ =
-              Includemod.strengthened_module_decl ~loc ~mark:true
-                ~aliasable sig_env ~mmodes:(Legacy None) md' path md in
+            let _ = if (not approx) then
+               ignore (Includemod.strengthened_module_decl ~loc ~mark:true
+                         ~aliasable sig_env ~mmodes:(Legacy None) md' path md)
+            in
             return ~ghosts ~replace_by:None real_path
           else
             let mty = md'.md_type in
@@ -931,8 +970,9 @@ module Merge = struct
             let newmd =
               Mtype.strengthen_decl ~aliasable:false md'' path in
             (* Inclusion check with the original signature *)
-            let _ = Includemod.modtypes ~mark:true ~loc sig_env
-                ~modes:(Legacy None) newmd.md_type md.md_type in
+            let _ = if (not approx) then
+               ignore (Includemod.modtypes ~mark:true ~loc sig_env
+                         ~modes:(Legacy None) newmd.md_type md.md_type) in
             return ~ghosts
               ~replace_by:(Some(Sig_module(id, pres, newmd, rs, priv)))
               real_path
@@ -940,7 +980,8 @@ module Merge = struct
     in
     let real_path,paths,_,sg = merge ~patch ~destructive env sg loc lid in
     let replace s p = Subst.Unsafe.add_module_path p path s in
-    let sg = post_process ~destructive loc lid env paths sg replace in
+    let sg =
+      post_process ~approx ~destructive loc lid env paths sg replace in
     real_path, lid, sg
 
   (** Module type constraint [sg with module type lid = mty]
@@ -977,7 +1018,7 @@ module Merge = struct
     in
     let path,paths,_,sg = merge ~patch ~destructive env sg loc lid in
     let replace s p = Subst.Unsafe.add_modtype_path p mty s in
-    let sg = post_process ~destructive loc lid env paths sg replace in
+    let sg = post_process ~approx ~destructive loc lid env paths sg replace in
     path, lid, sg
 
   (** Type constraints inside a first class module type [(module sg with type
@@ -1028,6 +1069,19 @@ module Merge = struct
   let () =
     Typetexp.check_package_with_type_constraints :=
       check_package_with_type_constraints
+
+  (* Helper for handling constraints on signatures: destructive constraints,
+     written with ":=", actually remove the field from the signature, whereas
+     non-destructive constraints just update the field. *)
+  let is_destructive constr =
+    match constr with
+    | Pwith_typesubst _
+      | Pwith_modtypesubst _
+      | Pwith_modsubst _ -> true
+    | Pwith_module _
+      | Pwith_type _
+      | Pwith_modtype _ -> false
+
 end
 
 (* Add recursion flags on declarations arising from a mutually recursive
@@ -1364,28 +1418,34 @@ and approx_modtype_info env sinfo =
   }
 
 and approx_constraint env body constr =
+  (* constraints are first approximated then merged, disabling all equivalence
+     and wellformedness checks. Only ill-formed constraints where the field does
+     not exists are caught at approximation phase, other errors (non-equivalent
+     constraints) will be caught when typechecking the signatures (with the
+     approximation in the environment). *)
+  let destructive = Merge.is_destructive constr in
   match constr with
-  (* type substitutions are ignored *)
-  | Pwith_type _
-  | Pwith_typesubst _ -> body
-  (* module type substitutions are approximated then merged *)
+  | Pwith_type (l, decl)
+  | Pwith_typesubst (l, decl) ->
+     Merge.merge_type_approx ~destructive env decl.ptype_loc body l
+
   | Pwith_modtype (id, smty)
   | Pwith_modtypesubst (id, smty) ->
-      let destructive =
-        (match constr with | Pwith_modtypesubst _ -> true | _ -> false) in
       let approx_smty = approx_modtype env smty in
       let _,_,sg = Merge.merge_modtype ~approx:true ~destructive
           env smty.pmty_loc body id approx_smty in
       sg
-  (* module substitutions are ignored, but checked for cyclicity *)
-  | Pwith_module (_, lid') ->
+  | Pwith_module (id, lid)
+  | Pwith_modsubst (id, lid) ->
       (* Lookup the module to make sure that it is not recursive.
          (GPR#1626) *)
-      ignore (Env.lookup_module_path ~use:false ~load:false
-                ~loc:lid'.loc lid'.txt env) ; body
-  | Pwith_modsubst (_, lid') ->
-      ignore (Env.lookup_module_path ~use:false ~load:false
-                ~loc:lid'.loc lid'.txt env) ; body
+      let path, approx_md, _ =
+        Env.lookup_module ~use:false ~loc:lid.loc lid.txt env in
+      let _,_,sg =
+        Merge.merge_module ~approx:true ~destructive env
+          lid.loc body id approx_md path false in
+      sg
+
 
 let approx_modtype env smty =
   Warnings.without_warnings
@@ -1803,10 +1863,7 @@ and transl_modtype_aux env smty =
       ;
 
 and transl_with ~loc env remove_aliases (rev_tcstrs, sg) constr =
-  let destructive = match constr with
-    | Pwith_typesubst _ | Pwith_modsubst _ | Pwith_modtypesubst _ -> true
-    | _ -> false
-  in
+  let destructive = Merge.is_destructive constr in
   let constr, (path, lid, sg) = match constr with
     | Pwith_type (l, decl)
     | Pwith_typesubst (l, decl) ->


### PR DESCRIPTION
Backports https://github.com/ocaml/ocaml/pull/14100.

### Stack
1. https://github.com/oxcaml/oxcaml/pull/4224
2. https://github.com/oxcaml/oxcaml/pull/4240
3. https://github.com/oxcaml/oxcaml/pull/4241
4. https://github.com/oxcaml/oxcaml/pull/4246
5. https://github.com/oxcaml/oxcaml/pull/4268