### PR TITLE
Simplify Value.Axis.t GADT

### DIFF
--- a/lambda/translmode.ml
+++ b/lambda/translmode.ml
@@ -29,11 +29,11 @@ let transl_locality_mode_r locality =
 
 let transl_alloc_mode_l mode =
   (* we only take the locality axis *)
-  Alloc.proj (Comonadic Areality) mode |> transl_locality_mode_l
+  Alloc.proj_comonadic Areality mode |> transl_locality_mode_l
 
 let transl_alloc_mode_r mode =
   (* we only take the locality axis *)
-  Alloc.proj (Comonadic Areality) mode |> transl_locality_mode_r
+  Alloc.proj_comonadic Areality mode |> transl_locality_mode_r
 
 let transl_alloc_mode (mode : Typedtree.alloc_mode) =
   transl_alloc_mode_r mode.mode

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1699,11 +1699,11 @@ let prim_mode mvar prim =
     from the given [m]. This function is too specific to be put in [mode.ml] *)
 let with_locality_and_yielding (locality, yielding) m =
   let m' = Alloc.newvar () in
-  Locality.equate_exn (Alloc.proj (Comonadic Areality) m') locality;
+  Locality.equate_exn (Alloc.proj_comonadic Areality m') locality;
   let yielding =
-    Option.value ~default:(Alloc.proj (Comonadic Yielding) m) yielding
+    Option.value ~default:(Alloc.proj_comonadic Yielding m) yielding
   in
-  Yielding.equate_exn (Alloc.proj (Comonadic Yielding) m') yielding;
+  Yielding.equate_exn (Alloc.proj_comonadic Yielding m') yielding;
   let c =
     { Alloc.Comonadic.Const.max with
       areality = Locality.Const.min;
@@ -5143,7 +5143,7 @@ let submode_with_cross env ~is_ret ty l r =
       (* the locality axis of the return mode cannot cross modes, because a
          local-returning function might allocate in the caller's region, and
          this info must be preserved. *)
-      Alloc.meet [r'; Alloc.max_with (Comonadic Areality) (Alloc.proj (Comonadic Areality) r)]
+      Alloc.meet [r'; Alloc.max_with_comonadic Areality (Alloc.proj_comonadic Areality r)]
     else
       r'
   in

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5143,7 +5143,9 @@ let submode_with_cross env ~is_ret ty l r =
       (* the locality axis of the return mode cannot cross modes, because a
          local-returning function might allocate in the caller's region, and
          this info must be preserved. *)
-      Alloc.meet [r'; Alloc.max_with_comonadic Areality (Alloc.proj_comonadic Areality r)]
+      Alloc.meet
+        [r';
+         Alloc.max_with_comonadic Areality (Alloc.proj_comonadic Areality r)]
     else
       r'
   in

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3295,7 +3295,7 @@ let lookup_ident_module (type a) (load : a load) ~errors ~use ~loc s env =
 let escape_mode ~errors ~env ~loc ~item ~lid vmode escaping_context =
   begin match
   Mode.Regionality.submode
-    (Mode.Value.proj (Comonadic Areality) vmode.mode)
+    (Mode.Value.proj_comonadic Areality vmode.mode)
     (Mode.Regionality.global)
   with
   | Ok () -> ()
@@ -3308,7 +3308,7 @@ let escape_mode ~errors ~env ~loc ~item ~lid vmode escaping_context =
 let share_mode ~errors ~env ~loc ~item ~lid vmode shared_context =
   match
     Mode.Linearity.submode
-      (Mode.Value.proj (Comonadic Linearity) vmode.mode)
+      (Mode.Value.proj_comonadic Linearity vmode.mode)
       Mode.Linearity.many
   with
   | Error _ ->
@@ -3342,7 +3342,7 @@ let closure_mode ~errors ~env ~loc ~item ~lid
 let exclave_mode ~errors ~env ~loc ~item ~lid vmode =
   match
   Mode.Regionality.submode
-    (Mode.Value.proj (Comonadic Areality) vmode.mode)
+    (Mode.Value.proj_comonadic Areality vmode.mode)
     Mode.Regionality.regional
 with
 | Ok () ->
@@ -3418,7 +3418,7 @@ let walk_locks_for_mutable_mode ~errors ~loc ~env locks m0 =
           let mode = mode |> Mode.value_to_alloc_r2g |> Mode.alloc_as_value in
           Mode.Value.meet
             [mode;
-             Mode.Value.max_with (Comonadic Areality)
+             Mode.Value.max_with_comonadic Areality
                                  (Mode.Regionality.regional)]
       | Exclave_lock ->
           (* If [m0] is [global], then inside the exclave we require new values

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -244,50 +244,50 @@ end
 
 (* CR zqian: refactor to remove the following two functions *)
 let zap_axis_to_floor
-  : type a d0 d1. (a, d0, d1) Mode.Value.Axis.t -> Mode.Value.l -> a
+  : type a. a Mode.Value.Axis.t -> Mode.Value.l -> a
   = fun ax m ->
   match ax with
   | Comonadic Areality ->
-      Mode.Regionality.zap_to_floor (Mode.Value.proj (Comonadic Areality) m)
+      Mode.Regionality.zap_to_floor (Mode.Value.proj_comonadic Areality m)
   | Comonadic Linearity ->
-      Mode.Linearity.zap_to_floor (Mode.Value.proj (Comonadic Linearity) m)
+      Mode.Linearity.zap_to_floor (Mode.Value.proj_comonadic Linearity m)
   | Comonadic Portability ->
-      Mode.Portability.zap_to_floor (Mode.Value.proj (Comonadic Portability)  m)
+      Mode.Portability.zap_to_floor (Mode.Value.proj_comonadic Portability  m)
   | Comonadic Yielding ->
-      Mode.Yielding.zap_to_floor (Mode.Value.proj (Comonadic Yielding) m)
+      Mode.Yielding.zap_to_floor (Mode.Value.proj_comonadic Yielding m)
   | Comonadic Statefulness ->
       Mode.Statefulness.zap_to_floor
-        (Mode.Value.proj (Comonadic Statefulness) m)
+        (Mode.Value.proj_comonadic Statefulness m)
   | Monadic Uniqueness ->
-      Mode.Uniqueness.zap_to_floor (Mode.Value.proj (Monadic Uniqueness) m)
+      Mode.Uniqueness.zap_to_floor (Mode.Value.proj_monadic Uniqueness m)
   | Monadic Contention ->
-      Mode.Contention.zap_to_floor (Mode.Value.proj (Monadic Contention) m)
+      Mode.Contention.zap_to_floor (Mode.Value.proj_monadic Contention m)
   | Monadic Visibility ->
-      Mode.Visibility.zap_to_floor (Mode.Value.proj (Monadic Visibility) m)
+      Mode.Visibility.zap_to_floor (Mode.Value.proj_monadic Visibility m)
 
 let zap_axis_to_ceil
-  : type a d0 d1. (a, d0, d1) Mode.Value.Axis.t -> Mode.Value.r -> a
+  : type a. a Mode.Value.Axis.t -> Mode.Value.r -> a
   = fun ax m ->
   match ax with
   | Comonadic Areality ->
-      Mode.Regionality.zap_to_ceil (Mode.Value.proj (Comonadic Areality) m)
+      Mode.Regionality.zap_to_ceil (Mode.Value.proj_comonadic Areality m)
   | Comonadic Linearity ->
-      Mode.Linearity.zap_to_ceil (Mode.Value.proj (Comonadic Linearity) m)
+      Mode.Linearity.zap_to_ceil (Mode.Value.proj_comonadic Linearity m)
   | Comonadic Portability ->
-      Mode.Portability.zap_to_ceil (Mode.Value.proj (Comonadic Portability) m)
+      Mode.Portability.zap_to_ceil (Mode.Value.proj_comonadic Portability m)
   | Comonadic Yielding ->
-      Mode.Yielding.zap_to_ceil (Mode.Value.proj (Comonadic Yielding) m)
+      Mode.Yielding.zap_to_ceil (Mode.Value.proj_comonadic Yielding m)
   | Comonadic Statefulness ->
-      Mode.Statefulness.zap_to_ceil (Mode.Value.proj (Comonadic Statefulness) m)
+      Mode.Statefulness.zap_to_ceil (Mode.Value.proj_comonadic Statefulness m)
   | Monadic Uniqueness ->
-      Mode.Uniqueness.zap_to_ceil (Mode.Value.proj (Monadic Uniqueness) m)
+      Mode.Uniqueness.zap_to_ceil (Mode.Value.proj_monadic Uniqueness m)
   | Monadic Contention ->
-      Mode.Contention.zap_to_ceil (Mode.Value.proj (Monadic Contention) m)
+      Mode.Contention.zap_to_ceil (Mode.Value.proj_monadic Contention m)
   | Monadic Visibility ->
-      Mode.Visibility.zap_to_ceil (Mode.Value.proj (Monadic Visibility) m)
+      Mode.Visibility.zap_to_ceil (Mode.Value.proj_monadic Visibility m)
 
 let print_out_mode
-: type a d0 d1. ?in_structure:_ -> (a, d0, d1) Mode.Value.Axis.t -> a -> _
+: type a. ?in_structure:_ -> a Mode.Value.Axis.t -> a -> _
 = fun ?(in_structure=true) ax mode ->
   let (module L) = Mode.Value.Const.lattice_of_axis ax in
   if in_structure then

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -177,7 +177,7 @@ module Axis = struct
   end
 
   type 'a t =
-    | Modal : ('a, _, _) Mode.Alloc.Axis.t -> 'a t
+    | Modal : 'a Mode.Alloc.Axis.t -> 'a t
     | Nonmodal : 'a Nonmodal.t -> 'a t
 
   type packed = Pack : 'a t -> packed [@@unboxed]

--- a/typing/jkind_axis.mli
+++ b/typing/jkind_axis.mli
@@ -59,7 +59,7 @@ module Axis : sig
 
   (** Represents an axis of a jkind *)
   type 'a t =
-    | Modal : ('a, _, _) Mode.Alloc.Axis.t -> 'a t
+    | Modal : 'a Mode.Alloc.Axis.t -> 'a t
     | Nonmodal : 'a Nonmodal.t -> 'a t
 
   type packed = Pack : 'a t -> packed [@@unboxed]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5138,8 +5138,12 @@ let with_explanation explanation f =
         raise (Error (loc', env', err))
 
 let unique_use ~loc ~env mode_l mode_r  =
-  let uniqueness = Uniqueness.disallow_left (Value.proj_monadic Uniqueness mode_r) in
-  let linearity = Linearity.disallow_right (Value.proj_comonadic Linearity mode_l) in
+  let uniqueness =
+    Uniqueness.disallow_left (Value.proj_monadic Uniqueness mode_r)
+  in
+  let linearity =
+    Linearity.disallow_right (Value.proj_comonadic Linearity mode_l)
+  in
   if not (Language_extension.is_at_least Unique
             Language_extension.maturity_of_unique_for_drf) then begin
     (* if unique extension is not enabled, we will not run uniqueness analysis;
@@ -5241,7 +5245,8 @@ let split_function_ty
       fst (register_allocation_value_mode mode)
   in
   if expected_mode.strictly_local then
-    Locality.submode_exn Locality.local (Alloc.proj_comonadic Areality alloc_mode);
+    Locality.submode_exn Locality.local
+      (Alloc.proj_comonadic Areality alloc_mode);
   let { ty = ty_fun; explanation }, loc_fun = in_function in
   let separate = !Clflags.principal || Env.has_local_constraints env in
   let { ty_arg; ty_ret; arg_mode; ret_mode } as filtered_arrow =
@@ -6003,7 +6008,8 @@ and type_expect_
             type_expect ~recarg new_env mode' sbody ty_expected_explained
           in
           submode ~loc ~env ~reason:Other
-            (Value.min_with_comonadic Areality Regionality.regional) expected_mode;
+            (Value.min_with_comonadic Areality Regionality.regional)
+            expected_mode;
           { exp_desc = Texp_exclave exp;
             exp_loc = loc;
             exp_extra = [];

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -523,7 +523,7 @@ mode is the mode of the function region *)
 let mode_return mode =
   { (mode_default (meet_regional mode)) with
     position = RTail (Regionality.disallow_left
-      (Value.proj (Comonadic Areality) mode), FTail);
+      (Value.proj_comonadic Areality mode), FTail);
     locality_context = Some Return;
   }
 
@@ -532,7 +532,7 @@ let mode_region mode =
   { (mode_default (meet_regional mode)) with
     position =
       RTail (Regionality.disallow_left
-        (Value.proj (Comonadic Areality) mode), FNontail);
+        (Value.proj_comonadic Areality mode), FNontail);
     locality_context = None;
   }
 
@@ -570,7 +570,7 @@ let mode_coerce mode expected_mode =
 let mode_lazy expected_mode =
   let expected_mode =
     mode_coerce (
-      Value.max_with (Comonadic Areality) Regionality.global
+      Value.max_with_comonadic Areality Regionality.global
       |> Value.meet_with Yielding Yielding.Const.Unyielding)
       expected_mode
   in
@@ -638,7 +638,7 @@ let mode_argument ~funct ~index ~position_and_mode ~partial_app marg =
   | _, _, (Nontail | Default) ->
      mode_default vmode, vmode
   | _, _, Tail -> begin
-    Regionality.submode_exn (Value.proj (Comonadic Areality) vmode)
+    Regionality.submode_exn (Value.proj_comonadic Areality vmode)
       Regionality.regional;
     mode_tailcall_argument vmode, vmode
   end
@@ -728,7 +728,7 @@ let optimise_allocations () =
   - Add it back when middle-end can really utilize this information. *)
   List.iter
     (fun mode ->
-      Locality.zap_to_ceil (Alloc.proj (Comonadic Areality) mode)
+      Locality.zap_to_ceil (Alloc.proj_comonadic Areality mode)
       |> ignore)
     !allocations;
   reset_allocations ()
@@ -1067,9 +1067,9 @@ let mode_mutate_mutable =
 (** The [expected_mode] of the lazy expression when forcing it. *)
 let mode_force_lazy =
   let mode =
-    Contention.Const.Uncontended
-    |> Contention.of_const
-    |> Value.max_with (Monadic Contention)
+    { Value.Const.max with
+      contention = Uncontended }
+    |> Value.of_const
   in
   { (mode_default mode) with
     contention_context = Some Force_lazy }
@@ -5138,8 +5138,8 @@ let with_explanation explanation f =
         raise (Error (loc', env', err))
 
 let unique_use ~loc ~env mode_l mode_r  =
-  let uniqueness = Uniqueness.disallow_left (Value.proj (Monadic Uniqueness) mode_r) in
-  let linearity = Linearity.disallow_right (Value.proj (Comonadic Linearity) mode_l) in
+  let uniqueness = Uniqueness.disallow_left (Value.proj_monadic Uniqueness mode_r) in
+  let linearity = Linearity.disallow_right (Value.proj_comonadic Linearity mode_l) in
   if not (Language_extension.is_at_least Unique
             Language_extension.maturity_of_unique_for_drf) then begin
     (* if unique extension is not enabled, we will not run uniqueness analysis;
@@ -5241,7 +5241,7 @@ let split_function_ty
       fst (register_allocation_value_mode mode)
   in
   if expected_mode.strictly_local then
-    Locality.submode_exn Locality.local (Alloc.proj (Comonadic Areality) alloc_mode);
+    Locality.submode_exn Locality.local (Alloc.proj_comonadic Areality alloc_mode);
   let { ty = ty_fun; explanation }, loc_fun = in_function in
   let separate = !Clflags.principal || Env.has_local_constraints env in
   let { ty_arg; ty_ret; arg_mode; ret_mode } as filtered_arrow =
@@ -6003,7 +6003,7 @@ and type_expect_
             type_expect ~recarg new_env mode' sbody ty_expected_explained
           in
           submode ~loc ~env ~reason:Other
-            (Value.min_with (Comonadic Areality) Regionality.regional) expected_mode;
+            (Value.min_with_comonadic Areality Regionality.regional) expected_mode;
           { exp_desc = Texp_exclave exp;
             exp_loc = loc;
             exp_extra = [];
@@ -6021,7 +6021,7 @@ and type_expect_
         | Tail ->
           let mode, _ =
             Value.newvar_below
-              (Value.max_with (Comonadic Areality) Regionality.regional)
+              (Value.max_with_comonadic Areality Regionality.regional)
           in
           mode, mode_tailcall_function mode
         | Nontail | Default ->
@@ -6329,7 +6329,7 @@ and type_expect_
       rue {
         exp_desc = Texp_setfield(record,
           Locality.disallow_right (regional_to_local
-            (Value.proj (Comonadic Areality) rmode)),
+            (Value.proj_comonadic Areality rmode)),
           label_loc, label, newval);
         exp_loc = loc; exp_extra = [];
         exp_type = instance Predef.type_unit;
@@ -7008,11 +7008,11 @@ and type_expect_
       | Texp_field (_, _, _, _, Boxing (alloc_mode, _), _) ->
         begin
           submode ~loc ~env
-            (Value.min_with (Comonadic Areality) Regionality.local)
+            (Value.min_with_comonadic Areality Regionality.local)
             expected_mode;
           match
             Locality.submode Locality.local
-              (Alloc.proj (Comonadic Areality) alloc_mode.mode)
+              (Alloc.proj_comonadic Areality alloc_mode.mode)
           with
           | Ok () -> ()
           | Error _ -> raise (Error (e.pexp_loc, env,
@@ -7032,7 +7032,7 @@ and type_expect_
           check primitive allocation here, and also improve the logic in [type_ident]. *)
           ->
           submode ~loc ~env
-            (Value.min_with (Comonadic Areality) Regionality.local)
+            (Value.min_with_comonadic Areality Regionality.local)
             expected_mode;
       | _ ->
         raise (Error (exp.exp_loc, env, Not_allocation))
@@ -7057,10 +7057,9 @@ and type_expect_
            and should have the areality expected here: *)
         Value.newvar_below
           (Value.meet [
-            Value.max_with (Monadic Uniqueness)
-              Uniqueness.(of_const Const.Unique);
-            Value.max_with (Comonadic Areality)
-              (Value.proj (Comonadic Areality) expected_mode.mode)])
+            Value.of_const {Value.Const.max with uniqueness = Unique};
+            Value.max_with_comonadic Areality
+              (Value.proj_comonadic Areality expected_mode.mode)])
       in
       let cell_type =
         (* CR uniqueness: this could be the jkind of exp2 *)
@@ -7331,7 +7330,7 @@ and type_ident env ?(recarg=Rejected) lid =
        (* if the locality of returned value of the primitive is poly
           we then register allocation for further optimization *)
        | (Prim_poly, _), Some mode ->
-           register_allocation_mode (Alloc.max_with (Comonadic Areality) mode)
+           register_allocation_mode (Alloc.max_with_comonadic Areality mode)
        | _ -> ()
        end;
        ty, Id_prim (Option.map Locality.disallow_right mode, sort)
@@ -8244,7 +8243,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
       in
       let eta_mode, _ = Value.newvar_below (alloc_as_value marg) in
       Regionality.submode_exn
-        (Value.proj (Comonadic Areality) eta_mode) Regionality.regional;
+        (Value.proj_comonadic Areality eta_mode) Regionality.regional;
       let eta_pat, eta_var = var_pair ~mode:eta_mode "eta" ty_arg in
       (* CR layouts v10: When we add abstract jkinds, the eta expansion here
          becomes impossible in some cases - we'll need better errors.  For test
@@ -8266,7 +8265,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
              (texp,
               args @ [Nolabel, Arg (eta_var, arg_sort)], Nontail,
               ret_mode
-              |> Value.proj (Comonadic Areality)
+              |> Value.proj_comonadic Areality
               |> regional_to_global
               |> Locality.disallow_right,
               None)}
@@ -8431,7 +8430,7 @@ and type_application env app_loc expected_mode position_and_mode
         | Error err -> raise (Error (app_loc, env, Function_type_not_rep (ty, err)))
       in
       let arg_sort = type_sort ~why:Function_argument ty_arg in
-      let ap_mode = Alloc.proj (Comonadic Areality) ret_mode in
+      let ap_mode = Alloc.proj_comonadic Areality ret_mode in
       let mode_res =
         cross_left env ty_ret (alloc_as_value ret_mode)
       in
@@ -8492,7 +8491,7 @@ and type_application env app_loc expected_mode position_and_mode
         end ~post:(fun (ty_ret, _, _, _) -> generalize_structure ty_ret)
       in
       let mode_ret = Alloc.disallow_right mode_ret in
-      let ap_mode = Alloc.proj (Comonadic Areality) mode_ret in
+      let ap_mode = Alloc.proj_comonadic Areality mode_ret in
       let mode_ret =
         cross_left env ty_ret (alloc_as_value mode_ret)
       in
@@ -9267,8 +9266,9 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
            heap-allocated. *)
         (* CR zqian: the multiple allocations should enjoy their own modes. *)
         let m, _ =
-          Value.newvar_below (Value.max_with (Comonadic Areality)
-            Regionality.global)
+          {Value.Const.max with areality = Global}
+          |> Value.of_const
+          |> Value.newvar_below
         in
         Some m
     | Nonrecursive -> None
@@ -10480,7 +10480,7 @@ let escaping_hint (failure_reason : Value.error) submode_reason
         match get_desc ty with
         | Tarrow ((_, _, res_mode), _, res_ty, _) ->
           begin match
-            Locality.Guts.check_const (Alloc.proj (Comonadic Areality) res_mode)
+            Locality.Guts.check_const (Alloc.proj_comonadic Areality res_mode)
           with
           | Some Global ->
             Some (n+1, true)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -3540,11 +3540,11 @@ let rec parse_native_repr_attributes env core_type ty rmode
     let mode =
       if Builtin_attributes.has_local_opt ct1.ptyp_attributes
       then Prim_poly
-      else prim_const_mode (Mode.Alloc.proj (Comonadic Areality) marg)
+      else prim_const_mode (Mode.Alloc.proj_comonadic Areality marg)
     in
     let repr_args, repr_res =
       parse_native_repr_attributes env ct2 t2
-        (prim_const_mode (Mode.Alloc.proj (Comonadic Areality) mret))
+        (prim_const_mode (Mode.Alloc.proj_comonadic Areality mret))
         ~global_repr ~is_layout_poly
     in
     ((mode, repr_arg) :: repr_args, repr_res)

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -146,7 +146,7 @@ let new_mode_var_from_annots (m : Alloc.Const.Option.t) =
 let register_allocation () =
   let m, _ =
     Alloc.(newvar_below
-      (max_with (Comonadic Areality) Locality.global))
+      (max_with_comonadic Areality Locality.global))
   in
   m, alloc_as_value m
 

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -25,7 +25,7 @@ exception Error of Location.t * error
 
 module Axis_pair = struct
   type 'm t =
-    | Modal_axis_pair : ('a, _, _) Mode.Alloc.Axis.t * 'a -> modal t
+    | Modal_axis_pair : 'a Mode.Alloc.Axis.t * 'a -> modal t
     | Any_axis_pair : 'a Axis.t * 'a -> maybe_nonmodal t
     | Everything_but_nullability : maybe_nonmodal t
 
@@ -316,8 +316,7 @@ let default_mode_annots (annots : Alloc.Const.Option.t) =
 let transl_mode_annots annots : Alloc.Const.Option.t =
   let step modifiers_so_far annot =
     let { txt =
-            Modal_axis_pair (type a d0 d1)
-              ((axis, mode) : (a, d0, d1) Mode.Alloc.Axis.t * a);
+            Modal_axis_pair (type a) ((axis, mode) : a Mode.Alloc.Axis.t * a);
           loc
         } =
       transl_annot ~annot_type:Mode ~required_mode_maturity:(Some Stable)


### PR DESCRIPTION
Currently, `Value.Axis.t` is a GADT with three parameters `a, d0, d1`. The `d0` and `d1` are to enable a polymorphic `proj` function that works for both monadic and comonadic modes. However, callers always know exactly which axis they are projecting, and thus never need this polymorphism. The `d0` and `d1` also complicates code elsewhere.

This PR removes these extra parameters.