### PR TITLE
Convert flambda2 API tests to diff tests

### DIFF
--- a/middle_end/flambda2/tests/api_tests/datalog.expected
+++ b/middle_end/flambda2/tests/api_tests/datalog.expected
@@ -1,0 +1,48 @@
+Database:
+  marked
+  ======
+  marked(node:1).
+  
+  edge
+  ====
+  edge(node:1, node:2).
+  edge(node:2, node:5).
+  edge(node:3, node:2).
+  edge(node:4, node:2).
+  edge(node:4, node:4).
+  edge(node:5, node:4).
+
+Marked nodes:
+  - node:1
+  
+Successors of node:1 (with cursor):
+  (node:2)
+
+Successors of node:1 (direct access):
+  (node:2)
+
+Successors of node:2 (parameterized):
+  (node:5)
+
+Predecessors of node:2 (parameterized):
+  - node:1
+  - node:3
+  - node:4
+  
+Database after schedule:
+  marked
+  ======
+  marked(node:1).
+  marked(node:2).
+  marked(node:4).
+  marked(node:5).
+  
+  edge
+  ====
+  edge(node:1, node:2).
+  edge(node:2, node:5).
+  edge(node:3, node:2).
+  edge(node:4, node:2).
+  edge(node:4, node:4).
+  edge(node:5, node:4).
+

--- a/middle_end/flambda2/tests/api_tests/dune
+++ b/middle_end/flambda2/tests/api_tests/dune
@@ -1,5 +1,18 @@
-(tests
- (names extension_meet)
+(rule
+ (target extension_meet.output)
+ (deps extension_meet.exe)
+ (action
+  (with-stderr-to
+   %{target}
+   (run %{deps}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff extension_meet.expected extension_meet.output)))
+
+(executable
+ (name extension_meet)
  (modes native)
  (instrumentation (backend bisect_ppx))
  (modules extension_meet)
@@ -8,9 +21,22 @@
   flambda2_bound_identifiers flambda2_cmx flambda2_identifiers flambda2_kinds
   flambda2_nominal flambda2_numbers flambda2_term_basics flambda2_types))
 
-(tests
-  (names datalog)
-  (modes native)
-  (instrumentation (backend bisect_ppx))
-  (modules datalog)
-  (libraries flambda2_datalog))
+(rule
+ (target datalog.output)
+ (deps datalog.exe)
+ (action
+  (with-stderr-to
+   %{target}
+   (run %{deps}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff datalog.expected datalog.output)))
+
+(executable
+ (name datalog)
+ (modes native)
+ (instrumentation (backend bisect_ppx))
+ (modules datalog)
+ (libraries flambda2_datalog))

--- a/middle_end/flambda2/tests/api_tests/extension_meet.expected
+++ b/middle_end/flambda2/tests/api_tests/extension_meet.expected
@@ -1,0 +1,52 @@
+Environment: ((defined_symbols { }) (code_age_relation {})
+              (levels
+               ((scope 1) (defined_vars
+                {([0m[38;5;111;1mz/2N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mx/0N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1my/1N[0m :: [0m[38;5;37;1m𝕍[0m Normal)}))
+               ((defined_vars { z/2N x/0N y/1N })
+                (equations
+                 ([0m[38;5;111;1mz/2N[0m :
+                   (Val!
+                    (Variant
+                     (blocks (alloc_mode Heap)
+                      (known
+                       {(tag_0 => (Known 3),
+                         ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mz/2N[0m)) (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mx/0N[0m)) (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1my/1N[0m))))}))))
+                  [0m[38;5;111;1mx/0N[0m :
+                   (Val!
+                    (Variant
+                     (blocks (alloc_mode Heap)
+                      (known
+                       {(tag_0 => (Known 3),
+                         ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mx/0N[0m)) (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1my/1N[0m)) (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mz/2N[0m))))}))))
+                  [0m[38;5;111;1my/1N[0m :
+                   (Val!
+                    (Variant
+                     (blocks (alloc_mode Heap)
+                      (known
+                       {(tag_0 => (Known 3),
+                         ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1my/1N[0m)) (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mz/2N[0m)) (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mx/0N[0m))))})))))))))
+              (aliases
+               ((canonical_elements {}) (aliases_of_canonical_names {})
+                (aliases_of_consts {}))))
+Result type: (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mx/0N[0m))
+New environment:
+((defined_symbols { }) (code_age_relation {})
+ (levels
+  ((scope 1) (defined_vars
+   {([0m[38;5;111;1mz/2N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mx/0N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1my/1N[0m :: [0m[38;5;37;1m𝕍[0m Normal)}))
+  ((defined_vars { z/2N x/0N y/1N })
+   (equations
+    ([0m[38;5;111;1mz/2N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mx/0N[0m))
+     [0m[38;5;111;1mx/0N[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known
+          {(tag_0 => (Known 3),
+            ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mx/0N[0m)) (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1my/1N[0m)) (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mz/2N[0m))))}))))
+     [0m[38;5;111;1my/1N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mx/0N[0m)))))))
+ (aliases
+  ((canonical_elements
+    {([0m[38;5;111;1mz/2N[0m ([0m[38;5;111;1mx/0N[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m)) ([0m[38;5;111;1my/1N[0m ([0m[38;5;111;1mx/0N[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))})
+   (aliases_of_canonical_names {([0m[38;5;111;1mx/0N[0m {(Normal {([0m[38;5;111;1mz/2N[0m [0m[38;5;243;1mid[0m) ([0m[38;5;111;1my/1N[0m [0m[38;5;243;1mid[0m)})})})
+   (aliases_of_consts {}))))

--- a/middle_end/flambda2/tests/dune
+++ b/middle_end/flambda2/tests/dune
@@ -1,5 +1,18 @@
-(tests
- (names meet_test)
+(rule
+ (target meet_test.output)
+ (deps meet_test.exe)
+ (action
+  (with-stderr-to
+   %{target}
+   (run %{deps}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff meet_test.expected meet_test.output)))
+
+(executable
+ (name meet_test)
  (modes native)
  (instrumentation (backend bisect_ppx))
  (libraries

--- a/middle_end/flambda2/tests/meet_test.expected
+++ b/middle_end/flambda2/tests/meet_test.expected
@@ -1,0 +1,451 @@
+MEET CHAINS WITH TWO VARS
+
+Initial situation:
+((defined_symbols { [0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m })
+ (code_age_relation {})
+ (levels
+  ((scope 1) (defined_vars {([0m[38;5;111;1mvar2/1N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mvar1/0N[0m :: [0m[38;5;37;1m𝕍[0m Normal)}))
+  ((defined_vars { var2/1N var1/0N })
+   (equations
+    ([0m[38;5;111;1mvar2/1N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mvar1/0N[0m))
+     [0m[38;5;111;1mvar1/0N[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known {(tag_0 => (Known 1), ((Val! (Variant (tagged_imms [0m[38;5;37;1m⊤[0m)))))})))))))))
+ (aliases
+  ((canonical_elements {([0m[38;5;111;1mvar2/1N[0m ([0m[38;5;111;1mvar1/0N[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))})
+   (aliases_of_canonical_names {([0m[38;5;111;1mvar1/0N[0m {(Normal {([0m[38;5;111;1mvar2/1N[0m [0m[38;5;243;1mid[0m)})})})
+   (aliases_of_consts {}))))
+New knowledge:
+var2/1N : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m))
+Extended env:
+((defined_symbols { [0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m })
+ (code_age_relation {})
+ (levels
+  ((scope 1) (defined_vars {([0m[38;5;111;1mvar2/1N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mvar1/0N[0m :: [0m[38;5;37;1m𝕍[0m Normal)}))
+  ((defined_vars { var2/1N var1/0N })
+   (equations
+    ([0m[38;5;111;1mvar2/1N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mvar1/0N[0m))
+     [0m[38;5;111;1mvar1/0N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m))
+     [0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known {(tag_0 => (Known 1), ((Val! (Variant (tagged_imms [0m[38;5;37;1m⊤[0m)))))})))))))))
+ (aliases
+  ((canonical_elements
+    {([0m[38;5;111;1mvar2/1N[0m ([0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))
+     ([0m[38;5;111;1mvar1/0N[0m ([0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))})
+   (aliases_of_canonical_names
+    {([0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m
+      {(Normal {([0m[38;5;111;1mvar2/1N[0m [0m[38;5;243;1mid[0m) ([0m[38;5;111;1mvar1/0N[0m [0m[38;5;243;1mid[0m)})})}) (aliases_of_consts {}))))
+Final situation:
+((defined_symbols { [0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m })
+ (code_age_relation {})
+ (levels
+  ((scope 1) (defined_vars {([0m[38;5;111;1mvar2/1N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mvar1/0N[0m :: [0m[38;5;37;1m𝕍[0m Normal)}))
+  ((defined_vars { var2/1N var1/0N })
+   (equations
+    ([0m[38;5;111;1mvar2/1N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mvar1/0N[0m))
+     [0m[38;5;111;1mvar1/0N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m))
+     [0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known {(tag_0 => (Known 1), ((Val! (Variant (tagged_imms [0m[38;5;37;1m⊤[0m)))))})))))))))
+ (aliases
+  ((canonical_elements
+    {([0m[38;5;111;1mvar2/1N[0m ([0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))
+     ([0m[38;5;111;1mvar1/0N[0m ([0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))})
+   (aliases_of_canonical_names
+    {([0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m
+      {(Normal {([0m[38;5;111;1mvar2/1N[0m [0m[38;5;243;1mid[0m) ([0m[38;5;111;1mvar1/0N[0m [0m[38;5;243;1mid[0m)})})}) (aliases_of_consts {}))))
+
+MEET CHAINS WITH THREE VARS
+
+Initial situation:
+((defined_symbols { [0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m })
+ (code_age_relation {})
+ (levels
+  ((scope 1) (defined_vars
+   {([0m[38;5;111;1mvar3/4N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mvar1/2N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mvar2/3N[0m :: [0m[38;5;37;1m𝕍[0m Normal)}))
+  ((defined_vars { var3/4N var1/2N var2/3N })
+   (equations
+    ([0m[38;5;111;1mvar3/4N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mvar1/2N[0m))
+     [0m[38;5;111;1mvar1/2N[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known {(tag_0 => (Known 1), ((Val! (Variant (tagged_imms [0m[38;5;37;1m⊤[0m)))))}))))
+     [0m[38;5;111;1mvar2/3N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mvar1/2N[0m)))))))
+ (aliases
+  ((canonical_elements
+    {([0m[38;5;111;1mvar3/4N[0m ([0m[38;5;111;1mvar1/2N[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m)) ([0m[38;5;111;1mvar2/3N[0m ([0m[38;5;111;1mvar1/2N[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))})
+   (aliases_of_canonical_names
+    {([0m[38;5;111;1mvar1/2N[0m {(Normal {([0m[38;5;111;1mvar3/4N[0m [0m[38;5;243;1mid[0m) ([0m[38;5;111;1mvar2/3N[0m [0m[38;5;243;1mid[0m)})})})
+   (aliases_of_consts {}))))
+New knowledge:
+var3/4N : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m))
+Extended env:
+((defined_symbols { [0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m })
+ (code_age_relation {})
+ (levels
+  ((scope 1) (defined_vars
+   {([0m[38;5;111;1mvar3/4N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mvar1/2N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mvar2/3N[0m :: [0m[38;5;37;1m𝕍[0m Normal)}))
+  ((defined_vars { var3/4N var1/2N var2/3N })
+   (equations
+    ([0m[38;5;111;1mvar3/4N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mvar1/2N[0m))
+     [0m[38;5;111;1mvar1/2N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m))
+     [0m[38;5;111;1mvar2/3N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mvar1/2N[0m))
+     [0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known {(tag_0 => (Known 1), ((Val! (Variant (tagged_imms [0m[38;5;37;1m⊤[0m)))))})))))))))
+ (aliases
+  ((canonical_elements
+    {([0m[38;5;111;1mvar3/4N[0m ([0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))
+     ([0m[38;5;111;1mvar1/2N[0m ([0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))
+     ([0m[38;5;111;1mvar2/3N[0m ([0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))})
+   (aliases_of_canonical_names
+    {([0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m
+      {(Normal {([0m[38;5;111;1mvar3/4N[0m [0m[38;5;243;1mid[0m) ([0m[38;5;111;1mvar1/2N[0m [0m[38;5;243;1mid[0m) ([0m[38;5;111;1mvar2/3N[0m [0m[38;5;243;1mid[0m)})})})
+   (aliases_of_consts {}))))
+Final situation:
+((defined_symbols { [0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m })
+ (code_age_relation {})
+ (levels
+  ((scope 1) (defined_vars
+   {([0m[38;5;111;1mvar3/4N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mvar1/2N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mvar2/3N[0m :: [0m[38;5;37;1m𝕍[0m Normal)}))
+  ((defined_vars { var3/4N var1/2N var2/3N })
+   (equations
+    ([0m[38;5;111;1mvar3/4N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mvar1/2N[0m))
+     [0m[38;5;111;1mvar1/2N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m))
+     [0m[38;5;111;1mvar2/3N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mvar1/2N[0m))
+     [0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known {(tag_0 => (Known 1), ((Val! (Variant (tagged_imms [0m[38;5;37;1m⊤[0m)))))})))))))))
+ (aliases
+  ((canonical_elements
+    {([0m[38;5;111;1mvar3/4N[0m ([0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))
+     ([0m[38;5;111;1mvar1/2N[0m ([0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))
+     ([0m[38;5;111;1mvar2/3N[0m ([0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))})
+   (aliases_of_canonical_names
+    {([0m[38;5;111;1m[0m[38;5;98;1mMeet_test.camlMeet_test__my_symbol[0m[38;5;111;1m[0m
+      {(Normal {([0m[38;5;111;1mvar3/4N[0m [0m[38;5;243;1mid[0m) ([0m[38;5;111;1mvar1/2N[0m [0m[38;5;243;1mid[0m) ([0m[38;5;111;1mvar2/3N[0m [0m[38;5;243;1mid[0m)})})})
+   (aliases_of_consts {}))))
+
+MEET VARIANT
+
+Meet:
+  (Val!
+   (Variant
+    (blocks (alloc_mode Heap)
+     (known
+      {(tag_0 => (Known 1), ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mx/5N[0m))))
+       (tag_1 => (Known 1), ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1my/6N[0m))))})))) /\
+  (Val!
+   (Variant
+    (blocks (alloc_mode Heap)
+     (known
+      {(tag_0 => (Known 1), ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1ma/7N[0m))))
+       (tag_1 => (Known 1), ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mb/8N[0m))))})))) =>
+  (Val!
+   (Variant
+    (blocks (alloc_mode Heap)
+     (known
+      {(tag_0 => (Known 1), ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mx/5N[0m)))
+        (equations ([0m[38;5;111;1ma/7N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mx/5N[0m)))))
+       (tag_1 => (Known 1), ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1my/6N[0m)))
+        (equations ([0m[38;5;111;1mb/8N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1my/6N[0m)))))})))) +
+  ((defined_symbols { }) (code_age_relation {})
+   (levels
+    ((scope 1) (defined_vars
+     {([0m[38;5;111;1ma/7N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mx/5N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mvariant/9N[0m :: [0m[38;5;37;1m𝕍[0m Normal)
+      ([0m[38;5;111;1mb/8N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1my/6N[0m :: [0m[38;5;37;1m𝕍[0m Normal)}))
+    ((defined_vars { a/7N x/5N variant/9N b/8N y/6N }) (equations ()))))
+   (aliases
+    ((canonical_elements {}) (aliases_of_canonical_names {})
+     (aliases_of_consts {}))))
+meet: (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;70;1m#1[0m))
+env:
+  ((defined_symbols { }) (code_age_relation {})
+   (levels
+    ((scope 1) (defined_vars
+     {([0m[38;5;111;1ma/7N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mx/5N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mvariant/9N[0m :: [0m[38;5;37;1m𝕍[0m Normal)
+      ([0m[38;5;111;1mnaked/10N[0m :: [0m[38;5;37;1mℕ𝕚[0m Normal) ([0m[38;5;111;1mb/8N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1my/6N[0m :: [0m[38;5;37;1m𝕍[0m Normal)}))
+    ((defined_vars { a/7N x/5N variant/9N naked/10N b/8N y/6N })
+     (equations
+      ([0m[38;5;111;1mvariant/9N[0m :
+        (Val!
+         (Variant
+          (blocks (alloc_mode Heap)
+           (known
+            {(tag_1 => (Known 1), ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1my/6N[0m)))
+              (equations ([0m[38;5;111;1mb/8N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1my/6N[0m)))))}))))
+       [0m[38;5;111;1mnaked/10N[0m : (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;70;1m#1[0m))
+       [0m[38;5;111;1mb/8N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1my/6N[0m)))))))
+   (aliases
+    ((canonical_elements
+      {([0m[38;5;111;1mnaked/10N[0m ([0m[38;5;70;1m#1[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m)) ([0m[38;5;111;1mb/8N[0m ([0m[38;5;111;1my/6N[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))})
+     (aliases_of_canonical_names {([0m[38;5;111;1my/6N[0m {(Normal {([0m[38;5;111;1mb/8N[0m [0m[38;5;243;1mid[0m)})})})
+     (aliases_of_consts {([0m[38;5;70;1m#1[0m {(Normal {([0m[38;5;111;1mnaked/10N[0m [0m[38;5;243;1mid[0m)})})}))))
+
+MEET TWO BLOCKS
+
+Res:
+(Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mblock1/11N[0m))
+Env:
+((defined_symbols { }) (code_age_relation {})
+ (levels
+  ((scope 1) (defined_vars
+   {([0m[38;5;111;1mfield1/12N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mblock2/13N[0m :: [0m[38;5;37;1m𝕍[0m Normal)
+    ([0m[38;5;111;1mblock1/11N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mfield2/14N[0m :: [0m[38;5;37;1m𝕍[0m Normal)}))
+  ((defined_vars { field1/12N block2/13N block1/11N field2/14N })
+   (equations
+    ([0m[38;5;111;1mblock2/13N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mblock1/11N[0m))
+     [0m[38;5;111;1mblock1/11N[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known {(tag_0 => (Known 1), ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mfield1/12N[0m))))}))))
+     [0m[38;5;111;1mfield2/14N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mfield1/12N[0m)))))))
+ (aliases
+  ((canonical_elements
+    {([0m[38;5;111;1mblock2/13N[0m ([0m[38;5;111;1mblock1/11N[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))
+     ([0m[38;5;111;1mfield2/14N[0m ([0m[38;5;111;1mfield1/12N[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))})
+   (aliases_of_canonical_names
+    {([0m[38;5;111;1mfield1/12N[0m {(Normal {([0m[38;5;111;1mfield2/14N[0m [0m[38;5;243;1mid[0m)})})
+     ([0m[38;5;111;1mblock1/11N[0m {(Normal {([0m[38;5;111;1mblock2/13N[0m [0m[38;5;243;1mid[0m)})})}) (aliases_of_consts {}))))
+
+Res:
+(Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mblock2/13N[0m))
+Env:
+((defined_symbols { }) (code_age_relation {})
+ (levels
+  ((scope 1) (defined_vars
+   {([0m[38;5;111;1mfield1/12N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mblock2/13N[0m :: [0m[38;5;37;1m𝕍[0m Normal)
+    ([0m[38;5;111;1mblock1/11N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mfield2/14N[0m :: [0m[38;5;37;1m𝕍[0m Normal)}))
+  ((defined_vars { field1/12N block2/13N block1/11N field2/14N })
+   (equations
+    ([0m[38;5;111;1mblock2/13N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mblock1/11N[0m))
+     [0m[38;5;111;1mblock1/11N[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known {(tag_0 => (Known 1), ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mfield1/12N[0m))))}))))
+     [0m[38;5;111;1mfield2/14N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mfield1/12N[0m)))))))
+ (aliases
+  ((canonical_elements
+    {([0m[38;5;111;1mblock2/13N[0m ([0m[38;5;111;1mblock1/11N[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))
+     ([0m[38;5;111;1mfield2/14N[0m ([0m[38;5;111;1mfield1/12N[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))})
+   (aliases_of_canonical_names
+    {([0m[38;5;111;1mfield1/12N[0m {(Normal {([0m[38;5;111;1mfield2/14N[0m [0m[38;5;243;1mid[0m)})})
+     ([0m[38;5;111;1mblock1/11N[0m {(Normal {([0m[38;5;111;1mblock2/13N[0m [0m[38;5;243;1mid[0m)})})}) (aliases_of_consts {}))))
+
+
+MEET ALIAS TO RECOVER 
+
+first type:
+  (Val!
+   (Variant
+    (tagged_imms (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;70;1m#0[0m)))
+    (blocks (alloc_mode Heap) (known {(tag_0 => (Known 0), ())}))))
+second type: (Val! (Variant (tagged_imms [0m[38;5;37;1m⊤[0m)))
+after meet: (Val ([0m[38;5;160;1m=[0m [0m[38;5;70;1m0[0m))
+
+MEET BOTTOM AFTER ALIAS
+
+first type: (Val! (Variant (tagged_imms (Naked_immediate ({ -1 0 1 })))))
+second type: (Val ([0m[38;5;160;1m=[0m [0m[38;5;70;1m3[0m))
+after meet: (Val [0m[38;5;37;1m⊥[0m)
+
+JOIN WITH EXTENSIONS
+
+Left:
+((defined_symbols { }) (code_age_relation {})
+ (levels
+  ((scope 2)
+  ((equations
+    ([0m[38;5;111;1my/17N[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known
+          {(tag_0 => (Known 1),
+            ((Val! (Variant (tagged_imms (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1ma/19N[0m)))))))
+           (tag_1 => (Known 0), ())}))))
+     [0m[38;5;111;1mx/18N[0m : (Val! (Variant (tagged_imms (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1ma/19N[0m))))))))))
+  ((scope 1) (defined_vars
+   {([0m[38;5;111;1mb/20N[0m :: [0m[38;5;37;1mℕ𝕚[0m Normal) ([0m[38;5;111;1ma/19N[0m :: [0m[38;5;37;1mℕ𝕚[0m Normal) ([0m[38;5;111;1my/17N[0m :: [0m[38;5;37;1m𝕍[0m Normal)
+    ([0m[38;5;111;1mx/18N[0m :: [0m[38;5;37;1m𝕍[0m Normal)}))
+  ((defined_vars { b/20N a/19N y/17N x/18N })
+   (equations
+    ([0m[38;5;111;1my/17N[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known {(tag_0 => (Known 1), ((Val [0m[38;5;37;1m⊤[0m))) (tag_1 => (Known 0), ())})))))))))
+ (aliases
+  ((canonical_elements {}) (aliases_of_canonical_names {})
+   (aliases_of_consts {}))))
+Right:
+((defined_symbols { }) (code_age_relation {})
+ (levels
+  ((scope 2)
+  ((equations
+    ([0m[38;5;111;1my/17N[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known
+          {(tag_0 => (Known 1),
+            ((Val! (Variant (tagged_imms (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1ma/19N[0m))))))
+            (equations ([0m[38;5;111;1mb/20N[0m : (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1ma/19N[0m)))))
+           (tag_1 => (Known 0), ())}))))
+     [0m[38;5;111;1mx/18N[0m : (Val! (Variant (tagged_imms (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1mb/20N[0m))))))))))
+  ((scope 1) (defined_vars
+   {([0m[38;5;111;1mb/20N[0m :: [0m[38;5;37;1mℕ𝕚[0m Normal) ([0m[38;5;111;1ma/19N[0m :: [0m[38;5;37;1mℕ𝕚[0m Normal) ([0m[38;5;111;1my/17N[0m :: [0m[38;5;37;1m𝕍[0m Normal)
+    ([0m[38;5;111;1mx/18N[0m :: [0m[38;5;37;1m𝕍[0m Normal)}))
+  ((defined_vars { b/20N a/19N y/17N x/18N })
+   (equations
+    ([0m[38;5;111;1my/17N[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known {(tag_0 => (Known 1), ((Val [0m[38;5;37;1m⊤[0m))) (tag_1 => (Known 0), ())})))))))))
+ (aliases
+  ((canonical_elements {}) (aliases_of_canonical_names {})
+   (aliases_of_consts {}))))
+Res:
+((defined_symbols { }) (code_age_relation {})
+ (levels
+  ((scope 2)
+  ((equations
+    ([0m[38;5;111;1my/17N[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known
+          {(tag_0 => (Known 1),
+            ((Val! (Variant (tagged_imms (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1ma/19N[0m)))))))
+           (tag_1 => (Known 0), ())}))))
+     [0m[38;5;111;1mx/18N[0m : (Val! (Variant (tagged_imms (Naked_immediate [0m[38;5;37;1m⊤[0m)))))))))
+  ((scope 1) (defined_vars
+   {([0m[38;5;111;1mb/20N[0m :: [0m[38;5;37;1mℕ𝕚[0m Normal) ([0m[38;5;111;1ma/19N[0m :: [0m[38;5;37;1mℕ𝕚[0m Normal) ([0m[38;5;111;1my/17N[0m :: [0m[38;5;37;1m𝕍[0m Normal)
+    ([0m[38;5;111;1mx/18N[0m :: [0m[38;5;37;1m𝕍[0m Normal)}))
+  ((defined_vars { b/20N a/19N y/17N x/18N })
+   (equations
+    ([0m[38;5;111;1my/17N[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known {(tag_0 => (Known 1), ((Val [0m[38;5;37;1m⊤[0m))) (tag_1 => (Known 0), ())})))))))))
+ (aliases
+  ((canonical_elements {}) (aliases_of_canonical_names {})
+   (aliases_of_consts {}))))
+
+JOIN WITH COMPLEX EXTENSIONS
+
+Left:
+((defined_symbols { }) (code_age_relation {})
+ (levels
+  ((scope 2)
+  ((equations
+    ([0m[38;5;111;1mw/23N[0m : (Val! (Variant (tagged_imms (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1ma/25N[0m)))))
+     [0m[38;5;111;1mz/24N[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known
+          {(tag_0 => (Known 2),
+            ((Val! (Variant (tagged_imms (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1mb/26N[0m)))))
+             (Val! (Variant (tagged_imms (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1mb/26N[0m)))))))
+           (tag_1 => (Known 0), ())}))))
+     [0m[38;5;111;1my/21N[0m : (Val! (Variant (tagged_imms (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1ma/25N[0m)))))
+     [0m[38;5;111;1mx/22N[0m : (Val! (Variant (tagged_imms (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1ma/25N[0m))))))))))
+  ((scope 1) (defined_vars
+   {([0m[38;5;111;1mw/23N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1md/28N[0m :: [0m[38;5;37;1mℕ𝕚[0m Normal) ([0m[38;5;111;1ma/25N[0m :: [0m[38;5;37;1mℕ𝕚[0m Normal)
+    ([0m[38;5;111;1mz/24N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1my/21N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mx/22N[0m :: [0m[38;5;37;1m𝕍[0m Normal)
+    ([0m[38;5;111;1mb/26N[0m :: [0m[38;5;37;1mℕ𝕚[0m Normal) ([0m[38;5;111;1mc/27N[0m :: [0m[38;5;37;1mℕ𝕚[0m Normal)}))
+  ((defined_vars { w/23N d/28N a/25N z/24N y/21N x/22N b/26N c/27N })
+   (equations
+    ([0m[38;5;111;1mz/24N[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known
+          {(tag_0 => (Known 2), ((Val [0m[38;5;37;1m⊤[0m) (Val [0m[38;5;37;1m⊤[0m))) (tag_1 => (Known 0), ())})))))))))
+ (aliases
+  ((canonical_elements {}) (aliases_of_canonical_names {})
+   (aliases_of_consts {}))))
+Right:
+((defined_symbols { }) (code_age_relation {})
+ (levels
+  ((scope 2)
+  ((equations
+    ([0m[38;5;111;1mw/23N[0m : (Val! (Variant (tagged_imms (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1md/28N[0m)))))
+     [0m[38;5;111;1mz/24N[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known
+          {(tag_0 => (Known 2),
+            ((Val! (Variant (tagged_imms (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1mb/26N[0m)))))
+             (Val! (Variant (tagged_imms (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1mb/26N[0m))))))
+            (equations
+             ([0m[38;5;111;1md/28N[0m : (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1mb/26N[0m))
+              [0m[38;5;111;1mc/27N[0m : (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1mb/26N[0m)))))
+           (tag_1 => (Known 0), ())}))))
+     [0m[38;5;111;1my/21N[0m : (Val! (Variant (tagged_imms (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1mc/27N[0m)))))
+     [0m[38;5;111;1mx/22N[0m : (Val! (Variant (tagged_imms (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1mb/26N[0m))))))))))
+  ((scope 1) (defined_vars
+   {([0m[38;5;111;1mw/23N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1md/28N[0m :: [0m[38;5;37;1mℕ𝕚[0m Normal) ([0m[38;5;111;1ma/25N[0m :: [0m[38;5;37;1mℕ𝕚[0m Normal)
+    ([0m[38;5;111;1mz/24N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1my/21N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mx/22N[0m :: [0m[38;5;37;1m𝕍[0m Normal)
+    ([0m[38;5;111;1mb/26N[0m :: [0m[38;5;37;1mℕ𝕚[0m Normal) ([0m[38;5;111;1mc/27N[0m :: [0m[38;5;37;1mℕ𝕚[0m Normal)}))
+  ((defined_vars { w/23N d/28N a/25N z/24N y/21N x/22N b/26N c/27N })
+   (equations
+    ([0m[38;5;111;1mz/24N[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known
+          {(tag_0 => (Known 2), ((Val [0m[38;5;37;1m⊤[0m) (Val [0m[38;5;37;1m⊤[0m))) (tag_1 => (Known 0), ())})))))))))
+ (aliases
+  ((canonical_elements {}) (aliases_of_canonical_names {})
+   (aliases_of_consts {}))))
+Res:
+((defined_symbols { }) (code_age_relation {})
+ (levels
+  ((scope 2)
+  ((equations
+    ([0m[38;5;111;1mw/23N[0m : (Val! (Variant (tagged_imms (Naked_immediate [0m[38;5;37;1m⊤[0m))))
+     [0m[38;5;111;1mz/24N[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known
+          {(tag_0 => (Known 2),
+            ((Val! (Variant (tagged_imms (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1mb/26N[0m)))))
+             (Val! (Variant (tagged_imms (Naked_immediate ([0m[38;5;160;1m=[0m [0m[38;5;111;1mb/26N[0m)))))))
+           (tag_1 => (Known 0), ())}))))
+     [0m[38;5;111;1my/21N[0m : (Val! (Variant (tagged_imms (Naked_immediate [0m[38;5;37;1m⊤[0m))))
+     [0m[38;5;111;1mx/22N[0m : (Val! (Variant (tagged_imms (Naked_immediate [0m[38;5;37;1m⊤[0m)))))))))
+  ((scope 1) (defined_vars
+   {([0m[38;5;111;1mw/23N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1md/28N[0m :: [0m[38;5;37;1mℕ𝕚[0m Normal) ([0m[38;5;111;1ma/25N[0m :: [0m[38;5;37;1mℕ𝕚[0m Normal)
+    ([0m[38;5;111;1mz/24N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1my/21N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mx/22N[0m :: [0m[38;5;37;1m𝕍[0m Normal)
+    ([0m[38;5;111;1mb/26N[0m :: [0m[38;5;37;1mℕ𝕚[0m Normal) ([0m[38;5;111;1mc/27N[0m :: [0m[38;5;37;1mℕ𝕚[0m Normal)}))
+  ((defined_vars { w/23N d/28N a/25N z/24N y/21N x/22N b/26N c/27N })
+   (equations
+    ([0m[38;5;111;1mz/24N[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known
+          {(tag_0 => (Known 2), ((Val [0m[38;5;37;1m⊤[0m) (Val [0m[38;5;37;1m⊤[0m))) (tag_1 => (Known 0), ())})))))))))
+ (aliases
+  ((canonical_elements {}) (aliases_of_canonical_names {})
+   (aliases_of_consts {}))))


### PR DESCRIPTION
These always output stuff when running `make runtest` and it causes confusion.

Ideally, they would only print things when there are errors; in the meantime, convert them to diff tests to avoid confusion.