### PR TITLE
Greedy allocator: minor optimizations

### DIFF
--- a/backend/regalloc/regalloc_gi.ml
+++ b/backend/regalloc/regalloc_gi.ml
@@ -114,6 +114,19 @@ let max_rounds = 32
 
 let max_temp_multiplier = 10
 
+let compile_spill_costs state cfg_with_infos ~flat () =
+  let costs = SpillCosts.compute cfg_with_infos ~flat () in
+  State.iter_introduced_temporaries state ~f:(fun (reg : Reg.t) ->
+      SpillCosts.add_to_reg costs reg 10_000);
+  if debug
+  then (
+    log "spilling costs";
+    indent ();
+    SpillCosts.iter costs ~f:(fun (reg : Reg.t) (cost : int) ->
+        log "%a: %d" Printreg.reg reg cost);
+    dedent ());
+  costs
+
 (* CR xclerc for xclerc: the `round` parameter is temporary; this is an hybrid
    version of "greedy" using the `rewrite` function from IRC when it needs to
    spill. *)
@@ -134,16 +147,7 @@ let rec main : round:int -> flat:bool -> State.t -> Cfg_with_infos.t -> unit =
     log "main, round #%d" round;
     log_cfg_with_infos cfg_with_infos);
   if debug then log "updating spilling costs";
-  let costs = SpillCosts.compute cfg_with_infos ~flat () in
-  State.iter_introduced_temporaries state ~f:(fun (reg : Reg.t) ->
-      SpillCosts.add_to_reg costs reg 10_000);
-  if debug
-  then (
-    log "spilling costs";
-    indent ();
-    SpillCosts.iter costs ~f:(fun (reg : Reg.t) (cost : int) ->
-        log "%a: %d" Printreg.reg reg cost);
-    dedent ());
+  let costs = lazy (compile_spill_costs state cfg_with_infos ~flat ()) in
   let hardware_registers, prio_queue =
     make_hardware_registers_and_prio_queue cfg_with_infos
   in
@@ -169,9 +173,7 @@ let rec main : round:int -> flat:bool -> State.t -> Cfg_with_infos.t -> unit =
         log "assigning %a to %a" Printreg.reg reg
           Hardware_register.print_location hardware_reg.location;
       State.add_assignment state reg ~to_:hardware_reg.location;
-      hardware_reg.assigned
-        <- { Hardware_register.pseudo_reg = reg; interval; evictable = true }
-           :: hardware_reg.assigned
+      Hardware_register.add_evictable hardware_reg reg interval
     | For_eviction { hardware_reg; evicted_regs } ->
       if debug
       then
@@ -194,19 +196,12 @@ let rec main : round:int -> flat:bool -> State.t -> Cfg_with_infos.t -> unit =
                evictable"
               Printreg.reg evict_reg;
           State.remove_assignment state evict_reg;
+          Hardware_register.remove_evictable hardware_reg evict_reg;
           Prio_queue.add prio_queue
             ~priority:(priority_heuristics evict_reg evict_interval)
             ~data:(evict_reg, evict_interval));
       State.add_assignment state reg ~to_:hardware_reg.location;
-      (* CR xclerc for xclerc: very inefficient. *)
-      hardware_reg.assigned
-        <- { Hardware_register.pseudo_reg = reg; interval; evictable = true }
-           :: List.filter hardware_reg.assigned
-                ~f:(fun { Hardware_register.pseudo_reg = r; _ } ->
-                  not
-                    (List.exists evicted_regs
-                       ~f:(fun { Hardware_register.pseudo_reg = r'; _ } ->
-                         Reg.same r r')))
+      Hardware_register.add_evictable hardware_reg reg interval
     | Split_or_spill ->
       (* CR xclerc for xclerc: we should actually try to split. *)
       if debug then log "spilling %a" Printreg.reg reg;

--- a/backend/regalloc/regalloc_gi_utils.mli
+++ b/backend/regalloc/regalloc_gi_utils.mli
@@ -122,10 +122,14 @@ module Hardware_register : sig
   type t =
     { location : location;
       interval : Interval.t;
-      mutable assigned : assigned list
+      assigned : assigned Reg.Tbl.t
     }
 
   val add_non_evictable : t -> Reg.t -> Interval.t -> unit
+
+  val add_evictable : t -> Reg.t -> Interval.t -> unit
+
+  val remove_evictable : t -> Reg.t -> unit
 end
 
 type available =
@@ -143,5 +147,6 @@ module Hardware_registers : sig
 
   val of_reg : t -> Reg.t -> Hardware_register.t option
 
-  val find_available : t -> SpillCosts.t -> Reg.t -> Interval.t -> available
+  val find_available :
+    t -> SpillCosts.t Lazy.t -> Reg.t -> Interval.t -> available
 end


### PR DESCRIPTION
This pull request:

- computes spilling costs only when needed;
- avoids filtering a list when evicting;
- avoids unconditionally computing both overlapping conditions.