### PR TITLE
Expose lambda to simplified flambda2 conversion

### DIFF
--- a/middle_end/flambda2/flambda2.mli
+++ b/middle_end/flambda2/flambda2.mli
@@ -14,15 +14,31 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** Translate Lambda code to Cmm using Flambda 2. *)
-
-(** This function is not currently re-entrant. *)
+(** Translate Lambda code to Cmm using Flambda 2.
+    This function is not currently re-entrant. *)
 val lambda_to_cmm :
   ppf_dump:Format.formatter ->
   prefixname:string ->
   keep_symbol_tables:bool ->
   Lambda.program ->
   Cmm.phrase list
+
+type flambda_result =
+  { flambda : Flambda_unit.t;
+    all_code : Exported_code.t;
+    offsets : Exported_offsets.t;
+    reachable_names : Flambda2_nominal.Name_occurrences.t
+  }
+
+(** Translate Lambda code into (potentially Simplified) Flambda 2.
+    This function is not currently re-entrant. *)
+val lambda_to_flambda :
+  ppf_dump:Format.formatter ->
+  prefixname:string ->
+  Lambda.program ->
+  flambda_result
+
+val reset_symbol_tables : unit -> unit
 
 val get_module_info :
   Compilation_unit.t -> Flambda2_cmx.Flambda_cmx_format.t option


### PR DESCRIPTION
Currently flambda2 converts lambda to cmm via flamda2; this PR exposes the lambda to flambda2 conversion (and simplification if enabled) in addition to the original `lambda_to_cmm`. The new `lambda_to_flambda` will be used in the future to serve as an input to `js_of_ocaml`.