### PR TITLE
Register allocators: move spills/reloads outside of loops when possible (CI job)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -302,6 +302,10 @@ jobs:
           ./_build/main/tools/regalloc/regalloc.exe _build \
             -validate -regalloc $allocator || exit 1; \
         done
+        for allocator in irc ls gi; do \
+          ./_build/main/tools/regalloc/regalloc.exe _build \
+            -validate -param SPLIT_AROUND_LOOPS:on -regalloc $allocator || exit 1; \
+        done
 
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }}


### PR DESCRIPTION
As per title, simply a CI job to test #4361
(in a different pull request, as it is not
clear we want to merge this one).