### PR TITLE
Moving Type Shapes into Shapes

### DIFF
--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -13,6 +13,9 @@
 (*                                                                        *)
 (**************************************************************************)
 
+module Layout = Jkind_types.Sort.Const
+type base_layout = Jkind_types.Sort.base
+
 module Uid = struct
   type t =
     | Compilation_unit of string
@@ -207,6 +210,154 @@ module Item = struct
   module Map = Map.Make(T)
 end
 
+module Predef = struct
+  type simd_vec_split =
+      (* 128 bit *)
+      | Int8x16
+      | Int16x8
+      | Int32x4
+      | Int64x2
+      | Float32x4
+      | Float64x2
+      (* 256 bit *)
+      | Int8x32
+      | Int16x16
+      | Int32x8
+      | Int64x4
+      | Float32x8
+      | Float64x4
+      (* 512 bit *)
+      | Int8x64
+      | Int16x32
+      | Int32x16
+      | Int64x8
+      | Float32x16
+      | Float64x8
+
+    type unboxed =
+      | Unboxed_float
+      | Unboxed_float32
+      | Unboxed_nativeint
+      | Unboxed_int64
+      | Unboxed_int32
+      | Unboxed_simd of simd_vec_split
+
+    type t =
+      | Array
+      | Bytes
+      | Char
+      | Extension_constructor
+      | Float
+      | Float32
+      | Floatarray
+      | Int
+      | Int32
+      | Int64
+      | Lazy_t
+      | Nativeint
+      | String
+      | Simd of simd_vec_split
+      | Exception
+      | Unboxed of unboxed
+
+    let simd_vec_split_to_string : simd_vec_split -> string = function
+      | Int8x16 -> "int8x16"
+      | Int16x8 -> "int16x8"
+      | Int32x4 -> "int32x4"
+      | Int64x2 -> "int64x2"
+      | Float32x4 -> "float32x4"
+      | Float64x2 -> "float64x2"
+      | Int8x32 -> "int8x32"
+      | Int16x16 -> "int16x16"
+      | Int32x8 -> "int32x8"
+      | Int64x4 -> "int64x4"
+      | Float32x8 -> "float32x8"
+      | Float64x4 -> "float64x4"
+      | Int8x64 -> "int8x64"
+      | Int16x32 -> "int16x32"
+      | Int32x16 -> "int32x16"
+      | Int64x8 -> "int64x8"
+      | Float32x16 -> "float32x16"
+      | Float64x8 -> "float64x8"
+
+    (* name of the type without the hash *)
+    let unboxed_to_string (u : unboxed) =
+      match u with
+      | Unboxed_float -> "float"
+      | Unboxed_float32 -> "float32"
+      | Unboxed_nativeint -> "nativeint"
+      | Unboxed_int64 -> "int64"
+      | Unboxed_int32 -> "int32"
+      | Unboxed_simd s -> simd_vec_split_to_string s
+
+    let to_string : t -> string = function
+      | Array -> "array"
+      | Bytes -> "bytes"
+      | Char -> "char"
+      | Extension_constructor -> "extension_constructor"
+      | Float -> "float"
+      | Float32 -> "float32"
+      | Floatarray -> "floatarray"
+      | Int -> "int"
+      | Int32 -> "int32"
+      | Int64 -> "int64"
+      | Lazy_t -> "lazy_t"
+      | Nativeint -> "nativeint"
+      | String -> "string"
+      | Simd s -> simd_vec_split_to_string s
+      | Exception -> "exn"
+      | Unboxed u -> unboxed_to_string u ^ "#"
+
+    let simd_vec_split_to_layout (b : simd_vec_split) : Jkind_types.Sort.base =
+      match b with
+      | Int8x16 -> Vec128
+      | Int16x8 -> Vec128
+      | Int32x4 -> Vec128
+      | Int64x2 -> Vec128
+      | Float32x4 -> Vec128
+      | Float64x2 -> Vec128
+      | Int8x32 -> Vec256
+      | Int16x16 -> Vec256
+      | Int32x8 -> Vec256
+      | Int64x4 -> Vec256
+      | Float32x8 -> Vec256
+      | Float64x4 -> Vec256
+      | Int8x64 -> Vec512
+      | Int16x32 -> Vec512
+      | Int32x16 -> Vec512
+      | Int64x8 -> Vec512
+      | Float32x16 -> Vec512
+      | Float64x8 -> Vec512
+
+    let unboxed_type_to_layout (b : unboxed) : Jkind_types.Sort.base =
+      match b with
+      | Unboxed_float -> Float64
+      | Unboxed_float32 -> Float32
+      | Unboxed_nativeint -> Word
+      | Unboxed_int64 -> Bits64
+      | Unboxed_int32 -> Bits32
+      | Unboxed_simd s -> simd_vec_split_to_layout s
+
+    let to_layout : t -> Layout.t = function
+      | Array -> Base Value
+      | Bytes -> Base Value
+      | Char -> Base Value
+      | Extension_constructor -> Base Value
+      | Float -> Base Value
+      | Float32 -> Base Value
+      | Floatarray -> Base Value
+      | Int -> Base Value
+      | Int32 -> Base Value
+      | Int64 -> Base Value
+      | Lazy_t -> Base Value
+      | Nativeint -> Base Value
+      | String -> Base Value
+      | Simd _ -> Base Value
+      | Exception -> Base Value
+      | Unboxed u -> Base (unboxed_type_to_layout u)
+end
+
+
 type var = Ident.t
 type t = { hash:int; uid: Uid.t option; desc: desc; approximated: bool }
 and desc =
@@ -219,6 +370,78 @@ and desc =
   | Proj of t * Item.t
   | Comp_unit of string
   | Error of string
+
+type without_layout = Layout_to_be_determined
+
+type 'a ts =
+  | Ts_constr of (Uid.t * Path.t * 'a) * without_layout ts list
+  | Ts_tuple of 'a ts list
+  | Ts_unboxed_tuple of 'a ts list
+  | Ts_var of string option * 'a
+  | Ts_predef of Predef.t * without_layout ts list
+  | Ts_arrow of without_layout ts * without_layout ts
+  | Ts_variant of 'a ts poly_variant_constructors
+  | Ts_other of 'a
+
+and 'a poly_variant_constructors = 'a poly_variant_constructor list
+
+and 'a poly_variant_constructor =
+  { pv_constr_name : string;
+    pv_constr_args : 'a list
+  }
+
+type tds_desc =
+  | Tds_variant of
+      { simple_constructors : string list;
+        (* CR sspies: Deduplicate these cases once type shapes have reached
+            a more stable form. *)
+        complex_constructors :
+          (without_layout ts * Layout.t)
+          complex_constructors
+      }
+  | Tds_variant_unboxed of
+      { name : string;
+        arg_name : string option;
+        arg_shape : without_layout ts;
+        arg_layout : Layout.t
+      }
+  | Tds_record of
+      { fields :
+          (string * without_layout ts * Layout.t) list;
+        kind : record_kind
+      }
+  | Tds_alias of without_layout ts
+  | Tds_other
+
+and record_kind =
+  | Record_unboxed
+  | Record_unboxed_product
+  | Record_boxed
+  | Record_mixed of mixed_product_shape
+  | Record_floats
+
+and 'a complex_constructors = 'a complex_constructor list
+
+and 'a complex_constructor =
+  { name : string;
+    kind : constructor_representation;
+    args : 'a complex_constructor_argument list
+  }
+
+and 'a complex_constructor_argument =
+  { field_name : string option;
+    field_value : 'a
+  }
+
+and constructor_representation = mixed_product_shape
+
+and mixed_product_shape = Layout.t array
+
+type tds =
+  { path : Path.t;
+    definition : tds_desc;
+    type_params : without_layout ts list
+  }
 
 let rec equal_desc d1 d2 =
   if d1 == d2 then true else
@@ -319,6 +542,117 @@ let print fmt t =
     Format.fprintf fmt "@[(approx)@ %a@]@;" aux t
   else
     Format.fprintf fmt "@[%a@]@;" aux t
+
+(* printing type shapes *)
+let rec print_type_shape : type a. Format.formatter -> a ts -> unit =
+  (* CR sspies: We should figure out pretty printing for shapes. For now, this
+    verbose non-boxed version should be fine. *)
+  fun ppf -> function
+  | Ts_predef (predef, shapes) ->
+    Format.fprintf ppf "%s (%a)" (Predef.to_string predef)
+      (Format.pp_print_list
+          ~pp_sep:(fun ppf () -> Format.pp_print_string ppf ", ")
+          print_type_shape)
+      shapes
+  | Ts_constr ((uid, path, _), shapes) ->
+    Format.fprintf ppf "Ts_constr uid=%a path=%a (%a)" Uid.print uid
+      Path.print path
+      (Format.pp_print_list
+          ~pp_sep:(fun ppf () -> Format.pp_print_string ppf ", ")
+          print_type_shape)
+      shapes
+  | Ts_tuple shapes ->
+    Format.fprintf ppf "Ts_tuple (%a)"
+      (Format.pp_print_list
+          ~pp_sep:(fun ppf () -> Format.pp_print_string ppf ", ")
+          print_type_shape)
+      shapes
+  | Ts_unboxed_tuple shapes ->
+    Format.fprintf ppf "Ts_unboxed_tuple (%a)"
+      (Format.pp_print_list
+          ~pp_sep:(fun ppf () -> Format.pp_print_string ppf ", ")
+          print_type_shape)
+      shapes
+  | Ts_var (name, _) ->
+    Format.fprintf ppf "Ts_var (%a)"
+      (fun ppf opt -> Format.pp_print_option Format.pp_print_string ppf opt)
+      name
+  | Ts_arrow (arg, ret) ->
+    Format.fprintf ppf "Ts_arrow (%a, %a)"
+      print_type_shape arg print_type_shape ret
+  | Ts_variant fields ->
+    Format.fprintf ppf "Ts_variant (%a)"
+      (Format.pp_print_list
+          ~pp_sep:(fun ppf () -> Format.pp_print_string ppf ", ")
+          (fun ppf { pv_constr_name; pv_constr_args } ->
+            Format.fprintf ppf "%s (%a)" pv_constr_name
+              (Format.pp_print_list
+                ~pp_sep:(fun ppf () -> Format.pp_print_string ppf ", ")
+                print_type_shape)
+              pv_constr_args))
+      fields
+  | Ts_other _ -> Format.fprintf ppf "Ts_other"
+
+(* printing type declaration shapes *)
+let print_one_entry print_value ppf { field_name; field_value } =
+  match field_name with
+  | Some name ->
+    Format.fprintf ppf "%a=%a" Format.pp_print_string name print_value
+      field_value
+  | None -> Format.fprintf ppf "%a" print_value field_value
+
+let print_sep_string sep ppf () = Format.pp_print_string ppf sep
+
+let print_complex_constructor print_value ppf { name; kind = _; args } =
+  Format.fprintf ppf "(%a: %a)" Format.pp_print_string name
+    (Format.pp_print_list ~pp_sep:(print_sep_string " * ")
+        (print_one_entry print_value))
+    args
+
+let print_only_shape ppf (shape, _) = print_type_shape ppf shape
+
+let print_field ppf
+    ((name, shape, _) : _ * without_layout ts * _) =
+  Format.fprintf ppf "%a: %a" Format.pp_print_string name print_type_shape
+    shape
+
+let print_record_type = function
+  | Record_boxed -> "_boxed"
+  | Record_floats -> "_floats"
+  | Record_mixed _ -> "_mixed"
+  | Record_unboxed -> " [@@unboxed]"
+  | Record_unboxed_product -> "_unboxed_product"
+
+let print_tds_desc ppf = function
+  (* CR sspies: We should figure out pretty printing for shapes. For now, this
+      verbose non-boxed version should be fine. *)
+  | Tds_variant { simple_constructors; complex_constructors } ->
+    Format.fprintf ppf
+      "Tds_variant simple_constructors=%a complex_constructors=%a"
+      (Format.pp_print_list ~pp_sep:Format.pp_print_space
+          Format.pp_print_string)
+      simple_constructors
+      (Format.pp_print_list ~pp_sep:(print_sep_string " | ")
+          (print_complex_constructor print_only_shape))
+      complex_constructors
+  | Tds_record { fields; kind } ->
+    Format.fprintf ppf "Tds_record%s { %a }" (print_record_type kind)
+      (Format.pp_print_list ~pp_sep:(print_sep_string "; ") print_field)
+      fields
+  | Tds_variant_unboxed { name; arg_name; arg_shape; arg_layout } ->
+    Format.fprintf ppf
+      "Tds_variant_unboxed name=%s arg_name=%s arg_shape=%a arg_layout=%a"
+      name
+      (Option.value ~default:"None" arg_name)
+      print_type_shape arg_shape Layout.format arg_layout
+  | Tds_alias type_shape ->
+    Format.fprintf ppf "Tds_alias %a" print_type_shape type_shape
+  | Tds_other -> Format.fprintf ppf "Tds_other"
+
+let print_type_decl_shape ppf t =
+  Format.fprintf ppf "path=%a, definition=(%a)" Path.print t.path print_tds_desc
+    t.definition
+
 
 let rec strip_head_aliases = function
   | { desc = Alias t; _ } -> strip_head_aliases t
@@ -452,6 +786,167 @@ let set_uid_if_none t uid =
   match t.uid with
   | None -> { t with uid = Some uid }
   | _ -> t
+
+let poly_variant_constructors_map f pvs =
+  List.map
+    (fun pv -> { pv with pv_constr_args = List.map f pv.pv_constr_args })
+    pvs
+
+let rec shape_layout (sh : Layout.t ts) : Layout.t =
+  match sh with
+  | Ts_constr ((_, _, ly), _) -> ly
+  | Ts_tuple _ -> Base Value
+  | Ts_unboxed_tuple shapes -> Product (List.map shape_layout shapes)
+  | Ts_var (_, ly) -> ly
+  | Ts_predef (predef, _) -> Predef.to_layout predef
+  | Ts_arrow _ -> Base Value
+  | Ts_variant _ -> Base Value
+  | Ts_other ly -> ly
+
+let complex_constructor_map f { name; kind; args } =
+  let args =
+    List.map
+      (fun { field_name; field_value } ->
+        { field_name; field_value = f field_value })
+      args
+  in
+  { name; kind; args }
+
+let complex_constructors_map f = List.map (complex_constructor_map f)
+
+let rec shape_with_layout ~(layout : Layout.t) (sh : without_layout ts) :
+    Layout.t ts =
+  match sh, layout with
+  | Ts_constr ((uid, path, Layout_to_be_determined), shapes), _ ->
+    Ts_constr ((uid, path, layout), shapes)
+  | Ts_tuple shapes, Base Value ->
+    let shapes_with_layout =
+      List.map (shape_with_layout ~layout:(Layout.Base Value)) shapes
+    in
+    Ts_tuple shapes_with_layout
+  | ( Ts_tuple _,
+      ( Product _
+      | Base
+          ( Void | Bits8 | Bits16 | Bits32 | Bits64 | Float64 | Float32
+          | Word | Vec128 | Vec256 | Vec512 ) ) ) ->
+    Misc.fatal_errorf "tuple shape must have layout value, but has layout %a"
+      Layout.format layout
+  | Ts_unboxed_tuple shapes, Product lys
+    when List.length shapes = List.length lys ->
+    let shapes_and_layouts = List.combine shapes lys in
+    let shapes_with_layout =
+      List.map
+        (fun (shape, layout) -> shape_with_layout ~layout shape)
+        shapes_and_layouts
+    in
+    Ts_unboxed_tuple shapes_with_layout
+  | Ts_unboxed_tuple shapes, Product lys ->
+    Misc.fatal_errorf "unboxed tuple shape has %d shapes, but %d layouts"
+      (List.length shapes) (List.length lys)
+  | ( Ts_unboxed_tuple _,
+      Base
+        ( Void | Value | Float32 | Float64 | Word | Bits8 | Bits16 | Bits32
+        | Bits64 | Vec128 | Vec256 | Vec512 ) ) ->
+    Misc.fatal_errorf
+      "unboxed tuple must have unboxed product layout, but has layout %a"
+      Layout.format layout
+  | Ts_var (name, Layout_to_be_determined), _ -> Ts_var (name, layout)
+  | Ts_arrow (arg, ret), Base Value -> Ts_arrow (arg, ret)
+  | Ts_arrow _, _ ->
+    Misc.fatal_errorf "function type shape must have layout value"
+  | Ts_predef (predef, shapes), _
+    when Layout.equal (Predef.to_layout predef) layout ->
+    Ts_predef (predef, shapes)
+  | Ts_predef (predef, _), _ ->
+    Misc.fatal_errorf
+      "predef %s has layout %a, but is expected to have layout %a"
+      (Predef.to_string predef) Layout.format (Predef.to_layout predef)
+      Layout.format layout
+  | Ts_variant fields, Base Value ->
+    let fields =
+      poly_variant_constructors_map
+        (shape_with_layout ~layout:(Layout.Base Value))
+        fields
+    in
+    Ts_variant fields
+  | Ts_variant _, _ ->
+    Misc.fatal_errorf "polymorphic variant must have layout value"
+  | Ts_other Layout_to_be_determined, _ -> Ts_other layout
+
+(* CR sspies: This is a hacky "solution" to do type variable substitution in
+    type expression shapes. In subsequent PRs, this code should be changed to
+    use the shape mechanism instead. *)
+let rec replace_tvar t ~(pairs : (without_layout ts * without_layout ts) list)
+    =
+  match
+    List.find_map
+      (fun (from, to_) -> if t = from then Some to_ else None)
+      pairs
+  with
+  | Some new_type -> new_type
+  | None -> (
+    match t with
+    | Ts_constr (uid, shape_list) ->
+      Ts_constr (uid, List.map (replace_tvar ~pairs) shape_list)
+    | Ts_tuple shape_list ->
+      Ts_tuple (List.map (replace_tvar ~pairs) shape_list)
+    | Ts_unboxed_tuple shape_list ->
+      Ts_unboxed_tuple (List.map (replace_tvar ~pairs) shape_list)
+    | Ts_var (name, ly) -> Ts_var (name, ly)
+    | Ts_predef (predef, shape_list) -> Ts_predef (predef, shape_list)
+    | Ts_arrow (arg, ret) ->
+      Ts_arrow (replace_tvar ~pairs arg, replace_tvar ~pairs ret)
+    | Ts_variant fields ->
+      let fields =
+        poly_variant_constructors_map (replace_tvar ~pairs) fields
+      in
+      Ts_variant fields
+    | Ts_other ly -> Ts_other ly)
+
+(* CR sspies: This is a hacky "solution" to do type variable substitution in
+    type declaration shapes. In subsequent PRs, this code should be changed to
+    use the shape mechanism instead. *)
+let replace_tvar (t : tds) (shapes : without_layout ts list) =
+  match List.length t.type_params == List.length shapes with
+  | true ->
+    let subst = List.combine t.type_params shapes in
+    let replace_tvar_ts = replace_tvar in
+    let replace_tvar (sh, ly) = replace_tvar_ts ~pairs:subst sh, ly in
+    let ret =
+      { type_params = [];
+        path = t.path;
+        definition =
+          (match t.definition with
+          | Tds_variant { simple_constructors; complex_constructors } ->
+            Tds_variant
+              { simple_constructors;
+                complex_constructors =
+                  complex_constructors_map replace_tvar complex_constructors
+              }
+          | Tds_variant_unboxed { name; arg_name; arg_shape; arg_layout } ->
+            Tds_variant_unboxed
+              { name;
+                arg_name;
+                arg_shape = replace_tvar_ts ~pairs:subst arg_shape;
+                arg_layout
+              }
+          | Tds_record { fields; kind } ->
+            Tds_record
+              { fields =
+                  List.map
+                    (fun (name, sh, ly) ->
+                      name, replace_tvar_ts ~pairs:subst sh, ly)
+                    fields;
+                kind
+              }
+          | Tds_alias type_shape ->
+            Tds_alias (replace_tvar_ts ~pairs:subst type_shape)
+          | Tds_other -> Tds_other)
+      }
+    in
+    ret
+  | false -> { type_params = []; path = t.path; definition = Tds_other }
+
 
 module Map = struct
   type shape = t

--- a/typing/shape.mli
+++ b/typing/shape.mli
@@ -49,6 +49,9 @@
     a talk about the reduction strategy
 *)
 
+module Layout = Jkind_types.Sort.Const
+type base_layout = Jkind_types.Sort.base
+
 (** A [Uid.t] is associated to every declaration in signatures and
     implementations. They uniquely identify bindings in the program. When
     associated with these bindings' locations they are useful to external tools
@@ -127,6 +130,65 @@ module Item : sig
   module Map : Map.S with type key = t
 end
 
+(* For several builtin types, we provide predefined type shapes with custom
+    logic associated with them for emitting the DWARF debugging information. *)
+module Predef : sig
+  type simd_vec_split =
+    (* 128 bit *)
+    | Int8x16
+    | Int16x8
+    | Int32x4
+    | Int64x2
+    | Float32x4
+    | Float64x2
+    (* 256 bit *)
+    | Int8x32
+    | Int16x16
+    | Int32x8
+    | Int64x4
+    | Float32x8
+    | Float64x4
+    (* 512 bit *)
+    | Int8x64
+    | Int16x32
+    | Int32x16
+    | Int64x8
+    | Float32x16
+    | Float64x8
+
+  type unboxed =
+    | Unboxed_float
+    | Unboxed_float32
+    | Unboxed_nativeint
+    | Unboxed_int64
+    | Unboxed_int32
+    | Unboxed_simd of simd_vec_split
+
+  type t =
+    | Array
+    | Bytes
+    | Char
+    | Extension_constructor
+    | Float
+    | Float32
+    | Floatarray
+    | Int
+    | Int32
+    | Int64
+    | Lazy_t
+    | Nativeint
+    | String
+    | Simd of simd_vec_split
+    | Exception
+    | Unboxed of unboxed
+
+  val to_string : t -> string
+
+  val unboxed_type_to_layout : unboxed -> Jkind_types.Sort.base
+
+  val to_layout : t -> Layout.t
+end
+
 type var = Ident.t
 type t = private { hash: int; uid: Uid.t option; desc: desc; approximated: bool }
 and desc =
@@ -140,6 +202,125 @@ and desc =
   | Comp_unit of string
   | Error of string
 
+(* Type shapes are abstract representations of type expressions. We define
+    them with a placeholder 'a for the layout inside. This allows one to
+    first create shapes without a type by picking [without_layout] for 'a
+    and then later substituting in a layout of type [Layout.t]. *)
+(* CR sspies: The layout merged into the type shapes is confusing and will
+    cause trouble when the type shapes are integrated into shapes. Move them
+    back out again in a subsequent PR and instead recurse over layout and shape
+    in the DWARF emission code. *)
+type without_layout = Layout_to_be_determined
+
+type 'a ts =
+  | Ts_constr of (Uid.t * Path.t * 'a) * without_layout ts list
+      (** [Ts_constr ((uid, p, ly), args)] is the shape of the type constructor
+      [p] applied to the arguments [args], resulting in data of layout [ly].
+      Unlike for the resulting data, we do not definitely know the layout
+      of the arguments yet. This is only fully determined once we look at the
+      declaration behind [p]. Thus, even when the type constructor application
+      [Ts_constr((uid, p, ly), args)] itself carries a layout, the layout of
+      the arguments is still to be determined.  *)
+  | Ts_tuple of 'a ts list
+  | Ts_unboxed_tuple of 'a ts list
+  | Ts_var of string option * 'a
+  | Ts_predef of Predef.t * without_layout ts list
+      (** [Ts_predef(p, args)] is the shape for predefined type shapes.
+        Analogously to [Ts_constr], its arguments do not carry a layout yet.
+      *)
+  | Ts_arrow of without_layout ts * without_layout ts
+      (** [Ts_arrow(arg, ret)] is the shape for the function type
+          [arg -> ret]. When emitting DWARF information for this type, there
+          is no need to inspect the type arguments, and we never find out
+          their layout. As such, these remain [without_layout] even after
+          substituting in layouts.   *)
+  | Ts_variant of 'a ts poly_variant_constructors
+  | Ts_other of 'a
+
+and 'a poly_variant_constructors = 'a poly_variant_constructor list
+
+and 'a poly_variant_constructor =
+  { pv_constr_name : string;
+    pv_constr_args : 'a list
+  }
+
+
+(** For type substitution to work as expected, we store the layouts in the
+    declaration alongside the shapes instead of directly going for the
+    substituted version. *)
+type tds_desc =
+  | Tds_variant of
+      { simple_constructors : string list;
+            (** The string is the name of the constructor. The runtime
+                representation of the constructor at index [i] in this list is
+                [2 * i + 1]. See [dwarf_type.ml] for more details. *)
+        complex_constructors :
+          (without_layout ts * Layout.t)
+          complex_constructors
+            (** All constructors in this category are represented as blocks.
+                The index [i] in the list indicates the tag at runtime. The
+                length of the constructor argument list [args] determines the
+                size of the block. *)
+      }
+  | Tds_variant_unboxed of
+      { name : string;
+        arg_name : string option;
+            (** if this is [None], we are looking at a singleton tuple;
+              otherwise, it is a singleton record. *)
+        arg_shape : without_layout ts;
+        arg_layout : Layout.t
+      }
+      (** An unboxed variant corresponds to the [@@unboxed] annotation.
+        It must have a single, complex constructor. *)
+  | Tds_record of
+      { fields :
+          (string * without_layout ts * Layout.t) list;
+        kind : record_kind
+      }
+  | Tds_alias of without_layout ts
+  | Tds_other
+
+and record_kind =
+  | Record_unboxed
+      (** [Record_unboxed] is the case for single-field records declared with
+          [@@unboxed], whose runtime representation is simply its contents
+          without any indirection. *)
+  | Record_unboxed_product
+      (** [Record_unboxed_product] is the truly unboxed record that
+            corresponds to [#{ ... }]. *)
+  | Record_boxed
+  | Record_mixed of mixed_product_shape
+  | Record_floats
+      (** Basically the same as [Record_mixed], but we don't reorder the
+          fields. *)
+
+and 'a complex_constructors = 'a complex_constructor list
+
+and 'a complex_constructor =
+  { name : string;
+    kind : constructor_representation;
+    args : 'a complex_constructor_argument list
+  }
+
+and 'a complex_constructor_argument =
+  { field_name : string option;
+    field_value : 'a
+  }
+
+(* Unlike in [types.ml], we use [Layout.t] entries here, because we can
+    represent flattened floats simply as float64 in the debugger. *)
+and constructor_representation = mixed_product_shape
+
+and mixed_product_shape = Layout.t array
+
+type tds =
+  { path : Path.t;
+    definition : tds_desc;
+    type_params : without_layout ts list
+  }
+
+
+(* Shapes *)
 val print : Format.formatter -> t -> unit
 
 val strip_head_aliases : t -> t
@@ -170,6 +351,27 @@ val decompose_abs : t -> (var * t) option
 (* CR lmaurer: Should really take a [Compilation_unit.t] *)
 val for_persistent_unit : string -> t
 val leaf_for_unpack : t
+
+(* Type shapes *)
+val shape_layout : Layout.t ts -> Layout.t
+
+val shape_with_layout : layout:Layout.t -> without_layout ts -> Layout.t ts
+
+val print_type_shape : Format.formatter -> 'a ts -> unit
+
+val poly_variant_constructors_map :
+  ('a -> 'b) -> 'a poly_variant_constructors -> 'b poly_variant_constructors
+
+(* Type declaration shapes *)
+val print_type_decl_shape : Format.formatter -> tds -> unit
+
+val replace_tvar : tds -> without_layout ts list -> tds
+
+val complex_constructor_map :
+  ('a -> 'b) -> 'a complex_constructor -> 'b complex_constructor
+
+val complex_constructors_map :
+  ('a -> 'b) -> 'a complex_constructors -> 'b complex_constructors
 
 module Map : sig
   type shape = t

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -159,7 +159,7 @@ module Type_shape = struct
           Layout_to_be_determined (* CR sspies: Support first-class modules. *)
 
   let of_type_expr (expr : Types.type_expr) uid_of_path =
-    of_type_expr_go ~visited:Numbers.Int.Set.empty ~depth:(-1) expr uid_of_path
+    of_type_expr_go ~visited:Numbers.Int.Set.empty ~depth:0 expr uid_of_path
 end
 
 module Type_decl_shape = struct

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -5,102 +5,7 @@ type base_layout = Jkind_types.Sort.base
 
 module Type_shape = struct
   module Predef = struct
-    type simd_vec_split =
-      (* 128 bit *)
-      | Int8x16
-      | Int16x8
-      | Int32x4
-      | Int64x2
-      | Float32x4
-      | Float64x2
-      (* 256 bit *)
-      | Int8x32
-      | Int16x16
-      | Int32x8
-      | Int64x4
-      | Float32x8
-      | Float64x4
-      (* 512 bit *)
-      | Int8x64
-      | Int16x32
-      | Int32x16
-      | Int64x8
-      | Float32x16
-      | Float64x8
-
-    type unboxed =
-      | Unboxed_float
-      | Unboxed_float32
-      | Unboxed_nativeint
-      | Unboxed_int64
-      | Unboxed_int32
-      | Unboxed_simd of simd_vec_split
-
-    type t =
-      | Array
-      | Bytes
-      | Char
-      | Extension_constructor
-      | Float
-      | Float32
-      | Floatarray
-      | Int
-      | Int32
-      | Int64
-      | Lazy_t
-      | Nativeint
-      | String
-      | Simd of simd_vec_split
-      | Exception
-      | Unboxed of unboxed
-
-    let simd_vec_split_to_string : simd_vec_split -> string = function
-      | Int8x16 -> "int8x16"
-      | Int16x8 -> "int16x8"
-      | Int32x4 -> "int32x4"
-      | Int64x2 -> "int64x2"
-      | Float32x4 -> "float32x4"
-      | Float64x2 -> "float64x2"
-      | Int8x32 -> "int8x32"
-      | Int16x16 -> "int16x16"
-      | Int32x8 -> "int32x8"
-      | Int64x4 -> "int64x4"
-      | Float32x8 -> "float32x8"
-      | Float64x4 -> "float64x4"
-      | Int8x64 -> "int8x64"
-      | Int16x32 -> "int16x32"
-      | Int32x16 -> "int32x16"
-      | Int64x8 -> "int64x8"
-      | Float32x16 -> "float32x16"
-      | Float64x8 -> "float64x8"
-
-    (* name of the type without the hash *)
-    let unboxed_to_string (u : unboxed) =
-      match u with
-      | Unboxed_float -> "float"
-      | Unboxed_float32 -> "float32"
-      | Unboxed_nativeint -> "nativeint"
-      | Unboxed_int64 -> "int64"
-      | Unboxed_int32 -> "int32"
-      | Unboxed_simd s -> simd_vec_split_to_string s
-
-    let to_string : t -> string = function
-      | Array -> "array"
-      | Bytes -> "bytes"
-      | Char -> "char"
-      | Extension_constructor -> "extension_constructor"
-      | Float -> "float"
-      | Float32 -> "float32"
-      | Floatarray -> "floatarray"
-      | Int -> "int"
-      | Int32 -> "int32"
-      | Int64 -> "int64"
-      | Lazy_t -> "lazy_t"
-      | Nativeint -> "nativeint"
-      | String -> "string"
-      | Simd s -> simd_vec_split_to_string s
-      | Exception -> "exn"
-      | Unboxed u -> unboxed_to_string u ^ "#"
+    open Shape.Predef
 
     let simd_base_type_of_path = function
       | p when Path.same p Predef.path_int8x16 -> Some Int8x16
@@ -176,90 +81,7 @@ module Type_shape = struct
           match unboxed_of_path p with
           | Some u -> Some (Unboxed u)
           | None -> None))
-
-    let simd_vec_split_to_layout (b : simd_vec_split) : Jkind_types.Sort.base =
-      match b with
-      | Int8x16 -> Vec128
-      | Int16x8 -> Vec128
-      | Int32x4 -> Vec128
-      | Int64x2 -> Vec128
-      | Float32x4 -> Vec128
-      | Float64x2 -> Vec128
-      | Int8x32 -> Vec256
-      | Int16x16 -> Vec256
-      | Int32x8 -> Vec256
-      | Int64x4 -> Vec256
-      | Float32x8 -> Vec256
-      | Float64x4 -> Vec256
-      | Int8x64 -> Vec512
-      | Int16x32 -> Vec512
-      | Int32x16 -> Vec512
-      | Int64x8 -> Vec512
-      | Float32x16 -> Vec512
-      | Float64x8 -> Vec512
-
-    let unboxed_type_to_layout (b : unboxed) : Jkind_types.Sort.base =
-      match b with
-      | Unboxed_float -> Float64
-      | Unboxed_float32 -> Float32
-      | Unboxed_nativeint -> Word
-      | Unboxed_int64 -> Bits64
-      | Unboxed_int32 -> Bits32
-      | Unboxed_simd s -> simd_vec_split_to_layout s
-
-    let to_layout : t -> Layout.t = function
-      | Array -> Base Value
-      | Bytes -> Base Value
-      | Char -> Base Value
-      | Extension_constructor -> Base Value
-      | Float -> Base Value
-      | Float32 -> Base Value
-      | Floatarray -> Base Value
-      | Int -> Base Value
-      | Int32 -> Base Value
-      | Int64 -> Base Value
-      | Lazy_t -> Base Value
-      | Nativeint -> Base Value
-      | String -> Base Value
-      | Simd _ -> Base Value
-      | Exception -> Base Value
-      | Unboxed u -> Base (unboxed_type_to_layout u)
   end
-
-  type without_layout = Layout_to_be_determined
-
-  type 'a ts =
-    | Ts_constr of (Uid.t * Path.t * 'a) * without_layout ts list
-    | Ts_tuple of 'a ts list
-    | Ts_unboxed_tuple of 'a ts list
-    | Ts_var of string option * 'a
-    | Ts_predef of Predef.t * without_layout ts list
-    | Ts_arrow of without_layout ts * without_layout ts
-    | Ts_variant of 'a ts poly_variant_constructors
-    | Ts_other of 'a
-
-  and 'a poly_variant_constructors = 'a poly_variant_constructor list
-
-  and 'a poly_variant_constructor =
-    { pv_constr_name : string;
-      pv_constr_args : 'a list
-    }
-
-  let poly_variant_constructors_map f pvs =
-    List.map
-      (fun pv -> { pv with pv_constr_args = List.map f pv.pv_constr_args })
-      pvs
-
-  let rec shape_layout (sh : Layout.t ts) : Layout.t =
-    match sh with
-    | Ts_constr ((_, _, ly), _) -> ly
-    | Ts_tuple _ -> Base Value
-    | Ts_unboxed_tuple shapes -> Product (List.map shape_layout shapes)
-    | Ts_var (_, ly) -> ly
-    | Ts_predef (predef, _) -> Predef.to_layout predef
-    | Ts_arrow _ -> Base Value
-    | Ts_variant _ -> Base Value
-    | Ts_other ly -> ly
 
   (* Similarly to [value_kind], we track a set of visited types to avoid cycles
      in the lookup and we, additionally, carry a maximal depth for the recursion.
@@ -268,6 +90,8 @@ module Type_shape = struct
      Also consider reverting to the original value kind depth limit (although 2
      seems low). *)
   let rec of_type_expr_go ~visited ~depth (expr : Types.type_expr) uid_of_path =
+    let predef_of_path = Predef.of_path in
+    let open Shape in
     let[@inline] cannot_proceed () =
       Numbers.Int.Set.mem (Types.get_id expr) visited || depth > 10
     in
@@ -284,7 +108,7 @@ module Type_shape = struct
       in
       match desc with
       | Tconstr (path, constrs, _abbrev_memo) -> (
-        match Predef.of_path path with
+        match predef_of_path path with
         | Some predef -> Ts_predef (predef, of_expr_list constrs)
         | None -> (
           match uid_of_path path with
@@ -335,211 +159,10 @@ module Type_shape = struct
           Layout_to_be_determined (* CR sspies: Support first-class modules. *)
 
   let of_type_expr (expr : Types.type_expr) uid_of_path =
-    of_type_expr_go ~visited:Numbers.Int.Set.empty ~depth:0 expr uid_of_path
-
-  let rec shape_with_layout ~(layout : Layout.t) (sh : without_layout ts) :
-      Layout.t ts =
-    match sh, layout with
-    | Ts_constr ((uid, path, Layout_to_be_determined), shapes), _ ->
-      Ts_constr ((uid, path, layout), shapes)
-    | Ts_tuple shapes, Base Value ->
-      let shapes_with_layout =
-        List.map (shape_with_layout ~layout:(Layout.Base Value)) shapes
-      in
-      Ts_tuple shapes_with_layout
-    | ( Ts_tuple _,
-        ( Product _
-        | Base
-            ( Void | Bits8 | Bits16 | Bits32 | Bits64 | Float64 | Float32 | Word
-            | Vec128 | Vec256 | Vec512 ) ) ) ->
-      Misc.fatal_errorf "tuple shape must have layout value, but has layout %a"
-        Layout.format layout
-    | Ts_unboxed_tuple shapes, Product lys
-      when List.length shapes = List.length lys ->
-      let shapes_and_layouts = List.combine shapes lys in
-      let shapes_with_layout =
-        List.map
-          (fun (shape, layout) -> shape_with_layout ~layout shape)
-          shapes_and_layouts
-      in
-      Ts_unboxed_tuple shapes_with_layout
-    | Ts_unboxed_tuple shapes, Product lys ->
-      Misc.fatal_errorf "unboxed tuple shape has %d shapes, but %d layouts"
-        (List.length shapes) (List.length lys)
-    | ( Ts_unboxed_tuple _,
-        Base
-          ( Void | Value | Float32 | Float64 | Word | Bits8 | Bits16 | Bits32
-          | Bits64 | Vec128 | Vec256 | Vec512 ) ) ->
-      Misc.fatal_errorf
-        "unboxed tuple must have unboxed product layout, but has layout %a"
-        Layout.format layout
-    | Ts_var (name, Layout_to_be_determined), _ -> Ts_var (name, layout)
-    | Ts_arrow (arg, ret), Base Value -> Ts_arrow (arg, ret)
-    | Ts_arrow _, _ ->
-      Misc.fatal_errorf "function type shape must have layout value"
-    | Ts_predef (predef, shapes), _
-      when Layout.equal (Predef.to_layout predef) layout ->
-      Ts_predef (predef, shapes)
-    | Ts_predef (predef, _), _ ->
-      Misc.fatal_errorf
-        "predef %s has layout %a, but is expected to have layout %a"
-        (Predef.to_string predef) Layout.format (Predef.to_layout predef)
-        Layout.format layout
-    | Ts_variant fields, Base Value ->
-      let fields =
-        poly_variant_constructors_map
-          (shape_with_layout ~layout:(Layout.Base Value))
-          fields
-      in
-      Ts_variant fields
-    | Ts_variant _, _ ->
-      Misc.fatal_errorf "polymorphic variant must have layout value"
-    | Ts_other Layout_to_be_determined, _ -> Ts_other layout
-
-  let rec print : type a. Format.formatter -> a ts -> unit =
-   (* CR sspies: We should figure out pretty printing for shapes. For now, this
-      verbose non-boxed version should be fine. *)
-   fun ppf -> function
-    | Ts_predef (predef, shapes) ->
-      Format.fprintf ppf "%s (%a)" (Predef.to_string predef)
-        (Format.pp_print_list
-           ~pp_sep:(fun ppf () -> Format.pp_print_string ppf ", ")
-           print)
-        shapes
-    | Ts_constr ((uid, path, _), shapes) ->
-      Format.fprintf ppf "Ts_constr uid=%a path=%a (%a)" Uid.print uid
-        Path.print path
-        (Format.pp_print_list
-           ~pp_sep:(fun ppf () -> Format.pp_print_string ppf ", ")
-           print)
-        shapes
-    | Ts_tuple shapes ->
-      Format.fprintf ppf "Ts_tuple (%a)"
-        (Format.pp_print_list
-           ~pp_sep:(fun ppf () -> Format.pp_print_string ppf ", ")
-           print)
-        shapes
-    | Ts_unboxed_tuple shapes ->
-      Format.fprintf ppf "Ts_unboxed_tuple (%a)"
-        (Format.pp_print_list
-           ~pp_sep:(fun ppf () -> Format.pp_print_string ppf ", ")
-           print)
-        shapes
-    | Ts_var (name, _) ->
-      Format.fprintf ppf "Ts_var (%a)"
-        (fun ppf opt -> Format.pp_print_option Format.pp_print_string ppf opt)
-        name
-    | Ts_arrow (arg, ret) ->
-      Format.fprintf ppf "Ts_arrow (%a, %a)" print arg print ret
-    | Ts_variant fields ->
-      Format.fprintf ppf "Ts_variant (%a)"
-        (Format.pp_print_list
-           ~pp_sep:(fun ppf () -> Format.pp_print_string ppf ", ")
-           (fun ppf { pv_constr_name; pv_constr_args } ->
-             Format.fprintf ppf "%s (%a)" pv_constr_name
-               (Format.pp_print_list
-                  ~pp_sep:(fun ppf () -> Format.pp_print_string ppf ", ")
-                  print)
-               pv_constr_args))
-        fields
-    | Ts_other _ -> Format.fprintf ppf "Ts_other"
-
-  (* CR sspies: This is a hacky "solution" to do type variable substitution in
-     type expression shapes. In subsequent PRs, this code should be changed to
-     use the shape mechanism instead. *)
-  let rec replace_tvar t ~(pairs : (without_layout ts * without_layout ts) list)
-      =
-    match
-      List.find_map
-        (fun (from, to_) -> if t = from then Some to_ else None)
-        pairs
-    with
-    | Some new_type -> new_type
-    | None -> (
-      match t with
-      | Ts_constr (uid, shape_list) ->
-        Ts_constr (uid, List.map (replace_tvar ~pairs) shape_list)
-      | Ts_tuple shape_list ->
-        Ts_tuple (List.map (replace_tvar ~pairs) shape_list)
-      | Ts_unboxed_tuple shape_list ->
-        Ts_unboxed_tuple (List.map (replace_tvar ~pairs) shape_list)
-      | Ts_var (name, ly) -> Ts_var (name, ly)
-      | Ts_predef (predef, shape_list) -> Ts_predef (predef, shape_list)
-      | Ts_arrow (arg, ret) ->
-        Ts_arrow (replace_tvar ~pairs arg, replace_tvar ~pairs ret)
-      | Ts_variant fields ->
-        let fields =
-          poly_variant_constructors_map (replace_tvar ~pairs) fields
-        in
-        Ts_variant fields
-      | Ts_other ly -> Ts_other ly)
+    of_type_expr_go ~visited:Numbers.Int.Set.empty ~depth:(-1) expr uid_of_path
 end
 
 module Type_decl_shape = struct
-  type tds_desc =
-    | Tds_variant of
-        { simple_constructors : string list;
-          (* CR sspies: Deduplicate these cases once type shapes have reached
-              a more stable form. *)
-          complex_constructors :
-            (Type_shape.without_layout Type_shape.ts * Layout.t)
-            complex_constructors
-        }
-    | Tds_variant_unboxed of
-        { name : string;
-          arg_name : string option;
-          arg_shape : Type_shape.without_layout Type_shape.ts;
-          arg_layout : Layout.t
-        }
-    | Tds_record of
-        { fields :
-            (string * Type_shape.without_layout Type_shape.ts * Layout.t) list;
-          kind : record_kind
-        }
-    | Tds_alias of Type_shape.without_layout Type_shape.ts
-    | Tds_other
-
-  and record_kind =
-    | Record_unboxed
-    | Record_unboxed_product
-    | Record_boxed
-    | Record_mixed of mixed_product_shape
-    | Record_floats
-
-  and 'a complex_constructors = 'a complex_constructor list
-
-  and 'a complex_constructor =
-    { name : string;
-      kind : constructor_representation;
-      args : 'a complex_constructor_argument list
-    }
-
-  and 'a complex_constructor_argument =
-    { field_name : string option;
-      field_value : 'a
-    }
-
-  and constructor_representation = mixed_product_shape
-
-  and mixed_product_shape = Layout.t array
-
-  type tds =
-    { path : Path.t;
-      definition : tds_desc;
-      type_params : Type_shape.without_layout Type_shape.ts list
-    }
-
-  let complex_constructor_map f { name; kind; args } =
-    let args =
-      List.map
-        (fun { field_name; field_value } ->
-          { field_name; field_value = f field_value })
-        args
-    in
-    { name; kind; args }
-
-  let complex_constructors_map f = List.map (complex_constructor_map f)
-
   let rec mixed_block_shape_to_layout =
     let open Jkind_types.Sort in
     function
@@ -572,7 +195,7 @@ module Type_decl_shape = struct
         List.map
           (fun ({ ca_type = type_expr; ca_sort = type_layout; _ } :
                  Types.constructor_argument) ->
-            { field_name = None;
+            { Shape.field_name = None;
               field_value =
                 Type_shape.of_type_expr type_expr uid_of_path, type_layout
             })
@@ -580,7 +203,7 @@ module Type_decl_shape = struct
       | Cstr_record list ->
         List.map
           (fun (lbl : Types.label_declaration) ->
-            { field_name = Some (Ident.name lbl.ld_id);
+            { Shape.field_name = Some (Ident.name lbl.ld_id);
               field_value =
                 Type_shape.of_type_expr lbl.ld_type uid_of_path, lbl.ld_sort
             })
@@ -590,7 +213,7 @@ module Type_decl_shape = struct
       match constructor_repr with
       | Constructor_mixed shapes ->
         List.iter2
-          (fun mix_shape { field_name = _; field_value = _, ly } ->
+          (fun mix_shape { Shape.field_name = _; field_value = _, ly } ->
             let ly2 = mixed_block_shape_to_layout mix_shape in
             if not (Layout.equal ly ly2)
             then
@@ -603,7 +226,7 @@ module Type_decl_shape = struct
       | Constructor_uniform_value ->
         let lys =
           List.map
-            (fun { field_name = _; field_value = _, ly } ->
+            (fun { Shape.field_name = _; field_value = _, ly } ->
               if not
                    (Layout.equal ly (Layout.Base Value)
                    || Layout.equal ly (Layout.Base Void))
@@ -617,7 +240,7 @@ module Type_decl_shape = struct
         in
         Array.of_list lys
     in
-    { name; kind = constructor_repr; args }
+    { Shape.name; kind = constructor_repr; args }
 
   let is_empty_constructor_list (cstr_args : Types.constructor_declaration) =
     match cstr_args.cd_args with
@@ -628,7 +251,7 @@ module Type_decl_shape = struct
       false
 
   let record_of_labels ~uid_of_path kind labels =
-    Tds_record
+    Shape.Tds_record
       { fields =
           List.map
             (fun (lbl : Types.label_declaration) ->
@@ -641,6 +264,8 @@ module Type_decl_shape = struct
 
   let of_type_declaration path (type_declaration : Types.type_declaration)
       uid_of_path =
+    let module Types_predef = Predef in
+    let open Shape in
     let definition =
       match type_declaration.type_manifest with
       | Some type_expr ->
@@ -705,7 +330,7 @@ module Type_decl_shape = struct
                 (fun (lbl : Types.label_declaration) ->
                   { lbl with
                     ld_sort = Base Float64;
-                    ld_type = Predef.type_unboxed_float
+                    ld_type = Types_predef.type_unboxed_float
                   })
                   (* CR sspies: We are changing the type and the layout here.
                      Consider adding a name for the types of the fields instead
@@ -730,117 +355,14 @@ module Type_decl_shape = struct
         type_declaration.type_params
     in
     { path; definition; type_params }
-
-  let print_one_entry print_value ppf { field_name; field_value } =
-    match field_name with
-    | Some name ->
-      Format.fprintf ppf "%a=%a" Format.pp_print_string name print_value
-        field_value
-    | None -> Format.fprintf ppf "%a" print_value field_value
-
-  let print_sep_string sep ppf () = Format.pp_print_string ppf sep
-
-  let print_complex_constructor print_value ppf { name; kind = _; args } =
-    Format.fprintf ppf "(%a: %a)" Format.pp_print_string name
-      (Format.pp_print_list ~pp_sep:(print_sep_string " * ")
-         (print_one_entry print_value))
-      args
-
-  let print_only_shape ppf (shape, _) = Type_shape.print ppf shape
-
-  let print_field ppf
-      ((name, shape, _) : _ * Type_shape.without_layout Type_shape.ts * _) =
-    Format.fprintf ppf "%a: %a" Format.pp_print_string name Type_shape.print
-      shape
-
-  let print_record_type = function
-    | Record_boxed -> "_boxed"
-    | Record_floats -> "_floats"
-    | Record_mixed _ -> "_mixed"
-    | Record_unboxed -> " [@@unboxed]"
-    | Record_unboxed_product -> "_unboxed_product"
-
-  let print_tds ppf = function
-    (* CR sspies: We should figure out pretty printing for shapes. For now, this
-       verbose non-boxed version should be fine. *)
-    | Tds_variant { simple_constructors; complex_constructors } ->
-      Format.fprintf ppf
-        "Tds_variant simple_constructors=%a complex_constructors=%a"
-        (Format.pp_print_list ~pp_sep:Format.pp_print_space
-           Format.pp_print_string)
-        simple_constructors
-        (Format.pp_print_list ~pp_sep:(print_sep_string " | ")
-           (print_complex_constructor print_only_shape))
-        complex_constructors
-    | Tds_record { fields; kind } ->
-      Format.fprintf ppf "Tds_record%s { %a }" (print_record_type kind)
-        (Format.pp_print_list ~pp_sep:(print_sep_string "; ") print_field)
-        fields
-    | Tds_variant_unboxed { name; arg_name; arg_shape; arg_layout } ->
-      Format.fprintf ppf
-        "Tds_variant_unboxed name=%s arg_name=%s arg_shape=%a arg_layout=%a"
-        name
-        (Option.value ~default:"None" arg_name)
-        Type_shape.print arg_shape Layout.format arg_layout
-    | Tds_alias type_shape ->
-      Format.fprintf ppf "Tds_alias %a" Type_shape.print type_shape
-    | Tds_other -> Format.fprintf ppf "Tds_other"
-
-  let print ppf t =
-    Format.fprintf ppf "path=%a, definition=(%a)" Path.print t.path print_tds
-      t.definition
-
-  (* CR sspies: This is a hacky "solution" to do type variable substitution in
-     type declaration shapes. In subsequent PRs, this code should be changed to
-     use the shape mechanism instead. *)
-  let replace_tvar (t : tds)
-      (shapes : Type_shape.without_layout Type_shape.ts list) =
-    match List.length t.type_params == List.length shapes with
-    | true ->
-      let subst = List.combine t.type_params shapes in
-      let replace_tvar (sh, ly) = Type_shape.replace_tvar ~pairs:subst sh, ly in
-      let ret =
-        { type_params = [];
-          path = t.path;
-          definition =
-            (match t.definition with
-            | Tds_variant { simple_constructors; complex_constructors } ->
-              Tds_variant
-                { simple_constructors;
-                  complex_constructors =
-                    complex_constructors_map replace_tvar complex_constructors
-                }
-            | Tds_variant_unboxed { name; arg_name; arg_shape; arg_layout } ->
-              Tds_variant_unboxed
-                { name;
-                  arg_name;
-                  arg_shape = Type_shape.replace_tvar ~pairs:subst arg_shape;
-                  arg_layout
-                }
-            | Tds_record { fields; kind } ->
-              Tds_record
-                { fields =
-                    List.map
-                      (fun (name, sh, ly) ->
-                        name, Type_shape.replace_tvar ~pairs:subst sh, ly)
-                      fields;
-                  kind
-                }
-            | Tds_alias type_shape ->
-              Tds_alias (Type_shape.replace_tvar ~pairs:subst type_shape)
-            | Tds_other -> Tds_other)
-        }
-      in
-      ret
-    | false -> { type_params = []; path = t.path; definition = Tds_other }
 end
 
 type shape_with_layout =
-  { type_shape : Type_shape.without_layout Type_shape.ts;
+  { type_shape : Shape.without_layout Shape.ts;
     type_layout : Layout.t
   }
 
-let (all_type_decls : Type_decl_shape.tds Uid.Tbl.t) = Uid.Tbl.create 16
+let (all_type_decls : Shape.tds Uid.Tbl.t) = Uid.Tbl.create 16
 
 let (all_type_shapes : shape_with_layout Uid.Tbl.t) = Uid.Tbl.create 16
 
@@ -875,12 +397,12 @@ let type_arg_list_to_string (strings : string list) =
 let find_in_type_decls (type_uid : Uid.t) =
   Uid.Tbl.find_opt all_type_decls type_uid
 
-let rec type_name : 'a. 'a Type_shape.ts -> _ =
+let rec type_name : 'a. 'a Shape.ts -> _ =
  fun type_shape ->
   match type_shape with
   | Ts_predef (predef, shapes) ->
     type_arg_list_to_string (List.map type_name shapes)
-    ^ Type_shape.Predef.to_string predef
+    ^ Shape.Predef.to_string predef
   | Ts_other _ -> "unknown"
   | Ts_tuple shapes -> tuple_to_string (List.map type_name shapes)
   | Ts_unboxed_tuple shapes ->
@@ -893,7 +415,7 @@ let rec type_name : 'a. 'a Type_shape.ts -> _ =
   | Ts_variant fields ->
     let field_constructors =
       List.map
-        (fun { Type_shape.pv_constr_name; pv_constr_args } ->
+        (fun { Shape.pv_constr_name; pv_constr_args } ->
           let arg_types = List.map (fun sh -> type_name sh) pv_constr_args in
           let arg_type_string = String.concat " ∩ " arg_types in
           (* CR sspies: Currently, our LLDB fork removes ampersands, because
@@ -920,9 +442,7 @@ let rec type_name : 'a. 'a Type_shape.ts -> _ =
     | Some type_decl_shape ->
       (* We have found type instantiation shapes [shapes] and a typing
          declaration shape [type_decl_shape]. *)
-      let type_decl_shape =
-        Type_decl_shape.replace_tvar type_decl_shape shapes
-      in
+      let type_decl_shape = Shape.replace_tvar type_decl_shape shapes in
       let args = type_arg_list_to_string (List.map type_name shapes) in
       let name = Path.name type_decl_shape.path in
       args ^ name)

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -454,7 +454,7 @@ let print_table_all_type_decls ppf =
     List.map
       (fun (k, v) ->
         ( Format.asprintf "%a" Uid.print k,
-          Format.asprintf "%a" Type_decl_shape.print v ))
+          Format.asprintf "%a" Shape.print_type_decl_shape v ))
       entries
   in
   let uids, decls = List.split entries in
@@ -467,7 +467,7 @@ let print_table_all_type_shapes ppf =
     List.map
       (fun (k, { type_shape; type_layout }) ->
         ( Format.asprintf "%a" Uid.print k,
-          ( Format.asprintf "%a" Type_shape.print type_shape,
+          ( Format.asprintf "%a" Shape.print_type_shape type_shape,
             Format.asprintf "%a" Layout.format type_layout ) ))
       entries
   in

--- a/typing/type_shape.mli
+++ b/typing/type_shape.mli
@@ -8,211 +8,19 @@ type base_layout = Jkind_types.Sort.base
    in from [t] to [ts] (for type shape) and [tds] (for type declaration shape).*)
 
 module Type_shape : sig
-  (* For several builtin types, we provide predefined type shapes with custom
-     logic associated with them for emitting the DWARF debugging information. *)
-  module Predef : sig
-    type simd_vec_split =
-      (* 128 bit *)
-      | Int8x16
-      | Int16x8
-      | Int32x4
-      | Int64x2
-      | Float32x4
-      | Float64x2
-      (* 256 bit *)
-      | Int8x32
-      | Int16x16
-      | Int32x8
-      | Int64x4
-      | Float32x8
-      | Float64x4
-      (* 512 bit *)
-      | Int8x64
-      | Int16x32
-      | Int32x16
-      | Int64x8
-      | Float32x16
-      | Float64x8
-
-    type unboxed =
-      | Unboxed_float
-      | Unboxed_float32
-      | Unboxed_nativeint
-      | Unboxed_int64
-      | Unboxed_int32
-      | Unboxed_simd of simd_vec_split
-
-    type t =
-      | Array
-      | Bytes
-      | Char
-      | Extension_constructor
-      | Float
-      | Float32
-      | Floatarray
-      | Int
-      | Int32
-      | Int64
-      | Lazy_t
-      | Nativeint
-      | String
-      | Simd of simd_vec_split
-      | Exception
-      | Unboxed of unboxed
-
-    val to_string : t -> string
-
-    val unboxed_type_to_layout : unboxed -> Jkind_types.Sort.base
-
-    val to_layout : t -> Layout.t
-  end
-
-  (* Type shapes are abstract representations of type expressions. We define
-     them with a placeholder 'a for the layout inside. This allows one to
-     first create shapes without a type by picking [without_layout] for 'a
-     and then later substituting in a layout of type [Layout.t]. *)
-  (* CR sspies: The layout merged into the type shapes is confusing and will
-     cause trouble when the type shapes are integrated into shapes. Move them
-     back out again in a subsequent PR and instead recurse over layout and shape
-     in the DWARF emission code. *)
-  type without_layout = Layout_to_be_determined
-
-  type 'a ts =
-    | Ts_constr of (Uid.t * Path.t * 'a) * without_layout ts list
-        (** [Ts_constr ((uid, p, ly), args)] is the shape of the type constructor
-        [p] applied to the arguments [args], resulting in data of layout [ly].
-        Unlike for the resulting data, we do not definitely know the layout
-        of the arguments yet. This is only fully determined once we look at the
-        declaration behind [p]. Thus, even when the type constructor application
-        [Ts_constr((uid, p, ly), args)] itself carries a layout, the layout of
-        the arguments is still to be determined.  *)
-    | Ts_tuple of 'a ts list
-    | Ts_unboxed_tuple of 'a ts list
-    | Ts_var of string option * 'a
-    | Ts_predef of Predef.t * without_layout ts list
-        (** [Ts_predef(p, args)] is the shape for predefined type shapes.
-          Analogously to [Ts_constr], its arguments do not carry a layout yet.
-        *)
-    | Ts_arrow of without_layout ts * without_layout ts
-        (** [Ts_arrow(arg, ret)] is the shape for the function type
-            [arg -> ret]. When emitting DWARF information for this type, there
-            is no need to inspect the type arguments, and we never find out
-            their layout. As such, these remain [without_layout] even after
-            substituting in layouts.   *)
-    | Ts_variant of 'a ts poly_variant_constructors
-    | Ts_other of 'a
-
-  and 'a poly_variant_constructors = 'a poly_variant_constructor list
-
-  and 'a poly_variant_constructor =
-    { pv_constr_name : string;
-      pv_constr_args : 'a list
-    }
-
-  val shape_layout : Layout.t ts -> Layout.t
-
-  val shape_with_layout : layout:Layout.t -> without_layout ts -> Layout.t ts
-
-  val print : Format.formatter -> 'a ts -> unit
-
-  val poly_variant_constructors_map :
-    ('a -> 'b) -> 'a poly_variant_constructors -> 'b poly_variant_constructors
 
   val of_type_expr :
-    Types.type_expr -> (Path.t -> Uid.t option) -> without_layout ts
+    Types.type_expr -> (Path.t -> Uid.t option) -> Shape.without_layout Shape.ts
 end
 
 module Type_decl_shape : sig
-  (** For type substitution to work as expected, we store the layouts in the
-      declaration alongside the shapes instead of directly going for the
-      substituted version. *)
-  type tds_desc =
-    | Tds_variant of
-        { simple_constructors : string list;
-              (** The string is the name of the constructor. The runtime
-                  representation of the constructor at index [i] in this list is
-                  [2 * i + 1]. See [dwarf_type.ml] for more details. *)
-          complex_constructors :
-            (Type_shape.without_layout Type_shape.ts * Layout.t)
-            complex_constructors
-              (** All constructors in this category are represented as blocks.
-                  The index [i] in the list indicates the tag at runtime. The
-                  length of the constructor argument list [args] determines the
-                  size of the block. *)
-        }
-    | Tds_variant_unboxed of
-        { name : string;
-          arg_name : string option;
-              (** if this is [None], we are looking at a singleton tuple;
-                otherwise, it is a singleton record. *)
-          arg_shape : Type_shape.without_layout Type_shape.ts;
-          arg_layout : Layout.t
-        }
-        (** An unboxed variant corresponds to the [@@unboxed] annotation.
-          It must have a single, complex constructor. *)
-    | Tds_record of
-        { fields :
-            (string * Type_shape.without_layout Type_shape.ts * Layout.t) list;
-          kind : record_kind
-        }
-    | Tds_alias of Type_shape.without_layout Type_shape.ts
-    | Tds_other
-
-  and record_kind =
-    | Record_unboxed
-        (** [Record_unboxed] is the case for single-field records declared with
-            [@@unboxed], whose runtime representation is simply its contents
-            without any indirection. *)
-    | Record_unboxed_product
-        (** [Record_unboxed_product] is the truly unboxed record that
-             corresponds to [#{ ... }]. *)
-    | Record_boxed
-    | Record_mixed of mixed_product_shape
-    | Record_floats
-        (** Basically the same as [Record_mixed], but we don't reorder the
-            fields. *)
-
-  and 'a complex_constructors = 'a complex_constructor list
-
-  and 'a complex_constructor =
-    { name : string;
-      kind : constructor_representation;
-      args : 'a complex_constructor_argument list
-    }
-
-  and 'a complex_constructor_argument =
-    { field_name : string option;
-      field_value : 'a
-    }
-
-  (* Unlike in [types.ml], we use [Layout.t] entries here, because we can
-     represent flattened floats simply as float64 in the debugger. *)
-  and constructor_representation = mixed_product_shape
-
-  and mixed_product_shape = Layout.t array
-
-  type tds =
-    { path : Path.t;
-      definition : tds_desc;
-      type_params : Type_shape.without_layout Type_shape.ts list
-    }
-
-  val print : Format.formatter -> tds -> unit
-
-  val replace_tvar : tds -> Type_shape.without_layout Type_shape.ts list -> tds
-
-  val complex_constructor_map :
-    ('a -> 'b) -> 'a complex_constructor -> 'b complex_constructor
-
-  val complex_constructors_map :
-    ('a -> 'b) -> 'a complex_constructors -> 'b complex_constructors
 
   val of_type_declaration :
-    Path.t -> Types.type_declaration -> (Path.t -> Uid.t option) -> tds
+    Path.t -> Types.type_declaration -> (Path.t -> Uid.t option) -> Shape.tds
 end
 
 type shape_with_layout =
-  { type_shape : Type_shape.without_layout Type_shape.ts;
+  { type_shape : Shape.without_layout Shape.ts;
     type_layout : Layout.t
   }
 (* CR sspies: There are two options here: We can fold the layout into the shape,
@@ -220,7 +28,7 @@ type shape_with_layout =
     make it easier to connect type shapes and shapes (which are agnostic about
    layouts) in subsequent PRs. *)
 
-val all_type_decls : Type_decl_shape.tds Uid.Tbl.t
+val all_type_decls : Shape.tds Uid.Tbl.t
 
 val all_type_shapes : shape_with_layout Uid.Tbl.t
 
@@ -235,9 +43,9 @@ val add_to_type_shapes :
   (Path.t -> Uid.t option) ->
   unit
 
-val find_in_type_decls : Uid.t -> Type_decl_shape.tds option
+val find_in_type_decls : Uid.t -> Shape.tds option
 
-val type_name : _ Type_shape.ts -> string
+val type_name : _ Shape.ts -> string
 
 val print_table_all_type_decls : Format.formatter -> unit
 

--- a/typing/type_shape.mli
+++ b/typing/type_shape.mli
@@ -8,13 +8,11 @@ type base_layout = Jkind_types.Sort.base
    in from [t] to [ts] (for type shape) and [tds] (for type declaration shape).*)
 
 module Type_shape : sig
-
   val of_type_expr :
     Types.type_expr -> (Path.t -> Uid.t option) -> Shape.without_layout Shape.ts
 end
 
 module Type_decl_shape : sig
-
   val of_type_declaration :
     Path.t -> Types.type_declaration -> (Path.t -> Uid.t option) -> Shape.tds
 end


### PR DESCRIPTION
This PR is part of the chain of PRs for propagating debugging information through the compiler (e.g., see also https://github.com/oxcaml/oxcaml/pull/3967). It moves the definition of type shapes into the shapes file, and fixes the resulting name conflicts as appropriate. It does not add or remove functionality. It does not yet connect shapes and type shapes. They remain entirely separate.