### PR TITLE
flambda2: More maintainable implementation of n-way join

### DIFF
--- a/middle_end/flambda2/identifiers/int_ids.mli
+++ b/middle_end/flambda2/identifiers/int_ids.mli
@@ -105,7 +105,7 @@ module Variable : sig
 
   type exported
 
-  include Container_types.S with type t := t
+  include Container_types.S_plus_iterator with type t := t
 
   module Lmap : Lmap.S with type key := t
 
@@ -129,7 +129,7 @@ module Symbol : sig
 
   type exported
 
-  include Container_types.S with type t := t
+  include Container_types.S_plus_iterator with type t := t
 
   (* CR lmaurer: This treats the [Linkage_name.t] as a string to be prefixed
      rather than the actual linkage name. That's not really consistent with the

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -13,6 +13,77 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(* Implement the join of typing envs, or more precisely of typing env levels.
+
+   Most of the code here is actually concerned with the join of *aliases*
+   specifically (keeping track of how names change between the different
+   environments), and delegates the actual join of types to the
+   [Meet_and_n_way_join] module.
+
+   The join involves multiple environments that are known under different names.
+   Within this file, we standardise on the following names:
+
+   - The {b source environment} is the initial value (before the join) of the
+   environment that we will extend. This is also called the "definition typing
+   env" in join_levels.ml; in the context of [Simplify], this is the environment
+   we would use to simplify the handler when not doing a join. This is different
+   from the "env at fork" in that the source environment is expected to already
+   have definitions for the params (and extra params) of the current handler.
+
+   - The {b target environment} is the final value (after the join) of the
+   source environment. This is also called the "handler env" in [Simplify]. This
+   environment does not exist until the join is completed, but it is still
+   helpful to refer to things that will exist there (those either also exist in
+   the source environment, or are existential variables added during the join).
+
+   - The {b joined environments} are each of the individual environments that we
+   are joining. In the context of [Simplify], these are the environments at each
+   use. The joined environments are uniquely identified (within the current
+   join) by an {!Index.t}.
+
+   {1:assumptions Assumptions}
+
+   We make the following assumptions on the input environments.
+
+   {2:scope_of_names Scope of variables and symbols}
+
+   We assume that any name (variable or symbol) defined in the source
+   environment is also be defined in all the joined environments.
+
+   Any name defined in the source environment is also necessarily defined in the
+   target environment by definition.
+
+   {2:lifted_constants Lifted constants}
+
+   We further assume that any symbol defined in one of the joined environments
+   is also defined in the source environment (and hence the target environment).
+   In the context of [Simplify], this means that we expect lifted constants from
+   the joined environments to have already been inserted into the source
+   environment with a suitable type.
+
+   In practice, this means that any of the symbols we manipulate can be assumed
+   to exist in both the source environment and in the target environemnt (but
+   not in the joined environments, as they could be lifted constants from
+   another branch).
+
+   {2:coherent_binding_times Coherent binding times}
+
+   We assume that a {b the relative order of variables defined in the source
+   environment is preserved across all the joined environments}.
+
+   More precisely, if [a] is defined before (resp. strictly before) [b] in the
+   source environment, then [a] is also defined before (resp. strictly before)
+   [b] in all of the joined environments. In the context of [Simplify], this
+   means that the continuation parameters must be added in the same order in the
+   handler and at all uses.
+
+   Note that this assumption does not impose any restriction on the relative
+   binding times of variables that don't exist in the source environment, even
+   if they exist in all the joined environments.
+
+   This assumption is used in [get_possible_canonical_in_source_env] and allows
+   an efficient (linear) implementation of this function. *)
+
 module K = Flambda_kind
 module TG = Type_grammar
 module TE = Typing_env
@@ -21,91 +92,258 @@ module TEE = Typing_env_extension
 module TEL = Typing_env_level
 module ET = Expand_head.Expanded_type
 
-(* This file implements the join of typing envs, or more precisely of typing env
-   levels.
+module Symbol_projection = struct
+  include Symbol_projection
+  include Container_types.Make (Symbol_projection)
+end
 
-   Most of it is actually concerned with the join of aliases, although some of
-   it is also taking care of robustly computing the join of env extensions and
-   nested env extensions.
+(* {1 Prelude: iterators} *)
 
-   In the following, we will call the "target env" the environment that is the
-   result of the join, and the "joined envs" the distinct environments that are
-   being joined.
+(* We start off with some utilities for using leapfrog iterators that will be
+   useful to compute intersections below.
 
-   We perform a full n-way join in four steps:
+   We use a local module to encapsulate the use of imperative iterators. *)
 
-   1) Process all demotions in the joined envs, building a relation between a
-   variable in the target env and its canonical name in each of the joined envs.
+(* CR bclement: These should be in [Flambda_algorithms]. *)
 
-   2) Compute shared demotions by detecting variables in the target env that
-   have the same canonicals in all of the joined envs. This relies on all
-   environments having a consistent binding times for the *shared variables*
-   (i.e. the variables that are defined in the target environment) in order to
-   avoid accidental quadratic complexity.
+module Iterator_utils : sig
+  (* Given two maps [m1] and [m2], calls [f name (find m1 name) (find m2 name)]
+     for each [name] in the intersection of [m1] and [m2]. *)
+  val fold_binary_join :
+    f:(Name.t -> 'a -> 'b -> 'c -> 'c) ->
+    init:'c ->
+    'a Name.Map.t ->
+    'b Name.Map.t ->
+    'c
 
-   At this point, we have found all the aliases between existing variables in
-   the target env. It remains to compute the type information.
+  type ('a, 'b) incremental_join_entry
 
-   3) Process all the non-alias type information in the joined envs, building a
-   relation between a canonical variable in the target env and its new types in
-   each of the joined envs. If a variable has been demoted in one of the joined
-   envs but not in the target env as part of the previous step, treat it as if
-   it had received the current type of its canonical in the joined env instead.
+  val fold_incremental_join_entry :
+    f:('a -> 'b -> 'c -> 'c) -> init:'c -> ('a, 'b) incremental_join_entry -> 'c
 
-   For instance, if we add the type "= x" to a variable [p] in one joined env
-   (demoting [p] to [x]) and we add a non-alias type [ty] to [p] in the other
-   joined env, we will compute the join of [ty] and the type of [x] in the first
-   joined env to assign to [p] in the target env.
+  type 'a incremental =
+    { previous : 'a;
+      diff : 'a;
+      current : 'a
+    }
 
-   4) For any variable that has been assigned a new type in all the joined envs
-   in the previous step, compute its new type in the target env by joining its
-   types in all the joined envs. If there is at least one joined env where the
-   variable did not get a new type, the result of the join can never be more
-   precise than that type, which is also the original type of the variable in
-   the target env. *)
+  type ('a, 'b) folder = { fold : 'c. ('a -> 'b -> 'c -> 'c) -> 'c -> 'c }
+
+  (* Compute an incremental join using the semi-naive algorithm from Datalog.
+
+     Given a set of incremental inputs [Ci = Pi + Δi] (where [Pi], [Δi] and [Ci]
+     are the [previous], [diff], and [current] fields of the {!incremental} type
+     above, and [+] is [Name.Map.union (fun _ _ v -> Some v)]), fold over the
+     entries in [join(C1, ..., Cn)] {b except for those that are also in
+     [join(P1, ..., Pn)]}.
+
+     {b Note}: The equality [Ci = Pi + Δi] must be ensured by the caller. *)
+  val fold_incremental_join :
+    f:(Name.t -> ('a, 'b) incremental_join_entry -> 'c -> 'c) ->
+    init:'c ->
+    ('a, 'b Name.Map.t incremental) folder ->
+    'c
+end = struct
+  module Name_map_iterator = Leapfrog.Map (Name)
+  module Name_map_join_iterator = Leapfrog.Join (Name_map_iterator)
+
+  let create_iterator ~init ~dummy =
+    let send_map, recv_map = Channel.create init in
+    let send_val, recv_val = Channel.create dummy in
+    let iterator = Name_map_iterator.create recv_map send_val in
+    send_map, iterator, recv_val
+
+  let naive_iterator ~init ~dummy =
+    let _send, iterator, recv = create_iterator ~init ~dummy in
+    iterator, recv
+
+  let join_iterators = Name_map_join_iterator.create
+
+  let[@inline] fold_iterator ~f ~init iterator =
+    let rec loop iterator acc =
+      match Name_map_join_iterator.current iterator with
+      | None -> acc
+      | Some name ->
+        Name_map_join_iterator.accept iterator;
+        let acc = (f [@inlined hint]) name acc in
+        Name_map_join_iterator.advance iterator;
+        loop iterator acc
+    in
+    Name_map_join_iterator.init iterator;
+    loop iterator init
+
+  let fold_binary_join ~f ~init a b =
+    (* CR bclement: create an [Name.Map.iterator], get its initial value, and
+       initialise the [Name_map_iterator] (and the [Name_map_join_iterator])
+       from it to avoid double lookups. *)
+    match Name.Map.choose_opt a, Name.Map.choose_opt b with
+    | None, _ | _, None -> init
+    | Some (_, dummy_a), Some (_, dummy_b) ->
+      let iterator_a, recv_a = naive_iterator ~init:a ~dummy:dummy_a in
+      let iterator_b, recv_b = naive_iterator ~init:b ~dummy:dummy_b in
+      let iterator = join_iterators [iterator_a; iterator_b] in
+      fold_iterator iterator ~init ~f:(fun name acc ->
+          f name (Channel.recv recv_a) (Channel.recv recv_b) acc)
+
+  type ('a, 'b) incremental_join_entry = ('a * 'b Channel.receiver) list
+
+  let fold_incremental_join_entry ~f ~init incremental_join_entry =
+    List.fold_left
+      (fun acc (index, receiver) -> f index (Channel.recv receiver) acc)
+      init incremental_join_entry
+
+  type 'a incremental =
+    { previous : 'a;
+      diff : 'a;
+      current : 'a
+    }
+
+  type ('a, 'b) folder = { fold : 'c. ('a -> 'b -> 'c -> 'c) -> 'c -> 'c }
+
+  exception Join_is_empty
+
+  let fold_incremental_join ~f ~init { fold } =
+    (* If $Ci = Pi + Δi$ (where $Ci$, $Pi$ and $Δi$ are the [current],
+       [previous], and [diff] fields, respectively), then we have:
+
+       $$join(C1, ..., Cn) = join(P1 + Δ1, ..., Pn + Δn)$$
+
+       By multilinearity: *)
+    (*
+     * join(C1, ..., Cn) =
+     *   join(P1, ..., Pn) +
+     *   join(Δ1, P2, ..., Pn) +       \
+     *   join(C1, Δ2, P3, ..., Pn) +    | n incremental joins
+     *   ... +                          |
+     *   join(C1, ..., C{n-1}, Δn)     /
+     *)
+    (* We are interested in computing the join {b incrementally}, so we want to
+       ignore the $join(P0, ..., Pn)$ part and only compute the new joined
+       equations that involve at least one of the $Δi$.
+
+       This can be done by initializing all join inputs to their previous ($Pi$)
+       value, then for each input $i$:
+
+       - Perform a join with $Δi$;
+
+       - Set the input to $Ci$ for the following joins.
+
+       In total, there are $n + 1$ joins, including the join of the previous
+       values that we don't want to compute and $n$ incremental joins involving
+       one of the $Δi$.
+
+       We can simplify the joins by noticing the following:
+
+       - We can remove any join where $Δi$ is empty
+
+       - Suppose that the first $p$ inputs have an empty $Pi$ (we can always
+       sort these first). Then the result of the first $p$ joins is necessarily
+       empty, since it involves an empty $Pi$. Note that these are the first $p$
+       join {b including the previous join}, so only the first $p - 1$
+       incremental joins.
+
+       This means that for any $i$ such that {b either} $Δi$ or $Pi$ is empty,
+       the $i$-th input to the [join] is invariant and always equal to $Ci$ (if
+       $Pi$ is empty, then all the non-empty joins use either $Ci$ or $Δi$; if
+       $Δi$ is empty, then all the non-empty joins use either $Ci$ or $Pi$). For
+       these inputs, we can simply initialize the input to $Ci$.
+
+       There is one caveat: usually we are skipping the first join since all
+       inputs are equal to their $Pi$ values. But if there is at least one of
+       the inputs that has an empty $Pi$ and a non-empty $Δi$, we have already
+       skipped this join by initializing that input to $Ci = Δi$ instead, and so
+       we must perform join with the initial inputs. *)
+    try
+      let senders, iterators, receivers, perform_initial_join =
+        fold
+          (fun index { previous; diff; current }
+               (senders, iterators, receivers, perform_initial_join) ->
+            let perform_initial_join =
+              perform_initial_join
+              || (Name.Map.is_empty previous && not (Name.Map.is_empty diff))
+            in
+            (* CR bclement: we should be able to initialise the iterator with
+               this value (see [fold_binary_join]). *)
+            match Name.Map.choose_opt current with
+            | None -> raise Join_is_empty
+            | Some (_, dummy) ->
+              if Name.Map.is_empty diff || Name.Map.is_empty previous
+              then
+                let iterator, receiver = naive_iterator ~init:current ~dummy in
+                ( senders,
+                  iterator :: iterators,
+                  (index, receiver) :: receivers,
+                  perform_initial_join )
+              else
+                let sender, iterator, receiver =
+                  create_iterator ~init:previous ~dummy
+                in
+                ( (sender, diff, current) :: senders,
+                  iterator :: iterators,
+                  (index, receiver) :: receivers,
+                  perform_initial_join ))
+          ([], [], [], false)
+      in
+      let iterator = join_iterators iterators in
+      let[@inline] f name acc = f name receivers acc in
+      let acc =
+        (* If any of the inputs has an empty $Pi$ and a non-empty $Δi$, then the
+           initial join is not $join(P1, ..., Pn)$ but a join involving this
+           $Δi$ and it must not be skipped. *)
+        if perform_initial_join then fold_iterator ~f ~init iterator else init
+      in
+      List.fold_left
+        (fun acc (sender, diff, current) ->
+          Channel.send sender diff;
+          let acc = fold_iterator ~f ~init:acc iterator in
+          Channel.send sender current;
+          acc)
+        acc senders
+    with Join_is_empty -> init
+end
+
+open Iterator_utils
+
+(* {1:type_safe_wrappers Type-safe wrappers}
+
+   Since we are dealing with many environments with distinct set of bound names,
+   we introduce small wrappers around the [Variable], [Name], [Simple] and
+   [Type_grammar] modules depending on the environment they live in. *)
 
 module Index : sig
   include Container_types.S
 
-  val zero : t
+  (* Fold over the list with a distinct index for each element.
 
-  val succ : t -> t
+     This is the only way to create [Index.t] values and is called when starting
+     a new join. *)
+  val fold_list : (t -> 'a -> 'b -> 'b) -> 'a list -> 'b -> 'b
 end = struct
   include Numeric_types.Int
 
-  let zero = 0
-
-  let succ n = n + 1
+  let fold_list f xs init =
+    let _, acc =
+      List.fold_left
+        (fun (index, acc) x -> index + 1, f index x acc)
+        (0, init) xs
+    in
+    acc
 end
 
-let get_nth_joined_env index joined_envs =
-  match Index.Map.find_opt index joined_envs with
-  | Some typing_env -> typing_env
-  | None ->
-    Misc.fatal_errorf "Joined environment %a is not available." Index.print
-      index
-
-(* The following are intended to help make sure we don't confuse things (names,
-   simples) that are living in one of the joined environments and those that
-   live in the target environment.
-
-   In particular, one simple in a joined environment can have multiple names in
-   the target environment if they have been demoted. *)
-
-module Thing_in_env (Thing : Container_types.S) () : sig
+module Id_in_env (Id : Container_types.S) () : sig
   include
     Container_types.S
-      with type t = private Thing.t
-       and type Set.t = private Thing.Set.t
-       and type +!'a Map.t = private 'a Thing.Map.t
+      with type t = private Id.t
+       and type Set.t = private Id.Set.t
+       and type +!'a Map.t = private 'a Id.Map.t
 
-  val create : Thing.t -> t
+  val create : Id.t -> t
 
-  val create_set : Thing.Set.t -> Set.t
+  val create_set : Id.Set.t -> Set.t
 
-  val create_map : 'a Thing.Map.t -> 'a Map.t
+  val create_map : 'a Id.Map.t -> 'a Map.t
 end = struct
-  include Thing
+  include Id
 
   let create thing = thing
 
@@ -114,83 +352,224 @@ end = struct
   let create_map m = m
 end
 
-module Variable_in_target_env = struct
-  include Thing_in_env (Variable) ()
+module Int_ids_in_env () = struct
+  module Variable = Id_in_env (Variable) ()
+
+  module Symbol = Id_in_env (Symbol) ()
+
+  module Name : sig
+    include module type of Id_in_env (Name) ()
+
+    val var : Variable.t -> t
+
+    val symbol : Symbol.t -> t
+
+    val pattern_match :
+      t -> var:(Variable.t -> 'a) -> symbol:(Symbol.t -> 'a) -> 'a
+  end = struct
+    include Id_in_env (Name) ()
+
+    let var (var : Variable.t) : t =
+      create (Name.var (var :> Int_ids.Variable.t))
+
+    let symbol (symbol : Symbol.t) =
+      create (Name.symbol (symbol :> Int_ids.Symbol.t))
+
+    let[@inline] pattern_match (t : t) ~var:when_var ~symbol:when_symbol =
+      Name.pattern_match
+        (t :> Name.t)
+        ~var:(fun var -> (when_var [@inlined hint]) (Variable.create var))
+        ~symbol:(fun symbol ->
+          (when_symbol [@inlined hint]) (Symbol.create symbol))
+  end
+
+  (* CR bclement: In practice, we consider that these must be canonicals in the
+     corresponding environment, so this could be renamed to [Canonical] (and
+     [Canonical_in_target_env] etc. below) for clarity. *)
+  module Simple : sig
+    include module type of Id_in_env (Simple) ()
+
+    val const : Reg_width_const.t -> t
+
+    val name : ?coercion:Coercion.t -> Name.t -> t
+
+    val symbol : ?coercion:Coercion.t -> Symbol.t -> t
+
+    val var : ?coercion:Coercion.t -> Variable.t -> t
+
+    val coercion : t -> Coercion.t
+
+    val without_coercion : t -> t
+
+    val apply_coercion_exn : t -> Coercion.t -> t
+
+    val pattern_match :
+      t ->
+      name:(Name.t -> coercion:Coercion.t -> 'a) ->
+      const:(Reg_width_const.t -> 'a) ->
+      'a
+
+    val pattern_match' :
+      t ->
+      var:(Variable.t -> coercion:Coercion.t -> 'a) ->
+      symbol:(Symbol.t -> coercion:Coercion.t -> 'a) ->
+      const:(Reg_width_const.t -> 'a) ->
+      'a
+  end = struct
+    include Id_in_env (Simple) ()
+
+    let const const = create (Simple.const const)
+
+    let name ?(coercion = Coercion.id) (name : Name.t) =
+      let simple_without_coercion = Simple.name (name :> Int_ids.Name.t) in
+      let simple = Simple.with_coercion simple_without_coercion coercion in
+      create simple
+
+    let symbol ?coercion symbol = name ?coercion (Name.symbol symbol)
+
+    let var ?coercion var = name ?coercion (Name.var var)
+
+    let coercion t = Simple.coercion (t : t :> Simple.t)
+
+    let without_coercion t =
+      create (Simple.without_coercion (t : t :> Simple.t))
+
+    let apply_coercion_exn t coercion =
+      create (Simple.apply_coercion_exn (t : t :> Simple.t) coercion)
+
+    let[@inline always] pattern_match (t : t) ~name:when_name ~const =
+      Simple.pattern_match
+        (t :> Simple.t)
+        ~name:(fun name ~coercion ->
+          (when_name [@inlined hint]) (Name.create name) ~coercion)
+        ~const
+
+    let[@inline always] pattern_match' (t : t) ~var:when_var ~symbol:when_symbol
+        ~const =
+      Simple.pattern_match'
+        (t :> Simple.t)
+        ~var:(fun var ~coercion ->
+          (when_var [@inlined hint]) (Variable.create var) ~coercion)
+        ~symbol:(fun symbol ~coercion ->
+          (when_symbol [@inlined hint]) (Symbol.create symbol) ~coercion)
+        ~const
+  end
 end
 
-module Name_in_target_env = struct
-  include Thing_in_env (Name) ()
+module Int_ids_in_source_env = Int_ids_in_env ()
 
-  let var (var : Variable_in_target_env.t) : t =
-    create (Name.var (var :> Variable.t))
+module Variable_in_source_env = Int_ids_in_source_env.Variable
+module Name_in_source_env = Int_ids_in_source_env.Name
+module Symbol_in_source_env = Int_ids_in_source_env.Symbol
+module Simple_in_source_env = Int_ids_in_source_env.Simple
 
-  let var_map (type a) (m : a Variable_in_target_env.Map.t) : a Map.t =
-    create_map (Name.var_map (m :> a Variable.Map.t))
+module Int_ids_from_source_env () = struct
+  module Int_ids_in_env = Int_ids_in_env ()
+
+  module Variable = struct
+    include Int_ids_in_env.Variable
+
+    (* See {!section-scope_of_names} *)
+    let from_source_env (var : Variable_in_source_env.t) =
+      create (var :> Variable.t)
+  end
+
+  module Symbol = Int_ids_in_env.Symbol
+
+  module Name = struct
+    include Int_ids_in_env.Name
+
+    (* See {!section-scope_of_names} *)
+    let from_source_env (name : Name_in_source_env.t) = create (name :> Name.t)
+
+    let from_source_env_map (type a) map =
+      create_map (map : a Name_in_source_env.Map.t :> a Name.Map.t)
+  end
+
+  module Simple = struct
+    include Int_ids_in_env.Simple
+
+    (* See {!section-scope_of_names} *)
+    let from_source_env (simple : Simple_in_source_env.t) =
+      create (simple :> Simple.t)
+  end
 end
 
-module Simple_in_target_env : sig
-  include module type of Thing_in_env (Simple) ()
+module Int_ids_in_target_env = Int_ids_from_source_env ()
 
-  val name : ?coercion:Coercion.t -> Name_in_target_env.t -> t
-end = struct
-  include Thing_in_env (Simple) ()
+module Variable_in_target_env = Int_ids_in_target_env.Variable
+module Symbol_in_target_env = Int_ids_in_target_env.Symbol
+module Name_in_target_env = Int_ids_in_target_env.Name
+module Simple_in_target_env = Int_ids_in_target_env.Simple
 
-  let name ?(coercion = Coercion.id) (name : Name_in_target_env.t) =
-    let simple_without_coercion = Simple.name (name :> Name.t) in
-    let simple = Simple.with_coercion simple_without_coercion coercion in
-    create simple
+module Int_ids_in_one_joined_env = Int_ids_from_source_env ()
+
+module Variable_in_one_joined_env = Int_ids_in_one_joined_env.Variable
+
+module Symbol_in_one_joined_env = struct
+  include Int_ids_in_one_joined_env.Symbol
+
+  (* See {!section-lifted_constants} *)
+  let in_source_env symbol =
+    Symbol_in_source_env.create (symbol : t :> Symbol.t)
 end
 
-module Name_in_one_joined_env = struct
-  include Thing_in_env (Name) ()
-end
+module Name_in_one_joined_env = Int_ids_in_one_joined_env.Name
+module Simple_in_one_joined_env = Int_ids_in_one_joined_env.Simple
 
-module Simple_in_one_joined_env : sig
-  include module type of Thing_in_env (Simple) ()
+module Type_in_env () : sig
+  type t = private TG.t
 
-  val pattern_match :
-    t ->
-    name:(Name_in_one_joined_env.t -> coercion:Coercion.t -> 'a) ->
-    const:(Reg_width_const.t -> 'a) ->
-    'a
-end = struct
-  include Thing_in_env (Simple) ()
+  val kind : t -> K.t
 
-  let[@inline always] pattern_match (t : t) ~name:on_name ~const =
-    Simple.pattern_match
-      (t :> Simple.t)
-      ~name:(fun name ~coercion ->
-        (on_name [@inlined hint]) (Name_in_one_joined_env.create name) ~coercion)
-      ~const
-end
+  val create : TG.t -> t
 
-module Simples_in_joined_envs : sig
-  include
-    Container_types.S
-      with type t = private Simple_in_one_joined_env.t Index.Map.t
-
-  val fold :
-    (Index.t -> Simple_in_one_joined_env.t -> 'a -> 'a) -> t -> 'a -> 'a
-
-  val distinct_from_simple_in_target_env : t -> Simple_in_target_env.t -> t
+  val create_equations : TG.t Name.Map.t -> t Name.Map.t
 
   val apply_coercion : t -> Coercion.t -> t
+end = struct
+  type t = TG.t
 
-  val is_empty : t -> bool
+  let kind = TG.kind
 
-  val empty : t
+  let create ty = ty
 
-  val in_same_envs : t -> as_:t -> t
+  let create_equations equations = equations
 
-  val in_envs : 'a Index.Map.t -> t -> t
+  let apply_coercion = TG.apply_coercion
+end
 
-  val is_defined_in : Index.Set.t -> t -> bool
+module Type_in_target_env : sig
+  include module type of Type_in_env ()
 
-  val raw_name : t -> string
+  val alias_type_of : K.t -> Simple_in_target_env.t -> t
+end = struct
+  include Type_in_env ()
 
-  val add : Index.t -> Simple_in_one_joined_env.t -> t -> t
+  let alias_type_of kind simple =
+    create (TG.alias_type_of kind (simple : Simple_in_target_env.t :> Simple.t))
+end
+
+module Type_in_one_joined_env : sig
+  include module type of Type_in_env ()
+
+  val alias_type_of : K.t -> Simple_in_one_joined_env.t -> t
+end = struct
+  include Type_in_env ()
+
+  let alias_type_of kind simple =
+    create
+      (TG.alias_type_of kind (simple : Simple_in_one_joined_env.t :> Simple.t))
+end
+
+(* {1:environments Environments} *)
+
+module Simples_in_joined_envs : sig
+  include Container_types.S with type t = Simple_in_one_joined_env.t Index.Map.t
 
   val of_list : (Index.t * Simple.t) list -> t
+
+  val choose_a_suitable_name : t -> string
 end = struct
   module T0 = struct
     type t = Simple_in_one_joined_env.t Index.Map.t
@@ -212,42 +591,13 @@ end = struct
   include T0
   include Container_types.Make (T0)
 
-  let fold = Index.Map.fold
+  let of_list simples =
+    List.fold_left
+      (fun simples (index, simple) ->
+        Index.Map.add index (Simple_in_one_joined_env.create simple) simples)
+      Index.Map.empty simples
 
-  let is_empty = Index.Map.is_empty
-
-  let empty = Index.Map.empty
-
-  let add = Index.Map.add
-
-  let apply_coercion t coercion =
-    if Coercion.is_id coercion
-    then t
-    else
-      Index.Map.map
-        (fun (simple : Simple_in_one_joined_env.t) ->
-          Simple_in_one_joined_env.create
-            (Simple.apply_coercion_exn (simple :> Simple.t) coercion))
-        t
-
-  let distinct_from_simple_in_target_env (t : t)
-      (simple_in_target_env : Simple_in_target_env.t) =
-    Index.Map.filter_map
-      (fun _ (simple_in_one_joined_env : Simple_in_one_joined_env.t) ->
-        if Simple.equal
-             (simple_in_one_joined_env :> Simple.t)
-             (simple_in_target_env :> Simple.t)
-        then None
-        else Some simple_in_one_joined_env)
-      t
-
-  let in_envs envs t = Index.Map.inter (fun _ _ simple -> simple) envs t
-
-  let in_same_envs t ~as_ = Index.Map.inter (fun _ _ simple -> simple) as_ t
-
-  let is_defined_in envs t = Index.Set.subset envs (Index.Map.keys t)
-
-  let raw_name (t : t) =
+  let choose_a_suitable_name t =
     let shared_name =
       try
         Index.Map.fold
@@ -262,1022 +612,1063 @@ end = struct
                 | Some raw_name when String.equal raw_name var_name ->
                   Some raw_name
                 | Some _ -> raise Not_found))
-          (t :> Simple.t Index.Map.t)
+          (t : t :> Simple.t Index.Map.t)
           None
       with Not_found -> None
     in
     match shared_name with Some raw_name -> raw_name | None -> "join_var"
-
-  let of_list list =
-    List.fold_left
-      (fun t (index, simple) ->
-        Index.Map.add index (Simple_in_one_joined_env.create simple) t)
-      empty list
 end
 
-module Join_aliases : sig
+module Bindings_in_source_env : sig
   type t
 
-  val empty : t
+  val create : TE.t -> t
 
-  (** [find ~exists_in_target_env ~is_bound_strictly_earlier simples t] is:
+  val code_age_relation : t -> Code_age_relation.t
 
-      - [Bottom] if [simples] is empty;
-      - [Ok simple] if there is a [simple] that is equal to each of the [simples]
-        in the corresponding environment, or otherwise an existential variable
-        introduced with [add_existential_var] for this set of [simples];
-      - [Unknown] otherwise.
+  val code_age_relation_resolver :
+    t -> Compilation_unit.t -> Code_age_relation.t option
 
-    [exists_in_target_env] converts a [Name_in_one_joined_env.t] into a
-    [Name_in_target_env.t] if the name exists in the target environment.
+  val exists_in_source_env : t -> Variable.t -> Variable_in_source_env.t option
 
-    [is_bound_strictly_earlier] determines whether a {b shared} name (i.e.
-    defined in the target env and in all joined envs) is bound earlier than
-    a {b shared} simple. Recall that we require a consistent ordering on
-    shared names.
+  type candidate_canonical_in_source_env =
+    | No_simples_in_joined_envs  (** The provided set of simples was empty. *)
+    | No_canonical_in_source_env
+        (** There is no [simple] in the source environment that is equal to this
+            specific set of simples in each joined environment. *)
+    | Canonical_in_all_joined_envs of Simple_in_one_joined_env.t
+        (** This [simple] is canonical in all the joined environments.
 
-    {b Note}: the [simples] must be canonical in their environment. *)
-  val find :
-    exists_in_target_env:
-      (Name_in_one_joined_env.t -> Name_in_target_env.t option) ->
-    is_bound_strictly_earlier:
-      (Name_in_target_env.t -> than:Simple_in_target_env.t -> bool) ->
-    Simples_in_joined_envs.t ->
+            It may or may not be defined in the source environment. *)
+    | Latest_bound_source_var of Variable_in_source_env.t * Coercion.t
+        (** This variable is the one with the latest binding time amongst
+            the variables in joined environments that exist in the source
+            environment.
+
+            If there is any simple in the source environment that is equal to
+            the provided set of simples in each joined environments, it can
+            only be this variable because of our assumption on binding times
+            being coherent (see {!section-coherent_binding_times}). *)
+
+  val candidate_canonical_in_source_env :
+    t -> Simples_in_joined_envs.t -> candidate_canonical_in_source_env
+end = struct
+  type t = { source_env : TE.t } [@@unboxed]
+
+  let create source_env = { source_env }
+
+  let code_age_relation { source_env } = TE.code_age_relation source_env
+
+  let code_age_relation_resolver { source_env } =
+    TE.code_age_relation_resolver source_env
+
+  let exists_in_source_env { source_env } var =
+    if TE.mem ~min_name_mode:Name_mode.in_types source_env (Name.var var)
+    then Some (Variable_in_source_env.create var)
+    else None
+
+  let total_compare_binding_times { source_env } var1 var2 =
+    TE.stable_compare_simples source_env
+      (Simple.var (var1 : Variable_in_source_env.t :> Variable.t))
+      (Simple.var (var2 : Variable_in_source_env.t :> Variable.t))
+
+  type candidate_canonical_in_source_env =
+    | No_simples_in_joined_envs
+    | No_canonical_in_source_env
+    | Canonical_in_all_joined_envs of Simple_in_one_joined_env.t
+    | Latest_bound_source_var of Variable_in_source_env.t * Coercion.t
+
+  let candidate_canonical_in_source_env t canonicals_in_joined_envs =
+    Index.Map.fold
+      (fun _index canonical possible_canonical_in_source_env ->
+        let[@inline] pattern_match_local_simple simple ~local_simple ~source_var
+            =
+          Simple_in_one_joined_env.pattern_match' simple
+            ~const:(fun _ -> local_simple simple)
+            ~symbol:(fun _ ~coercion:_ -> local_simple simple)
+            ~var:(fun var ~coercion ->
+              match
+                exists_in_source_env t
+                  (var : Variable_in_one_joined_env.t :> Variable.t)
+              with
+              | None -> local_simple simple
+              | Some var -> (source_var [@inlined hint]) var ~coercion)
+        in
+        let maybe_this_source_var () =
+          pattern_match_local_simple canonical
+            ~local_simple:(fun _ -> No_canonical_in_source_env)
+            ~source_var:(fun var ~coercion ->
+              Latest_bound_source_var (var, coercion))
+        in
+        let latest_source_var_with var ~coercion =
+          pattern_match_local_simple canonical
+            ~local_simple:(fun _ -> Latest_bound_source_var (var, coercion))
+            ~source_var:(fun var0 ~coercion:coercion0 ->
+              let c = total_compare_binding_times t var var0 in
+              if c < 0
+              then Latest_bound_source_var (var0, coercion0)
+              else (
+                if not (c > 0 || Variable_in_source_env.equal var0 var)
+                then
+                  Misc.fatal_errorf "Non-total extension of binding times order";
+                Latest_bound_source_var (var, coercion)))
+        in
+        match possible_canonical_in_source_env with
+        | No_simples_in_joined_envs -> Canonical_in_all_joined_envs canonical
+        | No_canonical_in_source_env -> maybe_this_source_var ()
+        | Latest_bound_source_var (var, coercion) ->
+          latest_source_var_with var ~coercion
+        | Canonical_in_all_joined_envs shared_simple ->
+          if Simple_in_one_joined_env.equal canonical shared_simple
+          then possible_canonical_in_source_env
+          else
+            pattern_match_local_simple shared_simple
+              ~local_simple:(fun _ -> maybe_this_source_var ())
+              ~source_var:(fun var ~coercion ->
+                latest_source_var_with var ~coercion))
+      canonicals_in_joined_envs No_simples_in_joined_envs
+end
+
+module Bindings_in_target_env : sig
+  (* This module is only concerned with providing a consistent name to represent
+     a set of simples in the joined environments.
+
+     Names in the target environment are either names that exist in the source
+     environment, and local variables that are created in the target environment
+     but do not exist in the source environment.
+
+     We currently maintain two types of relations between names in the joined
+     environment and names in the target environment:
+
+     - Imported variables represent a specific variable in all the joined
+     environments where it exists.
+
+     - Existentials represent a specific set of simples in the joined
+     environments.
+
+     {b Warning}: Each local variable is defined either as an imported variable
+     or as an existential, but imported variables and existentials are not
+     necessarily represented by local variables in the target environment: there
+     might already be a suitable name in the source environment to represent
+     this imported variable or existential.
+
+     For instance, consider that we are doing the join of [x: (= a)] in env 0
+     and [x: (= b)] in env 1, where [x] exists in the source environment but not
+     [a] and [b]. Then we can use [x] to represent [((0 a) (1 b))], we do not
+     have to create a local variable. Note that in the case of imported
+     variables, this effectively mean that we can rename variables as we import
+     them. *)
+
+  type t
+
+  val create : TE.t -> TE.t Index.Map.t -> t
+
+  val bindings_in_source_env : t -> Bindings_in_source_env.t
+
+  val exists_in_target_env : t -> Variable.t -> Variable_in_target_env.t option
+
+  (* Must only be called from the toplevel join, before creating any local
+     variable. *)
+  val add_alias_in_source_env :
+    t -> K.t -> Name_in_source_env.t -> Simple_in_target_env.t -> t
+
+  (* Must only be called from the toplevel join, before creating any local
+     variable. *)
+  val add_existential_for_these_simples :
     t ->
-    Simple_in_target_env.t Or_unknown_or_bottom.t
-
-  (** [add_existential_var ~mem_name simples t] returns a fresh variable [var]
-      and an updated [t] where [var] is associated with the [simples]. *)
-  val add_existential_var :
-    exists_in_target_env:
-      (Name_in_one_joined_env.t -> Name_in_target_env.t option) ->
+    name_in_source_env:Name_in_source_env.t ->
     Simples_in_joined_envs.t ->
-    t ->
-    Variable.t * t
+    K.t ->
+    t
 
-  type 'a add_result = private
-    { values_in_target_env : 'a Index.Map.t Name_in_target_env.Map.t;
-      touched_variables : Name_in_target_env.Set.t
+  (* Must only be called from the toplevel join, before creating any local
+     variable. *)
+  val add_imported_var :
+    t ->
+    name_in_source_env:Name_in_source_env.t ->
+    coercion_to_name_in_source_env:Coercion.t ->
+    Variable_in_one_joined_env.t ->
+    K.t ->
+    t
+
+  val import_from_all_envs :
+    t -> Variable_in_one_joined_env.t -> K.t -> Simple_in_target_env.t * t
+
+  val existential_for_these_simples :
+    t -> Simples_in_joined_envs.t -> K.t -> Simple_in_target_env.t * t
+
+  val is_imported_from_all_joined_envs :
+    t -> Variable_in_one_joined_env.t -> Simple_in_target_env.t option
+
+  val has_existential_for_these_simples :
+    t -> Simples_in_joined_envs.t -> Simple_in_target_env.t option
+
+  type definition_in_joined_envs =
+    | Imported_var of Variable_in_one_joined_env.t * K.t
+    | These_canonicals of Simple_in_one_joined_env.t Index.Map.t * K.t
+
+  val alias_types_in_target_env :
+    t -> Type_in_target_env.t Name_in_source_env.Map.t
+
+  val new_bindings :
+    t -> since:t -> definition_in_joined_envs Name_in_target_env.Map.t
+
+  (* val alias_types_in_target_env : t -> Type_in_target_env.t
+     Name_in_target_env.Map.t *)
+
+  val fold_created_variables :
+    (Variable_in_target_env.t -> K.t -> 'a -> 'a) -> t -> 'a -> 'a
+
+  (* These are for the join of env extensions, see [prepare_nested_join]. *)
+
+  val replay_definition_of_aliases_in_target_env :
+    t ->
+    Index.t ->
+    Type_in_one_joined_env.t Name.Map.t ->
+    Type_in_one_joined_env.t Name.Map.t
+
+  val definition_of_local_variables_in_one_joined_env :
+    t -> Index.t -> Type_in_one_joined_env.t Variable_in_target_env.Map.t
+end = struct
+  type coercion_to_canonical_in_target_env = Coercion.t
+
+  type definition_in_joined_envs =
+    | Imported_var of Variable_in_one_joined_env.t * K.t
+    | These_canonicals of Simple_in_one_joined_env.t Index.Map.t * K.t
+
+  type t =
+    { bindings_in_source_env : Bindings_in_source_env.t;
+      alias_types_in_target_env : Type_in_target_env.t Name_in_source_env.Map.t;
+      existential_for_these_simples :
+        Simple_in_target_env.t Simples_in_joined_envs.Map.t;
+      imported_variables :
+        Simple_in_target_env.t Variable_in_one_joined_env.Map.t;
+      created_variables : K.t Variable_in_target_env.Map.t;
+      definitions_in_joined_envs :
+        definition_in_joined_envs Name_in_target_env.Map.t;
+      aliases_of_names_in_joined_envs :
+        coercion_to_canonical_in_target_env Name_in_target_env.Map.t
+        Name_in_one_joined_env.Map.t
+        Index.Map.t;
+      equations_for_local_vars :
+        Type_in_one_joined_env.t Variable_in_target_env.Map.t Index.Map.t
     }
 
-  (** [add_in_target_env ~mem_name t values values_in_target_env] adds the values
-  in [values], keyed by their name in the corresponding environment, to the
-  [values_in_target_env], keyed with their name in the target environment.
-
-  More precisely, if there is an entry [index -> var -> value] in [values],
-  an entry [target_var -> index -> value] is added to [values_in_target_env]
-  for all variables [target_var] in the target environment that are equal to
-  [var] in the joined environment at [index]. *)
-  val add_in_target_env :
-    exists_in_target_env:
-      (Name_in_one_joined_env.t -> Name_in_target_env.t option) ->
-    t ->
-    'a Name_in_one_joined_env.Map.t Index.Map.t ->
-    'a Index.Map.t Name_in_target_env.Map.t ->
-    'a add_result
-
-  type join_result = private
-    { demoted_in_target_env : Simple_in_target_env.t Name_in_target_env.Map.t;
-          (** Variables that should be demoted in the target env as a result of the
-          join.
-
-          The demoted variables are no longer present in [t]. *)
-      demoted_in_some_envs : Simples_in_joined_envs.t Name_in_target_env.Map.t;
-          (** Variables that have been demoted in some (possibly all, if
-              they have been demoted to distinct canonicals) of the joined
-              environments, but not in the target enviroment.
-
-              These are still present in [t], but they need to be considered for
-              the join of types. *)
-      t : t
+  let create source_env _joined_envs =
+    { bindings_in_source_env = Bindings_in_source_env.create source_env;
+      alias_types_in_target_env = Name_in_source_env.Map.empty;
+      existential_for_these_simples = Simples_in_joined_envs.Map.empty;
+      imported_variables = Variable_in_one_joined_env.Map.empty;
+      aliases_of_names_in_joined_envs = Index.Map.empty;
+      definitions_in_joined_envs = Name_in_target_env.Map.empty;
+      equations_for_local_vars = Index.Map.empty;
+      created_variables = Variable_in_target_env.Map.empty
     }
 
-  val n_way_join :
-    exists_in_target_env:
-      (Name_in_one_joined_env.t -> Name_in_target_env.t option) ->
-    is_bound_strictly_earlier:
-      (Name_in_target_env.t -> than:Simple_in_target_env.t -> bool) ->
+  let add_alias t kind ~canonical_element:canonical_element_with_coercion
+      ~name_to_be_demoted ~coercion_to_name_to_be_demoted =
+    let canonical_element =
+      canonical_element_with_coercion |> Simple_in_target_env.without_coercion
+    in
+    let coercion_to_canonical =
+      Coercion.compose_exn
+        (Coercion.inverse coercion_to_name_to_be_demoted)
+        ~then_:
+          (Coercion.inverse
+             (Simple_in_target_env.coercion canonical_element_with_coercion))
+    in
+    if Simple_in_target_env.equal canonical_element
+         (Simple_in_target_env.from_source_env
+            (Simple_in_source_env.name name_to_be_demoted))
+    then
+      if Coercion.is_id coercion_to_canonical
+      then t
+      else
+        Misc.fatal_errorf
+          "Cannot add alias of %a to itself with a non-identity coercion@ %a"
+          Simple_in_target_env.print canonical_element Coercion.print
+          coercion_to_canonical
+    else
+      let alias_types_in_target_env =
+        Name_in_source_env.Map.add name_to_be_demoted
+          (Type_in_target_env.alias_type_of kind
+             (Simple_in_target_env.apply_coercion_exn canonical_element
+                (Coercion.inverse coercion_to_canonical)))
+          t.alias_types_in_target_env
+      in
+      { t with alias_types_in_target_env }
+
+  let alias_types_in_target_env t = t.alias_types_in_target_env
+
+  let new_bindings t ~since =
+    Name_in_target_env.Map.diff_shared
+      (fun _ new_definition _old_definition -> Some new_definition)
+      t.definitions_in_joined_envs since.definitions_in_joined_envs
+
+  let update_aliases_of_names_in_joined_envs ~f simples aliases_in_target_env =
+    Index.Map.fold
+      (fun index simple aliases_in_target_env ->
+        Simple_in_one_joined_env.pattern_match simple
+          ~const:(fun _ -> aliases_in_target_env)
+          ~name:(fun name ~coercion ->
+            Index.Map.update index
+              (fun aliases ->
+                let aliases =
+                  Name_in_one_joined_env.Map.update name
+                    (fun aliases ->
+                      let aliases =
+                        f coercion
+                          (Option.value ~default:Name_in_target_env.Map.empty
+                             aliases)
+                      in
+                      Some aliases)
+                    (Option.value ~default:Name_in_one_joined_env.Map.empty
+                       aliases)
+                in
+                Some aliases)
+              aliases_in_target_env))
+      simples aliases_in_target_env
+
+  let bindings_in_source_env { bindings_in_source_env; _ } =
+    bindings_in_source_env
+
+  let is_local_variable { created_variables; _ } name =
+    Name_in_target_env.pattern_match name
+      ~symbol:(fun _ -> None)
+      ~var:(fun var ->
+        if Variable_in_target_env.Map.mem var created_variables
+        then Some var
+        else None)
+
+  let exists_in_target_env t var =
+    match
+      Bindings_in_source_env.exists_in_source_env (bindings_in_source_env t) var
+    with
+    | Some var_in_source_env ->
+      Some (Variable_in_target_env.from_source_env var_in_source_env)
+    | None ->
+      let var = Variable_in_target_env.create var in
+      if Variable_in_target_env.Map.mem var t.created_variables
+      then Some var
+      else None
+
+  let add_alias_in_source_env t kind name canonical =
+    assert (not (Name_in_source_env.Map.mem name t.alias_types_in_target_env));
+    assert (
+      not
+        (Name_in_target_env.Map.mem
+           (Name_in_target_env.from_source_env name)
+           t.definitions_in_joined_envs));
+    add_alias t kind ~name_to_be_demoted:name
+      ~coercion_to_name_to_be_demoted:Coercion.id ~canonical_element:canonical
+
+  let record_definition_for t ~name_in_target_env
+      ~coercion_to_name_in_target_env definition =
+    (* name_in_target_env ~ coercion_to_name_in_target_env(definition) *)
+    let definitions_in_joined_envs =
+      Name_in_target_env.Map.add name_in_target_env definition
+        t.definitions_in_joined_envs
+    in
+    let canonical_in_target_env =
+      Simple_in_target_env.name
+        ~coercion:(Coercion.inverse coercion_to_name_in_target_env)
+        name_in_target_env
+    in
+    match definition with
+    | Imported_var (imported_var, _kind) ->
+      let imported_variables =
+        Variable_in_one_joined_env.Map.add imported_var canonical_in_target_env
+          t.imported_variables
+      in
+      ( canonical_in_target_env,
+        { t with imported_variables; definitions_in_joined_envs } )
+    | These_canonicals (simples, kind) ->
+      let equations_for_local_vars =
+        (* If the variable is a fresh variable, record it so that we can replay
+           its definition during the join of env extensions. *)
+        match is_local_variable t name_in_target_env with
+        | None -> t.equations_for_local_vars
+        | Some var ->
+          Index.Map.update_many
+            (fun _index existentials simple ->
+              let ty = Type_in_one_joined_env.alias_type_of kind simple in
+              let ty =
+                Type_in_one_joined_env.apply_coercion ty
+                  coercion_to_name_in_target_env
+              in
+              let existentials_in_one_joined_env =
+                Variable_in_target_env.Map.add var ty
+                  (Option.value ~default:Variable_in_target_env.Map.empty
+                     existentials)
+              in
+              Some existentials_in_one_joined_env)
+            t.equations_for_local_vars simples
+      in
+      let existential_for_these_simples =
+        Simples_in_joined_envs.Map.add simples canonical_in_target_env
+          t.existential_for_these_simples
+      in
+      let aliases_of_names_in_joined_envs =
+        update_aliases_of_names_in_joined_envs simples
+          t.aliases_of_names_in_joined_envs ~f:(fun coercion aliases ->
+            (* name_in_target_env ~ coercion_to_name_in_target_env(definition) *)
+            (* definition ~ coercion(name_in_joined_env) *)
+            let coercion_from_joined_to_target =
+              Coercion.compose_exn coercion
+                ~then_:coercion_to_name_in_target_env
+            in
+            Name_in_target_env.Map.add name_in_target_env
+              coercion_from_joined_to_target aliases)
+      in
+      ( canonical_in_target_env,
+        { t with
+          equations_for_local_vars;
+          existential_for_these_simples;
+          aliases_of_names_in_joined_envs;
+          definitions_in_joined_envs
+        } )
+
+  let create_name_for_definition t definition =
+    let var, kind =
+      match definition with
+      | Imported_var (var, kind) ->
+        let var = (var : Variable_in_one_joined_env.t :> Variable.t) in
+        Variable_in_target_env.create var, kind
+      | These_canonicals (simples, kind) ->
+        let name = Simples_in_joined_envs.choose_a_suitable_name simples in
+        Variable_in_target_env.create (Variable.create name), kind
+    in
+    let created_variables =
+      Variable_in_target_env.Map.add var kind t.created_variables
+    in
+    let t = { t with created_variables } in
+    let name_in_target_env = Name_in_target_env.var var in
+    record_definition_for t ~name_in_target_env
+      ~coercion_to_name_in_target_env:Coercion.id definition
+
+  let is_imported_from_all_joined_envs t var =
+    Variable_in_one_joined_env.Map.find_opt var t.imported_variables
+
+  let has_existential_for_these_simples t simples =
+    Simples_in_joined_envs.Map.find_opt simples t.existential_for_these_simples
+
+  let existing_canonical_for t definition =
+    match definition with
+    | Imported_var (imported_var, _kind) ->
+      is_imported_from_all_joined_envs t imported_var
+    | These_canonicals (simples, _kind) ->
+      has_existential_for_these_simples t simples
+
+  let add_name_for_definition t ~name_in_source_env
+      ~coercion_to_name_in_source_env definition =
+    (* name_in_source_env ~ coercion_to_name_in_source_env(definition) *)
+    let name_in_target_env =
+      Name_in_target_env.from_source_env name_in_source_env
+    in
+    match existing_canonical_for t definition with
+    | None ->
+      let _, t =
+        record_definition_for t ~name_in_target_env
+          ~coercion_to_name_in_target_env:coercion_to_name_in_source_env
+          definition
+      in
+      t
+    | Some existing_canonical ->
+      (* Note that we might add aliases in the "wrong" order w.r.t binding times
+         here, but it is not a problem -- we only care that we have a single
+         definition for each name during the join. We don't have to use the
+         proper binding time ordering; the typing env will take care of giving
+         the proper orientation to aliases after the join is complete. *)
+      let kind =
+        match definition with
+        | Imported_var (_, kind) | These_canonicals (_, kind) -> kind
+      in
+      add_alias t kind ~canonical_element:existing_canonical
+        ~name_to_be_demoted:name_in_source_env
+        ~coercion_to_name_to_be_demoted:coercion_to_name_in_source_env
+
+  let add_existential_for_these_simples t ~name_in_source_env simples kind =
+    add_name_for_definition t ~name_in_source_env
+      ~coercion_to_name_in_source_env:Coercion.id
+      (These_canonicals (simples, kind))
+
+  let add_imported_var t ~name_in_source_env ~coercion_to_name_in_source_env
+      imported_var kind =
+    add_name_for_definition t ~name_in_source_env
+      ~coercion_to_name_in_source_env
+      (Imported_var (imported_var, kind))
+
+  let get_or_create_canonical_for t definition =
+    match existing_canonical_for t definition with
+    | None -> create_name_for_definition t definition
+    | Some existing_canonical -> existing_canonical, t
+
+  let existential_for_these_simples t simples kind =
+    get_or_create_canonical_for t (These_canonicals (simples, kind))
+
+  let import_from_all_envs t imported_var kind =
+    get_or_create_canonical_for t (Imported_var (imported_var, kind))
+
+  let replay_definition_of_aliases_in_target_env t index equations =
+    match Index.Map.find_opt index t.aliases_of_names_in_joined_envs with
+    | None -> equations
+    | Some aliases_in_target_env ->
+      fold_binary_join equations
+        (aliases_in_target_env
+          : Coercion.t Name_in_target_env.Map.t Name_in_one_joined_env.Map.t
+          :> Coercion.t Name_in_target_env.Map.t Name.Map.t)
+        ~init:equations
+        ~f:(fun [@inline] name ty aliases equations ->
+          let kind = Type_in_one_joined_env.kind ty in
+          let ty = TG.alias_type_of kind (Simple.name name) in
+          Name_in_target_env.Map.fold
+            (fun alias coercion equations ->
+              (* alias = coercion(name) *)
+              let ty = TG.apply_coercion ty coercion in
+              Name.Map.add
+                (alias : Name_in_target_env.t :> Name.t)
+                (Type_in_one_joined_env.create ty)
+                equations)
+            aliases equations)
+
+  let definition_of_local_variables_in_one_joined_env t index =
+    match Index.Map.find_opt index t.equations_for_local_vars with
+    | None -> Variable_in_target_env.Map.empty
+    | Some existentials -> existentials
+
+  let fold_created_variables f t acc =
+    (* CR bclement: iterate in order consistent with the recorded binding
+       times. *)
+    Variable_in_target_env.Map.fold f t.created_variables acc
+end
+
+module Joined_envs : sig
+  type t
+
+  (* We use an [incremental] type for equations because the join of env
+     extensions needs to know about the equations that exist outside of the join
+     extension.
+
+     The [previous] field correspond to the equations added at higher scopes
+     (one layer of env extensions removed), and is empty for a top-level
+     join. *)
+  val create :
+    (TE.t * Type_in_one_joined_env.t Name.Map.t incremental) Index.Map.t -> t
+
+  val get_nth_joined_env : t -> Index.t -> TE.t
+
+  val equations_in_nth_joined_env :
+    t -> Index.t -> Type_in_one_joined_env.t Name.Map.t
+
+  val keys : t -> Index.Set.t
+
+  val alias_types_of :
     t ->
-    Simple_in_one_joined_env.t Name_in_one_joined_env.Map.t Index.Map.t ->
-    join_result Or_bottom.t
+    K.t ->
+    Variable_in_one_joined_env.t ->
+    Type_in_one_joined_env.t Index.Map.t
+
+  val expand_heads :
+    t ->
+    Type_in_one_joined_env.t Index.Map.t ->
+    Type_in_one_joined_env.t Index.Map.t
+
+  val equal_in_all_joined_envs :
+    t -> Simple_in_one_joined_env.t -> Simples_in_joined_envs.t -> bool
 end = struct
   type t =
-    { joined_simples : Name_in_target_env.t Simples_in_joined_envs.Map.t;
-          (** Maps a tuple of simples in the joined environments to the variable
-              that represents it in the target environment, if any.
-
-              If there is a mapping [simples -> var] in [joined_simples], then
-              [demoted_from_target_env(var) = simples]. *)
-      demoted_from_target_env :
-        Simples_in_joined_envs.t Name_in_target_env.Map.t;
-          (** Maps a variable defined in the target environment to its
-              canonicals in each joined environment {b where it has been
-              demoted}.
-
-              Missing entries in the map means that the variable has not been
-              demoted in the corresponding environment.
-
-              We assume that the binding time order for shared variables (i.e.
-              variables that are present in the target environment and in all
-              joined environments) is consistent across all environments.
-
-              When given a set of simples in all environments, this allows us
-              to find the appropriate variable quickly: if this set of simple
-              is the set of canonicals for a shared variable, it can only be
-              the case for the shared variable with the latest binding time
-              (because a shared variable with an earlier binding time can never
-              be demoted to a shared variable with a later binding time). *)
-      names_in_target_env :
-        Name_in_target_env.Set.t Name_in_one_joined_env.Map.t Index.Map.t
-          (** Maps a variable in a joined environment to the set of
-              (other) variables it is equal to in the target environment.
-
-              {b Note}: Although we use [Name_in_one_joined_env] and
-              [Name_in_target_env] here, we are only interested in {b
-              variables}; in particular, symbols are irrelevant (they are always
-              their own canonicals and can't be renamed during join). *)
+    { envs_and_equations :
+        (TE.t * Type_in_one_joined_env.t Name.Map.t incremental) Index.Map.t
     }
+  [@@unboxed]
 
-  let empty =
-    { joined_simples = Simples_in_joined_envs.Map.empty;
-      demoted_from_target_env = Name_in_target_env.Map.empty;
-      names_in_target_env = Index.Map.empty
-    }
+  let create envs_and_equations = { envs_and_equations }
 
-  (* Accumulator type for computing the simple with latest binding time from a
-     set. *)
-  type latest_bound_simple =
-    | No_simple  (** No [Simple.t] at all (bottom case). *)
-    | Only_local_simples
-        (** Non-empty, but only [Simple.t] that do not exist in the target
-            environment. *)
-    | Latest_bound of Simple_in_target_env.t
-        (** The [Simple.t] with the latest binding time amongst those that exist
-            in the target environment. *)
+  let envs_and_equations = function
+    | { envs_and_equations } -> envs_and_equations
 
-  let find
-      ~(exists_in_target_env :
-         Name_in_one_joined_env.t -> Name_in_target_env.t option)
-      ~(is_bound_strictly_earlier :
-         Name_in_target_env.t -> than:Simple_in_target_env.t -> bool)
-      (simples : Simples_in_joined_envs.t) t : _ Or_unknown_or_bottom.t =
-    let[@inline] simple_exists_in_target_env simple_in_one_joined_env =
-      Simple_in_one_joined_env.pattern_match simple_in_one_joined_env
-        ~const:(fun const ->
-          Some (Simple_in_target_env.create (Simple.const const)))
-        ~name:(fun name_in_one_joined_env ~coercion ->
-          match exists_in_target_env name_in_one_joined_env with
-          | None -> None
-          | Some name_in_target_env ->
-            Some (Simple_in_target_env.name ~coercion name_in_target_env))
-    in
-    (* We need to determine if the provided set of simples (which are assumed to
-       be canonicals in their own environment) has an existing name in the
-       target environment.
-
-       This existing name might be:
-
-       1) A constant or symbol, which can only happen if all the joined simples
-       are equal; or
-
-       2) A shared variable demoted in zero or more, but not all, environments;
-       or
-
-       3) A shared variable demoted in all environments; or
-
-       4) An existential variable previously created for this exact set of
-       simples.
-
-       To detect case 1), we need to pick one of the simples and check that is
-       it a) equal to all the other simples and b) exists in the target
-       environment.
-
-       To detect case 3) and 4), we make a lookup in the [join_simples] table.
-
-       To detect case 2), it is not enough to check that all the simples are
-       identical, because the shared variable might have been demoted in one but
-       not all environments, and performing a partial lookup in the
-       [join_simples] table (or pre-populating it) would give the join quadratic
-       complexity globally.
-
-       Instead, we exploit the fact that {b shared} variables are defined in the
-       same order in all environments: if the simples are equal to a shared
-       variable that has been demoted in some, but not all, environments, there
-       is at least one simple that is equal to that variable, and it is
-       necessary the latest bound shared variable because we can only demote to
-       variables that were bound earlier.
-
-       The code below computes the latest bound simple (considering that
-       constants and symbols are bound at an identical -oo binding time) that is
-       defined in the target environment to combine tests for cases 1) and
-       2). *)
-    let latest_bound_simple =
-      Simples_in_joined_envs.fold
-        (fun _ simple acc ->
-          match acc with
-          | No_simple | Only_local_simples -> (
-            match simple_exists_in_target_env simple with
-            | None -> Only_local_simples
-            | Some simple -> Latest_bound simple)
-          | Latest_bound existing_simple -> (
-            match Simple.must_be_var (simple :> Simple.t) with
-            | None -> acc
-            | Some (var, coercion) -> (
-              match
-                exists_in_target_env
-                  (Name_in_one_joined_env.create (Name.var var))
-              with
-              | None -> acc
-              | Some name_in_target_env ->
-                (* NB: These are not actually aliases in the target env yet. *)
-                if is_bound_strictly_earlier name_in_target_env
-                     ~than:existing_simple
-                then
-                  Latest_bound
-                    (Simple_in_target_env.create
-                       (Simple.with_coercion
-                          (Simple.name (name_in_target_env :> Name.t))
-                          coercion))
-                else acc)))
-        simples No_simple
-    in
-    let[@local] find_local_variable () : _ Or_unknown_or_bottom.t =
-      (* When looking for an existential variable, we only look for exact
-         matches.
-
-         This means that we might end up creating more local variables than
-         would be strictly necessary, but they have more precise types. *)
-      match Simples_in_joined_envs.Map.find_opt simples t.joined_simples with
-      | None -> Unknown
-      | Some name -> Ok (Simple_in_target_env.name name)
-    in
-    match latest_bound_simple with
-    | No_simple -> Bottom
-    | Only_local_simples ->
-      (* Join of existential variables can only be case 3) or 4) *)
-      find_local_variable ()
-    | Latest_bound latest_bound_simple -> (
-      let earlier_bound_simples =
-        Simples_in_joined_envs.distinct_from_simple_in_target_env simples
-          latest_bound_simple
-      in
-      match Simple.must_be_name (latest_bound_simple :> Simple.t) with
-      | None ->
-        (* Case 1), 3), or 4) *)
-        if Simples_in_joined_envs.is_empty earlier_bound_simples
-        then Ok latest_bound_simple
-        else find_local_variable ()
-      | Some (name, coercion) ->
-        (* Case 2), 3), or 4) *)
-        let coercion_to_name = Coercion.inverse coercion in
-        let earlier_bound_simples =
-          Simples_in_joined_envs.apply_coercion earlier_bound_simples
-            coercion_to_name
-        in
-        let canonicals_for_name =
-          Option.value ~default:Simples_in_joined_envs.empty
-            (Name_in_target_env.Map.find_opt
-               (Name_in_target_env.create name)
-               t.demoted_from_target_env)
-        in
-        (* Consider the case where we have [a -> (1:b, 2:c)], i.e. [a] has been
-           demoted to [b] in environment [1] and to [c] in environment [2], but
-           was not demoted in environment [0].
-
-           Suppose we are looking for a name for the tuple [(0:a, 1:b)] where
-           environment [2] is not present, because we are in a situation (e.g.
-           tag of a variant) which is impossible in environment [2].
-
-           We want to recognize this as being equal to [a], which we can do by
-           restricting the canonicals of [a] to those of the environments for
-           which we are making a lookup.
-
-           Note that an alternative would be to create a new existential
-           variable for the pair [(0:a, 1:b)], which could get a more precise
-           type. We can't record both informations without introducing an env
-           extension, so we favor preserving equalities for variables defined in
-           the target env and precision for existential variables (cf
-           [find_local_variable]). *)
-        let canonicals_for_name =
-          Simples_in_joined_envs.in_same_envs ~as_:simples canonicals_for_name
-        in
-        if Simples_in_joined_envs.equal earlier_bound_simples
-             canonicals_for_name
-        then Ok latest_bound_simple
-        else find_local_variable ())
-
-  let add_existential_var ~exists_in_target_env simples t =
-    (* We have encountered a [Simples_in_joined_envs.t] that does not cleanly
-       correspond to the demotion of a name in the target env, e.g. we have type
-       "= a" on the left and "= b" on the right but no variable that is equal to
-       "a" on the left and "b" on the right yet.
-
-       We now create a new existential variable for this pair of values, and
-       record it so that it can be found by [find] if we encounter the same set
-       of values later. *)
-    let raw_name = Simples_in_joined_envs.raw_name simples in
-    let var = Variable.create raw_name in
-    let var_as_name = Name_in_target_env.create (Name.var var) in
-    let joined_simples =
-      Simples_in_joined_envs.Map.add simples var_as_name t.joined_simples
-    in
-    let demoted_from_target_env =
-      Name_in_target_env.Map.add var_as_name simples t.demoted_from_target_env
-    in
-    let names_in_target_env =
-      Simples_in_joined_envs.fold
-        (fun index simple names_in_target_env ->
-          match Simple.must_be_var (simple :> Simple.t) with
-          | Some (joined_var, coercion) when Coercion.is_id coercion -> (
-            let name_in_joined_env =
-              Name_in_one_joined_env.create (Name.var joined_var)
-            in
-            match exists_in_target_env name_in_joined_env with
-            | None -> names_in_target_env
-            | Some (name_in_target_env : Name_in_target_env.t) ->
-              Index.Map.update index
-                (fun names_from_this_env_in_target_env ->
-                  let names_from_this_env_in_target_env =
-                    Option.value ~default:Name_in_one_joined_env.Map.empty
-                      names_from_this_env_in_target_env
-                  in
-                  Some
-                    (Name_in_one_joined_env.Map.update name_in_joined_env
-                       (function
-                         | None ->
-                           Some
-                             (Name_in_target_env.Set.singleton
-                                name_in_target_env)
-                         | Some existing_names ->
-                           Some
-                             (Name_in_target_env.Set.add name_in_target_env
-                                existing_names))
-                       names_from_this_env_in_target_env))
-                names_in_target_env)
-          | _ -> names_in_target_env)
-        simples t.names_in_target_env
-    in
-    var, { joined_simples; names_in_target_env; demoted_from_target_env }
-
-  let find_canonicals demoted_in_target_env t =
-    match
-      Name_in_target_env.Map.find_opt demoted_in_target_env
-        t.demoted_from_target_env
-    with
-    | Some canonicals -> canonicals
+  let get_nth_joined_env t index =
+    match Index.Map.find_opt index (envs_and_equations t) with
+    | Some (one_joined_env, _) -> one_joined_env
     | None ->
-      Misc.fatal_errorf "Variable %a was not demoted." Name_in_target_env.print
-        demoted_in_target_env
+      Misc.fatal_errorf "Join does not include environment %a" Index.print index
 
-  let forget_demoted_var demoted_in_target_env t =
-    (* [demoted_in_target_env] is demoted to the same simple in all
-       environments.
+  let equations_in_nth_joined_env t index =
+    match Index.Map.find_opt index (envs_and_equations t) with
+    | None ->
+      Misc.fatal_errorf "Join does not include environment %a" Index.print index
+    | Some (_, { current; _ }) -> current
 
-       Remove it from all maps (except [map_to_canonical], which records the
-       demotion) -- we don't need to treat it as an name in the target env of
-       joined simples, since we have its new canonical instead. *)
-    let canonicals = find_canonicals demoted_in_target_env t in
-    let demoted_from_target_env =
-      Name_in_target_env.Map.remove demoted_in_target_env
-        t.demoted_from_target_env
-    in
-    let names_in_target_env =
-      Simples_in_joined_envs.fold
-        (fun index simple names_in_target_env ->
-          match Simple.must_be_var (simple :> Simple.t) with
-          | Some (var, coercion) when Coercion.is_id coercion ->
-            let name_in_joined_env =
-              Name_in_one_joined_env.create (Name.var var)
-            in
-            Index.Map.update index
-              (fun names_for_index ->
-                let names_for_index =
-                  Option.value ~default:Name_in_one_joined_env.Map.empty
-                    names_for_index
-                in
-                let names_for_index =
-                  Name_in_one_joined_env.Map.update name_in_joined_env
-                    (fun names ->
-                      let names =
-                        Option.value ~default:Name_in_target_env.Set.empty names
-                      in
-                      let names =
-                        Name_in_target_env.Set.remove demoted_in_target_env
-                          names
-                      in
-                      if Name_in_target_env.Set.is_empty names
-                      then None
-                      else Some names)
-                    names_for_index
-                in
-                if Name_in_one_joined_env.Map.is_empty names_for_index
-                then None
-                else Some names_for_index)
-              names_in_target_env
-          | _ -> names_in_target_env)
-        canonicals t.names_in_target_env
-    in
-    { t with demoted_from_target_env; names_in_target_env }
+  let keys t = Index.Map.keys (envs_and_equations t)
 
-  (* This function is responsible for recording demotions, represented as a map
-     from names to their {b current canonical simple} in each joined env.
+  let get_canonical_simple_ignoring_name_mode typing_env simple =
+    Simple_in_one_joined_env.create
+      (TE.get_canonical_simple_ignoring_name_mode typing_env
+         (simple : Simple_in_one_joined_env.t :> Simple.t))
 
-     This means we must:
+  let equal_in_all_joined_envs t simple simples_in_joined_envs =
+    Index.Map.for_all
+      (fun index canonical ->
+        (* Avoid env lookup when not necessary *)
+        Simple_in_one_joined_env.equal canonical simple
+        || Simple_in_one_joined_env.equal canonical
+             (get_canonical_simple_ignoring_name_mode
+                (get_nth_joined_env t index)
+                simple))
+      simples_in_joined_envs
 
-     - Update the [names_in_target_env] map to ensure the keys are canonicals in
-     the corresponding joined env and, if demoting a name that exists in the
-     target env, include the new name as an alias of the new canonical.
-
-     - Update the [demoted_from_target_env] map with the new canonicals in the
-     joined envs (recall that [demoted_from_target_env] only stores canonicals
-     in the joined envs that are *distinct* from the name in the target env). *)
-  let apply_demotions ~exists_in_target_env t all_demotions =
-    Index.Map.fold
-      (fun index demotions
-           (demoted_from_target_env, names_in_target_env, touched_vars) ->
-        let names_from_this_env_in_target_env =
-          Option.value ~default:Name_in_one_joined_env.Map.empty
-            (Index.Map.find_opt index names_in_target_env)
-        in
-        let ( demoted_from_target_env,
-              names_from_this_env_in_target_env,
-              touched_vars ) =
-          Name_in_one_joined_env.Map.fold
-            (fun demoted_var
-                 (canonical_in_joined_env : Simple_in_one_joined_env.t)
-                 ( demoted_from_target_env,
-                   names_from_this_env_in_target_env,
-                   touched_vars ) ->
-              (* Usually, we expect that there is no entry in the
-                 [names_in_target_env] map for a variable we are demoting, since
-                 we only introduce entries on canonicals.
-
-                 However if we are processing an env extension with a demotion
-                 [y -> z], we could have demoted [x -> y] at the toplevel
-                 [cut_and_n_way_join], which would have introduced a mapping
-                 from [y] to [{ x }] (since [x] is a name for [y] in the target
-                 env). In this case, we need to remove the mapping for [y]
-                 (since it is no longer canonical in the extension) and
-                 introduce the mapping [z -> { x }] (if [y] does not exist in
-                 the target env) or [z -> { x, y }] (if [y] exists in the target
-                 env) instead. *)
-              let vars_in_target_env =
-                Option.value ~default:Name_in_target_env.Set.empty
-                  (Name_in_one_joined_env.Map.find_opt demoted_var
-                     names_from_this_env_in_target_env)
-              in
-              let vars_in_target_env =
-                match exists_in_target_env demoted_var with
-                | None -> vars_in_target_env
-                | Some name_in_target_env ->
-                  Name_in_target_env.Set.add name_in_target_env
-                    vars_in_target_env
-              in
-              let names_from_this_env_in_target_env =
-                let names_from_this_env_in_target_env =
-                  Name_in_one_joined_env.Map.remove demoted_var
-                    names_from_this_env_in_target_env
-                in
-                match
-                  Simple.must_be_var (canonical_in_joined_env :> Simple.t)
-                with
-                | Some (canonical_var, coercion) when Coercion.is_id coercion ->
-                  Name_in_one_joined_env.Map.update
-                    (Name_in_one_joined_env.create (Name.var canonical_var))
-                    (function
-                      | None -> Some vars_in_target_env
-                      | Some existing_vars ->
-                        Some
-                          (Name_in_target_env.Set.union existing_vars
-                             vars_in_target_env))
-                    names_from_this_env_in_target_env
-                | _ -> names_from_this_env_in_target_env
-              in
-              let demoted_from_target_env =
-                Name_in_target_env.Set.fold
-                  (fun var_in_target_env demoted_from_target_env ->
-                    Name_in_target_env.Map.update var_in_target_env
-                      (fun canonical_in_joined_envs ->
-                        let canonical_in_joined_envs =
-                          Option.value ~default:Simples_in_joined_envs.empty
-                            canonical_in_joined_envs
-                        in
-                        Some
-                          (Simples_in_joined_envs.add index
-                             canonical_in_joined_env canonical_in_joined_envs))
-                      demoted_from_target_env)
-                  vars_in_target_env demoted_from_target_env
-              in
-              ( demoted_from_target_env,
-                names_from_this_env_in_target_env,
-                Name_in_target_env.Set.union vars_in_target_env touched_vars ))
-            demotions
-            ( demoted_from_target_env,
-              names_from_this_env_in_target_env,
-              touched_vars )
-        in
-        ( demoted_from_target_env,
-          Index.Map.add index names_from_this_env_in_target_env
-            names_in_target_env,
-          touched_vars ))
-      all_demotions
-      ( t.demoted_from_target_env,
-        t.names_in_target_env,
-        Name_in_target_env.Set.empty )
-
-  type 'a add_result =
-    { values_in_target_env : 'a Index.Map.t Name_in_target_env.Map.t;
-      touched_variables : Name_in_target_env.Set.t
-    }
-
-  (* Takes a map of values in joined envs (i.e. a map from canonical names in a
-     joined env to values of type ['a] for each joined env) and transforms it
-     into a map of values in the target env by adding the values on name [n] to
-     all the aliases of [n] that are canonical in the target env. *)
-  let add_in_target_env ~exists_in_target_env t values_in_joined_envs
-      values_in_target_env =
-    let values_in_target_env, touched_variables =
-      Index.Map.fold
-        (fun index values_in_joined_env (values_in_target_env, touched_vars) ->
-          let names_from_this_env_in_target_env =
-            Option.value ~default:Name_in_one_joined_env.Map.empty
-              (Index.Map.find_opt index t.names_in_target_env)
+  let alias_types_of t kind var =
+    Index.Map.filter_map
+      (fun _index (env, _) ->
+        if TE.mem ~min_name_mode:Name_mode.in_types env
+             (Name.var (var : Variable_in_one_joined_env.t :> Variable.t))
+        then
+          let canonical =
+            get_canonical_simple_ignoring_name_mode env
+              (Simple_in_one_joined_env.var var)
           in
-          let values_in_target_env, touched_vars =
-            Name_in_one_joined_env.Map.fold
-              (fun var value (acc, touched_vars) ->
-                let vars_in_target_env =
-                  Option.value ~default:Name_in_target_env.Set.empty
-                    (Name_in_one_joined_env.Map.find_opt var
-                       names_from_this_env_in_target_env)
-                in
-                let vars_in_target_env =
-                  match exists_in_target_env var with
-                  | None -> vars_in_target_env
-                  | Some name_in_target_env ->
-                    Name_in_target_env.Set.add name_in_target_env
-                      vars_in_target_env
-                in
-                let values_in_target_env =
-                  Name_in_target_env.Set.fold
-                    (fun var_in_target_env values ->
-                      Name_in_target_env.Map.update var_in_target_env
-                        (function
-                          | None -> Some (Index.Map.singleton index value)
-                          | Some values_in_other_envs ->
-                            Some
-                              (Index.Map.add index value values_in_other_envs))
-                        values)
-                    vars_in_target_env acc
-                in
-                ( values_in_target_env,
-                  Name_in_target_env.Set.union vars_in_target_env touched_vars ))
-              values_in_joined_env
-              (values_in_target_env, touched_vars)
-          in
-          values_in_target_env, touched_vars)
-        values_in_joined_envs
-        (values_in_target_env, Name_in_target_env.Set.empty)
-    in
-    { values_in_target_env; touched_variables }
+          Some (Type_in_one_joined_env.alias_type_of kind canonical)
+        else None)
+      (envs_and_equations t)
 
-  type join_result =
-    { demoted_in_target_env : Simple_in_target_env.t Name_in_target_env.Map.t;
-      demoted_in_some_envs : Simples_in_joined_envs.t Name_in_target_env.Map.t;
-      t : t
-    }
-
-  let n_way_join0 ~exists_in_target_env ~is_bound_strictly_earlier t
-      all_demotions =
-    let demoted_from_target_env, names_in_target_env, touched_vars =
-      apply_demotions ~exists_in_target_env t all_demotions
-    in
-    let t = { t with demoted_from_target_env; names_in_target_env } in
-    let all_indices = Index.Map.keys all_demotions in
-    Name_in_target_env.Set.fold
-      (fun demoted_var { demoted_in_target_env; demoted_in_some_envs; t } ->
-        let canonicals = find_canonicals demoted_var t in
-        let[@local] is_demoted_in_some_envs t =
-          let demoted_in_some_envs =
-            Name_in_target_env.Map.add demoted_var canonicals
-              demoted_in_some_envs
-          in
-          { demoted_in_target_env; demoted_in_some_envs; t }
-        in
-        let[@local] is_demoted_in_all_envs t =
-          let joined_simples =
-            Simples_in_joined_envs.Map.add canonicals demoted_var
-              t.joined_simples
-          in
-          is_demoted_in_some_envs { t with joined_simples }
-        in
-        let[@local] is_demoted_in_target_env canonical t =
-          let t = forget_demoted_var demoted_var t in
-          let demoted_in_target_env =
-            Name_in_target_env.Map.add demoted_var canonical
-              demoted_in_target_env
-          in
-          { demoted_in_target_env; demoted_in_some_envs; t }
-        in
-        (* We keep stale entries in the [joined_simples] table here, which is OK
-           because we never iterate on it and we never look them up anymore
-           since they are non-canonical in at least one of the joined
-           environments.
-
-           This can only happen in the presence of env extensions. *)
-        if not (Simples_in_joined_envs.is_defined_in all_indices canonicals)
-        then is_demoted_in_some_envs t
-        else
-          match
-            find ~exists_in_target_env ~is_bound_strictly_earlier canonicals t
-          with
-          | Bottom ->
-            Misc.fatal_error
-              "Unexpected bottom for non-empty set of canonicals."
-          | Unknown -> is_demoted_in_all_envs t
-          | Ok simple -> is_demoted_in_target_env simple t)
-      touched_vars
-      { demoted_in_target_env = Name_in_target_env.Map.empty;
-        demoted_in_some_envs = Name_in_target_env.Map.empty;
-        t
-      }
-
-  let n_way_join ~exists_in_target_env ~is_bound_strictly_earlier t
-      all_demotions =
-    if Index.Map.is_empty all_demotions
-    then Or_bottom.Bottom
-    else
-      Or_bottom.Ok
-        (n_way_join0 ~exists_in_target_env ~is_bound_strictly_earlier t
-           all_demotions)
+  let expand_heads t types =
+    Index.Map.mapi
+      (fun index ty ->
+        let typing_env = get_nth_joined_env t index in
+        Type_in_one_joined_env.create
+          (ET.to_type
+             (Expand_head.expand_head typing_env
+                (ty : Type_in_one_joined_env.t :> TG.t))))
+      types
 end
 
-module Join_equations = struct
-  (** Maps a variable in the target environment to its {b updated} types in the
-  joined environments.
+(** {1 Public interface} *)
 
-  If the variable did not receive a new type (either explicitly or through demotion)
-  in a given environment, the corresponding entry is absent.
+type env_id = Index.t
 
-  {b Note}: A variable can have a more precise joined type if, and only if,
-  it has been given a new type in {b all} the joined environments. *)
-  type t = ET.t Index.Map.t Name_in_target_env.Map.t
+type 'a join_arg = env_id * 'a
 
-  let empty = Name_in_target_env.Map.empty
+type t =
+  { joined_envs : Joined_envs.t;
+    bindings : Bindings_in_target_env.t
+  }
 
-  let find var t =
-    Option.value ~default:Index.Map.empty
-      (Name_in_target_env.Map.find_opt var t)
+type n_way_join_type = t -> TG.t join_arg list -> TG.t Or_unknown.t * t
 
-  let n_way_join ~n_way_join_type vars equations st =
-    Name_in_target_env.Map.fold
-      (fun var types (equations, st) ->
-        let types =
+let joined_env t index = Joined_envs.get_nth_joined_env t.joined_envs index
+
+let code_age_relation t =
+  Bindings_in_source_env.code_age_relation
+    (Bindings_in_target_env.bindings_in_source_env t.bindings)
+
+let code_age_relation_resolver t =
+  Bindings_in_source_env.code_age_relation_resolver
+    (Bindings_in_target_env.bindings_in_source_env t.bindings)
+
+type canonical_in_target_env =
+  | Canonical_in_source_env of Simple_in_source_env.t
+  | Import_from_all_joined_envs of Variable_in_one_joined_env.t * Coercion.t
+  | Existential_for_these_simples
+
+let canonical_in_target_env ~bindings ~joined_envs canonicals_in_joined_envs =
+  let bindings_in_source_env =
+    Bindings_in_target_env.bindings_in_source_env bindings
+  in
+  match
+    Bindings_in_source_env.candidate_canonical_in_source_env
+      bindings_in_source_env canonicals_in_joined_envs
+  with
+  | No_simples_in_joined_envs | No_canonical_in_source_env ->
+    Existential_for_these_simples
+  | Canonical_in_all_joined_envs simple ->
+    Simple_in_one_joined_env.pattern_match' simple
+      ~const:(fun const ->
+        Canonical_in_source_env (Simple_in_source_env.const const))
+      ~symbol:(fun symbol ~coercion ->
+        Canonical_in_source_env
+          (Simple_in_source_env.symbol ~coercion
+             (Symbol_in_one_joined_env.in_source_env symbol)))
+      ~var:(fun var ~coercion ->
+        match
+          Bindings_in_source_env.exists_in_source_env bindings_in_source_env
+            (var : Variable_in_one_joined_env.t :> Variable.t)
+        with
+        | Some var ->
+          Canonical_in_source_env (Simple_in_source_env.var ~coercion var)
+        | None -> Import_from_all_joined_envs (var, coercion))
+  | Latest_bound_source_var (var, coercion) ->
+    let latest_simple = Simple_in_source_env.var var ~coercion in
+    if Joined_envs.equal_in_all_joined_envs joined_envs
+         (Simple_in_one_joined_env.from_source_env latest_simple)
+         canonicals_in_joined_envs
+    then Canonical_in_source_env latest_simple
+    else Existential_for_these_simples
+
+let n_way_join_simples t kind simples : _ Or_bottom.t * t =
+  match simples with
+  | [] -> Bottom, t
+  | _ :: _ -> (
+    let canonicals_in_joined_envs = Simples_in_joined_envs.of_list simples in
+    (* CR-someday bclement: somehow mark the local variable as used, so that it
+       can be re-processed in the current env extension if applicable (if a
+       local variable is created while processing an env extension, we currently
+       lose any equation that the extension had for that variable). *)
+    match
+      canonical_in_target_env ~bindings:t.bindings ~joined_envs:t.joined_envs
+        canonicals_in_joined_envs
+    with
+    | Canonical_in_source_env simple ->
+      Ok (simple : Simple_in_source_env.t :> Simple.t), t
+    | Import_from_all_joined_envs (var, coercion) ->
+      let simple, bindings =
+        Bindings_in_target_env.import_from_all_envs t.bindings var kind
+      in
+      let simple = Simple_in_target_env.apply_coercion_exn simple coercion in
+      Ok (simple : Simple_in_target_env.t :> Simple.t), { t with bindings }
+    | Existential_for_these_simples ->
+      let simple, bindings =
+        Bindings_in_target_env.existential_for_these_simples t.bindings
+          canonicals_in_joined_envs kind
+      in
+      Ok (simple : Simple_in_target_env.t :> Simple.t), { t with bindings })
+
+let fold_incremental_join ~f ~init equations_to_join =
+  fold_incremental_join ~f ~init
+    { fold =
+        (fun [@inline] f init ->
           Index.Map.fold
-            (fun index expanded acc -> (index, ET.to_type expanded) :: acc)
-            types []
-        in
-        match (n_way_join_type st types : _ Or_unknown.t * _) with
-        | Unknown, st -> equations, st
-        | Known ty, st -> Name_in_target_env.Map.add var ty equations, st)
-      vars (equations, st)
+            (fun index (env, maps) -> f (index, env) maps)
+            equations_to_join init)
+    }
 
-  let add_joined_simple ~joined_envs demoted_var canonicals kind joined_types =
-    Name_in_target_env.Map.update demoted_var
-      (fun types_of_demoted_var ->
-        let types_of_demoted_var =
-          Option.value ~default:Index.Map.empty types_of_demoted_var
-        in
-        let types_of_demoted_var =
-          Simples_in_joined_envs.fold
-            (fun index canonical types_of_demoted_var ->
-              let env = get_nth_joined_env index joined_envs in
-              let canonical_simple = (canonical :> Simple.t) in
-              let ty =
-                Simple.pattern_match canonical_simple
-                  ~const:More_type_creators.type_for_const
-                  ~name:(fun name ~coercion ->
-                    TG.apply_coercion (TE.find env name (Some kind)) coercion)
-              in
-              let expanded =
-                Expand_head.expand_head0 env ty
-                  ~known_canonical_simple_at_in_types_mode:
-                    (Some canonical_simple)
-              in
-              Index.Map.add index expanded types_of_demoted_var)
-            canonicals types_of_demoted_var
-        in
-        Some types_of_demoted_var)
-      joined_types
-end
+type types_in_joined_envs =
+  | Equals_in_all_envs of Simples_in_joined_envs.t * K.t
+  | No_alias_in_some_env of Type_in_one_joined_env.t Index.Map.t
 
-module Symbol_projection = struct
-  include Symbol_projection
-  include Container_types.Make (Symbol_projection)
-end
+let get_types_in_joined_envs join_entry : _ Or_bottom.t =
+  let kind, canonicals, concrete_equations =
+    fold_incremental_join_entry join_entry
+      ~init:(None, Index.Map.empty, Index.Map.empty)
+      ~f:(fun (index, env) ty (kind, canonicals, concrete_equations) ->
+        let kind =
+          match kind with
+          | None -> Type_in_one_joined_env.kind ty
+          | Some kind ->
+            if not (K.equal kind (Type_in_one_joined_env.kind ty))
+            then Misc.fatal_errorf "Incompatible kinds for variable during join";
+            kind
+        in
+        match TG.get_alias_opt (ty : Type_in_one_joined_env.t :> TG.t) with
+        | None ->
+          let concrete_equations = Index.Map.add index ty concrete_equations in
+          Some kind, canonicals, concrete_equations
+        | Some simple ->
+          let canonical =
+            Simple_in_one_joined_env.create
+              (TE.get_canonical_simple_ignoring_name_mode env simple)
+          in
+          let canonicals = Index.Map.add index canonical canonicals in
+          Some kind, canonicals, concrete_equations)
+  in
+  match kind with
+  | None ->
+    assert (
+      Index.Map.is_empty canonicals && Index.Map.is_empty concrete_equations);
+    Bottom
+  | Some kind ->
+    if Index.Map.is_empty concrete_equations
+    then Ok (Equals_in_all_envs (canonicals, kind))
+    else
+      (* CR-someday bclement: We could create a fresh (unique) existential here,
+         which would allow to preserve more information about identity in
+         subsequent joins, but it's not clear it would be useful. *)
+      let alias_equations =
+        Index.Map.map
+          (fun simple -> Type_in_one_joined_env.alias_type_of kind simple)
+          canonicals
+      in
+      Ok
+        (No_alias_in_some_env
+           (Index.Map.disjoint_union alias_equations concrete_equations))
 
-let n_way_join_symbol_projections ~exists_in_target_env
-    ~is_bound_strictly_earlier join_aliases joined_envs all_symbol_projections =
+(* Wrapper around [fold_incremental_join] so that we only fold over equations
+   for names that exist in the target env (see [prepare_join_of_equations]). *)
+let fold_incremental_join_in_target_env equations_to_join ~exists_in_target_env
+    ~init ~f =
+  fold_incremental_join equations_to_join ~init ~f:(fun name join_entry acc ->
+      Name.pattern_match name
+        ~var:(fun var ->
+          match exists_in_target_env var with
+          | None -> acc
+          | Some var_in_target_env ->
+            f (Name_in_target_env.var var_in_target_env) join_entry acc)
+        ~symbol:(fun symbol ->
+          (* See {!section-lifted_constants} *)
+          let symbol = Symbol_in_target_env.create symbol in
+          let name = Name_in_target_env.symbol symbol in
+          f name join_entry acc))
+
+let fold_incremental_join_in_source_env equations_to_join ~exists_in_source_env
+    ~init ~f =
+  fold_incremental_join equations_to_join ~init ~f:(fun name join_entry acc ->
+      Name.pattern_match name
+        ~var:(fun var ->
+          match exists_in_source_env var with
+          | None -> acc
+          | Some var_in_target_env ->
+            f (Name_in_source_env.var var_in_target_env) join_entry acc)
+        ~symbol:(fun symbol ->
+          (* See {!section-lifted_constants} *)
+          let symbol = Symbol_in_source_env.create symbol in
+          let name = Name_in_source_env.symbol symbol in
+          f name join_entry acc))
+
+(* This function is responsible for splitting the [equations_to_join] between
+   those that are demotions in all joined environments, that are replayed in the
+   target environment by adding to the bindings, and the rest, that are expanded
+   to equations on concrete types that will be joined later.
+
+   Note that we only care about names that have new types in all of the joined
+   environments, otherwise the join can never be more precise than what we had
+   initially. We also only care about names that exist in the target
+   environments; other names will be imported automatically during the join of
+   types and only if they are reachable. *)
+let join_aliases_into_bindings ~joined_envs ~bindings equations_to_join =
+  fold_incremental_join_in_source_env equations_to_join
+    ~exists_in_source_env:
+      (Bindings_in_source_env.exists_in_source_env
+         (Bindings_in_target_env.bindings_in_source_env bindings))
+    ~init:(Name_in_target_env.Map.empty, bindings)
+    ~f:(fun name join_entry (equations_to_join, bindings) ->
+      match get_types_in_joined_envs join_entry with
+      | Bottom -> Misc.fatal_error "Unexpected bottom during join"
+      | Ok (No_alias_in_some_env types) ->
+        let equations_to_join =
+          Name_in_target_env.Map.add
+            (Name_in_target_env.from_source_env name)
+            types equations_to_join
+        in
+        equations_to_join, bindings
+      | Ok (Equals_in_all_envs (canonicals, kind)) -> (
+        match canonical_in_target_env ~bindings ~joined_envs canonicals with
+        | Canonical_in_source_env canonical ->
+          let bindings =
+            Bindings_in_target_env.add_alias_in_source_env bindings kind name
+              (Simple_in_target_env.from_source_env canonical)
+          in
+          equations_to_join, bindings
+        | Import_from_all_joined_envs (var, coercion) ->
+          (* name = coercion(var) *)
+          let bindings =
+            Bindings_in_target_env.add_imported_var bindings
+              ~name_in_source_env:name ~coercion_to_name_in_source_env:coercion
+              var kind
+          in
+          equations_to_join, bindings
+        | Existential_for_these_simples ->
+          let bindings =
+            Bindings_in_target_env.add_existential_for_these_simples bindings
+              ~name_in_source_env:name canonicals kind
+          in
+          equations_to_join, bindings))
+
+let n_way_join_round ~(n_way_join_type : n_way_join_type) t equations_to_join
+    types_in_target_env =
+  Name_in_target_env.Map.fold
+    (fun name types (types_in_target_env, t) ->
+      if Flambda_features.check_light_invariants ()
+         && Name_in_target_env.Map.mem name types_in_target_env
+      then
+        Misc.fatal_errorf
+          "Processing join of %a but we already have a type for it."
+          Name_in_target_env.print name;
+      match
+        n_way_join_type t
+          (Index.Map.bindings (Joined_envs.expand_heads t.joined_envs types)
+            : (Index.t * Type_in_one_joined_env.t) list
+            :> (Index.t * TG.t) list)
+      with
+      | Unknown, t -> types_in_target_env, t
+      | Known ty, t ->
+        let ty = Type_in_target_env.create ty in
+        Name_in_target_env.Map.add name ty types_in_target_env, t)
+    equations_to_join (types_in_target_env, t)
+
+(** {2:n-way-join} Cut and n-way join *)
+
+let get_canonical_simple_if_exists ~bindings ~joined_envs simples =
+  match canonical_in_target_env ~bindings ~joined_envs simples with
+  | Canonical_in_source_env simple ->
+    Some (Simple_in_target_env.from_source_env simple)
+  | Import_from_all_joined_envs (var, coercion) -> (
+    match
+      Bindings_in_target_env.is_imported_from_all_joined_envs bindings var
+    with
+    | Some simple ->
+      Some (Simple_in_target_env.apply_coercion_exn simple coercion)
+    | None -> None)
+  | Existential_for_these_simples ->
+    Bindings_in_target_env.has_existential_for_these_simples bindings simples
+
+let n_way_join_symbol_projections t symbol_projections_to_join =
   let joined_projections =
     Index.Map.fold
       (fun index symbol_projections acc ->
-        let typing_env = get_nth_joined_env index joined_envs in
-        Variable.Map.fold
+        let typing_env = Joined_envs.get_nth_joined_env t.joined_envs index in
+        Variable_in_one_joined_env.Map.fold
           (fun var symbol_projection acc ->
             let canonical =
-              TE.get_canonical_simple_exn typing_env (Simple.var var)
-                ~min_name_mode:Name_mode.in_types
+              TE.get_canonical_simple_ignoring_name_mode typing_env
+                (Simple.var (var : Variable_in_one_joined_env.t :> Variable.t))
             in
             let canonical = Simple_in_one_joined_env.create canonical in
             Symbol_projection.Map.update symbol_projection
               (fun joined_projections ->
                 let joined_projections =
-                  Option.value joined_projections
-                    ~default:Simples_in_joined_envs.empty
+                  Option.value joined_projections ~default:Index.Map.empty
                 in
-                Some
-                  (Simples_in_joined_envs.add index canonical joined_projections))
+                Some (Index.Map.add index canonical joined_projections))
               acc)
           symbol_projections acc)
-      all_symbol_projections Symbol_projection.Map.empty
+      symbol_projections_to_join Symbol_projection.Map.empty
   in
-  let all_indices = Index.Map.keys joined_envs in
+  let all_indices = Joined_envs.keys t.joined_envs in
   Symbol_projection.Map.fold
     (fun symbol_projection simples symbol_projections ->
-      if not (Simples_in_joined_envs.is_defined_in all_indices simples)
+      if not (Index.Set.subset all_indices (Index.Map.keys simples))
       then symbol_projections
       else
         match
-          Join_aliases.find ~exists_in_target_env ~is_bound_strictly_earlier
-            simples join_aliases
+          get_canonical_simple_if_exists ~bindings:t.bindings
+            ~joined_envs:t.joined_envs simples
         with
-        | Bottom | Unknown -> symbol_projections
-        | Ok simple -> (
-          match Simple.must_be_var (simple :> Simple.t) with
-          | Some (var, coercion) when Coercion.is_id coercion ->
-            Variable.Map.add var symbol_projection symbol_projections
-          | _ -> symbol_projections))
-    joined_projections Variable.Map.empty
+        | Some simple ->
+          Simple_in_target_env.pattern_match' simple
+            ~var:(fun var ~coercion ->
+              if Coercion.is_id coercion
+              then
+                Variable_in_target_env.Map.add var symbol_projection
+                  symbol_projections
+              else symbol_projections)
+            ~symbol:(fun _ ~coercion:_ -> symbol_projections)
+            ~const:(fun _ -> symbol_projections)
+        | None -> symbol_projections)
+    joined_projections Variable_in_target_env.Map.empty
 
-type t =
-  { join_aliases : Join_aliases.t;
-    join_types : Join_equations.t;
-    existential_vars : K.t Variable.Map.t;
-    pending_vars : Simples_in_joined_envs.t Variable_in_target_env.Map.t;
-    (* Existential variables that have been defined by their names in all the
-       joined environment, but whose type has not yet been computed. *)
-    joined_envs : TE.t Index.Map.t;
-    (* Currently active joined environments.
-
-       {b Note}: This can be a subset of all the actual joined environments when
-       performing a join inside env extensions. *)
-    target_env : TE.t
-  }
-
-type join_result =
-  { demoted_in_target_env : Simple_in_target_env.t Name_in_target_env.Map.t;
-    extra_variables : K.t Variable.Map.t;
-    equations : TG.t Name_in_target_env.Map.t;
-    symbol_projections : Symbol_projection.t Variable.Map.t
-  }
-
-let n_way_join_levels ~n_way_join_type t all_levels : _ Or_bottom.t =
-  let all_demotions, all_expanded_equations, all_symbol_projections =
-    Index.Map.fold
-      (fun index level
-           (all_demotions, all_expanded_equations, all_symbol_projections) ->
-        let symbol_projections = TEL.symbol_projections level in
-        let equations = TEL.equations level in
-        let typing_env = get_nth_joined_env index t.joined_envs in
-        let demotions, expanded_equations =
-          Name.Map.fold
-            (fun name ty (demotions, expanded_equations) ->
-              match Name.must_be_var_opt name with
-              | None -> demotions, expanded_equations
-              | Some var -> (
-                let name_in_joined_env =
-                  Name_in_one_joined_env.create (Name.var var)
-                in
-                (* Note: we must compute the current canonical here, because
-                   [Join_aliases.n_way_join] expects a fully compressed map
-                   demotions (i.e. the right-hand side must not themselves be
-                   demoted) *)
-                match
-                  TE.get_alias_then_canonical_simple_exn
-                    ~min_name_mode:Name_mode.in_types typing_env ty
-                with
-                | canonical_simple ->
-                  ( Name_in_one_joined_env.Map.add name_in_joined_env
-                      (Simple_in_one_joined_env.create canonical_simple)
-                      demotions,
-                    expanded_equations )
-                | exception Not_found ->
-                  let expanded =
-                    Expand_head.expand_head0 typing_env ty
-                      ~known_canonical_simple_at_in_types_mode:
-                        (Some (Simple.var var))
-                  in
-                  ( demotions,
-                    Name_in_one_joined_env.Map.add name_in_joined_env expanded
-                      expanded_equations )))
-            equations
-            (Name_in_one_joined_env.Map.empty, Name_in_one_joined_env.Map.empty)
+let cut_and_n_way_join ~n_way_join_type ~meet_type ~cut_after source_env
+    joined_envs =
+  let joined_envs, equations_to_join, symbol_projections_to_join =
+    Index.fold_list
+      (fun index typing_env
+           (joined_envs, equations_to_join, symbol_projections_to_join) ->
+        let level = TE.cut typing_env ~cut_after in
+        let equations =
+          Type_in_one_joined_env.create_equations (TEL.equations level)
         in
-        ( Index.Map.add index demotions all_demotions,
-          Index.Map.add index expanded_equations all_expanded_equations,
-          Index.Map.add index symbol_projections all_symbol_projections ))
-      all_levels
+        let incremental_equations =
+          { previous = Name.Map.empty; diff = equations; current = equations }
+        in
+        let symbol_projections =
+          Variable_in_one_joined_env.create_map (TEL.symbol_projections level)
+        in
+        ( Index.Map.add index typing_env joined_envs,
+          Index.Map.add index
+            (typing_env, incremental_equations)
+            equations_to_join,
+          Index.Map.add index symbol_projections symbol_projections_to_join ))
+      joined_envs
       (Index.Map.empty, Index.Map.empty, Index.Map.empty)
   in
-  let target_env = t.target_env in
-  let exists_in_target_env (name : Name_in_one_joined_env.t) =
-    if TE.mem ~min_name_mode:Name_mode.in_types target_env (name :> Name.t)
-    then Some (Name_in_target_env.create (name :> Name.t))
-    else None
-  in
-  let is_bound_strictly_earlier (name : Name_in_target_env.t)
-      ~(than : Simple_in_target_env.t) =
-    TE.alias_is_bound_strictly_earlier t.target_env
-      ~bound_name:(name :> Name.t)
-      ~alias:(than :> Simple.t)
-  in
-  match
-    Join_aliases.n_way_join ~exists_in_target_env ~is_bound_strictly_earlier
-      t.join_aliases all_demotions
-  with
-  | Bottom -> Bottom
-  | Ok { demoted_in_target_env; demoted_in_some_envs; t = join_aliases } ->
-    let join_types =
-      Name_in_target_env.Map.fold
-        (fun name_in_target_env canonicals join_types ->
-          let canonicals =
-            Simples_in_joined_envs.in_envs all_levels canonicals
-          in
-          (* Passing [None] to [TE.find] here is OK, because [name] has been
-             demoted in at least one environment thus cannot be imported. *)
-          let ty_in_target_env =
-            TE.find target_env (name_in_target_env :> Name.t) None
-          in
-          let kind = TG.kind ty_in_target_env in
-          Join_equations.add_joined_simple ~joined_envs:t.joined_envs
-            name_in_target_env canonicals kind join_types)
-        demoted_in_some_envs t.join_types
+  try
+    let empty_bindings = Bindings_in_target_env.create source_env joined_envs in
+    let joined_envs = Joined_envs.create equations_to_join in
+    let concrete_equations_to_join, bindings =
+      join_aliases_into_bindings ~joined_envs ~bindings:empty_bindings
+        equations_to_join
     in
-    let { Join_aliases.values_in_target_env = join_types;
-          touched_variables = touched_vars
-        } =
-      Join_aliases.add_in_target_env ~exists_in_target_env join_aliases
-        all_expanded_equations join_types
+    let equations_for_bindings bindings ~since =
+      let new_bindings = Bindings_in_target_env.new_bindings bindings ~since in
+      Name_in_target_env.Map.map
+        (fun (definition : Bindings_in_target_env.definition_in_joined_envs) ->
+          match definition with
+          | Imported_var (var, kind) ->
+            Joined_envs.alias_types_of joined_envs kind var
+          | These_canonicals (simples, kind) ->
+            Index.Map.map
+              (fun simple -> Type_in_one_joined_env.alias_type_of kind simple)
+              simples)
+        new_bindings
     in
-    let touched_vars =
-      Name_in_target_env.Set.union touched_vars
-        (Name_in_target_env.Map.keys demoted_in_some_envs)
-    in
-    let t = { t with join_aliases; join_types } in
-    let all_indices = Index.Map.keys t.joined_envs in
     let equations_to_join =
-      Name_in_target_env.Set.fold
-        (fun var new_vars ->
-          let types = Join_equations.find var t.join_types in
-          if not (Index.Set.subset all_indices (Index.Map.keys types))
-          then new_vars
-          else
-            (* Restrict the indices in case we are joining env extensions that
-               are not defined in all environments *)
-            let types =
-              Index.Map.inter (fun _ _ expanded -> expanded) t.joined_envs types
-            in
-            Name_in_target_env.Map.add var types new_vars)
-        touched_vars Name_in_target_env.Map.empty
+      Name_in_target_env.Map.disjoint_union concrete_equations_to_join
+        (equations_for_bindings bindings ~since:empty_bindings)
     in
-    let rec loop equations_to_join joined_equations t =
-      let equations, t =
-        Join_equations.n_way_join ~n_way_join_type equations_to_join
-          joined_equations t
+    let rec loop t equations_to_join concrete_types_in_target_env =
+      let bindings_before_this_round = t.bindings in
+      let types_in_target_env, t =
+        n_way_join_round ~n_way_join_type t equations_to_join
+          concrete_types_in_target_env
       in
-      if Variable_in_target_env.Map.is_empty t.pending_vars
+      let new_equations_to_join =
+        equations_for_bindings t.bindings ~since:bindings_before_this_round
+      in
+      if Name_in_target_env.Map.is_empty new_equations_to_join
       then
-        let symbol_projections =
-          n_way_join_symbol_projections ~exists_in_target_env
-            ~is_bound_strictly_earlier t.join_aliases t.joined_envs
-            all_symbol_projections
-        in
-        Or_bottom.Ok
-          { demoted_in_target_env;
-            extra_variables = t.existential_vars;
-            equations;
-            symbol_projections
-          }
-      else
-        let join_types =
-          Variable_in_target_env.Map.fold
-            (fun var_in_target_env canonicals join_types ->
-              let canonicals =
-                Simples_in_joined_envs.in_envs all_levels canonicals
-              in
-              let kind =
-                try
-                  Variable.Map.find
-                    (var_in_target_env :> Variable.t)
-                    t.existential_vars
-                with Not_found ->
-                  Misc.fatal_errorf
-                    "Extra equations can only be added on existential \
-                     variables, which %a is not."
-                    Variable_in_target_env.print var_in_target_env
-              in
-              Join_equations.add_joined_simple ~joined_envs:t.joined_envs
-                (Name_in_target_env.var var_in_target_env)
-                canonicals kind join_types)
-            t.pending_vars t.join_types
-        in
-        let equations_to_join =
-          Variable_in_target_env.Map.mapi
-            (fun var _ ->
-              Join_equations.find (Name_in_target_env.var var) join_types)
-            t.pending_vars
-        in
-        let pending_vars = Variable_in_target_env.Map.empty in
-        loop
-          (Name_in_target_env.var_map equations_to_join)
-          equations
-          { t with pending_vars; join_types }
-    in
-    loop equations_to_join Name_in_target_env.Map.empty t
+        ( (* We compute symbol projections last so that we can pick up
+             existential variables, but there is no need to create existential
+             variables from symbol projections since they would not be
+             accessible.
 
-let cut_and_n_way_join ~n_way_join_type ~meet_type ~cut_after target_env
-    joined_envs =
-  let _, joined_envs, joined_levels =
-    List.fold_left
-      (fun (discriminant, joined_envs, joined_levels) typing_env ->
-        let level = TE.cut typing_env ~cut_after in
-        ( Index.succ discriminant,
-          Index.Map.add discriminant typing_env joined_envs,
-          Index.Map.add discriminant level joined_levels ))
-      (Index.zero, Index.Map.empty, Index.Map.empty)
-      joined_envs
-  in
-  match
-    n_way_join_levels ~n_way_join_type
-      { join_aliases = Join_aliases.empty;
-        join_types = Join_equations.empty;
-        existential_vars = Variable.Map.empty;
-        pending_vars = Variable_in_target_env.Map.empty;
-        joined_envs;
-        target_env
-      }
-      joined_levels
-  with
-  | Bottom ->
-    (* Join of zero envs -- should possibly return bottom? *)
-    target_env
-  | Ok { demoted_in_target_env; extra_variables; equations; symbol_projections }
-    ->
+             CR-someday bclement: perform CSE for symbol projections? *)
+          types_in_target_env,
+          n_way_join_symbol_projections t symbol_projections_to_join,
+          t.bindings )
+      else loop t new_equations_to_join types_in_target_env
+    in
+    let equations, symbol_projections, bindings =
+      loop { joined_envs; bindings } equations_to_join
+        (Name_in_target_env.from_source_env_map
+           (Bindings_in_target_env.alias_types_in_target_env bindings))
+    in
     let target_env =
-      Variable.Map.fold
+      Bindings_in_target_env.fold_created_variables
         (fun var kind target_env ->
-          TE.add_definition target_env
-            (Bound_name.create_var
-               (Bound_var.create var Flambda_debug_uid.none
-                  (* Variables with [Name_mode.in_types] do not exist at
-                     runtime, so we do not equip them with a
-                     [Flambda_debug_uid.t]. See #3967. *)
-                  Name_mode.in_types))
-            kind)
-        extra_variables target_env
+          TE.add_variable_definition target_env
+            (var : Variable_in_target_env.t :> Variable.t)
+            kind Name_mode.in_types)
+        bindings source_env
     in
     let target_env =
-      Name_in_target_env.Map.fold
-        (fun name (simple : Simple_in_target_env.t) target_env ->
-          let name = (name :> Name.t) in
-          let simple = (simple :> Simple.t) in
-          (* Passing [None] to [TE.find] here is OK, because [name] has been
-             demoted in at least one environment thus cannot be imported. *)
-          let kind = TG.kind (TE.find target_env name None) in
-          let ty = TG.alias_type_of kind simple in
-          ME.add_equation ~meet_type target_env name ty)
-        demoted_in_target_env target_env
+      ME.add_env_extension ~meet_type target_env
+        (TEE.from_map
+           (equations
+             : Type_in_target_env.t Name_in_target_env.Map.t
+             :> TG.t Name.Map.t))
     in
     let target_env =
-      Name_in_target_env.Map.fold
-        (fun name ty target_env ->
-          ME.add_equation ~meet_type target_env (name :> Name.t) ty)
-        equations target_env
-    in
-    let target_env =
-      Variable.Map.fold
+      Variable_in_target_env.Map.fold
         (fun var symbol_projection target_env ->
-          TE.add_symbol_projection target_env var symbol_projection)
+          TE.add_symbol_projection target_env
+            (var :> Variable.t)
+            symbol_projection)
         symbol_projections target_env
     in
     target_env
+  with Misc.Fatal_error ->
+    let bt = Printexc.get_raw_backtrace () in
+    Format.eprintf "\n@[<v 2>%tContext is:%t cut and join of levels:@ %a@]\n"
+      Flambda_colours.error Flambda_colours.pop
+      (Index.Map.print (fun ppf env -> TEL.print ppf (TE.cut ~cut_after env)))
+      joined_envs;
+    Printexc.raise_with_backtrace Misc.Fatal_error bt
 
-let n_way_join_env_extension ~n_way_join_type ~meet_type t envs_with_extensions
-    =
-  let joined_levels, joined_envs =
+(** {2:extensions} Join of extensions *)
+
+let prepare_nested_join ~meet_type ~joined_envs ~bindings extensions =
+  let extensions =
     List.fold_left
-      (fun (joined_levels, joined_envs) (index, extension) ->
-        let parent_env = get_nth_joined_env index t.joined_envs in
+      (fun joined_envs_and_levels (index, extension) ->
+        let parent_env = Joined_envs.get_nth_joined_env joined_envs index in
         (* The extension is not guaranteed to still be in canonical form, but we
            need the equations to be in canonical form to known which variables
            are actually touched by the extension, so we add it once then cut it.
@@ -1293,98 +1684,254 @@ let n_way_join_env_extension ~n_way_join_type ~meet_type t envs_with_extensions
           (* We can reach bottom here if the extension was created in a more
              generic context, but is added in a context where it is no longer
              reachable. *)
-          joined_levels, joined_envs
+          joined_envs_and_levels
         | Ok typing_env ->
           let level = TE.cut typing_env ~cut_after in
-          ( Index.Map.add index level joined_levels,
-            Index.Map.add index typing_env joined_envs ))
-      (Index.Map.empty, Index.Map.empty)
-      envs_with_extensions
+          let extension = TEL.as_extension_without_bindings level in
+          Index.Map.add index (typing_env, extension) joined_envs_and_levels)
+      Index.Map.empty extensions
   in
-  match
-    n_way_join_levels ~n_way_join_type
-      { join_aliases = t.join_aliases;
-        join_types = t.join_types;
-        existential_vars = t.existential_vars;
-        pending_vars = Variable_in_target_env.Map.empty;
-        joined_envs;
-        target_env = t.target_env
-      }
-      joined_levels
-  with
-  | Bottom -> Or_bottom.Bottom
-  | Ok { demoted_in_target_env; extra_variables; equations; symbol_projections }
-    ->
-    if not (Variable.Map.is_empty symbol_projections)
-    then Misc.fatal_error "Unexpected symbol projections in env extension.";
-    let joined_equations =
-      Name_in_target_env.Map.fold
-        (fun name (simple : Simple_in_target_env.t) equations ->
-          let kind =
-            (* Passing [None] to [TE.find] here is OK, because [name] has been
-               demoted in at least one environment thus cannot be imported. *)
-            match Name.must_be_var_opt (name :> Name.t) with
-            | None -> TG.kind (TE.find t.target_env (name :> Name.t) None)
-            | Some var -> (
-              match Variable.Map.find_opt var extra_variables with
-              | Some kind -> kind
-              | None -> TG.kind (TE.find t.target_env (name :> Name.t) None))
+  Index.Map.mapi
+    (fun index (env, diff_ext) ->
+      let previous_equations =
+        Joined_envs.equations_in_nth_joined_env joined_envs index
+      in
+      let diff_equations =
+        Type_in_one_joined_env.create_equations (TEE.to_map diff_ext)
+      in
+      (* The call below to [reintroduce_demotions_in_one_joined_env] is only
+         relevant when doing a nested join (join of env extensions); for a
+         toplevel join, [join_aliases] is empty and this does nothing.
+
+         Consider that we first perform the following join (assuming that [x]
+         and [y] exist in the source env and all other variables are local to
+         their joined env) of:
+
+         x: (= a) ; y: (= a)
+
+         and
+
+         x: (= c)
+
+         and that we later perform in the same context the join of nested
+         extensions:
+
+         a: (= d)
+
+         and
+
+         y: (= c)
+
+         We'd like to determine that the join of the extensions is:
+
+         x: (= y)
+
+         If we simply use the incremental join algorithm without taking
+         demotions into account, we'll find the join of [y: (= a)] (from the
+         outer scope in the left environment) and [y: (= c)] (from the nested
+         scope in the right environment) but we don't have a way to determine
+         that [x] and [y] are equal without reprocessing the equations on [x]
+         (in the outer scope, the canonicals for [x] were [(a, c)] so we
+         couldn't even find it from the canonicals of [y] in the inner scope,
+         which are [(d, c)]).
+
+         We do this by keeping track of the aliases of [a] in the joined env
+         ([x] and [y]), and adding back the corresponding demotions (only for
+         the variables that actually have an equation in the extension) to the
+         first extension, yielding:
+
+         x: (= a) ; y: (= a) ; a: (= d)
+
+         This will interact with the equation [y: (= c)] from the extension
+         scope in the right environment, and with the equation [x: (= c)] from
+         the parent scope in the right environment, from which we can deduce the
+         equality between [x] and [y].
+
+         Note that if we instead have:
+
+         x: (Block 0 (= a)) ; y: (Block 0 (= a))
+
+         and
+
+         x: (Block 0 (= c))
+
+         at the toplevel and
+
+         a: (= d)
+
+         and
+
+         y: (Block 0 (= c))
+
+         in the extensions, we will create a single existential variable [ac] at
+         the toplevel.
+
+         When performing the join of the extensions, we will add the equation
+         [ac: (= a)] to the left extension, but we also need to add an equation
+         [ac: (= c)] to the outer scope in the right env (see the call to
+         [defining_equations_of_existentials] below) in order to reprocess
+         [ac]. *)
+      let diff_equations =
+        Bindings_in_target_env.replay_definition_of_aliases_in_target_env
+          bindings index diff_equations
+      in
+      (* We call [union diff previous] rather than [union previous diff] because
+         we want maximum sharing with [diff] (see the computation of
+         [previous_equations] below). *)
+      let current_equations =
+        Name.Map.union_sharing
+          (fun _ diff_ty _previous_ty -> Some diff_ty)
+          diff_equations previous_equations
+      in
+      (* Drop variables from the previous level if they get a more precise type
+         in the current level (otherwise they would appear in both $Pi$ and $Δi$
+         and be processed twice -- see [incremental_join]). *)
+      let previous_equations =
+        Name.Map.diff_shared
+          (fun _ _current_ty _diff_ty -> None)
+          current_equations diff_equations
+      in
+      (* This call is only relevant if we are doing a nested join (join of env
+         extensions); for a toplevel join, we don't have existential variables.
+
+         When doing a nested join, we need to make sure that any existential
+         variables created at an earlier level are tracked in the previous level
+         so that they can correctly interact with equations added by
+         [reintroduce_demotions_in_one_joined_env] to the [diff_equations] of
+         another joined env (see the call to
+         [reintroduce_demotions_in_one_joined_env] above). *)
+      (* CR bclement: it would be more efficient to do an union of iterators to
+         avoid re-processing all the existentials every time. *)
+      let previous_equations =
+        let defining_equations_of_existential_vars =
+          Bindings_in_target_env.definition_of_local_variables_in_one_joined_env
+            bindings index
+        in
+        Name.Map.union
+          (fun _ previous _defining_eqn ->
+            (* Sometimes we might have already added the defining equation of an
+               existential due to [reintroduce_demotions_in_one_joined_env],
+               which is fine. *)
+            Some previous)
+          previous_equations
+          (Name.var_map
+             (defining_equations_of_existential_vars
+               : Type_in_one_joined_env.t Variable_in_target_env.Map.t
+               :> Type_in_one_joined_env.t Variable.Map.t))
+      in
+      let incremental_equations =
+        { previous = previous_equations;
+          diff = diff_equations;
+          current = current_equations
+        }
+      in
+      env, incremental_equations)
+    extensions
+
+(* For the join of env extensions, we cannot just accumulate aliases into the
+   [bindings] because any demotion we process is local *just* to the current env
+   extension, and stops being valid once we leave the extension.
+
+   Instead, we just accumulate the (local) alias equations directly. *)
+let join_aliases_in_env_extension ~joined_envs ~bindings equations_to_join =
+  fold_incremental_join_in_target_env equations_to_join
+    ~exists_in_target_env:(Bindings_in_target_env.exists_in_target_env bindings)
+    ~init:(Name_in_target_env.Map.empty, Name_in_target_env.Map.empty, bindings)
+    ~f:(fun
+         name
+         join_entry
+         (equations_in_target_env, equations_to_join, bindings)
+       ->
+      match get_types_in_joined_envs join_entry with
+      | Bottom -> Misc.fatal_error "Unexpected bottom during join"
+      | Ok (No_alias_in_some_env types) ->
+        let equations_to_join =
+          Name_in_target_env.Map.add name types equations_to_join
+        in
+        equations_in_target_env, equations_to_join, bindings
+      | Ok (Equals_in_all_envs (canonicals, kind)) -> (
+        match canonical_in_target_env ~bindings ~joined_envs canonicals with
+        | Canonical_in_source_env canonical ->
+          let equations_in_target_env =
+            Name_in_target_env.Map.add name
+              (Type_in_target_env.alias_type_of kind
+                 (Simple_in_target_env.from_source_env canonical))
+              equations_in_target_env
           in
-          let ty = TG.alias_type_of kind (simple :> Simple.t) in
-          Name.Map.add (name :> Name.t) ty equations)
-        demoted_in_target_env Name.Map.empty
-    in
-    let joined_equations =
-      Name_in_target_env.Map.fold
-        (fun name ty equations -> Name.Map.add (name :> Name.t) ty equations)
-        equations joined_equations
-    in
-    (* Preserve existential vars since we can't bind them in extensions. *)
-    let existential_vars = extra_variables in
-    Or_bottom.Ok (TEE.from_map joined_equations, { t with existential_vars })
+          equations_in_target_env, equations_to_join, bindings
+        | Import_from_all_joined_envs (var, coercion) ->
+          let simple, bindings =
+            Bindings_in_target_env.import_from_all_envs bindings var kind
+          in
+          let equations_in_target_env =
+            Name_in_target_env.Map.add name
+              (Type_in_target_env.alias_type_of kind
+                 (Simple_in_target_env.apply_coercion_exn simple coercion))
+              equations_in_target_env
+          in
+          equations_in_target_env, equations_to_join, bindings
+        | Existential_for_these_simples ->
+          let simple, bindings =
+            Bindings_in_target_env.existential_for_these_simples bindings
+              canonicals kind
+          in
+          let equations_in_target_env =
+            Name_in_target_env.Map.add name
+              (Type_in_target_env.alias_type_of kind simple)
+              equations_in_target_env
+          in
+          equations_in_target_env, equations_to_join, bindings))
 
-let n_way_join_simples t kind simples : _ Or_bottom.t * _ =
-  let simples = Simples_in_joined_envs.of_list simples in
-  let target_env = t.target_env in
-  let exists_in_target_env (name : Name_in_one_joined_env.t) =
-    if TE.mem ~min_name_mode:Name_mode.in_types target_env (name :> Name.t)
-    then Some (Name_in_target_env.create (name :> Name.t))
-    else None
+let n_way_join_env_extension ~n_way_join_type ~meet_type t extensions :
+    _ Or_bottom.t =
+  let joined_equations =
+    try
+      prepare_nested_join ~meet_type ~bindings:t.bindings
+        ~joined_envs:t.joined_envs extensions
+    with Misc.Fatal_error ->
+      let bt = Printexc.get_raw_backtrace () in
+      Format.eprintf
+        "\n@[<v 2>%tContext is:%t preparing join of env extensions:@ %a@]\n"
+        Flambda_colours.error Flambda_colours.pop
+        (Index.Map.print TEE.print)
+        (Index.Map.of_list extensions);
+      Printexc.raise_with_backtrace Misc.Fatal_error bt
   in
-  let is_bound_strictly_earlier (name : Name_in_target_env.t)
-      ~(than : Simple_in_target_env.t) =
-    TE.alias_is_bound_strictly_earlier t.target_env
-      ~bound_name:(name :> Name.t)
-      ~alias:(than :> Simple.t)
-  in
-  match
-    Join_aliases.find ~exists_in_target_env ~is_bound_strictly_earlier simples
-      t.join_aliases
-  with
-  | Bottom -> Bottom, t
-  | Ok simple -> Ok (simple :> Simple.t), t
-  | Unknown ->
-    let var, join_aliases =
-      Join_aliases.add_existential_var ~exists_in_target_env simples
-        t.join_aliases
-    in
-    let existential_vars = Variable.Map.add var kind t.existential_vars in
-    let pending_vars =
-      Variable_in_target_env.Map.add
-        (Variable_in_target_env.create var)
-        simples t.pending_vars
-    in
-    Ok (Simple.var var), { t with existential_vars; join_aliases; pending_vars }
-
-type env_id = Index.t
-
-type 'a join_arg = env_id * 'a
-
-let code_age_relation { target_env; _ } = TE.code_age_relation target_env
-
-let code_age_relation_resolver { target_env; _ } =
-  TE.code_age_relation_resolver target_env
-
-type n_way_join_type = t -> TG.t join_arg list -> TG.t Or_unknown.t * t
-
-let joined_env env index = get_nth_joined_env index env.joined_envs
+  if Index.Map.is_empty joined_equations
+  then Bottom
+  else
+    try
+      let joined_envs = Joined_envs.create joined_equations in
+      let alias_types_in_target_env, concrete_types_to_join, bindings =
+        join_aliases_in_env_extension ~joined_envs ~bindings:t.bindings
+          joined_equations
+      in
+      (* CR-someday bclement: if we create new existential variables during the
+         join of env extensions, we might need additional rounds for
+         completeness (see comment in [n_way_join_simples]) -- in practice one
+         round should be plenty. *)
+      let equations, { bindings; _ } =
+        n_way_join_round ~n_way_join_type { joined_envs; bindings }
+          concrete_types_to_join alias_types_in_target_env
+      in
+      Ok
+        ( TEE.from_map
+            (equations
+              : Type_in_target_env.t Name_in_target_env.Map.t
+              :> TG.t Name.Map.t),
+          { t with bindings } )
+    with Misc.Fatal_error ->
+      (* Note that we display the env extensions in their current canonical
+         form, which might differ from their form as recorded in the input
+         types. *)
+      let bt = Printexc.get_raw_backtrace () in
+      Format.eprintf "\n@[<v 2>%tContext is:%t join of env extensions:@ %a@]\n"
+        Flambda_colours.error Flambda_colours.pop
+        (Index.Map.print (fun ppf (_, extension) ->
+             TEE.print ppf
+               (TEE.from_map
+                  (extension.current
+                    : Type_in_one_joined_env.t Name.Map.t
+                    :> TG.t Name.Map.t))))
+        joined_equations;
+      Printexc.raise_with_backtrace Misc.Fatal_error bt


### PR DESCRIPTION
The n-way join algorithm introduced in #3538 is written in a somewhat confusing way (see also: #4279) and is full of subtleties. This is partly due to the way the `Join_aliases` module is dealing with more responsibilities than necessary, and partly because we try to do too much in a single pass over the environments. This makes the implementation deviate somewhat from the underlying algorithm it is supposed to implement; for instance, it was not clear how to correctly add the information required for the match-in-match heuristic even though it should theoretically have been straightforward.

This patch rewrites the implementation to more closely follow the underlying algorithm, and should greatly improve readability and maintainability. It also improves performance slightly due to using the efficient leapfrog join from the Datalog engine, but I don't expect this to matter too much in practice (although it does mean that the join can now have sub-linear performance when the joined levels have little variables in common).

I suggest not trying to review the diff on the `Join_env` module and to just read the new implementation. The implementation consists in four parts:

 1) Some things related to iterators and the computation of an
    incremental join using Datalog's seminaive algorithm. This should be
    shared with the `Flambda_datalog` module at some point, which also
    has an implementation of that algorithm, but it's not trivial to use for
    our purpose here.

 2) A bunch of modules for type-safety to represent simples and types in
    each of the environments involved in a join.  This is essentially
    lifted from the previous implementation, but with some more methods.

 3) Supporting modules, split off from the responsibilities of the old
    `Join_aliases` module. These are the `Bindings_in_source_env`,
    `Bindings_in_target_env`, and `Joined_envs` modules.

 4) The join itself (and supporting functions) at the toplevel.

Part 1) can be reviewed independently of the rest. Part 2 should be wholly unsurprising and self-explanatory. I suggest reading part 4 first, looking at part 3 when necessary, before reviewing part 3 proper.

Reviewers: @Ekdohibs  for part 1, @lthls for the rest.