### PR TITLE
Mask all signals in domains other than the main domain

### DIFF
--- a/otherlibs/systhreads/thread.mli
+++ b/otherlibs/systhreads/thread.mli
@@ -161,7 +161,7 @@ val wait_pid : int -> int * Unix.process_status
   Per-thread signal masks are supported only by the system thread library
   under Unix, but not under Win32, nor by the VM thread library. *)
 
-val sigmask : Unix.sigprocmask_command -> int list -> int list
+val sigmask : Unix.sigprocmask_command -> int list -> int list @@ nonportable
 (** [sigmask cmd sigs] changes the set of blocked signals for the
    calling thread.
    If [cmd] is [SIG_SETMASK], blocked signals are set to those in
@@ -170,7 +170,13 @@ val sigmask : Unix.sigprocmask_command -> int list -> int list
    the set of blocked signals.
    If [cmd] is [SIG_UNBLOCK], the signals in [sigs] are removed
    from the set of blocked signals.
-   [sigmask] returns the set of previously blocked signals for the thread. *)
+   [sigmask] returns the set of previously blocked signals for the thread.
+
+   This function is nonportable because signal handlers themselves are not
+   required to be portable - we mask all signals on domains other than the main
+   domain so that signal handlers are only executed on the main domain, and it
+   is unsafe to unmask signals on domains other than the main domain.
+*)
 
 
 val wait_signal : int list -> int

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -1163,7 +1163,7 @@ type sigprocmask_command =
   | SIG_BLOCK
   | SIG_UNBLOCK
 
-val sigprocmask : sigprocmask_command -> int list -> int list
+val sigprocmask : sigprocmask_command -> int list -> int list @@ nonportable
 (** [sigprocmask mode sigs] changes the set of blocked signals.
    If [mode] is [SIG_SETMASK], blocked signals are set to those in
    the list [sigs].
@@ -1176,6 +1176,11 @@ val sigprocmask : sigprocmask_command -> int list -> int list
    When the systhreads version of the [Thread] module is loaded, this
    function redirects to [Thread.sigmask]. I.e., [sigprocmask] only
    changes the mask of the current thread.
+
+   This function is nonportable because signal handlers themselves are not
+   required to be portable - we mask all signals on domains other than the main
+   domain so that signal handlers are only executed on the main domain, and it
+   is unsafe to change this sigmask on domains other than the main domain.
 
    @raise Invalid_argument on Windows (no inter-process signals on
    Windows) *)

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -1160,8 +1160,8 @@ type sigprocmask_command = Unix.sigprocmask_command =
   | SIG_BLOCK
   | SIG_UNBLOCK
 
-val sigprocmask : mode:sigprocmask_command -> int list -> int list
-(** [sigprocmask ~mode sigs] changes the set of blocked signals.
+val sigprocmask : sigprocmask_command -> int list -> int list @@ nonportable
+(** [sigprocmask mode sigs] changes the set of blocked signals.
    If [mode] is [SIG_SETMASK], blocked signals are set to those in
    the list [sigs].
    If [mode] is [SIG_BLOCK], the signals in [sigs] are added to
@@ -1173,6 +1173,11 @@ val sigprocmask : mode:sigprocmask_command -> int list -> int list
    When the systhreads version of the [Thread] module is loaded, this
    function redirects to [Thread.sigmask]. I.e., [sigprocmask] only
    changes the mask of the current thread.
+
+   This function is nonportable because signal handlers themselves are not
+   required to be portable - we mask all signals on domains other than the main
+   domain so that signal handlers are only executed on the main domain, and it
+   is unsafe to change this sigmask on domains other than the main domain.
 
    @raise Invalid_argument on Windows (no inter-process signals on
    Windows) *)

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -261,7 +261,6 @@ type signal_behavior =
 
 external signal :
   int -> signal_behavior -> signal_behavior @@ nonportable = "caml_install_signal_handler"
-[@@alert unsafe_multidomain "Use [Sys.Safe.signal]."]
 (** Set the behavior of the system on receipt of a given signal.  The
    first argument is the signal number.  Return the behavior
    previously associated with the signal. If the signal number is

--- a/testsuite/tests/lib-domain/signals.ml
+++ b/testsuite/tests/lib-domain/signals.ml
@@ -1,0 +1,55 @@
+(* TEST
+   flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
+   include systhreads;
+   runtime5;
+   hassysthreads;
+   multidomain;
+   { bytecode; }
+   { native; }
+*)
+
+(*
+   This test checks that signals are masked in all threads that are not part of the main
+   domain
+*)
+
+let get_sigmask () = Thread.sigmask SIG_BLOCK []
+let string_of_sigmask () =
+  match get_sigmask () with
+  | [] -> "<empty>"
+  | sigmask ->
+    sigmask
+    |> List.sort (Int.compare)
+    |> List.map string_of_int
+    |> String.concat ", "
+let print_sigmask prefix =
+  Printf.printf "%s %s\n" prefix (string_of_sigmask ())
+
+let () = print_sigmask "sigmask from toplevel:"
+
+let () =
+  Thread.create
+    (fun () -> print_sigmask "sigmask from thread in main domain:")
+    ()
+  |> Thread.join
+
+let () =
+  Domain.spawn
+    (fun () ->
+       print_sigmask "sigmask from main thread in child domain:";
+       Thread.create
+         (fun () -> print_sigmask "sigmask from other thread in child domain:")
+         ()
+       |> Thread.join
+    )
+  |> Domain.join
+
+(* Make sure we properly cleared the mask after spawning the thread *)
+
+let () = print_sigmask "sigmask from toplevel again:"
+
+let () =
+  Thread.create
+    (fun () -> print_sigmask "sigmask from thread in main domain again:")
+    ()
+  |> Thread.join

--- a/testsuite/tests/lib-domain/signals.reference
+++ b/testsuite/tests/lib-domain/signals.reference
@@ -1,0 +1,6 @@
+sigmask from toplevel: <empty>
+sigmask from thread in main domain: <empty>
+sigmask from main thread in child domain: -28, -27, -26, -25, -24, -23, -22, -21, -20, -19, -18, -17, -15, -14, -13, -12, -11, -10, -9, -8, -6, -5, -4, -3, -2, -1, 16, 28, 30, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64
+sigmask from other thread in child domain: -28, -27, -26, -25, -24, -23, -22, -21, -20, -19, -18, -17, -15, -14, -13, -12, -11, -10, -9, -8, -6, -5, -4, -3, -2, -1, 16, 28, 30, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64
+sigmask from toplevel again: <empty>
+sigmask from thread in main domain again: <empty>


### PR DESCRIPTION
Previously, we had annotated the function to register a non-portable signal handler using the `unsafe-multidomain` alert, and exposed a "Safe" version of signal handler registration that always required a portable signal handler. In practice, however, too many real-world signal handlers are domain-unsafe to make this practical to adopt - and the domain unsafety is real, having already caused undefined behavior in real-world applications that had silenced the `unsafe-multidomain` alert.

As an alternative, this change uses `pthread_sigmask` to mask all signals in domains other than the initial domain, so that only the initial domain receives signals, and annotates `sigmask` and `sigprocmask` as nonportable so that it is unsafe to *un*mask signals on domains other than the initial domain. Threads other than the main thread in thse child domains inherit the sigmask from the thread they're spawned in, and there's no way (as far as I'm aware) currently to spawn threads in domains other than the current domain, so those don't need any special treatment here. There's a new test checking this fact.

Since signal handlers can still be registered /from/ any domain, the function for registering a nonportable signal handler is still annotated as nonportable (so that the nonportable function you are registering is required to be owned by the initial capsule), but the unsafe_multidomain alert has been removed since this is now sound.

One alternative that was considered was to not mask signals in domains other than the initial one, but instead only execute the ocaml part of signal handlers in the initial domain. I didn't implement this primarily because it felt more complex and harder to do, but it might be worth considering if C libraries want to be able to execute signal handlers on threads spawned from non-initial domains.