### PR TITLE
Rename function to avoid confusion (peephole rules)

### DIFF
--- a/backend/peephole/peephole_rules.ml
+++ b/backend/peephole/peephole_rules.ml
@@ -35,10 +35,9 @@ let remove_overwritten_mov (cell : Cfg.basic Cfg.instruction DLL.cell) =
         Op
           ( Const_int _ | Const_float _ | Const_float32 _ | Const_vec128 _
           | Const_vec256 _ | Const_vec512 _ ) ) ->
-
-      (* Removing the second instruction is okay here since it doesn't change
-         the set of addresses we touch. *)
-      delete_snd_if_redundant ~fst ~fst_val ~snd_val
+      (* Removing the first instruction is okay here since it doesn't change the
+         set of addresses we touch. *)
+      delete_fst_if_redundant ~fst ~fst_val ~snd_val
     | Op (Spill | Reload), Op (Move | Spill | Reload) ->
       (* We only consider the removal of spill and reload instructions because a
          move from/to an arbitrary memory location could fail because of memory


### PR DESCRIPTION
As per title; the name made sense when
the function was first introduced, but
after switching to doubly-linked lists we
don't need to "reverse" elements anymore.