### PR TITLE
chore: Add Reg_width_const.is_null

### DIFF
--- a/middle_end/flambda2/identifiers/reg_width_const.ml
+++ b/middle_end/flambda2/identifiers/reg_width_const.ml
@@ -32,6 +32,8 @@ let of_descr (descr : Descr.t) =
   | Naked_vec512 v -> naked_vec512 v
   | Null -> const_null
 
+let is_null t = equal t const_null
+
 let is_naked_immediate t =
   match descr t with
   | Naked_immediate i -> Some i

--- a/middle_end/flambda2/identifiers/reg_width_const.mli
+++ b/middle_end/flambda2/identifiers/reg_width_const.mli
@@ -22,6 +22,8 @@ end
 
 val of_descr : Descr.t -> t
 
+val is_null : t -> bool
+
 val is_naked_immediate : t -> Targetint_31_63.t option
 
 val is_tagged_immediate : t -> Targetint_31_63.t option


### PR DESCRIPTION
Returns a boolean instead of an option because there is only one null constant.