### PR TITLE
Llvmize extcalls

### DIFF
--- a/backend/cfg/llvmize.ml
+++ b/backend/cfg/llvmize.ml
@@ -744,6 +744,7 @@ module F = struct
     (* Do the thing *)
     let res_ident = call_func args res_type in
     (* Unpack return values (is it possible to have multiple?) *)
+    (* CR yusumez: Handle function arguments + returns uniformly with OCaml calls *)
     Array.iteri
       (fun idx reg ->
         let temp = fresh_ident t in

--- a/oxcaml/tests/backend/llvmize/array_rev_ir.output
+++ b/oxcaml/tests/backend/llvmize/array_rev_ir.output
@@ -305,6 +305,9 @@ L151:                                                ; preds = %L1
   ret { { ptr }, { i64 } } %14
 }
 
+declare i64 @llvm.read_register.i64(metadata)
+declare void @llvm.write_register.i64(metadata, i64)
+
 @camlArray_rev__gc_roots = global { i64, i64 } { i64 0, i64 1792 }
 @camlArray_rev = global { ptr, i64 } { ptr @camlArray_rev__rev_1, i64 3063 }
 @camlArray_rev__rev_1 = global { ptr, i64 } { ptr @camlArray_rev__rev_HIDE_STAMP, i64 108086391056891909 }

--- a/oxcaml/tests/backend/llvmize/const_val_ir.output
+++ b/oxcaml/tests/backend/llvmize/const_val_ir.output
@@ -31,6 +31,9 @@ L104:                                                ; preds = %L1
   ret { { ptr }, { i64 } } %14
 }
 
+declare i64 @llvm.read_register.i64(metadata)
+declare void @llvm.write_register.i64(metadata, i64)
+
 @camlConst_val__gc_roots = global { i64, i64 } { i64 0, i64 1792 }
 @camlConst_val = global { i64 } { i64 75 }
 

--- a/oxcaml/tests/backend/llvmize/dune.inc
+++ b/oxcaml/tests/backend/llvmize/dune.inc
@@ -1,50 +1,34 @@
-
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
  (targets id_fn.output.corrected)
- (deps id_fn.ml filter.sh)
+ (deps id_fn.ml)
  (action
-  (with-outputs-to
-   id_fn.output.corrected
-   (pipe-outputs
-    (run
-     %{bin:ocamlopt.opt} id_fn.ml -g -c -O3 -llvm-backend -stop-after llvmize -keep-llvmir -dno-asm-comments)
-    (run cat id_fn.ll)
-    (run ./filter.sh)))))
+  (progn
+   (run %{bin:ocamlopt.opt} id_fn.ml -c -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion -g -O3 -opaque -dump-into-file -dcmm -dcfg -stop-after llvmize)
+   (with-outputs-to id_fn.output.corrected (pipe-outputs (run cat id_fn.ll) (run ./filter.sh))))))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
- (alias runtest)
+ (alias runtest-llvm)
  (deps id_fn.output id_fn.output.corrected)
  (action
   (diff id_fn.output id_fn.output.corrected)))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
- (targets const_val.output.exe const_val_ir.output.corrected)
- (deps  const_val_main.ml const_val.ml)
+ (targets const_val.cmx const_val_ir.output.corrected const_val_main.cmx const_val.output.exe)
+ (deps const_val.ml const_val_main.ml)
  (action
   (progn
-   
-   (run %{bin:ocamlopt.opt} const_val.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion)
+   (run %{bin:ocamlopt.opt} const_val.ml -c -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
+   (with-outputs-to const_val_ir.output.corrected (pipe-outputs (run cat const_val.ll) (run ./filter.sh)))
    (run %{bin:ocamlopt.opt} const_val_main.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
-   (run %{bin:ocamlopt.opt}  const_val.cmx const_val_main.cmx -opaque -o const_val.output.exe)
-   (with-outputs-to
-    const_val_ir.output.corrected
-    (pipe-outputs
-      (run cat const_val.ll)
-      (run ./filter.sh))))))
+   (run %{bin:ocamlopt.opt} const_val.cmx const_val_main.cmx -opaque -o const_val.output.exe))))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
  (alias runtest-llvm)
- (deps const_val_ir.output const_val_ir.output.corrected)
- (action
-  (diff const_val_ir.output const_val_ir.output.corrected)))
-
-(rule
- (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
- (deps const_val.output.exe)
+ (deps const_val.cmx const_val_main.cmx)
  (targets const_val.output.corrected)
  (action
   (with-outputs-to
@@ -60,30 +44,27 @@
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
- (targets int_ops.output.exe int_ops_ir.output.corrected)
- (deps int_ops_data.ml int_ops_main.ml int_ops.ml)
+ (alias runtest-llvm)
+ (deps const_val_ir.output const_val_ir.output.corrected)
+ (action
+  (diff const_val_ir.output const_val_ir.output.corrected)))
+
+(rule
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
+ (targets int_ops_data.cmx int_ops.cmx int_ops_ir.output.corrected int_ops_main.cmx int_ops.output.exe)
+ (deps int_ops_data.ml int_ops.ml int_ops_main.ml)
  (action
   (progn
-   (run %{bin:ocamlopt.opt} int_ops_data.ml -g -c -O3 -opaque )
-   (run %{bin:ocamlopt.opt} int_ops.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion)
+   (run %{bin:ocamlopt.opt} int_ops_data.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
+   (run %{bin:ocamlopt.opt} int_ops.ml -c -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
+   (with-outputs-to int_ops_ir.output.corrected (pipe-outputs (run cat int_ops.ll) (run ./filter.sh)))
    (run %{bin:ocamlopt.opt} int_ops_main.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
-   (run %{bin:ocamlopt.opt} int_ops_data.cmx int_ops.cmx int_ops_main.cmx -opaque -o int_ops.output.exe)
-   (with-outputs-to
-    int_ops_ir.output.corrected
-    (pipe-outputs
-      (run cat int_ops.ll)
-      (run ./filter.sh))))))
+   (run %{bin:ocamlopt.opt} int_ops_data.cmx int_ops.cmx int_ops_main.cmx -opaque -o int_ops.output.exe))))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
  (alias runtest-llvm)
- (deps int_ops_ir.output int_ops_ir.output.corrected)
- (action
-  (diff int_ops_ir.output int_ops_ir.output.corrected)))
-
-(rule
- (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
- (deps int_ops.output.exe)
+ (deps int_ops_data.cmx int_ops.cmx int_ops_main.cmx)
  (targets int_ops.output.corrected)
  (action
   (with-outputs-to
@@ -99,30 +80,27 @@
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
- (targets gcd.output.exe gcd_ir.output.corrected)
- (deps gcd_data.ml gcd_main.ml gcd.ml)
+ (alias runtest-llvm)
+ (deps int_ops_ir.output int_ops_ir.output.corrected)
+ (action
+  (diff int_ops_ir.output int_ops_ir.output.corrected)))
+
+(rule
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
+ (targets gcd_data.cmx gcd.cmx gcd_ir.output.corrected gcd_main.cmx gcd.output.exe)
+ (deps gcd_data.ml gcd.ml gcd_main.ml)
  (action
   (progn
-   (run %{bin:ocamlopt.opt} gcd_data.ml -g -c -O3 -opaque )
-   (run %{bin:ocamlopt.opt} gcd.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion)
+   (run %{bin:ocamlopt.opt} gcd_data.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
+   (run %{bin:ocamlopt.opt} gcd.ml -c -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
+   (with-outputs-to gcd_ir.output.corrected (pipe-outputs (run cat gcd.ll) (run ./filter.sh)))
    (run %{bin:ocamlopt.opt} gcd_main.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
-   (run %{bin:ocamlopt.opt} gcd_data.cmx gcd.cmx gcd_main.cmx -opaque -o gcd.output.exe)
-   (with-outputs-to
-    gcd_ir.output.corrected
-    (pipe-outputs
-      (run cat gcd.ll)
-      (run ./filter.sh))))))
+   (run %{bin:ocamlopt.opt} gcd_data.cmx gcd.cmx gcd_main.cmx -opaque -o gcd.output.exe))))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
  (alias runtest-llvm)
- (deps gcd_ir.output gcd_ir.output.corrected)
- (action
-  (diff gcd_ir.output gcd_ir.output.corrected)))
-
-(rule
- (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
- (deps gcd.output.exe)
+ (deps gcd_data.cmx gcd.cmx gcd_main.cmx)
  (targets gcd.output.corrected)
  (action
   (with-outputs-to
@@ -138,30 +116,27 @@
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
- (targets array_rev.output.exe array_rev_ir.output.corrected)
- (deps array_rev_data.ml array_rev_main.ml array_rev.ml)
+ (alias runtest-llvm)
+ (deps gcd_ir.output gcd_ir.output.corrected)
+ (action
+  (diff gcd_ir.output gcd_ir.output.corrected)))
+
+(rule
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
+ (targets array_rev_data.cmx array_rev.cmx array_rev_ir.output.corrected array_rev_main.cmx array_rev.output.exe)
+ (deps array_rev_data.ml array_rev.ml array_rev_main.ml)
  (action
   (progn
-   (run %{bin:ocamlopt.opt} array_rev_data.ml -g -c -O3 -opaque )
-   (run %{bin:ocamlopt.opt} array_rev.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion)
+   (run %{bin:ocamlopt.opt} array_rev_data.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
+   (run %{bin:ocamlopt.opt} array_rev.ml -c -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
+   (with-outputs-to array_rev_ir.output.corrected (pipe-outputs (run cat array_rev.ll) (run ./filter.sh)))
    (run %{bin:ocamlopt.opt} array_rev_main.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
-   (run %{bin:ocamlopt.opt} array_rev_data.cmx array_rev.cmx array_rev_main.cmx -opaque -o array_rev.output.exe)
-   (with-outputs-to
-    array_rev_ir.output.corrected
-    (pipe-outputs
-      (run cat array_rev.ll)
-      (run ./filter.sh))))))
+   (run %{bin:ocamlopt.opt} array_rev_data.cmx array_rev.cmx array_rev_main.cmx -opaque -o array_rev.output.exe))))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
  (alias runtest-llvm)
- (deps array_rev_ir.output array_rev_ir.output.corrected)
- (action
-  (diff array_rev_ir.output array_rev_ir.output.corrected)))
-
-(rule
- (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
- (deps array_rev.output.exe)
+ (deps array_rev_data.cmx array_rev.cmx array_rev_main.cmx)
  (targets array_rev.output.corrected)
  (action
   (with-outputs-to
@@ -177,30 +152,26 @@
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
- (targets float_ops.output.exe float_ops_ir.output.corrected)
- (deps  float_ops_main.ml float_ops.ml)
+ (alias runtest-llvm)
+ (deps array_rev_ir.output array_rev_ir.output.corrected)
+ (action
+  (diff array_rev_ir.output array_rev_ir.output.corrected)))
+
+(rule
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
+ (targets float_ops.cmx float_ops_ir.output.corrected float_ops_main.cmx float_ops.output.exe)
+ (deps float_ops.ml float_ops_main.ml)
  (action
   (progn
-   
-   (run %{bin:ocamlopt.opt} float_ops.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion)
+   (run %{bin:ocamlopt.opt} float_ops.ml -c -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
+   (with-outputs-to float_ops_ir.output.corrected (pipe-outputs (run cat float_ops.ll) (run ./filter.sh)))
    (run %{bin:ocamlopt.opt} float_ops_main.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
-   (run %{bin:ocamlopt.opt}  float_ops.cmx float_ops_main.cmx -opaque -o float_ops.output.exe)
-   (with-outputs-to
-    float_ops_ir.output.corrected
-    (pipe-outputs
-      (run cat float_ops.ll)
-      (run ./filter.sh))))))
+   (run %{bin:ocamlopt.opt} float_ops.cmx float_ops_main.cmx -opaque -o float_ops.output.exe))))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
  (alias runtest-llvm)
- (deps float_ops_ir.output float_ops_ir.output.corrected)
- (action
-  (diff float_ops_ir.output float_ops_ir.output.corrected)))
-
-(rule
- (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
- (deps float_ops.output.exe)
+ (deps float_ops.cmx float_ops_main.cmx)
  (targets float_ops.output.corrected)
  (action
   (with-outputs-to
@@ -216,30 +187,27 @@
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
- (targets many_args.output.exe many_args_ir.output.corrected)
- (deps many_args_defn.ml many_args_main.ml many_args.ml)
+ (alias runtest-llvm)
+ (deps float_ops_ir.output float_ops_ir.output.corrected)
+ (action
+  (diff float_ops_ir.output float_ops_ir.output.corrected)))
+
+(rule
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
+ (targets many_args_defn.cmx many_args.cmx many_args_ir.output.corrected many_args_main.cmx many_args.output.exe)
+ (deps many_args_defn.ml many_args.ml many_args_main.ml)
  (action
   (progn
-   (run %{bin:ocamlopt.opt} many_args_defn.ml -g -c -O3 -opaque -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion)
-   (run %{bin:ocamlopt.opt} many_args.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion)
+   (run %{bin:ocamlopt.opt} many_args_defn.ml -c -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
+   (run %{bin:ocamlopt.opt} many_args.ml -c -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
+   (with-outputs-to many_args_ir.output.corrected (pipe-outputs (run cat many_args.ll) (run ./filter.sh)))
    (run %{bin:ocamlopt.opt} many_args_main.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
-   (run %{bin:ocamlopt.opt} many_args_defn.cmx many_args.cmx many_args_main.cmx -opaque -o many_args.output.exe)
-   (with-outputs-to
-    many_args_ir.output.corrected
-    (pipe-outputs
-      (run cat many_args.ll)
-      (run ./filter.sh))))))
+   (run %{bin:ocamlopt.opt} many_args_defn.cmx many_args.cmx many_args_main.cmx -opaque -o many_args.output.exe))))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
  (alias runtest-llvm)
- (deps many_args_ir.output many_args_ir.output.corrected)
- (action
-  (diff many_args_ir.output many_args_ir.output.corrected)))
-
-(rule
- (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
- (deps many_args.output.exe)
+ (deps many_args_defn.cmx many_args.cmx many_args_main.cmx)
  (targets many_args.output.corrected)
  (action
   (with-outputs-to
@@ -255,30 +223,26 @@
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
- (targets multi_ret.output.exe multi_ret_ir.output.corrected)
- (deps  multi_ret_main.ml multi_ret.ml)
+ (alias runtest-llvm)
+ (deps many_args_ir.output many_args_ir.output.corrected)
+ (action
+  (diff many_args_ir.output many_args_ir.output.corrected)))
+
+(rule
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
+ (targets multi_ret.cmx multi_ret_ir.output.corrected multi_ret_main.cmx multi_ret.output.exe)
+ (deps multi_ret.ml multi_ret_main.ml)
  (action
   (progn
-   
-   (run %{bin:ocamlopt.opt} multi_ret.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion)
+   (run %{bin:ocamlopt.opt} multi_ret.ml -c -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
+   (with-outputs-to multi_ret_ir.output.corrected (pipe-outputs (run cat multi_ret.ll) (run ./filter.sh)))
    (run %{bin:ocamlopt.opt} multi_ret_main.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
-   (run %{bin:ocamlopt.opt}  multi_ret.cmx multi_ret_main.cmx -opaque -o multi_ret.output.exe)
-   (with-outputs-to
-    multi_ret_ir.output.corrected
-    (pipe-outputs
-      (run cat multi_ret.ll)
-      (run ./filter.sh))))))
+   (run %{bin:ocamlopt.opt} multi_ret.cmx multi_ret_main.cmx -opaque -o multi_ret.output.exe))))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
  (alias runtest-llvm)
- (deps multi_ret_ir.output multi_ret_ir.output.corrected)
- (action
-  (diff multi_ret_ir.output multi_ret_ir.output.corrected)))
-
-(rule
- (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
- (deps multi_ret.output.exe)
+ (deps multi_ret.cmx multi_ret_main.cmx)
  (targets multi_ret.output.corrected)
  (action
   (with-outputs-to
@@ -294,30 +258,26 @@
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
- (targets indirect_call.output.exe indirect_call_ir.output.corrected)
- (deps  indirect_call_main.ml indirect_call.ml)
+ (alias runtest-llvm)
+ (deps multi_ret_ir.output multi_ret_ir.output.corrected)
+ (action
+  (diff multi_ret_ir.output multi_ret_ir.output.corrected)))
+
+(rule
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
+ (targets indirect_call.cmx indirect_call_ir.output.corrected indirect_call_main.cmx indirect_call.output.exe)
+ (deps indirect_call.ml indirect_call_main.ml)
  (action
   (progn
-   
-   (run %{bin:ocamlopt.opt} indirect_call.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion)
+   (run %{bin:ocamlopt.opt} indirect_call.ml -c -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
+   (with-outputs-to indirect_call_ir.output.corrected (pipe-outputs (run cat indirect_call.ll) (run ./filter.sh)))
    (run %{bin:ocamlopt.opt} indirect_call_main.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
-   (run %{bin:ocamlopt.opt}  indirect_call.cmx indirect_call_main.cmx -opaque -o indirect_call.output.exe)
-   (with-outputs-to
-    indirect_call_ir.output.corrected
-    (pipe-outputs
-      (run cat indirect_call.ll)
-      (run ./filter.sh))))))
+   (run %{bin:ocamlopt.opt} indirect_call.cmx indirect_call_main.cmx -opaque -o indirect_call.output.exe))))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
  (alias runtest-llvm)
- (deps indirect_call_ir.output indirect_call_ir.output.corrected)
- (action
-  (diff indirect_call_ir.output indirect_call_ir.output.corrected)))
-
-(rule
- (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
- (deps indirect_call.output.exe)
+ (deps indirect_call.cmx indirect_call_main.cmx)
  (targets indirect_call.output.corrected)
  (action
   (with-outputs-to
@@ -330,3 +290,47 @@
  (deps indirect_call.output indirect_call.output.corrected)
  (action
   (diff indirect_call.output indirect_call.output.corrected)))
+
+(rule
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
+ (alias runtest-llvm)
+ (deps indirect_call_ir.output indirect_call_ir.output.corrected)
+ (action
+  (diff indirect_call_ir.output indirect_call_ir.output.corrected)))
+
+(rule
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
+ (targets extcalls_defn.o extcalls.cmx extcalls_ir.output.corrected extcalls_main.cmx extcalls.output.exe)
+ (deps extcalls_defn.c extcalls.ml extcalls_main.ml)
+ (action
+  (progn
+   (run clang extcalls_defn.c -c -g -O3 -I %{project_root}/runtime)
+   (run %{bin:ocamlopt.opt} extcalls.ml -c -llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir -dno-asm-comments -disable-poll-insertion -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
+   (with-outputs-to extcalls_ir.output.corrected (pipe-outputs (run cat extcalls.ll) (run ./filter.sh)))
+   (run %{bin:ocamlopt.opt} extcalls_main.ml -c -g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear)
+   (run %{bin:ocamlopt.opt} extcalls_defn.o extcalls.cmx extcalls_main.cmx -opaque -o extcalls.output.exe))))
+
+(rule
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
+ (alias runtest-llvm)
+ (deps extcalls_defn.o extcalls.cmx extcalls_main.cmx)
+ (targets extcalls.output.corrected)
+ (action
+  (with-outputs-to
+   extcalls.output.corrected
+   (run ./extcalls.output.exe))))
+
+(rule
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
+ (alias runtest-llvm)
+ (deps extcalls.output extcalls.output.corrected)
+ (action
+  (diff extcalls.output extcalls.output.corrected)))
+
+(rule
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))
+ (alias runtest-llvm)
+ (deps extcalls_ir.output extcalls_ir.output.corrected)
+ (action
+  (diff extcalls_ir.output extcalls_ir.output.corrected)))
+

--- a/oxcaml/tests/backend/llvmize/extcalls.ml
+++ b/oxcaml/tests/backend/llvmize/extcalls.ml
@@ -20,7 +20,7 @@ external int_and_float : int -> float -> int -> float -> unit = "int_and_float"
 let[@inline never] [@local never] call_too_many () =
   too_many 1 2 3 4 5 6 7 8 9 10 11 12
 
-let[@inline never] [@local never] call_print_and_add () = print_and_add 3 7
+let[@inline never] [@local never] call_print_and_add () = print_and_add 9 10
 
 (* let[@inline never] [@local never] call_int_and_float () = int_and_float 1 2.0
    3 4.0 *)

--- a/oxcaml/tests/backend/llvmize/extcalls.ml
+++ b/oxcaml/tests/backend/llvmize/extcalls.ml
@@ -1,0 +1,26 @@
+external print_and_add : int -> int -> int = "" "print_and_add"
+
+external too_many :
+  int ->
+  int ->
+  int ->
+  int ->
+  int ->
+  int ->
+  int ->
+  int ->
+  int ->
+  int ->
+  int ->
+  int ->
+  int = "" "too_many"
+
+external int_and_float : int -> float -> int -> float -> unit = "int_and_float"
+
+let[@inline never] [@local never] call_too_many () =
+  too_many 1 2 3 4 5 6 7 8 9 10 11 12
+
+let[@inline never] [@local never] call_print_and_add () = print_and_add 3 7
+
+(* let[@inline never] [@local never] call_int_and_float () = int_and_float 1 2.0
+   3 4.0 *)

--- a/oxcaml/tests/backend/llvmize/extcalls.output
+++ b/oxcaml/tests/backend/llvmize/extcalls.output
@@ -1,0 +1,4 @@
+Hello from C! 3 7
+too_many arg list: 1 2 3 4 5 6 7 8 9 10 11 12
+print_and_add res: 10
+too_many res: 10

--- a/oxcaml/tests/backend/llvmize/extcalls_defn.c
+++ b/oxcaml/tests/backend/llvmize/extcalls_defn.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+#include <caml/mlvalues.h>
+
+CAMLprim value print_and_add(value xv, value yv) {
+    long x = Long_val(xv), y = Long_val(yv);
+    printf("Hello from C! %ld %ld\n", x, y);
+    return Val_long(x + y);
+}
+
+CAMLprim value too_many(value x1, value x2, value x3, value x4,  value x5,  value x6,
+                        value x7, value x8, value x9, value x10, value x11, value x12) {
+    printf("too_many arg list: %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld\n",
+        Long_val(x1),
+        Long_val(x2),
+        Long_val(x3),
+        Long_val(x4),
+        Long_val(x5),
+        Long_val(x6),
+        Long_val(x7),
+        Long_val(x8),
+        Long_val(x9),
+        Long_val(x10),
+        Long_val(x11),
+        Long_val(x12));
+    fflush(stdout);
+    
+    return x10;
+}
+
+CAMLprim value int_and_float(value i1, value f2, value i3, value f4) {
+    printf("int_and_float arg list: %ld %f %ld %f\n",
+        Long_val(i1),
+        Double_val(f2),
+        Long_val(i3),
+        Double_val(f4));
+    fflush(stdout);
+    
+    return Val_unit;
+}

--- a/oxcaml/tests/backend/llvmize/extcalls_ir.output
+++ b/oxcaml/tests/backend/llvmize/extcalls_ir.output
@@ -1,0 +1,193 @@
+source_filename = "extcalls.ml"
+
+@camlExtcalls__data_begin = global i64 0
+define void @camlExtcalls__code_begin() { ret void }
+
+define cc 104 { { ptr }, { i64 } } @camlExtcalls__call_too_many_HIDE_STAMP(ptr %0, i64 %1)  {
+  %ds = alloca ptr
+  store ptr %0, ptr %ds
+  %3 = alloca i64
+  store i64 %1, ptr %3
+  %4 = alloca i64
+  %5 = alloca i64
+  %6 = alloca i64
+  %7 = alloca i64
+  %8 = alloca i64
+  %9 = alloca i64
+  %10 = alloca i64
+  %11 = alloca i64
+  %12 = alloca i64
+  %13 = alloca i64
+  %14 = alloca i64
+  %15 = alloca i64
+  %16 = alloca i64
+  %17 = alloca i64
+  %18 = alloca i64
+  %19 = alloca i64
+  %20 = alloca i64
+  %21 = alloca i64
+  %22 = alloca i64
+  %23 = alloca i64
+  %24 = alloca i64
+  %25 = alloca i64
+  %26 = alloca i64
+  %27 = alloca i64
+  %28 = alloca i64
+  %29 = alloca i64
+  br label %L1
+L1:
+  br label %L101
+L101:                                                ; preds = %L1
+  %30 = load i64, ptr %3
+  store i64 %30, ptr %10
+  store i64 25, ptr %11
+  store i64 23, ptr %12
+  store i64 21, ptr %13
+  store i64 19, ptr %14
+  store i64 17, ptr %15
+  store i64 15, ptr %16
+  store i64 13, ptr %17
+  store i64 11, ptr %18
+  store i64 9, ptr %19
+  store i64 7, ptr %20
+  store i64 5, ptr %21
+  store i64 3, ptr %22
+  %31 = load i64, ptr %22
+  store i64 %31, ptr %4
+  %32 = load i64, ptr %21
+  store i64 %32, ptr %5
+  %33 = load i64, ptr %20
+  store i64 %33, ptr %6
+  %34 = load i64, ptr %19
+  store i64 %34, ptr %7
+  %35 = load i64, ptr %18
+  store i64 %35, ptr %8
+  %36 = load i64, ptr %17
+  store i64 %36, ptr %9
+  %37 = load i64, ptr %16
+  store i64 %37, ptr %23
+  %38 = load i64, ptr %15
+  store i64 %38, ptr %24
+  %39 = load i64, ptr %14
+  store i64 %39, ptr %25
+  %40 = load i64, ptr %13
+  store i64 %40, ptr %26
+  %41 = load i64, ptr %12
+  store i64 %41, ptr %27
+  %42 = load i64, ptr %11
+  store i64 %42, ptr %28
+  %43 = load i64, ptr %4
+  %44 = load i64, ptr %5
+  %45 = load i64, ptr %6
+  %46 = load i64, ptr %7
+  %47 = load i64, ptr %8
+  %48 = load i64, ptr %9
+  %49 = load i64, ptr %23
+  %50 = load i64, ptr %24
+  %51 = load i64, ptr %25
+  %52 = load i64, ptr %26
+  %53 = load i64, ptr %27
+  %54 = load i64, ptr %28
+  %55 = call cc 105 { i64 } @caml_c_call_stack_args_llvm_backend(ptr @too_many, i64 48, i64 %43, i64 %44, i64 %45, i64 %46, i64 %47, i64 %48, i64 %49, i64 %50, i64 %51, i64 %52, i64 %53, i64 %54)
+  %56 = extractvalue { i64 } %55, 0
+  store i64 %56, ptr %3
+  br label %L103
+L103:                                                ; preds = %L101
+  %57 = load i64, ptr %3
+  store i64 %57, ptr %29
+  %58 = load i64, ptr %29
+  store i64 %58, ptr %3
+  %59 = extractvalue { { { ptr }, { i64 } } } poison, 0
+  %60 = load ptr, ptr %ds
+  %61 = insertvalue { { ptr }, { i64 } } %59, ptr %60, 0, 0
+  %62 = load i64, ptr %3
+  %63 = insertvalue { { ptr }, { i64 } } %61, i64 %62, 1, 0
+  ret { { ptr }, { i64 } } %63
+}
+
+define cc 104 { { ptr }, { i64 } } @camlExtcalls__call_print_and_add_HIDE_STAMP(ptr %0, i64 %1)  {
+  %ds = alloca ptr
+  store ptr %0, ptr %ds
+  %3 = alloca i64
+  store i64 %1, ptr %3
+  %4 = alloca i64
+  %5 = alloca i64
+  %6 = alloca i64
+  %7 = alloca i64
+  %8 = alloca i64
+  %9 = alloca i64
+  br label %L1
+L1:
+  br label %L105
+L105:                                                ; preds = %L1
+  %10 = load i64, ptr %3
+  store i64 %10, ptr %6
+  store i64 15, ptr %7
+  store i64 7, ptr %8
+  %11 = load i64, ptr %8
+  store i64 %11, ptr %4
+  %12 = load i64, ptr %7
+  store i64 %12, ptr %5
+  %13 = load i64, ptr %4
+  %14 = load i64, ptr %5
+  %15 = call cc 105 { i64 } @caml_c_call(ptr @print_and_add, i64 poison, i64 %13, i64 %14)
+  %16 = extractvalue { i64 } %15, 0
+  store i64 %16, ptr %3
+  br label %L107
+L107:                                                ; preds = %L105
+  %17 = load i64, ptr %3
+  store i64 %17, ptr %9
+  %18 = load i64, ptr %9
+  store i64 %18, ptr %3
+  %19 = extractvalue { { { ptr }, { i64 } } } poison, 0
+  %20 = load ptr, ptr %ds
+  %21 = insertvalue { { ptr }, { i64 } } %19, ptr %20, 0, 0
+  %22 = load i64, ptr %3
+  %23 = insertvalue { { ptr }, { i64 } } %21, i64 %22, 1, 0
+  ret { { ptr }, { i64 } } %23
+}
+
+define cc 104 { { ptr }, { i64 } } @camlExtcalls__entry(ptr %0)  {
+  %ds = alloca ptr
+  store ptr %0, ptr %ds
+  %2 = alloca i64
+  %3 = alloca i64
+  %4 = alloca i64
+  %5 = alloca i64
+  %6 = alloca i64
+  br label %L1
+L1:
+  br label %L112
+L112:                                                ; preds = %L1
+  store ptr @camlExtcalls, ptr %4
+  %7 = load i64, ptr %4
+  store i64 %7, ptr %5
+  %8 = load i64, ptr %5
+  store i64 %8, ptr %3
+  store i64 1, ptr %6
+  %9 = load i64, ptr %6
+  store i64 %9, ptr %2
+  %10 = extractvalue { { { ptr }, { i64 } } } poison, 0
+  %11 = load ptr, ptr %ds
+  %12 = insertvalue { { ptr }, { i64 } } %10, ptr %11, 0, 0
+  %13 = load i64, ptr %2
+  %14 = insertvalue { { ptr }, { i64 } } %12, i64 %13, 1, 0
+  ret { { ptr }, { i64 } } %14
+}
+
+declare i64 @llvm.read_register.i64(metadata)
+declare void @llvm.write_register.i64(metadata, i64)
+
+@camlExtcalls__gc_roots = global { i64, i64 } { i64 0, i64 2816 }
+@camlExtcalls = global { ptr, ptr, i64 } { ptr @camlExtcalls__call_too_many_2, ptr @camlExtcalls__call_print_and_add_3, i64 3063 }
+@camlExtcalls__call_print_and_add_3 = global { ptr, i64, i64 } { ptr @camlExtcalls__call_print_and_add_HIDE_STAMP, i64 108086391056891909, i64 3063 }
+@camlExtcalls__call_too_many_2 = global { ptr, i64, ptr, ptr, ptr } { ptr @camlExtcalls__call_too_many_HIDE_STAMP, i64 108086391056891909, ptr @int_and_float, ptr @too_many, ptr @print_and_add }
+@caml_c_call = external global ptr
+@caml_c_call_stack_args_llvm_backend = external global ptr
+@int_and_float = external global ptr
+@print_and_add = external global ptr
+@too_many = external global ptr
+
+@camlExtcalls__data_end = global i64 0
+define void @camlExtcalls__code_end() { ret void }
+@camlExtcalls__frametable = global i64 0

--- a/oxcaml/tests/backend/llvmize/extcalls_main.ml
+++ b/oxcaml/tests/backend/llvmize/extcalls_main.ml
@@ -1,0 +1,11 @@
+let () =
+  let print_and_add_res = Extcalls.call_print_and_add () in
+  Out_channel.flush stdout;
+  Format.printf "print_and_add res: %d\n" print_and_add_res;
+  Out_channel.flush stdout;
+  let too_many_res = Extcalls.call_too_many () in
+  Out_channel.flush stdout;
+  Format.printf "too_many res: %d\n" too_many_res;
+  Out_channel.flush stdout
+(* CR yusumez: Add float constants for this to work *)
+(* Extcalls.call_int_and_float () *)

--- a/oxcaml/tests/backend/llvmize/float_ops_ir.output
+++ b/oxcaml/tests/backend/llvmize/float_ops_ir.output
@@ -305,6 +305,9 @@ L140:                                                ; preds = %L1
 }
 
 declare  double @llvm.fabs.f64(double)
+declare i64 @llvm.read_register.i64(metadata)
+declare void @llvm.write_register.i64(metadata, i64)
+
 @camlFloat_ops__gc_roots = global { i64, i64 } { i64 0, i64 1792 }
 @camlFloat_ops = global { ptr, i64 } { ptr @camlFloat_ops__Pmakeblock253, i64 7936 }
 @camlFloat_ops__Pmakeblock253 = global { ptr, ptr, ptr, ptr, ptr, ptr, ptr, i64 } { ptr @camlFloat_ops__add_7, ptr @camlFloat_ops__sub_8, ptr @camlFloat_ops__mul_9, ptr @camlFloat_ops__div_10, ptr @camlFloat_ops__neg_11, ptr @camlFloat_ops__abs_12, ptr @camlFloat_ops__compare_13, i64 4087 }

--- a/oxcaml/tests/backend/llvmize/gcd_ir.output
+++ b/oxcaml/tests/backend/llvmize/gcd_ir.output
@@ -239,6 +239,9 @@ L154:                                                ; preds = %L1
 }
 
 declare  void @llvm.trap()
+declare i64 @llvm.read_register.i64(metadata)
+declare void @llvm.write_register.i64(metadata, i64)
+
 @camlGcd__gc_roots = global { i64, i64 } { i64 0, i64 1792 }
 @camlGcd = global { ptr, i64 } { ptr @camlGcd__gcd_1, i64 3063 }
 @camlGcd__gcd_1 = global { ptr, i64 } { ptr @camlGcd__gcd_HIDE_STAMP, i64 108086391056891909 }

--- a/oxcaml/tests/backend/llvmize/gen/gen_dune.ml
+++ b/oxcaml/tests/backend/llvmize/gen/gen_dune.ml
@@ -1,19 +1,169 @@
-let print_test ~extra_subst ~name ~buf rule_template =
+(* filenames don't contain extensions *)
+type task =
+  | C of string
+  | Ocaml_llvm of
+      { filename : string;
+        stop_after_llvmize : bool
+      }
+  | Ocaml_default of string
+  | Output_ir of
+      { source : string;
+        output : string
+      }
+
+let rule_of_task = function
+  | Ocaml_default filename ->
+    Format.sprintf "(run ${ocamlopt} %s.ml -c ${common_flags})" filename
+  | Ocaml_llvm { filename; stop_after_llvmize } ->
+    let common_flags =
+      if stop_after_llvmize
+      then "${stop_after_llvm_flags}"
+      else "${common_flags}"
+    in
+    Format.sprintf "(run ${ocamlopt} %s.ml -c ${llvm_flags} %s)" filename
+      common_flags
+  | Output_ir { source; output } ->
+    Format.sprintf
+      {|(with-outputs-to %s.output.corrected (pipe-outputs (run cat %s.ll) (run ./${filter})))|}
+      output source
+  | C filename -> Format.sprintf "(run clang %s.c ${c_flags})" filename
+
+let dependency_of_task = function
+  | Ocaml_llvm { filename; _ } | Ocaml_default filename ->
+    Some (filename ^ ".ml")
+  | C filename -> Some (filename ^ ".c")
+  | Output_ir _ -> None
+
+let target_of_task = function
+  | Output_ir { output; _ } -> Some (output ^ ".output.corrected")
+  | Ocaml_default filename | Ocaml_llvm { filename; stop_after_llvmize = false }
+    ->
+    Some (filename ^ ".cmx")
+  | C filename -> Some (filename ^ ".o")
+  | Ocaml_llvm { stop_after_llvmize = true; _ } -> None
+
+let can_run = function
+  | Output_ir _ -> false
+  | Ocaml_default _ | Ocaml_llvm _ | C _ -> true
+
+module F = struct
+  open Format
+
+  let pp_space ppf () = fprintf ppf " "
+
+  let pp_newline ppf () = fprintf ppf "\n   "
+
+  let pp_strings pp_sep = pp_print_list ~pp_sep pp_print_string
+
+  let exe_rule ~deps ~output =
+    asprintf "(run ${ocamlopt} %a -opaque -o %s.exe)" (pp_strings pp_space) deps
+      output
+
+  let pp_compile_rule ppf ~targets ~deps ~task_rules =
+    fprintf ppf
+      {|(rule
+ ${enabled_if}
+ (targets %a)
+ (deps %a)
+ (action
+  (progn
+   %a)))
+
+|}
+      (pp_strings pp_space) targets (pp_strings pp_space) deps
+      (pp_strings pp_newline) task_rules
+
+  let pp_run_exe_rule ppf ~deps ~output =
+    fprintf ppf
+      {|(rule
+ ${enabled_if}
+ (alias runtest-llvm)
+ (deps %a)
+ (targets %s.corrected)
+ (action
+  (with-outputs-to
+   %s.corrected
+   (run ./%s.exe))))
+
+|}
+      (pp_strings pp_space) deps output output output
+
+  let pp_compare_output_rule ppf ~output =
+    fprintf ppf
+      {|(rule
+ ${enabled_if}
+ (alias runtest-llvm)
+ (deps %s %s.corrected)
+ (action
+  (diff %s %s.corrected)))
+
+|}
+      output output output output
+
+  let pp_rule_template ~run ~tasks ppf () =
+    let run_args =
+      Option.map
+        (fun output ->
+          ( List.filter can_run tasks |> List.filter_map target_of_task,
+            output ^ ".output" ))
+        run
+    in
+    let deps = List.filter_map dependency_of_task tasks in
+    let targets =
+      List.filter_map target_of_task tasks
+      @ match run_args with None -> [] | Some (_, output) -> [output ^ ".exe"]
+    in
+    let task_rules =
+      List.map rule_of_task tasks
+      @
+      match run_args with
+      | None -> []
+      | Some (deps, output) -> [exe_rule ~deps ~output]
+    in
+    pp_compile_rule ppf ~deps ~targets ~task_rules;
+    (match run_args with
+    | None -> ()
+    | Some (deps, output) ->
+      pp_run_exe_rule ppf ~deps ~output;
+      pp_compare_output_rule ppf ~output);
+    List.iter
+      (function
+        | Output_ir { output; _ } ->
+          pp_compare_output_rule ppf ~output:(output ^ ".output")
+        | C _ | Ocaml_default _ | Ocaml_llvm _ -> ())
+      tasks
+end
+
+let print_test ~extra_subst ~run ~tasks ~buf =
   let enabled_if =
     {|(enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")))|}
   in
-  let output = name ^ ".output" in
   let subst = function
-    | "name" -> name
-    | "output" -> output
     | "ocamlopt" -> "%{bin:ocamlopt.opt}"
     | "enabled_if" -> enabled_if
+    | "filter" -> "filter.sh"
+    | "llvm_path" -> "${LLVM_PATH:-clang}"
+    | "llvm_flags" ->
+      (* We pass -dno-asm-comments to avoid printing flaky identifiers in Cfg
+         instructions *)
+      (* CR yusumez: remove -disable-poll-insertion once we can emit poll
+         insertions *)
+      (* CR yusumez: find a better way to detect LLVM_PATH *)
+      "-llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir \
+       -dno-asm-comments -disable-poll-insertion"
+    | "common_flags" -> "-g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear"
+    | "stop_after_llvm_flags" ->
+      "-g -O3 -opaque -dump-into-file -dcmm -dcfg -stop-after llvmize"
+    | "c_flags" -> "-c -g -O3 -I %{project_root}/runtime"
     | label -> (
       match
         List.find_opt (fun (label', _) -> String.equal label label') extra_subst
       with
       | Some (_, res) -> res
       | None -> assert false)
+  in
+  let rule_template =
+    Format.asprintf "%a" (F.pp_rule_template ~run ~tasks) ()
   in
   Buffer.clear buf;
   Buffer.add_substitute buf subst rule_template;
@@ -22,134 +172,51 @@ let print_test ~extra_subst ~name ~buf rule_template =
 let () =
   let buf = Buffer.create 1000 in
   let print_test_ir_only name =
-    (* We pass -stop-after llvmize since the compiler might not be configured
-       with clang *)
-    print_test
-      ~extra_subst:
-        [ "filter", "filter.sh";
-          ( "flags",
-            "-g -c -O3 -llvm-backend -stop-after llvmize -keep-llvmir \
-             -dno-asm-comments" ) ]
-      ~name ~buf
-      {|
-(rule
- ${enabled_if}
- (targets ${output}.corrected)
- (deps ${name}.ml ${filter})
- (action
-  (with-outputs-to
-   ${output}.corrected
-   (pipe-outputs
-    (run
-     ${ocamlopt} ${name}.ml ${flags})
-    (run cat ${name}.ll)
-    (run ./${filter})))))
-
-(rule
- ${enabled_if}
- (alias runtest)
- (deps ${output} ${output}.corrected)
- (action
-  (diff ${output} ${output}.corrected)))
-|}
+    print_test ~extra_subst:[] ~buf ~run:None
+      ~tasks:
+        [ Ocaml_llvm { filename = name; stop_after_llvmize = true };
+          Output_ir { source = name; output = name } ]
   in
-  let print_test_ir_and_run ?(extra_dep_with_llvm_backend = false)
-      ?extra_dep_suffix name =
-    (* We pass -dno-asm-comments to avoid printing flaky identifiers in Cfg
-       instructions *)
-    (* CR yusumez: remove -disable-poll-insertion once we can emit poll
-       insertions *)
-    (* CR yusumez: find a better way to detect LLVM_PATH *)
-    let llvm_flags =
-      "-llvm-backend -llvm-path ${LLVM_PATH:-clang} -keep-llvmir \
-       -dno-asm-comments -disable-poll-insertion"
-    in
-    let common_flags =
-      "-g -O3 -opaque -S -dump-into-file -dcmm -dcfg -dlinear"
-    in
-    let extra_dep_ml =
-      match extra_dep_suffix with
-      | Some suffix -> Format.asprintf "%s_%s.ml" name suffix
-      | None -> ""
-    in
-    let extra_dep_cmx =
-      match extra_dep_suffix with
-      | Some suffix -> Format.asprintf "%s_%s.cmx" name suffix
-      | None -> ""
-    in
-    let extra_dep_llvm_flags =
-      match extra_dep_with_llvm_backend with true -> llvm_flags | false -> ""
-    in
-    let run_extra_dep =
-      match extra_dep_suffix with
-      | Some _ ->
-        Format.asprintf "(run %%{bin:ocamlopt.opt} %s -g -c -O3 -opaque %s)"
-          extra_dep_ml extra_dep_llvm_flags
-      | None -> ""
-    in
-    print_test
-      ~extra_subst:
-        [ "main", name ^ "_main";
-          "ir_output", name ^ "_ir.output";
-          (* The extra dependency is needed for some tests since neither
-             allocation nor calling conventions are implemented yet. The way
-             it's being done here is rather ugly... *)
-          "extra_dep_ml", extra_dep_ml;
-          "extra_dep_cmx", extra_dep_cmx;
-          "run_extra_dep", run_extra_dep;
-          "extra_dep_llvm_flags", extra_dep_llvm_flags;
-          "llvm_flags", llvm_flags;
-          "common_flags", common_flags;
-          "filter", "filter.sh" ]
-      ~name ~buf
-      {|
-(rule
- ${enabled_if}
- (targets ${output}.exe ${ir_output}.corrected)
- (deps ${extra_dep_ml} ${main}.ml ${name}.ml)
- (action
-  (progn
-   ${run_extra_dep}
-   (run ${ocamlopt} ${name}.ml -c ${common_flags} ${llvm_flags})
-   (run ${ocamlopt} ${main}.ml -c ${common_flags})
-   (run ${ocamlopt} ${extra_dep_cmx} ${name}.cmx ${main}.cmx -opaque -o ${output}.exe)
-   (with-outputs-to
-    ${ir_output}.corrected
-    (pipe-outputs
-      (run cat ${name}.ll)
-      (run ./${filter}))))))
-
-(rule
- ${enabled_if}
- (alias runtest-llvm)
- (deps ${ir_output} ${ir_output}.corrected)
- (action
-  (diff ${ir_output} ${ir_output}.corrected)))
-
-(rule
- ${enabled_if}
- (deps ${output}.exe)
- (targets ${output}.corrected)
- (action
-  (with-outputs-to
-   ${output}.corrected
-   (run ./${output}.exe))))
-
-(rule
- ${enabled_if}
- (alias runtest-llvm)
- (deps ${output} ${output}.corrected)
- (action
-  (diff ${output} ${output}.corrected)))
-|}
+  let print_test_ir_and_run name =
+    let main_name = name ^ "_main" in
+    print_test ~extra_subst:[] ~buf ~run:(Some name)
+      ~tasks:
+        [ Ocaml_llvm { filename = name; stop_after_llvmize = false };
+          Output_ir { source = name; output = name ^ "_ir" };
+          Ocaml_default main_name ]
+  in
+  let print_test_ir_and_run_with_dep ~extra_dep_suffix
+      ?(extra_dep_with_llvm_backend = false) name =
+    let extra_dep_name = name ^ "_" ^ extra_dep_suffix in
+    let main_name = name ^ "_main" in
+    print_test ~extra_subst:[] ~buf ~run:(Some name)
+      ~tasks:
+        [ (if extra_dep_with_llvm_backend
+          then
+            Ocaml_llvm { filename = extra_dep_name; stop_after_llvmize = false }
+          else Ocaml_default extra_dep_name);
+          Ocaml_llvm { filename = name; stop_after_llvmize = false };
+          Output_ir { source = name; output = name ^ "_ir" };
+          Ocaml_default main_name ]
+  in
+  let print_test_c ~c_suffix name =
+    let c_name = name ^ "_" ^ c_suffix in
+    let main_name = name ^ "_main" in
+    print_test ~extra_subst:[] ~buf ~run:(Some name)
+      ~tasks:
+        [ C c_name;
+          Ocaml_llvm { filename = name; stop_after_llvmize = false };
+          Output_ir { source = name; output = name ^ "_ir" };
+          Ocaml_default main_name ]
   in
   print_test_ir_only "id_fn";
   print_test_ir_and_run "const_val";
-  print_test_ir_and_run ~extra_dep_suffix:"data" "int_ops";
-  print_test_ir_and_run ~extra_dep_suffix:"data" "gcd";
-  print_test_ir_and_run ~extra_dep_suffix:"data" "array_rev";
+  print_test_ir_and_run_with_dep ~extra_dep_suffix:"data" "int_ops";
+  print_test_ir_and_run_with_dep ~extra_dep_suffix:"data" "gcd";
+  print_test_ir_and_run_with_dep ~extra_dep_suffix:"data" "array_rev";
   print_test_ir_and_run "float_ops";
-  print_test_ir_and_run ~extra_dep_suffix:"defn"
+  print_test_ir_and_run_with_dep ~extra_dep_suffix:"defn"
     ~extra_dep_with_llvm_backend:true "many_args";
   print_test_ir_and_run "multi_ret";
-  print_test_ir_and_run "indirect_call"
+  print_test_ir_and_run "indirect_call";
+  print_test_c ~c_suffix:"defn" "extcalls"

--- a/oxcaml/tests/backend/llvmize/id_fn.output
+++ b/oxcaml/tests/backend/llvmize/id_fn.output
@@ -53,6 +53,9 @@ L107:                                                ; preds = %L1
   ret { { ptr }, { i64 } } %14
 }
 
+declare i64 @llvm.read_register.i64(metadata)
+declare void @llvm.write_register.i64(metadata, i64)
+
 @camlId_fn__gc_roots = global { i64, i64 } { i64 0, i64 1792 }
 @camlId_fn = global { ptr, i64 } { ptr @camlId_fn__f_1, i64 3063 }
 @camlId_fn__f_1 = global { ptr, i64 } { ptr @camlId_fn__f_HIDE_STAMP, i64 108086391056891909 }

--- a/oxcaml/tests/backend/llvmize/indirect_call_ir.output
+++ b/oxcaml/tests/backend/llvmize/indirect_call_ir.output
@@ -83,6 +83,9 @@ L109:                                                ; preds = %L1
   ret { { ptr }, { i64 } } %14
 }
 
+declare i64 @llvm.read_register.i64(metadata)
+declare void @llvm.write_register.i64(metadata, i64)
+
 @camlIndirect_call__gc_roots = global { i64, i64 } { i64 0, i64 1792 }
 @camlIndirect_call = global { ptr, i64 } { ptr @camlIndirect_call__apply_1, i64 4087 }
 @camlIndirect_call__apply_1 = global { ptr, i64, ptr } { ptr @caml_curry2, i64 180143985094819847, ptr @camlIndirect_call__apply_HIDE_STAMP }

--- a/oxcaml/tests/backend/llvmize/int_ops_ir.output
+++ b/oxcaml/tests/backend/llvmize/int_ops_ir.output
@@ -1352,6 +1352,9 @@ L308:                                                ; preds = %L1
 }
 
 declare  void @llvm.trap()
+declare i64 @llvm.read_register.i64(metadata)
+declare void @llvm.write_register.i64(metadata, i64)
+
 @camlInt_ops__gc_roots = global { i64, i64 } { i64 0, i64 25344 }
 @camlInt_ops = global { i64, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, i64 } { i64 9, ptr @camlInt_ops__add_23, ptr @camlInt_ops__sub_24, ptr @camlInt_ops__mul_25, ptr @camlInt_ops__div_26, ptr @camlInt_ops__mod__27, ptr @camlInt_ops__land__28, ptr @camlInt_ops__lor__29, ptr @camlInt_ops__lxor__30, ptr @camlInt_ops__lnot__31, ptr @camlInt_ops__lsl__32, ptr @camlInt_ops__lsr__33, ptr @camlInt_ops__asr__34, ptr @camlInt_ops__add_imm_35, ptr @camlInt_ops__sub_imm_36, ptr @camlInt_ops__mul_imm_37, ptr @camlInt_ops__div_imm_38, ptr @camlInt_ops__mod_imm_39, ptr @camlInt_ops__land_imm_40, ptr @camlInt_ops__lor_imm_41, ptr @camlInt_ops__lxor_imm_42, ptr @camlInt_ops__lsl_imm_43, ptr @camlInt_ops__lsr_imm_44, ptr @camlInt_ops__asr_imm_45, i64 3063 }
 @camlInt_ops__asr_imm_45 = global { ptr, i64, i64 } { ptr @camlInt_ops__asr_imm_HIDE_STAMP, i64 108086391056891909, i64 3063 }

--- a/oxcaml/tests/backend/llvmize/many_args_ir.output
+++ b/oxcaml/tests/backend/llvmize/many_args_ir.output
@@ -149,6 +149,9 @@ L111:                                                ; preds = %L1
 }
 
 declare cc 104 { { ptr }, { i64 } } @caml_apply13(ptr, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64)
+declare i64 @llvm.read_register.i64(metadata)
+declare void @llvm.write_register.i64(metadata, i64)
+
 @camlMany_args__gc_roots = global { i64, i64 } { i64 0, i64 1792 }
 @camlMany_args = global { ptr, i64 } { ptr @camlMany_args__call_with_1, i64 3063 }
 @camlMany_args__call_with_1 = global { ptr, i64 } { ptr @camlMany_args__call_with_HIDE_STAMP, i64 108086391056891909 }

--- a/oxcaml/tests/backend/llvmize/multi_ret_ir.output
+++ b/oxcaml/tests/backend/llvmize/multi_ret_ir.output
@@ -80,6 +80,9 @@ L107:                                                ; preds = %L1
   ret { { ptr }, { i64 } } %14
 }
 
+declare i64 @llvm.read_register.i64(metadata)
+declare void @llvm.write_register.i64(metadata, i64)
+
 @camlMulti_ret__gc_roots = global { i64, i64 } { i64 0, i64 2816 }
 @camlMulti_ret = global { ptr, ptr, i64 } { ptr @camlMulti_ret__empty_block4, ptr @camlMulti_ret__permute_1, i64 4087 }
 @camlMulti_ret__permute_1 = global { ptr, i64, ptr, i64 } { ptr @caml_curryF_F_F_F_RFFFF, i64 324259173170675719, ptr @camlMulti_ret__permute_HIDE_STAMP, i64 768 }

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -893,7 +893,24 @@ ENDFUNCTION(G(caml_c_call))
         LEAVE_FUNCTION;                                                 \
         RET_FROM_C_CALL         ;                                       \
     CFI_ENDPROC                 ;                                       \
-    ENDFUNCTION(G(caml_c_call_stack_args ## suffix))
+    ENDFUNCTION(G(caml_c_call_stack_args ## suffix));                   \
+                                                                        \
+    FUNCTION(G(caml_c_call_stack_args_llvm_backend ## suffix));         \
+    CFI_STARTPROC                       ;                               \
+        CFI_SIGNAL_FRAME;                                               \
+        ENTER_FUNCTION;                                                 \
+    /* Arguments:                                                       \
+        C arguments         : %rdi, %rsi, %rdx, %rcx, %r8, and %r9      \
+        C function          : %rax                                      \
+        C stack args        : offset=%r12                               \
+       Wrap caml_c_stack_args and prepare stack args for it */          \
+    /* Where rsp was right before the call */                           \
+        leaq	8(%rsp), %r13;                                          \
+        leaq	(%r13, %r12), %r12;                                     \
+        call	G(caml_c_call_stack_args ## suffix);                    \
+        ret;                                                            \
+    CFI_ENDPROC                 ;                                       \
+    ENDFUNCTION(G(caml_c_call_stack_args_llvm_backend ## suffix))       \
 
 Make_c_call_stack_args()
 Make_c_call_stack_args(_avx)


### PR DESCRIPTION
This PR adds calling C functions from OCaml. For this, a wrapper asm function was added to the runtime and a corresponding calling convention was added in [this PR](https://github.com/ocaml-flambda/llvm-project/pull/11). It also overhauls test generation to be more flexible and fixes a couple of minor issues in Llvmize.

As in [this previous PR](https://github.com/ocaml-flambda/llvm-project/pull/10), tests are not on Github CI and must be run with a build script. `_build` doesn't persist when the compiler is reconfigured, so it is advisable to move the directory `_build/llvm_test` somewhere else before configuring to avoid cloning and building LLVM again. The required repo/branch is specified in the PR mentioned in the previous paragraph.