### PR TITLE
build: Support `make boot-_install` with ocamllex on another device

### DIFF
--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -479,7 +479,7 @@ boot-_install: runtime-stdlib
 	mkdir -p _install/{bin,lib/ocaml}
 	$(cpl) _build/runtime_stdlib_install/bin/* _install/bin/
 	# can't use a hard link here because ocamllex comes from the system and
-	# is possibly on a difference device
+	# is possibly on a different device
 	ln -sf $(realpath _build/_bootinstall/bin/ocamllex.opt) _install/bin/ocamllex.opt
 	$(cpl) _build/_bootinstall/bin/ocaml{c,opt,mklib,dep,objinfo}.opt _install/bin/
 	( cd _install/bin; for i in *.opt; do ln -s $$i $${i%.opt}; done )


### PR DESCRIPTION
The `boot-_install` targets use hard links from the `_boot/_bootinstall/bin` directory to the `_install/bin` directory. However, the `_boot/_bootinstall/bin` directory contains a symbolic to the system's `ocamllex` executable, which might not be on the same device as the oxcaml repository.

Use a symbolic link for `ocamllex` in the `boot-_install` target instead.