### PR TITLE
Regalloc tool: print summary in CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -293,7 +293,7 @@ jobs:
       run: |
         for allocator in irc ls gi; do \
           ./_build/main/tools/regalloc/regalloc.exe _build \
-            -validate -regalloc $allocator || exit 1; \
+            -validate -summary -regalloc $allocator || exit 1; \
         done
 
     - uses: actions/upload-artifact@v4

--- a/external/gc-timings/gc_timings_stubs.c
+++ b/external/gc-timings/gc_timings_stubs.c
@@ -11,7 +11,7 @@
 
 #ifdef HAS_MACH_ABSOLUTE_TIME
 #include <mach/mach_time.h>
-#elif HAS_POSIX_MONOTONIC_CLOCK
+#elif defined(HAS_POSIX_MONOTONIC_CLOCK)
 #include <time.h>
 #endif
 

--- a/tools/regalloc/regalloc.ml
+++ b/tools/regalloc/regalloc.ml
@@ -294,6 +294,7 @@ let process_function (config : config) (cfg_with_layout : Cfg_with_layout.t)
 
 let process_file (file : string) (config : config) =
   if config.debug_output then Printf.eprintf "processing file %S...\n%!" file;
+  incr num_processed_files;
   let unit_info, _digest = Cfg_format.restore file in
   List.iter unit_info.items ~f:(fun (item : Cfg_format.cfg_item_info) ->
       begin
@@ -305,7 +306,6 @@ let process_file (file : string) (config : config) =
           let cfg_with_layout, relocatable_regs =
             cfg_with_layout_and_relocatable_regs
           in
-          incr num_processed_files;
           process_function config cfg_with_layout cmm_label reg_stamp
             relocatable_regs
       end)


### PR DESCRIPTION
After https://github.com/oxcaml/oxcaml/pull/4367, I am still a bit worried we would not
see easily whether `regalloc.exe` executions
failed. This pull request hence add a "summary"
option to `regalloc.exe` and uses it in the CI,
to print basic number about the amount of work
done.