### PR TITLE
WIP: Merge Type Shapes into Shapes for Functor Support in DWARF Emission

### DIFF
--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
@@ -212,7 +212,7 @@ let rec field_name_with_path base path =
   | [] -> base
   | i :: path -> field_name_with_path base path ^ ".#" ^ Int.to_string i
 
-type 'layout projected_field = string option * S.without_layout S.ts * 'layout
+type 'layout projected_field = string option * S.t * 'layout
 
 let project_field_given_path (fields : Layout.t projected_field array) path :
     base_layout projected_field =
@@ -232,7 +232,7 @@ let project_field_given_path (fields : Layout.t projected_field array) path :
     let field_name = Option.value ~default:("." ^ Int.to_string i) field_name in
     let field_name_with_projection = field_name_with_path field_name subpath in
     ( Some field_name_with_projection,
-      Ts_other Layout_to_be_determined,
+      Shape.leaf' None,
       (* CR sspies: To properly support unboxed records in mixed records, we we
          need to propagate the right shape information here. *)
       project_layout field_layout subpath )
@@ -271,13 +271,8 @@ let flatten_fields_in_mixed_record ~(mixed_block_shapes : Layout.t array)
 (* This function deals with variants that are annotated with [@@unboxed]. They
    are only allowed to have a single constructor. *)
 let create_attribute_unboxed_variant_die ~reference ~parent_proto_die ~name
-    ~constr_name ~arg_name ~(arg_layout : Layout.t) ~arg_die =
-  let base_layout =
-    match arg_layout with
-    | Base base_layout -> base_layout
-    | Product _ -> Misc.fatal_error "Not a base layout"
-  in
-  let width = base_layout_to_byte_size base_layout in
+    ~constr_name ~arg_name ~arg_layout ~arg_die =
+  let width = base_layout_to_byte_size arg_layout in
   let structure_ref = reference in
   let variant_part_ref = Proto_die.create_reference () in
   let variant_member_ref = Proto_die.create_reference () in
@@ -991,220 +986,155 @@ let create_base_layout_type ?(simd_vec_split = None) ~reference
       ~name:(Some name) ~split:simd_vec_split
 
 module Shape_with_layout = struct
+  type t =
+    { type_shape : Shape.t;
+      type_layout : Layout.t
+    }
+
   include Identifiable.Make (struct
-    type nonrec t = Layout.t S.ts
+    type nonrec t = t
 
     let compare = Stdlib.compare
     (* CR sspies: Fix compare and equals on this type. Move the module to type
        shape once it is more cleaned up. *)
 
-    let print = S.print_type_shape
+    let print fmt { type_shape; type_layout } =
+      Format.fprintf fmt "%a @ %a" Shape.print type_shape Layout.format
+        type_layout
 
-    let hash = Hashtbl.hash
+    let hash { type_shape; type_layout } =
+      Hashtbl.hash (type_shape.hash, type_layout)
 
-    let equal (x : t) y = x = y
+    let equal ({ type_shape = x1; type_layout = y1 } : t)
+        ({ type_shape = x2; type_layout = y2 } : t) =
+      Shape.equal x1 x2 && Layout.equal y1 y2
 
     let output _oc _t = Misc.fatal_error "unimplemented"
   end)
 end
 
+let name_reference = ref 0
+
+let mk_type_name () =
+  incr name_reference;
+  "unknown/" ^ string_of_int !name_reference
+
 module Cache = Shape_with_layout.Tbl
+(* We add a cache based on type shapes to handle, for example, recursive types.
+   One may be tempted to cache based on the type declaration rather than the
+   type shape. However, this approach has one crucial flaw: polymorphic
+   declarations instantiated with different type variables would result in the
+   same declaration (the first one), leading to incorrect debugging information.
+
+   We include the name in the cache to avoid cases where the type shape is the
+   same, but the type name differs (e.g., different declarations of int). *)
 
 let cache = Cache.create 16
 
-let rec type_shape_to_dwarf_die (type_shape : Layout.t S.ts) ~parent_proto_die
-    ~fallback_value_die =
-  match Cache.find_opt cache type_shape with
+let add_to_cache (type_shape : Shape.t) (type_layout : Layout.t) reference =
+  if Shape.is_mu_closed type_shape
+  then Cache.add cache { type_shape; type_layout } reference
+
+let rec type_shape_to_dwarf_die (type_shape : Shape.t)
+    (type_layout : base_layout) ~parent_proto_die ~fallback_value_die ~rec_env =
+  match
+    Cache.find_opt cache
+      ({ type_shape; type_layout = Base type_layout } : Shape_with_layout.t)
+  with
   | Some reference -> reference
   | None ->
     let reference = Proto_die.create_reference () in
-    (* We add the combination of shape and layout early in case of recursive
-       types, which can then look up their reference, before it is fully
-       defined. That way [type myintlist = MyNil | MyCons of int * myintlist]
-       will work correctly (as opposed to diverging). *)
-    Cache.add cache type_shape reference;
-    let type_name = Type_shape.type_name type_shape in
+    let type_name = mk_type_name () in
+    (* CR sspies: Fix the name here. *)
+    add_to_cache type_shape (Base type_layout) reference;
     let layout_name =
-      Format.asprintf "%a" Layout.format (S.shape_layout type_shape)
+      Format.asprintf "%a" Layout.format (Layout.Base type_layout)
     in
     let name = type_name ^ " @ " ^ layout_name in
-    (match type_shape with
-    | Ts_other type_layout | Ts_var (_, type_layout) -> (
-      match type_layout with
-      | Base b ->
-        create_base_layout_type ~reference b ~name ~parent_proto_die
-          ~fallback_value_die
-      | Product _ ->
-        Misc.fatal_errorf
-          "only base layouts supported, but found unboxed product layout %s"
-          layout_name)
-    | Ts_unboxed_tuple _ ->
-      Misc.fatal_errorf "unboxed tuples cannot have base layout %s" layout_name
-    | Ts_tuple fields ->
-      type_shape_to_dwarf_die_tuple ~reference ~parent_proto_die
-        ~fallback_value_die ~name fields
-    | Ts_predef (predef, args) ->
-      type_shape_to_dwarf_die_predef ~reference ~name ~parent_proto_die
-        ~fallback_value_die predef args
-    | Ts_constr ((type_uid, type_path, type_layout), shapes) -> (
-      match type_layout with
-      | Base b ->
-        type_shape_to_dwarf_die_type_constructor ~reference ~name
-          ~parent_proto_die ~fallback_value_die ~type_uid type_path b shapes
-      | Product _ ->
-        Misc.fatal_errorf
-          "only base layouts supported, but found product layout %s" layout_name
-      )
-    | Ts_variant fields ->
-      type_shape_to_dwarf_die_poly_variant ~reference ~name ~parent_proto_die
-        ~fallback_value_die ~constructors:fields
-    | Ts_arrow (arg, ret) ->
-      type_shape_to_dwarf_die_arrow ~reference ~name ~parent_proto_die
-        ~fallback_value_die arg ret);
-    reference
-
-and type_shape_to_dwarf_die_tuple ~name ~reference ~parent_proto_die
-    ~fallback_value_die fields =
-  let fields =
-    List.map
-      (type_shape_to_dwarf_die ~parent_proto_die ~fallback_value_die)
-      fields
-  in
-  create_tuple_die ~reference ~parent_proto_die ~name ~fields
-
-and type_shape_to_dwarf_die_predef ~name ~reference ~parent_proto_die
-    ~fallback_value_die (predef : S.Predef.t) args =
-  match predef, args with
-  | Array, [element_type_shape] ->
-    let element_type_shape =
-      S.shape_with_layout ~layout:(Base Value) element_type_shape
-    in
-    (* CR sspies: Check whether the elements of an array are always values and,
-       if not, where that information is maintained.
-
-       mshinwell: we need to handle unboxed arrays. See Cmm_helpers, but let's
-       wait until after we change the representation of these not to use custom
-       blocks. *)
-    let child_die =
-      type_shape_to_dwarf_die ~parent_proto_die ~fallback_value_die
-        element_type_shape
-    in
-    create_array_die ~reference ~parent_proto_die ~child_die ~name
-  | Array, args ->
-    Misc.fatal_errorf
-      "[Array] shapes must be applied to exactly one type shape (found %d)"
-      (List.length args)
-  | Char, _ -> create_char_die ~reference ~parent_proto_die ~name
-  | Unboxed b, _ ->
-    let type_layout = S.Predef.unboxed_type_to_layout b in
-    create_base_layout_type
-      ~simd_vec_split:(unboxed_base_type_to_simd_vec_split b)
-      ~reference type_layout ~name ~parent_proto_die ~fallback_value_die
-  | Simd s, _ ->
-    (* We represent these vectors as pointers of the form [struct {...} *],
-       because their runtime representations are blocks with tag [Abstract_tag]
-       (see [Cmm_helpers]). *)
-    let base_ref = Proto_die.create_reference () in
-    create_simd_vec_split_base_layout_die ~split:(Some s) ~reference:base_ref
-      ~name:None ~parent_proto_die;
-    Proto_die.create_ignore ~reference ~parent:(Some parent_proto_die)
-      ~tag:Dwarf_tag.Reference_type
-      ~attribute_values:
-        [ DAH.create_byte_size_exn ~byte_size:Arch.size_addr;
-          DAH.create_type_from_reference ~proto_die_reference:base_ref;
-          DAH.create_name name ]
-      ()
-  | Exception, _ ->
-    create_exception_die ~reference ~fallback_value_die ~parent_proto_die ~name
-  | ( ( Bytes | Extension_constructor | Float | Float32 | Floatarray | Int
-      | Int32 | Int64 | Lazy_t | Nativeint | String ),
-      _ ) ->
-    create_base_layout_type ~reference Value ~name ~parent_proto_die
-      ~fallback_value_die
-
-and type_shape_to_dwarf_die_type_constructor ~reference ~name ~parent_proto_die
-    ~fallback_value_die ~type_uid _type_path (type_layout : base_layout) shapes
-    =
-  match
-    (* CR sspies: Somewhat subtly, this case currently also handles [unit],
-       [bool], [option], and [list], because they are not treated as predefined
-       types and do have declarations. *)
-    Type_shape.find_in_type_decls type_uid
-  with
-  | None ->
-    create_base_layout_type ~reference type_layout ~name ~parent_proto_die
-      ~fallback_value_die
-  | Some type_decl_shape -> (
-    let type_decl_shape = S.replace_tvar type_decl_shape shapes in
-    match type_decl_shape.definition with
-    | Tds_other ->
+    (match type_shape.desc with
+    | Leaf ->
       create_base_layout_type ~reference type_layout ~name ~parent_proto_die
         ~fallback_value_die
-    | Tds_alias alias_shape ->
-      let alias_shape =
-        S.shape_with_layout ~layout:(Base type_layout) alias_shape
+    | Constr _ -> Misc.fatal_error "unimplemented"
+    | Unboxed_tuple _ ->
+      Misc.fatal_errorf "unboxed tuples cannot have base layout %s" layout_name
+    | Tuple fields ->
+      type_shape_to_dwarf_die_tuple ~reference ~parent_proto_die
+        ~fallback_value_die ~name ~rec_env fields
+    | Predef (predef, args) ->
+      let refs =
+        List.map
+          (fun s ->
+            type_shape_to_dwarf_die ~parent_proto_die ~fallback_value_die s
+              Jkind_types.Sort.Value ~rec_env)
+          (* CR sspies: Value layout here is wrong. The predef type should
+             determine which layouts the arguments. *)
+          args
       in
-      let alias_die =
-        type_shape_to_dwarf_die alias_shape ~parent_proto_die
-          ~fallback_value_die
-      in
-      create_typedef_die ~reference ~parent_proto_die ~child_die:alias_die ~name
-    | Tds_record { fields; kind = Record_boxed | Record_floats } ->
+      type_shape_to_dwarf_die_predef ~reference ~name ~parent_proto_die
+        ~fallback_value_die predef refs
+    | Poly_variant fields ->
+      type_shape_to_dwarf_die_poly_variant ~reference ~name ~parent_proto_die
+        ~fallback_value_die ~constructors:fields ~rec_env
+    | Arrow _ ->
+      type_shape_to_dwarf_die_arrow ~reference ~name ~parent_proto_die
+        ~fallback_value_die
+    | Record { fields; kind = Record_boxed | Record_floats } ->
       let fields =
         List.map
           (fun (name, type_shape, type_layout) ->
-            let type_shape' =
-              S.shape_with_layout ~layout:type_layout type_shape
+            let base_layout =
+              match type_layout with
+              | Layout.Base base_layout -> base_layout
+              | _ ->
+                Misc.fatal_error "Record fields should not have product layout"
+              (* CR sspies: Is this true? If not, how should they be handled? *)
             in
             ( name,
               Arch.size_addr,
               (* All fields here are machine word width *)
               type_shape_to_dwarf_die ~parent_proto_die ~fallback_value_die
-                type_shape' ))
+                type_shape ~rec_env base_layout ))
           fields
       in
       create_record_die ~reference ~parent_proto_die ~name ~fields
-    | Tds_record { fields = _; kind = Record_unboxed_product } ->
+    | Record { fields = _; kind = Record_unboxed_product } ->
       Misc.fatal_error
         "Unboxed records should not reach this stage. They are deconstructed \
          by unarization in earlier stages of the compiler."
-    | Tds_record
+    | Record
         { fields = [(field_name, sh, Base base_layout)]; kind = Record_unboxed }
       ->
-      let field_shape = S.shape_with_layout ~layout:(Base base_layout) sh in
       let field_die =
-        type_shape_to_dwarf_die ~parent_proto_die ~fallback_value_die
-          field_shape
+        type_shape_to_dwarf_die ~parent_proto_die ~fallback_value_die sh
+          base_layout ~rec_env
       in
       let field_size = base_layout_to_byte_size base_layout in
       create_attribute_unboxed_record_die ~reference ~parent_proto_die ~name
-        ~field_die ~field_name ~field_size
+        ~field_name ~field_size ~field_die
       (* The two cases below are filtered out by the flattening of shapes in
          [flatten_shape]. *)
-    | Tds_record { fields = [] | _ :: _ :: _; kind = Record_unboxed } ->
+    | Record { fields = [] | _ :: _ :: _; kind = Record_unboxed } ->
       assert false
-    | Tds_record { fields = [(_, _, Product _)]; kind = Record_unboxed } ->
+    | Record { fields = [(_, _, Product _)]; kind = Record_unboxed } ->
       assert false
-    | Tds_record { fields; kind = Record_mixed mixed_block_shapes } ->
+    | Record { fields; kind = Record_mixed mixed_block_shapes } ->
       let fields = List.map (fun (name, sh, ly) -> Some name, sh, ly) fields in
       let fields = flatten_fields_in_mixed_record ~mixed_block_shapes fields in
       let fields =
         List.map
           (fun (name, type_shape, base_layout) ->
-            let type_shape' =
-              S.shape_with_layout ~layout:(Base base_layout) type_shape
-            in
             match name with
             | Some name ->
               ( name,
                 base_layout_to_byte_size_in_mixed_block base_layout,
                 type_shape_to_dwarf_die ~parent_proto_die ~fallback_value_die
-                  type_shape' )
-            | _ -> assert false)
+                  type_shape base_layout ~rec_env )
+            | None -> assert false)
           fields
       in
       create_record_die ~reference ~parent_proto_die ~name ~fields
-    | Tds_variant { simple_constructors; complex_constructors } -> (
+    | Variant { simple_constructors; complex_constructors } -> (
       match complex_constructors with
       | [] ->
         create_simple_variant_die ~reference ~parent_proto_die ~name
@@ -1228,36 +1158,135 @@ and type_shape_to_dwarf_die_type_constructor ~reference ~name ~parent_proto_die
               ( constr_name,
                 List.map
                   (fun (field_name, sh, ly) ->
-                    let sh = S.shape_with_layout ~layout:(Layout.Base ly) sh in
                     ( field_name,
                       type_shape_to_dwarf_die ~parent_proto_die
-                        ~fallback_value_die sh,
+                        ~fallback_value_die ~rec_env sh ly,
                       ly ))
                   fields ))
             complex_constructors
         in
         create_complex_variant_die ~reference ~parent_proto_die ~name
           ~simple_constructors ~complex_constructors)
-    | Tds_variant_unboxed
-        { name = constr_name; arg_name; arg_shape; arg_layout } ->
-      let arg_shape = S.shape_with_layout ~layout:arg_layout arg_shape in
+    | Variant_unboxed { name = constr_name; arg_name; arg_shape; arg_layout } ->
+      let base_layout =
+        match arg_layout with
+        | Layout.Base base_layout -> base_layout
+        | _ ->
+          Misc.fatal_error
+            "unboxed product in unboxed constructor is not allowed"
+      in
       let arg_die =
         type_shape_to_dwarf_die ~parent_proto_die ~fallback_value_die arg_shape
+          base_layout ~rec_env
       in
       create_attribute_unboxed_variant_die ~reference ~parent_proto_die ~name
-        ~constr_name ~arg_name ~arg_layout ~arg_die)
+        ~constr_name ~arg_name ~arg_layout:base_layout ~arg_die
+    | Rec_var i -> (
+      match rec_env i with
+      | Some reference' ->
+        create_typedef_die ~reference ~parent_proto_die ~name
+          ~child_die:reference'
+      | None ->
+        (* CR sspies: This case should not happen. Consider weaking the error
+           and falling back to the default type. *)
+        assert false)
+    | Mu sh ->
+      let reference' =
+        (* CR avoid creating a new reference here. *)
+        type_shape_to_dwarf_die ~parent_proto_die ~fallback_value_die sh
+          type_layout ~rec_env:(fun i ->
+            if i = 0 then Some reference else rec_env (i - 1))
+      in
+      create_typedef_die ~reference ~parent_proto_die ~name
+        ~child_die:reference'
+    | Alias sh ->
+      let reference' =
+        type_shape_to_dwarf_die ~parent_proto_die ~fallback_value_die sh
+          type_layout ~rec_env
+      in
+      (* CR avoid creating a new reference here. *)
+      create_typedef_die ~reference ~parent_proto_die ~name
+        ~child_die:reference'
+    | App _ | Error _ | Proj _ ->
+      (* In these cases, something has gone wrong during reduction, because we
+         do not have sufficient information. *)
+      create_base_layout_type ~reference type_layout ~name ~parent_proto_die
+        ~fallback_value_die
+    | ProjDecl _ ->
+      (* CR sspies: This case should have been ruled out by the recursive
+         unfolding. *)
+      Misc.fatal_error
+        "Projections from mutually recursive definitions should have been \
+         resolved at this point."
+    | Abs _ | Comp_unit _ | Struct _ | Var _ | Mutrec _ ->
+      (* CR sspies: In these cases, we have generated an ill-formed term for
+         shape reduction, which should result in a louder error. *)
+      Misc.fatal_error
+        "Shape reduction should not result in any one of these normal forms");
+    reference
+
+and type_shape_to_dwarf_die_tuple ~name ~reference ~parent_proto_die
+    ~fallback_value_die ~rec_env fields =
+  let fields =
+    List.map
+      (fun sh ->
+        type_shape_to_dwarf_die ~parent_proto_die ~fallback_value_die ~rec_env
+          sh Jkind_types.Sort.Value)
+      fields
+  in
+  create_tuple_die ~reference ~parent_proto_die ~name ~fields
+
+and type_shape_to_dwarf_die_predef ~name ~reference ~parent_proto_die
+    ~fallback_value_die (predef : Shape.Predef.t) args =
+  match predef, args with
+  | Array, [child_die] ->
+    create_array_die ~reference ~parent_proto_die ~child_die ~name
+  | Array, _ ->
+    Misc.fatal_error "Array applied to zero or more than one type."
+    (* CR sspies: What should we do in this case. The old code supported it,
+       simply yielding the [fallback_value_die], but that seems strange. *)
+  | Char, _ -> create_char_die ~reference ~parent_proto_die ~name
+  | Unboxed b, _ ->
+    let type_layout = Shape.Predef.unboxed_type_to_base_layout b in
+    create_base_layout_type
+      ~simd_vec_split:(unboxed_base_type_to_simd_vec_split b)
+      ~reference type_layout ~name ~parent_proto_die ~fallback_value_die
+  | Simd s, _ ->
+    (* We represent these vectors as pointers of the form [struct {...} *],
+       because their runtime representation are abstract blocks. *)
+    let base_ref = Proto_die.create_reference () in
+    create_simd_vec_split_base_layout_die ~split:(Some s) ~reference:base_ref
+      ~parent_proto_die ~name:None;
+    Proto_die.create_ignore ~reference ~parent:(Some parent_proto_die)
+      ~tag:Dwarf_tag.Reference_type
+      ~attribute_values:
+        [ DAH.create_name name;
+          DAH.create_byte_size_exn ~byte_size:Arch.size_addr;
+          DAH.create_type_from_reference ~proto_die_reference:base_ref ]
+      ()
+  | Exception, _ ->
+    create_exception_die ~reference ~fallback_value_die ~parent_proto_die ~name
+  | ( ( Bytes | Extension_constructor | Float | Float32 | Floatarray | Int
+      | Int32 | Int64 | Lazy_t | Nativeint | String ),
+      _ ) ->
+    create_base_layout_type ~reference Value ~name ~parent_proto_die
+      ~fallback_value_die
 
 and type_shape_to_dwarf_die_arrow ~reference ~name ~parent_proto_die
-    ~fallback_value_die _arg _ret =
+    ~fallback_value_die =
   (* There is no need to inspect the argument and return value. *)
   create_typedef_die ~reference ~parent_proto_die ~name
     ~child_die:fallback_value_die
 
 and type_shape_to_dwarf_die_poly_variant ~reference ~parent_proto_die
-    ~fallback_value_die ~name ~constructors =
+    ~fallback_value_die ~name ~constructors ~rec_env =
   let constructors_with_references =
     S.poly_variant_constructors_map
-      (type_shape_to_dwarf_die ~parent_proto_die ~fallback_value_die)
+      (fun sh ->
+        type_shape_to_dwarf_die ~parent_proto_die ~fallback_value_die ~rec_env
+          sh Jkind_types.Sort.Value)
+      (* CR sspies: Can polymorphic variant constructors really only carry
+         values? If not, we should propagate that information here. *)
       constructors
   in
   create_type_shape_to_dwarf_die_poly_variant ~reference ~parent_proto_die ~name
@@ -1276,90 +1305,111 @@ let rec flatten_to_base_sorts (sort : Layout.t) : base_layout list =
    type is known, we produce [Known type_shape] for the fields. *)
 
 type shape_or_unknown =
-  | Known of Layout.t S.ts
+  | Known of S.t * base_layout
   | Unknown of base_layout
 
-let rec flatten_shape (type_shape : Layout.t S.ts) =
+let rec flatten_shape (type_shape : Shape.t) (type_layout : Layout.t) =
   let unknown_base_layouts layout =
     let base_sorts = flatten_to_base_sorts layout in
     List.map (fun base_sort -> Unknown base_sort) base_sorts
   in
-  match type_shape with
-  | Ts_var (_, Base _) -> [Known type_shape]
-  | Ts_var (_, (Product _ as type_layout)) -> unknown_base_layouts type_layout
-  | Ts_tuple _ ->
-    [Known type_shape]
-    (* tuples are word-width, as they are pointers to blocks *)
-  | Ts_unboxed_tuple shapes -> List.concat_map flatten_shape shapes
-  | Ts_predef _ -> [Known type_shape]
-  | Ts_arrow _ -> [Known type_shape]
-  | Ts_variant _ -> [Known type_shape]
-  | Ts_other layout ->
-    let base_layouts = flatten_to_base_sorts layout in
-    List.map (fun layout -> Unknown layout) base_layouts
-  | Ts_constr ((type_uid, _type_path, layout), shapes) -> (
-    match Type_shape.find_in_type_decls type_uid with
-    | None -> unknown_base_layouts layout
-    | Some { definition = Tds_other; _ } -> unknown_base_layouts layout
-    | Some type_decl_shape -> (
-      let type_decl_shape = S.replace_tvar type_decl_shape shapes in
-      match type_decl_shape.definition with
-      | Tds_other ->
-        unknown_base_layouts layout (* Cannot break up unknown type. *)
-      | Tds_alias alias_shape ->
-        let alias_shape = S.shape_with_layout ~layout alias_shape in
-        flatten_shape alias_shape
-        (* At first glance, this recursion could potentially diverge, for direct
-           cycles between type aliases and the defintion of the type. However,
-           it seems the compiler disallows direct cycles such as [type t = t]
-           and the like. If this ever causes trouble or the behvior of the
-           compiler changes with respect to recursive types, we can add a bound
-           on the maximal recursion depth. *)
-      | Tds_record
-          { fields = _; kind = Record_boxed | Record_mixed _ | Record_floats }
-        -> (
-        match layout with
-        | Base Value -> [Known type_shape]
-        | _ -> Misc.fatal_error "record must have value layout")
-      | Tds_record { fields = [(_, sh, ly)]; kind = Record_unboxed }
-        when Layout.equal ly layout -> (
-        match layout with
-        | Product _ -> flatten_shape (S.shape_with_layout ~layout sh)
-        (* for unboxed products of the form [{ field: ty } [@@unboxed]] where
-           [ty] is of product sort, we simply look through the unboxed product.
-           Otherwise, we will create an additional DWARF entry for it. *)
-        | Base _ -> [Known type_shape])
-      | Tds_record { fields = [_]; kind = Record_unboxed } ->
-        Misc.fatal_error "unboxed record at different layout from its field"
-      | Tds_record
-          { fields = ([] | _ :: _ :: _) as fields; kind = Record_unboxed } ->
-        Misc.fatal_errorf "unboxed record must have exactly one field, found %a"
-          (Format.pp_print_list ~pp_sep:Format.pp_print_space
-             Format.pp_print_string)
-          (List.map (fun (name, _, _) -> name) fields)
-      | Tds_record { fields; kind = Record_unboxed_product } -> (
-        match layout with
-        | Product prod_shapes when List.length prod_shapes = List.length fields
-          ->
-          let shapes =
-            List.map
-              (fun (_, sh, ly) -> S.shape_with_layout ~layout:ly sh)
-              fields
-          in
-          List.concat_map flatten_shape shapes
-        | Product _ -> Misc.fatal_error "unboxed record field mismatch"
-        | Base _ -> Misc.fatal_error "unboxed record must have product layout")
-      | Tds_variant _ -> (
-        match layout with
-        | Base Value -> [Known type_shape]
-        | _ -> Misc.fatal_error "variant must have value layout")
-      | Tds_variant_unboxed
-          { name = _; arg_name = _; arg_layout; arg_shape = _ } ->
-        if Layout.equal arg_layout layout
-        then [Known type_shape]
-        else
-          Misc.fatal_error
-            "unboxed variant must have same layout as its contents"))
+  match type_shape.desc, type_layout with
+  | Leaf, _ -> unknown_base_layouts type_layout
+  | Tuple _, Base Value ->
+    [Known (type_shape, Jkind_types.Sort.Value)]
+    (* tuples are only a single base layout wide *)
+  | Tuple _, _ -> Misc.fatal_error "tuple must have value layout"
+  | Unboxed_tuple shapes, _ -> (
+    match type_layout with
+    | Layout.Product layouts when List.length layouts = List.length shapes ->
+      let shapes_with_layout = List.combine shapes layouts in
+      List.concat_map (fun (sh, ly) -> flatten_shape sh ly) shapes_with_layout
+    | Layout.Product _ -> Misc.fatal_error "unboxed tuple field mismatch"
+    | Layout.Base _ -> Misc.fatal_error "unboxed tuple must have product layout"
+    )
+  | Constr _, _ -> Misc.fatal_error "unimplemented"
+  | Predef _, Base base_layout -> [Known (type_shape, base_layout)]
+  | Predef _, _ -> Misc.fatal_error "predefined type must have base layout"
+  | Arrow _, Base Value -> [Known (type_shape, Jkind_types.Sort.Value)]
+  | Arrow _, _ -> Misc.fatal_error "arrow must have value layout"
+  | Poly_variant _, Base Value -> [Known (type_shape, Jkind_types.Sort.Value)]
+  | Poly_variant _, _ -> Misc.fatal_error "poly_variant must have value layout"
+  | ( Record { fields = _; kind = Record_boxed | Record_mixed _ | Record_floats },
+      Base Value ) ->
+    [Known (type_shape, Jkind_types.Sort.Value)]
+  | ( Record { fields = _; kind = Record_boxed | Record_mixed _ | Record_floats },
+      _ ) ->
+    Misc.fatal_error "record must have value layout"
+  | Record { fields = [(_, sh, ly)]; kind = Record_unboxed }, _
+    when Layout.equal ly type_layout -> (
+    match type_layout with
+    | Product _ -> flatten_shape sh ly
+    (* for unboxed products of the form [{ field: ty } [@@unboxed]] where [ty]
+       is of product sort, we simply look through the unboxed product.
+       Otherwise, we will create an additional DWARF entry for it. *)
+    | Base b -> [Known (type_shape, b)])
+  | Record { fields = [_]; kind = Record_unboxed }, _ ->
+    Misc.fatal_error "unboxed record at different layout than its field"
+  | Record { fields = ([] | _ :: _ :: _) as fields; kind = Record_unboxed }, _
+    ->
+    Misc.fatal_errorf "unboxed record must have exactly one field, found %a"
+      (Format.pp_print_list ~pp_sep:Format.pp_print_space Format.pp_print_string)
+      (List.map (fun (name, _, _) -> name) fields)
+  | Record { fields; kind = Record_unboxed_product }, _ -> (
+    match type_layout with
+    | Layout.Product prod_shapes
+      when List.length prod_shapes = List.length fields ->
+      List.concat_map (fun (_, sh, ly) -> flatten_shape sh ly) fields
+    | Layout.Product _ -> Misc.fatal_error "unboxed record field mismatch"
+    | Layout.Base _ ->
+      Misc.fatal_error "unboxed record must have product layout")
+  | Variant _, Base Value -> [Known (type_shape, Jkind_types.Sort.Value)]
+  | Variant _, _ -> Misc.fatal_error "variant must have value layout"
+  | ( Variant_unboxed { name = _; arg_name = _; arg_layout; arg_shape = _ },
+      Base Value )
+    when Layout.equal arg_layout type_layout ->
+    [Known (type_shape, Jkind_types.Sort.Value)]
+  | Variant_unboxed _, _ ->
+    Misc.fatal_error
+      "unboxed variant must have value layout, and must have same layout as \
+       its contents"
+  | Rec_var i, _ ->
+    unknown_base_layouts type_layout
+    (* A projection should not reach the point of a recursive variable. *)
+  | Mu sh, _ -> flatten_shape sh type_layout
+  | Alias sh, _ -> flatten_shape sh type_layout
+  | (App _ | Error _ | Proj _), _ ->
+    (* In these cases, something has gone wrong during reduction, because we do
+       not have sufficient information. *)
+    unknown_base_layouts type_layout
+  | (Abs _ | Comp_unit _ | Struct _ | Var _ | ProjDecl _ | Mutrec _), _ ->
+    (* CR sspies: In these cases, we have generated an ill-formed term for shape
+       reduction, which should result in a louder error. *)
+    Misc.fatal_error
+      "Shape reduction should not result in any one of these normal forms"
+
+module With_cms_reduce = Shape_reduce.Make (struct
+  let fuel = 10
+
+  let read_unit_shape ~unit_name =
+    let filename = String.uncapitalize_ascii unit_name in
+    match Load_path.find_normalized (filename ^ ".cms") with
+    | exception Not_found -> None
+    | fn -> (
+      match Cms_format.read fn with
+      | exception Cms_format.Error _ ->
+        (* CR sspies: We could consider throwing a louder error here, since
+           there must be something like a [.cms] version mismatch here. For now,
+           since it's only debugging information, we fail silently. *)
+        None
+      | cms_infos -> cms_infos.cms_impl_shape)
+
+  let remove_uids = true
+
+  let unfold_recursive_types = true
+end)
+
+let debug_print_reduction_before_and_after = true
 
 let variable_to_die state (var_uid : Uid.t) ~parent_proto_die =
   let fallback_value_die =
@@ -1386,12 +1436,20 @@ let variable_to_die state (var_uid : Uid.t) ~parent_proto_die =
 
      mshinwell: or emit an "unknown layout" type *)
   | Some { type_shape; type_layout } -> (
-    let type_shape = S.shape_with_layout ~layout:type_layout type_shape in
+    let shape_reduce = With_cms_reduce.reduce Env.empty in
+    if debug_print_reduction_before_and_after
+    then Format.eprintf "before reduction %a@." Shape.print type_shape;
+    let type_shape = shape_reduce type_shape in
+    let type_shape = Type_shape.unfold_and_evaluate type_shape in
+    if debug_print_reduction_before_and_after
+    then Format.eprintf "after reduction %a@." Shape.print type_shape;
     let type_shape =
-      match unboxed_projection with
-      | None -> Known type_shape
-      | Some i ->
-        let flattened = flatten_shape type_shape in
+      match unboxed_projection, type_layout with
+      | None, Base b -> Known (type_shape, b)
+      | None, Product _ ->
+        Misc.fatal_error "product layout not flattened by unarization"
+      | Some i, _ ->
+        let flattened = flatten_shape type_shape type_layout in
         let flattened_length = List.length flattened in
         if i < 0 || i >= flattened_length
         then
@@ -1400,8 +1458,9 @@ let variable_to_die state (var_uid : Uid.t) ~parent_proto_die =
         List.nth flattened i
     in
     match type_shape with
-    | Known type_shape ->
-      type_shape_to_dwarf_die type_shape ~parent_proto_die ~fallback_value_die
+    | Known (type_shape, base_layout) ->
+      type_shape_to_dwarf_die type_shape base_layout ~parent_proto_die
+        ~fallback_value_die ~rec_env:(fun _ -> None)
     | Unknown base_layout ->
       let reference = Proto_die.create_reference () in
       create_base_layout_type ~reference ~parent_proto_die

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1592,6 +1592,11 @@ and transl_tupled_function
       end
   | _ -> None
 
+and env_shape_of_path env path ~args =
+  match Env.shape_of_path_opt ~namespace:Type env path with
+  | None -> None
+  | Some sh -> Some (Shape.app_list sh args)
+
 (* For the functions [add_type_shape_of_cases], [add_type_shapes_of_params], and
    [add_type_shapes_of_patterns] to be correct, we must ensure that at the type
    tree level, a [debug_uid] is never associated with more than one type
@@ -1610,7 +1615,7 @@ and add_type_shapes_of_pattern ~env sort pattern =
   let var_list = Typedtree.pat_bound_idents_full sort pattern in
   List.iter (fun (_ident, _loc, type_expr, var_uid, var_sort) ->
     Type_shape.add_to_type_shapes var_uid type_expr var_sort
-      (Env.find_uid_of_path env))
+      (env_shape_of_path env))
   var_list
 
 (** [add_type_shapes_of_cases] iterates through a given list of cases and

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1692,16 +1692,15 @@ let find_shape env (ns : Shape.Sig_component_kind.t) id =
   | Class_type ->
       (IdTbl.find_same id env.cltypes).cltda_shape
 
-let find_uid_of_path env path =
-  (* We currently only support looking up debugging uids in the current
-     environment. Future versions will support looking up declarations in other
-     files via the shape mechanism in [shape.ml]. *)
-  match find_type path env with
-  | exception Not_found -> None
-  | type_ -> let uid = type_.type_uid in Some uid
 
 let shape_of_path ~namespace env =
   Shape.of_path ~namespace ~find_shape:(find_shape env)
+
+let shape_of_path_opt ~namespace env path =
+  try
+    (Some (shape_of_path ~namespace env path))
+  with
+    Not_found -> None
 
 let shape_or_leaf uid = function
   | None -> Shape.leaf uid
@@ -2991,22 +2990,22 @@ let save_signature_with_imports ~alerts sg modname cu cmi imports =
 
 (* Make the initial environment, without language extensions *)
 let initial =
-  (* We collect all the type declarations that are added to the initial
-     environment in a table. *)
-  let added_types = Ident.Tbl.create 16 in
+  let shape_of_path env path ~args =
+    Option.map (fun sh -> Shape.app_list sh args)
+      (shape_of_path_opt ~namespace:Type env path)
+  in
   let add_type_and_remember_decl (type_ident : Ident.t) decl env =
-    Ident.Tbl.add added_types type_ident decl;
-    add_type type_ident decl env ~check:false
+    let shape = Type_shape.Type_decl_shape.of_type_declarations [type_ident, decl] (shape_of_path env) in
+    let shape = match shape with [shape] -> shape | _ -> assert false in
+    Uid.Tbl.add Type_shape.all_type_decls decl.type_uid shape;
+    (* CR sspies: Adding it to [all_type_decls] is not needed at this point. The
+       relevant information now lives in the shapes themselves. *)
+    add_type type_ident ~shape decl env ~check:false
   in
   let initial_env =
     Predef.build_initial_env add_type_and_remember_decl
       (add_extension ~check:false ~rebind:false) empty
   in
-  (* We record the type declarations for the type shapes. *)
-  Ident.Tbl.iter (fun type_ident decl ->
-    Type_shape.add_to_type_decls (Pident type_ident) decl
-      (find_uid_of_path initial_env)
-  ) added_types;
   initial_env
 
 let add_language_extension_types env =

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -131,10 +131,8 @@ val find_constructor_address: Path.t -> t -> address
 val shape_of_path:
   namespace:Shape.Sig_component_kind.t -> t -> Path.t -> Shape.t
 
-(* CR sspies: The function [find_uid_of_path] is only temporary and will be
-   removed in a subsequent PR that removes the paths from type shapes. For now,
-   it is here to reduce code duplication. *)
-val find_uid_of_path : t -> Path.t -> Uid.t option
+val shape_of_path_opt:
+  namespace:Shape.Sig_component_kind.t -> t -> Path.t -> Shape.t option
 
 val add_functor_arg: Ident.t -> t -> t
 val is_functor_arg: Path.t -> t -> bool

--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -503,6 +503,18 @@ let complex_constructor_map f { name; kind; args } =
 
 let complex_constructors_map f = List.map (complex_constructor_map f)
 
+let equal_complex_constructor_arguments eq
+  { field_name = field_name1; field_value = field_value1 }
+  { field_name = field_name2; field_value = field_value2 } =
+  Option.equal String.equal field_name1 field_name2 &&
+  eq field_value1 field_value2
+
+let equal_complex_constructor eq
+  { name = name1; kind = kind1; args = args1 }
+  { name = name2; kind = kind2; args = args2 } =
+  String.equal name1 name2 &&
+  Misc.Stdlib.Array.equal Layout.equal kind1 kind2 &&
+  List.equal (equal_complex_constructor_arguments eq) args1 args2
 
 let rec equal_desc d1 d2 =
   if d1 == d2 then true else
@@ -617,23 +629,6 @@ and equal_field (s1, sh1, ly1) (s2, sh2, ly2) =
   Layout.equal ly1 ly2
 
 and equal_simple_constructor c1 c2 = String.equal c1 c2
-
-and equal_complex_constructor eq
-  { name = name1; kind = kind1; args = args1 }
-  { name = name2; kind = kind2; args = args2 } =
-  String.equal name1 name2 &&
-  equal_constructor_representation kind1 kind2 &&
-  List.equal (equal_complex_constructor_arguments eq) args1 args2
-
-and equal_complex_constructor_arguments eq
-  { field_name = field_name1; field_value = field_value1 }
-  { field_name = field_name2; field_value = field_value2 } =
-  Option.equal String.equal field_name1 field_name2 &&
-  eq field_value1 field_value2
-
-and equal_constructor_representation lys1 lys2 =
-  Misc.Stdlib.Array.equal Layout.equal lys1 lys2
-
 
 and equal_poly_variant_constructor
   { pv_constr_name = name1; pv_constr_args = args1 }

--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -329,7 +329,7 @@ module Predef = struct
       | Float32x16 -> Vec512
       | Float64x8 -> Vec512
 
-    let unboxed_type_to_layout (b : unboxed) : Jkind_types.Sort.base =
+    let unboxed_type_to_base_layout (b : unboxed) : base_layout =
       match b with
       | Unboxed_float -> Float64
       | Unboxed_float32 -> Float32
@@ -354,7 +354,62 @@ module Predef = struct
       | String -> Base Value
       | Simd _ -> Base Value
       | Exception -> Base Value
-      | Unboxed u -> Base (unboxed_type_to_layout u)
+      | Unboxed u -> Base (unboxed_type_to_base_layout u)
+
+
+    let equal_simd_vec_split = fun s1 s2 ->
+      match s1, s2 with
+      | Int8x16, Int8x16 -> true
+      | Int16x8, Int16x8 -> true
+      | Int32x4, Int32x4 -> true
+      | Int64x2, Int64x2 -> true
+      | Float32x4, Float32x4 -> true
+      | Float64x2, Float64x2 -> true
+      | Int8x32, Int8x32 -> true
+      | Int16x16, Int16x16 -> true
+      | Int32x8, Int32x8 -> true
+      | Int64x4, Int64x4 -> true
+      | Float32x8, Float32x8 -> true
+      | Float64x4, Float64x4 -> true
+      | Int8x64, Int8x64 -> true
+      | Int16x32, Int16x32 -> true
+      | Int32x16, Int32x16 -> true
+      | Int64x8, Int64x8 -> true
+      | Float32x16, Float32x16 -> true
+      | Float64x8, Float64x8 -> true
+      | _, _ -> false
+
+
+    let equal_unboxed = fun u1 u2 ->
+      match u1, u2 with
+      | Unboxed_float, Unboxed_float -> true
+      | Unboxed_float32, Unboxed_float32 -> true
+      | Unboxed_nativeint, Unboxed_nativeint -> true
+      | Unboxed_int64, Unboxed_int64 -> true
+      | Unboxed_int32, Unboxed_int32 -> true
+      | Unboxed_simd s1, Unboxed_simd s2 -> equal_simd_vec_split s1 s2
+      | _, _ -> false
+
+    let equal p1 p2 =
+      match p1, p2 with
+      | Array, Array -> true
+      | Bytes, Bytes -> true
+      | Char, Char -> true
+      | Extension_constructor, Extension_constructor -> true
+      | Float, Float -> true
+      | Float32, Float32 -> true
+      | Floatarray, Floatarray -> true
+      | Int, Int -> true
+      | Int32, Int32 -> true
+      | Int64, Int64 -> true
+      | Lazy_t, Lazy_t -> true
+      | Nativeint, Nativeint -> true
+      | String, String -> true
+      | Simd s1, Simd s2 -> equal_simd_vec_split s1 s2
+      | Exception, Exception -> true
+      | Unboxed u1, Unboxed u2 -> equal_unboxed u1 u2
+      | _, _ -> false
+
 end
 
 
@@ -370,18 +425,35 @@ and desc =
   | Proj of t * Item.t
   | Comp_unit of string
   | Error of string
+  | Mu of t
+  | Rec_var of int
+  (** Recursive variable in DeBruijn representation. *)
 
-type without_layout = Layout_to_be_determined
+  | Mutrec of t Ident.Map.t
+  | ProjDecl of t * Ident.t
 
-type 'a ts =
-  | Ts_constr of (Uid.t * Path.t * 'a) * without_layout ts list
-  | Ts_tuple of 'a ts list
-  | Ts_unboxed_tuple of 'a ts list
-  | Ts_var of string option * 'a
-  | Ts_predef of Predef.t * without_layout ts list
-  | Ts_arrow of without_layout ts * without_layout ts
-  | Ts_variant of 'a ts poly_variant_constructors
-  | Ts_other of 'a
+  | Constr of Ident.t * t list
+  | Tuple of t list
+  | Unboxed_tuple of t list
+  | Predef of Predef.t * t list
+  | Arrow of t * t
+  | Poly_variant of t poly_variant_constructors
+
+  (* constructors for type declarations *)
+  | Variant of
+    { simple_constructors : string list;
+      complex_constructors : (t * Layout.t) complex_constructors
+    }
+  | Variant_unboxed of
+    { name : string;
+      arg_name : string option;
+      arg_shape : t;
+      arg_layout : Layout.t
+    }
+  | Record of
+      { fields : (string * t * Layout.t) list;
+        kind : record_kind
+      }
 
 and 'a poly_variant_constructors = 'a poly_variant_constructor list
 
@@ -389,29 +461,6 @@ and 'a poly_variant_constructor =
   { pv_constr_name : string;
     pv_constr_args : 'a list
   }
-
-type tds_desc =
-  | Tds_variant of
-      { simple_constructors : string list;
-        (* CR sspies: Deduplicate these cases once type shapes have reached
-            a more stable form. *)
-        complex_constructors :
-          (without_layout ts * Layout.t)
-          complex_constructors
-      }
-  | Tds_variant_unboxed of
-      { name : string;
-        arg_name : string option;
-        arg_shape : without_layout ts;
-        arg_layout : Layout.t
-      }
-  | Tds_record of
-      { fields :
-          (string * without_layout ts * Layout.t) list;
-        kind : record_kind
-      }
-  | Tds_alias of without_layout ts
-  | Tds_other
 
 and record_kind =
   | Record_unboxed
@@ -437,11 +486,23 @@ and constructor_representation = mixed_product_shape
 
 and mixed_product_shape = Layout.t array
 
-type tds =
-  { path : Path.t;
-    definition : tds_desc;
-    type_params : without_layout ts list
-  }
+
+let poly_variant_constructors_map f pvs =
+  List.map
+    (fun pv -> { pv with pv_constr_args = List.map f pv.pv_constr_args })
+    pvs
+
+let complex_constructor_map f { name; kind; args } =
+  let args =
+    List.map
+      (fun { field_name; field_value } ->
+        { field_name; field_value = f field_value })
+      args
+  in
+  { name; kind; args }
+
+let complex_constructors_map f = List.map (complex_constructor_map f)
+
 
 let rec equal_desc d1 d2 =
   if d1 == d2 then true else
@@ -456,21 +517,72 @@ let rec equal_desc d1 d2 =
     if not (equal t1 t2) then false
     else equal v1 v2
   | Leaf, Leaf -> true
+  | Mu (t1_body), Mu (t2_body) ->
+    equal t1_body t2_body
+  | Rec_var i1, Rec_var i2 -> Int.equal i1 i2
   | Struct t1, Struct t2 ->
     Item.Map.equal equal t1 t2
   | Proj (t1, i1), Proj (t2, i2) ->
     if Item.compare i1 i2 <> 0 then false
     else equal t1 t2
   | Comp_unit c1, Comp_unit c2 -> String.equal c1 c2
-  | Var _, (Abs _ | App _ | Struct _ | Leaf | Proj _ | Comp_unit _ | Alias _ | Error _)
-  | Abs _, (Var _ | App _ | Struct _ | Leaf | Proj _ | Comp_unit _ | Alias _ | Error _)
-  | App _, (Var _ | Abs _ | Struct _ | Leaf | Proj _ | Comp_unit _ | Alias _ | Error _)
-  | Struct _, (Var _ | Abs _ | App _ | Leaf | Proj _ | Comp_unit _ | Alias _ | Error _)
-  | Leaf, (Var _ | Abs _ | App _ | Struct _ | Proj _ | Comp_unit _ | Alias _ | Error _)
-  | Proj _, (Var _ | Abs _ | App _ | Struct _ | Leaf | Comp_unit _ | Alias _ | Error _)
-  | Comp_unit _, (Var _ | Abs _ | App _ | Struct _ | Leaf | Proj _ | Alias _ | Error _)
-  | Alias _, (Var _ | Abs _ | App _ | Struct _ | Leaf | Proj _ | Comp_unit _ | Error _)
-  | Error _, (Var _ | Abs _ | App _ | Struct _ | Leaf | Proj _ | Comp_unit _ | Alias _)
+
+  | Constr (c1, ts1), Constr (c2, ts2) ->
+    Ident.equal c1 c2
+    && List.equal equal ts1 ts2
+  | Mutrec t1, Mutrec t2 ->
+    Ident.Map.equal equal t1 t2
+  | ProjDecl (t1, i1), ProjDecl (t2, i2) ->
+    if Ident.equal i1 i2 then
+      equal t1 t2
+    else false
+  | Tuple t1, Tuple t2
+  | Unboxed_tuple t1, Unboxed_tuple t2 ->
+    List.equal equal t1 t2
+  | Predef (p1, ts1), Predef (p2, ts2) ->
+    if Predef.equal p1 p2 then
+      List.equal equal ts1 ts2
+    else
+      false
+  | Arrow (t1, t1'), Arrow (t2, t2') ->
+    equal t1 t2 && equal t1' t2'
+  | Poly_variant pvs1, Poly_variant pvs2 ->
+    List.equal equal_poly_variant_constructor pvs1 pvs2
+
+  | Variant c1, Variant c2 ->
+    List.equal equal_simple_constructor c1.simple_constructors c2.simple_constructors
+    && List.equal (equal_complex_constructor (fun (t1, l1) (t2, l2) -> equal t1 t2 && Layout.equal l1 l2)) c1.complex_constructors c2.complex_constructors
+  | Variant_unboxed c1, Variant_unboxed c2 ->
+    String.equal c1.name c2.name
+    && Option.equal String.equal c1.arg_name c2.arg_name
+    && equal c1.arg_shape c2.arg_shape
+    && Layout.equal c1.arg_layout c2.arg_layout
+  | Record r1, Record r2 ->
+    equal_record_kind r1.kind r2.kind
+    && List.equal equal_field r1.fields r2.fields
+
+  | Var _, (Abs _ | App _ | Struct _ | Leaf  | Constr _ | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Poly_variant _ | Variant _ | Variant_unboxed _ | Record _ | Mu _ | Rec_var _ | Proj _ | Comp_unit _ | Alias _ | Error _| Mutrec _ | ProjDecl _)
+  | Abs _, (Var _ | App _ | Struct _ | Leaf  | Constr _ | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Poly_variant _ | Variant _ | Variant_unboxed _ | Record _ | Mu _ | Rec_var _ | Proj _ | Comp_unit _ | Alias _ | Error _| Mutrec _ | ProjDecl _)
+  | App _, (Var _ | Abs _ | Struct _ | Leaf  | Constr _ | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Poly_variant _ | Variant _ | Variant_unboxed _ | Record _ | Mu _ | Rec_var _ | Proj _ | Comp_unit _ | Alias _ | Error _| Mutrec _ | ProjDecl _)
+  | Struct _, (Var _ | Abs _ | App _ | Leaf  | Constr _ | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Poly_variant _ | Variant _ | Variant_unboxed _ | Record _ | Mu _ | Rec_var _ | Proj _ | Comp_unit _ | Alias _ | Error _| Mutrec _ | ProjDecl _)
+  | Leaf, (Var _ | Abs _ | App _ | Struct _ | Proj _ | Constr _ | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Poly_variant _ | Variant _ | Variant_unboxed _ | Record _ | Mu _ | Rec_var _ | Comp_unit _ | Alias _ | Error _| Mutrec _ | ProjDecl _)
+  | Mu _, (Var _ | Abs _ | App _ | Struct _ | Leaf  | Constr _ | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Poly_variant _ | Variant _ | Variant_unboxed _ | Record _ | Rec_var _ | Proj _ | Comp_unit _ | Alias _ | Error _| Mutrec _ | ProjDecl _)
+  | Rec_var _, (Var _ | Abs _ | App _ | Struct _ | Leaf  | Constr _ | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Poly_variant _ | Variant _ | Variant_unboxed _ | Record _ | Mu _ | Proj _ | Comp_unit _ | Alias _ | Error _| Mutrec _ | ProjDecl _)
+  | Mutrec _, (Var _ | Abs _ | App _ | Struct _ | Leaf  | Constr _ | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Poly_variant _ | Variant _ | Variant_unboxed _ | Record _ | Mu _ | Proj _ | Comp_unit _ | Alias _ | Error _| ProjDecl _ | Rec_var _)
+  | ProjDecl _, (Var _ | Abs _ | App _ | Struct _ | Leaf  | Constr _ | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Poly_variant _ | Variant _ | Variant_unboxed _ | Record _ | Mu _ | Proj _ | Comp_unit _ | Alias _ | Error _| Mutrec _ | Rec_var _)
+  | Proj _, (Var _ | Abs _ | App _ | Struct _ | Leaf  | Constr _ | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Poly_variant _ | Variant _ | Variant_unboxed _ | Record _ | Mu _ | Rec_var _ | Comp_unit _ | Alias _ | Error _| Mutrec _ | ProjDecl _)
+  | Comp_unit _, (Var _ | Abs _ | App _ | Struct _ | Leaf  | Constr _ | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Poly_variant _ | Variant _ | Variant_unboxed _ | Record _ | Mu _ | Rec_var _ | Proj _ | Alias _ | Error _| Mutrec _ | ProjDecl _)
+  | Alias _, (Var _ | Abs _ | App _ | Struct _ | Leaf  | Constr _ | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Poly_variant _ | Variant _ | Variant_unboxed _ | Record _ | Mu _ | Rec_var _ | Proj _ | Comp_unit _ | Error _| Mutrec _ | ProjDecl _)
+  | Error _, (Var _ | Abs _ | App _ | Struct _ | Leaf  | Constr _ | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Poly_variant _ | Variant _ | Variant_unboxed _ | Record _ | Mu _ | Rec_var _ | Proj _ | Comp_unit _ | Alias _| Mutrec _ | ProjDecl _)
+  | Variant _, (Var _ | Abs _ | App _ | Struct _ | Leaf  | Constr _ | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Poly_variant _ | Variant_unboxed _ | Record _ | Mu _ | Rec_var _ | Proj _ | Comp_unit _ | Alias _ | Error _| Mutrec _ | ProjDecl _)
+  | Variant_unboxed _, (Var _ | Abs _ | App _ | Struct _ | Leaf  | Constr _ | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Variant _ | Poly_variant _ | Record _ | Mu _ | Rec_var _ | Proj _ | Comp_unit _ | Alias _ | Error _| Mutrec _ | ProjDecl _)
+  | Record _, (Var _ | Abs _ | App _ | Struct _ | Leaf  | Constr _ | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Poly_variant _ | Variant _ | Variant_unboxed _ | Mu _ | Rec_var _ | Proj _ | Comp_unit _ | Alias _ | Error _| Mutrec _ | ProjDecl _)
+  | Predef _, (Var _ | Abs _ | App _ | Struct _ | Leaf  | Constr _ | Tuple _ | Unboxed_tuple _ | Arrow _ | Poly_variant _ | Variant _ | Variant_unboxed _ | Record _ | Mu _ | Rec_var _ | Proj _ | Comp_unit _ | Alias _ | Error _| Mutrec _ | ProjDecl _)
+  | Arrow _, (Var _ | Abs _ | App _ | Struct _ | Leaf  | Constr _ | Tuple _ | Unboxed_tuple _ | Predef _ | Poly_variant _ | Variant _ | Variant_unboxed _ | Record _ | Mu _ | Rec_var _ | Proj _ | Comp_unit _ | Alias _ | Error _| Mutrec _ | ProjDecl _)
+  | Poly_variant _, (Var _ | Abs _ | App _ | Struct _ | Leaf  | Constr _ | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Variant _ | Variant_unboxed _ | Record _ | Mu _ | Rec_var _ | Proj _ | Comp_unit _ | Alias _ | Error _| Mutrec _ | ProjDecl _)
+  | Tuple _, (Var _ | Abs _ | App _ | Struct _ | Leaf  | Constr _ | Unboxed_tuple _ | Predef _ | Arrow _ | Poly_variant _ | Variant _ | Variant_unboxed _ | Record _ | Mu _ | Rec_var _ | Proj _ | Comp_unit _ | Alias _ | Error _| Mutrec _ | ProjDecl _)
+  | Unboxed_tuple _, (Var _ | Abs _ | App _ | Struct _ | Leaf  | Constr _ | Tuple _ | Predef _ | Arrow _ | Poly_variant _ | Variant _ | Variant_unboxed _ | Record _ | Mu _ | Rec_var _ | Proj _ | Comp_unit _ | Alias _ | Error _| Mutrec _ | ProjDecl _)
+  | Constr _, (Var _ | Abs _ | App _ | Struct _ | Leaf  | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Poly_variant _ | Variant _ | Variant_unboxed _ | Record _ | Mu _ | Rec_var _ | Proj _ | Comp_unit _ | Alias _ | Error _| Mutrec _ | ProjDecl _)
     -> false
 
 and equal t1 t2 =
@@ -479,9 +591,66 @@ and equal t1 t2 =
   else if not (Option.equal Uid.equal t1.uid t2.uid) then false
   else equal_desc t1.desc t2.desc
 
-let print fmt t =
+and equal_record_kind k1 k2 =
+  match k1, k2 with
+  | Record_unboxed, Record_unboxed -> true
+  | Record_unboxed_product, Record_unboxed_product -> true
+  | Record_boxed, Record_boxed -> true
+  | Record_mixed lys1, Record_mixed lys2 ->
+    Misc.Stdlib.Array.equal Layout.equal lys1 lys2
+  | Record_floats, Record_floats -> true
+  | Record_unboxed,
+    (Record_unboxed_product | Record_boxed | Record_mixed _ | Record_floats)
+  | Record_unboxed_product,
+    (Record_unboxed | Record_boxed | Record_mixed _ | Record_floats)
+  | Record_boxed,
+    (Record_unboxed | Record_unboxed_product | Record_mixed _ | Record_floats)
+  | Record_mixed _,
+    (Record_unboxed | Record_unboxed_product | Record_boxed | Record_floats)
+  | Record_floats,
+    (Record_unboxed | Record_unboxed_product | Record_boxed | Record_mixed _)
+    -> false
+
+and equal_field (s1, sh1, ly1) (s2, sh2, ly2) =
+  String.equal s1 s2 &&
+  equal sh1 sh2 &&
+  Layout.equal ly1 ly2
+
+and equal_simple_constructor c1 c2 = String.equal c1 c2
+
+and equal_complex_constructor eq
+  { name = name1; kind = kind1; args = args1 }
+  { name = name2; kind = kind2; args = args2 } =
+  String.equal name1 name2 &&
+  equal_constructor_representation kind1 kind2 &&
+  List.equal (equal_complex_constructor_arguments eq) args1 args2
+
+and equal_complex_constructor_arguments eq
+  { field_name = field_name1; field_value = field_value1 }
+  { field_name = field_name2; field_value = field_value2 } =
+  Option.equal String.equal field_name1 field_name2 &&
+  eq field_value1 field_value2
+
+and equal_constructor_representation lys1 lys2 =
+  Misc.Stdlib.Array.equal Layout.equal lys1 lys2
+
+
+and equal_poly_variant_constructor
+  { pv_constr_name = name1; pv_constr_args = args1 }
+  { pv_constr_name = name2; pv_constr_args = args2 } =
+  String.equal name1 name2 &&
+  List.equal equal args1 args2
+
+
+
+let rec print fmt t =
   let print_uid_opt =
     Format.pp_print_option (fun fmt -> Format.fprintf fmt "<%a>" Uid.print)
+  in
+  let print_nested fmt t =
+    match t.desc with
+    | Var _ | Leaf | Rec_var _ | Comp_unit _ | Error _ | Predef (_, []) -> print fmt t
+    | _ -> Format.fprintf fmt "(@[%a@])" print t
   in
   let rec aux fmt { uid; desc; hash = _ } =
     match desc with
@@ -504,10 +673,18 @@ let print fmt t =
         Format.fprintf fmt "Abs@[%a@,(@[%a,@ @[%a@]@])@]"
           print_uid_opt uid pp_idents (id :: other_idents) aux body
     | App (t1, t2) ->
-        Format.fprintf fmt "@[%a(@,%a)%a@]" aux t1 aux t2
+        Format.fprintf fmt "@[%a(@,%a) %a@]" aux t1 aux t2
           print_uid_opt uid
     | Leaf ->
         Format.fprintf fmt "<%a>" (Format.pp_print_option Uid.print) uid
+    | Mu (t_body) ->
+      Format.fprintf fmt "Rec@[%a %a@]"
+        print_uid_opt uid
+        print_nested t_body
+    | Rec_var id ->
+      Format.fprintf fmt "#%d%a"
+      id
+      print_uid_opt uid
     | Proj (t, item) ->
         begin match uid with
         | None ->
@@ -537,122 +714,108 @@ let print fmt t =
         Format.fprintf fmt "Alias@[(@[<v>%a@,%a@])@]" print_uid_opt uid aux t
     | Error s ->
         Format.fprintf fmt "Error %s" s
+    | Constr (id, args) ->
+        Format.fprintf fmt "Constr %a %a"
+          (Ident.print) id
+          (Format.pp_print_list print) args
+    | Tuple shapes ->
+      Format.fprintf fmt "@[%a@]"
+        (Format.pp_print_list
+            ~pp_sep:(fun fmt () -> Format.pp_print_string fmt " * ")
+            print_nested)
+        shapes
+    | Unboxed_tuple shapes ->
+      Format.fprintf fmt "Unboxed_tuple (%a)"
+        (Format.pp_print_list
+            ~pp_sep:(fun fmt () -> Format.pp_print_string fmt ", ")
+            print)
+        shapes
+    | Predef (predef, args) ->
+      Format.fprintf fmt "Predef %s (%a)"
+        (Predef.to_string predef)
+        (Format.pp_print_list print) args
+    | Arrow (arg, ret) ->
+      Format.fprintf fmt "Arrow (%a, %a)" print arg print ret
+    | Poly_variant fields ->
+      Format.fprintf fmt "Poly_variant (%a)"
+        (Format.pp_print_list
+            ~pp_sep:(fun fmt () -> Format.pp_print_string fmt ", ")
+            (fun fmt { pv_constr_name; pv_constr_args } ->
+              Format.fprintf fmt "%s (%a)" pv_constr_name
+                (Format.pp_print_list
+                  ~pp_sep:(fun fmt () -> Format.pp_print_string fmt ", ")
+                  print)
+                pv_constr_args))
+        fields
+    | Variant { simple_constructors; complex_constructors } ->
+      let constructors = List.map (fun c -> `Simple c) simple_constructors @
+        List.map (fun c -> `Complex c) complex_constructors in
+      let print_constructor fmt = function
+        | `Simple s -> Format.pp_print_string fmt s
+        | `Complex c -> print_complex_constructor (fun fmt (t, _) -> print_nested fmt t) fmt c
+      in
+      Format.fprintf fmt
+        "Variant %a"
+        (Format.pp_print_list ~pp_sep:(fun fmt () -> Format.fprintf fmt "@ | ")
+            print_constructor)
+        constructors
+  | Variant_unboxed { name; arg_name; arg_shape; arg_layout } ->
+    Format.fprintf fmt
+      "Variant_unboxed name=%s arg_name=%s arg_shape=%a arg_layout=%a"
+      name
+      (Option.value ~default:"None" arg_name)
+      print arg_shape Layout.format arg_layout
+  | Record { fields; kind } ->
+    Format.fprintf fmt "Record%s { %a }" (print_record_type kind)
+      (Format.pp_print_list ~pp_sep:(print_sep_string "; ") print_field)
+      fields
+  | Mutrec m ->
+    let print_decls fmt =
+        Ident.Map.iter (fun id t ->
+            Format.fprintf fmt "@[<hv 2>%a :=@ %a;@]@,"
+              Ident.print id
+              aux t
+          )
+      in
+    Format.fprintf fmt "Mutrec @[%a@]" print_decls m
+  | ProjDecl (t, id) ->
+    Format.fprintf fmt "(%a).%a"
+      aux t
+      Ident.print id
+
   in
   if t.approximated then
     Format.fprintf fmt "@[(approx)@ %a@]@;" aux t
   else
     Format.fprintf fmt "@[%a@]@;" aux t
 
-(* printing type shapes *)
-let rec print_type_shape : type a. Format.formatter -> a ts -> unit =
-  (* CR sspies: We should figure out pretty printing for shapes. For now, this
-    verbose non-boxed version should be fine. *)
-  fun ppf -> function
-  | Ts_predef (predef, shapes) ->
-    Format.fprintf ppf "%s (%a)" (Predef.to_string predef)
-      (Format.pp_print_list
-          ~pp_sep:(fun ppf () -> Format.pp_print_string ppf ", ")
-          print_type_shape)
-      shapes
-  | Ts_constr ((uid, path, _), shapes) ->
-    Format.fprintf ppf "Ts_constr uid=%a path=%a (%a)" Uid.print uid
-      Path.print path
-      (Format.pp_print_list
-          ~pp_sep:(fun ppf () -> Format.pp_print_string ppf ", ")
-          print_type_shape)
-      shapes
-  | Ts_tuple shapes ->
-    Format.fprintf ppf "Ts_tuple (%a)"
-      (Format.pp_print_list
-          ~pp_sep:(fun ppf () -> Format.pp_print_string ppf ", ")
-          print_type_shape)
-      shapes
-  | Ts_unboxed_tuple shapes ->
-    Format.fprintf ppf "Ts_unboxed_tuple (%a)"
-      (Format.pp_print_list
-          ~pp_sep:(fun ppf () -> Format.pp_print_string ppf ", ")
-          print_type_shape)
-      shapes
-  | Ts_var (name, _) ->
-    Format.fprintf ppf "Ts_var (%a)"
-      (fun ppf opt -> Format.pp_print_option Format.pp_print_string ppf opt)
-      name
-  | Ts_arrow (arg, ret) ->
-    Format.fprintf ppf "Ts_arrow (%a, %a)"
-      print_type_shape arg print_type_shape ret
-  | Ts_variant fields ->
-    Format.fprintf ppf "Ts_variant (%a)"
-      (Format.pp_print_list
-          ~pp_sep:(fun ppf () -> Format.pp_print_string ppf ", ")
-          (fun ppf { pv_constr_name; pv_constr_args } ->
-            Format.fprintf ppf "%s (%a)" pv_constr_name
-              (Format.pp_print_list
-                ~pp_sep:(fun ppf () -> Format.pp_print_string ppf ", ")
-                print_type_shape)
-              pv_constr_args))
-      fields
-  | Ts_other _ -> Format.fprintf ppf "Ts_other"
+(* We use custom strings as separators instead of pp_print_space, because the
+    latter introduces line breaks that can mess up the tables with all shapes.*)
+and print_sep_string str fmt () = Format.pp_print_string fmt str
 
-(* printing type declaration shapes *)
-let print_one_entry print_value ppf { field_name; field_value } =
+and print_one_entry print_value ppf { field_name; field_value } =
   match field_name with
   | Some name ->
     Format.fprintf ppf "%a=%a" Format.pp_print_string name print_value
       field_value
   | None -> Format.fprintf ppf "%a" print_value field_value
 
-let print_sep_string sep ppf () = Format.pp_print_string ppf sep
-
-let print_complex_constructor print_value ppf { name; kind = _; args } =
-  Format.fprintf ppf "(%a: %a)" Format.pp_print_string name
+and print_complex_constructor print_value ppf { name; kind = _; args } =
+  Format.fprintf ppf "@[%a of @[%a@]@]" Format.pp_print_string name
     (Format.pp_print_list ~pp_sep:(print_sep_string " * ")
         (print_one_entry print_value))
     args
 
-let print_only_shape ppf (shape, _) = print_type_shape ppf shape
+and print_field ppf
+    ((name, shape, _) : _ * t * _) =
+  Format.fprintf ppf "%a: %a" Format.pp_print_string name print shape
 
-let print_field ppf
-    ((name, shape, _) : _ * without_layout ts * _) =
-  Format.fprintf ppf "%a: %a" Format.pp_print_string name print_type_shape
-    shape
-
-let print_record_type = function
+and print_record_type = function
   | Record_boxed -> "_boxed"
   | Record_floats -> "_floats"
   | Record_mixed _ -> "_mixed"
   | Record_unboxed -> " [@@unboxed]"
   | Record_unboxed_product -> "_unboxed_product"
-
-let print_tds_desc ppf = function
-  (* CR sspies: We should figure out pretty printing for shapes. For now, this
-      verbose non-boxed version should be fine. *)
-  | Tds_variant { simple_constructors; complex_constructors } ->
-    Format.fprintf ppf
-      "Tds_variant simple_constructors=%a complex_constructors=%a"
-      (Format.pp_print_list ~pp_sep:Format.pp_print_space
-          Format.pp_print_string)
-      simple_constructors
-      (Format.pp_print_list ~pp_sep:(print_sep_string " | ")
-          (print_complex_constructor print_only_shape))
-      complex_constructors
-  | Tds_record { fields; kind } ->
-    Format.fprintf ppf "Tds_record%s { %a }" (print_record_type kind)
-      (Format.pp_print_list ~pp_sep:(print_sep_string "; ") print_field)
-      fields
-  | Tds_variant_unboxed { name; arg_name; arg_shape; arg_layout } ->
-    Format.fprintf ppf
-      "Tds_variant_unboxed name=%s arg_name=%s arg_shape=%a arg_layout=%a"
-      name
-      (Option.value ~default:"None" arg_name)
-      print_type_shape arg_shape Layout.format arg_layout
-  | Tds_alias type_shape ->
-    Format.fprintf ppf "Tds_alias %a" print_type_shape type_shape
-  | Tds_other -> Format.fprintf ppf "Tds_other"
-
-let print_type_decl_shape ppf t =
-  Format.fprintf ppf "path=%a, definition=(%a)" Path.print t.path print_tds_desc
-    t.definition
-
 
 let rec strip_head_aliases = function
   | { desc = Alias t; _ } -> strip_head_aliases t
@@ -667,6 +830,21 @@ let hash_app = 6
 let hash_comp_unit = 7
 let hash_alias = 8
 let hash_error = 9
+let hash_mu = 10
+let hash_rec_var = 11
+let hash_tuple = 12
+let hash_unboxed_tuple = 13
+let hash_predef = 14
+let hash_arrow = 15
+let hash_poly_variant = 16
+let hash_variant = 17
+let hash_variant_unboxed = 18
+let hash_record = 19
+
+let hash_constr = 20
+let hash_mutrec = 21
+let hash_proj_decl = 22
+
 
 let fresh_var ?(name="shape-var") uid =
   let var = Ident.create_local name in
@@ -678,6 +856,12 @@ let for_unnamed_functor_param = Ident.create_local "()"
 
 let var uid id =
   { uid = Some uid; desc = Var id;
+    hash = Hashtbl.hash (hash_var, Some uid, id);
+    approximated = false }
+
+(* variable without uid *)
+let var' uid id =
+  { uid; desc = Var id;
     hash = Hashtbl.hash (hash_var, uid, id);
     approximated = false }
 
@@ -731,6 +915,57 @@ let comp_unit ?uid s =
       { uid; desc = Comp_unit s; hash = Hashtbl.hash (hash_comp_unit, uid, s);
         approximated = false }
 
+let mu ?uid t_body =
+  { uid; desc = Mu (t_body); hash = Hashtbl.hash (hash_mu, uid, t_body.hash);
+    approximated = false }
+
+let rec_var ?uid n =
+  { uid; desc = Rec_var n; hash = Hashtbl.hash (hash_rec_var, uid, n);
+    approximated = false }
+
+let app_list (base_shape : t) (args : t list) : t =
+  List.fold_left (fun shape arg -> app shape ~arg) base_shape args
+  (* CR sspies: Double check whether this should be fold_left or fold_right. *)
+
+let abs_list (base_shape : t) (binders : Ident.t list) : t =
+  List.fold_right (fun shape id -> abs shape id) binders base_shape
+
+let tuple ?uid (ts : t list) = { uid; desc = Tuple ts; hash = Hashtbl.hash (hash_tuple, uid, List.map (fun t -> t.hash) ts); approximated = false }
+
+let unboxed_tuple ?uid (ts : t list) = { uid; desc = Unboxed_tuple ts; hash = Hashtbl.hash (hash_unboxed_tuple, uid, List.map (fun t -> t.hash) ts); approximated = false }
+
+let predef ?uid (p : Predef.t) (ts : t list) = { uid; desc = Predef (p, ts); hash = Hashtbl.hash (hash_predef, uid, p, List.map (fun t -> t.hash) ts); approximated = false }
+
+let arrow ?uid t1 t2 = { uid; desc = Arrow (t1, t2); hash = Hashtbl.hash (hash_arrow, uid, t1.hash, t2.hash); approximated = false }
+
+let poly_variant ?uid t = { uid; desc = Poly_variant t; hash = Hashtbl.hash (hash_poly_variant, uid, poly_variant_constructors_map (fun t -> t.hash) t); approximated = false }
+
+let variant ?uid simple_constructors complex_constructors =
+  { uid; desc = Variant { simple_constructors; complex_constructors };
+    hash = Hashtbl.hash (hash_variant, uid, simple_constructors,
+      complex_constructors_map (fun (t, ly) -> (t.hash, ly)) complex_constructors);
+    approximated = false }
+
+let variant_unboxed ?uid name arg_name arg_shape arg_layout =
+  { uid; desc = Variant_unboxed { name; arg_name; arg_shape; arg_layout };
+    hash = Hashtbl.hash (hash_variant_unboxed, uid, name, arg_name, arg_shape.hash, arg_layout);
+    approximated = false }
+
+let record ?uid kind fields =
+  { uid; desc = Record { fields; kind };
+    hash = Hashtbl.hash (hash_record, uid,
+      List.map (fun (i, t, ly) -> (i, t.hash, ly)) fields, kind);
+  approximated = false }
+
+let constr ?uid constr_uid args =
+  { uid; desc = Constr (constr_uid, args);
+    hash = Hashtbl.hash (hash_constr, uid, constr_uid, List.map (fun t -> t.hash) args);
+    approximated = false }
+
+let mutrec ?uid t = { uid; desc = Mutrec t; hash = Hashtbl.hash (hash_mutrec, uid, Ident.Map.map (fun t -> t.hash) t); approximated = false }
+
+let proj_decl ?uid t id = { uid; desc = ProjDecl (t, id); hash = Hashtbl.hash (hash_proj_decl, uid, t.hash, id); approximated = false }
+
 let no_fuel_left ?uid s = { s with uid }
 
 let decompose_abs t =
@@ -783,169 +1018,67 @@ let for_persistent_unit s =
 let leaf_for_unpack = leaf' None
 
 let set_uid_if_none t uid =
-  match t.uid with
-  | None -> { t with uid = Some uid }
-  | _ -> t
+  let uid = Option.value ~default:uid t.uid in
+  match t.desc with
+  | Var v -> var uid v
+  | Abs (x, t) -> abs ~uid x t
+  | App (t1, t2) -> app ~uid t1 ~arg:t2
+  | Struct t -> str ~uid t
+  | Alias t -> alias ~uid t
+  | Leaf -> leaf uid
+  | Proj (t, i) -> proj ~uid t i
+  | Comp_unit c -> comp_unit ~uid c
+  | Error s -> error ~uid s
+  | Mu t -> mu ~uid t
+  | Rec_var i -> rec_var ~uid i
+  | Constr (c, ts) -> constr ~uid c ts
+  | Tuple ts -> tuple ~uid ts
+  | Unboxed_tuple ts -> unboxed_tuple ~uid ts
+  | Predef (p, ts) -> predef ~uid p ts
+  | Arrow (t1, t2) -> arrow ~uid t1 t2
+  | Poly_variant t -> poly_variant ~uid t
+  | Variant t -> variant ~uid t.simple_constructors t.complex_constructors
+  | Variant_unboxed t -> variant_unboxed ~uid t.name t.arg_name t.arg_shape t.arg_layout
+  | Record t -> record ~uid t.kind t.fields
+  | Mutrec ts -> mutrec ~uid ts
+  | ProjDecl (t, i) -> proj_decl ~uid t i
 
-let poly_variant_constructors_map f pvs =
-  List.map
-    (fun pv -> { pv with pv_constr_args = List.map f pv.pv_constr_args })
-    pvs
 
-let rec shape_layout (sh : Layout.t ts) : Layout.t =
-  match sh with
-  | Ts_constr ((_, _, ly), _) -> ly
-  | Ts_tuple _ -> Base Value
-  | Ts_unboxed_tuple shapes -> Product (List.map shape_layout shapes)
-  | Ts_var (_, ly) -> ly
-  | Ts_predef (predef, _) -> Predef.to_layout predef
-  | Ts_arrow _ -> Base Value
-  | Ts_variant _ -> Base Value
-  | Ts_other ly -> ly
-
-let complex_constructor_map f { name; kind; args } =
-  let args =
-    List.map
-      (fun { field_name; field_value } ->
-        { field_name; field_value = f field_value })
-      args
-  in
-  { name; kind; args }
-
-let complex_constructors_map f = List.map (complex_constructor_map f)
-
-let rec shape_with_layout ~(layout : Layout.t) (sh : without_layout ts) :
-    Layout.t ts =
-  match sh, layout with
-  | Ts_constr ((uid, path, Layout_to_be_determined), shapes), _ ->
-    Ts_constr ((uid, path, layout), shapes)
-  | Ts_tuple shapes, Base Value ->
-    let shapes_with_layout =
-      List.map (shape_with_layout ~layout:(Layout.Base Value)) shapes
-    in
-    Ts_tuple shapes_with_layout
-  | ( Ts_tuple _,
-      ( Product _
-      | Base
-          ( Void | Bits8 | Bits16 | Bits32 | Bits64 | Float64 | Float32
-          | Word | Vec128 | Vec256 | Vec512 ) ) ) ->
-    Misc.fatal_errorf "tuple shape must have layout value, but has layout %a"
-      Layout.format layout
-  | Ts_unboxed_tuple shapes, Product lys
-    when List.length shapes = List.length lys ->
-    let shapes_and_layouts = List.combine shapes lys in
-    let shapes_with_layout =
-      List.map
-        (fun (shape, layout) -> shape_with_layout ~layout shape)
-        shapes_and_layouts
-    in
-    Ts_unboxed_tuple shapes_with_layout
-  | Ts_unboxed_tuple shapes, Product lys ->
-    Misc.fatal_errorf "unboxed tuple shape has %d shapes, but %d layouts"
-      (List.length shapes) (List.length lys)
-  | ( Ts_unboxed_tuple _,
-      Base
-        ( Void | Value | Float32 | Float64 | Word | Bits8 | Bits16 | Bits32
-        | Bits64 | Vec128 | Vec256 | Vec512 ) ) ->
-    Misc.fatal_errorf
-      "unboxed tuple must have unboxed product layout, but has layout %a"
-      Layout.format layout
-  | Ts_var (name, Layout_to_be_determined), _ -> Ts_var (name, layout)
-  | Ts_arrow (arg, ret), Base Value -> Ts_arrow (arg, ret)
-  | Ts_arrow _, _ ->
-    Misc.fatal_errorf "function type shape must have layout value"
-  | Ts_predef (predef, shapes), _
-    when Layout.equal (Predef.to_layout predef) layout ->
-    Ts_predef (predef, shapes)
-  | Ts_predef (predef, _), _ ->
-    Misc.fatal_errorf
-      "predef %s has layout %a, but is expected to have layout %a"
-      (Predef.to_string predef) Layout.format (Predef.to_layout predef)
-      Layout.format layout
-  | Ts_variant fields, Base Value ->
-    let fields =
-      poly_variant_constructors_map
-        (shape_with_layout ~layout:(Layout.Base Value))
-        fields
-    in
-    Ts_variant fields
-  | Ts_variant _, _ ->
-    Misc.fatal_errorf "polymorphic variant must have layout value"
-  | Ts_other Layout_to_be_determined, _ -> Ts_other layout
-
-(* CR sspies: This is a hacky "solution" to do type variable substitution in
-    type expression shapes. In subsequent PRs, this code should be changed to
-    use the shape mechanism instead. *)
-let rec replace_tvar t ~(pairs : (without_layout ts * without_layout ts) list)
-    =
-  match
-    List.find_map
-      (fun (from, to_) -> if t = from then Some to_ else None)
-      pairs
-  with
-  | Some new_type -> new_type
-  | None -> (
-    match t with
-    | Ts_constr (uid, shape_list) ->
-      Ts_constr (uid, List.map (replace_tvar ~pairs) shape_list)
-    | Ts_tuple shape_list ->
-      Ts_tuple (List.map (replace_tvar ~pairs) shape_list)
-    | Ts_unboxed_tuple shape_list ->
-      Ts_unboxed_tuple (List.map (replace_tvar ~pairs) shape_list)
-    | Ts_var (name, ly) -> Ts_var (name, ly)
-    | Ts_predef (predef, shape_list) -> Ts_predef (predef, shape_list)
-    | Ts_arrow (arg, ret) ->
-      Ts_arrow (replace_tvar ~pairs arg, replace_tvar ~pairs ret)
-    | Ts_variant fields ->
-      let fields =
-        poly_variant_constructors_map (replace_tvar ~pairs) fields
-      in
-      Ts_variant fields
-    | Ts_other ly -> Ts_other ly)
-
-(* CR sspies: This is a hacky "solution" to do type variable substitution in
-    type declaration shapes. In subsequent PRs, this code should be changed to
-    use the shape mechanism instead. *)
-let replace_tvar (t : tds) (shapes : without_layout ts list) =
-  match List.length t.type_params == List.length shapes with
-  | true ->
-    let subst = List.combine t.type_params shapes in
-    let replace_tvar_ts = replace_tvar in
-    let replace_tvar (sh, ly) = replace_tvar_ts ~pairs:subst sh, ly in
-    let ret =
-      { type_params = [];
-        path = t.path;
-        definition =
-          (match t.definition with
-          | Tds_variant { simple_constructors; complex_constructors } ->
-            Tds_variant
-              { simple_constructors;
-                complex_constructors =
-                  complex_constructors_map replace_tvar complex_constructors
-              }
-          | Tds_variant_unboxed { name; arg_name; arg_shape; arg_layout } ->
-            Tds_variant_unboxed
-              { name;
-                arg_name;
-                arg_shape = replace_tvar_ts ~pairs:subst arg_shape;
-                arg_layout
-              }
-          | Tds_record { fields; kind } ->
-            Tds_record
-              { fields =
-                  List.map
-                    (fun (name, sh, ly) ->
-                      name, replace_tvar_ts ~pairs:subst sh, ly)
-                    fields;
-                kind
-              }
-          | Tds_alias type_shape ->
-            Tds_alias (replace_tvar_ts ~pairs:subst type_shape)
-          | Tds_other -> Tds_other)
-      }
-    in
-    ret
-  | false -> { type_params = []; path = t.path; definition = Tds_other }
+let is_mu_closed t =
+  let rec debruijn_closed_shape (bound: int) (t: t) =
+    match t.desc with
+    | Var _ -> true
+      (* we only care about DeBruijn indices in recursive variables *)
+    | Abs (_, t) -> debruijn_closed_shape bound t
+    | App (t1, t2) ->
+      debruijn_closed_shape bound t1 && debruijn_closed_shape bound t2
+    | Struct t -> Item.Map.for_all (fun _ -> debruijn_closed_shape bound) t
+    | Alias t -> debruijn_closed_shape bound t
+    | Leaf -> true
+    | Proj (t, _) -> debruijn_closed_shape bound t
+    | Comp_unit _ -> true
+    | Error _ -> true
+    | Mu t -> debruijn_closed_shape (bound + 1) t
+    | Rec_var i -> i <= bound
+    | Constr (_, ts) -> List.for_all (debruijn_closed_shape bound) ts
+    | Tuple ts -> List.for_all (debruijn_closed_shape bound) ts
+    | Unboxed_tuple ts -> List.for_all (debruijn_closed_shape bound) ts
+    | Predef (_, ts) -> List.for_all (debruijn_closed_shape bound) ts
+    | Arrow (t1, t2) ->
+      debruijn_closed_shape bound t1 && debruijn_closed_shape bound t2
+    | Poly_variant t ->
+      List.for_all (fun { pv_constr_name = _; pv_constr_args = c } ->
+        List.for_all (debruijn_closed_shape bound) c) t
+    | Variant t ->
+      List.for_all (fun { kind = _; name = _; args = c } ->
+        List.for_all (fun { field_value = t, _; field_name = _} ->
+          debruijn_closed_shape bound t) c) t.complex_constructors
+    | Variant_unboxed t -> debruijn_closed_shape bound t.arg_shape
+    | Record t -> List.for_all (fun (_, t, _) ->
+      debruijn_closed_shape bound t) t.fields
+    | Mutrec ts -> Ident.Map.for_all (fun _ -> debruijn_closed_shape bound) ts
+    | ProjDecl (t, _) -> debruijn_closed_shape bound t
+  in debruijn_closed_shape (-1) t
 
 
 module Map = struct

--- a/typing/shape.mli
+++ b/typing/shape.mli
@@ -184,7 +184,7 @@ module Predef : sig
 
   val to_string : t -> string
 
-  val unboxed_type_to_layout : unboxed -> Jkind_types.Sort.base
+  val unboxed_type_to_base_layout : unboxed -> base_layout
 
   val to_layout : t -> Layout.t
 end
@@ -198,44 +198,57 @@ and desc =
   | Struct of t Item.Map.t
   | Alias of t
   | Leaf
+  (* This is used for unknown declarations and unknown types.*)
   | Proj of t * Item.t
   | Comp_unit of string
   | Error of string
+  | Mu of t
+  | Rec_var of int
 
-(* Type shapes are abstract representations of type expressions. We define
-    them with a placeholder 'a for the layout inside. This allows one to
-    first create shapes without a type by picking [without_layout] for 'a
-    and then later substituting in a layout of type [Layout.t]. *)
-(* CR sspies: The layout merged into the type shapes is confusing and will
-    cause trouble when the type shapes are integrated into shapes. Move them
-    back out again in a subsequent PR and instead recurse over layout and shape
-    in the DWARF emission code. *)
-type without_layout = Layout_to_be_determined
+  | Mutrec of t Ident.Map.t
+  | ProjDecl of t * Ident.t
 
-type 'a ts =
-  | Ts_constr of (Uid.t * Path.t * 'a) * without_layout ts list
-      (** [Ts_constr ((uid, p, ly), args)] is the shape of the type constructor
-      [p] applied to the arguments [args], resulting in data of layout [ly].
-      Unlike for the resulting data, we do not definitely know the layout
-      of the arguments yet. This is only fully determined once we look at the
-      declaration behind [p]. Thus, even when the type constructor application
-      [Ts_constr((uid, p, ly), args)] itself carries a layout, the layout of
-      the arguments is still to be determined.  *)
-  | Ts_tuple of 'a ts list
-  | Ts_unboxed_tuple of 'a ts list
-  | Ts_var of string option * 'a
-  | Ts_predef of Predef.t * without_layout ts list
-      (** [Ts_predef(p, args)] is the shape for predefined type shapes.
-        Analogously to [Ts_constr], its arguments do not carry a layout yet.
-      *)
-  | Ts_arrow of without_layout ts * without_layout ts
-      (** [Ts_arrow(arg, ret)] is the shape for the function type
-          [arg -> ret]. When emitting DWARF information for this type, there
-          is no need to inspect the type arguments, and we never find out
-          their layout. As such, these remain [without_layout] even after
-          substituting in layouts.   *)
-  | Ts_variant of 'a ts poly_variant_constructors
-  | Ts_other of 'a
+  (* constructors for types  *)
+  | Constr of Ident.t * t list
+  | Tuple of t list (* boxed tuple (value layout) *)
+  | Unboxed_tuple of t list (* unboxed tuple (product layout) *)
+  | Predef of Predef.t * t list (* predef type with arguments *)
+  | Arrow of t * t
+    (* CR sspies: We could in principle discard the arguments of the arrow,
+       since they are neither needed for printing nor for debug information. *)
+  | Poly_variant of t poly_variant_constructors
+
+  (* constructors for type declarations *)
+  | Variant of
+    { simple_constructors : string list;
+      (** The string is the name of the constructor. The runtime
+          representation of the constructor at index [i] in this list is
+          [2 * i + 1]. See [dwarf_type.ml] for more details. *)
+      complex_constructors : (t * Layout.t) complex_constructors
+      (** All constructors in this category are represented as blocks.
+          The index [i] in the list indicates the tag at runtime. The
+          length of the constructor argument list [args] determines the
+          size of the block. *)
+    }
+  | Variant_unboxed of
+    { name : string;
+      arg_name : string option;
+      (** if this is [None], we are looking at a singleton tuple;
+          otherwise, it is a singleton record. *)
+      arg_shape : t;
+      arg_layout : Layout.t
+    }
+    (** An unboxed variant corresponds to the [@@unboxed] annotation.
+        It must have a single, complex constructor. *)
+  | Record of
+      { fields : (string * t * Layout.t) list;
+        kind : record_kind
+      }
+
+(** For DWARF type emission to work as expected, we store the layouts in the
+    declaration alongside the shapes in those cases where the layout "expands"
+    again such as variant constructors, which themselves are values but do
+    point to blocks in memory with layouts for the individual fields. *)
 
 and 'a poly_variant_constructors = 'a poly_variant_constructor list
 
@@ -244,41 +257,6 @@ and 'a poly_variant_constructor =
     pv_constr_args : 'a list
   }
 
-
-(** For type substitution to work as expected, we store the layouts in the
-    declaration alongside the shapes instead of directly going for the
-    substituted version. *)
-type tds_desc =
-  | Tds_variant of
-      { simple_constructors : string list;
-            (** The string is the name of the constructor. The runtime
-                representation of the constructor at index [i] in this list is
-                [2 * i + 1]. See [dwarf_type.ml] for more details. *)
-        complex_constructors :
-          (without_layout ts * Layout.t)
-          complex_constructors
-            (** All constructors in this category are represented as blocks.
-                The index [i] in the list indicates the tag at runtime. The
-                length of the constructor argument list [args] determines the
-                size of the block. *)
-      }
-  | Tds_variant_unboxed of
-      { name : string;
-        arg_name : string option;
-            (** if this is [None], we are looking at a singleton tuple;
-              otherwise, it is a singleton record. *)
-        arg_shape : without_layout ts;
-        arg_layout : Layout.t
-      }
-      (** An unboxed variant corresponds to the [@@unboxed] annotation.
-        It must have a single, complex constructor. *)
-  | Tds_record of
-      { fields :
-          (string * without_layout ts * Layout.t) list;
-        kind : record_kind
-      }
-  | Tds_alias of without_layout ts
-  | Tds_other
 
 and record_kind =
   | Record_unboxed
@@ -313,14 +291,8 @@ and constructor_representation = mixed_product_shape
 
 and mixed_product_shape = Layout.t array
 
-type tds =
-  { path : Path.t;
-    definition : tds_desc;
-    type_params : without_layout ts list
-  }
 
 
-(* Shapes *)
 val print : Format.formatter -> t -> unit
 
 val strip_head_aliases : t -> t
@@ -333,6 +305,7 @@ val for_unnamed_functor_param : var
 val fresh_var : ?name:string -> Uid.t -> var * t
 
 val var : Uid.t -> Ident.t -> t
+val var': Uid.t option -> Ident.t -> t
 val abs : ?uid:Uid.t -> var -> t -> t
 val app : ?uid:Uid.t -> t -> arg:t -> t
 val str : ?uid:Uid.t -> t Item.Map.t -> t
@@ -341,10 +314,33 @@ val error : ?uid:Uid.t -> string -> t
 val proj : ?uid:Uid.t -> t -> Item.t -> t
 val leaf : Uid.t -> t
 val leaf' : Uid.t option -> t
+
+val tuple : ?uid:Uid.t -> t list -> t
+val unboxed_tuple : ?uid:Uid.t -> t list -> t
+val predef : ?uid:Uid.t -> Predef.t -> t list -> t
+val arrow : ?uid:Uid.t -> t -> t -> t
+val poly_variant : ?uid:Uid.t -> t poly_variant_constructors -> t
+
+val variant : ?uid:Uid.t -> string list -> (t * Layout.t) complex_constructors -> t
+val variant_unboxed : ?uid:Uid.t -> string -> string option -> t -> Layout.t -> t
+val record : ?uid:Uid.t -> record_kind -> (string * t * Layout.t) list -> t
+
+(* recursive binder, recursive occurrences should be leaves with the same uid *)
+val mu : ?uid:Uid.t -> t -> t
+val rec_var : ?uid:Uid.t -> int -> t
+
 val no_fuel_left : ?uid:Uid.t -> t -> t
 val comp_unit : ?uid:Uid.t -> string -> t
 
+val constr : ?uid:Uid.t -> Ident.t -> t list -> t
+val mutrec : ?uid:Uid.t -> t Ident.Map.t -> t
+val proj_decl : ?uid:Uid.t -> t -> Ident.t -> t
+
+
 val set_approximated : approximated:bool -> t -> t
+
+val app_list : t -> t list -> t
+val abs_list : t -> Ident.t list -> t
 
 val decompose_abs : t -> (var * t) option
 
@@ -352,26 +348,18 @@ val decompose_abs : t -> (var * t) option
 val for_persistent_unit : string -> t
 val leaf_for_unpack : t
 
-(* Type shapes *)
-val shape_layout : Layout.t ts -> Layout.t
-
-val shape_with_layout : layout:Layout.t -> without_layout ts -> Layout.t ts
-
-val print_type_shape : Format.formatter -> 'a ts -> unit
-
 val poly_variant_constructors_map :
   ('a -> 'b) -> 'a poly_variant_constructors -> 'b poly_variant_constructors
-
-(* Type declaration shapes *)
-val print_type_decl_shape : Format.formatter -> tds -> unit
-
-val replace_tvar : tds -> without_layout ts list -> tds
 
 val complex_constructor_map :
   ('a -> 'b) -> 'a complex_constructor -> 'b complex_constructor
 
 val complex_constructors_map :
   ('a -> 'b) -> 'a complex_constructors -> 'b complex_constructors
+
+val is_mu_closed : t -> bool
+  (** Checks whether the shape is closed with respect to the mu-binders and
+      recursive variables inside of it. *)
 
 module Map : sig
   type shape = t

--- a/typing/shape.mli
+++ b/typing/shape.mli
@@ -184,6 +184,8 @@ module Predef : sig
 
   val to_string : t -> string
 
+  val equal : t -> t -> bool
+
   val unboxed_type_to_base_layout : unboxed -> base_layout
 
   val to_layout : t -> Layout.t
@@ -298,6 +300,11 @@ val print : Format.formatter -> t -> unit
 val strip_head_aliases : t -> t
 
 val equal : t -> t -> bool
+
+val equal_record_kind : record_kind -> record_kind -> bool
+
+val equal_complex_constructor : 
+  ('a -> 'a -> bool) -> 'a complex_constructor -> 'a complex_constructor -> bool
 
 (* Smart constructors *)
 

--- a/typing/shape_reduce.ml
+++ b/typing/shape_reduce.ml
@@ -48,6 +48,7 @@ let find_shape env id =
 module Make(Params : sig
   val fuel : int
   val read_unit_shape : unit_name:string -> t option
+  val remove_uids : bool
 end) = struct
   (* We implement a strong call-by-need reduction, following an
      evaluator from Nathanaelle Courant. *)
@@ -63,6 +64,9 @@ end) = struct
     | NLeaf
     | NComp_unit of string
     | NError of string
+    | NMu of delayed_nf
+    | NRec_var of int
+    | NDelayed of delayed_nf
 
   (* A type of normal forms for strong call-by-need evaluation.
      The normal form of an abstraction
@@ -113,6 +117,8 @@ end) = struct
       if equal_nf v1 v2 then equal_nf t1 t2
       else false
     | NLeaf, NLeaf -> true
+    | NMu (nf1), NMu (nf2) -> equal_delayed_nf nf1 nf2
+    | NRec_var i1, NRec_var i2 -> Int.equal i1 i2
     | NStruct t1, NStruct t2 ->
       Item.Map.equal equal_delayed_nf t1 t2
     | NProj (t1, i1), NProj (t2, i2) ->
@@ -121,15 +127,19 @@ end) = struct
     | NComp_unit c1, NComp_unit c2 -> String.equal c1 c2
     | NAlias a1, NAlias a2 -> equal_delayed_nf a1 a2
     | NError e1, NError e2 -> String.equal e1 e2
-    | NVar _, (NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NError _)
-    | NLeaf, (NVar _ | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NError _)
-    | NApp _, (NVar _ | NLeaf | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NError _)
-    | NAbs _, (NVar _ | NLeaf | NApp _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NError _)
-    | NStruct _, (NVar _ | NLeaf | NApp _ | NAbs _ | NProj _ | NComp_unit _ | NAlias _ | NError _)
-    | NProj _, (NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NComp_unit _ | NAlias _ | NError _)
-    | NComp_unit _, (NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NAlias _ | NError _)
-    | NAlias _, (NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NError _)
-    | NError _, (NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _)
+    | NDelayed nf1, NDelayed nf2 -> equal_delayed_nf nf1 nf2
+    | NVar _, (NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NError _ | NDelayed _ | NMu _| NRec_var _)
+    | NLeaf, (NVar _ | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NError _ | NDelayed _ | NMu _| NRec_var _)
+    | NApp _, (NVar _ | NLeaf | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NError _ | NDelayed _ | NMu _| NRec_var _)
+    | NAbs _, (NVar _ | NLeaf | NApp _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NError _ | NDelayed _ | NMu _| NRec_var _)
+    | NStruct _, (NVar _ | NLeaf | NApp _ | NAbs _ | NProj _ | NComp_unit _ | NAlias _ | NError _ | NDelayed _ | NMu _| NRec_var _)
+    | NProj _, (NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NComp_unit _ | NAlias _ | NError _ | NDelayed _ | NMu _| NRec_var _)
+    | NComp_unit _, (NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NAlias _ | NError _ | NDelayed _ | NMu _| NRec_var _)
+    | NAlias _, (NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NError _ | NDelayed _ | NMu _| NRec_var _)
+    | NError _, (NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NDelayed _ | NMu _| NRec_var _)
+    | NMu _, (NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NError _ | NDelayed _ | NRec_var _  )
+    | NRec_var _, (NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NError _ | NDelayed _ | NMu _ )
+    | NDelayed _, (NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NError _ | NMu _ | NRec_var _ )
     -> false
 
   and equal_nf t1 t2 =
@@ -304,11 +314,16 @@ end) = struct
               reduce env res
           end
       | Leaf -> return NLeaf
+      | Mu t_body -> return (NMu (delay_reduce env t_body))
+      | Rec_var n -> return (NRec_var n)
       | Struct m ->
           let mnf = Item.Map.map (delay_reduce env) m in
           return (NStruct mnf)
       | Alias t -> return (NAlias (delay_reduce env t))
       | Error s -> approx_nf (return (NError s))
+      | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Poly_variant _
+      | Variant _ | Variant_unboxed _ | Record _ | Constr _ | Mutrec _ | ProjDecl _ ->
+        (return (NDelayed (delay_reduce env t)))
 
   and read_back env (nf : nf) : t =
   in_read_back_memo_table env.read_back_memo_table nf (read_back_ env) nf
@@ -323,9 +338,10 @@ end) = struct
   and read_back_desc ~uid env desc =
     let read_back nf = read_back env nf in
     let read_back_force dnf = read_back (force env dnf) in
+    let uid = if Params.remove_uids then None else uid in
     match desc with
     | NVar v ->
-      var (Option.get uid) v
+      var' uid v
     | NApp (nft, nfu) ->
         let f = read_back nft in
         let arg = read_back nfu in
@@ -343,6 +359,69 @@ end) = struct
     | NComp_unit s -> comp_unit ?uid s
     | NAlias nf -> alias ?uid (read_back_force nf)
     | NError t -> error ?uid t
+    | NMu (t_body) ->
+      mu ?uid (read_back_force t_body)
+    | NRec_var n ->
+      rec_var ?uid n
+    | NDelayed dnf ->
+      read_back_delayed ~uid env dnf
+
+
+  and read_back_delayed ~uid env (dnf : delayed_nf) : t =
+    let Thunk (l, t) = dnf in
+    let env = { env with local_env = l } in
+    force_reduce ~uid env t
+
+  (* CR sspies: We currently do not match the delayed reduction strategy for
+     type declarations that is used for the other parts, and instead
+     aggressively reduce the occurrences of shapes in type declarations. *)
+  and force_reduce ~uid env (t: t) =
+    let uid  = if Params.remove_uids then None else uid in
+    let reduce t = read_back env (reduce_ env t) in
+    (* For any recursive occurrence, we should reduce the internal shapes. *)
+    match t.desc with
+    | Variant { simple_constructors; complex_constructors } ->
+      Shape.variant ?uid simple_constructors
+      (List.map
+            (Shape.complex_constructor_map
+              (fun ((sh, ly): t * _) -> force_reduce ~uid:sh.uid env sh, ly)
+            )
+          complex_constructors)
+
+    | Variant_unboxed { name; arg_name; arg_shape; arg_layout } ->
+      Shape.variant_unboxed ?uid name arg_name
+      (force_reduce ~uid:arg_shape.uid env arg_shape) arg_layout
+    | Record { fields; kind } ->
+      Shape.record ?uid
+        kind
+        (List.map
+           (fun ((name, sh, ly): _ * t * _) -> name, force_reduce ~uid:sh.uid env sh, ly)
+           fields)
+    | Poly_variant constrs ->
+      Shape.poly_variant ?uid
+        (poly_variant_constructors_map (fun (sh: t) -> force_reduce ~uid:sh.uid env sh) constrs)
+    | Tuple args ->
+      Shape.tuple ?uid (List.map (fun (sh: t) -> force_reduce ~uid:sh.uid env sh) args)
+    | Unboxed_tuple args ->
+      Shape.unboxed_tuple ?uid (List.map (fun (sh: t) -> force_reduce ~uid:sh.uid env sh) args)
+    | Arrow (arg, ret) ->
+      Shape.arrow ?uid
+        (force_reduce ~uid:arg.uid env arg)
+        (force_reduce ~uid:ret.uid env ret)
+    | Predef (predef, args) ->
+      Shape.predef ?uid predef (List.map (fun (sh: t) -> force_reduce ~uid:sh.uid env sh) args)
+    | Constr (id, args) ->
+        let args = List.map (fun (sh: t) -> force_reduce ~uid:sh.uid env sh) args in
+        constr ?uid id args
+    | Mutrec defs ->
+        let defs = Ident.Map.map (fun (sh: t) -> force_reduce ~uid:sh.uid env sh) defs in
+        mutrec ?uid defs
+    | ProjDecl (t, id) -> proj_decl ?uid (force_reduce ~uid:t.uid env t) id
+    | (Mu _ | Rec_var _ | Alias _ | Error _ | Leaf | App _ | Proj _ | Var _
+       | Abs _ | Comp_unit _ | Struct _ )  ->
+      (* all of these are potentially type expressions *)
+      reduce t
+
 
   (* Sharing the memo tables is safe at the level of a compilation unit since
     idents should be unique *)
@@ -359,7 +438,7 @@ end) = struct
       read_back_memo_table = !read_back_memo_table;
       local_env;
     } in
-    reduce_ env t |> read_back env
+     reduce_ env t |> read_back env
 
   let rec is_stuck_on_comp_unit (nf : nf) =
     match nf.desc with
@@ -372,6 +451,9 @@ end) = struct
     | NComp_unit _ -> true
     | NError _ -> false
     | NLeaf -> false
+    | NMu _ -> false
+    | NRec_var _ -> false
+    | NDelayed _ -> false
 
   let rec reduce_aliases_for_uid env (nf : nf) =
     match nf with
@@ -409,6 +491,7 @@ module Local_reduce =
   Make(struct
     let fuel = 10
     let read_unit_shape ~unit_name:_ = None
+    let remove_uids = false
   end)
 
 let local_reduce = Local_reduce.reduce

--- a/typing/shape_reduce.ml
+++ b/typing/shape_reduce.ml
@@ -66,7 +66,28 @@ end) = struct
     | NError of string
     | NMu of delayed_nf
     | NRec_var of int
-    | NDelayed of delayed_nf
+    | NMutrec of delayed_nf Ident.Map.t
+    | NProjDecl of nf * Ident.t
+    | NConstr of Ident.t * nf list
+    | NTuple of nf list
+    | NUnboxed_tuple of nf list
+    | NPredef of Predef.t * nf list
+    | NArrow of nf * nf
+    | NPoly_variant of delayed_nf poly_variant_constructors
+    | NVariant of {
+      simple_constructors: string list;
+      complex_constructors: (delayed_nf * Layout.t) complex_constructors
+    }
+    | NVariant_unboxed of
+      { name : string;
+        arg_name : string option;
+        arg_shape : delayed_nf;
+        arg_layout : Layout.t
+      }
+    | NRecord of
+        { fields : (string * delayed_nf * Layout.t) list;
+          kind : record_kind
+        }
 
   (* A type of normal forms for strong call-by-need evaluation.
      The normal form of an abstraction
@@ -117,8 +138,6 @@ end) = struct
       if equal_nf v1 v2 then equal_nf t1 t2
       else false
     | NLeaf, NLeaf -> true
-    | NMu (nf1), NMu (nf2) -> equal_delayed_nf nf1 nf2
-    | NRec_var i1, NRec_var i2 -> Int.equal i1 i2
     | NStruct t1, NStruct t2 ->
       Item.Map.equal equal_delayed_nf t1 t2
     | NProj (t1, i1), NProj (t2, i2) ->
@@ -127,20 +146,185 @@ end) = struct
     | NComp_unit c1, NComp_unit c2 -> String.equal c1 c2
     | NAlias a1, NAlias a2 -> equal_delayed_nf a1 a2
     | NError e1, NError e2 -> String.equal e1 e2
-    | NDelayed nf1, NDelayed nf2 -> equal_delayed_nf nf1 nf2
-    | NVar _, (NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NError _ | NDelayed _ | NMu _| NRec_var _)
-    | NLeaf, (NVar _ | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NError _ | NDelayed _ | NMu _| NRec_var _)
-    | NApp _, (NVar _ | NLeaf | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NError _ | NDelayed _ | NMu _| NRec_var _)
-    | NAbs _, (NVar _ | NLeaf | NApp _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NError _ | NDelayed _ | NMu _| NRec_var _)
-    | NStruct _, (NVar _ | NLeaf | NApp _ | NAbs _ | NProj _ | NComp_unit _ | NAlias _ | NError _ | NDelayed _ | NMu _| NRec_var _)
-    | NProj _, (NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NComp_unit _ | NAlias _ | NError _ | NDelayed _ | NMu _| NRec_var _)
-    | NComp_unit _, (NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NAlias _ | NError _ | NDelayed _ | NMu _| NRec_var _)
-    | NAlias _, (NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NError _ | NDelayed _ | NMu _| NRec_var _)
-    | NError _, (NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NDelayed _ | NMu _| NRec_var _)
-    | NMu _, (NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NError _ | NDelayed _ | NRec_var _  )
-    | NRec_var _, (NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NError _ | NDelayed _ | NMu _ )
-    | NDelayed _, (NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _ | NAlias _ | NError _ | NMu _ | NRec_var _ )
-    -> false
+    | NMu (nf1), NMu (nf2) -> equal_delayed_nf nf1 nf2
+    | NRec_var i1, NRec_var i2 -> Int.equal i1 i2
+    | NMutrec defs1, NMutrec defs2 ->
+      Ident.Map.equal equal_delayed_nf defs1 defs2
+    | NProjDecl (nf1, id1), NProjDecl (nf2, id2) ->
+      Ident.equal id1 id2 && equal_nf nf1 nf2
+    | NConstr (id1, args1), NConstr (id2, args2) ->
+      Ident.equal id1 id2 && List.equal equal_nf args1 args2
+    | NTuple args1, NTuple args2 ->
+      List.equal equal_nf args1 args2
+    | NUnboxed_tuple args1, NUnboxed_tuple args2 ->
+      List.equal equal_nf args1 args2
+    | NPredef (p1, args1), NPredef (p2, args2) ->
+      Predef.equal p1 p2 && List.equal equal_nf args1 args2
+    | NArrow (arg1, ret1), NArrow (arg2, ret2) ->
+      equal_nf arg1 arg2 && equal_nf ret1 ret2
+    | NPoly_variant constrs1, NPoly_variant constrs2 ->
+      let equal_pv_constructor c1 c2 =
+        String.equal c1.pv_constr_name c2.pv_constr_name &&
+        List.equal equal_delayed_nf c1.pv_constr_args c2.pv_constr_args
+      in
+      List.equal equal_pv_constructor constrs1 constrs2
+    | NVariant { simple_constructors = sc1; complex_constructors = cc1 },
+      NVariant { simple_constructors = sc2; complex_constructors = cc2 } ->
+      List.equal String.equal sc1 sc2 &&
+      List.equal
+        (Shape.equal_complex_constructor
+          (fun (dnf1, ly1) (dnf2, ly2) ->
+            Layout.equal ly1 ly2 && equal_delayed_nf dnf1 dnf2))
+        cc1 cc2
+    | NVariant_unboxed { name = n1; arg_name = an1; arg_shape = as1;
+                         arg_layout = al1 },
+      NVariant_unboxed { name = n2; arg_name = an2; arg_shape = as2;
+                         arg_layout = al2 } ->
+      String.equal n1 n2 &&
+      Option.equal String.equal an1 an2 &&
+      Layout.equal al1 al2 &&
+      equal_delayed_nf as1 as2
+    | NRecord { fields = f1; kind = k1 }, NRecord { fields = f2; kind = k2 } ->
+      Shape.equal_record_kind k1 k2 &&
+      List.equal
+        (fun (name1, dnf1, ly1) (name2, dnf2, ly2) ->
+          String.equal name1 name2 &&
+          Layout.equal ly1 ly2 &&
+          equal_delayed_nf dnf1 dnf2)
+        f1 f2
+    | ( NVar _,
+        ( NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _
+        | NAlias _ | NError _ | NMu _ | NRec_var _ | NMutrec _
+        | NProjDecl _ | NConstr _ | NTuple _ | NUnboxed_tuple _
+        | NPredef _ | NArrow _ | NPoly_variant _ | NVariant _
+        | NVariant_unboxed _ | NRecord _ ) )
+    | ( NLeaf,
+        ( NVar _ | NApp _ | NAbs _ | NStruct _ | NProj _ | NComp_unit _
+        | NAlias _ | NError _ | NMu _ | NRec_var _ | NMutrec _
+        | NProjDecl _ | NConstr _ | NTuple _ | NUnboxed_tuple _
+        | NPredef _ | NArrow _ | NPoly_variant _ | NVariant _
+        | NVariant_unboxed _ | NRecord _ ) )
+    | ( NApp _,
+        ( NVar _ | NLeaf | NAbs _ | NStruct _ | NProj _ | NComp_unit _
+        | NAlias _ | NError _ | NMu _ | NRec_var _ | NMutrec _
+        | NProjDecl _ | NConstr _ | NTuple _ | NUnboxed_tuple _
+        | NPredef _ | NArrow _ | NPoly_variant _ | NVariant _
+        | NVariant_unboxed _ | NRecord _ ) )
+    | ( NAbs _,
+        ( NVar _ | NLeaf | NApp _ | NStruct _ | NProj _ | NComp_unit _
+        | NAlias _ | NError _ | NMu _ | NRec_var _ | NMutrec _
+        | NProjDecl _ | NConstr _ | NTuple _ | NUnboxed_tuple _
+        | NPredef _ | NArrow _ | NPoly_variant _ | NVariant _
+        | NVariant_unboxed _ | NRecord _ ) )
+    | ( NStruct _,
+        ( NVar _ | NLeaf | NApp _ | NAbs _ | NProj _ | NComp_unit _
+        | NAlias _ | NError _ | NMu _ | NRec_var _ | NMutrec _
+        | NProjDecl _ | NConstr _ | NTuple _ | NUnboxed_tuple _
+        | NPredef _ | NArrow _ | NPoly_variant _ | NVariant _
+        | NVariant_unboxed _ | NRecord _ ) )
+    | ( NProj _,
+        ( NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NComp_unit _
+        | NAlias _ | NError _ | NMu _ | NRec_var _ | NMutrec _
+        | NProjDecl _ | NConstr _ | NTuple _ | NUnboxed_tuple _
+        | NPredef _ | NArrow _ | NPoly_variant _ | NVariant _
+        | NVariant_unboxed _ | NRecord _ ) )
+    | ( NComp_unit _,
+        ( NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _ | NAlias _
+        | NError _ | NMu _ | NRec_var _ | NMutrec _ | NProjDecl _
+        | NConstr _ | NTuple _ | NUnboxed_tuple _ | NPredef _
+        | NArrow _ | NPoly_variant _ | NVariant _ | NVariant_unboxed _
+        | NRecord _ ) )
+    | ( NAlias _,
+        ( NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _
+        | NComp_unit _ | NError _ | NMu _ | NRec_var _ | NMutrec _
+        | NProjDecl _ | NConstr _ | NTuple _ | NUnboxed_tuple _
+        | NPredef _ | NArrow _ | NPoly_variant _ | NVariant _
+        | NVariant_unboxed _ | NRecord _ ) )
+    | ( NError _,
+        ( NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _
+        | NComp_unit _ | NAlias _ | NMu _ | NRec_var _ | NMutrec _
+        | NProjDecl _ | NConstr _ | NTuple _ | NUnboxed_tuple _
+        | NPredef _ | NArrow _ | NPoly_variant _ | NVariant _
+        | NVariant_unboxed _ | NRecord _ ) )
+    | ( NMu _,
+        ( NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _
+        | NComp_unit _ | NAlias _ | NError _ | NRec_var _ | NMutrec _
+        | NProjDecl _ | NConstr _ | NTuple _ | NUnboxed_tuple _
+        | NPredef _ | NArrow _ | NPoly_variant _ | NVariant _
+        | NVariant_unboxed _ | NRecord _ ) )
+    | ( NRec_var _,
+        ( NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _
+        | NComp_unit _ | NAlias _ | NError _ | NMu _ | NMutrec _
+        | NProjDecl _ | NConstr _ | NTuple _ | NUnboxed_tuple _
+        | NPredef _ | NArrow _ | NPoly_variant _ | NVariant _
+        | NVariant_unboxed _ | NRecord _ ) )
+    | ( NMutrec _,
+        ( NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _
+        | NComp_unit _ | NAlias _ | NError _ | NMu _ | NRec_var _
+        | NProjDecl _ | NConstr _ | NTuple _ | NUnboxed_tuple _
+        | NPredef _ | NArrow _ | NPoly_variant _ | NVariant _
+        | NVariant_unboxed _ | NRecord _ ) )
+    | ( NProjDecl _,
+        ( NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _
+        | NComp_unit _ | NAlias _ | NError _ | NMu _ | NRec_var _
+        | NMutrec _ | NConstr _ | NTuple _ | NUnboxed_tuple _
+        | NPredef _ | NArrow _ | NPoly_variant _ | NVariant _
+        | NVariant_unboxed _ | NRecord _ ) )
+    | ( NConstr _,
+        ( NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _
+        | NComp_unit _ | NAlias _ | NError _ | NMu _ | NRec_var _
+        | NMutrec _ | NProjDecl _ | NTuple _ | NUnboxed_tuple _
+        | NPredef _ | NArrow _ | NPoly_variant _ | NVariant _
+        | NVariant_unboxed _ | NRecord _ ) )
+    | ( NTuple _,
+        ( NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _
+        | NComp_unit _ | NAlias _ | NError _ | NMu _ | NRec_var _
+        | NMutrec _ | NProjDecl _ | NConstr _ | NUnboxed_tuple _
+        | NPredef _ | NArrow _ | NPoly_variant _ | NVariant _
+        | NVariant_unboxed _ | NRecord _ ) )
+    | ( NUnboxed_tuple _,
+        ( NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _
+        | NComp_unit _ | NAlias _ | NError _ | NMu _ | NRec_var _
+        | NMutrec _ | NProjDecl _ | NConstr _ | NTuple _ | NPredef _
+        | NArrow _ | NPoly_variant _ | NVariant _ | NVariant_unboxed _
+        | NRecord _ ) )
+    | ( NPredef _,
+        ( NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _
+        | NComp_unit _ | NAlias _ | NError _ | NMu _ | NRec_var _
+        | NMutrec _ | NProjDecl _ | NConstr _ | NTuple _
+        | NUnboxed_tuple _ | NArrow _ | NPoly_variant _ | NVariant _
+        | NVariant_unboxed _ | NRecord _ ) )
+    | ( NArrow _,
+        ( NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _
+        | NComp_unit _ | NAlias _ | NError _ | NMu _ | NRec_var _
+        | NMutrec _ | NProjDecl _ | NConstr _ | NTuple _
+        | NUnboxed_tuple _ | NPredef _ | NPoly_variant _ | NVariant _
+        | NVariant_unboxed _ | NRecord _ ) )
+    | ( NPoly_variant _,
+        ( NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _
+        | NComp_unit _ | NAlias _ | NError _ | NMu _ | NRec_var _
+        | NMutrec _ | NProjDecl _ | NConstr _ | NTuple _
+        | NUnboxed_tuple _ | NPredef _ | NArrow _ | NVariant _
+        | NVariant_unboxed _ | NRecord _ ) )
+    | ( NVariant _,
+        ( NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _
+        | NComp_unit _ | NAlias _ | NError _ | NMu _ | NRec_var _
+        | NMutrec _ | NProjDecl _ | NConstr _ | NTuple _
+        | NUnboxed_tuple _ | NPredef _ | NArrow _ | NPoly_variant _
+        | NVariant_unboxed _ | NRecord _ ) )
+    | ( NVariant_unboxed _,
+        ( NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _
+        | NComp_unit _ | NAlias _ | NError _ | NMu _ | NRec_var _
+        | NMutrec _ | NProjDecl _ | NConstr _ | NTuple _
+        | NUnboxed_tuple _ | NPredef _ | NArrow _ | NPoly_variant _
+        | NVariant _ | NRecord _ ) )
+    | ( NRecord _,
+        ( NVar _ | NLeaf | NApp _ | NAbs _ | NStruct _ | NProj _
+        | NComp_unit _ | NAlias _ | NError _ | NMu _ | NRec_var _
+        | NMutrec _ | NProjDecl _ | NConstr _ | NTuple _
+        | NUnboxed_tuple _ | NPredef _ | NArrow _ | NPoly_variant _
+        | NVariant _ | NVariant_unboxed _ ) ) ->
+      false
 
   and equal_nf t1 t2 =
     if not (Option.equal Uid.equal t1.uid t2.uid) then false
@@ -321,9 +505,46 @@ end) = struct
           return (NStruct mnf)
       | Alias t -> return (NAlias (delay_reduce env t))
       | Error s -> approx_nf (return (NError s))
-      | Tuple _ | Unboxed_tuple _ | Predef _ | Arrow _ | Poly_variant _
-      | Variant _ | Variant_unboxed _ | Record _ | Constr _ | Mutrec _ | ProjDecl _ ->
-        (return (NDelayed (delay_reduce env t)))
+      | Mutrec defs ->
+          let dnfs = Ident.Map.map (delay_reduce env) defs in
+          return (NMutrec dnfs)
+      | ProjDecl (t, id) ->
+          let nf = reduce env t in
+          return (NProjDecl (nf, id))
+      | Constr (id, args) ->
+          let nfs = List.map (reduce env) args in
+          return (NConstr (id, nfs))
+      | Tuple args ->
+          let nfs = List.map (reduce env) args in
+          return (NTuple nfs)
+      | Unboxed_tuple args ->
+          let nfs = List.map (reduce env) args in
+          return (NUnboxed_tuple nfs)
+      | Predef (p, args) ->
+          let nfs = List.map (reduce env) args in
+          return (NPredef (p, nfs))
+      | Arrow (arg, ret) ->
+          let arg_nf = reduce env arg in
+          let ret_nf = reduce env ret in
+          return (NArrow (arg_nf, ret_nf))
+      | Poly_variant constrs ->
+          let dnf_constrs = poly_variant_constructors_map
+                              (delay_reduce env) constrs in
+          return (NPoly_variant dnf_constrs)
+      | Variant { simple_constructors; complex_constructors } ->
+          let dnf_complex_constructors =
+            complex_constructors_map (fun (t, ly) ->
+              (delay_reduce env t, ly)) complex_constructors in
+          return (NVariant { simple_constructors;
+                             complex_constructors = dnf_complex_constructors })
+      | Variant_unboxed { name; arg_name; arg_shape; arg_layout } ->
+          let dnf_arg_shape = delay_reduce env arg_shape in
+          return (NVariant_unboxed { name; arg_name;
+                                     arg_shape = dnf_arg_shape; arg_layout })
+      | Record { fields; kind } ->
+          let dnf_fields = List.map (fun (name, t, ly) ->
+            (name, delay_reduce env t, ly)) fields in
+          return (NRecord { fields = dnf_fields; kind })
 
   and read_back env (nf : nf) : t =
   in_read_back_memo_table env.read_back_memo_table nf (read_back_ env) nf
@@ -363,65 +584,44 @@ end) = struct
       mu ?uid (read_back_force t_body)
     | NRec_var n ->
       rec_var ?uid n
-    | NDelayed dnf ->
-      read_back_delayed ~uid env dnf
-
-
-  and read_back_delayed ~uid env (dnf : delayed_nf) : t =
-    let Thunk (l, t) = dnf in
-    let env = { env with local_env = l } in
-    force_reduce ~uid env t
-
-  (* CR sspies: We currently do not match the delayed reduction strategy for
-     type declarations that is used for the other parts, and instead
-     aggressively reduce the occurrences of shapes in type declarations. *)
-  and force_reduce ~uid env (t: t) =
-    let uid  = if Params.remove_uids then None else uid in
-    let reduce t = read_back env (reduce_ env t) in
-    (* For any recursive occurrence, we should reduce the internal shapes. *)
-    match t.desc with
-    | Variant { simple_constructors; complex_constructors } ->
-      Shape.variant ?uid simple_constructors
-      (List.map
-            (Shape.complex_constructor_map
-              (fun ((sh, ly): t * _) -> force_reduce ~uid:sh.uid env sh, ly)
-            )
-          complex_constructors)
-
-    | Variant_unboxed { name; arg_name; arg_shape; arg_layout } ->
-      Shape.variant_unboxed ?uid name arg_name
-      (force_reduce ~uid:arg_shape.uid env arg_shape) arg_layout
-    | Record { fields; kind } ->
-      Shape.record ?uid
-        kind
-        (List.map
-           (fun ((name, sh, ly): _ * t * _) -> name, force_reduce ~uid:sh.uid env sh, ly)
-           fields)
-    | Poly_variant constrs ->
-      Shape.poly_variant ?uid
-        (poly_variant_constructors_map (fun (sh: t) -> force_reduce ~uid:sh.uid env sh) constrs)
-    | Tuple args ->
-      Shape.tuple ?uid (List.map (fun (sh: t) -> force_reduce ~uid:sh.uid env sh) args)
-    | Unboxed_tuple args ->
-      Shape.unboxed_tuple ?uid (List.map (fun (sh: t) -> force_reduce ~uid:sh.uid env sh) args)
-    | Arrow (arg, ret) ->
-      Shape.arrow ?uid
-        (force_reduce ~uid:arg.uid env arg)
-        (force_reduce ~uid:ret.uid env ret)
-    | Predef (predef, args) ->
-      Shape.predef ?uid predef (List.map (fun (sh: t) -> force_reduce ~uid:sh.uid env sh) args)
-    | Constr (id, args) ->
-        let args = List.map (fun (sh: t) -> force_reduce ~uid:sh.uid env sh) args in
-        constr ?uid id args
-    | Mutrec defs ->
-        let defs = Ident.Map.map (fun (sh: t) -> force_reduce ~uid:sh.uid env sh) defs in
-        mutrec ?uid defs
-    | ProjDecl (t, id) -> proj_decl ?uid (force_reduce ~uid:t.uid env t) id
-    | (Mu _ | Rec_var _ | Alias _ | Error _ | Leaf | App _ | Proj _ | Var _
-       | Abs _ | Comp_unit _ | Struct _ )  ->
-      (* all of these are potentially type expressions *)
-      reduce t
-
+    | NMutrec defs ->
+      let t_defs = Ident.Map.map read_back_force defs in
+      mutrec ?uid t_defs
+    | NProjDecl (nf, id) ->
+      let t = read_back nf in
+      proj_decl ?uid t id
+    | NConstr (id, args) ->
+      let t_args = List.map read_back args in
+      constr ?uid id t_args
+    | NTuple args ->
+      let t_args = List.map read_back args in
+      tuple ?uid t_args
+    | NUnboxed_tuple args ->
+      let t_args = List.map read_back args in
+      unboxed_tuple ?uid t_args
+    | NPredef (p, args) ->
+      let t_args = List.map read_back args in
+      predef ?uid p t_args
+    | NArrow (arg, ret) ->
+      let t_arg = read_back arg in
+      let t_ret = read_back ret in
+      arrow ?uid t_arg t_ret
+    | NPoly_variant constrs ->
+      let t_constrs = poly_variant_constructors_map read_back_force constrs in
+      poly_variant ?uid t_constrs
+    | NVariant { simple_constructors; complex_constructors } ->
+      let t_complex_constructors =
+        complex_constructors_map
+          (fun (dnf, ly) -> (read_back_force dnf, ly))
+          complex_constructors in
+      variant ?uid simple_constructors t_complex_constructors
+    | NVariant_unboxed { name; arg_name; arg_shape; arg_layout } ->
+      let t_arg_shape = read_back_force arg_shape in
+      variant_unboxed ?uid name arg_name t_arg_shape arg_layout
+    | NRecord { fields; kind } ->
+      let t_fields = List.map (fun (name, dnf, ly) ->
+        (name, read_back_force dnf, ly)) fields in
+      record ?uid kind t_fields
 
   (* Sharing the memo tables is safe at the level of a compilation unit since
     idents should be unique *)
@@ -453,7 +653,9 @@ end) = struct
     | NLeaf -> false
     | NMu _ -> false
     | NRec_var _ -> false
-    | NDelayed _ -> false
+    | NMutrec _ | NProjDecl _ | NConstr _ | NTuple _ | NUnboxed_tuple _
+    | NPredef _ | NArrow _ | NPoly_variant _ | NVariant _ | NVariant_unboxed _
+    | NRecord _ -> false
 
   let rec reduce_aliases_for_uid env (nf : nf) =
     match nf with

--- a/typing/shape_reduce.mli
+++ b/typing/shape_reduce.mli
@@ -45,6 +45,9 @@ module Make(_ : sig
     val fuel : int
 
     val read_unit_shape : unit_name:string -> Shape.t option
+
+    val remove_uids : bool
+
   end) : sig
   val reduce : Env.t -> Shape.t -> Shape.t
 

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -1,7 +1,119 @@
+(* CR sspies: Rename this file into [shapeify.ml], since it is no longer purely
+   about type shapes. *)
+
 module Uid = Shape.Uid
 module Layout = Jkind_types.Sort.Const
 
 type base_layout = Jkind_types.Sort.base
+
+type path_lookup = Path.t -> args:Shape.t list -> Shape.t option
+
+module Recursive_binder : sig
+  type t
+
+  val mk_recursive_binder : unit -> t
+
+  val use_recursive_binder : t -> Shape.t
+
+  val bind_recursive_binder : ?preserve_uid:bool -> t -> Shape.t -> Shape.t
+end = struct
+  (* CR sspies: To improve performance, consider replacing this pass with
+     a single pass over the resulting definition that simultaneously turns
+     all binders into DeBruijn indices. *)
+  let rec shape_subst_uid_with_rec_var ~preserve_uid uid rv outer =
+    let open Shape in
+    match outer.desc with
+    | Leaf when Option.equal Uid.equal outer.uid (Some uid) ->
+      let uid = if preserve_uid then Some uid else None in
+      Shape.rec_var ?uid rv
+    | Leaf | Error _ | Rec_var _ | Comp_unit _ | Var _ -> outer (* base cases *)
+    | Alias sh ->
+      Shape.alias ?uid:outer.uid
+        (shape_subst_uid_with_rec_var ~preserve_uid uid rv sh)
+    | App (sh, arg) ->
+      Shape.app ?uid:outer.uid
+        (shape_subst_uid_with_rec_var ~preserve_uid uid rv sh)
+        ~arg:(shape_subst_uid_with_rec_var ~preserve_uid uid rv arg)
+    | Proj (sh, item) ->
+      Shape.proj ?uid:outer.uid
+        (shape_subst_uid_with_rec_var ~preserve_uid uid rv sh)
+        item
+    | Struct map ->
+      Shape.str ?uid:outer.uid
+        (Item.Map.map (shape_subst_uid_with_rec_var ~preserve_uid uid rv) map)
+    | Abs (var, sh) ->
+      Shape.abs ?uid:outer.uid var
+        (shape_subst_uid_with_rec_var ~preserve_uid uid rv sh)
+    | Mu sh ->
+      Shape.mu ?uid:outer.uid
+        (shape_subst_uid_with_rec_var ~preserve_uid uid (rv + 1) sh)
+    | Mutrec map ->
+      Shape.mutrec ?uid:outer.uid
+        (Ident.Map.map
+           (fun sh -> shape_subst_uid_with_rec_var ~preserve_uid uid rv sh)
+           map)
+    | ProjDecl (sh, id) ->
+      Shape.proj_decl ?uid:outer.uid
+        (shape_subst_uid_with_rec_var ~preserve_uid uid rv sh)
+        id
+    | Constr (id, args) ->
+      Shape.constr ?uid:outer.uid id
+        (List.map (shape_subst_uid_with_rec_var ~preserve_uid uid rv) args)
+    | Tuple shapes ->
+      Shape.tuple ?uid:outer.uid
+        (List.map (shape_subst_uid_with_rec_var ~preserve_uid uid rv) shapes)
+    | Unboxed_tuple shapes ->
+      Shape.unboxed_tuple ?uid:outer.uid
+        (List.map (shape_subst_uid_with_rec_var ~preserve_uid uid rv) shapes)
+    | Predef (predef, args) ->
+      Shape.predef predef ?uid:outer.uid
+        (List.map
+           (fun sh -> shape_subst_uid_with_rec_var ~preserve_uid uid rv sh)
+           args)
+    | Arrow (arg, ret) ->
+      Shape.arrow ?uid:outer.uid
+        (shape_subst_uid_with_rec_var ~preserve_uid uid rv arg)
+        (shape_subst_uid_with_rec_var ~preserve_uid uid rv ret)
+    | Poly_variant fields ->
+      Shape.poly_variant ?uid:outer.uid
+        (poly_variant_constructors_map
+           (shape_subst_uid_with_rec_var ~preserve_uid uid rv)
+           fields)
+    | Record { fields; kind } ->
+      Shape.record ?uid:outer.uid kind
+        (List.map
+           (fun (name, sh, layout) ->
+             name, shape_subst_uid_with_rec_var ~preserve_uid uid rv sh, layout)
+           fields)
+    | Variant { simple_constructors; complex_constructors } ->
+      Shape.variant ?uid:outer.uid simple_constructors
+        (Shape.complex_constructors_map
+           (fun (sh, layout) ->
+             shape_subst_uid_with_rec_var ~preserve_uid uid rv sh, layout)
+           complex_constructors)
+    | Variant_unboxed { name; arg_name; arg_shape; arg_layout; _ } ->
+      Shape.variant_unboxed ?uid:outer.uid name arg_name
+        (shape_subst_uid_with_rec_var ~preserve_uid uid rv arg_shape)
+        arg_layout
+
+  type t =
+    { uid : Uid.t;
+      mutable used : bool
+    }
+
+  let mk_recursive_binder () = { uid = Uid.mk ~current_unit:None; used = false }
+
+  let use_recursive_binder db =
+    db.used <- true;
+    Shape.leaf db.uid
+
+  let bind_recursive_binder ?(preserve_uid = true) db sh =
+    if not db.used
+    then sh
+    else
+      let sh = shape_subst_uid_with_rec_var ~preserve_uid db.uid 0 sh in
+      Shape.mu ?uid:(if preserve_uid then Some db.uid else None) sh
+end
 
 module Type_shape = struct
   module Predef = struct
@@ -81,6 +193,11 @@ module Type_shape = struct
           match unboxed_of_path p with
           | Some u -> Some (Unboxed u)
           | None -> None))
+
+    let add_predefs_to_lookup f path ~args =
+      match of_path path with
+      | Some predef -> Some (Shape.predef predef args)
+      | None -> f path ~args
   end
 
   (* Similarly to [value_kind], we track a set of visited types to avoid cycles
@@ -89,83 +206,107 @@ module Type_shape = struct
   (* CR sspies: Consider additionally adding a max size for the set of visited types.
      Also consider reverting to the original value kind depth limit (although 2
      seems low). *)
-  let rec of_type_expr_go ~visited ~depth (expr : Types.type_expr) uid_of_path =
-    let predef_of_path = Predef.of_path in
+  let rec of_type_expr_go ~visited ~depth (expr : Types.type_expr)
+      (subst : (Types.type_expr * Shape.t) list) shape_of_path : Shape.t =
     let open Shape in
+    let unknown_shape = Shape.leaf' None in
+    (* Leaves indicate we do not know. *)
     let[@inline] cannot_proceed () =
-      Numbers.Int.Set.mem (Types.get_id expr) visited || depth > 10
+      Numbers.Int.Map.mem (Types.get_id expr) visited || depth > 10
     in
     if cannot_proceed ()
-    then Ts_other Layout_to_be_determined
+    then
+      match Numbers.Int.Map.find_opt (Types.get_id expr) visited with
+      | Some db -> Recursive_binder.use_recursive_binder db
+      | None -> unknown_shape
     else
-      let visited = Numbers.Int.Set.add (Types.get_id expr) visited in
-      let depth = depth + 1 in
-      let desc = Types.get_desc expr in
-      let of_expr_list (exprs : Types.type_expr list) =
-        List.map
-          (fun expr -> of_type_expr_go ~depth ~visited expr uid_of_path)
-          exprs
-      in
-      match desc with
-      | Tconstr (path, constrs, _abbrev_memo) -> (
-        match predef_of_path path with
-        | Some predef -> Ts_predef (predef, of_expr_list constrs)
-        | None -> (
-          match uid_of_path path with
-          | Some uid ->
-            Ts_constr
-              ((uid, path, Layout_to_be_determined), of_expr_list constrs)
-          | None -> Ts_other Layout_to_be_determined))
-      | Ttuple exprs -> Ts_tuple (of_expr_list (List.map snd exprs))
-      | Tvar { name; _ } -> Ts_var (name, Layout_to_be_determined)
-      | Tpoly (type_expr, _type_vars) ->
-        (* CR sspies: At the moment, we simply ignore the polymorphic variables.
-           This code used to only work for [_type_vars = []]. *)
-        of_type_expr_go ~depth ~visited type_expr uid_of_path
-      | Tunboxed_tuple exprs ->
-        Ts_unboxed_tuple (of_expr_list (List.map snd exprs))
-      | Tobject _ | Tnil | Tfield _ ->
-        Ts_other Layout_to_be_determined
-        (* Objects are currently not supported in the debugger. *)
-      | Tlink _ | Tsubst _ ->
-        Misc.fatal_error "linking and substitution should not reach this stage."
-      | Tvariant rd ->
-        let row_fields = Types.row_fields rd in
-        let row_fields =
-          List.concat_map
-            (fun (name, desc) ->
-              match Types.row_field_repr desc with
-              | Types.Rpresent (Some ty) ->
-                [ { pv_constr_name = name;
-                    pv_constr_args =
-                      [of_type_expr_go ~depth ~visited ty uid_of_path]
-                  } ]
-              | Types.Rpresent None ->
-                [{ pv_constr_name = name; pv_constr_args = [] }]
-              | Types.Rabsent -> [] (* we filter out absent constructors *)
-              | Types.Reither (_, args, _) ->
-                [{ pv_constr_name = name; pv_constr_args = of_expr_list args }])
-            row_fields
+      match
+        List.find_opt (fun (p, _) -> Types.get_id p == Types.get_id expr) subst
+      with
+      (* CR sspies: Physical equality is also how printing in [printtyp.ml] works. It
+         seems to be the way to substitute type parameters (after type inference has
+         already made them more precise). *)
+      | Some (_, s) -> s
+      | None ->
+        let rec_binder = Recursive_binder.mk_recursive_binder () in
+        let visited =
+          Numbers.Int.Map.add (Types.get_id expr) rec_binder visited
         in
-        Ts_variant row_fields
-      | Tarrow (_, arg, ret, _) ->
-        Ts_arrow
-          ( of_type_expr_go ~depth ~visited arg uid_of_path,
-            of_type_expr_go ~depth ~visited ret uid_of_path )
-      | Tunivar { name; _ } -> Ts_var (name, Layout_to_be_determined)
-      | Tof_kind _ -> Ts_other Layout_to_be_determined
-      | Tpackage _ ->
-        Ts_other
-          Layout_to_be_determined (* CR sspies: Support first-class modules. *)
+        let depth = depth + 1 in
+        let desc = Types.get_desc expr in
+        let map_expr_list (exprs : Types.type_expr list) =
+          List.map
+            (fun expr ->
+              of_type_expr_go ~depth ~visited expr subst shape_of_path)
+            exprs
+        in
+        let type_shape =
+          match desc with
+          | Tconstr (path, constrs, _) ->
+            let args = map_expr_list constrs in
+            let shape = shape_of_path path ~args in
+            Option.value shape ~default:unknown_shape
+          | Ttuple exprs -> Shape.tuple (map_expr_list (List.map snd exprs))
+          | Tvar _ -> unknown_shape
+          | Tpoly (type_expr, _type_vars) ->
+            (* CR sspies: At the moment, we simply ignore the polymorphic variables.
+               This code used to only work for [_type_vars = []]. Consider
+               alternatively introducing abstractions here? *)
+            of_type_expr_go ~depth ~visited type_expr subst shape_of_path
+          | Tunboxed_tuple exprs ->
+            Shape.unboxed_tuple (map_expr_list (List.map snd exprs))
+          | Tobject _ | Tnil | Tfield _ ->
+            unknown_shape
+            (* Objects are currently not supported in the debugger. *)
+          | Tlink _ | Tsubst _ ->
+            Misc.fatal_error
+              "linking and substitution should not reach this stage."
+          | Tvariant rd ->
+            let row_fields = Types.row_fields rd in
+            let row_fields =
+              List.concat_map
+                (fun (name, desc) ->
+                  match Types.row_field_repr desc with
+                  | Types.Rpresent (Some ty) ->
+                    [ { pv_constr_name = name;
+                        pv_constr_args =
+                          [ of_type_expr_go ~depth ~visited ty subst
+                              shape_of_path ]
+                      } ]
+                  | Types.Rpresent None ->
+                    [{ pv_constr_name = name; pv_constr_args = [] }]
+                  | Types.Rabsent -> [] (* we filter out absent constructors *)
+                  | Types.Reither (_, args, _) ->
+                    [ { pv_constr_name = name;
+                        pv_constr_args = map_expr_list args
+                      } ])
+                row_fields
+            in
+            Shape.poly_variant row_fields
+          | Tarrow (_, arg, ret, _) ->
+            Shape.arrow
+              (of_type_expr_go ~depth ~visited arg subst shape_of_path)
+              (of_type_expr_go ~depth ~visited ret subst shape_of_path)
+          | Tunivar _ -> unknown_shape
+          | Tof_kind _ -> unknown_shape
+          | Tpackage _ -> unknown_shape
+          (* CR sspies: Support first-class modules. *)
+        in
+        Recursive_binder.bind_recursive_binder ~preserve_uid:false rec_binder
+          type_shape
 
-  let of_type_expr (expr : Types.type_expr) uid_of_path =
-    of_type_expr_go ~visited:Numbers.Int.Set.empty ~depth:0 expr uid_of_path
+  let of_type_expr (expr : Types.type_expr) shape_of_path =
+    of_type_expr_go ~visited:Numbers.Int.Map.empty ~depth:0 expr []
+      (Predef.add_predefs_to_lookup shape_of_path)
+
+  let of_type_expr_with_type_subst (expr : Types.type_expr) shape_of_path subst
+      =
+    of_type_expr_go ~visited:Numbers.Int.Map.empty ~depth:0 expr subst
+      (Predef.add_predefs_to_lookup shape_of_path)
 end
 
 module Type_decl_shape = struct
-  let rec mixed_block_shape_to_layout =
-    let open Jkind_types.Sort in
-    function
+  let rec mixed_block_shape_to_layout = function
     | Types.Value -> Layout.Base Value
     | Types.Float_boxed ->
       Layout.Base Float64
@@ -186,9 +327,11 @@ module Type_decl_shape = struct
       Layout.Product
         (Array.to_list (Array.map mixed_block_shape_to_layout args))
 
-  let of_complex_constructor name (cstr_args : Types.constructor_declaration)
-      ((constructor_repr, _) : Types.constructor_representation * _) uid_of_path
-      =
+  let of_complex_constructor type_subst name
+      (cstr_args : Types.constructor_declaration)
+      ((constructor_repr, _) : Types.constructor_representation * _)
+      shape_of_path =
+    let open Shape in
     let args =
       match cstr_args.cd_args with
       | Cstr_tuple list ->
@@ -197,7 +340,9 @@ module Type_decl_shape = struct
                  Types.constructor_argument) ->
             { Shape.field_name = None;
               field_value =
-                Type_shape.of_type_expr type_expr uid_of_path, type_layout
+                ( Type_shape.of_type_expr_with_type_subst type_expr
+                    shape_of_path type_subst,
+                  type_layout )
             })
           list
       | Cstr_record list ->
@@ -205,7 +350,9 @@ module Type_decl_shape = struct
           (fun (lbl : Types.label_declaration) ->
             { Shape.field_name = Some (Ident.name lbl.ld_id);
               field_value =
-                Type_shape.of_type_expr lbl.ld_type uid_of_path, lbl.ld_sort
+                ( Type_shape.of_type_expr_with_type_subst lbl.ld_type
+                    shape_of_path type_subst,
+                  lbl.ld_sort )
             })
           list
     in
@@ -240,7 +387,7 @@ module Type_decl_shape = struct
         in
         Array.of_list lys
     in
-    { Shape.name; kind = constructor_repr; args }
+    { name; kind = constructor_repr; args }
 
   let is_empty_constructor_list (cstr_args : Types.constructor_declaration) =
     match cstr_args.cd_args with
@@ -250,26 +397,32 @@ module Type_decl_shape = struct
     (* Records are not allowed to have an empty list of fields.*) ->
       false
 
-  let record_of_labels ~uid_of_path kind labels =
-    Shape.Tds_record
-      { fields =
-          List.map
-            (fun (lbl : Types.label_declaration) ->
-              ( Ident.name lbl.ld_id,
-                Type_shape.of_type_expr lbl.ld_type uid_of_path,
-                lbl.ld_sort ))
-            labels;
-        kind
-      }
+  let record_of_labels ~shape_of_path ~type_subst kind labels =
+    Shape.record kind
+      (List.map
+         (fun (lbl : Types.label_declaration) ->
+           ( Ident.name lbl.ld_id,
+             Type_shape.of_type_expr_with_type_subst lbl.ld_type shape_of_path
+               type_subst,
+             lbl.ld_sort ))
+         labels)
 
-  let of_type_declaration path (type_declaration : Types.type_declaration)
-      uid_of_path =
+  let type_var_count = ref 0
+
+  let of_type_declaration_go (type_declaration : Types.type_declaration)
+      type_param_shapes shape_of_path =
     let module Types_predef = Predef in
     let open Shape in
+    let unknown_shape = Shape.leaf' None in
+    let type_params = type_declaration.type_params in
+    let type_subst = List.combine type_params type_param_shapes in
+    (* Duplicates are fine, the constraint system makes sure they are instantiated
+       with the same type expression. *)
     let definition =
       match type_declaration.type_manifest with
       | Some type_expr ->
-        Tds_alias (Type_shape.of_type_expr type_expr uid_of_path)
+        Type_shape.of_type_expr_with_type_subst type_expr shape_of_path
+          type_subst
       | None -> (
         match type_declaration.type_kind with
         | Type_variant (cstr_list, Variant_boxed layouts, _unsafe_mode_crossing)
@@ -285,10 +438,11 @@ module Type_decl_shape = struct
                 | true -> Left name
                 | false ->
                   Right
-                    (of_complex_constructor name cstr arg_layouts uid_of_path))
+                    (of_complex_constructor type_subst name cstr arg_layouts
+                       shape_of_path))
               cstrs_with_layouts
           in
-          Tds_variant { simple_constructors; complex_constructors }
+          Shape.variant simple_constructors complex_constructors
         | Type_variant ([cstr], Variant_unboxed, _unsafe_mode_crossing)
           when not (is_empty_constructor_list cstr) ->
           let name = Ident.name cstr.cd_id in
@@ -300,12 +454,10 @@ module Type_decl_shape = struct
             | Cstr_tuple _ | Cstr_record _ ->
               Misc.fatal_error "Unboxed variant must have exactly one argument."
           in
-          Tds_variant_unboxed
-            { name;
-              arg_name = field_name;
-              arg_layout = layout;
-              arg_shape = Type_shape.of_type_expr type_expr uid_of_path
-            }
+          Shape.variant_unboxed name field_name
+            (Type_shape.of_type_expr_with_type_subst type_expr shape_of_path
+               type_subst)
+            layout
         | Type_variant ([_], Variant_unboxed, _unsafe_mode_crossing) ->
           Misc.fatal_error "Unboxed variant must have constructor arguments."
         | Type_variant (([] | _ :: _ :: _), Variant_unboxed, _) ->
@@ -313,17 +465,17 @@ module Type_decl_shape = struct
         | Type_variant
             (_, (Variant_extensible | Variant_with_null), _unsafe_mode_crossing)
           ->
-          Tds_other (* CR sspies: These variants are not yet supported. *)
+          unknown_shape (* CR sspies: These variants are not yet supported. *)
         | Type_record (lbl_list, record_repr, _unsafe_mode_crossing) -> (
           match record_repr with
           | Record_boxed _ ->
-            record_of_labels ~uid_of_path Record_boxed lbl_list
+            record_of_labels ~shape_of_path ~type_subst Record_boxed lbl_list
           | Record_mixed fields ->
-            record_of_labels ~uid_of_path
+            record_of_labels ~shape_of_path ~type_subst
               (Record_mixed (Array.map mixed_block_shape_to_layout fields))
               lbl_list
           | Record_unboxed ->
-            record_of_labels ~uid_of_path Record_unboxed lbl_list
+            record_of_labels ~shape_of_path ~type_subst Record_unboxed lbl_list
           | Record_float | Record_ufloat ->
             let lbl_list =
               List.map
@@ -337,115 +489,328 @@ module Type_decl_shape = struct
                      of replacing it with [float#]. *)
                 lbl_list
             in
-            record_of_labels ~uid_of_path Record_floats lbl_list
+            record_of_labels ~shape_of_path ~type_subst Record_floats lbl_list
           | Record_inlined _ ->
             Misc.fatal_error "inlined records not allowed here"
-            (* Inline records of this form should not occur as part of type
-               declarations. They do not exist for top-level declarations, but
-               they do exist temporarily such as inside of a match (e.g., [t] is
-               an inline record in [match e with Foo t -> ...]). *))
-        | Type_abstract _ -> Tds_other
-        | Type_open -> Tds_other
+            (* Inline records of this form should not occur as part of type declarations.
+               They do not exist for top-level declarations, but they do exist temporarily
+               such as inside of a match (e.g., [t] is an inline record in
+               [match e with Foo t -> ...]). *))
+        | Type_abstract _ -> unknown_shape
+        | Type_open -> unknown_shape
         | Type_record_unboxed_product (lbl_list, _, _) ->
-          record_of_labels ~uid_of_path Record_unboxed_product lbl_list)
+          record_of_labels ~shape_of_path ~type_subst Record_unboxed_product
+            lbl_list)
     in
-    let type_params =
+    definition
+
+  (* Heuristic: In (a block of mutually) recursive defintions, it is possibly to
+     create recursive cycles that do not have a closed form. For example,
+
+        type 'a foo = A of 'a | B of (int * 'a) foo
+
+     does not have a closed form that we could compute, because in each recursive
+     iteration, the type argument grows by one tuple component. Thus, we employ
+     the following heuristic:
+       1. We support recursive occurrences (including of mutually recursive
+          declarations) if they are applied to exactly the same arguments as
+          the current declaration. This ensures that when we fully unfold the
+          type, including mutual recursion, the only thing that can happen is
+          that we encounter a type cycle (which DWARF can handle)---we cannot
+          end up in an infinite chain of new, unencountered types.
+       2. We support recursive occurrences (including of mutually recursive
+          declarations) if all of their arguments are closed. In these cases,
+          the expansion can also only lead to cycles, but not to finite chains.
+          We approximate closedness with the function [is_closed_shape] below.
+
+      For all other cases, we replace the type arguments with a leaf, which will
+      concepturally be handled as [Top], meaning the values of this type could be
+      any valid OCaml values (or any valid values of the corresponding layout).
+  *)
+
+  let rec is_closed_type_shape shape =
+    let open Shape in
+    match shape.desc with
+    | Leaf -> true
+    | Predef (_, args) -> List.for_all is_closed_type_shape args
+    | Constr (_, args) -> List.for_all is_closed_type_shape args
+    | Alias sh -> is_closed_type_shape sh
+    | Tuple shapes -> List.for_all is_closed_type_shape shapes
+    | Arrow (arg, ret) -> is_closed_type_shape arg && is_closed_type_shape ret
+    | Unboxed_tuple shapes -> List.for_all is_closed_type_shape shapes
+    | Poly_variant constrs ->
+      List.for_all
+        (fun { pv_constr_name = _; pv_constr_args = shs } ->
+          List.for_all is_closed_type_shape shs)
+        constrs
+    | Variant { simple_constructors = _; complex_constructors } ->
+      List.for_all
+        (fun { name = _; kind = _; args } ->
+          List.for_all
+            (fun { field_name = _; field_value = sh, _ } ->
+              is_closed_type_shape sh)
+            args)
+        complex_constructors
+    | Variant_unboxed { name = _; arg_name = _; arg_shape = sh; arg_layout = _ }
+      ->
+      is_closed_type_shape sh
+    | Record { fields; kind = _ } ->
+      List.for_all (fun (_, sh, _) -> is_closed_type_shape sh) fields
+    | _ -> false
+
+  let shape_of_path_with_declarations
+      (decl_lookup_map : Types.type_declaration Ident.Map.t) shape_of_path
+      ~recursive ~id:_ ~decl_args path ~args:inner_args =
+    match shape_of_path path ~args:inner_args with
+    | Some s -> Some s
+    | None -> (
+      match path with
+      | Path.Pident id' -> (
+        match Ident.Map.find_opt id' decl_lookup_map with
+        | None -> None
+        | Some _ when List.equal Shape.equal decl_args inner_args ->
+          recursive := true;
+          Some (Shape.constr id' inner_args)
+        | Some _ when List.for_all is_closed_type_shape inner_args ->
+          recursive := true;
+          Some (Shape.constr id' inner_args)
+        | Some _ ->
+          recursive := true;
+          (* We are applying the declaration to different arguments
+             that are not closed. In this case, we create a version of the type
+             that can have any OCaml values for its arguments. *)
+          Some
+            (Shape.constr id' (List.map (fun _ -> Shape.leaf' None) inner_args))
+        )
+      | _ -> None)
+
+  let of_type_declaration_with_variables (id : Ident.t)
+      (type_declaration : Types.type_declaration) shape_of_path =
+    let type_param_idents =
       List.map
-        (fun type_expr -> Type_shape.of_type_expr type_expr uid_of_path)
+        (fun _ ->
+          let name = Format.asprintf "a/%d" !type_var_count in
+          type_var_count := !type_var_count + 1;
+          Ident.create_local name)
         type_declaration.type_params
     in
-    { path; definition; type_params }
+    let type_param_shapes =
+      List.map (fun id -> Shape.var' None id) type_param_idents
+    in
+    let shape_of_path = shape_of_path ~id ~decl_args:type_param_shapes in
+    let definition =
+      of_type_declaration_go type_declaration type_param_shapes shape_of_path
+    in
+    let decl_shape = Shape.abs_list definition type_param_idents in
+    Shape.set_uid_if_none decl_shape type_declaration.type_uid
+
+  let of_type_declarations
+      (type_declarations : (Ident.t * Types.type_declaration) list)
+      shape_of_path =
+    let decl_lookup_map = Ident.Map.of_list type_declarations in
+    (* We unbind all declarations, to avoid accidental recursive cycles. *)
+    let shape_of_path path ~args =
+      match path with
+      | Path.Pident id when Ident.Map.mem id decl_lookup_map -> None
+      | _ -> shape_of_path path ~args
+    in
+    let shape_of_path = Type_shape.Predef.add_predefs_to_lookup shape_of_path in
+    let recursive = ref false in
+    (* We add a small optimization: For the block of declarations, we track via
+       this reference whether there are any recursive occurrenes. If not, we do
+       not have to add a mutually recursive binder for the declarations. *)
+    let shape_of_path =
+      shape_of_path_with_declarations ~recursive decl_lookup_map shape_of_path
+    in
+    let individual_declarations =
+      Ident.Map.mapi
+        (fun id decl ->
+          of_type_declaration_with_variables id decl shape_of_path)
+        decl_lookup_map
+    in
+    if !recursive
+    then
+      let mutrec = Shape.mutrec individual_declarations in
+      List.map (fun (id, _) -> Shape.proj_decl mutrec id) type_declarations
+    else
+      List.map
+        (fun (id, _) -> Ident.Map.find id individual_declarations)
+        type_declarations
 end
 
+let rec decompose_application (t : Shape.t) =
+  match t.Shape.desc with
+  | Shape.App (f, arg) ->
+    let head, tail = decompose_application f in
+    head, tail @ [arg]
+  | _ -> t, []
+
+let find_constr_id_with_args (subst_constr, _) id args =
+  match Ident.Map.find_opt id subst_constr with
+  | Some t ->
+    List.find_opt (fun (args', _) -> List.equal Shape.equal args args') t
+    |> Option.map snd
+  | None -> None
+
+let find_mut_rec_shape (_, subst_constr_mut) id =
+  Ident.Map.find_opt id subst_constr_mut
+
+let update_subst_with_id_arg_binder (subst_constr, subst_constr_mut) id args
+    rec_binder =
+  let new_list =
+    match Ident.Map.find_opt id subst_constr with
+    | Some t -> (args, rec_binder) :: t
+    | None -> [args, rec_binder]
+  in
+  Ident.Map.add id new_list subst_constr, subst_constr_mut
+
+let update_subst_with_mutrec_decl (subst_constr, subst_constr_mut) t map =
+  ( subst_constr,
+    Ident.Map.fold
+      (fun id _ map -> Ident.Map.add id (Shape.proj_decl t id) map)
+      map subst_constr_mut )
+
+(* To unroll the mutually recursive declarations, we perform a simple call by
+   value evaluation and catch cycles for ident binders. *)
+let rec unfold_and_evaluate subst_type subst_constr (t : Shape.t) =
+  (* we special case the case where the head is a projection, because of
+     recursive unfolding *)
+  let head, args = decompose_application t in
+  let maybe_evaluated_shape =
+    match head.Shape.desc with
+    | ProjDecl (str, i) -> (
+      let args = List.map (unfold_and_evaluate subst_type subst_constr) args in
+      let str = unfold_and_evaluate subst_type subst_constr str in
+      match str.Shape.desc with
+      | Mutrec ts ->
+        let rec_binder = Recursive_binder.mk_recursive_binder () in
+        let subst_constr = update_subst_with_mutrec_decl subst_constr str ts in
+        let subst_constr =
+          update_subst_with_id_arg_binder subst_constr i args rec_binder
+        in
+        let ts = Ident.Map.find i ts in
+        unfold_and_evaluate subst_type subst_constr (Shape.app_list ts args)
+        |> Recursive_binder.bind_recursive_binder ~preserve_uid:false rec_binder
+        |> Option.some
+      | _ -> assert false
+      (* projections are always directly applied to the mutrec *))
+    | _ -> None
+  in
+  match maybe_evaluated_shape with
+  | Some t -> t
+  | None -> (
+    match t.desc with
+    | Var id -> (
+      match Ident.Map.find_opt id subst_type with
+      | Some t -> t
+      | None -> Shape.leaf' None (* free type variable should not happen *))
+    | Constr (id, constr_args) -> (
+      let constr_args =
+        List.map (unfold_and_evaluate subst_type subst_constr) constr_args
+      in
+      match find_constr_id_with_args subst_constr id constr_args with
+      | Some t -> Recursive_binder.use_recursive_binder t
+      | None -> (
+        match find_mut_rec_shape subst_constr id with
+        | Some t ->
+          unfold_and_evaluate subst_type subst_constr
+            (Shape.app_list t constr_args)
+        | None -> Shape.leaf' None))
+    | App (f, arg) -> (
+      let f = unfold_and_evaluate subst_type subst_constr f in
+      let arg = unfold_and_evaluate subst_type subst_constr arg in
+      match f.Shape.desc with
+      | Abs (x, s') ->
+        unfold_and_evaluate (Ident.Map.add x arg subst_type) subst_constr s'
+      | _ -> Shape.app f ~arg)
+    | ProjDecl _ -> assert false (* see [maybe_evaluated_shape] above *)
+    | Variant { simple_constructors; complex_constructors } ->
+      let complex_constructors =
+        Shape.complex_constructors_map
+          (fun ((sh, ly) : Shape.t * _) ->
+            unfold_and_evaluate subst_type subst_constr sh, ly)
+          complex_constructors
+      in
+      Shape.variant simple_constructors complex_constructors
+    | Record { fields; kind } ->
+      Shape.record kind
+        (List.map
+           (fun ((name, sh, ly) : _ * Shape.t * _) ->
+             name, unfold_and_evaluate subst_type subst_constr sh, ly)
+           fields)
+    | Poly_variant constrs ->
+      Shape.poly_variant
+        (Shape.poly_variant_constructors_map
+           (fun (sh : Shape.t) ->
+             unfold_and_evaluate subst_type subst_constr sh)
+           constrs)
+    | Arrow (arg, ret) ->
+      Shape.arrow
+        (unfold_and_evaluate subst_type subst_constr arg)
+        (unfold_and_evaluate subst_type subst_constr ret)
+    | Variant_unboxed { name; arg_name; arg_shape; arg_layout } ->
+      Shape.variant_unboxed name arg_name
+        (unfold_and_evaluate subst_type subst_constr arg_shape)
+        arg_layout
+    | Proj (t, i) ->
+      Shape.proj (unfold_and_evaluate subst_type subst_constr t) i
+    | Tuple args ->
+      Shape.tuple
+        (List.map
+           (fun (sh : Shape.t) ->
+             unfold_and_evaluate subst_type subst_constr sh)
+           args)
+    | Unboxed_tuple args ->
+      Shape.unboxed_tuple
+        (List.map
+           (fun (sh : Shape.t) ->
+             unfold_and_evaluate subst_type subst_constr sh)
+           args)
+    | Predef (p, args) ->
+      Shape.predef p
+        (List.map
+           (fun (sh : Shape.t) ->
+             unfold_and_evaluate subst_type subst_constr sh)
+           args)
+    | Mu body -> Shape.mu (unfold_and_evaluate subst_type subst_constr body)
+    | Alias t -> Shape.alias (unfold_and_evaluate subst_type subst_constr t)
+    | Struct items ->
+      Shape.str
+        (Shape.Item.Map.map
+           (fun (sh : Shape.t) ->
+             unfold_and_evaluate subst_type subst_constr sh)
+           items)
+    (* normal forms for CBV evaluation *)
+    | Mutrec _ | Abs _ | Error _ | Comp_unit _ | Rec_var _ | Leaf ->
+      t (* normal form in this CBV evaluation *))
+
+let unfold_and_evaluate t =
+  unfold_and_evaluate Ident.Map.empty (Ident.Map.empty, Ident.Map.empty) t
+
 type shape_with_layout =
-  { type_shape : Shape.without_layout Shape.ts;
+  { type_shape : Shape.t;
     type_layout : Layout.t
   }
 
-let (all_type_decls : Shape.tds Uid.Tbl.t) = Uid.Tbl.create 16
+let (all_type_decls : Shape.t Uid.Tbl.t) = Uid.Tbl.create 16
 
 let (all_type_shapes : shape_with_layout Uid.Tbl.t) = Uid.Tbl.create 16
 
-let add_to_type_decls path (type_decl : Types.type_declaration) uid_of_path =
-  let type_decl_shape =
-    Type_decl_shape.of_type_declaration path type_decl uid_of_path
+let add_to_type_decls (decls : (Ident.t * Types.type_declaration) list)
+    shape_of_path =
+  let type_decl_shapes =
+    Type_decl_shape.of_type_declarations decls shape_of_path
   in
-  Uid.Tbl.add all_type_decls type_decl.type_uid type_decl_shape
+  List.iter
+    (fun ((_, decl), sh) -> Uid.Tbl.add all_type_decls decl.Types.type_uid sh)
+    (List.combine decls type_decl_shapes)
 
 let add_to_type_shapes var_uid type_expr type_layout uid_of_path =
   let type_shape = Type_shape.of_type_expr type_expr uid_of_path in
   Uid.Tbl.add all_type_shapes var_uid { type_shape; type_layout }
 
-let tuple_to_string (strings : string list) =
-  match strings with
-  | [] -> ""
-  | hd :: [] -> hd
-  | _ :: _ :: _ -> "(" ^ String.concat " * " strings ^ ")"
-
-let unboxed_tuple_to_string (strings : string list) =
-  match strings with
-  | [] -> ""
-  | hd :: [] -> hd
-  | _ :: _ :: _ -> "(" ^ String.concat " & " strings ^ ")"
-
-let type_arg_list_to_string (strings : string list) =
-  match strings with
-  | [] -> ""
-  | hd :: [] -> hd ^ " "
-  | _ :: _ :: _ -> "(" ^ String.concat ", " strings ^ ") "
-
 let find_in_type_decls (type_uid : Uid.t) =
   Uid.Tbl.find_opt all_type_decls type_uid
-
-let rec type_name : 'a. 'a Shape.ts -> _ =
- fun type_shape ->
-  match type_shape with
-  | Ts_predef (predef, shapes) ->
-    type_arg_list_to_string (List.map type_name shapes)
-    ^ Shape.Predef.to_string predef
-  | Ts_other _ -> "unknown"
-  | Ts_tuple shapes -> tuple_to_string (List.map type_name shapes)
-  | Ts_unboxed_tuple shapes ->
-    unboxed_tuple_to_string (List.map type_name shapes)
-  | Ts_var (name, _) -> "'" ^ Option.value name ~default:"?"
-  | Ts_arrow (shape1, shape2) ->
-    let arg_name = type_name shape1 in
-    let ret_name = type_name shape2 in
-    arg_name ^ " -> " ^ ret_name
-  | Ts_variant fields ->
-    let field_constructors =
-      List.map
-        (fun { Shape.pv_constr_name; pv_constr_args } ->
-          let arg_types = List.map (fun sh -> type_name sh) pv_constr_args in
-          let arg_type_string = String.concat " ∩ " arg_types in
-          (* CR sspies: Currently, our LLDB fork removes ampersands, because
-             it's elsewhere used for printing references. Would be great to fix
-             this in the future. For now we use an intersection. *)
-          let arg_type_string =
-            if List.length pv_constr_args = 0
-            then ""
-            else " of " ^ arg_type_string
-          in
-          "`" ^ pv_constr_name ^ arg_type_string)
-        fields
-    in
-    (* CR sspies: This type is imprecise. The polymorpic variant could
-       potentially have fewer/more constructors. However, there is no need to
-       fix this in this PR, because in a subsequent PR, this code will be
-       replaced by simply remembering the names of types alongside their shape,
-       making the type reconstruction here obsolete. *)
-    Format.asprintf "[ %s ]" (String.concat " | " field_constructors)
-  | Ts_constr ((type_uid, _type_path, _), shapes) -> (
-    match[@warning "-fragile-match"] find_in_type_decls type_uid with
-    | None -> "unknown"
-    | Some { definition = Tds_other; _ } -> "unknown"
-    | Some type_decl_shape ->
-      (* We have found type instantiation shapes [shapes] and a typing
-         declaration shape [type_decl_shape]. *)
-      let type_decl_shape = Shape.replace_tvar type_decl_shape shapes in
-      let args = type_arg_list_to_string (List.map type_name shapes) in
-      let name = Path.name type_decl_shape.path in
-      args ^ name)
 
 let print_table_all_type_decls ppf =
   let entries = Uid.Tbl.to_list all_type_decls in
@@ -453,8 +818,7 @@ let print_table_all_type_decls ppf =
   let entries =
     List.map
       (fun (k, v) ->
-        ( Format.asprintf "%a" Uid.print k,
-          Format.asprintf "%a" Shape.print_type_decl_shape v ))
+        Format.asprintf "%a" Uid.print k, Format.asprintf "%a" Shape.print v)
       entries
   in
   let uids, decls = List.split entries in
@@ -467,7 +831,7 @@ let print_table_all_type_shapes ppf =
     List.map
       (fun (k, { type_shape; type_layout }) ->
         ( Format.asprintf "%a" Uid.print k,
-          ( Format.asprintf "%a" Shape.print_type_shape type_shape,
+          ( Format.asprintf "%a" Shape.print type_shape,
             Format.asprintf "%a" Layout.format type_layout ) ))
       entries
   in

--- a/typing/type_shape.mli
+++ b/typing/type_shape.mli
@@ -3,50 +3,58 @@ module Layout = Jkind_types.Sort.Const
 
 type base_layout = Jkind_types.Sort.base
 
-(* CR sspies: To prepare for moving the definitions of this file into [shapes.ml]
-   the declarations for type shapes and type declaration shapes have been renamed
-   in from [t] to [ts] (for type shape) and [tds] (for type declaration shape).*)
+type path_lookup = Path.t -> args:Shape.t list -> Shape.t option
 
 module Type_shape : sig
-  val of_type_expr :
-    Types.type_expr -> (Path.t -> Uid.t option) -> Shape.without_layout Shape.ts
+  val of_type_expr : Types.type_expr -> path_lookup -> Shape.t
 end
 
 module Type_decl_shape : sig
-  val of_type_declaration :
-    Path.t -> Types.type_declaration -> (Path.t -> Uid.t option) -> Shape.tds
+  val of_type_declarations :
+    (Ident.t * Types.type_declaration) list -> path_lookup -> Shape.t list
 end
 
+(** When producing a type shape with [of_type_expr], the resulting shape is
+      not in normal form. In particular, it can contain mutually recursive
+      declarations from mutually recursive type declarations. This function
+      should be applied after shape reduction. It unfoldes the mutually
+      recursive types to result in one linearized form. *)
+val unfold_and_evaluate : Shape.t -> Shape.t
+
 type shape_with_layout =
-  { type_shape : Shape.without_layout Shape.ts;
+  { type_shape : Shape.t;
     type_layout : Layout.t
   }
-(* CR sspies: There are two options here: We can fold the layout into the shape,
-    or we can keep it on the outside. Currently, we keep it on the outside to
-    make it easier to connect type shapes and shapes (which are agnostic about
-   layouts) in subsequent PRs. *)
 
-val all_type_decls : Shape.tds Uid.Tbl.t
+val all_type_decls : Shape.t Uid.Tbl.t
 
 val all_type_shapes : shape_with_layout Uid.Tbl.t
 
 (* Passing [Path.t -> Uid.t] instead of [Env.t] to avoid a dependency cycle. *)
 val add_to_type_decls :
-  Path.t -> Types.type_declaration -> (Path.t -> Uid.t option) -> unit
+  (Ident.t * Types.type_declaration) list -> path_lookup -> unit
 
 val add_to_type_shapes :
   Uid.t ->
   Types.type_expr ->
   Jkind_types.Sort.Const.t ->
-  (Path.t -> Uid.t option) ->
+  path_lookup ->
   unit
 
-val find_in_type_decls : Uid.t -> Shape.tds option
-
-val type_name : _ Shape.ts -> string
+val find_in_type_decls : Uid.t -> Shape.t option
 
 val print_table_all_type_decls : Format.formatter -> unit
 
 val print_table_all_type_shapes : Format.formatter -> unit
 
 val print_debug_uid_tables : Format.formatter -> unit
+
+module Recursive_binder : sig
+  type t
+
+  val mk_recursive_binder : unit -> t
+
+  val use_recursive_binder : t -> Shape.t
+
+  val bind_recursive_binder : ?preserve_uid:bool -> t -> Shape.t -> Shape.t
+end

--- a/typing/type_shape.mli
+++ b/typing/type_shape.mli
@@ -35,11 +35,7 @@ val add_to_type_decls :
   (Ident.t * Types.type_declaration) list -> path_lookup -> unit
 
 val add_to_type_shapes :
-  Uid.t ->
-  Types.type_expr ->
-  Jkind_types.Sort.Const.t ->
-  path_lookup ->
-  unit
+  Uid.t -> Types.type_expr -> Layout.t -> path_lookup -> unit
 
 val find_in_type_decls : Uid.t -> Shape.t option
 

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -766,17 +766,17 @@ let verify_unboxed_attr unboxed_attr sdecl =
 *)
 
 
-let shape_map_labels =
+let merlin_shape_map_labels =
   List.fold_left (fun map { Types.ld_id; ld_uid; _} ->
     Shape.Map.add_label map ld_id ld_uid)
     Shape.Map.empty
 
-let shape_map_unboxed_labels =
+let merlin_shape_map_unboxed_labels =
   List.fold_left (fun map { Types.ld_id; ld_uid; _} ->
     Shape.Map.add_unboxed_label map ld_id ld_uid)
     Shape.Map.empty
 
-let shape_map_cstrs =
+let merlin_shape_map_cstrs =
   List.fold_left (fun map { Types.cd_id; cd_uid; cd_args; _ } ->
     let cstr_shape_map =
       let label_decls =
@@ -784,11 +784,24 @@ let shape_map_cstrs =
         | Cstr_tuple _ -> []
         | Cstr_record ldecls -> ldecls
       in
-      shape_map_labels label_decls
+      merlin_shape_map_labels label_decls
     in
     Shape.Map.add_constr map cd_id
       @@ Shape.str ~uid:cd_uid cstr_shape_map)
     (Shape.Map.empty)
+
+(* CR sspies: Decide whether to turn this into a function that takes the
+   declaration shape as input and then move the code to the Merlin
+   implementation. *)
+let _merlin_shape_declaration decl =
+  let uid = decl.type_uid in
+  match decl.type_kind with
+  | Type_variant (cstrs, _, _) -> Shape.str ~uid (merlin_shape_map_cstrs cstrs)
+  | Type_record (labels, _, _) ->
+    Shape.str ~uid (merlin_shape_map_labels labels)
+  | Type_record_unboxed_product (labels, _, _) ->
+    Shape.str ~uid (merlin_shape_map_unboxed_labels labels)
+  | Type_abstract _ | Type_open -> Shape.leaf uid
 
 let transl_declaration env sdecl (id, uid) =
   (* Bind type parameters *)
@@ -1068,6 +1081,10 @@ let transl_declaration env sdecl (id, uid) =
       in
       set_private_row env sdecl.ptype_loc p decl
     end;
+    (* CR sspies: We used to compute shapes here, which were then added to
+      various typing environments. The computation of the shapes has moved
+      further down in the translation, so they are currently not added to the
+      intermediate environments. Find out whether that is an issue.   *)
     let decl =
       {
         typ_id = id;
@@ -1083,17 +1100,7 @@ let transl_declaration env sdecl (id, uid) =
         typ_jkind_annotation = jkind_annotation
       }
     in
-    let typ_shape =
-      let uid = decl.typ_type.type_uid in
-      match decl.typ_type.type_kind with
-      | Type_variant (cstrs, _, _) -> Shape.str ~uid (shape_map_cstrs cstrs)
-      | Type_record (labels, _, _) ->
-        Shape.str ~uid (shape_map_labels labels)
-      | Type_record_unboxed_product (labels, _, _) ->
-        Shape.str ~uid (shape_map_unboxed_labels labels)
-      | Type_abstract _ | Type_open -> Shape.leaf uid
-    in
-    decl, typ_shape
+    decl
   end
 
 (* Note [Typechecking unboxed versions of types]
@@ -1773,8 +1780,15 @@ let update_constructor_representation
       Constructor_mixed shape
 
 
-let add_types_to_env decls shapes env =
-  List.fold_right2
+let add_types_to_env ?shapes decls env =
+  match shapes with
+  | None ->
+    List.fold_right
+      (fun (id, decl) env ->
+        add_type ~check:true id decl env)
+      decls env
+  | Some shapes ->
+    List.fold_right2
     (fun (id, decl) shape env ->
       add_type ~check:true ~shape id decl env)
     decls shapes env
@@ -2669,7 +2683,7 @@ let check_redefined_unit (td: Parsetree.type_declaration) =
 *)
 
 (* Normalize the jkinds in a list of (potentially mutually recursive) type declarations *)
-let normalize_decl_jkinds env shapes decls =
+let normalize_decl_jkinds env decls =
   let rec normalize_decl_jkind env original_decl allow_any_crossing decl path =
     let type_unboxed_version =
       Option.map (fun type_unboxed_version ->
@@ -2739,13 +2753,13 @@ let normalize_decl_jkinds env shapes decls =
   (* Add the types, with non-normalized kinds, to the environment to start, so that eg
      types can look up their own (potentially non-normalized) kinds *)
   let env =
-    List.fold_right2
-      (fun (id, _, _, decl) shape env ->
-         add_type ~check:true ~shape id decl env)
-      decls shapes env
+    List.fold_right
+      (fun (id, _, _, decl) env ->
+         add_type ~check:true id decl env)
+      decls env
   in
-  Misc.Stdlib.List.fold_left_map2
-    (fun env (id, original_decl, allow_any_crossing, decl) shape ->
+  List.fold_left_map
+    (fun env (id, original_decl, allow_any_crossing, decl) ->
        let decl =
          normalize_decl_jkind env original_decl allow_any_crossing decl
            (Pident id)
@@ -2753,12 +2767,11 @@ let normalize_decl_jkinds env shapes decls =
        (* Add the decl with the normalized kind back to the environment, so that later
           kinds don't have to normalize this kind if they mention this type in their
           with-bounds *)
-       let env = add_type ~check:false ~shape:shape id decl env in
+       let env = add_type ~check:false id decl env in
        env, (id, decl)
     )
     env
     decls
-    shapes
 
 (* Translate a set of type declarations, mutually recursive or not *)
 let transl_type_decl env rec_flag sdecl_list =
@@ -2792,7 +2805,7 @@ let transl_type_decl env rec_flag sdecl_list =
   (* Translate declarations, using a temporary environment where abbreviations
      expand to a generic type variable. After that, we check the coherence of
      the translated declarations in the resulting new environment. *)
-  let tdecls, decls, shapes, new_env, delayed_jkind_checks =
+  let tdecls, decls, new_env, delayed_jkind_checks =
     Ctype.with_local_level_iter ~post:generalize_decl begin fun () ->
       (* Enter types. *)
       let temp_env =
@@ -2833,7 +2846,6 @@ let transl_type_decl env rec_flag sdecl_list =
          enviroment. *)
       let tdecls =
         List.map2 transl_declaration sdecl_list (List.map ids_slots ids_list) in
-      let tdecls, shapes = List.split tdecls in
       let decls = List.map (fun d -> (d.typ_id, d.typ_type)) tdecls in
       let decls = derive_unboxed_versions decls env in
       let tdecls =
@@ -2844,7 +2856,7 @@ let transl_type_decl env rec_flag sdecl_list =
       (* Check for duplicates *)
       check_duplicates sdecl_list;
       (* Build the final env. *)
-      let new_env = add_types_to_env decls shapes env in
+      let new_env = add_types_to_env decls env in
       (* Update stubs *)
       let delayed_jkind_checks =
         match rec_flag with
@@ -2856,7 +2868,7 @@ let transl_type_decl env rec_flag sdecl_list =
                sdecl.ptype_loc)
             ids_list sdecl_list
       in
-      ((tdecls, decls, shapes, new_env, delayed_jkind_checks), List.map snd decls)
+      ((tdecls, decls, new_env, delayed_jkind_checks), List.map snd decls)
     end
   in
   (* Check for ill-formed abbrevs *)
@@ -2956,7 +2968,7 @@ let transl_type_decl env rec_flag sdecl_list =
         |> Typedecl_variance.update_decls env sdecl_list
         |> Typedecl_separability.update_decls env
         |> update_decls_jkind new_env
-        |> normalize_decl_jkinds new_env shapes
+        |> normalize_decl_jkinds new_env
       in
       let removed, decls = remove_unboxed_versions decls in
       if not (Path.Set.is_empty removed) then
@@ -2971,14 +2983,19 @@ let transl_type_decl env rec_flag sdecl_list =
   in
   (* Check re-exportation, updating [type_jkind] from the manifest *)
   let decls = List.map2 (check_abbrev new_env) sdecl_list decls in
+  (* Save the declarations in [Type_shape] for debug info. *)
+  let env_shape_of_path env path ~args =
+    match Env.shape_of_path_opt ~namespace:Type env path with
+    | Some sh -> Some (Shape.app_list sh args)
+    | None -> None
+  in
+  let shapes = Type_shape.Type_decl_shape.of_type_declarations decls (env_shape_of_path env) in
+  List.iter (fun (sh, (_, decl)) ->
+    let uid = decl.type_uid in
+    Uid.Tbl.add Type_shape.all_type_decls uid sh;
+  ) (List.combine shapes decls);
   (* Compute the final environment with variance and immediacy *)
-  let final_env = add_types_to_env decls shapes env in
-  (* Save the shapes of the declarations in [Type_shape] for debug info. *)
-  List.iter (fun (id, decl) ->
-    Type_shape.add_to_type_decls
-      (Pident id) decl
-      (Env.find_uid_of_path final_env)
-  ) decls;
+  let final_env = add_types_to_env decls ~shapes env in
   (* Keep original declaration *)
   let final_decls =
     List.map2
@@ -3129,7 +3146,7 @@ let transl_extension_constructor ~scope env type_path type_params
   in
   let shape =
     let map = match args with
-    | Cstr_record lbls -> shape_map_labels lbls
+    | Cstr_record lbls -> merlin_shape_map_labels lbls
     | _ -> Shape.Map.empty
     in
     Shape.str ~uid:ext_cstrs.ext_type.ext_uid map


### PR DESCRIPTION
This PR merges the recently introduced type shapes (#4253, #4318, and #4343) into the shape type of the compiler. This will allow debug information to leverage the shape mechanism of the compiler to resolve functor application and produce debug information based on `.cms` files of other `.ml` files.

Some aspects of this PR are still unfinished:

- [ ] Evaluating the impact on the size of `.cms` files now that the shapes store more information.
- [ ] Resolve the [name emission PR](https://github.com/oxcaml/oxcaml/pull/4391) and rebase on top of it; this PR currently uses `unknown/n` as type names.
- [ ] Evaluate the performance impact (and potentially improve the implementation of) the unfolding of type shapes.
- [ ] Potentially split the PR into two to simplify reviewing.
- [ ] Fix the support for Merlin. (We currently lose UIDs during the shape construction.)