### PR TITLE
`printlambda.ml`: Show nullability, print layouts as layouts

### DIFF
--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -19,19 +19,29 @@ open Primitive
 open Types
 open Lambda
 
-let unboxed_integer = function
-  | Unboxed_nativeint -> "unboxed_nativeint"
-  | Unboxed_int32 -> "unboxed_int32"
-  | Unboxed_int64 -> "unboxed_int64"
+let unboxed_integer_suffix = function
+  | Unboxed_nativeint -> "nativeint"
+  | Unboxed_int32 -> "int32"
+  | Unboxed_int64 -> "int64"
 
-let unboxed_float = function
-  | Unboxed_float64 -> "unboxed_float"
-  | Unboxed_float32 -> "unboxed_float32"
+let unboxed_float_suffix = function
+  | Unboxed_float64 -> "float"
+  | Unboxed_float32 -> "float32"
 
-let unboxed_vector = function
-  | Unboxed_vec128 -> "unboxed_vec128"
-  | Unboxed_vec256 -> "unboxed_vec256"
-  | Unboxed_vec512 -> "unboxed_vec512"
+let unboxed_vector_suffix = function
+  | Unboxed_vec128 -> "vec128"
+  | Unboxed_vec256 -> "vec256"
+  | Unboxed_vec512 -> "vec512"
+
+(* Uses in most contexts get the "unboxed_" prefix *)
+let unboxed_integer ui = "unboxed_" ^ unboxed_integer_suffix ui
+let unboxed_float uf = "unboxed_" ^ unboxed_float_suffix uf
+let unboxed_vector uv = "unboxed_" ^ unboxed_vector_suffix uv
+
+(* As a layout it's just the name *)
+let unboxed_integer_layout = unboxed_integer_suffix
+let unboxed_float_layout = unboxed_float_suffix
+let unboxed_vector_layout = unboxed_vector_suffix
 
 let boxed_integer = function
   | Boxed_nativeint -> "nativeint"
@@ -176,70 +186,58 @@ let tag_and_constructor_shape print_value_kind ppf (tag, shape) =
     (constructor_shape print_value_kind)
     shape
 
-let variant_kind or_null_suffix print_value_kind ppf ~consts ~non_consts =
-  fprintf ppf "@[<hov 1>[(consts (%a))@ (non_consts (%a))%s]@]"
+let variant_kind print_value_kind ppf ~consts ~non_consts =
+  fprintf ppf "@[<hov 1>(consts (%a))@ (non_consts (%a))@]"
     (Format.pp_print_list ~pp_sep:Format.pp_print_space Format.pp_print_int)
     consts
     (Format.pp_print_list ~pp_sep:Format.pp_print_space
       (tag_and_constructor_shape print_value_kind))
     non_consts
-    or_null_suffix
 
-let value_kind print_value_kind_non_null ppf vk =
-  let or_null_suffix =
-    match vk.nullable with
-    | Non_nullable -> ""
-    | Nullable -> " or_null"
-  in
-  print_value_kind_non_null or_null_suffix ppf vk.raw_kind
+let or_null_suffix ppf nullable =
+  match nullable with
+  | Non_nullable -> ()
+  | Nullable -> fprintf ppf "_or_null"
 
-let rec value_kind_non_null or_null_suffix ppf = function
-  | Pgenval -> ()
-  | Pintval -> fprintf ppf "[int%s]" or_null_suffix
-  | Pboxedfloatval bf ->
-    fprintf ppf "[%s%s]" (boxed_float bf) or_null_suffix
-  | Parrayval elt_kind ->
-    fprintf ppf "[%sarray%s]" (array_kind elt_kind) or_null_suffix
-  | Pboxedintval bi ->
-    fprintf ppf "[%s%s]" (boxed_integer bi) or_null_suffix
-  | Pboxedvectorval bv ->
-    fprintf ppf "[%s%s]" (boxed_vector bv) or_null_suffix
+let rec raw_value_kind ppf rk =
+  match rk with
+  | Pgenval -> fprintf ppf "value"
+  | Pintval -> fprintf ppf "int"
+  | Pboxedfloatval bf -> fprintf ppf "%s" (boxed_float bf)
+  | Parrayval elt_kind -> fprintf ppf "%sarray" (array_kind elt_kind)
+  | Pboxedintval bi -> fprintf ppf "%s" (boxed_integer bi)
+  | Pboxedvectorval bv -> fprintf ppf "%s" (boxed_vector bv)
   | Pvariant { consts; non_consts; } ->
-    variant_kind or_null_suffix (value_kind value_kind_non_null')
-      ppf ~consts ~non_consts
+    variant_kind value_kind ppf ~consts ~non_consts
 
-and value_kind_non_null' or_null_suffix ppf = function
-  | Pgenval -> fprintf ppf "*"
-  | Pintval -> fprintf ppf "[int%s]" or_null_suffix
-  | Pboxedfloatval bf ->
-    fprintf ppf "[%s%s]" (boxed_float bf) or_null_suffix
-  | Parrayval elt_kind ->
-    fprintf ppf "[%sarray%s]" (array_kind elt_kind) or_null_suffix
-  | Pboxedintval bi ->
-    fprintf ppf "[%s%s]" (boxed_integer bi) or_null_suffix
-  | Pboxedvectorval bv ->
-    fprintf ppf "[%s%s]" (boxed_vector bv) or_null_suffix
-  | Pvariant { consts; non_consts; } ->
-    variant_kind or_null_suffix (value_kind value_kind_non_null')
-      ppf ~consts ~non_consts
+and value_kind ppf vk =
+  match vk with
+  | { raw_kind = Pgenval; nullable = Non_nullable } -> fprintf ppf "*"
+  | { raw_kind = Pgenval; nullable = Nullable } -> fprintf ppf "?"
+  | { raw_kind; nullable } ->
+    fprintf ppf "@[<hov 1>value%a<@,%a>@]"
+      or_null_suffix nullable
+      raw_value_kind raw_kind
 
-let rec layout' is_top ppf layout_ =
+let rec layout ppf layout_ =
   match layout_ with
-  | Pvalue k ->
-    (if is_top then value_kind value_kind_non_null
-     else value_kind value_kind_non_null')
-      ppf k
-  | Ptop -> fprintf ppf "[top]"
-  | Pbottom -> fprintf ppf "[bottom]"
-  | Punboxed_float bf -> fprintf ppf "[%s]" (unboxed_float bf)
-  | Punboxed_int bi -> fprintf ppf "[%s]" (unboxed_integer bi)
-  | Punboxed_vector bv -> fprintf ppf "[%s]" (unboxed_vector bv)
+  | Pvalue k -> value_kind ppf k
+  | Ptop -> fprintf ppf "top"
+  | Pbottom -> fprintf ppf "bottom"
+  | Punboxed_float bf -> fprintf ppf "%s" (unboxed_float_layout bf)
+  | Punboxed_int bi -> fprintf ppf "%s" (unboxed_integer_layout bi)
+  | Punboxed_vector bv -> fprintf ppf "%s" (unboxed_vector_layout bv)
   | Punboxed_product layouts ->
     fprintf ppf "@[<hov 1>#(%a)@]"
-      (pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf ",@ ") (layout' false))
+      (pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf ",@ ") layout)
       layouts
 
-let layout ppf layout_ = layout' true ppf layout_
+let layout_annotation ppf layout_ =
+  match layout_ with
+  | Pvalue { raw_kind = Pgenval; nullable = Non_nullable } -> ()
+  | Pvalue { raw_kind = Pgenval; nullable = Nullable } ->
+    fprintf ppf "?"
+  | _ -> fprintf ppf "[%a]" layout layout_
 
 let return_kind ppf (mode, kind) =
   let smode = locality_mode_if_local mode in
@@ -263,37 +261,17 @@ let return_kind ppf (mode, kind) =
     | Pboxedvectorval bv ->
       fprintf ppf ": %s%s%s@ " smode (boxed_vector bv) or_null_suffix
     | Pvariant { consts; non_consts; } ->
-      variant_kind or_null_suffix (value_kind value_kind_non_null')
-        ppf ~consts ~non_consts
+      fprintf ppf ": %a@ "
+        (fun ppf () -> variant_kind value_kind ppf ~consts ~non_consts) ()
   end
   | Punboxed_float bf -> fprintf ppf ": %s@ " (unboxed_float bf)
   | Punboxed_int bi -> fprintf ppf ": %s@ " (unboxed_integer bi)
   | Punboxed_vector bv -> fprintf ppf ": %s@ " (unboxed_vector bv)
-  | Punboxed_product _ -> fprintf ppf ": %a" layout kind
+  | Punboxed_product _ -> fprintf ppf ": %a@ " layout kind
   | Ptop -> fprintf ppf ": top@ "
   | Pbottom -> fprintf ppf ": bottom@ "
 
-let field_kind_non_null or_null_suffix ppf = function
-  | Pgenval -> pp_print_string ppf "*"
-  | Pintval -> fprintf ppf "int%s" or_null_suffix
-  | Pboxedfloatval bf ->
-    fprintf ppf "%s%s" (boxed_float bf) or_null_suffix
-  | Parrayval elt_kind ->
-    fprintf ppf "%s-array%s" (array_kind elt_kind) or_null_suffix
-  | Pboxedintval bi ->
-    fprintf ppf "%s%s" (boxed_integer bi) or_null_suffix
-  | Pboxedvectorval bv ->
-    fprintf ppf "%s%s" (boxed_vector bv) or_null_suffix
-  | Pvariant { consts; non_consts; } ->
-    fprintf ppf "@[<hov 1>[(consts (%a))@ (non_consts (%a))%s]@]"
-      (Format.pp_print_list ~pp_sep:Format.pp_print_space Format.pp_print_int)
-      consts
-      (Format.pp_print_list ~pp_sep:Format.pp_print_space
-        (tag_and_constructor_shape (value_kind value_kind_non_null')))
-      non_consts
-      or_null_suffix
-
-let field_kind = value_kind field_kind_non_null
+let field_kind = value_kind
 
 let locality_kind = function
   | Alloc_heap -> ""
@@ -385,7 +363,7 @@ let rec mixed_block_element
   : 'a. (_ -> 'a -> _) -> _ -> 'a mixed_block_element -> _ =
   fun print_mode ppf elt ->
   match elt with
-  | Value vk -> value_kind value_kind_non_null ppf vk
+  | Value vk -> value_kind ppf vk
   | Float_boxed param -> fprintf ppf "float_boxed(%a)" print_mode param
   | Float64 -> fprintf ppf "float64"
   | Float32 -> fprintf ppf "float32"
@@ -583,11 +561,11 @@ let primitive ppf = function
   | Preperform -> fprintf ppf "reperform"
   | Pmake_unboxed_product layouts ->
       fprintf ppf "make_unboxed_product #(%a)"
-        (pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf ", ") (layout' false))
+        (pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf ", ") layout)
         layouts
   | Punboxed_product_field (n, layouts) ->
       fprintf ppf "unboxed_product_field %d #(%a)" n
-        (pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf ", ") (layout' false))
+        (pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf ", ") layout)
         layouts
   | Parray_element_size_in_bytes ak ->
       fprintf ppf "array_element_size_in_bytes (%s)" (array_kind ak)
@@ -1301,7 +1279,7 @@ let rec lam ppf = function
         | Lmutlet(k, id, _duid, arg, body) as l ->
            if sp then fprintf ppf "@ ";
            fprintf ppf "@[<2>%a =%s%a@ %a@]"
-             Ident.print id (let_kind l) layout k lam arg;
+             Ident.print id (let_kind l) layout_annotation k lam arg;
            letbody ~sp:true body
         | expr -> expr in
       fprintf ppf "@[<2>(let@ @[<hv 1>(";
@@ -1374,7 +1352,8 @@ let rec lam ppf = function
         lam lbody i
         (fun ppf vars ->
            List.iter
-             (fun (x, _duid, k) -> fprintf ppf " %a%a" Ident.print x layout k)
+             (fun (x, _duid, k) ->
+                fprintf ppf " %a%a" Ident.print x layout_annotation k)
              vars
         )
         vars
@@ -1451,7 +1430,8 @@ and lfunction ppf {kind; params; return; body; attr; ret_mode; mode} =
         List.iter (fun (p : Lambda.lparam) ->
             let { unbox_param } = p.attributes in
             fprintf ppf "@ %a%s%a%s"
-              Ident.print p.name (locality_kind p.mode) layout p.layout
+              Ident.print p.name (locality_kind p.mode)
+              layout_annotation p.layout
               (if unbox_param then "[@unboxable]" else "")
           ) params
     | Tupled ->
@@ -1463,7 +1443,7 @@ and lfunction ppf {kind; params; return; body; attr; ret_mode; mode} =
              if !first then first := false else fprintf ppf ",@ ";
              Ident.print ppf p.name;
              Format.fprintf ppf "%s" (locality_kind p.mode);
-             layout ppf p.layout;
+             layout_annotation ppf p.layout;
              if unbox_param then Format.fprintf ppf "[@unboxable]"
           )
           params;
@@ -1478,9 +1458,3 @@ let structured_constant = struct_const
 let lambda = lam
 
 let program ppf { code } = lambda ppf code
-
-let value_kind' = value_kind value_kind_non_null'
-
-let value_kind = value_kind value_kind_non_null
-
-let variant_kind = variant_kind ""

--- a/lambda/printlambda.mli
+++ b/lambda/printlambda.mli
@@ -29,7 +29,6 @@ val variant_kind : (formatter -> value_kind -> unit) ->
   formatter -> consts:int list -> non_consts:(int * constructor_shape) list ->
   unit
 val value_kind : formatter -> value_kind -> unit
-val value_kind' : formatter -> value_kind -> unit
 val layout : formatter -> layout -> unit
 val block_shape : formatter -> value_kind list option -> unit
 val record_rep : formatter -> Types.record_representation -> unit

--- a/testsuite/tests/basic-modules/anonymous.ocamlc.reference
+++ b/testsuite/tests/basic-modules/anonymous.ocamlc.reference
@@ -1,7 +1,9 @@
 (setglobal Anonymous!
   (seq
     (ignore
-      (let (x =[(consts ()) (non_consts ([0: [int], [int]]))] [0: 13 37])
+      (let
+        (x =[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>]
+           [0: 13 37])
         (makeblock 0 x)))
     (let
       (A =
@@ -12,20 +14,25 @@
            [0: "anonymous.ml" 35 6] [0: [0]]))
       (seq
         (ignore
-          (let (x =[(consts ()) (non_consts ([0: [int], [int]]))] [0: 4 2])
+          (let
+            (x =[value<
+                  (consts ()) (non_consts ([0: value<int>, value<int>]))>]
+               [0: 4 2])
             (makeblock 0 x)))
         (apply (field_imm 1 (global CamlinternalMod!)) [0: [0]] A A)
         (apply (field_imm 1 (global CamlinternalMod!)) [0: [0]] B
-          (let (x =[(consts ()) (non_consts ([0: *, *]))] [0: "foo" "bar"])
+          (let
+            (x =[value<(consts ()) (non_consts ([0: *, *]))>]
+               [0: "foo" "bar"])
             (makeblock 0)))
         (let
           (f = (function {nlocal = 0} param : int 0)
            s = (makemutable 0 (*) ""))
           (seq
             (ignore
-              (let (*match* =[int] (setfield_ptr 0 s "Hello World!"))
+              (let (*match* =[value<int>] (setfield_ptr 0 s "Hello World!"))
                 (makeblock 0)))
             (let
-              (drop = (function {nlocal = 0} param : int 0)
-               *match* =[int] (apply drop (field_mut 0 s)))
+              (drop = (function {nlocal = 0} param? : int 0)
+               *match* =[value<int>] (apply drop (field_mut 0 s)))
               (makeblock 0 A B f s drop))))))))

--- a/testsuite/tests/basic-modules/anonymous.ocamlopt.flambda.reference
+++ b/testsuite/tests/basic-modules/anonymous.ocamlopt.flambda.reference
@@ -1,6 +1,8 @@
 (seq
   (ignore
-    (let (x =[(consts ()) (non_consts ([0: [int], [int]]))] [0: 13 37])
+    (let
+      (x =[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>]
+         [0: 13 37])
       (makeblock 0 x)))
   (let
     (A =
@@ -11,20 +13,23 @@
          [0: "anonymous.ml" 35 6] [0: [0]]))
     (seq
       (ignore
-        (let (x =[(consts ()) (non_consts ([0: [int], [int]]))] [0: 4 2])
+        (let
+          (x =[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>]
+             [0: 4 2])
           (makeblock 0 x)))
       (apply (field_imm 1 (global CamlinternalMod!)) [0: [0]] A A)
       (apply (field_imm 1 (global CamlinternalMod!)) [0: [0]] B
-        (let (x =[(consts ()) (non_consts ([0: *, *]))] [0: "foo" "bar"])
+        (let
+          (x =[value<(consts ()) (non_consts ([0: *, *]))>] [0: "foo" "bar"])
           (makeblock 0)))
       (let
         (f = (function {nlocal = 0} param : int 0)
          s = (makemutable 0 (*) ""))
         (seq
           (ignore
-            (let (*match* =[int] (setfield_ptr 0 s "Hello World!"))
+            (let (*match* =[value<int>] (setfield_ptr 0 s "Hello World!"))
               (makeblock 0)))
           (let
-            (drop = (function {nlocal = 0} param : int 0)
-             *match* =[int] (apply drop (field_mut 0 s)))
+            (drop = (function {nlocal = 0} param? : int 0)
+             *match* =[value<int>] (apply drop (field_mut 0 s)))
             (makeblock 0 A B f s drop)))))))

--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -26,14 +26,20 @@ match (3, 2, 1) with
 | _ -> false
 ;;
 [%%expect{|
-(let (*match*/284 =[int] 3 *match*/285 =[int] 2 *match*/286 =[int] 1)
+(let
+  (*match*/284 =[value<int>] 3
+   *match*/285 =[value<int>] 2
+   *match*/286 =[value<int>] 1)
   (catch
     (catch
       (catch (if (!= *match*/285 3) (exit 3) (exit 1)) with (3)
         (if (!= *match*/284 1) (exit 2) (exit 1)))
      with (2) 0)
    with (1) 1))
-(let (*match*/284 =[int] 3 *match*/285 =[int] 2 *match*/286 =[int] 1)
+(let
+  (*match*/284 =[value<int>] 3
+   *match*/285 =[value<int>] 2
+   *match*/286 =[value<int>] 1)
   (catch (if (!= *match*/285 3) (if (!= *match*/284 1) 0 (exit 1)) (exit 1))
    with (1) 1))
 - : bool = false
@@ -47,31 +53,45 @@ match (3, 2, 1) with
 | _ -> false
 ;;
 [%%expect{|
-(let (*match*/289 =[int] 3 *match*/290 =[int] 2 *match*/291 =[int] 1)
+(let
+  (*match*/289 =[value<int>] 3
+   *match*/290 =[value<int>] 2
+   *match*/291 =[value<int>] 1)
   (catch
     (catch
       (catch
         (if (!= *match*/290 3) (exit 6)
           (let
-            (x/293 =a[(consts ()) (non_consts ([0: [int], [int], [int]]))]
+            (x/293 =a[value<
+                       (consts ())
+                        (non_consts ([0: value<int>, value<int>, value<int>]))>]
                (makeblock 0 *match*/289 *match*/290 *match*/291))
             (exit 4 x/293)))
        with (6)
         (if (!= *match*/289 1) (exit 5)
           (let
-            (x/292 =a[(consts ()) (non_consts ([0: [int], [int], [int]]))]
+            (x/292 =a[value<
+                       (consts ())
+                        (non_consts ([0: value<int>, value<int>, value<int>]))>]
                (makeblock 0 *match*/289 *match*/290 *match*/291))
             (exit 4 x/292))))
      with (5) 0)
-   with (4 x/287[(consts ()) (non_consts ([0: [int], [int], [int]]))])
+   with (4 x/287[value<
+                  (consts ())
+                   (non_consts ([0: value<int>, value<int>, value<int>]))>])
     (seq (ignore x/287) 1)))
-(let (*match*/289 =[int] 3 *match*/290 =[int] 2 *match*/291 =[int] 1)
+(let
+  (*match*/289 =[value<int>] 3
+   *match*/290 =[value<int>] 2
+   *match*/291 =[value<int>] 1)
   (catch
     (if (!= *match*/290 3)
       (if (!= *match*/289 1) 0
         (exit 4 (makeblock 0 *match*/289 *match*/290 *match*/291)))
       (exit 4 (makeblock 0 *match*/289 *match*/290 *match*/291)))
-   with (4 x/287[(consts ()) (non_consts ([0: [int], [int], [int]]))])
+   with (4 x/287[value<
+                  (consts ())
+                   (non_consts ([0: value<int>, value<int>, value<int>]))>])
     (seq (ignore x/287) 1)))
 - : bool = false
 |}];;
@@ -82,8 +102,8 @@ let _ = fun a b ->
   | ((true, _) as _g)
   | ((false, _) as _g) -> ()
 [%%expect{|
-(function {nlocal = 0} a/294[int] b/295 : int 0)
-(function {nlocal = 0} a/294[int] b/295 : int 0)
+(function {nlocal = 0} a/294[value<int>] b/295? : int 0)
+(function {nlocal = 0} a/294[value<int>] b/295? : int 0)
 - : bool -> 'a -> unit = <fun>
 |}];;
 
@@ -102,15 +122,14 @@ let _ = fun a b -> match a, b with
 | (false, _) as p -> p
 (* outside, trivial *)
 [%%expect {|
-(function {nlocal = 0} a/298[int] b/299
-  [(consts ()) (non_consts ([0: [int], *]))](let
-                                              (p/300 =a[(consts ())
-                                                        (non_consts (
-                                                        [0: [int], *]))]
-                                                 (makeblock 0 a/298 b/299))
-                                              p/300))
-(function {nlocal = 0} a/298[int] b/299
-  [(consts ()) (non_consts ([0: [int], *]))](makeblock 0 a/298 b/299))
+(function {nlocal = 0} a/298[value<int>] b/299?
+  : (consts ()) (non_consts ([0: value<int>, ?]))
+  (let
+    (p/300 =a[value<(consts ()) (non_consts ([0: value<int>, ?]))>]
+       (makeblock 0 a/298 b/299))
+    p/300))
+(function {nlocal = 0} a/298[value<int>] b/299?
+  : (consts ()) (non_consts ([0: value<int>, ?])) (makeblock 0 a/298 b/299))
 - : bool -> 'a -> bool * 'a = <fun>
 |}]
 
@@ -119,15 +138,14 @@ let _ = fun a b -> match a, b with
 | ((false, _) as p) -> p
 (* inside, trivial *)
 [%%expect{|
-(function {nlocal = 0} a/302[int] b/303
-  [(consts ()) (non_consts ([0: [int], *]))](let
-                                              (p/304 =a[(consts ())
-                                                        (non_consts (
-                                                        [0: [int], *]))]
-                                                 (makeblock 0 a/302 b/303))
-                                              p/304))
-(function {nlocal = 0} a/302[int] b/303
-  [(consts ()) (non_consts ([0: [int], *]))](makeblock 0 a/302 b/303))
+(function {nlocal = 0} a/302[value<int>] b/303?
+  : (consts ()) (non_consts ([0: value<int>, ?]))
+  (let
+    (p/304 =a[value<(consts ()) (non_consts ([0: value<int>, ?]))>]
+       (makeblock 0 a/302 b/303))
+    p/304))
+(function {nlocal = 0} a/302[value<int>] b/303?
+  : (consts ()) (non_consts ([0: value<int>, ?])) (makeblock 0 a/302 b/303))
 - : bool -> 'a -> bool * 'a = <fun>
 |}];;
 
@@ -136,20 +154,24 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, simple *)
 [%%expect {|
-(function {nlocal = 0} a/308[int] b/309
-  [(consts ())
-   (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
+(function {nlocal = 0} a/308[value<int>] b/309?
+  : (consts ())
+     (non_consts ([0: value<int>,
+                   value<(consts ()) (non_consts ([0: value<int>, ?]))>]))
   (let
-    (x/310 =a[int] a/308
-     p/311 =a[(consts ()) (non_consts ([0: [int], *]))]
+    (x/310 =a[value<int>] a/308
+     p/311 =a[value<(consts ()) (non_consts ([0: value<int>, ?]))>]
        (makeblock 0 a/308 b/309))
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/310
-      p/311)))
-(function {nlocal = 0} a/308[int] b/309
-  [(consts ())
-   (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
-  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/308
-    (makeblock 0 a/308 b/309)))
+    (makeblock 0 (value<int>,value<
+                              (consts ()) (non_consts ([0: value<int>, ?]))>)
+      x/310 p/311)))
+(function {nlocal = 0} a/308[value<int>] b/309?
+  : (consts ())
+     (non_consts ([0: value<int>,
+                   value<(consts ()) (non_consts ([0: value<int>, ?]))>]))
+  (makeblock 0 (value<int>,value<
+                            (consts ()) (non_consts ([0: value<int>, ?]))>)
+    a/308 (makeblock 0 a/308 b/309)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -158,20 +180,24 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, simple *)
 [%%expect {|
-(function {nlocal = 0} a/314[int] b/315
-  [(consts ())
-   (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
+(function {nlocal = 0} a/314[value<int>] b/315?
+  : (consts ())
+     (non_consts ([0: value<int>,
+                   value<(consts ()) (non_consts ([0: value<int>, ?]))>]))
   (let
-    (x/316 =a[int] a/314
-     p/317 =a[(consts ()) (non_consts ([0: [int], *]))]
+    (x/316 =a[value<int>] a/314
+     p/317 =a[value<(consts ()) (non_consts ([0: value<int>, ?]))>]
        (makeblock 0 a/314 b/315))
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/316
-      p/317)))
-(function {nlocal = 0} a/314[int] b/315
-  [(consts ())
-   (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
-  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/314
-    (makeblock 0 a/314 b/315)))
+    (makeblock 0 (value<int>,value<
+                              (consts ()) (non_consts ([0: value<int>, ?]))>)
+      x/316 p/317)))
+(function {nlocal = 0} a/314[value<int>] b/315?
+  : (consts ())
+     (non_consts ([0: value<int>,
+                   value<(consts ()) (non_consts ([0: value<int>, ?]))>]))
+  (makeblock 0 (value<int>,value<
+                            (consts ()) (non_consts ([0: value<int>, ?]))>)
+    a/314 (makeblock 0 a/314 b/315)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -180,30 +206,42 @@ let _ = fun a b -> match a, b with
 | (false, x) as p -> x, p
 (* outside, complex *)
 [%%expect{|
-(function {nlocal = 0} a/324[int] b/325[int]
-  [(consts ())
-   (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
+(function {nlocal = 0} a/324[value<int>] b/325[value<int>]
+  : (consts ())
+     (non_consts ([0: value<int>,
+                   value<
+                    (consts ()) (non_consts ([0: value<int>, value<int>]))>]))
   (if a/324
     (let
-      (x/326 =a[int] a/324
-       p/327 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+      (x/326 =a[value<int>] a/324
+       p/327 =a[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>]
          (makeblock 0 a/324 b/325))
-      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/326
-        p/327))
+      (makeblock 0 (value<int>,value<
+                                (consts ())
+                                 (non_consts ([0: value<int>, value<int>]))>)
+        x/326 p/327))
     (let
-      (x/328 =a[(consts ()) (non_consts ([0: ]))] b/325
-       p/329 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+      (x/328 =a[value<(consts ()) (non_consts ([0: ]))>] b/325
+       p/329 =a[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>]
          (makeblock 0 a/324 b/325))
-      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/328
-        p/329))))
-(function {nlocal = 0} a/324[int] b/325[int]
-  [(consts ())
-   (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
+      (makeblock 0 (value<int>,value<
+                                (consts ())
+                                 (non_consts ([0: value<int>, value<int>]))>)
+        x/328 p/329))))
+(function {nlocal = 0} a/324[value<int>] b/325[value<int>]
+  : (consts ())
+     (non_consts ([0: value<int>,
+                   value<
+                    (consts ()) (non_consts ([0: value<int>, value<int>]))>]))
   (if a/324
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/324
-      (makeblock 0 a/324 b/325))
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) b/325
-      (makeblock 0 a/324 b/325))))
+    (makeblock 0 (value<int>,value<
+                              (consts ())
+                               (non_consts ([0: value<int>, value<int>]))>)
+      a/324 (makeblock 0 a/324 b/325))
+    (makeblock 0 (value<int>,value<
+                              (consts ())
+                               (non_consts ([0: value<int>, value<int>]))>)
+      b/325 (makeblock 0 a/324 b/325))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -213,33 +251,49 @@ let _ = fun a b -> match a, b with
   -> x, p
 (* inside, complex *)
 [%%expect{|
-(function {nlocal = 0} a/330[int] b/331[int]
-  [(consts ())
-   (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
+(function {nlocal = 0} a/330[value<int>] b/331[value<int>]
+  : (consts ())
+     (non_consts ([0: value<int>,
+                   value<
+                    (consts ()) (non_consts ([0: value<int>, value<int>]))>]))
   (catch
     (if a/330
       (let
-        (x/338 =a[int] a/330
-         p/339 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+        (x/338 =a[value<int>] a/330
+         p/339 =a[value<
+                   (consts ()) (non_consts ([0: value<int>, value<int>]))>]
            (makeblock 0 a/330 b/331))
         (exit 10 x/338 p/339))
       (let
-        (x/336 =a[(consts ()) (non_consts ([0: ]))] b/331
-         p/337 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+        (x/336 =a[value<(consts ()) (non_consts ([0: ]))>] b/331
+         p/337 =a[value<
+                   (consts ()) (non_consts ([0: value<int>, value<int>]))>]
            (makeblock 0 a/330 b/331))
         (exit 10 x/336 p/337)))
-   with (10 x/332[int] p/333[(consts ()) (non_consts ([0: [int], [int]]))])
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/332
-      p/333)))
-(function {nlocal = 0} a/330[int] b/331[int]
-  [(consts ())
-   (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
+   with (10 x/332[value<int>] p/333[value<
+                                     (consts ())
+                                      (non_consts ([0: value<int>,
+                                                    value<int>]))>])
+    (makeblock 0 (value<int>,value<
+                              (consts ())
+                               (non_consts ([0: value<int>, value<int>]))>)
+      x/332 p/333)))
+(function {nlocal = 0} a/330[value<int>] b/331[value<int>]
+  : (consts ())
+     (non_consts ([0: value<int>,
+                   value<
+                    (consts ()) (non_consts ([0: value<int>, value<int>]))>]))
   (catch
     (if a/330 (exit 10 a/330 (makeblock 0 a/330 b/331))
       (exit 10 b/331 (makeblock 0 a/330 b/331)))
-   with (10 x/332[int] p/333[(consts ()) (non_consts ([0: [int], [int]]))])
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/332
-      p/333)))
+   with (10 x/332[value<int>] p/333[value<
+                                     (consts ())
+                                      (non_consts ([0: value<int>,
+                                                    value<int>]))>])
+    (makeblock 0 (value<int>,value<
+                              (consts ())
+                               (non_consts ([0: value<int>, value<int>]))>)
+      x/332 p/333)))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -252,30 +306,43 @@ let _ = fun a b -> match a, b with
 | (false as x, _) as p -> x, p
 (* outside, onecase *)
 [%%expect {|
-(function {nlocal = 0} a/340[int] b/341[int]
-  [(consts ())
-   (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
+(function {nlocal = 0} a/340[value<int>] b/341[value<int>]
+  : (consts ())
+     (non_consts ([0: value<int>,
+                   value<
+                    (consts ()) (non_consts ([0: value<int>, value<int>]))>]))
   (if a/340
     (let
-      (x/342 =a[int] a/340
-       _p/343 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+      (x/342 =a[value<int>] a/340
+       _p/343 =a[value<
+                  (consts ()) (non_consts ([0: value<int>, value<int>]))>]
          (makeblock 0 a/340 b/341))
-      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/342
-        [0: 1 1]))
+      (makeblock 0 (value<int>,value<
+                                (consts ())
+                                 (non_consts ([0: value<int>, value<int>]))>)
+        x/342 [0: 1 1]))
     (let
-      (x/344 =a[int] a/340
-       p/345 =a[(consts ()) (non_consts ([0: [int], [int]]))]
+      (x/344 =a[value<int>] a/340
+       p/345 =a[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>]
          (makeblock 0 a/340 b/341))
-      (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) x/344
-        p/345))))
-(function {nlocal = 0} a/340[int] b/341[int]
-  [(consts ())
-   (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], [int]]))]]))]
+      (makeblock 0 (value<int>,value<
+                                (consts ())
+                                 (non_consts ([0: value<int>, value<int>]))>)
+        x/344 p/345))))
+(function {nlocal = 0} a/340[value<int>] b/341[value<int>]
+  : (consts ())
+     (non_consts ([0: value<int>,
+                   value<
+                    (consts ()) (non_consts ([0: value<int>, value<int>]))>]))
   (if a/340
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/340
-      [0: 1 1])
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], [int]]))]) a/340
-      (makeblock 0 a/340 b/341))))
+    (makeblock 0 (value<int>,value<
+                              (consts ())
+                               (non_consts ([0: value<int>, value<int>]))>)
+      a/340 [0: 1 1])
+    (makeblock 0 (value<int>,value<
+                              (consts ())
+                               (non_consts ([0: value<int>, value<int>]))>)
+      a/340 (makeblock 0 a/340 b/341))))
 - : bool -> bool -> bool * (bool * bool) = <fun>
 |}]
 
@@ -284,20 +351,24 @@ let _ = fun a b -> match a, b with
 | ((false as x, _) as p) -> x, p
 (* inside, onecase *)
 [%%expect{|
-(function {nlocal = 0} a/346[int] b/347
-  [(consts ())
-   (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
+(function {nlocal = 0} a/346[value<int>] b/347?
+  : (consts ())
+     (non_consts ([0: value<int>,
+                   value<(consts ()) (non_consts ([0: value<int>, ?]))>]))
   (let
-    (x/348 =a[int] a/346
-     p/349 =a[(consts ()) (non_consts ([0: [int], *]))]
+    (x/348 =a[value<int>] a/346
+     p/349 =a[value<(consts ()) (non_consts ([0: value<int>, ?]))>]
        (makeblock 0 a/346 b/347))
-    (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) x/348
-      p/349)))
-(function {nlocal = 0} a/346[int] b/347
-  [(consts ())
-   (non_consts ([0: [int], [(consts ()) (non_consts ([0: [int], *]))]]))]
-  (makeblock 0 (int,[(consts ()) (non_consts ([0: [int], *]))]) a/346
-    (makeblock 0 a/346 b/347)))
+    (makeblock 0 (value<int>,value<
+                              (consts ()) (non_consts ([0: value<int>, ?]))>)
+      x/348 p/349)))
+(function {nlocal = 0} a/346[value<int>] b/347?
+  : (consts ())
+     (non_consts ([0: value<int>,
+                   value<(consts ()) (non_consts ([0: value<int>, ?]))>]))
+  (makeblock 0 (value<int>,value<
+                            (consts ()) (non_consts ([0: value<int>, ?]))>)
+    a/346 (makeblock 0 a/346 b/347)))
 - : bool -> 'a -> bool * (bool * 'a) = <fun>
 |}]
 
@@ -314,49 +385,32 @@ let _ =fun a b -> match a, b with
 | (_, _) as p -> p
 (* outside, tuplist *)
 [%%expect {|
-(function {nlocal = 0} a/359[int]
-  b/360[(consts (0))
-        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
-  [(consts ())
-   (non_consts ([0: [int], [(consts (0)) (non_consts ([0: *]))]]))](catch
-                                                                    (if a/359
-                                                                    (if b/360
-                                                                    (let
-                                                                    (p/361 =a
-                                                                    (field_imm 0
-                                                                    b/360))
-                                                                    p/361)
-                                                                    (exit 12))
-                                                                    (exit 12))
-                                                                    with (12)
-                                                                    (let
-                                                                    (p/362 =a
-                                                                    [(consts ())
-                                                                    (non_consts (
-                                                                    [0:
-                                                                    [int],
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *]))]]))]
-                                                                    (makeblock 0
-                                                                    a/359
-                                                                    b/360))
-                                                                    p/362)))
-(function {nlocal = 0} a/359[int]
-  b/360[(consts (0))
-        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
-  [(consts ())
-   (non_consts ([0: [int], [(consts (0)) (non_consts ([0: *]))]]))](catch
-                                                                    (if a/359
-                                                                    (if b/360
-                                                                    (field_imm 0
-                                                                    b/360)
-                                                                    (exit 12))
-                                                                    (exit 12))
-                                                                    with (12)
-                                                                    (makeblock 0
-                                                                    a/359
-                                                                    b/360)))
+(function {nlocal = 0} a/359[value<int>]
+  b/360[value<
+         (consts (0))
+          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+  : (consts ())
+     (non_consts ([0: value<int>, value<(consts (0)) (non_consts ([0: *]))>]))
+  (catch
+    (if a/359
+      (if b/360 (let (p/361 =a? (field_imm 0 b/360)) p/361) (exit 12))
+      (exit 12))
+   with (12)
+    (let
+      (p/362 =a[value<
+                 (consts ())
+                  (non_consts ([0: value<int>,
+                                value<(consts (0)) (non_consts ([0: *]))>]))>]
+         (makeblock 0 a/359 b/360))
+      p/362)))
+(function {nlocal = 0} a/359[value<int>]
+  b/360[value<
+         (consts (0))
+          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+  : (consts ())
+     (non_consts ([0: value<int>, value<(consts (0)) (non_consts ([0: *]))>]))
+  (catch (if a/359 (if b/360 (field_imm 0 b/360) (exit 12)) (exit 12))
+   with (12) (makeblock 0 a/359 b/360)))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]
 
@@ -365,72 +419,45 @@ let _ = fun a b -> match a, b with
 | ((_, _) as p) -> p
 (* inside, tuplist *)
 [%%expect{|
-(function {nlocal = 0} a/363[int]
-  b/364[(consts (0))
-        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
-  [(consts ())
-   (non_consts ([0: [int], [(consts (0)) (non_consts ([0: *]))]]))](catch
-                                                                    (catch
-                                                                    (if a/363
-                                                                    (if b/364
-                                                                    (let
-                                                                    (p/368 =a
-                                                                    (field_imm 0
-                                                                    b/364))
-                                                                    (exit 13
-                                                                    p/368))
-                                                                    (exit 14))
-                                                                    (exit 14))
-                                                                    with (14)
-                                                                    (let
-                                                                    (p/367 =a
-                                                                    [(consts ())
-                                                                    (non_consts (
-                                                                    [0:
-                                                                    [int],
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *]))]]))]
-                                                                    (makeblock 0
-                                                                    a/363
-                                                                    b/364))
-                                                                    (exit 13
-                                                                    p/367)))
-                                                                    with (13 p/365
-                                                                    [(consts ())
-                                                                    (non_consts (
-                                                                    [0:
-                                                                    [int],
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *]))]]))])
-                                                                    p/365))
-(function {nlocal = 0} a/363[int]
-  b/364[(consts (0))
-        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))]]))]
-  [(consts ())
-   (non_consts ([0: [int], [(consts (0)) (non_consts ([0: *]))]]))](catch
-                                                                    (catch
-                                                                    (if a/363
-                                                                    (if b/364
-                                                                    (exit 13
-                                                                    (field_imm 0
-                                                                    b/364))
-                                                                    (exit 14))
-                                                                    (exit 14))
-                                                                    with (14)
-                                                                    (exit 13
-                                                                    (makeblock 0
-                                                                    a/363
-                                                                    b/364)))
-                                                                    with (13 p/365
-                                                                    [(consts ())
-                                                                    (non_consts (
-                                                                    [0:
-                                                                    [int],
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *]))]]))])
-                                                                    p/365))
+(function {nlocal = 0} a/363[value<int>]
+  b/364[value<
+         (consts (0))
+          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+  : (consts ())
+     (non_consts ([0: value<int>, value<(consts (0)) (non_consts ([0: *]))>]))
+  (catch
+    (catch
+      (if a/363
+        (if b/364 (let (p/368 =a? (field_imm 0 b/364)) (exit 13 p/368))
+          (exit 14))
+        (exit 14))
+     with (14)
+      (let
+        (p/367 =a[value<
+                   (consts ())
+                    (non_consts ([0: value<int>,
+                                  value<(consts (0)) (non_consts ([0: *]))>]))>]
+           (makeblock 0 a/363 b/364))
+        (exit 13 p/367)))
+   with (13 p/365[value<
+                   (consts ())
+                    (non_consts ([0: value<int>,
+                                  value<(consts (0)) (non_consts ([0: *]))>]))>])
+    p/365))
+(function {nlocal = 0} a/363[value<int>]
+  b/364[value<
+         (consts (0))
+          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+  : (consts ())
+     (non_consts ([0: value<int>, value<(consts (0)) (non_consts ([0: *]))>]))
+  (catch
+    (catch
+      (if a/363 (if b/364 (exit 13 (field_imm 0 b/364)) (exit 14)) (exit 14))
+     with (14) (exit 13 (makeblock 0 a/363 b/364)))
+   with (13 p/365[value<
+                   (consts ())
+                    (non_consts ([0: value<int>,
+                                  value<(consts (0)) (non_consts ([0: *]))>]))>])
+    p/365))
 - : bool -> bool tuplist -> bool * bool tuplist = <fun>
 |}]

--- a/testsuite/tests/basic/patmatch_split_no_or.ml
+++ b/testsuite/tests/basic/patmatch_split_no_or.ml
@@ -17,7 +17,8 @@ let last_is_anys = function
 (let
   (last_is_anys/14 =
      (function {nlocal = 0}
-       param/16[(consts ()) (non_consts ([0: [int], [int]]))] : int
+       param/16[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>]
+       : int
        (catch
          (if (field_imm 0 param/16) (if (field_imm 1 param/16) (exit 1) 1)
            (if (field_imm 1 param/16) (exit 1) 2))
@@ -35,7 +36,8 @@ let last_is_vars = function
 (let
   (last_is_vars/21 =
      (function {nlocal = 0}
-       param/25[(consts ()) (non_consts ([0: [int], [int]]))] : int
+       param/25[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>]
+       : int
        (catch
          (if (field_imm 0 param/25) (if (field_imm 1 param/25) (exit 3) 1)
            (if (field_imm 1 param/25) (exit 3) 2))
@@ -73,13 +75,15 @@ let f = function
 ;;
 [%%expect{|
 (let
-  (C/31 = (apply (field_imm 0 (global Toploop!)) "C/31")
-   B/30 = (apply (field_imm 0 (global Toploop!)) "B/30")
-   A/29 = (apply (field_imm 0 (global Toploop!)) "A/29")
+  (C/31 =? (apply (field_imm 0 (global Toploop!)) "C/31")
+   B/30 =? (apply (field_imm 0 (global Toploop!)) "B/30")
+   A/29 =? (apply (field_imm 0 (global Toploop!)) "A/29")
    f/32 =
      (function {nlocal = 0}
-       param/34[(consts ()) (non_consts ([0: *, [int], [int]]))] : int
-       (let (*match*/35 =a (field_imm 0 param/34))
+       param/34[value<
+                 (consts ()) (non_consts ([0: *, value<int>, value<int>]))>]
+       : int
+       (let (*match*/35 =a? (field_imm 0 param/34))
          (catch
            (if (== *match*/35 A/29) (if (field_imm 1 param/34) 1 (exit 8))
              (exit 8))

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -182,7 +182,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
 (setglobal Test_locations!
   (letrec
     (fib
-       (function {nlocal = 0} n[int] : int
+       (function {nlocal = 0} n[value<int>] : int
          (funct-body Test_locations.fib test_locations.ml(17):548-606
            (if (isout 1 n)
              (before Test_locations.fib test_locations.ml(19):581-606

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -182,6 +182,6 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
 (setglobal Test_locations!
   (letrec
     (fib
-       (function {nlocal = 0} n[int] : int
+       (function {nlocal = 0} n[value<int>] : int
          (if (isout 1 n) (+ (apply fib (- n 1)) (apply fib (- n 2))) 1)))
     (makeblock 0 fib)))

--- a/testsuite/tests/functors/functors.compilers.reference
+++ b/testsuite/tests/functors/functors.compilers.reference
@@ -4,24 +4,28 @@
        (function {nlocal = 0} X is_a_functor always_inline never_loop
          (let
            (cow =
-              (function {nlocal = 0} x[int] : int (apply (field_imm 0 X) x))
-            sheep = (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
+              (function {nlocal = 0} x[value<int>] : int
+                (apply (field_imm 0 X) x))
+            sheep =
+              (function {nlocal = 0} x[value<int>] : int (+ 1 (apply cow x))))
            (makeblock 0 cow sheep)))
      F =
        (function {nlocal = 0} X Y is_a_functor always_inline never_loop
          (let
            (cow =
-              (function {nlocal = 0} x[int] : int
+              (function {nlocal = 0} x[value<int>] : int
                 (apply (field_imm 0 Y) (apply (field_imm 0 X) x)))
-            sheep = (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
+            sheep =
+              (function {nlocal = 0} x[value<int>] : int (+ 1 (apply cow x))))
            (makeblock 0 cow sheep)))
      F1 =
        (function {nlocal = 0} X Y is_a_functor always_inline never_loop
          (let
            (cow =
-              (function {nlocal = 0} x[int] : int
+              (function {nlocal = 0} x[value<int>] : int
                 (apply (field_imm 0 Y) (apply (field_imm 0 X) x)))
-            sheep = (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
+            sheep =
+              (function {nlocal = 0} x[value<int>] : int (+ 1 (apply cow x))))
            (makeblock 0 sheep)))
      F2 =
        (function {nlocal = 0} X Y is_a_functor always_inline never_loop
@@ -29,9 +33,10 @@
            (X =a (makeblock 0 (field_imm 1 X))
             Y =a (makeblock 0 (field_imm 1 Y))
             cow =
-              (function {nlocal = 0} x[int] : int
+              (function {nlocal = 0} x[value<int>] : int
                 (apply (field_imm 0 Y) (apply (field_imm 0 X) x)))
-            sheep = (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
+            sheep =
+              (function {nlocal = 0} x[value<int>] : int (+ 1 (apply cow x))))
            (makeblock 0 sheep)))
      M =
        (let
@@ -39,10 +44,11 @@
             (function {nlocal = 0} X Y is_a_functor always_inline never_loop
               (let
                 (cow =
-                   (function {nlocal = 0} x[int] : int
+                   (function {nlocal = 0} x[value<int>] : int
                      (apply (field_imm 0 Y) (apply (field_imm 0 X) x)))
                  sheep =
-                   (function {nlocal = 0} x[int] : int (+ 1 (apply cow x))))
+                   (function {nlocal = 0} x[value<int>] : int
+                     (+ 1 (apply cow x))))
                 (makeblock 0 cow sheep))))
          (makeblock 0
            (function {nlocal = 0} funarg funarg is_a_functor stub

--- a/testsuite/tests/lib-array/test_iarray_typeopt.ml
+++ b/testsuite/tests/lib-array/test_iarray_typeopt.ml
@@ -35,28 +35,28 @@ let _ = [| [: :] |];;
 
 let arr = [: 1; 2; 3 :];;
 [%%expect {|
-(let (arr/381 =[intarray] (makearray_imm[int] 1 2 3))
+(let (arr/381 =[value<intarray>] (makearray_imm[int] 1 2 3))
   (apply (field_imm 1 (global Toploop!)) "arr" arr/381))
 val arr : int iarray = [:1; 2; 3:]
 |}];;
 
 let _ = arr.:(1);;
 [%%expect {|
-(let (arr/381 = (apply (field_imm 0 (global Toploop!)) "arr"))
+(let (arr/381 =? (apply (field_imm 0 (global Toploop!)) "arr"))
   (iarray.get[int indexed by int] arr/381 1))
 - : int = 2
 |}]
 
 let _ = get arr 1;;
 [%%expect {|
-(let (arr/381 = (apply (field_imm 0 (global Toploop!)) "arr"))
+(let (arr/381 =? (apply (field_imm 0 (global Toploop!)) "arr"))
   (iarray.get[int indexed by int] arr/381 1))
 - : int = 2
 |}]
 
 let _ = unsafe_get arr 1;;
 [%%expect {|
-(let (arr/381 = (apply (field_imm 0 (global Toploop!)) "arr"))
+(let (arr/381 =? (apply (field_imm 0 (global Toploop!)) "arr"))
   (iarray.unsafe_get[int indexed by int] arr/381 1))
 - : int = 2
 |}]
@@ -66,28 +66,28 @@ let arr : int alias = [: 1; 2; 3 :];;
 [%%expect {|
 0
 type 'a alias = 'a iarray
-(let (arr/383 =[intarray] (makearray_imm[int] 1 2 3))
+(let (arr/383 =[value<intarray>] (makearray_imm[int] 1 2 3))
   (apply (field_imm 1 (global Toploop!)) "arr" arr/383))
 val arr : int alias = [:1; 2; 3:]
 |}];;
 
 let _ = arr.:(1);;
 [%%expect {|
-(let (arr/383 = (apply (field_imm 0 (global Toploop!)) "arr"))
+(let (arr/383 =? (apply (field_imm 0 (global Toploop!)) "arr"))
   (iarray.get[int indexed by int] arr/383 1))
 - : int = 2
 |}]
 
 let _ = get arr 1;;
 [%%expect {|
-(let (arr/383 = (apply (field_imm 0 (global Toploop!)) "arr"))
+(let (arr/383 =? (apply (field_imm 0 (global Toploop!)) "arr"))
   (iarray.get[int indexed by int] arr/383 1))
 - : int = 2
 |}]
 
 let _ = unsafe_get arr 1;;
 [%%expect {|
-(let (arr/383 = (apply (field_imm 0 (global Toploop!)) "arr"))
+(let (arr/383 =? (apply (field_imm 0 (global Toploop!)) "arr"))
   (iarray.unsafe_get[int indexed by int] arr/383 1))
 - : int = 2
 |}]
@@ -95,12 +95,12 @@ let _ = unsafe_get arr 1;;
 let mut_arr = [| 1; 2; 3 |];;
 let arr = of_array mut_arr;;
 [%%expect {|
-(let (mut_arr/384 =[intarray] (makearray[int] 1 2 3))
+(let (mut_arr/384 =[value<intarray>] (makearray[int] 1 2 3))
   (apply (field_imm 1 (global Toploop!)) "mut_arr" mut_arr/384))
 val mut_arr : int array = [|1; 2; 3|]
 (let
-  (mut_arr/384 = (apply (field_imm 0 (global Toploop!)) "mut_arr")
-   arr/385 =[intarray]
+  (mut_arr/384 =? (apply (field_imm 0 (global Toploop!)) "mut_arr")
+   arr/385 =[value<intarray>]
      (apply (field_imm 13 (global Stdlib_stable__Iarray!)) mut_arr/384))
   (apply (field_imm 1 (global Toploop!)) "arr" arr/385))
 val arr : int iarray = [:1; 2; 3:]
@@ -108,21 +108,21 @@ val arr : int iarray = [:1; 2; 3:]
 
 let _ = arr.:(1);;
 [%%expect {|
-(let (arr/385 = (apply (field_imm 0 (global Toploop!)) "arr"))
+(let (arr/385 =? (apply (field_imm 0 (global Toploop!)) "arr"))
   (iarray.get[int indexed by int] arr/385 1))
 - : int = 2
 |}]
 
 let _ = get arr 1;;
 [%%expect {|
-(let (arr/385 = (apply (field_imm 0 (global Toploop!)) "arr"))
+(let (arr/385 =? (apply (field_imm 0 (global Toploop!)) "arr"))
   (iarray.get[int indexed by int] arr/385 1))
 - : int = 2
 |}]
 
 let _ = unsafe_get arr 1;;
 [%%expect {|
-(let (arr/385 = (apply (field_imm 0 (global Toploop!)) "arr"))
+(let (arr/385 =? (apply (field_imm 0 (global Toploop!)) "arr"))
   (iarray.unsafe_get[int indexed by int] arr/385 1))
 - : int = 2
 |}]
@@ -131,28 +131,28 @@ let _ = unsafe_get arr 1;;
 
 let mut_arr = [| 1; 2; 3 |];;
 [%%expect {|
-(let (mut_arr/386 =[intarray] (makearray[int] 1 2 3))
+(let (mut_arr/386 =[value<intarray>] (makearray[int] 1 2 3))
   (apply (field_imm 1 (global Toploop!)) "mut_arr" mut_arr/386))
 val mut_arr : int array = [|1; 2; 3|]
 |}]
 
 let _ = mut_arr.(1);;
 [%%expect {|
-(let (mut_arr/386 = (apply (field_imm 0 (global Toploop!)) "mut_arr"))
+(let (mut_arr/386 =? (apply (field_imm 0 (global Toploop!)) "mut_arr"))
   (array.get[int indexed by int] mut_arr/386 1))
 - : int = 2
 |}]
 
 let _ = Array.get mut_arr 1;;
 [%%expect {|
-(let (mut_arr/386 = (apply (field_imm 0 (global Toploop!)) "mut_arr"))
+(let (mut_arr/386 =? (apply (field_imm 0 (global Toploop!)) "mut_arr"))
   (array.get[int indexed by int] mut_arr/386 1))
 - : int = 2
 |}]
 
 let _ = Array.unsafe_get mut_arr 1;;
 [%%expect {|
-(let (mut_arr/386 = (apply (field_imm 0 (global Toploop!)) "mut_arr"))
+(let (mut_arr/386 =? (apply (field_imm 0 (global Toploop!)) "mut_arr"))
   (array.unsafe_get[int indexed by int] mut_arr/386 1))
 - : int = 2
 |}]
@@ -162,28 +162,28 @@ let mut_arr : int alias = [| 1; 2; 3 |];;
 [%%expect {|
 0
 type 'a alias = 'a array
-(let (mut_arr/438 =[intarray] (makearray[int] 1 2 3))
+(let (mut_arr/438 =[value<intarray>] (makearray[int] 1 2 3))
   (apply (field_imm 1 (global Toploop!)) "mut_arr" mut_arr/438))
 val mut_arr : int alias = [|1; 2; 3|]
 |}];;
 
 let _ = mut_arr.(1);;
 [%%expect {|
-(let (mut_arr/438 = (apply (field_imm 0 (global Toploop!)) "mut_arr"))
+(let (mut_arr/438 =? (apply (field_imm 0 (global Toploop!)) "mut_arr"))
   (array.get[int indexed by int] mut_arr/438 1))
 - : int = 2
 |}]
 
 let _ = Array.get mut_arr 1;;
 [%%expect {|
-(let (mut_arr/438 = (apply (field_imm 0 (global Toploop!)) "mut_arr"))
+(let (mut_arr/438 =? (apply (field_imm 0 (global Toploop!)) "mut_arr"))
   (array.get[int indexed by int] mut_arr/438 1))
 - : int = 2
 |}]
 
 let _ = Array.unsafe_get mut_arr 1;;
 [%%expect {|
-(let (mut_arr/438 = (apply (field_imm 0 (global Toploop!)) "mut_arr"))
+(let (mut_arr/438 =? (apply (field_imm 0 (global Toploop!)) "mut_arr"))
   (array.unsafe_get[int indexed by int] mut_arr/438 1))
 - : int = 2
 |}]
@@ -191,12 +191,12 @@ let _ = Array.unsafe_get mut_arr 1;;
 let arr = [: 1; 2; 3 :];;
 let mut_arr = to_array arr;;
 [%%expect {|
-(let (arr/439 =[intarray] (makearray_imm[int] 1 2 3))
+(let (arr/439 =[value<intarray>] (makearray_imm[int] 1 2 3))
   (apply (field_imm 1 (global Toploop!)) "arr" arr/439))
 val arr : int iarray = [:1; 2; 3:]
 (let
-  (arr/439 = (apply (field_imm 0 (global Toploop!)) "arr")
-   mut_arr/440 =[intarray]
+  (arr/439 =? (apply (field_imm 0 (global Toploop!)) "arr")
+   mut_arr/440 =[value<intarray>]
      (apply (field_imm 12 (global Stdlib_stable__Iarray!)) arr/439))
   (apply (field_imm 1 (global Toploop!)) "mut_arr" mut_arr/440))
 val mut_arr : int array = [|1; 2; 3|]
@@ -204,21 +204,21 @@ val mut_arr : int array = [|1; 2; 3|]
 
 let _ = mut_arr.(1);;
 [%%expect {|
-(let (mut_arr/440 = (apply (field_imm 0 (global Toploop!)) "mut_arr"))
+(let (mut_arr/440 =? (apply (field_imm 0 (global Toploop!)) "mut_arr"))
   (array.get[int indexed by int] mut_arr/440 1))
 - : int = 2
 |}]
 
 let _ = Array.get mut_arr 1;;
 [%%expect {|
-(let (mut_arr/440 = (apply (field_imm 0 (global Toploop!)) "mut_arr"))
+(let (mut_arr/440 =? (apply (field_imm 0 (global Toploop!)) "mut_arr"))
   (array.get[int indexed by int] mut_arr/440 1))
 - : int = 2
 |}]
 
 let _ = Array.unsafe_get mut_arr 1;;
 [%%expect {|
-(let (mut_arr/440 = (apply (field_imm 0 (global Toploop!)) "mut_arr"))
+(let (mut_arr/440 =? (apply (field_imm 0 (global Toploop!)) "mut_arr"))
   (array.unsafe_get[int indexed by int] mut_arr/440 1))
 - : int = 2
 |}]

--- a/testsuite/tests/match-side-effects/partiality.ml
+++ b/testsuite/tests/match-side-effects/partiality.ml
@@ -28,10 +28,10 @@ type t = { a : bool; mutable b : int option; }
   (f/289 =
      (function {nlocal = 0} x/291 : int
        (if (field_int 0 x/291)
-         (let (*match*/295 =o (field_mut 1 x/291))
+         (let (*match*/295 =o? (field_mut 1 x/291))
            (if *match*/295
              (if (seq (setfield_ptr 1 x/291 0) 0) 2
-               (let (*match*/296 =o (field_mut 1 x/291))
+               (let (*match*/296 =o? (field_mut 1 x/291))
                  (field_imm 0 *match*/296)))
              1))
          0)))
@@ -59,7 +59,7 @@ type t = { a : bool; mutable b : int option; }
   (f/302 =
      (function {nlocal = 0} x/303 : int
        (if (field_int 0 x/303)
-         (let (*match*/307 =o (field_mut 1 x/303))
+         (let (*match*/307 =o? (field_mut 1 x/303))
            (if *match*/307 (field_imm 0 *match*/307) 1))
          0)))
   (apply (field_imm 1 (global Toploop!)) "f" f/302))
@@ -89,18 +89,18 @@ let f r =
      (function {nlocal = 0} r/310 : int
        (region
          (let
-           (*match*/312 =[(consts (0)) (non_consts ([0: *]))]
+           (*match*/312 =[value<(consts (0)) (non_consts ([0: ?]))>]
               (makelocalblock 0 (*) r/310))
            (catch
              (if *match*/312
-               (let (*match*/314 =o (field_mut 0 (field_imm 0 *match*/312)))
+               (let (*match*/314 =o? (field_mut 0 (field_imm 0 *match*/312)))
                  (if *match*/314 (exit 7) 0))
                (exit 7))
             with (7)
              (if (seq (setfield_ptr 0 r/310 0) 0) 1
                (if *match*/312
                  (let
-                   (*match*/316 =o (field_mut 0 (field_imm 0 *match*/312)))
+                   (*match*/316 =o? (field_mut 0 (field_imm 0 *match*/312)))
                    (field_imm 0 *match*/316))
                  3)))))))
   (apply (field_imm 1 (global Toploop!)) "f" f/309))
@@ -124,8 +124,9 @@ let test = function
 type _ t = Int : int -> int t | Bool : bool -> bool t
 (let
   (test/320 =
-     (function {nlocal = 0} param/323[(consts (0)) (non_consts ([0: *]))]
-       : int (if param/323 (field_imm 0 (field_imm 0 param/323)) 0)))
+     (function {nlocal = 0}
+       param/323[value<(consts (0)) (non_consts ([0: ?]))>] : int
+       (if param/323 (field_imm 0 (field_imm 0 param/323)) 0)))
   (apply (field_imm 1 (global Toploop!)) "test" test/320))
 val test : int t option -> int = <fun>
 |}]
@@ -146,7 +147,7 @@ type _ t = Int : int -> int t | Bool : bool -> bool t
 (let
   (test/328 =
      (function {nlocal = 0} param/330 : int
-       (let (*match*/331 =o (field_mut 0 param/330))
+       (let (*match*/331 =o? (field_mut 0 param/330))
          (if *match*/331 (field_imm 0 (field_imm 0 *match*/331)) 0))))
   (apply (field_imm 1 (global Toploop!)) "test" test/328))
 val test : int t option ref -> int = <fun>
@@ -170,22 +171,27 @@ let test n =
 type _ t = Int : int -> int t | Bool : bool -> bool t
 (let
   (test/336 =
-     (function {nlocal = 0} n/337 : int
+     (function {nlocal = 0} n/337? : int
        (region
          (let
-           (*match*/340 =[(consts (0)) (non_consts ([0: *]))]
-              (makelocalblock 0 ([(consts ())
-                                  (non_consts ([0: *,
-                                                [(consts ())
-                                                 (non_consts ([1: [int]]
-                                                 [0: [int]]))]]))])
-                (makelocalblock 0 (*,[(consts ()) (non_consts ([1: [int]]
-                                      [0: [int]]))])
-                  (makelocalmutable 0 (int) 1) [0: 42])))
+           (*match*/340 =[value<(consts (0)) (non_consts ([0: ?]))>]
+              (makelocalblock 0 (value<
+                                  (consts ())
+                                   (non_consts ([0: *,
+                                                 value<
+                                                  (consts ())
+                                                   (non_consts ([1:
+                                                                 value<int>]
+                                                   [0: value<int>]))>]))>)
+                (makelocalblock 0 (*,value<
+                                      (consts ())
+                                       (non_consts ([1: value<int>]
+                                       [0: value<int>]))>)
+                  (makelocalmutable 0 (value<int>) 1) [0: 42])))
            (if *match*/340
              (let
-               (*match*/341 =a (field_imm 0 *match*/340)
-                *match*/343 =o (field_mut 0 (field_imm 0 *match*/341)))
+               (*match*/341 =a? (field_imm 0 *match*/340)
+                *match*/343 =o? (field_mut 0 (field_imm 0 *match*/341)))
                (if *match*/343 (field_imm 0 (field_imm 1 *match*/341))
                  (~ (field_imm 0 (field_imm 1 *match*/341)))))
              3)))))

--- a/testsuite/tests/match-side-effects/test_contexts_code.ml
+++ b/testsuite/tests/match-side-effects/test_contexts_code.ml
@@ -32,40 +32,25 @@ let example_1 () =
   | { a = true; b = Either.Left y } -> Result.Ok y;;
 (let
   (example_1/304 =
-     (function {nlocal = 0} param/328[int]
-       [(consts ()) (non_consts ([1: *] [0: *]))](region
-                                                   (let
-                                                     (input/306 =
-                                                        (makelocalmutable 0 (int,
-                                                          [(consts ())
-                                                           (non_consts (
-                                                           [1: *] [0: *]))])
-                                                          1 [0: 1]))
-                                                     (if
-                                                       (field_int 0
-                                                         input/306)
-                                                       (let
-                                                         (*match*/331 =o
-                                                            (field_mut 1
-                                                              input/306))
-                                                         (switch* *match*/331
-                                                          case tag 0:
-                                                           (if
-                                                             (seq
-                                                               (setfield_ptr(maybe-stack) 1
-                                                                 input/306
-                                                                 [1: 3])
-                                                               0)
-                                                             [1: 3]
-                                                             (let
-                                                               (*match*/333 =o
-                                                                  (field_mut 1
-                                                                    input/306))
-                                                               (makeblock 0 (int)
-                                                                 (field_imm 0
-                                                                   *match*/333))))
-                                                          case tag 1: [1: 2]))
-                                                       [1: 1])))))
+     (function {nlocal = 0} param/328[value<int>]
+       : (consts ()) (non_consts ([1: ?] [0: ?]))
+       (region
+         (let
+           (input/306 =
+              (makelocalmutable 0 (value<int>,value<
+                                               (consts ())
+                                                (non_consts ([1: ?] [0: ?]))>)
+                1 [0: 1]))
+           (if (field_int 0 input/306)
+             (let (*match*/331 =o? (field_mut 1 input/306))
+               (switch* *match*/331
+                case tag 0:
+                 (if (seq (setfield_ptr(maybe-stack) 1 input/306 [1: 3]) 0)
+                   [1: 3]
+                   (let (*match*/333 =o? (field_mut 1 input/306))
+                     (makeblock 0 (value<int>) (field_imm 0 *match*/333))))
+                case tag 1: [1: 2]))
+             [1: 1])))))
   (apply (field_imm 1 (global Toploop!)) "example_1" example_1/304))
 val example_1 : unit -> (bool, int) Result.t = <fun>
 |}]
@@ -96,48 +81,31 @@ let example_2 () =
   | { a = true; b = { mut = Either.Left y } } -> Result.Ok y;;
 (let
   (example_2/343 =
-     (function {nlocal = 0} param/347[int]
-       [(consts ()) (non_consts ([1: *] [0: *]))](region
-                                                   (let
-                                                     (input/345 =[(consts ())
-                                                                  (non_consts (
-                                                                  [0: [int],
-                                                                   *]))]
-                                                        (makelocalblock 0 (int,*)
-                                                          1
-                                                          (makelocalmutable 0 (
-                                                            [(consts ())
-                                                             (non_consts (
-                                                             [1: *] [0: *]))])
-                                                            [0: 1])))
-                                                     (if
-                                                       (field_int 0
-                                                         input/345)
-                                                       (let
-                                                         (*match*/351 =o
-                                                            (field_mut 0
-                                                              (field_imm 1
-                                                                input/345)))
-                                                         (switch* *match*/351
-                                                          case tag 0:
-                                                           (if
-                                                             (seq
-                                                               (setfield_ptr(maybe-stack) 0
-                                                                 (field_imm 1
-                                                                   input/345)
-                                                                 [1: 3])
-                                                               0)
-                                                             [1: 3]
-                                                             (let
-                                                               (*match*/354 =o
-                                                                  (field_mut 0
-                                                                    (field_imm 1
-                                                                    input/345)))
-                                                               (makeblock 0 (int)
-                                                                 (field_imm 0
-                                                                   *match*/354))))
-                                                          case tag 1: [1: 2]))
-                                                       [1: 1])))))
+     (function {nlocal = 0} param/347[value<int>]
+       : (consts ()) (non_consts ([1: ?] [0: ?]))
+       (region
+         (let
+           (input/345 =[value<(consts ()) (non_consts ([0: value<int>, *]))>]
+              (makelocalblock 0 (value<int>,*) 1
+                (makelocalmutable 0 (value<
+                                      (consts ()) (non_consts ([1: ?]
+                                       [0: ?]))>)
+                  [0: 1])))
+           (if (field_int 0 input/345)
+             (let (*match*/351 =o? (field_mut 0 (field_imm 1 input/345)))
+               (switch* *match*/351
+                case tag 0:
+                 (if
+                   (seq
+                     (setfield_ptr(maybe-stack) 0 (field_imm 1 input/345)
+                       [1: 3])
+                     0)
+                   [1: 3]
+                   (let
+                     (*match*/354 =o? (field_mut 0 (field_imm 1 input/345)))
+                     (makeblock 0 (value<int>) (field_imm 0 *match*/354))))
+                case tag 1: [1: 2]))
+             [1: 1])))))
   (apply (field_imm 1 (global Toploop!)) "example_2" example_2/343))
 val example_2 : unit -> (bool, int) Result.t = <fun>
 |}]
@@ -166,39 +134,26 @@ let example_3 () =
   | { mut = (true, Either.Left y) } -> Result.Ok y;;
 (let
   (example_3/361 =
-     (function {nlocal = 0} param/365[int]
-       [(consts ()) (non_consts ([1: *] [0: *]))](region
-                                                   (let
-                                                     (input/363 =mut[(consts ())
-                                                                    (non_consts (
-                                                                    [0:
-                                                                    [int],
-                                                                    [(consts ())
-                                                                    (non_consts (
-                                                                    [1: *]
-                                                                    [0: *]))]]))]
-                                                        [0: 1 [0: 1]]
-                                                      *match*/366 =o
-                                                        *input/363)
-                                                     (if
-                                                       (field_imm 0
-                                                         *match*/366)
-                                                       (switch* (field_imm 1
-                                                                  *match*/366)
-                                                        case tag 0:
-                                                         (if
-                                                           (seq
-                                                             (assign
-                                                               input/363
-                                                               [0: 1 [1: 3]])
-                                                             0)
-                                                           [1: 3]
-                                                           (makeblock 0 (int)
-                                                             (field_imm 0
-                                                               (field_imm 1
-                                                                 *match*/366))))
-                                                        case tag 1: [1: 2])
-                                                       [1: 1])))))
+     (function {nlocal = 0} param/365[value<int>]
+       : (consts ()) (non_consts ([1: ?] [0: ?]))
+       (region
+         (let
+           (input/363 =mut[value<
+                            (consts ())
+                             (non_consts ([0: value<int>,
+                                           value<
+                                            (consts ()) (non_consts (
+                                             [1: ?] [0: ?]))>]))>]
+              [0: 1 [0: 1]]
+            *match*/366 =o? *input/363)
+           (if (field_imm 0 *match*/366)
+             (switch* (field_imm 1 *match*/366)
+              case tag 0:
+               (if (seq (assign input/363 [0: 1 [1: 3]]) 0) [1: 3]
+                 (makeblock 0 (value<int>)
+                   (field_imm 0 (field_imm 1 *match*/366))))
+              case tag 1: [1: 2])
+             [1: 1])))))
   (apply (field_imm 1 (global Toploop!)) "example_3" example_3/361))
 val example_3 : unit -> (bool, int) Result.t = <fun>
 |}]

--- a/testsuite/tests/ppx-empty-cases/test.compilers.reference
+++ b/testsuite/tests/ppx-empty-cases/test.compilers.reference
@@ -1,19 +1,19 @@
 (setglobal Test!
   (let
     (empty_cases_returning_string/275 =
-       (function {nlocal = 0} param/277
+       (function {nlocal = 0} param/277?
          (raise
            (makeblock 0 (getpredef Match_failure/42!!) [0: "test.ml" 28 50])))
      empty_cases_returning_float64/278 =
-       (function {nlocal = 0} param/280 : unboxed_float
+       (function {nlocal = 0} param/280? : unboxed_float
          (raise
            (makeblock 0 (getpredef Match_failure/42!!) [0: "test.ml" 29 50])))
      empty_cases_accepting_string/281 =
-       (function {nlocal = 0} param/283
+       (function {nlocal = 0} param/283?
          (raise
            (makeblock 0 (getpredef Match_failure/42!!) [0: "test.ml" 30 50])))
      empty_cases_accepting_float64/284 =
-       (function {nlocal = 0} param/286[unboxed_float]
+       (function {nlocal = 0} param/286[float]
          (raise
            (makeblock 0 (getpredef Match_failure/42!!) [0: "test.ml" 31 50])))
      non_empty_cases_returning_string/287 =
@@ -29,7 +29,7 @@
          (raise
            (makeblock 0 (getpredef Assert_failure/52!!) [0: "test.ml" 34 68])))
      non_empty_cases_accepting_float64/296 =
-       (function {nlocal = 0} param/298[unboxed_float]
+       (function {nlocal = 0} param/298[float]
          (raise
            (makeblock 0 (getpredef Assert_failure/52!!) [0: "test.ml" 35 68]))))
     (makeblock 0 empty_cases_returning_string/275

--- a/testsuite/tests/syntactic-arity/max_arity_locals.compilers.reference
+++ b/testsuite/tests/syntactic-arity/max_arity_locals.compilers.reference
@@ -1,418 +1,506 @@
 (let
   (no_local_params =
-     (function {nlocal = 0} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14
-       x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31
-       x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43 x44 x45 x46 x47 x48
-       x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59 x60 x61 x62 x63 x64 x65
-       x66 x67 x68 x69 x70 x71 x72 x73 x74 x75 x76 x77 x78 x79 x80 x81 x82
-       x83 x84 x85 x86 x87 x88 x89 x90 x91 x92 x93 x94 x95 x96 x97 x98 x99
-       x100 x101 x102 x103 x104 x105 x106 x107 x108 x109 x110 x111 x112 x113
-       x114 x115 x116 x117 x118 x119 x120 x121 x122 x123 x124 x125 x126
-       (function {nlocal = 0} x127 x128 x129 x130 x131 : int 0))
+     (function {nlocal = 0} x1? x2? x3? x4? x5? x6? x7? x8? x9? x10? x11?
+       x12? x13? x14? x15? x16? x17? x18? x19? x20? x21? x22? x23? x24? x25?
+       x26? x27? x28? x29? x30? x31? x32? x33? x34? x35? x36? x37? x38? x39?
+       x40? x41? x42? x43? x44? x45? x46? x47? x48? x49? x50? x51? x52? x53?
+       x54? x55? x56? x57? x58? x59? x60? x61? x62? x63? x64? x65? x66? x67?
+       x68? x69? x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+       x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93? x94? x95?
+       x96? x97? x98? x99? x100? x101? x102? x103? x104? x105? x106? x107?
+       x108? x109? x110? x111? x112? x113? x114? x115? x116? x117? x118?
+       x119? x120? x121? x122? x123? x124? x125? x126?
+       (function {nlocal = 0} x127? x128? x129? x130? x131? : int 0))
    no_local_params__local_returning =
-     (function {nlocal = 0} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14
-       x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31
-       x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43 x44 x45 x46 x47 x48
-       x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59 x60 x61 x62 x63 x64 x65
-       x66 x67 x68 x69 x70 x71 x72 x73 x74 x75 x76 x77 x78 x79 x80 x81 x82
-       x83 x84 x85 x86 x87 x88 x89 x90 x91 x92 x93 x94 x95 x96 x97 x98 x99
-       x100 x101 x102 x103 x104 x105 x106 x107 x108 x109 x110 x111 x112 x113
-       x114 x115 x116 x117 x118 x119 x120 x121 x122 x123 x124 x125 x126
-       (function {nlocal = 1} x127 x128 x129 x130 x131
-         [(consts ()) (non_consts ([0: *, *]))](makelocalblock 0 x1 x2)))
+     (function {nlocal = 0} x1? x2? x3? x4? x5? x6? x7? x8? x9? x10? x11?
+       x12? x13? x14? x15? x16? x17? x18? x19? x20? x21? x22? x23? x24? x25?
+       x26? x27? x28? x29? x30? x31? x32? x33? x34? x35? x36? x37? x38? x39?
+       x40? x41? x42? x43? x44? x45? x46? x47? x48? x49? x50? x51? x52? x53?
+       x54? x55? x56? x57? x58? x59? x60? x61? x62? x63? x64? x65? x66? x67?
+       x68? x69? x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+       x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93? x94? x95?
+       x96? x97? x98? x99? x100? x101? x102? x103? x104? x105? x106? x107?
+       x108? x109? x110? x111? x112? x113? x114? x115? x116? x117? x118?
+       x119? x120? x121? x122? x123? x124? x125? x126?
+       (function {nlocal = 1} x127? x128? x129? x130? x131?
+         : (consts ()) (non_consts ([0: ?, ?])) (makelocalblock 0 x1 x2)))
    local_param_after_split =
-     (function {nlocal = 0} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14
-       x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31
-       x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43 x44 x45 x46 x47 x48
-       x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59 x60 x61 x62 x63 x64 x65
-       x66 x67 x68 x69 x70 x71 x72 x73 x74 x75 x76 x77 x78 x79 x80 x81 x82
-       x83 x84 x85 x86 x87 x88 x89 x90 x91 x92 x93 x94 x95 x96 x97 x98 x99
-       x100 x101 x102 x103 x104 x105 x106 x107 x108 x109 x110 x111 x112 x113
-       x114 x115 x116 x117 x118 x119 x120 x121 x122 x123 x124 x125 x126
-       (function {nlocal = 2} x127 x128 x129 x130[L] x131 : int 0))
+     (function {nlocal = 0} x1? x2? x3? x4? x5? x6? x7? x8? x9? x10? x11?
+       x12? x13? x14? x15? x16? x17? x18? x19? x20? x21? x22? x23? x24? x25?
+       x26? x27? x28? x29? x30? x31? x32? x33? x34? x35? x36? x37? x38? x39?
+       x40? x41? x42? x43? x44? x45? x46? x47? x48? x49? x50? x51? x52? x53?
+       x54? x55? x56? x57? x58? x59? x60? x61? x62? x63? x64? x65? x66? x67?
+       x68? x69? x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+       x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93? x94? x95?
+       x96? x97? x98? x99? x100? x101? x102? x103? x104? x105? x106? x107?
+       x108? x109? x110? x111? x112? x113? x114? x115? x116? x117? x118?
+       x119? x120? x121? x122? x123? x124? x125? x126?
+       (function {nlocal = 2} x127? x128? x129? x130[L]? x131? : int 0))
    local_param_after_split__local_returning =
-     (function {nlocal = 0} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14
-       x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31
-       x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43 x44 x45 x46 x47 x48
-       x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59 x60 x61 x62 x63 x64 x65
-       x66 x67 x68 x69 x70 x71 x72 x73 x74 x75 x76 x77 x78 x79 x80 x81 x82
-       x83 x84 x85 x86 x87 x88 x89 x90 x91 x92 x93 x94 x95 x96 x97 x98 x99
-       x100 x101 x102 x103 x104 x105 x106 x107 x108 x109 x110 x111 x112 x113
-       x114 x115 x116 x117 x118 x119 x120 x121 x122 x123 x124 x125 x126
-       (function {nlocal = 2} x127 x128 x129 x130[L] x131
-         [(consts ()) (non_consts ([0: *, *]))](makelocalblock 0 x1 x130)))
+     (function {nlocal = 0} x1? x2? x3? x4? x5? x6? x7? x8? x9? x10? x11?
+       x12? x13? x14? x15? x16? x17? x18? x19? x20? x21? x22? x23? x24? x25?
+       x26? x27? x28? x29? x30? x31? x32? x33? x34? x35? x36? x37? x38? x39?
+       x40? x41? x42? x43? x44? x45? x46? x47? x48? x49? x50? x51? x52? x53?
+       x54? x55? x56? x57? x58? x59? x60? x61? x62? x63? x64? x65? x66? x67?
+       x68? x69? x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+       x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93? x94? x95?
+       x96? x97? x98? x99? x100? x101? x102? x103? x104? x105? x106? x107?
+       x108? x109? x110? x111? x112? x113? x114? x115? x116? x117? x118?
+       x119? x120? x121? x122? x123? x124? x125? x126?
+       (function {nlocal = 2} x127? x128? x129? x130[L]? x131?
+         : (consts ()) (non_consts ([0: ?, ?])) (makelocalblock 0 x1 x130)))
    local_param_just_after_split =
-     (function {nlocal = 0} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14
-       x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31
-       x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43 x44 x45 x46 x47 x48
-       x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59 x60 x61 x62 x63 x64 x65
-       x66 x67 x68 x69 x70 x71 x72 x73 x74 x75 x76 x77 x78 x79 x80 x81 x82
-       x83 x84 x85 x86 x87 x88 x89 x90 x91 x92 x93 x94 x95 x96 x97 x98 x99
-       x100 x101 x102 x103 x104 x105 x106 x107 x108 x109 x110 x111 x112 x113
-       x114 x115 x116 x117 x118 x119 x120 x121 x122 x123 x124 x125 x126
-       (function {nlocal = 5} x127[L] x128 x129 x130 x131 : int 0))
+     (function {nlocal = 0} x1? x2? x3? x4? x5? x6? x7? x8? x9? x10? x11?
+       x12? x13? x14? x15? x16? x17? x18? x19? x20? x21? x22? x23? x24? x25?
+       x26? x27? x28? x29? x30? x31? x32? x33? x34? x35? x36? x37? x38? x39?
+       x40? x41? x42? x43? x44? x45? x46? x47? x48? x49? x50? x51? x52? x53?
+       x54? x55? x56? x57? x58? x59? x60? x61? x62? x63? x64? x65? x66? x67?
+       x68? x69? x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+       x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93? x94? x95?
+       x96? x97? x98? x99? x100? x101? x102? x103? x104? x105? x106? x107?
+       x108? x109? x110? x111? x112? x113? x114? x115? x116? x117? x118?
+       x119? x120? x121? x122? x123? x124? x125? x126?
+       (function {nlocal = 5} x127[L]? x128? x129? x130? x131? : int 0))
    local_param_just_after_split__local_returning =
-     (function {nlocal = 0} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14
-       x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31
-       x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43 x44 x45 x46 x47 x48
-       x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59 x60 x61 x62 x63 x64 x65
-       x66 x67 x68 x69 x70 x71 x72 x73 x74 x75 x76 x77 x78 x79 x80 x81 x82
-       x83 x84 x85 x86 x87 x88 x89 x90 x91 x92 x93 x94 x95 x96 x97 x98 x99
-       x100 x101 x102 x103 x104 x105 x106 x107 x108 x109 x110 x111 x112 x113
-       x114 x115 x116 x117 x118 x119 x120 x121 x122 x123 x124 x125 x126
-       (function {nlocal = 5} x127[L] x128 x129 x130 x131
-         [(consts ()) (non_consts ([0: *, *]))](makelocalblock 0 x1 x127)))
+     (function {nlocal = 0} x1? x2? x3? x4? x5? x6? x7? x8? x9? x10? x11?
+       x12? x13? x14? x15? x16? x17? x18? x19? x20? x21? x22? x23? x24? x25?
+       x26? x27? x28? x29? x30? x31? x32? x33? x34? x35? x36? x37? x38? x39?
+       x40? x41? x42? x43? x44? x45? x46? x47? x48? x49? x50? x51? x52? x53?
+       x54? x55? x56? x57? x58? x59? x60? x61? x62? x63? x64? x65? x66? x67?
+       x68? x69? x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+       x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93? x94? x95?
+       x96? x97? x98? x99? x100? x101? x102? x103? x104? x105? x106? x107?
+       x108? x109? x110? x111? x112? x113? x114? x115? x116? x117? x118?
+       x119? x120? x121? x122? x123? x124? x125? x126?
+       (function {nlocal = 5} x127[L]? x128? x129? x130? x131?
+         : (consts ()) (non_consts ([0: ?, ?])) (makelocalblock 0 x1 x127)))
    local_param_just_before_split =
-     (function {nlocal = 1} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14
-       x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31
-       x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43 x44 x45 x46 x47 x48
-       x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59 x60 x61 x62 x63 x64 x65
-       x66 x67 x68 x69 x70 x71 x72 x73 x74 x75 x76 x77 x78 x79 x80 x81 x82
-       x83 x84 x85 x86 x87 x88 x89 x90 x91 x92 x93 x94 x95 x96 x97 x98 x99
-       x100 x101 x102 x103 x104 x105 x106 x107 x108 x109 x110 x111 x112 x113
-       x114 x115 x116 x117 x118 x119 x120 x121 x122 x123 x124 x125 x126[L]
-       : local (function[L] {nlocal = 5} x127 x128 x129 x130 x131 : int 0))
+     (function {nlocal = 1} x1? x2? x3? x4? x5? x6? x7? x8? x9? x10? x11?
+       x12? x13? x14? x15? x16? x17? x18? x19? x20? x21? x22? x23? x24? x25?
+       x26? x27? x28? x29? x30? x31? x32? x33? x34? x35? x36? x37? x38? x39?
+       x40? x41? x42? x43? x44? x45? x46? x47? x48? x49? x50? x51? x52? x53?
+       x54? x55? x56? x57? x58? x59? x60? x61? x62? x63? x64? x65? x66? x67?
+       x68? x69? x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+       x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93? x94? x95?
+       x96? x97? x98? x99? x100? x101? x102? x103? x104? x105? x106? x107?
+       x108? x109? x110? x111? x112? x113? x114? x115? x116? x117? x118?
+       x119? x120? x121? x122? x123? x124? x125? x126[L]? : local
+       (function[L] {nlocal = 5} x127? x128? x129? x130? x131? : int 0))
    local_param_just_before_split__local_returning =
-     (function {nlocal = 1} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14
-       x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31
-       x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43 x44 x45 x46 x47 x48
-       x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59 x60 x61 x62 x63 x64 x65
-       x66 x67 x68 x69 x70 x71 x72 x73 x74 x75 x76 x77 x78 x79 x80 x81 x82
-       x83 x84 x85 x86 x87 x88 x89 x90 x91 x92 x93 x94 x95 x96 x97 x98 x99
-       x100 x101 x102 x103 x104 x105 x106 x107 x108 x109 x110 x111 x112 x113
-       x114 x115 x116 x117 x118 x119 x120 x121 x122 x123 x124 x125 x126[L]
-       : local
-       (function[L] {nlocal = 5} x127 x128 x129 x130 x131
-         [(consts ()) (non_consts ([0: *, *]))](makelocalblock 0 x1 x126)))
+     (function {nlocal = 1} x1? x2? x3? x4? x5? x6? x7? x8? x9? x10? x11?
+       x12? x13? x14? x15? x16? x17? x18? x19? x20? x21? x22? x23? x24? x25?
+       x26? x27? x28? x29? x30? x31? x32? x33? x34? x35? x36? x37? x38? x39?
+       x40? x41? x42? x43? x44? x45? x46? x47? x48? x49? x50? x51? x52? x53?
+       x54? x55? x56? x57? x58? x59? x60? x61? x62? x63? x64? x65? x66? x67?
+       x68? x69? x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+       x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93? x94? x95?
+       x96? x97? x98? x99? x100? x101? x102? x103? x104? x105? x106? x107?
+       x108? x109? x110? x111? x112? x113? x114? x115? x116? x117? x118?
+       x119? x120? x121? x122? x123? x124? x125? x126[L]? : local
+       (function[L] {nlocal = 5} x127? x128? x129? x130? x131?
+         : (consts ()) (non_consts ([0: ?, ?])) (makelocalblock 0 x1 x126)))
    local_param_before_split =
-     (function {nlocal = 119} x1 x2 x3 x4 x5 x6 x7 x8[L] x9 x10 x11 x12 x13
-       x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30
-       x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43 x44 x45 x46 x47
-       x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59 x60 x61 x62 x63 x64
-       x65 x66 x67 x68 x69 x70 x71 x72 x73 x74 x75 x76 x77 x78 x79 x80 x81
-       x82 x83 x84 x85 x86 x87 x88 x89 x90 x91 x92 x93 x94 x95 x96 x97 x98
-       x99 x100 x101 x102 x103 x104 x105 x106 x107 x108 x109 x110 x111 x112
-       x113 x114 x115 x116 x117 x118 x119 x120 x121 x122 x123 x124 x125 x126
-       : local (function[L] {nlocal = 5} x127 x128 x129 x130 x131 : int 0))
+     (function {nlocal = 119} x1? x2? x3? x4? x5? x6? x7? x8[L]? x9? x10?
+       x11? x12? x13? x14? x15? x16? x17? x18? x19? x20? x21? x22? x23? x24?
+       x25? x26? x27? x28? x29? x30? x31? x32? x33? x34? x35? x36? x37? x38?
+       x39? x40? x41? x42? x43? x44? x45? x46? x47? x48? x49? x50? x51? x52?
+       x53? x54? x55? x56? x57? x58? x59? x60? x61? x62? x63? x64? x65? x66?
+       x67? x68? x69? x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80?
+       x81? x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93? x94?
+       x95? x96? x97? x98? x99? x100? x101? x102? x103? x104? x105? x106?
+       x107? x108? x109? x110? x111? x112? x113? x114? x115? x116? x117?
+       x118? x119? x120? x121? x122? x123? x124? x125? x126? : local
+       (function[L] {nlocal = 5} x127? x128? x129? x130? x131? : int 0))
    local_param_before_split__local_returning =
-     (function {nlocal = 119} x1 x2 x3 x4 x5 x6 x7 x8[L] x9 x10 x11 x12 x13
-       x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30
-       x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43 x44 x45 x46 x47
-       x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59 x60 x61 x62 x63 x64
-       x65 x66 x67 x68 x69 x70 x71 x72 x73 x74 x75 x76 x77 x78 x79 x80 x81
-       x82 x83 x84 x85 x86 x87 x88 x89 x90 x91 x92 x93 x94 x95 x96 x97 x98
-       x99 x100 x101 x102 x103 x104 x105 x106 x107 x108 x109 x110 x111 x112
-       x113 x114 x115 x116 x117 x118 x119 x120 x121 x122 x123 x124 x125 x126
-       : local
-       (function[L] {nlocal = 5} x127 x128 x129 x130 x131
-         [(consts ()) (non_consts ([0: *, *]))](makelocalblock 0 x1 x8)))
+     (function {nlocal = 119} x1? x2? x3? x4? x5? x6? x7? x8[L]? x9? x10?
+       x11? x12? x13? x14? x15? x16? x17? x18? x19? x20? x21? x22? x23? x24?
+       x25? x26? x27? x28? x29? x30? x31? x32? x33? x34? x35? x36? x37? x38?
+       x39? x40? x41? x42? x43? x44? x45? x46? x47? x48? x49? x50? x51? x52?
+       x53? x54? x55? x56? x57? x58? x59? x60? x61? x62? x63? x64? x65? x66?
+       x67? x68? x69? x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80?
+       x81? x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93? x94?
+       x95? x96? x97? x98? x99? x100? x101? x102? x103? x104? x105? x106?
+       x107? x108? x109? x110? x111? x112? x113? x114? x115? x116? x117?
+       x118? x119? x120? x121? x122? x123? x124? x125? x126? : local
+       (function[L] {nlocal = 5} x127? x128? x129? x130? x131?
+         : (consts ()) (non_consts ([0: ?, ?])) (makelocalblock 0 x1 x8)))
    two_splits =
-     (function {nlocal = 0} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14
-       x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31
-       x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43 x44 x45 x46 x47 x48
-       x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59 x60 x61 x62 x63 x64 x65
-       x66 x67 x68 x69 x70 x71 x72 x73 x74 x75 x76 x77 x78 x79 x80 x81 x82
-       x83 x84 x85 x86 x87 x88 x89 x90 x91 x92 x93 x94 x95 x96 x97 x98 x99
-       x100 x101 x102 x103 x104 x105 x106 x107 x108 x109 x110 x111 x112 x113
-       x114 x115 x116 x117 x118 x119 x120 x121 x122 x123 x124 x125 x126
-       (function {nlocal = 0} x127 x128 x129 x130 x131 x132 x133 x134 x135
-         x136 x137 x138 x139 x140 x141 x142 x143 x144 x145 x146 x147 x148
-         x149 x150 x151 x152 x153 x154 x155 x156 x157 x158 x159 x160 x161
-         x162 x163 x164 x165 x166 x167 x168 x169 x170 x171 x172 x173 x174
-         x175 x176 x177 x178 x179 x180 x181 x182 x183 x184 x185 x186 x187
-         x188 x189 x190 x191 x192 x193 x194 x195 x196 x197 x198 x199 x200
-         x201 x202 x203 x204 x205 x206 x207 x208 x209 x210 x211 x212 x213
-         x214 x215 x216 x217 x218 x219 x220 x221 x222 x223 x224 x225 x226
-         x227 x228 x229 x230 x231 x232 x233 x234 x235 x236 x237 x238 x239
-         x240 x241 x242 x243 x244 x245 x246 x247 x248 x249 x250 x251 x252
-         (function {nlocal = 0} x253 x254 x255 x256 x257 x258 : int 0)))
+     (function {nlocal = 0} x1? x2? x3? x4? x5? x6? x7? x8? x9? x10? x11?
+       x12? x13? x14? x15? x16? x17? x18? x19? x20? x21? x22? x23? x24? x25?
+       x26? x27? x28? x29? x30? x31? x32? x33? x34? x35? x36? x37? x38? x39?
+       x40? x41? x42? x43? x44? x45? x46? x47? x48? x49? x50? x51? x52? x53?
+       x54? x55? x56? x57? x58? x59? x60? x61? x62? x63? x64? x65? x66? x67?
+       x68? x69? x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+       x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93? x94? x95?
+       x96? x97? x98? x99? x100? x101? x102? x103? x104? x105? x106? x107?
+       x108? x109? x110? x111? x112? x113? x114? x115? x116? x117? x118?
+       x119? x120? x121? x122? x123? x124? x125? x126?
+       (function {nlocal = 0} x127? x128? x129? x130? x131? x132? x133? x134?
+         x135? x136? x137? x138? x139? x140? x141? x142? x143? x144? x145?
+         x146? x147? x148? x149? x150? x151? x152? x153? x154? x155? x156?
+         x157? x158? x159? x160? x161? x162? x163? x164? x165? x166? x167?
+         x168? x169? x170? x171? x172? x173? x174? x175? x176? x177? x178?
+         x179? x180? x181? x182? x183? x184? x185? x186? x187? x188? x189?
+         x190? x191? x192? x193? x194? x195? x196? x197? x198? x199? x200?
+         x201? x202? x203? x204? x205? x206? x207? x208? x209? x210? x211?
+         x212? x213? x214? x215? x216? x217? x218? x219? x220? x221? x222?
+         x223? x224? x225? x226? x227? x228? x229? x230? x231? x232? x233?
+         x234? x235? x236? x237? x238? x239? x240? x241? x242? x243? x244?
+         x245? x246? x247? x248? x249? x250? x251? x252?
+         (function {nlocal = 0} x253? x254? x255? x256? x257? x258? : int 0)))
    two_splits__local_returning =
-     (function {nlocal = 0} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14
-       x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31
-       x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43 x44 x45 x46 x47 x48
-       x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59 x60 x61 x62 x63 x64 x65
-       x66 x67 x68 x69 x70 x71 x72 x73 x74 x75 x76 x77 x78 x79 x80 x81 x82
-       x83 x84 x85 x86 x87 x88 x89 x90 x91 x92 x93 x94 x95 x96 x97 x98 x99
-       x100 x101 x102 x103 x104 x105 x106 x107 x108 x109 x110 x111 x112 x113
-       x114 x115 x116 x117 x118 x119 x120 x121 x122 x123 x124 x125 x126
-       (function {nlocal = 0} x127 x128 x129 x130 x131 x132 x133 x134 x135
-         x136 x137 x138 x139 x140 x141 x142 x143 x144 x145 x146 x147 x148
-         x149 x150 x151 x152 x153 x154 x155 x156 x157 x158 x159 x160 x161
-         x162 x163 x164 x165 x166 x167 x168 x169 x170 x171 x172 x173 x174
-         x175 x176 x177 x178 x179 x180 x181 x182 x183 x184 x185 x186 x187
-         x188 x189 x190 x191 x192 x193 x194 x195 x196 x197 x198 x199 x200
-         x201 x202 x203 x204 x205 x206 x207 x208 x209 x210 x211 x212 x213
-         x214 x215 x216 x217 x218 x219 x220 x221 x222 x223 x224 x225 x226
-         x227 x228 x229 x230 x231 x232 x233 x234 x235 x236 x237 x238 x239
-         x240 x241 x242 x243 x244 x245 x246 x247 x248 x249 x250 x251 x252
-         (function {nlocal = 1} x253 x254 x255 x256 x257 x258
-           [(consts ()) (non_consts ([0: *, *]))](makelocalblock 0 x1 x258))))
+     (function {nlocal = 0} x1? x2? x3? x4? x5? x6? x7? x8? x9? x10? x11?
+       x12? x13? x14? x15? x16? x17? x18? x19? x20? x21? x22? x23? x24? x25?
+       x26? x27? x28? x29? x30? x31? x32? x33? x34? x35? x36? x37? x38? x39?
+       x40? x41? x42? x43? x44? x45? x46? x47? x48? x49? x50? x51? x52? x53?
+       x54? x55? x56? x57? x58? x59? x60? x61? x62? x63? x64? x65? x66? x67?
+       x68? x69? x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+       x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93? x94? x95?
+       x96? x97? x98? x99? x100? x101? x102? x103? x104? x105? x106? x107?
+       x108? x109? x110? x111? x112? x113? x114? x115? x116? x117? x118?
+       x119? x120? x121? x122? x123? x124? x125? x126?
+       (function {nlocal = 0} x127? x128? x129? x130? x131? x132? x133? x134?
+         x135? x136? x137? x138? x139? x140? x141? x142? x143? x144? x145?
+         x146? x147? x148? x149? x150? x151? x152? x153? x154? x155? x156?
+         x157? x158? x159? x160? x161? x162? x163? x164? x165? x166? x167?
+         x168? x169? x170? x171? x172? x173? x174? x175? x176? x177? x178?
+         x179? x180? x181? x182? x183? x184? x185? x186? x187? x188? x189?
+         x190? x191? x192? x193? x194? x195? x196? x197? x198? x199? x200?
+         x201? x202? x203? x204? x205? x206? x207? x208? x209? x210? x211?
+         x212? x213? x214? x215? x216? x217? x218? x219? x220? x221? x222?
+         x223? x224? x225? x226? x227? x228? x229? x230? x231? x232? x233?
+         x234? x235? x236? x237? x238? x239? x240? x241? x242? x243? x244?
+         x245? x246? x247? x248? x249? x250? x251? x252?
+         (function {nlocal = 1} x253? x254? x255? x256? x257? x258?
+           : (consts ()) (non_consts ([0: ?, ?])) (makelocalblock 0 x1 x258))))
    two_splits_local_param =
-     (function {nlocal = 0} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14
-       x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31
-       x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43 x44 x45 x46 x47 x48
-       x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59 x60 x61 x62 x63 x64 x65
-       x66 x67 x68 x69 x70 x71 x72 x73 x74 x75 x76 x77 x78 x79 x80 x81 x82
-       x83 x84 x85 x86 x87 x88 x89 x90 x91 x92 x93 x94 x95 x96 x97 x98 x99
-       x100 x101 x102 x103 x104 x105 x106 x107 x108 x109 x110 x111 x112 x113
-       x114 x115 x116 x117 x118 x119 x120 x121 x122 x123 x124 x125 x126
-       (function {nlocal = 101} x127 x128 x129 x130 x131 x132 x133 x134 x135
-         x136 x137 x138 x139 x140 x141 x142 x143 x144 x145 x146 x147 x148
-         x149 x150 x151 x152[L] x153 x154 x155 x156 x157 x158 x159 x160 x161
-         x162 x163 x164 x165 x166 x167 x168 x169 x170 x171 x172 x173 x174
-         x175 x176 x177 x178 x179 x180 x181 x182 x183 x184 x185 x186 x187
-         x188 x189 x190 x191 x192 x193 x194 x195 x196 x197 x198 x199 x200
-         x201 x202 x203 x204 x205 x206 x207 x208 x209 x210 x211 x212 x213
-         x214 x215 x216 x217 x218 x219 x220 x221 x222 x223 x224 x225 x226
-         x227 x228 x229 x230 x231 x232 x233 x234 x235 x236 x237 x238 x239
-         x240 x241 x242 x243 x244 x245 x246 x247 x248 x249 x250 x251 x252
-         : local
-         (function[L] {nlocal = 6} x253 x254 x255 x256 x257 x258 : int 0)))
+     (function {nlocal = 0} x1? x2? x3? x4? x5? x6? x7? x8? x9? x10? x11?
+       x12? x13? x14? x15? x16? x17? x18? x19? x20? x21? x22? x23? x24? x25?
+       x26? x27? x28? x29? x30? x31? x32? x33? x34? x35? x36? x37? x38? x39?
+       x40? x41? x42? x43? x44? x45? x46? x47? x48? x49? x50? x51? x52? x53?
+       x54? x55? x56? x57? x58? x59? x60? x61? x62? x63? x64? x65? x66? x67?
+       x68? x69? x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+       x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93? x94? x95?
+       x96? x97? x98? x99? x100? x101? x102? x103? x104? x105? x106? x107?
+       x108? x109? x110? x111? x112? x113? x114? x115? x116? x117? x118?
+       x119? x120? x121? x122? x123? x124? x125? x126?
+       (function {nlocal = 101} x127? x128? x129? x130? x131? x132? x133?
+         x134? x135? x136? x137? x138? x139? x140? x141? x142? x143? x144?
+         x145? x146? x147? x148? x149? x150? x151? x152[L]? x153? x154? x155?
+         x156? x157? x158? x159? x160? x161? x162? x163? x164? x165? x166?
+         x167? x168? x169? x170? x171? x172? x173? x174? x175? x176? x177?
+         x178? x179? x180? x181? x182? x183? x184? x185? x186? x187? x188?
+         x189? x190? x191? x192? x193? x194? x195? x196? x197? x198? x199?
+         x200? x201? x202? x203? x204? x205? x206? x207? x208? x209? x210?
+         x211? x212? x213? x214? x215? x216? x217? x218? x219? x220? x221?
+         x222? x223? x224? x225? x226? x227? x228? x229? x230? x231? x232?
+         x233? x234? x235? x236? x237? x238? x239? x240? x241? x242? x243?
+         x244? x245? x246? x247? x248? x249? x250? x251? x252? : local
+         (function[L] {nlocal = 6} x253? x254? x255? x256? x257? x258? : int
+           0)))
    two_splits_local_param__local_returning =
-     (function {nlocal = 0} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14
-       x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27 x28 x29 x30 x31
-       x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43 x44 x45 x46 x47 x48
-       x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59 x60 x61 x62 x63 x64 x65
-       x66 x67 x68 x69 x70 x71 x72 x73 x74 x75 x76 x77 x78 x79 x80 x81 x82
-       x83 x84 x85 x86 x87 x88 x89 x90 x91 x92 x93 x94 x95 x96 x97 x98 x99
-       x100 x101 x102 x103 x104 x105 x106 x107 x108 x109 x110 x111 x112 x113
-       x114 x115 x116 x117 x118 x119 x120 x121 x122 x123 x124 x125 x126
-       (function {nlocal = 101} x127 x128 x129 x130 x131 x132 x133 x134 x135
-         x136 x137 x138 x139 x140 x141 x142 x143 x144 x145 x146 x147 x148
-         x149 x150 x151 x152[L] x153 x154 x155 x156 x157 x158 x159 x160 x161
-         x162 x163 x164 x165 x166 x167 x168 x169 x170 x171 x172 x173 x174
-         x175 x176 x177 x178 x179 x180 x181 x182 x183 x184 x185 x186 x187
-         x188 x189 x190 x191 x192 x193 x194 x195 x196 x197 x198 x199 x200
-         x201 x202 x203 x204 x205 x206 x207 x208 x209 x210 x211 x212 x213
-         x214 x215 x216 x217 x218 x219 x220 x221 x222 x223 x224 x225 x226
-         x227 x228 x229 x230 x231 x232 x233 x234 x235 x236 x237 x238 x239
-         x240 x241 x242 x243 x244 x245 x246 x247 x248 x249 x250 x251 x252
-         : local
-         (function[L] {nlocal = 6} x253 x254 x255 x256 x257 x258
-           [(consts ()) (non_consts ([0: *, *]))](makelocalblock 0 x1 x152))))
+     (function {nlocal = 0} x1? x2? x3? x4? x5? x6? x7? x8? x9? x10? x11?
+       x12? x13? x14? x15? x16? x17? x18? x19? x20? x21? x22? x23? x24? x25?
+       x26? x27? x28? x29? x30? x31? x32? x33? x34? x35? x36? x37? x38? x39?
+       x40? x41? x42? x43? x44? x45? x46? x47? x48? x49? x50? x51? x52? x53?
+       x54? x55? x56? x57? x58? x59? x60? x61? x62? x63? x64? x65? x66? x67?
+       x68? x69? x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+       x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93? x94? x95?
+       x96? x97? x98? x99? x100? x101? x102? x103? x104? x105? x106? x107?
+       x108? x109? x110? x111? x112? x113? x114? x115? x116? x117? x118?
+       x119? x120? x121? x122? x123? x124? x125? x126?
+       (function {nlocal = 101} x127? x128? x129? x130? x131? x132? x133?
+         x134? x135? x136? x137? x138? x139? x140? x141? x142? x143? x144?
+         x145? x146? x147? x148? x149? x150? x151? x152[L]? x153? x154? x155?
+         x156? x157? x158? x159? x160? x161? x162? x163? x164? x165? x166?
+         x167? x168? x169? x170? x171? x172? x173? x174? x175? x176? x177?
+         x178? x179? x180? x181? x182? x183? x184? x185? x186? x187? x188?
+         x189? x190? x191? x192? x193? x194? x195? x196? x197? x198? x199?
+         x200? x201? x202? x203? x204? x205? x206? x207? x208? x209? x210?
+         x211? x212? x213? x214? x215? x216? x217? x218? x219? x220? x221?
+         x222? x223? x224? x225? x226? x227? x228? x229? x230? x231? x232?
+         x233? x234? x235? x236? x237? x238? x239? x240? x241? x242? x243?
+         x244? x245? x246? x247? x248? x249? x250? x251? x252? : local
+         (function[L] {nlocal = 6} x253? x254? x255? x256? x257? x258?
+           : (consts ()) (non_consts ([0: ?, ?])) (makelocalblock 0 x1 x152))))
    create_local =
-     (function {nlocal = 1} param[int]
-       [(consts ())
-        (non_consts ([0: *, *, *, *, *, *, *, *, *, *, *, *, *, *]))]
+     (function {nlocal = 1} param[value<int>]
+       : (consts ())
+          (non_consts ([0: *, *, *, *, *, *, *, *, *, *, *, *, *, *]))
        (let
          (no_local_params =
-            (function[L] {nlocal = 126} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11
-              x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27
-              x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43
-              x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59
-              x60 x61 x62 x63 x64 x65 x66 x67 x68 x69 x70 x71 x72 x73 x74 x75
-              x76 x77 x78 x79 x80 x81 x82 x83 x84 x85 x86 x87 x88 x89 x90 x91
-              x92 x93 x94 x95 x96 x97 x98 x99 x100 x101 x102 x103 x104 x105
-              x106 x107 x108 x109 x110 x111 x112 x113 x114 x115 x116 x117
-              x118 x119 x120 x121 x122 x123 x124 x125 x126 : local
-              (function[L] {nlocal = 5} x127 x128 x129 x130 x131 : int 0))
+            (function[L] {nlocal = 126} x1? x2? x3? x4? x5? x6? x7? x8? x9?
+              x10? x11? x12? x13? x14? x15? x16? x17? x18? x19? x20? x21?
+              x22? x23? x24? x25? x26? x27? x28? x29? x30? x31? x32? x33?
+              x34? x35? x36? x37? x38? x39? x40? x41? x42? x43? x44? x45?
+              x46? x47? x48? x49? x50? x51? x52? x53? x54? x55? x56? x57?
+              x58? x59? x60? x61? x62? x63? x64? x65? x66? x67? x68? x69?
+              x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+              x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93?
+              x94? x95? x96? x97? x98? x99? x100? x101? x102? x103? x104?
+              x105? x106? x107? x108? x109? x110? x111? x112? x113? x114?
+              x115? x116? x117? x118? x119? x120? x121? x122? x123? x124?
+              x125? x126? : local
+              (function[L] {nlocal = 5} x127? x128? x129? x130? x131? : int
+                0))
           no_local_params__local_returning =
-            (function[L] {nlocal = 126} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11
-              x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27
-              x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43
-              x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59
-              x60 x61 x62 x63 x64 x65 x66 x67 x68 x69 x70 x71 x72 x73 x74 x75
-              x76 x77 x78 x79 x80 x81 x82 x83 x84 x85 x86 x87 x88 x89 x90 x91
-              x92 x93 x94 x95 x96 x97 x98 x99 x100 x101 x102 x103 x104 x105
-              x106 x107 x108 x109 x110 x111 x112 x113 x114 x115 x116 x117
-              x118 x119 x120 x121 x122 x123 x124 x125 x126 : local
-              (function[L] {nlocal = 5} x127 x128 x129 x130 x131
-                [(consts ()) (non_consts ([0: *, *]))](makelocalblock 0 x1
-                                                        x2)))
+            (function[L] {nlocal = 126} x1? x2? x3? x4? x5? x6? x7? x8? x9?
+              x10? x11? x12? x13? x14? x15? x16? x17? x18? x19? x20? x21?
+              x22? x23? x24? x25? x26? x27? x28? x29? x30? x31? x32? x33?
+              x34? x35? x36? x37? x38? x39? x40? x41? x42? x43? x44? x45?
+              x46? x47? x48? x49? x50? x51? x52? x53? x54? x55? x56? x57?
+              x58? x59? x60? x61? x62? x63? x64? x65? x66? x67? x68? x69?
+              x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+              x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93?
+              x94? x95? x96? x97? x98? x99? x100? x101? x102? x103? x104?
+              x105? x106? x107? x108? x109? x110? x111? x112? x113? x114?
+              x115? x116? x117? x118? x119? x120? x121? x122? x123? x124?
+              x125? x126? : local
+              (function[L] {nlocal = 5} x127? x128? x129? x130? x131?
+                : (consts ()) (non_consts ([0: ?, ?]))
+                (makelocalblock 0 x1 x2)))
           local_param_after_split =
-            (function[L] {nlocal = 126} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11
-              x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27
-              x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43
-              x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59
-              x60 x61 x62 x63 x64 x65 x66 x67 x68 x69 x70 x71 x72 x73 x74 x75
-              x76 x77 x78 x79 x80 x81 x82 x83 x84 x85 x86 x87 x88 x89 x90 x91
-              x92 x93 x94 x95 x96 x97 x98 x99 x100 x101 x102 x103 x104 x105
-              x106 x107 x108 x109 x110 x111 x112 x113 x114 x115 x116 x117
-              x118 x119 x120 x121 x122 x123 x124 x125 x126 : local
-              (function[L] {nlocal = 5} x127 x128 x129 x130[L] x131 : int 0))
+            (function[L] {nlocal = 126} x1? x2? x3? x4? x5? x6? x7? x8? x9?
+              x10? x11? x12? x13? x14? x15? x16? x17? x18? x19? x20? x21?
+              x22? x23? x24? x25? x26? x27? x28? x29? x30? x31? x32? x33?
+              x34? x35? x36? x37? x38? x39? x40? x41? x42? x43? x44? x45?
+              x46? x47? x48? x49? x50? x51? x52? x53? x54? x55? x56? x57?
+              x58? x59? x60? x61? x62? x63? x64? x65? x66? x67? x68? x69?
+              x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+              x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93?
+              x94? x95? x96? x97? x98? x99? x100? x101? x102? x103? x104?
+              x105? x106? x107? x108? x109? x110? x111? x112? x113? x114?
+              x115? x116? x117? x118? x119? x120? x121? x122? x123? x124?
+              x125? x126? : local
+              (function[L] {nlocal = 5} x127? x128? x129? x130[L]? x131?
+                : int 0))
           local_param_after_split__local_returning =
-            (function[L] {nlocal = 126} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11
-              x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27
-              x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43
-              x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59
-              x60 x61 x62 x63 x64 x65 x66 x67 x68 x69 x70 x71 x72 x73 x74 x75
-              x76 x77 x78 x79 x80 x81 x82 x83 x84 x85 x86 x87 x88 x89 x90 x91
-              x92 x93 x94 x95 x96 x97 x98 x99 x100 x101 x102 x103 x104 x105
-              x106 x107 x108 x109 x110 x111 x112 x113 x114 x115 x116 x117
-              x118 x119 x120 x121 x122 x123 x124 x125 x126 : local
-              (function[L] {nlocal = 5} x127 x128 x129 x130[L] x131
-                [(consts ()) (non_consts ([0: *, *]))](makelocalblock 0 x1
-                                                        x130)))
+            (function[L] {nlocal = 126} x1? x2? x3? x4? x5? x6? x7? x8? x9?
+              x10? x11? x12? x13? x14? x15? x16? x17? x18? x19? x20? x21?
+              x22? x23? x24? x25? x26? x27? x28? x29? x30? x31? x32? x33?
+              x34? x35? x36? x37? x38? x39? x40? x41? x42? x43? x44? x45?
+              x46? x47? x48? x49? x50? x51? x52? x53? x54? x55? x56? x57?
+              x58? x59? x60? x61? x62? x63? x64? x65? x66? x67? x68? x69?
+              x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+              x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93?
+              x94? x95? x96? x97? x98? x99? x100? x101? x102? x103? x104?
+              x105? x106? x107? x108? x109? x110? x111? x112? x113? x114?
+              x115? x116? x117? x118? x119? x120? x121? x122? x123? x124?
+              x125? x126? : local
+              (function[L] {nlocal = 5} x127? x128? x129? x130[L]? x131?
+                : (consts ()) (non_consts ([0: ?, ?]))
+                (makelocalblock 0 x1 x130)))
           local_param_just_after_split =
-            (function[L] {nlocal = 126} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11
-              x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27
-              x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43
-              x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59
-              x60 x61 x62 x63 x64 x65 x66 x67 x68 x69 x70 x71 x72 x73 x74 x75
-              x76 x77 x78 x79 x80 x81 x82 x83 x84 x85 x86 x87 x88 x89 x90 x91
-              x92 x93 x94 x95 x96 x97 x98 x99 x100 x101 x102 x103 x104 x105
-              x106 x107 x108 x109 x110 x111 x112 x113 x114 x115 x116 x117
-              x118 x119 x120 x121 x122 x123 x124 x125 x126 : local
-              (function[L] {nlocal = 5} x127[L] x128 x129 x130 x131 : int 0))
+            (function[L] {nlocal = 126} x1? x2? x3? x4? x5? x6? x7? x8? x9?
+              x10? x11? x12? x13? x14? x15? x16? x17? x18? x19? x20? x21?
+              x22? x23? x24? x25? x26? x27? x28? x29? x30? x31? x32? x33?
+              x34? x35? x36? x37? x38? x39? x40? x41? x42? x43? x44? x45?
+              x46? x47? x48? x49? x50? x51? x52? x53? x54? x55? x56? x57?
+              x58? x59? x60? x61? x62? x63? x64? x65? x66? x67? x68? x69?
+              x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+              x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93?
+              x94? x95? x96? x97? x98? x99? x100? x101? x102? x103? x104?
+              x105? x106? x107? x108? x109? x110? x111? x112? x113? x114?
+              x115? x116? x117? x118? x119? x120? x121? x122? x123? x124?
+              x125? x126? : local
+              (function[L] {nlocal = 5} x127[L]? x128? x129? x130? x131?
+                : int 0))
           local_param_just_after_split__local_returning =
-            (function[L] {nlocal = 126} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11
-              x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27
-              x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43
-              x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59
-              x60 x61 x62 x63 x64 x65 x66 x67 x68 x69 x70 x71 x72 x73 x74 x75
-              x76 x77 x78 x79 x80 x81 x82 x83 x84 x85 x86 x87 x88 x89 x90 x91
-              x92 x93 x94 x95 x96 x97 x98 x99 x100 x101 x102 x103 x104 x105
-              x106 x107 x108 x109 x110 x111 x112 x113 x114 x115 x116 x117
-              x118 x119 x120 x121 x122 x123 x124 x125 x126 : local
-              (function[L] {nlocal = 5} x127[L] x128 x129 x130 x131
-                [(consts ()) (non_consts ([0: *, *]))](makelocalblock 0 x1
-                                                        x127)))
+            (function[L] {nlocal = 126} x1? x2? x3? x4? x5? x6? x7? x8? x9?
+              x10? x11? x12? x13? x14? x15? x16? x17? x18? x19? x20? x21?
+              x22? x23? x24? x25? x26? x27? x28? x29? x30? x31? x32? x33?
+              x34? x35? x36? x37? x38? x39? x40? x41? x42? x43? x44? x45?
+              x46? x47? x48? x49? x50? x51? x52? x53? x54? x55? x56? x57?
+              x58? x59? x60? x61? x62? x63? x64? x65? x66? x67? x68? x69?
+              x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+              x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93?
+              x94? x95? x96? x97? x98? x99? x100? x101? x102? x103? x104?
+              x105? x106? x107? x108? x109? x110? x111? x112? x113? x114?
+              x115? x116? x117? x118? x119? x120? x121? x122? x123? x124?
+              x125? x126? : local
+              (function[L] {nlocal = 5} x127[L]? x128? x129? x130? x131?
+                : (consts ()) (non_consts ([0: ?, ?]))
+                (makelocalblock 0 x1 x127)))
           local_param_just_before_split =
-            (function[L] {nlocal = 126} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11
-              x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27
-              x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43
-              x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59
-              x60 x61 x62 x63 x64 x65 x66 x67 x68 x69 x70 x71 x72 x73 x74 x75
-              x76 x77 x78 x79 x80 x81 x82 x83 x84 x85 x86 x87 x88 x89 x90 x91
-              x92 x93 x94 x95 x96 x97 x98 x99 x100 x101 x102 x103 x104 x105
-              x106 x107 x108 x109 x110 x111 x112 x113 x114 x115 x116 x117
-              x118 x119 x120 x121 x122 x123 x124 x125 x126[L] : local
-              (function[L] {nlocal = 5} x127 x128 x129 x130 x131 : int 0))
+            (function[L] {nlocal = 126} x1? x2? x3? x4? x5? x6? x7? x8? x9?
+              x10? x11? x12? x13? x14? x15? x16? x17? x18? x19? x20? x21?
+              x22? x23? x24? x25? x26? x27? x28? x29? x30? x31? x32? x33?
+              x34? x35? x36? x37? x38? x39? x40? x41? x42? x43? x44? x45?
+              x46? x47? x48? x49? x50? x51? x52? x53? x54? x55? x56? x57?
+              x58? x59? x60? x61? x62? x63? x64? x65? x66? x67? x68? x69?
+              x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+              x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93?
+              x94? x95? x96? x97? x98? x99? x100? x101? x102? x103? x104?
+              x105? x106? x107? x108? x109? x110? x111? x112? x113? x114?
+              x115? x116? x117? x118? x119? x120? x121? x122? x123? x124?
+              x125? x126[L]? : local
+              (function[L] {nlocal = 5} x127? x128? x129? x130? x131? : int
+                0))
           local_param_just_before_split__local_returning =
-            (function[L] {nlocal = 126} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11
-              x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27
-              x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43
-              x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59
-              x60 x61 x62 x63 x64 x65 x66 x67 x68 x69 x70 x71 x72 x73 x74 x75
-              x76 x77 x78 x79 x80 x81 x82 x83 x84 x85 x86 x87 x88 x89 x90 x91
-              x92 x93 x94 x95 x96 x97 x98 x99 x100 x101 x102 x103 x104 x105
-              x106 x107 x108 x109 x110 x111 x112 x113 x114 x115 x116 x117
-              x118 x119 x120 x121 x122 x123 x124 x125 x126[L] : local
-              (function[L] {nlocal = 5} x127 x128 x129 x130 x131
-                [(consts ()) (non_consts ([0: *, *]))](makelocalblock 0 x1
-                                                        x126)))
+            (function[L] {nlocal = 126} x1? x2? x3? x4? x5? x6? x7? x8? x9?
+              x10? x11? x12? x13? x14? x15? x16? x17? x18? x19? x20? x21?
+              x22? x23? x24? x25? x26? x27? x28? x29? x30? x31? x32? x33?
+              x34? x35? x36? x37? x38? x39? x40? x41? x42? x43? x44? x45?
+              x46? x47? x48? x49? x50? x51? x52? x53? x54? x55? x56? x57?
+              x58? x59? x60? x61? x62? x63? x64? x65? x66? x67? x68? x69?
+              x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+              x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93?
+              x94? x95? x96? x97? x98? x99? x100? x101? x102? x103? x104?
+              x105? x106? x107? x108? x109? x110? x111? x112? x113? x114?
+              x115? x116? x117? x118? x119? x120? x121? x122? x123? x124?
+              x125? x126[L]? : local
+              (function[L] {nlocal = 5} x127? x128? x129? x130? x131?
+                : (consts ()) (non_consts ([0: ?, ?]))
+                (makelocalblock 0 x1 x126)))
           local_param_before_split =
-            (function[L] {nlocal = 126} x1 x2 x3 x4 x5 x6 x7 x8[L] x9 x10 x11
-              x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27
-              x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43
-              x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59
-              x60 x61 x62 x63 x64 x65 x66 x67 x68 x69 x70 x71 x72 x73 x74 x75
-              x76 x77 x78 x79 x80 x81 x82 x83 x84 x85 x86 x87 x88 x89 x90 x91
-              x92 x93 x94 x95 x96 x97 x98 x99 x100 x101 x102 x103 x104 x105
-              x106 x107 x108 x109 x110 x111 x112 x113 x114 x115 x116 x117
-              x118 x119 x120 x121 x122 x123 x124 x125 x126 : local
-              (function[L] {nlocal = 5} x127 x128 x129 x130 x131 : int 0))
+            (function[L] {nlocal = 126} x1? x2? x3? x4? x5? x6? x7? x8[L]?
+              x9? x10? x11? x12? x13? x14? x15? x16? x17? x18? x19? x20? x21?
+              x22? x23? x24? x25? x26? x27? x28? x29? x30? x31? x32? x33?
+              x34? x35? x36? x37? x38? x39? x40? x41? x42? x43? x44? x45?
+              x46? x47? x48? x49? x50? x51? x52? x53? x54? x55? x56? x57?
+              x58? x59? x60? x61? x62? x63? x64? x65? x66? x67? x68? x69?
+              x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+              x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93?
+              x94? x95? x96? x97? x98? x99? x100? x101? x102? x103? x104?
+              x105? x106? x107? x108? x109? x110? x111? x112? x113? x114?
+              x115? x116? x117? x118? x119? x120? x121? x122? x123? x124?
+              x125? x126? : local
+              (function[L] {nlocal = 5} x127? x128? x129? x130? x131? : int
+                0))
           local_param_before_split__local_returning =
-            (function[L] {nlocal = 126} x1 x2 x3 x4 x5 x6 x7 x8[L] x9 x10 x11
-              x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27
-              x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43
-              x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59
-              x60 x61 x62 x63 x64 x65 x66 x67 x68 x69 x70 x71 x72 x73 x74 x75
-              x76 x77 x78 x79 x80 x81 x82 x83 x84 x85 x86 x87 x88 x89 x90 x91
-              x92 x93 x94 x95 x96 x97 x98 x99 x100 x101 x102 x103 x104 x105
-              x106 x107 x108 x109 x110 x111 x112 x113 x114 x115 x116 x117
-              x118 x119 x120 x121 x122 x123 x124 x125 x126 : local
-              (function[L] {nlocal = 5} x127 x128 x129 x130 x131
-                [(consts ()) (non_consts ([0: *, *]))](makelocalblock 0 x1
-                                                        x8)))
+            (function[L] {nlocal = 126} x1? x2? x3? x4? x5? x6? x7? x8[L]?
+              x9? x10? x11? x12? x13? x14? x15? x16? x17? x18? x19? x20? x21?
+              x22? x23? x24? x25? x26? x27? x28? x29? x30? x31? x32? x33?
+              x34? x35? x36? x37? x38? x39? x40? x41? x42? x43? x44? x45?
+              x46? x47? x48? x49? x50? x51? x52? x53? x54? x55? x56? x57?
+              x58? x59? x60? x61? x62? x63? x64? x65? x66? x67? x68? x69?
+              x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+              x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93?
+              x94? x95? x96? x97? x98? x99? x100? x101? x102? x103? x104?
+              x105? x106? x107? x108? x109? x110? x111? x112? x113? x114?
+              x115? x116? x117? x118? x119? x120? x121? x122? x123? x124?
+              x125? x126? : local
+              (function[L] {nlocal = 5} x127? x128? x129? x130? x131?
+                : (consts ()) (non_consts ([0: ?, ?]))
+                (makelocalblock 0 x1 x8)))
           two_splits =
-            (function[L] {nlocal = 126} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11
-              x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27
-              x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43
-              x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59
-              x60 x61 x62 x63 x64 x65 x66 x67 x68 x69 x70 x71 x72 x73 x74 x75
-              x76 x77 x78 x79 x80 x81 x82 x83 x84 x85 x86 x87 x88 x89 x90 x91
-              x92 x93 x94 x95 x96 x97 x98 x99 x100 x101 x102 x103 x104 x105
-              x106 x107 x108 x109 x110 x111 x112 x113 x114 x115 x116 x117
-              x118 x119 x120 x121 x122 x123 x124 x125 x126 : local
-              (function[L] {nlocal = 126} x127 x128 x129 x130 x131 x132 x133
-                x134 x135 x136 x137 x138 x139 x140 x141 x142 x143 x144 x145
-                x146 x147 x148 x149 x150 x151 x152 x153 x154 x155 x156 x157
-                x158 x159 x160 x161 x162 x163 x164 x165 x166 x167 x168 x169
-                x170 x171 x172 x173 x174 x175 x176 x177 x178 x179 x180 x181
-                x182 x183 x184 x185 x186 x187 x188 x189 x190 x191 x192 x193
-                x194 x195 x196 x197 x198 x199 x200 x201 x202 x203 x204 x205
-                x206 x207 x208 x209 x210 x211 x212 x213 x214 x215 x216 x217
-                x218 x219 x220 x221 x222 x223 x224 x225 x226 x227 x228 x229
-                x230 x231 x232 x233 x234 x235 x236 x237 x238 x239 x240 x241
-                x242 x243 x244 x245 x246 x247 x248 x249 x250 x251 x252
+            (function[L] {nlocal = 126} x1? x2? x3? x4? x5? x6? x7? x8? x9?
+              x10? x11? x12? x13? x14? x15? x16? x17? x18? x19? x20? x21?
+              x22? x23? x24? x25? x26? x27? x28? x29? x30? x31? x32? x33?
+              x34? x35? x36? x37? x38? x39? x40? x41? x42? x43? x44? x45?
+              x46? x47? x48? x49? x50? x51? x52? x53? x54? x55? x56? x57?
+              x58? x59? x60? x61? x62? x63? x64? x65? x66? x67? x68? x69?
+              x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+              x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93?
+              x94? x95? x96? x97? x98? x99? x100? x101? x102? x103? x104?
+              x105? x106? x107? x108? x109? x110? x111? x112? x113? x114?
+              x115? x116? x117? x118? x119? x120? x121? x122? x123? x124?
+              x125? x126? : local
+              (function[L] {nlocal = 126} x127? x128? x129? x130? x131? x132?
+                x133? x134? x135? x136? x137? x138? x139? x140? x141? x142?
+                x143? x144? x145? x146? x147? x148? x149? x150? x151? x152?
+                x153? x154? x155? x156? x157? x158? x159? x160? x161? x162?
+                x163? x164? x165? x166? x167? x168? x169? x170? x171? x172?
+                x173? x174? x175? x176? x177? x178? x179? x180? x181? x182?
+                x183? x184? x185? x186? x187? x188? x189? x190? x191? x192?
+                x193? x194? x195? x196? x197? x198? x199? x200? x201? x202?
+                x203? x204? x205? x206? x207? x208? x209? x210? x211? x212?
+                x213? x214? x215? x216? x217? x218? x219? x220? x221? x222?
+                x223? x224? x225? x226? x227? x228? x229? x230? x231? x232?
+                x233? x234? x235? x236? x237? x238? x239? x240? x241? x242?
+                x243? x244? x245? x246? x247? x248? x249? x250? x251? x252?
                 : local
-                (function[L] {nlocal = 6} x253 x254 x255 x256 x257 x258 : int
-                  0)))
+                (function[L] {nlocal = 6} x253? x254? x255? x256? x257? x258?
+                  : int 0)))
           two_splits__local_returning =
-            (function[L] {nlocal = 126} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11
-              x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27
-              x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43
-              x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59
-              x60 x61 x62 x63 x64 x65 x66 x67 x68 x69 x70 x71 x72 x73 x74 x75
-              x76 x77 x78 x79 x80 x81 x82 x83 x84 x85 x86 x87 x88 x89 x90 x91
-              x92 x93 x94 x95 x96 x97 x98 x99 x100 x101 x102 x103 x104 x105
-              x106 x107 x108 x109 x110 x111 x112 x113 x114 x115 x116 x117
-              x118 x119 x120 x121 x122 x123 x124 x125 x126 : local
-              (function[L] {nlocal = 126} x127 x128 x129 x130 x131 x132 x133
-                x134 x135 x136 x137 x138 x139 x140 x141 x142 x143 x144 x145
-                x146 x147 x148 x149 x150 x151 x152 x153 x154 x155 x156 x157
-                x158 x159 x160 x161 x162 x163 x164 x165 x166 x167 x168 x169
-                x170 x171 x172 x173 x174 x175 x176 x177 x178 x179 x180 x181
-                x182 x183 x184 x185 x186 x187 x188 x189 x190 x191 x192 x193
-                x194 x195 x196 x197 x198 x199 x200 x201 x202 x203 x204 x205
-                x206 x207 x208 x209 x210 x211 x212 x213 x214 x215 x216 x217
-                x218 x219 x220 x221 x222 x223 x224 x225 x226 x227 x228 x229
-                x230 x231 x232 x233 x234 x235 x236 x237 x238 x239 x240 x241
-                x242 x243 x244 x245 x246 x247 x248 x249 x250 x251 x252
+            (function[L] {nlocal = 126} x1? x2? x3? x4? x5? x6? x7? x8? x9?
+              x10? x11? x12? x13? x14? x15? x16? x17? x18? x19? x20? x21?
+              x22? x23? x24? x25? x26? x27? x28? x29? x30? x31? x32? x33?
+              x34? x35? x36? x37? x38? x39? x40? x41? x42? x43? x44? x45?
+              x46? x47? x48? x49? x50? x51? x52? x53? x54? x55? x56? x57?
+              x58? x59? x60? x61? x62? x63? x64? x65? x66? x67? x68? x69?
+              x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+              x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93?
+              x94? x95? x96? x97? x98? x99? x100? x101? x102? x103? x104?
+              x105? x106? x107? x108? x109? x110? x111? x112? x113? x114?
+              x115? x116? x117? x118? x119? x120? x121? x122? x123? x124?
+              x125? x126? : local
+              (function[L] {nlocal = 126} x127? x128? x129? x130? x131? x132?
+                x133? x134? x135? x136? x137? x138? x139? x140? x141? x142?
+                x143? x144? x145? x146? x147? x148? x149? x150? x151? x152?
+                x153? x154? x155? x156? x157? x158? x159? x160? x161? x162?
+                x163? x164? x165? x166? x167? x168? x169? x170? x171? x172?
+                x173? x174? x175? x176? x177? x178? x179? x180? x181? x182?
+                x183? x184? x185? x186? x187? x188? x189? x190? x191? x192?
+                x193? x194? x195? x196? x197? x198? x199? x200? x201? x202?
+                x203? x204? x205? x206? x207? x208? x209? x210? x211? x212?
+                x213? x214? x215? x216? x217? x218? x219? x220? x221? x222?
+                x223? x224? x225? x226? x227? x228? x229? x230? x231? x232?
+                x233? x234? x235? x236? x237? x238? x239? x240? x241? x242?
+                x243? x244? x245? x246? x247? x248? x249? x250? x251? x252?
                 : local
-                (function[L] {nlocal = 6} x253 x254 x255 x256 x257 x258
-                  [(consts ()) (non_consts ([0: *, *]))](makelocalblock 0 x1
-                                                          x258))))
+                (function[L] {nlocal = 6} x253? x254? x255? x256? x257? x258?
+                  : (consts ()) (non_consts ([0: ?, ?]))
+                  (makelocalblock 0 x1 x258))))
           two_splits_local_param =
-            (function[L] {nlocal = 126} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11
-              x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27
-              x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43
-              x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59
-              x60 x61 x62 x63 x64 x65 x66 x67 x68 x69 x70 x71 x72 x73 x74 x75
-              x76 x77 x78 x79 x80 x81 x82 x83 x84 x85 x86 x87 x88 x89 x90 x91
-              x92 x93 x94 x95 x96 x97 x98 x99 x100 x101 x102 x103 x104 x105
-              x106 x107 x108 x109 x110 x111 x112 x113 x114 x115 x116 x117
-              x118 x119 x120 x121 x122 x123 x124 x125 x126 : local
-              (function[L] {nlocal = 126} x127 x128 x129 x130 x131 x132 x133
-                x134 x135 x136 x137 x138 x139 x140 x141 x142 x143 x144 x145
-                x146 x147 x148 x149 x150 x151 x152[L] x153 x154 x155 x156
-                x157 x158 x159 x160 x161 x162 x163 x164 x165 x166 x167 x168
-                x169 x170 x171 x172 x173 x174 x175 x176 x177 x178 x179 x180
-                x181 x182 x183 x184 x185 x186 x187 x188 x189 x190 x191 x192
-                x193 x194 x195 x196 x197 x198 x199 x200 x201 x202 x203 x204
-                x205 x206 x207 x208 x209 x210 x211 x212 x213 x214 x215 x216
-                x217 x218 x219 x220 x221 x222 x223 x224 x225 x226 x227 x228
-                x229 x230 x231 x232 x233 x234 x235 x236 x237 x238 x239 x240
-                x241 x242 x243 x244 x245 x246 x247 x248 x249 x250 x251 x252
-                : local
-                (function[L] {nlocal = 6} x253 x254 x255 x256 x257 x258 : int
-                  0)))
+            (function[L] {nlocal = 126} x1? x2? x3? x4? x5? x6? x7? x8? x9?
+              x10? x11? x12? x13? x14? x15? x16? x17? x18? x19? x20? x21?
+              x22? x23? x24? x25? x26? x27? x28? x29? x30? x31? x32? x33?
+              x34? x35? x36? x37? x38? x39? x40? x41? x42? x43? x44? x45?
+              x46? x47? x48? x49? x50? x51? x52? x53? x54? x55? x56? x57?
+              x58? x59? x60? x61? x62? x63? x64? x65? x66? x67? x68? x69?
+              x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+              x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93?
+              x94? x95? x96? x97? x98? x99? x100? x101? x102? x103? x104?
+              x105? x106? x107? x108? x109? x110? x111? x112? x113? x114?
+              x115? x116? x117? x118? x119? x120? x121? x122? x123? x124?
+              x125? x126? : local
+              (function[L] {nlocal = 126} x127? x128? x129? x130? x131? x132?
+                x133? x134? x135? x136? x137? x138? x139? x140? x141? x142?
+                x143? x144? x145? x146? x147? x148? x149? x150? x151?
+                x152[L]? x153? x154? x155? x156? x157? x158? x159? x160?
+                x161? x162? x163? x164? x165? x166? x167? x168? x169? x170?
+                x171? x172? x173? x174? x175? x176? x177? x178? x179? x180?
+                x181? x182? x183? x184? x185? x186? x187? x188? x189? x190?
+                x191? x192? x193? x194? x195? x196? x197? x198? x199? x200?
+                x201? x202? x203? x204? x205? x206? x207? x208? x209? x210?
+                x211? x212? x213? x214? x215? x216? x217? x218? x219? x220?
+                x221? x222? x223? x224? x225? x226? x227? x228? x229? x230?
+                x231? x232? x233? x234? x235? x236? x237? x238? x239? x240?
+                x241? x242? x243? x244? x245? x246? x247? x248? x249? x250?
+                x251? x252? : local
+                (function[L] {nlocal = 6} x253? x254? x255? x256? x257? x258?
+                  : int 0)))
           two_splits_local_param__local_returning =
-            (function[L] {nlocal = 126} x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11
-              x12 x13 x14 x15 x16 x17 x18 x19 x20 x21 x22 x23 x24 x25 x26 x27
-              x28 x29 x30 x31 x32 x33 x34 x35 x36 x37 x38 x39 x40 x41 x42 x43
-              x44 x45 x46 x47 x48 x49 x50 x51 x52 x53 x54 x55 x56 x57 x58 x59
-              x60 x61 x62 x63 x64 x65 x66 x67 x68 x69 x70 x71 x72 x73 x74 x75
-              x76 x77 x78 x79 x80 x81 x82 x83 x84 x85 x86 x87 x88 x89 x90 x91
-              x92 x93 x94 x95 x96 x97 x98 x99 x100 x101 x102 x103 x104 x105
-              x106 x107 x108 x109 x110 x111 x112 x113 x114 x115 x116 x117
-              x118 x119 x120 x121 x122 x123 x124 x125 x126 : local
-              (function[L] {nlocal = 126} x127 x128 x129 x130 x131 x132 x133
-                x134 x135 x136 x137 x138 x139 x140 x141 x142 x143 x144 x145
-                x146 x147 x148 x149 x150 x151 x152[L] x153 x154 x155 x156
-                x157 x158 x159 x160 x161 x162 x163 x164 x165 x166 x167 x168
-                x169 x170 x171 x172 x173 x174 x175 x176 x177 x178 x179 x180
-                x181 x182 x183 x184 x185 x186 x187 x188 x189 x190 x191 x192
-                x193 x194 x195 x196 x197 x198 x199 x200 x201 x202 x203 x204
-                x205 x206 x207 x208 x209 x210 x211 x212 x213 x214 x215 x216
-                x217 x218 x219 x220 x221 x222 x223 x224 x225 x226 x227 x228
-                x229 x230 x231 x232 x233 x234 x235 x236 x237 x238 x239 x240
-                x241 x242 x243 x244 x245 x246 x247 x248 x249 x250 x251 x252
-                : local
-                (function[L] {nlocal = 6} x253 x254 x255 x256 x257 x258
-                  [(consts ()) (non_consts ([0: *, *]))](makelocalblock 0 x1
-                                                          x152)))))
+            (function[L] {nlocal = 126} x1? x2? x3? x4? x5? x6? x7? x8? x9?
+              x10? x11? x12? x13? x14? x15? x16? x17? x18? x19? x20? x21?
+              x22? x23? x24? x25? x26? x27? x28? x29? x30? x31? x32? x33?
+              x34? x35? x36? x37? x38? x39? x40? x41? x42? x43? x44? x45?
+              x46? x47? x48? x49? x50? x51? x52? x53? x54? x55? x56? x57?
+              x58? x59? x60? x61? x62? x63? x64? x65? x66? x67? x68? x69?
+              x70? x71? x72? x73? x74? x75? x76? x77? x78? x79? x80? x81?
+              x82? x83? x84? x85? x86? x87? x88? x89? x90? x91? x92? x93?
+              x94? x95? x96? x97? x98? x99? x100? x101? x102? x103? x104?
+              x105? x106? x107? x108? x109? x110? x111? x112? x113? x114?
+              x115? x116? x117? x118? x119? x120? x121? x122? x123? x124?
+              x125? x126? : local
+              (function[L] {nlocal = 126} x127? x128? x129? x130? x131? x132?
+                x133? x134? x135? x136? x137? x138? x139? x140? x141? x142?
+                x143? x144? x145? x146? x147? x148? x149? x150? x151?
+                x152[L]? x153? x154? x155? x156? x157? x158? x159? x160?
+                x161? x162? x163? x164? x165? x166? x167? x168? x169? x170?
+                x171? x172? x173? x174? x175? x176? x177? x178? x179? x180?
+                x181? x182? x183? x184? x185? x186? x187? x188? x189? x190?
+                x191? x192? x193? x194? x195? x196? x197? x198? x199? x200?
+                x201? x202? x203? x204? x205? x206? x207? x208? x209? x210?
+                x211? x212? x213? x214? x215? x216? x217? x218? x219? x220?
+                x221? x222? x223? x224? x225? x226? x227? x228? x229? x230?
+                x231? x232? x233? x234? x235? x236? x237? x238? x239? x240?
+                x241? x242? x243? x244? x245? x246? x247? x248? x249? x250?
+                x251? x252? : local
+                (function[L] {nlocal = 6} x253? x254? x255? x256? x257? x258?
+                  : (consts ()) (non_consts ([0: ?, ?]))
+                  (makelocalblock 0 x1 x152)))))
          (makelocalblock 0 (*,*,*,*,*,*,*,*,*,*,*,*,*,*) no_local_params
            no_local_params__local_returning local_param_after_split
            local_param_after_split__local_returning

--- a/testsuite/tests/tmc/readable_output.ml
+++ b/testsuite/tests/tmc/readable_output.ml
@@ -12,36 +12,44 @@ let[@tail_mod_cons] rec map f = function
 (letrec
   (map
      (function {nlocal = 0} f
-       param[(consts (0))
-             (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+       param[value<
+              (consts (0))
+               (non_consts ([0: ?,
+                             value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
        tail_mod_cons
-       [(consts (0))
-        (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+       : (consts (0))
+          (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))
        (if param
          (let
            (block =
-              (makemutable 0 (*,[(consts (0))
-                                 (non_consts ([0: *,
-                                               [(consts (0))
-                                                (non_consts ([0: *, *]))]]))])
+              (makemutable 0 (?,value<
+                                 (consts (0))
+                                  (non_consts ([0: ?,
+                                                value<
+                                                 (consts (0))
+                                                  (non_consts ([0: ?, *]))>]))>)
                 (apply f (field_imm 0 param)) 24029))
            (seq (apply map_dps block 1 f (field_imm 1 param)) block))
          0))
     map_dps
-      (function {nlocal = 0} dst offset[int] f
-        param[(consts (0))
-              (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+      (function {nlocal = 0} dst offset[value<int>] f
+        param[value<
+               (consts (0))
+                (non_consts ([0: ?,
+                              value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
         tail_mod_cons
-        [(consts (0))
-         (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+        : (consts (0))
+           (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))
         (if param
           (let
-            (block0_arg0 = (apply f (field_imm 0 param))
+            (block0_arg0 =? (apply f (field_imm 0 param))
              block =
-               (makemutable 0 (*,[(consts (0))
-                                  (non_consts ([0: *,
-                                                [(consts (0))
-                                                 (non_consts ([0: *, *]))]]))])
+               (makemutable 0 (?,value<
+                                  (consts (0))
+                                   (non_consts ([0: ?,
+                                                 value<
+                                                  (consts (0))
+                                                   (non_consts ([0: ?, *]))>]))>)
                  block0_arg0 24029))
             (seq (setfield_ptr(heap-init)_computed dst offset block)
               (apply map_dps block 1 f (field_imm 1 param) tailcall)))
@@ -66,64 +74,45 @@ let[@tail_mod_cons] rec rec_map f = function
 [%%expect{|
 (letrec
   (rec_map
-     (function {nlocal = 0} f param[(consts (0)) (non_consts ([0: *]))]
-       tail_mod_cons
-       [(consts (0)) (non_consts ([0: *]))](if param
-                                             (let
-                                               (*match* =a
-                                                  (field_imm 0 param))
-                                               (makeblock 0 ([(consts ())
-                                                              (non_consts (
-                                                              [0: *,
-                                                               [(consts (0))
-                                                                (non_consts (
-                                                                [0: *]))]]))])
-                                                 (let
-                                                   (block =
-                                                      (makemutable 0 (*,
-                                                        [(consts (0))
-                                                         (non_consts (
-                                                         [0: *]))])
-                                                        (apply f
-                                                          (field_imm 0
-                                                            *match*))
-                                                        24029))
-                                                   (seq
-                                                     (apply rec_map_dps block
-                                                       1 f
-                                                       (field_imm 1 *match*))
-                                                     block))))
-                                             0))
+     (function {nlocal = 0} f
+       param[value<(consts (0)) (non_consts ([0: ?]))>] tail_mod_cons
+       : (consts (0)) (non_consts ([0: ?]))
+       (if param
+         (let (*match* =a? (field_imm 0 param))
+           (makeblock 0 (value<
+                          (consts ())
+                           (non_consts ([0: *,
+                                         value<
+                                          (consts (0)) (non_consts ([0: ?]))>]))>)
+             (let
+               (block =
+                  (makemutable 0 (*,value<(consts (0)) (non_consts ([0: ?]))>)
+                    (apply f (field_imm 0 *match*)) 24029))
+               (seq (apply rec_map_dps block 1 f (field_imm 1 *match*))
+                 block))))
+         0))
     rec_map_dps
-      (function {nlocal = 0} dst offset[int] f
-        param[(consts (0)) (non_consts ([0: *]))] tail_mod_cons
-        [(consts (0)) (non_consts ([0: *]))](if param
-                                              (let
-                                                (*match* =a
-                                                   (field_imm 0 param)
-                                                 block1_arg0 =
-                                                   (apply f
-                                                     (field_imm 0 *match*))
-                                                 block =
-                                                   (makemutable 0 (*,
-                                                     [(consts (0))
-                                                      (non_consts ([0: *]))])
-                                                     block1_arg0 24029))
-                                                (seq
-                                                  (setfield_ptr(heap-init)_computed
-                                                    dst offset
-                                                    (makeblock 0 ([(consts ())
-                                                                   (non_consts (
-                                                                   [0: *,
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *]))]]))])
-                                                      block))
-                                                  (apply rec_map_dps block 1
-                                                    f
-                                                    (field_imm 1 *match*) tailcall)))
-                                              (setfield_ptr(heap-init)_computed
-                                                dst offset 0))))
+      (function {nlocal = 0} dst offset[value<int>] f
+        param[value<(consts (0)) (non_consts ([0: ?]))>] tail_mod_cons
+        : (consts (0)) (non_consts ([0: ?]))
+        (if param
+          (let
+            (*match* =a? (field_imm 0 param)
+             block1_arg0 =? (apply f (field_imm 0 *match*))
+             block =
+               (makemutable 0 (*,value<(consts (0)) (non_consts ([0: ?]))>)
+                 block1_arg0 24029))
+            (seq
+              (setfield_ptr(heap-init)_computed dst offset
+                (makeblock 0 (value<
+                               (consts ())
+                                (non_consts ([0: *,
+                                              value<
+                                               (consts (0))
+                                                (non_consts ([0: ?]))>]))>)
+                  block))
+              (apply rec_map_dps block 1 f (field_imm 1 *match*) tailcall)))
+          (setfield_ptr(heap-init)_computed dst offset 0))))
   (apply (field_imm 1 (global Toploop!)) "rec_map" rec_map))
 val rec_map : ('a -> 'b) -> 'a rec_list -> 'b rec_list = <fun>
 |}]
@@ -139,66 +128,82 @@ let[@tail_mod_cons] rec trip = function
 (letrec
   (trip
      (function {nlocal = 0}
-       param[(consts (0))
-             (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+       param[value<
+              (consts (0))
+               (non_consts ([0: ?,
+                             value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
        tail_mod_cons
-       [(consts (0))
-        (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+       : (consts (0))
+          (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))
        (if param
-         (let (x =a (field_imm 0 param))
-           (makeblock 0 ([(consts ()) (non_consts ([0: *, [int]]))],[(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *,
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))]]))])
-             (makeblock 0 (*,int) x 0)
-             (makeblock 0 ([(consts ()) (non_consts ([0: *, [int]]))],
-               [(consts (0))
-                (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))])
-               (makeblock 0 (*,int) x 1)
+         (let (x =a? (field_imm 0 param))
+           (makeblock 0 (value<(consts ()) (non_consts ([0: ?, value<int>]))>,
+             value<
+              (consts (0))
+               (non_consts ([0: ?,
+                             value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+             (makeblock 0 (?,value<int>) x 0)
+             (makeblock 0 (value<
+                            (consts ()) (non_consts ([0: ?, value<int>]))>,
+               value<
+                (consts (0))
+                 (non_consts ([0: ?,
+                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+               (makeblock 0 (?,value<int>) x 1)
                (let
                  (block =
-                    (makemutable 0 ([(consts ())
-                                     (non_consts ([0: *, [int]]))],[(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *,
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))]]))])
-                      (makeblock 0 (*,int) x 2) 24029))
+                    (makemutable 0 (value<
+                                     (consts ())
+                                      (non_consts ([0: ?, value<int>]))>,
+                      value<
+                       (consts (0))
+                        (non_consts ([0: ?,
+                                      value<
+                                       (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                      (makeblock 0 (?,value<int>) x 2) 24029))
                  (seq (apply trip_dps block 1 (field_imm 1 param)) block)))))
          0))
     trip_dps
-      (function {nlocal = 0} dst offset[int]
-        param[(consts (0))
-              (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+      (function {nlocal = 0} dst offset[value<int>]
+        param[value<
+               (consts (0))
+                (non_consts ([0: ?,
+                              value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
         tail_mod_cons
-        [(consts (0))
-         (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+        : (consts (0))
+           (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))
         (if param
           (let
-            (x =a (field_imm 0 param)
-             block0_arg0 = (makeblock 0 (*,int) x 0)
-             block1_arg0 = (makeblock 0 (*,int) x 1)
-             block2_arg0 = (makeblock 0 (*,int) x 2)
+            (x =a? (field_imm 0 param)
+             block0_arg0 =? (makeblock 0 (?,value<int>) x 0)
+             block1_arg0 =? (makeblock 0 (?,value<int>) x 1)
+             block2_arg0 =? (makeblock 0 (?,value<int>) x 2)
              block =
-               (makemutable 0 ([(consts ()) (non_consts ([0: *, [int]]))],
-                 [(consts (0))
-                  (non_consts ([0: *,
-                                [(consts (0)) (non_consts ([0: *, *]))]]))])
+               (makemutable 0 (value<
+                                (consts ()) (non_consts ([0: ?, value<int>]))>,
+                 value<
+                  (consts (0))
+                   (non_consts ([0: ?,
+                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
                  block2_arg0 24029))
             (seq
               (setfield_ptr(heap-init)_computed dst offset
-                (makeblock 0 ([(consts ()) (non_consts ([0: *, [int]]))],
-                  [(consts (0))
-                   (non_consts ([0: *,
-                                 [(consts (0)) (non_consts ([0: *, *]))]]))])
+                (makeblock 0 (value<
+                               (consts ()) (non_consts ([0: ?, value<int>]))>,
+                  value<
+                   (consts (0))
+                    (non_consts ([0: ?,
+                                  value<
+                                   (consts (0)) (non_consts ([0: ?, *]))>]))>)
                   block0_arg0
-                  (makeblock 0 ([(consts ()) (non_consts ([0: *, [int]]))],
-                    [(consts (0))
-                     (non_consts ([0: *,
-                                   [(consts (0)) (non_consts ([0: *, *]))]]))])
+                  (makeblock 0 (value<
+                                 (consts ())
+                                  (non_consts ([0: ?, value<int>]))>,
+                    value<
+                     (consts (0))
+                      (non_consts ([0: ?,
+                                    value<
+                                     (consts (0)) (non_consts ([0: ?, *]))>]))>)
                     block1_arg0 block)))
               (apply trip_dps block 1 (field_imm 1 param) tailcall)))
           (setfield_ptr(heap-init)_computed dst offset 0))))
@@ -217,51 +222,63 @@ let[@tail_mod_cons] rec effects f = function
 (letrec
   (effects
      (function {nlocal = 0} f
-       param[(consts (0))
-             (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+       param[value<
+              (consts (0))
+               (non_consts ([0: ?,
+                             value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
        tail_mod_cons
-       [(consts (0))
-        (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+       : (consts (0))
+          (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))
        (if param
-         (let (*match* =a (field_imm 0 param))
-           (makeblock 0 (*,[(consts (0))
-                            (non_consts ([0: *,
-                                          [(consts (0))
-                                           (non_consts ([0: *, *]))]]))])
+         (let (*match* =a? (field_imm 0 param))
+           (makeblock 0 (?,value<
+                            (consts (0))
+                             (non_consts ([0: ?,
+                                           value<
+                                            (consts (0))
+                                             (non_consts ([0: ?, *]))>]))>)
              (apply f (field_imm 0 *match*))
              (let
                (block =
-                  (makemutable 0 (*,[(consts (0))
-                                     (non_consts ([0: *,
-                                                   [(consts (0))
-                                                    (non_consts ([0: *, *]))]]))])
+                  (makemutable 0 (?,value<
+                                     (consts (0))
+                                      (non_consts ([0: ?,
+                                                    value<
+                                                     (consts (0))
+                                                      (non_consts ([0: ?, *]))>]))>)
                     (apply f (field_imm 1 *match*)) 24029))
                (seq (apply effects_dps block 1 f (field_imm 1 param)) block))))
          0))
     effects_dps
-      (function {nlocal = 0} dst offset[int] f
-        param[(consts (0))
-              (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+      (function {nlocal = 0} dst offset[value<int>] f
+        param[value<
+               (consts (0))
+                (non_consts ([0: ?,
+                              value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
         tail_mod_cons
-        [(consts (0))
-         (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+        : (consts (0))
+           (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))
         (if param
           (let
-            (*match* =a (field_imm 0 param)
-             block0_arg0 = (apply f (field_imm 0 *match*))
-             block1_arg0 = (apply f (field_imm 1 *match*))
+            (*match* =a? (field_imm 0 param)
+             block0_arg0 =? (apply f (field_imm 0 *match*))
+             block1_arg0 =? (apply f (field_imm 1 *match*))
              block =
-               (makemutable 0 (*,[(consts (0))
-                                  (non_consts ([0: *,
-                                                [(consts (0))
-                                                 (non_consts ([0: *, *]))]]))])
+               (makemutable 0 (?,value<
+                                  (consts (0))
+                                   (non_consts ([0: ?,
+                                                 value<
+                                                  (consts (0))
+                                                   (non_consts ([0: ?, *]))>]))>)
                  block1_arg0 24029))
             (seq
               (setfield_ptr(heap-init)_computed dst offset
-                (makeblock 0 (*,[(consts (0))
-                                 (non_consts ([0: *,
-                                               [(consts (0))
-                                                (non_consts ([0: *, *]))]]))])
+                (makeblock 0 (?,value<
+                                 (consts (0))
+                                  (non_consts ([0: ?,
+                                                value<
+                                                 (consts (0))
+                                                  (non_consts ([0: ?, *]))>]))>)
                   block0_arg0 block))
               (apply effects_dps block 1 f (field_imm 1 param) tailcall)))
           (setfield_ptr(heap-init)_computed dst offset 0))))
@@ -283,49 +300,60 @@ let[@tail_mod_cons] rec map_stutter f xs =
 (letrec
   (map_stutter
      (function {nlocal = 0} f
-       xs[(consts (0))
-          (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+       xs[value<
+           (consts (0))
+            (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
        tail_mod_cons
-       [(consts (0))
-        (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
-       (makeblock 0 (*,[(consts (0))
-                        (non_consts ([0: *,
-                                      [(consts (0)) (non_consts ([0: *, *]))]]))])
+       : (consts (0))
+          (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))
+       (makeblock 0 (?,value<
+                        (consts (0))
+                         (non_consts ([0: ?,
+                                       value<
+                                        (consts (0)) (non_consts ([0: ?, *]))>]))>)
          (apply f 0)
          (if xs
            (let
              (block =
-                (makemutable 0 (*,[(consts (0))
-                                   (non_consts ([0: *,
-                                                 [(consts (0))
-                                                  (non_consts ([0: *, *]))]]))])
+                (makemutable 0 (?,value<
+                                   (consts (0))
+                                    (non_consts ([0: ?,
+                                                  value<
+                                                   (consts (0))
+                                                    (non_consts ([0: ?, *]))>]))>)
                   (apply f (makeblock 0 (field_imm 0 xs))) 24029))
              (seq (apply map_stutter_dps block 1 f (field_imm 1 xs)) block))
            0)))
     map_stutter_dps
-      (function {nlocal = 0} dst offset[int] f
-        xs[(consts (0))
-           (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+      (function {nlocal = 0} dst offset[value<int>] f
+        xs[value<
+            (consts (0))
+             (non_consts ([0: ?,
+                           value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
         tail_mod_cons
-        [(consts (0))
-         (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+        : (consts (0))
+           (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))
         (let
-          (block0_arg0 = (apply f 0)
+          (block0_arg0 =? (apply f 0)
            block =
-             (makemutable 0 (*,[(consts (0))
-                                (non_consts ([0: *,
-                                              [(consts (0))
-                                               (non_consts ([0: *, *]))]]))])
+             (makemutable 0 (?,value<
+                                (consts (0))
+                                 (non_consts ([0: ?,
+                                               value<
+                                                (consts (0))
+                                                 (non_consts ([0: ?, *]))>]))>)
                block0_arg0 24029))
           (seq (setfield_ptr(heap-init)_computed dst offset block)
             (if xs
               (let
-                (block0_arg0 = (apply f (makeblock 0 (field_imm 0 xs)))
+                (block0_arg0 =? (apply f (makeblock 0 (field_imm 0 xs)))
                  block =
-                   (makemutable 0 (*,[(consts (0))
-                                      (non_consts ([0: *,
-                                                    [(consts (0))
-                                                     (non_consts ([0: *, *]))]]))])
+                   (makemutable 0 (?,value<
+                                      (consts (0))
+                                       (non_consts ([0: ?,
+                                                     value<
+                                                      (consts (0))
+                                                       (non_consts ([0: ?, *]))>]))>)
                      block0_arg0 24029))
                 (seq (setfield_ptr(heap-init)_computed block 1 block)
                   (apply map_stutter_dps block 1 f (field_imm 1 xs) tailcall)))
@@ -352,49 +380,58 @@ let[@tail_mod_cons] rec smap_stutter f xs n =
 type 'a stream = { hd : 'a; tl : unit -> 'a stream; }
 (letrec
   (smap_stutter
-     (function {nlocal = 0} f xs[(consts ()) (non_consts ([0: *, *]))] n[int]
-       tail_mod_cons
-       [(consts (0))
-        (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+     (function {nlocal = 0} f xs[value<(consts ()) (non_consts ([0: *, *]))>]
+       n[value<int>] tail_mod_cons
+       : (consts (0))
+          (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))
        (if (== n 0) 0
-         (makeblock 0 (*,[(consts (0))
-                          (non_consts ([0: *,
-                                        [(consts (0))
-                                         (non_consts ([0: *, *]))]]))])
+         (makeblock 0 (?,value<
+                          (consts (0))
+                           (non_consts ([0: ?,
+                                         value<
+                                          (consts (0))
+                                           (non_consts ([0: ?, *]))>]))>)
            (apply f 0)
            (let
-             (v = (apply f (makeblock 0 (*) (field_imm 0 xs)))
+             (v =? (apply f (makeblock 0 (*) (field_imm 0 xs)))
               block =
-                (makemutable 0 (*,[(consts (0))
-                                   (non_consts ([0: *,
-                                                 [(consts (0))
-                                                  (non_consts ([0: *, *]))]]))])
+                (makemutable 0 (?,value<
+                                   (consts (0))
+                                    (non_consts ([0: ?,
+                                                  value<
+                                                   (consts (0))
+                                                    (non_consts ([0: ?, *]))>]))>)
                   v 24029))
              (seq
                (apply smap_stutter_dps block 1 f (apply (field_imm 1 xs) 0)
                  (- n 1))
                block)))))
     smap_stutter_dps
-      (function {nlocal = 0} dst offset[int] f
-        xs[(consts ()) (non_consts ([0: *, *]))] n[int] tail_mod_cons
-        [(consts (0))
-         (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+      (function {nlocal = 0} dst offset[value<int>] f
+        xs[value<(consts ()) (non_consts ([0: *, *]))>] n[value<int>]
+        tail_mod_cons
+        : (consts (0))
+           (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))
         (if (== n 0) (setfield_ptr(heap-init)_computed dst offset 0)
           (let
-            (block0_arg0 = (apply f 0)
-             v = (apply f (makeblock 0 (*) (field_imm 0 xs)))
+            (block0_arg0 =? (apply f 0)
+             v =? (apply f (makeblock 0 (*) (field_imm 0 xs)))
              block =
-               (makemutable 0 (*,[(consts (0))
-                                  (non_consts ([0: *,
-                                                [(consts (0))
-                                                 (non_consts ([0: *, *]))]]))])
+               (makemutable 0 (?,value<
+                                  (consts (0))
+                                   (non_consts ([0: ?,
+                                                 value<
+                                                  (consts (0))
+                                                   (non_consts ([0: ?, *]))>]))>)
                  v 24029))
             (seq
               (setfield_ptr(heap-init)_computed dst offset
-                (makeblock 0 (*,[(consts (0))
-                                 (non_consts ([0: *,
-                                               [(consts (0))
-                                                (non_consts ([0: *, *]))]]))])
+                (makeblock 0 (?,value<
+                                 (consts (0))
+                                  (non_consts ([0: ?,
+                                                value<
+                                                 (consts (0))
+                                                  (non_consts ([0: ?, *]))>]))>)
                   block0_arg0 block))
               (apply smap_stutter_dps block 1 f (apply (field_imm 1 xs) 0)
                 (- n 1) tailcall))))))

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_lambda.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_lambda.compilers.reference
@@ -1,1 +1,2 @@
-(setglobal Stop_after_lambda! (let (*match*/7 =[int] ( 1)) (makeblock 0)))
+(setglobal Stop_after_lambda!
+  (let (*match*/7 =[value<int>] ( 1)) (makeblock 0)))

--- a/testsuite/tests/translprim/array_spec.stack.flat.reference
+++ b/testsuite/tests/translprim/array_spec.stack.flat.reference
@@ -1,90 +1,97 @@
 (setglobal Array_spec!
   (let
-    (int_a =[intarray] (makearray[int] 1 2 3)
-     float_a =[floatarray] (makearray[float] 1. 2. 3.)
-     addr_a =[addrarray] (makearray[addr] "a" "b" "c"))
+    (int_a =[value<intarray>] (makearray[int] 1 2 3)
+     float_a =[value<floatarray>] (makearray[float] 1. 2. 3.)
+     addr_a =[value<addrarray>] (makearray[addr] "a" "b" "c"))
     (seq (array.length[int] int_a) (array.length[float] float_a)
       (array.length[addr] addr_a)
-      (function {nlocal = 0} a[genarray] : int (array.length[gen] a))
+      (function {nlocal = 0} a[value<genarray>] : int (array.length[gen] a))
       (array.get[int indexed by int] int_a 0)
       (array.get[float indexed by int] float_a 0)
       (array.get[addr indexed by int] addr_a 0)
-      (function {nlocal = 0} a[genarray] (array.get[gen indexed by int] a 0))
+      (function {nlocal = 0} a[value<genarray>]
+        (array.get[gen indexed by int] a 0))
       (array.unsafe_get[int indexed by int] int_a 0)
       (array.unsafe_get[float indexed by int] float_a 0)
       (array.unsafe_get[addr indexed by int] addr_a 0)
-      (function {nlocal = 0} a[genarray]
+      (function {nlocal = 0} a[value<genarray>]
         (array.unsafe_get[gen indexed by int] a 0))
       (array.set[int indexed by int] int_a 0 1)
       (array.set[float indexed by int] float_a 0 1.)
       (array.set[addr indexed by int] addr_a 0 "a")
-      (function {nlocal = 2} a[genarray] x : int
+      (function {nlocal = 2} a[value<genarray>] x : int
         (array.set[gen indexed by int] a 0 x))
       (array.unsafe_set[int indexed by int] int_a 0 1)
       (array.unsafe_set[float indexed by int] float_a 0 1.)
       (array.unsafe_set[addr indexed by int] addr_a 0 "a")
-      (function {nlocal = 2} a[genarray] x : int
+      (function {nlocal = 2} a[value<genarray>] x : int
         (array.unsafe_set[gen indexed by int] a 0 x))
       (let
         (eta_gen_len =
-           (function {nlocal = 0} prim[genarray] stub : int
+           (function {nlocal = 0} prim[value<genarray>] stub : int
              (array.length[gen] prim))
          eta_gen_safe_get =
-           (function {nlocal = 0} prim[genarray] prim[int] stub
+           (function {nlocal = 0} prim[value<genarray>] prim[value<int>] stub
              (array.get[gen indexed by int] prim prim))
          eta_gen_unsafe_get =
-           (function {nlocal = 0} prim[genarray] prim[int] stub
+           (function {nlocal = 0} prim[value<genarray>] prim[value<int>] stub
              (array.unsafe_get[gen indexed by int] prim prim))
          eta_gen_safe_set =
-           (function {nlocal = 0} prim[genarray] prim[int] prim stub : int
-             (array.set[gen indexed by int] prim prim prim))
+           (function {nlocal = 0} prim[value<genarray>] prim[value<int>] prim
+             stub : int (array.set[gen indexed by int] prim prim prim))
          eta_gen_unsafe_set =
-           (function {nlocal = 0} prim[genarray] prim[int] prim stub : int
+           (function {nlocal = 0} prim[value<genarray>] prim[value<int>] prim
+             stub : int
              (array.unsafe_set[gen indexed by int] prim prim prim))
          eta_int_len =
-           (function {nlocal = 0} prim[intarray] stub : int
+           (function {nlocal = 0} prim[value<intarray>] stub : int
              (array.length[int] prim))
          eta_int_safe_get =
-           (function {nlocal = 0} prim[intarray] prim[int] stub : int
-             (array.get[int indexed by int] prim prim))
+           (function {nlocal = 0} prim[value<intarray>] prim[value<int>] stub
+             : int (array.get[int indexed by int] prim prim))
          eta_int_unsafe_get =
-           (function {nlocal = 0} prim[intarray] prim[int] stub : int
-             (array.unsafe_get[int indexed by int] prim prim))
+           (function {nlocal = 0} prim[value<intarray>] prim[value<int>] stub
+             : int (array.unsafe_get[int indexed by int] prim prim))
          eta_int_safe_set =
-           (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
-             : int (array.set[int indexed by int] prim prim prim))
+           (function {nlocal = 0} prim[value<intarray>] prim[value<int>]
+             prim[value<int>] stub : int
+             (array.set[int indexed by int] prim prim prim))
          eta_int_unsafe_set =
-           (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
-             : int (array.unsafe_set[int indexed by int] prim prim prim))
+           (function {nlocal = 0} prim[value<intarray>] prim[value<int>]
+             prim[value<int>] stub : int
+             (array.unsafe_set[int indexed by int] prim prim prim))
          eta_float_len =
-           (function {nlocal = 0} prim[floatarray] stub : int
+           (function {nlocal = 0} prim[value<floatarray>] stub : int
              (array.length[float] prim))
          eta_float_safe_get =
-           (function {nlocal = 0} prim[floatarray] prim[int] stub : float
-             (array.get[float indexed by int] prim prim))
+           (function {nlocal = 0} prim[value<floatarray>] prim[value<int>]
+             stub : float (array.get[float indexed by int] prim prim))
          eta_float_unsafe_get =
-           (function {nlocal = 0} prim[floatarray] prim[int] stub : float
-             (array.unsafe_get[float indexed by int] prim prim))
+           (function {nlocal = 0} prim[value<floatarray>] prim[value<int>]
+             stub : float (array.unsafe_get[float indexed by int] prim prim))
          eta_float_safe_set =
-           (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
-             : int (array.set[float indexed by int] prim prim prim))
+           (function {nlocal = 0} prim[value<floatarray>] prim[value<int>]
+             prim[value<float>] stub : int
+             (array.set[float indexed by int] prim prim prim))
          eta_float_unsafe_set =
-           (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
-             : int (array.unsafe_set[float indexed by int] prim prim prim))
+           (function {nlocal = 0} prim[value<floatarray>] prim[value<int>]
+             prim[value<float>] stub : int
+             (array.unsafe_set[float indexed by int] prim prim prim))
          eta_addr_len =
-           (function {nlocal = 0} prim[addrarray] stub : int
+           (function {nlocal = 0} prim[value<addrarray>] stub : int
              (array.length[addr] prim))
          eta_addr_safe_get =
-           (function {nlocal = 0} prim[addrarray] prim[int] stub
-             (array.get[addr indexed by int] prim prim))
+           (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+             stub (array.get[addr indexed by int] prim prim))
          eta_addr_unsafe_get =
-           (function {nlocal = 0} prim[addrarray] prim[int] stub
-             (array.unsafe_get[addr indexed by int] prim prim))
+           (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+             stub (array.unsafe_get[addr indexed by int] prim prim))
          eta_addr_safe_set =
-           (function {nlocal = 0} prim[addrarray] prim[int] prim stub : int
-             (array.set[addr indexed by int] prim prim prim))
+           (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+             prim stub : int (array.set[addr indexed by int] prim prim prim))
          eta_addr_unsafe_set =
-           (function {nlocal = 0} prim[addrarray] prim[int] prim stub : int
+           (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+             prim stub : int
              (array.unsafe_set[addr indexed by int] prim prim prim)))
         (makeblock 0 int_a float_a addr_a eta_gen_len eta_gen_safe_get
           eta_gen_unsafe_get eta_gen_safe_set eta_gen_unsafe_set eta_int_len

--- a/testsuite/tests/translprim/comparison_table.stack.reference
+++ b/testsuite/tests/translprim/comparison_table.stack.reference
@@ -1,488 +1,495 @@
 (setglobal Comparison_table!
   (let
     (gen_cmp = (function {nlocal = 0} x y : int (caml_compare x y))
-     int_cmp = (function {nlocal = 0} x[int] y[int] : int (compare_ints x y))
+     int_cmp =
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int
+         (compare_ints x y))
      bool_cmp =
-       (function {nlocal = 0} x[int] y[int] : int (compare_ints x y))
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int
+         (compare_ints x y))
      intlike_cmp =
-       (function {nlocal = 0} x[int] y[int] : int (compare_ints x y))
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int
+         (compare_ints x y))
      float_cmp =
-       (function {nlocal = 0} x[float] y[float] : int
+       (function {nlocal = 0} x[value<float>] y[value<float>] : int
          (compare_floats float x y))
      string_cmp = (function {nlocal = 0} x y : int (caml_string_compare x y))
      int32_cmp =
-       (function {nlocal = 0} x[int32] y[int32] : int
+       (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
          (compare_bints int32 x y))
      int64_cmp =
-       (function {nlocal = 0} x[int64] y[int64] : int
+       (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
          (compare_bints int64 x y))
      nativeint_cmp =
-       (function {nlocal = 0} x[nativeint] y[nativeint] : int
+       (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
          (compare_bints nativeint x y))
      gen_eq = (function {nlocal = 0} x y : int (caml_equal x y))
-     int_eq = (function {nlocal = 0} x[int] y[int] : int (== x y))
-     bool_eq = (function {nlocal = 0} x[int] y[int] : int (== x y))
-     intlike_eq = (function {nlocal = 0} x[int] y[int] : int (== x y))
+     int_eq =
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int (== x y))
+     bool_eq =
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int (== x y))
+     intlike_eq =
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int (== x y))
      float_eq =
-       (function {nlocal = 0} x[float] y[float] : int (Float.== x y))
+       (function {nlocal = 0} x[value<float>] y[value<float>] : int
+         (Float.== x y))
      string_eq = (function {nlocal = 0} x y : int (caml_string_equal x y))
      int32_eq =
-       (function {nlocal = 0} x[int32] y[int32] : int (Int32.== x y))
+       (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
+         (Int32.== x y))
      int64_eq =
-       (function {nlocal = 0} x[int64] y[int64] : int (Int64.== x y))
+       (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
+         (Int64.== x y))
      nativeint_eq =
-       (function {nlocal = 0} x[nativeint] y[nativeint] : int
+       (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
          (Nativeint.== x y))
      gen_ne = (function {nlocal = 0} x y : int (caml_notequal x y))
-     int_ne = (function {nlocal = 0} x[int] y[int] : int (!= x y))
-     bool_ne = (function {nlocal = 0} x[int] y[int] : int (!= x y))
-     intlike_ne = (function {nlocal = 0} x[int] y[int] : int (!= x y))
+     int_ne =
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int (!= x y))
+     bool_ne =
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int (!= x y))
+     intlike_ne =
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int (!= x y))
      float_ne =
-       (function {nlocal = 0} x[float] y[float] : int (Float.!= x y))
+       (function {nlocal = 0} x[value<float>] y[value<float>] : int
+         (Float.!= x y))
      string_ne = (function {nlocal = 0} x y : int (caml_string_notequal x y))
      int32_ne =
-       (function {nlocal = 0} x[int32] y[int32] : int (Int32.!= x y))
+       (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
+         (Int32.!= x y))
      int64_ne =
-       (function {nlocal = 0} x[int64] y[int64] : int (Int64.!= x y))
+       (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
+         (Int64.!= x y))
      nativeint_ne =
-       (function {nlocal = 0} x[nativeint] y[nativeint] : int
+       (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
          (Nativeint.!= x y))
      gen_lt = (function {nlocal = 0} x y : int (caml_lessthan x y))
-     int_lt = (function {nlocal = 0} x[int] y[int] : int (< x y))
-     bool_lt = (function {nlocal = 0} x[int] y[int] : int (< x y))
-     intlike_lt = (function {nlocal = 0} x[int] y[int] : int (< x y))
-     float_lt = (function {nlocal = 0} x[float] y[float] : int (Float.< x y))
+     int_lt =
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int (< x y))
+     bool_lt =
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int (< x y))
+     intlike_lt =
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int (< x y))
+     float_lt =
+       (function {nlocal = 0} x[value<float>] y[value<float>] : int
+         (Float.< x y))
      string_lt = (function {nlocal = 0} x y : int (caml_string_lessthan x y))
-     int32_lt = (function {nlocal = 0} x[int32] y[int32] : int (Int32.< x y))
-     int64_lt = (function {nlocal = 0} x[int64] y[int64] : int (Int64.< x y))
+     int32_lt =
+       (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
+         (Int32.< x y))
+     int64_lt =
+       (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
+         (Int64.< x y))
      nativeint_lt =
-       (function {nlocal = 0} x[nativeint] y[nativeint] : int
+       (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
          (Nativeint.< x y))
      gen_gt = (function {nlocal = 0} x y : int (caml_greaterthan x y))
-     int_gt = (function {nlocal = 0} x[int] y[int] : int (> x y))
-     bool_gt = (function {nlocal = 0} x[int] y[int] : int (> x y))
-     intlike_gt = (function {nlocal = 0} x[int] y[int] : int (> x y))
-     float_gt = (function {nlocal = 0} x[float] y[float] : int (Float.> x y))
+     int_gt =
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int (> x y))
+     bool_gt =
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int (> x y))
+     intlike_gt =
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int (> x y))
+     float_gt =
+       (function {nlocal = 0} x[value<float>] y[value<float>] : int
+         (Float.> x y))
      string_gt =
        (function {nlocal = 0} x y : int (caml_string_greaterthan x y))
-     int32_gt = (function {nlocal = 0} x[int32] y[int32] : int (Int32.> x y))
-     int64_gt = (function {nlocal = 0} x[int64] y[int64] : int (Int64.> x y))
+     int32_gt =
+       (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
+         (Int32.> x y))
+     int64_gt =
+       (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
+         (Int64.> x y))
      nativeint_gt =
-       (function {nlocal = 0} x[nativeint] y[nativeint] : int
+       (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
          (Nativeint.> x y))
      gen_le = (function {nlocal = 0} x y : int (caml_lessequal x y))
-     int_le = (function {nlocal = 0} x[int] y[int] : int (<= x y))
-     bool_le = (function {nlocal = 0} x[int] y[int] : int (<= x y))
-     intlike_le = (function {nlocal = 0} x[int] y[int] : int (<= x y))
+     int_le =
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int (<= x y))
+     bool_le =
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int (<= x y))
+     intlike_le =
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int (<= x y))
      float_le =
-       (function {nlocal = 0} x[float] y[float] : int (Float.<= x y))
+       (function {nlocal = 0} x[value<float>] y[value<float>] : int
+         (Float.<= x y))
      string_le =
        (function {nlocal = 0} x y : int (caml_string_lessequal x y))
      int32_le =
-       (function {nlocal = 0} x[int32] y[int32] : int (Int32.<= x y))
+       (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
+         (Int32.<= x y))
      int64_le =
-       (function {nlocal = 0} x[int64] y[int64] : int (Int64.<= x y))
+       (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
+         (Int64.<= x y))
      nativeint_le =
-       (function {nlocal = 0} x[nativeint] y[nativeint] : int
+       (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
          (Nativeint.<= x y))
      gen_ge = (function {nlocal = 0} x y : int (caml_greaterequal x y))
-     int_ge = (function {nlocal = 0} x[int] y[int] : int (>= x y))
-     bool_ge = (function {nlocal = 0} x[int] y[int] : int (>= x y))
-     intlike_ge = (function {nlocal = 0} x[int] y[int] : int (>= x y))
+     int_ge =
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int (>= x y))
+     bool_ge =
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int (>= x y))
+     intlike_ge =
+       (function {nlocal = 0} x[value<int>] y[value<int>] : int (>= x y))
      float_ge =
-       (function {nlocal = 0} x[float] y[float] : int (Float.>= x y))
+       (function {nlocal = 0} x[value<float>] y[value<float>] : int
+         (Float.>= x y))
      string_ge =
        (function {nlocal = 0} x y : int (caml_string_greaterequal x y))
      int32_ge =
-       (function {nlocal = 0} x[int32] y[int32] : int (Int32.>= x y))
+       (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
+         (Int32.>= x y))
      int64_ge =
-       (function {nlocal = 0} x[int64] y[int64] : int (Int64.>= x y))
+       (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
+         (Int64.>= x y))
      nativeint_ge =
-       (function {nlocal = 0} x[nativeint] y[nativeint] : int
+       (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
          (Nativeint.>= x y))
      eta_gen_cmp =
        (function {nlocal = 0} prim prim stub : int (caml_compare prim prim))
      eta_int_cmp =
-       (function {nlocal = 0} prim[int] prim[int] stub : int
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
          (compare_ints prim prim))
      eta_bool_cmp =
-       (function {nlocal = 0} prim[int] prim[int] stub : int
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
          (compare_ints prim prim))
      eta_intlike_cmp =
-       (function {nlocal = 0} prim[int] prim[int] stub : int
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
          (compare_ints prim prim))
      eta_float_cmp =
-       (function {nlocal = 0} prim[float] prim[float] stub : int
-         (compare_floats float prim prim))
+       (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
+         : int (compare_floats float prim prim))
      eta_string_cmp =
        (function {nlocal = 0} prim prim stub : int
          (caml_string_compare prim prim))
      eta_int32_cmp =
-       (function {nlocal = 0} prim[int32] prim[int32] stub : int
-         (compare_bints int32 prim prim))
+       (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
+         : int (compare_bints int32 prim prim))
      eta_int64_cmp =
-       (function {nlocal = 0} prim[int64] prim[int64] stub : int
-         (compare_bints int64 prim prim))
+       (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
+         : int (compare_bints int64 prim prim))
      eta_nativeint_cmp =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
-         (compare_bints nativeint prim prim))
+       (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+         stub : int (compare_bints nativeint prim prim))
      eta_gen_eq =
        (function {nlocal = 0} prim prim stub : int (caml_equal prim prim))
      eta_int_eq =
-       (function {nlocal = 0} prim[int] prim[int] stub : int (== prim prim))
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+         (== prim prim))
      eta_bool_eq =
-       (function {nlocal = 0} prim[int] prim[int] stub : int (== prim prim))
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+         (== prim prim))
      eta_intlike_eq =
-       (function {nlocal = 0} prim[int] prim[int] stub : int (== prim prim))
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+         (== prim prim))
      eta_float_eq =
-       (function {nlocal = 0} prim[float] prim[float] stub : int
-         (Float.== prim prim))
+       (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
+         : int (Float.== prim prim))
      eta_string_eq =
        (function {nlocal = 0} prim prim stub : int
          (caml_string_equal prim prim))
      eta_int32_eq =
-       (function {nlocal = 0} prim[int32] prim[int32] stub : int
-         (Int32.== prim prim))
+       (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
+         : int (Int32.== prim prim))
      eta_int64_eq =
-       (function {nlocal = 0} prim[int64] prim[int64] stub : int
-         (Int64.== prim prim))
+       (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
+         : int (Int64.== prim prim))
      eta_nativeint_eq =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
-         (Nativeint.== prim prim))
+       (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+         stub : int (Nativeint.== prim prim))
      eta_gen_ne =
        (function {nlocal = 0} prim prim stub : int (caml_notequal prim prim))
      eta_int_ne =
-       (function {nlocal = 0} prim[int] prim[int] stub : int (!= prim prim))
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+         (!= prim prim))
      eta_bool_ne =
-       (function {nlocal = 0} prim[int] prim[int] stub : int (!= prim prim))
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+         (!= prim prim))
      eta_intlike_ne =
-       (function {nlocal = 0} prim[int] prim[int] stub : int (!= prim prim))
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+         (!= prim prim))
      eta_float_ne =
-       (function {nlocal = 0} prim[float] prim[float] stub : int
-         (Float.!= prim prim))
+       (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
+         : int (Float.!= prim prim))
      eta_string_ne =
        (function {nlocal = 0} prim prim stub : int
          (caml_string_notequal prim prim))
      eta_int32_ne =
-       (function {nlocal = 0} prim[int32] prim[int32] stub : int
-         (Int32.!= prim prim))
+       (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
+         : int (Int32.!= prim prim))
      eta_int64_ne =
-       (function {nlocal = 0} prim[int64] prim[int64] stub : int
-         (Int64.!= prim prim))
+       (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
+         : int (Int64.!= prim prim))
      eta_nativeint_ne =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
-         (Nativeint.!= prim prim))
+       (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+         stub : int (Nativeint.!= prim prim))
      eta_gen_lt =
        (function {nlocal = 0} prim prim stub : int (caml_lessthan prim prim))
      eta_int_lt =
-       (function {nlocal = 0} prim[int] prim[int] stub : int (< prim prim))
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+         (< prim prim))
      eta_bool_lt =
-       (function {nlocal = 0} prim[int] prim[int] stub : int (< prim prim))
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+         (< prim prim))
      eta_intlike_lt =
-       (function {nlocal = 0} prim[int] prim[int] stub : int (< prim prim))
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+         (< prim prim))
      eta_float_lt =
-       (function {nlocal = 0} prim[float] prim[float] stub : int
-         (Float.< prim prim))
+       (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
+         : int (Float.< prim prim))
      eta_string_lt =
        (function {nlocal = 0} prim prim stub : int
          (caml_string_lessthan prim prim))
      eta_int32_lt =
-       (function {nlocal = 0} prim[int32] prim[int32] stub : int
-         (Int32.< prim prim))
+       (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
+         : int (Int32.< prim prim))
      eta_int64_lt =
-       (function {nlocal = 0} prim[int64] prim[int64] stub : int
-         (Int64.< prim prim))
+       (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
+         : int (Int64.< prim prim))
      eta_nativeint_lt =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
-         (Nativeint.< prim prim))
+       (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+         stub : int (Nativeint.< prim prim))
      eta_gen_gt =
        (function {nlocal = 0} prim prim stub : int
          (caml_greaterthan prim prim))
      eta_int_gt =
-       (function {nlocal = 0} prim[int] prim[int] stub : int (> prim prim))
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+         (> prim prim))
      eta_bool_gt =
-       (function {nlocal = 0} prim[int] prim[int] stub : int (> prim prim))
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+         (> prim prim))
      eta_intlike_gt =
-       (function {nlocal = 0} prim[int] prim[int] stub : int (> prim prim))
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+         (> prim prim))
      eta_float_gt =
-       (function {nlocal = 0} prim[float] prim[float] stub : int
-         (Float.> prim prim))
+       (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
+         : int (Float.> prim prim))
      eta_string_gt =
        (function {nlocal = 0} prim prim stub : int
          (caml_string_greaterthan prim prim))
      eta_int32_gt =
-       (function {nlocal = 0} prim[int32] prim[int32] stub : int
-         (Int32.> prim prim))
+       (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
+         : int (Int32.> prim prim))
      eta_int64_gt =
-       (function {nlocal = 0} prim[int64] prim[int64] stub : int
-         (Int64.> prim prim))
+       (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
+         : int (Int64.> prim prim))
      eta_nativeint_gt =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
-         (Nativeint.> prim prim))
+       (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+         stub : int (Nativeint.> prim prim))
      eta_gen_le =
        (function {nlocal = 0} prim prim stub : int
          (caml_lessequal prim prim))
      eta_int_le =
-       (function {nlocal = 0} prim[int] prim[int] stub : int (<= prim prim))
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+         (<= prim prim))
      eta_bool_le =
-       (function {nlocal = 0} prim[int] prim[int] stub : int (<= prim prim))
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+         (<= prim prim))
      eta_intlike_le =
-       (function {nlocal = 0} prim[int] prim[int] stub : int (<= prim prim))
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+         (<= prim prim))
      eta_float_le =
-       (function {nlocal = 0} prim[float] prim[float] stub : int
-         (Float.<= prim prim))
+       (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
+         : int (Float.<= prim prim))
      eta_string_le =
        (function {nlocal = 0} prim prim stub : int
          (caml_string_lessequal prim prim))
      eta_int32_le =
-       (function {nlocal = 0} prim[int32] prim[int32] stub : int
-         (Int32.<= prim prim))
+       (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
+         : int (Int32.<= prim prim))
      eta_int64_le =
-       (function {nlocal = 0} prim[int64] prim[int64] stub : int
-         (Int64.<= prim prim))
+       (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
+         : int (Int64.<= prim prim))
      eta_nativeint_le =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
-         (Nativeint.<= prim prim))
+       (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+         stub : int (Nativeint.<= prim prim))
      eta_gen_ge =
        (function {nlocal = 0} prim prim stub : int
          (caml_greaterequal prim prim))
      eta_int_ge =
-       (function {nlocal = 0} prim[int] prim[int] stub : int (>= prim prim))
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+         (>= prim prim))
      eta_bool_ge =
-       (function {nlocal = 0} prim[int] prim[int] stub : int (>= prim prim))
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+         (>= prim prim))
      eta_intlike_ge =
-       (function {nlocal = 0} prim[int] prim[int] stub : int (>= prim prim))
+       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+         (>= prim prim))
      eta_float_ge =
-       (function {nlocal = 0} prim[float] prim[float] stub : int
-         (Float.>= prim prim))
+       (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
+         : int (Float.>= prim prim))
      eta_string_ge =
        (function {nlocal = 0} prim prim stub : int
          (caml_string_greaterequal prim prim))
      eta_int32_ge =
-       (function {nlocal = 0} prim[int32] prim[int32] stub : int
-         (Int32.>= prim prim))
+       (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
+         : int (Int32.>= prim prim))
      eta_int64_ge =
-       (function {nlocal = 0} prim[int64] prim[int64] stub : int
-         (Int64.>= prim prim))
+       (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
+         : int (Int64.>= prim prim))
      eta_nativeint_ge =
-       (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
-         (Nativeint.>= prim prim))
-     int_vec =[(consts (0))
-               (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+       (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+         stub : int (Nativeint.>= prim prim))
+     int_vec =[value<
+                (consts (0))
+                 (non_consts ([0: ?,
+                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
        [0: [0: 1 1] [0: [0: 1 2] [0: [0: 2 1] 0]]]
-     bool_vec =[(consts (0))
-                (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+     bool_vec =[value<
+                 (consts (0))
+                  (non_consts ([0: ?,
+                                value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
        [0: [0: 0 0] [0: [0: 0 1] [0: [0: 1 0] 0]]]
-     intlike_vec =[(consts (0))
-                   (non_consts ([0: *,
-                                 [(consts (0)) (non_consts ([0: *, *]))]]))]
+     intlike_vec =[value<
+                    (consts (0))
+                     (non_consts ([0: ?,
+                                   value<
+                                    (consts (0)) (non_consts ([0: ?, *]))>]))>]
        [0: [0: 0 0] [0: [0: 0 1] [0: [0: 1 0] 0]]]
-     float_vec =[(consts (0))
-                 (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+     float_vec =[value<
+                  (consts (0))
+                   (non_consts ([0: ?,
+                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
        [0: [0: 1. 1.] [0: [0: 1. 2.] [0: [0: 2. 1.] 0]]]
-     string_vec =[(consts (0))
-                  (non_consts ([0: *,
-                                [(consts (0)) (non_consts ([0: *, *]))]]))]
+     string_vec =[value<
+                   (consts (0))
+                    (non_consts ([0: ?,
+                                  value<
+                                   (consts (0)) (non_consts ([0: ?, *]))>]))>]
        [0: [0: "1" "1"] [0: [0: "1" "2"] [0: [0: "2" "1"] 0]]]
-     int32_vec =[(consts (0))
-                 (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+     int32_vec =[value<
+                  (consts (0))
+                   (non_consts ([0: ?,
+                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
        [0: [0: 1l 1l] [0: [0: 1l 2l] [0: [0: 2l 1l] 0]]]
-     int64_vec =[(consts (0))
-                 (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
+     int64_vec =[value<
+                  (consts (0))
+                   (non_consts ([0: ?,
+                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
        [0: [0: 1L 1L] [0: [0: 1L 2L] [0: [0: 2L 1L] 0]]]
-     nativeint_vec =[(consts (0))
-                     (non_consts ([0: *,
-                                   [(consts (0)) (non_consts ([0: *, *]))]]))]
+     nativeint_vec =[value<
+                      (consts (0))
+                       (non_consts ([0: ?,
+                                     value<
+                                      (consts (0)) (non_consts ([0: ?, *]))>]))>]
        [0: [0: 1n 1n] [0: [0: 1n 2n] [0: [0: 2n 1n] 0]]]
      test_vec =
        (function {nlocal = 0} cmp eq ne lt gt le ge
-         vec[(consts (0))
-             (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
-         [(consts ())
-          (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))],
-                        [(consts (0)) (non_consts ([0: *, *]))]]))](let
-                                                                    (uncurry =
-                                                                    (function
-                                                                    {nlocal = 0}
-                                                                    f
-                                                                    param
-                                                                    [(consts ())
-                                                                    (non_consts (
-                                                                    [0: *, *]))]
-                                                                    (apply f
-                                                                    (field_imm 0
-                                                                    param)
-                                                                    (field_imm 1
-                                                                    param)))
-                                                                    map =
-                                                                    (function
-                                                                    {nlocal = 2}
-                                                                    f
-                                                                    l[(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *,
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))]]))]
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *,
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))]]))]
-                                                                    (apply
-                                                                    (field_imm 19
-                                                                    (global Stdlib__List!))
-                                                                    (apply
-                                                                    uncurry
-                                                                    f) l)))
-                                                                    (makeblock 0 (
-                                                                    [(consts ())
-                                                                    (non_consts (
-                                                                    [0:
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))],
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))]]))],
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *,
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))]]))])
-                                                                    (makeblock 0 (
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *,
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))]]))],
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *,
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))]]))])
-                                                                    (apply
-                                                                    map
-                                                                    gen_cmp
-                                                                    vec)
-                                                                    (apply
-                                                                    map cmp
-                                                                    vec))
-                                                                    (apply
-                                                                    map
-                                                                    (function
-                                                                    {nlocal = 2}
-                                                                    gen spec
-                                                                    [(consts ())
-                                                                    (non_consts (
-                                                                    [0:
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))],
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))]]))]
-                                                                    (makeblock 0 (
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *,
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))]]))],
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *,
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))]]))])
-                                                                    (apply
-                                                                    map gen
-                                                                    vec)
-                                                                    (apply
-                                                                    map spec
-                                                                    vec)))
-                                                                    (makeblock 0 (
-                                                                    [(consts ())
-                                                                    (non_consts (
-                                                                    [0: *, *]))],
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *,
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))]]))])
-                                                                    (makeblock 0 (*,*)
-                                                                    gen_eq
-                                                                    eq)
-                                                                    (makeblock 0 (
-                                                                    [(consts ())
-                                                                    (non_consts (
-                                                                    [0: *, *]))],
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *,
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))]]))])
-                                                                    (makeblock 0 (*,*)
-                                                                    gen_ne
-                                                                    ne)
-                                                                    (makeblock 0 (
-                                                                    [(consts ())
-                                                                    (non_consts (
-                                                                    [0: *, *]))],
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *,
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))]]))])
-                                                                    (makeblock 0 (*,*)
-                                                                    gen_lt
-                                                                    lt)
-                                                                    (makeblock 0 (
-                                                                    [(consts ())
-                                                                    (non_consts (
-                                                                    [0: *, *]))],
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *,
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))]]))])
-                                                                    (makeblock 0 (*,*)
-                                                                    gen_gt
-                                                                    gt)
-                                                                    (makeblock 0 (
-                                                                    [(consts ())
-                                                                    (non_consts (
-                                                                    [0: *, *]))],
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *,
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))]]))])
-                                                                    (makeblock 0 (*,*)
-                                                                    gen_le
-                                                                    le)
-                                                                    (makeblock 0 (
-                                                                    [(consts ())
-                                                                    (non_consts (
-                                                                    [0: *, *]))],
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *,
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))]]))])
-                                                                    (makeblock 0 (*,*)
-                                                                    gen_ge
-                                                                    ge) 0)))))))))))
+         vec[value<
+              (consts (0))
+               (non_consts ([0: ?,
+                             value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+         : (consts ())
+            (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>,
+                          value<(consts (0)) (non_consts ([0: ?, *]))>]))
+         (let
+           (uncurry =
+              (function {nlocal = 0} f
+                param[value<(consts ()) (non_consts ([0: ?, ?]))>]
+                (apply f (field_imm 0 param) (field_imm 1 param)))
+            map =
+              (function {nlocal = 2} f
+                l[value<
+                   (consts (0))
+                    (non_consts ([0: ?,
+                                  value<
+                                   (consts (0)) (non_consts ([0: ?, *]))>]))>]
+                : (consts (0))
+                   (non_consts ([0: ?,
+                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))
+                (apply (field_imm 19 (global Stdlib__List!))
+                  (apply uncurry f) l)))
+           (makeblock 0 (value<
+                          (consts ())
+                           (non_consts ([0:
+                                         value<
+                                          (consts (0))
+                                           (non_consts ([0: ?, *]))>,
+                                         value<
+                                          (consts (0))
+                                           (non_consts ([0: ?, *]))>]))>,
+             value<
+              (consts (0))
+               (non_consts ([0: ?,
+                             value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+             (makeblock 0 (value<
+                            (consts (0))
+                             (non_consts ([0: ?,
+                                           value<
+                                            (consts (0))
+                                             (non_consts ([0: ?, *]))>]))>,
+               value<
+                (consts (0))
+                 (non_consts ([0: ?,
+                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+               (apply map gen_cmp vec) (apply map cmp vec))
+             (apply map
+               (function {nlocal = 2} gen spec
+                 : (consts ())
+                    (non_consts ([0:
+                                  value<
+                                   (consts (0)) (non_consts ([0: ?, *]))>,
+                                  value<
+                                   (consts (0)) (non_consts ([0: ?, *]))>]))
+                 (makeblock 0 (value<
+                                (consts (0))
+                                 (non_consts ([0: ?,
+                                               value<
+                                                (consts (0))
+                                                 (non_consts ([0: ?, *]))>]))>,
+                   value<
+                    (consts (0))
+                     (non_consts ([0: ?,
+                                   value<
+                                    (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                   (apply map gen vec) (apply map spec vec)))
+               (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
+                 value<
+                  (consts (0))
+                   (non_consts ([0: ?,
+                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+                 (makeblock 0 (*,*) gen_eq eq)
+                 (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
+                   value<
+                    (consts (0))
+                     (non_consts ([0: ?,
+                                   value<
+                                    (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                   (makeblock 0 (*,*) gen_ne ne)
+                   (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
+                     value<
+                      (consts (0))
+                       (non_consts ([0: ?,
+                                     value<
+                                      (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                     (makeblock 0 (*,*) gen_lt lt)
+                     (makeblock 0 (value<
+                                    (consts ()) (non_consts ([0: *, *]))>,
+                       value<
+                        (consts (0))
+                         (non_consts ([0: ?,
+                                       value<
+                                        (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                       (makeblock 0 (*,*) gen_gt gt)
+                       (makeblock 0 (value<
+                                      (consts ()) (non_consts ([0: *, *]))>,
+                         value<
+                          (consts (0))
+                           (non_consts ([0: ?,
+                                         value<
+                                          (consts (0))
+                                           (non_consts ([0: ?, *]))>]))>)
+                         (makeblock 0 (*,*) gen_le le)
+                         (makeblock 0 (value<
+                                        (consts ()) (non_consts ([0: *, *]))>,
+                           value<
+                            (consts (0))
+                             (non_consts ([0: ?,
+                                           value<
+                                            (consts (0))
+                                             (non_consts ([0: ?, *]))>]))>)
+                           (makeblock 0 (*,*) gen_ge ge) 0)))))))))))
     (seq
       (apply test_vec int_cmp int_eq int_ne int_lt int_gt int_le int_ge
         int_vec)
@@ -503,93 +510,128 @@
       (let
         (eta_test_vec =
            (function {nlocal = 0} cmp eq ne lt gt le ge
-             vec[(consts (0))
-                 (non_consts ([0: *, [(consts (0)) (non_consts ([0: *, *]))]]))]
-             [(consts ())
-              (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))],
-                            [(consts (0)) (non_consts ([0: *, *]))]]))]
+             vec[value<
+                  (consts (0))
+                   (non_consts ([0: ?,
+                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+             : (consts ())
+                (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>,
+                              value<(consts (0)) (non_consts ([0: ?, *]))>]))
              (let
                (uncurry =
                   (function {nlocal = 0} f
-                    param[(consts ()) (non_consts ([0: *, *]))]
+                    param[value<(consts ()) (non_consts ([0: ?, ?]))>]
                     (apply f (field_imm 0 param) (field_imm 1 param)))
                 map =
                   (function {nlocal = 2} f
-                    l[(consts (0))
-                      (non_consts ([0: *,
-                                    [(consts (0)) (non_consts ([0: *, *]))]]))]
-                    [(consts (0))
-                     (non_consts ([0: *,
-                                   [(consts (0)) (non_consts ([0: *, *]))]]))]
+                    l[value<
+                       (consts (0))
+                        (non_consts ([0: ?,
+                                      value<
+                                       (consts (0)) (non_consts ([0: ?, *]))>]))>]
+                    : (consts (0))
+                       (non_consts ([0: ?,
+                                     value<
+                                      (consts (0)) (non_consts ([0: ?, *]))>]))
                     (apply (field_imm 19 (global Stdlib__List!))
                       (apply uncurry f) l)))
-               (makeblock 0 ([(consts ())
-                              (non_consts ([0:
-                                            [(consts (0))
-                                             (non_consts ([0: *, *]))],
-                                            [(consts (0))
-                                             (non_consts ([0: *, *]))]]))],
-                 [(consts (0))
-                  (non_consts ([0: *,
-                                [(consts (0)) (non_consts ([0: *, *]))]]))])
-                 (makeblock 0 ([(consts (0))
-                                (non_consts ([0: *,
-                                              [(consts (0))
-                                               (non_consts ([0: *, *]))]]))],
-                   [(consts (0))
-                    (non_consts ([0: *,
-                                  [(consts (0)) (non_consts ([0: *, *]))]]))])
+               (makeblock 0 (value<
+                              (consts ())
+                               (non_consts ([0:
+                                             value<
+                                              (consts (0))
+                                               (non_consts ([0: ?, *]))>,
+                                             value<
+                                              (consts (0))
+                                               (non_consts ([0: ?, *]))>]))>,
+                 value<
+                  (consts (0))
+                   (non_consts ([0: ?,
+                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+                 (makeblock 0 (value<
+                                (consts (0))
+                                 (non_consts ([0: ?,
+                                               value<
+                                                (consts (0))
+                                                 (non_consts ([0: ?, *]))>]))>,
+                   value<
+                    (consts (0))
+                     (non_consts ([0: ?,
+                                   value<
+                                    (consts (0)) (non_consts ([0: ?, *]))>]))>)
                    (apply map eta_gen_cmp vec) (apply map cmp vec))
                  (apply map
                    (function {nlocal = 2} gen spec
-                     [(consts ())
-                      (non_consts ([0:
-                                    [(consts (0)) (non_consts ([0: *, *]))],
-                                    [(consts (0)) (non_consts ([0: *, *]))]]))]
-                     (makeblock 0 ([(consts (0))
-                                    (non_consts ([0: *,
-                                                  [(consts (0))
-                                                   (non_consts ([0: *, *]))]]))],
-                       [(consts (0))
-                        (non_consts ([0: *,
-                                      [(consts (0)) (non_consts ([0: *, *]))]]))])
+                     : (consts ())
+                        (non_consts ([0:
+                                      value<
+                                       (consts (0)) (non_consts ([0: ?, *]))>,
+                                      value<
+                                       (consts (0)) (non_consts ([0: ?, *]))>]))
+                     (makeblock 0 (value<
+                                    (consts (0))
+                                     (non_consts ([0: ?,
+                                                   value<
+                                                    (consts (0))
+                                                     (non_consts ([0: ?, *]))>]))>,
+                       value<
+                        (consts (0))
+                         (non_consts ([0: ?,
+                                       value<
+                                        (consts (0)) (non_consts ([0: ?, *]))>]))>)
                        (apply map gen vec) (apply map spec vec)))
-                   (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],
-                     [(consts (0))
-                      (non_consts ([0: *,
-                                    [(consts (0)) (non_consts ([0: *, *]))]]))])
+                   (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
+                     value<
+                      (consts (0))
+                       (non_consts ([0: ?,
+                                     value<
+                                      (consts (0)) (non_consts ([0: ?, *]))>]))>)
                      (makeblock 0 (*,*) eta_gen_eq eq)
-                     (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],
-                       [(consts (0))
-                        (non_consts ([0: *,
-                                      [(consts (0)) (non_consts ([0: *, *]))]]))])
+                     (makeblock 0 (value<
+                                    (consts ()) (non_consts ([0: *, *]))>,
+                       value<
+                        (consts (0))
+                         (non_consts ([0: ?,
+                                       value<
+                                        (consts (0)) (non_consts ([0: ?, *]))>]))>)
                        (makeblock 0 (*,*) eta_gen_ne ne)
-                       (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],
-                         [(consts (0))
-                          (non_consts ([0: *,
-                                        [(consts (0))
-                                         (non_consts ([0: *, *]))]]))])
+                       (makeblock 0 (value<
+                                      (consts ()) (non_consts ([0: *, *]))>,
+                         value<
+                          (consts (0))
+                           (non_consts ([0: ?,
+                                         value<
+                                          (consts (0))
+                                           (non_consts ([0: ?, *]))>]))>)
                          (makeblock 0 (*,*) eta_gen_lt lt)
-                         (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],
-                           [(consts (0))
-                            (non_consts ([0: *,
-                                          [(consts (0))
-                                           (non_consts ([0: *, *]))]]))])
+                         (makeblock 0 (value<
+                                        (consts ()) (non_consts ([0: *, *]))>,
+                           value<
+                            (consts (0))
+                             (non_consts ([0: ?,
+                                           value<
+                                            (consts (0))
+                                             (non_consts ([0: ?, *]))>]))>)
                            (makeblock 0 (*,*) eta_gen_gt gt)
-                           (makeblock 0 ([(consts ())
-                                          (non_consts ([0: *, *]))],[(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *,
-                                                                    [(consts (0))
-                                                                    (non_consts (
-                                                                    [0: *, *]))]]))])
+                           (makeblock 0 (value<
+                                          (consts ())
+                                           (non_consts ([0: *, *]))>,
+                             value<
+                              (consts (0))
+                               (non_consts ([0: ?,
+                                             value<
+                                              (consts (0))
+                                               (non_consts ([0: ?, *]))>]))>)
                              (makeblock 0 (*,*) eta_gen_le le)
-                             (makeblock 0 ([(consts ())
-                                            (non_consts ([0: *, *]))],
-                               [(consts (0))
-                                (non_consts ([0: *,
-                                              [(consts (0))
-                                               (non_consts ([0: *, *]))]]))])
+                             (makeblock 0 (value<
+                                            (consts ())
+                                             (non_consts ([0: *, *]))>,
+                               value<
+                                (consts (0))
+                                 (non_consts ([0: ?,
+                                               value<
+                                                (consts (0))
+                                                 (non_consts ([0: ?, *]))>]))>)
                                (makeblock 0 (*,*) eta_gen_ge ge) 0)))))))))))
         (seq
           (apply eta_test_vec eta_int_cmp eta_int_eq eta_int_ne eta_int_lt

--- a/testsuite/tests/translprim/module_coercion.compilers.flat.reference
+++ b/testsuite/tests/translprim/module_coercion.compilers.flat.reference
@@ -2,60 +2,70 @@
   (let (M = (makeblock 0))
     (makeblock 0 M
       (makeblock 0
-        (function {nlocal = 0} prim[intarray] stub : int
+        (function {nlocal = 0} prim[value<intarray>] stub : int
           (array.length[int] prim))
-        (function {nlocal = 0} prim[intarray] prim[int] stub : int
-          (array.get[int indexed by int] prim prim))
-        (function {nlocal = 0} prim[intarray] prim[int] stub : int
-          (array.unsafe_get[int indexed by int] prim prim))
-        (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub : int
+        (function {nlocal = 0} prim[value<intarray>] prim[value<int>] stub
+          : int (array.get[int indexed by int] prim prim))
+        (function {nlocal = 0} prim[value<intarray>] prim[value<int>] stub
+          : int (array.unsafe_get[int indexed by int] prim prim))
+        (function {nlocal = 0} prim[value<intarray>] prim[value<int>]
+          prim[value<int>] stub : int
           (array.set[int indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub : int
+        (function {nlocal = 0} prim[value<intarray>] prim[value<int>]
+          prim[value<int>] stub : int
           (array.unsafe_set[int indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub : int
+        (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
           (compare_ints prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub : int (== prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub : int (!= prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub : int (< prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub : int (> prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub : int (<= prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub : int (>= prim prim)))
+        (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+          (== prim prim))
+        (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+          (!= prim prim))
+        (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+          (< prim prim))
+        (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+          (> prim prim))
+        (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+          (<= prim prim))
+        (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+          (>= prim prim)))
       (makeblock 0
-        (function {nlocal = 0} prim[floatarray] stub : int
+        (function {nlocal = 0} prim[value<floatarray>] stub : int
           (array.length[float] prim))
-        (function {nlocal = 0} prim[floatarray] prim[int] stub : float
-          (array.get[float indexed by int] prim prim))
-        (function {nlocal = 0} prim[floatarray] prim[int] stub : float
-          (array.unsafe_get[float indexed by int] prim prim))
-        (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
-          : int (array.set[float indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[floatarray] prim[int] prim[float] stub
-          : int (array.unsafe_set[float indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub : int
-          (compare_floats float prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub : int
-          (Float.== prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub : int
-          (Float.!= prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub : int
-          (Float.< prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub : int
-          (Float.> prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub : int
-          (Float.<= prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub : int
-          (Float.>= prim prim)))
+        (function {nlocal = 0} prim[value<floatarray>] prim[value<int>] stub
+          : float (array.get[float indexed by int] prim prim))
+        (function {nlocal = 0} prim[value<floatarray>] prim[value<int>] stub
+          : float (array.unsafe_get[float indexed by int] prim prim))
+        (function {nlocal = 0} prim[value<floatarray>] prim[value<int>]
+          prim[value<float>] stub : int
+          (array.set[float indexed by int] prim prim prim))
+        (function {nlocal = 0} prim[value<floatarray>] prim[value<int>]
+          prim[value<float>] stub : int
+          (array.unsafe_set[float indexed by int] prim prim prim))
+        (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
+          : int (compare_floats float prim prim))
+        (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
+          : int (Float.== prim prim))
+        (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
+          : int (Float.!= prim prim))
+        (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
+          : int (Float.< prim prim))
+        (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
+          : int (Float.> prim prim))
+        (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
+          : int (Float.<= prim prim))
+        (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
+          : int (Float.>= prim prim)))
       (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub : int
+        (function {nlocal = 0} prim[value<addrarray>] stub : int
           (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
+        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
           (array.get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
+        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
           (array.unsafe_get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim stub : int
-          (array.set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim stub : int
-          (array.unsafe_set[addr indexed by int] prim prim prim))
+        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] prim
+          stub : int (array.set[addr indexed by int] prim prim prim))
+        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] prim
+          stub : int (array.unsafe_set[addr indexed by int] prim prim prim))
         (function {nlocal = 0} prim prim stub : int
           (caml_string_compare prim prim))
         (function {nlocal = 0} prim prim stub : int
@@ -71,77 +81,83 @@
         (function {nlocal = 0} prim prim stub : int
           (caml_string_greaterequal prim prim)))
       (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub : int
+        (function {nlocal = 0} prim[value<addrarray>] stub : int
           (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub : int32
-          (array.get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub : int32
-          (array.unsafe_get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub
-          : int (array.set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub
-          : int (array.unsafe_set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub : int
-          (compare_bints int32 prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub : int
-          (Int32.== prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub : int
-          (Int32.!= prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub : int
-          (Int32.< prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub : int
-          (Int32.> prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub : int
-          (Int32.<= prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub : int
-          (Int32.>= prim prim)))
+        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+          : int32 (array.get[addr indexed by int] prim prim))
+        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+          : int32 (array.unsafe_get[addr indexed by int] prim prim))
+        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+          prim[value<int32>] stub : int
+          (array.set[addr indexed by int] prim prim prim))
+        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+          prim[value<int32>] stub : int
+          (array.unsafe_set[addr indexed by int] prim prim prim))
+        (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
+          : int (compare_bints int32 prim prim))
+        (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
+          : int (Int32.== prim prim))
+        (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
+          : int (Int32.!= prim prim))
+        (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
+          : int (Int32.< prim prim))
+        (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
+          : int (Int32.> prim prim))
+        (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
+          : int (Int32.<= prim prim))
+        (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
+          : int (Int32.>= prim prim)))
       (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub : int
+        (function {nlocal = 0} prim[value<addrarray>] stub : int
           (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub : int64
-          (array.get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub : int64
-          (array.unsafe_get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub
-          : int (array.set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub
-          : int (array.unsafe_set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub : int
-          (compare_bints int64 prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub : int
-          (Int64.== prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub : int
-          (Int64.!= prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub : int
-          (Int64.< prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub : int
-          (Int64.> prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub : int
-          (Int64.<= prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub : int
-          (Int64.>= prim prim)))
+        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+          : int64 (array.get[addr indexed by int] prim prim))
+        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+          : int64 (array.unsafe_get[addr indexed by int] prim prim))
+        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+          prim[value<int64>] stub : int
+          (array.set[addr indexed by int] prim prim prim))
+        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+          prim[value<int64>] stub : int
+          (array.unsafe_set[addr indexed by int] prim prim prim))
+        (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
+          : int (compare_bints int64 prim prim))
+        (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
+          : int (Int64.== prim prim))
+        (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
+          : int (Int64.!= prim prim))
+        (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
+          : int (Int64.< prim prim))
+        (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
+          : int (Int64.> prim prim))
+        (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
+          : int (Int64.<= prim prim))
+        (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
+          : int (Int64.>= prim prim)))
       (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub : int
+        (function {nlocal = 0} prim[value<addrarray>] stub : int
           (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub : nativeint
-          (array.get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub : nativeint
-          (array.unsafe_get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[nativeint] stub
-          : int (array.set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[nativeint] stub
-          : int (array.unsafe_set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
-          (compare_bints nativeint prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
-          (Nativeint.== prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
-          (Nativeint.!= prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
-          (Nativeint.< prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
-          (Nativeint.> prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
-          (Nativeint.<= prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub : int
-          (Nativeint.>= prim prim))))))
+        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+          : nativeint (array.get[addr indexed by int] prim prim))
+        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+          : nativeint (array.unsafe_get[addr indexed by int] prim prim))
+        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+          prim[value<nativeint>] stub : int
+          (array.set[addr indexed by int] prim prim prim))
+        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+          prim[value<nativeint>] stub : int
+          (array.unsafe_set[addr indexed by int] prim prim prim))
+        (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+          stub : int (compare_bints nativeint prim prim))
+        (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+          stub : int (Nativeint.== prim prim))
+        (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+          stub : int (Nativeint.!= prim prim))
+        (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+          stub : int (Nativeint.< prim prim))
+        (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+          stub : int (Nativeint.> prim prim))
+        (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+          stub : int (Nativeint.<= prim prim))
+        (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+          stub : int (Nativeint.>= prim prim))))))

--- a/testsuite/tests/translprim/ref_spec.stack.reference
+++ b/testsuite/tests/translprim/ref_spec.stack.reference
@@ -1,23 +1,25 @@
 (setglobal Ref_spec!
   (let
-    (int_ref = (makemutable 0 (int) 1)
-     var_ref = (makemutable 0 (int) 65)
+    (int_ref = (makemutable 0 (value<int>) 1)
+     var_ref = (makemutable 0 (value<int>) 65)
      vargen_ref = (makemutable 0 (*) 65)
-     cst_ref = (makemutable 0 (int) 0)
-     gen_ref = (makemutable 0 ([(consts (0)) (non_consts ([0: *]))]) 0)
-     flt_ref = (makemutable 0 (float) 0.))
+     cst_ref = (makemutable 0 (value<int>) 0)
+     gen_ref = (makemutable 0 (value<(consts (0)) (non_consts ([0: *]))>) 0)
+     flt_ref = (makemutable 0 (value<float>) 0.))
     (seq (setfield_imm 0 int_ref 2) (setfield_imm 0 var_ref 66)
       (setfield_ptr 0 vargen_ref [0: 66 0]) (setfield_ptr 0 vargen_ref 67)
       (setfield_imm 0 cst_ref 1) (setfield_ptr 0 gen_ref [0: "foo"])
       (setfield_ptr 0 gen_ref 0) (setfield_ptr 0 flt_ref 1.)
       (let
-        (int_rec = (makemutable 0 (int,int) 0 1)
-         var_rec = (makemutable 0 (int,int) 0 65)
-         vargen_rec = (makemutable 0 (int,*) 0 65)
-         cst_rec = (makemutable 0 (int,int) 0 0)
+        (int_rec = (makemutable 0 (value<int>,value<int>) 0 1)
+         var_rec = (makemutable 0 (value<int>,value<int>) 0 65)
+         vargen_rec = (makemutable 0 (value<int>,*) 0 65)
+         cst_rec = (makemutable 0 (value<int>,value<int>) 0 0)
          gen_rec =
-           (makemutable 0 (int,[(consts (0)) (non_consts ([0: *]))]) 0 0)
-         flt_rec = (makemutable 0 (int,float) 0 0.)
+           (makemutable 0 (value<int>,value<
+                                       (consts (0)) (non_consts ([0: *]))>)
+             0 0)
+         flt_rec = (makemutable 0 (value<int>,value<float>) 0 0.)
          flt_rec' = (makefloatblock Mutable 0. 0.))
         (seq (setfield_imm 1 int_rec 2) (setfield_imm 1 var_rec 66)
           (setfield_ptr 1 vargen_rec [0: 66 0])
@@ -28,11 +30,14 @@
             (set_open_poly =
                (function {nlocal = 2} r y : int (setfield_ptr 0 r y))
              set_open_poly =
-               (function {nlocal = 2} r y[int] : int (setfield_imm 0 r y))
+               (function {nlocal = 2} r y[value<int>] : int
+                 (setfield_imm 0 r y))
              set_open_poly =
-               (function {nlocal = 2} r y[int] : int (setfield_imm 0 r y))
+               (function {nlocal = 2} r y[value<int>] : int
+                 (setfield_imm 0 r y))
              set_open_poly =
-               (function {nlocal = 2} r y[int] : int (setfield_imm 0 r y))
+               (function {nlocal = 2} r y[value<int>] : int
+                 (setfield_imm 0 r y))
              set_open_poly =
                (function {nlocal = 2} r y : int (setfield_ptr 0 r y))
              set_open_poly =

--- a/testsuite/tests/typing-layouts-or-null/non_float_array.ml
+++ b/testsuite/tests/typing-layouts-or-null/non_float_array.ml
@@ -20,7 +20,7 @@ let get_gen (xs : 'a array) i = xs.(i)
 [%%expect{|
 (let
   (get_gen =
-     (function {nlocal = 0} xs[genarray] i[int]
+     (function {nlocal = 0} xs[value<genarray>] i[value<int>]
        (array.get[gen indexed by int] xs i)))
   (apply (field_imm 1 (global Toploop!)) "get_gen" get_gen))
 val get_gen : 'a array -> int -> 'a = <fun>
@@ -30,7 +30,7 @@ let set_gen (xs : 'a array) x i = xs.(i) <- x
 [%%expect{|
 (let
   (set_gen =
-     (function {nlocal = 0} xs[genarray] x i[int] : int
+     (function {nlocal = 0} xs[value<genarray>] x i[value<int>] : int
        (array.set[gen indexed by int] xs i x)))
   (apply (field_imm 1 (global Toploop!)) "set_gen" set_gen))
 val set_gen : 'a array -> 'a -> int -> unit = <fun>
@@ -52,7 +52,7 @@ let get (type t : value mod non_float) (xs : t array) i = xs.(i)
 [%%expect{|
 (let
   (get =
-     (function {nlocal = 0} xs[addrarray] i[int]
+     (function {nlocal = 0} xs[value<addrarray>] i[value<int>]
        (array.get[addr indexed by int] xs i)))
   (apply (field_imm 1 (global Toploop!)) "get" get))
 val get : ('t : value mod non_float). 't array -> int -> 't = <fun>
@@ -63,7 +63,7 @@ let set (type t : value mod non_float) (xs : t array) x i = xs.(i) <- x
 [%%expect{|
 (let
   (set =
-     (function {nlocal = 0} xs[addrarray] x i[int] : int
+     (function {nlocal = 0} xs[value<addrarray>] x i[value<int>] : int
        (array.set[addr indexed by int] xs i x)))
   (apply (field_imm 1 (global Toploop!)) "set" set))
 val set : ('t : value mod non_float). 't array -> 't -> int -> unit = <fun>
@@ -86,8 +86,10 @@ end
 [%%expect{|
 (apply (field_imm 1 (global Toploop!)) "X/371"
   (let
-    (x1 =[(consts ()) (non_consts ([0: *, [int]]))] [0: "first" 1]
-     x2 =[(consts ()) (non_consts ([0: *, [int]]))] [0: "second" 2])
+    (x1 =[value<(consts ()) (non_consts ([0: *, value<int>]))>]
+       [0: "first" 1]
+     x2 =[value<(consts ()) (non_consts ([0: *, value<int>]))>]
+       [0: "second" 2])
     (makeblock 0 x1 x2)))
 module X : sig type t : immutable_data val x1 : t val x2 : t end
 |}]
@@ -105,9 +107,9 @@ let () =
 
 [%%expect{|
 (let
-  (X = (apply (field_imm 0 (global Toploop!)) "X/371")
-   *match* =[int]
-     (let (xs =[addrarray] (caml_make_vect 4 (field_imm 0 X)))
+  (X =? (apply (field_imm 0 (global Toploop!)) "X/371")
+   *match* =[value<int>]
+     (let (xs =[value<addrarray>] (caml_make_vect 4 (field_imm 0 X)))
        (seq (array.set[addr indexed by int] xs 1 (field_imm 1 X))
          (array.set[addr indexed by int] xs 2 (field_imm 1 X))
          (if

--- a/testsuite/tests/typing-layouts-or-null/non_float_array_no_separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/non_float_array_no_separability.ml
@@ -16,7 +16,7 @@ let get_gen (xs : 'a array) i = xs.(i)
 [%%expect{|
 (let
   (get_gen =
-     (function {nlocal = 0} xs[genarray] i[int]
+     (function {nlocal = 0} xs[value<genarray>] i[value<int>]
        (array.get[gen indexed by int] xs i)))
   (apply (field_imm 1 (global Toploop!)) "get_gen" get_gen))
 val get_gen : 'a array -> int -> 'a = <fun>
@@ -26,7 +26,7 @@ let set_gen (xs : 'a array) x i = xs.(i) <- x
 [%%expect{|
 (let
   (set_gen =
-     (function {nlocal = 0} xs[genarray] x i[int] : int
+     (function {nlocal = 0} xs[value<genarray>] x i[value<int>] : int
        (array.set[gen indexed by int] xs i x)))
   (apply (field_imm 1 (global Toploop!)) "set_gen" set_gen))
 val set_gen : 'a array -> 'a -> int -> unit = <fun>
@@ -48,7 +48,7 @@ let get (type t : value mod non_float) (xs : t array) i = xs.(i)
 [%%expect{|
 (let
   (get =
-     (function {nlocal = 0} xs[genarray] i[int]
+     (function {nlocal = 0} xs[value<genarray>] i[value<int>]
        (array.get[gen indexed by int] xs i)))
   (apply (field_imm 1 (global Toploop!)) "get" get))
 val get : ('t : value mod non_float). 't array -> int -> 't = <fun>
@@ -59,7 +59,7 @@ let set (type t : value mod non_float) (xs : t array) x i = xs.(i) <- x
 [%%expect{|
 (let
   (set =
-     (function {nlocal = 0} xs[genarray] x i[int] : int
+     (function {nlocal = 0} xs[value<genarray>] x i[value<int>] : int
        (array.set[gen indexed by int] xs i x)))
   (apply (field_imm 1 (global Toploop!)) "set" set))
 val set : ('t : value mod non_float). 't array -> 't -> int -> unit = <fun>
@@ -82,8 +82,10 @@ end
 [%%expect{|
 (apply (field_imm 1 (global Toploop!)) "X/371"
   (let
-    (x1 =[(consts ()) (non_consts ([0: *, [int]]))] [0: "first" 1]
-     x2 =[(consts ()) (non_consts ([0: *, [int]]))] [0: "second" 2])
+    (x1 =[value<(consts ()) (non_consts ([0: *, value<int>]))>]
+       [0: "first" 1]
+     x2 =[value<(consts ()) (non_consts ([0: *, value<int>]))>]
+       [0: "second" 2])
     (makeblock 0 x1 x2)))
 module X : sig type t : immutable_data val x1 : t val x2 : t end
 |}]
@@ -101,9 +103,9 @@ let () =
 
 [%%expect{|
 (let
-  (X = (apply (field_imm 0 (global Toploop!)) "X/371")
-   *match* =[int]
-     (let (xs =[genarray] (caml_make_vect 4 (field_imm 0 X)))
+  (X =? (apply (field_imm 0 (global Toploop!)) "X/371")
+   *match* =[value<int>]
+     (let (xs =[value<genarray>] (caml_make_vect 4 (field_imm 0 X)))
        (seq (array.set[gen indexed by int] xs 1 (field_imm 1 X))
          (array.set[gen indexed by int] xs 2 (field_imm 1 X))
          (if

--- a/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
+++ b/testsuite/tests/typing-unique/overwriting_proj_push_down_bug.ml
@@ -17,14 +17,14 @@ type record = { x : string; y : string @@ many aliased; }
 
 let aliased_use x = x
 [%%expect{|
-(let (aliased_use/289 = (function {nlocal = 0} x/291 x/291))
+(let (aliased_use/289 = (function {nlocal = 0} x/291? x/291))
   (apply (field_imm 1 (global Toploop!)) "aliased_use" aliased_use/289))
 val aliased_use : 'a -> 'a = <fun>
 |}]
 
 let unique_use (unique_ x) = x
 [%%expect{|
-(let (unique_use/292 = (function {nlocal = 0} x/294 x/294))
+(let (unique_use/292 = (function {nlocal = 0} x/294? x/294))
   (apply (field_imm 1 (global Toploop!)) "unique_use" unique_use/292))
 val unique_use : 'a @ unique -> 'a = <fun>
 |}]
@@ -36,16 +36,18 @@ let proj_aliased r =
   (r, y)
 [%%expect{|
 (let
-  (aliased_use/289 = (apply (field_imm 0 (global Toploop!)) "aliased_use")
+  (aliased_use/289 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    proj_aliased/295 =
-     (function {nlocal = 0} r/297[(consts ()) (non_consts ([0: *, *]))]
-       [(consts ())
-        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))], *]))]
+     (function {nlocal = 0}
+       r/297[value<(consts ()) (non_consts ([0: *, *]))>]
+       : (consts ())
+          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let
          (y/298 = (field_imm 1 r/297)
-          r/299 =[(consts ()) (non_consts ([0: *, *]))]
+          r/299 =[value<(consts ()) (non_consts ([0: *, *]))>]
             (apply aliased_use/289 r/297))
-         (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/299 y/298))))
+         (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,*) r/299
+           y/298))))
   (apply (field_imm 1 (global Toploop!)) "proj_aliased" proj_aliased/295))
 val proj_aliased : record -> record * string = <fun>
 |}]
@@ -56,16 +58,18 @@ let proj_unique r =
   (r, y)
 [%%expect{|
 (let
-  (unique_use/292 = (apply (field_imm 0 (global Toploop!)) "unique_use")
+  (unique_use/292 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
    proj_unique/300 =
-     (function {nlocal = 0} r/302[(consts ()) (non_consts ([0: *, *]))]
-       [(consts ())
-        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))], *]))]
+     (function {nlocal = 0}
+       r/302[value<(consts ()) (non_consts ([0: *, *]))>]
+       : (consts ())
+          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let
          (y/303 = (field_mut 1 r/302)
-          r/304 =[(consts ()) (non_consts ([0: *, *]))]
+          r/304 =[value<(consts ()) (non_consts ([0: *, *]))>]
             (apply unique_use/292 r/302))
-         (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/304 y/303))))
+         (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,*) r/304
+           y/303))))
   (apply (field_imm 1 (global Toploop!)) "proj_unique" proj_unique/300))
 val proj_unique : record @ unique -> record * string = <fun>
 |}]
@@ -79,15 +83,16 @@ let match_aliased r =
     (r, y)
 [%%expect{|
 (let
-  (aliased_use/289 = (apply (field_imm 0 (global Toploop!)) "aliased_use")
+  (aliased_use/289 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    match_aliased/305 =
-     (function {nlocal = 0} r/307[(consts ()) (non_consts ([0: *, *]))]
-       [(consts ())
-        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))], *]))]
+     (function {nlocal = 0}
+       r/307[value<(consts ()) (non_consts ([0: *, *]))>]
+       : (consts ())
+          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let
-         (r/309 =[(consts ()) (non_consts ([0: *, *]))]
+         (r/309 =[value<(consts ()) (non_consts ([0: *, *]))>]
             (apply aliased_use/289 r/307))
-         (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/309
+         (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,*) r/309
            (field_imm 1 r/307)))))
   (apply (field_imm 1 (global Toploop!)) "match_aliased" match_aliased/305))
 val match_aliased : record -> record * string = <fun>
@@ -101,16 +106,18 @@ let match_unique r =
     (r, y)
 [%%expect{|
 (let
-  (unique_use/292 = (apply (field_imm 0 (global Toploop!)) "unique_use")
+  (unique_use/292 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
    match_unique/311 =
-     (function {nlocal = 0} r/313[(consts ()) (non_consts ([0: *, *]))]
-       [(consts ())
-        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))], *]))]
+     (function {nlocal = 0}
+       r/313[value<(consts ()) (non_consts ([0: *, *]))>]
+       : (consts ())
+          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let
-         (y/314 =o (field_mut 1 r/313)
-          r/315 =[(consts ()) (non_consts ([0: *, *]))]
+         (y/314 =o? (field_mut 1 r/313)
+          r/315 =[value<(consts ()) (non_consts ([0: *, *]))>]
             (apply unique_use/292 r/313))
-         (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/315 y/314))))
+         (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,*) r/315
+           y/314))))
   (apply (field_imm 1 (global Toploop!)) "match_unique" match_unique/311))
 val match_unique : record @ unique -> record * string = <fun>
 |}]
@@ -125,16 +132,17 @@ let match_mini_anf_aliased r =
   (r, y)
 [%%expect{|
 (let
-  (aliased_use/289 = (apply (field_imm 0 (global Toploop!)) "aliased_use")
+  (aliased_use/289 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    match_mini_anf_aliased/317 =
-     (function {nlocal = 0} r/319[(consts ()) (non_consts ([0: *, *]))]
-       [(consts ())
-        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))], *]))]
+     (function {nlocal = 0}
+       r/319[value<(consts ()) (non_consts ([0: *, *]))>]
+       : (consts ())
+          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let
-         (*match*/325 =[int] 1
-          r/322 =[(consts ()) (non_consts ([0: *, *]))]
+         (*match*/325 =[value<int>] 1
+          r/322 =[value<(consts ()) (non_consts ([0: *, *]))>]
             (apply aliased_use/289 r/319))
-         (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/322
+         (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,*) r/322
            (field_imm 1 r/319)))))
   (apply (field_imm 1 (global Toploop!)) "match_mini_anf_aliased"
     match_mini_anf_aliased/317))
@@ -151,17 +159,19 @@ let match_mini_anf_unique r =
   (r, y)
 [%%expect{|
 (let
-  (unique_use/292 = (apply (field_imm 0 (global Toploop!)) "unique_use")
+  (unique_use/292 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
    match_mini_anf_unique/327 =
-     (function {nlocal = 0} r/329[(consts ()) (non_consts ([0: *, *]))]
-       [(consts ())
-        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))], *]))]
+     (function {nlocal = 0}
+       r/329[value<(consts ()) (non_consts ([0: *, *]))>]
+       : (consts ())
+          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (let
-         (y/331 =o (field_mut 1 r/329)
-          *match*/335 =[int] 1
-          r/332 =[(consts ()) (non_consts ([0: *, *]))]
+         (y/331 =o? (field_mut 1 r/329)
+          *match*/335 =[value<int>] 1
+          r/332 =[value<(consts ()) (non_consts ([0: *, *]))>]
             (apply unique_use/292 r/329))
-         (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/332 y/331))))
+         (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,*) r/332
+           y/331))))
   (apply (field_imm 1 (global Toploop!)) "match_mini_anf_unique"
     match_mini_anf_unique/327))
 val match_mini_anf_unique : record @ unique -> record * string = <fun>
@@ -177,20 +187,22 @@ let match_anf_aliased r =
   (r, y)
 [%%expect{|
 (let
-  (aliased_use/289 = (apply (field_imm 0 (global Toploop!)) "aliased_use")
+  (aliased_use/289 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    match_anf_aliased/337 =
-     (function {nlocal = 0} r/339[(consts ()) (non_consts ([0: *, *]))]
-       [(consts ())
-        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))], *]))]
+     (function {nlocal = 0}
+       r/339[value<(consts ()) (non_consts ([0: *, *]))>]
+       : (consts ())
+          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (catch
-         (let (y/341 =a (field_imm 1 r/339))
-           (if (== y/341 "") (let (*match*/348 =[int] 0) (exit 8 y/341))
-             (let (*match*/346 =[int] 1) (exit 8 (field_imm 1 r/339)))))
+         (let (y/341 =a? (field_imm 1 r/339))
+           (if (== y/341 "")
+             (let (*match*/348 =[value<int>] 0) (exit 8 y/341))
+             (let (*match*/346 =[value<int>] 1) (exit 8 (field_imm 1 r/339)))))
         with (8 y/340)
          (let
-           (r/343 =[(consts ()) (non_consts ([0: *, *]))]
+           (r/343 =[value<(consts ()) (non_consts ([0: *, *]))>]
               (apply aliased_use/289 r/339))
-           (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/343
+           (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,*) r/343
              y/340)))))
   (apply (field_imm 1 (global Toploop!)) "match_anf_aliased"
     match_anf_aliased/337))
@@ -208,21 +220,23 @@ let match_anf_unique r =
   (r, y)
 [%%expect{|
 (let
-  (unique_use/292 = (apply (field_imm 0 (global Toploop!)) "unique_use")
+  (unique_use/292 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
    match_anf_unique/349 =
-     (function {nlocal = 0} r/351[(consts ()) (non_consts ([0: *, *]))]
-       [(consts ())
-        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))], *]))]
+     (function {nlocal = 0}
+       r/351[value<(consts ()) (non_consts ([0: *, *]))>]
+       : (consts ())
+          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
        (catch
-         (let (y/353 =o (field_mut 1 r/351))
-           (if (== y/353 "") (let (*match*/360 =[int] 0) (exit 14 y/353))
-             (let (y/354 =o (field_mut 1 r/351) *match*/358 =[int] 1)
+         (let (y/353 =o? (field_mut 1 r/351))
+           (if (== y/353 "")
+             (let (*match*/360 =[value<int>] 0) (exit 14 y/353))
+             (let (y/354 =o? (field_mut 1 r/351) *match*/358 =[value<int>] 1)
                (exit 14 y/354))))
         with (14 y/352)
          (let
-           (r/355 =[(consts ()) (non_consts ([0: *, *]))]
+           (r/355 =[value<(consts ()) (non_consts ([0: *, *]))>]
               (apply unique_use/292 r/351))
-           (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/355
+           (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,*) r/355
              y/352)))))
   (apply (field_imm 1 (global Toploop!)) "match_anf_unique"
     match_anf_unique/349))
@@ -253,68 +267,116 @@ let swap_inner (t : tree) =
 (let
   (swap_inner/367 =
      (function {nlocal = 0}
-       t/369[(consts (0))
-             (non_consts ([0: [(consts (0)) (non_consts ([0: *, [int], *]))],
-                           [int],
-                           [(consts (0)) (non_consts ([0: *, [int], *]))]]))]
-       [(consts (0))
-        (non_consts ([0: [(consts (0)) (non_consts ([0: *, [int], *]))],
-                      [int], [(consts (0)) (non_consts ([0: *, [int], *]))]]))]
+       t/369[value<
+              (consts (0))
+               (non_consts ([0:
+                             value<
+                              (consts (0))
+                               (non_consts ([0: *, value<int>, *]))>,
+                             value<int>,
+                             value<
+                              (consts (0))
+                               (non_consts ([0: *, value<int>, *]))>]))>]
+       : (consts (0))
+          (non_consts ([0:
+                        value<
+                         (consts (0)) (non_consts ([0: *, value<int>, *]))>,
+                        value<int>,
+                        value<
+                         (consts (0)) (non_consts ([0: *, value<int>, *]))>]))
        (catch
          (if t/369
-           (let (*match*/378 =a (field_imm 0 t/369))
+           (let (*match*/378 =a? (field_imm 0 t/369))
              (if *match*/378
-               (let (*match*/382 =a (field_imm 2 t/369))
+               (let (*match*/382 =a? (field_imm 2 t/369))
                  (if *match*/382
-                   (makeblock 0 ([(consts (0))
+                   (makeblock 0 (value<
+                                  (consts (0))
+                                   (non_consts ([0:
+                                                 value<
+                                                  (consts (0))
+                                                   (non_consts ([0: *,
+                                                                 value<int>,
+                                                                 *]))>,
+                                                 value<int>,
+                                                 value<
+                                                  (consts (0))
+                                                   (non_consts ([0: *,
+                                                                 value<int>,
+                                                                 *]))>]))>,
+                     value<int>,value<
+                                 (consts (0))
                                   (non_consts ([0:
-                                                [(consts (0))
-                                                 (non_consts ([0: *, [int],
-                                                               *]))], [int],
-                                                [(consts (0))
-                                                 (non_consts ([0: *, [int],
-                                                               *]))]]))],int,
-                     [(consts (0))
-                      (non_consts ([0:
-                                    [(consts (0))
-                                     (non_consts ([0: *, [int], *]))], [int],
-                                    [(consts (0))
-                                     (non_consts ([0: *, [int], *]))]]))])
-                     (makeblock 0 ([(consts (0))
+                                                value<
+                                                 (consts (0))
+                                                  (non_consts ([0: *,
+                                                                value<int>,
+                                                                *]))>,
+                                                value<int>,
+                                                value<
+                                                 (consts (0))
+                                                  (non_consts ([0: *,
+                                                                value<int>,
+                                                                *]))>]))>)
+                     (makeblock 0 (value<
+                                    (consts (0))
+                                     (non_consts ([0:
+                                                   value<
+                                                    (consts (0))
+                                                     (non_consts ([0: *,
+                                                                   value<int>,
+                                                                   *]))>,
+                                                   value<int>,
+                                                   value<
+                                                    (consts (0))
+                                                     (non_consts ([0: *,
+                                                                   value<int>,
+                                                                   *]))>]))>,
+                       value<int>,value<
+                                   (consts (0))
                                     (non_consts ([0:
-                                                  [(consts (0))
-                                                   (non_consts ([0: *, [int],
-                                                                 *]))],
-                                                  [int],
-                                                  [(consts (0))
-                                                   (non_consts ([0: *, [int],
-                                                                 *]))]]))],int,
-                       [(consts (0))
-                        (non_consts ([0:
-                                      [(consts (0))
-                                       (non_consts ([0: *, [int], *]))],
-                                      [int],
-                                      [(consts (0))
-                                       (non_consts ([0: *, [int], *]))]]))])
+                                                  value<
+                                                   (consts (0))
+                                                    (non_consts ([0: *,
+                                                                  value<int>,
+                                                                  *]))>,
+                                                  value<int>,
+                                                  value<
+                                                   (consts (0))
+                                                    (non_consts ([0: *,
+                                                                  value<int>,
+                                                                  *]))>]))>)
                        (field_imm 0 *match*/378) (field_int 1 *match*/378)
                        (field_imm 0 *match*/382))
                      (field_int 1 t/369)
-                     (makeblock 0 ([(consts (0))
+                     (makeblock 0 (value<
+                                    (consts (0))
+                                     (non_consts ([0:
+                                                   value<
+                                                    (consts (0))
+                                                     (non_consts ([0: *,
+                                                                   value<int>,
+                                                                   *]))>,
+                                                   value<int>,
+                                                   value<
+                                                    (consts (0))
+                                                     (non_consts ([0: *,
+                                                                   value<int>,
+                                                                   *]))>]))>,
+                       value<int>,value<
+                                   (consts (0))
                                     (non_consts ([0:
-                                                  [(consts (0))
-                                                   (non_consts ([0: *, [int],
-                                                                 *]))],
-                                                  [int],
-                                                  [(consts (0))
-                                                   (non_consts ([0: *, [int],
-                                                                 *]))]]))],int,
-                       [(consts (0))
-                        (non_consts ([0:
-                                      [(consts (0))
-                                       (non_consts ([0: *, [int], *]))],
-                                      [int],
-                                      [(consts (0))
-                                       (non_consts ([0: *, [int], *]))]]))])
+                                                  value<
+                                                   (consts (0))
+                                                    (non_consts ([0: *,
+                                                                  value<int>,
+                                                                  *]))>,
+                                                  value<int>,
+                                                  value<
+                                                   (consts (0))
+                                                    (non_consts ([0: *,
+                                                                  value<int>,
+                                                                  *]))>]))>)
                        (field_imm 2 *match*/378) (field_int 1 *match*/382)
                        (field_imm 2 *match*/382)))
                    (exit 19)))
@@ -351,25 +413,26 @@ let match_guard r =
     (r, y)
 [%%expect{|
 (let
-  (unique_use/292 = (apply (field_imm 0 (global Toploop!)) "unique_use")
-   aliased_use/289 = (apply (field_imm 0 (global Toploop!)) "aliased_use")
+  (unique_use/292 =? (apply (field_imm 0 (global Toploop!)) "unique_use")
+   aliased_use/289 =? (apply (field_imm 0 (global Toploop!)) "aliased_use")
    match_guard/385 =
-     (function {nlocal = 0} r/387[(consts ()) (non_consts ([0: *, *]))]
-       [(consts ())
-        (non_consts ([0: [(consts ()) (non_consts ([0: *, *]))], *]))]
-       (let (y/388 =o (field_mut 1 r/387))
+     (function {nlocal = 0}
+       r/387[value<(consts ()) (non_consts ([0: *, *]))>]
+       : (consts ())
+          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>, *]))
+       (let (y/388 =o? (field_mut 1 r/387))
          (if (apply (field_imm 8 (global Stdlib__String!)) y/388 "")
            (let
-             (r/459 =[(consts ()) (non_consts ([0: *, *]))]
+             (r/459 =[value<(consts ()) (non_consts ([0: *, *]))>]
                 (apply aliased_use/289 r/387))
-             (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/459
-               y/388))
+             (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,*)
+               r/459 y/388))
            (let
-             (y/389 =o (field_mut 1 r/387)
-              r/460 =[(consts ()) (non_consts ([0: *, *]))]
+             (y/389 =o? (field_mut 1 r/387)
+              r/460 =[value<(consts ()) (non_consts ([0: *, *]))>]
                 (apply unique_use/292 r/387))
-             (makeblock 0 ([(consts ()) (non_consts ([0: *, *]))],*) r/460
-               y/389))))))
+             (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,*)
+               r/460 y/389))))))
   (apply (field_imm 1 (global Toploop!)) "match_guard" match_guard/385))
 val match_guard : record @ unique -> record * string = <fun>
 |}]


### PR DESCRIPTION
This kinda mission-creeped on me but here's the gist. In printing lambda code:

* Rather than elide the layout altogether when a bound variable has layout `value_or_null`, put a `?` after it.
* In deeper value kinds like records, use `?` to indicate `value_or_null` rather than using `*` to indicate either `value` or `value_or_null`.
* When indicating the layout of a binding, actually specify a layout. Thus `float` is THE LAYOUT `float`. Something of _type_ `float` has layout `value`, and its value kind is `float`. This now gets notated as `value<float>`. (I would also accept `boxed_float` as `value` is implied there, but note that in general that gets weird with things like `boxed_unboxed_floatarray`.) Something of type `float or_null` will show as `value_or_null<float>`.
* Only use square brackets to indicate that something _has a layout_. The same layout in the middle of a struct doesn't need square brackets.
* Fix a few small bugs that could cause extremely bad wrapping behavior.
* Refactor. We did not need to implement `value_kind_non_null` three times.