### PR TITLE
Fix function applications for JSIR translation

### DIFF
--- a/middle_end/flambda2/to_jsir/to_jsir_env.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_env.ml
@@ -2,7 +2,7 @@ type t =
   { module_symbol : Symbol.t;
     return_continuation : Continuation.t;
     exn_continuation : Continuation.t;
-    continuations : Jsir.Addr.t Continuation.Map.t;
+    continuations : Jsir.Var.t Continuation.Map.t;
     vars : Jsir.Var.t Variable.Map.t;
     symbols : Jsir.Var.t Symbol.Map.t;
     code_ids : (Jsir.Addr.t * Jsir.Var.t list) Code_id.Map.t;
@@ -51,14 +51,14 @@ let add_value_slot t vslot jvar =
 type continuation =
   | Return
   | Exception
-  | Block of Jsir.Addr.t
+  | Function of Jsir.Var.t
 
 let get_continuation_exn t cont =
   if cont = t.return_continuation
   then Return
   else if cont = t.exn_continuation
   then Exception
-  else Block (Continuation.Map.find cont t.continuations)
+  else Function (Continuation.Map.find cont t.continuations)
 
 let get_var_exn t fvar = Variable.Map.find fvar t.vars
 

--- a/middle_end/flambda2/to_jsir/to_jsir_env.mli
+++ b/middle_end/flambda2/to_jsir/to_jsir_env.mli
@@ -29,8 +29,8 @@ val enter_function_body :
 (** Symbol corresponding to the module currently compiling. *)
 val module_symbol : t -> Symbol.t
 
-(** Map a Flambda2 continuation to a JSIR block address. *)
-val add_continuation : t -> Continuation.t -> Jsir.Addr.t -> t
+(** Map a Flambda2 continuation to a JSIR variable (bound to the corresponding function). *)
+val add_continuation : t -> Continuation.t -> Jsir.Var.t -> t
 
 (** Map a Flambda2 variable to a JSIR variable. *)
 val add_var : t -> Variable.t -> Jsir.Var.t -> t
@@ -58,7 +58,7 @@ val add_value_slot : t -> Value_slot.t -> Jsir.Var.t -> t
 type continuation =
   | Return
   | Exception
-  | Block of Jsir.Addr.t
+  | Function of Jsir.Var.t
 
 (** Return the block address for the given continuation. Raises if given an
     unbound continuation. *)

--- a/middle_end/flambda2/to_jsir/to_jsir_shared.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_shared.ml
@@ -54,3 +54,14 @@ let simples ~env ~res simples =
       let var, res = simple ~env ~res s in
       var :: vars, res)
     simples ([], res)
+
+let bound_parameters ~env bound_params =
+  (* The natural fold instead of [List.fold_left] to preserve order of
+     parameters *)
+  List.fold_right
+    (fun bound_param (params, env) ->
+      let var = Jsir.Var.fresh () in
+      let env = To_jsir_env.add_var env (Bound_parameter.var bound_param) var in
+      var :: params, env)
+    (Bound_parameters.to_list bound_params)
+    ([], env)

--- a/middle_end/flambda2/to_jsir/to_jsir_shared.mli
+++ b/middle_end/flambda2/to_jsir/to_jsir_shared.mli
@@ -37,3 +37,8 @@ val simples :
   res:To_jsir_result.t ->
   Simple.t list ->
   Jsir.Var.t list * To_jsir_result.t
+
+(** Take in [Bound_parameters.t] and bind each parameter to fresh JSIR variables in the
+    environment, and return the variables in order *)
+val bound_parameters :
+  env:To_jsir_env.t -> Bound_parameters.t -> Jsir.Var.t list * To_jsir_env.t

--- a/middle_end/flambda2/to_jsir/to_jsir_static_const.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_static_const.ml
@@ -146,19 +146,7 @@ let code ~env ~res ~translate_body ~code_id code =
          [my_closure] is actually used for *)
       let var = Jsir.Var.fresh () in
       let env = To_jsir_env.add_var env my_closure var in
-      let env, fn_params =
-        (* The natural fold instead of [List.fold_left] to preserve order of
-           parameters *)
-        List.fold_right
-          (fun bound_param (env, params) ->
-            let var = Jsir.Var.fresh () in
-            let env =
-              To_jsir_env.add_var env (Bound_parameter.var bound_param) var
-            in
-            env, var :: params)
-          (Bound_parameters.to_list bound_params)
-          (env, [])
-      in
+      let fn_params, env = To_jsir_shared.bound_parameters ~env bound_params in
       let res, addr = To_jsir_result.new_block res ~params:[] in
       let env = To_jsir_env.add_code_id env code_id ~addr ~params:fn_params in
       let _env, res =


### PR DESCRIPTION
Previously there was a restriction that function applications were only supported when the return continuation is the caller's return continuation. This PR relaxes this restriction. 

Now
```ocaml
let rec f x =
  let y = f x in
  let z = f y in
  z
;;
```
gets translated to
```
==== 0 () ====
  v9 = fun(v3){1 ()}
  (assign) v1 = v9
  v10 = imm{tag=0; 0 = v1}
  v11 = "caml_register_global"(0, v10, "Cont"j)
  stop

==== 1 () ====
  v6 = fun(v4){2 ()}
  v7 = v1(v3)
  v8 = v6!(v7)
  return v8

==== 2 () ====
  v5 = v1(v4)
  return v5
  ```