### PR TITLE
Prepare to use `Mode.Crossing` in `Jkind_mod_bounds` and cleanup `typemode`

### DIFF
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5097,7 +5097,7 @@ let mode_crossing_functor =
   }}
 
 (** The mode crossing of any module. *)
-let mode_crossing_module = Mode.Crossing.top
+let mode_crossing_module = Mode.Crossing.max
 
 let zap_modalities_to_floor_if_at_least level =
   if Language_extension.(is_at_least Mode level)
@@ -5111,7 +5111,7 @@ let crossing_of_jkind env jkind =
 let crossing_of_ty env ?modalities ty =
   let crossing =
     if not (is_principal ty)
-      then Crossing.top
+      then Crossing.max
     else
       let jkind = type_jkind_purely env ty in
       crossing_of_jkind env jkind

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -86,7 +86,7 @@ let child_modes_with_modalities id ~modalities:(moda0, moda1) = function
       Ok (Specific (m0, m1, c))
     end
 
-let check_modes env ?(crossing = Crossing.top) ~item ?typ = function
+let check_modes env ?(crossing = Crossing.max) ~item ?typ = function
   | All -> Ok ()
   | Specific (m0, m1, c) ->
       let m0 =

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -174,10 +174,15 @@ module Axis = struct
       | Externality : Externality.t t
       | Nullability : Nullability.t t
       | Separability : Separability.t t
+
+    let get (type a) : a t -> (module Axis_ops with type t = a) = function
+      | Externality -> (module Externality)
+      | Nullability -> (module Nullability)
+      | Separability -> (module Separability)
   end
 
   type 'a t =
-    | Modal : 'a Mode.Alloc.Axis.t -> 'a t
+    | Modal : 'a Mode.Value.Axis.t -> 'a t
     | Nonmodal : 'a Nonmodal.t -> 'a t
 
   type packed = Pack : 'a t -> packed [@@unboxed]
@@ -197,10 +202,8 @@ module Axis = struct
 
   let get (type a) : a t -> (module Axis_ops with type t = a) = function
     | Modal axis ->
-      (module Accent_lattice ((val Mode.Alloc.Const.lattice_of_axis axis)))
-    | Nonmodal Externality -> (module Externality)
-    | Nonmodal Nullability -> (module Nullability)
-    | Nonmodal Separability -> (module Separability)
+      (module Accent_lattice ((val Mode.Value.Const.lattice_of_axis axis)))
+    | Nonmodal axis -> Nonmodal.get axis
 
   let all =
     [ Pack (Modal (Comonadic Areality));
@@ -216,7 +219,7 @@ module Axis = struct
       Pack (Nonmodal Separability) ]
 
   let name (type a) : a t -> string = function
-    | Modal axis -> Format.asprintf "%a" Mode.Alloc.Axis.print axis
+    | Modal axis -> Format.asprintf "%a" Mode.Value.Axis.print axis
     | Nonmodal Externality -> "externality"
     | Nonmodal Nullability -> "nullability"
     | Nonmodal Separability -> "separability"

--- a/typing/jkind_axis.mli
+++ b/typing/jkind_axis.mli
@@ -55,11 +55,13 @@ module Axis : sig
       | Externality : Externality.t t
       | Nullability : Nullability.t t
       | Separability : Separability.t t
+
+    val get : 'a t -> (module Axis_ops with type t = 'a)
   end
 
   (** Represents an axis of a jkind *)
   type 'a t =
-    | Modal : 'a Mode.Alloc.Axis.t -> 'a t
+    | Modal : 'a Mode.Value.Axis.t -> 'a t
     | Nonmodal : 'a Nonmodal.t -> 'a t
 
   type packed = Pack : 'a t -> packed [@@unboxed]

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -577,7 +577,7 @@ let mode_lazy expected_mode =
   let mode_crossing =
     Crossing.of_bounds {
       comonadic = {
-        Alloc.Comonadic.Const.max with
+        Value.Comonadic.Const.max with
         (* The thunk is evaluated only once, so we only require it to be [once],
           even if the [lazy] is [many]. *)
         linearity = Many;
@@ -585,7 +585,7 @@ let mode_lazy expected_mode =
           only require it to be [nonportable], even if the [lazy] is [portable].
           *)
         portability = Portable };
-      monadic = Alloc.Monadic.Const.min }
+      monadic = Value.Monadic.Const.min }
   in
   let closure_mode =
     expected_mode |> as_single_mode |> Crossing.apply_right mode_crossing

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -8,107 +8,88 @@ open Jkind_axis
    externality/nullability) will stay in this file, while [transl_modifiers]
    should go into [typekind.ml] and calls [transl_modalities]. *)
 
-type modal = private |
-
-type maybe_nonmodal = private |
-
-type 'm annot_type =
-  | Modifier : maybe_nonmodal annot_type
-  | Mode : modal annot_type
-  | Modality : modal annot_type
+type annot_type =
+  | Modifier
+  | Mode
+  | Modality
 
 type error =
   | Duplicated_axis : _ Axis.t -> error
-  | Unrecognized_modifier : _ annot_type * string -> error
+  | Unrecognized_modifier : annot_type * string -> error
 
 exception Error of Location.t * error
 
-module Axis_pair = struct
-  type 'm t =
-    | Modal_axis_pair : 'a Mode.Alloc.Axis.t * 'a -> modal t
-    | Any_axis_pair : 'a Axis.t * 'a -> maybe_nonmodal t
-    | Everything_but_nullability : maybe_nonmodal t
+module Modal_axis_pair = struct
+  [@@@warning "-18"]
 
-  let of_string s =
-    let open Mode in
+  type t = P : 'a Alloc.Axis.t * 'a -> t
+
+  type t_value = P : 'a Value.Axis.t * 'a -> t_value
+
+  let to_value (P (ax, a) : t) : t_value =
+    match Const.Axis.is_areality ax with
+    | Left Refl -> P (Comonadic Areality, Const.locality_as_regionality a)
+    | Right ax -> P (ax, a)
+
+  let of_string s : t =
+    let comonadic (type a) (ax : a Alloc.Comonadic.Axis.t) (a : a) : t =
+      P (Comonadic ax, a)
+    in
+    let monadic (type a) (ax : a Alloc.Monadic.Axis.t) (a : a) : t =
+      P (Monadic ax, a)
+    in
     match s with
-    | "local" -> Any_axis_pair (Modal (Comonadic Areality), Locality.Const.Local)
-    | "global" ->
-      Any_axis_pair (Modal (Comonadic Areality), Locality.Const.Global)
-    | "unique" ->
-      Any_axis_pair (Modal (Monadic Uniqueness), Uniqueness.Const.Unique)
-    | "aliased" ->
-      Any_axis_pair (Modal (Monadic Uniqueness), Uniqueness.Const.Aliased)
-    | "once" -> Any_axis_pair (Modal (Comonadic Linearity), Linearity.Const.Once)
-    | "many" -> Any_axis_pair (Modal (Comonadic Linearity), Linearity.Const.Many)
-    | "nonportable" ->
-      Any_axis_pair
-        (Modal (Comonadic Portability), Portability.Const.Nonportable)
-    | "portable" ->
-      Any_axis_pair (Modal (Comonadic Portability), Portability.Const.Portable)
-    | "contended" ->
-      Any_axis_pair (Modal (Monadic Contention), Contention.Const.Contended)
-    | "shared" ->
-      Any_axis_pair (Modal (Monadic Contention), Contention.Const.Shared)
-    | "uncontended" ->
-      Any_axis_pair (Modal (Monadic Contention), Contention.Const.Uncontended)
-    | "maybe_null" ->
-      Any_axis_pair (Nonmodal Nullability, Nullability.Maybe_null)
-    | "non_null" -> Any_axis_pair (Nonmodal Nullability, Nullability.Non_null)
-    | "internal" -> Any_axis_pair (Nonmodal Externality, Externality.Internal)
-    | "external64" ->
-      Any_axis_pair (Nonmodal Externality, Externality.External64)
-    | "external_" -> Any_axis_pair (Nonmodal Externality, Externality.External)
-    | "yielding" ->
-      Any_axis_pair (Modal (Comonadic Yielding), Yielding.Const.Yielding)
-    | "unyielding" ->
-      Any_axis_pair (Modal (Comonadic Yielding), Yielding.Const.Unyielding)
-    | "stateless" ->
-      Any_axis_pair
-        (Modal (Comonadic Statefulness), Statefulness.Const.Stateless)
-    | "observing" ->
-      Any_axis_pair
-        (Modal (Comonadic Statefulness), Statefulness.Const.Observing)
-    | "stateful" ->
-      Any_axis_pair (Modal (Comonadic Statefulness), Statefulness.Const.Stateful)
-    | "immutable" ->
-      Any_axis_pair (Modal (Monadic Visibility), Visibility.Const.Immutable)
-    | "read" -> Any_axis_pair (Modal (Monadic Visibility), Visibility.Const.Read)
-    | "read_write" ->
-      Any_axis_pair (Modal (Monadic Visibility), Visibility.Const.Read_write)
-    | "maybe_separable" ->
-      Any_axis_pair (Nonmodal Separability, Separability.Maybe_separable)
-    | "separable" ->
-      Any_axis_pair (Nonmodal Separability, Separability.Separable)
-    | "non_float" ->
-      Any_axis_pair (Nonmodal Separability, Separability.Non_float)
-    | "everything" -> Everything_but_nullability
+    | "local" -> comonadic Areality Local
+    | "global" -> comonadic Areality Global
+    | "unique" -> monadic Uniqueness Unique
+    | "aliased" -> monadic Uniqueness Aliased
+    | "once" -> comonadic Linearity Once
+    | "many" -> comonadic Linearity Many
+    | "nonportable" -> comonadic Portability Nonportable
+    | "portable" -> comonadic Portability Portable
+    | "contended" -> monadic Contention Contended
+    | "shared" -> monadic Contention Shared
+    | "uncontended" -> monadic Contention Uncontended
+    | "yielding" -> comonadic Yielding Yielding
+    | "unyielding" -> comonadic Yielding Unyielding
+    | "stateless" -> comonadic Statefulness Stateless
+    | "observing" -> comonadic Statefulness Observing
+    | "stateful" -> comonadic Statefulness Stateful
+    | "immutable" -> monadic Visibility Immutable
+    | "read" -> monadic Visibility Read
+    | "read_write" -> monadic Visibility Read_write
     | _ -> raise Not_found
 end
 
-let transl_annot (type m) ~(annot_type : m annot_type) ~required_mode_maturity
-    annot : m Axis_pair.t Location.loc =
-  Option.iter
-    (fun maturity ->
-      Language_extension.assert_enabled ~loc:annot.loc Mode maturity)
-    required_mode_maturity;
-  let pair : m Axis_pair.t =
-    match Axis_pair.of_string annot.txt, annot_type with
-    | Any_axis_pair (Nonmodal _, _), (Mode | Modality)
-    | Everything_but_nullability, (Mode | Modality)
-    | (exception Not_found) ->
-      raise (Error (annot.loc, Unrecognized_modifier (annot_type, annot.txt)))
-    | Any_axis_pair (Modal axis, mode), Mode -> Modal_axis_pair (axis, mode)
-    | Any_axis_pair (Modal axis, mode), Modality -> Modal_axis_pair (axis, mode)
-    | pair, Modifier -> pair
-  in
-  { txt = pair; loc = annot.loc }
+module Axis_pair = struct
+  type t = P : 'a Axis.t * 'a -> t
 
-let unpack_mode_annot { txt = Parsetree.Mode s; loc } = { txt = s; loc }
+  [@@@warning "-18"]
+
+  let of_string s =
+    match Modal_axis_pair.of_string s with
+    | modal ->
+      let (P (ax, a)) = Modal_axis_pair.to_value modal in
+      P (Modal ax, a)
+    | exception Not_found -> (
+      let nonmodal (type a) (ax : a Axis.Nonmodal.t) (a : a) : t =
+        P (Nonmodal ax, a)
+      in
+      match s with
+      | "maybe_null" -> nonmodal Nullability Maybe_null
+      | "non_null" -> nonmodal Nullability Non_null
+      | "internal" -> nonmodal Externality Internal
+      | "external64" -> nonmodal Externality External64
+      | "external_" -> nonmodal Externality External
+      | "maybe_separable" -> nonmodal Separability Maybe_separable
+      | "separable" -> nonmodal Separability Separable
+      | "non_float" -> nonmodal Separability Non_float
+      | _ -> raise Not_found)
+end
 
 module Transled_modifiers = struct
   type t =
-    { locality : Mode.Locality.Const.t Location.loc option;
+    { areality : Mode.Regionality.Const.t Location.loc option;
       linearity : Mode.Linearity.Const.t Location.loc option;
       uniqueness : Mode.Uniqueness.Const.t Location.loc option;
       portability : Mode.Portability.Const.t Location.loc option;
@@ -122,7 +103,7 @@ module Transled_modifiers = struct
     }
 
   let empty =
-    { locality = None;
+    { areality = None;
       linearity = None;
       uniqueness = None;
       portability = None;
@@ -137,7 +118,7 @@ module Transled_modifiers = struct
 
   let get (type a) ~(axis : a Axis.t) (t : t) : a Location.loc option =
     match axis with
-    | Modal (Comonadic Areality) -> t.locality
+    | Modal (Comonadic Areality) -> t.areality
     | Modal (Comonadic Linearity) -> t.linearity
     | Modal (Monadic Uniqueness) -> t.uniqueness
     | Modal (Comonadic Portability) -> t.portability
@@ -152,7 +133,7 @@ module Transled_modifiers = struct
   let set (type a) ~(axis : a Axis.t) (t : t) (value : a Location.loc option) :
       t =
     match axis with
-    | Modal (Comonadic Areality) -> { t with locality = value }
+    | Modal (Comonadic Areality) -> { t with areality = value }
     | Modal (Comonadic Linearity) -> { t with linearity = value }
     | Modal (Monadic Uniqueness) -> { t with uniqueness = value }
     | Modal (Comonadic Portability) -> { t with portability = value }
@@ -166,12 +147,9 @@ module Transled_modifiers = struct
 end
 
 let transl_mod_bounds annots =
-  let step bounds_so_far annot =
-    match
-      transl_annot ~annot_type:Modifier ~required_mode_maturity:None
-      @@ unpack_mode_annot annot
-    with
-    | { txt = Any_axis_pair (type a) ((axis, mode) : a Axis.t * a); loc } ->
+  let step bounds_so_far { txt = Parsetree.Mode txt; loc } =
+    match Axis_pair.of_string txt with
+    | P (type a) ((axis, mode) : a Axis.t * a) ->
       let (module A) = Axis.get axis in
       let is_top = A.le A.max mode in
       if is_top
@@ -184,24 +162,27 @@ let transl_mod_bounds annots =
       let is_dup =
         Option.is_some (Transled_modifiers.get ~axis bounds_so_far)
       in
-      if is_dup then raise (Error (annot.loc, Duplicated_axis axis));
+      if is_dup then raise (Error (loc, Duplicated_axis axis));
       Transled_modifiers.set ~axis bounds_so_far (Some { txt = mode; loc })
-    | { txt = Everything_but_nullability; loc } ->
-      Transled_modifiers.
-        { locality = Some { txt = Locality.Const.min; loc };
-          linearity = Some { txt = Linearity.Const.min; loc };
-          uniqueness = Some { txt = Uniqueness.Const_op.min; loc };
-          portability = Some { txt = Portability.Const.min; loc };
-          contention = Some { txt = Contention.Const_op.min; loc };
-          yielding = Some { txt = Yielding.Const.min; loc };
-          externality = Some { txt = Externality.min; loc };
-          statefulness = Some { txt = Statefulness.Const.min; loc };
-          visibility = Some { txt = Visibility.Const_op.min; loc };
-          nullability =
-            Transled_modifiers.get ~axis:(Nonmodal Nullability) bounds_so_far;
-          separability =
-            Transled_modifiers.get ~axis:(Nonmodal Separability) bounds_so_far
-        }
+    | exception Not_found -> (
+      match txt with
+      | "everything" ->
+        Transled_modifiers.
+          { areality = Some { txt = Regionality.Const.min; loc };
+            linearity = Some { txt = Linearity.Const.min; loc };
+            uniqueness = Some { txt = Uniqueness.Const_op.min; loc };
+            portability = Some { txt = Portability.Const.min; loc };
+            contention = Some { txt = Contention.Const_op.min; loc };
+            yielding = Some { txt = Yielding.Const.min; loc };
+            externality = Some { txt = Externality.min; loc };
+            statefulness = Some { txt = Statefulness.Const.min; loc };
+            visibility = Some { txt = Visibility.Const_op.min; loc };
+            nullability =
+              Transled_modifiers.get ~axis:(Nonmodal Nullability) bounds_so_far;
+            separability =
+              Transled_modifiers.get ~axis:(Nonmodal Separability) bounds_so_far
+          }
+      | _ -> raise (Error (loc, Unrecognized_modifier (Modifier, txt))))
   in
   let empty_modifiers = Transled_modifiers.empty in
   let modifiers = List.fold_left step empty_modifiers annots in
@@ -212,7 +193,7 @@ let transl_mod_bounds annots =
       ( Transled_modifiers.get ~axis:(Modal (Comonadic Yielding)) modifiers,
         Transled_modifiers.get ~axis:(Modal (Comonadic Areality)) modifiers )
     with
-    | None, Some { txt = Locality.Const.Global; _ } ->
+    | None, Some { txt = Regionality.Const.Global; _ } ->
       Transled_modifiers.set ~axis:(Modal (Comonadic Yielding)) modifiers
         (Some { txt = Yielding.Const.Unyielding; loc = Location.none })
     | _, _ -> modifiers
@@ -244,8 +225,8 @@ let transl_mod_bounds annots =
     | _, _ -> modifiers
   in
   let open Types.Jkind_mod_bounds in
-  let locality =
-    Option.fold ~some:Location.get_txt ~none:Locality.max modifiers.locality
+  let areality =
+    Option.fold ~some:Location.get_txt ~none:Areality.max modifiers.areality
   in
   let linearity =
     Option.fold ~some:Location.get_txt ~none:Linearity.max modifiers.linearity
@@ -282,7 +263,7 @@ let transl_mod_bounds annots =
     Option.fold ~some:Location.get_txt ~none:Separability.max
       modifiers.separability
   in
-  create ~locality ~linearity ~uniqueness ~portability ~contention ~yielding
+  create ~areality ~linearity ~uniqueness ~portability ~contention ~yielding
     ~statefulness ~visibility ~externality ~nullability ~separability
 
 let default_mode_annots (annots : Alloc.Const.Option.t) =
@@ -314,31 +295,19 @@ let default_mode_annots (annots : Alloc.Const.Option.t) =
   { annots with yielding; contention; portability }
 
 let transl_mode_annots annots : Alloc.Const.Option.t =
-  let step modifiers_so_far annot =
-    let { txt =
-            Modal_axis_pair (type a) ((axis, mode) : a Mode.Alloc.Axis.t * a);
-          loc
-        } =
-      transl_annot ~annot_type:Mode ~required_mode_maturity:(Some Stable)
-      @@ unpack_mode_annot annot
+  let step modes_so_far { txt = Parsetree.Mode txt; loc } =
+    Language_extension.assert_enabled ~loc Mode Language_extension.Stable;
+    let (P (ax, a)) =
+      try Modal_axis_pair.of_string txt
+      with Not_found -> raise (Error (loc, Unrecognized_modifier (Mode, txt)))
     in
-    let axis = Axis.Modal axis in
-    if Option.is_some (Transled_modifiers.get ~axis modifiers_so_far)
-    then raise (Error (annot.loc, Duplicated_axis axis));
-    Transled_modifiers.set ~axis modifiers_so_far (Some { txt = mode; loc })
+    if Option.is_some (Alloc.Const.Option.proj ax modes_so_far)
+    then
+      let (P ax) = Const.Axis.alloc_as_value (P ax) in
+      raise (Error (loc, Duplicated_axis (Modal ax)))
+    else Alloc.Const.Option.set ax (Some a) modes_so_far
   in
-  let empty_modifiers = Transled_modifiers.empty in
-  let modes = List.fold_left step empty_modifiers annots in
-  default_mode_annots
-    { areality = Option.map get_txt modes.locality;
-      linearity = Option.map get_txt modes.linearity;
-      uniqueness = Option.map get_txt modes.uniqueness;
-      portability = Option.map get_txt modes.portability;
-      contention = Option.map get_txt modes.contention;
-      yielding = Option.map get_txt modes.yielding;
-      statefulness = Option.map get_txt modes.statefulness;
-      visibility = Option.map get_txt modes.visibility
-    }
+  List.fold_left step Alloc.Const.Option.none annots |> default_mode_annots
 
 let untransl_mode_annots (modes : Mode.Alloc.Const.Option.t) =
   let print_to_string_opt print a = Option.map (Format.asprintf "%a" print) a in
@@ -397,65 +366,26 @@ let untransl_mode_annots (modes : Mode.Alloc.Const.Option.t) =
       visibility ]
 
 let transl_modality ~maturity { txt = Parsetree.Modality modality; loc } =
-  let axis_pair =
-    transl_annot ~annot_type:Modality ~required_mode_maturity:(Some maturity)
-      { txt = modality; loc }
+  Language_extension.assert_enabled ~loc Mode maturity;
+  let (P (ax, a)) =
+    try Modal_axis_pair.(of_string modality |> to_value)
+    with Not_found ->
+      raise (Error (loc, Unrecognized_modifier (Modality, modality)))
   in
   let atom =
-    match axis_pair.txt with
-    | Modal_axis_pair (Comonadic Areality, mode) ->
-      Modality.Atom
-        (Comonadic Areality, Meet_with (Const.locality_as_regionality mode))
-    | Modal_axis_pair (Comonadic Linearity, mode) ->
-      Modality.Atom (Comonadic Linearity, Meet_with mode)
-    | Modal_axis_pair (Comonadic Portability, mode) ->
-      Modality.Atom (Comonadic Portability, Meet_with mode)
-    | Modal_axis_pair (Monadic Uniqueness, mode) ->
-      Modality.Atom (Monadic Uniqueness, Join_with mode)
-    | Modal_axis_pair (Monadic Contention, mode) ->
-      Modality.Atom (Monadic Contention, Join_with mode)
-    | Modal_axis_pair (Comonadic Yielding, mode) ->
-      Modality.Atom (Comonadic Yielding, Meet_with mode)
-    | Modal_axis_pair (Comonadic Statefulness, mode) ->
-      Modality.Atom (Comonadic Statefulness, Meet_with mode)
-    | Modal_axis_pair (Monadic Visibility, mode) ->
-      Modality.Atom (Monadic Visibility, Join_with mode)
+    match ax with
+    | Comonadic _ -> Modality.Atom (ax, Meet_with a)
+    | Monadic _ -> Modality.Atom (ax, Join_with a)
   in
   atom, loc
 
 let untransl_modality (a : Modality.t) : Parsetree.modality loc =
   let s =
     match a with
-    | Atom (Comonadic Areality, Meet_with Regionality.Const.Global) -> "global"
-    | Atom (Comonadic Areality, Meet_with Regionality.Const.Local) -> "local"
-    | Atom (Comonadic Linearity, Meet_with Linearity.Const.Many) -> "many"
-    | Atom (Comonadic Linearity, Meet_with Linearity.Const.Once) -> "once"
-    | Atom (Monadic Uniqueness, Join_with Uniqueness.Const.Aliased) -> "aliased"
-    | Atom (Monadic Uniqueness, Join_with Uniqueness.Const.Unique) -> "unique"
-    | Atom (Comonadic Portability, Meet_with Portability.Const.Portable) ->
-      "portable"
-    | Atom (Comonadic Portability, Meet_with Portability.Const.Nonportable) ->
-      "nonportable"
-    | Atom (Monadic Contention, Join_with Contention.Const.Contended) ->
-      "contended"
-    | Atom (Monadic Contention, Join_with Contention.Const.Shared) -> "shared"
-    | Atom (Monadic Contention, Join_with Contention.Const.Uncontended) ->
-      "uncontended"
-    | Atom (Comonadic Yielding, Meet_with Yielding.Const.Yielding) -> "yielding"
-    | Atom (Comonadic Yielding, Meet_with Yielding.Const.Unyielding) ->
-      "unyielding"
-    | Atom (Comonadic Statefulness, Meet_with Statefulness.Const.Stateless) ->
-      "stateless"
-    | Atom (Comonadic Statefulness, Meet_with Statefulness.Const.Observing) ->
-      "observing"
-    | Atom (Comonadic Statefulness, Meet_with Statefulness.Const.Stateful) ->
-      "stateful"
-    | Atom (Monadic Visibility, Join_with Visibility.Const.Immutable) ->
-      "immutable"
-    | Atom (Monadic Visibility, Join_with Visibility.Const.Read) -> "read"
-    | Atom (Monadic Visibility, Join_with Visibility.Const.Read_write) ->
-      "read_write"
-    | _ -> failwith "BUG: impossible modality atom"
+    | Atom (ax, Meet_with a) ->
+      Format.asprintf "%a" (Value.Const.print_axis ax) a
+    | Atom (ax, Join_with a) ->
+      Format.asprintf "%a" (Value.Const.print_axis ax) a
   in
   { txt = Modality s; loc = Location.none }
 

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -36,7 +36,7 @@ let mutable_mode m0 : _ Mode.Value.t =
 (* Type expressions for the core language *)
 
 module Jkind_mod_bounds = struct
-  module Locality = Mode.Locality.Const
+  module Areality = Mode.Regionality.Const
   module Linearity = Mode.Linearity.Const
   module Uniqueness = Mode.Uniqueness.Const_op
   module Portability = Mode.Portability.Const
@@ -49,7 +49,7 @@ module Jkind_mod_bounds = struct
   module Separability = Jkind_axis.Separability
 
   type t = {
-    locality: Locality.t;
+    areality: Areality.t;
     linearity: Linearity.t;
     uniqueness: Uniqueness.t;
     portability: Portability.t;
@@ -62,7 +62,7 @@ module Jkind_mod_bounds = struct
     separability: Separability.t;
   }
 
-  let[@inline] locality t = t.locality
+  let[@inline] areality t = t.areality
   let[@inline] linearity t = t.linearity
   let[@inline] uniqueness t = t.uniqueness
   let[@inline] portability t = t.portability
@@ -75,7 +75,7 @@ module Jkind_mod_bounds = struct
   let[@inline] separability t = t.separability
 
   let[@inline] create
-      ~locality
+      ~areality
       ~linearity
       ~uniqueness
       ~portability
@@ -87,7 +87,7 @@ module Jkind_mod_bounds = struct
       ~nullability
       ~separability =
     {
-      locality;
+      areality;
       linearity;
       uniqueness;
       portability;
@@ -100,7 +100,7 @@ module Jkind_mod_bounds = struct
       separability;
     }
 
-  let[@inline] set_locality locality t = { t with locality }
+  let[@inline] set_areality areality t = { t with areality }
   let[@inline] set_linearity linearity t = { t with linearity }
   let[@inline] set_uniqueness uniqueness t = { t with uniqueness }
   let[@inline] set_portability portability t = { t with portability }
@@ -116,10 +116,10 @@ module Jkind_mod_bounds = struct
     let open Jkind_axis.Axis_set in
     (* a little optimization *)
     if is_empty max_axes then t else
-    let locality =
+    let areality =
       if mem max_axes (Modal (Comonadic Areality))
-      then Locality.max
-      else t.locality
+      then Areality.max
+      else t.areality
     in
     let linearity =
       if mem max_axes (Modal (Comonadic Linearity))
@@ -172,7 +172,7 @@ module Jkind_mod_bounds = struct
       else t.separability
     in
     {
-      locality;
+      areality;
       linearity;
       uniqueness;
       portability;
@@ -189,10 +189,10 @@ module Jkind_mod_bounds = struct
     let open Jkind_axis.Axis_set in
     (* a little optimization *)
     if is_empty min_axes then t else
-    let locality =
+    let areality =
       if mem min_axes (Modal (Comonadic Areality))
-      then Locality.min
-      else t.locality
+      then Areality.min
+      else t.areality
     in
     let linearity =
       if mem min_axes (Modal (Comonadic Linearity))
@@ -245,7 +245,7 @@ module Jkind_mod_bounds = struct
       else t.separability
     in
     {
-      locality;
+      areality;
       linearity;
       uniqueness;
       portability;
@@ -261,7 +261,7 @@ module Jkind_mod_bounds = struct
   let[@inline] is_max_within_set t axes =
     let open Jkind_axis.Axis_set in
     (not (mem axes (Modal (Comonadic Areality))) ||
-     Locality.(le max (locality t))) &&
+     Areality.(le max (areality t))) &&
     (not (mem axes (Modal (Comonadic Linearity))) ||
      Linearity.(le max (linearity t))) &&
     (not (mem axes (Modal (Monadic Uniqueness))) ||
@@ -284,7 +284,7 @@ module Jkind_mod_bounds = struct
      Separability.(le max (separability t)))
 
   let max =
-      { locality = Locality.max;
+      { areality = Areality.max;
         linearity = Linearity.max;
         uniqueness = Uniqueness.max;
         portability = Portability.max;
@@ -300,7 +300,7 @@ module Jkind_mod_bounds = struct
 
 
   let debug_print ppf
-        { locality;
+        { areality;
           linearity;
           uniqueness;
           portability;
@@ -311,11 +311,11 @@ module Jkind_mod_bounds = struct
           externality;
           nullability;
           separability } =
-    Format.fprintf ppf "@[{ locality = %a;@ linearity = %a;@ uniqueness = %a;@ \
+    Format.fprintf ppf "@[{ areality = %a;@ linearity = %a;@ uniqueness = %a;@ \
       portability = %a;@ contention = %a;@ yielding = %a;@ statefulness = %a;@ \
       visibility = %a;@ externality = %a;@ \
       nullability = %a;@ separability = %a }@]"
-      Locality.print locality
+      Areality.print areality
       Linearity.print linearity
       Uniqueness.print uniqueness
       Portability.print portability

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -73,7 +73,7 @@ val mutable_mode : ('l * 'r) Mode.Value.Comonadic.t -> ('l * 'r) Mode.Value.t
 
 (** The mod-bounds of a jkind *)
 module Jkind_mod_bounds : sig
-  module Locality = Mode.Locality.Const
+  module Areality = Mode.Regionality.Const
   module Linearity = Mode.Linearity.Const
   module Uniqueness = Mode.Uniqueness.Const_op
   module Portability = Mode.Portability.Const
@@ -88,7 +88,7 @@ module Jkind_mod_bounds : sig
   type t
 
   val create :
-    locality:Locality.t ->
+    areality:Areality.t ->
     linearity:Linearity.t ->
     uniqueness:Uniqueness.t ->
     portability:Portability.t ->
@@ -101,7 +101,7 @@ module Jkind_mod_bounds : sig
     separability:Separability.t ->
     t
 
-  val locality : t -> Locality.t
+  val areality : t -> Areality.t
   val linearity : t -> Linearity.t
   val uniqueness : t -> Uniqueness.t
   val portability : t -> Portability.t
@@ -113,7 +113,7 @@ module Jkind_mod_bounds : sig
   val nullability : t -> Nullability.t
   val separability : t -> Separability.t
 
-  val set_locality : Locality.t -> t -> t
+  val set_areality : Areality.t -> t -> t
   val set_linearity : Linearity.t -> t -> t
   val set_uniqueness : Uniqueness.t -> t -> t
   val set_portability : Portability.t -> t -> t


### PR DESCRIPTION
Towards #4273 , I need to modify `Jkind_Axis` to prepare for using `Mode.Crossing` in `Jkind_mod_bounds`.

A side effect is I had to clean up `typemode.ml` (which is still not in the most ideal state, but better).