### PR TITLE
Reinterpret vector widths

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -1474,15 +1474,18 @@ let emit_reinterpret_cast (cast : Cmm.reinterpret_cast) i =
   | Int_of_value | Value_of_int -> if distinct then I.mov (arg i 0) (res i 0)
   | Float_of_float32 | Float32_of_float ->
     if distinct then movss (arg i 0) (res i 0)
-  | V128_of_v128 -> if distinct then movpd ~unaligned:false (arg i 0) (res i 0)
-  | V256_of_v256 ->
+  | V128_of_vec (Vec128 | Vec256) ->
+    if distinct then movpd ~unaligned:false (argX i 0) (res i 0)
+  | V256_of_vec Vec128 ->
+    if distinct then movpd ~unaligned:false (arg i 0) (resX i 0)
+  | V256_of_vec Vec256 ->
     (* CR-soon mslater: align vec256/512 stack slots *)
     if distinct
     then
       if Reg.is_stack i.arg.(0)
       then I.simd vmovupd_Y_Ym256 [| arg i 0; res i 0 |]
       else I.simd vmovupd_Ym256_Y [| arg i 0; res i 0 |]
-  | V512_of_v512 ->
+  | V128_of_vec Vec512 | V256_of_vec Vec512 | V512_of_vec _ ->
     (* CR-soon mslater: avx512 *)
     Misc.fatal_error "avx512 instructions not yet implemented"
   | Float_of_int64 | Int64_of_float -> movq (arg i 0) (res i 0)

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -151,8 +151,8 @@ let rbp = phys_reg Int 12
 let destroy_xmm =
   let types =
     ([ Float; Float32; Vec128 ] : machtype_component list)
-    |> add_hard_vec256_regs ~f:(fun _ -> Vec256)
-    |> add_hard_vec512_regs ~f:(fun _ -> Vec512)
+    |> add_hard_vec256_regs ~f:(fun _ : machtype_component -> Vec256)
+    |> add_hard_vec512_regs ~f:(fun _ : machtype_component -> Vec512)
     |> Array.of_list
   in
   fun n -> Array.map (fun t -> phys_reg t (100 + n)) types
@@ -713,10 +713,10 @@ let has_three_operand_float_ops () = Arch.Extension.enabled AVX
 
 let operation_supported = function
   | Cpopcnt -> Arch.Extension.enabled POPCNT
-  | Creinterpret_cast V256_of_v256
+  | Creinterpret_cast (V256_of_vec (Vec128 | Vec256) | V128_of_vec Vec256)
   | Cstatic_cast (V256_of_scalar _ | Scalar_of_v256 _) ->
     Arch.Extension.enabled_vec256 ()
-  | Creinterpret_cast V512_of_v512
+  | Creinterpret_cast (V512_of_vec _ | V128_of_vec Vec512 | V256_of_vec Vec512)
   | Cstatic_cast (V512_of_scalar _ | Scalar_of_v512 _) ->
     Arch.Extension.enabled_vec512 ()
   | Cprefetch _ | Catomic _
@@ -739,7 +739,7 @@ let operation_supported = function
                        Int64_of_float | Float_of_int64 |
                        Float32_of_float | Float_of_float32 |
                        Float32_of_int32 | Int32_of_float32 |
-                       V128_of_v128)
+                       V128_of_vec Vec128)
   | Cstatic_cast (Float_of_float32 | Float32_of_float |
                   Int_of_float Float32 | Float_of_int Float32 |
                   Float_of_int Float64 | Int_of_float Float64 |

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -207,8 +207,8 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
     May_still_have_spilled_registers
   | Op
       (Reinterpret_cast
-        ( Float_of_float32 | Float32_of_float | V128_of_v128 | V256_of_v256
-        | V512_of_v512 ))
+        ( Float_of_float32 | Float32_of_float | V128_of_vec _ | V256_of_vec _
+        | V512_of_vec _ ))
   | Op (Static_cast (V128_of_scalar Float64x2 | Scalar_of_v128 Float64x2))
   | Op (Static_cast (V128_of_scalar Float32x4 | Scalar_of_v128 Float32x4))
   | Op (Static_cast (V256_of_scalar Float64x4 | Scalar_of_v256 Float64x4))

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1268,8 +1268,10 @@ module BR = Branch_relaxation.Make (struct
           ( Float32_of_float | Float_of_float32 | Float32_of_int32
           | Int32_of_float32 )) ->
       1
-    | Lop (Reinterpret_cast V128_of_v128) -> 1
-    | Lop (Reinterpret_cast (V256_of_v256 | V512_of_v512)) ->
+    | Lop (Reinterpret_cast (V128_of_vec Vec128)) -> 1
+    | Lop
+        (Reinterpret_cast
+          (V128_of_vec (Vec256 | Vec512) | V256_of_vec _ | V512_of_vec _)) ->
       Misc.fatal_error "arm64: got 256/512 bit vector"
     | Lop (Static_cast (Float_of_int Float64 | Int_of_float Float64)) -> 1
     | Lop
@@ -1568,13 +1570,13 @@ let emit_reinterpret_cast (cast : Cmm.reinterpret_cast) i =
       DSL.check_reg Float32 src;
       DSL.check_reg Float dst;
       DSL.ins I.FMOV [| DSL.emit_reg_d dst; DSL.emit_reg_d src |])
-  | V128_of_v128 ->
+  | V128_of_vec Vec128 ->
     if distinct
     then (
       DSL.check_reg Vec128 src;
       DSL.check_reg Vec128 dst;
       DSL.ins I.MOV [| DSL.emit_reg_v16b dst; DSL.emit_reg_v16b src |])
-  | V256_of_v256 | V512_of_v512 ->
+  | V128_of_vec (Vec256 | Vec512) | V256_of_vec _ | V512_of_vec _ ->
     Misc.fatal_error "arm64: got 256/512 bit vector"
   | Int_of_value | Value_of_int -> move src dst
 

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -340,7 +340,8 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
   | Poptrap _ | Prologue
   | Op (Reinterpret_cast (Int_of_value | Value_of_int | Float_of_float32 |
                           Float32_of_float | Float_of_int64 | Int64_of_float |
-                          Float32_of_int32 | Int32_of_float32 | V128_of_vec Vec128))
+                          Float32_of_int32 | Int32_of_float32 |
+                          V128_of_vec Vec128))
     -> [||]
   | Stack_check _ -> assert false (* not supported *)
   | Op (Const_vec256 _ | Const_vec512 _)

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -340,7 +340,7 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
   | Poptrap _ | Prologue
   | Op (Reinterpret_cast (Int_of_value | Value_of_int | Float_of_float32 |
                           Float32_of_float | Float_of_int64 | Int64_of_float |
-                          Float32_of_int32 | Int32_of_float32 | V128_of_v128))
+                          Float32_of_int32 | Int32_of_float32 | V128_of_vec Vec128))
     -> [||]
   | Stack_check _ -> assert false (* not supported *)
   | Op (Const_vec256 _ | Const_vec512 _)
@@ -352,7 +352,8 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
           ((Twofiftysix_aligned|Twofiftysix_unaligned|
             Fivetwelve_aligned|Fivetwelve_unaligned),
             _, _))
-  | Op (Reinterpret_cast (V256_of_v256 | V512_of_v512))
+  | Op (Reinterpret_cast (V128_of_vec (Vec256 | Vec512) |
+                          V256_of_vec _ | V512_of_vec _))
   | Op (Static_cast (V256_of_scalar _ | Scalar_of_v256 _ |
                      V512_of_scalar _ | Scalar_of_v512 _))
     -> Misc.fatal_error "arm64: got 256/512 bit vector"
@@ -451,7 +452,8 @@ let has_three_operand_float_ops () = false
 
 let operation_supported : Cmm.operation -> bool = function
   | Cprefetch _ | Catomic _
-  | Creinterpret_cast (V256_of_v256 | V512_of_v512)
+  | Creinterpret_cast (V128_of_vec (Vec256 | Vec512) |
+                       V256_of_vec _ | V512_of_vec _)
   | Cstatic_cast (V256_of_scalar _ | Scalar_of_v256 _ |
                   V512_of_scalar _ | Scalar_of_v512 _) ->
     false
@@ -477,7 +479,7 @@ let operation_supported : Cmm.operation -> bool = function
                        Int64_of_float | Float_of_int64 |
                        Float32_of_float | Float_of_float32 |
                        Float32_of_int32 | Int32_of_float32 |
-                       V128_of_v128)
+                       V128_of_vec Vec128)
   | Cstatic_cast (Float_of_float32 | Float32_of_float |
                   Int_of_float Float32 | Float_of_int Float32 |
                   Float_of_int Float64 | Int_of_float Float64 |

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -296,6 +296,11 @@ type float_width =
   | Float64
   | Float32
 
+type vector_width =
+  | Vec128
+  | Vec256
+  | Vec512
+
 type memory_chunk =
   | Byte_unsigned
   | Byte_signed
@@ -323,9 +328,9 @@ type reinterpret_cast =
   | Int64_of_float
   | Float32_of_int32
   | Int32_of_float32
-  | V128_of_v128
-  | V256_of_v256
-  | V512_of_v512
+  | V128_of_vec of vector_width
+  | V256_of_vec of vector_width
+  | V512_of_vec of vector_width
 
 type static_cast =
   | Float_of_int of float_width
@@ -811,6 +816,13 @@ let equal_float_width left right =
   | Float32, Float32 -> true
   | (Float32 | Float64), _ -> false
 
+let equal_vector_width left right =
+  match left, right with
+  | Vec128, Vec128 -> true
+  | Vec256, Vec256 -> true
+  | Vec512, Vec512 -> true
+  | (Vec128 | Vec256 | Vec512), _ -> false
+
 let equal_reinterpret_cast (left : reinterpret_cast) (right : reinterpret_cast)
     =
   match left, right with
@@ -822,12 +834,13 @@ let equal_reinterpret_cast (left : reinterpret_cast) (right : reinterpret_cast)
   | Int64_of_float, Int64_of_float -> true
   | Float32_of_int32, Float32_of_int32 -> true
   | Int32_of_float32, Int32_of_float32 -> true
-  | V128_of_v128, V128_of_v128 -> true
-  | V256_of_v256, V256_of_v256 -> true
-  | V512_of_v512, V512_of_v512 -> true
+  | V128_of_vec w1, V128_of_vec w2
+  | V256_of_vec w1, V256_of_vec w2
+  | V512_of_vec w1, V512_of_vec w2 ->
+    equal_vector_width w1 w2
   | ( ( Int_of_value | Value_of_int | Float_of_float32 | Float32_of_float
       | Float_of_int64 | Int64_of_float | Float32_of_int32 | Int32_of_float32
-      | V128_of_v128 | V256_of_v256 | V512_of_v512 ),
+      | V128_of_vec _ | V256_of_vec _ | V512_of_vec _ ),
       _ ) ->
     false
 

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -235,6 +235,11 @@ type float_width =
   | Float64
   | Float32
 
+type vector_width =
+  | Vec128
+  | Vec256
+  | Vec512
+
 type vec128_type =
   | Int8x16
   | Int16x8
@@ -291,9 +296,11 @@ type reinterpret_cast =
   | Int64_of_float
   | Float32_of_int32
   | Int32_of_float32
-  | V128_of_v128
-  | V256_of_v256
-  | V512_of_v512 (* Converts between vector types of the same width. *)
+  (* When reinterpreting a smaller vector as a larger vector, the upper bits are
+     unspecified. *)
+  | V128_of_vec of vector_width
+  | V256_of_vec of vector_width
+  | V512_of_vec of vector_width
 
 (* These casts may require a particular value-preserving operation, e.g.
    truncating a float to an int. *)

--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -335,11 +335,11 @@ let transl_vec_builtin name args dbg _typ_res =
   | "caml_vec512_low_to_vec128" ->
     let op = Creinterpret_cast (V128_of_vec Vec512) in
     if_operation_supported op ~f:(fun () -> Cop (op, args, dbg))
-  | "caml_vec512_low_of_vec512" ->
-    let op = Creinterpret_cast (V512_of_vec Vec512) in
+  | "caml_vec512_low_of_vec256" ->
+    let op = Creinterpret_cast (V512_of_vec Vec256) in
     if_operation_supported op ~f:(fun () -> Cop (op, args, dbg))
-  | "caml_vec512_low_to_vec512" ->
-    let op = Creinterpret_cast (V512_of_vec Vec512) in
+  | "caml_vec512_low_to_vec256" ->
+    let op = Creinterpret_cast (V256_of_vec Vec512) in
     if_operation_supported op ~f:(fun () -> Cop (op, args, dbg))
   (* Scalar casts. These leave the top bits of the vector unspecified. *)
   | "caml_float64x2_low_of_float" ->

--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -315,13 +315,31 @@ let transl_vec_builtin name args dbg _typ_res =
   match name with
   (* Vector casts (no-ops) *)
   | "caml_vec128_cast" ->
-    let op = Creinterpret_cast V128_of_v128 in
+    let op = Creinterpret_cast (V128_of_vec Vec128) in
     if_operation_supported op ~f:(fun () -> Cop (op, args, dbg))
   | "caml_vec256_cast" ->
-    let op = Creinterpret_cast V256_of_v256 in
+    let op = Creinterpret_cast (V256_of_vec Vec256) in
     if_operation_supported op ~f:(fun () -> Cop (op, args, dbg))
   | "caml_vec512_cast" ->
-    let op = Creinterpret_cast V512_of_v512 in
+    let op = Creinterpret_cast (V512_of_vec Vec512) in
+    if_operation_supported op ~f:(fun () -> Cop (op, args, dbg))
+  | "caml_vec256_low_of_vec128" ->
+    let op = Creinterpret_cast (V256_of_vec Vec128) in
+    if_operation_supported op ~f:(fun () -> Cop (op, args, dbg))
+  | "caml_vec256_low_to_vec128" ->
+    let op = Creinterpret_cast (V128_of_vec Vec256) in
+    if_operation_supported op ~f:(fun () -> Cop (op, args, dbg))
+  | "caml_vec512_low_of_vec128" ->
+    let op = Creinterpret_cast (V512_of_vec Vec128) in
+    if_operation_supported op ~f:(fun () -> Cop (op, args, dbg))
+  | "caml_vec512_low_to_vec128" ->
+    let op = Creinterpret_cast (V128_of_vec Vec512) in
+    if_operation_supported op ~f:(fun () -> Cop (op, args, dbg))
+  | "caml_vec512_low_of_vec512" ->
+    let op = Creinterpret_cast (V512_of_vec Vec512) in
+    if_operation_supported op ~f:(fun () -> Cop (op, args, dbg))
+  | "caml_vec512_low_to_vec512" ->
+    let op = Creinterpret_cast (V512_of_vec Vec512) in
     if_operation_supported op ~f:(fun () -> Cop (op, args, dbg))
   (* Scalar casts. These leave the top bits of the vector unspecified. *)
   | "caml_float64x2_low_of_float" ->

--- a/backend/operation.ml
+++ b/backend/operation.ml
@@ -342,7 +342,7 @@ let is_pure = function
   | Floatop _ -> true
   | Csel _ -> true
   | Reinterpret_cast
-      ( V128_of_v128 | V256_of_v256 | V512_of_v512 | Float32_of_float
+      ( V128_of_vec _ | V256_of_vec _ | V512_of_vec _ | Float32_of_float
       | Float32_of_int32 | Float_of_float32 | Float_of_int64 | Int64_of_float
       | Int32_of_float32 ) ->
     true

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -218,9 +218,9 @@ let to_string msg =
     ppf msg
 
 let reinterpret_cast : Cmm.reinterpret_cast -> string = function
-  | V128_of_vec w -> Printf.sprintf "vec128 as %s" (vector_width w)
-  | V256_of_vec w -> Printf.sprintf "vec256 as %s" (vector_width w)
-  | V512_of_vec w -> Printf.sprintf "vec512 as %s" (vector_width w)
+  | V128_of_vec w -> Printf.sprintf "%s as vec128" (vector_width w)
+  | V256_of_vec w -> Printf.sprintf "%s as vec256" (vector_width w)
+  | V512_of_vec w -> Printf.sprintf "%s as vec512" (vector_width w)
   | Value_of_int -> "int as value"
   | Int_of_value -> "value as int"
   | Float32_of_float -> "float as float32"

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -98,6 +98,11 @@ let float_comparison = function
   | CFge -> ">="
   | CFnge -> "!>="
 
+let vector_width = function
+  | Vec128 -> "vec128"
+  | Vec256 -> "vec256"
+  | Vec512 -> "vec512"
+
 let vec128_name = function
   | Int8x16 -> "int8x16"
   | Int16x8 -> "int16x8"
@@ -213,9 +218,9 @@ let to_string msg =
     ppf msg
 
 let reinterpret_cast : Cmm.reinterpret_cast -> string = function
-  | V128_of_v128 -> "vec128 as vec128"
-  | V256_of_v256 -> "vec256 as vec256"
-  | V512_of_v512 -> "vec512 as vec512"
+  | V128_of_vec w -> Printf.sprintf "vec128 as %s" (vector_width w)
+  | V256_of_vec w -> Printf.sprintf "vec256 as %s" (vector_width w)
+  | V512_of_vec w -> Printf.sprintf "vec512 as %s" (vector_width w)
   | Value_of_int -> "int as value"
   | Int_of_value -> "value as int"
   | Float32_of_float -> "float as float32"

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -206,9 +206,9 @@ let oper_result_type = function
   | Cpackf32 -> typ_float
   | Ccsel ty -> ty
   | Creinterpret_cast Value_of_int -> typ_val
-  | Creinterpret_cast V128_of_v128 -> typ_vec128
-  | Creinterpret_cast V256_of_v256 -> typ_vec256
-  | Creinterpret_cast V512_of_v512 -> typ_vec512
+  | Creinterpret_cast (V128_of_vec _) -> typ_vec128
+  | Creinterpret_cast (V256_of_vec _) -> typ_vec256
+  | Creinterpret_cast (V512_of_vec _) -> typ_vec512
   | Creinterpret_cast (Float_of_int64 | Float_of_float32) -> typ_float
   | Creinterpret_cast (Float32_of_int32 | Float32_of_float) -> typ_float32
   | Creinterpret_cast (Int_of_value | Int64_of_float | Int32_of_float32) ->

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -2533,7 +2533,7 @@ end = struct
         | Reinterpret_cast
             ( Float32_of_float | Float_of_float32 | Float_of_int64
             | Int64_of_float | Float32_of_int32 | Int32_of_float32
-            | V128_of_v128 | V256_of_v256 | V512_of_v512 )
+            | V128_of_vec _ | V256_of_vec _ | V512_of_vec _ )
         | Static_cast _ | Csel _ ->
           if not (Operation.is_pure op)
           then

--- a/oxcaml/tests/simd/stubs256.c
+++ b/oxcaml/tests/simd/stubs256.c
@@ -12,6 +12,8 @@
 
 BUILTIN(caml_vec256_unreachable);
 BUILTIN(caml_vec256_cast);
+BUILTIN(caml_vec256_low_of_vec128);
+BUILTIN(caml_vec256_low_to_vec128);
 BUILTIN(caml_float32x8_low_of_float32);
 BUILTIN(caml_float32x8_low_to_float32);
 BUILTIN(caml_float64x4_low_of_float);

--- a/oxcaml/tests/simd/utils256.ml
+++ b/oxcaml/tests/simd/utils256.ml
@@ -1,5 +1,7 @@
 [@@@ocaml.warning "-unused-module"]
 
+open Utils
+
 external int64x4_of_int64s : int64 -> int64 -> int64 -> int64 -> int64x4
   = "" "vec256_of_int64s"
   [@@noalloc] [@@unboxed]
@@ -323,4 +325,21 @@ module Vector256_casts = struct
     eq a b c d 13L 14L 15L 16L;
     let a, b, c, d = int64x4_to_quadruple _4 in
     eq a b c d 17L 18L 19L 20L
+
+  external int64x4_of_int64x2 : int64x2 -> int64x4
+    = "caml_vec256_unreachable" "caml_vec256_low_of_vec128"
+    [@@noalloc] [@@unboxed] [@@builtin]
+
+  external int64x2_of_int64x4 : int64x4 -> int64x2
+    = "caml_vec256_unreachable" "caml_vec256_low_to_vec128"
+    [@@noalloc] [@@unboxed] [@@builtin]
+
+  let () =
+    let _12 = int64x2_of_int64s 1L 2L in
+    let up = int64x4_of_int64x2 (Sys.opaque_identity _12) in
+    let down = int64x2_of_int64x4 (Sys.opaque_identity up) in
+    let _d, _c, b, a = int64x4_to_quadruple up in
+    eq a b 0L 0L 1L 2L 0L 0L;
+    let a, b = int64x2_low_int64 down, int64x2_high_int64 down in
+    eq a b 0L 0L 1L 2L 0L 0L
 end


### PR DESCRIPTION
Extends vector reinterpret-cast to allow converting between widths. When converting a smaller vector to a larger vector, the upper bits are left unspecified (they'll be zero if a move is generated, or the existing bits if coalesced). 