### PR TITLE
Annotate key functions on strings as taking strings as `local`

### DIFF
--- a/stdlib/string.ml
+++ b/stdlib/string.ml
@@ -18,6 +18,8 @@ open! Stdlib
 
 [@@@ocaml.flambda_o3]
 
+type t = string
+
 (* String operations, based on byte sequence operations *)
 
 (* WARNING: Some functions in this file are duplicated in bytes.ml for
@@ -26,9 +28,10 @@ open! Stdlib
    These functions have a "duplicated" comment above their definition.
 *)
 
-external length : string -> int @@ portable = "%string_length"
-external get : string -> int -> char @@ portable = "%string_safe_get"
-external unsafe_get : string -> int -> char @@ portable = "%string_unsafe_get"
+external length : (t[@local_opt]) -> int @@ portable = "%string_length"
+external get : (t[@local_opt]) -> int -> char @@ portable = "%string_safe_get"
+external unsafe_get :
+  (t[@local_opt]) -> int -> char @@ portable = "%string_unsafe_get"
 external unsafe_blit : string -> int ->  bytes -> int -> int -> unit @@ portable
                      = "caml_blit_string" [@@noalloc]
 
@@ -223,7 +226,8 @@ let ends_with ~suffix s =
     else aux (i + 1)
   in diff >= 0 && aux 0
 
-external seeded_hash : int -> string -> int @@ portable = "caml_string_hash" [@@noalloc]
+external seeded_hash :
+  int -> (t[@local_opt]) -> int @@ portable = "caml_string_hash" [@@noalloc]
 let hash x = seeded_hash 0 x
 
 (* duplicated in bytes.ml *)
@@ -238,10 +242,11 @@ let split_on_char sep s =
   done;
   sub s 0 !j :: !r
 
-type t = string
-
-let compare (x: t) (y: t) = Stdlib.compare x y
-external equal : string -> string -> bool @@ portable = "caml_string_equal" [@@noalloc]
+external compare :
+  (t[@local_opt]) -> (t[@local_opt]) -> int @@ portable = "%compare"
+external equal :
+  (t[@local_opt]) -> (t[@local_opt]) -> bool @@ portable =
+  "caml_string_equal" [@@noalloc]
 
 (** {1 Iterators} *)
 

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -99,10 +99,10 @@ val empty : string
     @since 4.13
 *)
 
-external length : string -> int = "%string_length"
+external length : (t[@local_opt]) -> int = "%string_length"
 (** [length s] is the length (number of bytes/characters) of [s]. *)
 
-external get : string -> int -> char = "%string_safe_get"
+external get : (t[@local_opt]) -> int -> char = "%string_safe_get"
 (** [get s i] is the character at index [i] in [s]. This is the same
     as writing [s.[i]].
 
@@ -149,12 +149,13 @@ val cat : string -> string -> string
 
 (** {1:predicates Predicates and comparisons} *)
 
-val equal : t -> t -> bool
+external equal :
+  (t[@local_opt]) -> (t[@local_opt]) -> bool = "caml_string_equal" [@@noalloc]
 (** [equal s0 s1] is [true] if and only if [s0] and [s1] are character-wise
     equal.
     @since 4.03 (4.05 in StringLabels) *)
 
-val compare : t -> t -> int
+external compare : (t[@local_opt]) -> (t[@local_opt]) -> int = "%compare"
 (** [compare s0 s1] sorts [s0] and [s1] in lexicographical order. [compare]
     behaves like {!Stdlib.compare} on strings but may be more efficient. *)
 
@@ -488,14 +489,15 @@ val get_int32_ne : string -> int -> int32
     @since 4.13
 *)
 
-val hash : t -> int
+val hash : t @ local -> int
 (** An unseeded hash function for strings, with the same output value as
     {!Hashtbl.hash}. This function allows this module to be passed as argument
     to the functor {!Hashtbl.Make}.
 
     @since 5.0 *)
 
-val seeded_hash : int -> t -> int
+external seeded_hash :
+  int -> (t[@local_opt]) -> int @@ portable = "caml_string_hash" [@@noalloc]
 (** A seeded hash function for strings, with the same output value as
     {!Hashtbl.seeded_hash}. This function allows this module to be passed as
     argument to the functor {!Hashtbl.MakeSeeded}.
@@ -541,7 +543,7 @@ val get_int64_le : string -> int -> int64
 
 (* The following is for system use only. Do not call directly. *)
 
-external unsafe_get : string -> int -> char = "%string_unsafe_get"
+external unsafe_get : (t[@local_opt]) -> int -> char = "%string_unsafe_get"
 external unsafe_blit :
   string -> int -> bytes -> int -> int ->
     unit = "caml_blit_string" [@@noalloc]

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -101,10 +101,10 @@ val empty : string
     @since 4.13
 *)
 
-external length : string -> int = "%string_length"
+external length : (t[@local_opt]) -> int = "%string_length"
 (** [length s] is the length (number of bytes/characters) of [s]. *)
 
-external get : string -> int -> char = "%string_safe_get"
+external get : (t[@local_opt]) -> int -> char = "%string_safe_get"
 (** [get s i] is the character at index [i] in [s]. This is the same
     as writing [s.[i]].
 
@@ -151,12 +151,13 @@ val cat : string -> string -> string
 
 (** {1:predicates Predicates and comparisons} *)
 
-val equal : t -> t -> bool
+external equal :
+  (t[@local_opt]) -> (t[@local_opt]) -> bool = "caml_string_equal" [@@noalloc]
 (** [equal s0 s1] is [true] if and only if [s0] and [s1] are character-wise
     equal.
     @since 4.03 (4.05 in StringLabels) *)
 
-val compare : t -> t -> int
+external compare : (t[@local_opt]) -> (t[@local_opt]) -> int = "%compare"
 (** [compare s0 s1] sorts [s0] and [s1] in lexicographical order. [compare]
     behaves like {!Stdlib.compare} on strings but may be more efficient. *)
 
@@ -490,14 +491,15 @@ val get_int32_ne : string -> int -> int32
     @since 4.13
 *)
 
-val hash : t -> int
+val hash : t @ local -> int
 (** An unseeded hash function for strings, with the same output value as
     {!Hashtbl.hash}. This function allows this module to be passed as argument
     to the functor {!Hashtbl.Make}.
 
     @since 5.0 *)
 
-val seeded_hash : int -> t -> int
+external seeded_hash :
+  int -> (t[@local_opt]) -> int @@ portable = "caml_string_hash" [@@noalloc]
 (** A seeded hash function for strings, with the same output value as
     {!Hashtbl.seeded_hash}. This function allows this module to be passed as
     argument to the functor {!Hashtbl.MakeSeeded}.
@@ -543,7 +545,7 @@ val get_int64_le : string -> int -> int64
 
 (* The following is for system use only. Do not call directly. *)
 
-external unsafe_get : string -> int -> char = "%string_unsafe_get"
+external unsafe_get : (t[@local_opt]) -> int -> char = "%string_unsafe_get"
 external unsafe_blit :
   src:string -> src_pos:int -> dst:bytes -> dst_pos:int -> len:int ->
     unit = "caml_blit_string" [@@noalloc]

--- a/testsuite/tests/lib-array/test_iarray.ml
+++ b/testsuite/tests/lib-array/test_iarray.ml
@@ -979,7 +979,7 @@ Iarray.stable_sort
      "five"; "six"; "seven"; "eight"; "nine";
      "ten" :];;
 [%%expect{|
-- : string iarray =
+- : String.t iarray =
 [:"one"; "two"; "six"; "ten"; "zero"; "four"; "five"; "nine"; "three";
   "seven"; "eight":]
 |}];;

--- a/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
+++ b/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
@@ -421,7 +421,7 @@ let match_guard r =
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let (y/388 =o? (field_mut 1 r/387))
-         (if (apply (field_imm 8 (global Stdlib__String!)) y/388 "")
+         (if (caml_string_equal y/388 "")
            (let
              (r/459 =[value<(consts ()) (non_consts ([0: *, *]))>]
                 (apply aliased_use/289 r/387))


### PR DESCRIPTION
This annotates some key functions on strings, namely `length`, `get`, `unsafe_get`, `equal`, `compare`, `hash`, and `seeded_hash`, as taking the string as `local`.