### PR TITLE
Use run-length encoding for small object free lists

### DIFF
--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -60,7 +60,8 @@ static_assert(sizeof(pool) == Bsize_wsize(POOL_HEADER_WSIZE), "");
 #define POOL_SLAB_WOFFSET(sz) (POOL_HEADER_WSIZE + wastage_sizeclass[sz])
 #define POOL_FIRST_BLOCK(p, sz) ((header_t*)(p) + POOL_SLAB_WOFFSET(sz))
 #define POOL_END(p) ((header_t*)(p) + POOL_WSIZE)
-
+#define POOL_BLOCKS(sz) ((POOL_WSIZE - POOL_HEADER_WSIZE) / \
+                         wsize_sizeclass[sz])
 
 /* Free blocks are combined into adjacent runs. The first free block
    in a run has a header with No_scan_tag and NOT_MARKABLE, and a size
@@ -333,19 +334,19 @@ static void calc_pool_stats(pool* a, sizeclass_t sz, struct heap_stats* s)
   mlsize_t wh = wsize_sizeclass[sz];
   s->pool_frag_words += POOL_SLAB_WOFFSET(sz);
 
-  while (p + wh <= end) {
+  do {
     header_t hd = (header_t)atomic_load_relaxed((atomic_uintnat*)p);
-    if (!POOL_BLOCK_FREE_HD(hd)) {
+    if (POOL_BLOCK_FREE_HD(hd)) {
+      p += wh * Wosize_hd(hd); /* skip contiguous free blocks */
+    } else {
       s->pool_live_words += Whsize_hd(hd);
       s->pool_frag_words += wh - Whsize_hd(hd);
       s->pool_live_blocks++;
-    } else {
-      p += wh * Wosize_hd(hd); /* skip contiguous free blocks */
     }
-
     p += wh;
-  }
+  } while (p < end);
   CAMLassert(end == p);
+
   s->pool_words += POOL_WSIZE;
 }
 
@@ -355,18 +356,17 @@ Caml_inline void pool_initialize(pool* r,
                                  caml_domain_state* owner)
 {
   header_t* p = POOL_FIRST_BLOCK(r, sz);
-  header_t* end = POOL_END(r);
-  uintnat pool_blocks = (end - p) / wsize_sizeclass[sz];
 
   r->next = 0;
   r->owner = owner;
   r->next_obj = (value*)p;
   r->sz = sz;
 
-  p[0] = POOL_FREE_HEADER(pool_blocks-1);
+  p[0] = POOL_FREE_HEADER(POOL_BLOCKS(sz)-1);
   p[1] = 0;
 
 #ifdef DEBUG
+  header_t *end = POOL_END(r);
   for (p += 2; p < end; p++) *p = Debug_free_major;
 #endif
 
@@ -495,7 +495,7 @@ static void* pool_allocate(struct caml_heap_state* local, sizeclass_t sz) {
 
   p = r->next_obj;
   /* assert that p is inside the pool */
-  CAMLassert(p >= (value*)r + POOL_HEADER_WSIZE);
+  CAMLassert(p >= (value*)POOL_FIRST_BLOCK(r, sz));
   CAMLassert(p < (value*)r + POOL_WSIZE);
   CAMLassert(POOL_BLOCK_FREE_HP(p));
 
@@ -512,17 +512,14 @@ static void* pool_allocate(struct caml_heap_state* local, sizeclass_t sz) {
   }
 
   r->next_obj = next;
+
   if (!next) {
     local->avail_pools[sz] = r->next;
     r->next = local->full_pools[sz];
     local->full_pools[sz] = r;
+  } else {
+    CAMLassert(POOL_BLOCK_FREE_HP(next));
   }
-
-  CAMLassert(
-    /* either there's no more free space and we've moved the pool */
-    (r->next_obj == 0 && local->full_pools[sz] == r)
-    /* or there's still free space */
-    || POOL_BLOCK_FREE_HP(r->next_obj));
 
   return p;
 }
@@ -628,9 +625,9 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
 
   {
     header_t* p = POOL_FIRST_BLOCK(a, sz);
-    header_t* last_free_block = NULL;
     const header_t* end = POOL_END(a);
     const mlsize_t wh = wsize_sizeclass[sz];
+    header_t* last_free_block = NULL;
     bool full = true;
     CAMLassert(a->owner == local->owner);
 
@@ -646,15 +643,13 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
       if (Has_status_hd(hd, caml_global_heap_state.GARBAGE)) {
         clear_garbage (p, hd, wh, local);
 
-        /* add to freelist. This could be optimised, we don't need
-        to write the free header if we're going to merge it with a prior
-        free block but it makes this codepath more complex. */
-        *p = POOL_FREE_HEADER(0);
         local->owner->swept_words += Whsize_hd(hd);
         work += wh;
 
-        /* reload hd */
-        hd = POOL_FREE_HEADER(0);
+        /* add to freelist. This could be optimised, we don't need
+        to write the free header if we're going to merge it with a prior
+        free block but it makes this codepath more complex. */
+        *p = hd = POOL_FREE_HEADER(0);
       }
 
       /* If the current block is now free, either merge it with the
@@ -686,8 +681,7 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
           last_free_block = p;
         }
 
-        /* add the free blocks following this block, skipping over them */
-        p += wh * Wosize_hd(hd);
+        p += wh * Wosize_hd(hd); /* skip contiguous free blocks */
       } else {
         /* there's still a live block, the pool can't be released to the global
             freelist */
@@ -695,11 +689,11 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
         work += wh;
       }
       p += wh;
-    }
+    } while (p < end);
     CAMLassert(p == end);
 
     if (full) {
-      CAMLassert(!a->next_obj)
+      CAMLassert(!a->next_obj);
     } else {
       /* the last free block should have 0 as its next pointer */
       last_free_block[1] = 0;
@@ -806,20 +800,26 @@ uintnat caml_heap_blocks(struct caml_heap_state* local) {
   return local->stats.pool_live_blocks + local->stats.large_blocks;
 }
 
+/* TODO: remove this unused function */
+
 void caml_redarken_pool(struct pool* r, scanning_action f, void* fdata) {
-  mlsize_t wh = wsize_sizeclass[r->sz];
   header_t* p = POOL_FIRST_BLOCK(r, r->sz);
   header_t* end = POOL_END(r);
+  mlsize_t wh = wsize_sizeclass[r->sz];
 
-  while (p + wh <= end) {
+  do {
     header_t hd = p[0];
-    if (Has_status_hd(hd, caml_global_heap_state.MARKED)) {
-      f(fdata, Val_hp(p), 0);
+    if (POOL_BLOCK_FREE_HD(hd)) {
+      p += wh * Wosize_hd(hd); /* skip contiguous free blocks */
+    } else {
+      if (Has_status_hd(hd, caml_global_heap_state.MARKED)) {
+        f(fdata, Val_hp(p), 0);
+      }
     }
     p += wh;
-  }
+  } while (p < end);
+  CAMLassert(end == p);
 }
-
 
 /* Heap and freelist stats */
 
@@ -1014,24 +1014,28 @@ uintnat caml_compact_unmap = 0;
 
 /* Checks that all blocks in a pool have the right size class,
  * and (optionally) whether the pool is full. */
-static void compact_debug_check_pools(pool* p, bool full)
+static void compact_debug_check_pools(pool* pool, bool full)
 {
-  while (p) {
+  while (pool) {
     /* go through each block and check the size is sz */
-    header_t* block = POOL_FIRST_BLOCK(p, p->sz);
-    header_t* end = POOL_END(p);
+    header_t* p = POOL_FIRST_BLOCK(pool, pool->sz);
+    header_t* end = POOL_END(pool);
+    mlsize_t wh = wsize_sizeclass[pool->sz];
 
-    while (block < end) {
-      CAMLassert (*block || !full);
-      if (*block) {
-        sizeclass_t sz = sizeclass_wsize[Whsize_hd(*block)];
-        CAMLassert(sz == p->sz);
+    do {
+      header_t hd = Hd_hp(p);
+      if (POOL_BLOCK_FREE_HD(hd)) {
+        CAMLassert(!full);
+        p += wh * Wosize_hd(hd); /* skip contiguous free blocks */
+      } else {
+        sizeclass_t sz = sizeclass_wsize[Whsize_hd(hd)];
+        CAMLassert(sz == pool->sz);
       }
+      p += wh;
+    } while (p < end);
+    CAMLassert(end == p);
 
-      block += wsize_sizeclass[p->sz];
-    }
-
-    p = p->next;
+    pool = pool->next;
   }
 }
 
@@ -1191,17 +1195,19 @@ static void compact_update_pools(pool *cur_pool)
     header_t* end = POOL_END(cur_pool);
     mlsize_t wh = wsize_sizeclass[cur_pool->sz];
 
-    while (p + wh <= end) {
-      if (!POOL_BLOCK_FREE_HP(p)) {
-        if (Has_status_val(Val_hp(p), caml_global_heap_state.UNMARKED)) {
+    do {
+      header_t hd = Hd_hp(p);
+      if (POOL_BLOCK_FREE_HD(hd)) {
+        p += wh * Wosize_hd(hd); /* skip contiguous free blocks */
+      } else {
+        if (Has_status_hd(hd, caml_global_heap_state.UNMARKED)) {
           compact_update_block(p);
         }
-      } else {
-        /* Skip over free blocks */
-        p += wh * Wosize_hp(p);
       }
       p += wh;
-    }
+    } while (p < end);
+    CAMLassert(end == p);
+
     cur_pool = cur_pool->next;
   }
 }
@@ -1383,25 +1389,23 @@ static void compact_algorithm_52(caml_domain_state* domain_state,
       pool_stats[k].free_blocks = 0;
       pool_stats[k].live_blocks = 0;
 
-      while (p + wh <= end) {
-        header_t h = (header_t)atomic_load_relaxed((atomic_uintnat*)p);
+      do {
+        header_t hd = (header_t)atomic_load_relaxed((atomic_uintnat*)p);
 
-        if (POOL_BLOCK_FREE_HD(h)) {
-          /* this tells us the number of spaces of size wh after this */
-          mlsize_t wosize = Wosize_hd(h);
-
-          pool_stats[k].free_blocks += wosize + 1;
+        if (POOL_BLOCK_FREE_HD(hd)) {
+          mlsize_t wosize = Wosize_hd(hd);
+          pool_stats[k].free_blocks += (wosize + 1);
 #ifdef DEBUG
-          total_free_blocks += wosize + 1;
+          total_free_blocks += (wosize + 1);
 #endif
-          /* skip to the next block */
-          p += wh * wosize;
-        } else if (Has_status_hd(h, caml_global_heap_state.UNMARKED)) {
+          p += wh * wosize; /* skip contiguous free blocks */
+        } else if (Has_status_hd(hd, caml_global_heap_state.UNMARKED)) {
           total_live_blocks++;
           pool_stats[k].live_blocks++;
         }
         p += wh;
-      }
+      } while (p < end);
+      CAMLassert(end == p);
 
       cur_pool = cur_pool->next;
       k++;
@@ -1460,10 +1464,12 @@ static void compact_algorithm_52(caml_domain_state* domain_state,
       header_t* end = POOL_END(cur_pool);
       mlsize_t wh = wsize_sizeclass[sz_class];
 
-      while (p + wh <= end) {
+      do {
         header_t hd = (header_t)atomic_load_relaxed((atomic_uintnat*)p);
 
-        if (!POOL_BLOCK_FREE_HD(hd)) {
+        if (POOL_BLOCK_FREE_HD(hd)) {
+          p += wh * Wosize_hd(hd); /* skip contiguous free blocks */
+        } else {
           CAMLassert (!Has_status_hd(hd, caml_global_heap_state.MARKED));
           CAMLassert (!Has_status_hd(hd, NOT_MARKABLE));
 
@@ -1515,14 +1521,11 @@ static void compact_algorithm_52(caml_domain_state* domain_state,
           } else if (Has_status_hd(hd, caml_global_heap_state.GARBAGE)) {
             clear_garbage(p, hd, wh, heap);
           }
-        } else {
-          /* This tells us the number of spaces of size whsize after this */
-          mlsize_t wosize = Wosize_hd(hd);
-          p += wosize * wh;
         }
-
         p += wh;
-      }
+      } while (p < end);
+      CAMLassert(end == p);
+
       /* move pool to evacuated pools list, continue to next pool */
       pool *next = cur_pool->next;
       cur_pool->next = evacuated_pools;
@@ -1694,24 +1697,43 @@ void compact_phase_one_mark(struct caml_heap_state* heap)
     while (cur_pool) {
       header_t* p = POOL_FIRST_BLOCK(cur_pool, sz_class);
       header_t* end = POOL_END(cur_pool);
+      header_t* last_end = NULL;
+      header_t* last_free = NULL;
 
-      while (p + wh <= end) {
-        header_t h = (header_t)atomic_load_relaxed((atomic_uintnat*)p);
-        /* A zero header indicates an empty space */
-        if (h) {
-          if (Has_status_hd(h, caml_global_heap_state.UNMARKED)) {
+      do {
+        header_t hd = (header_t)atomic_load_relaxed((atomic_uintnat*)p);
+        if (Has_status_hd(hd, caml_global_heap_state.GARBAGE)) {
+          /* Free GARBAGE block so it can be evacuated into. */
+          clear_garbage(p, hd, wh, heap);
+          *p = hd = POOL_FREE_HEADER(0);
+        }
+        if (POOL_BLOCK_FREE_HD(hd)) {
+          mlsize_t free_blocks = Wosize_hd(hd) + 1;
+          if (p == last_end) { /* contiguous with previous run */
+            *last_free = POOL_FREE_HEADER(Wosize_hp(last_free) + free_blocks);
+            last_end += free_blocks * wh;
+          } else { /* Not contiguous with preceding run */
+            if (last_free) {
+              last_free[1] = (header_t)p;
+            } else {
+              cur_pool->next_obj = (value*)p;
+            }
+            last_free = p;
+            last_end = p + free_blocks * wh;
+          }
+          p = last_end;
+        } else {
+          if (Has_status_hd(hd, caml_global_heap_state.UNMARKED)) {
             /* Count UNMARKED (live) block */
             total_live_blocks++;
-          } else if (Has_status_hd(h, caml_global_heap_state.GARBAGE)) {
-            /* Free GARBAGE block so it can be evacuated into. */
-            clear_garbage(p, h, wh, heap);
-            atomic_store_relaxed((atomic_uintnat *)p, 0);
-            p[1] = (value)cur_pool->next_obj;
-            cur_pool->next_obj = (value *)p;
           }
+          p += wh;
         }
-        p += wh;
-      }
+      } while (p < end);
+      CAMLassert(end == p);
+      CAMLassert(last_free != NULL); /* in an avail_pool, something must be free */
+      last_free[1] = (header_t)NULL;
+
       cur_pool = cur_pool->next;
     }
 
@@ -2070,11 +2092,11 @@ void compact_run_phase(struct caml_heap_state* heap,
       header_t* end = POOL_END(evac_pool);
       mlsize_t wh = wsize_sizeclass[sz_class];
 
-      while (p + wh <= end) {
+      do {
         header_t hd = (header_t)atomic_load_relaxed((atomic_uintnat*)p);
-
-        /* A zero header indicates an empty space */
-        if (hd) {
+        if (POOL_BLOCK_FREE_HD(hd)) {
+          p += wh * Wosize_hd(hd); /* skip contiguous free blocks */
+        } else {
           CAMLassert (!Has_status_hd(hd, caml_global_heap_state.MARKED));
           CAMLassert (!Has_status_hd(hd, NOT_MARKABLE));
 
@@ -2082,7 +2104,7 @@ void compact_run_phase(struct caml_heap_state* heap,
           if (Has_status_hd(hd, caml_global_heap_state.UNMARKED)) {
             /* live block in an evacuating pool, */
 
-            /* Find a slot to evacuate it to. */
+            /* Find a pool to evacuate it to. */
             while ((to_pool == NULL) || (to_pool->next_obj == NULL)) {
               if (to_pool) {
                 /* No block left in to_pool */
@@ -2095,9 +2117,15 @@ void compact_run_phase(struct caml_heap_state* heap,
               }
             }
 
-            /* pop free slot off free list */
+            /* Get free slot from to_pool free list */
             value* new_p = to_pool->next_obj;
+            mlsize_t run_length = Wosize_hp(new_p);
             value *next = (value*)new_p[1];
+            if (run_length > 0) {
+              next = new_p + wh;
+              next[0] = POOL_FREE_HEADER(run_length - 1);
+              next[1] = new_p[1];
+            }
             to_pool->next_obj = next;
 
             /* Copy the block to the new location */
@@ -2112,13 +2140,13 @@ void compact_run_phase(struct caml_heap_state* heap,
             header_t new_hd = With_status_hd(hd, caml_global_heap_state.MARKED);
             atomic_store_relaxed((atomic_uintnat*)p, new_hd);
           } else if (Has_status_hd(hd, caml_global_heap_state.GARBAGE)) {
-            /* Process with garbage as we are implicitly sweeping this pool */
+            /* Process garbage as we are implicitly sweeping this pool */
             clear_garbage(p, hd, wh, heap);
           }
         }
-
         p += wh;
-      }
+      } while (p < end);
+      CAMLassert(end == p);
 
       evac_pool = evac_pool->next;
     }
@@ -2337,29 +2365,27 @@ static void verify_pool(pool* a, sizeclass_t sz, struct mem_stats* s) {
     mlsize_t wh = wsize_sizeclass[sz];
     s->overhead += POOL_SLAB_WOFFSET(sz);
 
-    while (p + wh <= end) {
+    do {
       /* This header can be read here and concurrently marked by the GC, but
          this is fine: marking can only turn UNMARKED objects into MARKED or
          NOT_MARKABLE, which is of no consequence for this verification
          (namely, that there is no garbage left). */
       header_t hd = Hd_hp(p);
-      CAMLassert(
-        POOL_BLOCK_FREE_HD(hd) ||
-          !Has_status_hd(hd, caml_global_heap_state.GARBAGE)
-      );
-      if (!POOL_BLOCK_FREE_HD(hd)) {
-        s->live += Whsize_hd(hd);
-        s->overhead += wh - Whsize_hd(hd);
-        s->live_blocks++;
-      } else {
+      if (POOL_BLOCK_FREE_HD(hd)) {
         /* count the free block and any that follow it (stored in the
            size bits in the header)*/
         s->free += wh * (1 + Wosize_hd(hd));
-        p += Wosize_hd(hd) * wh;
+        p += wh * Wosize_hd(hd); /* skip contiguous free blocks */
+      } else {
+        CAMLassert(!Has_status_hd(hd, caml_global_heap_state.GARBAGE));
+        s->live += Whsize_hd(hd);
+        s->overhead += wh - Whsize_hd(hd);
+        s->live_blocks++;
       }
       p += wh;
-    }
+    } while (p < end);
     CAMLassert(end == p);
+
     s->alloced += POOL_WSIZE;
   }
 }


### PR DESCRIPTION
This is a port of ocaml/ocaml#13616 to the OxCaml tree, which is needed to accurately account for work during sweeping (Sweeping already-free blocks should not count towards sweeping "work").

A few parts of the OxCaml-specific compactor needed reworking to handle the RLE free lists.

Since this change touches every loop which iterates over blocks in a pool, I took the opportunity to make all such loops consistent, as far as possible. There are ten such loops in `shared_heap.c`, all of which are touched by the RLE change anyway. They are now consistently like this (with variation on the pool name `a`, and on the line of code which fetches `hd` from `p`):

```
{
  header_t* p = POOL_FIRST_BLOCK(a, sz);
  header_t* end = POOL_END(a);
  mlsize_t wh = wsize_sizeclass[a->sz];

  do {
    header_t hd = (header_t)atomic_load_relaxed((atomic_uintnat*)p);
    if (POOL_BLOCK_FREE_HD(hd)) {
      p += wh * Wosize_hd(hd); /* skip contiguous free blocks */
    } else {
      // ... 
    }
    p += wh;
  } while (p < end);
  CAMLassert(end == p);
}
```
