### PR TITLE
Reduce nearby address collisions in [Hash_retaddr]

### DIFF
--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -151,7 +151,7 @@ Caml_inline bool frame_has_debug(frame_descr *d) {
   (void*)(((uintnat)(p) + sizeof(ty) - 1) & -sizeof(ty))
 
 #define Hash_retaddr(addr, mask)                          \
-  (((uintnat)(addr) * 715827883) & (mask))
+  ((((uintnat)(addr) * 52437813) >> 5) & (mask))
 
 #define Retaddr_frame(d) \
   ((uintnat)&(d)->retaddr_rel + \

--- a/runtime4/caml/stack.h
+++ b/runtime4/caml/stack.h
@@ -145,7 +145,7 @@ extern frame_descr ** caml_frame_descriptors;
 extern uintnat caml_frame_descriptors_mask;
 
 #define Hash_retaddr(addr) \
-  (((uintnat)(addr) * 715827883) & caml_frame_descriptors_mask)
+  ((((uintnat)(addr) * 52437813) >> 5) & caml_frame_descriptors_mask)
 
 #define Retaddr_frame(d) \
   ((uintnat)&(d)->retaddr_rel + \


### PR DESCRIPTION
Currently the `Hash_retaddr` that populates the frame description hashtable is just `x >> 3`. Consequently, registering a large number of symbols with nearby addresses causes many collisions and substantially degrades the performance of programs that rely on exceptions for control flow / error handling.

This PR changes the hash function to `x * 715827883`, which is good enough to fix the regression we encountered internally and still much cheaper than e.g. a proper FNV hash.