### PR TITLE
Do not expose the target typing env from the join env

### DIFF
--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1375,7 +1375,10 @@ type env_id = Index.t
 
 type 'a join_arg = env_id * 'a
 
-let target_join_env { target_env; _ } = target_env
+let code_age_relation { target_env; _ } = TE.code_age_relation target_env
+
+let code_age_relation_resolver { target_env; _ } =
+  TE.code_age_relation_resolver target_env
 
 type n_way_join_type = t -> TG.t join_arg list -> TG.t Or_unknown.t * t
 

--- a/middle_end/flambda2/types/env/join_env.mli
+++ b/middle_end/flambda2/types/env/join_env.mli
@@ -19,15 +19,18 @@ type 'a join_arg = env_id * 'a
 
 type t
 
-val target_join_env : t -> Typing_env.t
+type n_way_join_type =
+  t -> Type_grammar.t join_arg list -> Type_grammar.t Or_unknown.t * t
 
 val joined_env : t -> env_id -> Typing_env.t
 
+val code_age_relation : t -> Code_age_relation.t
+
+val code_age_relation_resolver :
+  t -> Compilation_unit.t -> Code_age_relation.t option
+
 val n_way_join_simples :
   t -> Flambda_kind.t -> Simple.t join_arg list -> Simple.t Or_bottom.t * t
-
-type n_way_join_type =
-  t -> Type_grammar.t join_arg list -> Type_grammar.t Or_unknown.t * t
 
 val n_way_join_env_extension :
   n_way_join_type:n_way_join_type ->

--- a/middle_end/flambda2/types/meet_and_n_way_join.ml
+++ b/middle_end/flambda2/types/meet_and_n_way_join.ml
@@ -2762,7 +2762,10 @@ and n_way_join_function_type (env : Join_env.t)
     match func_types with
     | [] -> Bottom, env
     | (id1, { code_id = code_id1; rec_info = rec_info1 }) :: func_types -> (
-      let target_typing_env = Join_env.target_join_env env in
+      let target_code_age_relation = Join_env.code_age_relation env in
+      let target_code_age_relation_resolver =
+        Join_env.code_age_relation_resolver env
+      in
       let code_id, _, rec_infos =
         List.fold_left
           (fun (code_id1, code_age_relation1, rec_infos)
@@ -2775,18 +2778,14 @@ and n_way_join_function_type (env : Join_env.t)
                code age relation meet would remain though as it's useful
                elsewhere.) *)
             match
-              Code_age_relation.join
-                ~target_t:(TE.code_age_relation target_typing_env)
-                ~resolver:(TE.code_age_relation_resolver target_typing_env)
-                code_age_relation1
+              Code_age_relation.join ~target_t:target_code_age_relation
+                ~resolver:target_code_age_relation_resolver code_age_relation1
                 (TE.code_age_relation (Join_env.joined_env env id2))
                 code_id1 code_id2
             with
             | Unknown -> raise Unknown_result
             | Known code_id ->
-              ( code_id,
-                TE.code_age_relation target_typing_env,
-                (id2, rec_info2) :: rec_infos ))
+              code_id, target_code_age_relation, (id2, rec_info2) :: rec_infos)
           ( code_id1,
             TE.code_age_relation (Join_env.joined_env env id1),
             [id1, rec_info1] )


### PR DESCRIPTION
It is only used to access the `code_age_relation`, and `code_age_relation_resolver`, so just expose these instead.