### PR TITLE
Add Stdlib.Or_null to generic optional arguments

### DIFF
--- a/ocamldoc/odoc_info.mli
+++ b/ocamldoc/odoc_info.mli
@@ -794,7 +794,8 @@ val create_index_lists : 'a list -> ('a -> string) -> 'a list list
 (** Take a type and remove the option top constructor. This is
    useful when printing labels, we then remove the top option constructor
    for optional labels.*)
-val remove_option : Types.arg_label -> Types.type_expr -> Types.type_expr
+val remove_option :
+  Btype.optional_module_path -> Types.type_expr -> Types.type_expr
 
 (** Return [true] if the given label is optional.*)
 val is_optional : Types.arg_label -> bool

--- a/ocamldoc/odoc_info.mli
+++ b/ocamldoc/odoc_info.mli
@@ -794,7 +794,7 @@ val create_index_lists : 'a list -> ('a -> string) -> 'a list list
 (** Take a type and remove the option top constructor. This is
    useful when printing labels, we then remove the top option constructor
    for optional labels.*)
-val remove_option : Types.type_expr -> Types.type_expr
+val remove_option : Types.arg_label -> Types.type_expr -> Types.type_expr
 
 (** Return [true] if the given label is optional.*)
 val is_optional : Types.arg_label -> bool

--- a/ocamldoc/odoc_misc.ml
+++ b/ocamldoc/odoc_misc.ml
@@ -486,7 +486,7 @@ let create_index_lists elements string_of_ele =
 
 (*** for labels *)
 
-let is_optional = Btype.is_optional_arg
+let is_optional = Btype.is_optional
 let label_name = Btype.label_name
 
 let remove_option lbl typ =
@@ -497,8 +497,8 @@ let remove_option lbl typ =
       when Path.same path
             (match Btype.classify_optionality lbl with
             | Required_or_position_arg -> assert false
-            | Optional_arg path -> (
-                match Btype.classify_module_path path with
+            | Optional_arg mpath ->
+                (match mpath with
                 | Stdlib_option -> Predef.path_option
                 | Stdlib_or_null -> Predef.path_or_null))
         -> get_desc ty

--- a/ocamldoc/odoc_misc.ml
+++ b/ocamldoc/odoc_misc.ml
@@ -486,15 +486,23 @@ let create_index_lists elements string_of_ele =
 
 (*** for labels *)
 
-let is_optional = Btype.is_optional
+let is_optional = Btype.is_optional_arg
 let label_name = Btype.label_name
 
-let remove_option typ =
+let remove_option lbl typ =
   let open Types in
   let rec trim t =
     match t with
     | Tconstr(path, [ty], _)
-      when Path.same path Predef.path_option -> get_desc ty
+        when Path.same path
+              (match Btype.classify_optionality lbl with
+              | Not_optional_arg -> assert false
+              | Optional_arg path -> (
+                  match Btype.classify_module_path path with
+                  | Stdlib_option -> Predef.path_option
+                  | Stdlib_or_null -> Predef.path_or_null
+              ))
+        -> get_desc ty
     | Tconstr _
     | Tvar _
     | Tunivar _

--- a/ocamldoc/odoc_misc.ml
+++ b/ocamldoc/odoc_misc.ml
@@ -489,18 +489,12 @@ let create_index_lists elements string_of_ele =
 let is_optional = Btype.is_optional
 let label_name = Btype.label_name
 
-let remove_option lbl typ =
+let remove_option mpath typ =
   let open Types in
   let rec trim t =
     match t with
     | Tconstr(path, [ty], _)
-      when Path.same path
-            (match Btype.classify_optionality lbl with
-            | Required_or_position_arg -> assert false
-            | Optional_arg mpath ->
-                (match mpath with
-                | Stdlib_option -> Predef.path_option
-                | Stdlib_or_null -> Predef.path_or_null))
+      when Path.same path (Ctype.predef_path_of_optional_module_path mpath)
         -> get_desc ty
     | Tconstr _
     | Tvar _

--- a/ocamldoc/odoc_misc.ml
+++ b/ocamldoc/odoc_misc.ml
@@ -494,14 +494,13 @@ let remove_option lbl typ =
   let rec trim t =
     match t with
     | Tconstr(path, [ty], _)
-        when Path.same path
-              (match Btype.classify_optionality lbl with
-              | Not_optional_arg -> assert false
-              | Optional_arg path -> (
-                  match Btype.classify_module_path path with
-                  | Stdlib_option -> Predef.path_option
-                  | Stdlib_or_null -> Predef.path_or_null
-              ))
+      when Path.same path
+            (match Btype.classify_optionality lbl with
+            | Required_or_position_arg -> assert false
+            | Optional_arg path -> (
+                match Btype.classify_module_path path with
+                | Stdlib_option -> Predef.path_option
+                | Stdlib_or_null -> Predef.path_or_null))
         -> get_desc ty
     | Tconstr _
     | Tvar _

--- a/ocamldoc/odoc_misc.mli
+++ b/ocamldoc/odoc_misc.mli
@@ -112,7 +112,8 @@ val search_string_backward : pat: string -> s: string -> int
 (** Take a type and remove the option top constructor. This is
    useful when printing labels, we then remove the top option constructor
    for optional labels.*)
-val remove_option : Types.arg_label -> Types.type_expr -> Types.type_expr
+val remove_option :
+   Btype.optional_module_path -> Types.type_expr -> Types.type_expr
 
 (** Return [true] if the given label is optional.*)
 val is_optional : Types.arg_label -> bool

--- a/ocamldoc/odoc_misc.mli
+++ b/ocamldoc/odoc_misc.mli
@@ -112,7 +112,7 @@ val search_string_backward : pat: string -> s: string -> int
 (** Take a type and remove the option top constructor. This is
    useful when printing labels, we then remove the top option constructor
    for optional labels.*)
-val remove_option : Types.type_expr -> Types.type_expr
+val remove_option : Types.arg_label -> Types.type_expr -> Types.type_expr
 
 (** Return [true] if the given label is optional.*)
 val is_optional : Types.arg_label -> bool

--- a/ocamldoc/odoc_str.ml
+++ b/ocamldoc/odoc_str.ml
@@ -144,7 +144,7 @@ let string_of_class_params c =
           (if parent then "(" else "")
           (Odoc_print.string_of_type_expr
              (if Odoc_misc.is_optional label then
-               Odoc_misc.remove_option t
+               Odoc_misc.remove_option label t
              else
                t
              )

--- a/ocamldoc/odoc_str.ml
+++ b/ocamldoc/odoc_str.ml
@@ -143,11 +143,9 @@ let string_of_class_params c =
           )
           (if parent then "(" else "")
           (Odoc_print.string_of_type_expr
-             (if Odoc_misc.is_optional label then
-               Odoc_misc.remove_option label t
-             else
-               t
-             )
+             (match Btype.classify_optionality label with
+             | Optional_arg mpath -> Odoc_misc.remove_option mpath t
+             | Required_or_position_arg -> t)
           )
           (if parent then ")" else "");
         iter ctype

--- a/testsuite/tests/generic-optional-arguments/arg_label_compatibility.ml
+++ b/testsuite/tests/generic-optional-arguments/arg_label_compatibility.ml
@@ -1,0 +1,22 @@
+(* TEST
+flags = "-extension-universe alpha ";
+
+ expect;
+*)
+
+(* Comprehensive test suite for argument label compatibility *)
+
+(* CR generic-optional: Test compatibility matrix for all parameter types (Nolabel, ~x, ?x, 
+   Option.?'x, Or_null.?'x, ~(x:t)) with all argument types *)
+
+(* CR generic-optional: Test multi-argument functions with mixed types, partial application,
+   and argument reordering *)
+
+(* CR generic-optional: Test module inclusion for signatures/structures with different 
+   optional argument types *)
+
+(* CR generic-optional: Test higher-order functions taking/returning functions with optional args *)
+
+(* CR generic-optional: Test object/class methods with optional arguments and inheritance *)
+
+(* CR generic-optional: Test edge cases: conflicting paths, empty labels, error messages *)

--- a/testsuite/tests/generic-optional-arguments/calling_compatibility.ml
+++ b/testsuite/tests/generic-optional-arguments/calling_compatibility.ml
@@ -1,0 +1,221 @@
+(* TEST
+flags = "-extension-universe alpha ";
+
+ expect;
+*)
+
+(* Comprehensive test of calling compatibility for optional arguments *)
+
+(* Three function definitions *)
+let f_vanilla ?(x : int option) () = match x with None -> 0 | Some v -> v
+let f_option Stdlib.Option.?'(x = 0) () = x
+let f_or_null Stdlib.Or_null.?'(x: int or_null) () = x
+(* CR generic-optional: This seg faults *)
+(*= let f_or_null Stdlib.Or_null.?'(x = 0) () = x *)
+
+[%%expect{|
+val f_vanilla : ?x:int -> unit -> int = <fun>
+val f_option : Stdlib.Option.?'x:int -> unit -> int = <fun>
+val f_or_null : Stdlib.Or_null.?'x:int -> unit -> int or_null = <fun>
+|}]
+
+(* ===================================================================== *)
+(* Testing f_vanilla with 7 calling styles                               *)
+(* ===================================================================== *)
+
+(* 1. f_vanilla with ~x:1 *)
+let _ = f_vanilla ~x:1 ()
+[%%expect{|
+- : int = 1
+|}]
+
+(* 2. f_vanilla with ?x:(Some 1) *)
+let _ = f_vanilla ?x:(Some 1) ()
+[%%expect{|
+- : int = 1
+|}]
+
+(* 3. f_vanilla with ?x:(This 1) *)
+let _ = f_vanilla ?x:(This 1) ()
+[%%expect{|
+Line 1, characters 22-26:
+1 | let _ = f_vanilla ?x:(This 1) ()
+                          ^^^^
+Error: This variant expression is expected to have type "int option"
+       There is no constructor "This" within type "option"
+|}]
+
+(* 4. f_vanilla with Stdlib.Option.?'x:(Some 1) *)
+let _ = f_vanilla Stdlib.Option.?'x:(Some 1) ()
+[%%expect{|
+- : int = 1
+|}]
+
+(* 5. f_vanilla with Stdlib.Option.?'x:(This 1) *)
+let _ = f_vanilla Stdlib.Option.?'x:(This 1) ()
+[%%expect{|
+Line 1, characters 37-41:
+1 | let _ = f_vanilla Stdlib.Option.?'x:(This 1) ()
+                                         ^^^^
+Error: This variant expression is expected to have type "int option"
+       There is no constructor "This" within type "option"
+|}]
+
+(* 6. f_vanilla with Stdlib.Or_null.?'x:(Some 1) *)
+let _ = f_vanilla Stdlib.Or_null.?'x:(Some 1) ()
+[%%expect{|
+Line 1, characters 37-45:
+1 | let _ = f_vanilla Stdlib.Or_null.?'x:(Some 1) ()
+                                         ^^^^^^^^
+Error: The function applied to this argument has type ?x:int -> int
+This argument cannot be applied with label "Stdlib.Or_null.?'x"
+|}]
+
+(* 7. f_vanilla with Stdlib.Or_null.?'x:(This 1) *)
+let _ = f_vanilla Stdlib.Or_null.?'x:(This 1) ()
+[%%expect{|
+Line 1, characters 37-45:
+1 | let _ = f_vanilla Stdlib.Or_null.?'x:(This 1) ()
+                                         ^^^^^^^^
+Error: The function applied to this argument has type ?x:int -> int
+This argument cannot be applied with label "Stdlib.Or_null.?'x"
+|}]
+
+(* ===================================================================== *)
+(* Testing f_option with 7 calling styles                                *)
+(* ===================================================================== *)
+
+(* 1. f_option with ~x:1 *)
+let _ = f_option ~x:1 ()
+[%%expect{|
+- : int = 1
+|}]
+
+(* 2. f_option with ?x:(Some 1) *)
+let _ = f_option ?x:(Some 1) ()
+[%%expect{|
+- : int = 1
+|}]
+
+(* 3. f_option with ?x:(This 1) *)
+let _ = f_option ?x:(This 1) ()
+[%%expect{|
+Line 1, characters 21-25:
+1 | let _ = f_option ?x:(This 1) ()
+                         ^^^^
+Error: This variant expression is expected to have type "int option"
+       There is no constructor "This" within type "option"
+|}]
+
+(* 4. f_option with Stdlib.Option.?'x:(Some 1) *)
+let _ = f_option Stdlib.Option.?'x:(Some 1) ()
+[%%expect{|
+- : int = 1
+|}]
+
+(* 5. f_option with Stdlib.Option.?'x:(This 1) *)
+let _ = f_option Stdlib.Option.?'x:(This 1) ()
+[%%expect{|
+Line 1, characters 36-40:
+1 | let _ = f_option Stdlib.Option.?'x:(This 1) ()
+                                        ^^^^
+Error: This variant expression is expected to have type "int option"
+       There is no constructor "This" within type "option"
+|}]
+
+(* 6. f_option with Stdlib.Or_null.?'x:(Some 1) *)
+let _ = f_option Stdlib.Or_null.?'x:(Some 1) ()
+[%%expect{|
+Line 1, characters 36-44:
+1 | let _ = f_option Stdlib.Or_null.?'x:(Some 1) ()
+                                        ^^^^^^^^
+Error: The function applied to this argument has type
+         Stdlib.Option.?'x:int -> int
+This argument cannot be applied with label "Stdlib.Or_null.?'x"
+|}]
+
+(* 7. f_option with Stdlib.Or_null.?'x:(This 1) *)
+let _ = f_option Stdlib.Or_null.?'x:(This 1) ()
+[%%expect{|
+Line 1, characters 36-44:
+1 | let _ = f_option Stdlib.Or_null.?'x:(This 1) ()
+                                        ^^^^^^^^
+Error: The function applied to this argument has type
+         Stdlib.Option.?'x:int -> int
+This argument cannot be applied with label "Stdlib.Or_null.?'x"
+|}]
+
+(* ===================================================================== *)
+(* Testing f_or_null with 7 calling styles                               *)
+(* ===================================================================== *)
+
+(*= CR generic-optional : These test cases will cause a segfault. *)
+
+(* 1. f_or_null with ~x:1 *)
+let _ = f_or_null ~x:1 ()
+[%%expect{|
+- : int or_null = This 1
+|}]
+
+(* 2. f_or_null with ?x:(Some 1) *)
+let _ = f_or_null ?x:(Some 1) ()
+[%%expect{|
+Line 1, characters 21-29:
+1 | let _ = f_or_null ?x:(Some 1) ()
+                         ^^^^^^^^
+Error: The function applied to this argument has type
+         Stdlib.Or_null.?'x:int -> int or_null
+This argument cannot be applied with label "?x"
+|}]
+
+(* 3. f_or_null with ?x:(This 1) *)
+let _ = f_or_null ?x:(This 1) ()
+[%%expect{|
+Line 1, characters 21-29:
+1 | let _ = f_or_null ?x:(This 1) ()
+                         ^^^^^^^^
+Error: The function applied to this argument has type
+         Stdlib.Or_null.?'x:int -> int or_null
+This argument cannot be applied with label "?x"
+|}]
+
+(* 4. f_or_null with Stdlib.Option.?'x:(Some 1) *)
+let _ = f_or_null Stdlib.Option.?'x:(Some 1) ()
+[%%expect{|
+Line 1, characters 36-44:
+1 | let _ = f_or_null Stdlib.Option.?'x:(Some 1) ()
+                                        ^^^^^^^^
+Error: The function applied to this argument has type
+         Stdlib.Or_null.?'x:int -> int or_null
+This argument cannot be applied with label "Stdlib.Option.?'x"
+|}]
+
+
+(* 5. f_or_null with Stdlib.Option.?'x:(This 1) *)
+let _ = f_or_null Stdlib.Option.?'x:(This 1) ()
+[%%expect{|
+Line 1, characters 36-44:
+1 | let _ = f_or_null Stdlib.Option.?'x:(This 1) ()
+                                        ^^^^^^^^
+Error: The function applied to this argument has type
+         Stdlib.Or_null.?'x:int -> int or_null
+This argument cannot be applied with label "Stdlib.Option.?'x"
+|}]
+
+
+(* 6. f_or_null with Stdlib.Or_null.?'x:(Some 1) *)
+let _ = f_or_null Stdlib.Or_null.?'x:(Some 1) ()
+[%%expect{|
+Line 1, characters 38-42:
+1 | let _ = f_or_null Stdlib.Or_null.?'x:(Some 1) ()
+                                          ^^^^
+Error: This variant expression is expected to have type "int or_null"
+       There is no constructor "Some" within type "or_null"
+|}]
+
+
+(* 7. f_or_null with Stdlib.Or_null.?'x:(This 1) *)
+let _ = f_or_null Stdlib.Or_null.?'x:(This 1) ()
+[%%expect{|
+- : int or_null = This 1
+|}]

--- a/testsuite/tests/generic-optional-arguments/incompatible_gen_opt_1.compilers.reference
+++ b/testsuite/tests/generic-optional-arguments/incompatible_gen_opt_1.compilers.reference
@@ -1,0 +1,6 @@
+File "incompatible_gen_opt_1.ml", line 17, characters 31-32:
+17 | let g x = M.f Stdlib.Or_null.?'x ()
+                                    ^
+Error: The function applied to this argument has type
+         Stdlib.Option.?'x:int -> int
+This argument cannot be applied with label "Stdlib.Or_null.?'x"

--- a/testsuite/tests/generic-optional-arguments/incompatible_gen_opt_1.ml
+++ b/testsuite/tests/generic-optional-arguments/incompatible_gen_opt_1.ml
@@ -1,0 +1,17 @@
+(* TEST
+ flags = "-extension-universe alpha";
+
+ setup-ocamlc.byte-build-env;
+ ocamlc_byte_exit_status = "2";
+ ocamlc.byte;
+ check-ocamlc.byte-output;
+*)
+
+(* Function signature mismatch - different generic optional modules *)
+module M = struct
+  let f Stdlib.Option.?'(x : int = 42) () = x
+end
+
+(* This should fail - trying to call with Stdlib.Or_null instead of
+   Stdlib.Option *)
+let g x = M.f Stdlib.Or_null.?'x ()

--- a/testsuite/tests/generic-optional-arguments/incompatible_gen_opt_2.compilers.reference
+++ b/testsuite/tests/generic-optional-arguments/incompatible_gen_opt_2.compilers.reference
@@ -1,0 +1,5 @@
+File "incompatible_gen_opt_2.ml", line 17, characters 31-32:
+17 | let g x = M.f Stdlib.Or_null.?'x ()
+                                    ^
+Error: The function applied to this argument has type ?x:int -> int
+This argument cannot be applied with label "Stdlib.Or_null.?'x"

--- a/testsuite/tests/generic-optional-arguments/incompatible_gen_opt_2.ml
+++ b/testsuite/tests/generic-optional-arguments/incompatible_gen_opt_2.ml
@@ -1,0 +1,17 @@
+(* TEST
+ flags = "-extension-universe alpha";
+
+ setup-ocamlc.byte-build-env;
+ ocamlc_byte_exit_status = "2";
+ ocamlc.byte;
+ check-ocamlc.byte-output;
+*)
+
+(* Stdlib.Or_null.?' is incompatible with vanilla ? *)
+module M = struct
+  let f ?x () = match x with None -> 0 | Some v -> v
+end
+
+(* This should fail - trying to call vanilla ? function with
+   Stdlib.Or_null.?' *)
+let g x = M.f Stdlib.Or_null.?'x ()

--- a/testsuite/tests/generic-optional-arguments/incompatible_gen_opt_3.compilers.reference
+++ b/testsuite/tests/generic-optional-arguments/incompatible_gen_opt_3.compilers.reference
@@ -1,0 +1,21 @@
+File "incompatible_gen_opt_3.ml", lines 15-19, characters 15-3:
+15 | ...............struct
+16 |   (* This should fail - implementation uses Stdlib.Or_null.?' but interface
+17 |      declares Stdlib.Option.?' *)
+18 |   let f Stdlib.Or_null.?'(x : int = 42) () = x
+19 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : Stdlib.Or_null.?'x:int -> unit -> int @@ stateless end
+       is not included in
+         S
+       Values do not match:
+         val f : Stdlib.Or_null.?'x:int -> unit -> int @@ stateless
+       is not included in
+         val f : Stdlib.Option.?'x:int -> unit -> int
+       The type "Stdlib.Or_null.?'x:int -> unit -> int"
+       is not compatible with the type "Stdlib.Option.?'x:int -> unit -> int"
+       File "incompatible_gen_opt_3.ml", line 12, characters 2-46:
+         Expected declaration
+       File "incompatible_gen_opt_3.ml", line 18, characters 6-7:
+         Actual declaration

--- a/testsuite/tests/generic-optional-arguments/incompatible_gen_opt_3.ml
+++ b/testsuite/tests/generic-optional-arguments/incompatible_gen_opt_3.ml
@@ -1,0 +1,19 @@
+(* TEST
+ flags = "-extension-universe alpha";
+
+ setup-ocamlc.byte-build-env;
+ ocamlc_byte_exit_status = "2";
+ ocamlc.byte;
+ check-ocamlc.byte-output;
+*)
+
+(* Module interface vs implementation mismatch *)
+module type S = sig
+  val f : Stdlib.Option.?'x:int -> unit -> int
+end
+
+module M : S = struct
+  (* This should fail - implementation uses Stdlib.Or_null.?' but interface
+     declares Stdlib.Option.?' *)
+  let f Stdlib.Or_null.?'(x : int = 42) () = x
+end

--- a/testsuite/tests/generic-optional-arguments/test.ml
+++ b/testsuite/tests/generic-optional-arguments/test.ml
@@ -6,15 +6,19 @@
 module type S = sig
 val concat : Stdlib.Option.?'sep:string -> string list -> string
 
-val concat_2 : ?sep:string -> string list -> string
+val concat_2 : Stdlib.Or_null.?'sep:string -> string list -> string
 end
 
 (* Implementation *)
 module M : S = struct
 let concat Stdlib.Option.?'(sep : string = " ") xs =
   String.concat sep xs
-let concat_2 Stdlib.Option.?'(sep=" ") xs =
-  String.concat sep xs
+let concat_2 Stdlib.Or_null.?'(sep : string or_null) xs =
+  String.concat (
+    match sep with
+    | Null -> " "
+    | This s -> s
+  ) xs
 end
 
 (* Usage *)
@@ -25,7 +29,11 @@ let chain_call Stdlib.Option.?'(sep : string option) arg =
   M.concat Stdlib.Option.?'sep arg
 
 let chain_call_2 Stdlib.Option.?'(sep) arg =
-  String.concat (match sep with None -> " " | Some s -> s) arg
+  M.concat_2 Stdlib.Or_null.?'sep:(
+    match sep with
+    | None -> Null
+    | Some x -> This x
+  ) arg
 
 let () =
   print_endline (default_concat ["x"; "y"; "z"]);

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1503,15 +1503,13 @@ The following syntaxes are tested
 module type S = sig
   val concat :
     Stdlib.Option.?'sep:string -> string Stdlib.List.t -> string
-  val concat_2 : ?sep:string -> string Stdlib.List.t -> string
+    (* CR generic-optional : signature ascription for generic optional types *)
+  (*= val concat_2 : ?sep:string -> string Stdlib.List.t -> string *)
 end
 
 [%%expect{|
 module type S =
-  sig
-    val concat : ?sep:string -> string List.t -> string
-    val concat_2 : ?sep:string -> string List.t -> string
-  end
+  sig val concat : Stdlib.Option.?'sep:string -> string List.t -> string end
 |}]
 
 
@@ -1520,9 +1518,11 @@ module M : S = struct
   let rec concat Stdlib.Option.?'(sep : string = " ")
     (xs : string Stdlib.List.t) =
       String.concat sep xs
-  (* okay to omit type annotations *)
-  let concat_2 Stdlib.Option.?'(sep=" ") (xs : string Stdlib.List.t) =
-    String.concat sep xs
+  (*
+  CR generic-optional : signature ascriptions
+  okay to omit type annotations *)
+  (*= let concat_2 Stdlib.Option.?'(sep=" ") (xs : string Stdlib.List.t) =
+    String.concat sep xs *)
 end
 
 [%%expect{|
@@ -1559,7 +1559,8 @@ let chain_call Stdlib.Option.?'(sep : string option) arg =
 chain_call ["x"; "y"; "z"] ;;
 
 [%%expect{|
-val chain_call : ?sep:string -> string List.t -> string = <fun>
+val chain_call : Stdlib.Option.?'sep:string -> string List.t -> string =
+  <fun>
 - : string = "x y z"
 |}]
 
@@ -1568,7 +1569,8 @@ let chain_call Stdlib.Option.?'sep:(sep : string option) arg =
 chain_call Stdlib.Option.?'sep:(Some ",") ["x"; "y"; "z"] ;;
 
 [%%expect{|
-val chain_call : ?sep:string -> string List.t -> string = <fun>
+val chain_call : Stdlib.Option.?'sep:string -> string List.t -> string =
+  <fun>
 - : string = "x,y,z"
 |}]
 
@@ -1578,6 +1580,7 @@ let chain_call_2 Stdlib.Option.?'(sep) arg =
 chain_call_2 ?sep:(Some ",") ["x"; "y"; "z"] ;;
 
 [%%expect{|
-val chain_call_2 : ?sep:string -> string List.t -> string = <fun>
+val chain_call_2 : Stdlib.Option.?'sep:string -> string List.t -> string =
+  <fun>
 - : string = "x,y,z"
 |}]

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -677,15 +677,19 @@ let prefixed_label_name ppf l =
 let arg_label_compatible param_label arg_label =
   match param_label, arg_label with
   | Nolabel, Nolabel -> true
-  | (Labelled s | Optional s | Generic_optional(_, s)), Labelled s' -> s = s'
-  | _ ->
+  | Nolabel, _ | _, Nolabel -> false
+  | (Labelled s | Optional s | Generic_optional(_, s) | Position s), Labelled s'
+      -> s = s'
+  | _, (Optional _ | Generic_optional _ | Position _) ->
     (match classify_optionality param_label, classify_optionality arg_label with
     | Optional_arg l_path, Optional_arg l_path' ->
-        l_path = l_path' && (label_name param_label = label_name arg_label)
-    | _ ->
-      (* when positional labels are involved,
-        we only care whether label names are equal*)
-      label_name param_label = label_name arg_label)
+        l_path = l_path' && label_name param_label = label_name arg_label
+    | Optional_arg _, Required_or_position_arg
+    | Required_or_position_arg, Optional_arg _
+    | Required_or_position_arg, Required_or_position_arg
+        (* when positional labels are involved,
+          we only care whether label names are equal*)
+        -> label_name param_label = label_name arg_label)
 
 let rec extract_label_aux hd l (* param label*) = function
   | [] -> None

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -626,6 +626,7 @@ let is_optional_parsetree : Parsetree.arg_label -> bool = function
 
 (* CR generic-optional: temporary function, to remove *)
 type optional_module_path = Stdlib_option | Stdlib_or_null
+
 let classify_module_path : Longident.t -> optional_module_path = function
   | Ldot(Lident "Stdlib", "Option") -> Stdlib_option
   | Ldot(Lident "Stdlib", "Or_null") -> Stdlib_or_null
@@ -637,15 +638,17 @@ type optionality = Optional_arg of optional_module_path
 let classify_optionality (lbl: Types.arg_label) = match lbl with
   | Optional _ -> Optional_arg Stdlib_option
   | Generic_optional(path, _) -> Optional_arg (classify_module_path path.txt)
-  | _ -> Required_or_position_arg
+  | Labelled _ | Position _ | Nolabel -> Required_or_position_arg
 
 let classify_optionality_parsetree (lbl : Parsetree.arg_label) = match lbl with
   | Optional _ -> Optional_arg Stdlib_option
   | Generic_optional(path, _) -> Optional_arg (classify_module_path path.txt)
-  | _ -> Required_or_position_arg
+  | Labelled _ | Nolabel -> Required_or_position_arg
 
 let is_optional arg =
-  not (classify_optionality arg = Required_or_position_arg)
+  match classify_optionality arg with
+  | Optional_arg _ -> true
+  | Required_or_position_arg -> false
 
 let is_position = function Position _ -> true | _ -> false
 

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -624,18 +624,27 @@ let is_optional_parsetree : Parsetree.arg_label -> bool = function
   | Generic_optional _ -> true
   | _ -> false
 
-type optionality = Optional_arg of Longident.t
+(* CR generic-optional: temporary function, to remove *)
+type optional_module_path = Stdlib_option | Stdlib_or_null
+let classify_module_path : Longident.t -> optional_module_path = function
+  | Ldot(Lident "Stdlib", "Option") -> Stdlib_option
+  | Ldot(Lident "Stdlib", "Or_null") -> Stdlib_or_null
+  | _ -> failwith "Only expected Stdlib.Option and Stdlib.Or_null"
+
+type optionality = Optional_arg of optional_module_path
                  | Required_or_position_arg
 
-let classify_optionality : Types.arg_label -> optionality = function
-  | Optional _ -> Optional_arg (Ldot (Lident "Stdlib", "Option"))
-  | Generic_optional(path, _) -> Optional_arg (path.txt)
+let classify_optionality (lbl: Types.arg_label) = match lbl with
+  | Optional _ -> Optional_arg Stdlib_option
+  | Generic_optional(path, _) -> Optional_arg (classify_module_path path.txt)
   | _ -> Required_or_position_arg
 
-(* is_optional is really buggy when generic optionals are involved.
-Renaming it to prevent its use
-*)
-let is_optional_arg arg =
+let classify_optionality_parsetree (lbl : Parsetree.arg_label) = match lbl with
+  | Optional _ -> Optional_arg Stdlib_option
+  | Generic_optional(path, _) -> Optional_arg (classify_module_path path.txt)
+  | _ -> Required_or_position_arg
+
+let is_optional arg =
   not (classify_optionality arg = Required_or_position_arg)
 
 let is_position = function Position _ -> true | _ -> false
@@ -653,22 +662,14 @@ let label_name = function
   | Position s -> s
   | Generic_optional (_, s) -> s
 
-(* CR generic-optional: temporary function, to remove *)
-type module_path = Stdlib_option | Stdlib_or_null
-let classify_module_path : Longident.t -> module_path = function
-  | Ldot(Lident "Stdlib", "Option") -> Stdlib_option
-  | Ldot(Lident "Stdlib", "Or_null") -> Stdlib_or_null
-  | _ -> failwith "Only expected Stdlib.Option and Stdlib.Or_null"
-
-let prefixed_label_name = function
-    Nolabel -> ""
-  | Labelled s | Position s -> "~" ^ s
-  | Optional s -> "?" ^ s
+let prefixed_label_name ppf l =
+  let open Format in
+  match l with
+    Nolabel -> fprintf ppf  ""
+  | Labelled s | Position s -> fprintf ppf "~%s" s
+  | Optional s -> fprintf ppf "?%s" s
   | Generic_optional (path, s) ->
-    (match classify_module_path path.txt with
-      | Stdlib_option -> "Stdlib.Option"
-      | Stdlib_or_null -> "Stdlib.Or_null")
-    ^ ".?'" ^ s
+      fprintf ppf "%a.?'%s" Pprintast.longident path.txt s
 
 let arg_label_compatible param_label arg_label =
   match param_label, arg_label with
@@ -682,7 +683,6 @@ let arg_label_compatible param_label arg_label =
       (* when positional labels are involved,
         we only care whether label names are equal*)
       label_name param_label = label_name arg_label)
-
 
 let rec extract_label_aux hd l (* param label*) = function
   | [] -> None

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -259,24 +259,25 @@ val backtrack: snapshot -> unit
 
 (**** Utilities for labels ****)
 
-val is_optional_parsetree : Parsetree.arg_label -> bool
-type optionality = Optional_arg of Longident.t
+(* CR generic-optional: temporary function, to remove *)
+type optional_module_path = Stdlib_option | Stdlib_or_null
+val classify_module_path : Longident.t -> optional_module_path
+
+type optionality = Optional_arg of optional_module_path
 (* The reason this is called [Required_or_position_arg] instead of
  [Required_arg] is that [Position] are omittable (thus not required),
  but is not optional *)
                  | Required_or_position_arg
-val is_optional_arg : arg_label -> bool
+val is_optional : arg_label -> bool
+val is_optional_parsetree : Parsetree.arg_label -> bool
 val classify_optionality : arg_label -> optionality
+val classify_optionality_parsetree : Parsetree.arg_label -> optionality
 val is_position : arg_label -> bool
 val is_omittable : arg_label -> bool
 val label_name : arg_label -> label
 
-(* CR generic-optional: temporary function, to remove *)
-type module_path = Stdlib_option | Stdlib_or_null
-val classify_module_path : Longident.t -> module_path
-
 (* Returns the label name with first character '?' or '~' as appropriate. *)
-val prefixed_label_name : arg_label -> label
+val prefixed_label_name : Format.formatter -> arg_label -> unit
 
 val arg_label_compatible : arg_label -> arg_label -> bool
 val extract_label :

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -259,15 +259,15 @@ val backtrack: snapshot -> unit
 
 (**** Utilities for labels ****)
 
-(* CR generic-optional: temporary function, to remove *)
 type optional_module_path = Stdlib_option | Stdlib_or_null
 val classify_module_path : Longident.t -> optional_module_path
 
 type optionality = Optional_arg of optional_module_path
+                 | Required_or_position_arg
 (* The reason this is called [Required_or_position_arg] instead of
  [Required_arg] is that [Position] are omittable (thus not required),
  but is not optional *)
-                 | Required_or_position_arg
+
 val is_optional : arg_label -> bool
 val is_optional_parsetree : Parsetree.arg_label -> bool
 val classify_optionality : arg_label -> optionality

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -261,9 +261,10 @@ val backtrack: snapshot -> unit
 
 val is_optional_parsetree : Parsetree.arg_label -> bool
 type optionality = Optional_arg of Longident.t
-(* The reason this is called [Not_optional_arg] instead of [Required_arg] is
-that [Position] are omittable (thus not required), but is not optional *)
-                 | Not_optional_arg
+(* The reason this is called [Required_or_position_arg] instead of
+ [Required_arg] is that [Position] are omittable (thus not required),
+ but is not optional *)
+                 | Required_or_position_arg
 val is_optional_arg : arg_label -> bool
 val classify_optionality : arg_label -> optionality
 val is_position : arg_label -> bool

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -260,16 +260,26 @@ val backtrack: snapshot -> unit
 (**** Utilities for labels ****)
 
 val is_optional_parsetree : Parsetree.arg_label -> bool
-val is_optional : arg_label -> bool
+type optionality = Optional_arg of Longident.t
+(* The reason this is called [Not_optional_arg] instead of [Required_arg] is
+that [Position] are omittable (thus not required), but is not optional *)
+                 | Not_optional_arg
+val is_optional_arg : arg_label -> bool
+val classify_optionality : arg_label -> optionality
 val is_position : arg_label -> bool
 val is_omittable : arg_label -> bool
 val label_name : arg_label -> label
 
+(* CR generic-optional: temporary function, to remove *)
+type module_path = Stdlib_option | Stdlib_or_null
+val classify_module_path : Longident.t -> module_path
+
 (* Returns the label name with first character '?' or '~' as appropriate. *)
 val prefixed_label_name : arg_label -> label
 
+val arg_label_compatible : arg_label -> arg_label -> bool
 val extract_label :
-    label -> (arg_label * 'a) list ->
+    arg_label (* param label *) -> (arg_label * 'a) list ->
     (arg_label * 'a * bool * (arg_label * 'a) list) option
 (* actual label,
    value,

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4546,12 +4546,12 @@ let filter_arrow env t l ~force_tpoly =
     let ty_arg =
       if not force_tpoly then begin
         (* polymorphic arguments are never optional *)
-        assert (not (is_optional_arg l));
+        assert (not (is_optional l));
         newvar2 level k_arg
       end else begin
         let t1 =
           match classify_optionality l with
-          | Optional_arg path ->
+          | Optional_arg mpath ->
             (* CR: For generic optional arguments, we need to construct the
                 appropriate type based on the module path. e.g.
 
@@ -4563,7 +4563,7 @@ let filter_arrow env t l ~force_tpoly =
 
             *)
             let t_cons, arg_jkind =
-              match classify_module_path path with
+              match mpath with
               | Stdlib_option ->
                   Predef.path_option, Predef.option_argument_jkind
               | Stdlib_or_null ->

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3319,7 +3319,12 @@ let arg_label_equal l1 l2 =
   | Generic_optional(path1, str1), Generic_optional(path2, str2) ->
       str1 = str2 &&
         classify_module_path path1.txt = classify_module_path path2.txt
-  | _ -> l1 = l2
+  | Optional str1, Optional str2
+  | Position str1, Position str2
+  | Labelled str1, Labelled str2 -> str1 = str2
+  | Nolabel, Nolabel -> true
+  | (Generic_optional _ | Optional _ | Position _ | Labelled _ | Nolabel), _
+      -> false
 
 let equivalent_with_nolabels l1 l2 =
   arg_label_equal l1 l2 || (match l1, l2 with
@@ -4541,10 +4546,12 @@ type filtered_arrow =
     ret_mode : Mode.Alloc.lr
   }
 
+(* CR generic-optional: Remove predef_ prefix when adding non-predef paths *)
 let predef_path_of_optional_module_path = function
   | Stdlib_option -> Predef.path_option
   | Stdlib_or_null -> Predef.path_or_null
 
+(* CR generic-optional: Remove predef_ prefix when adding non-predef jkinds *)
 let predef_jkind_of_optional_module_path = function
   | Stdlib_option -> Predef.option_argument_jkind
   | Stdlib_or_null -> Jkind.for_or_null_argument Predef.ident_or_null

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3315,12 +3315,9 @@ let rec expands_to_datatype env ty =
 let arg_label_equal l1 l2 =
   match l1, l2 with
   | Generic_optional(path1, str1), Generic_optional(path2, str2) ->
-      str1 = str2 && (
-        classify_module_path path1.txt = classify_module_path path2.txt
-      )
+      str1 = str2 &&
+        (classify_module_path path1.txt = classify_module_path path2.txt)
   | _ -> l1 = l2
-
-
 
 let equivalent_with_nolabels l1 l2 =
   arg_label_equal l1 l2 || (match l1, l2 with
@@ -4547,59 +4544,43 @@ let filter_arrow env t l ~force_tpoly =
     let k_arg = Jkind.Builtin.any ~why:Inside_of_Tarrow in
     let k_res = Jkind.Builtin.any ~why:Inside_of_Tarrow in
     let ty_arg =
-      match force_tpoly with
-      | false ->
-          begin
-            (* polymorphic arguments are never optional *)
-            assert (not (is_optional_arg l));
-            newvar2 level k_arg
-          end
-      | true ->
-          let t1 =
-            match classify_optionality l with
-              (* CR layouts v5: Change the Jkind.Builtin.value when option
-                      can hold non-values.
-                {v
-                  match l with
-                  | Optional _ ->
-                    newty2 ~level
-                      (Tconstr(Predef.path_option,
-                              [newvar2 level Predef.option_argument_jkind],
-                              ref Mnil))
-                v}
+      if not force_tpoly then begin
+        (* polymorphic arguments are never optional *)
+        assert (not (is_optional_arg l));
+        newvar2 level k_arg
+      end else begin
+        let t1 =
+          match classify_optionality l with
+          | Optional_arg path ->
+            (* CR: For generic optional arguments, we need to construct the
+                appropriate type based on the module path. e.g.
 
-                zhichen: This CR is from outdated code for handling optional
-                          arg.
+              {v
+              let type_ident : Longident.t
+                = Ldot (Ldot (path.txt, "Opt_syntax"), "t") in
+              let (path, _) = Env.lookup_type ~loc:path.loc type_ident env in
+              v}
+
             *)
-            | Optional_arg path ->
-              (* CR: For generic optional arguments, we need to construct the
-                  appropriate type based on the module path. e.g.
-
-                {v
-                let type_ident : Longident.t
-                  = Ldot (Ldot (path.txt, "Opt_syntax"), "t") in
-                let (path, _) = Env.lookup_type ~loc:path.loc type_ident env in
-                v}
-
-              *)
-              let t_cons, arg_jkind =
-                match classify_module_path path with
-                | Stdlib_option ->
-                    Predef.path_option, Predef.option_argument_jkind
-                | Stdlib_or_null ->
-                    Predef.path_or_null,
-                      Jkind.for_or_null_argument Predef.ident_or_null
-              in
-              newty2 ~level (Tconstr(t_cons,
-                [newvar2 level arg_jkind], ref Mnil))
-            | _ ->
-              if is_position l then
-                newty2 ~level
-                  (Tconstr (Predef.path_lexing_position, [], ref Mnil))
-              else
-                newvar2 level k_arg
-          in
-          newty2 ~level (Tpoly(t1, []))
+            let t_cons, arg_jkind =
+              match classify_module_path path with
+              | Stdlib_option ->
+                  Predef.path_option, Predef.option_argument_jkind
+              | Stdlib_or_null ->
+                  Predef.path_or_null,
+                    Jkind.for_or_null_argument Predef.ident_or_null
+            in
+            newty2 ~level (Tconstr(t_cons,
+              [newvar2 level arg_jkind], ref Mnil))
+          | _ ->
+            if is_position l then
+              newty2 ~level
+                (Tconstr (Predef.path_lexing_position, [], ref Mnil))
+            else
+              newvar2 level k_arg
+        in
+        newty2 ~level (Tpoly(t1, []))
+      end
     in
     let ty_ret = newvar2 level k_res in
     let arg_mode = Alloc.newvar () in

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -311,6 +311,9 @@ type filtered_arrow =
     ret_mode : Mode.Alloc.lr
   }
 
+val predef_path_of_optional_module_path: Btype.optional_module_path -> Path.t
+val predef_jkind_of_optional_module_path: Btype.optional_module_path -> jkind_lr
+
 val filter_arrow: Env.t -> type_expr -> arg_label -> force_tpoly:bool ->
                   filtered_arrow
         (* A special case of unification (with l:'a -> 'b). If

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -168,6 +168,8 @@ val ident_none : Ident.t
 val ident_some : Ident.t
 
 val ident_or_null : Ident.t
+val ident_null : Ident.t
+val ident_this : Ident.t
 
 (* The jkind used for optional function argument types *)
 val option_argument_jkind : jkind_lr

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1518,14 +1518,13 @@ let rec tree_of_typexp mode alloc_mode ty =
                 tree_of_typexp mode arg_mode ty
             | Generic_optional (genopt_path, _), Tconstr(path, [ty], _)
               when Path.same path
-                    (match Btype.classify_module_path genopt_path.txt with
-                    | Stdlib_option -> Predef.path_option
-                    | Stdlib_or_null -> Predef.path_or_null) ->
+                    (Ctype.predef_path_of_optional_module_path
+                      (Btype.classify_module_path genopt_path.txt)) ->
                 tree_of_typexp mode arg_mode ty
-            (* this case will show up when there is a bug in the compiler
-               when incorrect types are assigned to optional arguments *)
+            (* This case is normally impossible, indicating a compiler bug due
+               to an incorrect type assigned to an optional argument. *)
             | (Optional _ | Generic_optional _), _ -> Otyp_stuff "<hidden>"
-            | _ -> assert false
+            | (Position _ | Labelled _ | Nolabel), _ -> assert false
           else
             tree_of_typexp mode arg_mode ty1
         in
@@ -2395,18 +2394,20 @@ let rec tree_of_class_type mode params =
         else Nolabel
       in
       let tr =
-       match l, get_desc (Ctype.expand_head !printing_env ty) with
-       | Optional _, Tconstr(path, [ty], _)
-         when Path.same path Predef.path_option ->
-           tree_of_typexp mode ty
-       | Generic_optional (genopt_path, _), Tconstr(path, [ty], _)
-         when Path.same path
-                (match Btype.classify_module_path genopt_path.txt with
-                | Stdlib_option -> Predef.path_option
-                | Stdlib_or_null -> Predef.path_or_null) ->
-           tree_of_typexp mode ty
-       | (Optional _ | Generic_optional _), _ -> Otyp_stuff "<hidden>"
-       | _ -> tree_of_typexp mode ty in
+        match l, get_desc (Ctype.expand_head !printing_env ty) with
+        | Optional _, Tconstr(path, [ty], _)
+          when Path.same path Predef.path_option ->
+            tree_of_typexp mode ty
+        | Generic_optional (genopt_path, _), Tconstr(path, [ty], _)
+          when Path.same path
+                  (Ctype.predef_path_of_optional_module_path
+                    (Btype.classify_module_path genopt_path.txt)) ->
+            tree_of_typexp mode ty
+          (* This case is normally impossible, indicating a compiler bug due
+              to an incorrect type assigned to an optional argument. *)
+        | (Optional _ | Generic_optional _), _ -> Otyp_stuff "<hidden>"
+        | (Labelled _ | Position _ | Nolabel), _ -> tree_of_typexp mode ty
+      in
       Octy_arrow (lab, tr, tree_of_class_type mode params cty)
 
 let class_type ppf cty =

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1509,7 +1509,7 @@ let rec tree_of_typexp mode alloc_mode ty =
            at legacy, we will be able to omit printing them. *)
         let arg_mode = Alloc.zap_to_legacy marg in
         let t1 =
-          if is_optional_arg l then
+          if is_optional l then
             match
               l, get_desc (Ctype.expand_head !printing_env (tpoly_get_mono ty1))
             with
@@ -1522,6 +1522,8 @@ let rec tree_of_typexp mode alloc_mode ty =
                     | Stdlib_option -> Predef.path_option
                     | Stdlib_or_null -> Predef.path_or_null) ->
                 tree_of_typexp mode arg_mode ty
+            (* this case will show up when there is a bug in the compiler
+               when incorrect types are assigned to optional arguments *)
             | (Optional _ | Generic_optional _), _ -> Otyp_stuff "<hidden>"
             | _ -> assert false
           else

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -457,7 +457,8 @@ and class_type_aux env virt self_scope scty =
         | Optional_arg mpath ->
             let t_cons = Ctype.predef_path_of_optional_module_path mpath in
             Ctype.newty (Tconstr(t_cons,[ty], ref Mnil))
-        | Required_or_position_arg -> ty in
+        | Required_or_position_arg -> ty
+      in
       let clty = class_type env virt self_scope scty in
       let typ = Cty_arrow (l, ty, clty.cltyp_type) in
       cltyp (Tcty_arrow (l, cty, clty)) typ

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -884,7 +884,6 @@ let constant_or_raise env loc cst =
       c
   | Error err -> raise (Error (loc, env, err))
 
-
 (* Specific version of type_option, using newty rather than newgenty *)
 
 let type_option mpath ty =
@@ -4164,8 +4163,7 @@ let collect_apply_args env funct ignore_labels ty_fun ty_fun0 mode_fun sargs ret
             match sargs with
             | [] -> assert false
             | (l', sarg) :: remaining_sargs ->
-                if (arg_label_compatible l l')
-                  || (not omittable && l' = Nolabel)
+                if arg_label_compatible l l' || (not omittable && l' = Nolabel)
                 then
                   (remaining_sargs, use_arg ~commuted:false sarg l')
                 else if
@@ -7487,7 +7485,8 @@ and type_function
               match arg_label, classify_optionality_parsetree arg_label with
               | (Optional arg_label | Generic_optional (_, arg_label)),
                  Optional_arg mpath -> arg_label, mpath
-              | _ ->
+              | (Optional _ | Generic_optional _), Required_or_position_arg
+              | (Labelled _ | Nolabel), _ ->
                 Misc.fatal_error "[default] allowed only with optional argument"
             in
             let default_arg_jkind, default_arg_sort =
@@ -8440,7 +8439,9 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
       | Position _, Required_or_position_arg ->
           let arg = src_pos (Location.ghostify funct.exp_loc) [] env in
           (lbl, Arg (arg, Mode.Value.legacy, sort_arg))
-      | _ -> assert false)
+      | (Optional _| Generic_optional _), Required_or_position_arg
+      | (Position _ | Labelled _ | Nolabel), _
+          -> assert false)
   | Omitted _ as arg -> (lbl, arg)
 
 and type_application env app_loc expected_mode position_and_mode

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -885,41 +885,35 @@ let constant_or_raise env loc cst =
   | Error err -> raise (Error (loc, env, err))
 
 
-let predef_path_of_arg_label arg_label =
-  match classify_optionality arg_label with
-  | Optional_arg path ->
-      (match classify_module_path path with
-        | Stdlib_option -> Predef.path_option
-        | Stdlib_or_null -> Predef.path_or_null)
-  | Required_or_position_arg ->
-      failwith "predef_path_of_arg_label expects optional label"
+let predef_path_of_optional_module_path = function
+  | Stdlib_option -> Predef.path_option
+  | Stdlib_or_null -> Predef.path_or_null
+
+let predef_jkind_of_optional_module_path = function
+  | Stdlib_option -> Predef.option_argument_jkind
+  | Stdlib_or_null -> Jkind.for_or_null_argument Predef.ident_or_null
 
 (* Specific version of type_option, using newty rather than newgenty *)
 
-let type_option (lbl : Types.arg_label) ty =
-  newty (Tconstr(predef_path_of_arg_label lbl,[ty], ref Mnil))
+let type_option (mpath : optional_module_path) ty =
+  newty (Tconstr(predef_path_of_optional_module_path mpath,[ty], ref Mnil))
 
 let mkexp exp_desc exp_type exp_loc exp_env =
   { exp_desc; exp_type;
     exp_loc; exp_env; exp_extra = []; exp_attributes = [] }
 
-let type_option_none env lbl ty loc =
+let type_option_none env mpath ty loc =
   let lid = Longident.Lident "None" in
-  let cnone =
-    match classify_optionality lbl with
-    | Required_or_position_arg ->
-        failwith "type_option_none expects optional label"
-    | Optional_arg path ->
-        match classify_module_path path with
-        | Stdlib_option -> Env.find_ident_constructor Predef.ident_none env
-        | Stdlib_or_null -> Env.find_ident_constructor Predef.ident_null env
+  let cnone = match mpath with
+    | Stdlib_option -> Env.find_ident_constructor Predef.ident_none env
+    | Stdlib_or_null -> Env.find_ident_constructor Predef.ident_null env
   in
   mkexp (Texp_construct(mknoloc lid, cnone, [], None)) ty loc env
 
-let extract_option_type env lbl ty =
+let extract_option_type env mpath ty =
   match get_desc (expand_head env ty) with
   | Tconstr(path, [ty], _) when
-      Path.same path (predef_path_of_arg_label lbl) -> ty
+      Path.same path (predef_path_of_optional_module_path mpath) -> ty
   | _ -> assert false
 
 let protect_expansion env ty =
@@ -3305,9 +3299,12 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
       end;
       List.iter (fun f -> f()) tps.tps_pattern_force;
       (* CR layouts v5: value restriction here to be relaxed *)
-      if is_optional_arg l then
-        unify_pat val_env pat
-          (type_option l (newvar Predef.option_argument_jkind));
+      (match classify_optionality l with
+      | Optional_arg mpath ->
+          unify_pat val_env pat
+            (type_option mpath
+              (newvar (predef_jkind_of_optional_module_path mpath)))
+      | Required_or_position_arg -> ());
       tps.tps_pattern_variables, pat
     end
       ~post:(fun (pvs, _) -> iter_pattern_variables_type generalize_structure
@@ -4151,10 +4148,10 @@ let collect_apply_args env funct ignore_labels ty_fun ty_fun0 mode_fun sargs ret
                                      Function_type_not_rep(ty_arg, err)))
         in
         let name = label_name l
-        and optional = is_optional_arg l
+        and optional = is_optional l
         and omittable = is_omittable l in
         let use_arg ~commuted sarg l' =
-          let wrapped_in_some = optional && not (is_optional_arg l') in
+          let wrapped_in_some = optional && not (is_optional l') in
           if wrapped_in_some then
             may_warn sarg.pexp_loc
               (Warnings.Not_principal "using an optional argument here");
@@ -4200,7 +4197,7 @@ let collect_apply_args env funct ignore_labels ty_fun ty_fun0 mode_fun sargs ret
                   may_warn sarg.pexp_loc
                     (Warnings.Not_principal "commuting this argument")
                 end;
-                if not optional && is_optional_arg l' then (
+                if not optional && is_optional l' then (
                   let label = Printtyp.string_of_label l in
                   if is_position l
                   then
@@ -4520,11 +4517,8 @@ let rec approx_type env sty =
       let p = Typetexp.transl_label p (Some arg_sty) in
       (* CR layouts v5: value requirement here to be relaxed *)
       match classify_optionality p with
-      | Optional_arg path ->
-         (match classify_module_path path with
-          | Stdlib_option ->  newvar Predef.option_argument_jkind
-          | Stdlib_or_null ->
-            newvar (Jkind.for_or_null_argument Predef.ident_or_null))
+      | Optional_arg mpath ->
+          newvar (predef_jkind_of_optional_module_path mpath)
       | Required_or_position_arg ->
       begin
         let arg_mode = Typemode.transl_alloc_mode arg_mode in
@@ -4545,11 +4539,9 @@ let rec approx_type env sty =
       let p = Typetexp.transl_label p (Some arg_sty) in
       let arg =
         match classify_optionality p with
-        | Optional_arg path ->
-            (match classify_module_path path with
-              | Stdlib_option -> newvar Predef.option_argument_jkind
-              | Stdlib_or_null ->
-                  newvar (Jkind.for_or_null_argument Predef.ident_or_null))
+        | Optional_arg mpath ->
+            type_option mpath
+              (newvar (predef_jkind_of_optional_module_path mpath))
         | Required_or_position_arg ->
             newvar (Jkind.Builtin.any ~why:Inside_of_Tarrow)
       in
@@ -4618,7 +4610,7 @@ let type_approx_fun_one_param
     | Some spat ->
         let mode_annots = mode_annots_from_pat spat in
         let has_poly = has_poly_constraint spat in
-        if has_poly && is_optional_arg label then
+        if has_poly && is_optional label then
           raise(Error(spat.ppat_loc, env, Optional_poly_param));
         Some mode_annots, has_poly
   in
@@ -7500,12 +7492,11 @@ and type_function
         match default_arg with
         | None -> ty_arg_mono, None
         | Some default ->
-            let str_arg_label =
-              match arg_label with
-              | Optional arg_label -> arg_label
-              (* CR generic-optional : CHECK THIS *)
-              | Generic_optional (_, arg_label) -> arg_label
-              | Nolabel | Labelled _ ->
+            let arg_label, mpath =
+              match arg_label, classify_optionality_parsetree arg_label with
+              | (Optional arg_label | Generic_optional (_, arg_label)),
+                 Optional_arg mpath -> arg_label, mpath
+              | _ ->
                 Misc.fatal_error "[default] allowed only with optional argument"
             in
             let default_arg_jkind, default_arg_sort =
@@ -7513,12 +7504,7 @@ and type_function
             in
             let ty_default_arg = newvar default_arg_jkind in
             begin
-              try unify env (type_option (
-                match arg_label with
-                | Optional s -> Optional s
-                | Generic_optional (path, s) -> Generic_optional (path, s)
-                | _ -> assert false
-              ) ty_default_arg) ty_arg_mono
+              try unify env (type_option mpath ty_default_arg) ty_arg_mono
               with Unify _ -> assert false;
             end;
             (* Issue#12668: Retain type-directed disambiguation of
@@ -7536,7 +7522,7 @@ and type_function
             let default_arg =
               type_expect env mode_legacy default (mk_expected ty_default_arg)
             in
-            ty_default_arg, Some (default_arg, str_arg_label, default_arg_sort)
+            ty_default_arg, Some (default_arg, arg_label, default_arg_sort)
       in
       let (pat, params, body, ret_info, newtypes, contains_gadt, curry), partial =
         (* Check everything else in the scope of the parameter. *)
@@ -7623,7 +7609,7 @@ and type_function
         let ls, tvar = list_labels env ty in
         List.for_all (( <> ) Nolabel) ls && not tvar
       in
-      if is_optional_arg typed_arg_label && not_nolabel_function ty_ret then
+      if is_optional typed_arg_label && not_nolabel_function ty_ret then
         Location.prerr_warning pat.pat_loc
           Warnings.Unerasable_optional_argument
       else if is_position typed_arg_label && not_nolabel_function ty_ret then
@@ -8040,23 +8026,18 @@ and type_format loc str env =
   with Failure msg ->
     raise (Error (loc, env, Invalid_format msg))
 
-and type_option_some env lbl expected_mode sarg ty ty0 =
-  let ty' = extract_option_type env lbl ty in
-  let ty0' = extract_option_type env lbl ty0 in
+and type_option_some env mpath expected_mode sarg ty ty0 =
+  let ty' = extract_option_type env mpath ty in
+  let ty0' = extract_option_type env mpath ty0 in
   let alloc_mode, argument_mode = register_allocation expected_mode in
   let arg = type_argument ~overwrite:No_overwrite env argument_mode sarg ty' ty0' in
-  let lid, csome = (
-    match classify_optionality lbl with
-    | Optional_arg path ->
-        (match classify_module_path path with
-          | Stdlib_option -> (Longident.Lident "Some",
-            Env.find_ident_constructor Predef.ident_some env)
-          | Stdlib_or_null -> (Longident.Lident "This",
-            Env.find_ident_constructor Predef.ident_this env))
-    | _ -> failwith "type_option_some expected Optional or Generic_optional"
-  ) in
+  let lid, csome = (match mpath with
+    | Stdlib_option -> (Longident.Lident "Some",
+      Env.find_ident_constructor Predef.ident_some env)
+    | Stdlib_or_null -> (Longident.Lident "This",
+      Env.find_ident_constructor Predef.ident_this env)) in
   mkexp (Texp_construct(mknoloc lid , csome, [arg], Some alloc_mode))
-    (type_option lbl arg.exp_type) arg.exp_loc arg.exp_env
+    (type_option mpath arg.exp_type) arg.exp_loc arg.exp_env
 
 (* [expected_mode] is the expected mode of the field. It's already adjusted for
    allocation, mutation and modalities. *)
@@ -8228,9 +8209,12 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
       in
       let rec make_args args ty_fun =
         match get_desc (expand_head env ty_fun) with
-        | Tarrow ((l,_marg,_mret),ty_arg,ty_fun,_) when is_optional_arg l ->
+        | Tarrow ((l,_marg,_mret),ty_arg,ty_fun,_) when is_optional l ->
+            let mpath = (match classify_optionality l with
+              | Optional_arg mpath -> mpath
+              | Required_or_position_arg -> assert false) in
             let ty =
-              type_option_none env l (instance (tpoly_get_mono ty_arg))
+              type_option_none env mpath (instance (tpoly_get_mono ty_arg))
                 sarg.pexp_loc
             in
             (* CR layouts v5: change value assumption below when we allow
@@ -8384,19 +8368,14 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
       in
       (match lbl with
        | Labelled _ | Nolabel -> ()
-       | Optional _ ->
+       | Optional _ | Generic_optional _ ->
            (* CR layouts v5: relax value requirement *)
-           unify_exp env arg
-             (type_option lbl (newvar Predef.option_argument_jkind))
-       | Generic_optional (path, _) ->
-           (match classify_module_path path.txt with
-            | Stdlib_option ->
-                unify_exp env arg
-                  (type_option lbl (newvar Predef.option_argument_jkind))
-            | Stdlib_or_null ->
-                unify_exp env arg
-                  (type_option lbl
-                    (newvar (Jkind.for_or_null_argument Predef.ident_or_null))))
+          (match classify_optionality lbl with
+          | Optional_arg mpath ->
+              unify_exp env arg
+                (type_option mpath
+                  (newvar (predef_jkind_of_optional_module_path mpath)))
+          | Required_or_position_arg -> assert false)
        | Position _ ->
            unify_exp env arg (instance Predef.type_lexing_position));
       (lbl, Arg (arg, mode_arg, sort_arg))
@@ -8409,7 +8388,10 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
         if vars = [] then begin
           let ty_arg0' = tpoly_get_mono ty_arg0 in
           if wrapped_in_some then begin
-            type_option_some env lbl expected_mode sarg ty_arg' ty_arg0'
+            (match classify_optionality lbl with
+            | Optional_arg mpath ->
+                type_option_some env mpath expected_mode sarg ty_arg' ty_arg0'
+            | Required_or_position_arg -> assert false)
           end else begin
             type_argument ~overwrite:No_overwrite env expected_mode sarg ty_arg' ty_arg0'
           end
@@ -8457,17 +8439,16 @@ and type_apply_arg env ~app_loc ~funct ~index ~position_and_mode ~partial_app (l
       in
       (lbl, Arg (arg, mode_arg, sort_arg))
   | Arg (Eliminated_optional_arg { ty_arg; sort_arg; expected_label; _ }) ->
-      (match expected_label with
-      | Optional _
-      | Generic_optional _ ->
-          let arg = type_option_none env expected_label
+      (match expected_label, classify_optionality expected_label with
+      | (Optional _| Generic_optional _), Optional_arg mpath ->
+          let arg = type_option_none env mpath
                       (instance ty_arg) Location.none
           in
           (lbl, Arg (arg, Mode.Value.legacy, sort_arg))
-      | Position _ ->
+      | Position _, Required_or_position_arg ->
           let arg = src_pos (Location.ghostify funct.exp_loc) [] env in
           (lbl, Arg (arg, Mode.Value.legacy, sort_arg))
-      | Labelled _ | Nolabel -> assert false)
+      | _ -> assert false)
   | Omitted _ as arg -> (lbl, arg)
 
 and type_application env app_loc expected_mode position_and_mode
@@ -10763,7 +10744,7 @@ let report_error ~loc env =
         | Nolabel -> fprintf ppf "without label"
         |(Labelled _ | Optional _ | Generic_optional _) as l ->
             fprintf ppf "with label %a"
-              Style.inline_code (prefixed_label_name l)
+              (Style.as_inline_code prefixed_label_name) l
         | Position _ -> assert false
           (* Since Position labels never occur in function applications,
              this case is never run *)
@@ -10926,9 +10907,10 @@ let report_error ~loc env =
         | Position l -> Style.inline_code ppf (sprintf "~(%s:[%%call_pos])" l)
         | (Labelled _ | Optional _ | Generic_optional _) as l ->
             if long then
-              fprintf ppf "labeled %a" Style.inline_code (prefixed_label_name l)
+              fprintf ppf "labeled %a"
+                (Style.as_inline_code prefixed_label_name) l
             else
-              Style.inline_code ppf (prefixed_label_name l)
+              fprintf ppf "%a" (Style.as_inline_code prefixed_label_name) l
       in
       let second_long = match got, expected with
         | Nolabel, _ | _, Nolabel -> true

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -160,10 +160,10 @@ val type_argument:
         type_expr -> type_expr -> Typedtree.expression
 
 val type_option_some:
-        Env.t -> Typedtree.arg_label -> Parsetree.expression ->
+        Env.t -> Btype.optional_module_path -> Parsetree.expression ->
         type_expr-> type_expr -> Typedtree.expression
 val type_option_none:
-        Env.t -> Typedtree.arg_label -> type_expr ->
+        Env.t -> Btype.optional_module_path -> type_expr ->
         Location.t -> Typedtree.expression
 val generalizable: int -> type_expr -> bool
 val generalize_structure_exp: Typedtree.expression -> unit

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -160,10 +160,11 @@ val type_argument:
         type_expr -> type_expr -> Typedtree.expression
 
 val type_option_some:
-        Env.t -> Parsetree.expression ->
+        Env.t -> Typedtree.arg_label -> Parsetree.expression ->
         type_expr-> type_expr -> Typedtree.expression
 val type_option_none:
-        Env.t -> type_expr -> Location.t -> Typedtree.expression
+        Env.t -> Typedtree.arg_label -> type_expr ->
+        Location.t -> Typedtree.expression
 val generalizable: int -> type_expr -> bool
 val generalize_structure_exp: Typedtree.expression -> unit
 val reset_delayed_checks: unit -> unit

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -679,6 +679,7 @@ let transl_label (label : Parsetree.arg_label)
                 Env.empty,
                 Unsupported_extension Generic_optional_arguments));
     | true ->
+        (* CR generic-optional: allow more module names / use path lookup *)
         if path.txt = Longident.Ldot (Lident "Stdlib", "Option") ||
           path.txt = Longident.Ldot (Lident "Stdlib", "Or_null")
         then
@@ -793,9 +794,8 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
               if not (Btype.tpoly_is_mono arg_ty) then
                 raise (Error (arg.ptyp_loc, env, Polymorphic_optional_param));
               let path = match Btype.classify_optionality l with
-                | Optional_arg mpath -> (match mpath with
-                    | Stdlib_option -> Predef.path_option
-                    | Stdlib_or_null -> Predef.path_or_null)
+                | Optional_arg mpath ->
+                    Ctype.predef_path_of_optional_module_path mpath
                 | Required_or_position_arg -> assert false
               in
               newmono

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -788,17 +788,15 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
             if Btype.is_Tpoly arg_ty then arg_ty else newmono arg_ty
           in
           let arg_ty =
-            if not (Btype.is_optional_arg l) then arg_ty
+            if not (Btype.is_optional l) then arg_ty
             else begin
               if not (Btype.tpoly_is_mono arg_ty) then
                 raise (Error (arg.ptyp_loc, env, Polymorphic_optional_param));
-              let path = match l with
-                | Optional _ -> Predef.path_option
-                | Generic_optional (path, _) ->
-                    (match Btype.classify_module_path path.txt with
+              let path = match Btype.classify_optionality l with
+                | Optional_arg mpath -> (match mpath with
                     | Stdlib_option -> Predef.path_option
                     | Stdlib_or_null -> Predef.path_or_null)
-                | _ -> assert false
+                | Required_or_position_arg -> assert false
               in
               newmono
                 (newconstr path [Btype.tpoly_get_mono arg_ty])


### PR DESCRIPTION
Add type checking support for `Stdlib.Or_null` as module path in generic optional arguments.

- Type checking code that inserts option/Some/None now takes an additional parameter `mpath` that specifies whether it is `Option` or `Or_null`
- Added test cases `for` calling compatibilities between vanilla options and generic options