### PR TITLE
Move solver side effects out of `assert`

### DIFF
--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1669,11 +1669,11 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let meet l = Solver.meet obj l
 
-  let submode_exn m0 m1 = assert (submode m0 m1 |> Result.is_ok)
+  let submode_exn m0 m1 = submode m0 m1 |> Result.get_ok
 
   let equate a b = try_with_log (equate_from_submode submode_log a b)
 
-  let equate_exn m0 m1 = assert (equate m0 m1 |> Result.is_ok)
+  let equate_exn m0 m1 = equate m0 m1 |> Result.get_ok
 
   let print ?verbose () ppf m = Solver.print ?verbose obj ppf m
 
@@ -1747,11 +1747,11 @@ module Monadic_gen (Obj : Obj) = struct
 
   let meet l = Solver.join obj l
 
-  let submode_exn m0 m1 = assert (submode m0 m1 |> Result.is_ok)
+  let submode_exn m0 m1 = submode m0 m1 |> Result.get_ok
 
   let equate a b = try_with_log (equate_from_submode submode_log a b)
 
-  let equate_exn m0 m1 = assert (equate m0 m1 |> Result.is_ok)
+  let equate_exn m0 m1 = equate m0 m1 |> Result.get_ok
 
   let print ?verbose () ppf m = Solver.print ?verbose obj ppf m
 

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -337,7 +337,7 @@ module Solver_mono (C : Lattices_mono) = struct
       let f' = C.left_adjoint obj f in
       let src = C.src obj f in
       let a' = C.apply src f' a in
-      assert (Result.is_ok (submode_cv ~log src a' v));
+      submode_cv ~log src a' v |> Result.get_ok;
       Ok ()
 
   (** Returns [Ok ()] if success; [Error x] if failed, and [x] is the next best
@@ -575,7 +575,7 @@ module Solver_mono (C : Lattices_mono) = struct
   let zap_to_ceil : type a l. a C.obj -> (a, l * allowed) mode -> log:_ -> a =
    fun obj m ~log ->
     let ceil = get_ceil obj m in
-    assert (submode obj (Amode ceil) m ~log |> Result.is_ok);
+    submode obj (Amode ceil) m ~log |> Result.get_ok;
     ceil
 
   (** Zap [mv] to its lower bound. Returns the [log] of the zapping, in
@@ -629,7 +629,7 @@ module Solver_mono (C : Lattices_mono) = struct
           mvs a
       in
       VarMap.iter
-        (fun _ mv -> assert (submode_mvc obj mv floor ~log |> Result.is_ok))
+        (fun _ mv -> submode_mvc obj mv floor ~log |> Result.get_ok)
         mvs;
       floor
 
@@ -685,14 +685,14 @@ module Solver_mono (C : Lattices_mono) = struct
     | Amodevar mv ->
       let u = fresh obj in
       let mu = Amorphvar (u, C.id) in
-      assert (Result.is_ok (submode_mvmv obj ~log:None mu mv));
+      submode_mvmv obj ~log:None mu mv |> Result.get_ok;
       allow_left (Amodevar mu), true
     | Amodemeet (a, mvs) ->
       let u = fresh obj in
       let mu = Amorphvar (u, C.id) in
-      assert (Result.is_ok (submode_mvc obj ~log:None mu a));
+      submode_mvc obj ~log:None mu a |> Result.get_ok;
       VarMap.iter
-        (fun _ mv -> assert (Result.is_ok (submode_mvmv obj ~log:None mu mv)))
+        (fun _ mv -> submode_mvmv obj ~log:None mu mv |> Result.get_ok)
         mvs;
       allow_left (Amodevar mu), true
 end


### PR DESCRIPTION
Expressions inside `assert` might be not evaluated when built with `-noassert`, which might give unexpected behavior when the expressions have side effects. This PR moves such expressions out of `assert` in the mode solver.