### PR TITLE
Slightly better printer for nullable values

### DIFF
--- a/middle_end/flambda2/lattices/or_unknown_or_bottom.ml
+++ b/middle_end/flambda2/lattices/or_unknown_or_bottom.ml
@@ -30,7 +30,7 @@ let print f ppf t =
     if Flambda_features.unicode ()
     then Format.fprintf ppf "%t@<1>\u{22a5}%t" colour Flambda_colours.pop
     else Format.fprintf ppf "%t_|_%t" colour Flambda_colours.pop
-  | Ok contents -> Format.fprintf ppf "@[(%a)@]" f contents
+  | Ok contents -> f ppf contents
 
 let equal eq_contents t1 t2 =
   match t1, t2 with

--- a/testsuite/tests/tool-ocamlobjinfo/question.reference
+++ b/testsuite/tests/tool-ocamlobjinfo/question.reference
@@ -41,27 +41,26 @@ Typing env:
   {([0m[38;5;169;1mcamlQuestion__answer_0_1_code[0m [0m[38;5;169;1mcamlQuestion__answer_0_0_code[0m)})
  (type_equations
   {([0m[38;5;111;1m[0m[38;5;98;1mQuestion.camlQuestion[0m[38;5;111;1m[0m
-    (Val
-     ( ((Variant
-         (blocks
-          ((alloc_mode Heap) (known
-            {(tag_0 => (Known 1),
-              ((Val (([0m[38;5;160;1m=[0m [0m[38;5;111;1m[0m[38;5;98;1mQuestion.camlQuestion__answer_1[0m[38;5;111;1m[0m)))))})
-           (other Bottom))) (tagged_imms (Naked_immediate [0m[38;5;37;1m⊥[0m))))!)))
+    (Val!
+     (Variant
+      (blocks
+       ((alloc_mode Heap) (known
+         {(tag_0 => (Known 1), ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1m[0m[38;5;98;1mQuestion.camlQuestion__answer_1[0m[38;5;111;1m[0m))))})
+        (other Bottom))) (tagged_imms (Naked_immediate [0m[38;5;37;1m⊥[0m)))))
    ([0m[38;5;111;1m[0m[38;5;98;1mQuestion.camlQuestion__answer_1[0m[38;5;111;1m[0m
-    (Val
-     ( (((alloc_mode Heap) (known
-          {([0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m
-            => (Known ((closures { [0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m }) (value_slots { }))),
-            ((function_types
-              {([0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m
-                ((function_type (code_id [0m[38;5;169;1mcamlQuestion__answer_0_1_code[0m)
-                  (rec_info (Rec_info ([0m[38;5;249;1m0[0m))))))})
-             (closure_types
-              ((function_slot_components_by_index
-                {([0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m (Val (([0m[38;5;160;1m=[0m [0m[38;5;111;1m[0m[38;5;98;1mQuestion.camlQuestion__answer_1[0m[38;5;111;1m[0m))))})))
-             (value_slot_types ((value_slot_components_by_index {})))))})
-         (other Bottom)))!)))})
+    (Val!
+     ((alloc_mode Heap) (known
+       {([0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m
+         => (Known ((closures { [0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m }) (value_slots { }))),
+         ((function_types
+           {([0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m
+             (function_type (code_id [0m[38;5;169;1mcamlQuestion__answer_0_1_code[0m)
+              (rec_info (Rec_info [0m[38;5;249;1m0[0m))))})
+          (closure_types
+           ((function_slot_components_by_index
+             {([0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1m[0m[38;5;98;1mQuestion.camlQuestion__answer_1[0m[38;5;111;1m[0m)))})))
+          (value_slot_types ((value_slot_components_by_index {})))))})
+      (other Bottom))))})
  (aliases
   ((canonical_elements {}) (aliases_of_canonical_names {})
    (aliases_of_consts {}))))


### PR DESCRIPTION
Print "Val!" and "Val?" prefixes instead of burying the "!" or "?" marker somewhere in a nest of parentheses (currently, it is usually hidden at the end of a "))!))" or "))?))" line).