### PR TITLE
Revert "`('a : value mod non_float) or_null` is `non_float`"

### DIFF
--- a/otherlibs/stdlib_stable/or_null.ml
+++ b/otherlibs/stdlib_stable/or_null.ml
@@ -12,7 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type 'a t : value_or_null = 'a or_null [@@or_null_reexport]
+type 'a t : immediate_or_null with 'a = 'a or_null [@@or_null_reexport]
 
 let null = Null
 let this v = This v

--- a/otherlibs/stdlib_stable/or_null.mli
+++ b/otherlibs/stdlib_stable/or_null.mli
@@ -24,10 +24,10 @@
 (* CR layouts: enable ocamlformat for this module when it starts supporting
    jkind annotations. *)
 
-type 'a t : value_or_null = 'a or_null [@@or_null_reexport]
+type 'a t : immediate_or_null with 'a = 'a or_null [@@or_null_reexport]
       (** The type of nullable values. Either [Null] or a value [This v].
-          ['a or_null] accepts arguments of kind [value] while itself
-          having kind [value_or_null], forbidding [_ or_null or_null]. *)
+          ['a or_null] has a non-standard [immediate_or_null with 'a] layout,
+          preventing the type constructor from being nested. *)
 
 val null : 'a t
 (** [null] is [Null]. *)

--- a/testsuite/tests/typing-layouts-or-null/containers.ml
+++ b/testsuite/tests/typing-layouts-or-null/containers.ml
@@ -63,8 +63,8 @@ Line 1, characters 21-25:
                          ^^^^
 Error: This expression has type "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of 'a or_null is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of 'a or_null must be a subkind of value
          because it's the type of an array element,
          chosen to have kind value.
@@ -129,8 +129,8 @@ Line 1, characters 28-32:
                                 ^^^^
 Error: This expression has type "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of 'a or_null is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of 'a or_null must be a subkind of value
          because it's the type of an array element,
          chosen to have kind value.
@@ -260,8 +260,7 @@ let should_work_option3 = None
 
 [%%expect{|
 val should_work_option1 : float or_null option = Some (This 3.4)
-val should_work_option2 :
-  ('a : value_or_null mod non_null). 'a or_null option = Some Null
+val should_work_option2 : 'a or_null option = Some Null
 val should_work_option3 : 'a option = None
 |}]
 

--- a/testsuite/tests/typing-layouts-or-null/immediate.ml
+++ b/testsuite/tests/typing-layouts-or-null/immediate.ml
@@ -85,9 +85,21 @@ type should_work = int_or_null accept_immediate_or_null
 type should_work = int_or_null accept_immediate_or_null
 |}]
 
+(* CR layouts v2.8: this is a bug in principal inference with with-kinds. *)
+
 type should_work = int or_null accept_immediate_or_null
 [%%expect{|
 type should_work = int or_null accept_immediate_or_null
+|}, Principal{|
+Line 1, characters 19-30:
+1 | type should_work = int or_null accept_immediate_or_null
+                       ^^^^^^^^^^^
+Error: This type "int or_null" should be an instance of type
+         "('a : immediate_or_null)"
+       The kind of int or_null is immediate_or_null with int
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of int or_null must be a subkind of immediate_or_null
+         because of the definition of accept_immediate_or_null at line 1, characters 0-54.
 |}]
 
 (* Values. *)
@@ -106,6 +118,8 @@ external write_imm : ('a : immediate_or_null). 'a myref -> 'a -> unit
 external equal : ('a : immediate_or_null). 'a -> 'a -> bool = "%equal"
 |}]
 
+(* CR layouts v2.8: this is a bug in principal inference with with-kinds. *)
+
 let () =
   let r = { v = (Null : int or_null) } in
   let x = read_imm r in
@@ -115,15 +129,14 @@ let () =
 ;;
 
 [%%expect{|
-|}]
-
-(* [immediate_or_null] is [non_float]: *)
-
-type ('a : value_or_null mod non_float) accepts_nonfloat
-
-type succeeds = t_immediate_or_null accepts_nonfloat
-
-[%%expect{|
-type ('a : value_or_null mod non_float) accepts_nonfloat
-type succeeds = t_immediate_or_null accepts_nonfloat
+|}, Principal{|
+Line 2, characters 16-36:
+2 |   let r = { v = (Null : int or_null) } in
+                    ^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type "int or_null"
+       but an expression was expected of type "('a : immediate_or_null)"
+       The kind of int or_null is immediate_or_null with int
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of int or_null must be a subkind of immediate_or_null
+         because of the definition of myref at line 1, characters 0-56.
 |}]

--- a/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -5,24 +5,23 @@
 (* CR layouts v3.5: ['a or_null] can't be re-exported normally,
    because users can't define their own [Null]-like constructors. *)
 module Or_null = struct
-  type ('a : value) t : value_or_null = 'a or_null =
+  type ('a : value) t : immediate_or_null with 'a = 'a or_null =
     | Null
     | This of 'a
 end
 [%%expect{|
 Lines 2-4, characters 2-16:
-2 | ..type ('a : value) t : value_or_null = 'a or_null =
+2 | ..type ('a : value) t : immediate_or_null with 'a = 'a or_null =
 3 |     | Null
 4 |     | This of 'a
-Error: This variant or record definition does not match that of type
-         "'a or_null"
-       Their internal representations differ:
-       the original definition has a constructor represented as a null pointer.
-       Hint: add [@@or_null_reexport].
+Error: The kind of type "t" is immutable_data with 'a
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of immediate_or_null with 'a
+         because of the annotation on the declaration of the type t.
 |}]
 
 module Or_null = struct
-  type ('a : value) t : value_or_null = 'a or_null
+  type ('a : value) t : immediate_or_null with 'a = 'a or_null
 end
 [%%expect{|
 module Or_null : sig type 'a t = 'a or_null end
@@ -51,7 +50,7 @@ Error: Unbound constructor "Or_null.This"
 (* [@@or_null_reexport] re-exports those constructors. *)
 
 module Or_null = struct
-  type ('a : value) t : value_or_null with 'a = 'a or_null [@@or_null_reexport]
+  type ('a : value) t : immediate_or_null with 'a = 'a or_null [@@or_null_reexport]
 end
 let n = Or_null.Null
 let t v = Or_null.This v
@@ -71,10 +70,10 @@ Line 1, characters 24-40:
                             ^^^^^^^^^^^^^^^^
 Error: This expression has type "'a Or_null.t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a Or_null.t is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of 'a Or_null.t is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of 'a Or_null.t must be a subkind of value
-         because of the definition of t at line 2, characters 2-79.
+         because of the definition of t at line 2, characters 2-83.
 |}]
 
 (* Type annotations are not required. *)
@@ -92,8 +91,8 @@ Line 4, characters 24-40:
                             ^^^^^^^^^^^^^^^^
 Error: This expression has type "'a Or_null.t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a Or_null.t is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of 'a Or_null.t is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of 'a Or_null.t must be a subkind of value
          because of the definition of t at line 2, characters 2-45.
 |}]
@@ -106,8 +105,8 @@ type 'a t : value = 'a or_null [@@or_null_reexport]
 Line 1, characters 0-51:
 1 | type 'a t : value = 'a or_null [@@or_null_reexport]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a or_null" is value_or_null
-         because it is the primitive value_or_null type or_null.
+Error: The kind of type "'a or_null" is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of type "'a or_null" must be a subkind of value
          because of the definition of t at line 1, characters 0-51.
 |}]
@@ -119,7 +118,7 @@ Line 1, characters 0-53:
 1 | type 'a t : float64 = 'a or_null [@@or_null_reexport]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type "'a or_null" is value
-         because it is the primitive value_or_null type or_null.
+         because it is the primitive immediate_or_null type or_null.
        But the layout of type "'a or_null" must be a sublayout of float64
          because of the definition of t at line 1, characters 0-53.
 |}]
@@ -130,8 +129,7 @@ type ('a : float64) t = 'a or_null [@@or_null_reexport]
 Line 1, characters 24-26:
 1 | type ('a : float64) t = 'a or_null [@@or_null_reexport]
                             ^^
-Error: This type "('a : float64)" should be an instance of type
-         "('b : value_or_null mod non_null)"
+Error: This type "('a : float64)" should be an instance of type "('b : value)"
        The layout of 'a is float64
          because of the annotation on 'a in the declaration of the type t.
        But the layout of 'a must overlap with value
@@ -148,19 +146,15 @@ let fail = Or_null.This (Or_null.This 5)
 
 [%%expect{|
 module Or_null :
-  sig
-    type ('a : value_or_null mod non_null) t = 'a or_null = Null | This of 'a [@@or_null_reexport]
-  end
+  sig type 'a t = 'a or_null = Null | This of 'a [@@or_null_reexport] end
 Line 4, characters 24-40:
 4 | let fail = Or_null.This (Or_null.This 5)
                             ^^^^^^^^^^^^^^^^
 Error: This expression has type "'a Or_null.t" = "'a or_null"
-       but an expression was expected of type
-         "('b : value_or_null mod non_null)"
-       The kind of 'a Or_null.t is value_or_null
-         because it is the primitive value_or_null type or_null.
-       But the kind of 'a Or_null.t must be a subkind of
-           value_or_null mod non_null
+       but an expression was expected of type "('b : value)"
+       The kind of 'a Or_null.t is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of 'a Or_null.t must be a subkind of value
          because of the definition of t at line 2, characters 2-63.
 |}]
 

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -467,80 +467,86 @@ type succeeds = t2 accepts_nonfloat
 
 (* [or_null] and separability. *)
 
-(* ['a] must be [non_float] for ['a or_null] to be [non_float] or [separable].  *)
+(* ['a or_null] is not separable: *)
 
-type 'a narrowed = 'a or_null accepts_nonfloat
+type 'a fails = 'a or_null accepts_nonfloat
 
 [%%expect{|
-type ('a : value mod non_float) narrowed = 'a or_null accepts_nonfloat
+Line 1, characters 16-26:
+1 | type 'a fails = 'a or_null accepts_nonfloat
+                    ^^^^^^^^^^
+Error: This type "'a or_null" should be an instance of type
+         "('b : any mod non_float)"
+       The kind of 'a or_null is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of 'a or_null must be a subkind of any mod non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-46.
 |}]
 
-type 'a narrowed = 'a or_null accepts_sep
+type 'a fails = 'a or_null accepts_sep
 
 [%%expect{|
-type ('a : value mod non_float) narrowed = 'a or_null accepts_sep
-|}]
-
-type 'a succeds = 'a or_null accepts_maybesep
-
-[%%expect{|
-type 'a succeds = 'a or_null accepts_maybesep
-|}]
-
-type t_val_nonfloat : value mod non_float
-
-type succeeds = t_val_nonfloat or_null accepts_nonfloat
-
-[%%expect{|
-type t_val_nonfloat : value mod non_float
-type succeeds = t_val_nonfloat or_null accepts_nonfloat
-|}]
-
-type fails = t_val or_null accepts_sep
-
-[%%expect{|
-Line 1, characters 13-26:
-1 | type fails = t_val or_null accepts_sep
-                 ^^^^^^^^^^^^^
-Error: This type "t_val or_null" should be an instance of type
-         "('a : any mod separable)"
-       The kind of t_val or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
-       But the kind of t_val or_null must be a subkind of any mod separable
+Line 1, characters 16-26:
+1 | type 'a fails = 'a or_null accepts_sep
+                    ^^^^^^^^^^
+Error: This type "'a or_null" should be an instance of type
+         "('b : any mod separable)"
+       The kind of 'a or_null is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of 'a or_null must be a subkind of any mod separable
          because of the definition of accepts_sep at line 2, characters 0-41.
 |}]
 
-type fails = t_b64 or_null accepts_maybesep
+type 'a succeds = 'a or_null accepts_maybesep
 
 [%%expect{|
-Line 1, characters 13-18:
-1 | type fails = t_b64 or_null accepts_maybesep
-                 ^^^^^
-Error: This type "t_b64" should be an instance of type
-         "('a : value_or_null mod non_null)"
-       The layout of t_b64 is bits64
-         because of the definition of t_b64 at line 1, characters 0-19.
-       But the layout of t_b64 must be a sublayout of value
-         because the type argument of or_null has layout value.
+type 'a succeds = 'a or_null accepts_maybesep
 |}]
 
+(* CR layouts v3.4: [or_null] should be able accept maybe-separable values? *)
+
 type t_maybesep_val : value_or_null mod non_null
-type succeeds = t_maybesep_val or_null
+type fails = t_maybesep_val or_null
 
 [%%expect{|
 type t_maybesep_val : value_or_null mod non_null
-type succeeds = t_maybesep_val or_null
+Line 2, characters 13-27:
+2 | type fails = t_maybesep_val or_null
+                 ^^^^^^^^^^^^^^
+Error: This type "t_maybesep_val" should be an instance of type "('a : value)"
+       The kind of t_maybesep_val is value_or_null mod non_null
+         because of the definition of t_maybesep_val at line 1, characters 0-48.
+       But the kind of t_maybesep_val must be a subkind of value
+         because the type argument of or_null has kind value.
 |}]
 
-type ('a : value mod non_float) succeeds = 'a or_null accepts_nonfloat
+(* CR layouts v3.4: ['a or_null] where 'a is non-float should be non-float. *)
+
+type ('a : value mod non_float) should_succeed = 'a or_null accepts_nonfloat
 
 [%%expect{|
-type ('a : value mod non_float) succeeds = 'a or_null accepts_nonfloat
+Line 1, characters 49-59:
+1 | type ('a : value mod non_float) should_succeed = 'a or_null accepts_nonfloat
+                                                     ^^^^^^^^^^
+Error: This type "'a or_null" should be an instance of type
+         "('b : any mod non_float)"
+       The kind of 'a or_null is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of 'a or_null must be a subkind of any mod non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-46.
 |}]
 
-type ('a : value mod non_float) succeeds = 'a or_null accepts_sep
+type ('a : value mod non_float) should_succeed = 'a or_null accepts_sep
 [%%expect{|
-type ('a : value mod non_float) succeeds = 'a or_null accepts_sep
+Line 1, characters 49-59:
+1 | type ('a : value mod non_float) should_succeed = 'a or_null accepts_sep
+                                                     ^^^^^^^^^^
+Error: This type "'a or_null" should be an instance of type
+         "('b : any mod separable)"
+       The kind of 'a or_null is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of 'a or_null must be a subkind of any mod separable
+         because of the definition of accepts_sep at line 2, characters 0-41.
 |}]
 
 type ('a : value mod non_float) succeeds = 'a or_null accepts_maybesep
@@ -549,6 +555,7 @@ type ('a : value mod non_float) succeeds = 'a or_null accepts_maybesep
 type ('a : value mod non_float) succeeds = 'a or_null accepts_maybesep
 |}]
 
+(* CR layouts v2.8: fix error reporting difference. *)
 (* [float or_null] is not separable: *)
 
 type fails = float or_null accepts_sep
@@ -559,8 +566,19 @@ Line 1, characters 13-26:
                  ^^^^^^^^^^^^^
 Error: This type "float or_null" should be an instance of type
          "('a : any mod separable)"
-       The kind of float or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of float or_null is
+           value_or_null mod many unyielding stateless immutable
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of float or_null must be a subkind of any mod separable
+         because of the definition of accepts_sep at line 2, characters 0-41.
+|}, Principal{|
+Line 1, characters 13-26:
+1 | type fails = float or_null accepts_sep
+                 ^^^^^^^^^^^^^
+Error: This type "float or_null" should be an instance of type
+         "('a : any mod separable)"
+       The kind of float or_null is immediate_or_null with float
+         because it is the primitive immediate_or_null type or_null.
        But the kind of float or_null must be a subkind of any mod separable
          because of the definition of accepts_sep at line 2, characters 0-41.
 |}]
@@ -600,8 +618,18 @@ Line 1, characters 22-33:
                           ^^^^^^^^^^^
 Error: This type "int or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of int or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of int or_null is immediate_or_null
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of int or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}, Principal{|
+Line 1, characters 22-33:
+1 | type should_succeed = int or_null array
+                          ^^^^^^^^^^^
+Error: This type "int or_null" should be an instance of type
+         "('a : any_non_null)"
+       The kind of int or_null is immediate_or_null with int
+         because it is the primitive immediate_or_null type or_null.
        But the kind of int or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
 |}]
@@ -614,8 +642,19 @@ Line 1, characters 22-36:
                           ^^^^^^^^^^^^^^
 Error: This type "string or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of string or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of string or_null is
+           value_or_null mod many unyielding stateless immutable
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of string or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}, Principal{|
+Line 1, characters 22-36:
+1 | type should_succeed = string or_null array
+                          ^^^^^^^^^^^^^^
+Error: This type "string or_null" should be an instance of type
+         "('a : any_non_null)"
+       The kind of string or_null is immediate_or_null with string
+         because it is the primitive immediate_or_null type or_null.
        But the kind of string or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
 |}]
@@ -630,8 +669,19 @@ Line 1, characters 13-26:
                  ^^^^^^^^^^^^^
 Error: This type "float or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of float or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of float or_null is
+           value_or_null mod many unyielding stateless immutable
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of float or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}, Principal{|
+Line 1, characters 13-26:
+1 | type fails = float or_null array
+                 ^^^^^^^^^^^^^
+Error: This type "float or_null" should be an instance of type
+         "('a : any_non_null)"
+       The kind of float or_null is immediate_or_null with float
+         because it is the primitive immediate_or_null type or_null.
        But the kind of float or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
 |}]
@@ -646,8 +696,19 @@ Line 1, characters 22-36:
                           ^^^^^^^^^^^^^^
 Error: This type "string or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of string or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of string or_null is
+           value_or_null mod many unyielding stateless immutable
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of string or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}, Principal{|
+Line 1, characters 22-36:
+1 | type should_succeed = string or_null array
+                          ^^^^^^^^^^^^^^
+Error: This type "string or_null" should be an instance of type
+         "('a : any_non_null)"
+       The kind of string or_null is immediate_or_null with string
+         because it is the primitive immediate_or_null type or_null.
        But the kind of string or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
 |}]
@@ -660,8 +721,18 @@ Line 1, characters 22-33:
                           ^^^^^^^^^^^
 Error: This type "int or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of int or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of int or_null is immediate_or_null
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of int or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}, Principal{|
+Line 1, characters 22-33:
+1 | type should_succeed = int or_null array
+                          ^^^^^^^^^^^
+Error: This type "int or_null" should be an instance of type
+         "('a : any_non_null)"
+       The kind of int or_null is immediate_or_null with int
+         because it is the primitive immediate_or_null type or_null.
        But the kind of int or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
 |}]
@@ -681,22 +752,14 @@ type ('a : value_or_null) smth : immediate with 'a
 
 type ('a : immediate) bounded
 
-(* CR layouts v2.8: with-bounds don't peek through unboxed-like types. *)
+(* CR layouts v2.8: broken mode crossing with [-principal]. *)
 
 type works = int or_null smth bounded
 
 [%%expect{|
 type 'a smth : immediate with 'a
 type ('a : immediate) bounded
-Line 7, characters 13-29:
-7 | type works = int or_null smth bounded
-                 ^^^^^^^^^^^^^^^^
-Error: This type "int or_null smth" should be an instance of type
-         "('a : immediate)"
-       The kind of int or_null smth is value mod non_float
-         because of the definition of smth at line 1, characters 0-50.
-       But the kind of int or_null smth must be a subkind of immediate
-         because of the definition of bounded at line 3, characters 0-29.
+type works = int or_null smth bounded
 |}, Principal{|
 type 'a smth : immediate with 'a
 type ('a : immediate) bounded
@@ -774,113 +837,4 @@ type ('c : value & value & float64 mod non_null non_float) fails = unit constrai
 [%%expect{|
 type c = #(float * float or_null * float#)
 type 'a fails = unit constraint 'a = c
-|}]
-
-(* Separability and [@@or_null_reexport]. *)
-
-(* Re-exported [or_null] types preserve separability behavior. *)
-
-module Or_null_reexport = struct
-  type 'a t = 'a or_null [@@or_null_reexport]
-end
-
-(* Generic ['a or_null] re-export is still maybe-separable. *)
-
-type 'a narrowed = 'a Or_null_reexport.t accepts_nonfloat
-
-[%%expect{|
-module Or_null_reexport :
-  sig type 'a t = 'a or_null = Null | This of 'a [@@or_null_reexport] end
-type ('a : value mod non_float) narrowed =
-    'a Or_null_reexport.t accepts_nonfloat
-|}]
-
-type 'a narrowed = 'a Or_null_reexport.t accepts_sep
-
-[%%expect{|
-type ('a : value mod non_float) narrowed = 'a Or_null_reexport.t accepts_sep
-|}]
-
-type 'a succeeds = 'a Or_null_reexport.t accepts_maybesep
-
-[%%expect{|
-type 'a succeeds = 'a Or_null_reexport.t accepts_maybesep
-|}]
-
-(* Non-float constraints are preserved through re-export. *)
-
-type ('a : value mod non_float) succeeds = 'a Or_null_reexport.t accepts_nonfloat
-
-[%%expect{|
-type ('a : value mod non_float) succeeds =
-    'a Or_null_reexport.t accepts_nonfloat
-|}]
-
-(* Specific type instances preserve their separability. *)
-
-type succeeds = int Or_null_reexport.t accepts_nonfloat
-
-[%%expect{|
-type succeeds = int Or_null_reexport.t accepts_nonfloat
-|}]
-
-type fails = float Or_null_reexport.t accepts_nonfloat
-
-[%%expect{|
-Line 1, characters 13-37:
-1 | type fails = float Or_null_reexport.t accepts_nonfloat
-                 ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type "float Or_null_reexport.t" = "float or_null"
-       should be an instance of type "('a : any mod non_float)"
-       The kind of float Or_null_reexport.t is value_or_null
-         because it is the primitive value_or_null type or_null.
-       But the kind of float Or_null_reexport.t must be a subkind of
-           any mod non_float
-         because of the definition of accepts_nonfloat at line 3, characters 0-46.
-|}]
-
-type fails = float Or_null_reexport.t accepts_sep
-
-[%%expect{|
-Line 1, characters 13-37:
-1 | type fails = float Or_null_reexport.t accepts_sep
-                 ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type "float Or_null_reexport.t" = "float or_null"
-       should be an instance of type "('a : any mod separable)"
-       The kind of float Or_null_reexport.t is value_or_null
-         because it is the primitive value_or_null type or_null.
-       But the kind of float Or_null_reexport.t must be a subkind of
-           any mod separable
-         because of the definition of accepts_sep at line 2, characters 0-41.
-|}]
-
-(* Peeking through unboxed types *)
-
-(* CR or-null: test [('a : value_or_null) unbx] when it's allowed. *)
-
-type 'a unbx : value = Box of 'a [@@unboxed]
-
-[%%expect{|
-type 'a unbx = Box of 'a [@@unboxed]
-|}]
-
-type succeeds = string unbx or_null accepts_nonfloat
-
-[%%expect{|
-type succeeds = string unbx or_null accepts_nonfloat
-|}]
-
-type fails = float unbx or_null accepts_sep
-
-[%%expect{|
-Line 1, characters 13-31:
-1 | type fails = float unbx or_null accepts_sep
-                 ^^^^^^^^^^^^^^^^^^
-Error: This type "float unbx or_null" should be an instance of type
-         "('a : any mod separable)"
-       The kind of float unbx or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
-       But the kind of float unbx or_null must be a subkind of
-           any mod separable
-         because of the definition of accepts_sep at line 2, characters 0-41.
 |}]

--- a/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -2,7 +2,7 @@
  expect;
 *)
 
-type ('a : value) t : value_or_null = 'a or_null [@@or_null_reexport]
+type ('a : value) t : immediate_or_null with 'a = 'a or_null [@@or_null_reexport]
 
 [%%expect{|
 type 'a t = 'a or_null = Null | This of 'a [@@or_null_reexport]
@@ -97,12 +97,19 @@ type nested = int or_null or_null
 Line 1, characters 14-25:
 1 | type nested = int or_null or_null
                   ^^^^^^^^^^^
-Error: This type "int or_null" should be an instance of type
-         "('a : value_or_null mod non_null)"
-       The kind of int or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
-       But the kind of int or_null must be a subkind of
-           value_or_null mod non_null
+Error: This type "int or_null" should be an instance of type "('a : value)"
+       The kind of int or_null is immediate_or_null
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of int or_null must be a subkind of value
+         because the type argument of or_null has kind value.
+|}, Principal{|
+Line 1, characters 14-25:
+1 | type nested = int or_null or_null
+                  ^^^^^^^^^^^
+Error: This type "int or_null" should be an instance of type "('a : value)"
+       The kind of int or_null is immediate_or_null with int
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of int or_null must be a subkind of value
          because the type argument of or_null has kind value.
 |}]
 
@@ -114,10 +121,10 @@ Line 1, characters 23-31:
                            ^^^^^^^^
 Error: This expression has type "'a t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a t is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of 'a t is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of 'a t must be a subkind of value
-         because of the definition of t at line 1, characters 0-69.
+         because of the definition of t at line 1, characters 0-81.
 |}]
 
 let should_also_fail = This Null
@@ -128,10 +135,10 @@ Line 1, characters 28-32:
                                 ^^^^
 Error: This expression has type "'a t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a t is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of 'a t is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of 'a t must be a subkind of value
-         because of the definition of t at line 1, characters 0-69.
+         because of the definition of t at line 1, characters 0-81.
 |}]
 
 let mk' n = `Foo (This n)
@@ -193,8 +200,8 @@ Line 1, characters 21-25:
                          ^^^^
 Error: This expression has type "'a t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a t is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of 'a t is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of 'a t must be a subkind of value
          because it's the type of an array element,
          chosen to have kind value.
@@ -208,8 +215,19 @@ Line 1, characters 19-32:
                        ^^^^^^^^^^^^^
 Error: This type "float or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of float or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of float or_null is
+           value_or_null mod many unyielding stateless immutable
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of float or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}, Principal{|
+Line 1, characters 19-32:
+1 | type should_fail = float or_null array
+                       ^^^^^^^^^^^^^
+Error: This type "float or_null" should be an instance of type
+         "('a : any_non_null)"
+       The kind of float or_null is immediate_or_null with float
+         because it is the primitive immediate_or_null type or_null.
        But the kind of float or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
 |}]
@@ -236,8 +254,8 @@ Line 1, characters 21-25:
                          ^^^^
 Error: This expression has type "'a t" = "'a or_null"
        but an expression was expected of type "('b : value)"
-       The kind of 'a t is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of 'a t is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of 'a t must be a subkind of value
          because it's the type of an array element,
          chosen to have kind value.
@@ -251,8 +269,19 @@ Line 1, characters 19-32:
                        ^^^^^^^^^^^^^
 Error: This type "float or_null" should be an instance of type
          "('a : any_non_null)"
-       The kind of float or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of float or_null is
+           value_or_null mod many unyielding stateless immutable
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of float or_null must be a subkind of any_non_null
+         because it's the type argument to the array type.
+|}, Principal{|
+Line 1, characters 19-32:
+1 | type should_fail = float or_null array
+                       ^^^^^^^^^^^^^
+Error: This type "float or_null" should be an instance of type
+         "('a : any_non_null)"
+       The kind of float or_null is immediate_or_null with float
+         because it is the primitive immediate_or_null type or_null.
        But the kind of float or_null must be a subkind of any_non_null
          because it's the type argument to the array type.
 |}]
@@ -265,8 +294,17 @@ Line 1, characters 26-42:
 1 | type object_with_null = < x : int or_null; .. >
                               ^^^^^^^^^^^^^^^^
 Error: Object field types must have layout value.
-       The kind of "int or_null" is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of "int or_null" is immediate_or_null
+         because it is the primitive immediate_or_null type or_null.
+       But the kind of "int or_null" must be a subkind of value
+         because it's the type of an object field.
+|}, Principal{|
+Line 1, characters 26-42:
+1 | type object_with_null = < x : int or_null; .. >
+                              ^^^^^^^^^^^^^^^^
+Error: Object field types must have layout value.
+       The kind of "int or_null" is immediate_or_null with int
+         because it is the primitive immediate_or_null type or_null.
        But the kind of "int or_null" must be a subkind of value
          because it's the type of an object field.
 |}]
@@ -282,8 +320,8 @@ Line 3, characters 8-9:
 3 |     val x = Null
             ^
 Error: Variables bound in a class must have layout value.
-       The kind of x is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of x is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of x must be a subkind of value
          because it's the type of a class field.
 |}]
@@ -352,8 +390,8 @@ Line 1, characters 45-55:
 1 | type (_, _) fail = Fail : 'a or_null -> ('a, 'a or_null) fail [@@unboxed]
                                                  ^^^^^^^^^^
 Error: This type "'a or_null" should be an instance of type "('b : value)"
-       The kind of 'a or_null is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of 'a or_null is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of 'a or_null must be a subkind of value
          because it instantiates an unannotated type parameter of fail,
          chosen to have kind value.
@@ -392,10 +430,10 @@ Line 1, characters 35-51:
                                        ^^^^^^^^^^^^^^^^
 Error: This expression has type "unboxed_rec"
        but an expression was expected of type "('a : value)"
-       The kind of unboxed_rec is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of unboxed_rec is immediate_or_null
+         because it is the primitive immediate_or_null type or_null.
        But the kind of unboxed_rec must be a subkind of value
-         because of the definition of t at line 1, characters 0-69.
+         because of the definition of t at line 1, characters 0-81.
 |}]
 
 let should_fail_unboxed_var = This (Wrap Null)
@@ -406,10 +444,10 @@ Line 1, characters 35-46:
                                        ^^^^^^^^^^^
 Error: This expression has type "unboxed_var"
        but an expression was expected of type "('a : value)"
-       The kind of unboxed_var is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of unboxed_var is immediate_or_null
+         because it is the primitive immediate_or_null type or_null.
        But the kind of unboxed_var must be a subkind of value
-         because of the definition of t at line 1, characters 0-69.
+         because of the definition of t at line 1, characters 0-81.
 |}]
 
 let should_fail_unboxed_gadt = This (Gadt Null)
@@ -420,8 +458,8 @@ Line 1, characters 36-47:
                                         ^^^^^^^^^^^
 Error: This expression has type "('a, 'a or_null) gadt"
        but an expression was expected of type "('b : value)"
-       The kind of ('a, 'a or_null) gadt is value_or_null
-         because it is the primitive value_or_null type or_null.
+       The kind of ('a, 'a or_null) gadt is immediate_or_null with 'a
+         because it is the primitive immediate_or_null type or_null.
        But the kind of ('a, 'a or_null) gadt must be a subkind of value
-         because of the definition of t at line 1, characters 0-69.
+         because of the definition of t at line 1, characters 0-81.
 |}]

--- a/testsuite/tests/typing-modal-kinds/everything.ml
+++ b/testsuite/tests/typing-modal-kinds/everything.ml
@@ -11,7 +11,7 @@ type t_float64 : float64
 type t_float64_mod_e : float64 mod everything
 [%%expect{|
 type t_value
-type t_value_mod_e : value_or_null mod everything mod non_null separable
+type t_value_mod_e : immediate_or_null mod non_null separable
 type t_float64 : float64
 type t_float64_mod_e : float64 mod everything
 |}]
@@ -257,11 +257,11 @@ type t : value_or_null mod everything
 type bad : value = t
 
 [%%expect{|
-type t : value_or_null mod everything
+type t : immediate_or_null
 Line 2, characters 0-20:
 2 | type bad : value = t
     ^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value_or_null mod everything
+Error: The kind of type "t" is immediate_or_null
          because of the definition of t at line 1, characters 0-37.
        But the kind of type "t" must be a subkind of value
          because of the definition of bad at line 2, characters 0-20.
@@ -295,15 +295,15 @@ type t : immediate & immediate
 type t : value & float64 mod everything
 [%%expect{|
 type t
-  : value_or_null mod everything mod non_null separable
+  : immediate_or_null mod non_null separable
     & float64 mod global aliased many stateless immutable external_
 |}]
 
 type t : value & (immediate & bits64) & float32 mod everything
 [%%expect{|
 type t
-  : value_or_null mod everything mod non_null separable
-    & (value_or_null mod everything mod non_null separable
+  : immediate_or_null mod non_null separable
+    & (immediate_or_null mod non_null separable
       & bits64 mod global aliased many stateless immutable external_)
     & float32 mod global aliased many stateless immutable external_
 |}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2168,8 +2168,6 @@ type unbox_result =
   | Stepped of unwrapped_type_expr
   (* unboxing process unboxed a product. Invariant: length >= 2 *)
   | Stepped_record_unboxed_product of unwrapped_type_expr list
-  (* unboxing process unboxed an [or_null] type *)
-  | Stepped_or_null of unwrapped_type_expr
   (* no step to make; we're all done here *)
   | Final_result
   (* definition not in environment: missing cmi *)
@@ -2209,16 +2207,6 @@ let unbox_once env ty =
                                    modality = ld.ld_modalities }) lbls)
         | Type_record_unboxed_product ([], _, _) ->
           Misc.fatal_error "Ctype.unboxed_once: fieldless record"
-        | Type_variant ([_; cd2], Variant_with_null, _) ->
-          begin match cd2.cd_args with
-          | Cstr_tuple [arg] ->
-            (* [arg.ca_modalities] is currently always empty, but won't be
-               when we let users define custom or-null-like types. *)
-            Stepped_or_null { ty = apply arg.ca_type;
-                              is_open = false;
-                              modality = arg.ca_modalities }
-          | _ -> Misc.fatal_error "Invalid constructor for Variant_with_null"
-          end
         | Type_abstract _ | Type_record _ | Type_variant _ | Type_open ->
           Final_result
         end
@@ -2235,7 +2223,6 @@ let contained_without_boxing env ty =
   | Tconstr _ ->
     begin match unbox_once env ty with
     | Stepped { ty; is_open = _; modality = _ } -> [ty]
-    | Stepped_or_null { ty; is_open = _; modality = _ } -> [ty]
     | Stepped_record_unboxed_product tys ->
       List.map (fun { ty; _ } -> ty) tys
     | Final_result | Missing _ -> []
@@ -2264,7 +2251,7 @@ let rec get_unboxed_type_representation
       in
       get_unboxed_type_representation
         ~is_open ~modality env ty ty2 (fuel - 1)
-    | Stepped_or_null _ | Stepped_record_unboxed_product _ | Final_result ->
+    | Stepped_record_unboxed_product _ | Final_result ->
       Ok { ty; is_open; modality }
     | Missing _ -> Ok { ty = ty_prev; is_open; modality }
 
@@ -2536,34 +2523,6 @@ let constrain_type_jkind ~fixed env ty jkind =
                   (Not_a_subjkind (ty's_jkind, jkind, sub_failure_reasons)))
              end
           in
-          let or_null ~fuel ty is_open modality =
-            let error () =
-              Error (Jkind.Violation.of_ ~jkind_of_type
-                (Not_a_subjkind (ty's_jkind, jkind, sub_failure_reasons)))
-            in
-            let jkind = Jkind.apply_modality_r modality jkind in
-            match
-              Jkind.apply_or_null jkind
-            with
-            | Ok jkind ->
-              (match
-                loop ~fuel ~expanded:false ty ~is_open
-                  (estimate_type_jkind env ty) jkind
-              with
-              | Ok () -> Ok ()
-              | Error _ ->
-                (* CR or_null:
-                   Since [constrain_type_jkind] reports errors for the original
-                   type on the left, return the original error.
-                   We could do something smarter here, updating the [loop]-ed
-                   error to have correct jkinds. *)
-                error ())
-            | Error () ->
-              (* CR or_null:
-                 [_ or_null] fails against a non-null jkind.
-                 We could still estimate the kind on the left better. *)
-              error ()
-          in
           match get_desc ty with
           | Tconstr _ ->
              if not expanded
@@ -2586,8 +2545,6 @@ let constrain_type_jkind ~fixed env ty jkind =
                  let jkind = Jkind.apply_modality_r modality jkind in
                  loop ~fuel:(fuel - 1) ~expanded:false ty ~is_open
                    (estimate_type_jkind env ty) jkind
-               | Stepped_or_null { ty; is_open = is_open2; modality } ->
-                 or_null ~fuel:(fuel - 1) ty (is_open || is_open2) modality
                | Stepped_record_unboxed_product tys_modalities ->
                  product ~fuel:(fuel - 1) tys_modalities
                end

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -180,9 +180,9 @@ let value_descriptions ~loc env name
              let ty2, mode_l2, mode_y2, _ = Ctype.instance_prim p2 vd2.val_type in
              Option.iter (Mode.Locality.equate_exn loc) mode_l2;
              Option.iter (Mode.Yielding.equate_exn yield) mode_y2;
-             try
+             try 
                Ctype.moregeneral env true ty1 ty2
-             with Ctype.Moregen err ->
+             with Ctype.Moregen err -> 
                raise (Dont_match (Type err))
            ) yielding
          ) locality;
@@ -688,8 +688,7 @@ let report_type_mismatch first second decl env ppf err =
   | With_null_representation ord ->
       pr "Their internal representations differ:@ %s %s %s."
          (choose ord first second) decl
-         "has a constructor represented as a null pointer";
-      pr "@ Hint: add [%@%@or_null_reexport]."
+         "has a null constructor"
   | Jkind v ->
       Jkind.Violation.report_with_name ~name:first ppf v
   | Unsafe_mode_crossing mismatch ->

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1444,7 +1444,7 @@ module Const = struct
     let immediate_or_null =
       { jkind =
           mk_jkind (Base Value) ~mode_crossing:true ~nullability:Maybe_null
-            ~separability:Non_float;
+            ~separability:Maybe_separable;
         name = "immediate_or_null"
       }
 
@@ -2423,24 +2423,6 @@ let for_non_float ~(why : History.value_creation_reason) =
     { layout = Sort (Base Value); mod_bounds; with_bounds = No_with_bounds }
     ~annotation:None ~why:(Value_creation why)
 
-let for_or_null_argument ident =
-  let why =
-    History.Type_argument
-      { parent_path = Path.Pident ident; position = 1; arity = 1 }
-  in
-  let mod_bounds =
-    Mod_bounds.create ~locality:Locality.Const.max
-      ~linearity:Linearity.Const.max ~portability:Portability.Const.max
-      ~yielding:Yielding.Const.max ~uniqueness:Uniqueness.Const_op.max
-      ~contention:Contention.Const_op.max ~statefulness:Statefulness.Const.max
-      ~visibility:Visibility.Const_op.max ~externality:Externality.max
-      ~nullability:Nullability.Non_null
-      ~separability:Separability.Maybe_separable
-  in
-  fresh_jkind
-    { layout = Sort (Base Value); mod_bounds; with_bounds = No_with_bounds }
-    ~annotation:None ~why:(Value_creation why)
-
 let for_abbreviation ~type_jkind_purely ~modality ty =
   (* CR layouts v2.8: This should really use layout_of *)
   let jkind = type_jkind_purely ty in
@@ -2754,18 +2736,6 @@ let apply_modality_r modality jk =
       (Axis_set.complement relevant_axes)
   in
   { jk with jkind = { jk.jkind with mod_bounds } } |> disallow_left
-
-let apply_or_null jkind =
-  match Mod_bounds.nullability jkind.jkind.mod_bounds with
-  | Maybe_null ->
-    let jkind = set_nullability_upper_bound jkind Non_null in
-    let jkind =
-      match Mod_bounds.separability jkind.jkind.mod_bounds with
-      | Maybe_separable -> jkind
-      | Separable | Non_float -> set_separability_upper_bound jkind Non_float
-    in
-    Ok jkind
-  | Non_null -> Error ()
 
 let get_annotation jk = jk.annotation
 

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -530,9 +530,6 @@ val for_float : Ident.t -> Types.jkind_l
 (** The jkind for values that are not floats. *)
 val for_non_float : why:History.value_creation_reason -> 'd Types.jkind
 
-(** The jkind for [or_null] type arguments. *)
-val for_or_null_argument : Ident.t -> 'd Types.jkind
-
 (** The jkind for an abbreviation declaration. This implements the design
     in rule FIND_ABBREV in kind-inference.md, where we consider a definition
 
@@ -626,7 +623,7 @@ val set_externality_upper_bound :
 (** Gets the nullability from a jkind. *)
 val get_nullability :
   jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
-  Types.jkind_l ->
+  'd Types.jkind ->
   Jkind_axis.Nullability.t
 
 (** Computes a jkind that is the same as the input but with an updated maximum
@@ -654,12 +651,6 @@ val apply_modality_l :
     will all be top. The with-bounds are left unchanged. *)
 val apply_modality_r :
   Mode.Modality.Value.Const.t -> ('l * allowed) Types.jkind -> Types.jkind_r
-
-(** Change a jkind to be appropriate for an expectation of a type passed to
-    the [or_null] constructor. Adjusts nullability to be [Non_null], and
-    separability to be [Non_float] if it is demanded to be [Separable].
-    If the jkind is already [Non_null], fails. *)
-val apply_or_null : Types.jkind_r -> (Types.jkind_r, unit) result
 
 (** Extract out component jkinds from the product. Because there are no product
     jkinds, this is a bit of a lie: instead, this decomposes the layout but just

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -678,8 +678,12 @@ let or_null_kind tvar =
   in
   Type_variant (cstrs, Variant_with_null, None)
 
-let or_null_jkind _ =
-  Jkind.Builtin.value_or_null ~why:(Primitive ident_or_null)
+let or_null_jkind param =
+  Jkind.Builtin.immediate_or_null ~why:(Primitive ident_or_null) |>
+  Jkind.add_with_bounds
+    ~modality:Mode.Modality.Value.Const.id
+    ~type_expr:param |>
+  Jkind.mark_best
 
 let add_or_null add_type env =
   let add_type1 = mk_add_type1 add_type in
@@ -695,7 +699,6 @@ let add_or_null add_type env =
      the most argument types, and forbid arrays from accepting [or_null]s.
      In the future, we will track separability in the jkind system. *)
   ~kind:or_null_kind
-  ~param_jkind:(Jkind.for_or_null_argument ident_or_null)
   ~jkind:or_null_jkind
 
 let builtin_values =


### PR DESCRIPTION
Reverts oxcaml/oxcaml#4158, which broke mode-crossing inferencefor `or_null`.