### PR TITLE
Regalloc tool: tweak the semantics of the `-regalloc` command-line option

### DIFF
--- a/tools/regalloc/regalloc.ml
+++ b/tools/regalloc/regalloc.ml
@@ -23,17 +23,26 @@ let string_of_register_allocator = function
   | IRC -> "irc"
   | LS -> "ls"
 
-let allocators =
-  List.map register_allocators ~f:(fun ra ->
-      string_of_register_allocator ra, ra)
+type strategy =
+  | Allocator of register_allocator
+  | Default
+  | Custom
+
+let stategies =
+  ["default", Default; "custom", Custom]
+  @ List.map register_allocators ~f:(fun ra ->
+        string_of_register_allocator ra, Allocator ra)
 
 type config =
-  { register_allocator : register_allocator;
+  { strategy : strategy;
     validation : bool;
+    linscan_threshold : int;
     debug_output : bool;
     csv_output : bool;
     paths : string list
   }
+
+let is_entry_function_name name = String.ends_with ~suffix:"__entry" name
 
 external time_include_children : bool -> float
   = "caml_sys_time_include_children"
@@ -129,7 +138,7 @@ let collect_in_stats (cfg_with_infos : Cfg_with_infos.t)
     DLL.fold_left instrs ~init:0 ~f:(fun acc instr ->
         if is_high_pressure_point instr then succ acc else acc)
   in
-  let is_entry_function = String.ends_with ~suffix:"__entry" cfg.fun_name in
+  let is_entry_function = is_entry_function_name cfg.fun_name in
   let num_regs = List.length relocatable_regs in
   let num_blocks = Label.Tbl.length cfg.blocks in
   let num_instrs, num_destruction_points, num_high_pressure_points =
@@ -210,6 +219,22 @@ let collect_out_stats (cfg_with_infos : Cfg_with_infos.t) =
             }
           | _ -> acc))
 
+(* note: this is unfortunately a reimplementation of
+   `Asmgen.should_use_linscan`, which cannot be used because we have lost bit of
+   information / are using different types here. *)
+let should_use_linscan config cfg_with_layout =
+  is_entry_function_name (Cfg_with_layout.cfg cfg_with_layout).fun_name
+  || List.compare_length_with
+       (Reg.all_relocatable_regs ())
+       ~len:config.linscan_threshold
+     > 0
+
+let select_allocator config cfg_with_layout =
+  match config.strategy with
+  | Allocator allocator -> allocator
+  | Default -> if should_use_linscan config cfg_with_layout then LS else IRC
+  | Custom -> fatal "not implemented"
+
 let process_function (config : config) (cfg_with_layout : Cfg_with_layout.t)
     (cmm_label : Label.t) (reg_stamp : int) (relocatable_regs : Reg.t list) =
   if config.debug_output
@@ -231,8 +256,9 @@ let process_function (config : config) (cfg_with_layout : Cfg_with_layout.t)
     | true -> Some (Regalloc_validate.Description.create cfg_with_layout)
   in
   let start_time = cpu_time () in
+  let allocator = select_allocator config cfg_with_layout in
   let (_, rounds_ref) : Cfg_with_infos.t * int ref =
-    match config.register_allocator with
+    match allocator with
     | GI -> Regalloc_gi.run cfg_with_infos, Regalloc_gi.For_testing.rounds
     | IRC -> Regalloc_irc.run cfg_with_infos, Regalloc_irc.For_testing.rounds
     | LS -> Regalloc_ls.run cfg_with_infos, Regalloc_ls.For_testing.rounds
@@ -251,7 +277,7 @@ let process_function (config : config) (cfg_with_layout : Cfg_with_layout.t)
     let out_stats = collect_out_stats cfg_with_infos in
     let cfg = Cfg_with_layout.cfg cfg_with_layout in
     print_row
-      ~allocator:(string_of_register_allocator config.register_allocator)
+      ~allocator:(string_of_register_allocator allocator)
       ~function_name:cfg.fun_name ~duration ~rounds:!rounds_ref ~in_stats
       ~out_stats
   end;
@@ -301,36 +327,41 @@ let collect_files (paths : string list) =
   List.sort ~cmp:String.compare !files
 
 let parse_command_line () =
-  let register_allocator = ref None in
-  let set_register_allocator str =
-    match List.assoc_opt str allocators with
+  let strategy = ref None in
+  let set_strategy str =
+    match List.assoc_opt str stategies with
     | None -> assert false
-    | Some allocator -> register_allocator := Some allocator
+    | Some strat -> strategy := Some strat
   in
   let validate = ref false in
+  let linscan_threshold = ref !Oxcaml_flags.regalloc_linscan_threshold in
   let csv_output = ref false in
   let debug_output = ref false in
   let paths = ref [] in
   let args : (Arg.key * Arg.spec * Arg.doc) list =
     [ ( "-regalloc",
-        Arg.Symbol (List.map allocators ~f:fst, set_register_allocator),
+        Arg.Symbol (List.map stategies ~f:fst, set_strategy),
         "  Choose register allocator" );
       ( "-param",
         Arg.String
           (fun s ->
             Oxcaml_flags.regalloc_params := s :: !Oxcaml_flags.regalloc_params),
         " Pass a parameter to the register allocator" );
+      ( "-linscan-threshold",
+        Arg.Set_int linscan_threshold,
+        "Select linscan if the number of registers is above the threshold" );
       "-validate", Arg.Set validate, "Enable validation";
       "-csv-output", Arg.Set csv_output, "Enable CSV output";
       "-debug-output", Arg.Set debug_output, "Enable debug output" ]
   in
   let anonymous path = paths := path :: !paths in
   Arg.parse args anonymous "run register allocation on .cmir-cfg-regalloc files";
-  match !register_allocator with
+  match !strategy with
   | None -> fatal "register allocator was not set (use -regalloc)"
-  | Some register_allocator ->
-    { register_allocator;
+  | Some strategy ->
+    { strategy;
       validation = !validate;
+      linscan_threshold = !linscan_threshold;
       csv_output = !csv_output;
       debug_output = !debug_output;
       paths = !paths


### PR DESCRIPTION
This pull request changes the semantics of
the `-regalloc` option. It used to accept
one of the three allocators (`irc`, `ls`, and
`gi`), and now additionally accepts:

- `default`, which will choose between
  `irc` and `ls` roughly as the compiler does;
- `custom`, to be implemented in a follow-up
  pull request.