### PR TITLE
Configuration flag to enable OxCaml DWARF

### DIFF
--- a/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
+++ b/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
@@ -97,7 +97,7 @@ let use_g () =
   then use_g1 ()
   else current_debug_settings := bytecode_g
 
-let restrict_to_upstream_dwarf = ref true
+let restrict_to_upstream_dwarf = ref (not Config.oxcaml_dwarf)
 
 (* Currently the maximum number of stack slots, see asmgen.ml *)
 let dwarf_max_function_complexity = ref 50

--- a/configure.ac
+++ b/configure.ac
@@ -196,6 +196,7 @@ AC_ARG_ENABLE([stack_checks],
 AC_SUBST([enable_runtime5])
 AC_SUBST([runtime_suffix])
 AC_SUBST([enable_stack_checks])
+AC_SUBST([enable_oxcaml_dwarf])
 AC_SUBST([CONFIGURE_ARGS])
 AC_SUBST([native_compiler])
 AC_SUBST([default_build_target])
@@ -638,6 +639,12 @@ AC_ARG_ENABLE([flambda2],
 AC_ARG_ENABLE([cmm-invariants],
   [AS_HELP_STRING([--enable-cmm-invariants],
     [enable invariants checks in Cmm])])
+
+AC_ARG_ENABLE([oxcaml-dwarf],
+  [AS_HELP_STRING([--enable-oxcaml-dwarf],
+    [enable OxCaml DWARF by default @<:@default=no@:>@])],
+  [],
+  [enable_oxcaml_dwarf=no])
 
 AC_ARG_WITH([target-bindir],
   [AS_HELP_STRING([--with-target-bindir],

--- a/utils/config.common.ml.in
+++ b/utils/config.common.ml.in
@@ -149,6 +149,7 @@ let configuration_variables () =
   p_bool "multidomain" multidomain;
   p_bool "poll_insertion" poll_insertion;
   p_bool "ox" oxcaml;
+  p_bool "oxcaml_dwarf" oxcaml_dwarf;
 ]
 
 let print_config_value oc = function

--- a/utils/config.generated.ml.in
+++ b/utils/config.generated.ml.in
@@ -130,3 +130,5 @@ let has_bmi2 = "@has_bmi2@" = "yes"
 let has_avx = "@has_avx@" = "yes"
 
 let has_avx2 = "@has_avx2@" = "yes"
+
+let oxcaml_dwarf = "@enable_oxcaml_dwarf@" = "yes"

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -354,3 +354,6 @@ val has_avx : bool
 
 val has_avx2 : bool
 (* Whether the compiler was configured on a machine with AVX2 *)
+
+val oxcaml_dwarf : bool
+(* Whether OxCaml DWARF is used by default *)


### PR DESCRIPTION
This PR adds the flag `--enable-oxcaml-dwarf`, which controls the default for emitting upstream DWARF. Enabling it is equivalent to always compiling with `-gno-upstream-dwarf`:

 - When `--enable-oxcaml-dwarf` is used (`Config.oxcaml_dwarf = true`), `restrict_to_upstream_dwarf` becomes `false`
 - When `--enable-oxcaml-dwarf` is not used (`Config.oxcaml_dwarf = false`), `restrict_to_upstream_dwarf` becomes `true`