### PR TITLE
Relax `Sys.opaque_identity` to allow local arguments

### DIFF
--- a/stdlib/sys.ml.in
+++ b/stdlib/sys.ml.in
@@ -199,7 +199,8 @@ let ocaml_release = {
 
 (* Optimization *)
 
-external[@layout_poly] opaque_identity : ('a : any). 'a -> 'a @@ portable = "%opaque"
+external[@layout_poly] opaque_identity :
+  ('a : any). ('a[@local_opt]) -> ('a[@local_opt]) @@ portable = "%opaque"
 
 module Immediate64 = struct
   module type Non_immediate = sig

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -451,7 +451,8 @@ val runtime_warnings_enabled: unit -> bool
 
 (** {1 Optimization} *)
 
-external[@layout_poly] opaque_identity : ('a : any). 'a -> 'a = "%opaque"
+external[@layout_poly] opaque_identity :
+  ('a : any). ('a[@local_opt]) -> ('a[@local_opt]) = "%opaque"
 (** For the purposes of optimization, [opaque_identity] behaves like an
     unknown (and thus possibly side-effecting) function.
 

--- a/testsuite/tests/async-exns/async_exns_1.ml
+++ b/testsuite/tests/async-exns/async_exns_1.ml
@@ -39,7 +39,7 @@ let () =
           while true do
             (* This allocation will eventually trigger the finaliser *)
             extra_arg2 := Sys.opaque_identity "K";
-            let _ = Sys.opaque_identity (42, Random.int 42) in
+            let _ @ global = Sys.opaque_identity (42, Random.int 42) in
             ()
           done
         with exn -> Printf.printf "1. wrong handler\n%!"; assert false
@@ -72,7 +72,7 @@ let raise_break_from_finaliser () =
   try
     r := None;
     while true do
-      let _ = Sys.opaque_identity (42, Random.int 42) in
+      let _ @ global = Sys.opaque_identity (42, Random.int 42) in
       ()
     done
   with exn -> Printf.printf "3a/b/c/d. wrong handler\n%!"; exit 1

--- a/testsuite/tests/async-exns/async_exns_2.ml
+++ b/testsuite/tests/async-exns/async_exns_2.ml
@@ -33,7 +33,7 @@ let test1 () =
           (* Make nested fiber stacks, then continue allocating until the
              finaliser gets called *)
           let rec make_new_stacks num_stacks =
-            let _ = Sys.opaque_identity (42, Random.int 42) in
+            let _ @ global = Sys.opaque_identity (42, Random.int 42) in
             if num_stacks > fiber_stack_limit then
               make_new_stacks num_stacks
             else

--- a/testsuite/tests/callback/signals_alloc.ml
+++ b/testsuite/tests/callback/signals_alloc.ml
@@ -25,7 +25,7 @@ let do_test () =
   seen_states.(!pos) <- 1; pos := !pos + 1;
   raise_sigusr1 ();
   seen_states.(!pos) <- 2; pos := !pos + 1;
-  let _ = Sys.opaque_identity (ref 1) in
+  let _ @ global = Sys.opaque_identity (ref 1) in
   seen_states.(!pos) <- 4; pos := !pos + 1;
   Sys.set_signal Sys.sigusr1 Sys.Signal_default;
   Array.iter (Printf.printf "%d") seen_states;

--- a/testsuite/tests/typing-local/regions.ml
+++ b/testsuite/tests/typing-local/regions.ml
@@ -46,7 +46,7 @@ let[@inline never] int_as_pointer_global x =
      function calls don't allocate on the region (superficially). The first call
      secretly does, hence stack space leaking. *)
   leak_in_current_region x;
-  let _ = Sys.opaque_identity (follow ext) in
+  let _ @ global = Sys.opaque_identity (follow ext) in
   ()
 
 let () =
@@ -293,7 +293,7 @@ let[@inline never] create_local () =
   { x = opaque_identity 0 }
 let create_and_ignore () =
   let x = create_local () in
-  ignore (Sys.opaque_identity x : t)
+  ignore (Sys.opaque_identity x : t @ global)
 
 let () =
   create_and_ignore ();


### PR DESCRIPTION
This annotates the parameter and result of `Sys.opaque_identity` as `local_opt` to allow use with locals.