### PR TITLE
Don't gate finaliser GC phase changes on work availability

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -2026,8 +2026,15 @@ mark_again:
 
   if (mode != Slice_opportunistic && caml_marking_started()) {
     /* Finalisers */
+
+    /* TODO: various improvement work here:
+     * - updating finalisers should be made incremental;
+     * - we should measure and account for the work of it against work meters.
+     * - but until it is made incremental, don't gate it on available work,
+     *   because we have to do it (and therefore advance the phase) in domains
+     *   which don't allocate. */
+
     if (caml_gc_phase == Phase_mark_final &&
-        get_major_slice_markwork(mode) > 0 &&
         caml_final_update_first(domain_state)) {
       /* This domain has updated finalise first values */
       atomic_fetch_add_verify_ge0(&num_domains_to_final_update_first, -1);
@@ -2036,9 +2043,9 @@ mark_again:
         goto mark_again;
     }
 
-    /* TODO measure and account for the work of updating finalisers */
+    /* TODO finaliser improvement work as listed above. */
+
     if (caml_gc_phase == Phase_sweep_ephe &&
-        get_major_slice_markwork(mode) > 0 &&
         caml_final_update_last(domain_state)) {
       /* This domain has updated finalise last values */
       atomic_fetch_add_verify_ge0(&num_domains_to_final_update_last, -1);


### PR DESCRIPTION
A domain which does no allocation may block the GC phase from advancing, because it can never get enough "work" to call the finaliser table update functions. Noticed and [diagnosed](https://github.com/ocaml/ocaml/pull/13580#issuecomment-3032198669) by @kayceesrk in ocaml/ocaml#13580.