### PR TITLE
Use correct C compilation flags for otherlibs and external

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL = /usr/bin/env bash
-include Makefile.config
+ROOTDIR = .
+include Makefile.build_config
 export ARCH
 
 boot_ocamlc = main_native.exe

--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -22,7 +22,15 @@ define dune_boot_context
   (profile dev)
   (env (_
     (flags (:standard -warn-error +A -alert -unsafe_multidomain))
-    (env-vars ("OCAMLPARAM" ""))))))
+    (env-vars
+      ("OCAMLPARAM" "")
+
+      ; Avoid using the full OC_CFLAGS for C code compiled during the boot
+      ; In particular, we should avoid using ASan here even if it is otherwise
+      ; enabled, since (a) it is of little benefit, because it has no effect
+      ; on the final compiler, and (b) it breaks, because linking is missing
+      ; the matching -fsanitize=address flag
+      ("OC_CFLAGS_SEXP" "boot_oc_cflags.sexp"))))))
 endef
 
 ifneq ($(origin BUILD_OCAMLPARAM), undefined)
@@ -164,6 +172,7 @@ _build/_bootinstall: Makefile.config $(dune_config_targets)
 
 # flags.sexp
 	echo '(:standard $(if $(filter true,$(FUNCTION_SECTIONS)),-function-sections,))' > ocamlopt_flags.sexp
+	echo '( )' > boot_oc_cflags.sexp
 	echo '( $(OC_CFLAGS) )' > oc_cflags.sexp
 	echo '( $(OC_CPPFLAGS) )' > oc_cppflags.sexp
 	echo '( $(SHAREDLIB_CFLAGS) )' > sharedlib_cflags.sexp
@@ -478,4 +487,3 @@ boot-_install: runtime-stdlib
 	find _build/default/ \( -name "flambda2*.cmi" \
           -or -name "flambda2*.cmti" -or -name "flambda2*.cmt" \) \
           -print0 | xargs -0 -I '{}' cp -f '{}' _install/lib/ocaml/compiler-libs
-

--- a/external/gc-timings/dune
+++ b/external/gc-timings/dune
@@ -4,7 +4,7 @@
   (language c)
   (names gc_timings_stubs)
   (flags
-   ((:include %{project_root}/oc_cflags.sexp)
+   ((:include %{project_root}/%{env:OC_CFLAGS_SEXP=oc_cflags.sexp})
     (:include %{project_root}/sharedlib_cflags.sexp)
     (:include %{project_root}/oc_cppflags.sexp))))
  (synopsis "OCaml library to extract timing information from the GC"))

--- a/external/gc-timings/gc_timings_stubs.c
+++ b/external/gc-timings/gc_timings_stubs.c
@@ -62,19 +62,19 @@ int64_t time_counter(void)
 int64_t caml_timing_major_gc = 0.;
 int64_t caml_timing_minor_gc = 0.;
 
-void caml_timing_collect_gc_minor_begin_hook() {
+void caml_timing_collect_gc_minor_begin_hook(void) {
   caml_timing_minor_gc -= time_counter();
 }
 
-void caml_timing_collect_gc_minor_end_hook() {
+void caml_timing_collect_gc_minor_end_hook(void) {
   caml_timing_minor_gc += time_counter();
 }
 
-void caml_timing_collect_gc_major_begin_hook() {
+void caml_timing_collect_gc_major_begin_hook(void) {
   caml_timing_major_gc -= time_counter();
 }
 
-void caml_timing_collect_gc_major_end_hook() {
+void caml_timing_collect_gc_major_end_hook(void) {
   caml_timing_major_gc += time_counter();
 }
 

--- a/external/owee/dune
+++ b/external/owee/dune
@@ -6,7 +6,7 @@
   (language c)
   (names owee_stubs)
   (flags
-   ((:include %{project_root}/oc_cflags.sexp)
+   ((:include %{project_root}/%{env:OC_CFLAGS_SEXP=oc_cflags.sexp})
     (:include %{project_root}/sharedlib_cflags.sexp)
     (:include %{project_root}/oc_cppflags.sexp))))
  (synopsis "OCaml library to work with DWARF format"))

--- a/external/owee/owee_stubs.c
+++ b/external/owee/owee_stubs.c
@@ -2,16 +2,16 @@
 #include <stdio.h>
 #include <string.h>
 
-#define CAML_INTERNALS
-
 #include <caml/version.h>
+#if OCAML_VERSION >= 41200
+#define CAML_INTERNALS
+#include <caml/codefrag.h>
+#undef CAML_INTERNALS
+#endif
 #include <caml/alloc.h>
 #include <caml/memory.h>
 #include <caml/bigarray.h>
 #include <caml/address_class.h>
-#if OCAML_VERSION >= 41200
-#include <caml/codefrag.h>
-#endif
 
 /* Use dladdr. Should work at least with Linux, FreeBSD and OS X. */
 #define _GNU_SOURCE

--- a/middle_end/flambda2/algorithms/dune
+++ b/middle_end/flambda2/algorithms/dune
@@ -8,7 +8,7 @@
   (language c)
   (names builtin_stubs)
   (flags
-   ((:include %{project_root}/oc_cflags.sexp)
+   ((:include %{project_root}/%{env:OC_CFLAGS_SEXP=oc_cflags.sexp})
     (:include %{project_root}/sharedlib_cflags.sexp)
     (:include %{project_root}/oc_cppflags.sexp))))
  (ocamlopt_flags

--- a/middle_end/flambda2/numbers/floats/dune
+++ b/middle_end/flambda2/numbers/floats/dune
@@ -9,7 +9,7 @@
   (language c)
   (names float32_stubs)
   (flags
-   ((:include %{project_root}/oc_cflags.sexp)
+   ((:include %{project_root}/%{env:OC_CFLAGS_SEXP=oc_cflags.sexp})
     (:include %{project_root}/sharedlib_cflags.sexp)
     (:include %{project_root}/oc_cppflags.sexp))))
  (ocamlopt_flags

--- a/ocamltest/dune
+++ b/ocamltest/dune
@@ -47,9 +47,7 @@
   (language c)
   (names run_unix run_stubs)
   (flags
-   ((-DCAML_INTERNALS)
-    (:include %{project_root}/oc_cflags.sexp)
-    (:include %{project_root}/oc_cppflags.sexp)))))
+   ((-DCAML_INTERNALS)))))
 
 (rule
  (copy main.exe ocamltest.native))

--- a/otherlibs/unix/mmap_ba.c
+++ b/otherlibs/unix/mmap_ba.c
@@ -80,6 +80,7 @@ caml_unix_mapped_alloc(int flags, int num_dims, void * data, intnat * dim)
 #ifdef CAML_RUNTIME_5
   caml_memprof_sample_block(res, mem_words, mem_words, CAML_MEMPROF_SRC_CUSTOM);
 #else
+  (void)mem_words; /* unused in runtime4 */
   caml_memprof_track_custom(res, mem_bytes);
 #endif
   b = Caml_ba_array_val(res);

--- a/otherlibs/unix/signals.c
+++ b/otherlibs/unix/signals.c
@@ -79,12 +79,11 @@ CAMLprim value caml_unix_sigprocmask(value vaction, value vset)
 CAMLprim value caml_unix_sigpending(value unit)
 {
   sigset_t pending;
-  uintnat curr;
   if (sigpending(&pending) == -1) caml_uerror("sigpending", Nothing);
 #ifdef CAML_RUNTIME_5
   /* Add signals which are "pending" in the runtime */
   for (int i = 0; i < NSIG_WORDS; i++) {
-    curr = atomic_load(&caml_pending_signals[i]);
+    uintnat curr = atomic_load(&caml_pending_signals[i]);
     if (curr == 0) continue;
     for (int j = 0; j < BITS_PER_WORD; j++) {
       if (curr & ((uintnat)1 << j)) {


### PR DESCRIPTION
A mistake during the 5.2 merge means that we've been using the wrong C compilation flags for libraries in otherlibs and external for some time, because the `OC_CFLAGS` variable moved from `Makefile.config` to `Makefile.build_config` and we continued looking in the wrong place.

This patch fixes it by updating the location in `Makefile`. This requires a couple of other tweaks in otherlibs, external and ocamltest to make everything build with the correct flags (which in particular, are stricter about prototypes, to the extent that the 4.14.1 headers don't work with `CAML_INTERNALS` defined)

In particular, this patch now means that Unix and Systhreads are compiled with optimisations enabled, which might matter. (Systhreads in runtime4 previously had optimisations enabled, because it was moved to the `runtime4` directory which is not affected by this issue)