### PR TITLE
fix(build): Support building with an OCaml 5 system compiler

### DIFF
--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -200,7 +200,7 @@ _install: compiler
 	$(cpl) _build/install/main/bin/* _install/bin/
 	( cd _install/bin; for i in *.opt; do ln -s $$i $${i%.opt}; done )
 	$(cpl) -R _build/runtime_stdlib_install/lib/ocaml_runtime_stdlib/* _install/lib/ocaml/
-	rm -f _install/lib/ocaml/{META,dune-package,Makefile.config,dynlink.cmxa}
+	rm -f _install/lib/ocaml/{META,dune-package,Makefile.config,dynlink.cmxa,dynlink/dynlink.cmxa}
 	$(cpl) -R _build/install/main/lib/ocaml/* _install/lib/ocaml/
 	if [ "x$(legacy_layout)" == "xyes" ] ; \
 	then \
@@ -466,7 +466,7 @@ boot-_install: runtime-stdlib
 	$(cpl) _build/_bootinstall/bin/* _install/bin/
 	$(cpl) -R _build/runtime_stdlib_install/lib/ocaml_runtime_stdlib/* \
     _install/lib/ocaml/
-	rm -f _install/lib/ocaml/{META,dune-package,Makefile.config,dynlink.cmxa}
+	rm -f _install/lib/ocaml/{META,dune-package,Makefile.config,dynlink.cmxa,dynlink/dynlink.cmxa}
 	$(cpl) -R _build/_bootinstall/lib/ocaml/* _install/lib/ocaml/
 	rm -f _install/lib/ocaml/{META,dune-package}
 	rm -f _install/lib/ocaml/compiler-libs/*.cmo


### PR DESCRIPTION
Building oxcaml with an OCaml 5 (or OxCaml) system compiler fails when running `make compiler` with errors related to not being able to build `.cmxs` files -- even though the compiler and stdlib report they are being able to build shared libraries just fine!

I tracked this to being due to the combination of multiple factors:

 - `ocamlc` returns `Sys.ocaml_version` as the `version` field when asked for its `-config` ;

 - For the boot-compiler, `Sys.ocaml_version` is the version of the system compiler that was used to build the boot compiler ;

 - `dune` uses `ocamlc -config` to determine the compiler's version ;

 - `dune` only believes that the compiler can make `.cmxs` if it finds a `dynlink.cmxa` at the root of the stdlib for OCaml 4 installations, but checks `dynlink/dynlink.cmxa` for OCaml 5 installations instead.

This means that when the system compiler is OCaml 4, we need to have a file in
`_build/runtime_stdlib_install/lib/ocaml_runtime_stdlib/dynlink.cmxa` so that `dune` accepts to build shared libraries, but when the system compiler is OCaml 5, we need to use
`_build/runtime_stdlib_install/lib/ocaml_runtime_stdlib/dynlink.cmxa` instead.

Just create the file in both locations.