### PR TITLE
Operations on `Mutex` and `Condition` do not let things escape

### DIFF
--- a/stdlib/condition.ml
+++ b/stdlib/condition.ml
@@ -17,6 +17,8 @@ open! Stdlib
 
 type t : value mod portable contended
 external create: unit -> t @@ portable = "caml_ml_condition_new"
-external wait: t -> Mutex.t -> unit @@ portable = "caml_ml_condition_wait"
-external signal: t -> unit @@ portable = "caml_ml_condition_signal"
-external broadcast: t -> unit @@ portable = "caml_ml_condition_broadcast"
+external wait:
+  t @ local -> Mutex.t @ local -> unit @@ portable = "caml_ml_condition_wait"
+external signal: t @ local -> unit @@ portable = "caml_ml_condition_signal"
+external broadcast:
+  t @ local -> unit @@ portable = "caml_ml_condition_broadcast"

--- a/stdlib/condition.mli
+++ b/stdlib/condition.mli
@@ -152,7 +152,7 @@ val create : unit -> t
    with a certain mutex [m] and with a certain property {i P} of the data
    structure that is protected by the mutex [m]. *)
 
-val wait : t -> Mutex.t -> unit
+val wait : t @ local -> Mutex.t @ local -> unit
 (**The call [wait c m] is permitted only if [m] is the mutex associated
    with the condition variable [c], and only if [m] is currently locked.
    This call atomically unlocks the mutex [m] and suspends the
@@ -164,7 +164,7 @@ val wait : t -> Mutex.t -> unit
    variable [c] holds when [wait] returns; one must explicitly test
    whether {i P} holds after calling [wait]. *)
 
-val signal : t -> unit
+val signal : t @ local -> unit
 (**[signal c] wakes up one of the threads waiting on the condition
    variable [c], if there is one. If there is none, this call has
    no effect.
@@ -172,7 +172,7 @@ val signal : t -> unit
    It is recommended to call [signal c] inside a critical section,
    that is, while the mutex [m] associated with [c] is locked. *)
 
-val broadcast : t -> unit
+val broadcast : t @ local -> unit
 (**[broadcast c] wakes up all threads waiting on the condition
    variable [c]. If there are none, this call has no effect.
 

--- a/stdlib/mutex.ml
+++ b/stdlib/mutex.ml
@@ -15,9 +15,9 @@
 
 type t : value mod portable contended
 external create: unit -> t @@ portable = "caml_ml_mutex_new"
-external lock: t -> unit @@ portable = "caml_ml_mutex_lock"
-external try_lock: t -> bool @@ portable = "caml_ml_mutex_try_lock"
-external unlock: t -> unit @@ portable = "caml_ml_mutex_unlock"
+external lock: t @ local -> unit @@ portable = "caml_ml_mutex_lock"
+external try_lock: t @ local -> bool @@ portable = "caml_ml_mutex_try_lock"
+external unlock: t @ local -> unit @@ portable = "caml_ml_mutex_unlock"
 
 (* private re-export *)
 external reraise : exn -> 'a @@ portable = "%reraise"

--- a/stdlib/mutex.mli
+++ b/stdlib/mutex.mli
@@ -34,7 +34,7 @@ type t : value mod portable contended
 val create : unit -> t
 (** Return a new mutex. *)
 
-val lock : t -> unit
+val lock : t @ local -> unit
 (** Lock the given mutex. Only one thread can have the mutex locked
    at any time. A thread that attempts to lock a mutex already locked
    by another thread will suspend until the other thread unlocks
@@ -46,13 +46,13 @@ val lock : t -> unit
    @before 4.12 {!Sys_error} was not raised for recursive locking
    (platform-dependent behaviour) *)
 
-val try_lock : t -> bool
+val try_lock : t @ local -> bool
 (** Same as {!Mutex.lock}, but does not suspend the calling thread if
    the mutex is already locked: just return [false] immediately
    in that case. If the mutex is unlocked, lock it and
    return [true]. *)
 
-val unlock : t -> unit
+val unlock : t @ local -> unit
 (** Unlock the given mutex. Other threads suspended trying to lock
    the mutex will restart.  The mutex must have been previously locked
    by the thread that calls {!Mutex.unlock}.
@@ -61,7 +61,7 @@ val unlock : t -> unit
    @before 4.12 {!Sys_error} was not raised when unlocking an unlocked mutex
    or when unlocking a mutex from a different thread. *)
 
-val protect : t -> (unit -> 'a) -> 'a
+val protect : t @ local -> (unit -> 'a) @ local -> 'a
 (** [protect mutex f] runs [f()] in a critical section where [mutex]
     is locked (using {!lock}); it then takes care of releasing [mutex],
     whether [f()] returned a value or raised an exception.


### PR DESCRIPTION
This marks operations on `Mutex` and `Condition` as taking their arguments as `@ local`, i.e. the arguments do not escape.