### PR TITLE
Fixes in the DWARF Emission Code

### DIFF
--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -280,6 +280,27 @@ module Predef = struct
       | Float32x16 -> "float32x16"
       | Float64x8 -> "float64x8"
 
+    let simd_vec_split_to_byte_size : simd_vec_split -> int = function
+      | Int8x16
+      | Int16x8
+      | Int32x4
+      | Int64x2
+      | Float32x4
+      | Float64x2 -> 16
+      | Int8x32
+      | Int16x16
+      | Int32x8
+      | Int64x4
+      | Float32x8
+      | Float64x4 -> 32
+      | Int8x64
+      | Int16x32
+      | Int32x16
+      | Int64x8
+      | Float32x16
+      | Float64x8 -> 64
+
+
     (* name of the type without the hash *)
     let unboxed_to_string (u : unboxed) =
       match u with

--- a/typing/shape.mli
+++ b/typing/shape.mli
@@ -187,6 +187,8 @@ module Predef : sig
   val unboxed_type_to_layout : unboxed -> Jkind_types.Sort.base
 
   val to_layout : t -> Layout.t
+
+  val simd_vec_split_to_byte_size : simd_vec_split -> int
 end
 
 type var = Ident.t

--- a/typing/type_shape.mli
+++ b/typing/type_shape.mli
@@ -43,6 +43,11 @@ val add_to_type_shapes :
 
 val find_in_type_decls : Uid.t -> Shape.tds option
 
+val estimate_layout_from_type_shape :
+  Shape.without_layout Shape.ts -> Layout.t option
+
+val estimate_layout_from_type_decl_shape : Shape.tds -> Layout.t option
+
 val type_name : _ Shape.ts -> string
 
 val print_table_all_type_decls : Format.formatter -> unit

--- a/typing/type_shape.mli
+++ b/typing/type_shape.mli
@@ -3,10 +3,6 @@ module Layout = Jkind_types.Sort.Const
 
 type base_layout = Jkind_types.Sort.base
 
-(* CR sspies: To prepare for moving the definitions of this file into [shapes.ml]
-   the declarations for type shapes and type declaration shapes have been renamed
-   in from [t] to [ts] (for type shape) and [tds] (for type declaration shape).*)
-
 module Type_shape : sig
   val of_type_expr :
     Types.type_expr -> (Path.t -> Uid.t option) -> Shape.without_layout Shape.ts
@@ -25,6 +21,21 @@ type shape_with_layout =
     or we can keep it on the outside. Currently, we keep it on the outside to
     make it easier to connect type shapes and shapes (which are agnostic about
    layouts) in subsequent PRs. *)
+(* CR sspies: We need to revist the treatment of layouts for type shapes.
+   Currently, as the declaration above indicates, we use the layout from the
+   binder of the variable and propagate it through. Once type shapes are merged
+   into shapes, we should compute layouts on-demand from shapes directly. The
+   reason is that, in the future, the layouts stored in the constructors of type
+   declarations will become unreliable as a source of information. Instead, the
+   strategy for layouts should be the following:
+
+    1. For the closed types that we obtain at binders, compute the shape. In
+       this step, type declarations with arguments should become lambdas, and
+       type application should become application.
+    2. When emitting the DWARF information, reduce the shape to resolve all
+       abstraction/application pairs. Then emit the DWARF information by
+       recursion on the resulting shape.
+*)
 
 val all_type_decls : Shape.tds Uid.Tbl.t
 
@@ -43,6 +54,14 @@ val add_to_type_shapes :
 
 val find_in_type_decls : Uid.t -> Shape.tds option
 
+(* CR sspies: [estimate_layout_from_shape] below is only an approximation. It
+   does, for example, not deal with type application and, as a result, can find
+   type variables that would have been substituted. This layout computation
+   needs to be revisited once type shapes have been integrated into shapes.
+
+   If the function returns [Some], the layout is precise (regardless of the
+   issues mentioned above). It returns [None] whenever estimation failed.
+*)
 val estimate_layout_from_type_shape :
   Shape.without_layout Shape.ts -> Layout.t option
 


### PR DESCRIPTION
This PR contains several fixes for the code emitting DWARF information. Specifically, it:

- corrects the size of DWARF structs for SIMD vector splits
- adds basic handling of unboxed types in arrays
- bounds DWARF emission to avoid infinite cycles