### PR TITLE
Improved meet for naked immediates

### DIFF
--- a/middle_end/flambda2/tests/meet_test.expected
+++ b/middle_end/flambda2/tests/meet_test.expected
@@ -260,7 +260,7 @@ after meet: (Val ([0m[38;5;160;1m=[0m [0m[38;5;70;1m0[0m))
 
 MEET BOTTOM AFTER ALIAS
 
-first type: (Val! (Variant (tagged_imms (Naked_immediate ({ -1 0 1 })))))
+first type: (Val! (Variant (tagged_imms (Naked_immediate { -1 0 1 }))))
 second type: (Val ([0m[38;5;160;1m=[0m [0m[38;5;70;1m3[0m))
 after meet: (Val [0m[38;5;37;1m⊥[0m)
 

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1553,7 +1553,8 @@ let rec add_inverse_relation_to_env_extension ?(seen = Name.Set.empty)
   let empty_descr : TG.Head_of_kind_naked_immediate.descr =
     { naked_immediates = Unknown; inverse_relations = TG.Relation.Map.empty }
   in
-  let[@inline] type_from_descr (descr : TG.Head_of_kind_naked_immediate.descr) =
+  let[@inline] updated_type_from_descr
+      (descr : TG.Head_of_kind_naked_immediate.descr) =
     let inverse_relations =
       TG.Relation.Map.update relation
         (function
@@ -1567,7 +1568,8 @@ let rec add_inverse_relation_to_env_extension ?(seen = Name.Set.empty)
   in
   match Name.Map.find_opt name (TEE.to_map env_extension) with
   | None ->
-    TEE.add_or_replace_equation env_extension name (type_from_descr empty_descr)
+    TEE.add_or_replace_equation env_extension name
+      (updated_type_from_descr empty_descr)
   | Some existing_ty -> (
     match TG.descr existing_ty with
     | Naked_immediate Bottom ->
@@ -1578,12 +1580,13 @@ let rec add_inverse_relation_to_env_extension ?(seen = Name.Set.empty)
       (* This should not happen, as we would usually only only store non-obvious
          types in extensions -- but it's also harmless. *)
       TEE.add_or_replace_equation env_extension name
-        (type_from_descr empty_descr)
+        (updated_type_from_descr empty_descr)
     | Naked_immediate (Ok (No_alias head)) ->
       (* There is a concrete type for this name in the extension; augment it
          with the reverse relation. *)
       let descr = TG.Head_of_kind_naked_immediate.descr head in
-      TEE.add_or_replace_equation env_extension name (type_from_descr descr)
+      TEE.add_or_replace_equation env_extension name
+        (updated_type_from_descr descr)
     | Naked_immediate (Ok (Equals simple)) ->
       (* Usually we expect that the name we are adding an alias for would be
          canonical in the env extension, but it could (rarely) happen that it is
@@ -1598,7 +1601,7 @@ let rec add_inverse_relation_to_env_extension ?(seen = Name.Set.empty)
                break the loop to store the non-alias type anywhere, so we might
                as well do it when we detect the loop. *)
             TEE.add_or_replace_equation env_extension name
-              (type_from_descr empty_descr)
+              (updated_type_from_descr empty_descr)
           else
             add_inverse_relation_to_env_extension ~seen:(Name.Set.add name seen)
               env_extension name' relation ~scrutinee)

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1548,10 +1548,174 @@ let join_aliases_into_bindings ~joined_envs ~bindings equations_to_join =
           in
           equations_to_join, bindings))
 
+let rec add_inverse_relation_to_env_extension ?(seen = Name.Set.empty)
+    env_extension name relation ~scrutinee =
+  let empty_descr : TG.Head_of_kind_naked_immediate.descr =
+    { naked_immediates = Unknown; inverse_relations = TG.Relation.Map.empty }
+  in
+  let[@inline] type_from_descr (descr : TG.Head_of_kind_naked_immediate.descr) =
+    let inverse_relations =
+      TG.Relation.Map.update relation
+        (function
+          | None -> Some (Name.Set.singleton scrutinee)
+          | Some existing_args -> Some (Name.Set.add scrutinee existing_args))
+        descr.inverse_relations
+    in
+    TG.create_from_head_naked_immediate
+      (TG.Head_of_kind_naked_immediate.from_descr_non_empty
+         { descr with inverse_relations })
+  in
+  match Name.Map.find_opt name (TEE.to_map env_extension) with
+  | None ->
+    TEE.add_or_replace_equation env_extension name (type_from_descr empty_descr)
+  | Some existing_ty -> (
+    match TG.descr existing_ty with
+    | Naked_immediate Bottom ->
+      (* If we already know that we are bottom, we don't need to store anything
+         more precise. *)
+      env_extension
+    | Naked_immediate Unknown ->
+      (* This should not happen, as we would usually only only store non-obvious
+         types in extensions -- but it's also harmless. *)
+      TEE.add_or_replace_equation env_extension name
+        (type_from_descr empty_descr)
+    | Naked_immediate (Ok (No_alias head)) ->
+      (* There is a concrete type for this name in the extension; augment it
+         with the reverse relation. *)
+      let descr = TG.Head_of_kind_naked_immediate.descr head in
+      TEE.add_or_replace_equation env_extension name (type_from_descr descr)
+    | Naked_immediate (Ok (Equals simple)) ->
+      (* Usually we expect that the name we are adding an alias for would be
+         canonical in the env extension, but it could (rarely) happen that it is
+         not the case. We simply follow the aliases until we either find one
+         that has a concrete type in the extension, or until we detect a
+         loop. *)
+      Simple.pattern_match simple
+        ~name:(fun name' ~coercion:_ ->
+          if Name.Set.mem name' seen
+          then
+            (* There is an alias loop in the env extension -- it is fine to
+               break the loop to store the non-alias type anywhere, so we might
+               as well do it when we detect the loop. *)
+            TEE.add_or_replace_equation env_extension name
+              (type_from_descr empty_descr)
+          else
+            add_inverse_relation_to_env_extension ~seen:(Name.Set.add name seen)
+              env_extension name' relation ~scrutinee)
+        ~const:(fun _ ->
+          (* We do not store reverse relations on constants as that would be
+             both expensive and of dubious use. *)
+          env_extension)
+    | Value _ | Naked_float32 _ | Naked_float _ | Naked_int8 _ | Naked_int16 _
+    | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _ | Naked_vec128 _
+    | Naked_vec256 _ | Naked_vec512 _ | Rec_info _ | Region _ ->
+      Misc.fatal_error "Kind mismatch for output of relation: expected %a")
+
+let add_to_inverse_relations inverse_relations name relation ~scrutinee =
+  Name.Map.union_total_shared
+    (fun _ inv_rels1 inv_rels2 ->
+      TG.Relation.Map.union_total_shared
+        (fun _ names1 names2 -> Name.Set.union names1 names2)
+        inv_rels1 inv_rels2)
+    inverse_relations
+    (Name.Map.singleton name
+       (TG.Relation.Map.singleton relation (Name.Set.singleton scrutinee)))
+
+let recover_inverse_relations inverse_relations name ty =
+  match TG.descr ty with
+  | Value (Ok (No_alias { is_null = Not_null; non_null = Ok head })) -> (
+    match head with
+    | Variant { immediates = Known imm_ty; get_tag = Some get_tag_var; _ }
+      when TG.is_obviously_bottom imm_ty ->
+      (* If we have no immediates, we can add the inverse relation on [get_tag]
+         at the toplevel. *)
+      let inverse_relations =
+        add_to_inverse_relations inverse_relations (Name.var get_tag_var)
+          TG.Relation.get_tag ~scrutinee:name
+      in
+      ty, inverse_relations
+    | Variant
+        { is_int;
+          get_tag;
+          immediates = (Known _ | Unknown) as immediates;
+          blocks;
+          extensions;
+          is_unique
+        } ->
+      (* In the general case, we must store the [Get_tag] equation inside the
+         "block" env extension. This is because storing a [Get_tag] reverse
+         relation on a naked immediate allows us to perform a reduction to learn
+         that the target of the relation is a block, which is not valid if it
+         could be an immediate. *)
+      let inverse_relations =
+        match is_int with
+        | None -> inverse_relations
+        | Some is_int_var ->
+          add_to_inverse_relations inverse_relations (Name.var is_int_var)
+            TG.Relation.is_int ~scrutinee:name
+      in
+      let ty =
+        match get_tag with
+        | None -> ty
+        | Some get_tag_var ->
+          let when_immediate, when_block =
+            match extensions with
+            | No_extensions -> TEE.empty, TEE.empty
+            | Ext { when_immediate; when_block } -> when_immediate, when_block
+          in
+          let when_block =
+            add_inverse_relation_to_env_extension when_block
+              (Name.var get_tag_var) TG.Relation.get_tag ~scrutinee:name
+          in
+          let head' =
+            TG.Head_of_kind_value_non_null.create_variant ~is_unique ~blocks
+              ~immediates
+              ~extensions:(Ext { when_immediate; when_block })
+              ~is_int ~get_tag
+          in
+          TG.create_from_head_value { is_null = Not_null; non_null = Ok head' }
+      in
+      ty, inverse_relations
+    | Mutable_block _
+    | Boxed_float32 (_, _)
+    | Boxed_float (_, _)
+    | Boxed_int32 (_, _)
+    | Boxed_int64 (_, _)
+    | Boxed_nativeint (_, _)
+    | Boxed_vec128 (_, _)
+    | Boxed_vec256 (_, _)
+    | Boxed_vec512 (_, _)
+    | Closures _ | String _ | Array _ ->
+      ty, inverse_relations)
+  | Value (Ok (No_alias { is_null = Maybe_null { is_null }; non_null = _ })) ->
+    (* CR bclement: if we are possibly null, we can't recover inverse relations
+       from the non-null case because we don't have an appropriate env extension
+       to place them in.
+
+       We can't store them directly in the env for the same reason we can't do
+       it for [Get_tag], see the comment for the [Variant] case. *)
+    let inverse_relations =
+      match is_null with
+      | None -> inverse_relations
+      | Some is_null_var ->
+        add_to_inverse_relations inverse_relations (Name.var is_null_var)
+          TG.Relation.is_null ~scrutinee:name
+    in
+    ty, inverse_relations
+  | Value
+      ( Ok
+          ( Equals _
+          | No_alias { is_null = Not_null; non_null = Unknown | Bottom } )
+      | Unknown | Bottom )
+  | Naked_immediate _ | Naked_float32 _ | Naked_float _ | Naked_int8 _
+  | Naked_int16 _ | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _
+  | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Rec_info _ | Region _ ->
+    ty, inverse_relations
+
 let n_way_join_round ~(n_way_join_type : n_way_join_type) t equations_to_join
-    types_in_target_env =
+    types_in_target_env inverse_relations =
   Name_in_target_env.Map.fold
-    (fun name types (types_in_target_env, t) ->
+    (fun name types (types_in_target_env, inverse_relations, t) ->
       if
         Flambda_features.check_light_invariants ()
         && Name_in_target_env.Map.mem name types_in_target_env
@@ -1565,11 +1729,17 @@ let n_way_join_round ~(n_way_join_type : n_way_join_type) t equations_to_join
             : (Index.t * Type_in_one_joined_env.t) list
             :> (Index.t * TG.t) list)
       with
-      | Unknown, t -> types_in_target_env, t
+      | Unknown, t -> types_in_target_env, inverse_relations, t
       | Known ty, t ->
+        let ty, inverse_relations =
+          recover_inverse_relations inverse_relations (name :> Name.t) ty
+        in
         let ty = Type_in_target_env.create ty in
-        Name_in_target_env.Map.add name ty types_in_target_env, t)
-    equations_to_join (types_in_target_env, t)
+        ( Name_in_target_env.Map.add name ty types_in_target_env,
+          inverse_relations,
+          t ))
+    equations_to_join
+    (types_in_target_env, inverse_relations, t)
 
 (** {2:n-way-join Cut and n-way join} *)
 
@@ -1671,17 +1841,27 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
       Name_in_target_env.Map.disjoint_union concrete_equations_to_join
         (equations_for_bindings bindings ~since:empty_bindings)
     in
-    let rec loop t equations_to_join concrete_types_in_target_env =
+    let rec loop t equations_to_join concrete_types_in_target_env
+        inverse_relations =
       let bindings_before_this_round = t.bindings in
-      let types_in_target_env, t =
+      let types_in_target_env, inverse_relations, t =
         n_way_join_round ~n_way_join_type t equations_to_join
-          concrete_types_in_target_env
+          concrete_types_in_target_env inverse_relations
       in
       let new_equations_to_join =
         equations_for_bindings t.bindings ~since:bindings_before_this_round
       in
       if Name_in_target_env.Map.is_empty new_equations_to_join
       then
+        let env_extension_for_inverse_relations =
+          TEE.from_map
+            (Name.Map.map
+               (fun inverse_relations ->
+                 TG.create_from_head_naked_immediate
+                   (TG.Head_of_kind_naked_immediate.create_inverse_relations
+                      inverse_relations))
+               inverse_relations)
+        in
         ( (* We compute symbol projections last so that we can pick up
              existential variables, but there is no need to create existential
              variables from symbol projections since they would not be
@@ -1689,14 +1869,19 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
 
              CR-someday bclement: perform CSE for symbol projections? *)
           types_in_target_env,
+          env_extension_for_inverse_relations,
           n_way_join_symbol_projections t symbol_projections_to_join,
           t.bindings )
-      else loop t new_equations_to_join types_in_target_env
+      else loop t new_equations_to_join types_in_target_env inverse_relations
     in
-    let equations, symbol_projections, bindings =
+    let ( equations,
+          env_extension_for_inverse_relations,
+          symbol_projections,
+          bindings ) =
       loop { joined_envs; bindings } equations_to_join
         (Name_in_target_env.from_source_env_map
            (Bindings_in_target_env.alias_types_in_target_env bindings))
+        Name.Map.empty
     in
     let target_env =
       Bindings_in_target_env.fold_created_variables
@@ -1712,6 +1897,10 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
            (equations
              : Type_in_target_env.t Name_in_target_env.Map.t
              :> TG.t Name.Map.t))
+    in
+    let target_env =
+      ME.add_env_extension ~meet_type target_env
+        env_extension_for_inverse_relations
     in
     let target_env =
       Variable_in_target_env.Map.fold
@@ -2219,9 +2408,11 @@ let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head t extensions :
          join of env extensions, we might need additional rounds for
          completeness (see comment in [n_way_join_simples]) -- in practice one
          round should be plenty. *)
-      let equations, { bindings = bindings_after_extension; _ } =
+      let ( equations,
+            _env_extension_for_inverse_relations,
+            { bindings = bindings_after_extension; _ } ) =
         n_way_join_round ~n_way_join_type { joined_envs; bindings }
-          concrete_types_to_join alias_types_in_target_env
+          concrete_types_to_join alias_types_in_target_env Name.Map.empty
       in
       (* It is possible for the call to [add_env_extension] in
          [prepare_nested_join] above to create new variables, which do not exist

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1899,7 +1899,7 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
              :> TG.t Name.Map.t))
     in
     let target_env =
-      ME.add_env_extension ~meet_type target_env
+      ME.add_env_extension ~meet_expanded_head target_env
         env_extension_for_inverse_relations
     in
     let target_env =

--- a/middle_end/flambda2/types/equal_types_for_debug.ml
+++ b/middle_end/flambda2/types/equal_types_for_debug.ml
@@ -313,16 +313,18 @@ let equal_head_of_kind_value ~equal_type env (t1 : TG.head_of_kind_value)
       (equal_head_of_kind_value_non_null ~equal_type env)
       t1.non_null t2.non_null
 
-let equal_head_of_kind_naked_immediate ~equal_type env
+let equal_head_of_kind_naked_immediate ~equal_type:_ _env
     (t1 : TG.head_of_kind_naked_immediate)
     (t2 : TG.head_of_kind_naked_immediate) =
-  match t1, t2 with
-  | Naked_immediates is1, Naked_immediates is2 ->
-    Target_ocaml_int.Set.equal is1 is2
-  | Is_int t1, Is_int t2 -> equal_type env t1 t2
-  | Get_tag t1, Get_tag t2 -> equal_type env t1 t2
-  | Is_null t1, Is_null t2 -> equal_type env t1 t2
-  | (Naked_immediates _ | Is_int _ | Get_tag _ | Is_null _), _ -> false
+  match
+    ( TG.Head_of_kind_naked_immediate.descr t1,
+      TG.Head_of_kind_naked_immediate.descr t2 )
+  with
+  | ( { naked_immediates = is1; inverse_relations = rs1 },
+      { naked_immediates = is2; inverse_relations = rs2 } ) ->
+    (* CR bclement: reduce names to their canonicals *)
+    Or_unknown.equal Target_ocaml_int.Set.equal is1 is2
+    && TG.Relation.Map.equal Name.Set.equal rs1 rs2
 
 let equal_head_of_kind_naked_float32 (t1 : TG.head_of_kind_naked_float32)
     (t2 : TG.head_of_kind_naked_float32) =

--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -16,18 +16,18 @@
 
 module Typing_env = struct
   include Typing_env
-  open Meet_env
+  module ME = Meet_env
 
   let add_equation t name ty =
-    add_equation t name ty ~meet_expanded_head:(Meet.meet_expanded_head ())
+    ME.add_equation t name ty ~meet_expanded_head:(Meet.meet_expanded_head ())
 
   let add_equation_on_simple t simple ty =
-    add_equation_on_simple t simple ty
+    ME.add_equation_on_simple t simple ty
       ~meet_expanded_head:(Meet.meet_expanded_head ())
 
   let add_is_null_relation t name ~scrutinee =
     let machine_width = machine_width t in
-    use_meet_env t ~f:(fun t ->
+    ME.use_meet_env t ~f:(fun t ->
         let t =
           add_equation t name (Type_grammar.is_null ~machine_width ~scrutinee)
         in
@@ -44,7 +44,7 @@ module Typing_env = struct
 
   let add_is_int_relation t name ~scrutinee =
     let machine_width = machine_width t in
-    use_meet_env t ~f:(fun t ->
+    ME.use_meet_env t ~f:(fun t ->
         let t =
           add_equation t name
             (Type_grammar.is_int_for_scrutinee ~machine_width ~scrutinee)
@@ -66,7 +66,7 @@ module Typing_env = struct
             add_equation_on_simple t scrutinee scrutinee_ty))
 
   let add_get_tag_relation t name ~scrutinee =
-    use_meet_env t ~f:(fun t ->
+    ME.use_meet_env t ~f:(fun t ->
         let t =
           add_equation t name (Type_grammar.get_tag_for_block ~block:scrutinee)
         in
@@ -90,21 +90,21 @@ module Typing_env = struct
             add_equation_on_simple t scrutinee scrutinee_ty))
 
   let add_equation t name ty =
-    use_meet_env t ~f:(fun t -> add_equation t name ty)
+    ME.use_meet_env t ~f:(fun t -> add_equation t name ty)
 
   let add_equations_on_params t ~params ~param_types =
-    use_meet_env t ~f:(fun t ->
-        add_equations_on_params t ~params ~param_types
+    ME.use_meet_env t ~f:(fun t ->
+        ME.add_equations_on_params t ~params ~param_types
           ~meet_expanded_head:(Meet.meet_expanded_head ()))
 
   let add_env_extension t extension =
-    use_meet_env t ~f:(fun t ->
-        add_env_extension t extension
+    ME.use_meet_env t ~f:(fun t ->
+        ME.add_env_extension t extension
           ~meet_expanded_head:(Meet.meet_expanded_head ()))
 
   let add_env_extension_with_extra_variables t extension =
-    use_meet_env t ~f:(fun t ->
-        add_env_extension_with_extra_variables t extension
+    ME.use_meet_env t ~f:(fun t ->
+        ME.add_env_extension_with_extra_variables t extension
           ~meet_expanded_head:(Meet.meet_expanded_head ()))
 
   module Alias_set = Aliases.Alias_set

--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -26,8 +26,11 @@ module Typing_env = struct
       ~meet_expanded_head:(Meet.meet_expanded_head ())
 
   let add_is_null_relation t name ~scrutinee =
+    let machine_width = machine_width t in
     use_meet_env t ~f:(fun t ->
-        let t = add_equation t name (Type_grammar.is_null ~scrutinee) in
+        let t =
+          add_equation t name (Type_grammar.is_null ~machine_width ~scrutinee)
+        in
         Name.pattern_match name
           ~symbol:(fun _ -> t)
           ~var:(fun var ->
@@ -40,9 +43,11 @@ module Typing_env = struct
             add_equation_on_simple t scrutinee scrutinee_ty))
 
   let add_is_int_relation t name ~scrutinee =
+    let machine_width = machine_width t in
     use_meet_env t ~f:(fun t ->
         let t =
-          add_equation t name (Type_grammar.is_int_for_scrutinee ~scrutinee)
+          add_equation t name
+            (Type_grammar.is_int_for_scrutinee ~machine_width ~scrutinee)
         in
         Name.pattern_match name
           ~symbol:(fun _ -> t)
@@ -108,12 +113,13 @@ end
 module Typing_env_extension = struct
   include Typing_env_extension
 
-  let add_is_null_relation t name ~scrutinee =
-    add_or_replace_equation t name (Type_grammar.is_null ~scrutinee)
-
-  let add_is_int_relation t name ~scrutinee =
+  let add_is_null_relation ~machine_width t name ~scrutinee =
     add_or_replace_equation t name
-      (Type_grammar.is_int_for_scrutinee ~scrutinee)
+      (Type_grammar.is_null ~machine_width ~scrutinee)
+
+  let add_is_int_relation ~machine_width t name ~scrutinee =
+    add_or_replace_equation t name
+      (Type_grammar.is_int_for_scrutinee ~machine_width ~scrutinee)
 
   let add_get_tag_relation t name ~scrutinee =
     add_or_replace_equation t name

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -77,9 +77,19 @@ module Typing_env_extension : sig
 
   val add_or_replace_equation : t -> Name.t -> flambda_type -> t
 
-  val add_is_null_relation : t -> Name.t -> scrutinee:Simple.t -> t
+  val add_is_null_relation :
+    machine_width:Target_system.Machine_width.t ->
+    t ->
+    Name.t ->
+    scrutinee:Simple.t ->
+    t
 
-  val add_is_int_relation : t -> Name.t -> scrutinee:Simple.t -> t
+  val add_is_int_relation :
+    machine_width:Target_system.Machine_width.t ->
+    t ->
+    Name.t ->
+    scrutinee:Simple.t ->
+    t
 
   val add_get_tag_relation : t -> Name.t -> scrutinee:Simple.t -> t
 

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -70,6 +70,14 @@ module Relation : sig
 
   val descr : t -> descr
 end = struct
+  (* We use a slightly awkward separation between [t] (represented as an [int])
+     and [descr] (user-facing) so that we can use patricia trees for sets and
+     maps.
+
+     It's probably overkill for now, but expected to be useful when we add
+     support for more relations -- in particular, it gives access to efficient
+     [diff] and [union] implementations. *)
+
   type t = int
 
   let is_null = 0
@@ -3210,6 +3218,8 @@ and project_inverse_relations ~to_project ~expand inverse_relations =
                 else
                   match get_alias_opt (expand var) with
                   | None ->
+                    (* CR bclement: we should arguably update the set of known
+                       naked immediates based on the expanded type of [var]. *)
                     changed := true;
                     names
                   | Some simple ->
@@ -4631,6 +4641,9 @@ module Head_of_kind_naked_immediate = struct
       Misc.fatal_error
         "Head_of_kind_naked_immediates.create_naked_immediates_non_empty";
     Naked_immediates imms
+
+  let create_inverse_relations inverse_relations =
+    Inverse_relations inverse_relations
 end
 
 module Make_head_of_kind_naked_number (N : Container_types.S) = struct

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -46,6 +46,88 @@ type is_null =
   | Not_null
   | Maybe_null of { is_null : Variable.t option }
 
+module Relation : sig
+  type t
+
+  val is_null : t
+
+  val is_int : t
+
+  val get_tag : t
+
+  val of_const :
+    machine_width:Target_system.Machine_width.t ->
+    t ->
+    Reg_width_const.t ->
+    Target_ocaml_int.t Or_bottom.t
+
+  include Container_types.S with type t := t
+
+  type descr =
+    | Is_null
+    | Is_int
+    | Get_tag
+
+  val descr : t -> descr
+end = struct
+  type t = int
+
+  let is_null = 0
+
+  let is_int = 1
+
+  let get_tag = 2
+
+  type descr =
+    | Is_null
+    | Is_int
+    | Get_tag
+
+  let descr = function
+    | 0 -> Is_null
+    | 1 -> Is_int
+    | 2 -> Get_tag
+    | _ -> Misc.fatal_error "Invalid relation"
+
+  let to_string t =
+    match descr t with
+    | Is_null -> "%is_null"
+    | Is_int -> "%is_int"
+    | Get_tag -> "%get_tag"
+
+  let of_const ~machine_width t const : _ Or_bottom.t =
+    match descr t with
+    | Is_null -> Ok (Target_ocaml_int.bool machine_width (RWC.is_null const))
+    | Is_int ->
+      Ok (Target_ocaml_int.bool machine_width (not (RWC.is_null const)))
+    | Get_tag -> Bottom
+
+  module T0 = struct
+    let compare = Numeric_types.Int.compare
+
+    let equal = Numeric_types.Int.equal
+
+    let hash = Numeric_types.Int.hash
+
+    let print ppf t = Format.pp_print_string ppf (to_string t)
+  end
+
+  include T0
+
+  module T = struct
+    type nonrec t = t
+
+    include T0
+  end
+
+  module Tree = Patricia_tree.Make (struct
+    let print = print
+  end)
+
+  module Set = Tree.Set
+  module Map = Tree.Map
+end
+
 (* The grammar of Flambda types. *)
 type t =
   | Value of head_of_kind_value TD.t
@@ -131,9 +213,11 @@ and head_of_kind_value_non_null =
    particularly useful if we switch several times on the same scrutinee. *)
 and head_of_kind_naked_immediate =
   | Naked_immediates of Target_ocaml_int.Set.t
-  | Is_int of t
-  | Get_tag of t
-  | Is_null of t
+  | Inverse_relations of Name.Set.t Relation.Map.t
+  | Naked_immediates_and_inverse_relations of
+      { naked_immediates : Target_ocaml_int.Set.t;
+        inverse_relations : Name.Set.t Relation.Map.t
+      }
 
 and head_of_kind_naked_float32 = Float32.Set.t
 
@@ -308,6 +392,31 @@ let row_like_for_blocks_is_bottom { known_tags; other_tags; alloc_mode = _ } =
 let or_unknown_is_bottom is_bottom (or_unknown : _ Or_unknown.t) =
   match or_unknown with Known x -> is_bottom x | Unknown -> false
 
+let naked_immediates :
+    head_of_kind_naked_immediate -> Target_ocaml_int.Set.t Or_unknown.t =
+  function
+  | Naked_immediates naked_immediates
+  | Naked_immediates_and_inverse_relations { naked_immediates; _ } ->
+    Known naked_immediates
+  | Inverse_relations _ -> Unknown
+
+let inverse_relations :
+    head_of_kind_naked_immediate -> Name.Set.t Relation.Map.t = function
+  | Naked_immediates _ -> Relation.Map.empty
+  | Inverse_relations inverse_relations
+  | Naked_immediates_and_inverse_relations { inverse_relations; _ } ->
+    inverse_relations
+
+let create_head_of_kind_naked_immediate ~naked_immediates ~inverse_relations =
+  match (naked_immediates : _ Or_unknown.t) with
+  | Unknown -> Inverse_relations inverse_relations
+  | Known naked_immediates ->
+    if Relation.Map.is_empty inverse_relations
+    then Naked_immediates naked_immediates
+    else
+      Naked_immediates_and_inverse_relations
+        { naked_immediates; inverse_relations }
+
 let rec free_names0 ~follow_value_slots t =
   let[@inline] type_descr_free_names ~free_names_head ty =
     if follow_value_slots
@@ -420,10 +529,17 @@ and free_names_head_of_kind_value_non_null ~follow_value_slots head =
       (free_names0 ~follow_value_slots length)
       fields
 
+and free_names_inverse_relations0 ~follow_value_slots:_ inverse_relations =
+  Relation.Map.fold
+    (fun _ names free_names ->
+      Name.Set.fold
+        (fun name free_names ->
+          Name_occurrences.add_name free_names name Name_mode.in_types)
+        names free_names)
+    inverse_relations Name_occurrences.empty
+
 and free_names_head_of_kind_naked_immediate0 ~follow_value_slots head =
-  match head with
-  | Naked_immediates _ -> Name_occurrences.empty
-  | Is_int ty | Get_tag ty | Is_null ty -> free_names0 ~follow_value_slots ty
+  free_names_inverse_relations0 ~follow_value_slots (inverse_relations head)
 
 and free_names_head_of_kind_naked_float32 _ = Name_occurrences.empty
 
@@ -825,18 +941,32 @@ and apply_renaming_head_of_kind_value_non_null head renaming =
           alloc_mode
         }
 
+and apply_renaming_inverse_relations inverse_relations renaming =
+  Relation.Map.map_sharing
+    (fun names ->
+      let changed = ref false in
+      let names' =
+        Name.Set.fold
+          (fun name names ->
+            let name' = Renaming.apply_name renaming name in
+            if name' != name then changed := true;
+            Name.Set.add name' names)
+          names Name.Set.empty
+      in
+      if !changed then names' else names)
+    inverse_relations
+
 and apply_renaming_head_of_kind_naked_immediate head renaming =
-  match head with
-  | Naked_immediates _ -> head
-  | Is_int ty ->
-    let ty' = apply_renaming ty renaming in
-    if ty == ty' then head else Is_int ty'
-  | Get_tag ty ->
-    let ty' = apply_renaming ty renaming in
-    if ty == ty' then head else Get_tag ty'
-  | Is_null ty ->
-    let ty' = apply_renaming ty renaming in
-    if ty == ty' then head else Is_null ty'
+  let inverse_relations = inverse_relations head in
+  let inverse_relations' =
+    apply_renaming_inverse_relations inverse_relations renaming
+  in
+  if inverse_relations' == inverse_relations
+  then head
+  else
+    create_head_of_kind_naked_immediate
+      ~naked_immediates:(naked_immediates head)
+      ~inverse_relations:inverse_relations'
 
 and apply_renaming_head_of_kind_naked_float32 head _ = head
 
@@ -1230,12 +1360,15 @@ and print_head_of_kind_value_non_null ppf head =
       (Array.to_list fields)
 
 and print_head_of_kind_naked_immediate ppf head =
-  match head with
-  | Naked_immediates is ->
-    Format.fprintf ppf "@[<hov 1>(%a)@]" Target_ocaml_int.Set.print is
-  | Is_int ty -> Format.fprintf ppf "@[<hov 1>(Is_int@ %a)@]" print ty
-  | Get_tag ty -> Format.fprintf ppf "@[<hov 1>(Get_tag@ %a)@]" print ty
-  | Is_null ty -> Format.fprintf ppf "@[<hov 1>(Is_null@ %a)@]" print ty
+  Or_unknown.print Target_ocaml_int.Set.print ppf (naked_immediates head);
+  Relation.Map.iter
+    (fun relation names ->
+      Name.Set.iter
+        (fun name ->
+          Format.fprintf ppf "@ @[<hov 1>(%a@ %a)@]" Relation.print relation
+            Name.print name)
+        names)
+    (inverse_relations head)
 
 and print_head_of_kind_naked_float32 ppf head =
   Format.fprintf ppf "@[(Naked_float32@ (%a))@]" Float32.Set.print head
@@ -1501,10 +1634,16 @@ and ids_for_export_head_of_kind_value_non_null head =
       (fun ids field -> Ids_for_export.union ids (ids_for_export field))
       (ids_for_export length) fields
 
+and ids_for_export_inverse_relations inverse_relations =
+  Relation.Map.fold
+    (fun _ names ids_for_export ->
+      Name.Set.fold
+        (fun name ids_for_export -> Ids_for_export.add_name ids_for_export name)
+        names ids_for_export)
+    inverse_relations Ids_for_export.empty
+
 and ids_for_export_head_of_kind_naked_immediate head =
-  match head with
-  | Naked_immediates _ -> Ids_for_export.empty
-  | Is_int t | Get_tag t | Is_null t -> ids_for_export t
+  ids_for_export_inverse_relations (inverse_relations head)
 
 and ids_for_export_head_of_kind_naked_float32 _ = Ids_for_export.empty
 
@@ -2328,28 +2467,44 @@ and remove_unused_value_slots_and_shortcut_aliases_head_of_kind_value_non_null
           alloc_mode
         }
 
+and remove_unused_value_slots_and_shortcut_aliases_inverse_relations
+    inverse_relations ~used_value_slots:_ ~canonicalise =
+  Relation.Map.filter_map_sharing
+    (fun _ names ->
+      let changed = ref false in
+      let names' =
+        Name.Set.fold
+          (fun name names ->
+            Simple.pattern_match
+              (canonicalise (Simple.name name))
+              ~const:(fun _ ->
+                (* CR bclement: We should arguably update the set of known
+                   naked_immediates *)
+                changed := true;
+                names)
+              ~name:(fun name' ~coercion:_ ->
+                if name' != name then changed := true;
+                Name.Set.add name' names))
+          names Name.Set.empty
+      in
+      if !changed
+      then if Name.Set.is_empty names' then None else Some names'
+      else Some names)
+    inverse_relations
+
 and remove_unused_value_slots_and_shortcut_aliases_head_of_kind_naked_immediate
     head ~used_value_slots ~canonicalise =
-  match head with
-  | Naked_immediates _ -> head
-  | Is_int ty ->
-    let ty' =
-      remove_unused_value_slots_and_shortcut_aliases ty ~used_value_slots
-        ~canonicalise
-    in
-    if ty == ty' then head else Is_int ty'
-  | Get_tag ty ->
-    let ty' =
-      remove_unused_value_slots_and_shortcut_aliases ty ~used_value_slots
-        ~canonicalise
-    in
-    if ty == ty' then head else Get_tag ty'
-  | Is_null ty ->
-    let ty' =
-      remove_unused_value_slots_and_shortcut_aliases ty ~used_value_slots
-        ~canonicalise
-    in
-    if ty == ty' then head else Is_null ty'
+  let inverse_relations = inverse_relations head in
+  let inverse_relations' =
+    remove_unused_value_slots_and_shortcut_aliases_inverse_relations
+      inverse_relations ~used_value_slots ~canonicalise
+  in
+  if inverse_relations' == inverse_relations
+  then head
+  else
+    create_head_of_kind_naked_immediate
+      ~naked_immediates:(naked_immediates head)
+      ~inverse_relations:inverse_relations'
 
 and remove_unused_value_slots_and_shortcut_aliases_head_of_kind_naked_float32
     head ~used_value_slots:_ ~canonicalise:_ =
@@ -3040,18 +3195,51 @@ and project_head_of_kind_value_non_null ~to_project ~expand head =
           alloc_mode
         }
 
+and project_inverse_relations ~to_project ~expand inverse_relations =
+  Relation.Map.filter_map_sharing
+    (fun _ names ->
+      let changed = ref false in
+      let names' =
+        Name.Set.fold
+          (fun name names ->
+            Name.pattern_match name
+              ~symbol:(fun _ -> Name.Set.add name names)
+              ~var:(fun var ->
+                if not (Variable.Set.mem var to_project)
+                then Name.Set.add name names
+                else
+                  match get_alias_opt (expand var) with
+                  | None ->
+                    changed := true;
+                    names
+                  | Some simple ->
+                    Simple.pattern_match simple
+                      ~const:(fun _ ->
+                        (* CR bclement: we should arguably update the set of
+                           known naked_immediates *)
+                        changed := true;
+                        names)
+                      ~name:(fun name' ~coercion:_ ->
+                        if name' != name then changed := true;
+                        Name.Set.add name' names)))
+          names Name.Set.empty
+      in
+      if !changed
+      then if Name.Set.is_empty names' then None else Some names'
+      else Some names)
+    inverse_relations
+
 and project_head_of_kind_naked_immediate ~to_project ~expand head =
-  match head with
-  | Naked_immediates _ -> head
-  | Is_int ty ->
-    let ty' = project_variables_out ~to_project ~expand ty in
-    if ty == ty' then head else Is_int ty'
-  | Get_tag ty ->
-    let ty' = project_variables_out ~to_project ~expand ty in
-    if ty == ty' then head else Get_tag ty'
-  | Is_null ty ->
-    let ty' = project_variables_out ~to_project ~expand ty in
-    if ty == ty' then head else Is_null ty'
+  let inverse_relations = inverse_relations head in
+  let inverse_relations' =
+    project_inverse_relations ~to_project ~expand inverse_relations
+  in
+  if inverse_relations' == inverse_relations
+  then head
+  else
+    create_head_of_kind_naked_immediate
+      ~naked_immediates:(naked_immediates head)
+      ~inverse_relations:inverse_relations'
 
 and project_head_of_kind_naked_float32 ~to_project:_ ~expand:_ head = head
 
@@ -4083,14 +4271,56 @@ let tagged_immediate_alias_to ~naked_immediate : t =
   tag_immediate
     (Naked_immediate (TD.create_equals (Simple.var naked_immediate)))
 
-let is_int_for_scrutinee ~scrutinee : t =
-  Naked_immediate (TD.create (Is_int (alias_type_of K.value scrutinee)))
+let is_int_for_scrutinee ~machine_width ~scrutinee : t =
+  let descr =
+    Simple.pattern_match scrutinee
+      ~const:(fun _ ->
+        TD.create_equals (Simple.untagged_const_true machine_width))
+      ~name:(fun name ~coercion:_ ->
+        let head =
+          create_head_of_kind_naked_immediate
+            ~naked_immediates:(Known (Target_ocaml_int.all_bools machine_width))
+            ~inverse_relations:
+              (Relation.Map.singleton Relation.is_int (Name.Set.singleton name))
+        in
+        TD.create head)
+  in
+  Naked_immediate descr
 
 let get_tag_for_block ~block : t =
-  Naked_immediate (TD.create (Get_tag (alias_type_of K.value block)))
+  let descr =
+    Simple.pattern_match block
+      ~const:(fun _ ->
+        (* CR bclement: it's not clear that it is safe to use bottom here,
+           because we are a bit loose about creating [get_tag] relations of
+           things that might not be blocks. *)
+        TD.unknown)
+      ~name:(fun name ~coercion:_ ->
+        let head =
+          create_head_of_kind_naked_immediate ~naked_immediates:Unknown
+            ~inverse_relations:
+              (Relation.Map.singleton Relation.get_tag (Name.Set.singleton name))
+        in
+        TD.create head)
+  in
+  Naked_immediate descr
 
-let is_null ~scrutinee : t =
-  Naked_immediate (TD.create (Is_null (alias_type_of K.value scrutinee)))
+let is_null ~machine_width ~scrutinee : t =
+  let descr =
+    Simple.pattern_match scrutinee
+      ~const:(fun const ->
+        TD.create_equals
+          (Simple.untagged_const_bool machine_width (RWC.is_null const)))
+      ~name:(fun name ~coercion:_ ->
+        let head =
+          create_head_of_kind_naked_immediate
+            ~naked_immediates:(Known (Target_ocaml_int.all_bools machine_width))
+            ~inverse_relations:
+              (Relation.Map.singleton Relation.is_null (Name.Set.singleton name))
+        in
+        TD.create head)
+  in
+  Naked_immediate descr
 
 let boxed_float32_alias_to ~naked_float32 =
   box_float32 (Naked_float32 (TD.create_equals (Simple.var naked_float32)))
@@ -4362,6 +4592,31 @@ end
 module Head_of_kind_naked_immediate = struct
   type t = head_of_kind_naked_immediate
 
+  type descr =
+    { naked_immediates : Target_ocaml_int.Set.t Or_unknown.t;
+      inverse_relations : Name.Set.t Relation.Map.t
+    }
+
+  let descr head =
+    { naked_immediates = naked_immediates head;
+      inverse_relations = inverse_relations head
+    }
+
+  let from_descr { naked_immediates; inverse_relations } : _ Or_bottom.t =
+    match naked_immediates with
+    | Known imms when Target_ocaml_int.Set.is_empty imms -> Bottom
+    | Known _ | Unknown ->
+      Ok
+        (create_head_of_kind_naked_immediate ~naked_immediates
+           ~inverse_relations)
+
+  let from_descr_non_empty { naked_immediates; inverse_relations } =
+    match naked_immediates with
+    | Known imms when Target_ocaml_int.Set.is_empty imms ->
+      Misc.fatal_error "Head_of_kind_naked_immediates.from_descr_non_empty"
+    | Known _ | Unknown ->
+      create_head_of_kind_naked_immediate ~naked_immediates ~inverse_relations
+
   let create_naked_immediate imm =
     Naked_immediates (Target_ocaml_int.Set.singleton imm)
 
@@ -4376,12 +4631,6 @@ module Head_of_kind_naked_immediate = struct
       Misc.fatal_error
         "Head_of_kind_naked_immediates.create_naked_immediates_non_empty";
     Naked_immediates imms
-
-  let create_is_int ty = Is_int ty
-
-  let create_get_tag ty = Get_tag ty
-
-  let create_is_null ty = Is_null ty
 end
 
 module Make_head_of_kind_naked_number (N : Container_types.S) = struct
@@ -4490,13 +4739,17 @@ let rec must_be_singleton t : RWC.t option =
                   Reg_width_const.print const)))))
   | Naked_immediate ty -> (
     match TD.descr ty with
-    | Unknown | Bottom | Ok (No_alias (Is_int _ | Get_tag _ | Is_null _)) ->
-      None
+    | Unknown | Bottom -> None
     | Ok (Equals simple) -> Simple.must_be_const simple
-    | Ok (No_alias (Naked_immediates is)) -> (
-      match Target_ocaml_int.Set.get_singleton is with
-      | Some i -> Some (RWC.naked_immediate i)
-      | None -> None))
+    | Ok (No_alias head) -> (
+      (* It should be fine to discard the inverse relations here because the
+         [meet] will have propagated them already. *)
+      match naked_immediates head with
+      | Unknown -> None
+      | Known is -> (
+        match Target_ocaml_int.Set.get_singleton is with
+        | Some i -> Some (RWC.naked_immediate i)
+        | None -> None)))
   | Naked_float32 ty -> (
     match TD.descr ty with
     | Unknown | Bottom -> None

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -107,6 +107,9 @@ end = struct
     match descr t with
     | Is_null -> Ok (Target_ocaml_int.bool machine_width (RWC.is_null const))
     | Is_int ->
+      (* Constants can never be blocks, so the result of [%is_int] on a constant
+         is either [1] if the constant is not null, or [0] if the constant is
+         null. *)
       Ok (Target_ocaml_int.bool machine_width (not (RWC.is_null const)))
     | Get_tag -> Bottom
 

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -33,6 +33,31 @@ type is_null =
   | Not_null
   | Maybe_null of { is_null : Variable.t option }
 
+module Relation : sig
+  type t
+
+  include Container_types.S with type t := t
+
+  val is_null : t
+
+  val is_int : t
+
+  val get_tag : t
+
+  val of_const :
+    machine_width:Target_system.Machine_width.t ->
+    t ->
+    Reg_width_const.t ->
+    Target_ocaml_int.t Or_bottom.t
+
+  type descr =
+    | Is_null
+    | Is_int
+    | Get_tag
+
+  val descr : t -> descr
+end
+
 type t = private
   | Value of head_of_kind_value Type_descr.t
   | Naked_immediate of head_of_kind_naked_immediate Type_descr.t
@@ -86,11 +111,7 @@ and head_of_kind_value_non_null = private
         alloc_mode : Alloc_mode.For_types.t
       }
 
-and head_of_kind_naked_immediate = private
-  | Naked_immediates of Target_ocaml_int.Set.t
-  | Is_int of t  (** For variants only *)
-  | Get_tag of t  (** For variants only *)
-  | Is_null of t
+and head_of_kind_naked_immediate
 
 (** Invariant: the float/integer sets for naked float, int<N>, and nativeint
     heads are non-empty. (Empty sets are represented as an overall bottom type.)
@@ -390,11 +411,13 @@ val tagged_immediate_alias_to : naked_immediate:Variable.t -> t
 (** This function checks the kind of its argument. *)
 val tag_immediate : t -> t
 
-val is_int_for_scrutinee : scrutinee:Simple.t -> t
+val is_int_for_scrutinee :
+  machine_width:Target_system.Machine_width.t -> scrutinee:Simple.t -> t
 
 val get_tag_for_block : block:Simple.t -> t
 
-val is_null : scrutinee:Simple.t -> t
+val is_null :
+  machine_width:Target_system.Machine_width.t -> scrutinee:Simple.t -> t
 
 val create_variant :
   is_unique:bool ->
@@ -874,17 +897,22 @@ end
 module Head_of_kind_naked_immediate : sig
   type t = head_of_kind_naked_immediate
 
+  type descr =
+    { naked_immediates : Target_ocaml_int.Set.t Or_unknown.t;
+      inverse_relations : Name.Set.t Relation.Map.t
+    }
+
+  val descr : t -> descr
+
+  val from_descr : descr -> t Or_bottom.t
+
+  val from_descr_non_empty : descr -> t
+
   val create_naked_immediate : Target_ocaml_int.t -> t
 
   val create_naked_immediates : Target_ocaml_int.Set.t -> t Or_bottom.t
 
   val create_naked_immediates_non_empty : Target_ocaml_int.Set.t -> t
-
-  val create_is_int : flambda_type -> t
-
-  val create_get_tag : flambda_type -> t
-
-  val create_is_null : flambda_type -> t
 end
 
 module type Head_of_kind_naked_number_intf = sig

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -913,6 +913,8 @@ module Head_of_kind_naked_immediate : sig
   val create_naked_immediates : Target_ocaml_int.Set.t -> t Or_bottom.t
 
   val create_naked_immediates_non_empty : Target_ocaml_int.Set.t -> t
+
+  val create_inverse_relations : Name.Set.t Relation.Map.t -> t
 end
 
 module type Head_of_kind_naked_number_intf = sig

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -693,15 +693,6 @@ let meet_code_id (env : ME.t) (code_id1 : Code_id.t) (code_id2 : Code_id.t) :
       then Ok (Right_input, env)
       else Ok (New_result code_id, env)
 
-type meet_keep_side =
-  | Left
-  | Right
-
-(* type meet_expanded_head_result =
- *   | Left_head_unchanged
- *   | Right_head_unchanged
- *   | New_head of ET.t * TEE.t *)
-
 let meet_alloc_mode env (alloc_mode1 : Alloc_mode.For_types.t)
     (alloc_mode2 : Alloc_mode.For_types.t) : Alloc_mode.For_types.t meet_result
     =
@@ -776,6 +767,107 @@ let join_array_element_kinds (element_kind1 : _ Or_unknown_or_bottom.t)
         ~when_used_at:element_kind1
     then Ok element_kind1
     else Unknown
+
+let reduce_head_of_kind_naked_immediate env head : _ Or_bottom.t =
+  let descr = TG.Head_of_kind_naked_immediate.descr head in
+  let changed = ref false in
+  let exception Bottom_result in
+  match
+    TG.Relation.Map.fold
+      (fun relation names (imms, inverse_relations) ->
+        let imms, names' =
+          Name.Set.fold
+            (fun name (imms, names) ->
+              Simple.pattern_match
+                (TE.get_canonical_simple_ignoring_name_mode env
+                   (Simple.name name))
+                ~const:(fun const : (_ Or_unknown.t * Name.Set.t) ->
+                  match
+                    TG.Relation.of_const ~machine_width:(TE.machine_width env)
+                      relation const
+                  with
+                  | Bottom ->
+                    (* CR bclement: we need to ignore [Bottom] here because
+                       unboxing can create inverse relations that wouldn't be
+                       valid e.g. for [get_tag] of something that we don't know
+                       is a block. *)
+                    changed := true;
+                    imms, names
+                  | Ok imm -> (
+                    let imms' = Target_ocaml_int.Set.singleton imm in
+                    match (imms : _ Or_unknown.t) with
+                    | Known imms ->
+                      if Target_ocaml_int.Set.equal imms' imms
+                      then Known imms, names
+                      else (
+                        if not (Target_ocaml_int.Set.mem imm imms)
+                        then raise Bottom_result;
+                        changed := true;
+                        Known imms', names)
+                    | Unknown ->
+                      changed := true;
+                      Known imms', names))
+                ~name:(fun name' ~coercion:_ ->
+                  if name' != name then changed := true;
+                  imms, Name.Set.add name' names))
+            names (imms, Name.Set.empty)
+        in
+        imms, TG.Relation.Map.add relation names' inverse_relations)
+      descr.inverse_relations
+      (descr.naked_immediates, TG.Relation.Map.empty)
+  with
+  | exception Bottom_result -> Bottom
+  | naked_immediates, inverse_relations ->
+    if not !changed
+    then Ok head
+    else
+      TG.Head_of_kind_naked_immediate.from_descr
+        { naked_immediates; inverse_relations }
+
+type 'a reverse_mapping_meet_return_value =
+  { left_inputs : 'a;
+    any_input : 'a meet_return_value;
+    right_inputs : 'a
+  }
+
+let meet_inverse_relations inverse_relations1 inverse_relations2 =
+  if inverse_relations1 == inverse_relations2
+  then
+    { left_inputs = TG.Relation.Map.empty;
+      any_input = Both_inputs;
+      right_inputs = TG.Relation.Map.empty
+    }
+  else
+    let left_inputs = ref TG.Relation.Map.empty in
+    let right_inputs = ref TG.Relation.Map.empty in
+    let inverse_relations =
+      TG.Relation.Map.merge
+        (fun relation names1 names2 ->
+          let names1 = Option.value ~default:Name.Set.empty names1 in
+          let names2 = Option.value ~default:Name.Set.empty names2 in
+          let left_input = Name.Set.diff names1 names2 in
+          let right_input = Name.Set.diff names2 names1 in
+          if not (Name.Set.is_empty left_input)
+          then
+            left_inputs := TG.Relation.Map.add relation left_input !left_inputs;
+          if not (Name.Set.is_empty right_input)
+          then
+            right_inputs
+              := TG.Relation.Map.add relation right_input !right_inputs;
+          Some (Name.Set.union names1 names2))
+        inverse_relations1 inverse_relations2
+    in
+    let any_input =
+      match
+        ( TG.Relation.Map.is_empty !left_inputs,
+          TG.Relation.Map.is_empty !right_inputs )
+      with
+      | true, true -> Both_inputs
+      | false, true -> Left_input
+      | true, false -> Right_input
+      | false, false -> New_result inverse_relations
+    in
+    { left_inputs = !left_inputs; any_input; right_inputs = !right_inputs }
 
 let rec meet env t1 t2 = ME.meet_type env t1 t2 ~meet_expanded_head
 
@@ -1214,111 +1306,130 @@ and meet_variant env ~(is_int1 : Variable.t option)
     ~left_b:(get_tag1, blocks1, imms1, extensions1)
     ~right_b:(get_tag2, blocks2, imms2, extensions2)
 
+and reduce_inverse_relations env naked_immediates inverse_relations :
+    _ Or_bottom.t =
+  let module I = struct
+    include Target_ocaml_int
+
+    let machine_width = TE.machine_width (ME.typing_env env)
+
+    let zero = zero machine_width
+
+    let one = one machine_width
+  end in
+  match (naked_immediates : _ Or_unknown.t) with
+  | Unknown -> Ok env
+  | Known imms -> (
+    let exception Bottom_result in
+    match
+      TG.Relation.Map.fold
+        (fun relation names env ->
+          Name.Set.fold
+            (fun name env ->
+              let add_equation ty =
+                match add_equation (Simple.name name) ty env ~meet_type with
+                | Ok (_, env) -> env
+                | Bottom _ -> raise Bottom_result
+              in
+              match TG.Relation.descr relation with
+              | Is_null -> (
+                match I.Set.mem I.zero imms, I.Set.mem I.one imms with
+                | false, false -> raise Bottom_result
+                | true, true -> env
+                | true, false -> add_equation TG.any_non_null_value
+                | false, true -> add_equation TG.null)
+              | Is_int -> (
+                match I.Set.mem I.zero imms, I.Set.mem I.one imms with
+                | false, false -> raise Bottom_result
+                | true, true -> env
+                | true, false -> add_equation MTC.any_block
+                | false, true -> add_equation MTC.any_tagged_immediate)
+              | Get_tag -> (
+                let tags =
+                  I.Set.fold
+                    (fun tag tags ->
+                      match Tag.create_from_targetint I.machine_width tag with
+                      | Some tag -> Tag.Set.add tag tags
+                      | None -> tags (* No blocks exist with this tag *))
+                    imms Tag.Set.empty
+                in
+                match
+                  MTC.blocks_with_these_tags ~machine_width:I.machine_width tags
+                    (Alloc_mode.For_types.unknown ())
+                with
+                | Known shape -> add_equation shape
+                | Unknown -> env))
+            names env)
+        inverse_relations env
+    with
+    | exception Bottom_result -> Bottom
+    | env -> Ok env)
+
 and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
     (t2 : TG.head_of_kind_naked_immediate) :
     TG.head_of_kind_naked_immediate meet_result =
   let module I = Target_ocaml_int in
-  let keep_side side : _ meet_result =
-    match side with
-    | Left -> Ok (Left_input, env)
-    | Right -> Ok (Right_input, env)
-  in
-  let bottom_other_side side : _ meet_result =
-    match side with Left -> Bottom Right_input | Right -> Bottom Left_input
-  in
-  let meet_with_shape ~rebuild ty shape side =
-    map_result ~f:rebuild
-      (match side with Left -> meet env ty shape | Right -> meet env shape ty)
-  in
-  let is_int_immediate ~is_int_ty ~immediates ~is_int_side =
-    match I.Set.choose_opt immediates with
-    | None -> bottom_other_side is_int_side
-    | Some arbitrary_int -> (
-      let rebuild = TG.Head_of_kind_naked_immediate.create_is_int in
-      let machine_width = I.machine_width arbitrary_int in
-      match
-        ( I.Set.mem (I.zero machine_width) immediates,
-          I.Set.mem (I.one machine_width) immediates )
-      with
-      | false, false -> Bottom (New_result ())
-      | true, true -> keep_side is_int_side
-      | true, false ->
-        meet_with_shape ~rebuild is_int_ty MTC.any_block is_int_side
-      | false, true ->
-        meet_with_shape ~rebuild is_int_ty MTC.any_tagged_immediate is_int_side)
-  in
-  let is_null_immediate ~is_null_ty ~immediates ~is_null_side =
-    if I.Set.is_empty immediates
-    then bottom_other_side is_null_side
-    else
-      let rebuild = TG.Head_of_kind_naked_immediate.create_is_null in
-      let machine_width = ME.machine_width env in
-      match
-        ( I.Set.mem (I.zero machine_width) immediates,
-          I.Set.mem (I.one machine_width) immediates )
-      with
-      | false, false -> Bottom (New_result ())
-      | true, true -> keep_side is_null_side
-      | true, false ->
-        meet_with_shape ~rebuild is_null_ty TG.any_non_null_value is_null_side
-      | false, true -> meet_with_shape ~rebuild is_null_ty TG.null is_null_side
-  in
-  let get_tag_immediate ~get_tag_ty ~immediates ~get_tag_side =
-    match I.Set.choose_opt immediates with
-    | None -> bottom_other_side get_tag_side
-    | Some arbitrary_int -> (
-      let tags =
-        I.Set.fold
-          (fun tag tags ->
-            let machine_width = I.machine_width arbitrary_int in
-            match Tag.create_from_targetint machine_width tag with
-            | Some tag -> Tag.Set.add tag tags
-            | None -> tags (* No blocks exist with this tag *))
-          immediates Tag.Set.empty
+  match
+    ( reduce_head_of_kind_naked_immediate (ME.typing_env env) t1,
+      reduce_head_of_kind_naked_immediate (ME.typing_env env) t2 )
+  with
+  | Bottom, Bottom -> Bottom Both_inputs
+  | Bottom, Ok _ -> Bottom Left_input
+  | Ok _, Bottom -> Bottom Right_input
+  | Ok t1, Ok t2 -> (
+    let descr1 = TG.Head_of_kind_naked_immediate.descr t1 in
+    let descr2 = TG.Head_of_kind_naked_immediate.descr t2 in
+    let naked_immediates =
+      meet_unknown
+        (set_meet (module I.Set) ~of_set:Fun.id)
+        ~contents_is_bottom:I.Set.is_empty env descr1.naked_immediates
+        descr2.naked_immediates
+    in
+    match naked_immediates with
+    | Bottom r -> Bottom r
+    | Ok (naked_immediates, env) -> (
+      let inverse_relations =
+        meet_inverse_relations descr1.inverse_relations descr2.inverse_relations
       in
-      if Tag.Set.is_empty tags
-      then Bottom (New_result ())
-      else
-        let machine_width = ME.machine_width env in
-        match
-          MTC.blocks_with_these_tags ~machine_width tags
-            (Alloc_mode.For_types.unknown ())
-        with
-        | Known shape ->
-          meet_with_shape
-            ~rebuild:TG.Head_of_kind_naked_immediate.create_get_tag get_tag_ty
-            shape get_tag_side
-        | Unknown -> keep_side get_tag_side)
-  in
-  match t1, t2 with
-  | Naked_immediates is1, Naked_immediates is2 ->
-    map_result
-      ~f:TG.Head_of_kind_naked_immediate.create_naked_immediates_non_empty
-      (set_meet (module I.Set) env is1 is2 ~of_set:Fun.id)
-  | Is_int is_int_ty, Naked_immediates immediates ->
-    is_int_immediate ~is_int_ty ~immediates ~is_int_side:Left
-  | Naked_immediates immediates, Is_int is_int_ty ->
-    is_int_immediate ~is_int_ty ~immediates ~is_int_side:Right
-  | Get_tag get_tag_ty, Naked_immediates immediates ->
-    get_tag_immediate ~get_tag_ty ~immediates ~get_tag_side:Left
-  | Naked_immediates immediates, Get_tag get_tag_ty ->
-    get_tag_immediate ~get_tag_ty ~immediates ~get_tag_side:Right
-  | Is_null is_null_ty, Naked_immediates immediates ->
-    is_null_immediate ~is_null_ty ~immediates ~is_null_side:Left
-  | Naked_immediates immediates, Is_null is_null_ty ->
-    is_null_immediate ~is_null_ty ~immediates ~is_null_side:Right
-  | (Is_int _ | Get_tag _ | Is_null _), (Is_int _ | Get_tag _ | Is_null _) ->
-    (* CR mshinwell: introduce improved handling for
-     *   Is_int meet Is_int
-     *   Get_tag meet Get_tag
-     * i.e. a better fix for PR1515, at which point we might also be able
-     * to consider improving:
-     *   Is_int meet Get_tag
-     * and vice-versa. *)
-    (* We can't return Bottom, as it would be unsound, so we need to either do
-       the actual meet with Naked_immediates, or just give up and return one of
-       the arguments. *)
-    Ok (Left_input, env)
+      let head =
+        combine_meet_return_values naked_immediates inverse_relations.any_input
+          (fun () ->
+            let naked_immediates =
+              extract_value naked_immediates descr1.naked_immediates
+                descr2.naked_immediates
+            in
+            let inverse_relations =
+              extract_value inverse_relations.any_input descr1.inverse_relations
+                descr2.inverse_relations
+            in
+            TG.Head_of_kind_naked_immediate.from_descr_non_empty
+              { naked_immediates; inverse_relations })
+      in
+      let[@local] head_in_env_or_bottom (env_ob : _ Or_bottom.t) =
+        match env_ob with
+        | Bottom -> Bottom (New_result ())
+        | Ok env -> Ok (head, env)
+      in
+      (* Only perform reverse reductions for relations that were not already
+         known in the corresponding side, e.g. if we meet [(Naked_immediate (0 1
+         2) (%get_tag x)] and [(Naked_immediate T (%get_tag y))] we only update
+         the tag of [y], but not of [x] (which we assume to already have been
+         reduced). *)
+      match naked_immediates with
+      | Both_inputs -> Ok (head, env)
+      | Left_input ->
+        head_in_env_or_bottom
+          (reduce_inverse_relations env descr1.naked_immediates
+             inverse_relations.right_inputs)
+      | Right_input ->
+        head_in_env_or_bottom
+          (reduce_inverse_relations env descr2.naked_immediates
+             inverse_relations.left_inputs)
+      | New_result naked_immediates ->
+        head_in_env_or_bottom
+          (reduce_inverse_relations env naked_immediates
+             (extract_value inverse_relations.any_input descr1.inverse_relations
+                descr2.inverse_relations))))
 
 and meet_head_of_kind_naked_float32 env t1 t2 =
   set_meet
@@ -1928,69 +2039,54 @@ and join_head_of_kind_naked_immediate env
     (head2 : TG.Head_of_kind_naked_immediate.t) :
     TG.Head_of_kind_naked_immediate.t Or_unknown.t =
   let module I = Target_ocaml_int in
-  match head1, head2 with
-  | Naked_immediates is1, Naked_immediates is2 -> (
-    assert (not (Target_ocaml_int.Set.is_empty is1));
-    assert (not (Target_ocaml_int.Set.is_empty is2));
-    let is = I.Set.union is1 is2 in
-    let head = TG.Head_of_kind_naked_immediate.create_naked_immediates is in
-    match head with
-    | Ok head -> Known head
-    | Bottom ->
-      Misc.fatal_error "Did not expect [Bottom] from [create_naked_immediates]")
-  | Is_int ty1, Is_int ty2 ->
-    let>+ ty = join env ty1 ty2 in
-    TG.Head_of_kind_naked_immediate.create_is_int ty
-  | Get_tag ty1, Get_tag ty2 ->
-    let>+ ty = join env ty1 ty2 in
-    TG.Head_of_kind_naked_immediate.create_get_tag ty
-  | Is_null ty1, Is_null ty2 ->
-    let>+ ty = join env ty1 ty2 in
-    TG.Head_of_kind_naked_immediate.create_is_null ty
-  (* From now on: Irregular cases *)
-  (* CR vlaviron: There could be improvements based on reduction (trying to
-     reduce the is_int and get_tag cases to naked_immediate sets, then joining
-     those) but this looks unlikely to be useful and could end up begin quite
-     expensive. *)
-  | Is_int ty, Naked_immediates is_int | Naked_immediates is_int, Is_int ty -> (
-    match I.Set.choose_opt is_int with
-    | None -> Known (TG.Head_of_kind_naked_immediate.create_is_int ty)
-    | Some arbitrary_int -> (
-      let machine_width = I.machine_width arbitrary_int in
-      (* Slightly better than Unknown *)
-      let head =
-        TG.Head_of_kind_naked_immediate.create_naked_immediates
-          (I.Set.add (I.zero machine_width)
-             (I.Set.add (I.one machine_width) is_int))
-      in
-      match head with
-      | Ok head -> Known head
-      | Bottom ->
-        Misc.fatal_error
-          "Did not expect [Bottom] from [create_naked_immediates]"))
-  | Get_tag ty, Naked_immediates tags | Naked_immediates tags, Get_tag ty ->
-    if I.Set.is_empty tags
-    then Known (TG.Head_of_kind_naked_immediate.create_get_tag ty)
-    else Unknown
-  | Is_null ty, Naked_immediates is_null | Naked_immediates is_null, Is_null ty
-    -> (
-    match I.Set.choose_opt is_null with
-    | None -> Known (TG.Head_of_kind_naked_immediate.create_is_null ty)
-    | Some arbitrary_int -> (
-      let machine_width = I.machine_width arbitrary_int in
-      (* Slightly better than Unknown *)
-      let head =
-        TG.Head_of_kind_naked_immediate.create_naked_immediates
-          (I.Set.add (I.zero machine_width)
-             (I.Set.add (I.one machine_width) is_null))
-      in
-      match head with
-      | Ok head -> Known head
-      | Bottom ->
-        Misc.fatal_error
-          "Did not expect [Bottom] from [create_naked_immediates]"))
-  | (Is_int _ | Get_tag _ | Is_null _), (Is_int _ | Get_tag _ | Is_null _) ->
+  let only_in_target_join_env inverse_relations =
+    TG.Relation.Map.filter_map
+      (fun _ names ->
+        let names' =
+          Name.Set.filter
+            (fun name -> TE.mem (Join_env.target_join_env env) name)
+            names
+        in
+        if Name.Set.is_empty names' then None else Some names')
+      inverse_relations
+  in
+  match
+    ( reduce_head_of_kind_naked_immediate (Join_env.left_join_env env) head1,
+      reduce_head_of_kind_naked_immediate (Join_env.right_join_env env) head2 )
+  with
+  | Bottom, Bottom ->
+    (* Tough luck. We don't have a way to represent bottom here, so there'll be
+       some imprecision anyway; don't bother trying to do something more
+       precise. This should be rare. *)
     Unknown
+  | Bottom, Ok head | Ok head, Bottom ->
+    let descr = TG.Head_of_kind_naked_immediate.descr head in
+    let inverse_relations = only_in_target_join_env descr.inverse_relations in
+    Known
+      (TG.Head_of_kind_naked_immediate.from_descr_non_empty
+         { descr with inverse_relations })
+  | Ok head1, Ok head2 -> (
+    let descr1 = TG.Head_of_kind_naked_immediate.descr head1 in
+    let descr2 = TG.Head_of_kind_naked_immediate.descr head2 in
+    let naked_immediates =
+      join_unknown
+        (fun _ is1 is2 : _ Or_unknown.t -> Known (I.Set.union is1 is2))
+        env descr1.naked_immediates descr2.naked_immediates
+    in
+    let inverse_relations =
+      TG.Relation.Map.inter
+        (fun _relation names1 names2 ->
+          (* CR bclement: Maybe we should expand aliases here. *)
+          Name.Set.inter names1 names2)
+        descr1.inverse_relations descr2.inverse_relations
+    in
+    let inverse_relations = only_in_target_join_env inverse_relations in
+    match naked_immediates with
+    | Unknown when TG.Relation.Map.is_empty inverse_relations -> Unknown
+    | Unknown | Known _ ->
+      Known
+        (TG.Head_of_kind_naked_immediate.from_descr_non_empty
+           { naked_immediates; inverse_relations }))
 
 and join_head_of_kind_naked_float32 _env t1 t2 : _ Or_unknown.t =
   Known (TG.Head_of_kind_naked_float32.union t1 t2)

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -1331,9 +1331,11 @@ and reduce_inverse_relations env naked_immediates inverse_relations :
           Name.Set.fold
             (fun name env ->
               let add_equation ty =
-                match add_equation (Simple.name name) ty env ~meet_type with
-                | Ok (_, env) -> env
-                | Bottom _ -> raise Bottom_result
+                match
+                  ME.add_equation_strict env name ty ~meet_expanded_head
+                with
+                | Ok env -> env
+                | Bottom -> raise Bottom_result
               in
               match TG.Relation.descr relation with
               | Is_null -> (

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -825,21 +825,21 @@ let reduce_head_of_kind_naked_immediate env head : _ Or_bottom.t =
         { naked_immediates; inverse_relations }
 
 type 'a reverse_mapping_meet_return_value =
-  { left_inputs : 'a;
-    any_input : 'a meet_return_value;
-    right_inputs : 'a
+  { left_inputs_only : 'a;
+    meet_return_value : 'a meet_return_value;
+    right_inputs_only : 'a
   }
 
 let meet_inverse_relations inverse_relations1 inverse_relations2 =
   if inverse_relations1 == inverse_relations2
   then
-    { left_inputs = TG.Relation.Map.empty;
-      any_input = Both_inputs;
-      right_inputs = TG.Relation.Map.empty
+    { left_inputs_only = TG.Relation.Map.empty;
+      meet_return_value = Both_inputs;
+      right_inputs_only = TG.Relation.Map.empty
     }
   else
-    let left_inputs = ref TG.Relation.Map.empty in
-    let right_inputs = ref TG.Relation.Map.empty in
+    let left_inputs_only = ref TG.Relation.Map.empty in
+    let right_inputs_only = ref TG.Relation.Map.empty in
     let inverse_relations =
       TG.Relation.Map.merge
         (fun relation names1 names2 ->
@@ -849,25 +849,29 @@ let meet_inverse_relations inverse_relations1 inverse_relations2 =
           let right_input = Name.Set.diff names2 names1 in
           if not (Name.Set.is_empty left_input)
           then
-            left_inputs := TG.Relation.Map.add relation left_input !left_inputs;
+            left_inputs_only
+              := TG.Relation.Map.add relation left_input !left_inputs_only;
           if not (Name.Set.is_empty right_input)
           then
-            right_inputs
-              := TG.Relation.Map.add relation right_input !right_inputs;
+            right_inputs_only
+              := TG.Relation.Map.add relation right_input !right_inputs_only;
           Some (Name.Set.union names1 names2))
         inverse_relations1 inverse_relations2
     in
-    let any_input =
+    let meet_return_value =
       match
-        ( TG.Relation.Map.is_empty !left_inputs,
-          TG.Relation.Map.is_empty !right_inputs )
+        ( TG.Relation.Map.is_empty !left_inputs_only,
+          TG.Relation.Map.is_empty !right_inputs_only )
       with
       | true, true -> Both_inputs
       | false, true -> Left_input
       | true, false -> Right_input
       | false, false -> New_result inverse_relations
     in
-    { left_inputs = !left_inputs; any_input; right_inputs = !right_inputs }
+    { left_inputs_only = !left_inputs_only;
+      meet_return_value;
+      right_inputs_only = !right_inputs_only
+    }
 
 let rec meet env t1 t2 = ME.meet_type env t1 t2 ~meet_expanded_head
 
@@ -1392,15 +1396,15 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
         meet_inverse_relations descr1.inverse_relations descr2.inverse_relations
       in
       let head =
-        combine_meet_return_values naked_immediates inverse_relations.any_input
-          (fun () ->
+        combine_meet_return_values naked_immediates
+          inverse_relations.meet_return_value (fun () ->
             let naked_immediates =
               extract_value naked_immediates descr1.naked_immediates
                 descr2.naked_immediates
             in
             let inverse_relations =
-              extract_value inverse_relations.any_input descr1.inverse_relations
-                descr2.inverse_relations
+              extract_value inverse_relations.meet_return_value
+                descr1.inverse_relations descr2.inverse_relations
             in
             TG.Head_of_kind_naked_immediate.from_descr_non_empty
               { naked_immediates; inverse_relations })
@@ -1420,16 +1424,16 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
       | Left_input ->
         head_in_env_or_bottom
           (reduce_inverse_relations env descr1.naked_immediates
-             inverse_relations.right_inputs)
+             inverse_relations.right_inputs_only)
       | Right_input ->
         head_in_env_or_bottom
           (reduce_inverse_relations env descr2.naked_immediates
-             inverse_relations.left_inputs)
+             inverse_relations.left_inputs_only)
       | New_result naked_immediates ->
         head_in_env_or_bottom
           (reduce_inverse_relations env naked_immediates
-             (extract_value inverse_relations.any_input descr1.inverse_relations
-                descr2.inverse_relations))))
+             (extract_value inverse_relations.meet_return_value
+                descr1.inverse_relations descr2.inverse_relations))))
 
 and meet_head_of_kind_naked_float32 env t1 t2 =
   set_meet
@@ -2039,17 +2043,6 @@ and join_head_of_kind_naked_immediate env
     (head2 : TG.Head_of_kind_naked_immediate.t) :
     TG.Head_of_kind_naked_immediate.t Or_unknown.t =
   let module I = Target_ocaml_int in
-  let only_in_target_join_env inverse_relations =
-    TG.Relation.Map.filter_map
-      (fun _ names ->
-        let names' =
-          Name.Set.filter
-            (fun name -> TE.mem (Join_env.target_join_env env) name)
-            names
-        in
-        if Name.Set.is_empty names' then None else Some names')
-      inverse_relations
-  in
   match
     ( reduce_head_of_kind_naked_immediate (Join_env.left_join_env env) head1,
       reduce_head_of_kind_naked_immediate (Join_env.right_join_env env) head2 )
@@ -2059,12 +2052,7 @@ and join_head_of_kind_naked_immediate env
        some imprecision anyway; don't bother trying to do something more
        precise. This should be rare. *)
     Unknown
-  | Bottom, Ok head | Ok head, Bottom ->
-    let descr = TG.Head_of_kind_naked_immediate.descr head in
-    let inverse_relations = only_in_target_join_env descr.inverse_relations in
-    Known
-      (TG.Head_of_kind_naked_immediate.from_descr_non_empty
-         { descr with inverse_relations })
+  | Bottom, Ok head | Ok head, Bottom -> Known head
   | Ok head1, Ok head2 -> (
     let descr1 = TG.Head_of_kind_naked_immediate.descr head1 in
     let descr2 = TG.Head_of_kind_naked_immediate.descr head2 in
@@ -2080,7 +2068,6 @@ and join_head_of_kind_naked_immediate env
           Name.Set.inter names1 names2)
         descr1.inverse_relations descr2.inverse_relations
     in
-    let inverse_relations = only_in_target_join_env inverse_relations in
     match naked_immediates with
     | Unknown when TG.Relation.Map.is_empty inverse_relations -> Unknown
     | Unknown | Known _ ->

--- a/middle_end/flambda2/types/meet_and_n_way_join.ml
+++ b/middle_end/flambda2/types/meet_and_n_way_join.ml
@@ -1045,106 +1045,6 @@ let meet_inverse_relations inverse_relations1 inverse_relations2 =
       right_inputs_only = !right_inputs_only
     }
 
-let rec meet env (t1 : TG.t) (t2 : TG.t) : TG.t meet_result =
-  (* Kind mismatches should have been caught (either turned into Invalid or a
-     fatal error) before we get here. *)
-  if not (K.equal (TG.kind t1) (TG.kind t2))
-  then
-    Misc.fatal_errorf "Kind mismatch upon meet:@ %a@ versus@ %a" TG.print t1
-      TG.print t2;
-  let kind = TG.kind t1 in
-  let simple1 =
-    match
-      TE.get_alias_then_canonical_simple_exn (ME.typing_env env) t1
-        ~min_name_mode:Name_mode.in_types
-    with
-    | exception Not_found -> None
-    | canonical_simple -> Some canonical_simple
-  in
-  let simple2 =
-    match
-      TE.get_alias_then_canonical_simple_exn (ME.typing_env env) t2
-        ~min_name_mode:Name_mode.in_types
-    with
-    | exception Not_found -> None
-    | canonical_simple -> Some canonical_simple
-  in
-  match simple1 with
-  | None -> (
-    let expanded1 =
-      Expand_head.expand_head0 (ME.typing_env env) t1
-        ~known_canonical_simple_at_in_types_mode:simple1
-    in
-    match simple2 with
-    | None ->
-      let expanded2 =
-        Expand_head.expand_head0 (ME.typing_env env) t2
-          ~known_canonical_simple_at_in_types_mode:simple2
-      in
-      map_result ~f:ET.to_type (meet_expanded_head env expanded1 expanded2)
-    | Some simple2 -> (
-      (* Here we are meeting a non-alias type on the left with an alias on the
-         right. In all cases, the return type is the alias, so we will always
-         return [Right_input]; the interesting part will be the environment.
-
-         [add_equation] will meet [expanded1] with the existing type of
-         [simple2]. *)
-      let env : unit meet_result =
-        add_equation simple2 (ET.to_type expanded1) env ~meet_type
-      in
-      match env with
-      | Ok (_, env) -> Ok (Right_input, env)
-      | Bottom r -> Bottom r))
-  | Some simple1 -> (
-    match simple2 with
-    | None -> (
-      let expanded2 =
-        Expand_head.expand_head0 (ME.typing_env env) t2
-          ~known_canonical_simple_at_in_types_mode:simple2
-      in
-      (* We always return [Left_input] (see comment above) *)
-      let env : unit meet_result =
-        add_equation simple1 (ET.to_type expanded2) env ~meet_type
-      in
-      match env with
-      | Ok (_, env) -> Ok (Left_input, env)
-      | Bottom r -> Bottom r)
-    | Some simple2 -> (
-      if
-        (* We are doing a meet between two alias types. Whatever happens, the
-           resulting environment will contain an alias equation between the two
-           inputs, so both the left-hand alias and the right-hand alias are
-           correct results for the meet, allowing us to return [Both_inputs] in
-           all cases. *)
-        Simple.equal simple1 simple2
-      then
-        (* The alias is already present; no need to add any equation here *)
-        Ok (Both_inputs, env)
-      else
-        let env =
-          Simple.pattern_match simple2
-            ~name:(fun _ ~coercion:_ ->
-              add_equation simple2
-                (TG.alias_type_of kind simple1)
-                env ~meet_type)
-            ~const:(fun const2 ->
-              Simple.pattern_match simple1
-                ~name:(fun _ ~coercion:_ ->
-                  add_equation simple1
-                    (TG.alias_type_of kind simple2)
-                    env ~meet_type)
-                ~const:(fun const1 : unit meet_result ->
-                  if Reg_width_const.equal const1 const2
-                  then Ok (New_result (), env)
-                  else Bottom (New_result ())))
-        in
-        (* [add_equation] will have called [meet] on the underlying types, so
-           [env] now contains all extra equations arising from meeting the
-           expanded heads. *)
-        match env with
-        | Ok (_, env) -> Ok (Both_inputs, env)
-        | Bottom r -> Bottom r))
-
 let rec meet env t1 t2 = ME.meet_type env t1 t2 ~meet_expanded_head
 
 and meet_or_unknown_or_bottom : type a b.
@@ -1603,9 +1503,11 @@ and reduce_inverse_relations env naked_immediates inverse_relations :
           Name.Set.fold
             (fun name env ->
               let add_equation ty =
-                match add_equation (Simple.name name) ty env ~meet_type with
-                | Ok (_, env) -> env
-                | Bottom _ -> raise Bottom_result
+                match
+                  ME.add_equation_strict env name ty ~meet_expanded_head
+                with
+                | Ok env -> env
+                | Bottom -> raise Bottom_result
               in
               match TG.Relation.descr relation with
               | Is_null -> (

--- a/middle_end/flambda2/types/meet_and_n_way_join.ml
+++ b/middle_end/flambda2/types/meet_and_n_way_join.ml
@@ -735,15 +735,6 @@ let meet_code_id (env : ME.t) (code_id1 : Code_id.t) (code_id2 : Code_id.t) :
       then Ok (Right_input, env)
       else Ok (New_result code_id, env)
 
-type meet_keep_side =
-  | Left
-  | Right
-
-(* type meet_expanded_head_result =
- *   | Left_head_unchanged
- *   | Right_head_unchanged
- *   | New_head of ET.t * TEE.t *)
-
 let meet_alloc_mode env (alloc_mode1 : Alloc_mode.For_types.t)
     (alloc_mode2 : Alloc_mode.For_types.t) : Alloc_mode.For_types.t meet_result
     =
@@ -948,6 +939,207 @@ let join_array_element_kinds (element_kind1 : _ Or_unknown_or_bottom.t)
         ~when_used_at:element_kind1
     then Ok element_kind1
     else Unknown
+
+let reduce_head_of_kind_naked_immediate env head : _ Or_bottom.t =
+  let descr = TG.Head_of_kind_naked_immediate.descr head in
+  let changed = ref false in
+  let exception Bottom_result in
+  match
+    TG.Relation.Map.fold
+      (fun relation names (imms, inverse_relations) ->
+        let imms, names' =
+          Name.Set.fold
+            (fun name (imms, names) ->
+              Simple.pattern_match
+                (TE.get_canonical_simple_ignoring_name_mode env
+                   (Simple.name name))
+                ~const:(fun const : (_ Or_unknown.t * Name.Set.t) ->
+                  match
+                    TG.Relation.of_const ~machine_width:(TE.machine_width env)
+                      relation const
+                  with
+                  | Bottom ->
+                    (* CR bclement: we need to ignore [Bottom] here because
+                       unboxing can create inverse relations that wouldn't be
+                       valid e.g. for [get_tag] of something that we don't know
+                       is a block. *)
+                    changed := true;
+                    imms, names
+                  | Ok imm -> (
+                    let imms' = Target_ocaml_int.Set.singleton imm in
+                    match (imms : _ Or_unknown.t) with
+                    | Known imms ->
+                      if Target_ocaml_int.Set.equal imms' imms
+                      then Known imms, names
+                      else (
+                        if not (Target_ocaml_int.Set.mem imm imms)
+                        then raise Bottom_result;
+                        changed := true;
+                        Known imms', names)
+                    | Unknown ->
+                      changed := true;
+                      Known imms', names))
+                ~name:(fun name' ~coercion:_ ->
+                  if name' != name then changed := true;
+                  imms, Name.Set.add name' names))
+            names (imms, Name.Set.empty)
+        in
+        imms, TG.Relation.Map.add relation names' inverse_relations)
+      descr.inverse_relations
+      (descr.naked_immediates, TG.Relation.Map.empty)
+  with
+  | exception Bottom_result -> Bottom
+  | naked_immediates, inverse_relations ->
+    if not !changed
+    then Ok head
+    else
+      TG.Head_of_kind_naked_immediate.from_descr
+        { naked_immediates; inverse_relations }
+
+type 'a reverse_mapping_meet_return_value =
+  { left_inputs : 'a;
+    any_input : 'a meet_return_value;
+    right_inputs : 'a
+  }
+
+let meet_inverse_relations inverse_relations1 inverse_relations2 =
+  if inverse_relations1 == inverse_relations2
+  then
+    { left_inputs = TG.Relation.Map.empty;
+      any_input = Both_inputs;
+      right_inputs = TG.Relation.Map.empty
+    }
+  else
+    let left_inputs = ref TG.Relation.Map.empty in
+    let right_inputs = ref TG.Relation.Map.empty in
+    let inverse_relations =
+      TG.Relation.Map.merge
+        (fun relation names1 names2 ->
+          let names1 = Option.value ~default:Name.Set.empty names1 in
+          let names2 = Option.value ~default:Name.Set.empty names2 in
+          let left_input = Name.Set.diff names1 names2 in
+          let right_input = Name.Set.diff names2 names1 in
+          if not (Name.Set.is_empty left_input)
+          then
+            left_inputs := TG.Relation.Map.add relation left_input !left_inputs;
+          if not (Name.Set.is_empty right_input)
+          then
+            right_inputs
+              := TG.Relation.Map.add relation right_input !right_inputs;
+          Some (Name.Set.union names1 names2))
+        inverse_relations1 inverse_relations2
+    in
+    let any_input =
+      match
+        ( TG.Relation.Map.is_empty !left_inputs,
+          TG.Relation.Map.is_empty !right_inputs )
+      with
+      | true, true -> Both_inputs
+      | false, true -> Left_input
+      | true, false -> Right_input
+      | false, false -> New_result inverse_relations
+    in
+    { left_inputs = !left_inputs; any_input; right_inputs = !right_inputs }
+
+let rec meet env (t1 : TG.t) (t2 : TG.t) : TG.t meet_result =
+  (* Kind mismatches should have been caught (either turned into Invalid or a
+     fatal error) before we get here. *)
+  if not (K.equal (TG.kind t1) (TG.kind t2))
+  then
+    Misc.fatal_errorf "Kind mismatch upon meet:@ %a@ versus@ %a" TG.print t1
+      TG.print t2;
+  let kind = TG.kind t1 in
+  let simple1 =
+    match
+      TE.get_alias_then_canonical_simple_exn (ME.typing_env env) t1
+        ~min_name_mode:Name_mode.in_types
+    with
+    | exception Not_found -> None
+    | canonical_simple -> Some canonical_simple
+  in
+  let simple2 =
+    match
+      TE.get_alias_then_canonical_simple_exn (ME.typing_env env) t2
+        ~min_name_mode:Name_mode.in_types
+    with
+    | exception Not_found -> None
+    | canonical_simple -> Some canonical_simple
+  in
+  match simple1 with
+  | None -> (
+    let expanded1 =
+      Expand_head.expand_head0 (ME.typing_env env) t1
+        ~known_canonical_simple_at_in_types_mode:simple1
+    in
+    match simple2 with
+    | None ->
+      let expanded2 =
+        Expand_head.expand_head0 (ME.typing_env env) t2
+          ~known_canonical_simple_at_in_types_mode:simple2
+      in
+      map_result ~f:ET.to_type (meet_expanded_head env expanded1 expanded2)
+    | Some simple2 -> (
+      (* Here we are meeting a non-alias type on the left with an alias on the
+         right. In all cases, the return type is the alias, so we will always
+         return [Right_input]; the interesting part will be the environment.
+
+         [add_equation] will meet [expanded1] with the existing type of
+         [simple2]. *)
+      let env : unit meet_result =
+        add_equation simple2 (ET.to_type expanded1) env ~meet_type
+      in
+      match env with
+      | Ok (_, env) -> Ok (Right_input, env)
+      | Bottom r -> Bottom r))
+  | Some simple1 -> (
+    match simple2 with
+    | None -> (
+      let expanded2 =
+        Expand_head.expand_head0 (ME.typing_env env) t2
+          ~known_canonical_simple_at_in_types_mode:simple2
+      in
+      (* We always return [Left_input] (see comment above) *)
+      let env : unit meet_result =
+        add_equation simple1 (ET.to_type expanded2) env ~meet_type
+      in
+      match env with
+      | Ok (_, env) -> Ok (Left_input, env)
+      | Bottom r -> Bottom r)
+    | Some simple2 -> (
+      if
+        (* We are doing a meet between two alias types. Whatever happens, the
+           resulting environment will contain an alias equation between the two
+           inputs, so both the left-hand alias and the right-hand alias are
+           correct results for the meet, allowing us to return [Both_inputs] in
+           all cases. *)
+        Simple.equal simple1 simple2
+      then
+        (* The alias is already present; no need to add any equation here *)
+        Ok (Both_inputs, env)
+      else
+        let env =
+          Simple.pattern_match simple2
+            ~name:(fun _ ~coercion:_ ->
+              add_equation simple2
+                (TG.alias_type_of kind simple1)
+                env ~meet_type)
+            ~const:(fun const2 ->
+              Simple.pattern_match simple1
+                ~name:(fun _ ~coercion:_ ->
+                  add_equation simple1
+                    (TG.alias_type_of kind simple2)
+                    env ~meet_type)
+                ~const:(fun const1 : unit meet_result ->
+                  if Reg_width_const.equal const1 const2
+                  then Ok (New_result (), env)
+                  else Bottom (New_result ())))
+        in
+        (* [add_equation] will have called [meet] on the underlying types, so
+           [env] now contains all extra equations arising from meeting the
+           expanded heads. *)
+        match env with
+        | Ok (_, env) -> Ok (Both_inputs, env)
+        | Bottom r -> Bottom r))
 
 let rec meet env t1 t2 = ME.meet_type env t1 t2 ~meet_expanded_head
 
@@ -1386,111 +1578,130 @@ and meet_variant env ~(is_int1 : Variable.t option)
     ~left_b:(get_tag1, blocks1, imms1, extensions1)
     ~right_b:(get_tag2, blocks2, imms2, extensions2)
 
+and reduce_inverse_relations env naked_immediates inverse_relations :
+    _ Or_bottom.t =
+  let module I = struct
+    include Target_ocaml_int
+
+    let machine_width = TE.machine_width (ME.typing_env env)
+
+    let zero = zero machine_width
+
+    let one = one machine_width
+  end in
+  match (naked_immediates : _ Or_unknown.t) with
+  | Unknown -> Ok env
+  | Known imms -> (
+    let exception Bottom_result in
+    match
+      TG.Relation.Map.fold
+        (fun relation names env ->
+          Name.Set.fold
+            (fun name env ->
+              let add_equation ty =
+                match add_equation (Simple.name name) ty env ~meet_type with
+                | Ok (_, env) -> env
+                | Bottom _ -> raise Bottom_result
+              in
+              match TG.Relation.descr relation with
+              | Is_null -> (
+                match I.Set.mem I.zero imms, I.Set.mem I.one imms with
+                | false, false -> raise Bottom_result
+                | true, true -> env
+                | true, false -> add_equation TG.any_non_null_value
+                | false, true -> add_equation TG.null)
+              | Is_int -> (
+                match I.Set.mem I.zero imms, I.Set.mem I.one imms with
+                | false, false -> raise Bottom_result
+                | true, true -> env
+                | true, false -> add_equation MTC.any_block
+                | false, true -> add_equation MTC.any_tagged_immediate)
+              | Get_tag -> (
+                let tags =
+                  I.Set.fold
+                    (fun tag tags ->
+                      match Tag.create_from_targetint I.machine_width tag with
+                      | Some tag -> Tag.Set.add tag tags
+                      | None -> tags (* No blocks exist with this tag *))
+                    imms Tag.Set.empty
+                in
+                match
+                  MTC.blocks_with_these_tags ~machine_width:I.machine_width tags
+                    (Alloc_mode.For_types.unknown ())
+                with
+                | Known shape -> add_equation shape
+                | Unknown -> env))
+            names env)
+        inverse_relations env
+    with
+    | exception Bottom_result -> Bottom
+    | env -> Ok env)
+
 and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
     (t2 : TG.head_of_kind_naked_immediate) :
     TG.head_of_kind_naked_immediate meet_result =
   let module I = Target_ocaml_int in
-  let keep_side side : _ meet_result =
-    match side with
-    | Left -> Ok (Left_input, env)
-    | Right -> Ok (Right_input, env)
-  in
-  let bottom_other_side side : _ meet_result =
-    match side with Left -> Bottom Right_input | Right -> Bottom Left_input
-  in
-  let meet_with_shape ~rebuild ty shape side =
-    map_result ~f:rebuild
-      (match side with Left -> meet env ty shape | Right -> meet env shape ty)
-  in
-  let is_int_immediate ~is_int_ty ~immediates ~is_int_side =
-    if I.Set.is_empty immediates
-    then bottom_other_side is_int_side
-    else
-      let rebuild = TG.Head_of_kind_naked_immediate.create_is_int in
-      let machine_width = ME.machine_width env in
-      match
-        ( I.Set.mem (I.zero machine_width) immediates,
-          I.Set.mem (I.one machine_width) immediates )
-      with
-      | false, false -> Bottom (New_result ())
-      | true, true -> keep_side is_int_side
-      | true, false ->
-        meet_with_shape ~rebuild is_int_ty MTC.any_block is_int_side
-      | false, true ->
-        meet_with_shape ~rebuild is_int_ty MTC.any_tagged_immediate is_int_side
-  in
-  let is_null_immediate ~is_null_ty ~immediates ~is_null_side =
-    if I.Set.is_empty immediates
-    then bottom_other_side is_null_side
-    else
-      let rebuild = TG.Head_of_kind_naked_immediate.create_is_null in
-      let machine_width = ME.machine_width env in
-      match
-        ( I.Set.mem (I.zero machine_width) immediates,
-          I.Set.mem (I.one machine_width) immediates )
-      with
-      | false, false -> Bottom (New_result ())
-      | true, true -> keep_side is_null_side
-      | true, false ->
-        meet_with_shape ~rebuild is_null_ty TG.any_non_null_value is_null_side
-      | false, true -> meet_with_shape ~rebuild is_null_ty TG.null is_null_side
-  in
-  let get_tag_immediate ~get_tag_ty ~immediates ~get_tag_side =
-    if I.Set.is_empty immediates
-    then bottom_other_side get_tag_side
-    else
-      let tags =
-        I.Set.fold
-          (fun tag tags ->
-            let machine_width = ME.machine_width env in
-            match Tag.create_from_targetint machine_width tag with
-            | Some tag -> Tag.Set.add tag tags
-            | None -> tags (* No blocks exist with this tag *))
-          immediates Tag.Set.empty
+  match
+    ( reduce_head_of_kind_naked_immediate (ME.typing_env env) t1,
+      reduce_head_of_kind_naked_immediate (ME.typing_env env) t2 )
+  with
+  | Bottom, Bottom -> Bottom Both_inputs
+  | Bottom, Ok _ -> Bottom Left_input
+  | Ok _, Bottom -> Bottom Right_input
+  | Ok t1, Ok t2 -> (
+    let descr1 = TG.Head_of_kind_naked_immediate.descr t1 in
+    let descr2 = TG.Head_of_kind_naked_immediate.descr t2 in
+    let naked_immediates =
+      meet_unknown
+        (set_meet (module I.Set) ~of_set:Fun.id)
+        ~contents_is_bottom:I.Set.is_empty env descr1.naked_immediates
+        descr2.naked_immediates
+    in
+    match naked_immediates with
+    | Bottom r -> Bottom r
+    | Ok (naked_immediates, env) -> (
+      let inverse_relations =
+        meet_inverse_relations descr1.inverse_relations descr2.inverse_relations
       in
-      if Tag.Set.is_empty tags
-      then Bottom (New_result ())
-      else
-        let machine_width = ME.machine_width env in
-        match
-          MTC.blocks_with_these_tags ~machine_width tags
-            (Alloc_mode.For_types.unknown ())
-        with
-        | Known shape ->
-          meet_with_shape
-            ~rebuild:TG.Head_of_kind_naked_immediate.create_get_tag get_tag_ty
-            shape get_tag_side
-        | Unknown -> keep_side get_tag_side
-  in
-  match t1, t2 with
-  | Naked_immediates is1, Naked_immediates is2 ->
-    map_result
-      ~f:TG.Head_of_kind_naked_immediate.create_naked_immediates_non_empty
-      (set_meet (module I.Set) env is1 is2 ~of_set:Fun.id)
-  | Is_int is_int_ty, Naked_immediates immediates ->
-    is_int_immediate ~is_int_ty ~immediates ~is_int_side:Left
-  | Naked_immediates immediates, Is_int is_int_ty ->
-    is_int_immediate ~is_int_ty ~immediates ~is_int_side:Right
-  | Get_tag get_tag_ty, Naked_immediates immediates ->
-    get_tag_immediate ~get_tag_ty ~immediates ~get_tag_side:Left
-  | Naked_immediates immediates, Get_tag get_tag_ty ->
-    get_tag_immediate ~get_tag_ty ~immediates ~get_tag_side:Right
-  | Is_null is_null_ty, Naked_immediates immediates ->
-    is_null_immediate ~is_null_ty ~immediates ~is_null_side:Left
-  | Naked_immediates immediates, Is_null is_null_ty ->
-    is_null_immediate ~is_null_ty ~immediates ~is_null_side:Right
-  | (Is_int _ | Get_tag _ | Is_null _), (Is_int _ | Get_tag _ | Is_null _) ->
-    (* CR mshinwell: introduce improved handling for
-     *   Is_int meet Is_int
-     *   Get_tag meet Get_tag
-     * i.e. a better fix for PR1515, at which point we might also be able
-     * to consider improving:
-     *   Is_int meet Get_tag
-     * and vice-versa. *)
-    (* We can't return Bottom, as it would be unsound, so we need to either do
-       the actual meet with Naked_immediates, or just give up and return one of
-       the arguments. *)
-    Ok (Left_input, env)
+      let head =
+        combine_meet_return_values naked_immediates inverse_relations.any_input
+          (fun () ->
+            let naked_immediates =
+              extract_value naked_immediates descr1.naked_immediates
+                descr2.naked_immediates
+            in
+            let inverse_relations =
+              extract_value inverse_relations.any_input descr1.inverse_relations
+                descr2.inverse_relations
+            in
+            TG.Head_of_kind_naked_immediate.from_descr_non_empty
+              { naked_immediates; inverse_relations })
+      in
+      let[@local] head_in_env_or_bottom (env_ob : _ Or_bottom.t) =
+        match env_ob with
+        | Bottom -> Bottom (New_result ())
+        | Ok env -> Ok (head, env)
+      in
+      (* Only perform reverse reductions for relations that were not already
+         known in the corresponding side, e.g. if we meet [(Naked_immediate (0 1
+         2) (%get_tag x)] and [(Naked_immediate T (%get_tag y))] we only update
+         the tag of [y], but not of [x] (which we assume to already have been
+         reduced). *)
+      match naked_immediates with
+      | Both_inputs -> Ok (head, env)
+      | Left_input ->
+        head_in_env_or_bottom
+          (reduce_inverse_relations env descr1.naked_immediates
+             inverse_relations.right_inputs)
+      | Right_input ->
+        head_in_env_or_bottom
+          (reduce_inverse_relations env descr2.naked_immediates
+             inverse_relations.left_inputs)
+      | New_result naked_immediates ->
+        head_in_env_or_bottom
+          (reduce_inverse_relations env naked_immediates
+             (extract_value inverse_relations.any_input descr1.inverse_relations
+                descr2.inverse_relations))))
 
 and meet_head_of_kind_naked_float32 env t1 t2 =
   set_meet
@@ -2423,53 +2634,46 @@ and n_way_join_head_of_kind_naked_immediate env
     (heads : TG.Head_of_kind_naked_immediate.t Join_env.join_arg list) :
     TG.Head_of_kind_naked_immediate.t n_way_join_result =
   let module I = Target_ocaml_int in
-  let immediates, is_int, get_tag, is_null =
+  let immediates, _relations (* TODO *) =
     List.fold_left
-      (fun (immediates, is_int, get_tag, is_null) (id2, head2) ->
-        match (head2 : TG.head_of_kind_naked_immediate) with
-        | Is_int ty -> immediates, (id2, ty) :: is_int, get_tag, is_null
-        | Get_tag ty -> immediates, is_int, (id2, ty) :: get_tag, is_null
-        | Is_null ty -> immediates, is_int, get_tag, (id2, ty) :: is_null
-        | Naked_immediates is ->
-          I.Set.union is immediates, is_int, get_tag, is_null)
-      (I.Set.empty, [], [], []) heads
+      (fun ((immediates : _ Or_unknown.t), relations) (id2, head2) ->
+        match
+          reduce_head_of_kind_naked_immediate
+            (Join_env.joined_env env id2)
+            head2
+        with
+        | Bottom -> immediates, relations
+        | Ok head2 ->
+          let descr2 = TG.Head_of_kind_naked_immediate.descr head2 in
+          let immediates : _ Or_unknown.t =
+            match immediates, descr2.naked_immediates with
+            | Unknown, _ | _, Unknown -> Unknown
+            | Known imms, Known imms2 -> Known (I.Set.union imms imms2)
+          in
+          let relations =
+            (* CR bclement: The inverse relations should be rebuilt from the
+               direct relations during join. *)
+            TG.Relation.Map.update_many
+              (fun _relation names names2 ->
+                match Name.Set.get_singleton names2 with
+                | None -> Some Or_unknown.Unknown
+                | Some name2 -> (
+                  match (names : _ Or_unknown.t option) with
+                  | None -> Some (Or_unknown.Known [id2, name2])
+                  | Some Unknown -> Some Or_unknown.Unknown
+                  | Some (Known names) ->
+                    Some (Or_unknown.Known ((id2, name2) :: names))))
+              relations descr2.inverse_relations
+          in
+          immediates, relations)
+      (Or_unknown.Known I.Set.empty, TG.Relation.Map.empty)
+      heads
   in
-  match is_int, get_tag, is_null with
-  | [], [], [] -> (
-    let head =
-      TG.Head_of_kind_naked_immediate.create_naked_immediates immediates
-    in
-    match head with
-    | Ok head -> Known head, env
-    | Bottom ->
-      Misc.fatal_error "Did not expect [Bottom] from [create_naked_immediates]")
-  | _ :: _, [], [] when I.Set.is_empty immediates ->
-    let>>+ ty = n_way_join env is_int in
-    TG.Head_of_kind_naked_immediate.create_is_int ty
-  | [], _ :: _, [] when I.Set.is_empty immediates ->
-    let>>+ ty = n_way_join env get_tag in
-    TG.Head_of_kind_naked_immediate.create_get_tag ty
-  | [], [], _ :: _ when I.Set.is_empty immediates ->
-    let>>+ ty = n_way_join env is_null in
-    TG.Head_of_kind_naked_immediate.create_is_null ty
-  (* From now on: Irregular cases *)
-  (* CR vlaviron: There could be improvements based on reduction (trying to
-     reduce the is_int and get_tag cases to naked_immediate sets, then joining
-     those) but this looks unlikely to be useful and could end up begin quite
-     expensive. *)
-  | _, _ :: _, _ -> Unknown, env
-  | _ :: _, [], _ | _, [], _ :: _ -> (
-    (* Slightly better than Unknown *)
-    let head =
-      let machine_width = Join_env.machine_width env in
-      TG.Head_of_kind_naked_immediate.create_naked_immediates
-        (I.Set.add (I.zero machine_width)
-           (I.Set.add (I.one machine_width) immediates))
-    in
-    match head with
-    | Ok head -> Known head, env
-    | Bottom ->
-      Misc.fatal_error "Did not expect [Bottom] from [create_naked_immediates]")
+  let head =
+    Or_unknown.map immediates
+      ~f:TG.Head_of_kind_naked_immediate.create_naked_immediates_non_empty
+  in
+  head, env
 
 and n_way_join_head_of_kind_naked_float32 env t1 ts : _ n_way_join_result =
   n_way_join_head_of_kind_naked_number

--- a/middle_end/flambda2/types/meet_and_n_way_join.ml
+++ b/middle_end/flambda2/types/meet_and_n_way_join.ml
@@ -997,21 +997,21 @@ let reduce_head_of_kind_naked_immediate env head : _ Or_bottom.t =
         { naked_immediates; inverse_relations }
 
 type 'a reverse_mapping_meet_return_value =
-  { left_inputs : 'a;
-    any_input : 'a meet_return_value;
-    right_inputs : 'a
+  { left_inputs_only : 'a;
+    meet_return_value : 'a meet_return_value;
+    right_inputs_only : 'a
   }
 
 let meet_inverse_relations inverse_relations1 inverse_relations2 =
   if inverse_relations1 == inverse_relations2
   then
-    { left_inputs = TG.Relation.Map.empty;
-      any_input = Both_inputs;
-      right_inputs = TG.Relation.Map.empty
+    { left_inputs_only = TG.Relation.Map.empty;
+      meet_return_value = Both_inputs;
+      right_inputs_only = TG.Relation.Map.empty
     }
   else
-    let left_inputs = ref TG.Relation.Map.empty in
-    let right_inputs = ref TG.Relation.Map.empty in
+    let left_inputs_only = ref TG.Relation.Map.empty in
+    let right_inputs_only = ref TG.Relation.Map.empty in
     let inverse_relations =
       TG.Relation.Map.merge
         (fun relation names1 names2 ->
@@ -1021,25 +1021,29 @@ let meet_inverse_relations inverse_relations1 inverse_relations2 =
           let right_input = Name.Set.diff names2 names1 in
           if not (Name.Set.is_empty left_input)
           then
-            left_inputs := TG.Relation.Map.add relation left_input !left_inputs;
+            left_inputs_only
+              := TG.Relation.Map.add relation left_input !left_inputs_only;
           if not (Name.Set.is_empty right_input)
           then
-            right_inputs
-              := TG.Relation.Map.add relation right_input !right_inputs;
+            right_inputs_only
+              := TG.Relation.Map.add relation right_input !right_inputs_only;
           Some (Name.Set.union names1 names2))
         inverse_relations1 inverse_relations2
     in
-    let any_input =
+    let meet_return_value =
       match
-        ( TG.Relation.Map.is_empty !left_inputs,
-          TG.Relation.Map.is_empty !right_inputs )
+        ( TG.Relation.Map.is_empty !left_inputs_only,
+          TG.Relation.Map.is_empty !right_inputs_only )
       with
       | true, true -> Both_inputs
       | false, true -> Left_input
       | true, false -> Right_input
       | false, false -> New_result inverse_relations
     in
-    { left_inputs = !left_inputs; any_input; right_inputs = !right_inputs }
+    { left_inputs_only = !left_inputs_only;
+      meet_return_value;
+      right_inputs_only = !right_inputs_only
+    }
 
 let rec meet env (t1 : TG.t) (t2 : TG.t) : TG.t meet_result =
   (* Kind mismatches should have been caught (either turned into Invalid or a
@@ -1664,15 +1668,15 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
         meet_inverse_relations descr1.inverse_relations descr2.inverse_relations
       in
       let head =
-        combine_meet_return_values naked_immediates inverse_relations.any_input
-          (fun () ->
+        combine_meet_return_values naked_immediates
+          inverse_relations.meet_return_value (fun () ->
             let naked_immediates =
               extract_value naked_immediates descr1.naked_immediates
                 descr2.naked_immediates
             in
             let inverse_relations =
-              extract_value inverse_relations.any_input descr1.inverse_relations
-                descr2.inverse_relations
+              extract_value inverse_relations.meet_return_value
+                descr1.inverse_relations descr2.inverse_relations
             in
             TG.Head_of_kind_naked_immediate.from_descr_non_empty
               { naked_immediates; inverse_relations })
@@ -1692,16 +1696,16 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
       | Left_input ->
         head_in_env_or_bottom
           (reduce_inverse_relations env descr1.naked_immediates
-             inverse_relations.right_inputs)
+             inverse_relations.right_inputs_only)
       | Right_input ->
         head_in_env_or_bottom
           (reduce_inverse_relations env descr2.naked_immediates
-             inverse_relations.left_inputs)
+             inverse_relations.left_inputs_only)
       | New_result naked_immediates ->
         head_in_env_or_bottom
           (reduce_inverse_relations env naked_immediates
-             (extract_value inverse_relations.any_input descr1.inverse_relations
-                descr2.inverse_relations))))
+             (extract_value inverse_relations.meet_return_value
+                descr1.inverse_relations descr2.inverse_relations))))
 
 and meet_head_of_kind_naked_float32 env t1 t2 =
   set_meet
@@ -2634,15 +2638,17 @@ and n_way_join_head_of_kind_naked_immediate env
     (heads : TG.Head_of_kind_naked_immediate.t Join_env.join_arg list) :
     TG.Head_of_kind_naked_immediate.t n_way_join_result =
   let module I = Target_ocaml_int in
-  let immediates, _relations (* TODO *) =
+  (* We drop the reverse relations here -- they are instead rebuilt from the
+     direct relations during the join (see join_env.ml). *)
+  let immediates =
     List.fold_left
-      (fun ((immediates : _ Or_unknown.t), relations) (id2, head2) ->
+      (fun (immediates : _ Or_unknown.t) (id2, head2) ->
         match
           reduce_head_of_kind_naked_immediate
             (Join_env.joined_env env id2)
             head2
         with
-        | Bottom -> immediates, relations
+        | Bottom -> immediates
         | Ok head2 ->
           let descr2 = TG.Head_of_kind_naked_immediate.descr head2 in
           let immediates : _ Or_unknown.t =
@@ -2650,24 +2656,8 @@ and n_way_join_head_of_kind_naked_immediate env
             | Unknown, _ | _, Unknown -> Unknown
             | Known imms, Known imms2 -> Known (I.Set.union imms imms2)
           in
-          let relations =
-            (* CR bclement: The inverse relations should be rebuilt from the
-               direct relations during join. *)
-            TG.Relation.Map.update_many
-              (fun _relation names names2 ->
-                match Name.Set.get_singleton names2 with
-                | None -> Some Or_unknown.Unknown
-                | Some name2 -> (
-                  match (names : _ Or_unknown.t option) with
-                  | None -> Some (Or_unknown.Known [id2, name2])
-                  | Some Unknown -> Some Or_unknown.Unknown
-                  | Some (Known names) ->
-                    Some (Or_unknown.Known ((id2, name2) :: names))))
-              relations descr2.inverse_relations
-          in
-          immediates, relations)
-      (Or_unknown.Known I.Set.empty, TG.Relation.Map.empty)
-      heads
+          immediates)
+      (Or_unknown.Known I.Set.empty) heads
   in
   let head =
     Or_unknown.map immediates

--- a/middle_end/flambda2/types/traversals.ml
+++ b/middle_end/flambda2/types/traversals.ml
@@ -1035,11 +1035,12 @@ struct
 
   and rewrite_head_of_kind_naked_immediate
       (head : TG.head_of_kind_naked_immediate) : _ Or_unknown.t =
-    match head with
-    | Naked_immediates _ -> Or_unknown.Known head
-    | Is_int _ | Get_tag _ | Is_null _ ->
-      (* CR bclement: replace with prove. *)
-      Or_unknown.Unknown
+    match TG.Head_of_kind_naked_immediate.descr head with
+    | { naked_immediates; inverse_relations = _ } ->
+      (* CR bclement: keep inverse_relations *)
+      Or_unknown.Known
+        (TG.Head_of_kind_naked_immediate.from_descr_non_empty
+           { naked_immediates; inverse_relations = TG.Relation.Map.empty })
 
   and rewrite_head_of_kind_naked_float32 head : _ Or_unknown.t =
     Or_unknown.Known head

--- a/testsuite/tests/flambda2/simplify/naked_immediates_many_relations.ml
+++ b/testsuite/tests/flambda2/simplify/naked_immediates_many_relations.ml
@@ -19,7 +19,7 @@ type t = A of (int -> int) | B of (int -> int)
    as an indirect call.
  *)
 
-let r b =
+let r =
   let f x = x in
   let g x = x in
   let k x y =
@@ -28,46 +28,43 @@ let r b =
       begin match x, y with
       | A ax, A ay -> ax (ay 0)
       | B bx, B by -> by (bx 0)
+      | _ -> assert false
       end
+    | _ -> assert false
   in
-  let x = if b then A f else B g in
-  let y = if b then A g else B f in
+  let x = if Sys.opaque_identity true then A f else B g in
+  let y = if Sys.opaque_identity true then A g else B f in
   (k[@inlined]) x y
 [%%expect_fexpr Simplify{|
-let $camlTOP3__immstring68 = "" in
-let $camlTOP3__const_block76 = Block 0 ($camlTOP3__immstring68, 19, 4) in
-let $camlTOP3__Pmakeblock79 =
-  Block 0 ($`*predef*`.caml_exn_Match_failure, $camlTOP3__const_block76)
+let $camlTOP3__immstring54 = "" in
+let $camlTOP3__const_block56 = Block 0 ($camlTOP3__immstring54, 27, 11) in
+let $camlTOP3__Pmakeblock59 =
+  Block 0 ($`*predef*`.caml_exn_Assert_failure, $camlTOP3__const_block56)
 in
-let code r_0 deleted in
-let code loopify(never) size(52) newer_version_of(r_0)
-      r_0_1 (b : imm tagged)
-        my_closure _region _ghost_region my_depth
-        -> k * k1
-        : imm tagged =
-  (let untagged = %untag_imm (b) in
-   switch untagged
-     | 0 -> k2 (1i)
-     | 1 -> k2 (0i))
-    where k2 (tag : imm) =
-      ((let untagged = %untag_imm (b) in
-        switch untagged
-          | 0 -> k2 (1i)
-          | 1 -> k2 (0i))
-         where k2 (tag_1 : imm) =
-           (switch tag
-              | 0 -> k2
-              | 1 -> k3
-              where k3 =
-                switch tag_1
-                  | 0 -> k1 pop(regular k1) ($camlTOP3__Pmakeblock79)
-                  | 1 -> k (0)
-              where k2 =
-                switch tag_1
-                  | 0 -> k (0)
-                  | 1 -> k1 pop(regular k1) ($camlTOP3__Pmakeblock79)))
-in
-let $camlTOP3__r_3 = closure r_0_1 @r in
-let $camlTOP3 = Block 0 ($camlTOP3__r_3) in
-cont done ($camlTOP3)
+(let Popaque = %opaque (1) in
+ let untagged = %untag_imm (Popaque) in
+ switch untagged
+   | 0 -> k1 (1i)
+   | 1 -> k1 (0i))
+  where k1 (tag : imm) =
+    ((let Popaque = %opaque (1) in
+      let untagged = %untag_imm (Popaque) in
+      switch untagged
+        | 0 -> k1 (1i)
+        | 1 -> k1 (0i))
+       where k1 (tag_1 : imm) =
+         (switch tag
+            | 0 -> k1
+            | 1 -> k2
+            where k2 =
+              switch tag_1
+                | 0 -> error pop(regular error) ($camlTOP3__Pmakeblock59)
+                | 1 -> k
+            where k1 =
+              switch tag_1
+                | 0 -> k
+                | 1 -> error pop(regular error) ($camlTOP3__Pmakeblock59)))
+  where k =
+    let $camlTOP3 = Block 0 (0) in
+    cont done ($camlTOP3)
 |}]

--- a/testsuite/tests/flambda2/simplify/naked_immediates_many_relations.ml
+++ b/testsuite/tests/flambda2/simplify/naked_immediates_many_relations.ml
@@ -1,0 +1,73 @@
+(* TEST
+   compile_only = "true";
+   flambda2;
+   expect.opt with dump-simplify;
+ *)
+
+[@@@ocaml.flambda_o3]
+
+
+type t = A of (int -> int) | B of (int -> int)
+
+(* It used to be that we were only able to record a single relation between a
+   naked immediate value and a variant. This test shows a situation where it is
+   useful to be able to have multiple such relations.
+
+   When tracking a single relation, in the re-simplification of [k] when it is
+   called as the result of [r], we forget its relation with either [x] or [y],
+   and can only inline one of the two calls in each branch -- the other remain
+   as an indirect call.
+ *)
+
+let r b =
+  let f x = x in
+  let g x = x in
+  let k x y =
+    match x, y with
+    | A _, A _ | B _, B _ ->
+      begin match x, y with
+      | A ax, A ay -> ax (ay 0)
+      | B bx, B by -> by (bx 0)
+      end
+  in
+  let x = if b then A f else B g in
+  let y = if b then A g else B f in
+  (k[@inlined]) x y
+[%%expect_fexpr Simplify{|
+let $camlTOP3__immstring68 = "" in
+let $camlTOP3__const_block76 = Block 0 ($camlTOP3__immstring68, 19, 4) in
+let $camlTOP3__Pmakeblock79 =
+  Block 0 ($`*predef*`.caml_exn_Match_failure, $camlTOP3__const_block76)
+in
+let code r_0 deleted in
+let code loopify(never) size(52) newer_version_of(r_0)
+      r_0_1 (b : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  (let untagged = %untag_imm (b) in
+   switch untagged
+     | 0 -> k2 (1i)
+     | 1 -> k2 (0i))
+    where k2 (tag : imm) =
+      ((let untagged = %untag_imm (b) in
+        switch untagged
+          | 0 -> k2 (1i)
+          | 1 -> k2 (0i))
+         where k2 (tag_1 : imm) =
+           (switch tag
+              | 0 -> k2
+              | 1 -> k3
+              where k3 =
+                switch tag_1
+                  | 0 -> k1 pop(regular k1) ($camlTOP3__Pmakeblock79)
+                  | 1 -> k (0)
+              where k2 =
+                switch tag_1
+                  | 0 -> k (0)
+                  | 1 -> k1 pop(regular k1) ($camlTOP3__Pmakeblock79)))
+in
+let $camlTOP3__r_3 = closure r_0_1 @r in
+let $camlTOP3 = Block 0 ($camlTOP3__r_3) in
+cont done ($camlTOP3)
+|}]


### PR DESCRIPTION
This is one part of #4112, with information stored in the types in the style of #2259 (which it replaces).

One crucial difference with #2259 is that during the meet, we only reduce new information. For instance, if we are meeting:

  (Naked_immediate {0, 1, 2} (Get_tag x))

and

  (Naked_immediate {1, 2} (Get_tag y))

then we will propagate:

 - Nothing if `x` and `y` have the same canonical;

 - The set of tags `{1, 2}` on `x` otherwise.

This provides a way to solve potential reduction loops with forward reductions from the value itself: if the set of possible tags of `x` shrinks to a new set `S`, and we know that `get_tag(x) = get_tag_x`, then we can add the equation

	get_tag_x : (Naked_immediate S (Get_tag x))

If we already know this set of possible values for `get_tag_x`, then nothing happens. If we know (or learn through intersection with `S`) a more precise set of values for `get_tag_x`, the reduction on `get_tag_x` will add a type on `x` with tags `S'` and `get_tag` variable `get_tag_x`. Since `S'` is a subset of `S`, we will then not propagate things back onto `get_tag_x`.