### PR TITLE
flambda2(types): Extract meet-related functions to a separate module

### DIFF
--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -16,6 +16,7 @@
 module K = Flambda_kind
 module TG = Type_grammar
 module TE = Typing_env
+module ME = Meet_env
 module TEE = Typing_env_extension
 module TEL = Typing_env_level
 module ET = Expand_head.Expanded_type
@@ -1203,13 +1204,13 @@ let cut_and_n_way_join ~n_way_join_type ~meet_type ~cut_after target_env
           let simple = (simple :> Simple.t) in
           let kind = TG.kind (TE.find target_env name None) in
           let ty = TG.alias_type_of kind simple in
-          TE.add_equation ~meet_type target_env name ty)
+          ME.add_equation ~meet_type target_env name ty)
         demoted_in_target_env target_env
     in
     let target_env =
       Name_in_target_env.Map.fold
         (fun name ty target_env ->
-          TE.add_equation ~meet_type target_env (name :> Name.t) ty)
+          ME.add_equation ~meet_type target_env (name :> Name.t) ty)
         equations target_env
     in
     let target_env =
@@ -1236,7 +1237,7 @@ let n_way_join_env_extension ~n_way_join_type ~meet_type t envs_with_extensions
         assert (not (TE.is_bottom parent_env));
         let cut_after = TE.current_scope parent_env in
         let typing_env = TE.increment_scope parent_env in
-        match TE.add_env_extension_strict ~meet_type typing_env extension with
+        match ME.add_env_extension_strict ~meet_type typing_env extension with
         | Bottom ->
           (* We can reach bottom here if the extension was created in a more
              generic context, but is added in a context where it is no longer

--- a/middle_end/flambda2/types/env/join_env.mli
+++ b/middle_end/flambda2/types/env/join_env.mli
@@ -31,14 +31,14 @@ type n_way_join_type =
 
 val n_way_join_env_extension :
   n_way_join_type:n_way_join_type ->
-  meet_type:Typing_env.meet_type ->
+  meet_type:Meet_env.meet_type ->
   t ->
   Typing_env_extension.t join_arg list ->
   (Typing_env_extension.t * t) Or_bottom.t
 
 val cut_and_n_way_join :
   n_way_join_type:n_way_join_type ->
-  meet_type:Typing_env.meet_type ->
+  meet_type:Meet_env.meet_type ->
   cut_after:Scope.t ->
   Typing_env.t ->
   Typing_env.t list ->

--- a/middle_end/flambda2/types/env/meet_env.ml
+++ b/middle_end/flambda2/types/env/meet_env.ml
@@ -1,0 +1,235 @@
+module MTC = More_type_creators
+module TG = Type_grammar
+module TE = Typing_env
+module TEL = Typing_env_level
+
+type 'a meet_return_value =
+  | Left_input
+  | Right_input
+  | Both_inputs
+  | New_result of 'a
+
+type meet_type =
+  TE.t ->
+  Type_grammar.t ->
+  Type_grammar.t ->
+  (Type_grammar.t meet_return_value * TE.t) Or_bottom.t
+
+let replace_concrete_equation t name ty =
+  match TG.must_be_singleton ty with
+  | None ->
+    (* [ty] must be a concrete type. *)
+    (match TG.get_alias_opt ty with
+    | None -> ()
+    | Some alias ->
+      Misc.fatal_errorf "Expected concrete type for %a but got an alias to %a"
+        Name.print name Simple.print alias);
+    TE.replace_equation t name ty
+  | Some const -> (
+    match
+      TE.add_alias t ~canonical_element1:(Simple.name name)
+        ~canonical_element2:(Simple.const const)
+    with
+    | Bottom ->
+      Misc.fatal_error "Unexpected bottom while adding alias to constant"
+    | Unknown ->
+      (* This should only happen when adding aliases between names defined in
+         external compilation units, but we are adding an alias to a
+         constant. *)
+      Misc.fatal_error "Unexpected failure while adding alias to constant"
+    | Ok { canonical_element; demoted_name; t } ->
+      if (not (Name.equal demoted_name name))
+         || not (Simple.equal canonical_element (Simple.const const))
+      then Misc.fatal_error "Unexpected demotion of constant.";
+      let kind = MTC.kind_for_const const in
+      let ty = TG.alias_type_of kind canonical_element in
+      TE.replace_equation t demoted_name ty)
+
+exception Bottom_equation
+
+let add_concrete_equation_on_canonical ~raise_on_bottom t simple ty
+    ~(meet_type : meet_type) =
+  (* When adding a type to a canonical name, we need to call [meet] with the
+     existing type for that name in order to ensure we record the most precise
+     type available.
+
+     For example, suppose [p] is defined earlier than [x], with [p] of type
+     [ty1] and [x] of type [ty2]. If the caller says that the type of [p] is now
+     to be "= x", then we will instead add a type "= p" on [x] and demote [x] to
+     [p], due to the definition ordering. We then need to record the information
+     that [p] now has type [ty1 meet ty2], otherwise the type [ty2] would be
+     lost.
+
+     If instead we say that the type of [p] is to be "= c", where [c] is a
+     constant, we will add the type "= c" to [p] and demote [p] to [c]. We have
+     no type to record for [c], however we still need to check that [c] is
+     compatible with the previous type of [p].
+
+     Note also that [p] and [x] may have different name modes! *)
+  Simple.pattern_match simple
+    ~const:(fun const ->
+      match meet_type t ty (MTC.type_for_const const) with
+      | Ok (_, env) -> env
+      | Bottom -> if raise_on_bottom then raise Bottom_equation else t)
+    ~name:(fun name ~coercion ->
+      (* If [(coerce name coercion)] has type [ty], then [name] has type
+         [(coerce ty coercion^-1)]. *)
+      let ty = TG.apply_coercion ty (Coercion.inverse coercion) in
+      (* Note: this will check that the [existing_ty] has the expected kind. *)
+      let existing_ty = TE.find t name (Some (TG.kind ty)) in
+      match meet_type t ty existing_ty with
+      | Bottom ->
+        if raise_on_bottom
+        then raise Bottom_equation
+        else TE.replace_equation t name (MTC.bottom (TG.kind ty))
+      | Ok ((Right_input | Both_inputs), env) -> env
+      | Ok (Left_input, env) -> replace_concrete_equation env name ty
+      | Ok (New_result ty', env) -> replace_concrete_equation env name ty')
+
+let record_demotion ~raise_on_bottom t kind demoted canonical ~meet_type =
+  (* We have demoted [demoted], which used to be canonical, to [canonical] in
+     the aliases structure.
+
+     We now need to record that information in the types structure, and add the
+     previous type of [demoted] to [canonical] to ensure we do not lose
+     information that was only stored on the type of [demoted]. *)
+  let ty_of_demoted = TE.find t demoted (Some kind) in
+  (if Flambda_features.check_light_invariants ()
+  then
+    match TG.get_alias_opt ty_of_demoted with
+    | None -> ()
+    | Some alias ->
+      Misc.fatal_errorf
+        "Expected %a to have a concrete type, not an alias type to %a"
+        Name.print demoted Simple.print alias);
+  let t = TE.replace_equation t demoted (TG.alias_type_of kind canonical) in
+  add_concrete_equation_on_canonical ~raise_on_bottom t canonical ty_of_demoted
+    ~meet_type
+
+let add_alias_between_canonicals ~raise_on_bottom t kind canonical_element1
+    canonical_element2 ~meet_type =
+  (* We are adding an equality between two canonical simples [canonical1] and
+     [canonical2].
+
+     We'll ask the aliases structure to record the equality and determine which
+     of [canonical1] or [canonical2] should remain canonical, then forward to
+     [record_demotion] which takes care of recording an alias type on the
+     demoted element and updating the type of the element that remains
+     canonical. *)
+  if Simple.equal canonical_element1 canonical_element2
+  then t
+  else
+    match TE.add_alias t ~canonical_element1 ~canonical_element2 with
+    | Bottom -> if raise_on_bottom then raise Bottom_equation else t
+    | Unknown ->
+      (* Addition of aliases between names that are both in external compilation
+         units failed, e.g. due to a missing .cmx file. Simply drop the
+         equation. *)
+      t
+    | Ok { demoted_name; canonical_element; t } ->
+      record_demotion ~raise_on_bottom t kind demoted_name canonical_element
+        ~meet_type
+
+let add_equation_on_canonical ~raise_on_bottom t simple ty ~meet_type =
+  (* We are adding a type [ty] to [simple], which must be canonical. There are
+     two general cases to consider:
+
+     - Either [ty] is a concrete (non-alias) type, to be recorded in the types
+     structure on the [canonical_simple];
+
+     - or [ty] is an alias "= alias" to another simple, to be recorded in the
+     aliases structure. *)
+  match TG.get_alias_opt ty with
+  | None ->
+    add_concrete_equation_on_canonical ~raise_on_bottom t simple ty ~meet_type
+  | Some alias ->
+    let alias = TE.get_canonical_simple_ignoring_name_mode t alias in
+    add_alias_between_canonicals ~raise_on_bottom t (TG.kind ty) simple alias
+      ~meet_type
+
+let add_equation_on_simple ~raise_on_bottom t simple ty ~meet_type =
+  let canonical = TE.get_canonical_simple_ignoring_name_mode t simple in
+  add_equation_on_canonical ~raise_on_bottom t canonical ty ~meet_type
+
+let add_equation ~raise_on_bottom t name ty ~meet_type =
+  add_equation_on_simple ~raise_on_bottom t (Simple.name name) ty ~meet_type
+
+let add_env_extension ~raise_on_bottom t
+    (env_extension : Typing_env_extension.t) ~meet_type =
+  Typing_env_extension.fold
+    ~equation:(fun name ty t ->
+      add_equation ~raise_on_bottom t name ty ~meet_type)
+    env_extension t
+
+let add_env_extension_with_extra_variables t
+    (env_extension : Typing_env_extension.With_extra_variables.t) ~meet_type =
+  Typing_env_extension.With_extra_variables.fold
+    ~variable:(fun var kind t ->
+      TE.add_variable_definition t var kind Name_mode.in_types)
+    ~equation:(fun name ty t ->
+      try add_equation ~raise_on_bottom:true t name ty ~meet_type
+      with Bottom_equation -> TE.make_bottom t)
+    env_extension t
+
+let add_env_extension_from_level t level ~meet_type : TE.t =
+  let t =
+    TEL.fold_on_defined_vars
+      (fun var kind t ->
+        TE.add_variable_definition t var kind Name_mode.in_types)
+      level t
+  in
+  let t =
+    Name.Map.fold
+      (fun name ty t ->
+        try add_equation ~raise_on_bottom:true t name ty ~meet_type
+        with Bottom_equation -> TE.make_bottom t)
+      (TEL.equations level) t
+  in
+  Variable.Map.fold
+    (fun var proj t -> TE.add_symbol_projection t var proj)
+    (TEL.symbol_projections level)
+    t
+
+let add_equation_strict t name ty ~meet_type : _ Or_bottom.t =
+  if TE.is_bottom t
+  then Bottom
+  else
+    try Ok (add_equation ~raise_on_bottom:true t name ty ~meet_type)
+    with Bottom_equation -> Bottom
+
+let add_env_extension_strict t env_extension ~meet_type : _ Or_bottom.t =
+  if TE.is_bottom t
+  then Bottom
+  else
+    try Ok (add_env_extension ~raise_on_bottom:true t env_extension ~meet_type)
+    with Bottom_equation -> Bottom
+
+let add_env_extension_maybe_bottom t env_extension ~meet_type =
+  add_env_extension ~raise_on_bottom:false t env_extension ~meet_type
+
+let add_equation t name ty ~meet_type =
+  try add_equation ~raise_on_bottom:true t name ty ~meet_type
+  with Bottom_equation -> TE.make_bottom t
+
+let add_env_extension t env_extension ~meet_type =
+  try add_env_extension ~raise_on_bottom:true t env_extension ~meet_type
+  with Bottom_equation -> TE.make_bottom t
+
+let check_params_and_types ~params ~param_types =
+  if Flambda_features.check_invariants ()
+     && List.compare_lengths (Bound_parameters.to_list params) param_types <> 0
+  then
+    Misc.fatal_errorf
+      "Mismatch between number of [params] and [param_types]:@ (%a)@ and@ %a"
+      Bound_parameters.print params
+      (Format.pp_print_list ~pp_sep:Format.pp_print_space TG.print)
+      param_types
+
+let add_equations_on_params t ~params ~param_types ~meet_type =
+  check_params_and_types ~params ~param_types;
+  List.fold_left2
+    (fun t param param_type ->
+      add_equation t (Bound_parameter.name param) param_type ~meet_type)
+    t
+    (Bound_parameters.to_list params)
+    param_types

--- a/middle_end/flambda2/types/env/meet_env.mli
+++ b/middle_end/flambda2/types/env/meet_env.mli
@@ -1,0 +1,43 @@
+open Typing_env
+
+type 'a meet_return_value =
+  | Left_input
+  | Right_input
+  | Both_inputs
+  | New_result of 'a
+
+type meet_type =
+  t ->
+  Type_grammar.t ->
+  Type_grammar.t ->
+  (Type_grammar.t meet_return_value * t) Or_bottom.t
+
+val add_equation : t -> Name.t -> Type_grammar.t -> meet_type:meet_type -> t
+
+val add_equation_strict :
+  t -> Name.t -> Type_grammar.t -> meet_type:meet_type -> t Or_bottom.t
+
+val add_equations_on_params :
+  t ->
+  params:Bound_parameters.t ->
+  param_types:Type_grammar.t list ->
+  meet_type:meet_type ->
+  t
+
+val add_env_extension : t -> Typing_env_extension.t -> meet_type:meet_type -> t
+
+val add_env_extension_maybe_bottom :
+  t -> Typing_env_extension.t -> meet_type:meet_type -> t
+
+val add_env_extension_strict :
+  t -> Typing_env_extension.t -> meet_type:meet_type -> t Or_bottom.t
+
+val add_env_extension_with_extra_variables :
+  t -> Typing_env_extension.With_extra_variables.t -> meet_type:meet_type -> t
+
+(* CR vlaviron: If the underlying level in the extension defines several
+   variables, then there is no guarantee that the binding order in the result
+   will match the binding order used to create the level. If they don't match,
+   then adding equations in the wrong order can make equations disappear. *)
+val add_env_extension_from_level :
+  t -> Typing_env_level.t -> meet_type:meet_type -> t

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -245,14 +245,6 @@ end = struct
             now_meeting_or_joining_names t name1 name2))
 end
 
-type 'a meet_return_value =
-  | Left_input
-  | Right_input
-  | Both_inputs
-  | New_result of 'a
-
-type meet_type = t -> TG.t -> TG.t -> (TG.t meet_return_value * t) Or_bottom.t
-
 module Join_env : sig
   type t
 
@@ -784,8 +776,6 @@ let invariant_for_new_equation (t : t) name ty =
       Misc.fatal_errorf "New equation@ %a@ =@ %a@ has unbound names@ (%a):@ %a"
         Name.print name TG.print ty Name_occurrences.print unbound_names print t)
 
-exception Bottom_equation
-
 let replace_equation (t : t) name ty =
   (if Flambda_features.Debug.concrete_types_only_on_canonicals ()
   then
@@ -844,214 +834,22 @@ let aliases_add t ~canonical_element1 ~canonical_element2 =
     ~binding_times_and_modes:(names_to_types t) ~canonical_element1
     ~canonical_element2
 
-let replace_concrete_equation t name ty =
-  match TG.must_be_singleton ty with
-  | None ->
-    (* [ty] must be a concrete type. *)
-    (match TG.get_alias_opt ty with
-    | None -> ()
-    | Some alias ->
-      Misc.fatal_errorf "Expected concrete type for %a but got an alias to %a"
-        Name.print name Simple.print alias);
-    replace_equation t name ty
-  | Some const -> (
-    match
-      aliases_add t ~canonical_element1:(Simple.name name)
-        ~canonical_element2:(Simple.const const)
-    with
-    | Bottom ->
-      Misc.fatal_error "Unexpected bottom while adding alias to constant"
-    | exception Binding_time_resolver_failure ->
-      (* This should only happen when adding aliases between names defined in
-         external compilation units, but we are adding an alias to a
-         constant. *)
-      Misc.fatal_error
-        "Unexpected resolver failure while adding alias to constant"
-    | Ok { canonical_element; demoted_name; t = aliases } ->
-      if (not (Name.equal demoted_name name))
-         || not (Simple.equal canonical_element (Simple.const const))
-      then Misc.fatal_error "Unexpected demotion of constant.";
-      let kind = MTC.kind_for_const const in
-      let ty = TG.alias_type_of kind canonical_element in
-      let t = with_aliases t ~aliases in
-      replace_equation t demoted_name ty)
+type add_alias_result =
+  { canonical_element : Simple.t;
+    demoted_name : Name.t;
+    t : t
+  }
 
-let add_concrete_equation_on_canonical ~raise_on_bottom t simple ty
-    ~(meet_type : meet_type) =
-  (* When adding a type to a canonical name, we need to call [meet] with the
-     existing type for that name in order to ensure we record the most precise
-     type available.
-
-     For example, suppose [p] is defined earlier than [x], with [p] of type
-     [ty1] and [x] of type [ty2]. If the caller says that the type of [p] is now
-     to be "= x", then we will instead add a type "= p" on [x] and demote [x] to
-     [p], due to the definition ordering. We then need to record the information
-     that [p] now has type [ty1 meet ty2], otherwise the type [ty2] would be
-     lost.
-
-     If instead we say that the type of [p] is to be "= c", where [c] is a
-     constant, we will add the type "= c" to [p] and demote [p] to [c]. We have
-     no type to record for [c], however we still need to check that [c] is
-     compatible with the previous type of [p].
-
-     Note also that [p] and [x] may have different name modes! *)
-  Simple.pattern_match simple
-    ~const:(fun const ->
-      match meet_type t ty (MTC.type_for_const const) with
-      | Ok (_, env) -> env
-      | Bottom -> if raise_on_bottom then raise Bottom_equation else t)
-    ~name:(fun name ~coercion ->
-      (* If [(coerce name coercion)] has type [ty], then [name] has type
-         [(coerce ty coercion^-1)]. *)
-      let ty = TG.apply_coercion ty (Coercion.inverse coercion) in
-      (* Note: this will check that the [existing_ty] has the expected kind. *)
-      let existing_ty = find t name (Some (TG.kind ty)) in
-      match meet_type t ty existing_ty with
-      | Bottom ->
-        if raise_on_bottom
-        then raise Bottom_equation
-        else replace_equation t name (MTC.bottom (TG.kind ty))
-      | Ok ((Right_input | Both_inputs), env) -> env
-      | Ok (Left_input, env) -> replace_concrete_equation env name ty
-      | Ok (New_result ty', env) -> replace_concrete_equation env name ty')
-
-let record_demotion ~raise_on_bottom t kind demoted canonical ~meet_type =
-  (* We have demoted [demoted], which used to be canonical, to [canonical] in
-     the aliases structure.
-
-     We now need to record that information in the types structure, and add the
-     previous type of [demoted] to [canonical] to ensure we do not lose
-     information that was only stored on the type of [demoted]. *)
-  let ty_of_demoted = find t demoted (Some kind) in
-  (if Flambda_features.check_light_invariants ()
-  then
-    match TG.get_alias_opt ty_of_demoted with
-    | None -> ()
-    | Some alias ->
-      Misc.fatal_errorf
-        "Expected %a to have a concrete type, not an alias type to %a"
-        Name.print demoted Simple.print alias);
-  let t = replace_equation t demoted (TG.alias_type_of kind canonical) in
-  add_concrete_equation_on_canonical ~raise_on_bottom t canonical ty_of_demoted
-    ~meet_type
-
-let add_alias_between_canonicals ~raise_on_bottom t kind canonical_element1
-    canonical_element2 ~meet_type =
-  (* We are adding an equality between two canonical simples [canonical1] and
-     [canonical2].
-
-     We'll ask the aliases structure to record the equality and determine which
-     of [canonical1] or [canonical2] should remain canonical, then forward to
-     [record_demotion] which takes care of recording an alias type on the
-     demoted element and updating the type of the element that remains
-     canonical. *)
-  if Simple.equal canonical_element1 canonical_element2
-  then t
-  else
-    match aliases_add t ~canonical_element1 ~canonical_element2 with
-    | Bottom -> if raise_on_bottom then raise Bottom_equation else t
-    | exception Binding_time_resolver_failure ->
-      (* Addition of aliases between names that are both in external compilation
-         units failed, e.g. due to a missing .cmx file. Simply drop the
-         equation. *)
-      t
-    | Ok { demoted_name; canonical_element; t = aliases } ->
-      let t = with_aliases t ~aliases in
-      record_demotion ~raise_on_bottom t kind demoted_name canonical_element
-        ~meet_type
-
-let get_canonical_simple_ignoring_name_mode t simple =
-  Simple.pattern_match simple
-    ~const:(fun _ -> simple)
-    ~name:(fun name ~coercion ->
-      let canonical_of_name =
-        Aliases.get_canonical_ignoring_name_mode (aliases t) name
-      in
-      Simple.apply_coercion_exn canonical_of_name coercion)
-
-let add_equation_on_canonical ~raise_on_bottom t simple ty ~meet_type =
-  (* We are adding a type [ty] to [simple], which must be canonical. There are
-     two general cases to consider:
-
-     - Either [ty] is a concrete (non-alias) type, to be recorded in the types
-     structure on the [canonical_simple];
-
-     - or [ty] is an alias "= alias" to another simple, to be recorded in the
-     aliases structure. *)
-  match TG.get_alias_opt ty with
-  | None ->
-    add_concrete_equation_on_canonical ~raise_on_bottom t simple ty ~meet_type
-  | Some alias ->
-    let alias = get_canonical_simple_ignoring_name_mode t alias in
-    add_alias_between_canonicals ~raise_on_bottom t (TG.kind ty) simple alias
-      ~meet_type
-
-let add_equation_on_simple ~raise_on_bottom t simple ty ~meet_type =
-  let canonical = get_canonical_simple_ignoring_name_mode t simple in
-  add_equation_on_canonical ~raise_on_bottom t canonical ty ~meet_type
-
-let add_equation ~raise_on_bottom t name ty ~meet_type =
-  add_equation_on_simple ~raise_on_bottom t (Simple.name name) ty ~meet_type
-
-let add_env_extension ~raise_on_bottom t
-    (env_extension : Typing_env_extension.t) ~meet_type =
-  Typing_env_extension.fold
-    ~equation:(fun name ty t ->
-      add_equation ~raise_on_bottom t name ty ~meet_type)
-    env_extension t
-
-let add_env_extension_with_extra_variables t
-    (env_extension : Typing_env_extension.With_extra_variables.t) ~meet_type =
-  Typing_env_extension.With_extra_variables.fold
-    ~variable:(fun var kind t ->
-      add_variable_definition t var kind Name_mode.in_types)
-    ~equation:(fun name ty t ->
-      try add_equation ~raise_on_bottom:true t name ty ~meet_type
-      with Bottom_equation -> make_bottom t)
-    env_extension t
-
-let add_env_extension_from_level t level ~meet_type : t =
-  let t =
-    TEL.fold_on_defined_vars
-      (fun var kind t -> add_variable_definition t var kind Name_mode.in_types)
-      level t
-  in
-  let t =
-    Name.Map.fold
-      (fun name ty t ->
-        try add_equation ~raise_on_bottom:true t name ty ~meet_type
-        with Bottom_equation -> make_bottom t)
-      (TEL.equations level) t
-  in
-  Variable.Map.fold
-    (fun var proj t -> add_symbol_projection t var proj)
-    (TEL.symbol_projections level)
-    t
-
-let add_equation_strict t name ty ~meet_type : _ Or_bottom.t =
-  if t.is_bottom
-  then Bottom
-  else
-    try Ok (add_equation ~raise_on_bottom:true t name ty ~meet_type)
-    with Bottom_equation -> Bottom
-
-let add_env_extension_strict t env_extension ~meet_type : _ Or_bottom.t =
-  if t.is_bottom
-  then Bottom
-  else
-    try Ok (add_env_extension ~raise_on_bottom:true t env_extension ~meet_type)
-    with Bottom_equation -> Bottom
-
-let add_env_extension_maybe_bottom t env_extension ~meet_type =
-  add_env_extension ~raise_on_bottom:false t env_extension ~meet_type
-
-let add_equation t name ty ~meet_type =
-  try add_equation ~raise_on_bottom:true t name ty ~meet_type
-  with Bottom_equation -> make_bottom t
-
-let add_env_extension t env_extension ~meet_type =
-  try add_env_extension ~raise_on_bottom:true t env_extension ~meet_type
-  with Bottom_equation -> make_bottom t
+let add_alias t ~canonical_element1 ~canonical_element2 :
+    _ Or_unknown_or_bottom.t =
+  match aliases_add t ~canonical_element1 ~canonical_element2 with
+  | Bottom -> Bottom
+  | exception Binding_time_resolver_failure ->
+    (* Addition of aliases between names that are both in external compilation
+       units failed, e.g. due to a .cmx file. Simply drop the equation. *)
+    Unknown
+  | Ok { canonical_element; demoted_name; t = aliases } ->
+    Ok { canonical_element; demoted_name; t = with_aliases t ~aliases }
 
 let add_definitions_of_params t ~params =
   List.fold_left
@@ -1063,25 +861,6 @@ let add_definitions_of_params t ~params =
         (Flambda_kind.With_subkind.kind (Bound_parameter.kind param)))
     t
     (Bound_parameters.to_list params)
-
-let check_params_and_types ~params ~param_types =
-  if Flambda_features.check_invariants ()
-     && List.compare_lengths (Bound_parameters.to_list params) param_types <> 0
-  then
-    Misc.fatal_errorf
-      "Mismatch between number of [params] and [param_types]:@ (%a)@ and@ %a"
-      Bound_parameters.print params
-      (Format.pp_print_list ~pp_sep:Format.pp_print_space TG.print)
-      param_types
-
-let add_equations_on_params t ~params ~param_types ~meet_type =
-  check_params_and_types ~params ~param_types;
-  List.fold_left2
-    (fun t param param_type ->
-      add_equation t (Bound_parameter.name param) param_type ~meet_type)
-    t
-    (Bound_parameters.to_list params)
-    param_types
 
 let add_to_code_age_relation t ~new_code_id ~old_code_id =
   let code_age_relation =
@@ -1167,6 +946,15 @@ let type_simple_in_term_exn t ?min_name_mode simple =
   | exception Binding_time_resolver_failure ->
     TG.alias_type_of kind simple, simple
   | alias -> TG.alias_type_of kind alias, alias
+
+let get_canonical_simple_ignoring_name_mode t simple =
+  Simple.pattern_match simple
+    ~const:(fun _ -> simple)
+    ~name:(fun name ~coercion ->
+      let canonical_of_name =
+        Aliases.get_canonical_ignoring_name_mode (aliases t) name
+      in
+      Simple.apply_coercion_exn canonical_of_name coercion)
 
 let get_canonical_simple_exn t ?min_name_mode ?name_mode_of_existing_simple
     simple =

--- a/middle_end/flambda2/types/equal_types_for_debug.ml
+++ b/middle_end/flambda2/types/equal_types_for_debug.ml
@@ -17,6 +17,7 @@ module TE = Typing_env
 module TEE = Typing_env_extension
 module TG = Type_grammar
 module ET = Expand_head.Expanded_type
+module ME = Meet_env
 
 type renaming =
   { mutable left_renaming : Variable.t Variable.Map.t;
@@ -43,7 +44,7 @@ type env =
   { parent_env : TE.t;
     left_env : TE.t;
     right_env : TE.t;
-    meet_type : TE.meet_type;
+    meet_type : ME.meet_type;
     renaming : renaming
   }
 
@@ -54,12 +55,12 @@ let extension_env env left_env right_env = { env with left_env; right_env }
 
 let add_env_extension env ext1 ext2 =
   extension_env env
-    (TE.add_env_extension ~meet_type:env.meet_type env.left_env ext1)
-    (TE.add_env_extension ~meet_type:env.meet_type env.right_env ext2)
+    (ME.add_env_extension ~meet_type:env.meet_type env.left_env ext1)
+    (ME.add_env_extension ~meet_type:env.meet_type env.right_env ext2)
 
 let add_env_extension_strict env ext1 ext2 =
-  ( TE.add_env_extension_strict ~meet_type:env.meet_type env.left_env ext1,
-    TE.add_env_extension_strict ~meet_type:env.meet_type env.right_env ext2 )
+  ( ME.add_env_extension_strict ~meet_type:env.meet_type env.left_env ext1,
+    ME.add_env_extension_strict ~meet_type:env.meet_type env.right_env ext2 )
 
 let exists_in_parent_env env name =
   TE.mem ~min_name_mode:Name_mode.in_types env.parent_env name
@@ -127,9 +128,9 @@ let equal_env_extension ~equal_type env ext1 ext2 =
 let equal_row_like_case ~equal_type ~equal_maps_to ~equal_lattice ~equal_shape
     env (t1 : (_, _, _) TG.row_like_case) (t2 : (_, _, _) TG.row_like_case) =
   match
-    ( TE.add_env_extension_strict env.left_env t1.env_extension
+    ( ME.add_env_extension_strict env.left_env t1.env_extension
         ~meet_type:env.meet_type,
-      TE.add_env_extension_strict env.right_env t2.env_extension
+      ME.add_env_extension_strict env.right_env t2.env_extension
         ~meet_type:env.meet_type )
   with
   | Or_bottom.Bottom, Or_bottom.Bottom -> true

--- a/middle_end/flambda2/types/equal_types_for_debug.mli
+++ b/middle_end/flambda2/types/equal_types_for_debug.mli
@@ -25,35 +25,35 @@
    the levels as existentials. *)
 
 val equal_type :
-  meet_type:Typing_env.meet_type ->
+  meet_type:Meet_env.meet_type ->
   Typing_env.t ->
   Type_grammar.t ->
   Type_grammar.t ->
   bool
 
 val equal_env_extension :
-  meet_type:Typing_env.meet_type ->
+  meet_type:Meet_env.meet_type ->
   Typing_env.t ->
   Typing_env_extension.t ->
   Typing_env_extension.t ->
   bool
 
 val names_with_non_equal_types_env_extension :
-  meet_type:Typing_env.meet_type ->
+  meet_type:Meet_env.meet_type ->
   Typing_env.t ->
   Typing_env_extension.t ->
   Typing_env_extension.t ->
   Name.Set.t
 
 val equal_level_ignoring_name_mode :
-  meet_type:Typing_env.meet_type ->
+  meet_type:Meet_env.meet_type ->
   Typing_env.t ->
   Typing_env_level.t ->
   Typing_env_level.t ->
   bool
 
 val names_with_non_equal_types_level_ignoring_name_mode :
-  meet_type:Typing_env.meet_type ->
+  meet_type:Meet_env.meet_type ->
   Typing_env.t ->
   Typing_env_level.t ->
   Typing_env_level.t ->

--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -16,6 +16,7 @@
 
 module Typing_env = struct
   include Typing_env
+  open Meet_env
 
   let add_equation t name ty =
     add_equation t name ty ~meet_type:(Meet.meet_type ())

--- a/middle_end/flambda2/types/join_levels.ml
+++ b/middle_end/flambda2/types/join_levels.ml
@@ -111,5 +111,5 @@ let cut_and_n_way_join definition_typing_env ts_and_use_ids ~params ~cut_after
        Format.eprintf "@[Names with distinct types:@ %a@]" Name.Set.print
          distinct_names;
        Format.eprintf "@]@\n%s@." (String.make 60 '=')));
-    TE.add_env_extension_from_level definition_typing_env new_joined_level
+    Meet_env.add_env_extension_from_level definition_typing_env new_joined_level
       ~meet_type:(Meet.meet_type ())

--- a/middle_end/flambda2/types/join_levels_old.ml
+++ b/middle_end/flambda2/types/join_levels_old.ml
@@ -17,6 +17,7 @@
 module K = Flambda_kind
 module MTC = More_type_creators
 module TE = Typing_env
+module ME = Meet_env
 module TEE = Typing_env_extension
 module TEL = Typing_env_level
 module TG = Type_grammar
@@ -84,7 +85,7 @@ let join_types ~env_at_fork envs_with_levels =
         (* CR vlaviron: This is very likely quadratic (number of uses times
            number of variables in all uses). However it's hard to know how we
            could do better. *)
-        TE.add_env_extension_maybe_bottom base_env
+        ME.add_env_extension_maybe_bottom base_env
           (TEE.from_map joined_types)
           ~meet_type:Meet_and_join.meet_type
       in
@@ -331,7 +332,7 @@ let cut_and_n_way_join definition_typing_env ts_and_use_ids ~params ~cut_after
       ~extra_lifted_consts_in_use_envs ~extra_allowed_names
   in
   let result_env =
-    TE.add_env_extension_from_level definition_typing_env level
+    ME.add_env_extension_from_level definition_typing_env level
       ~meet_type:Meet_and_join.meet_type
   in
   TE.compute_joined_aliases result_env alias_candidates

--- a/middle_end/flambda2/types/meet.mli
+++ b/middle_end/flambda2/types/meet.mli
@@ -19,7 +19,7 @@ val meet :
   Type_grammar.t ->
   (Type_grammar.t * Typing_env.t) Or_bottom.t
 
-val meet_type : unit -> Typing_env.meet_type
+val meet_type : unit -> Meet_env.meet_type
 
 val meet_shape :
   Typing_env.t ->

--- a/middle_end/flambda2/types/meet_and_join.mli
+++ b/middle_end/flambda2/types/meet_and_join.mli
@@ -41,4 +41,4 @@ val meet_type :
   Typing_env.t ->
   Type_grammar.t ->
   Type_grammar.t ->
-  (Type_grammar.t Typing_env.meet_return_value * Typing_env.t) Or_bottom.t
+  (Type_grammar.t Meet_env.meet_return_value * Typing_env.t) Or_bottom.t

--- a/middle_end/flambda2/types/meet_and_n_way_join.mli
+++ b/middle_end/flambda2/types/meet_and_n_way_join.mli
@@ -39,4 +39,4 @@ val meet_type :
   Typing_env.t ->
   Type_grammar.t ->
   Type_grammar.t ->
-  (Type_grammar.t Typing_env.meet_return_value * Typing_env.t) Or_bottom.t
+  (Type_grammar.t Meet_env.meet_return_value * Typing_env.t) Or_bottom.t


### PR DESCRIPTION
Extract the meet-related functions (`add_equation` and the like) from the typing env to a separate `Meet_env` module.

For now the `Meet_env` module is just providing functions that operate on a `Typing_env.t`, but this is a first step towards a separate `Meet_env.t` type to be used during meets. This serves multiple purposes:

 - It makes it easier to record per-meet statistics ;
 - It makes the implementation of the `reducer`s in #4112 less awkward/fragile ;
 - It frees up the `Typing_env` module from meet-related concerns, making it closer to a dumb store of information. This provides a better separation of concerns and is also a motivation to extract these functions in a separate module rather than in a nested `Typing_env.Meet_env` module.