### PR TITLE
CI: fix path to `regalloc.exe`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,7 +299,7 @@ jobs:
       if: matrix.run_regalloc_tool == true
       run: |
         for allocator in irc ls gi; do \
-          find _build -name \*.cmir-cfg-regalloc -exec ./_build/main/tools/regalloc/regalloc.exe \
+          ./_build/main/tools/regalloc/regalloc.exe _build \
             -validate -regalloc $allocator {} \; ; \
         done
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,7 +300,7 @@ jobs:
       run: |
         for allocator in irc ls gi; do \
           ./_build/main/tools/regalloc/regalloc.exe _build \
-            -validate -regalloc $allocator; \
+            -validate -regalloc $allocator || exit 1; \
         done
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,7 +299,7 @@ jobs:
       if: matrix.run_regalloc_tool == true
       run: |
         for allocator in irc ls gi; do \
-          find _build -name \*.cmir-cfg-regalloc -exec ./_build/default/tools/regalloc/regalloc.exe \
+          find _build -name \*.cmir-cfg-regalloc -exec ./_build/main/tools/regalloc/regalloc.exe \
             -validate -regalloc $allocator {} \; ; \
         done
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,7 +300,7 @@ jobs:
       run: |
         for allocator in irc ls gi; do \
           ./_build/main/tools/regalloc/regalloc.exe _build \
-            -validate -regalloc $allocator {} \; ; \
+            -validate -regalloc $allocator; \
         done
 
     - uses: actions/upload-artifact@v4


### PR DESCRIPTION
In #4301, I forgot to update the path
to `regalloc.exe` in the CI jobs.
Unfortunately the error exit code was
swallowed by (I think) either the bash
`for` loop or `find`.