### PR TITLE
Correct Max Mod Bounds

### DIFF
--- a/typing/types.ml
+++ b/typing/types.ml
@@ -283,8 +283,7 @@ module Jkind_mod_bounds = struct
     (not (mem axes (Nonmodal Separability)) ||
      Separability.(le max (separability t)))
 
-  let[@inline] is_max m =
-    m =
+  let max =
       { locality = Locality.max;
         linearity = Linearity.max;
         uniqueness = Uniqueness.max;
@@ -296,6 +295,9 @@ module Jkind_mod_bounds = struct
         externality = Externality.max;
         nullability = Nullability.max;
         separability = Separability.max}
+
+  let[@inline] is_max m = m = max
+
 
   let debug_print ppf
         { locality;


### PR DESCRIPTION
Fixes a bug in a function `is_max` for checking if a set of mod-bounds is the max possible. In particular, `Portable` is not the max of portability, `External` is not the max of externality. This function is used as part of the early termination condition for the normalization in `constrain_type_jkind`.