### PR TITLE
fix(flambda2): Avoid quadratic call to merge in control_flow_graph

### DIFF
--- a/middle_end/flambda2/simplify/flow/control_flow_graph.ml
+++ b/middle_end/flambda2/simplify/flow/control_flow_graph.ml
@@ -59,13 +59,11 @@ let create ~dummy_toplevel_cont { T.Acc.map; _ } =
             acc
         in
         let acc =
-          Continuation.Map.merge
-            (fun _callee acc args ->
-              match acc, args with
-              | None, None -> assert false
-              | Some set, None -> Some set
-              | None, Some _ -> Some (Continuation.Set.singleton caller)
-              | Some set, Some _ -> Some (Continuation.Set.add caller set))
+          Continuation.Map.update_many
+            (fun _callee acc_opt _args ->
+              match acc_opt with
+              | None -> Some (Continuation.Set.singleton caller)
+              | Some set -> Some (Continuation.Set.add caller set))
             acc elt.apply_cont_args
         in
         acc)


### PR DESCRIPTION
Note: this PR is rebased on top of (and includes) #4262 ; only the last commit "[fix(flambda2): Avoid quadratic call to merge in control_flow_graph](https://github.com/oxcaml/oxcaml/commit/d053811a6cdce2c92ebaf4c6b32ff001048f721e)" is part of this PR.