### PR TITLE
Use `Mode.Crossing` in jkinds

### DIFF
--- a/dune
+++ b/dune
@@ -102,6 +102,7 @@
    -w
    -67-47
    ; remove -w -67 by adding the camlinternalMenhirLib hack like the Makefile
+   ; -47 needed because [@inline available] is not recognized by the system compiler
    ))
  (ocamlopt_flags
   (:include %{project_root}/ocamlopt_flags.sexp))

--- a/dune
+++ b/dune
@@ -100,7 +100,7 @@
    -safe-string
    -strict-formats
    -w
-   -67
+   -67-47
    ; remove -w -67 by adding the camlinternalMenhirLib hack like the Makefile
    ))
  (ocamlopt_flags

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5092,38 +5092,27 @@ let zap_modalities_to_floor_if_modes_enabled_at level =
 
 (** The mode crossing of the memory block of a structure. *)
 let mode_crossing_structure_memaddr =
-  (* CR-someday lmaurer: This is hard to read or maintain. We should have a
-     constructor for [Mode.Crossing.t] that takes a simple [Cross] or
-     [Don't_cross] for each axis. *)
-  Mode.Crossing.of_bounds
-  { monadic = {
-      uniqueness = Unique;
-      contention = Contended;
-      visibility = Immutable
-    };
-    comonadic = {
-      areality = Local;
-      linearity = Many;
-      portability = Portable;
-      yielding = Unyielding;
-      statefulness = Stateless;
-  }}
+  Mode.Crossing.create
+    ~uniqueness:false
+    ~contention:true
+    ~visibility:true
+    ~regionality:false
+    ~linearity:true
+    ~portability:true
+    ~yielding:true
+    ~statefulness:true
 
 (** The mode crossing of a functor. *)
 let mode_crossing_functor =
-  Mode.Crossing.of_bounds
-  { monadic = {
-      uniqueness = Aliased;
-      contention = Contended;
-      visibility = Immutable
-    };
-    comonadic = {
-      areality = Local;
-      linearity = Once;
-      portability = Nonportable;
-      yielding = Yielding;
-      statefulness = Stateful;
-  }}
+  Mode.Crossing.create
+    ~uniqueness:true
+    ~contention:true
+    ~visibility:true
+    ~regionality:false
+    ~linearity:false
+    ~portability:false
+    ~yielding:false
+    ~statefulness:false
 
 (** The mode crossing of any module. *)
 let mode_crossing_module = Mode.Crossing.max

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -295,11 +295,11 @@ let zap_axis_to_ceil
 let print_out_mode
 : type a. ?in_structure:_ -> a Mode.Value.Axis.t -> a -> _
 = fun ?(in_structure=true) ax mode ->
-  let (module L) = Mode.Value.Const.lattice_of_axis ax in
+  let print = Mode.Value.Const.print_axis ax in
   if in_structure then
-    Format.dprintf " (* in a structure at %a *)" L.print mode
+    Format.dprintf " (* in a structure at %a *)" print mode
   else
-    Format.dprintf " (* at %a *)" L.print mode
+    Format.dprintf " (* at %a *)" print mode
 
 let maybe_print_mode_l ~is_modal (mode : Mode.Value.l) =
   match is_modal with

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -413,7 +413,7 @@ let relevant_axes_of_modality ~relevant_for_shallow ~modality =
   Axis_set.create ~f:(fun ~axis:(Pack axis) ->
       match axis with
       | Modal axis ->
-        let (P axis) = Mode.Modality.Axis.of_value (P axis) in
+        let (P axis) = P axis |> Crossing.Axis.to_modality in
         let modality = Mode.Modality.Const.proj axis modality in
         not (Mode.Modality.Per_axis.is_constant axis modality)
       (* The kind-inference.md document (in the repo) discusses both constant
@@ -438,89 +438,50 @@ module Mod_bounds = struct
   include Types.Jkind_mod_bounds
 
   let min =
-    create ~areality:Areality.min ~linearity:Linearity.min
-      ~uniqueness:Uniqueness.min ~portability:Portability.min
-      ~contention:Contention.min ~yielding:Yielding.min
-      ~statefulness:Statefulness.min ~visibility:Visibility.min
-      ~externality:Externality.min ~nullability:Nullability.min
-      ~separability:Separability.min
+    create Crossing.min ~externality:Externality.min
+      ~nullability:Nullability.min ~separability:Separability.min
 
   let max =
-    create ~areality:Areality.max ~linearity:Linearity.max
-      ~uniqueness:Uniqueness.max ~portability:Portability.max
-      ~contention:Contention.max ~yielding:Yielding.max
-      ~statefulness:Statefulness.max ~visibility:Visibility.max
-      ~externality:Externality.max ~nullability:Nullability.max
-      ~separability:Separability.max
+    create Crossing.max ~externality:Externality.max
+      ~nullability:Nullability.max ~separability:Separability.max
 
   let join t1 t2 =
-    let areality = Areality.join (areality t1) (areality t2) in
-    let linearity = Linearity.join (linearity t1) (linearity t2) in
-    let uniqueness = Uniqueness.join (uniqueness t1) (uniqueness t2) in
-    let portability = Portability.join (portability t1) (portability t2) in
-    let contention = Contention.join (contention t1) (contention t2) in
-    let yielding = Yielding.join (yielding t1) (yielding t2) in
-    let statefulness = Statefulness.join (statefulness t1) (statefulness t2) in
-    let visibility = Visibility.join (visibility t1) (visibility t2) in
+    let crossing = Crossing.join (crossing t1) (crossing t2) in
     let externality = Externality.join (externality t1) (externality t2) in
     let nullability = Nullability.join (nullability t1) (nullability t2) in
     let separability = Separability.join (separability t1) (separability t2) in
-    create ~areality ~linearity ~uniqueness ~portability ~contention ~yielding
-      ~statefulness ~visibility ~externality ~nullability ~separability
+    create crossing ~externality ~nullability ~separability
 
   let meet t1 t2 =
-    let areality = Areality.meet (areality t1) (areality t2) in
-    let linearity = Linearity.meet (linearity t1) (linearity t2) in
-    let uniqueness = Uniqueness.meet (uniqueness t1) (uniqueness t2) in
-    let portability = Portability.meet (portability t1) (portability t2) in
-    let contention = Contention.meet (contention t1) (contention t2) in
-    let yielding = Yielding.meet (yielding t1) (yielding t2) in
-    let statefulness = Statefulness.meet (statefulness t1) (statefulness t2) in
-    let visibility = Visibility.meet (visibility t1) (visibility t2) in
+    let crossing = Crossing.meet (crossing t1) (crossing t2) in
     let externality = Externality.meet (externality t1) (externality t2) in
     let nullability = Nullability.meet (nullability t1) (nullability t2) in
     let separability = Separability.meet (separability t1) (separability t2) in
-    create ~areality ~linearity ~uniqueness ~portability ~contention ~yielding
-      ~statefulness ~visibility ~externality ~nullability ~separability
+    create crossing ~externality ~nullability ~separability
 
   let less_or_equal t1 t2 =
+    let[@inline] modal_less_or_equal ax : Sub_result.t =
+      let a = t1 |> crossing |> Crossing.proj ax in
+      let b = t2 |> crossing |> Crossing.proj ax in
+      match Crossing.Per_axis.le ax a b, Crossing.Per_axis.le ax b a with
+      | true, true -> Equal
+      | true, false -> Less
+      | false, _ -> Not_le [Axis_disagreement (Pack (Modal ax))]
+    in
     let[@inline] axis_less_or_equal ~le ~axis a b : Sub_result.t =
       match le a b, le b a with
       | true, true -> Equal
       | true, false -> Less
       | false, _ -> Not_le [Axis_disagreement axis]
     in
-    Sub_result.combine
-      (axis_less_or_equal ~le:Areality.le
-         ~axis:(Pack (Modal (Comonadic Areality))) (areality t1) (areality t2))
-    @@ Sub_result.combine
-         (axis_less_or_equal ~le:Uniqueness.le
-            ~axis:(Pack (Modal (Monadic Uniqueness))) (uniqueness t1)
-            (uniqueness t2))
-    @@ Sub_result.combine
-         (axis_less_or_equal ~le:Linearity.le
-            ~axis:(Pack (Modal (Comonadic Linearity))) (linearity t1)
-            (linearity t2))
-    @@ Sub_result.combine
-         (axis_less_or_equal ~le:Contention.le
-            ~axis:(Pack (Modal (Monadic Contention))) (contention t1)
-            (contention t2))
-    @@ Sub_result.combine
-         (axis_less_or_equal ~le:Portability.le
-            ~axis:(Pack (Modal (Comonadic Portability))) (portability t1)
-            (portability t2))
-    @@ Sub_result.combine
-         (axis_less_or_equal ~le:Yielding.le
-            ~axis:(Pack (Modal (Comonadic Yielding))) (yielding t1)
-            (yielding t2))
-    @@ Sub_result.combine
-         (axis_less_or_equal ~le:Statefulness.le
-            ~axis:(Pack (Modal (Comonadic Statefulness))) (statefulness t1)
-            (statefulness t2))
-    @@ Sub_result.combine
-         (axis_less_or_equal ~le:Visibility.le
-            ~axis:(Pack (Modal (Monadic Visibility))) (visibility t1)
-            (visibility t2))
+    Sub_result.combine (modal_less_or_equal (Comonadic Areality))
+    @@ Sub_result.combine (modal_less_or_equal (Monadic Uniqueness))
+    @@ Sub_result.combine (modal_less_or_equal (Comonadic Linearity))
+    @@ Sub_result.combine (modal_less_or_equal (Monadic Contention))
+    @@ Sub_result.combine (modal_less_or_equal (Comonadic Portability))
+    @@ Sub_result.combine (modal_less_or_equal (Comonadic Yielding))
+    @@ Sub_result.combine (modal_less_or_equal (Comonadic Statefulness))
+    @@ Sub_result.combine (modal_less_or_equal (Monadic Visibility))
     @@ Sub_result.combine
          (axis_less_or_equal ~le:Externality.le
             ~axis:(Pack (Nonmodal Externality)) (externality t1)
@@ -534,28 +495,14 @@ module Mod_bounds = struct
          (separability t2)
 
   let equal t1 t2 =
-    Areality.equal (areality t1) (areality t2)
-    && Linearity.equal (linearity t1) (linearity t2)
-    && Uniqueness.equal (uniqueness t1) (uniqueness t2)
-    && Portability.equal (portability t1) (portability t2)
-    && Contention.equal (contention t1) (contention t2)
-    && Yielding.equal (yielding t1) (yielding t2)
-    && Statefulness.equal (statefulness t1) (statefulness t2)
-    && Visibility.equal (visibility t1) (visibility t2)
+    Misc.Le_result.equal ~le:Crossing.le (crossing t1) (crossing t2)
     && Externality.equal (externality t1) (externality t2)
     && Nullability.equal (nullability t1) (nullability t2)
     && Separability.equal (separability t1) (separability t2)
 
   let[@inline] get (type a) ~(axis : a Axis.t) t : a =
     match axis with
-    | Modal (Monadic Uniqueness) -> uniqueness t
-    | Modal (Comonadic Areality) -> areality t
-    | Modal (Monadic Contention) -> contention t
-    | Modal (Comonadic Linearity) -> linearity t
-    | Modal (Comonadic Portability) -> portability t
-    | Modal (Comonadic Yielding) -> yielding t
-    | Modal (Comonadic Statefulness) -> statefulness t
-    | Modal (Monadic Visibility) -> visibility t
+    | Modal ax -> t |> crossing |> Crossing.proj ax
     | Nonmodal Externality -> externality t
     | Nonmodal Nullability -> nullability t
     | Nonmodal Separability -> separability t
@@ -565,31 +512,20 @@ module Mod_bounds = struct
     let[@inline] add_if b ax axis_set =
       if b then Axis_set.add axis_set ax else axis_set
     in
+    let[@inline] add_crossing_if ax axis_set =
+      if Crossing.Per_axis.(le ax (max ax) (Crossing.proj ax (crossing t)))
+      then Axis_set.add axis_set (Modal ax)
+      else axis_set
+    in
     Axis_set.empty
-    |> add_if
-         (Areality.le Areality.max (areality t))
-         (Modal (Comonadic Areality))
-    |> add_if
-         (Linearity.le Linearity.max (linearity t))
-         (Modal (Comonadic Linearity))
-    |> add_if
-         (Uniqueness.le Uniqueness.max (uniqueness t))
-         (Modal (Monadic Uniqueness))
-    |> add_if
-         (Portability.le Portability.max (portability t))
-         (Modal (Comonadic Portability))
-    |> add_if
-         (Contention.le Contention.max (contention t))
-         (Modal (Monadic Contention))
-    |> add_if
-         (Yielding.le Yielding.max (yielding t))
-         (Modal (Comonadic Yielding))
-    |> add_if
-         (Statefulness.le Statefulness.max (statefulness t))
-         (Modal (Comonadic Statefulness))
-    |> add_if
-         (Visibility.le Visibility.max (visibility t))
-         (Modal (Monadic Visibility))
+    |> add_crossing_if (Comonadic Areality)
+    |> add_crossing_if (Comonadic Linearity)
+    |> add_crossing_if (Monadic Uniqueness)
+    |> add_crossing_if (Comonadic Portability)
+    |> add_crossing_if (Monadic Contention)
+    |> add_crossing_if (Comonadic Yielding)
+    |> add_crossing_if (Comonadic Statefulness)
+    |> add_crossing_if (Monadic Visibility)
     |> add_if
          (Externality.le Externality.max (externality t))
          (Nonmodal Externality)
@@ -601,29 +537,15 @@ module Mod_bounds = struct
          (Nonmodal Separability)
 
   let for_arrow =
-    create ~linearity:Linearity.max ~areality:Areality.max
-      ~uniqueness:Uniqueness.min ~portability:Portability.max
-      ~contention:Contention.min ~yielding:Yielding.max
-      ~statefulness:Statefulness.max ~visibility:Visibility.min
-      ~externality:Externality.max ~nullability:Nullability.Non_null
-      ~separability:Separability.Non_float
+    let crossing =
+      Crossing.create ~linearity:false ~regionality:false ~uniqueness:true
+        ~portability:false ~contention:true ~yielding:false ~statefulness:false
+        ~visibility:true
+    in
+    create crossing ~externality:Externality.max
+      ~nullability:Nullability.Non_null ~separability:Separability.Non_float
 
-  let to_mode_crossing t =
-    Mode.Crossing.of_bounds
-      Types.Jkind_mod_bounds.
-        { comonadic =
-            { areality = areality t;
-              linearity = linearity t;
-              portability = portability t;
-              yielding = yielding t;
-              statefulness = statefulness t
-            };
-          monadic =
-            { uniqueness = uniqueness t;
-              contention = contention t;
-              visibility = visibility t
-            }
-        }
+  let to_mode_crossing t = crossing t
 end
 
 module With_bounds = struct
@@ -1116,22 +1038,33 @@ module Layout_and_axes = struct
               let value_for_axis (type a) ~(axis : a Axis.t) : a =
                 if Axis_set.mem relevant_axes axis
                 then
-                  let (module Bound_ops) = Axis.get axis in
-                  Bound_ops.join (Mod_bounds.get ~axis b1)
+                  Per_axis.join axis (Mod_bounds.get ~axis b1)
                     (Mod_bounds.get ~axis b2)
                 else Mod_bounds.get ~axis b1
               in
-              Mod_bounds.create
-                ~areality:(value_for_axis ~axis:(Modal (Comonadic Areality)))
-                ~linearity:(value_for_axis ~axis:(Modal (Comonadic Linearity)))
-                ~uniqueness:(value_for_axis ~axis:(Modal (Monadic Uniqueness)))
-                ~portability:
-                  (value_for_axis ~axis:(Modal (Comonadic Portability)))
-                ~contention:(value_for_axis ~axis:(Modal (Monadic Contention)))
-                ~yielding:(value_for_axis ~axis:(Modal (Comonadic Yielding)))
-                ~statefulness:
-                  (value_for_axis ~axis:(Modal (Comonadic Statefulness)))
-                ~visibility:(value_for_axis ~axis:(Modal (Monadic Visibility)))
+              let monadic =
+                Mod_bounds.Crossing.Monadic.create
+                  ~uniqueness:
+                    (value_for_axis ~axis:(Modal (Monadic Uniqueness)))
+                  ~contention:
+                    (value_for_axis ~axis:(Modal (Monadic Contention)))
+                  ~visibility:
+                    (value_for_axis ~axis:(Modal (Monadic Visibility)))
+              in
+              let comonadic =
+                Mod_bounds.Crossing.Comonadic.create
+                  ~regionality:
+                    (value_for_axis ~axis:(Modal (Comonadic Areality)))
+                  ~linearity:
+                    (value_for_axis ~axis:(Modal (Comonadic Linearity)))
+                  ~portability:
+                    (value_for_axis ~axis:(Modal (Comonadic Portability)))
+                  ~yielding:(value_for_axis ~axis:(Modal (Comonadic Yielding)))
+                  ~statefulness:
+                    (value_for_axis ~axis:(Modal (Comonadic Statefulness)))
+              in
+              let crossing : Mod_bounds.Crossing.t = { monadic; comonadic } in
+              Mod_bounds.create crossing
                 ~externality:(value_for_axis ~axis:(Nonmodal Externality))
                 ~nullability:(value_for_axis ~axis:(Nonmodal Nullability))
                 ~separability:(value_for_axis ~axis:(Nonmodal Separability))
@@ -1424,15 +1357,14 @@ module Const = struct
       { jkind =
           { layout = Base Value;
             mod_bounds =
-              Mod_bounds.create ~areality:Regionality.Const.max
-                ~linearity:Linearity.Const.min
-                ~portability:Portability.Const.min ~yielding:Yielding.Const.min
-                ~uniqueness:Uniqueness.Const_op.max
-                ~contention:Contention.Const_op.min
-                ~statefulness:Statefulness.Const.min
-                ~visibility:Visibility.Const_op.min ~externality:Externality.max
-                ~nullability:Nullability.Non_null
-                ~separability:Separability.Non_float;
+              (let crossing =
+                 Crossing.create ~regionality:false ~linearity:true
+                   ~portability:true ~yielding:true ~uniqueness:false
+                   ~contention:true ~statefulness:true ~visibility:true
+               in
+               Mod_bounds.create crossing ~externality:Externality.max
+                 ~nullability:Nullability.Non_null
+                 ~separability:Separability.Non_float);
             with_bounds = No_with_bounds
           };
         name = "immutable_data"
@@ -1442,15 +1374,14 @@ module Const = struct
       { jkind =
           { layout = Base Value;
             mod_bounds =
-              Mod_bounds.create ~areality:Regionality.Const.max
-                ~linearity:Linearity.Const.max
-                ~portability:Portability.Const.min ~yielding:Yielding.Const.max
-                ~uniqueness:Uniqueness.Const_op.max
-                ~contention:Contention.Const_op.min
-                ~statefulness:Statefulness.Const.max
-                ~visibility:Visibility.Const_op.max ~externality:Externality.max
-                ~nullability:Nullability.Non_null
-                ~separability:Separability.Non_float;
+              (let crossing =
+                 Crossing.create ~regionality:false ~linearity:false
+                   ~portability:true ~yielding:false ~uniqueness:false
+                   ~contention:true ~statefulness:false ~visibility:false
+               in
+               Mod_bounds.create crossing ~externality:Externality.max
+                 ~nullability:Nullability.Non_null
+                 ~separability:Separability.Non_float);
             with_bounds = No_with_bounds
           };
         name = "exn"
@@ -1460,15 +1391,14 @@ module Const = struct
       { jkind =
           { layout = Base Value;
             mod_bounds =
-              Mod_bounds.create ~areality:Regionality.Const.max
-                ~linearity:Linearity.Const.min
-                ~portability:Portability.Const.min ~yielding:Yielding.Const.min
-                ~uniqueness:Uniqueness.Const_op.max
-                ~contention:Contention.Const_op.min
-                ~statefulness:Statefulness.Const.min
-                ~visibility:Visibility.Const_op.max ~externality:Externality.max
-                ~nullability:Nullability.Non_null
-                ~separability:Separability.Non_float;
+              (let crossing =
+                 Crossing.create ~regionality:false ~linearity:true
+                   ~portability:true ~yielding:true ~uniqueness:false
+                   ~contention:true ~statefulness:true ~visibility:false
+               in
+               Mod_bounds.create crossing ~externality:Externality.max
+                 ~nullability:Nullability.Non_null
+                 ~separability:Separability.Non_float);
             with_bounds = No_with_bounds
           };
         name = "sync_data"
@@ -1478,15 +1408,14 @@ module Const = struct
       { jkind =
           { layout = Base Value;
             mod_bounds =
-              Mod_bounds.create ~areality:Regionality.Const.max
-                ~linearity:Linearity.Const.min
-                ~portability:Portability.Const.min ~yielding:Yielding.Const.min
-                ~contention:Contention.Const_op.max
-                ~uniqueness:Uniqueness.Const_op.max
-                ~statefulness:Statefulness.Const.min
-                ~visibility:Visibility.Const_op.max ~externality:Externality.max
-                ~nullability:Nullability.Non_null
-                ~separability:Separability.Non_float;
+              (let crossing =
+                 Crossing.create ~regionality:false ~linearity:true
+                   ~portability:true ~yielding:true ~contention:false
+                   ~uniqueness:false ~statefulness:true ~visibility:false
+               in
+               Mod_bounds.create crossing ~externality:Externality.max
+                 ~nullability:Nullability.Non_null
+                 ~separability:Separability.Non_float);
             with_bounds = No_with_bounds
           };
         name = "mutable_data"
@@ -1821,17 +1750,16 @@ module Const = struct
       }
 
     let get_modal_bound (type a) ~(axis : a Axis.t) ~(base : a) (actual : a) =
-      let (module A) = Axis.get axis in
       (* CR layouts v2.8: Fix printing! Internal ticket 5096. *)
       let less_or_equal a b =
-        let (module Axis_ops) = Axis.get axis in
-        Axis_ops.less_or_equal a b
+        Misc.Le_result.less_or_equal ~le:(Per_axis.le axis) a b
       in
       match less_or_equal actual base with
       | Less | Equal -> (
         match less_or_equal base actual with
         | Less | Equal -> `Valid None
-        | Not_le -> `Valid (Some (Format.asprintf "%a" A.print actual)))
+        | Not_le ->
+          `Valid (Some (Format.asprintf "%a" (Per_axis.print axis) actual)))
       | Not_le -> `Invalid
 
     let get_modal_bounds ~(base : Mod_bounds.t) (actual : Mod_bounds.t) =
@@ -1887,18 +1815,11 @@ module Const = struct
       List.fold_left
         (fun acc (Axis.Pack axis) ->
           match axis with
-          | Modal axis ->
-            let (P (type a) (axis : a Mode.Modality.Axis.t)) =
-              Mode.Modality.Axis.of_value (P axis)
-            in
-            let t : a =
-              match axis with
-              | Monadic ax ->
-                Join_with (Mode.Value.Monadic.Const.Per_axis.max ax)
-              | Comonadic ax ->
-                Meet_with (Mode.Value.Comonadic.Const.Per_axis.min ax)
-            in
-            Modality.Const.set axis t acc
+          | Modal axis -> (
+            match axis, Crossing.Per_axis.min axis with
+            | Monadic ax, Modality t -> Modality.Const.set (Monadic ax) t acc
+            | Comonadic ax, Modality t ->
+              Modality.Const.set (Comonadic ax) t acc)
           | Nonmodal _ ->
             (* TODO: don't know how to print *)
             acc)
@@ -2546,11 +2467,7 @@ let for_unboxed_record lbls =
 
 let for_non_float ~(why : History.value_creation_reason) =
   let mod_bounds =
-    Mod_bounds.create ~areality:Regionality.Const.max
-      ~linearity:Linearity.Const.max ~portability:Portability.Const.max
-      ~yielding:Yielding.Const.max ~uniqueness:Uniqueness.Const_op.max
-      ~contention:Contention.Const_op.max ~statefulness:Statefulness.Const.max
-      ~visibility:Visibility.Const_op.max ~externality:Externality.max
+    Mod_bounds.create Crossing.max ~externality:Externality.max
       ~nullability:Nullability.Non_null ~separability:Separability.Non_float
   in
   fresh_jkind
@@ -2562,11 +2479,7 @@ let for_or_null_argument ident =
     Type_argument { parent_path = Path.Pident ident; position = 1; arity = 1 }
   in
   let mod_bounds =
-    Mod_bounds.create ~areality:Regionality.Const.max
-      ~linearity:Linearity.Const.max ~portability:Portability.Const.max
-      ~yielding:Yielding.Const.max ~uniqueness:Uniqueness.Const_op.max
-      ~contention:Contention.Const_op.max ~statefulness:Statefulness.Const.max
-      ~visibility:Visibility.Const_op.max ~externality:Externality.max
+    Mod_bounds.create Crossing.max ~externality:Externality.max
       ~nullability:Nullability.Non_null
       ~separability:Separability.Maybe_separable
   in
@@ -2670,11 +2583,7 @@ let for_boxed_tuple elts =
 
 let for_open_boxed_row =
   let mod_bounds =
-    Mod_bounds.create ~areality:Regionality.Const.max
-      ~linearity:Linearity.Const.max ~portability:Portability.Const.max
-      ~yielding:Yielding.Const.max ~uniqueness:Uniqueness.Const_op.max
-      ~contention:Contention.Const_op.max ~statefulness:Statefulness.Const.max
-      ~visibility:Visibility.Const_op.max ~externality:Externality.max
+    Mod_bounds.create Crossing.max ~externality:Externality.max
       ~nullability:Nullability.Non_null ~separability:Separability.Non_float
   in
   fresh_jkind
@@ -2710,31 +2619,25 @@ let for_object =
   (* The crossing of objects are based on the fact that they are
      produced/defined/allocated at legacy, which applies to only the
      comonadic axes. *)
-  let ({ linearity; areality; portability; yielding; statefulness }
-        : Mode.Value.Comonadic.Const.t) =
-    Value.Comonadic.Const.legacy
-  in
-  let ({ contention; uniqueness; visibility } : Mode.Value.Monadic.Const_op.t) =
-    Value.Monadic.Const_op.max
-  in
+  let comonadic = Crossing.Comonadic.legacy in
+  let monadic = Crossing.Monadic.max in
   fresh_jkind
     { layout = Sort (Base Value);
       mod_bounds =
-        Mod_bounds.create ~linearity ~areality ~uniqueness ~portability
-          ~contention ~yielding ~statefulness ~visibility
-          ~externality:Externality.max ~nullability:Non_null
-          ~separability:Separability.Non_float;
+        Mod_bounds.create { comonadic; monadic } ~externality:Externality.max
+          ~nullability:Non_null ~separability:Separability.Non_float;
       with_bounds = No_with_bounds
     }
     ~annotation:None ~why:(Value_creation Object)
 
 let for_float ident =
+  let crossing =
+    Crossing.create ~regionality:false ~linearity:true ~portability:true
+      ~yielding:true ~uniqueness:false ~contention:true ~statefulness:true
+      ~visibility:true
+  in
   let mod_bounds =
-    Mod_bounds.create ~areality:Regionality.Const.max
-      ~linearity:Linearity.Const.min ~portability:Portability.Const.min
-      ~yielding:Yielding.Const.min ~uniqueness:Uniqueness.Const_op.max
-      ~contention:Contention.Const_op.min ~statefulness:Statefulness.Const.min
-      ~visibility:Visibility.Const_op.min ~externality:Externality.max
+    Mod_bounds.create crossing ~externality:Externality.max
       ~nullability:Nullability.Non_null ~separability:Separability.Separable
   in
   fresh_jkind
@@ -2744,11 +2647,7 @@ let for_float ident =
 
 let for_array_argument =
   let mod_bounds =
-    Mod_bounds.create ~areality:Regionality.Const.max
-      ~linearity:Linearity.Const.max ~portability:Portability.Const.max
-      ~yielding:Yielding.Const.max ~uniqueness:Uniqueness.Const_op.max
-      ~contention:Contention.Const_op.max ~statefulness:Statefulness.Const.max
-      ~visibility:Visibility.Const_op.max ~externality:Externality.max
+    Mod_bounds.create Crossing.max ~externality:Externality.max
       ~nullability:Nullability.Maybe_null ~separability:Separability.Separable
   in
   fresh_jkind
@@ -2811,31 +2710,14 @@ let get_layout jk : Layout.Const.t option = Layout.get_const jk.jkind.layout
 
 let extract_layout jk = jk.jkind.layout
 
-let get_modal_bounds (type l r) ~context (jk : (l * r) jkind) =
+let get_mode_crossing (type l r) ~context (jk : (l * r) jkind) =
   let ( ({ layout = _; mod_bounds; with_bounds = No_with_bounds } :
           (_ * allowed) jkind_desc),
         _ ) =
     Layout_and_axes.normalize ~mode:Ignore_best
       ~skip_axes:Axis_set.all_nonmodal_axes ~context jk.jkind
   in
-  Mod_bounds.
-    { comonadic =
-        { areality = areality mod_bounds;
-          linearity = linearity mod_bounds;
-          portability = portability mod_bounds;
-          yielding = yielding mod_bounds;
-          statefulness = statefulness mod_bounds
-        };
-      monadic =
-        { uniqueness = uniqueness mod_bounds;
-          contention = contention mod_bounds;
-          visibility = visibility mod_bounds
-        }
-    }
-
-let get_mode_crossing (type l r) ~context (jk : (l * r) jkind) =
-  let bounds = get_modal_bounds ~context jk in
-  Mode.Crossing.of_bounds bounds
+  Mod_bounds.crossing mod_bounds
 
 let to_unsafe_mode_crossing jkind =
   { unsafe_mod_bounds = Mod_bounds.to_mode_crossing jkind.jkind.mod_bounds;
@@ -3472,9 +3354,8 @@ module Violation = struct
         |> List.iter (fun (Pack axis : Axis.packed) ->
                let pp_bound ppf jkind =
                  let mod_bound = Mod_bounds.get ~axis jkind.mod_bounds in
-                 let (module Axis_ops) = Axis.get axis in
                  let with_bounds =
-                   match Axis_ops.(le max mod_bound) with
+                   match Per_axis.(le axis (max axis) mod_bound) with
                    | true ->
                      (* If the mod_bound is max, then no with-bounds are
                         relevant *)
@@ -3494,7 +3375,9 @@ module Violation = struct
                      (fun acc with_bound ->
                        Outcometree.Ojkind_const_with (acc, with_bound, []))
                      (Outcometree.Ojkind_const_mod
-                        (None, [Format.asprintf "%a" Axis_ops.print mod_bound]))
+                        ( None,
+                          [Format.asprintf "%a" (Per_axis.print axis) mod_bound]
+                        ))
                      with_bounds
                  in
                  !Oprint.out_jkind_const ppf ojkind

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -249,12 +249,6 @@ module Per_axis = struct
       | Nullability, Nullability -> Some Refl
       | Separability, Separability -> Some Refl
       | _ -> None
-
-    let print_obj : type a. Format.formatter -> a t -> unit =
-     fun ppf -> function
-      | Externality -> Format.fprintf ppf "externality"
-      | Nullability -> Format.fprintf ppf "nullability"
-      | Separability -> Format.fprintf ppf "separability"
   end
 
   let min : type a. a t -> a = function
@@ -289,9 +283,7 @@ module Per_axis = struct
     | _ -> None
 
   let print_obj : type a. Format.formatter -> a t -> unit =
-   fun ppf -> function
-    | Modal ax -> Mode.Crossing.Per_axis.print_obj ppf ax
-    | Nonmodal ax -> Nonmodal.print_obj ppf ax
+   fun ppf ax -> Format.pp_print_string ppf (name ax)
 end
 
 module Axis_set = struct

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -222,20 +222,26 @@ module Per_axis = struct
       | Nullability -> Nullability.max
       | Separability -> Separability.max
 
-    let le : type a. a t -> a -> a -> bool = function
-      | Externality -> Externality.le
-      | Nullability -> Nullability.le
-      | Separability -> Separability.le
+    let le : type a. a t -> a -> a -> bool =
+     fun ax a b ->
+      match ax with
+      | Externality -> Externality.le a b
+      | Nullability -> Nullability.le a b
+      | Separability -> Separability.le a b
 
-    let meet : type a. a t -> a -> a -> a = function
-      | Externality -> Externality.meet
-      | Nullability -> Nullability.meet
-      | Separability -> Separability.meet
+    let meet : type a. a t -> a -> a -> a =
+     fun ax a b ->
+      match ax with
+      | Externality -> Externality.meet a b
+      | Nullability -> Nullability.meet a b
+      | Separability -> Separability.meet a b
 
-    let join : type a. a t -> a -> a -> a = function
-      | Externality -> Externality.join
-      | Nullability -> Nullability.join
-      | Separability -> Separability.join
+    let join : type a. a t -> a -> a -> a =
+     fun ax a b ->
+      match ax with
+      | Externality -> Externality.join a b
+      | Nullability -> Nullability.join a b
+      | Separability -> Separability.join a b
 
     let print : type a. a t -> Format.formatter -> a -> unit = function
       | Externality -> Externality.print
@@ -251,25 +257,31 @@ module Per_axis = struct
       | _ -> None
   end
 
-  let min : type a. a t -> a = function
-    | Modal ax -> Mode.Crossing.Per_axis.min ax
-    | Nonmodal ax -> Nonmodal.min ax
+  let min : type a. a t -> a = function[@inline available]
+    | Modal ax -> (Mode.Crossing.Per_axis.min [@inlined hint]) ax
+    | Nonmodal ax -> (Nonmodal.min [@inlined hint]) ax
 
-  let max : type a. a t -> a = function
-    | Modal ax -> Mode.Crossing.Per_axis.max ax
-    | Nonmodal ax -> Nonmodal.max ax
+  let max : type a. a t -> a = function[@inline available]
+    | Modal ax -> (Mode.Crossing.Per_axis.max [@inlined hint]) ax
+    | Nonmodal ax -> (Nonmodal.max [@inlined hint]) ax
 
-  let le : type a. a t -> a -> a -> bool = function
-    | Modal ax -> Mode.Crossing.Per_axis.le ax
-    | Nonmodal ax -> Nonmodal.le ax
+  let le : type a. a t -> a -> a -> bool =
+   fun [@inline available] ax a b ->
+    match ax with
+    | Modal ax -> (Mode.Crossing.Per_axis.le [@inlined hint]) ax a b
+    | Nonmodal ax -> (Nonmodal.le [@inlined hint]) ax a b
 
-  let meet : type a. a t -> a -> a -> a = function
-    | Modal ax -> Mode.Crossing.Per_axis.meet ax
-    | Nonmodal ax -> Nonmodal.meet ax
+  let meet : type a. a t -> a -> a -> a =
+   fun [@inline available] ax a b ->
+    match ax with
+    | Modal ax -> (Mode.Crossing.Per_axis.meet [@inlined hint]) ax a b
+    | Nonmodal ax -> (Nonmodal.meet [@inlined hint]) ax a b
 
-  let join : type a. a t -> a -> a -> a = function
-    | Modal ax -> Mode.Crossing.Per_axis.join ax
-    | Nonmodal ax -> Nonmodal.join ax
+  let join : type a. a t -> a -> a -> a =
+   fun [@inline available] ax a b ->
+    match ax with
+    | Modal ax -> (Mode.Crossing.Per_axis.join [@inlined hint]) ax a b
+    | Nonmodal ax -> (Nonmodal.join [@inlined hint]) ax a b
 
   let print : type a. a t -> Format.formatter -> a -> unit = function
     | Modal ax -> Mode.Crossing.Per_axis.print ax

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -174,36 +174,13 @@ module Axis = struct
       | Externality : Externality.t t
       | Nullability : Nullability.t t
       | Separability : Separability.t t
-
-    let get (type a) : a t -> (module Axis_ops with type t = a) = function
-      | Externality -> (module Externality)
-      | Nullability -> (module Nullability)
-      | Separability -> (module Separability)
   end
 
   type 'a t =
-    | Modal : 'a Mode.Value.Axis.t -> 'a t
+    | Modal : 'a Mode.Crossing.Axis.t -> 'a t
     | Nonmodal : 'a Nonmodal.t -> 'a t
 
   type packed = Pack : 'a t -> packed [@@unboxed]
-
-  module Accent_lattice (M : Mode_intf.Lattice) = struct
-    (* A functor to add some convenient functions to modal axes *)
-    include M
-
-    let[@inline] less_or_equal a b : Misc.Le_result.t =
-      match le a b, le b a with
-      | true, true -> Equal
-      | true, false -> Less
-      | false, _ -> Not_le
-
-    let equal a b = Misc.Le_result.is_equal (less_or_equal a b)
-  end
-
-  let get (type a) : a t -> (module Axis_ops with type t = a) = function
-    | Modal axis ->
-      (module Accent_lattice ((val Mode.Value.Const.lattice_of_axis axis)))
-    | Nonmodal axis -> Nonmodal.get axis
 
   let all =
     [ Pack (Modal (Comonadic Areality));
@@ -219,10 +196,102 @@ module Axis = struct
       Pack (Nonmodal Separability) ]
 
   let name (type a) : a t -> string = function
-    | Modal axis -> Format.asprintf "%a" Mode.Value.Axis.print axis
+    | Modal ax ->
+      let (P ax) =
+        P ax |> Mode.Crossing.Axis.to_modality |> Mode.Modality.Axis.to_value
+      in
+      Format.asprintf "%a" Mode.Value.Axis.print ax
     | Nonmodal Externality -> "externality"
     | Nonmodal Nullability -> "nullability"
     | Nonmodal Separability -> "separability"
+end
+
+module Per_axis = struct
+  open Axis
+
+  module Nonmodal = struct
+    open Axis.Nonmodal
+
+    let min : type a. a t -> a = function
+      | Externality -> Externality.min
+      | Nullability -> Nullability.min
+      | Separability -> Separability.min
+
+    let max : type a. a t -> a = function
+      | Externality -> Externality.max
+      | Nullability -> Nullability.max
+      | Separability -> Separability.max
+
+    let le : type a. a t -> a -> a -> bool = function
+      | Externality -> Externality.le
+      | Nullability -> Nullability.le
+      | Separability -> Separability.le
+
+    let meet : type a. a t -> a -> a -> a = function
+      | Externality -> Externality.meet
+      | Nullability -> Nullability.meet
+      | Separability -> Separability.meet
+
+    let join : type a. a t -> a -> a -> a = function
+      | Externality -> Externality.join
+      | Nullability -> Nullability.join
+      | Separability -> Separability.join
+
+    let print : type a. a t -> Format.formatter -> a -> unit = function
+      | Externality -> Externality.print
+      | Nullability -> Nullability.print
+      | Separability -> Separability.print
+
+    let eq_obj : type a b. a t -> b t -> (a, b) Misc.eq option =
+     fun a b ->
+      match a, b with
+      | Externality, Externality -> Some Refl
+      | Nullability, Nullability -> Some Refl
+      | Separability, Separability -> Some Refl
+      | _ -> None
+
+    let print_obj : type a. Format.formatter -> a t -> unit =
+     fun ppf -> function
+      | Externality -> Format.fprintf ppf "externality"
+      | Nullability -> Format.fprintf ppf "nullability"
+      | Separability -> Format.fprintf ppf "separability"
+  end
+
+  let min : type a. a t -> a = function
+    | Modal ax -> Mode.Crossing.Per_axis.min ax
+    | Nonmodal ax -> Nonmodal.min ax
+
+  let max : type a. a t -> a = function
+    | Modal ax -> Mode.Crossing.Per_axis.max ax
+    | Nonmodal ax -> Nonmodal.max ax
+
+  let le : type a. a t -> a -> a -> bool = function
+    | Modal ax -> Mode.Crossing.Per_axis.le ax
+    | Nonmodal ax -> Nonmodal.le ax
+
+  let meet : type a. a t -> a -> a -> a = function
+    | Modal ax -> Mode.Crossing.Per_axis.meet ax
+    | Nonmodal ax -> Nonmodal.meet ax
+
+  let join : type a. a t -> a -> a -> a = function
+    | Modal ax -> Mode.Crossing.Per_axis.join ax
+    | Nonmodal ax -> Nonmodal.join ax
+
+  let print : type a. a t -> Format.formatter -> a -> unit = function
+    | Modal ax -> Mode.Crossing.Per_axis.print ax
+    | Nonmodal ax -> Nonmodal.print ax
+
+  let eq_obj : type a b. a t -> b t -> (a, b) Misc.eq option =
+   fun a b ->
+    match a, b with
+    | Modal ax0, Modal ax1 -> Mode.Crossing.Per_axis.eq_obj ax0 ax1
+    | Nonmodal ax0, Nonmodal ax1 -> Nonmodal.eq_obj ax0 ax1
+    | _ -> None
+
+  let print_obj : type a. Format.formatter -> a t -> unit =
+   fun ppf -> function
+    | Modal ax -> Mode.Crossing.Per_axis.print_obj ppf ax
+    | Nonmodal ax -> Nonmodal.print_obj ppf ax
 end
 
 module Axis_set = struct

--- a/typing/jkind_axis.mli
+++ b/typing/jkind_axis.mli
@@ -55,26 +55,22 @@ module Axis : sig
       | Externality : Externality.t t
       | Nullability : Nullability.t t
       | Separability : Separability.t t
-
-    val get : 'a t -> (module Axis_ops with type t = 'a)
   end
 
   (** Represents an axis of a jkind *)
   type 'a t =
-    | Modal : 'a Mode.Value.Axis.t -> 'a t
+    | Modal : 'a Mode.Crossing.Axis.t -> 'a t
     | Nonmodal : 'a Nonmodal.t -> 'a t
 
   type packed = Pack : 'a t -> packed [@@unboxed]
-
-  (* CR zqian: push ['a t] into the module to avoid first-class module. *)
-
-  (** Given a jkind axis, get its interface *)
-  val get : 'a t -> (module Axis_ops with type t = 'a)
 
   val all : packed list
 
   val name : _ t -> string
 end
+
+module Per_axis :
+  Solver_intf.Lattices with type 'a elt := 'a and type 'a obj := 'a Axis.t
 
 module Axis_set : sig
   (** A set of [Axis.t], represented as a bitfield for efficiency. *)

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2518,7 +2518,6 @@ end
 
 module Visibility = struct
   module Const = C.Visibility
-  module Const_op = C.Visibility_op
 
   module Obj = struct
     type const = Const.t
@@ -2560,7 +2559,6 @@ end
 
 module Uniqueness = struct
   module Const = C.Uniqueness
-  module Const_op = C.Uniqueness_op
 
   module Obj = struct
     type const = Const.t
@@ -2581,7 +2579,6 @@ end
 
 module Contention = struct
   module Const = C.Contention
-  module Const_op = C.Contention_op
 
   module Obj = struct
     type const = Const.t
@@ -2709,15 +2706,6 @@ module Comonadic_with (Areality : Areality) = struct
         let obj = proj_obj ax in
         C.print_obj ppf obj
     end
-
-    let lattice_of_axis (type a) (axis : a Axis.t) :
-        (module Lattice with type t = a) =
-      match axis with
-      | Areality -> (module Areality.Const)
-      | Linearity -> (module Linearity.Const)
-      | Portability -> (module Portability.Const)
-      | Yielding -> (module Yielding.Const)
-      | Statefulness -> (module Statefulness.Const)
   end
 
   let proj ax m = Solver.apply ~hint:Skip (proj_obj ax) (Proj (Obj.obj, ax)) m
@@ -2857,16 +2845,7 @@ module Monadic = struct
         let obj = proj_obj ax in
         C.print_obj ppf obj
     end
-
-    let lattice_of_axis (type a) (axis : a Axis.t) :
-        (module Lattice with type t = a) =
-      match axis with
-      | Uniqueness -> (module Uniqueness.Const_op)
-      | Contention -> (module Contention.Const_op)
-      | Visibility -> (module Visibility.Const_op)
   end
-
-  module Const_op = C.Monadic_op
 
   let proj ax m = Solver.apply ~hint:Skip (proj_obj ax) (Proj (Obj.obj, ax)) m
 
@@ -3093,12 +3072,6 @@ module Value_with (Areality : Areality) = struct
       let monadic = Monadic.join m0.monadic m1.monadic in
       let comonadic = Comonadic.join m0.comonadic m1.comonadic in
       merge { monadic; comonadic }
-
-    let lattice_of_axis (type a) (axis : a Axis.t) :
-        (module Lattice with type t = a) =
-      match axis with
-      | Comonadic ax -> Comonadic.lattice_of_axis ax
-      | Monadic ax -> Monadic.lattice_of_axis ax
 
     module Option = struct
       type some = t

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2666,7 +2666,7 @@ module Comonadic_with (Areality : Areality) = struct
       |> List.sort (fun (P ax0) (P ax1) -> compare ax0 ax1)
   end
 
-  let proj_obj ax = C.proj_obj ax Obj.obj
+  let proj_obj ax = (C.proj_obj [@inlined hint]) ax Obj.obj
 
   module Const = struct
     include C.Comonadic_with (Areality.Const)
@@ -2678,24 +2678,24 @@ module Comonadic_with (Areality : Areality) = struct
         C.print obj ppf a
 
       let le ax a b =
-        let obj = proj_obj ax in
-        C.le obj a b
+        let obj = (proj_obj [@inlined hint]) ax in
+        (C.le [@inlined hint]) obj a b
 
       let join ax a b =
-        let obj = proj_obj ax in
-        C.join obj a b
+        let obj = (proj_obj [@inlined hint]) ax in
+        (C.join [@inlined hint]) obj a b
 
       let meet ax a b =
-        let obj = proj_obj ax in
-        C.meet obj a b
+        let obj = (proj_obj [@inlined hint]) ax in
+        (C.meet [@inlined hint]) obj a b
 
       let max ax =
-        let obj = proj_obj ax in
-        C.max obj
+        let obj = (proj_obj [@inlined hint]) ax in
+        (C.max [@inlined hint]) obj
 
       let min ax =
-        let obj = proj_obj ax in
-        C.min obj
+        let obj = (proj_obj [@inlined hint]) ax in
+        (C.min [@inlined hint]) obj
 
       let eq_obj ax0 ax1 =
         let obj0 = proj_obj ax0 in
@@ -2805,7 +2805,7 @@ module Monadic = struct
       |> List.sort (fun (P ax0) (P ax1) -> compare ax0 ax1)
   end
 
-  let proj_obj ax = C.proj_obj ax Obj.obj
+  let proj_obj ax = (C.proj_obj [@inlined hint]) ax Obj.obj
 
   module Const = struct
     include C.Monadic
@@ -2817,24 +2817,24 @@ module Monadic = struct
         C.print obj ppf a
 
       let le ax a b =
-        let obj = proj_obj ax in
-        C.le obj b a
+        let obj = (proj_obj [@inlined hint]) ax in
+        (C.le [@inlined hint]) obj b a
 
       let join ax a b =
-        let obj = proj_obj ax in
-        C.meet obj a b
+        let obj = (proj_obj [@inlined hint]) ax in
+        (C.meet [@inlined hint]) obj a b
 
       let meet ax a b =
-        let obj = proj_obj ax in
-        C.join obj a b
+        let obj = (proj_obj [@inlined hint]) ax in
+        (C.join [@inlined hint]) obj a b
 
       let max ax =
-        let obj = proj_obj ax in
-        C.min obj
+        let obj = (proj_obj [@inlined hint]) ax in
+        (C.min [@inlined hint]) obj
 
       let min ax =
-        let obj = proj_obj ax in
-        C.max obj
+        let obj = (proj_obj [@inlined hint]) ax in
+        (C.max [@inlined hint]) obj
 
       let eq_obj ax0 ax1 =
         let obj0 = proj_obj ax0 in
@@ -4125,15 +4125,18 @@ module Crossing = struct
     module Atom = struct
       type 'a t = Modality of 'a Modality.Atom.t [@@unboxed]
 
-      let min ax = Modality (Join_with (Mode.Const.Per_axis.max ax))
+      let min ax =
+        Modality (Join_with ((Mode.Const.Per_axis.max [@inlined hint]) ax))
 
-      let max ax = Modality (Join_with (Mode.Const.Per_axis.min ax))
+      let max ax =
+        Modality (Join_with ((Mode.Const.Per_axis.min [@inlined hint]) ax))
 
       let le ax (Modality (Join_with c0)) (Modality (Join_with c1)) =
-        Mode.Const.Per_axis.le ax c1 c0
+        (Mode.Const.Per_axis.le [@inlined hint]) ax c1 c0
 
       let join ax (Modality (Join_with c0)) (Modality (Join_with c1)) =
-        Modality (Join_with (Mode.Const.Per_axis.meet ax c0 c1))
+        Modality
+          (Join_with ((Mode.Const.Per_axis.meet [@inlined hint]) ax c0 c1))
 
       let meet ax (Modality (Join_with c0)) (Modality (Join_with c1)) =
         Modality (Join_with (Mode.Const.Per_axis.join ax c0 c1))
@@ -4160,7 +4163,7 @@ module Crossing = struct
 
     let proj (type a) (ax : a Mode.Axis.t) (Modality (Join_const c)) : a Atom.t
         =
-      Modality (Join_with (Axis.proj ax c))
+      Modality (Join_with ((Axis.proj [@inlined hint]) ax c))
 
     let le (Modality (Join_const c0)) (Modality (Join_const c1)) =
       Mode.Const.le c1 c0
@@ -4191,15 +4194,18 @@ module Crossing = struct
     module Atom = struct
       type 'a t = Modality of 'a Modality.Atom.t [@@unboxed]
 
-      let min ax = Modality (Meet_with (Mode.Const.Per_axis.min ax))
+      let min ax =
+        Modality (Meet_with ((Mode.Const.Per_axis.min [@inlined hint]) ax))
 
-      let max ax = Modality (Meet_with (Mode.Const.Per_axis.max ax))
+      let max ax =
+        Modality (Meet_with ((Mode.Const.Per_axis.max [@inlined hint]) ax))
 
       let le ax (Modality (Meet_with c0)) (Modality (Meet_with c1)) =
-        Mode.Const.Per_axis.le ax c0 c1
+        (Mode.Const.Per_axis.le [@inlined hint]) ax c0 c1
 
       let join ax (Modality (Meet_with c0)) (Modality (Meet_with c1)) =
-        Modality (Meet_with (Mode.Const.Per_axis.join ax c0 c1))
+        Modality
+          (Meet_with ((Mode.Const.Per_axis.join [@inlined hint]) ax c0 c1))
 
       let meet ax (Modality (Meet_with c0)) (Modality (Meet_with c1)) =
         Modality (Meet_with (Mode.Const.Per_axis.meet ax c0 c1))
@@ -4220,7 +4226,7 @@ module Crossing = struct
 
     let proj (type a) (ax : a Mode.Axis.t) (Modality (Meet_const c)) : a Atom.t
         =
-      Modality (Meet_with (Axis.proj ax c))
+      Modality (Meet_with ((Axis.proj [@inlined hint]) ax c))
 
     let modality m (Modality t) = Modality (Modality.Const.concat ~then_:t m)
 
@@ -4287,25 +4293,31 @@ module Crossing = struct
   module Per_axis = struct
     open Axis
 
-    let le : type a. a t -> a -> a -> bool = function
-      | Monadic ax -> Monadic.Atom.le ax
-      | Comonadic ax -> Comonadic.Atom.le ax
+    let le : type a. a t -> a -> a -> bool =
+     fun [@inline available] ax a b ->
+      match ax with
+      | Monadic ax -> (Monadic.Atom.le [@inlined hint]) ax a b
+      | Comonadic ax -> (Comonadic.Atom.le [@inlined hint]) ax a b
 
-    let min : type a. a t -> a = function
-      | Monadic ax -> Monadic.Atom.min ax
-      | Comonadic ax -> Comonadic.Atom.min ax
+    let min : type a. a t -> a = function[@inline available]
+      | Monadic ax -> (Monadic.Atom.min [@inlined hint]) ax
+      | Comonadic ax -> (Comonadic.Atom.min [@inlined hint]) ax
 
-    let max : type a. a t -> a = function
-      | Monadic ax -> Monadic.Atom.max ax
-      | Comonadic ax -> Comonadic.Atom.max ax
+    let max : type a. a t -> a = function[@inline available]
+      | Monadic ax -> (Monadic.Atom.max [@inlined hint]) ax
+      | Comonadic ax -> (Comonadic.Atom.max [@inlined hint]) ax
 
-    let meet : type a. a t -> a -> a -> a = function
-      | Monadic ax -> Monadic.Atom.meet ax
-      | Comonadic ax -> Comonadic.Atom.meet ax
+    let meet : type a. a t -> a -> a -> a =
+     fun [@inline available] ax a b ->
+      match ax with
+      | Monadic ax -> (Monadic.Atom.meet [@inlined hint]) ax a b
+      | Comonadic ax -> (Comonadic.Atom.meet [@inlined hint]) ax a b
 
-    let join : type a. a t -> a -> a -> a = function
-      | Monadic ax -> Monadic.Atom.join ax
-      | Comonadic ax -> Comonadic.Atom.join ax
+    let join : type a. a t -> a -> a -> a =
+     fun [@inline available] ax a b ->
+      match ax with
+      | Monadic ax -> (Monadic.Atom.join [@inlined hint]) ax a b
+      | Comonadic ax -> (Comonadic.Atom.join [@inlined hint]) ax a b
 
     let print : type a. a t -> Format.formatter -> a -> unit = function
       | Monadic ax -> Monadic.Atom.print ax
@@ -4396,10 +4408,11 @@ module Crossing = struct
 
   let equal t0 t1 = le t0 t1 && le t1 t0
 
-  let proj (type a) (ax : a Axis.t) { monadic; comonadic } : a =
+  let[@inline available] proj (type a) (ax : a Axis.t) { monadic; comonadic } :
+      a =
     match ax with
-    | Monadic ax -> Monadic.proj ax monadic
-    | Comonadic ax -> Comonadic.proj ax comonadic
+    | Monadic ax -> (Monadic.proj [@inlined hint]) ax monadic
+    | Comonadic ax -> (Comonadic.proj [@inlined hint]) ax comonadic
 
   let create ~regionality ~linearity ~uniqueness ~portability ~contention
       ~yielding ~statefulness ~visibility =

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -859,8 +859,8 @@ module type S = sig
   module Crossing : sig
     module Monadic : sig
       module Atom : sig
-        (** The mode crossing capability on an axis whose carrier type is ['a].
-      Currently it has only one constructor and is thus unboxed. *)
+        (** The mode crossing capability on a monadic axis whose carrier type is
+      ['a]. Currently it has only one constructor and is thus unboxed. *)
         type 'a t =
           | Modality of 'a Modality.Monadic.Atom.t
               (** The mode crossing caused by a modality atom on an axis whose
@@ -873,10 +873,13 @@ module type S = sig
         [@@unboxed]
       end
 
+      (** The mode crossing capability on the whole monadic fragment. *)
       type t
 
       include Lattice with type t := t
 
+      (** Create a mode crossing on the monadic fragment from the collection of mode
+      crossings on each monadic axes. *)
       val create :
         uniqueness:Uniqueness.Const.t Atom.t ->
         contention:Contention.Const.t Atom.t ->
@@ -886,13 +889,21 @@ module type S = sig
 
     module Comonadic : sig
       module Atom : sig
-        type 'a t = Modality of 'a Modality.Comonadic.Atom.t [@@unboxed]
+        (** The mode crossing capability on a comonadic axis whose carrier type is
+      ['a]. Currently it has only one constructor and is thus unboxed. *)
+        type 'a t =
+          | Modality of 'a Modality.Comonadic.Atom.t
+              (** See comment on the similar constructor in [Monadic.Atom.t] *)
+        [@@unboxed]
       end
 
+      (** The mode crossing capability on the whole comonadic fragment. *)
       type t
 
       include Lattice with type t := t
 
+      (** Create a mode crossing on the comonadic fragment from the collection
+      of mode crossings on each comonadic axes. *)
       val create :
         regionality:Regionality.Const.t Atom.t ->
         linearity:Linearity.Const.t Atom.t ->
@@ -902,10 +913,13 @@ module type S = sig
         t
     end
 
-    (** The mode crossing capability on all axes *)
+    (** The mode crossing capability on all axes, split into monadic and
+        comonadic fragments. *)
     type t = (Monadic.t, Comonadic.t) monadic_comonadic
 
     module Axis : sig
+      (** ['a t] specifies an axis whose mode crossing capability is represented
+          as ['a] *)
       type 'a t =
         | Monadic : 'a Value.Monadic.Axis.t -> 'a Monadic.Atom.t t
         | Comonadic : 'a Value.Comonadic.Axis.t -> 'a Comonadic.Atom.t t
@@ -920,6 +934,10 @@ module type S = sig
     module Per_axis :
       Solver_intf.Lattices with type 'a elt := 'a and type 'a obj := 'a Axis.t
 
+    (** Convenience for creating a mode crossing capability on all axes, using a
+    boolean for each axis where [true] means full crossing and [false] means no
+    crossing. Alternatively, call [Monadic.create] and [Comonadic.create] and
+    pack the results into a record of type [t]. *)
     val create :
       regionality:bool ->
       linearity:bool ->
@@ -931,6 +949,7 @@ module type S = sig
       visibility:bool ->
       t
 
+    (** Project a mode crossing (of all axes) onto the specified axis. *)
     val proj : 'a Axis.t -> t -> 'a
 
     include Lattice with type t := t

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -853,9 +853,22 @@ module type S = sig
     val max : t
   end
 
-  (** Some modes might be indistinguishable for values of some type, in which
-    case the actual/expected mode of values can be adjusted accordingly to make
-    more programs mode-check. The adjustment is called mode crossing. *)
+  (** Some modes on an axis might be indistinguishable for values of some type,
+    in which case the actual mode of values can be strenghthened (or
+    equivalently the expected mode loosened) accordingly to make more programs
+    mode-check. The capabilities/permissions to perform such adjustments are
+    called mode crossing and depicted in this module.
+
+    We define an ordering on the crossings: [t0 <= t1] iff [t0] allows more
+    adjustments than [t1]. By this ordering, the currently representable
+    crossings form a lattice:
+    - The bottom crossing allows any adjustments on this axis, which trivializes
+      the axis.
+    - The top crossing allows no adjustments on this axis, which is the safe
+      default.
+    - Joining two crossings gives a crossing that's less permissive than both.
+    - Meeting two crossings gives a crossing that's more permissive than both.
+    *)
   module Crossing : sig
     module Monadic : sig
       module Atom : sig

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -344,8 +344,6 @@ module type S = sig
       include Lattice with type t := t
     end
 
-    module Const_op : Lattice with type t = Const.t
-
     include Common_axis_neg with module Const := Const
 
     val aliased : lr
@@ -362,8 +360,6 @@ module type S = sig
 
       include Lattice with type t := t
     end
-
-    module Const_op : Lattice with type t = Const.t
 
     include Common_axis_neg with module Const := Const
   end
@@ -412,8 +408,6 @@ module type S = sig
 
       include Lattice with type t := t
     end
-
-    module Const_op : Lattice with type t = Const.t
 
     include Common_axis_neg with module Const := Const
 
@@ -470,8 +464,6 @@ module type S = sig
            and type 'd hint_morph := 'd neg_hint_morph
            and type 'd hint_const := 'd neg_hint_const
 
-      module Const_op : Lattice with type t = Const.t
-
       val proj : 'a Axis.t -> ('r * 'l) t -> ('a, 'l * 'r) mode
 
       val min_with : 'a Axis.t -> ('a, 'l * 'r) mode -> ('r * disallowed) t
@@ -525,10 +517,6 @@ module type S = sig
               Statefulness.Const.t,
               Visibility.Const.t )
             modes
-
-      (** Gets the normal lattice for comonadic axes and the "op"ped lattice for
-        monadic ones. *)
-      val lattice_of_axis : 'a Axis.t -> (module Lattice with type t = 'a)
 
       module Option : sig
         type some = t

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -572,17 +572,9 @@ let mode_lazy expected_mode =
       expected_mode
   in
   let mode_crossing =
-    Crossing.of_bounds {
-      comonadic = {
-        Value.Comonadic.Const.max with
-        (* The thunk is evaluated only once, so we only require it to be [once],
-          even if the [lazy] is [many]. *)
-        linearity = Many;
-        (* The thunk is evaluated only when the [lazy] is [uncontended], so we
-          only require it to be [nonportable], even if the [lazy] is [portable].
-          *)
-        portability = Portable };
-      monadic = Value.Monadic.Const.min }
+    Crossing.create ~linearity:true ~portability:true
+      ~regionality:false ~uniqueness:false ~contention:false ~statefulness:false
+      ~visibility:false ~yielding:false
   in
   let closure_mode =
     expected_mode |> as_single_mode |> Crossing.apply_right mode_crossing

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -62,7 +62,7 @@ module Jkind_mod_bounds = struct
 
   let crossing t = t.crossing
 
-  let[@inline] modal ax t = t |> crossing |> Crossing.proj ax
+  let[@inline] modal ax t = t |> crossing |> (Crossing.proj [@inlined hint]) ax
   let areality = Crossing.Axis.Comonadic Areality
   let linearity = Crossing.Axis.Comonadic Linearity
   let uniqueness = Crossing.Axis.Monadic Uniqueness
@@ -94,9 +94,9 @@ module Jkind_mod_bounds = struct
 
   let[@inline] set_max_in_set t max_axes =
     let open Jkind_axis.Axis_set in
-    let modal ax =
+    let[@inline] modal ax =
       if mem max_axes (Modal ax)
-      then Crossing.Per_axis.max ax
+      then (Crossing.Per_axis.max [@inlined hint]) ax
       else modal ax t
     in
     (* a little optimization *)
@@ -143,7 +143,7 @@ module Jkind_mod_bounds = struct
     let open Jkind_axis.Axis_set in
     let modal ax =
       if mem min_axes (Modal ax)
-      then Crossing.Per_axis.min ax
+      then (Crossing.Per_axis.min [@inlined hint]) ax
       else modal ax t
     in
     (* a little optimization *)
@@ -190,7 +190,8 @@ module Jkind_mod_bounds = struct
     let open Jkind_axis.Axis_set in
     let modal ax =
       not (mem axes (Modal ax)) ||
-      Crossing.Per_axis.(le ax (max ax) (modal ax t))
+      Crossing.Per_axis.((le [@inlined hint]) ax ((max [@inlined hint]) ax)
+        (modal ax t))
     in
     modal areality &&
     modal linearity &&

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -48,126 +48,67 @@ let mutable_mode m0 : _ Mode.Value.t =
 (* Type expressions for the core language *)
 
 module Jkind_mod_bounds = struct
-  module Areality = Mode.Regionality.Const
-  module Linearity = Mode.Linearity.Const
-  module Uniqueness = Mode.Uniqueness.Const_op
-  module Portability = Mode.Portability.Const
-  module Contention = Mode.Contention.Const_op
-  module Yielding = Mode.Yielding.Const
-  module Statefulness = Mode.Statefulness.Const
-  module Visibility = Mode.Visibility.Const_op
+  module Crossing = Mode.Crossing
   module Externality = Jkind_axis.Externality
   module Nullability = Jkind_axis.Nullability
   module Separability = Jkind_axis.Separability
 
   type t = {
-    areality: Areality.t;
-    linearity: Linearity.t;
-    uniqueness: Uniqueness.t;
-    portability: Portability.t;
-    contention: Contention.t;
-    yielding: Yielding.t;
-    statefulness: Statefulness.t;
-    visibility: Visibility.t;
+    crossing : Crossing.t;
     externality: Externality.t;
     nullability: Nullability.t;
     separability: Separability.t;
   }
 
-  let[@inline] areality t = t.areality
-  let[@inline] linearity t = t.linearity
-  let[@inline] uniqueness t = t.uniqueness
-  let[@inline] portability t = t.portability
-  let[@inline] contention t = t.contention
-  let[@inline] yielding t = t.yielding
-  let[@inline] statefulness t = t.statefulness
-  let[@inline] visibility t = t.visibility
+  let crossing t = t.crossing
+
+  let[@inline] modal ax t = t |> crossing |> Crossing.proj ax
+  let areality = Crossing.Axis.Comonadic Areality
+  let linearity = Crossing.Axis.Comonadic Linearity
+  let uniqueness = Crossing.Axis.Monadic Uniqueness
+  let portability = Crossing.Axis.Comonadic Portability
+  let contention = Crossing.Axis.Monadic Contention
+  let yielding = Crossing.Axis.Comonadic Yielding
+  let statefulness = Crossing.Axis.Comonadic Statefulness
+  let visibility = Crossing.Axis.Monadic Visibility
   let[@inline] externality t = t.externality
   let[@inline] nullability t = t.nullability
   let[@inline] separability t = t.separability
 
   let[@inline] create
-      ~areality
-      ~linearity
-      ~uniqueness
-      ~portability
-      ~contention
-      ~yielding
-      ~statefulness
-      ~visibility
+      crossing
       ~externality
       ~nullability
       ~separability =
     {
-      areality;
-      linearity;
-      uniqueness;
-      portability;
-      contention;
-      yielding;
-      statefulness;
-      visibility;
+      crossing;
       externality;
       nullability;
       separability;
     }
 
-  let[@inline] set_areality areality t = { t with areality }
-  let[@inline] set_linearity linearity t = { t with linearity }
-  let[@inline] set_uniqueness uniqueness t = { t with uniqueness }
-  let[@inline] set_portability portability t = { t with portability }
-  let[@inline] set_contention contention t = { t with contention }
-  let[@inline] set_yielding yielding t = { t with yielding }
-  let[@inline] set_statefulness statefulness t = { t with statefulness }
-  let[@inline] set_visibility visibility t = { t with visibility }
+  let[@inline] set_crossing crossing t = { t with crossing }
   let[@inline] set_externality externality t = { t with externality }
   let[@inline] set_nullability nullability t = { t with nullability }
   let[@inline] set_separability separability t = { t with separability }
 
   let[@inline] set_max_in_set t max_axes =
     let open Jkind_axis.Axis_set in
+    let modal ax =
+      if mem max_axes (Modal ax)
+      then Crossing.Per_axis.max ax
+      else modal ax t
+    in
     (* a little optimization *)
     if is_empty max_axes then t else
-    let areality =
-      if mem max_axes (Modal (Comonadic Areality))
-      then Areality.max
-      else t.areality
-    in
-    let linearity =
-      if mem max_axes (Modal (Comonadic Linearity))
-      then Linearity.max
-      else t.linearity
-    in
-    let uniqueness =
-      if mem max_axes (Modal (Monadic Uniqueness))
-      then Uniqueness.max
-      else t.uniqueness
-    in
-    let portability =
-      if mem max_axes (Modal (Comonadic Portability))
-      then Portability.max
-      else t.portability
-    in
-    let contention =
-      if mem max_axes (Modal (Monadic Contention))
-      then Contention.max
-      else t.contention
-    in
-    let yielding =
-      if mem max_axes (Modal (Comonadic Yielding))
-      then Yielding.max
-      else t.yielding
-    in
-    let statefulness =
-      if mem max_axes (Modal (Comonadic Statefulness))
-      then Statefulness.max
-      else t.statefulness
-    in
-    let visibility =
-      if mem max_axes (Modal (Monadic Visibility))
-      then Visibility.max
-      else t.visibility
-    in
+    let regionality = modal areality in
+    let linearity = modal linearity in
+    let uniqueness = modal uniqueness in
+    let portability = modal portability in
+    let contention = modal contention in
+    let yielding = modal yielding in
+    let statefulness = modal statefulness in
+    let visibility = modal visibility in
     let externality =
       if mem max_axes (Nonmodal Externality)
       then Externality.max
@@ -183,15 +124,16 @@ module Jkind_mod_bounds = struct
       then Separability.max
       else t.separability
     in
+    let monadic =
+      Crossing.Monadic.create ~uniqueness ~contention ~visibility
+    in
+    let comonadic =
+      Crossing.Comonadic.create ~regionality ~linearity ~portability ~yielding
+        ~statefulness
+    in
+    let crossing : Mode.Crossing.t = { monadic; comonadic } in
     {
-      areality;
-      linearity;
-      uniqueness;
-      portability;
-      contention;
-      yielding;
-      statefulness;
-      visibility;
+      crossing;
       externality;
       nullability;
       separability;
@@ -199,48 +141,21 @@ module Jkind_mod_bounds = struct
 
   let[@inline] set_min_in_set t min_axes =
     let open Jkind_axis.Axis_set in
+    let modal ax =
+      if mem min_axes (Modal ax)
+      then Crossing.Per_axis.min ax
+      else modal ax t
+    in
     (* a little optimization *)
     if is_empty min_axes then t else
-    let areality =
-      if mem min_axes (Modal (Comonadic Areality))
-      then Areality.min
-      else t.areality
-    in
-    let linearity =
-      if mem min_axes (Modal (Comonadic Linearity))
-      then Linearity.min
-      else t.linearity
-    in
-    let uniqueness =
-      if mem min_axes (Modal (Monadic Uniqueness))
-      then Uniqueness.min
-      else t.uniqueness
-    in
-    let portability =
-      if mem min_axes (Modal (Comonadic Portability))
-      then Portability.min
-      else t.portability
-    in
-    let contention =
-      if mem min_axes (Modal (Monadic Contention))
-      then Contention.min
-      else t.contention
-    in
-    let yielding =
-      if mem min_axes (Modal (Comonadic Yielding))
-      then Yielding.min
-      else t.yielding
-    in
-    let statefulness =
-      if mem min_axes (Modal (Comonadic Statefulness))
-      then Statefulness.min
-      else t.statefulness
-    in
-    let visibility =
-      if mem min_axes (Modal (Monadic Visibility))
-      then Visibility.min
-      else t.visibility
-    in
+    let regionality = modal areality in
+    let linearity = modal linearity in
+    let uniqueness = modal uniqueness in
+    let portability = modal portability in
+    let contention = modal contention in
+    let yielding = modal yielding in
+    let statefulness = modal statefulness in
+    let visibility = modal visibility in
     let externality =
       if mem min_axes (Nonmodal Externality)
       then Externality.min
@@ -256,15 +171,16 @@ module Jkind_mod_bounds = struct
       then Separability.min
       else t.separability
     in
+    let monadic =
+      Crossing.Monadic.create ~uniqueness ~contention ~visibility
+    in
+    let comonadic =
+      Crossing.Comonadic.create ~regionality ~linearity ~portability ~yielding
+        ~statefulness
+    in
+    let crossing : Mode.Crossing.t = { monadic; comonadic } in
     {
-      areality;
-      linearity;
-      uniqueness;
-      portability;
-      contention;
-      statefulness;
-      visibility;
-      yielding;
+      crossing;
       externality;
       nullability;
       separability;
@@ -272,22 +188,18 @@ module Jkind_mod_bounds = struct
 
   let[@inline] is_max_within_set t axes =
     let open Jkind_axis.Axis_set in
-    (not (mem axes (Modal (Comonadic Areality))) ||
-     Areality.(le max (areality t))) &&
-    (not (mem axes (Modal (Comonadic Linearity))) ||
-     Linearity.(le max (linearity t))) &&
-    (not (mem axes (Modal (Monadic Uniqueness))) ||
-     Uniqueness.(le max (uniqueness t))) &&
-    (not (mem axes (Modal (Comonadic Portability))) ||
-     Portability.(le max (portability t))) &&
-    (not (mem axes (Modal (Monadic Contention))) ||
-     Contention.(le max (contention t))) &&
-    (not (mem axes (Modal (Comonadic Yielding))) ||
-     Yielding.(le max (yielding t))) &&
-    (not (mem axes (Modal (Comonadic Statefulness))) ||
-     Statefulness.(le max (statefulness t))) &&
-    (not (mem axes (Modal (Monadic Visibility))) ||
-     Visibility.(le max (visibility t))) &&
+    let modal ax =
+      not (mem axes (Modal ax)) ||
+      Crossing.Per_axis.(le ax (max ax) (modal ax t))
+    in
+    modal areality &&
+    modal linearity &&
+    modal uniqueness &&
+    modal portability &&
+    modal contention &&
+    modal yielding &&
+    modal statefulness &&
+    modal visibility &&
     (not (mem axes (Nonmodal Externality)) ||
      Externality.(le max (externality t))) &&
     (not (mem axes (Nonmodal Nullability)) ||
@@ -296,45 +208,20 @@ module Jkind_mod_bounds = struct
      Separability.(le max (separability t)))
 
   let max =
-      { areality = Areality.max;
-        linearity = Linearity.max;
-        uniqueness = Uniqueness.max;
-        portability = Portability.max;
-        contention = Contention.max;
-        yielding = Yielding.max;
-        statefulness = Statefulness.max;
-        visibility = Visibility.max;
-        externality = Externality.max;
-        nullability = Nullability.max;
-        separability = Separability.max}
+    { crossing = Mode.Crossing.max;
+      externality = Externality.max;
+      nullability = Nullability.max;
+      separability = Separability.max }
 
   let[@inline] is_max m = m = max
-
-
   let debug_print ppf
-        { areality;
-          linearity;
-          uniqueness;
-          portability;
-          contention;
-          yielding;
-          statefulness;
-          visibility;
+        { crossing;
           externality;
           nullability;
           separability } =
-    Format.fprintf ppf "@[{ areality = %a;@ linearity = %a;@ uniqueness = %a;@ \
-      portability = %a;@ contention = %a;@ yielding = %a;@ statefulness = %a;@ \
-      visibility = %a;@ externality = %a;@ \
+    Format.fprintf ppf "@[{ crossing = %a;@ externality = %a;@ \
       nullability = %a;@ separability = %a }@]"
-      Areality.print areality
-      Linearity.print linearity
-      Uniqueness.print uniqueness
-      Portability.print portability
-      Contention.print contention
-      Yielding.print yielding
-      Statefulness.print statefulness
-      Visibility.print visibility
+      Crossing.print crossing
       Externality.print externality
       Nullability.print nullability
       Separability.print separability

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -85,14 +85,7 @@ val mutable_mode : ('l * 'r) Mode.Value.Comonadic.t -> ('l * 'r) Mode.Value.t
 
 (** The mod-bounds of a jkind *)
 module Jkind_mod_bounds : sig
-  module Areality = Mode.Regionality.Const
-  module Linearity = Mode.Linearity.Const
-  module Uniqueness = Mode.Uniqueness.Const_op
-  module Portability = Mode.Portability.Const
-  module Contention = Mode.Contention.Const_op
-  module Yielding = Mode.Yielding.Const
-  module Statefulness = Mode.Statefulness.Const
-  module Visibility = Mode.Visibility.Const_op
+  module Crossing = Mode.Crossing
   module Externality = Jkind_axis.Externality
   module Nullability = Jkind_axis.Nullability
   module Separability = Jkind_axis.Separability
@@ -100,39 +93,18 @@ module Jkind_mod_bounds : sig
   type t
 
   val create :
-    areality:Areality.t ->
-    linearity:Linearity.t ->
-    uniqueness:Uniqueness.t ->
-    portability:Portability.t ->
-    contention:Contention.t ->
-    yielding:Yielding.t ->
-    statefulness:Statefulness.t ->
-    visibility:Visibility.t ->
+    Crossing.t->
     externality:Externality.t ->
     nullability:Nullability.t ->
     separability:Separability.t ->
     t
 
-  val areality : t -> Areality.t
-  val linearity : t -> Linearity.t
-  val uniqueness : t -> Uniqueness.t
-  val portability : t -> Portability.t
-  val contention : t -> Contention.t
-  val yielding : t -> Yielding.t
-  val statefulness : t -> Statefulness.t
-  val visibility : t -> Visibility.t
+  val crossing : t -> Crossing.t
   val externality : t -> Externality.t
   val nullability : t -> Nullability.t
   val separability : t -> Separability.t
 
-  val set_areality : Areality.t -> t -> t
-  val set_linearity : Linearity.t -> t -> t
-  val set_uniqueness : Uniqueness.t -> t -> t
-  val set_portability : Portability.t -> t -> t
-  val set_contention : Contention.t -> t -> t
-  val set_yielding : Yielding.t -> t -> t
-  val set_statefulness : Statefulness.t -> t -> t
-  val set_visibility : Visibility.t -> t -> t
+  val set_crossing : Crossing.t -> t -> t
   val set_externality : Externality.t -> t -> t
   val set_nullability : Nullability.t -> t -> t
   val set_separability : Separability.t -> t -> t


### PR DESCRIPTION
Based on #4619 

**_Please review by commit_**

This PR enriches `Mode.Crossing` and and use the new types in places where suitable.

This PR is bigger than ideal - I attempted to split this into smaller PRs but couldn't. In particular `Jkind_axis` and `types` and `jkind` are all interwined, and to split the changes would require some placeholder code that will be replaced by subsequent changes, which I think is not worthwhile.

# Performance concern

The changes to `types.ml` add indirection and might affect performance.
UPDATE:
Running `-dtimings` on `typecore.ml` , and the `typing` part is `1.2768s`  (10 runs average), compared to `1.2652s` in the `main` branch.