### PR TITLE
Remove SA_NODEFER from the `sa_flags` of the SIGSEGV handler

### DIFF
--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -151,7 +151,7 @@ void caml_init_nat_signals(void)
 {
   struct sigaction act, oldact;
   SET_SIGACT(act, segv_handler);
-  act.sa_flags |= SA_ONSTACK | SA_NODEFER;
+  act.sa_flags |= SA_ONSTACK;
   sigemptyset(&act.sa_mask);
   sigaction(SIGSEGV, &act, &oldact);
   if (oldact.sa_sigaction != (sigaction_t)SIG_DFL) {


### PR DESCRIPTION
SA_NODEFER allows signal handlers to recurse. This is generally a bad idea - if we segfault in our segfault handler, nothing good will come from attempting to handle it.

We have it because this code has been copied around [since 1999](https://github.com/oxcaml/oxcaml/commit/7afdd2ae849a093effe543307e17a0cda69826db) and it's unclear why it was added even at the time.