### PR TITLE
Use the installed compiler to build `regalloc.exe`

### DIFF
--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -69,8 +69,7 @@ boot_targets = \
   $(boot_ocamlmklib) \
   $(boot_ocamldep) \
   $(boot_ocamlobjinfo) \
-  ocamltest/ocamltest.native \
-  tools/regalloc/regalloc.exe
+  ocamltest/ocamltest.native
 
 boot-compiler: _build/_bootinstall
 	RUNTIME_DIR=$(RUNTIME_DIR) $(dune) build $(ws_boot) $(coverage_dune_flags) $(boot_targets)
@@ -97,6 +96,7 @@ compiler: runtime-stdlib
           ASPP="$(ASPP)" ASPPFLAGS="$(ASPPFLAGS)" \
           $(dune) build $(ws_main) \
           --only-package=ocaml @install \
+          tools/regalloc/regalloc.exe \
           oxcaml/testsuite/tools/expect.exe \
           oxcaml/testsuite/tools/codegen_main.exe \
           oxcaml/testsuite/tools/asmgen_$(ARCH).o \


### PR DESCRIPTION
#4294 revealed that `regalloc.exe` was
built with the wrong compiler. This
pull request ensure the "main" profile
is used to build the tool.