### PR TITLE
`module rec` defaults to legacy modes

### DIFF
--- a/testsuite/tests/typing-modes/module.ml
+++ b/testsuite/tests/typing-modes/module.ml
@@ -416,3 +416,31 @@ module type S =
     module rec M : sig module N : sig end end
   end
 |}]
+
+module rec Foo : sig
+    val bar : unit -> unit
+end = struct
+include (Foo : module type of struct
+    include Foo
+end)
+let (bar @ stateful) () = ()
+end
+[%%expect{|
+Lines 3-8, characters 6-3:
+3 | ......struct
+4 | include (Foo : module type of struct
+5 |     include Foo
+6 | end)
+7 | let (bar @ stateful) () = ()
+8 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val bar : unit -> unit end (* at nonportable *)
+       is not included in
+         sig val bar : unit -> unit end (* at portable *)
+       Values do not match:
+         val bar : unit -> unit (* in a structure at nonportable *)
+       is not included in
+         val bar : unit -> unit (* in a structure at portable *)
+       The first is "nonportable" but the second is "portable".
+|}]

--- a/testsuite/tests/typing-modes/module.ml
+++ b/testsuite/tests/typing-modes/module.ml
@@ -426,21 +426,5 @@ end)
 let (bar @ stateful) () = ()
 end
 [%%expect{|
-Lines 3-8, characters 6-3:
-3 | ......struct
-4 | include (Foo : module type of struct
-5 |     include Foo
-6 | end)
-7 | let (bar @ stateful) () = ()
-8 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig val bar : unit -> unit end (* at nonportable *)
-       is not included in
-         sig val bar : unit -> unit end (* at portable *)
-       Values do not match:
-         val bar : unit -> unit (* in a structure at nonportable *)
-       is not included in
-         val bar : unit -> unit (* in a structure at portable *)
-       The first is "nonportable" but the second is "portable".
+module rec Foo : sig val bar : unit -> unit end
 |}]

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -726,7 +726,6 @@ end = struct
 end
 [%%expect{|
 module rec M : sig module N : sig val foo : 'a -> 'a @@ global many end end
-  @@ stateless
 |}]
 
 
@@ -1405,8 +1404,8 @@ end @ nonportable = struct
   let f = M0.f
 end
 [%%expect{|
-module rec M0 : sig val f : 'a -> 'a end @@ stateless
-and M1 : sig val f : 'a -> 'a @@ portable end @@ stateless nonportable
+module rec M0 : sig val f : 'a -> 'a end @@ portable
+and M1 : sig val f : 'a -> 'a @@ portable end
 |}]
 
 
@@ -1427,11 +1426,11 @@ Lines 8-10, characters 20-3:
 10 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : 'a -> 'a @@ stateless nonportable end (* at nonportable *)
+         sig val f : 'a -> 'a end (* at nonportable *)
        is not included in
          sig val f : 'a -> 'a @@ portable end (* at nonportable *)
        Values do not match:
-         val f : 'a -> 'a @@ stateless nonportable (* in a structure at nonportable *)
+         val f : 'a -> 'a (* in a structure at nonportable *)
        is not included in
          val f : 'a -> 'a @@ portable (* in a structure at nonportable *)
        The first is "nonportable" but the second is "portable".
@@ -1454,11 +1453,11 @@ Lines 3-5, characters 17-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : 'a -> 'a @@ stateless nonportable end (* at nonportable *)
+         sig val f : 'a -> 'a end (* at nonportable *)
        is not included in
          sig val f : 'a -> 'a end (* at portable *)
        Values do not match:
-         val f : 'a -> 'a @@ stateless nonportable (* in a structure at nonportable *)
+         val f : 'a -> 'a (* in a structure at nonportable *)
        is not included in
          val f : 'a -> 'a (* in a structure at portable *)
        The first is "nonportable" but the second is "portable".

--- a/testsuite/tests/typing-modules/pr7726.ml
+++ b/testsuite/tests/typing-modules/pr7726.ml
@@ -63,7 +63,7 @@ module M :
 module type S =
   sig
     module F : functor (X : T) -> T @@ stateless
-    module rec Fixed : sig type t = F(Fixed).t end @@ stateless
+    module rec Fixed : sig type t = F(Fixed).t end
   end
 module Id : functor (X : T) -> sig type t = X.t end
 |}]

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2419,8 +2419,11 @@ and transl_recmodule_modtypes env ~sig_modalities sdecls =
          in
          let mmode =
            Option.map (fun smmode ->
-            smmode |> Typemode.transl_mode_annots |> new_mode_var_from_annots
-            ) smmode
+            smmode
+            |> Typemode.transl_mode_annots
+            |> Alloc.Const.Option.value ~default:Alloc.Const.legacy
+            |> Alloc.of_const
+            |> alloc_as_value) smmode
           in
          (id_shape, pmd.pmd_name, md, mmode, ()))
       ids sdecls

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2421,6 +2421,9 @@ and transl_recmodule_modtypes env ~sig_modalities sdecls =
            Option.map (fun smmode ->
             smmode
             |> Typemode.transl_mode_annots
+            (* CR zqian: mode annotations on rec modules default to legacy for
+            now. We can remove this workaround once [module type of] doesn't
+            require zapping. *)
             |> Alloc.Const.Option.value ~default:Alloc.Const.legacy
             |> Alloc.of_const
             |> alloc_as_value) smmode


### PR DESCRIPTION
Consider the example:

```
module rec Foo : sig
    val bar : unit -> unit
end = struct
include (Foo : module type of struct
    include Foo
end)
let (bar @ stateful) () = ()
end
```
This errors currently; it goes as follows:
1. `Foo` is added to the environment at undecided modes 
2. We type check the `struct`, in particular the `module type of`, which wants to give the strongest modality. In order to do that, it wants the strongest mode for `Foo.bar`, which requires zapping `Foo` to the strongest mode (`stateless`).
3. However, the actual `bar` is not `stateless`, hence type error.

This PR make it so that `module rec Foo` defaults to legacy, which solves this problem for legacy code. Maybe we should adopt the same behavior for regular `module Foo` as well to avoid confusing the users.

Long term solutions is to make `module type of` not zap modes.