### PR TITLE
Ignore alloc mode when comparing types

### DIFF
--- a/middle_end/flambda2/types/equal_types_for_debug.mli
+++ b/middle_end/flambda2/types/equal_types_for_debug.mli
@@ -24,7 +24,12 @@
    {b Note}: The functions operating on levels treat all variables defined by
    the levels as existentials. *)
 
+type config
+
+val create_config : ?ignore_alloc_mode:bool -> unit -> config
+
 val equal_type :
+  ?config:config ->
   meet_type:Meet_env.meet_type ->
   Typing_env.t ->
   Type_grammar.t ->
@@ -32,6 +37,7 @@ val equal_type :
   bool
 
 val equal_env_extension :
+  ?config:config ->
   meet_type:Meet_env.meet_type ->
   Typing_env.t ->
   Typing_env_extension.t ->
@@ -39,6 +45,7 @@ val equal_env_extension :
   bool
 
 val names_with_non_equal_types_env_extension :
+  ?config:config ->
   meet_type:Meet_env.meet_type ->
   Typing_env.t ->
   Typing_env_extension.t ->
@@ -46,6 +53,7 @@ val names_with_non_equal_types_env_extension :
   Name.Set.t
 
 val equal_level_ignoring_name_mode :
+  ?config:config ->
   meet_type:Meet_env.meet_type ->
   Typing_env.t ->
   Typing_env_level.t ->
@@ -53,6 +61,7 @@ val equal_level_ignoring_name_mode :
   bool
 
 val names_with_non_equal_types_level_ignoring_name_mode :
+  ?config:config ->
   meet_type:Meet_env.meet_type ->
   Typing_env.t ->
   Typing_env_level.t ->

--- a/middle_end/flambda2/types/join_levels.ml
+++ b/middle_end/flambda2/types/join_levels.ml
@@ -80,9 +80,12 @@ let cut_and_n_way_join definition_typing_env ts_and_use_ids ~params ~cut_after
         ~extra_lifted_consts_in_use_envs
     in
     let new_joined_level = TE.cut new_joined_env ~cut_after:scope in
-    (let distinct_names =
+    (let config =
+       Equal_types_for_debug.create_config ~ignore_alloc_mode:true ()
+     in
+     let distinct_names =
        Equal_types_for_debug.names_with_non_equal_types_level_ignoring_name_mode
-         ~meet_type:(Meet.meet_type ()) typing_env old_joined_level
+         ~config ~meet_type:(Meet.meet_type ()) typing_env old_joined_level
          new_joined_level
      in
      let distinct_names =


### PR DESCRIPTION
This is a source of spurious differences between the old and new join (the new join being better about tracking this).