### PR TITLE
Refactor simd extension checks

### DIFF
--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -90,8 +90,8 @@ module Extension = struct
 
   let enabled_by_default = function
     | SSE3 | SSSE3 | SSE4_1 | SSE4_2
-    | POPCNT | CLMUL | LZCNT | BMI | BMI2 | AVX -> true
-    | AVX2 | PREFETCHW | PREFETCHWT1 | AVX512F -> false
+    | POPCNT | CLMUL | LZCNT | BMI | BMI2 | AVX | AVX2 -> true
+    | PREFETCHW | PREFETCHWT1 | AVX512F -> false
 
   let all =
     Set.of_list

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -40,10 +40,8 @@ module Extension : sig
   val enabled : t -> bool
   val available : unit -> t list
 
-  val allow_vec256 : unit -> bool
-  val allow_vec512 : unit -> bool
-  val require_vec256 : unit -> unit
-  val require_vec512 : unit -> unit
+  val require : t -> unit
+  val require_simd : Amd64_simd_instrs.instr -> unit
 end
 
 val trap_notes : bool ref

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -113,11 +113,11 @@ let hard_float32_reg =
   Array.map (fun r -> {r with Reg.typ = Float32}) hard_float_reg
 
 let add_hard_vec256_regs list ~f =
-  if Arch.Extension.allow_vec256 ()
+  if Arch.Extension.enabled AVX
   then f hard_vec256_reg :: list else list
 
 let add_hard_vec512_regs list ~f =
-  if Arch.Extension.allow_vec512 ()
+  if Arch.Extension.enabled AVX512F
   then f hard_vec512_reg :: list else list
 
 let all_phys_regs =
@@ -133,10 +133,10 @@ let phys_reg ty n =
   | Float32 -> hard_float32_reg.(n - 100)
   | Vec128 | Valx2 -> hard_vec128_reg.(n - 100)
   | Vec256 ->
-    Arch.Extension.require_vec256 ();
+    Arch.Extension.require AVX;
     hard_vec256_reg.(n - 100)
   | Vec512 ->
-    Arch.Extension.require_vec512 ();
+    Arch.Extension.require AVX512F;
     hard_vec512_reg.(n - 100)
 
 let rax = phys_reg Int 0
@@ -222,7 +222,7 @@ let calling_conventions
         ofs := !ofs + size_vec128
       end
     | Vec256 ->
-      Arch.Extension.require_vec256 ();
+      Arch.Extension.require AVX;
       if !float <= last_float then begin
         loc.(i) <- phys_reg Vec256 !float;
         incr float
@@ -233,7 +233,7 @@ let calling_conventions
         ofs := !ofs + size_vec256
       end
     | Vec512 ->
-      Arch.Extension.require_vec512 ();
+      Arch.Extension.require AVX512F;
       if !float <= last_float then begin
         loc.(i) <- phys_reg Vec512 !float;
         incr float
@@ -711,10 +711,10 @@ let operation_supported = function
   | Cpopcnt -> Arch.Extension.enabled POPCNT
   | Creinterpret_cast V256_of_v256
   | Cstatic_cast (V256_of_scalar _ | Scalar_of_v256 _) ->
-    Arch.Extension.allow_vec256 ()
+    Arch.Extension.enabled AVX
   | Creinterpret_cast V512_of_v512
   | Cstatic_cast (V512_of_scalar _ | Scalar_of_v512 _) ->
-    Arch.Extension.allow_vec512 ()
+    Arch.Extension.enabled AVX512F
   | Cprefetch _ | Catomic _
   | Capply _ | Cextcall _ | Cload _ | Calloc _ | Cstore _
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi
@@ -747,7 +747,7 @@ let expression_supported = function
   | Cconst_vec128 _ | Cconst_symbol _  | Cvar _ | Clet _ | Cphantom_let _
   | Ctuple _ | Cop _ | Csequence _ | Cifthenelse _ | Cswitch _ | Ccatch _
   | Cexit _ -> true
-  | Cconst_vec256 _ -> Arch.Extension.allow_vec256 ()
-  | Cconst_vec512 _ -> Arch.Extension.allow_vec512 ()
+  | Cconst_vec256 _ -> Arch.Extension.enabled AVX
+  | Cconst_vec512 _ -> Arch.Extension.enabled AVX512F
 
 let trap_size_in_bytes = 16

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -904,9 +904,11 @@ let rd_of_reg = function
 let emit_simd b (instr : Amd64_simd_instrs.instr) args =
   let open Amd64_simd_defs in
   let imm, args =
+    let n = Array.length args in
     match instr.imm with
-    | true -> Some args.(0), Array.sub args 1 (Array.length args - 1)
-    | false -> None, args
+    | Imm_spec | Imm_reg ->
+      Some args.(0), Array.sub args 1 (n - 1)
+    | Imm_none -> None, args
   in
   let enc i =
     match instr.res with

--- a/backend/x86_dsl.ml
+++ b/backend/x86_dsl.ml
@@ -282,5 +282,7 @@ module I = struct
 
   let tzcnt x y = emit (TZCNT (x, y))
 
-  let simd instr args = emit (SIMD (instr, args))
+  let simd instr args =
+    Arch.Extension.require_simd instr;
+    emit (SIMD (instr, args))
 end

--- a/tools/simdgen/amd64_simd_defs.ml
+++ b/tools/simdgen/amd64_simd_defs.ml
@@ -14,6 +14,19 @@
 
 [@@@ocaml.warning "+a-42"]
 
+(* amd64 extension *)
+type ext =
+  | SSE
+  | SSE2
+  | SSE3
+  | SSSE3
+  | SSE4_1
+  | SSE4_2
+  | PCLMULQDQ
+  | BMI2
+  | AVX
+  | AVX2
+
 (* Fixed machine register location *)
 type reg =
   | RAX
@@ -48,6 +61,7 @@ type loc_enc =
   | RM_rm
   | Vex_v
   | Implicit
+  | Immediate
 
 type arg =
   { loc : loc;
@@ -103,13 +117,19 @@ type enc =
     opcode : int
   }
 
+type imm =
+  | Imm_none
+  | Imm_reg
+  | Imm_spec
+
 (* CR-someday gyorsh: restructure to avoid 'id and make the backend independent
    of simdgen, backend should only depend on the result of simdgen. *)
 type 'id instr =
   { id : 'id;
+    ext : ext array;
     args : arg array;
     res : res;
-    imm : bool;
+    imm : imm;
     mnemonic : string;
     enc : enc
   }
@@ -161,7 +181,7 @@ let loc_allows_mem = function
 let loc_is_pinned = function Pin reg -> Some reg | Temp _ -> None
 
 let arg_is_implicit ({ enc; _ } : arg) =
-  match enc with Implicit -> true | RM_r | RM_rm | Vex_v -> false
+  match enc with Implicit -> true | Immediate | RM_r | RM_rm | Vex_v -> false
 
 type bit_width =
   | Eight

--- a/tools/simdgen/amd64_simd_instrs.ml
+++ b/tools/simdgen/amd64_simd_instrs.ml
@@ -3,7664 +3,8526 @@
 open Amd64_simd_defs
 
 type id = 
-  | Pmovmskb_r64_X
-  | Addsubps
-  | Vpextrw_r64m16_X
-  | Vpcmpestri
-  | Vpabsd_Y_Ym256
-  | Vinsertf128
-  | Psraw_X
-  | Vmulpd_Y_Y_Ym256
-  | Vmulpd_X_X_Xm128
-  | Vpsubw_Y_Y_Ym256
-  | Vpsubw_X_X_Xm128
-  | Vpinsrq
-  | Vunpcklps_Y_Y_Ym256
-  | Vunpcklps_X_X_Xm128
-  | Movq_Xm64_X
-  | Vmaxss
-  | Vpmovsxdq_Y_Xm128
-  | Vdppd
-  | Sqrtpd
-  | Vpextrd
-  | Vmaskmovpd_m256_Y_Y
-  | Vmaskmovpd_m128_X_X
-  | Pmaxub_X_Xm128
-  | Movaps_Xm128_X
-  | Addsd
-  | Vpsrlvq_Y_Y_Ym256
-  | Vpsrlvq_X_X_Xm128
-  | Rcpps
-  | Vmovapd_Xm128_X
-  | Maxsd
-  | Subps
-  | Vpmulhuw_Y_Y_Ym256
-  | Vpmulhuw_X_X_Xm128
-  | Vblendps_Y_Y_Ym256
-  | Vblendps_X_X_Xm128
-  | Movd_X_r32m32
-  | Vpshuflw_Y_Ym256
-  | Divss
-  | Punpckhqdq
-  | Vpmaxuw_Y_Y_Ym256
-  | Vpmaxuw_X_X_Xm128
-  | Vpsubq_Y_Y_Ym256
-  | Vpsubq_X_X_Xm128
-  | Vpmulhrsw_Y_Y_Ym256
-  | Vpmulhrsw_X_X_Xm128
-  | Vdpps_Y_Y_Ym256
-  | Vdpps_X_X_Xm128
-  | Shrx_r32_r32m32_r32
-  | Vpsubusb_Y_Y_Ym256
-  | Vpsubusb_X_X_Xm128
-  | Pextrw_r64_X
-  | Pcmpeqb
-  | Vmovapd_Ym256_Y
-  | Vpermilps_Y_Y_Ym256
-  | Vpermilps_X_X_Xm128
-  | Vmovshdup_Y_Ym256
-  | Vpmaddwd_Y_Y_Ym256
-  | Vpmaddwd_X_X_Xm128
-  | Pminud
-  | Vpavgb_Y_Y_Ym256
-  | Vpavgb_X_X_Xm128
-  | Vpackuswb_Y_Y_Ym256
-  | Vpackuswb_X_X_Xm128
-  | Movmskpd
-  | Vpcmpistrm
-  | Vhaddps_Y_Y_Ym256
-  | Vhaddps_X_X_Xm128
-  | Psllq_X_Xm128
-  | Vmovapd_X_Xm128
-  | Vpunpckldq_Y_Y_Ym256
-  | Vpunpckldq_X_X_Xm128
-  | Vpshufb_Y_Y_Ym256
-  | Vpshufb_X_X_Xm128
-  | Pinsrb
-  | Bzhi_r64_r64m64_r64
-  | Psllq_X
-  | Vpand_Y_Y_Ym256
-  | Vpand_X_X_Xm128
-  | Vinsertps
-  | Vmaskmovpd_Y_Y_m256
-  | Vmaskmovpd_X_X_m128
-  | Unpckhps
-  | Vpmovzxbq_Y_Xm32
-  | Vzeroupper
-  | Vpminub_Y_Y_Ym256
-  | Vpminub_X_X_Xm128
-  | Mulpd
-  | Vpmaskmovd_Y_Y_m256
-  | Vpmaskmovd_X_X_m128
-  | Vroundss
-  | Vpaddq_Y_Y_Ym256
-  | Vpaddq_X_X_Xm128
-  | Vpsrld_X_X
-  | Phaddsw_M_Mm64
-  | Vpinsrd
-  | Cvtsi2sd_X_r64m64
-  | Minps
-  | Vinserti128
-  | Pavgw_X_Xm128
-  | Movups_Xm128_X
-  | Movss_Xm32_X
-  | Blendps
-  | Vpandn_Y_Y_Ym256
-  | Vpandn_X_X_Xm128
-  | Cvttsd2si_r64_Xm64
-  | Movntpd
-  | Vmovhpd_X_X_m64
-  | Crc32_r64_r8m8
-  | Vcvtdq2pd_Y_Xm128
-  | Pcmpeqd
-  | Vpsllq_Y_Y
-  | Vmovd_X_r32m32
-  | Pmulhrsw_M_Mm64
-  | Vdivpd_Y_Y_Ym256
-  | Vdivpd_X_X_Xm128
-  | Vpminud_Y_Y_Ym256
-  | Vpminud_X_X_Xm128
-  | Vpmaxsw_Y_Y_Ym256
-  | Vpmaxsw_X_X_Xm128
-  | Vcvttps2dq_Y_Ym256
-  | Pmuludq_X_Xm128
-  | Addps
-  | Vmovq_X_Xm64
-  | Vcomiss
-  | Vhsubps_Y_Y_Ym256
-  | Vhsubps_X_X_Xm128
-  | Sqrtps
-  | Vminps_Y_Y_Ym256
-  | Vminps_X_X_Xm128
-  | Pcmpgtb
-  | Vcvtsd2si_r64_Xm64
-  | Vpermilpd_Y_Y_Ym256
-  | Vpermilpd_X_X_Xm128
-  | Vpermd
-  | Sqrtsd
-  | Vbroadcastf128
-  | Vaddsubps_Y_Y_Ym256
-  | Vaddsubps_X_X_Xm128
-  | Vpmovsxwd_X_Xm64
-  | Vpsrlq_X_X
-  | Movntdqa
-  | Vpmovzxdq_X_Xm64
-  | Vpminsw_Y_Y_Ym256
-  | Vpminsw_X_X_Xm128
-  | Vpcmpeqb_Y_Y_Ym256
-  | Vpcmpeqb_X_X_Xm128
-  | Psubsb
-  | Roundss
-  | Vpmovzxbd_X_Xm32
-  | Pext_r32_r32_r32m32
-  | Vpsignw_Y_Y_Ym256
-  | Vpsignw_X_X_Xm128
-  | Pinsrd
-  | Vphaddd_Y_Y_Ym256
-  | Vphaddd_X_X_Xm128
-  | Vucomiss
-  | Subpd
+  | Vcvtpd2dq_X_Ym256
+  | Vcvtpd2dq_X_Xm128
+  | Paddsw
+  | Vpmuldq_Y_Y_Ym256
+  | Pslld_X_Xm128
   | Pmulhw
-  | Vpmovzxbw_Y_Xm128
-  | Pminsw_M_Mm64
-  | Vminsd
-  | Vmovups_Xm128_X
-  | Vlddqu_Y_m256
-  | Vhaddpd_Y_Y_Ym256
-  | Vhaddpd_X_X_Xm128
-  | Vsqrtps_X_Xm128
-  | Vpsrld_Y_Y
-  | Paddusw
-  | Cvtsi2ss_X_r32m32
-  | Blendvpd
-  | Vcvtss2si_r64_Xm32
-  | Movsd_X_m64
-  | Movsd_X_X
-  | Ptest
-  | Pext_r64_r64_r64m64
-  | Vcvttps2dq_X_Xm128
-  | Vpcmpgtq_Y_Y_Ym256
-  | Vpcmpgtq_X_X_Xm128
-  | Rcpss
-  | Movhpd_X_m64
-  | Vmovaps_Ym256_Y
-  | Vcomisd
-  | Vpsrlvd_Y_Y_Ym256
-  | Vpsrlvd_X_X_Xm128
-  | Vpbroadcastq_X_Xm64
-  | Vpmaddubsw_Y_Y_Ym256
-  | Vpmaddubsw_X_X_Xm128
-  | Vpsllvq_Y_Y_Ym256
-  | Vpsllvq_X_X_Xm128
-  | Psignw_X_Xm128
-  | Pmulld
-  | Vmovapd_Y_Ym256
-  | Vmovlhps
-  | Vpshufd_Y_Ym256
-  | Vmulss
-  | Vpsignd_Y_Y_Ym256
-  | Vpsignd_X_X_Xm128
-  | Vcvttss2si_r32_Xm32
-  | Vextractps
-  | Vpmaxsb_Y_Y_Ym256
-  | Vpmaxsb_X_X_Xm128
-  | Vpsllw_Y_Y_Xm128
-  | Vpsllw_X_X_Xm128
-  | Vpmovzxwd_Y_Xm128
-  | Phaddsw_X_Xm128
-  | Vpunpckhqdq_Y_Y_Ym256
-  | Vpunpckhqdq_X_X_Xm128
-  | Pshufd
-  | Vmovmskpd_r64_X
-  | Pdep_r32_r32_r32m32
-  | Vmovhpd_m64_X
-  | Pmovsxbw
-  | Vmovss_X_X_X
-  | Vpabsw_Y_Ym256
-  | Movupd_Xm128_X
-  | Movntdq
+  | Pcmpeqd
+  | Vpsubq_Y_Y_Ym256
+  | Vdivss
+  | Vmovq_X_r64m64
+  | Subpd
+  | Psignb_M_Mm64
+  | Vpcmpgtb_X_X_Xm128
+  | Vsubps_Y_Y_Ym256
+  | Vsubps_X_X_Xm128
+  | Vroundps_Y_Ym256
+  | Vroundps_X_Xm128
+  | Vpblendvb_X_X_Xm128_X
+  | Andps
+  | Vpbroadcastw_Y_Xm16
+  | Vpbroadcastw_X_Xm16
+  | Movhlps
+  | Vcvttpd2dq_X_Ym256
+  | Vcvttpd2dq_X_Xm128
+  | Vrcpss
+  | Vpcmpistrm
+  | Vmovdqu_Y_Ym256
+  | Vmovdqu_X_Xm128
+  | Maxps
+  | Vpmovsxbq_Y_Xm32
+  | Vpcmpeqw_Y_Y_Ym256
+  | Vpaddd_Y_Y_Ym256
+  | Psrad_X
+  | Phaddw_M_Mm64
+  | Movss_Xm32_X
+  | Pshufhw
+  | Pmulhuw_M_Mm64
+  | Vbroadcasti128
+  | Vpunpcklwd_Y_Y_Ym256
+  | Pmulhrsw_X_Xm128
+  | Comisd
   | Vmaskmovdqu
+  | Pblendvb
+  | Cvtsi2ss_X_r32m32
+  | Vpabsw_Y_Ym256
+  | Psadbw_M_Mm64
+  | Vdivps_Y_Y_Ym256
+  | Vdivps_X_X_Xm128
+  | Vcvtsi2sd_X_X_r64m64
+  | Vcvtsi2sd_X_X_r32m32
+  | Pslld_X
+  | Vmovsd_X_m64
+  | Vpunpcklwd_X_X_Xm128
+  | Vpmulhrsw_Y_Y_Ym256
   | Vorpd_Y_Y_Ym256
   | Vorpd_X_X_Xm128
-  | Vcmpsd
-  | Crc32_r32_r32m32
-  | Crc32_r32_r16m16
-  | Vpermpd
-  | Vpunpckhdq_Y_Y_Ym256
-  | Vpunpckhdq_X_X_Xm128
-  | Psrldq
-  | Vpextrq
-  | Pabsb_M_Mm64
-  | Vroundsd
-  | Pcmpeqq
-  | Vmovdqu_X_Xm128
-  | Vcvtsd2si_r32_Xm64
-  | Vmovmskpd_r64_Y
-  | Vcvttsd2si_r32_Xm64
-  | Vpsubsb_Y_Y_Ym256
-  | Vpsubsb_X_X_Xm128
-  | Paddusb
-  | Cvtpd2ps
-  | Psraw_X_Xm128
-  | Vldmxcsr
-  | Vmovsd_X_X_X
-  | Vmovsldup_Y_Ym256
-  | Shlx_r64_r64m64_r64
-  | Vcvttsd2si_r64_Xm64
-  | Vpsllvd_Y_Y_Ym256
-  | Vpsllvd_X_X_Xm128
-  | Phsubsw_X_Xm128
-  | Psubb
-  | Vpmaxub_Y_Y_Ym256
-  | Vpmaxub_X_X_Xm128
-  | Paddd
-  | Movmskps
-  | Vminpd_Y_Y_Ym256
-  | Vminpd_X_X_Xm128
-  | Psrld_X
-  | Movdqu_X_Xm128
-  | Subsd
-  | Vpmovmskb_r64_X
-  | Extractps
-  | Crc32_r32_r8m8
-  | Psubq_X_Xm128
-  | Vmovaps_Xm128_X
-  | Movapd_Xm128_X
-  | Vmovsd_m64_X
-  | Vpmovsxwd_Y_Xm128
-  | Vpsrlw_Y_Y_Xm128
-  | Vpsrlw_X_X_Xm128
-  | Pmaxsd
-  | Paddw
-  | Cvttss2si_r32_Xm32
-  | Vpmaxsd_Y_Y_Ym256
-  | Vpmaxsd_X_X_Xm128
-  | Movlhps
-  | Vmpsadbw_Y_Y_Ym256
-  | Vmpsadbw_X_X_Xm128
-  | Vpinsrb
-  | Cvtsd2si_r64_Xm64
-  | Pmovsxbq
-  | Pslldq
-  | Pmaddwd
-  | Vdivss
-  | Pmovsxbd
-  | Vphsubw_Y_Y_Ym256
-  | Vphsubw_X_X_Xm128
-  | Vaddsubpd_Y_Y_Ym256
-  | Vaddsubpd_X_X_Xm128
+  | Vpunpckldq_X_X_Xm128
+  | Phsubd_X_Xm128
   | Vpsrlq_Y_Y_Xm128
-  | Vpsrlq_X_X_Xm128
-  | Pmulhuw_X_Xm128
-  | Psrlq_X
-  | Vmovaps_Y_Ym256
-  | Vcvtss2si_r32_Xm32
-  | Cvtsd2si_r32_Xm64
-  | Vrcpps_X_Xm128
-  | Vpackssdw_Y_Y_Ym256
-  | Vpackssdw_X_X_Xm128
-  | Vbroadcastsd_Y_X
-  | Vbroadcastsd_Y_m64
-  | Roundsd
-  | Por
-  | Vucomisd
-  | Vaddss
-  | Vpshufhw_Y_Ym256
-  | Vcmpss
-  | Punpckhbw
-  | Pmaxud
-  | Vpabsb_X_Xm128
-  | Psllw_X
-  | Vlddqu_X_m128
-  | Vpmulld_Y_Y_Ym256
-  | Vpmulld_X_X_Xm128
-  | Movsldup
-  | Psubd
-  | Movq_X_r64m64
-  | Vperm2f128
+  | Vpcmpgtw_X_X_Xm128
+  | Vpbroadcastd_Y_Xm32
+  | Vpbroadcastd_X_Xm32
+  | Vpextrd
+  | Vsqrtps_Y_Ym256
+  | Vsqrtps_X_Xm128
+  | Vpmovzxwq_Y_Xm64
+  | Vpmaskmovd_Y_Y_m256
+  | Vpmaskmovd_X_X_m128
+  | Vmovdqa_Y_Ym256
+  | Vmovdqa_X_Xm128
+  | Punpcklwd
+  | Movhps_X_m64
+  | Vandps_Y_Y_Ym256
+  | Vandps_X_X_Xm128
+  | Pmaxsb
+  | Vmpsadbw_Y_Y_Ym256
+  | Vbroadcastf128
   | Vsubpd_Y_Y_Ym256
   | Vsubpd_X_X_Xm128
-  | Vpmaskmovq_m256_Y_Y
-  | Vpmaskmovq_m128_X_X
-  | Xorpd
-  | Vpunpcklqdq_Y_Y_Ym256
-  | Vpunpcklqdq_X_X_Xm128
-  | Pmaddubsw_M_Mm64
-  | Pmaxuw
-  | Vpextrb
-  | Vandnpd_Y_Y_Ym256
-  | Vandnpd_X_X_Xm128
-  | Vpmaskmovd_m256_Y_Y
-  | Vpmaskmovd_m128_X_X
-  | Cvtsi2ss_X_r64m64
-  | Psrad_X
-  | Vrsqrtss
-  | Vandpd_Y_Y_Ym256
-  | Vandpd_X_X_Xm128
-  | Vpor_Y_Y_Ym256
-  | Vpor_X_X_Xm128
-  | Pextrd
-  | Vmovntdq_m256_Y
-  | Pcmpestrm
-  | Vxorps_Y_Y_Ym256
-  | Vxorps_X_X_Xm128
-  | Rsqrtss
-  | Psignd_X_Xm128
-  | Vpunpckhwd_Y_Y_Ym256
-  | Vpunpckhwd_X_X_Xm128
-  | Pmullw
-  | Vmovss_m32_X
-  | Vmovdqu_Y_Ym256
-  | Vshufpd_Y_Y_Ym256
-  | Vshufpd_X_X_Xm128
-  | Pabsd_X_Xm128
-  | Vpermq
-  | Vpaddw_Y_Y_Ym256
-  | Vpaddw_X_X_Xm128
-  | Phaddd_M_Mm64
-  | Vmovntps_m256_Y
-  | Cvtps2pd
-  | Vcmppd_Y_Y_Ym256
-  | Vcmppd_X_X_Xm128
-  | Andnps
-  | Sqrtss
-  | Phaddw_X_Xm128
-  | Vpmaskmovq_Y_Y_m256
-  | Vpmaskmovq_X_X_m128
-  | Addpd
-  | Vpalignr_Y_Y_Ym256
-  | Vpalignr_X_X_Xm128
-  | Vrcpss
-  | Pmovzxdq
-  | Vmovntpd_m256_Y
-  | Shufpd
-  | Vpsrad_Y_Y
-  | Vpbroadcastd_Y_Xm32
-  | Vmovups_X_Xm128
-  | Vmovhps_X_X_m64
-  | Pinsrw_X_r32m16
-  | Psignw_M_Mm64
-  | Phsubd_X_Xm128
-  | Vpcmpestrm
-  | Vmovddup_X_Xm64
-  | Shlx_r32_r32m32_r32
-  | Vpsrad_Y_Y_Xm128
-  | Vpsrad_X_X_Xm128
-  | Vpmovzxwq_X_Xm32
-  | Vbroadcastss_Y_X
-  | Vbroadcastss_Y_m32
-  | Punpcklbw
-  | Paddb
-  | Pminsw_X_Xm128
-  | Vpextrw_r64_X
-  | Cvtpd2dq
-  | Vpcmpgtw_Y_Y_Ym256
-  | Vpcmpgtw_X_X_Xm128
+  | Addsubpd
   | Vpmaxud_Y_Y_Ym256
-  | Vpmaxud_X_X_Xm128
-  | Vpsadbw_Y_Y_Ym256
-  | Vpsadbw_X_X_Xm128
-  | Vpmuldq_Y_Y_Ym256
-  | Vpmuldq_X_X_Xm128
-  | Psadbw_X_Xm128
-  | Vpsraw_Y_Y
-  | Vandnps_Y_Y_Ym256
-  | Vandnps_X_X_Xm128
-  | Vpsrldq_Y_Y
-  | Pmovsxdq
-  | Haddpd
-  | Vpsraw_Y_Y_Xm128
-  | Vpsraw_X_X_Xm128
-  | Vmovups_Ym256_Y
-  | Vphsubsw_Y_Y_Ym256
-  | Vphsubsw_X_X_Xm128
-  | Mulss
-  | Vpmovsxbq_X_Xm16
-  | Cmpsd
-  | Movddup
-  | Cvtsi2sd_X_r32m32
-  | Cvtss2sd
-  | Andpd
-  | Pminuw
-  | Psrad_X_Xm128
-  | Packusdw
-  | Vpcmpeqd_Y_Y_Ym256
-  | Vpcmpeqd_X_X_Xm128
-  | Phsubw_X_Xm128
-  | Rorx_r32_r32m32
-  | Pclmulqdq
-  | Vrsqrtps_X_Xm128
-  | Pshufb_M_Mm64
-  | Phaddw_M_Mm64
-  | Vmovntps_m128_X
-  | Vpermps
-  | Paddsw
-  | Vcvttpd2dq_X_Xm128
-  | Phminposuw
-  | Pminsb
-  | Vmovlpd_X_X_m64
-  | Vpbroadcastb_X_Xm8
-  | Rorx_r64_r64m64
-  | Vpsrlw_X_X
-  | Pblendw
-  | Vhsubpd_Y_Y_Ym256
-  | Vhsubpd_X_X_Xm128
-  | Vsqrtpd_X_Xm128
-  | Vcvtps2pd_Y_Xm128
-  | Andnpd
-  | Pextrb
-  | Vpaddb_Y_Y_Ym256
-  | Vpaddb_X_X_Xm128
-  | Vmovntpd_m128_X
-  | Vcvtsi2sd_X_X_r32m32
-  | Mulsd
-  | Psubusb
-  | Pminsd
-  | Pmaxub_M_Mm64
-  | Vcvtdq2ps_X_Xm128
-  | Psrld_X_Xm128
-  | Vpshuflw_X_Xm128
-  | Vcvtpd2ps_X_Xm128
-  | Movntps
-  | Palignr_M_Mm64
-  | Cvtdq2pd
-  | Pcmpistrm
-  | Vpaddusw_Y_Y_Ym256
-  | Vpaddusw_X_X_Xm128
+  | Paddusw
   | Addss
   | Vaddpd_Y_Y_Ym256
   | Vaddpd_X_X_Xm128
-  | Vpmovsxbd_Y_Xm64
-  | Vdivps_Y_Y_Ym256
-  | Vdivps_X_X_Xm128
-  | Vpslld_Y_Y
-  | Vmulsd
-  | Comiss
-  | Shufps
-  | Vrcpps_Y_Ym256
-  | Rsqrtps
-  | Vmovdqa_Xm128_X
-  | Vcvttss2si_r64_Xm32
-  | Vpblendd_Y_Y_Ym256
-  | Vpblendd_X_X_Xm128
-  | Movlpd_X_m64
-  | Vblendvpd_Y_Y_Ym256_Y
-  | Vblendvpd_X_X_Xm128_X
-  | Vcvttpd2dq_X_Ym256
-  | Psrlw_X_Xm128
-  | Minsd
-  | Vaddps_Y_Y_Ym256
-  | Vaddps_X_X_Xm128
-  | Vminss
-  | Cvtss2si_r32_Xm32
-  | Vmovq_X_r64m64
-  | Vphaddsw_Y_Y_Ym256
-  | Vphaddsw_X_X_Xm128
-  | Vsubsd
-  | Vpermilpd_X_Xm128
-  | Vroundps_X_Xm128
-  | Vpsubd_Y_Y_Ym256
-  | Vpsubd_X_X_Xm128
-  | Pslld_X_Xm128
-  | Vpcmpgtb_Y_Y_Ym256
-  | Vpcmpgtb_X_X_Xm128
-  | Vmovntdq_m128_X
-  | Vshufps_Y_Y_Ym256
-  | Vshufps_X_X_Xm128
-  | Movapd_X_Xm128
-  | Hsubps
-  | Vcvtsi2sd_X_X_r64m64
-  | Vpmovsxwq_Y_Xm64
-  | Vpmovsxbd_X_Xm32
-  | Vpminsb_Y_Y_Ym256
-  | Vpminsb_X_X_Xm128
-  | Vpsrld_Y_Y_Xm128
-  | Vpsrld_X_X_Xm128
-  | Andps
-  | Vpmuludq_Y_Y_Ym256
-  | Vpmuludq_X_X_Xm128
-  | Dpps
-  | Pextrw_r64_M
-  | Cvtdq2ps
-  | Vmovupd_X_Xm128
-  | Pcmpeqw
-  | Vcvtss2sd
-  | Vpbroadcastq_Y_Xm64
-  | Vpabsd_X_Xm128
-  | Vpslldq_Y_Y
-  | Psignb_M_Mm64
-  | Vpmovzxwd_X_Xm64
-  | Vpackusdw_Y_Y_Ym256
-  | Vpackusdw_X_X_Xm128
-  | Vcvtsi2ss_X_X_r32m32
-  | Vpsllq_X_X
-  | Psllw_X_Xm128
-  | Vpavgw_Y_Y_Ym256
-  | Vpavgw_X_X_Xm128
-  | Vpermilps_X_Xm128
-  | Punpckhdq
-  | Phsubd_M_Mm64
-  | Vunpckhps_Y_Y_Ym256
-  | Vunpckhps_X_X_Xm128
-  | Movlps_m64_X
-  | Vextracti128
-  | Vpaddd_Y_Y_Ym256
-  | Vpaddd_X_X_Xm128
-  | Vcvtps2dq_Y_Ym256
-  | Pxor
-  | Maxpd
-  | Vpmovsxbq_Y_Xm32
-  | Pmovsxwq
-  | Vpslldq_X_X
-  | Vmaskmovps_m256_Y_Y
-  | Vmaskmovps_m128_X_X
-  | Phsubsw_M_Mm64
-  | Pmulhuw_M_Mm64
-  | Maskmovdqu
-  | Vcmpps_Y_Y_Ym256
-  | Vcmpps_X_X_Xm128
-  | Movlps_X_m64
-  | Pinsrw_M_r32m16
-  | Vpcmpgtd_Y_Y_Ym256
-  | Vpcmpgtd_X_X_Xm128
-  | Cvtss2si_r64_Xm32
-  | Vpmovzxbq_X_Xm16
-  | Hsubpd
-  | Vmovupd_Ym256_Y
-  | Movq_X_Xm64
-  | Vcvtsd2ss
-  | Movaps_X_Xm128
-  | Punpcklwd
-  | Vmovhps_m64_X
-  | Blendvps
-  | Vpblendw_Y_Y_Ym256
-  | Vpblendw_X_X_Xm128
-  | Vcvtdq2ps_Y_Ym256
-  | Mpsadbw
-  | Vmovlps_m64_X
-  | Pavgb_X_Xm128
-  | Vdivsd
-  | Vpmovsxdq_X_Xm64
-  | Vpunpcklbw_Y_Y_Ym256
-  | Vpunpcklbw_X_X_Xm128
-  | Movdqa_X_Xm128
-  | Pblendvb
-  | Pmovzxwq
-  | Unpcklps
-  | Vpsubusw_Y_Y_Ym256
-  | Vpsubusw_X_X_Xm128
-  | Bzhi_r32_r32m32_r32
-  | Vandps_Y_Y_Ym256
-  | Vandps_X_X_Xm128
-  | Pminub_X_Xm128
-  | Psubsw
-  | Vpshufd_X_Xm128
-  | Ucomisd
-  | Vpmovzxbw_X_Xm64
-  | Pmovzxbq
-  | Vcvtpd2ps_X_Ym256
-  | Movlpd_m64_X
-  | Vmovdqa_Y_Ym256
-  | Pmovzxwd
-  | Pavgw_M_Mm64
-  | Vmaxsd
-  | Vsqrtss
+  | Vpsubusb_Y_Y_Ym256
+  | Vpmovmskb_r64_X
+  | Vpunpckhbw_Y_Y_Ym256
+  | Psrlq_X
+  | Vcvtss2si_r32_Xm32
+  | Maxsd
   | Xorps
-  | Vpinsrw
-  | Cvttps2dq
-  | Vpsrlq_Y_Y
-  | Vmovdqa_Ym256_Y
-  | Vpsrldq_X_X
-  | Vcvtdq2pd_X_Xm64
-  | Unpckhpd
-  | Vpminsd_Y_Y_Ym256
-  | Vpminsd_X_X_Xm128
-  | Paddq
-  | Cmppd
-  | Sarx_r32_r32m32_r32
-  | Movsd_Xm64_X
-  | Pavgb_M_Mm64
-  | Cvttss2si_r64_Xm32
-  | Psubusw
-  | Vpmovzxbd_Y_Xm64
-  | Vsqrtps_Y_Ym256
-  | Unpcklpd
-  | Vsubps_Y_Y_Ym256
-  | Vsubps_X_X_Xm128
-  | Vpabsb_Y_Ym256
-  | Pmuldq
-  | Vpsllw_X_X
-  | Cmpps
-  | Vpcmpistri
-  | Pcmpgtd
-  | Pand
-  | Pcmpgtq
-  | Pabsd_M_Mm64
-  | Crc32_r64_r64m64
-  | Vextractf128
-  | Movupd_X_Xm128
-  | Vpbroadcastw_X_Xm16
-  | Vpsravd_Y_Y_Ym256
-  | Vpsravd_X_X_Xm128
-  | Pslld_X
-  | Pmaxsw_X_Xm128
-  | Vtestps_Y_Ym256
-  | Vtestps_X_Xm128
-  | Vpcmpeqw_Y_Y_Ym256
-  | Vpcmpeqw_X_X_Xm128
-  | Vmovmskps_r64_X
-  | Palignr_X_Xm128
-  | Psignb_X_Xm128
-  | Vphsubd_Y_Y_Ym256
-  | Vphsubd_X_X_Xm128
-  | Vpaddusb_Y_Y_Ym256
-  | Vpaddusb_X_X_Xm128
-  | Pandn
-  | Vpxor_Y_Y_Ym256
-  | Vpxor_X_X_Xm128
-  | Vmovdqa_X_Xm128
-  | Vmaxps_Y_Y_Ym256
-  | Vmaxps_X_X_Xm128
-  | Vpmullw_Y_Y_Ym256
-  | Vpmullw_X_X_Xm128
-  | Vphminposuw
-  | Psubw
-  | Vpbroadcastb_Y_Xm8
-  | Vptest_Y_Ym256
-  | Vptest_X_Xm128
-  | Packuswb
-  | Haddps
-  | Vmovshdup_X_Xm128
-  | Vmovaps_X_Xm128
-  | Vaddsd
-  | Movdqa_Xm128_X
-  | Orpd
-  | Paddsb
-  | Vpsrad_X_X
-  | Vbroadcasti128
-  | Vpbroadcastd_X_Xm32
-  | Vperm2i128
-  | Vmaskmovps_Y_Y_m256
-  | Vmaskmovps_X_X_m128
-  | Packsswb
-  | Movss_X_m32
-  | Movss_X_X
-  | Vroundpd_Y_Ym256
-  | Vpslld_Y_Y_Xm128
-  | Vpslld_X_X_Xm128
-  | Minpd
-  | Movhlps
-  | Vsubss
-  | Vsqrtpd_Y_Ym256
-  | Vpmovmskb_r64_Y
   | Psrlq_X_Xm128
-  | Vmovhlps
-  | Blendpd
-  | Vstmxcsr
-  | Vcvtpd2dq_X_Xm128
-  | Vmovupd_Xm128_X
-  | Vmovddup_Y_Ym256
-  | Pextrw_r64m16_X
-  | Vmovntdqa_Y_m256
-  | Vpslld_X_X
-  | Cvttpd2dq
-  | Vmovupd_Y_Ym256
-  | Packssdw
-  | Vunpcklpd_Y_Y_Ym256
-  | Vunpcklpd_X_X_Xm128
-  | Divpd
-  | Pmuludq_M_Mm64
-  | Pabsb_X_Xm128
   | Vblendpd_Y_Y_Ym256
   | Vblendpd_X_X_Xm128
-  | Pmaxsb
-  | Vmovups_Y_Ym256
-  | Vrsqrtps_Y_Ym256
-  | Vmaxpd_Y_Y_Ym256
-  | Vmaxpd_X_X_Xm128
-  | Vpsllw_Y_Y
-  | Vphaddw_Y_Y_Ym256
-  | Vphaddw_X_X_Xm128
-  | Insertps
-  | Vsqrtsd
+  | Minsd
+  | Vcvtsd2si_r64_Xm64
+  | Vpsllw_Y_Y_Xm128
+  | Pextrw_r64m16_X
+  | Vpmaddwd_Y_Y_Ym256
+  | Vpaddw_X_X_Xm128
+  | Vmovaps_Y_Ym256
+  | Vmovaps_X_Xm128
+  | Vaddsubps_Y_Y_Ym256
+  | Vaddsubps_X_X_Xm128
+  | Vpsllq_Y_Y
+  | Vpcmpgtq_X_X_Xm128
+  | Divpd
+  | Vpcmpeqd_X_X_Xm128
+  | Vpmovzxwd_Y_Xm128
+  | Vmovsd_X_X_X
+  | Vlddqu_Y_m256
+  | Vlddqu_X_m128
+  | Andnpd
+  | Vpsraw_X_X_Xm128
+  | Movapd_X_Xm128
+  | Vpsrld_X_X
+  | Vpmuludq_Y_Y_Ym256
+  | Vpcmpeqw_X_X_Xm128
+  | Vpcmpgtd_X_X_Xm128
   | Pshuflw
-  | Cvtsd2ss
-  | Pminub_M_Mm64
-  | Vmulps_Y_Y_Ym256
-  | Vmulps_X_X_Xm128
-  | Vmovq_Xm64_X
-  | Vpaddsw_Y_Y_Ym256
-  | Vpaddsw_X_X_Xm128
-  | Pabsw_M_Mm64
-  | Punpcklqdq
-  | Subss
-  | Punpckldq
-  | Vpunpckhbw_Y_Y_Ym256
-  | Vpunpckhbw_X_X_Xm128
-  | Vcvtsi2ss_X_X_r64m64
-  | Ucomiss
-  | Movhpd_m64_X
-  | Addsubpd
-  | Pmaxsw_M_Mm64
-  | Minss
-  | Vorps_Y_Y_Ym256
-  | Vorps_X_X_Xm128
-  | Vroundps_Y_Ym256
-  | Vcvtps2dq_X_Xm128
-  | Vpshufhw_X_Xm128
-  | Psadbw_M_Mm64
-  | Cmpss
-  | Vbroadcastss_X_X
-  | Vbroadcastss_X_m32
-  | Vpcmpeqq_Y_Y_Ym256
-  | Vpcmpeqq_X_X_Xm128
-  | Maxps
-  | Vxorpd_Y_Y_Ym256
-  | Vxorpd_X_X_Xm128
-  | Pmovzxbw
-  | Vmovlpd_m64_X
-  | Vpacksswb_Y_Y_Ym256
-  | Vpacksswb_X_X_Xm128
-  | Vmovmskps_r64_Y
+  | Pmulhuw_X_Xm128
+  | Vsqrtss
+  | Palignr_M_Mm64
+  | Phaddw_X_Xm128
+  | Vpmuldq_X_X_Xm128
+  | Pmaxsw_X_Xm128
+  | Movdqa_X_Xm128
+  | Vpsrlq_Y_Y
+  | Psignd_M_Mm64
+  | Vpsignw_X_X_Xm128
+  | Vunpckhps_Y_Y_Ym256
+  | Vunpckhps_X_X_Xm128
+  | Vandpd_Y_Y_Ym256
+  | Vandpd_X_X_Xm128
+  | Vmovntdqa_Y_m256
+  | Unpcklpd
+  | Vpmovzxbw_X_Xm64
+  | Vpcmpgtw_Y_Y_Ym256
+  | Movlhps
+  | Movhpd_X_m64
+  | Vpsignb_Y_Y_Ym256
   | Movshdup
-  | Vcvtps2pd_X_Xm64
-  | Vpbroadcastw_Y_Xm16
-  | Vpunpcklwd_Y_Y_Ym256
-  | Vpunpcklwd_X_X_Xm128
-  | Vpsraw_X_X
-  | Pinsrq
-  | Cvttsd2si_r32_Xm64
-  | Shrx_r64_r64m64_r64
-  | Divps
-  | Pabsw_X_Xm128
-  | Vmovsldup_X_Xm128
-  | Psubq_M_Mm64
-  | Pshufb_X_Xm128
-  | Vpsubb_Y_Y_Ym256
-  | Vpsubb_X_X_Xm128
-  | Pmovmskb_r64_M
-  | Vpmovzxdq_Y_Xm128
-  | Vmovss_X_m32
-  | Vpaddsb_Y_Y_Ym256
-  | Vpaddsb_X_X_Xm128
-  | Movhps_X_m64
-  | Pmulhrsw_X_Xm128
-  | Mulps
-  | Vzeroall
-  | Vpmovsxbw_Y_Xm128
-  | Pcmpestri
-  | Vmovsd_X_m64
-  | Maxss
-  | Vroundpd_X_Xm128
-  | Movhps_m64_X
-  | Psrlw_X
-  | Roundpd
-  | Dppd
-  | Vunpckhpd_Y_Y_Ym256
-  | Vunpckhpd_X_X_Xm128
-  | Vpabsw_X_Xm128
-  | Pextrq
-  | Vcvtpd2dq_X_Ym256
-  | Ldmxcsr
-  | Pmovzxbd
-  | Vpmovsxbw_X_Xm64
-  | Vpminuw_Y_Y_Ym256
-  | Vpminuw_X_X_Xm128
-  | Pshufhw
+  | Psubusw
+  | Vpsrld_Y_Y
+  | Vmovss_m32_X
+  | Vpsrlq_X_X_Xm128
+  | Addpd
+  | Vpsllw_X_X
+  | Packsswb
+  | Cvtsi2ss_X_r64m64
+  | Paddsb
+  | Divsd
+  | Movntdq
+  | Pinsrw_X_r32m16
+  | Vmovntdqa_X_m128
+  | Dpps
+  | Paddw
+  | Cvtsd2si_r32_Xm64
+  | Vphaddsw_X_X_Xm128
   | Vtestpd_Y_Ym256
   | Vtestpd_X_Xm128
-  | Divsd
-  | Psignd_M_Mm64
-  | Comisd
-  | Vpmulhw_Y_Y_Ym256
-  | Vpmulhw_X_X_Xm128
-  | Vpmovsxwq_X_Xm32
-  | Cvtps2dq
-  | Vpsignb_Y_Y_Ym256
-  | Vpsignb_X_X_Xm128
-  | Orps
-  | Movups_X_Xm128
-  | Punpckhwd
-  | Vpsllq_Y_Y_Xm128
-  | Vpsllq_X_X_Xm128
-  | Pcmpistri
-  | Vpsubsw_Y_Y_Ym256
-  | Vpsubsw_X_X_Xm128
-  | Pmovsxwd
-  | Pmaddubsw_X_Xm128
-  | Vpblendvb_Y_Y_Ym256_Y
-  | Vpblendvb_X_X_Xm128_X
+  | Roundps
+  | Vpextrw_r64m16_X
+  | Movdqa_Xm128_X
+  | Vpmovsxbd_X_Xm32
+  | Vcvttss2si_r32_Xm32
+  | Vcvtpd2ps_X_Ym256
+  | Vcvtpd2ps_X_Xm128
+  | Vpsubusb_X_X_Xm128
+  | Vpmuludq_X_X_Xm128
+  | Cvtss2si_r32_Xm32
+  | Vmaxsd
+  | Pextrb
+  | Vpinsrw
   | Vblendvps_Y_Y_Ym256_Y
   | Vblendvps_X_X_Xm128_X
-  | Pcmpgtw
-  | Vpermilps_Y_Ym256
-  | Roundps
-  | Phsubw_M_Mm64
-  | Vmovntdqa_X_m128
-  | Vpermilpd_Y_Ym256
-  | Sarx_r64_r64m64_r64
-  | Pdep_r64_r64_r64m64
+  | Pmovsxbd
+  | Mpsadbw
+  | Vpmovsxbq_X_Xm16
+  | Vpinsrd
+  | Cvtdq2pd
+  | Vphaddsw_Y_Y_Ym256
+  | Vpsrlq_X_X
+  | Pminuw
+  | Vpmovzxwd_X_Xm64
+  | Cvtss2si_r64_Xm32
+  | Pabsw_X_Xm128
+  | Cvttss2si_r32_Xm32
+  | Vpunpcklqdq_Y_Y_Ym256
+  | Movupd_Xm128_X
+  | Vpmaxsw_X_X_Xm128
+  | Pcmpistrm
+  | Vmovd_X_r32m32
+  | Movdqu_X_Xm128
+  | Blendvpd
+  | Vmovsldup_Y_Ym256
+  | Vmovsldup_X_Xm128
+  | Vpmovzxdq_X_Xm64
+  | Vpavgb_X_X_Xm128
+  | Vpor_Y_Y_Ym256
+  | Vpmaxsd_Y_Y_Ym256
+  | Vblendps_Y_Y_Ym256
+  | Vblendps_X_X_Xm128
+  | Vcvtsi2ss_X_X_r64m64
+  | Vcvtsi2ss_X_X_r32m32
+  | Psignb_X_Xm128
+  | Mulss
+  | Vpunpckhdq_Y_Y_Ym256
+  | Vtestps_Y_Ym256
+  | Vtestps_X_Xm128
+  | Vpinsrq
+  | Vmaskmovps_Y_Y_m256
+  | Vmaskmovps_X_X_m128
+  | Pmaddubsw_X_Xm128
+  | Vzeroupper
+  | Pminsw_M_Mm64
+  | Vpackssdw_Y_Y_Ym256
   | Vmovlps_X_X_m64
-  | Vpmovzxwq_Y_Xm64
-  | Vpsrlw_Y_Y
+  | Vcvttsd2si_r64_Xm64
+  | Subsd
+  | Vpextrq
+  | Pblendw
+  | Vpminud_X_X_Xm128
+  | Shlx_r64_r64m64_r64
+  | Shlx_r32_r32m32_r32
+  | Vmpsadbw_X_X_Xm128
+  | Movq_X_r64m64
+  | Vpmovsxdq_X_Xm64
+  | Vpaddusw_Y_Y_Ym256
+  | Crc32_r64_r8m8
+  | Crc32_r32_r8m8
+  | Vpandn_Y_Y_Ym256
+  | Vpmaxsb_Y_Y_Ym256
+  | Vmovq_X_Xm64
+  | Vpsrad_X_X
+  | Vminsd
+  | Psllw_X
+  | Psraw_X
+  | Punpckhwd
+  | Vrsqrtss
+  | Vmovupd_Ym256_Y
+  | Vmovupd_Xm128_X
+  | Vpxor_Y_Y_Ym256
+  | Punpcklbw
+  | Movlpd_X_m64
+  | Vpslld_Y_Y
+  | Vpmovsxbd_Y_Xm64
+  | Vpsadbw_Y_Y_Ym256
+  | Andnps
+  | Vaddps_Y_Y_Ym256
+  | Vaddps_X_X_Xm128
+  | Vpmovzxbq_Y_Xm32
+  | Vextractf128
+  | Vpsrld_Y_Y_Xm128
+  | Vpslld_X_X_Xm128
+  | Vmovntpd_m256_Y
+  | Vmovntpd_m128_X
+  | Vpsrlvq_Y_Y_Ym256
+  | Vpsrlvq_X_X_Xm128
+  | Vpsrad_X_X_Xm128
+  | Pavgw_X_Xm128
+  | Vpermpd
+  | Vpshufhw_Y_Ym256
+  | Vpblendd_Y_Y_Ym256
+  | Vpblendd_X_X_Xm128
+  | Blendpd
+  | Pabsb_X_Xm128
+  | Vpaddsw_X_X_Xm128
+  | Pminsw_X_Xm128
+  | Vpshufhw_X_Xm128
+  | Divss
+  | Vmovss_X_m32
+  | Vpermd
+  | Vpbroadcastq_Y_Xm64
+  | Vpbroadcastq_X_Xm64
+  | Vphaddw_Y_Y_Ym256
+  | Ucomiss
+  | Movlps_X_m64
+  | Vpsubw_Y_Y_Ym256
+  | Pslldq
+  | Pmovsxbq
+  | Vpaddsw_Y_Y_Ym256
+  | Vpcmpgtq_Y_Y_Ym256
+  | Vpmovsxdq_Y_Xm128
+  | Vbroadcastsd_Y_X
+  | Vpavgb_Y_Y_Ym256
+  | Vpaddb_X_X_Xm128
+  | Vpunpcklbw_X_X_Xm128
+  | Sqrtpd
+  | Vmovhlps
+  | Vmovaps_Ym256_Y
+  | Vmovaps_Xm128_X
+  | Pavgb_M_Mm64
+  | Vpmovzxwq_X_Xm32
+  | Vphsubsw_Y_Y_Ym256
+  | Vucomiss
+  | Vminss
+  | Vcvtdq2pd_Y_Xm128
+  | Vcvtdq2pd_X_Xm64
+  | Vmovhps_m64_X
+  | Psrad_X_Xm128
+  | Vpslldq_X_X
+  | Pmovzxbw
+  | Vpextrw_r64_X
+  | Vpaddusb_Y_Y_Ym256
+  | Movntpd
+  | Vpshuflw_X_Xm128
+  | Vpor_X_X_Xm128
+  | Vsubsd
+  | Vpmulld_Y_Y_Ym256
+  | Phsubsw_M_Mm64
+  | Vinsertps
+  | Vpsrad_Y_Y_Xm128
+  | Vpavgw_Y_Y_Ym256
+  | Movss_X_m32
+  | Movss_X_X
+  | Pabsd_X_Xm128
+  | Vmovhps_X_X_m64
+  | Pmovsxdq
+  | Comiss
+  | Cvttps2dq
   | Stmxcsr
+  | Vroundpd_Y_Ym256
+  | Vroundpd_X_Xm128
+  | Pclmulqdq
+  | Vpmovsxwd_Y_Xm128
+  | Vpmovsxwq_Y_Xm64
+  | Vzeroall
+  | Vpermq
+  | Ucomisd
+  | Vminps_Y_Y_Ym256
+  | Vminps_X_X_Xm128
+  | Hsubpd
+  | Vunpckhpd_Y_Y_Ym256
+  | Vunpckhpd_X_X_Xm128
+  | Vpabsd_X_Xm128
+  | Addsd
+  | Vpmovsxbw_Y_Xm128
+  | Vmovntps_m256_Y
+  | Vmovntps_m128_X
+  | Punpckhdq
+  | Vpcmpeqb_Y_Y_Ym256
+  | Vmulsd
+  | Vcvtsd2ss
+  | Vpermps
+  | Pdep_r64_r64_r64m64
+  | Pdep_r32_r32_r32m32
+  | Vpackssdw_X_X_Xm128
+  | Pshufd
+  | Cvtsd2ss
+  | Vpblendw_Y_Y_Ym256
+  | Vpermilpd_Y_Y_Ym256
+  | Vpermilpd_X_X_Xm128
+  | Vpmovmskb_r64_Y
+  | Pinsrw_M_r32m16
+  | Vpsrld_X_X_Xm128
+  | Vpabsb_Y_Ym256
+  | Vpmovzxbd_X_Xm32
+  | Vmovsd_m64_X
+  | Vpsraw_Y_Y
+  | Pmaxub_X_Xm128
+  | Bzhi_r64_r64m64_r64
+  | Bzhi_r32_r32m32_r32
+  | Pcmpistri
+  | Orpd
+  | Vpmaskmovq_Y_Y_m256
+  | Vpmaskmovq_X_X_m128
+  | Vpunpckldq_Y_Y_Ym256
+  | Vpunpcklbw_Y_Y_Ym256
+  | Vpsubsb_X_X_Xm128
+  | Vpaddq_Y_Y_Ym256
+  | Vpsubsb_Y_Y_Ym256
+  | Vcvttsd2si_r32_Xm64
+  | Vroundss
+  | Vpunpckhqdq_Y_Y_Ym256
+  | Shrx_r64_r64m64_r64
+  | Shrx_r32_r32m32_r32
+  | Pextrw_r64_M
+  | Vmovapd_Y_Ym256
+  | Vmovapd_X_Xm128
+  | Vptest_Y_Ym256
+  | Vptest_X_Xm128
+  | Punpckhqdq
+  | Addps
+  | Pabsb_M_Mm64
+  | Vmulss
+  | Vpcmpeqd_Y_Y_Ym256
+  | Vpand_Y_Y_Ym256
+  | Subss
+  | Vmovlps_m64_X
+  | Vpsignd_Y_Y_Ym256
+  | Xorpd
+  | Vpshuflw_Y_Ym256
+  | Cvtps2dq
+  | Vucomisd
+  | Rsqrtss
+  | Vpacksswb_Y_Y_Ym256
+  | Vpmulhrsw_X_X_Xm128
+  | Vminpd_Y_Y_Ym256
+  | Vminpd_X_X_Xm128
+  | Vpminsb_Y_Y_Ym256
+  | Subps
+  | Pmovsxbw
+  | Pmovzxbq
+  | Movq_X_Xm64
+  | Vpermilpd_Y_Ym256
+  | Vpermilpd_X_Xm128
+  | Movaps_Xm128_X
+  | Cvttpd2dq
+  | Cmpsd
+  | Vmaskmovps_m256_Y_Y
+  | Vmaskmovps_m128_X_X
+  | Psignw_M_Mm64
+  | Vpsubsw_X_X_Xm128
+  | Vcmpsd
+  | Pavgb_X_Xm128
+  | Vorps_Y_Y_Ym256
+  | Vorps_X_X_Xm128
+  | Pmaddubsw_M_Mm64
+  | Vpsignd_X_X_Xm128
+  | Phaddd_M_Mm64
+  | Psubw
+  | Vpminud_Y_Y_Ym256
+  | Vcvtdq2ps_Y_Ym256
+  | Vcvtdq2ps_X_Xm128
+  | Psubq_M_Mm64
+  | Vpmaxsd_X_X_Xm128
+  | Ldmxcsr
+  | Vmovshdup_Y_Ym256
+  | Vmovshdup_X_Xm128
+  | Unpcklps
+  | Palignr_X_Xm128
+  | Vdivpd_Y_Y_Ym256
+  | Vdivpd_X_X_Xm128
+  | Vpmulhw_Y_Y_Ym256
+  | Pmovmskb_r64_M
+  | Vshufpd_Y_Y_Ym256
+  | Vshufpd_X_X_Xm128
+  | Vpmovzxdq_Y_Xm128
+  | Maxpd
+  | Pmulhrsw_M_Mm64
+  | Vpmaxud_X_X_Xm128
+  | Psrld_X_Xm128
+  | Vpaddq_X_X_Xm128
+  | Movddup
+  | Vroundsd
+  | Vsubss
+  | Movhps_m64_X
+  | Vhaddps_Y_Y_Ym256
+  | Vhaddps_X_X_Xm128
+  | Cvtdq2ps
+  | Vpaddsb_X_X_Xm128
+  | Vdpps_Y_Y_Ym256
+  | Vdpps_X_X_Xm128
+  | Movapd_Xm128_X
+  | Cmpss
+  | Vshufps_Y_Y_Ym256
+  | Vshufps_X_X_Xm128
+  | Vpmaddubsw_X_X_Xm128
+  | Blendps
+  | Vpavgw_X_X_Xm128
+  | Andpd
+  | Phaddsw_X_Xm128
+  | Vaddsubpd_Y_Y_Ym256
+  | Vaddsubpd_X_X_Xm128
+  | Psubsw
+  | Vpsraw_Y_Y_Xm128
+  | Vsqrtsd
+  | Vpshufd_Y_Ym256
+  | Psllw_X_Xm128
+  | Vpermilps_Y_Y_Ym256
+  | Vpermilps_X_X_Xm128
+  | Vpmaskmovd_m256_Y_Y
+  | Vpmaskmovd_m128_X_X
+  | Ptest
+  | Vpmovzxbq_X_Xm16
+  | Vcvttps2dq_Y_Ym256
+  | Vcvttps2dq_X_Xm128
+  | Phsubd_M_Mm64
+  | Vcomisd
+  | Vpminsb_X_X_Xm128
+  | Vmovhpd_m64_X
+  | Cvttsd2si_r64_Xm64
+  | Cvtss2sd
+  | Psadbw_X_Xm128
+  | Vmulps_Y_Y_Ym256
+  | Vmulps_X_X_Xm128
+  | Vphaddd_Y_Y_Ym256
+  | Vunpcklps_Y_Y_Ym256
+  | Vunpcklps_X_X_Xm128
+  | Vpslldq_Y_Y
+  | Pextrd
+  | Vcvtsd2si_r32_Xm64
+  | Vpmovsxwq_X_Xm32
+  | Psrlw_X
+  | Pmovzxwq
+  | Vcmppd_Y_Y_Ym256
+  | Vcmppd_X_X_Xm128
+  | Vpaddsb_Y_Y_Ym256
+  | Vpacksswb_X_X_Xm128
+  | Mulsd
+  | Pmaxsw_M_Mm64
+  | Movmskps
+  | Vmaskmovpd_m256_Y_Y
+  | Vmaskmovpd_m128_X_X
+  | Rorx_r32_r32m32
+  | Vcvtss2si_r64_Xm32
+  | Vmovntdq_m256_Y
+  | Vmovntdq_m128_X
+  | Vpunpcklqdq_X_X_Xm128
+  | Paddb
+  | Vpaddd_X_X_Xm128
+  | Vperm2f128
+  | Unpckhpd
+  | Orps
+  | Vpinsrb
+  | Vpaddusw_X_X_Xm128
+  | Phsubw_M_Mm64
+  | Vpcmpeqq_X_X_Xm128
+  | Psrld_X
+  | Psubq_X_Xm128
+  | Vpsignw_Y_Y_Ym256
+  | Extractps
+  | Vpmulhw_X_X_Xm128
+  | Vpmovsxbw_X_Xm64
+  | Psignd_X_Xm128
+  | Pcmpeqq
+  | Vpsignb_X_X_Xm128
+  | Vpsadbw_X_X_Xm128
+  | Vpshufd_X_Xm128
+  | Pinsrd
+  | Pcmpestrm
+  | Pmuldq
+  | Paddq
+  | Vmovlpd_m64_X
+  | Blendvps
+  | Vpminsw_X_X_Xm128
+  | Vpminub_Y_Y_Ym256
+  | Pcmpeqb
+  | Movups_X_Xm128
+  | Movd_X_r32m32
+  | Pmovmskb_r64_X
+  | Pminsd
+  | Packssdw
+  | Vperm2i128
+  | Vpmaddubsw_Y_Y_Ym256
+  | Vmulpd_Y_Y_Ym256
+  | Vmulpd_X_X_Xm128
+  | Movntps
+  | Vblendvpd_Y_Y_Ym256_Y
+  | Vblendvpd_X_X_Xm128_X
+  | Vpsrad_Y_Y
+  | Vmaxps_Y_Y_Ym256
+  | Vmaxps_X_X_Xm128
+  | Vpackusdw_X_X_Xm128
+  | Vmovq_Xm64_X
+  | Sqrtss
+  | Vpshufb_X_X_Xm128
+  | Vpminuw_Y_Y_Ym256
+  | Paddd
+  | Psubd
+  | Vpsrlw_Y_Y_Xm128
+  | Vpmovzxbw_Y_Xm128
+  | Vpmaxsw_Y_Y_Ym256
+  | Vmovups_Y_Ym256
+  | Vmovups_X_Xm128
+  | Vpsrlvd_Y_Y_Ym256
+  | Vpsrlvd_X_X_Xm128
+  | Unpckhps
+  | Pminub_M_Mm64
+  | Vaddsd
+  | Shufpd
+  | Vmovss_X_X_X
+  | Pmaddwd
+  | Vpsllw_Y_Y
+  | Packusdw
+  | Pcmpgtd
+  | Vpsrldq_Y_Y
+  | Vpunpckhqdq_X_X_Xm128
+  | Cvtsi2sd_X_r64m64
+  | Vphsubw_Y_Y_Ym256
+  | Vxorpd_Y_Y_Ym256
+  | Vxorpd_X_X_Xm128
+  | Vcomiss
+  | Movmskpd
+  | Sqrtsd
+  | Vrcpps_Y_Ym256
+  | Vrcpps_X_Xm128
+  | Vpsubw_X_X_Xm128
+  | Pabsw_M_Mm64
+  | Vpmaddwd_X_X_Xm128
+  | Vpsrlw_X_X_Xm128
+  | Rorx_r64_r64m64
+  | Vpmullw_Y_Y_Ym256
+  | Vpaddw_Y_Y_Ym256
+  | Pxor
+  | Vpcmpestrm
+  | Vpalignr_X_X_Xm128
+  | Vextracti128
+  | Psubusb
+  | Vcmpss
+  | Vmovlpd_X_X_m64
+  | Vbroadcastss_Y_m32
+  | Vbroadcastss_X_m32
+  | Rcpps
+  | Vdppd
+  | Vcvtps2pd_Y_Xm128
+  | Vcvtps2pd_X_Xm64
+  | Vpsllq_X_X
+  | Vandnps_Y_Y_Ym256
+  | Vandnps_X_X_Xm128
+  | Vpsllw_X_X_Xm128
+  | Roundpd
+  | Pavgw_M_Mm64
+  | Movntdqa
+  | Divps
+  | Pmovzxdq
+  | Vpunpckhwd_Y_Y_Ym256
+  | Insertps
+  | Phsubsw_X_Xm128
+  | Pmullw
+  | Vphaddw_X_X_Xm128
+  | Pmovsxwd
+  | Punpcklqdq
+  | Vpextrb
+  | Pmovzxwd
+  | Vpmaxsb_X_X_Xm128
+  | Vrsqrtps_Y_Ym256
+  | Vrsqrtps_X_Xm128
+  | Maskmovdqu
+  | Vpmovsxwd_X_Xm64
+  | Cvttss2si_r64_Xm32
+  | Movlpd_m64_X
+  | Vphsubd_X_X_Xm128
+  | Vpxor_X_X_Xm128
+  | Pmovzxbd
+  | Mulps
+  | Pabsd_M_Mm64
+  | Movsldup
+  | Movaps_X_Xm128
+  | Vpslld_X_X
+  | Vcmpps_Y_Y_Ym256
+  | Vcmpps_X_X_Xm128
+  | Vhaddpd_Y_Y_Ym256
+  | Vhaddpd_X_X_Xm128
+  | Vpsllvq_Y_Y_Ym256
+  | Vpsllvq_X_X_Xm128
+  | Vmaskmovpd_Y_Y_m256
+  | Vmaskmovpd_X_X_m128
+  | Vpmulhuw_Y_Y_Ym256
+  | Vpmaxuw_X_X_Xm128
+  | Vmovdqa_Ym256_Y
+  | Vmovdqa_Xm128_X
+  | Pand
+  | Shufps
+  | Vbroadcastss_Y_X
+  | Vbroadcastss_X_X
+  | Psignw_X_Xm128
+  | Movsd_X_m64
+  | Movsd_X_X
+  | Roundsd
+  | Pshufb_M_Mm64
+  | Movhpd_m64_X
+  | Psllq_X_Xm128
+  | Vpclmulqdq
+  | Vpsllq_Y_Y_Xm128
+  | Vpblendvb_Y_Y_Ym256_Y
+  | Pminub_X_Xm128
+  | Vpsubb_X_X_Xm128
+  | Vpbroadcastb_Y_Xm8
+  | Vpbroadcastb_X_Xm8
+  | Punpckhbw
+  | Vpminsd_X_X_Xm128
+  | Movups_Xm128_X
+  | Vmovapd_Ym256_Y
+  | Vmovapd_Xm128_X
+  | Rcpss
+  | Vpmaskmovq_m256_Y_Y
+  | Vpmaskmovq_m128_X_X
+  | Vpcmpistri
+  | Vpshufb_Y_Y_Ym256
+  | Vphsubw_X_X_Xm128
+  | Pmovsxwq
+  | Movupd_X_Xm128
+  | Vpackuswb_X_X_Xm128
+  | Vinsertf128
+  | Vpsrldq_X_X
+  | Vpmovzxbd_Y_Xm64
+  | Dppd
+  | Pmaxuw
+  | Vpabsb_X_Xm128
+  | Roundss
+  | Psllq_X
+  | Pcmpgtb
+  | Psubsb
+  | Vpandn_X_X_Xm128
+  | Vpabsd_Y_Ym256
+  | Vpsrlw_Y_Y
+  | Vpand_X_X_Xm128
+  | Vphaddd_X_X_Xm128
+  | Addsubps
+  | Vpsubd_Y_Y_Ym256
+  | Pcmpestri
+  | Vpsraw_X_X
+  | Vpaddb_Y_Y_Ym256
+  | Hsubps
+  | Pminud
+  | Vsqrtpd_Y_Ym256
+  | Vsqrtpd_X_Xm128
+  | Vpsubb_Y_Y_Ym256
+  | Pextrq
+  | Vpmulld_X_X_Xm128
+  | Pinsrq
+  | Haddps
+  | Vpsllq_X_X_Xm128
+  | Pminsb
+  | Sarx_r64_r64m64_r64
+  | Sarx_r32_r32m32_r32
+  | Vextractps
+  | Vpminsd_Y_Y_Ym256
+  | Pmaxud
+  | Vpcmpgtd_Y_Y_Ym256
+  | Rsqrtps
+  | Vpslld_Y_Y_Xm128
   | Phaddd_X_Xm128
+  | Vldmxcsr
+  | Vpsravd_Y_Y_Ym256
+  | Vpsravd_X_X_Xm128
+  | Vpminub_X_X_Xm128
+  | Cvtpd2ps
+  | Pshufb_X_Xm128
+  | Vpcmpeqb_X_X_Xm128
+  | Vmovlhps
+  | Vcvtps2dq_Y_Ym256
+  | Vcvtps2dq_X_Xm128
+  | Sqrtps
+  | Vphminposuw
+  | Movq_Xm64_X
+  | Movlps_m64_X
+  | Crc32_r64_r64m64
+  | Crc32_r32_r32m32
+  | Crc32_r32_r16m16
+  | Vpcmpestri
+  | Phminposuw
+  | Vmovupd_Y_Ym256
+  | Vmovupd_X_Xm128
+  | Vpunpckhbw_X_X_Xm128
+  | Cvtpd2dq
+  | Vbroadcastsd_Y_m64
+  | Vmovhpd_X_X_m64
+  | Vcvttss2si_r64_Xm32
+  | Movsd_Xm64_X
+  | Psrldq
+  | Vpmulhuw_X_X_Xm128
+  | Phsubw_X_Xm128
+  | Vpackusdw_Y_Y_Ym256
+  | Vhsubps_Y_Y_Ym256
+  | Vhsubps_X_X_Xm128
+  | Vpmaxub_X_X_Xm128
+  | Vpsrlw_X_X
+  | Vunpcklpd_Y_Y_Ym256
+  | Vunpcklpd_X_X_Xm128
+  | Minpd
+  | Pmaxub_M_Mm64
+  | Vstmxcsr
+  | Vpsubusw_X_X_Xm128
+  | Phaddsw_M_Mm64
+  | Vpunpckhdq_X_X_Xm128
+  | Cvtsi2sd_X_r32m32
+  | Pinsrb
+  | Vdivsd
+  | Vmovups_Ym256_Y
+  | Vmovups_Xm128_X
+  | Vcvtss2sd
+  | Vpsllvd_Y_Y_Ym256
+  | Vpsllvd_X_X_Xm128
+  | Pcmpgtw
+  | Paddusb
+  | Packuswb
+  | Vphsubd_Y_Y_Ym256
+  | Vpmaxub_Y_Y_Ym256
+  | Cmpps
+  | Cvttsd2si_r32_Xm64
+  | Cvtsd2si_r64_Xm64
+  | Vpcmpgtb_Y_Y_Ym256
+  | Vhsubpd_Y_Y_Ym256
+  | Vhsubpd_X_X_Xm128
+  | Vphsubsw_X_X_Xm128
+  | Pextrw_r64_X
+  | Por
+  | Pext_r64_r64_r64m64
+  | Pext_r32_r32_r32m32
+  | Vpmullw_X_X_Xm128
+  | Pcmpgtq
+  | Vpackuswb_Y_Y_Ym256
+  | Vmovmskpd_r64_Y
+  | Vmovmskpd_r64_X
+  | Psrlw_X_Xm128
+  | Vandnpd_Y_Y_Ym256
+  | Vandnpd_X_X_Xm128
+  | Vpminuw_X_X_Xm128
+  | Cvtps2pd
+  | Vmaxss
+  | Vpsubq_X_X_Xm128
+  | Vpmaxuw_Y_Y_Ym256
+  | Pandn
+  | Vpminsw_Y_Y_Ym256
+  | Vxorps_Y_Y_Ym256
+  | Vxorps_X_X_Xm128
+  | Vpsubsw_Y_Y_Ym256
+  | Vpaddusb_X_X_Xm128
+  | Vmaxpd_Y_Y_Ym256
+  | Vmaxpd_X_X_Xm128
+  | Vpunpckhwd_X_X_Xm128
+  | Punpckldq
+  | Psubb
+  | Vpabsw_X_Xm128
+  | Vpsubusw_Y_Y_Ym256
+  | Pmuludq_X_Xm128
+  | Pmulld
+  | Haddpd
+  | Cmppd
+  | Pcmpeqw
+  | Vpalignr_Y_Y_Ym256
+  | Vmovddup_Y_Ym256
+  | Vmovddup_X_Xm64
+  | Minss
+  | Vaddss
+  | Psraw_X_Xm128
+  | Mulpd
+  | Vpermilps_Y_Ym256
+  | Vpermilps_X_Xm128
+  | Pmuludq_M_Mm64
+  | Pmaxsd
+  | Vpblendw_X_X_Xm128
+  | Vinserti128
+  | Vmovmskps_r64_Y
+  | Vmovmskps_r64_X
+  | Minps
+  | Vpsubd_X_X_Xm128
+  | Vpcmpeqq_Y_Y_Ym256
+  | Maxss
 
 type nonrec instr = id instr
 
-let pmovmskb_r64_X = {
-    id = Pmovmskb_r64_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pmovmskb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 215 }
-}
-let addsubps = {
-    id = Addsubps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "addsubps"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 208 }
-}
-let vpextrw_r64m16_X = {
-    id = Vpextrw_r64m16_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|R64;M16|]; enc = RM_rm }
-  ; imm = true
-  ; mnemonic = "vpextrw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 21 }
-}
-let vpcmpestri = {
-    id = Vpcmpestri
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Pin RAX; enc = Implicit };{ loc = Pin RDX; enc = Implicit }|]
-  ; res = Res { loc = Pin RCX; enc = Implicit }
-  ; imm = true
-  ; mnemonic = "vpcmpestri"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 97 }
-}
-let vpabsd_Y_Ym256 = {
-    id = Vpabsd_Y_Ym256
+let vcvtpd2dq_X_Ym256 = {
+    id = Vcvtpd2dq_X_Ym256
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpabsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 30 }
-}
-let vinsertf128 = {
-    id = Vinsertf128
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vinsertf128"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 24 }
-}
-let psraw_X = {
-    id = Psraw_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "psraw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 4; opcode = 113 }
-}
-let vmulpd_Y_Y_Ym256 = {
-    id = Vmulpd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmulpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 89 }
-}
-let vmulpd_X_X_Xm128 = {
-    id = Vmulpd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmulpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 89 }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtpd2dq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 230 }
 }
-let vpsubw_Y_Y_Ym256 = {
-    id = Vpsubw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsubw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 249 }
-}
-let vpsubw_X_X_Xm128 = {
-    id = Vpsubw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsubw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 249 }
-}
-let vpinsrq = {
-    id = Vpinsrq
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "vpinsrq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = true; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 34 }
-}
-let vunpcklps_Y_Y_Ym256 = {
-    id = Vunpcklps_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vunpcklps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 20 }
-}
-let vunpcklps_X_X_Xm128 = {
-    id = Vunpcklps_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vunpcklps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 20 }
-}
-let movq_Xm64_X = {
-    id = Movq_Xm64_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|XMM;M64|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "movq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 214 }
-}
-let vmaxss = {
-    id = Vmaxss
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmaxss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 95 }
-}
-let vpmovsxdq_Y_Xm128 = {
-    id = Vpmovsxdq_Y_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovsxdq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 37 }
-}
-let vdppd = {
-    id = Vdppd
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vdppd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 65 }
-}
-let sqrtpd = {
-    id = Sqrtpd
+let vcvtpd2dq_X_Xm128 = {
+    id = Vcvtpd2dq_X_Xm128
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "sqrtpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 81 }
-}
-let vpextrd = {
-    id = Vpextrd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|R32;M32|]; enc = RM_rm }
-  ; imm = true
-  ; mnemonic = "vpextrd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 22 }
-}
-let vmaskmovpd_m256_Y_Y = {
-    id = Vmaskmovpd_m256_Y_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M256|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmaskmovpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 47 }
-}
-let vmaskmovpd_m128_X_X = {
-    id = Vmaskmovpd_m128_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmaskmovpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 47 }
-}
-let pmaxub_X_Xm128 = {
-    id = Pmaxub_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmaxub"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 222 }
-}
-let movaps_Xm128_X = {
-    id = Movaps_Xm128_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "movaps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 41 }
-}
-let addsd = {
-    id = Addsd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "addsd"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 88 }
-}
-let vpsrlvq_Y_Y_Ym256 = {
-    id = Vpsrlvq_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsrlvq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 69 }
-}
-let vpsrlvq_X_X_Xm128 = {
-    id = Vpsrlvq_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsrlvq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 69 }
-}
-let rcpps = {
-    id = Rcpps
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "rcpps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 83 }
-}
-let vmovapd_Xm128_X = {
-    id = Vmovapd_Xm128_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovapd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 41 }
-}
-let maxsd = {
-    id = Maxsd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "maxsd"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 95 }
-}
-let subps = {
-    id = Subps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "subps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 92 }
-}
-let vpmulhuw_Y_Y_Ym256 = {
-    id = Vpmulhuw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmulhuw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 228 }
-}
-let vpmulhuw_X_X_Xm128 = {
-    id = Vpmulhuw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmulhuw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 228 }
-}
-let vblendps_Y_Y_Ym256 = {
-    id = Vblendps_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vblendps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 12 }
-}
-let vblendps_X_X_Xm128 = {
-    id = Vblendps_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vblendps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 12 }
-}
-let movd_X_r32m32 = {
-    id = Movd_X_r32m32
-  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "movd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 110 }
-}
-let vpshuflw_Y_Ym256 = {
-    id = Vpshuflw_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vpshuflw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 112 }
-}
-let divss = {
-    id = Divss
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "divss"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 94 }
-}
-let punpckhqdq = {
-    id = Punpckhqdq
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "punpckhqdq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 109 }
-}
-let vpmaxuw_Y_Y_Ym256 = {
-    id = Vpmaxuw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaxuw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 62 }
-}
-let vpmaxuw_X_X_Xm128 = {
-    id = Vpmaxuw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaxuw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 62 }
-}
-let vpsubq_Y_Y_Ym256 = {
-    id = Vpsubq_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsubq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 251 }
-}
-let vpsubq_X_X_Xm128 = {
-    id = Vpsubq_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsubq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 251 }
-}
-let vpmulhrsw_Y_Y_Ym256 = {
-    id = Vpmulhrsw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmulhrsw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 11 }
-}
-let vpmulhrsw_X_X_Xm128 = {
-    id = Vpmulhrsw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmulhrsw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 11 }
-}
-let vdpps_Y_Y_Ym256 = {
-    id = Vdpps_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vdpps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 64 }
-}
-let vdpps_X_X_Xm128 = {
-    id = Vdpps_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vdpps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 64 }
-}
-let shrx_r32_r32m32_r32 = {
-    id = Shrx_r32_r32m32_r32
-  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm };{ loc = Temp [|R32|]; enc = Vex_v }|]
-  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "shrx"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 247 }
-}
-let vpsubusb_Y_Y_Ym256 = {
-    id = Vpsubusb_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsubusb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 216 }
-}
-let vpsubusb_X_X_Xm128 = {
-    id = Vpsubusb_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsubusb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 216 }
-}
-let pextrw_r64_X = {
-    id = Pextrw_r64_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "pextrw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 197 }
-}
-let pcmpeqb = {
-    id = Pcmpeqb
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pcmpeqb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 116 }
-}
-let vmovapd_Ym256_Y = {
-    id = Vmovapd_Ym256_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|YMM;M256|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovapd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 41 }
-}
-let vpermilps_Y_Y_Ym256 = {
-    id = Vpermilps_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpermilps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 12 }
-}
-let vpermilps_X_X_Xm128 = {
-    id = Vpermilps_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpermilps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 12 }
-}
-let vmovshdup_Y_Ym256 = {
-    id = Vmovshdup_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovshdup"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 22 }
-}
-let vpmaddwd_Y_Y_Ym256 = {
-    id = Vpmaddwd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaddwd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 245 }
-}
-let vpmaddwd_X_X_Xm128 = {
-    id = Vpmaddwd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaddwd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 245 }
-}
-let pminud = {
-    id = Pminud
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pminud"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 59 }
-}
-let vpavgb_Y_Y_Ym256 = {
-    id = Vpavgb_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpavgb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 224 }
-}
-let vpavgb_X_X_Xm128 = {
-    id = Vpavgb_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpavgb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 224 }
-}
-let vpackuswb_Y_Y_Ym256 = {
-    id = Vpackuswb_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpackuswb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 103 }
-}
-let vpackuswb_X_X_Xm128 = {
-    id = Vpackuswb_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpackuswb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 103 }
-}
-let movmskpd = {
-    id = Movmskpd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "movmskpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 80 }
-}
-let vpcmpistrm = {
-    id = Vpcmpistrm
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Pin XMM0; enc = Implicit }
-  ; imm = true
-  ; mnemonic = "vpcmpistrm"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 98 }
-}
-let vhaddps_Y_Y_Ym256 = {
-    id = Vhaddps_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vhaddps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 124 }
-}
-let vhaddps_X_X_Xm128 = {
-    id = Vhaddps_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vhaddps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 124 }
-}
-let psllq_X_Xm128 = {
-    id = Psllq_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psllq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 243 }
-}
-let vmovapd_X_Xm128 = {
-    id = Vmovapd_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovapd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 40 }
-}
-let vpunpckldq_Y_Y_Ym256 = {
-    id = Vpunpckldq_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpunpckldq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 98 }
-}
-let vpunpckldq_X_X_Xm128 = {
-    id = Vpunpckldq_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpunpckldq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 98 }
-}
-let movd_X_r32m32 = {
-    id = Movd_X_r32m32
-  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "movd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 126 }
-}
-let vpshufb_Y_Y_Ym256 = {
-    id = Vpshufb_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpshufb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 0 }
-}
-let vpshufb_X_X_Xm128 = {
-    id = Vpshufb_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpshufb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 0 }
-}
-let pinsrb = {
-    id = Pinsrb
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|R32;M8|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "pinsrb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 32 }
-}
-let bzhi_r64_r64m64_r64 = {
-    id = Bzhi_r64_r64m64_r64
-  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm };{ loc = Temp [|R64|]; enc = Vex_v }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "bzhi"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 245 }
-}
-let psllq_X = {
-    id = Psllq_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "psllq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 6; opcode = 115 }
-}
-let vpand_Y_Y_Ym256 = {
-    id = Vpand_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpand"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 219 }
-}
-let vpand_X_X_Xm128 = {
-    id = Vpand_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpand"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 219 }
-}
-let vinsertps = {
-    id = Vinsertps
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vinsertps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 33 }
-}
-let vmaskmovpd_Y_Y_m256 = {
-    id = Vmaskmovpd_Y_Y_m256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmaskmovpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 45 }
-}
-let vmaskmovpd_X_X_m128 = {
-    id = Vmaskmovpd_X_X_m128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmaskmovpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 45 }
-}
-let unpckhps = {
-    id = Unpckhps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "unpckhps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 21 }
-}
-let vpmovzxbq_Y_Xm32 = {
-    id = Vpmovzxbq_Y_Xm32
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovzxbq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 50 }
-}
-let vzeroupper = {
-    id = Vzeroupper
-  ; args = [||]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "vzeroupper"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 119 }
-}
-let vpminub_Y_Y_Ym256 = {
-    id = Vpminub_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpminub"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 218 }
-}
-let vpminub_X_X_Xm128 = {
-    id = Vpminub_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpminub"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 218 }
-}
-let mulpd = {
-    id = Mulpd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "mulpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 89 }
-}
-let vpmaskmovd_Y_Y_m256 = {
-    id = Vpmaskmovd_Y_Y_m256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaskmovd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 140 }
-}
-let vpmaskmovd_X_X_m128 = {
-    id = Vpmaskmovd_X_X_m128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaskmovd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 140 }
-}
-let vroundss = {
-    id = Vroundss
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vroundss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 10 }
-}
-let vpaddq_Y_Y_Ym256 = {
-    id = Vpaddq_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpaddq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 212 }
-}
-let vpaddq_X_X_Xm128 = {
-    id = Vpaddq_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpaddq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 212 }
-}
-let vpsrld_X_X = {
-    id = Vpsrld_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpsrld"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 2; opcode = 114 }
-}
-let phaddsw_M_Mm64 = {
-    id = Phaddsw_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "phaddsw"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 3 }
-}
-let vpinsrd = {
-    id = Vpinsrd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "vpinsrd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 34 }
-}
-let cvtsi2sd_X_r64m64 = {
-    id = Cvtsi2sd_X_r64m64
-  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvtsi2sd"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_w; escape = Esc_0F }; rm_reg = Reg; opcode = 42 }
-}
-let minps = {
-    id = Minps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "minps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 93 }
-}
-let vinserti128 = {
-    id = Vinserti128
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vinserti128"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 56 }
-}
-let pavgw_X_Xm128 = {
-    id = Pavgw_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pavgw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 227 }
-}
-let movups_Xm128_X = {
-    id = Movups_Xm128_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "movups"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 17 }
-}
-let movss_Xm32_X = {
-    id = Movss_Xm32_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|XMM;M32|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "movss"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 17 }
-}
-let blendps = {
-    id = Blendps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "blendps"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 12 }
-}
-let vpandn_Y_Y_Ym256 = {
-    id = Vpandn_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpandn"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 223 }
-}
-let vpandn_X_X_Xm128 = {
-    id = Vpandn_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpandn"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 223 }
-}
-let cvttsd2si_r64_Xm64 = {
-    id = Cvttsd2si_r64_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvttsd2si"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_w; escape = Esc_0F }; rm_reg = Reg; opcode = 44 }
-}
-let movntpd = {
-    id = Movntpd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "movntpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 43 }
-}
-let vmovhpd_X_X_m64 = {
-    id = Vmovhpd_X_X_m64
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovhpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 22 }
-}
-let crc32_r64_r8m8 = {
-    id = Crc32_r64_r8m8
-  ; args = [|{ loc = Temp [|R64|]; enc = RM_r };{ loc = Temp [|R8;M8|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "crc32"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_w; escape = Esc_0F38 }; rm_reg = Reg; opcode = 240 }
-}
-let vcvtdq2pd_Y_Xm128 = {
-    id = Vcvtdq2pd_Y_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtdq2pd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 230 }
-}
-let pcmpeqd = {
-    id = Pcmpeqd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pcmpeqd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 118 }
-}
-let vpsllq_Y_Y = {
-    id = Vpsllq_Y_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpsllq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 6; opcode = 115 }
-}
-let vmovd_X_r32m32 = {
-    id = Vmovd_X_r32m32
-  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 126 }
-}
-let pmulhrsw_M_Mm64 = {
-    id = Pmulhrsw_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmulhrsw"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 11 }
-}
-let vmovd_X_r32m32 = {
-    id = Vmovd_X_r32m32
-  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 110 }
-}
-let vdivpd_Y_Y_Ym256 = {
-    id = Vdivpd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vdivpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 94 }
-}
-let vdivpd_X_X_Xm128 = {
-    id = Vdivpd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vdivpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 94 }
-}
-let vpminud_Y_Y_Ym256 = {
-    id = Vpminud_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpminud"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 59 }
-}
-let vpminud_X_X_Xm128 = {
-    id = Vpminud_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpminud"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 59 }
-}
-let vpmaxsw_Y_Y_Ym256 = {
-    id = Vpmaxsw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaxsw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 238 }
-}
-let vpmaxsw_X_X_Xm128 = {
-    id = Vpmaxsw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaxsw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 238 }
-}
-let vcvttps2dq_Y_Ym256 = {
-    id = Vcvttps2dq_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvttps2dq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 91 }
-}
-let pmuludq_X_Xm128 = {
-    id = Pmuludq_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmuludq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 244 }
-}
-let addps = {
-    id = Addps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "addps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 88 }
-}
-let vmovq_X_Xm64 = {
-    id = Vmovq_X_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 126 }
-}
-let vcomiss = {
-    id = Vcomiss
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcomiss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 47 }
-}
-let vhsubps_Y_Y_Ym256 = {
-    id = Vhsubps_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vhsubps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 125 }
-}
-let vhsubps_X_X_Xm128 = {
-    id = Vhsubps_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vhsubps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 125 }
-}
-let sqrtps = {
-    id = Sqrtps
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "sqrtps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 81 }
-}
-let vminps_Y_Y_Ym256 = {
-    id = Vminps_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vminps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 93 }
-}
-let vminps_X_X_Xm128 = {
-    id = Vminps_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vminps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 93 }
-}
-let pcmpgtb = {
-    id = Pcmpgtb
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pcmpgtb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 100 }
-}
-let vcvtsd2si_r64_Xm64 = {
-    id = Vcvtsd2si_r64_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtsd2si"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = true; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 45 }
-}
-let vpermilpd_Y_Y_Ym256 = {
-    id = Vpermilpd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpermilpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 13 }
-}
-let vpermilpd_X_X_Xm128 = {
-    id = Vpermilpd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpermilpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 13 }
-}
-let vpermd = {
-    id = Vpermd
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpermd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 54 }
-}
-let sqrtsd = {
-    id = Sqrtsd
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "sqrtsd"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 81 }
-}
-let vbroadcastf128 = {
-    id = Vbroadcastf128
-  ; args = [|{ loc = Temp [|M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vbroadcastf128"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 26 }
-}
-let vaddsubps_Y_Y_Ym256 = {
-    id = Vaddsubps_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vaddsubps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 208 }
-}
-let vaddsubps_X_X_Xm128 = {
-    id = Vaddsubps_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vaddsubps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 208 }
-}
-let vpmovsxwd_X_Xm64 = {
-    id = Vpmovsxwd_X_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovsxwd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 35 }
-}
-let vpsrlq_X_X = {
-    id = Vpsrlq_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpsrlq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 2; opcode = 115 }
-}
-let movntdqa = {
-    id = Movntdqa
-  ; args = [|{ loc = Temp [|M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "movntdqa"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 42 }
-}
-let vpmovzxdq_X_Xm64 = {
-    id = Vpmovzxdq_X_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovzxdq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 53 }
-}
-let vpminsw_Y_Y_Ym256 = {
-    id = Vpminsw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpminsw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 234 }
-}
-let vpminsw_X_X_Xm128 = {
-    id = Vpminsw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpminsw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 234 }
-}
-let vpcmpeqb_Y_Y_Ym256 = {
-    id = Vpcmpeqb_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpcmpeqb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 116 }
-}
-let vpcmpeqb_X_X_Xm128 = {
-    id = Vpcmpeqb_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpcmpeqb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 116 }
-}
-let psubsb = {
-    id = Psubsb
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psubsb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 232 }
-}
-let roundss = {
-    id = Roundss
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "roundss"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 10 }
-}
-let vpmovzxbd_X_Xm32 = {
-    id = Vpmovzxbd_X_Xm32
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovzxbd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 49 }
-}
-let pext_r32_r32_r32m32 = {
-    id = Pext_r32_r32_r32m32
-  ; args = [|{ loc = Temp [|R32|]; enc = Vex_v };{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pext"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 245 }
-}
-let vpsignw_Y_Y_Ym256 = {
-    id = Vpsignw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsignw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 9 }
-}
-let vpsignw_X_X_Xm128 = {
-    id = Vpsignw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsignw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 9 }
-}
-let pinsrd = {
-    id = Pinsrd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "pinsrd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 34 }
-}
-let vphaddd_Y_Y_Ym256 = {
-    id = Vphaddd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vphaddd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 2 }
-}
-let vphaddd_X_X_Xm128 = {
-    id = Vphaddd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vphaddd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 2 }
-}
-let vucomiss = {
-    id = Vucomiss
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "vucomiss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 46 }
-}
-let subpd = {
-    id = Subpd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "subpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 92 }
-}
-let pmulhw = {
-    id = Pmulhw
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmulhw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 229 }
-}
-let vpmovzxbw_Y_Xm128 = {
-    id = Vpmovzxbw_Y_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovzxbw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 48 }
-}
-let pminsw_M_Mm64 = {
-    id = Pminsw_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pminsw"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 234 }
-}
-let vminsd = {
-    id = Vminsd
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vminsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 93 }
-}
-let vmovups_Xm128_X = {
-    id = Vmovups_Xm128_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovups"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 17 }
-}
-let vlddqu_Y_m256 = {
-    id = Vlddqu_Y_m256
-  ; args = [|{ loc = Temp [|M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vlddqu"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 240 }
-}
-let vhaddpd_Y_Y_Ym256 = {
-    id = Vhaddpd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vhaddpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 124 }
-}
-let vhaddpd_X_X_Xm128 = {
-    id = Vhaddpd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vhaddpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 124 }
-}
-let vsqrtps_X_Xm128 = {
-    id = Vsqrtps_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vsqrtps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 81 }
-}
-let vpsrld_Y_Y = {
-    id = Vpsrld_Y_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpsrld"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 2; opcode = 114 }
-}
-let paddusw = {
-    id = Paddusw
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "paddusw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 221 }
-}
-let cvtsi2ss_X_r32m32 = {
-    id = Cvtsi2ss_X_r32m32
-  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvtsi2ss"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 42 }
-}
-let blendvpd = {
-    id = Blendvpd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Pin XMM0; enc = Implicit }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "blendvpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 21 }
-}
-let vcvtss2si_r64_Xm32 = {
-    id = Vcvtss2si_r64_Xm32
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtss2si"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = true; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 45 }
-}
-let movsd_X_m64 = {
-    id = Movsd_X_m64
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "movsd"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 16 }
-}
-let movsd_X_X = {
-    id = Movsd_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "movsd"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 16 }
-}
-let ptest = {
-    id = Ptest
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "ptest"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 23 }
-}
-let pext_r64_r64_r64m64 = {
-    id = Pext_r64_r64_r64m64
-  ; args = [|{ loc = Temp [|R64|]; enc = Vex_v };{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pext"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 245 }
-}
-let vcvttps2dq_X_Xm128 = {
-    id = Vcvttps2dq_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvttps2dq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 91 }
-}
-let vpcmpgtq_Y_Y_Ym256 = {
-    id = Vpcmpgtq_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpcmpgtq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 55 }
-}
-let vpcmpgtq_X_X_Xm128 = {
-    id = Vpcmpgtq_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpcmpgtq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 55 }
-}
-let rcpss = {
-    id = Rcpss
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "rcpss"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 83 }
-}
-let movhpd_X_m64 = {
-    id = Movhpd_X_m64
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "movhpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 22 }
-}
-let vmovaps_Ym256_Y = {
-    id = Vmovaps_Ym256_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|YMM;M256|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovaps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 41 }
-}
-let vcomisd = {
-    id = Vcomisd
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcomisd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 47 }
-}
-let vpsrlvd_Y_Y_Ym256 = {
-    id = Vpsrlvd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsrlvd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 69 }
-}
-let vpsrlvd_X_X_Xm128 = {
-    id = Vpsrlvd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsrlvd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 69 }
-}
-let vpbroadcastq_X_Xm64 = {
-    id = Vpbroadcastq_X_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpbroadcastq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 89 }
-}
-let vpmaddubsw_Y_Y_Ym256 = {
-    id = Vpmaddubsw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaddubsw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 4 }
-}
-let vpmaddubsw_X_X_Xm128 = {
-    id = Vpmaddubsw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaddubsw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 4 }
-}
-let vpsllvq_Y_Y_Ym256 = {
-    id = Vpsllvq_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsllvq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 71 }
-}
-let vpsllvq_X_X_Xm128 = {
-    id = Vpsllvq_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsllvq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 71 }
-}
-let psignw_X_Xm128 = {
-    id = Psignw_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psignw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 9 }
-}
-let pmulld = {
-    id = Pmulld
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmulld"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 64 }
-}
-let vmovapd_Y_Ym256 = {
-    id = Vmovapd_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovapd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 40 }
-}
-let vmovlhps = {
-    id = Vmovlhps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "vmovlhps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 22 }
-}
-let vpshufd_Y_Ym256 = {
-    id = Vpshufd_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vpshufd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 112 }
-}
-let vmulss = {
-    id = Vmulss
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmulss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 89 }
-}
-let vpsignd_Y_Y_Ym256 = {
-    id = Vpsignd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsignd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 10 }
-}
-let vpsignd_X_X_Xm128 = {
-    id = Vpsignd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsignd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 10 }
-}
-let vcvttss2si_r32_Xm32 = {
-    id = Vcvttss2si_r32_Xm32
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvttss2si"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 44 }
-}
-let vextractps = {
-    id = Vextractps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|R64;M32|]; enc = RM_rm }
-  ; imm = true
-  ; mnemonic = "vextractps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 23 }
-}
-let vpmaxsb_Y_Y_Ym256 = {
-    id = Vpmaxsb_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaxsb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 60 }
-}
-let vpmaxsb_X_X_Xm128 = {
-    id = Vpmaxsb_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaxsb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 60 }
-}
-let vpsllw_Y_Y_Xm128 = {
-    id = Vpsllw_Y_Y_Xm128
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsllw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 241 }
-}
-let vpsllw_X_X_Xm128 = {
-    id = Vpsllw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsllw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 241 }
-}
-let vpmovzxwd_Y_Xm128 = {
-    id = Vpmovzxwd_Y_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovzxwd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 51 }
-}
-let phaddsw_X_Xm128 = {
-    id = Phaddsw_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "phaddsw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 3 }
-}
-let vpunpckhqdq_Y_Y_Ym256 = {
-    id = Vpunpckhqdq_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpunpckhqdq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 109 }
-}
-let vpunpckhqdq_X_X_Xm128 = {
-    id = Vpunpckhqdq_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpunpckhqdq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 109 }
-}
-let pshufd = {
-    id = Pshufd
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "pshufd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 112 }
-}
-let vmovmskpd_r64_X = {
-    id = Vmovmskpd_r64_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovmskpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 80 }
-}
-let pdep_r32_r32_r32m32 = {
-    id = Pdep_r32_r32_r32m32
-  ; args = [|{ loc = Temp [|R32|]; enc = Vex_v };{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pdep"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 245 }
-}
-let vmovhpd_m64_X = {
-    id = Vmovhpd_m64_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M64|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovhpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 23 }
-}
-let pmovsxbw = {
-    id = Pmovsxbw
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pmovsxbw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 32 }
-}
-let vmovss_X_X_X = {
-    id = Vmovss_X_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 17 }
-}
-let vpabsw_Y_Ym256 = {
-    id = Vpabsw_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpabsw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 29 }
-}
-let movupd_Xm128_X = {
-    id = Movupd_Xm128_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "movupd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 17 }
-}
-let movntdq = {
-    id = Movntdq
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "movntdq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 231 }
-}
-let vmaskmovdqu = {
-    id = Vmaskmovdqu
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "vmaskmovdqu"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 247 }
-}
-let vorpd_Y_Y_Ym256 = {
-    id = Vorpd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vorpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 86 }
-}
-let vorpd_X_X_Xm128 = {
-    id = Vorpd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vorpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 86 }
-}
-let vcmpsd = {
-    id = Vcmpsd
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vcmpsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 194 }
-}
-let crc32_r32_r32m32 = {
-    id = Crc32_r32_r32m32
-  ; args = [|{ loc = Temp [|R32|]; enc = RM_r };{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "crc32"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 241 }
-}
-let crc32_r32_r16m16 = {
-    id = Crc32_r32_r16m16
-  ; args = [|{ loc = Temp [|R32|]; enc = RM_r };{ loc = Temp [|R16;M16|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "crc32"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 241 }
-}
-let vpermpd = {
-    id = Vpermpd
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vpermpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = true; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 1 }
-}
-let vpunpckhdq_Y_Y_Ym256 = {
-    id = Vpunpckhdq_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpunpckhdq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 106 }
-}
-let vpunpckhdq_X_X_Xm128 = {
-    id = Vpunpckhdq_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpunpckhdq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 106 }
-}
-let psrldq = {
-    id = Psrldq
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "psrldq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 3; opcode = 115 }
-}
-let vpextrq = {
-    id = Vpextrq
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|R64;M64|]; enc = RM_rm }
-  ; imm = true
-  ; mnemonic = "vpextrq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = true; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 22 }
-}
-let pabsb_M_Mm64 = {
-    id = Pabsb_M_Mm64
-  ; args = [|{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|MM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pabsb"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 28 }
-}
-let vroundsd = {
-    id = Vroundsd
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vroundsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 11 }
-}
-let pcmpeqq = {
-    id = Pcmpeqq
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pcmpeqq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 41 }
-}
-let vmovdqu_X_Xm128 = {
-    id = Vmovdqu_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovdqu"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 111 }
-}
-let vcvtsd2si_r32_Xm64 = {
-    id = Vcvtsd2si_r32_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtsd2si"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 45 }
-}
-let vmovmskpd_r64_Y = {
-    id = Vmovmskpd_r64_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovmskpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 80 }
-}
-let vcvttsd2si_r32_Xm64 = {
-    id = Vcvttsd2si_r32_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvttsd2si"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 44 }
-}
-let vpsubsb_Y_Y_Ym256 = {
-    id = Vpsubsb_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsubsb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 232 }
-}
-let vpsubsb_X_X_Xm128 = {
-    id = Vpsubsb_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsubsb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 232 }
-}
-let paddusb = {
-    id = Paddusb
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "paddusb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 220 }
-}
-let cvtpd2ps = {
-    id = Cvtpd2ps
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvtpd2ps"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 90 }
-}
-let psraw_X_Xm128 = {
-    id = Psraw_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psraw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 225 }
-}
-let vldmxcsr = {
-    id = Vldmxcsr
-  ; args = [|{ loc = Temp [|M32|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "vldmxcsr"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Spec 2; opcode = 174 }
-}
-let vmovsd_X_X_X = {
-    id = Vmovsd_X_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 17 }
-}
-let vmovsldup_Y_Ym256 = {
-    id = Vmovsldup_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovsldup"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 18 }
-}
-let shlx_r64_r64m64_r64 = {
-    id = Shlx_r64_r64m64_r64
-  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm };{ loc = Temp [|R64|]; enc = Vex_v }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "shlx"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 247 }
-}
-let vcvttsd2si_r64_Xm64 = {
-    id = Vcvttsd2si_r64_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvttsd2si"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = true; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 44 }
-}
-let vpsllvd_Y_Y_Ym256 = {
-    id = Vpsllvd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsllvd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 71 }
-}
-let vpsllvd_X_X_Xm128 = {
-    id = Vpsllvd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsllvd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 71 }
-}
-let phsubsw_X_Xm128 = {
-    id = Phsubsw_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "phsubsw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 7 }
-}
-let psubb = {
-    id = Psubb
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psubb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 248 }
-}
-let vpmaxub_Y_Y_Ym256 = {
-    id = Vpmaxub_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaxub"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 222 }
-}
-let vpmaxub_X_X_Xm128 = {
-    id = Vpmaxub_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaxub"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 222 }
-}
-let paddd = {
-    id = Paddd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "paddd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 254 }
-}
-let movmskps = {
-    id = Movmskps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "movmskps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 80 }
-}
-let vminpd_Y_Y_Ym256 = {
-    id = Vminpd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vminpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 93 }
-}
-let vminpd_X_X_Xm128 = {
-    id = Vminpd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vminpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 93 }
-}
-let psrld_X = {
-    id = Psrld_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "psrld"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 2; opcode = 114 }
-}
-let movdqu_X_Xm128 = {
-    id = Movdqu_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "movdqu"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 111 }
-}
-let subsd = {
-    id = Subsd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "subsd"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 92 }
-}
-let vpmovmskb_r64_X = {
-    id = Vpmovmskb_r64_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovmskb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 215 }
-}
-let extractps = {
-    id = Extractps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|R64;M32|]; enc = RM_rm }
-  ; imm = true
-  ; mnemonic = "extractps"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 23 }
-}
-let crc32_r32_r8m8 = {
-    id = Crc32_r32_r8m8
-  ; args = [|{ loc = Temp [|R32|]; enc = RM_r };{ loc = Temp [|R8;M8|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "crc32"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 240 }
-}
-let psubq_X_Xm128 = {
-    id = Psubq_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psubq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 251 }
-}
-let vmovaps_Xm128_X = {
-    id = Vmovaps_Xm128_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovaps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 41 }
-}
-let movapd_Xm128_X = {
-    id = Movapd_Xm128_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "movapd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 41 }
-}
-let vmovsd_m64_X = {
-    id = Vmovsd_m64_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M64|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 17 }
-}
-let vpmovsxwd_Y_Xm128 = {
-    id = Vpmovsxwd_Y_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovsxwd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 35 }
-}
-let vpsrlw_Y_Y_Xm128 = {
-    id = Vpsrlw_Y_Y_Xm128
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsrlw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 209 }
-}
-let vpsrlw_X_X_Xm128 = {
-    id = Vpsrlw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsrlw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 209 }
-}
-let pmaxsd = {
-    id = Pmaxsd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmaxsd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 61 }
-}
-let paddw = {
-    id = Paddw
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "paddw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 253 }
-}
-let cvttss2si_r32_Xm32 = {
-    id = Cvttss2si_r32_Xm32
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvttss2si"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 44 }
-}
-let vpmaxsd_Y_Y_Ym256 = {
-    id = Vpmaxsd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaxsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 61 }
-}
-let vpmaxsd_X_X_Xm128 = {
-    id = Vpmaxsd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaxsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 61 }
-}
-let movlhps = {
-    id = Movlhps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "movlhps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 22 }
-}
-let vmpsadbw_Y_Y_Ym256 = {
-    id = Vmpsadbw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vmpsadbw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 66 }
-}
-let vmpsadbw_X_X_Xm128 = {
-    id = Vmpsadbw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vmpsadbw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 66 }
-}
-let vpinsrb = {
-    id = Vpinsrb
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|R32;M8|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "vpinsrb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 32 }
-}
-let cvtsd2si_r64_Xm64 = {
-    id = Cvtsd2si_r64_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvtsd2si"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_w; escape = Esc_0F }; rm_reg = Reg; opcode = 45 }
-}
-let pmovsxbq = {
-    id = Pmovsxbq
-  ; args = [|{ loc = Temp [|XMM;M16|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pmovsxbq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 34 }
-}
-let pslldq = {
-    id = Pslldq
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "pslldq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 7; opcode = 115 }
-}
-let pmaddwd = {
-    id = Pmaddwd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmaddwd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 245 }
-}
-let vdivss = {
-    id = Vdivss
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vdivss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 94 }
-}
-let pmovsxbd = {
-    id = Pmovsxbd
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pmovsxbd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 33 }
-}
-let vphsubw_Y_Y_Ym256 = {
-    id = Vphsubw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r };{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "vphsubw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 5 }
-}
-let vphsubw_X_X_Xm128 = {
-    id = Vphsubw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "vphsubw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 5 }
-}
-let vaddsubpd_Y_Y_Ym256 = {
-    id = Vaddsubpd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vaddsubpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 208 }
-}
-let vaddsubpd_X_X_Xm128 = {
-    id = Vaddsubpd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vaddsubpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 208 }
-}
-let vpsrlq_Y_Y_Xm128 = {
-    id = Vpsrlq_Y_Y_Xm128
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsrlq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 211 }
-}
-let vpsrlq_X_X_Xm128 = {
-    id = Vpsrlq_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsrlq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 211 }
-}
-let pmulhuw_X_Xm128 = {
-    id = Pmulhuw_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmulhuw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 228 }
-}
-let psrlq_X = {
-    id = Psrlq_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "psrlq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 2; opcode = 115 }
-}
-let vmovaps_Y_Ym256 = {
-    id = Vmovaps_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovaps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 40 }
-}
-let vcvtss2si_r32_Xm32 = {
-    id = Vcvtss2si_r32_Xm32
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtss2si"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 45 }
-}
-let cvtsd2si_r32_Xm64 = {
-    id = Cvtsd2si_r32_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvtsd2si"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 45 }
-}
-let vrcpps_X_Xm128 = {
-    id = Vrcpps_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vrcpps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 83 }
-}
-let vpackssdw_Y_Y_Ym256 = {
-    id = Vpackssdw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpackssdw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 107 }
-}
-let vpackssdw_X_X_Xm128 = {
-    id = Vpackssdw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpackssdw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 107 }
-}
-let vbroadcastsd_Y_X = {
-    id = Vbroadcastsd_Y_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vbroadcastsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 25 }
-}
-let vbroadcastsd_Y_m64 = {
-    id = Vbroadcastsd_Y_m64
-  ; args = [|{ loc = Temp [|M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vbroadcastsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 25 }
-}
-let roundsd = {
-    id = Roundsd
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "roundsd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 11 }
-}
-let por = {
-    id = Por
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "por"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 235 }
-}
-let vucomisd = {
-    id = Vucomisd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "vucomisd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 46 }
-}
-let vaddss = {
-    id = Vaddss
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vaddss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 88 }
-}
-let vpshufhw_Y_Ym256 = {
-    id = Vpshufhw_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vpshufhw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 112 }
-}
-let vcmpss = {
-    id = Vcmpss
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vcmpss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 194 }
-}
-let punpckhbw = {
-    id = Punpckhbw
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "punpckhbw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 104 }
-}
-let pmaxud = {
-    id = Pmaxud
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmaxud"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 63 }
-}
-let vpabsb_X_Xm128 = {
-    id = Vpabsb_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpabsb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 28 }
-}
-let psllw_X = {
-    id = Psllw_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "psllw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 6; opcode = 113 }
-}
-let vmovdqu_X_Xm128 = {
-    id = Vmovdqu_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovdqu"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 127 }
-}
-let vlddqu_X_m128 = {
-    id = Vlddqu_X_m128
-  ; args = [|{ loc = Temp [|M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vlddqu"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 240 }
-}
-let vpmulld_Y_Y_Ym256 = {
-    id = Vpmulld_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmulld"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 64 }
-}
-let vpmulld_X_X_Xm128 = {
-    id = Vpmulld_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmulld"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 64 }
-}
-let movsldup = {
-    id = Movsldup
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "movsldup"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 18 }
-}
-let psubd = {
-    id = Psubd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psubd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 250 }
-}
-let movq_X_r64m64 = {
-    id = Movq_X_r64m64
-  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "movq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_w; escape = Esc_0F }; rm_reg = Reg; opcode = 110 }
-}
-let vperm2f128 = {
-    id = Vperm2f128
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vperm2f128"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 6 }
-}
-let vsubpd_Y_Y_Ym256 = {
-    id = Vsubpd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vsubpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 92 }
-}
-let vsubpd_X_X_Xm128 = {
-    id = Vsubpd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vsubpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 92 }
-}
-let vpmaskmovq_m256_Y_Y = {
-    id = Vpmaskmovq_m256_Y_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M256|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vpmaskmovq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 142 }
-}
-let vpmaskmovq_m128_X_X = {
-    id = Vpmaskmovq_m128_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vpmaskmovq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 142 }
-}
-let xorpd = {
-    id = Xorpd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "xorpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 87 }
-}
-let vpunpcklqdq_Y_Y_Ym256 = {
-    id = Vpunpcklqdq_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpunpcklqdq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 108 }
-}
-let vpunpcklqdq_X_X_Xm128 = {
-    id = Vpunpcklqdq_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpunpcklqdq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 108 }
-}
-let pmaddubsw_M_Mm64 = {
-    id = Pmaddubsw_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmaddubsw"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 4 }
-}
-let pmaxuw = {
-    id = Pmaxuw
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmaxuw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 62 }
-}
-let vpextrb = {
-    id = Vpextrb
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|R64;M8|]; enc = RM_rm }
-  ; imm = true
-  ; mnemonic = "vpextrb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 20 }
-}
-let vandnpd_Y_Y_Ym256 = {
-    id = Vandnpd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vandnpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 85 }
-}
-let vandnpd_X_X_Xm128 = {
-    id = Vandnpd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vandnpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 85 }
-}
-let vpmaskmovd_m256_Y_Y = {
-    id = Vpmaskmovd_m256_Y_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M256|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vpmaskmovd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 142 }
-}
-let vpmaskmovd_m128_X_X = {
-    id = Vpmaskmovd_m128_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vpmaskmovd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 142 }
-}
-let cvtsi2ss_X_r64m64 = {
-    id = Cvtsi2ss_X_r64m64
-  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvtsi2ss"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_w; escape = Esc_0F }; rm_reg = Reg; opcode = 42 }
-}
-let psrad_X = {
-    id = Psrad_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "psrad"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 4; opcode = 114 }
-}
-let vrsqrtss = {
-    id = Vrsqrtss
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vrsqrtss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 82 }
-}
-let vandpd_Y_Y_Ym256 = {
-    id = Vandpd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vandpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 84 }
-}
-let vandpd_X_X_Xm128 = {
-    id = Vandpd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vandpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 84 }
-}
-let vpor_Y_Y_Ym256 = {
-    id = Vpor_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpor"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 235 }
-}
-let vpor_X_X_Xm128 = {
-    id = Vpor_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpor"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 235 }
-}
-let pextrd = {
-    id = Pextrd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|R32;M32|]; enc = RM_rm }
-  ; imm = true
-  ; mnemonic = "pextrd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 22 }
-}
-let vmovntdq_m256_Y = {
-    id = Vmovntdq_m256_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M256|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovntdq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 231 }
-}
-let pcmpestrm = {
-    id = Pcmpestrm
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Pin RAX; enc = Implicit };{ loc = Pin RDX; enc = Implicit }|]
-  ; res = Res { loc = Pin XMM0; enc = Implicit }
-  ; imm = true
-  ; mnemonic = "pcmpestrm"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 96 }
-}
-let vxorps_Y_Y_Ym256 = {
-    id = Vxorps_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vxorps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 87 }
-}
-let vxorps_X_X_Xm128 = {
-    id = Vxorps_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vxorps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 87 }
-}
-let rsqrtss = {
-    id = Rsqrtss
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "rsqrtss"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 82 }
-}
-let psignd_X_Xm128 = {
-    id = Psignd_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psignd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 10 }
-}
-let vpunpckhwd_Y_Y_Ym256 = {
-    id = Vpunpckhwd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpunpckhwd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 105 }
-}
-let vpunpckhwd_X_X_Xm128 = {
-    id = Vpunpckhwd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpunpckhwd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 105 }
-}
-let pmullw = {
-    id = Pmullw
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmullw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 213 }
-}
-let vmovss_m32_X = {
-    id = Vmovss_m32_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M32|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 17 }
-}
-let vmovdqu_Y_Ym256 = {
-    id = Vmovdqu_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovdqu"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 111 }
-}
-let vshufpd_Y_Y_Ym256 = {
-    id = Vshufpd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vshufpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 198 }
-}
-let vshufpd_X_X_Xm128 = {
-    id = Vshufpd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vshufpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 198 }
-}
-let pabsd_X_Xm128 = {
-    id = Pabsd_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pabsd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 30 }
-}
-let vpermq = {
-    id = Vpermq
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vpermq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = true; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 0 }
-}
-let vpaddw_Y_Y_Ym256 = {
-    id = Vpaddw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpaddw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 253 }
-}
-let vpaddw_X_X_Xm128 = {
-    id = Vpaddw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpaddw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 253 }
-}
-let phaddd_M_Mm64 = {
-    id = Phaddd_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "phaddd"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 2 }
-}
-let vmovntps_m256_Y = {
-    id = Vmovntps_m256_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M256|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovntps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 43 }
-}
-let cvtps2pd = {
-    id = Cvtps2pd
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvtps2pd"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 90 }
-}
-let vcmppd_Y_Y_Ym256 = {
-    id = Vcmppd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vcmppd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 194 }
-}
-let vcmppd_X_X_Xm128 = {
-    id = Vcmppd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vcmppd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 194 }
-}
-let andnps = {
-    id = Andnps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "andnps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 85 }
-}
-let sqrtss = {
-    id = Sqrtss
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "sqrtss"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 81 }
-}
-let phaddw_X_Xm128 = {
-    id = Phaddw_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "phaddw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 1 }
-}
-let vpmaskmovq_Y_Y_m256 = {
-    id = Vpmaskmovq_Y_Y_m256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaskmovq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 140 }
-}
-let vpmaskmovq_X_X_m128 = {
-    id = Vpmaskmovq_X_X_m128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaskmovq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 140 }
-}
-let addpd = {
-    id = Addpd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "addpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 88 }
-}
-let vpalignr_Y_Y_Ym256 = {
-    id = Vpalignr_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vpalignr"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 15 }
-}
-let vpalignr_X_X_Xm128 = {
-    id = Vpalignr_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vpalignr"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 15 }
-}
-let vrcpss = {
-    id = Vrcpss
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vrcpss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 83 }
-}
-let pmovzxdq = {
-    id = Pmovzxdq
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pmovzxdq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 53 }
-}
-let vmovntpd_m256_Y = {
-    id = Vmovntpd_m256_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M256|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovntpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 43 }
-}
-let shufpd = {
-    id = Shufpd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "shufpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 198 }
-}
-let vpsrad_Y_Y = {
-    id = Vpsrad_Y_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpsrad"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 4; opcode = 114 }
-}
-let vpbroadcastd_Y_Xm32 = {
-    id = Vpbroadcastd_Y_Xm32
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpbroadcastd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 88 }
-}
-let vmovups_X_Xm128 = {
-    id = Vmovups_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovups"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 16 }
-}
-let vmovhps_X_X_m64 = {
-    id = Vmovhps_X_X_m64
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovhps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 22 }
-}
-let pinsrw_X_r32m16 = {
-    id = Pinsrw_X_r32m16
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|R32;M16|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "pinsrw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 196 }
-}
-let psignw_M_Mm64 = {
-    id = Psignw_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psignw"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 9 }
-}
-let phsubd_X_Xm128 = {
-    id = Phsubd_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "phsubd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 6 }
-}
-let vpcmpestrm = {
-    id = Vpcmpestrm
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Pin RAX; enc = Implicit };{ loc = Pin RDX; enc = Implicit }|]
-  ; res = Res { loc = Pin XMM0; enc = Implicit }
-  ; imm = true
-  ; mnemonic = "vpcmpestrm"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 96 }
-}
-let vmovddup_X_Xm64 = {
-    id = Vmovddup_X_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovddup"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 18 }
-}
-let shlx_r32_r32m32_r32 = {
-    id = Shlx_r32_r32m32_r32
-  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm };{ loc = Temp [|R32|]; enc = Vex_v }|]
-  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "shlx"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 247 }
-}
-let vpsrad_Y_Y_Xm128 = {
-    id = Vpsrad_Y_Y_Xm128
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsrad"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 226 }
-}
-let vpsrad_X_X_Xm128 = {
-    id = Vpsrad_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsrad"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 226 }
-}
-let vpmovzxwq_X_Xm32 = {
-    id = Vpmovzxwq_X_Xm32
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovzxwq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 52 }
-}
-let vbroadcastss_Y_X = {
-    id = Vbroadcastss_Y_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vbroadcastss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 24 }
-}
-let vbroadcastss_Y_m32 = {
-    id = Vbroadcastss_Y_m32
-  ; args = [|{ loc = Temp [|M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vbroadcastss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 24 }
-}
-let punpcklbw = {
-    id = Punpcklbw
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "punpcklbw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 96 }
-}
-let paddb = {
-    id = Paddb
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "paddb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 252 }
-}
-let pminsw_X_Xm128 = {
-    id = Pminsw_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pminsw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 234 }
-}
-let vpextrw_r64_X = {
-    id = Vpextrw_r64_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vpextrw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 197 }
-}
-let cvtpd2dq = {
-    id = Cvtpd2dq
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvtpd2dq"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 230 }
-}
-let vpcmpgtw_Y_Y_Ym256 = {
-    id = Vpcmpgtw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpcmpgtw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 101 }
-}
-let vpcmpgtw_X_X_Xm128 = {
-    id = Vpcmpgtw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpcmpgtw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 101 }
-}
-let vpmaxud_Y_Y_Ym256 = {
-    id = Vpmaxud_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaxud"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 63 }
-}
-let vpmaxud_X_X_Xm128 = {
-    id = Vpmaxud_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmaxud"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 63 }
-}
-let vpsadbw_Y_Y_Ym256 = {
-    id = Vpsadbw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsadbw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 246 }
-}
-let vpsadbw_X_X_Xm128 = {
-    id = Vpsadbw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsadbw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 246 }
-}
-let vpmuldq_Y_Y_Ym256 = {
-    id = Vpmuldq_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmuldq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 40 }
-}
-let vpmuldq_X_X_Xm128 = {
-    id = Vpmuldq_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmuldq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 40 }
-}
-let psadbw_X_Xm128 = {
-    id = Psadbw_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psadbw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 246 }
-}
-let vpsraw_Y_Y = {
-    id = Vpsraw_Y_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpsraw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 4; opcode = 113 }
-}
-let vandnps_Y_Y_Ym256 = {
-    id = Vandnps_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vandnps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 85 }
-}
-let vandnps_X_X_Xm128 = {
-    id = Vandnps_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vandnps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 85 }
-}
-let vpsrldq_Y_Y = {
-    id = Vpsrldq_Y_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpsrldq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 3; opcode = 115 }
-}
-let pmovsxdq = {
-    id = Pmovsxdq
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pmovsxdq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 37 }
-}
-let haddpd = {
-    id = Haddpd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "haddpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 124 }
-}
-let vpsraw_Y_Y_Xm128 = {
-    id = Vpsraw_Y_Y_Xm128
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsraw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 225 }
-}
-let vpsraw_X_X_Xm128 = {
-    id = Vpsraw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsraw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 225 }
-}
-let vmovups_Ym256_Y = {
-    id = Vmovups_Ym256_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|YMM;M256|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovups"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 17 }
-}
-let vphsubsw_Y_Y_Ym256 = {
-    id = Vphsubsw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r };{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "vphsubsw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 7 }
-}
-let vphsubsw_X_X_Xm128 = {
-    id = Vphsubsw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "vphsubsw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 7 }
-}
-let mulss = {
-    id = Mulss
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "mulss"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 89 }
-}
-let vpmovsxbq_X_Xm16 = {
-    id = Vpmovsxbq_X_Xm16
-  ; args = [|{ loc = Temp [|XMM;M16|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovsxbq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 34 }
-}
-let cmpsd = {
-    id = Cmpsd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "cmpsd"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 194 }
-}
-let movddup = {
-    id = Movddup
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "movddup"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 18 }
-}
-let cvtsi2sd_X_r32m32 = {
-    id = Cvtsi2sd_X_r32m32
-  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvtsi2sd"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 42 }
-}
-let cvtss2sd = {
-    id = Cvtss2sd
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvtss2sd"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 90 }
-}
-let andpd = {
-    id = Andpd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "andpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 84 }
-}
-let pminuw = {
-    id = Pminuw
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pminuw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 58 }
-}
-let psrad_X_Xm128 = {
-    id = Psrad_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psrad"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 226 }
-}
-let packusdw = {
-    id = Packusdw
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "packusdw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 43 }
-}
-let vpcmpeqd_Y_Y_Ym256 = {
-    id = Vpcmpeqd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpcmpeqd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 118 }
-}
-let vpcmpeqd_X_X_Xm128 = {
-    id = Vpcmpeqd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpcmpeqd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 118 }
-}
-let phsubw_X_Xm128 = {
-    id = Phsubw_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "phsubw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 5 }
-}
-let rorx_r32_r32m32 = {
-    id = Rorx_r32_r32m32
-  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "rorx"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 240 }
-}
-let pclmulqdq = {
-    id = Pclmulqdq
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "pclmulqdq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 68 }
-}
-let vrsqrtps_X_Xm128 = {
-    id = Vrsqrtps_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vrsqrtps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 82 }
-}
-let pshufb_M_Mm64 = {
-    id = Pshufb_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pshufb"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 0 }
-}
-let phaddw_M_Mm64 = {
-    id = Phaddw_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "phaddw"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 1 }
-}
-let vmovntps_m128_X = {
-    id = Vmovntps_m128_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovntps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 43 }
-}
-let vpermps = {
-    id = Vpermps
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpermps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 22 }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtpd2dq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 230 }
 }
 let paddsw = {
     id = Paddsw
+  ; ext = [|SSE2|]
   ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = First_arg
-  ; imm = false
+  ; imm = Imm_none
   ; mnemonic = "paddsw"
   ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 237 }
 }
-let vcvttpd2dq_X_Xm128 = {
-    id = Vcvttpd2dq_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvttpd2dq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 230 }
-}
-let phminposuw = {
-    id = Phminposuw
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "phminposuw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 65 }
-}
-let pminsb = {
-    id = Pminsb
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pminsb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 56 }
-}
-let vmovlpd_X_X_m64 = {
-    id = Vmovlpd_X_X_m64
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "vmovlpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 18 }
-}
-let vpbroadcastb_X_Xm8 = {
-    id = Vpbroadcastb_X_Xm8
-  ; args = [|{ loc = Temp [|XMM;M8|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpbroadcastb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 120 }
-}
-let rorx_r64_r64m64 = {
-    id = Rorx_r64_r64m64
-  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "rorx"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = true; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 240 }
-}
-let vpsrlw_X_X = {
-    id = Vpsrlw_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpsrlw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 2; opcode = 113 }
-}
-let pblendw = {
-    id = Pblendw
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "pblendw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 14 }
-}
-let vhsubpd_Y_Y_Ym256 = {
-    id = Vhsubpd_Y_Y_Ym256
+let vpmuldq_Y_Y_Ym256 = {
+    id = Vpmuldq_Y_Y_Ym256
+  ; ext = [|AVX2|]
   ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vhsubpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 125 }
-}
-let vhsubpd_X_X_Xm128 = {
-    id = Vhsubpd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vhsubpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 125 }
-}
-let vsqrtpd_X_Xm128 = {
-    id = Vsqrtpd_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vsqrtpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 81 }
-}
-let vcvtps2pd_Y_Xm128 = {
-    id = Vcvtps2pd_Y_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtps2pd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 90 }
-}
-let andnpd = {
-    id = Andnpd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "andnpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 85 }
-}
-let pextrb = {
-    id = Pextrb
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|R64;M8|]; enc = RM_rm }
-  ; imm = true
-  ; mnemonic = "pextrb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 20 }
-}
-let vpaddb_Y_Y_Ym256 = {
-    id = Vpaddb_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpaddb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 252 }
-}
-let vpaddb_X_X_Xm128 = {
-    id = Vpaddb_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpaddb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 252 }
-}
-let vmovntpd_m128_X = {
-    id = Vmovntpd_m128_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovntpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 43 }
-}
-let vcvtsi2sd_X_X_r32m32 = {
-    id = Vcvtsi2sd_X_X_r32m32
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtsi2sd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 42 }
-}
-let mulsd = {
-    id = Mulsd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "mulsd"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 89 }
-}
-let psubusb = {
-    id = Psubusb
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psubusb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 216 }
-}
-let pminsd = {
-    id = Pminsd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pminsd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 57 }
-}
-let pmaxub_M_Mm64 = {
-    id = Pmaxub_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmaxub"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 222 }
-}
-let vcvtdq2ps_X_Xm128 = {
-    id = Vcvtdq2ps_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtdq2ps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 91 }
-}
-let psrld_X_Xm128 = {
-    id = Psrld_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psrld"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 210 }
-}
-let vpshuflw_X_Xm128 = {
-    id = Vpshuflw_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vpshuflw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 112 }
-}
-let vcvtpd2ps_X_Xm128 = {
-    id = Vcvtpd2ps_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtpd2ps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 90 }
-}
-let movntps = {
-    id = Movntps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "movntps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 43 }
-}
-let palignr_M_Mm64 = {
-    id = Palignr_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "palignr"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 15 }
-}
-let cvtdq2pd = {
-    id = Cvtdq2pd
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvtdq2pd"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 230 }
-}
-let pcmpistrm = {
-    id = Pcmpistrm
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Pin XMM0; enc = Implicit }
-  ; imm = true
-  ; mnemonic = "pcmpistrm"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 98 }
-}
-let vpaddusw_Y_Y_Ym256 = {
-    id = Vpaddusw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpaddusw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 221 }
-}
-let vpaddusw_X_X_Xm128 = {
-    id = Vpaddusw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpaddusw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 221 }
-}
-let addss = {
-    id = Addss
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "addss"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 88 }
-}
-let vaddpd_Y_Y_Ym256 = {
-    id = Vaddpd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vaddpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 88 }
-}
-let vaddpd_X_X_Xm128 = {
-    id = Vaddpd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vaddpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 88 }
-}
-let vpmovsxbd_Y_Xm64 = {
-    id = Vpmovsxbd_Y_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovsxbd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 33 }
-}
-let vdivps_Y_Y_Ym256 = {
-    id = Vdivps_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vdivps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 94 }
-}
-let vdivps_X_X_Xm128 = {
-    id = Vdivps_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vdivps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 94 }
-}
-let vpslld_Y_Y = {
-    id = Vpslld_Y_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpslld"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 6; opcode = 114 }
-}
-let vmulsd = {
-    id = Vmulsd
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmulsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 89 }
-}
-let comiss = {
-    id = Comiss
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "comiss"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 47 }
-}
-let shufps = {
-    id = Shufps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "shufps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 198 }
-}
-let vrcpps_Y_Ym256 = {
-    id = Vrcpps_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vrcpps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 83 }
-}
-let rsqrtps = {
-    id = Rsqrtps
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "rsqrtps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 82 }
-}
-let vmovdqa_Xm128_X = {
-    id = Vmovdqa_Xm128_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovdqa"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 127 }
-}
-let vcvttss2si_r64_Xm32 = {
-    id = Vcvttss2si_r64_Xm32
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvttss2si"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = true; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 44 }
-}
-let vpblendd_Y_Y_Ym256 = {
-    id = Vpblendd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vpblendd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 2 }
-}
-let vpblendd_X_X_Xm128 = {
-    id = Vpblendd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vpblendd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 2 }
-}
-let movlpd_X_m64 = {
-    id = Movlpd_X_m64
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "movlpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 18 }
-}
-let vblendvpd_Y_Y_Ym256_Y = {
-    id = Vblendvpd_Y_Y_Ym256_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm };{ loc = Temp [|YMM|]; enc = Implicit }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vblendvpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 75 }
-}
-let vblendvpd_X_X_Xm128_X = {
-    id = Vblendvpd_X_X_Xm128_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Temp [|XMM|]; enc = Implicit }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vblendvpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 75 }
-}
-let vcvttpd2dq_X_Ym256 = {
-    id = Vcvttpd2dq_X_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvttpd2dq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 230 }
-}
-let psrlw_X_Xm128 = {
-    id = Psrlw_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psrlw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 209 }
-}
-let minsd = {
-    id = Minsd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "minsd"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 93 }
-}
-let vaddps_Y_Y_Ym256 = {
-    id = Vaddps_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vaddps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 88 }
-}
-let vaddps_X_X_Xm128 = {
-    id = Vaddps_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vaddps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 88 }
-}
-let vminss = {
-    id = Vminss
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vminss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 93 }
-}
-let cvtss2si_r32_Xm32 = {
-    id = Cvtss2si_r32_Xm32
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvtss2si"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 45 }
-}
-let vmovq_X_r64m64 = {
-    id = Vmovq_X_r64m64
-  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = true; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 110 }
-}
-let vphaddsw_Y_Y_Ym256 = {
-    id = Vphaddsw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vphaddsw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 3 }
-}
-let vphaddsw_X_X_Xm128 = {
-    id = Vphaddsw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vphaddsw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 3 }
-}
-let vsubsd = {
-    id = Vsubsd
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vsubsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 92 }
-}
-let vpermilpd_X_Xm128 = {
-    id = Vpermilpd_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vpermilpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 5 }
-}
-let vroundps_X_Xm128 = {
-    id = Vroundps_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vroundps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 8 }
-}
-let vpsubd_Y_Y_Ym256 = {
-    id = Vpsubd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsubd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 250 }
-}
-let vpsubd_X_X_Xm128 = {
-    id = Vpsubd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsubd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 250 }
+  ; imm = Imm_none
+  ; mnemonic = "vpmuldq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 40 }
 }
 let pslld_X_Xm128 = {
     id = Pslld_X_Xm128
+  ; ext = [|SSE2|]
   ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = First_arg
-  ; imm = false
+  ; imm = Imm_none
   ; mnemonic = "pslld"
   ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 242 }
 }
-let vpcmpgtb_Y_Y_Ym256 = {
-    id = Vpcmpgtb_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpcmpgtb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 100 }
-}
-let vpcmpgtb_X_X_Xm128 = {
-    id = Vpcmpgtb_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpcmpgtb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 100 }
-}
-let vmovntdq_m128_X = {
-    id = Vmovntdq_m128_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovntdq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 231 }
-}
-let vshufps_Y_Y_Ym256 = {
-    id = Vshufps_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vshufps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 198 }
-}
-let vshufps_X_X_Xm128 = {
-    id = Vshufps_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vshufps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 198 }
-}
-let movapd_X_Xm128 = {
-    id = Movapd_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "movapd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 40 }
-}
-let hsubps = {
-    id = Hsubps
+let pmulhw = {
+    id = Pmulhw
+  ; ext = [|SSE2|]
   ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = First_arg
-  ; imm = false
-  ; mnemonic = "hsubps"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 125 }
+  ; imm = Imm_none
+  ; mnemonic = "pmulhw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 229 }
 }
-let vcvtsi2sd_X_X_r64m64 = {
-    id = Vcvtsi2sd_X_X_r64m64
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtsi2sd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = true; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 42 }
+let pcmpeqd = {
+    id = Pcmpeqd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pcmpeqd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 118 }
 }
-let vpmovsxwq_Y_Xm64 = {
-    id = Vpmovsxwq_Y_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovsxwq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 36 }
-}
-let vpmovsxbd_X_Xm32 = {
-    id = Vpmovsxbd_X_Xm32
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovsxbd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 33 }
-}
-let vpminsb_Y_Y_Ym256 = {
-    id = Vpminsb_Y_Y_Ym256
+let vpsubq_Y_Y_Ym256 = {
+    id = Vpsubq_Y_Y_Ym256
+  ; ext = [|AVX2|]
   ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpminsb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 56 }
+  ; imm = Imm_none
+  ; mnemonic = "vpsubq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 251 }
 }
-let vpminsb_X_X_Xm128 = {
-    id = Vpminsb_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpminsb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 56 }
-}
-let vpsrld_Y_Y_Xm128 = {
-    id = Vpsrld_Y_Y_Xm128
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsrld"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 210 }
-}
-let vpsrld_X_X_Xm128 = {
-    id = Vpsrld_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsrld"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 210 }
-}
-let andps = {
-    id = Andps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "andps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 84 }
-}
-let vpmuludq_Y_Y_Ym256 = {
-    id = Vpmuludq_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmuludq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 244 }
-}
-let vpmuludq_X_X_Xm128 = {
-    id = Vpmuludq_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmuludq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 244 }
-}
-let dpps = {
-    id = Dpps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "dpps"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 64 }
-}
-let pextrw_r64_M = {
-    id = Pextrw_r64_M
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "pextrw"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 197 }
-}
-let cvtdq2ps = {
-    id = Cvtdq2ps
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvtdq2ps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 91 }
-}
-let vmovupd_X_Xm128 = {
-    id = Vmovupd_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovupd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 16 }
-}
-let pcmpeqw = {
-    id = Pcmpeqw
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pcmpeqw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 117 }
-}
-let vcvtss2sd = {
-    id = Vcvtss2sd
+let vdivss = {
+    id = Vdivss
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtss2sd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 90 }
-}
-let vpbroadcastq_Y_Xm64 = {
-    id = Vpbroadcastq_Y_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpbroadcastq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 89 }
-}
-let vpabsd_X_Xm128 = {
-    id = Vpabsd_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpabsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 30 }
-}
-let vpslldq_Y_Y = {
-    id = Vpslldq_Y_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpslldq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 7; opcode = 115 }
-}
-let psignb_M_Mm64 = {
-    id = Psignb_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psignb"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 8 }
-}
-let vpmovzxwd_X_Xm64 = {
-    id = Vpmovzxwd_X_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovzxwd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 51 }
-}
-let vpackusdw_Y_Y_Ym256 = {
-    id = Vpackusdw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpackusdw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 43 }
-}
-let vpackusdw_X_X_Xm128 = {
-    id = Vpackusdw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpackusdw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 43 }
-}
-let vcvtsi2ss_X_X_r32m32 = {
-    id = Vcvtsi2ss_X_X_r32m32
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtsi2ss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 42 }
-}
-let vpsllq_X_X = {
-    id = Vpsllq_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpsllq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 6; opcode = 115 }
-}
-let psllw_X_Xm128 = {
-    id = Psllw_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psllw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 241 }
-}
-let vpavgw_Y_Y_Ym256 = {
-    id = Vpavgw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpavgw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 227 }
-}
-let vpavgw_X_X_Xm128 = {
-    id = Vpavgw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpavgw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 227 }
-}
-let vpermilps_X_Xm128 = {
-    id = Vpermilps_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vpermilps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 4 }
-}
-let punpckhdq = {
-    id = Punpckhdq
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "punpckhdq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 106 }
-}
-let phsubd_M_Mm64 = {
-    id = Phsubd_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "phsubd"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 6 }
-}
-let vunpckhps_Y_Y_Ym256 = {
-    id = Vunpckhps_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vunpckhps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 21 }
-}
-let vunpckhps_X_X_Xm128 = {
-    id = Vunpckhps_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vunpckhps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 21 }
-}
-let movlps_m64_X = {
-    id = Movlps_m64_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M64|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "movlps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 19 }
-}
-let vextracti128 = {
-    id = Vextracti128
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
-  ; imm = true
-  ; mnemonic = "vextracti128"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 57 }
-}
-let vpaddd_Y_Y_Ym256 = {
-    id = Vpaddd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpaddd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 254 }
-}
-let vpaddd_X_X_Xm128 = {
-    id = Vpaddd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpaddd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 254 }
-}
-let vcvtps2dq_Y_Ym256 = {
-    id = Vcvtps2dq_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtps2dq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 91 }
-}
-let pxor = {
-    id = Pxor
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pxor"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 239 }
+  ; imm = Imm_none
+  ; mnemonic = "vdivss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 94 }
 }
 let vmovq_X_r64m64 = {
     id = Vmovq_X_r64m64
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
+  ; imm = Imm_none
   ; mnemonic = "vmovq"
   ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = true; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 126 }
 }
-let maxpd = {
-    id = Maxpd
+let subpd = {
+    id = Subpd
+  ; ext = [|SSE2|]
   ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = First_arg
-  ; imm = false
-  ; mnemonic = "maxpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 95 }
+  ; imm = Imm_none
+  ; mnemonic = "subpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 92 }
 }
-let vpmovsxbq_Y_Xm32 = {
-    id = Vpmovsxbq_Y_Xm32
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovsxbq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 34 }
-}
-let pmovsxwq = {
-    id = Pmovsxwq
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pmovsxwq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 36 }
-}
-let vpslldq_X_X = {
-    id = Vpslldq_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpslldq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 7; opcode = 115 }
-}
-let vmaskmovps_m256_Y_Y = {
-    id = Vmaskmovps_m256_Y_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M256|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmaskmovps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 46 }
-}
-let vmaskmovps_m128_X_X = {
-    id = Vmaskmovps_m128_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmaskmovps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 46 }
-}
-let phsubsw_M_Mm64 = {
-    id = Phsubsw_M_Mm64
+let psignb_M_Mm64 = {
+    id = Psignb_M_Mm64
+  ; ext = [|SSSE3|]
   ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
   ; res = First_arg
-  ; imm = false
-  ; mnemonic = "phsubsw"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 7 }
+  ; imm = Imm_none
+  ; mnemonic = "psignb"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 8 }
 }
-let pmulhuw_M_Mm64 = {
-    id = Pmulhuw_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmulhuw"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 228 }
-}
-let maskmovdqu = {
-    id = Maskmovdqu
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "maskmovdqu"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 247 }
-}
-let vcmpps_Y_Y_Ym256 = {
-    id = Vcmpps_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vcmpps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 194 }
-}
-let vcmpps_X_X_Xm128 = {
-    id = Vcmpps_X_X_Xm128
+let vpcmpgtb_X_X_Xm128 = {
+    id = Vpcmpgtb_X_X_Xm128
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vcmpps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 194 }
-}
-let movlps_X_m64 = {
-    id = Movlps_X_m64
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "movlps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 18 }
-}
-let pinsrw_M_r32m16 = {
-    id = Pinsrw_M_r32m16
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|R32;M16|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "pinsrw"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 196 }
-}
-let vpcmpgtd_Y_Y_Ym256 = {
-    id = Vpcmpgtd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpcmpgtd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 102 }
-}
-let vpcmpgtd_X_X_Xm128 = {
-    id = Vpcmpgtd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpcmpgtd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 102 }
-}
-let cvtss2si_r64_Xm32 = {
-    id = Cvtss2si_r64_Xm32
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvtss2si"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_w; escape = Esc_0F }; rm_reg = Reg; opcode = 45 }
-}
-let vpmovzxbq_X_Xm16 = {
-    id = Vpmovzxbq_X_Xm16
-  ; args = [|{ loc = Temp [|XMM;M16|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovzxbq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 50 }
-}
-let hsubpd = {
-    id = Hsubpd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "hsubpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 125 }
-}
-let vmovupd_Ym256_Y = {
-    id = Vmovupd_Ym256_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|YMM;M256|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovupd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 17 }
-}
-let movq_X_Xm64 = {
-    id = Movq_X_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "movq"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 126 }
-}
-let vcvtsd2ss = {
-    id = Vcvtsd2ss
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtsd2ss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 90 }
-}
-let movaps_X_Xm128 = {
-    id = Movaps_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "movaps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 40 }
-}
-let punpcklwd = {
-    id = Punpcklwd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "punpcklwd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 97 }
-}
-let vmovhps_m64_X = {
-    id = Vmovhps_m64_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M64|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovhps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 23 }
-}
-let blendvps = {
-    id = Blendvps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Pin XMM0; enc = Implicit }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "blendvps"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 20 }
-}
-let vpblendw_Y_Y_Ym256 = {
-    id = Vpblendw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vpblendw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 14 }
-}
-let vpblendw_X_X_Xm128 = {
-    id = Vpblendw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vpblendw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 14 }
-}
-let vcvtdq2ps_Y_Ym256 = {
-    id = Vcvtdq2ps_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtdq2ps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 91 }
-}
-let mpsadbw = {
-    id = Mpsadbw
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "mpsadbw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 66 }
-}
-let vmovlps_m64_X = {
-    id = Vmovlps_m64_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M64|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovlps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 19 }
-}
-let pavgb_X_Xm128 = {
-    id = Pavgb_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pavgb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 224 }
-}
-let vdivsd = {
-    id = Vdivsd
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vdivsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 94 }
-}
-let vpmovsxdq_X_Xm64 = {
-    id = Vpmovsxdq_X_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovsxdq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 37 }
-}
-let vpunpcklbw_Y_Y_Ym256 = {
-    id = Vpunpcklbw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpunpcklbw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 96 }
-}
-let vpunpcklbw_X_X_Xm128 = {
-    id = Vpunpcklbw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpunpcklbw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 96 }
-}
-let movdqa_X_Xm128 = {
-    id = Movdqa_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "movdqa"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 111 }
-}
-let pblendvb = {
-    id = Pblendvb
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Pin XMM0; enc = Implicit }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pblendvb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 16 }
-}
-let pmovzxwq = {
-    id = Pmovzxwq
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pmovzxwq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 52 }
-}
-let unpcklps = {
-    id = Unpcklps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "unpcklps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 20 }
-}
-let vpsubusw_Y_Y_Ym256 = {
-    id = Vpsubusw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsubusw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 217 }
-}
-let vpsubusw_X_X_Xm128 = {
-    id = Vpsubusw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsubusw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 217 }
-}
-let bzhi_r32_r32m32_r32 = {
-    id = Bzhi_r32_r32m32_r32
-  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm };{ loc = Temp [|R32|]; enc = Vex_v }|]
-  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "bzhi"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 245 }
-}
-let vandps_Y_Y_Ym256 = {
-    id = Vandps_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vandps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 84 }
-}
-let vandps_X_X_Xm128 = {
-    id = Vandps_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vandps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 84 }
-}
-let pminub_X_Xm128 = {
-    id = Pminub_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pminub"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 218 }
-}
-let psubsw = {
-    id = Psubsw
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psubsw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 233 }
-}
-let vpshufd_X_Xm128 = {
-    id = Vpshufd_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vpshufd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 112 }
-}
-let ucomisd = {
-    id = Ucomisd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "ucomisd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 46 }
-}
-let vpmovzxbw_X_Xm64 = {
-    id = Vpmovzxbw_X_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovzxbw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 48 }
-}
-let pmovzxbq = {
-    id = Pmovzxbq
-  ; args = [|{ loc = Temp [|XMM;M16|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pmovzxbq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 50 }
-}
-let vcvtpd2ps_X_Ym256 = {
-    id = Vcvtpd2ps_X_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtpd2ps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 90 }
-}
-let movlpd_m64_X = {
-    id = Movlpd_m64_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M64|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "movlpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 19 }
-}
-let vmovdqa_Y_Ym256 = {
-    id = Vmovdqa_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovdqa"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 111 }
-}
-let pmovzxwd = {
-    id = Pmovzxwd
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pmovzxwd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 51 }
-}
-let pavgw_M_Mm64 = {
-    id = Pavgw_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pavgw"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 227 }
-}
-let vmaxsd = {
-    id = Vmaxsd
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmaxsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 95 }
-}
-let vsqrtss = {
-    id = Vsqrtss
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vsqrtss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 81 }
-}
-let xorps = {
-    id = Xorps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "xorps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 87 }
-}
-let vpinsrw = {
-    id = Vpinsrw
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|R32;M16|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "vpinsrw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 196 }
-}
-let cvttps2dq = {
-    id = Cvttps2dq
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvttps2dq"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 91 }
-}
-let vpsrlq_Y_Y = {
-    id = Vpsrlq_Y_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpsrlq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 2; opcode = 115 }
-}
-let vmovdqa_Ym256_Y = {
-    id = Vmovdqa_Ym256_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|YMM;M256|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovdqa"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 127 }
-}
-let vpsrldq_X_X = {
-    id = Vpsrldq_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpsrldq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 3; opcode = 115 }
-}
-let vcvtdq2pd_X_Xm64 = {
-    id = Vcvtdq2pd_X_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtdq2pd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 230 }
-}
-let unpckhpd = {
-    id = Unpckhpd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "unpckhpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 21 }
-}
-let vpminsd_Y_Y_Ym256 = {
-    id = Vpminsd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpminsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 57 }
-}
-let vpminsd_X_X_Xm128 = {
-    id = Vpminsd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpminsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 57 }
-}
-let paddq = {
-    id = Paddq
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "paddq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 212 }
-}
-let cmppd = {
-    id = Cmppd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "cmppd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 194 }
-}
-let sarx_r32_r32m32_r32 = {
-    id = Sarx_r32_r32m32_r32
-  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm };{ loc = Temp [|R32|]; enc = Vex_v }|]
-  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "sarx"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 247 }
-}
-let movsd_Xm64_X = {
-    id = Movsd_Xm64_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|XMM;M64|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "movsd"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 17 }
-}
-let pavgb_M_Mm64 = {
-    id = Pavgb_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pavgb"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 224 }
-}
-let cvttss2si_r64_Xm32 = {
-    id = Cvttss2si_r64_Xm32
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvttss2si"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_w; escape = Esc_0F }; rm_reg = Reg; opcode = 44 }
-}
-let psubusw = {
-    id = Psubusw
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psubusw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 217 }
-}
-let vpmovzxbd_Y_Xm64 = {
-    id = Vpmovzxbd_Y_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovzxbd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 49 }
-}
-let vsqrtps_Y_Ym256 = {
-    id = Vsqrtps_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vsqrtps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 81 }
-}
-let unpcklpd = {
-    id = Unpcklpd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "unpcklpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 20 }
+  ; imm = Imm_none
+  ; mnemonic = "vpcmpgtb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 100 }
 }
 let vsubps_Y_Y_Ym256 = {
     id = Vsubps_Y_Y_Ym256
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
+  ; imm = Imm_none
   ; mnemonic = "vsubps"
   ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 92 }
 }
 let vsubps_X_X_Xm128 = {
     id = Vsubps_X_X_Xm128
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
+  ; imm = Imm_none
   ; mnemonic = "vsubps"
   ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 92 }
 }
-let vpabsb_Y_Ym256 = {
-    id = Vpabsb_Y_Ym256
+let vroundps_Y_Ym256 = {
+    id = Vroundps_Y_Ym256
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpabsb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 28 }
+  ; imm = Imm_spec
+  ; mnemonic = "vroundps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 8 }
 }
-let pmuldq = {
-    id = Pmuldq
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmuldq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 40 }
-}
-let vmovdqu_Y_Ym256 = {
-    id = Vmovdqu_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovdqu"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 127 }
-}
-let vpsllw_X_X = {
-    id = Vpsllw_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpsllw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 6; opcode = 113 }
-}
-let cmpps = {
-    id = Cmpps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "cmpps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 194 }
-}
-let vpcmpistri = {
-    id = Vpcmpistri
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Pin RCX; enc = Implicit }
-  ; imm = true
-  ; mnemonic = "vpcmpistri"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 99 }
-}
-let pcmpgtd = {
-    id = Pcmpgtd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pcmpgtd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 102 }
-}
-let pand = {
-    id = Pand
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pand"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 219 }
-}
-let pcmpgtq = {
-    id = Pcmpgtq
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pcmpgtq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 55 }
-}
-let pabsd_M_Mm64 = {
-    id = Pabsd_M_Mm64
-  ; args = [|{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|MM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pabsd"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 30 }
-}
-let crc32_r64_r64m64 = {
-    id = Crc32_r64_r64m64
-  ; args = [|{ loc = Temp [|R64|]; enc = RM_r };{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "crc32"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_w; escape = Esc_0F38 }; rm_reg = Reg; opcode = 241 }
-}
-let vextractf128 = {
-    id = Vextractf128
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
-  ; imm = true
-  ; mnemonic = "vextractf128"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 25 }
-}
-let movupd_X_Xm128 = {
-    id = Movupd_X_Xm128
+let vroundps_X_Xm128 = {
+    id = Vroundps_X_Xm128
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "movupd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 16 }
+  ; imm = Imm_spec
+  ; mnemonic = "vroundps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 8 }
+}
+let vpblendvb_X_X_Xm128_X = {
+    id = Vpblendvb_X_X_Xm128_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Temp [|XMM|]; enc = Immediate }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_reg
+  ; mnemonic = "vpblendvb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 76 }
+}
+let andps = {
+    id = Andps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "andps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 84 }
+}
+let vpbroadcastw_Y_Xm16 = {
+    id = Vpbroadcastw_Y_Xm16
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM;M16|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpbroadcastw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 121 }
 }
 let vpbroadcastw_X_Xm16 = {
     id = Vpbroadcastw_X_Xm16
+  ; ext = [|AVX2|]
   ; args = [|{ loc = Temp [|XMM;M16|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
+  ; imm = Imm_none
   ; mnemonic = "vpbroadcastw"
   ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 121 }
 }
-let vpsravd_Y_Y_Ym256 = {
-    id = Vpsravd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsravd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 70 }
-}
-let vpsravd_X_X_Xm128 = {
-    id = Vpsravd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsravd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 70 }
-}
-let pslld_X = {
-    id = Pslld_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "pslld"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 6; opcode = 114 }
-}
-let pmaxsw_X_Xm128 = {
-    id = Pmaxsw_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmaxsw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 238 }
-}
-let vtestps_Y_Ym256 = {
-    id = Vtestps_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "vtestps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 14 }
-}
-let vtestps_X_Xm128 = {
-    id = Vtestps_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "vtestps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 14 }
-}
-let vpcmpeqw_Y_Y_Ym256 = {
-    id = Vpcmpeqw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpcmpeqw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 117 }
-}
-let vpcmpeqw_X_X_Xm128 = {
-    id = Vpcmpeqw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpcmpeqw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 117 }
-}
-let vmovmskps_r64_X = {
-    id = Vmovmskps_r64_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovmskps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 80 }
-}
-let palignr_X_Xm128 = {
-    id = Palignr_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "palignr"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 15 }
-}
-let psignb_X_Xm128 = {
-    id = Psignb_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psignb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 8 }
-}
-let vphsubd_Y_Y_Ym256 = {
-    id = Vphsubd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r };{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "vphsubd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 6 }
-}
-let vphsubd_X_X_Xm128 = {
-    id = Vphsubd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "vphsubd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 6 }
-}
-let vpaddusb_Y_Y_Ym256 = {
-    id = Vpaddusb_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpaddusb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 220 }
-}
-let vpaddusb_X_X_Xm128 = {
-    id = Vpaddusb_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpaddusb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 220 }
-}
-let pandn = {
-    id = Pandn
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pandn"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 223 }
-}
-let movdqu_X_Xm128 = {
-    id = Movdqu_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "movdqu"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 127 }
-}
-let vpxor_Y_Y_Ym256 = {
-    id = Vpxor_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpxor"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 239 }
-}
-let vpxor_X_X_Xm128 = {
-    id = Vpxor_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpxor"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 239 }
-}
-let vmovdqa_X_Xm128 = {
-    id = Vmovdqa_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovdqa"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 111 }
-}
-let vmaxps_Y_Y_Ym256 = {
-    id = Vmaxps_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmaxps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 95 }
-}
-let vmaxps_X_X_Xm128 = {
-    id = Vmaxps_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmaxps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 95 }
-}
-let vpmullw_Y_Y_Ym256 = {
-    id = Vpmullw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmullw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 213 }
-}
-let vpmullw_X_X_Xm128 = {
-    id = Vpmullw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmullw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 213 }
-}
-let vphminposuw = {
-    id = Vphminposuw
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vphminposuw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 65 }
-}
-let psubw = {
-    id = Psubw
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psubw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 249 }
-}
-let vpbroadcastb_Y_Xm8 = {
-    id = Vpbroadcastb_Y_Xm8
-  ; args = [|{ loc = Temp [|XMM;M8|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpbroadcastb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 120 }
-}
-let vptest_Y_Ym256 = {
-    id = Vptest_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "vptest"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 23 }
-}
-let vptest_X_Xm128 = {
-    id = Vptest_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "vptest"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 23 }
-}
-let packuswb = {
-    id = Packuswb
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "packuswb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 103 }
-}
-let haddps = {
-    id = Haddps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "haddps"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 124 }
-}
-let vmovshdup_X_Xm128 = {
-    id = Vmovshdup_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovshdup"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 22 }
-}
-let vmovaps_X_Xm128 = {
-    id = Vmovaps_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovaps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 40 }
-}
-let vaddsd = {
-    id = Vaddsd
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vaddsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 88 }
-}
-let movdqa_Xm128_X = {
-    id = Movdqa_Xm128_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "movdqa"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 127 }
-}
-let orpd = {
-    id = Orpd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "orpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 86 }
-}
-let vmovss_X_X_X = {
-    id = Vmovss_X_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 16 }
-}
-let paddsb = {
-    id = Paddsb
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "paddsb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 236 }
-}
-let vpsrad_X_X = {
-    id = Vpsrad_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpsrad"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 4; opcode = 114 }
-}
-let vbroadcasti128 = {
-    id = Vbroadcasti128
-  ; args = [|{ loc = Temp [|M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vbroadcasti128"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 90 }
-}
-let vpbroadcastd_X_Xm32 = {
-    id = Vpbroadcastd_X_Xm32
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpbroadcastd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 88 }
-}
-let vperm2i128 = {
-    id = Vperm2i128
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vperm2i128"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 70 }
-}
-let vmaskmovps_Y_Y_m256 = {
-    id = Vmaskmovps_Y_Y_m256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmaskmovps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 44 }
-}
-let vmaskmovps_X_X_m128 = {
-    id = Vmaskmovps_X_X_m128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmaskmovps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 44 }
-}
-let packsswb = {
-    id = Packsswb
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "packsswb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 99 }
-}
-let movss_X_m32 = {
-    id = Movss_X_m32
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|M32|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "movss"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 16 }
-}
-let movss_X_X = {
-    id = Movss_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "movss"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 16 }
-}
-let vroundpd_Y_Ym256 = {
-    id = Vroundpd_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vroundpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 9 }
-}
-let vpslld_Y_Y_Xm128 = {
-    id = Vpslld_Y_Y_Xm128
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpslld"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 242 }
-}
-let vpslld_X_X_Xm128 = {
-    id = Vpslld_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpslld"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 242 }
-}
-let minpd = {
-    id = Minpd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "minpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 93 }
-}
 let movhlps = {
     id = Movhlps
+  ; ext = [|SSE|]
   ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = RM_rm }|]
   ; res = First_arg
-  ; imm = false
+  ; imm = Imm_none
   ; mnemonic = "movhlps"
   ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 18 }
 }
-let vsubss = {
-    id = Vsubss
+let vcvttpd2dq_X_Ym256 = {
+    id = Vcvttpd2dq_X_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvttpd2dq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 230 }
+}
+let vcvttpd2dq_X_Xm128 = {
+    id = Vcvttpd2dq_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvttpd2dq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 230 }
+}
+let vrcpss = {
+    id = Vrcpss
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vsubss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 92 }
+  ; imm = Imm_none
+  ; mnemonic = "vrcpss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 83 }
 }
-let vsqrtpd_Y_Ym256 = {
-    id = Vsqrtpd_Y_Ym256
+let vpcmpistrm = {
+    id = Vpcmpistrm
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Pin XMM0; enc = Implicit }
+  ; imm = Imm_spec
+  ; mnemonic = "vpcmpistrm"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 98 }
+}
+let vmovdqu_Y_Ym256 = {
+    id = Vmovdqu_Y_Ym256
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vsqrtpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 81 }
+  ; imm = Imm_none
+  ; mnemonic = "vmovdqu"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 127 }
 }
-let vpmovmskb_r64_Y = {
-    id = Vpmovmskb_r64_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
+let vmovdqu_X_Xm128 = {
+    id = Vmovdqu_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovdqu"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 127 }
+}
+let maxps = {
+    id = Maxps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "maxps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 95 }
+}
+let vpmovsxbq_Y_Xm32 = {
+    id = Vpmovsxbq_Y_Xm32
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovsxbq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 34 }
+}
+let vpcmpeqw_Y_Y_Ym256 = {
+    id = Vpcmpeqw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpcmpeqw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 117 }
+}
+let vpaddd_Y_Y_Ym256 = {
+    id = Vpaddd_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpaddd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 254 }
+}
+let psrad_X = {
+    id = Psrad_X
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "psrad"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 4; opcode = 114 }
+}
+let phaddw_M_Mm64 = {
+    id = Phaddw_M_Mm64
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "phaddw"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 1 }
+}
+let movss_Xm32_X = {
+    id = Movss_Xm32_X
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|XMM;M32|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "movss"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 17 }
+}
+let pshufhw = {
+    id = Pshufhw
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "pshufhw"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 112 }
+}
+let pmulhuw_M_Mm64 = {
+    id = Pmulhuw_M_Mm64
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmulhuw"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 228 }
+}
+let vbroadcasti128 = {
+    id = Vbroadcasti128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vbroadcasti128"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 90 }
+}
+let vpunpcklwd_Y_Y_Ym256 = {
+    id = Vpunpcklwd_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpunpcklwd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 97 }
+}
+let pmulhrsw_X_Xm128 = {
+    id = Pmulhrsw_X_Xm128
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmulhrsw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 11 }
+}
+let comisd = {
+    id = Comisd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "comisd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 47 }
+}
+let vmaskmovdqu = {
+    id = Vmaskmovdqu
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "vmaskmovdqu"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 247 }
+}
+let pblendvb = {
+    id = Pblendvb
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Pin XMM0; enc = Implicit }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pblendvb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 16 }
+}
+let cvtsi2ss_X_r32m32 = {
+    id = Cvtsi2ss_X_r32m32
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvtsi2ss"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 42 }
+}
+let vpabsw_Y_Ym256 = {
+    id = Vpabsw_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpabsw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 29 }
+}
+let psadbw_M_Mm64 = {
+    id = Psadbw_M_Mm64
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psadbw"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 246 }
+}
+let vdivps_Y_Y_Ym256 = {
+    id = Vdivps_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vdivps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 94 }
+}
+let vdivps_X_X_Xm128 = {
+    id = Vdivps_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vdivps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 94 }
+}
+let vcvtsi2sd_X_X_r64m64 = {
+    id = Vcvtsi2sd_X_X_r64m64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtsi2sd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = true; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 42 }
+}
+let vcvtsi2sd_X_X_r32m32 = {
+    id = Vcvtsi2sd_X_X_r32m32
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtsi2sd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 42 }
+}
+let pslld_X = {
+    id = Pslld_X
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "pslld"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 6; opcode = 114 }
+}
+let vmovsd_X_m64 = {
+    id = Vmovsd_X_m64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 16 }
+}
+let vpunpcklwd_X_X_Xm128 = {
+    id = Vpunpcklwd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpunpcklwd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 97 }
+}
+let vpmulhrsw_Y_Y_Ym256 = {
+    id = Vpmulhrsw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmulhrsw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 11 }
+}
+let vorpd_Y_Y_Ym256 = {
+    id = Vorpd_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vorpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 86 }
+}
+let vorpd_X_X_Xm128 = {
+    id = Vorpd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vorpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 86 }
+}
+let vpunpckldq_X_X_Xm128 = {
+    id = Vpunpckldq_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpunpckldq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 98 }
+}
+let phsubd_X_Xm128 = {
+    id = Phsubd_X_Xm128
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "phsubd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 6 }
+}
+let vpsrlq_Y_Y_Xm128 = {
+    id = Vpsrlq_Y_Y_Xm128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsrlq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 211 }
+}
+let vpcmpgtw_X_X_Xm128 = {
+    id = Vpcmpgtw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpcmpgtw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 101 }
+}
+let vpbroadcastd_Y_Xm32 = {
+    id = Vpbroadcastd_Y_Xm32
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpbroadcastd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 88 }
+}
+let vpbroadcastd_X_Xm32 = {
+    id = Vpbroadcastd_X_Xm32
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpbroadcastd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 88 }
+}
+let vpextrd = {
+    id = Vpextrd
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|R32;M32|]; enc = RM_rm }
+  ; imm = Imm_spec
+  ; mnemonic = "vpextrd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 22 }
+}
+let vsqrtps_Y_Ym256 = {
+    id = Vsqrtps_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vsqrtps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 81 }
+}
+let vsqrtps_X_Xm128 = {
+    id = Vsqrtps_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vsqrtps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 81 }
+}
+let vpmovzxwq_Y_Xm64 = {
+    id = Vpmovzxwq_Y_Xm64
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovzxwq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 52 }
+}
+let vpmaskmovd_Y_Y_m256 = {
+    id = Vpmaskmovd_Y_Y_m256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaskmovd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 140 }
+}
+let vpmaskmovd_X_X_m128 = {
+    id = Vpmaskmovd_X_X_m128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaskmovd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 140 }
+}
+let vmovdqa_Y_Ym256 = {
+    id = Vmovdqa_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovdqa"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 111 }
+}
+let vmovdqa_X_Xm128 = {
+    id = Vmovdqa_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovdqa"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 111 }
+}
+let punpcklwd = {
+    id = Punpcklwd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "punpcklwd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 97 }
+}
+let movhps_X_m64 = {
+    id = Movhps_X_m64
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "movhps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 22 }
+}
+let vandps_Y_Y_Ym256 = {
+    id = Vandps_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vandps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 84 }
+}
+let vandps_X_X_Xm128 = {
+    id = Vandps_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vandps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 84 }
+}
+let pmaxsb = {
+    id = Pmaxsb
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmaxsb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 60 }
+}
+let vmpsadbw_Y_Y_Ym256 = {
+    id = Vmpsadbw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vmpsadbw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 66 }
+}
+let vbroadcastf128 = {
+    id = Vbroadcastf128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vbroadcastf128"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 26 }
+}
+let vsubpd_Y_Y_Ym256 = {
+    id = Vsubpd_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vsubpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 92 }
+}
+let vsubpd_X_X_Xm128 = {
+    id = Vsubpd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vsubpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 92 }
+}
+let addsubpd = {
+    id = Addsubpd
+  ; ext = [|SSE3|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "addsubpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 208 }
+}
+let vpmaxud_Y_Y_Ym256 = {
+    id = Vpmaxud_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaxud"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 63 }
+}
+let paddusw = {
+    id = Paddusw
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "paddusw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 221 }
+}
+let addss = {
+    id = Addss
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "addss"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 88 }
+}
+let vaddpd_Y_Y_Ym256 = {
+    id = Vaddpd_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vaddpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 88 }
+}
+let vaddpd_X_X_Xm128 = {
+    id = Vaddpd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vaddpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 88 }
+}
+let vpsubusb_Y_Y_Ym256 = {
+    id = Vpsubusb_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsubusb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 216 }
+}
+let vpmovmskb_r64_X = {
+    id = Vpmovmskb_r64_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
+  ; imm = Imm_none
   ; mnemonic = "vpmovmskb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 215 }
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 215 }
+}
+let vpunpckhbw_Y_Y_Ym256 = {
+    id = Vpunpckhbw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpunpckhbw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 104 }
+}
+let psrlq_X = {
+    id = Psrlq_X
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "psrlq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 2; opcode = 115 }
+}
+let vcvtss2si_r32_Xm32 = {
+    id = Vcvtss2si_r32_Xm32
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtss2si"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 45 }
+}
+let maxsd = {
+    id = Maxsd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "maxsd"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 95 }
+}
+let xorps = {
+    id = Xorps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "xorps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 87 }
 }
 let psrlq_X_Xm128 = {
     id = Psrlq_X_Xm128
+  ; ext = [|SSE2|]
   ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = First_arg
-  ; imm = false
+  ; imm = Imm_none
   ; mnemonic = "psrlq"
   ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 211 }
 }
-let vmovhlps = {
-    id = Vmovhlps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "vmovhlps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 18 }
-}
-let blendpd = {
-    id = Blendpd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "blendpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 13 }
-}
-let vstmxcsr = {
-    id = Vstmxcsr
-  ; args = [||]
-  ; res = Res { loc = Temp [|M32|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vstmxcsr"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Spec 3; opcode = 174 }
-}
-let vcvtpd2dq_X_Xm128 = {
-    id = Vcvtpd2dq_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtpd2dq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 230 }
-}
-let vmovupd_Xm128_X = {
-    id = Vmovupd_Xm128_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovupd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 17 }
-}
-let vmovddup_Y_Ym256 = {
-    id = Vmovddup_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovddup"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 18 }
-}
-let pextrw_r64m16_X = {
-    id = Pextrw_r64m16_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|R64;M16|]; enc = RM_rm }
-  ; imm = true
-  ; mnemonic = "pextrw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 21 }
-}
-let vmovntdqa_Y_m256 = {
-    id = Vmovntdqa_Y_m256
-  ; args = [|{ loc = Temp [|M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovntdqa"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 42 }
-}
-let vpslld_X_X = {
-    id = Vpslld_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpslld"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 6; opcode = 114 }
-}
-let cvttpd2dq = {
-    id = Cvttpd2dq
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvttpd2dq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 230 }
-}
-let vmovupd_Y_Ym256 = {
-    id = Vmovupd_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovupd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 16 }
-}
-let packssdw = {
-    id = Packssdw
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "packssdw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 107 }
-}
-let vunpcklpd_Y_Y_Ym256 = {
-    id = Vunpcklpd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vunpcklpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 20 }
-}
-let vunpcklpd_X_X_Xm128 = {
-    id = Vunpcklpd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vunpcklpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 20 }
-}
-let divpd = {
-    id = Divpd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "divpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 94 }
-}
-let pmuludq_M_Mm64 = {
-    id = Pmuludq_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmuludq"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 244 }
-}
-let pabsb_X_Xm128 = {
-    id = Pabsb_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pabsb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 28 }
-}
 let vblendpd_Y_Y_Ym256 = {
     id = Vblendpd_Y_Y_Ym256
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
+  ; imm = Imm_spec
   ; mnemonic = "vblendpd"
   ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 13 }
 }
 let vblendpd_X_X_Xm128 = {
     id = Vblendpd_X_X_Xm128
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
+  ; imm = Imm_spec
   ; mnemonic = "vblendpd"
   ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 13 }
 }
-let pmaxsb = {
-    id = Pmaxsb
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+let minsd = {
+    id = Minsd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
   ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmaxsb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 60 }
+  ; imm = Imm_none
+  ; mnemonic = "minsd"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 93 }
 }
-let vmovups_Y_Ym256 = {
-    id = Vmovups_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+let vcvtsd2si_r64_Xm64 = {
+    id = Vcvtsd2si_r64_Xm64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtsd2si"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = true; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 45 }
+}
+let vpsllw_Y_Y_Xm128 = {
+    id = Vpsllw_Y_Y_Xm128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovups"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 16 }
+  ; imm = Imm_none
+  ; mnemonic = "vpsllw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 241 }
 }
-let vrsqrtps_Y_Ym256 = {
-    id = Vrsqrtps_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vrsqrtps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 82 }
+let pextrw_r64m16_X = {
+    id = Pextrw_r64m16_X
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|R64;M16|]; enc = RM_rm }
+  ; imm = Imm_spec
+  ; mnemonic = "pextrw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 21 }
 }
-let vmaxpd_Y_Y_Ym256 = {
-    id = Vmaxpd_Y_Y_Ym256
+let vpmaddwd_Y_Y_Ym256 = {
+    id = Vpmaddwd_Y_Y_Ym256
+  ; ext = [|AVX2|]
   ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmaxpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 95 }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaddwd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 245 }
 }
-let vmaxpd_X_X_Xm128 = {
-    id = Vmaxpd_X_X_Xm128
+let vpaddw_X_X_Xm128 = {
+    id = Vpaddw_X_X_Xm128
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmaxpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 95 }
+  ; imm = Imm_none
+  ; mnemonic = "vpaddw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 253 }
 }
-let vpsllw_Y_Y = {
-    id = Vpsllw_Y_Y
+let vmovaps_Y_Ym256 = {
+    id = Vmovaps_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovaps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 40 }
+}
+let vmovaps_X_Xm128 = {
+    id = Vmovaps_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovaps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 40 }
+}
+let vaddsubps_Y_Y_Ym256 = {
+    id = Vaddsubps_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vaddsubps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 208 }
+}
+let vaddsubps_X_X_Xm128 = {
+    id = Vaddsubps_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vaddsubps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 208 }
+}
+let vpsllq_Y_Y = {
+    id = Vpsllq_Y_Y
+  ; ext = [|AVX2|]
   ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|YMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpsllw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 6; opcode = 113 }
+  ; imm = Imm_spec
+  ; mnemonic = "vpsllq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 6; opcode = 115 }
 }
-let vphaddw_Y_Y_Ym256 = {
-    id = Vphaddw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vphaddw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 1 }
-}
-let vphaddw_X_X_Xm128 = {
-    id = Vphaddw_X_X_Xm128
+let vpcmpgtq_X_X_Xm128 = {
+    id = Vpcmpgtq_X_X_Xm128
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vphaddw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 1 }
+  ; imm = Imm_none
+  ; mnemonic = "vpcmpgtq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 55 }
 }
-let insertps = {
-    id = Insertps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "insertps"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 33 }
-}
-let vsqrtsd = {
-    id = Vsqrtsd
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vsqrtsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 81 }
-}
-let pshuflw = {
-    id = Pshuflw
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "pshuflw"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 112 }
-}
-let cvtsd2ss = {
-    id = Cvtsd2ss
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvtsd2ss"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 90 }
-}
-let pminub_M_Mm64 = {
-    id = Pminub_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pminub"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 218 }
-}
-let vmulps_Y_Y_Ym256 = {
-    id = Vmulps_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmulps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 89 }
-}
-let vmulps_X_X_Xm128 = {
-    id = Vmulps_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmulps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 89 }
-}
-let vmovq_Xm64_X = {
-    id = Vmovq_Xm64_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|XMM;M64|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 214 }
-}
-let vpaddsw_Y_Y_Ym256 = {
-    id = Vpaddsw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpaddsw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 237 }
-}
-let vpaddsw_X_X_Xm128 = {
-    id = Vpaddsw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpaddsw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 237 }
-}
-let pabsw_M_Mm64 = {
-    id = Pabsw_M_Mm64
-  ; args = [|{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|MM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pabsw"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 29 }
-}
-let punpcklqdq = {
-    id = Punpcklqdq
+let divpd = {
+    id = Divpd
+  ; ext = [|SSE2|]
   ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = First_arg
-  ; imm = false
-  ; mnemonic = "punpcklqdq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 108 }
+  ; imm = Imm_none
+  ; mnemonic = "divpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 94 }
 }
-let subss = {
-    id = Subss
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "subss"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 92 }
-}
-let punpckldq = {
-    id = Punpckldq
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "punpckldq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 98 }
-}
-let vpunpckhbw_Y_Y_Ym256 = {
-    id = Vpunpckhbw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpunpckhbw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 104 }
-}
-let vpunpckhbw_X_X_Xm128 = {
-    id = Vpunpckhbw_X_X_Xm128
+let vpcmpeqd_X_X_Xm128 = {
+    id = Vpcmpeqd_X_X_Xm128
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpunpckhbw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 104 }
+  ; imm = Imm_none
+  ; mnemonic = "vpcmpeqd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 118 }
 }
-let vcvtsi2ss_X_X_r64m64 = {
-    id = Vcvtsi2ss_X_X_r64m64
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtsi2ss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = true; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 42 }
-}
-let ucomiss = {
-    id = Ucomiss
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "ucomiss"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 46 }
-}
-let movhpd_m64_X = {
-    id = Movhpd_m64_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M64|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "movhpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 23 }
-}
-let addsubpd = {
-    id = Addsubpd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "addsubpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 208 }
-}
-let pmaxsw_M_Mm64 = {
-    id = Pmaxsw_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmaxsw"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 238 }
-}
-let minss = {
-    id = Minss
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "minss"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 93 }
-}
-let vorps_Y_Y_Ym256 = {
-    id = Vorps_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vorps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 86 }
-}
-let vorps_X_X_Xm128 = {
-    id = Vorps_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vorps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 86 }
-}
-let vroundps_Y_Ym256 = {
-    id = Vroundps_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vroundps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 8 }
-}
-let vcvtps2dq_X_Xm128 = {
-    id = Vcvtps2dq_X_Xm128
+let vpmovzxwd_Y_Xm128 = {
+    id = Vpmovzxwd_Y_Xm128
+  ; ext = [|AVX2|]
   ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtps2dq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 91 }
-}
-let vpshufhw_X_Xm128 = {
-    id = Vpshufhw_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vpshufhw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 112 }
-}
-let psadbw_M_Mm64 = {
-    id = Psadbw_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psadbw"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 246 }
-}
-let cmpss = {
-    id = Cmpss
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "cmpss"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 194 }
-}
-let vbroadcastss_X_X = {
-    id = Vbroadcastss_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vbroadcastss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 24 }
-}
-let vbroadcastss_X_m32 = {
-    id = Vbroadcastss_X_m32
-  ; args = [|{ loc = Temp [|M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vbroadcastss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 24 }
-}
-let vpcmpeqq_Y_Y_Ym256 = {
-    id = Vpcmpeqq_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpcmpeqq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 41 }
-}
-let vpcmpeqq_X_X_Xm128 = {
-    id = Vpcmpeqq_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpcmpeqq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 41 }
-}
-let maxps = {
-    id = Maxps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "maxps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 95 }
-}
-let vxorpd_Y_Y_Ym256 = {
-    id = Vxorpd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vxorpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 87 }
-}
-let vxorpd_X_X_Xm128 = {
-    id = Vxorpd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vxorpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 87 }
-}
-let pmovzxbw = {
-    id = Pmovzxbw
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pmovzxbw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 48 }
-}
-let vmovlpd_m64_X = {
-    id = Vmovlpd_m64_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M64|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "vmovlpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 19 }
-}
-let vpacksswb_Y_Y_Ym256 = {
-    id = Vpacksswb_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpacksswb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 99 }
-}
-let vpacksswb_X_X_Xm128 = {
-    id = Vpacksswb_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpacksswb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 99 }
-}
-let vmovmskps_r64_Y = {
-    id = Vmovmskps_r64_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovmskps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 80 }
-}
-let movshdup = {
-    id = Movshdup
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "movshdup"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 22 }
-}
-let movq_X_r64m64 = {
-    id = Movq_X_r64m64
-  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "movq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_w; escape = Esc_0F }; rm_reg = Reg; opcode = 126 }
-}
-let vcvtps2pd_X_Xm64 = {
-    id = Vcvtps2pd_X_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtps2pd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 90 }
-}
-let vpbroadcastw_Y_Xm16 = {
-    id = Vpbroadcastw_Y_Xm16
-  ; args = [|{ loc = Temp [|XMM;M16|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpbroadcastw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 121 }
-}
-let vpunpcklwd_Y_Y_Ym256 = {
-    id = Vpunpcklwd_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpunpcklwd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 97 }
-}
-let vpunpcklwd_X_X_Xm128 = {
-    id = Vpunpcklwd_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpunpcklwd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 97 }
-}
-let vpsraw_X_X = {
-    id = Vpsraw_X_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpsraw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 4; opcode = 113 }
-}
-let pinsrq = {
-    id = Pinsrq
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "pinsrq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_w; escape = Esc_0F3A }; rm_reg = Reg; opcode = 34 }
-}
-let cvttsd2si_r32_Xm64 = {
-    id = Cvttsd2si_r32_Xm64
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvttsd2si"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 44 }
-}
-let shrx_r64_r64m64_r64 = {
-    id = Shrx_r64_r64m64_r64
-  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm };{ loc = Temp [|R64|]; enc = Vex_v }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "shrx"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 247 }
-}
-let divps = {
-    id = Divps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "divps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 94 }
-}
-let pabsw_X_Xm128 = {
-    id = Pabsw_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pabsw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 29 }
-}
-let vmovsldup_X_Xm128 = {
-    id = Vmovsldup_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovsldup"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 18 }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovzxwd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 51 }
 }
 let vmovsd_X_X_X = {
     id = Vmovsd_X_X_X
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
+  ; imm = Imm_none
   ; mnemonic = "vmovsd"
   ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 16 }
 }
-let psubq_M_Mm64 = {
-    id = Psubq_M_Mm64
+let vlddqu_Y_m256 = {
+    id = Vlddqu_Y_m256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vlddqu"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 240 }
+}
+let vlddqu_X_m128 = {
+    id = Vlddqu_X_m128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vlddqu"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 240 }
+}
+let andnpd = {
+    id = Andnpd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "andnpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 85 }
+}
+let vpsraw_X_X_Xm128 = {
+    id = Vpsraw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsraw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 225 }
+}
+let movapd_X_Xm128 = {
+    id = Movapd_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "movapd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 40 }
+}
+let vpsrld_X_X = {
+    id = Vpsrld_X_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
+  ; imm = Imm_spec
+  ; mnemonic = "vpsrld"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 2; opcode = 114 }
+}
+let vpmuludq_Y_Y_Ym256 = {
+    id = Vpmuludq_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmuludq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 244 }
+}
+let vpcmpeqw_X_X_Xm128 = {
+    id = Vpcmpeqw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpcmpeqw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 117 }
+}
+let vpcmpgtd_X_X_Xm128 = {
+    id = Vpcmpgtd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpcmpgtd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 102 }
+}
+let pshuflw = {
+    id = Pshuflw
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "pshuflw"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 112 }
+}
+let pmulhuw_X_Xm128 = {
+    id = Pmulhuw_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmulhuw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 228 }
+}
+let vsqrtss = {
+    id = Vsqrtss
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vsqrtss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 81 }
+}
+let palignr_M_Mm64 = {
+    id = Palignr_M_Mm64
+  ; ext = [|SSSE3|]
   ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
   ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psubq"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 251 }
+  ; imm = Imm_spec
+  ; mnemonic = "palignr"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 15 }
 }
-let pshufb_X_Xm128 = {
-    id = Pshufb_X_Xm128
+let phaddw_X_Xm128 = {
+    id = Phaddw_X_Xm128
+  ; ext = [|SSSE3|]
   ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pshufb"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 0 }
+  ; imm = Imm_none
+  ; mnemonic = "phaddw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 1 }
 }
-let vpsubb_Y_Y_Ym256 = {
-    id = Vpsubb_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsubb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 248 }
-}
-let vpsubb_X_X_Xm128 = {
-    id = Vpsubb_X_X_Xm128
+let vpmuldq_X_X_Xm128 = {
+    id = Vpmuldq_X_X_Xm128
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsubb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 248 }
+  ; imm = Imm_none
+  ; mnemonic = "vpmuldq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 40 }
 }
-let pmovmskb_r64_M = {
-    id = Pmovmskb_r64_M
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pmovmskb"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 215 }
+let pmaxsw_X_Xm128 = {
+    id = Pmaxsw_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmaxsw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 238 }
 }
-let vpmovzxdq_Y_Xm128 = {
-    id = Vpmovzxdq_Y_Xm128
+let movdqa_X_Xm128 = {
+    id = Movdqa_X_Xm128
+  ; ext = [|SSE2|]
   ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovzxdq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 53 }
-}
-let vmovss_X_m32 = {
-    id = Vmovss_X_m32
-  ; args = [|{ loc = Temp [|M32|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovss"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 16 }
+  ; imm = Imm_none
+  ; mnemonic = "movdqa"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 111 }
 }
-let vpaddsb_Y_Y_Ym256 = {
-    id = Vpaddsb_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpaddsb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 236 }
+let vpsrlq_Y_Y = {
+    id = Vpsrlq_Y_Y
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = Vex_v }
+  ; imm = Imm_spec
+  ; mnemonic = "vpsrlq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 2; opcode = 115 }
 }
-let vpaddsb_X_X_Xm128 = {
-    id = Vpaddsb_X_X_Xm128
+let psignd_M_Mm64 = {
+    id = Psignd_M_Mm64
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psignd"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 10 }
+}
+let vpsignw_X_X_Xm128 = {
+    id = Vpsignw_X_X_Xm128
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpaddsb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 236 }
+  ; imm = Imm_none
+  ; mnemonic = "vpsignw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 9 }
 }
-let movhps_X_m64 = {
-    id = Movhps_X_m64
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "movhps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 22 }
-}
-let pmulhrsw_X_Xm128 = {
-    id = Pmulhrsw_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmulhrsw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 11 }
-}
-let mulps = {
-    id = Mulps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "mulps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 89 }
-}
-let vzeroall = {
-    id = Vzeroall
-  ; args = [||]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "vzeroall"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 119 }
-}
-let vpmovsxbw_Y_Xm128 = {
-    id = Vpmovsxbw_Y_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovsxbw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 32 }
-}
-let pcmpestri = {
-    id = Pcmpestri
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Pin RAX; enc = Implicit };{ loc = Pin RDX; enc = Implicit }|]
-  ; res = Res { loc = Pin RCX; enc = Implicit }
-  ; imm = true
-  ; mnemonic = "pcmpestri"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 97 }
-}
-let vmovsd_X_m64 = {
-    id = Vmovsd_X_m64
-  ; args = [|{ loc = Temp [|M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovsd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 16 }
-}
-let maxss = {
-    id = Maxss
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "maxss"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 95 }
-}
-let crc32_r32_r8m8 = {
-    id = Crc32_r32_r8m8
-  ; args = [|{ loc = Temp [|R32|]; enc = RM_r };{ loc = Temp [|R8;M8|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "crc32"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex; escape = Esc_0F38 }; rm_reg = Reg; opcode = 240 }
-}
-let vroundpd_X_Xm128 = {
-    id = Vroundpd_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vroundpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 9 }
-}
-let movhps_m64_X = {
-    id = Movhps_m64_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|M64|]; enc = RM_rm }
-  ; imm = false
-  ; mnemonic = "movhps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 23 }
-}
-let psrlw_X = {
-    id = Psrlw_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "psrlw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 2; opcode = 113 }
-}
-let roundpd = {
-    id = Roundpd
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "roundpd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 9 }
-}
-let dppd = {
-    id = Dppd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = true
-  ; mnemonic = "dppd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 65 }
-}
-let vunpckhpd_Y_Y_Ym256 = {
-    id = Vunpckhpd_Y_Y_Ym256
+let vunpckhps_Y_Y_Ym256 = {
+    id = Vunpckhps_Y_Y_Ym256
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vunpckhpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 21 }
+  ; imm = Imm_none
+  ; mnemonic = "vunpckhps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 21 }
 }
-let vunpckhpd_X_X_Xm128 = {
-    id = Vunpckhpd_X_X_Xm128
+let vunpckhps_X_X_Xm128 = {
+    id = Vunpckhps_X_X_Xm128
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vunpckhpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 21 }
+  ; imm = Imm_none
+  ; mnemonic = "vunpckhps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 21 }
 }
-let vpabsw_X_Xm128 = {
-    id = Vpabsw_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+let vandpd_Y_Y_Ym256 = {
+    id = Vandpd_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vandpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 84 }
+}
+let vandpd_X_X_Xm128 = {
+    id = Vandpd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpabsw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 29 }
+  ; imm = Imm_none
+  ; mnemonic = "vandpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 84 }
 }
-let pextrq = {
-    id = Pextrq
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
-  ; res = Res { loc = Temp [|R64;M64|]; enc = RM_rm }
-  ; imm = true
-  ; mnemonic = "pextrq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_w; escape = Esc_0F3A }; rm_reg = Reg; opcode = 22 }
+let vmovntdqa_Y_m256 = {
+    id = Vmovntdqa_Y_m256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovntdqa"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 42 }
 }
-let vcvtpd2dq_X_Ym256 = {
-    id = Vcvtpd2dq_X_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vcvtpd2dq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 230 }
-}
-let ldmxcsr = {
-    id = Ldmxcsr
-  ; args = [|{ loc = Temp [|M32|]; enc = RM_rm }|]
+let unpcklpd = {
+    id = Unpcklpd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = First_arg
-  ; imm = false
-  ; mnemonic = "ldmxcsr"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 2; opcode = 174 }
+  ; imm = Imm_none
+  ; mnemonic = "unpcklpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 20 }
 }
-let pmovzxbd = {
-    id = Pmovzxbd
-  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pmovzxbd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 49 }
-}
-let vpmovsxbw_X_Xm64 = {
-    id = Vpmovsxbw_X_Xm64
+let vpmovzxbw_X_Xm64 = {
+    id = Vpmovzxbw_X_Xm64
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovsxbw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 32 }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovzxbw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 48 }
 }
-let vpminuw_Y_Y_Ym256 = {
-    id = Vpminuw_Y_Y_Ym256
+let vpcmpgtw_Y_Y_Ym256 = {
+    id = Vpcmpgtw_Y_Y_Ym256
+  ; ext = [|AVX2|]
   ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpminuw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 58 }
+  ; imm = Imm_none
+  ; mnemonic = "vpcmpgtw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 101 }
 }
-let vpminuw_X_X_Xm128 = {
-    id = Vpminuw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpminuw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 58 }
+let movlhps = {
+    id = Movlhps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "movlhps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 22 }
 }
-let pshufhw = {
-    id = Pshufhw
+let movhpd_X_m64 = {
+    id = Movhpd_X_m64
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "movhpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 22 }
+}
+let vpsignb_Y_Y_Ym256 = {
+    id = Vpsignb_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsignb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 8 }
+}
+let movshdup = {
+    id = Movshdup
+  ; ext = [|SSE3|]
   ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "pshufhw"
-  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 112 }
+  ; imm = Imm_none
+  ; mnemonic = "movshdup"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 22 }
+}
+let psubusw = {
+    id = Psubusw
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psubusw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 217 }
+}
+let vpsrld_Y_Y = {
+    id = Vpsrld_Y_Y
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = Vex_v }
+  ; imm = Imm_spec
+  ; mnemonic = "vpsrld"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 2; opcode = 114 }
+}
+let vmovss_m32_X = {
+    id = Vmovss_m32_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M32|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 17 }
+}
+let vpsrlq_X_X_Xm128 = {
+    id = Vpsrlq_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsrlq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 211 }
+}
+let addpd = {
+    id = Addpd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "addpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 88 }
+}
+let vpsllw_X_X = {
+    id = Vpsllw_X_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
+  ; imm = Imm_spec
+  ; mnemonic = "vpsllw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 6; opcode = 113 }
+}
+let packsswb = {
+    id = Packsswb
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "packsswb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 99 }
+}
+let cvtsi2ss_X_r64m64 = {
+    id = Cvtsi2ss_X_r64m64
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvtsi2ss"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_w; escape = Esc_0F }; rm_reg = Reg; opcode = 42 }
+}
+let paddsb = {
+    id = Paddsb
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "paddsb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 236 }
+}
+let divsd = {
+    id = Divsd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "divsd"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 94 }
+}
+let movntdq = {
+    id = Movntdq
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "movntdq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 231 }
+}
+let pinsrw_X_r32m16 = {
+    id = Pinsrw_X_r32m16
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|R32;M16|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "pinsrw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 196 }
+}
+let vmovntdqa_X_m128 = {
+    id = Vmovntdqa_X_m128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovntdqa"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 42 }
+}
+let dpps = {
+    id = Dpps
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "dpps"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 64 }
+}
+let paddw = {
+    id = Paddw
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "paddw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 253 }
+}
+let cvtsd2si_r32_Xm64 = {
+    id = Cvtsd2si_r32_Xm64
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvtsd2si"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 45 }
+}
+let vphaddsw_X_X_Xm128 = {
+    id = Vphaddsw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vphaddsw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 3 }
 }
 let vtestpd_Y_Ym256 = {
     id = Vtestpd_Y_Ym256
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|YMM|]; enc = RM_r };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
   ; res = First_arg
-  ; imm = false
+  ; imm = Imm_none
   ; mnemonic = "vtestpd"
   ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 15 }
 }
 let vtestpd_X_Xm128 = {
     id = Vtestpd_X_Xm128
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = First_arg
-  ; imm = false
+  ; imm = Imm_none
   ; mnemonic = "vtestpd"
   ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 15 }
 }
-let divsd = {
-    id = Divsd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "divsd"
-  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 94 }
-}
-let psignd_M_Mm64 = {
-    id = Psignd_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "psignd"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 10 }
-}
-let comisd = {
-    id = Comisd
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+let roundps = {
+    id = Roundps
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "comisd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 47 }
+  ; imm = Imm_spec
+  ; mnemonic = "roundps"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 8 }
 }
-let vpmulhw_Y_Y_Ym256 = {
-    id = Vpmulhw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmulhw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 229 }
+let vpextrw_r64m16_X = {
+    id = Vpextrw_r64m16_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|R64;M16|]; enc = RM_rm }
+  ; imm = Imm_spec
+  ; mnemonic = "vpextrw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 21 }
 }
-let vpmulhw_X_X_Xm128 = {
-    id = Vpmulhw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmulhw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 229 }
+let movdqa_Xm128_X = {
+    id = Movdqa_Xm128_X
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "movdqa"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 127 }
 }
-let vpmovsxwq_X_Xm32 = {
-    id = Vpmovsxwq_X_Xm32
+let vpmovsxbd_X_Xm32 = {
+    id = Vpmovsxbd_X_Xm32
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovsxwq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 36 }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovsxbd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 33 }
 }
-let cvtps2dq = {
-    id = Cvtps2dq
+let vcvttss2si_r32_Xm32 = {
+    id = Vcvttss2si_r32_Xm32
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvttss2si"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 44 }
+}
+let vcvtpd2ps_X_Ym256 = {
+    id = Vcvtpd2ps_X_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtpd2ps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 90 }
+}
+let vcvtpd2ps_X_Xm128 = {
+    id = Vcvtpd2ps_X_Xm128
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "cvtps2dq"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 91 }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtpd2ps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 90 }
 }
-let vpsignb_Y_Y_Ym256 = {
-    id = Vpsignb_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsignb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 8 }
-}
-let vpsignb_X_X_Xm128 = {
-    id = Vpsignb_X_X_Xm128
+let vpsubusb_X_X_Xm128 = {
+    id = Vpsubusb_X_X_Xm128
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsignb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 8 }
+  ; imm = Imm_none
+  ; mnemonic = "vpsubusb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 216 }
 }
-let orps = {
-    id = Orps
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "orps"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 86 }
-}
-let movups_X_Xm128 = {
-    id = Movups_X_Xm128
-  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "movups"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 16 }
-}
-let punpckhwd = {
-    id = Punpckhwd
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "punpckhwd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 105 }
-}
-let vpsllq_Y_Y_Xm128 = {
-    id = Vpsllq_Y_Y_Xm128
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsllq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 243 }
-}
-let vpsllq_X_X_Xm128 = {
-    id = Vpsllq_X_X_Xm128
+let vpmuludq_X_X_Xm128 = {
+    id = Vpmuludq_X_X_Xm128
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsllq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 243 }
+  ; imm = Imm_none
+  ; mnemonic = "vpmuludq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 244 }
 }
-let pcmpistri = {
-    id = Pcmpistri
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
-  ; res = Res { loc = Pin RCX; enc = Implicit }
-  ; imm = true
-  ; mnemonic = "pcmpistri"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 99 }
+let cvtss2si_r32_Xm32 = {
+    id = Cvtss2si_r32_Xm32
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvtss2si"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 45 }
 }
-let vpsubsw_Y_Y_Ym256 = {
-    id = Vpsubsw_Y_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsubsw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 233 }
-}
-let vpsubsw_X_X_Xm128 = {
-    id = Vpsubsw_X_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+let vmaxsd = {
+    id = Vmaxsd
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpsubsw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 233 }
+  ; imm = Imm_none
+  ; mnemonic = "vmaxsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 95 }
 }
-let pmovsxwd = {
-    id = Pmovsxwd
-  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pmovsxwd"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 35 }
+let pextrb = {
+    id = Pextrb
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|R64;M8|]; enc = RM_rm }
+  ; imm = Imm_spec
+  ; mnemonic = "pextrb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 20 }
 }
-let pmaddubsw_X_Xm128 = {
-    id = Pmaddubsw_X_Xm128
-  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+let vpinsrw = {
+    id = Vpinsrw
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|R32;M16|]; enc = RM_rm }|]
   ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pmaddubsw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 4 }
-}
-let vpblendvb_Y_Y_Ym256_Y = {
-    id = Vpblendvb_Y_Y_Ym256_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm };{ loc = Temp [|YMM|]; enc = Implicit }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpblendvb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 76 }
-}
-let vpblendvb_X_X_Xm128_X = {
-    id = Vpblendvb_X_X_Xm128_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Temp [|XMM|]; enc = Implicit }|]
-  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpblendvb"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 76 }
+  ; imm = Imm_spec
+  ; mnemonic = "vpinsrw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 196 }
 }
 let vblendvps_Y_Y_Ym256_Y = {
     id = Vblendvps_Y_Y_Ym256_Y
-  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm };{ loc = Temp [|YMM|]; enc = Implicit }|]
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm };{ loc = Temp [|YMM|]; enc = Immediate }|]
   ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
+  ; imm = Imm_reg
   ; mnemonic = "vblendvps"
   ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 74 }
 }
 let vblendvps_X_X_Xm128_X = {
     id = Vblendvps_X_X_Xm128_X
-  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Temp [|XMM|]; enc = Implicit }|]
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Temp [|XMM|]; enc = Immediate }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
+  ; imm = Imm_reg
   ; mnemonic = "vblendvps"
   ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 74 }
 }
-let pcmpgtw = {
-    id = Pcmpgtw
+let pmovsxbd = {
+    id = Pmovsxbd
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pmovsxbd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 33 }
+}
+let mpsadbw = {
+    id = Mpsadbw
+  ; ext = [|SSE4_1|]
   ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = First_arg
-  ; imm = false
-  ; mnemonic = "pcmpgtw"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 101 }
+  ; imm = Imm_spec
+  ; mnemonic = "mpsadbw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 66 }
 }
-let vpermilps_Y_Ym256 = {
-    id = Vpermilps_Y_Ym256
-  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+let vpmovsxbq_X_Xm16 = {
+    id = Vpmovsxbq_X_Xm16
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M16|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovsxbq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 34 }
+}
+let vpinsrd = {
+    id = Vpinsrd
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "vpinsrd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 34 }
+}
+let cvtdq2pd = {
+    id = Cvtdq2pd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvtdq2pd"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 230 }
+}
+let vphaddsw_Y_Y_Ym256 = {
+    id = Vphaddsw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vpermilps"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 4 }
+  ; imm = Imm_none
+  ; mnemonic = "vphaddsw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 3 }
 }
-let roundps = {
-    id = Roundps
+let vpsrlq_X_X = {
+    id = Vpsrlq_X_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
+  ; imm = Imm_spec
+  ; mnemonic = "vpsrlq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 2; opcode = 115 }
+}
+let pminuw = {
+    id = Pminuw
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pminuw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 58 }
+}
+let vpmovzxwd_X_Xm64 = {
+    id = Vpmovzxwd_X_Xm64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovzxwd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 51 }
+}
+let cvtss2si_r64_Xm32 = {
+    id = Cvtss2si_r64_Xm32
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvtss2si"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_w; escape = Esc_0F }; rm_reg = Reg; opcode = 45 }
+}
+let pabsw_X_Xm128 = {
+    id = Pabsw_X_Xm128
+  ; ext = [|SSSE3|]
   ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "roundps"
-  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 8 }
+  ; imm = Imm_none
+  ; mnemonic = "pabsw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 29 }
 }
-let phsubw_M_Mm64 = {
-    id = Phsubw_M_Mm64
-  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
-  ; res = First_arg
-  ; imm = false
-  ; mnemonic = "phsubw"
-  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 5 }
+let cvttss2si_r32_Xm32 = {
+    id = Cvttss2si_r32_Xm32
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvttss2si"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 44 }
 }
-let vmovntdqa_X_m128 = {
-    id = Vmovntdqa_X_m128
-  ; args = [|{ loc = Temp [|M128|]; enc = RM_rm }|]
+let vpunpcklqdq_Y_Y_Ym256 = {
+    id = Vpunpcklqdq_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpunpcklqdq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 108 }
+}
+let movupd_Xm128_X = {
+    id = Movupd_Xm128_X
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "movupd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 17 }
+}
+let vpmaxsw_X_X_Xm128 = {
+    id = Vpmaxsw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vmovntdqa"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 42 }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaxsw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 238 }
 }
-let vpermilpd_Y_Ym256 = {
-    id = Vpermilpd_Y_Ym256
+let pcmpistrm = {
+    id = Pcmpistrm
+  ; ext = [|SSE4_2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Pin XMM0; enc = Implicit }
+  ; imm = Imm_spec
+  ; mnemonic = "pcmpistrm"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 98 }
+}
+let vmovd_X_r32m32 = {
+    id = Vmovd_X_r32m32
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 126 }
+}
+let movdqu_X_Xm128 = {
+    id = Movdqu_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "movdqu"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 127 }
+}
+let blendvpd = {
+    id = Blendvpd
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Pin XMM0; enc = Implicit }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "blendvpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 21 }
+}
+let vmovsldup_Y_Ym256 = {
+    id = Vmovsldup_Y_Ym256
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = true
-  ; mnemonic = "vpermilpd"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 5 }
+  ; imm = Imm_none
+  ; mnemonic = "vmovsldup"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 18 }
 }
-let sarx_r64_r64m64_r64 = {
-    id = Sarx_r64_r64m64_r64
-  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm };{ loc = Temp [|R64|]; enc = Vex_v }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "sarx"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 247 }
+let vmovsldup_X_Xm128 = {
+    id = Vmovsldup_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovsldup"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 18 }
 }
-let pdep_r64_r64_r64m64 = {
-    id = Pdep_r64_r64_r64m64
-  ; args = [|{ loc = Temp [|R64|]; enc = Vex_v };{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "pdep"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 245 }
+let vpmovzxdq_X_Xm64 = {
+    id = Vpmovzxdq_X_Xm64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovzxdq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 53 }
+}
+let vpavgb_X_X_Xm128 = {
+    id = Vpavgb_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpavgb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 224 }
+}
+let vpor_Y_Y_Ym256 = {
+    id = Vpor_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpor"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 235 }
+}
+let vpmaxsd_Y_Y_Ym256 = {
+    id = Vpmaxsd_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaxsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 61 }
+}
+let vblendps_Y_Y_Ym256 = {
+    id = Vblendps_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vblendps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 12 }
+}
+let vblendps_X_X_Xm128 = {
+    id = Vblendps_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vblendps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 12 }
+}
+let vcvtsi2ss_X_X_r64m64 = {
+    id = Vcvtsi2ss_X_X_r64m64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtsi2ss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = true; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 42 }
+}
+let vcvtsi2ss_X_X_r32m32 = {
+    id = Vcvtsi2ss_X_X_r32m32
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtsi2ss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 42 }
+}
+let psignb_X_Xm128 = {
+    id = Psignb_X_Xm128
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psignb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 8 }
+}
+let vmovq_X_r64m64 = {
+    id = Vmovq_X_r64m64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = true; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 110 }
+}
+let mulss = {
+    id = Mulss
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "mulss"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 89 }
+}
+let vpunpckhdq_Y_Y_Ym256 = {
+    id = Vpunpckhdq_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpunpckhdq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 106 }
+}
+let vtestps_Y_Ym256 = {
+    id = Vtestps_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "vtestps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 14 }
+}
+let vtestps_X_Xm128 = {
+    id = Vtestps_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "vtestps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 14 }
+}
+let vpinsrq = {
+    id = Vpinsrq
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "vpinsrq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = true; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 34 }
+}
+let vmaskmovps_Y_Y_m256 = {
+    id = Vmaskmovps_Y_Y_m256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmaskmovps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 44 }
+}
+let vmaskmovps_X_X_m128 = {
+    id = Vmaskmovps_X_X_m128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmaskmovps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 44 }
+}
+let pmaddubsw_X_Xm128 = {
+    id = Pmaddubsw_X_Xm128
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmaddubsw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 4 }
+}
+let vzeroupper = {
+    id = Vzeroupper
+  ; ext = [|AVX|]
+  ; args = [||]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "vzeroupper"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 119 }
+}
+let pminsw_M_Mm64 = {
+    id = Pminsw_M_Mm64
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pminsw"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 234 }
+}
+let vpackssdw_Y_Y_Ym256 = {
+    id = Vpackssdw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpackssdw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 107 }
 }
 let vmovlps_X_X_m64 = {
     id = Vmovlps_X_X_m64
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|M64|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
-  ; imm = false
+  ; imm = Imm_none
   ; mnemonic = "vmovlps"
   ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 18 }
 }
-let vpmovzxwq_Y_Xm64 = {
-    id = Vpmovzxwq_Y_Xm64
+let vcvttsd2si_r64_Xm64 = {
+    id = Vcvttsd2si_r64_Xm64
+  ; ext = [|AVX|]
   ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
-  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
-  ; imm = false
-  ; mnemonic = "vpmovzxwq"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 52 }
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvttsd2si"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = true; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 44 }
 }
-let vpsrlw_Y_Y = {
-    id = Vpsrlw_Y_Y
+let subsd = {
+    id = Subsd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "subsd"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 92 }
+}
+let vpextrq = {
+    id = Vpextrq
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|R64;M64|]; enc = RM_rm }
+  ; imm = Imm_spec
+  ; mnemonic = "vpextrq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = true; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 22 }
+}
+let pblendw = {
+    id = Pblendw
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "pblendw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 14 }
+}
+let vpminud_X_X_Xm128 = {
+    id = Vpminud_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpminud"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 59 }
+}
+let shlx_r64_r64m64_r64 = {
+    id = Shlx_r64_r64m64_r64
+  ; ext = [|BMI2|]
+  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm };{ loc = Temp [|R64|]; enc = Vex_v }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "shlx"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 247 }
+}
+let shlx_r32_r32m32_r32 = {
+    id = Shlx_r32_r32m32_r32
+  ; ext = [|BMI2|]
+  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm };{ loc = Temp [|R32|]; enc = Vex_v }|]
+  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "shlx"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 247 }
+}
+let vmpsadbw_X_X_Xm128 = {
+    id = Vmpsadbw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vmpsadbw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 66 }
+}
+let movq_X_r64m64 = {
+    id = Movq_X_r64m64
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "movq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_w; escape = Esc_0F }; rm_reg = Reg; opcode = 110 }
+}
+let vpmovsxdq_X_Xm64 = {
+    id = Vpmovsxdq_X_Xm64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovsxdq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 37 }
+}
+let vpaddusw_Y_Y_Ym256 = {
+    id = Vpaddusw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpaddusw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 221 }
+}
+let crc32_r64_r8m8 = {
+    id = Crc32_r64_r8m8
+  ; ext = [|SSE4_2|]
+  ; args = [|{ loc = Temp [|R64|]; enc = RM_r };{ loc = Temp [|R8;M8|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "crc32"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_w; escape = Esc_0F38 }; rm_reg = Reg; opcode = 240 }
+}
+let crc32_r32_r8m8 = {
+    id = Crc32_r32_r8m8
+  ; ext = [|SSE4_2|]
+  ; args = [|{ loc = Temp [|R32|]; enc = RM_r };{ loc = Temp [|R8;M8|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "crc32"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex; escape = Esc_0F38 }; rm_reg = Reg; opcode = 240 }
+}
+let crc32_r32_r8m8 = {
+    id = Crc32_r32_r8m8
+  ; ext = [|SSE4_2|]
+  ; args = [|{ loc = Temp [|R32|]; enc = RM_r };{ loc = Temp [|R8;M8|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "crc32"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 240 }
+}
+let vpandn_Y_Y_Ym256 = {
+    id = Vpandn_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpandn"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 223 }
+}
+let vpmaxsb_Y_Y_Ym256 = {
+    id = Vpmaxsb_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaxsb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 60 }
+}
+let vmovq_X_Xm64 = {
+    id = Vmovq_X_Xm64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 126 }
+}
+let vpsrad_X_X = {
+    id = Vpsrad_X_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
+  ; imm = Imm_spec
+  ; mnemonic = "vpsrad"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 4; opcode = 114 }
+}
+let vminsd = {
+    id = Vminsd
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vminsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 93 }
+}
+let psllw_X = {
+    id = Psllw_X
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "psllw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 6; opcode = 113 }
+}
+let psraw_X = {
+    id = Psraw_X
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "psraw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 4; opcode = 113 }
+}
+let punpckhwd = {
+    id = Punpckhwd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "punpckhwd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 105 }
+}
+let vrsqrtss = {
+    id = Vrsqrtss
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vrsqrtss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 82 }
+}
+let vmovupd_Ym256_Y = {
+    id = Vmovupd_Ym256_Y
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|YMM;M256|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovupd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 17 }
+}
+let vmovupd_Xm128_X = {
+    id = Vmovupd_Xm128_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovupd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 17 }
+}
+let vpxor_Y_Y_Ym256 = {
+    id = Vpxor_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpxor"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 239 }
+}
+let punpcklbw = {
+    id = Punpcklbw
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "punpcklbw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 96 }
+}
+let movlpd_X_m64 = {
+    id = Movlpd_X_m64
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "movlpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 18 }
+}
+let vpslld_Y_Y = {
+    id = Vpslld_Y_Y
+  ; ext = [|AVX2|]
   ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
   ; res = Res { loc = Temp [|YMM|]; enc = Vex_v }
-  ; imm = true
-  ; mnemonic = "vpsrlw"
-  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 2; opcode = 113 }
+  ; imm = Imm_spec
+  ; mnemonic = "vpslld"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 6; opcode = 114 }
+}
+let vpmovsxbd_Y_Xm64 = {
+    id = Vpmovsxbd_Y_Xm64
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovsxbd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 33 }
+}
+let vpsadbw_Y_Y_Ym256 = {
+    id = Vpsadbw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsadbw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 246 }
+}
+let andnps = {
+    id = Andnps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "andnps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 85 }
+}
+let vaddps_Y_Y_Ym256 = {
+    id = Vaddps_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vaddps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 88 }
+}
+let vaddps_X_X_Xm128 = {
+    id = Vaddps_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vaddps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 88 }
+}
+let vpmovzxbq_Y_Xm32 = {
+    id = Vpmovzxbq_Y_Xm32
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovzxbq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 50 }
+}
+let vextractf128 = {
+    id = Vextractf128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
+  ; imm = Imm_spec
+  ; mnemonic = "vextractf128"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 25 }
+}
+let vpsrld_Y_Y_Xm128 = {
+    id = Vpsrld_Y_Y_Xm128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsrld"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 210 }
+}
+let vpslld_X_X_Xm128 = {
+    id = Vpslld_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpslld"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 242 }
+}
+let vmovntpd_m256_Y = {
+    id = Vmovntpd_m256_Y
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M256|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovntpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 43 }
+}
+let vmovntpd_m128_X = {
+    id = Vmovntpd_m128_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovntpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 43 }
+}
+let vpsrlvq_Y_Y_Ym256 = {
+    id = Vpsrlvq_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsrlvq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 69 }
+}
+let vpsrlvq_X_X_Xm128 = {
+    id = Vpsrlvq_X_X_Xm128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsrlvq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 69 }
+}
+let vpsrad_X_X_Xm128 = {
+    id = Vpsrad_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsrad"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 226 }
+}
+let pavgw_X_Xm128 = {
+    id = Pavgw_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pavgw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 227 }
+}
+let vpermpd = {
+    id = Vpermpd
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpermpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = true; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 1 }
+}
+let vpshufhw_Y_Ym256 = {
+    id = Vpshufhw_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpshufhw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 112 }
+}
+let vpblendd_Y_Y_Ym256 = {
+    id = Vpblendd_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpblendd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 2 }
+}
+let vpblendd_X_X_Xm128 = {
+    id = Vpblendd_X_X_Xm128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpblendd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 2 }
+}
+let blendpd = {
+    id = Blendpd
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "blendpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 13 }
+}
+let pabsb_X_Xm128 = {
+    id = Pabsb_X_Xm128
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pabsb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 28 }
+}
+let vpaddsw_X_X_Xm128 = {
+    id = Vpaddsw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpaddsw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 237 }
+}
+let pminsw_X_Xm128 = {
+    id = Pminsw_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pminsw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 234 }
+}
+let vpshufhw_X_Xm128 = {
+    id = Vpshufhw_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpshufhw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 112 }
+}
+let divss = {
+    id = Divss
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "divss"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 94 }
+}
+let vmovss_X_m32 = {
+    id = Vmovss_X_m32
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 16 }
+}
+let vpermd = {
+    id = Vpermd
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpermd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 54 }
+}
+let vpbroadcastq_Y_Xm64 = {
+    id = Vpbroadcastq_Y_Xm64
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpbroadcastq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 89 }
+}
+let vpbroadcastq_X_Xm64 = {
+    id = Vpbroadcastq_X_Xm64
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpbroadcastq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 89 }
+}
+let vphaddw_Y_Y_Ym256 = {
+    id = Vphaddw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vphaddw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 1 }
+}
+let ucomiss = {
+    id = Ucomiss
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "ucomiss"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 46 }
+}
+let movlps_X_m64 = {
+    id = Movlps_X_m64
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "movlps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 18 }
+}
+let vpsubw_Y_Y_Ym256 = {
+    id = Vpsubw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsubw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 249 }
+}
+let pslldq = {
+    id = Pslldq
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "pslldq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 7; opcode = 115 }
+}
+let pmovsxbq = {
+    id = Pmovsxbq
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM;M16|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pmovsxbq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 34 }
+}
+let vpaddsw_Y_Y_Ym256 = {
+    id = Vpaddsw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpaddsw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 237 }
+}
+let vpcmpgtq_Y_Y_Ym256 = {
+    id = Vpcmpgtq_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpcmpgtq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 55 }
+}
+let vpmovsxdq_Y_Xm128 = {
+    id = Vpmovsxdq_Y_Xm128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovsxdq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 37 }
+}
+let vbroadcastsd_Y_X = {
+    id = Vbroadcastsd_Y_X
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vbroadcastsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 25 }
+}
+let vpavgb_Y_Y_Ym256 = {
+    id = Vpavgb_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpavgb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 224 }
+}
+let vpaddb_X_X_Xm128 = {
+    id = Vpaddb_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpaddb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 252 }
+}
+let vpunpcklbw_X_X_Xm128 = {
+    id = Vpunpcklbw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpunpcklbw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 96 }
+}
+let sqrtpd = {
+    id = Sqrtpd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "sqrtpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 81 }
+}
+let vmovhlps = {
+    id = Vmovhlps
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "vmovhlps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 18 }
+}
+let vmovaps_Ym256_Y = {
+    id = Vmovaps_Ym256_Y
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|YMM;M256|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovaps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 41 }
+}
+let vmovaps_Xm128_X = {
+    id = Vmovaps_Xm128_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovaps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 41 }
+}
+let pavgb_M_Mm64 = {
+    id = Pavgb_M_Mm64
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pavgb"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 224 }
+}
+let vpmovzxwq_X_Xm32 = {
+    id = Vpmovzxwq_X_Xm32
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovzxwq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 52 }
+}
+let vphsubsw_Y_Y_Ym256 = {
+    id = Vphsubsw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r };{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "vphsubsw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 7 }
+}
+let vucomiss = {
+    id = Vucomiss
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "vucomiss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 46 }
+}
+let vminss = {
+    id = Vminss
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vminss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 93 }
+}
+let vcvtdq2pd_Y_Xm128 = {
+    id = Vcvtdq2pd_Y_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtdq2pd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 230 }
+}
+let vcvtdq2pd_X_Xm64 = {
+    id = Vcvtdq2pd_X_Xm64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtdq2pd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 230 }
+}
+let vmovhps_m64_X = {
+    id = Vmovhps_m64_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M64|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovhps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 23 }
+}
+let psrad_X_Xm128 = {
+    id = Psrad_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psrad"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 226 }
+}
+let vpslldq_X_X = {
+    id = Vpslldq_X_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
+  ; imm = Imm_spec
+  ; mnemonic = "vpslldq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 7; opcode = 115 }
+}
+let pmovzxbw = {
+    id = Pmovzxbw
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pmovzxbw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 48 }
+}
+let vpextrw_r64_X = {
+    id = Vpextrw_r64_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpextrw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 197 }
+}
+let vpaddusb_Y_Y_Ym256 = {
+    id = Vpaddusb_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpaddusb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 220 }
+}
+let movntpd = {
+    id = Movntpd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "movntpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 43 }
+}
+let vpshuflw_X_Xm128 = {
+    id = Vpshuflw_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpshuflw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 112 }
+}
+let vpor_X_X_Xm128 = {
+    id = Vpor_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpor"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 235 }
+}
+let vsubsd = {
+    id = Vsubsd
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vsubsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 92 }
+}
+let vpmulld_Y_Y_Ym256 = {
+    id = Vpmulld_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmulld"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 64 }
+}
+let phsubsw_M_Mm64 = {
+    id = Phsubsw_M_Mm64
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "phsubsw"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 7 }
+}
+let vinsertps = {
+    id = Vinsertps
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vinsertps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 33 }
+}
+let vpsrad_Y_Y_Xm128 = {
+    id = Vpsrad_Y_Y_Xm128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsrad"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 226 }
+}
+let vpavgw_Y_Y_Ym256 = {
+    id = Vpavgw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpavgw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 227 }
+}
+let movss_X_m32 = {
+    id = Movss_X_m32
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|M32|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "movss"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 16 }
+}
+let movss_X_X = {
+    id = Movss_X_X
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "movss"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 16 }
+}
+let pabsd_X_Xm128 = {
+    id = Pabsd_X_Xm128
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pabsd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 30 }
+}
+let vmovhps_X_X_m64 = {
+    id = Vmovhps_X_X_m64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovhps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 22 }
+}
+let pmovsxdq = {
+    id = Pmovsxdq
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pmovsxdq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 37 }
+}
+let comiss = {
+    id = Comiss
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "comiss"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 47 }
+}
+let cvttps2dq = {
+    id = Cvttps2dq
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvttps2dq"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 91 }
 }
 let stmxcsr = {
     id = Stmxcsr
+  ; ext = [|SSE|]
   ; args = [||]
   ; res = Res { loc = Temp [|M32|]; enc = RM_rm }
-  ; imm = false
+  ; imm = Imm_none
   ; mnemonic = "stmxcsr"
   ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 3; opcode = 174 }
 }
-let phaddd_X_Xm128 = {
-    id = Phaddd_X_Xm128
+let vroundpd_Y_Ym256 = {
+    id = Vroundpd_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vroundpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 9 }
+}
+let vroundpd_X_Xm128 = {
+    id = Vroundpd_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vroundpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 9 }
+}
+let pclmulqdq = {
+    id = Pclmulqdq
+  ; ext = [|PCLMULQDQ|]
   ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
   ; res = First_arg
-  ; imm = false
+  ; imm = Imm_spec
+  ; mnemonic = "pclmulqdq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 68 }
+}
+let vpmovsxwd_Y_Xm128 = {
+    id = Vpmovsxwd_Y_Xm128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovsxwd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 35 }
+}
+let vpmovsxwq_Y_Xm64 = {
+    id = Vpmovsxwq_Y_Xm64
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovsxwq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 36 }
+}
+let vzeroall = {
+    id = Vzeroall
+  ; ext = [|AVX|]
+  ; args = [||]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "vzeroall"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 119 }
+}
+let vpermq = {
+    id = Vpermq
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpermq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = true; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 0 }
+}
+let ucomisd = {
+    id = Ucomisd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "ucomisd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 46 }
+}
+let vminps_Y_Y_Ym256 = {
+    id = Vminps_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vminps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 93 }
+}
+let vminps_X_X_Xm128 = {
+    id = Vminps_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vminps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 93 }
+}
+let hsubpd = {
+    id = Hsubpd
+  ; ext = [|SSE3|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "hsubpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 125 }
+}
+let vunpckhpd_Y_Y_Ym256 = {
+    id = Vunpckhpd_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vunpckhpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 21 }
+}
+let vunpckhpd_X_X_Xm128 = {
+    id = Vunpckhpd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vunpckhpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 21 }
+}
+let vpabsd_X_Xm128 = {
+    id = Vpabsd_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpabsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 30 }
+}
+let addsd = {
+    id = Addsd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "addsd"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 88 }
+}
+let vpmovsxbw_Y_Xm128 = {
+    id = Vpmovsxbw_Y_Xm128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovsxbw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 32 }
+}
+let vmovntps_m256_Y = {
+    id = Vmovntps_m256_Y
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M256|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovntps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 43 }
+}
+let vmovntps_m128_X = {
+    id = Vmovntps_m128_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovntps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 43 }
+}
+let punpckhdq = {
+    id = Punpckhdq
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "punpckhdq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 106 }
+}
+let vpcmpeqb_Y_Y_Ym256 = {
+    id = Vpcmpeqb_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpcmpeqb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 116 }
+}
+let vmulsd = {
+    id = Vmulsd
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmulsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 89 }
+}
+let vcvtsd2ss = {
+    id = Vcvtsd2ss
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtsd2ss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 90 }
+}
+let vpermps = {
+    id = Vpermps
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpermps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 22 }
+}
+let pdep_r64_r64_r64m64 = {
+    id = Pdep_r64_r64_r64m64
+  ; ext = [|BMI2|]
+  ; args = [|{ loc = Temp [|R64|]; enc = Vex_v };{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pdep"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 245 }
+}
+let pdep_r32_r32_r32m32 = {
+    id = Pdep_r32_r32_r32m32
+  ; ext = [|BMI2|]
+  ; args = [|{ loc = Temp [|R32|]; enc = Vex_v };{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pdep"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 245 }
+}
+let vpackssdw_X_X_Xm128 = {
+    id = Vpackssdw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpackssdw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 107 }
+}
+let pshufd = {
+    id = Pshufd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "pshufd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 112 }
+}
+let cvtsd2ss = {
+    id = Cvtsd2ss
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvtsd2ss"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 90 }
+}
+let vpblendw_Y_Y_Ym256 = {
+    id = Vpblendw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpblendw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 14 }
+}
+let vpermilpd_Y_Y_Ym256 = {
+    id = Vpermilpd_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpermilpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 13 }
+}
+let vpermilpd_X_X_Xm128 = {
+    id = Vpermilpd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpermilpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 13 }
+}
+let vpmovmskb_r64_Y = {
+    id = Vpmovmskb_r64_Y
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovmskb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 215 }
+}
+let pinsrw_M_r32m16 = {
+    id = Pinsrw_M_r32m16
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|R32;M16|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "pinsrw"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 196 }
+}
+let vpsrld_X_X_Xm128 = {
+    id = Vpsrld_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsrld"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 210 }
+}
+let vpabsb_Y_Ym256 = {
+    id = Vpabsb_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpabsb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 28 }
+}
+let vpmovzxbd_X_Xm32 = {
+    id = Vpmovzxbd_X_Xm32
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovzxbd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 49 }
+}
+let vmovsd_m64_X = {
+    id = Vmovsd_m64_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M64|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 17 }
+}
+let vpsraw_Y_Y = {
+    id = Vpsraw_Y_Y
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = Vex_v }
+  ; imm = Imm_spec
+  ; mnemonic = "vpsraw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 4; opcode = 113 }
+}
+let pmaxub_X_Xm128 = {
+    id = Pmaxub_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmaxub"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 222 }
+}
+let bzhi_r64_r64m64_r64 = {
+    id = Bzhi_r64_r64m64_r64
+  ; ext = [|BMI2|]
+  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm };{ loc = Temp [|R64|]; enc = Vex_v }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "bzhi"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 245 }
+}
+let bzhi_r32_r32m32_r32 = {
+    id = Bzhi_r32_r32m32_r32
+  ; ext = [|BMI2|]
+  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm };{ loc = Temp [|R32|]; enc = Vex_v }|]
+  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "bzhi"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 245 }
+}
+let pcmpistri = {
+    id = Pcmpistri
+  ; ext = [|SSE4_2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Pin RCX; enc = Implicit }
+  ; imm = Imm_spec
+  ; mnemonic = "pcmpistri"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 99 }
+}
+let orpd = {
+    id = Orpd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "orpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 86 }
+}
+let vpmaskmovq_Y_Y_m256 = {
+    id = Vpmaskmovq_Y_Y_m256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaskmovq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 140 }
+}
+let vpmaskmovq_X_X_m128 = {
+    id = Vpmaskmovq_X_X_m128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaskmovq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 140 }
+}
+let vpunpckldq_Y_Y_Ym256 = {
+    id = Vpunpckldq_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpunpckldq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 98 }
+}
+let vpunpcklbw_Y_Y_Ym256 = {
+    id = Vpunpcklbw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpunpcklbw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 96 }
+}
+let vpsubsb_X_X_Xm128 = {
+    id = Vpsubsb_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsubsb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 232 }
+}
+let vpaddq_Y_Y_Ym256 = {
+    id = Vpaddq_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpaddq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 212 }
+}
+let vpsubsb_Y_Y_Ym256 = {
+    id = Vpsubsb_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsubsb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 232 }
+}
+let vcvttsd2si_r32_Xm64 = {
+    id = Vcvttsd2si_r32_Xm64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvttsd2si"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 44 }
+}
+let vroundss = {
+    id = Vroundss
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vroundss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 10 }
+}
+let vpunpckhqdq_Y_Y_Ym256 = {
+    id = Vpunpckhqdq_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpunpckhqdq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 109 }
+}
+let shrx_r64_r64m64_r64 = {
+    id = Shrx_r64_r64m64_r64
+  ; ext = [|BMI2|]
+  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm };{ loc = Temp [|R64|]; enc = Vex_v }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "shrx"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 247 }
+}
+let shrx_r32_r32m32_r32 = {
+    id = Shrx_r32_r32m32_r32
+  ; ext = [|BMI2|]
+  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm };{ loc = Temp [|R32|]; enc = Vex_v }|]
+  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "shrx"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 247 }
+}
+let pextrw_r64_M = {
+    id = Pextrw_r64_M
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "pextrw"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 197 }
+}
+let vmovapd_Y_Ym256 = {
+    id = Vmovapd_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovapd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 40 }
+}
+let vmovapd_X_Xm128 = {
+    id = Vmovapd_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovapd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 40 }
+}
+let vptest_Y_Ym256 = {
+    id = Vptest_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "vptest"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 23 }
+}
+let vptest_X_Xm128 = {
+    id = Vptest_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "vptest"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 23 }
+}
+let punpckhqdq = {
+    id = Punpckhqdq
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "punpckhqdq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 109 }
+}
+let addps = {
+    id = Addps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "addps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 88 }
+}
+let pabsb_M_Mm64 = {
+    id = Pabsb_M_Mm64
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|MM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pabsb"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 28 }
+}
+let vmulss = {
+    id = Vmulss
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmulss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 89 }
+}
+let vpcmpeqd_Y_Y_Ym256 = {
+    id = Vpcmpeqd_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpcmpeqd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 118 }
+}
+let vpand_Y_Y_Ym256 = {
+    id = Vpand_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpand"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 219 }
+}
+let subss = {
+    id = Subss
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "subss"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 92 }
+}
+let vmovlps_m64_X = {
+    id = Vmovlps_m64_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M64|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovlps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 19 }
+}
+let vpsignd_Y_Y_Ym256 = {
+    id = Vpsignd_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsignd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 10 }
+}
+let xorpd = {
+    id = Xorpd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "xorpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 87 }
+}
+let vpshuflw_Y_Ym256 = {
+    id = Vpshuflw_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpshuflw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 112 }
+}
+let cvtps2dq = {
+    id = Cvtps2dq
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvtps2dq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 91 }
+}
+let vucomisd = {
+    id = Vucomisd
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "vucomisd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 46 }
+}
+let rsqrtss = {
+    id = Rsqrtss
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "rsqrtss"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 82 }
+}
+let vpacksswb_Y_Y_Ym256 = {
+    id = Vpacksswb_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpacksswb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 99 }
+}
+let vpmulhrsw_X_X_Xm128 = {
+    id = Vpmulhrsw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmulhrsw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 11 }
+}
+let vminpd_Y_Y_Ym256 = {
+    id = Vminpd_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vminpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 93 }
+}
+let vminpd_X_X_Xm128 = {
+    id = Vminpd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vminpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 93 }
+}
+let vpminsb_Y_Y_Ym256 = {
+    id = Vpminsb_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpminsb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 56 }
+}
+let subps = {
+    id = Subps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "subps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 92 }
+}
+let pmovsxbw = {
+    id = Pmovsxbw
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pmovsxbw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 32 }
+}
+let pmovzxbq = {
+    id = Pmovzxbq
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM;M16|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pmovzxbq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 50 }
+}
+let movq_X_Xm64 = {
+    id = Movq_X_Xm64
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "movq"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 126 }
+}
+let vpermilpd_Y_Ym256 = {
+    id = Vpermilpd_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpermilpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 5 }
+}
+let vpermilpd_X_Xm128 = {
+    id = Vpermilpd_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpermilpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 5 }
+}
+let movaps_Xm128_X = {
+    id = Movaps_Xm128_X
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "movaps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 41 }
+}
+let cvttpd2dq = {
+    id = Cvttpd2dq
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvttpd2dq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 230 }
+}
+let cmpsd = {
+    id = Cmpsd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "cmpsd"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 194 }
+}
+let vmaskmovps_m256_Y_Y = {
+    id = Vmaskmovps_m256_Y_Y
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M256|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmaskmovps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 46 }
+}
+let vmaskmovps_m128_X_X = {
+    id = Vmaskmovps_m128_X_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmaskmovps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 46 }
+}
+let psignw_M_Mm64 = {
+    id = Psignw_M_Mm64
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psignw"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 9 }
+}
+let vpsubsw_X_X_Xm128 = {
+    id = Vpsubsw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsubsw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 233 }
+}
+let vcmpsd = {
+    id = Vcmpsd
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vcmpsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 194 }
+}
+let pavgb_X_Xm128 = {
+    id = Pavgb_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pavgb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 224 }
+}
+let vorps_Y_Y_Ym256 = {
+    id = Vorps_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vorps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 86 }
+}
+let vorps_X_X_Xm128 = {
+    id = Vorps_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vorps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 86 }
+}
+let pmaddubsw_M_Mm64 = {
+    id = Pmaddubsw_M_Mm64
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmaddubsw"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 4 }
+}
+let vpsignd_X_X_Xm128 = {
+    id = Vpsignd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsignd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 10 }
+}
+let phaddd_M_Mm64 = {
+    id = Phaddd_M_Mm64
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "phaddd"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 2 }
+}
+let psubw = {
+    id = Psubw
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psubw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 249 }
+}
+let vpminud_Y_Y_Ym256 = {
+    id = Vpminud_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpminud"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 59 }
+}
+let vcvtdq2ps_Y_Ym256 = {
+    id = Vcvtdq2ps_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtdq2ps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 91 }
+}
+let vcvtdq2ps_X_Xm128 = {
+    id = Vcvtdq2ps_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtdq2ps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 91 }
+}
+let psubq_M_Mm64 = {
+    id = Psubq_M_Mm64
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psubq"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 251 }
+}
+let vpmaxsd_X_X_Xm128 = {
+    id = Vpmaxsd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaxsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 61 }
+}
+let ldmxcsr = {
+    id = Ldmxcsr
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|M32|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "ldmxcsr"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 2; opcode = 174 }
+}
+let vmovshdup_Y_Ym256 = {
+    id = Vmovshdup_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovshdup"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 22 }
+}
+let vmovshdup_X_Xm128 = {
+    id = Vmovshdup_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovshdup"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 22 }
+}
+let unpcklps = {
+    id = Unpcklps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "unpcklps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 20 }
+}
+let palignr_X_Xm128 = {
+    id = Palignr_X_Xm128
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "palignr"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 15 }
+}
+let vdivpd_Y_Y_Ym256 = {
+    id = Vdivpd_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vdivpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 94 }
+}
+let vdivpd_X_X_Xm128 = {
+    id = Vdivpd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vdivpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 94 }
+}
+let vpmulhw_Y_Y_Ym256 = {
+    id = Vpmulhw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmulhw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 229 }
+}
+let pmovmskb_r64_M = {
+    id = Pmovmskb_r64_M
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pmovmskb"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 215 }
+}
+let vshufpd_Y_Y_Ym256 = {
+    id = Vshufpd_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vshufpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 198 }
+}
+let vshufpd_X_X_Xm128 = {
+    id = Vshufpd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vshufpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 198 }
+}
+let vpmovzxdq_Y_Xm128 = {
+    id = Vpmovzxdq_Y_Xm128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovzxdq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 53 }
+}
+let maxpd = {
+    id = Maxpd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "maxpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 95 }
+}
+let pmulhrsw_M_Mm64 = {
+    id = Pmulhrsw_M_Mm64
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmulhrsw"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 11 }
+}
+let vpmaxud_X_X_Xm128 = {
+    id = Vpmaxud_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaxud"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 63 }
+}
+let psrld_X_Xm128 = {
+    id = Psrld_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psrld"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 210 }
+}
+let vpaddq_X_X_Xm128 = {
+    id = Vpaddq_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpaddq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 212 }
+}
+let movddup = {
+    id = Movddup
+  ; ext = [|SSE3|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "movddup"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 18 }
+}
+let vroundsd = {
+    id = Vroundsd
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vroundsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 11 }
+}
+let vsubss = {
+    id = Vsubss
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vsubss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 92 }
+}
+let movhps_m64_X = {
+    id = Movhps_m64_X
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M64|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "movhps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 23 }
+}
+let vhaddps_Y_Y_Ym256 = {
+    id = Vhaddps_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vhaddps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 124 }
+}
+let vhaddps_X_X_Xm128 = {
+    id = Vhaddps_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vhaddps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 124 }
+}
+let cvtdq2ps = {
+    id = Cvtdq2ps
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvtdq2ps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 91 }
+}
+let vpaddsb_X_X_Xm128 = {
+    id = Vpaddsb_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpaddsb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 236 }
+}
+let vdpps_Y_Y_Ym256 = {
+    id = Vdpps_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vdpps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 64 }
+}
+let vdpps_X_X_Xm128 = {
+    id = Vdpps_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vdpps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 64 }
+}
+let movapd_Xm128_X = {
+    id = Movapd_Xm128_X
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "movapd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 41 }
+}
+let cmpss = {
+    id = Cmpss
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "cmpss"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 194 }
+}
+let vshufps_Y_Y_Ym256 = {
+    id = Vshufps_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vshufps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 198 }
+}
+let vshufps_X_X_Xm128 = {
+    id = Vshufps_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vshufps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 198 }
+}
+let vpmaddubsw_X_X_Xm128 = {
+    id = Vpmaddubsw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaddubsw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 4 }
+}
+let blendps = {
+    id = Blendps
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "blendps"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 12 }
+}
+let vpavgw_X_X_Xm128 = {
+    id = Vpavgw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpavgw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 227 }
+}
+let andpd = {
+    id = Andpd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "andpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 84 }
+}
+let phaddsw_X_Xm128 = {
+    id = Phaddsw_X_Xm128
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "phaddsw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 3 }
+}
+let vaddsubpd_Y_Y_Ym256 = {
+    id = Vaddsubpd_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vaddsubpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 208 }
+}
+let vaddsubpd_X_X_Xm128 = {
+    id = Vaddsubpd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vaddsubpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 208 }
+}
+let psubsw = {
+    id = Psubsw
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psubsw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 233 }
+}
+let vpsraw_Y_Y_Xm128 = {
+    id = Vpsraw_Y_Y_Xm128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsraw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 225 }
+}
+let movdqu_X_Xm128 = {
+    id = Movdqu_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "movdqu"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 111 }
+}
+let vsqrtsd = {
+    id = Vsqrtsd
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vsqrtsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 81 }
+}
+let vpshufd_Y_Ym256 = {
+    id = Vpshufd_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpshufd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 112 }
+}
+let psllw_X_Xm128 = {
+    id = Psllw_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psllw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 241 }
+}
+let vpermilps_Y_Y_Ym256 = {
+    id = Vpermilps_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpermilps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 12 }
+}
+let vpermilps_X_X_Xm128 = {
+    id = Vpermilps_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpermilps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 12 }
+}
+let vpmaskmovd_m256_Y_Y = {
+    id = Vpmaskmovd_m256_Y_Y
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M256|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaskmovd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 142 }
+}
+let vpmaskmovd_m128_X_X = {
+    id = Vpmaskmovd_m128_X_X
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaskmovd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 142 }
+}
+let ptest = {
+    id = Ptest
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "ptest"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 23 }
+}
+let vpmovzxbq_X_Xm16 = {
+    id = Vpmovzxbq_X_Xm16
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M16|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovzxbq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 50 }
+}
+let vcvttps2dq_Y_Ym256 = {
+    id = Vcvttps2dq_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvttps2dq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 91 }
+}
+let vcvttps2dq_X_Xm128 = {
+    id = Vcvttps2dq_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvttps2dq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 91 }
+}
+let phsubd_M_Mm64 = {
+    id = Phsubd_M_Mm64
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "phsubd"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 6 }
+}
+let vcomisd = {
+    id = Vcomisd
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcomisd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 47 }
+}
+let vpminsb_X_X_Xm128 = {
+    id = Vpminsb_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpminsb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 56 }
+}
+let vmovhpd_m64_X = {
+    id = Vmovhpd_m64_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M64|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovhpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 23 }
+}
+let cvttsd2si_r64_Xm64 = {
+    id = Cvttsd2si_r64_Xm64
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvttsd2si"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_w; escape = Esc_0F }; rm_reg = Reg; opcode = 44 }
+}
+let cvtss2sd = {
+    id = Cvtss2sd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvtss2sd"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 90 }
+}
+let psadbw_X_Xm128 = {
+    id = Psadbw_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psadbw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 246 }
+}
+let vmulps_Y_Y_Ym256 = {
+    id = Vmulps_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmulps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 89 }
+}
+let vmulps_X_X_Xm128 = {
+    id = Vmulps_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmulps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 89 }
+}
+let vphaddd_Y_Y_Ym256 = {
+    id = Vphaddd_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vphaddd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 2 }
+}
+let vunpcklps_Y_Y_Ym256 = {
+    id = Vunpcklps_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vunpcklps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 20 }
+}
+let vunpcklps_X_X_Xm128 = {
+    id = Vunpcklps_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vunpcklps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 20 }
+}
+let vpslldq_Y_Y = {
+    id = Vpslldq_Y_Y
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = Vex_v }
+  ; imm = Imm_spec
+  ; mnemonic = "vpslldq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 7; opcode = 115 }
+}
+let pextrd = {
+    id = Pextrd
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|R32;M32|]; enc = RM_rm }
+  ; imm = Imm_spec
+  ; mnemonic = "pextrd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 22 }
+}
+let vcvtsd2si_r32_Xm64 = {
+    id = Vcvtsd2si_r32_Xm64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtsd2si"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 45 }
+}
+let vpmovsxwq_X_Xm32 = {
+    id = Vpmovsxwq_X_Xm32
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovsxwq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 36 }
+}
+let psrlw_X = {
+    id = Psrlw_X
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "psrlw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 2; opcode = 113 }
+}
+let pmovzxwq = {
+    id = Pmovzxwq
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pmovzxwq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 52 }
+}
+let vcmppd_Y_Y_Ym256 = {
+    id = Vcmppd_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vcmppd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 194 }
+}
+let vcmppd_X_X_Xm128 = {
+    id = Vcmppd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vcmppd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 194 }
+}
+let vpaddsb_Y_Y_Ym256 = {
+    id = Vpaddsb_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpaddsb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 236 }
+}
+let vmovsd_X_X_X = {
+    id = Vmovsd_X_X_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 17 }
+}
+let vpacksswb_X_X_Xm128 = {
+    id = Vpacksswb_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpacksswb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 99 }
+}
+let mulsd = {
+    id = Mulsd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "mulsd"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 89 }
+}
+let pmaxsw_M_Mm64 = {
+    id = Pmaxsw_M_Mm64
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmaxsw"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 238 }
+}
+let movmskps = {
+    id = Movmskps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "movmskps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 80 }
+}
+let vmaskmovpd_m256_Y_Y = {
+    id = Vmaskmovpd_m256_Y_Y
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M256|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmaskmovpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 47 }
+}
+let vmaskmovpd_m128_X_X = {
+    id = Vmaskmovpd_m128_X_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmaskmovpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 47 }
+}
+let rorx_r32_r32m32 = {
+    id = Rorx_r32_r32m32
+  ; ext = [|BMI2|]
+  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "rorx"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 240 }
+}
+let vcvtss2si_r64_Xm32 = {
+    id = Vcvtss2si_r64_Xm32
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtss2si"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = true; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 45 }
+}
+let vmovntdq_m256_Y = {
+    id = Vmovntdq_m256_Y
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M256|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovntdq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 231 }
+}
+let vmovntdq_m128_X = {
+    id = Vmovntdq_m128_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovntdq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 231 }
+}
+let vpunpcklqdq_X_X_Xm128 = {
+    id = Vpunpcklqdq_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpunpcklqdq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 108 }
+}
+let vmovdqu_Y_Ym256 = {
+    id = Vmovdqu_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovdqu"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 111 }
+}
+let vmovdqu_X_Xm128 = {
+    id = Vmovdqu_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovdqu"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 111 }
+}
+let paddb = {
+    id = Paddb
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "paddb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 252 }
+}
+let vpaddd_X_X_Xm128 = {
+    id = Vpaddd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpaddd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 254 }
+}
+let vperm2f128 = {
+    id = Vperm2f128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vperm2f128"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 6 }
+}
+let unpckhpd = {
+    id = Unpckhpd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "unpckhpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 21 }
+}
+let orps = {
+    id = Orps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "orps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 86 }
+}
+let vpinsrb = {
+    id = Vpinsrb
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|R32;M8|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "vpinsrb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 32 }
+}
+let vpaddusw_X_X_Xm128 = {
+    id = Vpaddusw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpaddusw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 221 }
+}
+let phsubw_M_Mm64 = {
+    id = Phsubw_M_Mm64
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "phsubw"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 5 }
+}
+let vpcmpeqq_X_X_Xm128 = {
+    id = Vpcmpeqq_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpcmpeqq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 41 }
+}
+let psrld_X = {
+    id = Psrld_X
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "psrld"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 2; opcode = 114 }
+}
+let psubq_X_Xm128 = {
+    id = Psubq_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psubq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 251 }
+}
+let vpsignw_Y_Y_Ym256 = {
+    id = Vpsignw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsignw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 9 }
+}
+let extractps = {
+    id = Extractps
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|R64;M32|]; enc = RM_rm }
+  ; imm = Imm_spec
+  ; mnemonic = "extractps"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 23 }
+}
+let vpmulhw_X_X_Xm128 = {
+    id = Vpmulhw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmulhw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 229 }
+}
+let vpmovsxbw_X_Xm64 = {
+    id = Vpmovsxbw_X_Xm64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovsxbw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 32 }
+}
+let psignd_X_Xm128 = {
+    id = Psignd_X_Xm128
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psignd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 10 }
+}
+let pcmpeqq = {
+    id = Pcmpeqq
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pcmpeqq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 41 }
+}
+let vpsignb_X_X_Xm128 = {
+    id = Vpsignb_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsignb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 8 }
+}
+let vpsadbw_X_X_Xm128 = {
+    id = Vpsadbw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsadbw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 246 }
+}
+let vpshufd_X_Xm128 = {
+    id = Vpshufd_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpshufd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 112 }
+}
+let pinsrd = {
+    id = Pinsrd
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "pinsrd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 34 }
+}
+let pcmpestrm = {
+    id = Pcmpestrm
+  ; ext = [|SSE4_2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Pin RAX; enc = Implicit };{ loc = Pin RDX; enc = Implicit }|]
+  ; res = Res { loc = Pin XMM0; enc = Implicit }
+  ; imm = Imm_spec
+  ; mnemonic = "pcmpestrm"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 96 }
+}
+let vmovd_X_r32m32 = {
+    id = Vmovd_X_r32m32
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 110 }
+}
+let pmuldq = {
+    id = Pmuldq
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmuldq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 40 }
+}
+let paddq = {
+    id = Paddq
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "paddq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 212 }
+}
+let vmovlpd_m64_X = {
+    id = Vmovlpd_m64_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M64|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovlpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 19 }
+}
+let blendvps = {
+    id = Blendvps
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Pin XMM0; enc = Implicit }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "blendvps"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 20 }
+}
+let vpminsw_X_X_Xm128 = {
+    id = Vpminsw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpminsw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 234 }
+}
+let vpminub_Y_Y_Ym256 = {
+    id = Vpminub_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpminub"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 218 }
+}
+let pcmpeqb = {
+    id = Pcmpeqb
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pcmpeqb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 116 }
+}
+let movups_X_Xm128 = {
+    id = Movups_X_Xm128
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "movups"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 16 }
+}
+let movd_X_r32m32 = {
+    id = Movd_X_r32m32
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "movd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 126 }
+}
+let pmovmskb_r64_X = {
+    id = Pmovmskb_r64_X
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pmovmskb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 215 }
+}
+let pminsd = {
+    id = Pminsd
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pminsd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 57 }
+}
+let packssdw = {
+    id = Packssdw
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "packssdw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 107 }
+}
+let vperm2i128 = {
+    id = Vperm2i128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vperm2i128"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 70 }
+}
+let vpmaddubsw_Y_Y_Ym256 = {
+    id = Vpmaddubsw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaddubsw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 4 }
+}
+let vmulpd_Y_Y_Ym256 = {
+    id = Vmulpd_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmulpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 89 }
+}
+let vmulpd_X_X_Xm128 = {
+    id = Vmulpd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmulpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 89 }
+}
+let movntps = {
+    id = Movntps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "movntps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 43 }
+}
+let vblendvpd_Y_Y_Ym256_Y = {
+    id = Vblendvpd_Y_Y_Ym256_Y
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm };{ loc = Temp [|YMM|]; enc = Immediate }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_reg
+  ; mnemonic = "vblendvpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 75 }
+}
+let vblendvpd_X_X_Xm128_X = {
+    id = Vblendvpd_X_X_Xm128_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Temp [|XMM|]; enc = Immediate }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_reg
+  ; mnemonic = "vblendvpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 75 }
+}
+let vpsrad_Y_Y = {
+    id = Vpsrad_Y_Y
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = Vex_v }
+  ; imm = Imm_spec
+  ; mnemonic = "vpsrad"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 4; opcode = 114 }
+}
+let vmaxps_Y_Y_Ym256 = {
+    id = Vmaxps_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmaxps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 95 }
+}
+let vmaxps_X_X_Xm128 = {
+    id = Vmaxps_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmaxps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 95 }
+}
+let vpackusdw_X_X_Xm128 = {
+    id = Vpackusdw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpackusdw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 43 }
+}
+let vmovq_Xm64_X = {
+    id = Vmovq_Xm64_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|XMM;M64|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 214 }
+}
+let sqrtss = {
+    id = Sqrtss
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "sqrtss"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 81 }
+}
+let vpshufb_X_X_Xm128 = {
+    id = Vpshufb_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpshufb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 0 }
+}
+let vpminuw_Y_Y_Ym256 = {
+    id = Vpminuw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpminuw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 58 }
+}
+let paddd = {
+    id = Paddd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "paddd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 254 }
+}
+let psubd = {
+    id = Psubd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psubd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 250 }
+}
+let vpsrlw_Y_Y_Xm128 = {
+    id = Vpsrlw_Y_Y_Xm128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsrlw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 209 }
+}
+let vpmovzxbw_Y_Xm128 = {
+    id = Vpmovzxbw_Y_Xm128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovzxbw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 48 }
+}
+let vpmaxsw_Y_Y_Ym256 = {
+    id = Vpmaxsw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaxsw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 238 }
+}
+let vmovups_Y_Ym256 = {
+    id = Vmovups_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovups"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 16 }
+}
+let vmovups_X_Xm128 = {
+    id = Vmovups_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovups"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 16 }
+}
+let vpsrlvd_Y_Y_Ym256 = {
+    id = Vpsrlvd_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsrlvd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 69 }
+}
+let vpsrlvd_X_X_Xm128 = {
+    id = Vpsrlvd_X_X_Xm128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsrlvd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 69 }
+}
+let unpckhps = {
+    id = Unpckhps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "unpckhps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 21 }
+}
+let pminub_M_Mm64 = {
+    id = Pminub_M_Mm64
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pminub"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 218 }
+}
+let vaddsd = {
+    id = Vaddsd
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vaddsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 88 }
+}
+let shufpd = {
+    id = Shufpd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "shufpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 198 }
+}
+let vmovss_X_X_X = {
+    id = Vmovss_X_X_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 16 }
+}
+let pmaddwd = {
+    id = Pmaddwd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmaddwd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 245 }
+}
+let vpsllw_Y_Y = {
+    id = Vpsllw_Y_Y
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = Vex_v }
+  ; imm = Imm_spec
+  ; mnemonic = "vpsllw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 6; opcode = 113 }
+}
+let packusdw = {
+    id = Packusdw
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "packusdw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 43 }
+}
+let pcmpgtd = {
+    id = Pcmpgtd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pcmpgtd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 102 }
+}
+let vpsrldq_Y_Y = {
+    id = Vpsrldq_Y_Y
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = Vex_v }
+  ; imm = Imm_spec
+  ; mnemonic = "vpsrldq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 3; opcode = 115 }
+}
+let vpunpckhqdq_X_X_Xm128 = {
+    id = Vpunpckhqdq_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpunpckhqdq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 109 }
+}
+let cvtsi2sd_X_r64m64 = {
+    id = Cvtsi2sd_X_r64m64
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvtsi2sd"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_w; escape = Esc_0F }; rm_reg = Reg; opcode = 42 }
+}
+let vphsubw_Y_Y_Ym256 = {
+    id = Vphsubw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r };{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "vphsubw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 5 }
+}
+let vxorpd_Y_Y_Ym256 = {
+    id = Vxorpd_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vxorpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 87 }
+}
+let vxorpd_X_X_Xm128 = {
+    id = Vxorpd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vxorpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 87 }
+}
+let vcomiss = {
+    id = Vcomiss
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcomiss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 47 }
+}
+let movmskpd = {
+    id = Movmskpd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "movmskpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 80 }
+}
+let sqrtsd = {
+    id = Sqrtsd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "sqrtsd"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 81 }
+}
+let vrcpps_Y_Ym256 = {
+    id = Vrcpps_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vrcpps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 83 }
+}
+let vrcpps_X_Xm128 = {
+    id = Vrcpps_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vrcpps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 83 }
+}
+let vpsubw_X_X_Xm128 = {
+    id = Vpsubw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsubw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 249 }
+}
+let pabsw_M_Mm64 = {
+    id = Pabsw_M_Mm64
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|MM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pabsw"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 29 }
+}
+let vpmaddwd_X_X_Xm128 = {
+    id = Vpmaddwd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaddwd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 245 }
+}
+let vpsrlw_X_X_Xm128 = {
+    id = Vpsrlw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsrlw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 209 }
+}
+let rorx_r64_r64m64 = {
+    id = Rorx_r64_r64m64
+  ; ext = [|BMI2|]
+  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "rorx"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = true; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 240 }
+}
+let vpmullw_Y_Y_Ym256 = {
+    id = Vpmullw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmullw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 213 }
+}
+let vpaddw_Y_Y_Ym256 = {
+    id = Vpaddw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpaddw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 253 }
+}
+let pxor = {
+    id = Pxor
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pxor"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 239 }
+}
+let vpcmpestrm = {
+    id = Vpcmpestrm
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Pin RAX; enc = Implicit };{ loc = Pin RDX; enc = Implicit }|]
+  ; res = Res { loc = Pin XMM0; enc = Implicit }
+  ; imm = Imm_spec
+  ; mnemonic = "vpcmpestrm"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 96 }
+}
+let vpalignr_X_X_Xm128 = {
+    id = Vpalignr_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpalignr"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 15 }
+}
+let vextracti128 = {
+    id = Vextracti128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
+  ; imm = Imm_spec
+  ; mnemonic = "vextracti128"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 57 }
+}
+let psubusb = {
+    id = Psubusb
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psubusb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 216 }
+}
+let vcmpss = {
+    id = Vcmpss
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vcmpss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 194 }
+}
+let vmovlpd_X_X_m64 = {
+    id = Vmovlpd_X_X_m64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "vmovlpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 18 }
+}
+let vbroadcastss_Y_m32 = {
+    id = Vbroadcastss_Y_m32
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vbroadcastss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 24 }
+}
+let vbroadcastss_X_m32 = {
+    id = Vbroadcastss_X_m32
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vbroadcastss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 24 }
+}
+let rcpps = {
+    id = Rcpps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "rcpps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 83 }
+}
+let vdppd = {
+    id = Vdppd
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vdppd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 65 }
+}
+let vcvtps2pd_Y_Xm128 = {
+    id = Vcvtps2pd_Y_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtps2pd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 90 }
+}
+let vcvtps2pd_X_Xm64 = {
+    id = Vcvtps2pd_X_Xm64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtps2pd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 90 }
+}
+let vpsllq_X_X = {
+    id = Vpsllq_X_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
+  ; imm = Imm_spec
+  ; mnemonic = "vpsllq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 6; opcode = 115 }
+}
+let vandnps_Y_Y_Ym256 = {
+    id = Vandnps_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vandnps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 85 }
+}
+let vandnps_X_X_Xm128 = {
+    id = Vandnps_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vandnps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 85 }
+}
+let vpsllw_X_X_Xm128 = {
+    id = Vpsllw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsllw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 241 }
+}
+let roundpd = {
+    id = Roundpd
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "roundpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 9 }
+}
+let pavgw_M_Mm64 = {
+    id = Pavgw_M_Mm64
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pavgw"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 227 }
+}
+let movntdqa = {
+    id = Movntdqa
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "movntdqa"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 42 }
+}
+let divps = {
+    id = Divps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "divps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 94 }
+}
+let pmovzxdq = {
+    id = Pmovzxdq
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pmovzxdq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 53 }
+}
+let vpunpckhwd_Y_Y_Ym256 = {
+    id = Vpunpckhwd_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpunpckhwd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 105 }
+}
+let insertps = {
+    id = Insertps
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "insertps"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 33 }
+}
+let phsubsw_X_Xm128 = {
+    id = Phsubsw_X_Xm128
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "phsubsw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 7 }
+}
+let pmullw = {
+    id = Pmullw
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmullw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 213 }
+}
+let vphaddw_X_X_Xm128 = {
+    id = Vphaddw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vphaddw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 1 }
+}
+let pmovsxwd = {
+    id = Pmovsxwd
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pmovsxwd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 35 }
+}
+let punpcklqdq = {
+    id = Punpcklqdq
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "punpcklqdq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 108 }
+}
+let vpextrb = {
+    id = Vpextrb
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|R64;M8|]; enc = RM_rm }
+  ; imm = Imm_spec
+  ; mnemonic = "vpextrb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 20 }
+}
+let pmovzxwd = {
+    id = Pmovzxwd
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pmovzxwd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 51 }
+}
+let vpmaxsb_X_X_Xm128 = {
+    id = Vpmaxsb_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaxsb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 60 }
+}
+let vrsqrtps_Y_Ym256 = {
+    id = Vrsqrtps_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vrsqrtps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 82 }
+}
+let vrsqrtps_X_Xm128 = {
+    id = Vrsqrtps_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vrsqrtps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 82 }
+}
+let maskmovdqu = {
+    id = Maskmovdqu
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "maskmovdqu"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 247 }
+}
+let vpmovsxwd_X_Xm64 = {
+    id = Vpmovsxwd_X_Xm64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovsxwd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 35 }
+}
+let cvttss2si_r64_Xm32 = {
+    id = Cvttss2si_r64_Xm32
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvttss2si"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_w; escape = Esc_0F }; rm_reg = Reg; opcode = 44 }
+}
+let movlpd_m64_X = {
+    id = Movlpd_m64_X
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M64|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "movlpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 19 }
+}
+let vphsubd_X_X_Xm128 = {
+    id = Vphsubd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "vphsubd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 6 }
+}
+let vpxor_X_X_Xm128 = {
+    id = Vpxor_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpxor"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 239 }
+}
+let pmovzxbd = {
+    id = Pmovzxbd
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pmovzxbd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 49 }
+}
+let mulps = {
+    id = Mulps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "mulps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 89 }
+}
+let pabsd_M_Mm64 = {
+    id = Pabsd_M_Mm64
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|MM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pabsd"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 30 }
+}
+let movsldup = {
+    id = Movsldup
+  ; ext = [|SSE3|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "movsldup"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 18 }
+}
+let movaps_X_Xm128 = {
+    id = Movaps_X_Xm128
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "movaps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 40 }
+}
+let vpslld_X_X = {
+    id = Vpslld_X_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
+  ; imm = Imm_spec
+  ; mnemonic = "vpslld"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 6; opcode = 114 }
+}
+let vcmpps_Y_Y_Ym256 = {
+    id = Vcmpps_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vcmpps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 194 }
+}
+let vcmpps_X_X_Xm128 = {
+    id = Vcmpps_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vcmpps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 194 }
+}
+let vhaddpd_Y_Y_Ym256 = {
+    id = Vhaddpd_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vhaddpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 124 }
+}
+let vhaddpd_X_X_Xm128 = {
+    id = Vhaddpd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vhaddpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 124 }
+}
+let vpsllvq_Y_Y_Ym256 = {
+    id = Vpsllvq_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsllvq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 71 }
+}
+let vpsllvq_X_X_Xm128 = {
+    id = Vpsllvq_X_X_Xm128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsllvq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 71 }
+}
+let vmaskmovpd_Y_Y_m256 = {
+    id = Vmaskmovpd_Y_Y_m256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmaskmovpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 45 }
+}
+let vmaskmovpd_X_X_m128 = {
+    id = Vmaskmovpd_X_X_m128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmaskmovpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 45 }
+}
+let vpmulhuw_Y_Y_Ym256 = {
+    id = Vpmulhuw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmulhuw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 228 }
+}
+let vpmaxuw_X_X_Xm128 = {
+    id = Vpmaxuw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaxuw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 62 }
+}
+let vmovdqa_Ym256_Y = {
+    id = Vmovdqa_Ym256_Y
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|YMM;M256|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovdqa"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 127 }
+}
+let vmovdqa_Xm128_X = {
+    id = Vmovdqa_Xm128_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovdqa"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 127 }
+}
+let pand = {
+    id = Pand
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pand"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 219 }
+}
+let shufps = {
+    id = Shufps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "shufps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 198 }
+}
+let vbroadcastss_Y_X = {
+    id = Vbroadcastss_Y_X
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vbroadcastss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 24 }
+}
+let vbroadcastss_X_X = {
+    id = Vbroadcastss_X_X
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vbroadcastss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 24 }
+}
+let psignw_X_Xm128 = {
+    id = Psignw_X_Xm128
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psignw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 9 }
+}
+let movsd_X_m64 = {
+    id = Movsd_X_m64
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "movsd"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 16 }
+}
+let movsd_X_X = {
+    id = Movsd_X_X
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "movsd"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 16 }
+}
+let roundsd = {
+    id = Roundsd
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "roundsd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 11 }
+}
+let pshufb_M_Mm64 = {
+    id = Pshufb_M_Mm64
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pshufb"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 0 }
+}
+let movhpd_m64_X = {
+    id = Movhpd_m64_X
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M64|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "movhpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 23 }
+}
+let psllq_X_Xm128 = {
+    id = Psllq_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psllq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 243 }
+}
+let vpclmulqdq = {
+    id = Vpclmulqdq
+  ; ext = [|PCLMULQDQ;AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpclmulqdq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 68 }
+}
+let vpsllq_Y_Y_Xm128 = {
+    id = Vpsllq_Y_Y_Xm128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsllq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 243 }
+}
+let vpblendvb_Y_Y_Ym256_Y = {
+    id = Vpblendvb_Y_Y_Ym256_Y
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm };{ loc = Temp [|YMM|]; enc = Immediate }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_reg
+  ; mnemonic = "vpblendvb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 76 }
+}
+let pminub_X_Xm128 = {
+    id = Pminub_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pminub"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 218 }
+}
+let vpsubb_X_X_Xm128 = {
+    id = Vpsubb_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsubb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 248 }
+}
+let vpbroadcastb_Y_Xm8 = {
+    id = Vpbroadcastb_Y_Xm8
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM;M8|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpbroadcastb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 120 }
+}
+let vpbroadcastb_X_Xm8 = {
+    id = Vpbroadcastb_X_Xm8
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM;M8|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpbroadcastb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 120 }
+}
+let punpckhbw = {
+    id = Punpckhbw
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "punpckhbw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 104 }
+}
+let vpminsd_X_X_Xm128 = {
+    id = Vpminsd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpminsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 57 }
+}
+let movups_Xm128_X = {
+    id = Movups_Xm128_X
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "movups"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 17 }
+}
+let vmovapd_Ym256_Y = {
+    id = Vmovapd_Ym256_Y
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|YMM;M256|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovapd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 41 }
+}
+let vmovapd_Xm128_X = {
+    id = Vmovapd_Xm128_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovapd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 41 }
+}
+let rcpss = {
+    id = Rcpss
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "rcpss"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 83 }
+}
+let vpmaskmovq_m256_Y_Y = {
+    id = Vpmaskmovq_m256_Y_Y
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M256|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaskmovq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 142 }
+}
+let vpmaskmovq_m128_X_X = {
+    id = Vpmaskmovq_m128_X_X
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaskmovq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 142 }
+}
+let vpcmpistri = {
+    id = Vpcmpistri
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Pin RCX; enc = Implicit }
+  ; imm = Imm_spec
+  ; mnemonic = "vpcmpistri"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 99 }
+}
+let vpshufb_Y_Y_Ym256 = {
+    id = Vpshufb_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpshufb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 0 }
+}
+let vphsubw_X_X_Xm128 = {
+    id = Vphsubw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "vphsubw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 5 }
+}
+let pmovsxwq = {
+    id = Pmovsxwq
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pmovsxwq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 36 }
+}
+let movupd_X_Xm128 = {
+    id = Movupd_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "movupd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 16 }
+}
+let vpackuswb_X_X_Xm128 = {
+    id = Vpackuswb_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpackuswb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 103 }
+}
+let vinsertf128 = {
+    id = Vinsertf128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vinsertf128"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 24 }
+}
+let vpsrldq_X_X = {
+    id = Vpsrldq_X_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
+  ; imm = Imm_spec
+  ; mnemonic = "vpsrldq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 3; opcode = 115 }
+}
+let vpmovzxbd_Y_Xm64 = {
+    id = Vpmovzxbd_Y_Xm64
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmovzxbd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 49 }
+}
+let dppd = {
+    id = Dppd
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "dppd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 65 }
+}
+let pmaxuw = {
+    id = Pmaxuw
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmaxuw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 62 }
+}
+let vpabsb_X_Xm128 = {
+    id = Vpabsb_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpabsb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 28 }
+}
+let roundss = {
+    id = Roundss
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "roundss"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 10 }
+}
+let psllq_X = {
+    id = Psllq_X
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "psllq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 6; opcode = 115 }
+}
+let pcmpgtb = {
+    id = Pcmpgtb
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pcmpgtb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 100 }
+}
+let psubsb = {
+    id = Psubsb
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psubsb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 232 }
+}
+let vpandn_X_X_Xm128 = {
+    id = Vpandn_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpandn"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 223 }
+}
+let movq_X_r64m64 = {
+    id = Movq_X_r64m64
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "movq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_w; escape = Esc_0F }; rm_reg = Reg; opcode = 126 }
+}
+let vpabsd_Y_Ym256 = {
+    id = Vpabsd_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpabsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 30 }
+}
+let vpsrlw_Y_Y = {
+    id = Vpsrlw_Y_Y
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = Vex_v }
+  ; imm = Imm_spec
+  ; mnemonic = "vpsrlw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Spec 2; opcode = 113 }
+}
+let vpand_X_X_Xm128 = {
+    id = Vpand_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpand"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 219 }
+}
+let vphaddd_X_X_Xm128 = {
+    id = Vphaddd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vphaddd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 2 }
+}
+let addsubps = {
+    id = Addsubps
+  ; ext = [|SSE3|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "addsubps"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 208 }
+}
+let vpsubd_Y_Y_Ym256 = {
+    id = Vpsubd_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsubd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 250 }
+}
+let pcmpestri = {
+    id = Pcmpestri
+  ; ext = [|SSE4_2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Pin RAX; enc = Implicit };{ loc = Pin RDX; enc = Implicit }|]
+  ; res = Res { loc = Pin RCX; enc = Implicit }
+  ; imm = Imm_spec
+  ; mnemonic = "pcmpestri"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 97 }
+}
+let vpsraw_X_X = {
+    id = Vpsraw_X_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
+  ; imm = Imm_spec
+  ; mnemonic = "vpsraw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 4; opcode = 113 }
+}
+let vmovss_X_X_X = {
+    id = Vmovss_X_X_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 17 }
+}
+let vpaddb_Y_Y_Ym256 = {
+    id = Vpaddb_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpaddb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 252 }
+}
+let hsubps = {
+    id = Hsubps
+  ; ext = [|SSE3|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "hsubps"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 125 }
+}
+let pminud = {
+    id = Pminud
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pminud"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 59 }
+}
+let vsqrtpd_Y_Ym256 = {
+    id = Vsqrtpd_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vsqrtpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 81 }
+}
+let vsqrtpd_X_Xm128 = {
+    id = Vsqrtpd_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vsqrtpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 81 }
+}
+let vpsubb_Y_Y_Ym256 = {
+    id = Vpsubb_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsubb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 248 }
+}
+let pextrq = {
+    id = Pextrq
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|R64;M64|]; enc = RM_rm }
+  ; imm = Imm_spec
+  ; mnemonic = "pextrq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_w; escape = Esc_0F3A }; rm_reg = Reg; opcode = 22 }
+}
+let vpmulld_X_X_Xm128 = {
+    id = Vpmulld_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmulld"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 64 }
+}
+let pinsrq = {
+    id = Pinsrq
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "pinsrq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_w; escape = Esc_0F3A }; rm_reg = Reg; opcode = 34 }
+}
+let haddps = {
+    id = Haddps
+  ; ext = [|SSE3|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "haddps"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 124 }
+}
+let vpsllq_X_X_Xm128 = {
+    id = Vpsllq_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsllq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 243 }
+}
+let pminsb = {
+    id = Pminsb
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pminsb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 56 }
+}
+let sarx_r64_r64m64_r64 = {
+    id = Sarx_r64_r64m64_r64
+  ; ext = [|BMI2|]
+  ; args = [|{ loc = Temp [|R64;M64|]; enc = RM_rm };{ loc = Temp [|R64|]; enc = Vex_v }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "sarx"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 247 }
+}
+let sarx_r32_r32m32_r32 = {
+    id = Sarx_r32_r32m32_r32
+  ; ext = [|BMI2|]
+  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm };{ loc = Temp [|R32|]; enc = Vex_v }|]
+  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "sarx"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 247 }
+}
+let vextractps = {
+    id = Vextractps
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|R64;M32|]; enc = RM_rm }
+  ; imm = Imm_spec
+  ; mnemonic = "vextractps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 23 }
+}
+let vpminsd_Y_Y_Ym256 = {
+    id = Vpminsd_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpminsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 57 }
+}
+let pmaxud = {
+    id = Pmaxud
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmaxud"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 63 }
+}
+let vpcmpgtd_Y_Y_Ym256 = {
+    id = Vpcmpgtd_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpcmpgtd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 102 }
+}
+let rsqrtps = {
+    id = Rsqrtps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "rsqrtps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 82 }
+}
+let vpslld_Y_Y_Xm128 = {
+    id = Vpslld_Y_Y_Xm128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpslld"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 242 }
+}
+let phaddd_X_Xm128 = {
+    id = Phaddd_X_Xm128
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
   ; mnemonic = "phaddd"
   ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 2 }
+}
+let vldmxcsr = {
+    id = Vldmxcsr
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|M32|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "vldmxcsr"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Spec 2; opcode = 174 }
+}
+let vpsravd_Y_Y_Ym256 = {
+    id = Vpsravd_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsravd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 70 }
+}
+let vpsravd_X_X_Xm128 = {
+    id = Vpsravd_X_X_Xm128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsravd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 70 }
+}
+let vpminub_X_X_Xm128 = {
+    id = Vpminub_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpminub"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 218 }
+}
+let cvtpd2ps = {
+    id = Cvtpd2ps
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvtpd2ps"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 90 }
+}
+let pshufb_X_Xm128 = {
+    id = Pshufb_X_Xm128
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pshufb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 0 }
+}
+let vpcmpeqb_X_X_Xm128 = {
+    id = Vpcmpeqb_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpcmpeqb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 116 }
+}
+let vmovlhps = {
+    id = Vmovlhps
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "vmovlhps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 22 }
+}
+let vcvtps2dq_Y_Ym256 = {
+    id = Vcvtps2dq_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtps2dq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 91 }
+}
+let vcvtps2dq_X_Xm128 = {
+    id = Vcvtps2dq_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtps2dq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 91 }
+}
+let sqrtps = {
+    id = Sqrtps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "sqrtps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 81 }
+}
+let vphminposuw = {
+    id = Vphminposuw
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vphminposuw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 65 }
+}
+let movq_Xm64_X = {
+    id = Movq_Xm64_X
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|XMM;M64|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "movq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 214 }
+}
+let movlps_m64_X = {
+    id = Movlps_m64_X
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|M64|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "movlps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 19 }
+}
+let crc32_r64_r64m64 = {
+    id = Crc32_r64_r64m64
+  ; ext = [|SSE4_2|]
+  ; args = [|{ loc = Temp [|R64|]; enc = RM_r };{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "crc32"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_w; escape = Esc_0F38 }; rm_reg = Reg; opcode = 241 }
+}
+let crc32_r32_r32m32 = {
+    id = Crc32_r32_r32m32
+  ; ext = [|SSE4_2|]
+  ; args = [|{ loc = Temp [|R32|]; enc = RM_r };{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "crc32"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 241 }
+}
+let crc32_r32_r16m16 = {
+    id = Crc32_r32_r16m16
+  ; ext = [|SSE4_2|]
+  ; args = [|{ loc = Temp [|R32|]; enc = RM_r };{ loc = Temp [|R16;M16|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "crc32"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 241 }
+}
+let vpcmpestri = {
+    id = Vpcmpestri
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm };{ loc = Pin RAX; enc = Implicit };{ loc = Pin RDX; enc = Implicit }|]
+  ; res = Res { loc = Pin RCX; enc = Implicit }
+  ; imm = Imm_spec
+  ; mnemonic = "vpcmpestri"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 97 }
+}
+let phminposuw = {
+    id = Phminposuw
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "phminposuw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 65 }
+}
+let vmovupd_Y_Ym256 = {
+    id = Vmovupd_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovupd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 16 }
+}
+let vmovupd_X_Xm128 = {
+    id = Vmovupd_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovupd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 16 }
+}
+let vpunpckhbw_X_X_Xm128 = {
+    id = Vpunpckhbw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpunpckhbw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 104 }
+}
+let cvtpd2dq = {
+    id = Cvtpd2dq
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvtpd2dq"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 230 }
+}
+let vbroadcastsd_Y_m64 = {
+    id = Vbroadcastsd_Y_m64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vbroadcastsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 25 }
+}
+let vmovhpd_X_X_m64 = {
+    id = Vmovhpd_X_X_m64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovhpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 22 }
+}
+let vcvttss2si_r64_Xm32 = {
+    id = Vcvttss2si_r64_Xm32
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvttss2si"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = true; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 44 }
+}
+let movsd_Xm64_X = {
+    id = Movsd_Xm64_X
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|XMM;M64|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "movsd"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 17 }
+}
+let psrldq = {
+    id = Psrldq
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "psrldq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Spec 3; opcode = 115 }
+}
+let vpmulhuw_X_X_Xm128 = {
+    id = Vpmulhuw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmulhuw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 228 }
+}
+let phsubw_X_Xm128 = {
+    id = Phsubw_X_Xm128
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "phsubw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 5 }
+}
+let vpackusdw_Y_Y_Ym256 = {
+    id = Vpackusdw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpackusdw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 43 }
+}
+let vhsubps_Y_Y_Ym256 = {
+    id = Vhsubps_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vhsubps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 125 }
+}
+let vhsubps_X_X_Xm128 = {
+    id = Vhsubps_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vhsubps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 125 }
+}
+let vpmaxub_X_X_Xm128 = {
+    id = Vpmaxub_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaxub"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 222 }
+}
+let vpsrlw_X_X = {
+    id = Vpsrlw_X_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = Vex_v }
+  ; imm = Imm_spec
+  ; mnemonic = "vpsrlw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Spec 2; opcode = 113 }
+}
+let vunpcklpd_Y_Y_Ym256 = {
+    id = Vunpcklpd_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vunpcklpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 20 }
+}
+let vunpcklpd_X_X_Xm128 = {
+    id = Vunpcklpd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vunpcklpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 20 }
+}
+let minpd = {
+    id = Minpd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "minpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 93 }
+}
+let pmaxub_M_Mm64 = {
+    id = Pmaxub_M_Mm64
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmaxub"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 222 }
+}
+let vstmxcsr = {
+    id = Vstmxcsr
+  ; ext = [|AVX|]
+  ; args = [||]
+  ; res = Res { loc = Temp [|M32|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vstmxcsr"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Spec 3; opcode = 174 }
+}
+let vpsubusw_X_X_Xm128 = {
+    id = Vpsubusw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsubusw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 217 }
+}
+let phaddsw_M_Mm64 = {
+    id = Phaddsw_M_Mm64
+  ; ext = [|SSSE3|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "phaddsw"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 3 }
+}
+let vpunpckhdq_X_X_Xm128 = {
+    id = Vpunpckhdq_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpunpckhdq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 106 }
+}
+let cvtsi2sd_X_r32m32 = {
+    id = Cvtsi2sd_X_r32m32
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvtsi2sd"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 42 }
+}
+let pinsrb = {
+    id = Pinsrb
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|R32;M8|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "pinsrb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F3A }; rm_reg = Reg; opcode = 32 }
+}
+let vdivsd = {
+    id = Vdivsd
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vdivsd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 94 }
+}
+let vmovups_Ym256_Y = {
+    id = Vmovups_Ym256_Y
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|YMM;M256|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovups"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 17 }
+}
+let vmovups_Xm128_X = {
+    id = Vmovups_Xm128_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r }|]
+  ; res = Res { loc = Temp [|XMM;M128|]; enc = RM_rm }
+  ; imm = Imm_none
+  ; mnemonic = "vmovups"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 17 }
+}
+let vcvtss2sd = {
+    id = Vcvtss2sd
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vcvtss2sd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 90 }
+}
+let vpsllvd_Y_Y_Ym256 = {
+    id = Vpsllvd_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsllvd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 71 }
+}
+let vpsllvd_X_X_Xm128 = {
+    id = Vpsllvd_X_X_Xm128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsllvd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 71 }
+}
+let pcmpgtw = {
+    id = Pcmpgtw
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pcmpgtw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 101 }
+}
+let paddusb = {
+    id = Paddusb
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "paddusb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 220 }
+}
+let packuswb = {
+    id = Packuswb
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "packuswb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 103 }
+}
+let vphsubd_Y_Y_Ym256 = {
+    id = Vphsubd_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_r };{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "vphsubd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 6 }
+}
+let vpmaxub_Y_Y_Ym256 = {
+    id = Vpmaxub_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaxub"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 222 }
+}
+let cmpps = {
+    id = Cmpps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "cmpps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 194 }
+}
+let cvttsd2si_r32_Xm64 = {
+    id = Cvttsd2si_r32_Xm64
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvttsd2si"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 44 }
+}
+let cvtsd2si_r64_Xm64 = {
+    id = Cvtsd2si_r64_Xm64
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvtsd2si"
+  ; enc = { prefix = Legacy { prefix = Prx_F2; rex = Rex_w; escape = Esc_0F }; rm_reg = Reg; opcode = 45 }
+}
+let vpcmpgtb_Y_Y_Ym256 = {
+    id = Vpcmpgtb_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpcmpgtb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 100 }
+}
+let vhsubpd_Y_Y_Ym256 = {
+    id = Vhsubpd_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vhsubpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 125 }
+}
+let vhsubpd_X_X_Xm128 = {
+    id = Vhsubpd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vhsubpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 125 }
+}
+let vphsubsw_X_X_Xm128 = {
+    id = Vphsubsw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "vphsubsw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 7 }
+}
+let pextrw_r64_X = {
+    id = Pextrw_r64_X
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "pextrw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 197 }
+}
+let por = {
+    id = Por
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "por"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 235 }
+}
+let pext_r64_r64_r64m64 = {
+    id = Pext_r64_r64_r64m64
+  ; ext = [|BMI2|]
+  ; args = [|{ loc = Temp [|R64|]; enc = Vex_v };{ loc = Temp [|R64;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pext"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = true; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 245 }
+}
+let pext_r32_r32_r32m32 = {
+    id = Pext_r32_r32_r32m32
+  ; ext = [|BMI2|]
+  ; args = [|{ loc = Temp [|R32|]; enc = Vex_v };{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R32|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "pext"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 245 }
+}
+let vpmullw_X_X_Xm128 = {
+    id = Vpmullw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmullw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 213 }
+}
+let pcmpgtq = {
+    id = Pcmpgtq
+  ; ext = [|SSE4_2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pcmpgtq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 55 }
+}
+let vpackuswb_Y_Y_Ym256 = {
+    id = Vpackuswb_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpackuswb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 103 }
+}
+let vmovmskpd_r64_Y = {
+    id = Vmovmskpd_r64_Y
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovmskpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 80 }
+}
+let vmovmskpd_r64_X = {
+    id = Vmovmskpd_r64_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovmskpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 80 }
+}
+let psrlw_X_Xm128 = {
+    id = Psrlw_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psrlw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 209 }
+}
+let vandnpd_Y_Y_Ym256 = {
+    id = Vandnpd_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vandnpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 85 }
+}
+let vandnpd_X_X_Xm128 = {
+    id = Vandnpd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vandnpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 85 }
+}
+let vpminuw_X_X_Xm128 = {
+    id = Vpminuw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpminuw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 58 }
+}
+let cvtps2pd = {
+    id = Cvtps2pd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "cvtps2pd"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 90 }
+}
+let vmaxss = {
+    id = Vmaxss
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmaxss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 95 }
+}
+let vpsubq_X_X_Xm128 = {
+    id = Vpsubq_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsubq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 251 }
+}
+let vpmaxuw_Y_Y_Ym256 = {
+    id = Vpmaxuw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpmaxuw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 62 }
+}
+let pandn = {
+    id = Pandn
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pandn"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 223 }
+}
+let vpminsw_Y_Y_Ym256 = {
+    id = Vpminsw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpminsw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 234 }
+}
+let vxorps_Y_Y_Ym256 = {
+    id = Vxorps_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vxorps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 87 }
+}
+let vxorps_X_X_Xm128 = {
+    id = Vxorps_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vxorps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 87 }
+}
+let vpsubsw_Y_Y_Ym256 = {
+    id = Vpsubsw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsubsw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 233 }
+}
+let vpaddusb_X_X_Xm128 = {
+    id = Vpaddusb_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpaddusb"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 220 }
+}
+let vmaxpd_Y_Y_Ym256 = {
+    id = Vmaxpd_Y_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmaxpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 95 }
+}
+let vmaxpd_X_X_Xm128 = {
+    id = Vmaxpd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmaxpd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 95 }
+}
+let vpunpckhwd_X_X_Xm128 = {
+    id = Vpunpckhwd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpunpckhwd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 105 }
+}
+let punpckldq = {
+    id = Punpckldq
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "punpckldq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 98 }
+}
+let psubb = {
+    id = Psubb
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psubb"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 248 }
+}
+let vpabsw_X_Xm128 = {
+    id = Vpabsw_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpabsw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 29 }
+}
+let vpsubusw_Y_Y_Ym256 = {
+    id = Vpsubusw_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsubusw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 217 }
+}
+let movd_X_r32m32 = {
+    id = Movd_X_r32m32
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|R32;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "movd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 110 }
+}
+let pmuludq_X_Xm128 = {
+    id = Pmuludq_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmuludq"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 244 }
+}
+let pmulld = {
+    id = Pmulld
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmulld"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 64 }
+}
+let haddpd = {
+    id = Haddpd
+  ; ext = [|SSE3|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "haddpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 124 }
+}
+let cmppd = {
+    id = Cmppd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_spec
+  ; mnemonic = "cmppd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 194 }
+}
+let pcmpeqw = {
+    id = Pcmpeqw
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pcmpeqw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 117 }
+}
+let vpalignr_Y_Y_Ym256 = {
+    id = Vpalignr_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpalignr"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 15 }
+}
+let vmovddup_Y_Ym256 = {
+    id = Vmovddup_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovddup"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 18 }
+}
+let vmovddup_X_Xm64 = {
+    id = Vmovddup_X_Xm64
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M64|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovddup"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F2 }; rm_reg = Reg; opcode = 18 }
+}
+let minss = {
+    id = Minss
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "minss"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 93 }
+}
+let vaddss = {
+    id = Vaddss
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vaddss"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_F3 }; rm_reg = Reg; opcode = 88 }
+}
+let psraw_X_Xm128 = {
+    id = Psraw_X_Xm128
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "psraw"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 225 }
+}
+let mulpd = {
+    id = Mulpd
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "mulpd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 89 }
+}
+let vpermilps_Y_Ym256 = {
+    id = Vpermilps_Y_Ym256
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpermilps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 4 }
+}
+let vpermilps_X_Xm128 = {
+    id = Vpermilps_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpermilps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 4 }
+}
+let pmuludq_M_Mm64 = {
+    id = Pmuludq_M_Mm64
+  ; ext = [|SSE2|]
+  ; args = [|{ loc = Temp [|MM|]; enc = RM_r };{ loc = Temp [|MM;M64|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmuludq"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 244 }
+}
+let pmaxsd = {
+    id = Pmaxsd
+  ; ext = [|SSE4_1|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "pmaxsd"
+  ; enc = { prefix = Legacy { prefix = Prx_66; rex = Rex_none; escape = Esc_0F38 }; rm_reg = Reg; opcode = 61 }
+}
+let vpblendw_X_X_Xm128 = {
+    id = Vpblendw_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vpblendw"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 14 }
+}
+let vinserti128 = {
+    id = Vinserti128
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_spec
+  ; mnemonic = "vinserti128"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F3A; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 56 }
+}
+let vmovmskps_r64_Y = {
+    id = Vmovmskps_r64_Y
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovmskps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = true; vex_p = Prx_none }; rm_reg = Reg; opcode = 80 }
+}
+let vmovmskps_r64_X = {
+    id = Vmovmskps_r64_X
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|R64|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vmovmskps"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_none }; rm_reg = Reg; opcode = 80 }
+}
+let minps = {
+    id = Minps
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "minps"
+  ; enc = { prefix = Legacy { prefix = Prx_none; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 93 }
+}
+let vpsubd_X_X_Xm128 = {
+    id = Vpsubd_X_X_Xm128
+  ; ext = [|AVX|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = Vex_v };{ loc = Temp [|XMM;M128|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|XMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpsubd"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F; vex_w = false; vex_l = false; vex_p = Prx_66 }; rm_reg = Reg; opcode = 250 }
+}
+let vpcmpeqq_Y_Y_Ym256 = {
+    id = Vpcmpeqq_Y_Y_Ym256
+  ; ext = [|AVX2|]
+  ; args = [|{ loc = Temp [|YMM|]; enc = Vex_v };{ loc = Temp [|YMM;M256|]; enc = RM_rm }|]
+  ; res = Res { loc = Temp [|YMM|]; enc = RM_r }
+  ; imm = Imm_none
+  ; mnemonic = "vpcmpeqq"
+  ; enc = { prefix = Vex { vex_m = Vexm_0F38; vex_w = false; vex_l = true; vex_p = Prx_66 }; rm_reg = Reg; opcode = 41 }
+}
+let maxss = {
+    id = Maxss
+  ; ext = [|SSE|]
+  ; args = [|{ loc = Temp [|XMM|]; enc = RM_r };{ loc = Temp [|XMM;M32|]; enc = RM_rm }|]
+  ; res = First_arg
+  ; imm = Imm_none
+  ; mnemonic = "maxss"
+  ; enc = { prefix = Legacy { prefix = Prx_F3; rex = Rex_none; escape = Esc_0F }; rm_reg = Reg; opcode = 95 }
 }

--- a/tools/simdgen/simdgen.ml
+++ b/tools/simdgen/simdgen.ml
@@ -72,10 +72,9 @@ let parse in_ =
   csv []
 
 let rec parse_args mnemonic acc encs args imm res =
-  let set_imm () =
-    if !imm then failwith mnemonic;
-    imm := true;
-    None
+  let set_imm i =
+    if !imm <> Imm_none then failwith mnemonic;
+    imm := i
   in
   let set_res loc enc =
     (* MULX has two results *)
@@ -92,7 +91,9 @@ let rec parse_args mnemonic acc encs args imm res =
       | "<RCX>" -> Some (Pin RCX)
       | "<RDX>" -> Some (Pin RDX)
       | "<XMM0>" -> Some (Pin XMM0)
-      | "imm8" -> set_imm ()
+      | "imm8" ->
+        set_imm Imm_spec;
+        None
       | "r8/m8" | "r/m8" -> Some (Temp [| R8; M8 |])
       | "r16/m16" | "r/m16" -> Some (Temp [| R16; M16 |])
       | "r32/m32" | "r/m32" -> Some (Temp [| R32; M32 |])
@@ -148,9 +149,12 @@ let rec parse_args mnemonic acc encs args imm res =
       | "ModRM:r/m" -> RM_rm
       | "VEX.vvvv" -> Vex_v
       | "NA" | "<XMM0>" | "<RAX>" | "<RCX>" | "<RDX>" | "implicit" -> Implicit
-      | enc when String.starts_with (String.lowercase_ascii enc) ~prefix:"imm"
-        ->
-        Implicit
+      | "Imm8" | "imm8" | "imm8[3:0]" | "imm8[7:4]" ->
+        if Option.is_some loc
+        then (
+          set_imm Imm_reg;
+          Immediate)
+        else Implicit
       | enc -> fail mnemonic enc
     in
     match loc with
@@ -164,7 +168,7 @@ let rec parse_args mnemonic acc encs args imm res =
   | _ -> failwith mnemonic
 
 let parse_args mnemonic enc args =
-  let imm = ref false in
+  let imm = ref Imm_none in
   let res = ref First_arg in
   let args = parse_args mnemonic [] enc args imm res in
   Array.of_list args, !imm, !res
@@ -313,6 +317,18 @@ let binding instr =
   else instr.mnemonic
 
 let print_one instr =
+  let print_ext : ext -> string = function
+    | SSE -> "SSE"
+    | SSE2 -> "SSE2"
+    | SSE3 -> "SSE3"
+    | SSSE3 -> "SSSE3"
+    | SSE4_1 -> "SSE4_1"
+    | SSE4_2 -> "SSE4_2"
+    | PCLMULQDQ -> "PCLMULQDQ"
+    | BMI2 -> "BMI2"
+    | AVX -> "AVX"
+    | AVX2 -> "AVX2"
+  in
   let print_temp : temp -> string = function
     | R8 -> "R8"
     | R16 -> "R16"
@@ -344,6 +360,12 @@ let print_one instr =
     | RM_rm -> "RM_rm"
     | Vex_v -> "Vex_v"
     | Implicit -> "Implicit"
+    | Immediate -> "Immediate"
+  in
+  let print_imm = function
+    | Imm_none -> "Imm_none"
+    | Imm_reg -> "Imm_reg"
+    | Imm_spec -> "Imm_spec"
   in
   let print_res : res -> string = function
     | First_arg -> "First_arg"
@@ -393,6 +415,9 @@ let print_one instr =
   in
   let binding = binding instr in
   let constructor = String.capitalize_ascii binding in
+  let ext =
+    Array.map print_ext instr.ext |> Array.to_list |> String.concat ";"
+  in
   let args =
     Array.map
       (fun (arg : arg) ->
@@ -402,18 +427,20 @@ let print_one instr =
     |> Array.to_list |> String.concat ";"
   in
   let res = print_res instr.res in
+  let imm = print_imm instr.imm in
   let enc = print_enc instr.enc in
   printf
     {|
 let %s = {
     id = %s
+  ; ext = [|%s|]
   ; args = [|%s|]
   ; res = %s
-  ; imm = %b
+  ; imm = %s
   ; mnemonic = "%s"
   ; enc = %s
 }|}
-    binding constructor args res instr.imm instr.mnemonic enc
+    binding constructor ext args res imm instr.mnemonic enc
 
 let print_all () =
   print_endline "type id = ";
@@ -430,12 +457,19 @@ let print_all () =
   print_endline "\ntype nonrec instr = id instr";
   Hashtbl.iter (fun instr () -> print_one instr) all_instructions
 
-let relevant_ext = function
-  (* CR-soon mslater: AVX512 *)
-  | "SSE" | "SSE2" | "SSE3" | "SSSE3" | "SSE4_1" | "SSE4_2" | "PCLMULQDQ"
-  | "BMI2" | "AVX" | "AVX2" ->
-    true
-  | _ -> false
+let parse_ext = function
+  | "SSE" -> Some [| SSE |]
+  | "SSE2" -> Some [| SSE2 |]
+  | "SSE3" -> Some [| SSE3 |]
+  | "SSSE3" -> Some [| SSSE3 |]
+  | "SSE4_1" -> Some [| SSE4_1 |]
+  | "SSE4_2" -> Some [| SSE4_2 |]
+  | "PCLMULQDQ" -> Some [| PCLMULQDQ |]
+  | "PCLMULQDQ AVX" -> Some [| PCLMULQDQ; AVX |]
+  | "BMI2" -> Some [| BMI2 |]
+  | "AVX" -> Some [| AVX |]
+  | "AVX2" -> Some [| AVX2 |]
+  | _ -> None
 
 let amd64 () =
   let csv = In_channel.with_open_text "amd64/amd64.csv" parse in
@@ -444,16 +478,16 @@ let amd64 () =
     |> List.filter_map (function
          | mnemonic :: enc :: ext :: encs -> (
            try
-             match relevant_ext ext with
-             | true ->
+             match parse_ext ext with
+             | Some ext ->
                let mnemonic, args = first_word mnemonic in
                let mnemonic = String.lowercase_ascii mnemonic in
                let args, imm, res =
                  String.split_on_char ',' args |> parse_args mnemonic encs
                in
                let enc = parse_enc mnemonic enc in
-               Some { id = Dummy; args; res; imm; mnemonic; enc }
-             | false -> None
+               Some { id = Dummy; ext; args; res; imm; mnemonic; enc }
+             | None -> None
            with Unsupported -> None)
          | _ -> None)
   in


### PR DESCRIPTION
Refactors the flags/checks for enabling amd64 SIMD extensions. Should not change behavior.

- Gets rid of `allow/require` in favor of checking the base extension. The flag to enable AVX2 now also implies AVX, so this is fine.
- `simdgen` now records the extension of the instruction, and we check that it's enabled upon emission.
- Distinguishes between instructions with a specialization immediate and another register encoded as an immediate (for use in #4272)