### PR TITLE
Printing Support for the Debugging UID Tables

### DIFF
--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -46,6 +46,8 @@ let raw_lambda_to_bytecode i raw_lambda ~as_arg_for =
            arg_block_idx } ->
        Builtin_attributes.warn_unused ();
        lambda
+       |> print_if i.ppf_dump Clflags.dump_debug_uid_tables
+          (fun ppf _ -> Type_shape.print_debug_uid_tables ppf)
        |> print_if i.ppf_dump Clflags.dump_rawlambda Printlambda.lambda
        |> Simplif.simplify_lambda
        |> print_if i.ppf_dump Clflags.dump_lambda Printlambda.lambda

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -576,6 +576,16 @@ let mk_no_unboxed_types f =
   " unannotated unboxable types will not be unboxed (default)"
 ;;
 
+let mk_dump_debug_uids f =
+  "-ddebug-uids", Arg.Unit f,
+  " dump debug uids when printing variables"
+;;
+
+let mk_dump_debug_uid_tables f =
+  "-ddebug-uid-tables", Arg.Unit f,
+  " dump tables associating debug uids with shapes"
+;;
+
 let mk_unsafe f =
   "-unsafe", Arg.Unit f,
   " Do not compile bounds checking on array and string access"
@@ -955,6 +965,8 @@ module type Common_options = sig
   val _no_strict_formats : unit -> unit
   val _unboxed_types : unit -> unit
   val _no_unboxed_types : unit -> unit
+  val _dump_debug_uids : unit -> unit
+  val _dump_debug_uid_tables : unit -> unit
   val _verbose_types : unit -> unit
   val _no_verbose_types : unit -> unit
   val _version : unit -> unit
@@ -1279,6 +1291,8 @@ struct
     mk_thread F._thread;
     mk_unboxed_types F._unboxed_types;
     mk_no_unboxed_types F._no_unboxed_types;
+    mk_dump_debug_uids F._dump_debug_uids;
+    mk_dump_debug_uid_tables F._dump_debug_uid_tables;
     mk_unsafe F._unsafe;
     mk_use_runtime F._use_runtime;
     mk_use_runtime_2 F._use_runtime;
@@ -1375,6 +1389,8 @@ struct
     mk_no_strict_formats F._no_strict_formats;
     mk_unboxed_types F._unboxed_types;
     mk_no_unboxed_types F._no_unboxed_types;
+    mk_dump_debug_uids F._dump_debug_uids;
+    mk_dump_debug_uid_tables F._dump_debug_uid_tables;
     mk_unsafe F._unsafe;
     mk_verbose_types F._verbose_types;
     mk_no_verbose_types F._no_verbose_types;
@@ -1535,6 +1551,8 @@ struct
     mk_inline_max_unroll F._inline_max_unroll;
     mk_unboxed_types F._unboxed_types;
     mk_no_unboxed_types F._no_unboxed_types;
+    mk_dump_debug_uids F._dump_debug_uids;
+    mk_dump_debug_uid_tables F._dump_debug_uid_tables;
     mk_unsafe F._unsafe;
     mk_v F._v;
     mk_verbose F._verbose;
@@ -1664,6 +1682,8 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_unbox_closures_factor F._unbox_closures_factor;
     mk_unboxed_types F._unboxed_types;
     mk_no_unboxed_types F._no_unboxed_types;
+    mk_dump_debug_uids F._dump_debug_uids;
+    mk_dump_debug_uid_tables F._dump_debug_uid_tables;
     mk_unsafe F._unsafe;
     mk_verbose F._verbose;
     mk_verbose_types F._verbose_types;
@@ -1749,6 +1769,8 @@ struct
     mk_thread F._thread;
     mk_unboxed_types F._unboxed_types;
     mk_no_unboxed_types F._no_unboxed_types;
+    mk_dump_debug_uids F._dump_debug_uids;
+    mk_dump_debug_uid_tables F._dump_debug_uid_tables;
     mk_v F._v;
     mk_verbose F._verbose;
     mk_verbose_types F._verbose_types;
@@ -1852,6 +1874,8 @@ module Default = struct
     let _strict_formats = set strict_formats
     let _strict_sequence = set strict_sequence
     let _unboxed_types = set unboxed_types
+    let _dump_debug_uids = set dump_debug_uids
+    let _dump_debug_uid_tables = set dump_debug_uid_tables
     let _verbose_types = set verbose_types
     let _w s =
       Warnings.parse_options false s |> Option.iter Location.(prerr_alert none)

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -54,6 +54,8 @@ module type Common_options = sig
   val _no_strict_formats : unit -> unit
   val _unboxed_types : unit -> unit
   val _no_unboxed_types : unit -> unit
+  val _dump_debug_uids : unit -> unit
+  val _dump_debug_uid_tables : unit -> unit
   val _verbose_types : unit -> unit
   val _no_verbose_types : unit -> unit
   val _version : unit -> unit

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -42,6 +42,8 @@ let make_arg_descr ~param ~arg_block_idx : Lambda.arg_descr option =
 
 let compile_from_raw_lambda i raw_lambda ~unix ~pipeline ~as_arg_for =
   raw_lambda
+  |> print_if i.ppf_dump Clflags.dump_debug_uid_tables
+        (fun ppf _ -> Type_shape.print_debug_uid_tables ppf)
   |> print_if i.ppf_dump Clflags.dump_rawlambda Printlambda.program
   |> Compiler_hooks.execute_and_pipe Compiler_hooks.Raw_lambda
   |> Profile.(record generate)

--- a/testsuite/tests/tool-toplevel/pr6468.compilers.reference
+++ b/testsuite/tests/tool-toplevel/pr6468.compilers.reference
@@ -11,5 +11,5 @@ Exception: E.
 Raised at f in file "//toplevel//", line 4, characters 11-18
 Called from g in file "//toplevel//", line 1, characters 11-15
 Called from <unknown> in file "//toplevel//", line 1, characters 0-4
-Called from Topeval.load_lambda in file "toplevel/byte/topeval.ml", line 89, characters 4-14
+Called from Topeval.load_lambda in file "toplevel/byte/topeval.ml", line 90, characters 4-14
 

--- a/testsuite/tests/tool-toplevel/pr9701.compilers.reference
+++ b/testsuite/tests/tool-toplevel/pr9701.compilers.reference
@@ -1,4 +1,4 @@
 Exception: Failure "test".
 Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from <unknown> in file "pr9701.ml", line 5, characters 9-16
-Called from Topeval.load_lambda in file "toplevel/byte/topeval.ml", line 89, characters 4-14
+Called from Topeval.load_lambda in file "toplevel/byte/topeval.ml", line 90, characters 4-14

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -67,6 +67,7 @@ include Topcommon.MakeEvalPrinter(EvalBase)
 let may_trace = ref false (* Global lock on tracing *)
 
 let load_lambda ppf lam =
+  if !Clflags.dump_debug_uid_tables then Type_shape.print_debug_uid_tables ppf;
   if !Clflags.dump_rawlambda then fprintf ppf "%a@." Printlambda.lambda lam;
   let slam = Simplif.simplify_lambda lam in
   if !Clflags.dump_lambda then fprintf ppf "%a@." Printlambda.lambda slam;

--- a/toplevel/native/opttoploop.ml
+++ b/toplevel/native/opttoploop.ml
@@ -282,6 +282,7 @@ let default_load ppf (program : Lambda.program) =
   res
 
 let load_lambda ppf ~compilation_unit ~required_globals lam size =
+  if !Clflags.dump_debug_uid_tables then Type_shape.print_debug_uid_tables ppf;
   if !Clflags.dump_rawlambda then fprintf ppf "%a@." Printlambda.lambda lam;
   let slam = Simplif.simplify_lambda lam in
   if !Clflags.dump_lambda then fprintf ppf "%a@." Printlambda.lambda slam;

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -96,6 +96,7 @@ include Topcommon.MakeEvalPrinter(EvalBase)
 let may_trace = ref false (* Global lock on tracing *)
 
 let load_lambda ppf ~compilation_unit ~required_globals phrase_name lam size =
+  if !Clflags.dump_debug_uid_tables then Type_shape.print_debug_uid_tables ppf;
   if !Clflags.dump_rawlambda then fprintf ppf "%a@." Printlambda.lambda lam;
   let slam = Simplif.simplify_lambda lam in
   if !Clflags.dump_lambda then fprintf ppf "%a@." Printlambda.lambda slam;

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -925,3 +925,38 @@ let rec type_name : 'a. 'a Type_shape.ts -> _ =
       let args = type_arg_list_to_string (List.map type_name shapes) in
       let name = Path.name type_decl_shape.path in
       args ^ name)
+
+let print_table_all_type_decls ppf =
+  let entries = Uid.Tbl.to_list all_type_decls in
+  let entries = List.sort (fun (a, _) (b, _) -> Uid.compare a b) entries in
+  let entries =
+    List.map
+      (fun (k, v) ->
+        ( Format.asprintf "%a" Uid.print k,
+          Format.asprintf "%a" Type_decl_shape.print v ))
+      entries
+  in
+  let uids, decls = List.split entries in
+  Misc.pp_table ppf ["UID", uids; "Type Declaration", decls]
+
+let print_table_all_type_shapes ppf =
+  let entries = Uid.Tbl.to_list all_type_shapes in
+  let entries = List.sort (fun (a, _) (b, _) -> Uid.compare a b) entries in
+  let entries =
+    List.map
+      (fun (k, { type_shape; type_layout }) ->
+        ( Format.asprintf "%a" Uid.print k,
+          ( Format.asprintf "%a" Type_shape.print type_shape,
+            Format.asprintf "%a" Layout.format type_layout ) ))
+      entries
+  in
+  let uids, rest = List.split entries in
+  let types, sorts = List.split rest in
+  Misc.pp_table ppf ["UID", uids; "Type", types; "Sort", sorts]
+
+(* Print debug uid tables when the command line flag [-ddebug-uids] is set. *)
+let print_debug_uid_tables ppf =
+  Format.fprintf ppf "\n";
+  print_table_all_type_decls ppf;
+  Format.fprintf ppf "\n";
+  print_table_all_type_shapes ppf

--- a/typing/type_shape.mli
+++ b/typing/type_shape.mli
@@ -238,3 +238,9 @@ val add_to_type_shapes :
 val find_in_type_decls : Uid.t -> Type_decl_shape.tds option
 
 val type_name : _ Type_shape.ts -> string
+
+val print_table_all_type_decls : Format.formatter -> unit
+
+val print_table_all_type_shapes : Format.formatter -> unit
+
+val print_debug_uid_tables : Format.formatter -> unit

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -451,6 +451,10 @@ let error_style_reader = {
 
 let unboxed_types = ref false
 
+let dump_debug_uids = ref false         (* -ddebug-uids *)
+
+let dump_debug_uid_tables = ref false    (* -ddebug-uid-tables *)
+
 (* This is used by the -save-ir-after and -save-ir-before options. *)
 module Compiler_ir = struct
   type t = Linear | Cfg | Llvmir

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -235,6 +235,10 @@ val error_style_reader : Misc.Error_style.setting env_reader
 
 val unboxed_types : bool ref
 
+val dump_debug_uids : bool ref         (* -ddebug-uids *)
+
+val dump_debug_uid_tables : bool ref   (* -ddebug-uid-tables *)
+
 val insn_sched : bool ref
 val insn_sched_default : bool
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -778,7 +778,8 @@ end
 
 val print_if :
   Format.formatter -> bool ref -> (Format.formatter -> 'a -> unit) -> 'a -> 'a
-(** [print_if ppf flag fmt x] prints [x] with [fmt] on [ppf] if [b] is true. *)
+(** [print_if ppf flag fmt x] prints [x] with [fmt] on [ppf]
+    if [flag] is true. *)
 
 val pp_two_columns :
   ?sep:string -> ?max_lines:int ->
@@ -805,6 +806,11 @@ val pp_two_columns :
     bb  | dddddd
     v}
 *)
+
+val pp_table : Format.formatter -> (string * string list) list -> unit
+(** [pp_table ppf l] prints the table [l], a list of columns with their
+    header. The function fails with a fatal error if the columns have
+    different length. *)
 
 val pp_parens_if :
      bool


### PR DESCRIPTION
This PR adds support for printing the debugging UIDs collected in the type shape tables (introduced in #4253). To do so, it adds two new flags, namely `-ddebug-uids` and `-ddebug-uid-tables`. The former adds uid information to binders and the latter prints the tables with debug uids in `type_shape.ml`. At the moment, it only supports printing the tables for the lambda and rawlambda representations. In #4255, this is expanded with support for the other intermediate representations.