### PR TITLE
Fix warning (undefined macro)

### DIFF
--- a/external/gc-timings/gc_timings_stubs.c
+++ b/external/gc-timings/gc_timings_stubs.c
@@ -11,7 +11,7 @@
 
 #ifdef HAS_MACH_ABSOLUTE_TIME
 #include <mach/mach_time.h>
-#elif HAS_POSIX_MONOTONIC_CLOCK
+#elif defined(HAS_POSIX_MONOTONIC_CLOCK)
 #include <time.h>
 #endif
 


### PR DESCRIPTION
As per title; I am not exactly sure
why it does not show up on the
CI.