### PR TITLE
Fix some ASan test flakiness

### DIFF
--- a/oxcaml/tests/backend/address_sanitizer/stubs.c
+++ b/oxcaml/tests/backend/address_sanitizer/stubs.c
@@ -14,9 +14,11 @@
 
 CAMLprim value ocaml_address_sanitizer_test_alloc(size_t len, int64_t tag) {
   assert(len > 0);
-  assert(tag >= No_scan_tag);
   header_t *block = malloc((len * sizeof(value)) + sizeof(header_t));
   *block = Caml_out_of_heap_header(/*wosize=*/len, /*tag=*/tag);
+  if (tag < No_scan_tag) {
+    for (size_t i = 0; i < len; i++) Op_hp(block)[i] = Val_unit;
+  }
   return Val_hp(block);
 }
 


### PR DESCRIPTION
The ASan tests were doing some invalid operations (using `caml_modify` on blocks which did not contain valid values), which ASan sometimes detects and explodes on. This patch is a bit more careful about block contents in the ASan tests.