### PR TITLE
Avoid closure in the mode solver

### DIFF
--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -430,8 +430,9 @@ module Solver_mono (C : Lattices_mono) = struct
           let src = C.src dst g in
           let g'f = C.compose src g' (C.disallow_right f) in
           let x = Amorphvar (v, g'f) in
-          if not (VarMap.exists (fun _ mv -> eq_morphvar mv x) u.vlower)
-          then set_vlower ~log u (VarMap.add (get_key x) x u.vlower);
+          let key = get_key x in
+          if not (VarMap.mem key u.vlower)
+          then set_vlower ~log u (VarMap.add key x u.vlower);
           Ok ())
 
   let cnt_id = ref 0


### PR DESCRIPTION
Fixes #4323 

# Benchmark
Use the script in #4323 to generate `test.ml` with size 8192.

Runs `_build/_bootinstall/bin/ocamlopt.opt test.ml -nostdlib -nopervasives -c -dtimings`

Before PR, `typing` takes 5.927s.
After this PR, `typing` takes 0.661s.