### PR TITLE
Make unboxed numbers modules in `Stdlib_upstream_compatible` @@ portable

### DIFF
--- a/otherlibs/stdlib_upstream_compatible/float_u.ml
+++ b/otherlibs/stdlib_upstream_compatible/float_u.ml
@@ -19,9 +19,11 @@ open! Stdlib
 
 type t = float#
 
-external to_float : t -> (float[@local_opt]) = "%box_float" [@@warning "-187"]
+external to_float : t -> (float[@local_opt]) @@ portable =
+  "%box_float" [@@warning "-187"]
 
-external of_float : (float[@local_opt]) -> t = "%unbox_float" [@@warning "-187"]
+external of_float : (float[@local_opt]) -> t @@ portable =
+  "%unbox_float" [@@warning "-187"]
 
 (* CR layouts: Investigate whether it's worth making these things externals.
    Are there situations where the middle-end won't inline them and remove the

--- a/otherlibs/stdlib_upstream_compatible/float_u.mli
+++ b/otherlibs/stdlib_upstream_compatible/float_u.mli
@@ -17,6 +17,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+@@ portable
+
 open! Stdlib
 
 (* CR layouts v4: This file is based on [float.mli], which itself is generated

--- a/otherlibs/stdlib_upstream_compatible/int32_u.ml
+++ b/otherlibs/stdlib_upstream_compatible/int32_u.ml
@@ -19,9 +19,11 @@ open! Stdlib
 
 type t = int32#
 
-external to_int32 : t -> (int32[@local_opt]) = "%box_int32" [@@warning "-187"]
+external to_int32 : t -> (int32[@local_opt]) @@ portable =
+  "%box_int32" [@@warning "-187"]
 
-external of_int32 : (int32[@local_opt]) -> t = "%unbox_int32" [@@warning "-187"]
+external of_int32 : (int32[@local_opt]) -> t @@ portable =
+  "%unbox_int32" [@@warning "-187"]
 
 let[@inline always] neg x = of_int32 (Int32.neg (to_int32 x))
 

--- a/otherlibs/stdlib_upstream_compatible/int32_u.mli
+++ b/otherlibs/stdlib_upstream_compatible/int32_u.mli
@@ -16,6 +16,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+@@ portable
+
 open! Stdlib
 
 (** Unboxed 32-bit integers.  This file primarily duplicates

--- a/otherlibs/stdlib_upstream_compatible/int64_u.ml
+++ b/otherlibs/stdlib_upstream_compatible/int64_u.ml
@@ -19,9 +19,11 @@ open! Stdlib
 
 type t = int64#
 
-external to_int64 : t -> (int64[@local_opt]) = "%box_int64" [@@warning "-187"]
+external to_int64 : t -> (int64[@local_opt]) @@ portable =
+  "%box_int64" [@@warning "-187"]
 
-external of_int64 : (int64[@local_opt]) -> t = "%unbox_int64" [@@warning "-187"]
+external of_int64 : (int64[@local_opt]) -> t @@ portable =
+  "%unbox_int64" [@@warning "-187"]
 
 let[@inline always] neg x = of_int64 (Int64.neg (to_int64 x))
 

--- a/otherlibs/stdlib_upstream_compatible/int64_u.mli
+++ b/otherlibs/stdlib_upstream_compatible/int64_u.mli
@@ -16,6 +16,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+@@ portable
+
 open! Stdlib
 
 (** Unboxed 64-bit integers.  This file primarily duplicates

--- a/otherlibs/stdlib_upstream_compatible/nativeint_u.ml
+++ b/otherlibs/stdlib_upstream_compatible/nativeint_u.ml
@@ -19,9 +19,10 @@ open! Stdlib
 
 type t = nativeint#
 
-external to_nativeint : t -> (nativeint[@local_opt]) = "%box_nativeint" [@@warning "-187"]
+external to_nativeint : t -> (nativeint[@local_opt]) @@ portable =
+  "%box_nativeint" [@@warning "-187"]
 
-external of_nativeint : (nativeint[@local_opt]) -> t =
+external of_nativeint : (nativeint[@local_opt]) -> t @@ portable =
   "%unbox_nativeint" [@@warning "-187"]
 
 let[@inline always] neg x = of_nativeint (Nativeint.neg (to_nativeint x))

--- a/otherlibs/stdlib_upstream_compatible/nativeint_u.mli
+++ b/otherlibs/stdlib_upstream_compatible/nativeint_u.mli
@@ -16,6 +16,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+@@ portable
+
 open! Stdlib
 
 (** Unboxed processor-native integers.  This file primarily duplicates


### PR DESCRIPTION
The modules were not materially changed. All I did was add `@@ portable` in the appropriate places.