### PR TITLE
Use iarray in parallel with array in typeopt

### DIFF
--- a/testsuite/tests/lib-array/test_iarray_typeopt.ml
+++ b/testsuite/tests/lib-array/test_iarray_typeopt.ml
@@ -35,7 +35,7 @@ let _ = [| [: :] |];;
 
 let arr = [: 1; 2; 3 :];;
 [%%expect {|
-(let (arr/381 = (makearray_imm[int] 1 2 3))
+(let (arr/381 =[intarray] (makearray_imm[int] 1 2 3))
   (apply (field_imm 1 (global Toploop!)) "arr" arr/381))
 val arr : int iarray = [:1; 2; 3:]
 |}];;
@@ -66,7 +66,7 @@ let arr : int alias = [: 1; 2; 3 :];;
 [%%expect {|
 0
 type 'a alias = 'a iarray
-(let (arr/383 = (makearray_imm[int] 1 2 3))
+(let (arr/383 =[intarray] (makearray_imm[int] 1 2 3))
   (apply (field_imm 1 (global Toploop!)) "arr" arr/383))
 val arr : int alias = [:1; 2; 3:]
 |}];;
@@ -100,7 +100,7 @@ let arr = of_array mut_arr;;
 val mut_arr : int array = [|1; 2; 3|]
 (let
   (mut_arr/384 = (apply (field_imm 0 (global Toploop!)) "mut_arr")
-   arr/385 =
+   arr/385 =[intarray]
      (apply (field_imm 13 (global Stdlib_stable__Iarray!)) mut_arr/384))
   (apply (field_imm 1 (global Toploop!)) "arr" arr/385))
 val arr : int iarray = [:1; 2; 3:]
@@ -191,7 +191,7 @@ let _ = Array.unsafe_get mut_arr 1;;
 let arr = [: 1; 2; 3 :];;
 let mut_arr = to_array arr;;
 [%%expect {|
-(let (arr/439 = (makearray_imm[int] 1 2 3))
+(let (arr/439 =[intarray] (makearray_imm[int] 1 2 3))
   (apply (field_imm 1 (global Toploop!)) "arr" arr/439))
 val arr : int iarray = [:1; 2; 3:]
 (let

--- a/testsuite/tests/typing-layouts-products/product_iarrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_iarrays.ml
@@ -460,9 +460,9 @@ let f_scannable_literal arr : #(bool option * string * int) =
   | [: #(x, y, z) :] -> #(z, y, x)
   | _ -> assert false
 [%%expect{|
-Line 3, characters 4-9:
-3 |   | [: :] -> #(None, "hi", 42)
-        ^^^^^
+Line 2, characters 8-11:
+2 |   match arr with
+            ^^^
 Error: Immutable arrays of unboxed products are not yet supported.
 |}]
 
@@ -472,9 +472,9 @@ let f_ignorable_literal arr : #(#(int64# * float#) * int32# * int) =
   | [: #(x, y, #(z, q)) :] -> #(#(q, z), y, x)
   | _ -> assert false
 [%%expect{|
-Line 3, characters 4-9:
-3 |   | [: :] -> #(#(#42L, #3.14), #10l, 43)
-        ^^^^^
+Line 2, characters 8-11:
+2 |   match arr with
+            ^^^
 Error: Immutable arrays of unboxed products are not yet supported.
 |}]
 

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -558,6 +558,8 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
     num_nodes_visited, non_nullable Pintval
   | Tconstr(p, _, _) when Path.same p Predef.path_int16 ->
     num_nodes_visited, non_nullable Pintval
+  | Tconstr(p, _, _) when Path.same p Predef.path_floatarray ->
+    num_nodes_visited, non_nullable (Parrayval Pfloatarray)
   | Tconstr(p, _, _) when Path.same p Predef.path_float ->
     num_nodes_visited, non_nullable (Pboxedfloatval Boxed_float64)
   | Tconstr(p, _, _) when Path.same p Predef.path_float32 ->
@@ -606,7 +608,7 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
     num_nodes_visited, non_nullable (Pboxedvectorval Boxed_vec512)
   | Tconstr(p, [arg], _)
     when (Path.same p Predef.path_array
-          || Path.same p Predef.path_floatarray) ->
+          || Path.same p Predef.path_iarray) ->
     (* CR layouts: [~elt_sort:None] here is bad for performance. To
        fix it, we need a place to store the sort on a [Tconstr]. *)
     let ak = array_type_kind ~elt_ty:(Some arg) ~elt_sort:None env loc ty in

--- a/typing/vicuna_traverse_typed_tree.ml
+++ b/typing/vicuna_traverse_typed_tree.ml
@@ -121,6 +121,7 @@ let classify env ty : classification =
       else if Path.same p Predef.path_string
               || Path.same p Predef.path_bytes
               || Path.same p Predef.path_array
+              || Path.same p Predef.path_iarray
               || Path.same p Predef.path_nativeint
               || Path.same p Predef.path_int32
               || Path.same p Predef.path_int64


### PR DESCRIPTION
This might fix the zero-alloc problem we've spotted with iarray. I have not tested this yet, and will not have time to do so in an appropriate amount of time; would be happy for another volunteer. (Perhaps @riaqn, who has been asking for this. Just cherry-pick this on the last release and try to build.)

Even if it doesn't fix that problem, I think this is an improvement over the status quo.

Review: @ccasin. Should be quick.