### PR TITLE
Revert "Revert (the merged parts of) atomic record fields"

### DIFF
--- a/chamelon/compat.ox.ml
+++ b/chamelon/compat.ox.ml
@@ -307,7 +307,9 @@ let mkTpat_alias ~id:(mode, ty) (p, ident, name) =
 type tpat_array_identifier = mutability * Jkind.sort
 
 let mkTpat_array
-    ?id:(mut, arg_sort = (Mutable Value.Comonadic.legacy, Jkind.Sort.value)) l =
+    ?id:(mut, arg_sort =
+        ( Mutable { mode = Value.Comonadic.legacy; atomic = Nonatomic },
+          Jkind.Sort.value )) l =
   Tpat_array (mut, arg_sort, l)
 
 type tpat_tuple_identifier = string option list

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -245,6 +245,14 @@ let frame_pointers = make
      "frame-pointers available"
      "frame-pointers not available")
 
+let no_frame_pointers = make
+  ~name:"no-frame_pointers"
+  ~description:"Pass if frame pointers are available"
+  ~does_something:false
+  (Actions_helpers.predicate (not Ocamltest_config.frame_pointers)
+     "frame-pointers not available"
+     "frame-pointers available")
+
 let probes = make
   ~name:"probes"
   ~description:"Pass if probes are available"
@@ -420,6 +428,7 @@ let init () =
     arch_power;
     function_sections;
     frame_pointers;
+    no_frame_pointers;
     naked_pointers;
     file_exists;
     copy;

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -69,6 +69,7 @@ let warn_unused () =
    misplaced attribute warnings. *)
 let builtin_attrs =
   [ "inline"
+  ; "atomic"
   ; "inlined"
   ; "specialise"
   ; "specialised"
@@ -1113,3 +1114,5 @@ let get_tracing_probe_payload (payload : Parsetree.payload) =
     | _ -> Error ()
   in
   Ok { name; name_loc; enabled_at_init; arg }
+
+let has_atomic attrs = has_attribute "atomic" attrs

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -345,3 +345,5 @@ type tracing_probe =
 *)
 val get_tracing_probe_payload :
   Parsetree.payload -> (tracing_probe, unit) result
+
+val has_atomic: Parsetree.attributes -> bool

--- a/testsuite/tests/atomic-locs/atomic_fields.ml
+++ b/testsuite/tests/atomic-locs/atomic_fields.ml
@@ -1,0 +1,143 @@
+(* TEST
+   expect;
+*)
+
+type t = {
+  x : int;
+  mutable y : int [@atomic];
+}
+
+let get_y (t : t) = t.y
+let set_y (t : t) new_y = t.y <- new_y
+[%%expect{|
+type t = { x : int; mutable y : int [@atomic]; }
+val get_y : t -> int = <fun>
+val set_y : t -> int -> unit = <fun>
+|}]
+
+let t : t = { x = 1; y = 2 }
+[%%expect{|
+val t : t = {x = 1; y = 2}
+|}]
+
+let () = Format.printf "%d@." (get_y t)
+[%%expect{|
+2
+|}]
+
+let () = set_y t 7
+[%%expect{|
+|}]
+
+let () = Format.printf "%d@." (get_y t)
+[%%expect{|
+7
+|}]
+
+(* Test with non-immediates too *)
+
+type u = {
+  x : int;
+  mutable y : string [@atomic];
+}
+
+let get_y (t : u) = t.y
+let set_y (t : u) new_y = t.y <- new_y
+[%%expect{|
+type u = { x : int; mutable y : string [@atomic]; }
+val get_y : u -> string = <fun>
+val set_y : u -> string -> unit = <fun>
+|}]
+
+let t : u = { x = 1; y = "two" }
+[%%expect{|
+val t : u = {x = 1; y = "two"}
+|}]
+
+let () = Format.printf "%s@." (get_y t)
+[%%expect{|
+two
+|}]
+
+let () = set_y t "seven"
+[%%expect{|
+|}]
+
+let () = Format.printf "%s@." (get_y t)
+[%%expect{|
+seven
+|}]
+
+(* Test with floats *)
+
+module Floats_some_atomic = struct
+  type t =
+    { x : float
+    ; mutable y : float
+    ; mutable z : float [@atomic]
+    }
+  [@@warning "-214"]
+
+  let t : t = { x = 1.; y = 2.; z = 3.; }
+
+  let () = Format.printf "after init, x = %f@." (t.x)
+  let () = Format.printf "after init, y = %f@." (t.y)
+  let () = Format.printf "after init, z = %f@." (t.z)
+
+  let () =
+    t.y <- 2.5;
+    t.z <- 3.5
+
+
+  let () = Format.printf "after set, x = %f@." (t.x)
+  let () = Format.printf "after set, y = %f@." (t.y)
+  let () = Format.printf "after set, z = %f@." (t.z)
+end
+[%%expect{|
+after init, x = 1.000000
+after init, y = 2.000000
+after init, z = 3.000000
+after set, x = 1.000000
+after set, y = 2.500000
+after set, z = 3.500000
+module Floats_some_atomic :
+  sig
+    type t = { x : float; mutable y : float; mutable z : float [@atomic]; }
+    val t : t
+  end
+|}]
+
+(* Test with or_null *)
+
+type string_or_null_atomic = { mutable s : string or_null [@atomic] }
+
+let print t = match t.s with
+  | Null -> Format.printf "Null@.";
+  | This s -> Format.printf "This %s@." s;
+;;
+[%%expect{|
+type string_or_null_atomic = { mutable s : string or_null [@atomic]; }
+val print : string_or_null_atomic -> unit = <fun>
+|}]
+
+let x : string_or_null_atomic = { s = Null } ;;
+[%%expect{|
+val x : string_or_null_atomic = {s = Null}
+|}]
+
+let () = print x ;;
+[%%expect{|
+Null
+|}]
+
+let () = x.s <- This "Value" ;;
+let () = print x ;;
+[%%expect{|
+This Value
+|}]
+
+let () = x.s <- Null ;;
+let () = print x ;;
+[%%expect{|
+Null
+|}]

--- a/testsuite/tests/atomic-locs/cmm.compilers.reference
+++ b/testsuite/tests/atomic-locs/cmm.compilers.reference
@@ -1,0 +1,56 @@
+(data global "camlCmm__gc_roots": int 0)
+(data
+ int 5888
+ global "camlCmm":
+ addr G:"camlCmm__standard_atomic_get_7"
+ addr G:"camlCmm__get_8"
+ addr G:"camlCmm__set_9"
+ addr G:"camlCmm__get_imm_10"
+ addr G:"camlCmm__set_imm_11")
+(data
+ int 4087
+ global "camlCmm__set_imm_11":
+ addr G:"caml_curry2"
+ int 180143985094819847
+ addr G:"camlCmm__set_imm_5_11_code")
+(data
+ int 3063
+ global "camlCmm__get_imm_10":
+ addr G:"camlCmm__get_imm_4_10_code"
+ int 108086391056891909)
+(data
+ int 4087
+ global "camlCmm__set_9":
+ addr G:"caml_curry2"
+ int 180143985094819847
+ addr G:"camlCmm__set_3_9_code")
+(data
+ int 3063
+ global "camlCmm__get_8":
+ addr G:"camlCmm__get_2_8_code"
+ int 108086391056891909)
+(data
+ int 4087
+ global "camlCmm__standard_atomic_get_7":
+ addr G:"caml_curry2"
+ int 180143985094819847
+ addr G:"camlCmm__standard_atomic_get_1_7_code")
+(function camlCmm__standard_atomic_get_1_7_code (r: val v: val) : int
+ (extcall "caml_atomic_exchange_field" r 1 v ->val) 1 )
+
+(function camlCmm__get_2_8_code (r: val) : val
+ (load_mut_atomic val (+a r 8)) )
+
+(function camlCmm__set_3_9_code (r: val v: val) : int
+ (extcall "caml_atomic_exchange_field" r 3 v ->val) 1 )
+
+(function camlCmm__get_imm_4_10_code (r: val) : int
+ (load_mut_atomic int (+a r 8)) )
+
+(function camlCmm__set_imm_5_11_code (r: val v: int) : int
+ (atomic exchange v (+a r 8)) 1 )
+
+(function no_cse reduce_code_size linscan camlCmm__entry () : val
+ (catch (exit 1 G:"camlCmm") with(1 *ret*: val) 1) )
+
+(data)

--- a/testsuite/tests/atomic-locs/cmm.ml
+++ b/testsuite/tests/atomic-locs/cmm.ml
@@ -1,0 +1,50 @@
+(* TEST_BELOW *)
+
+(* standard atomics *)
+
+let standard_atomic_get (r : 'a Atomic.t) =
+  Atomic.get r
+
+let standard_atomic_get (r : 'a Atomic.t) v =
+  Atomic.set r v
+
+(* atomic record fields *)
+
+type 'a atomic = { filler : unit; mutable x : 'a [@atomic] }
+
+let get (r : 'a atomic) : 'a =
+  r.x
+
+let set (r : 'a atomic) v =
+  r.x <- v
+
+(* check immediates too *)
+
+let get_imm (r : int atomic) : int =
+  r.x
+
+let set_imm (r : int atomic) v =
+  r.x <- v
+
+(* TEST
+   arch_amd64;
+   flambda;
+   no-tsan;
+   (* frame_pointers causes different, unstable CMM output, so we skip this test
+      when it's enabled *)
+   no-frame_pointers;
+
+   flags = "-c -dcmm -dno-locations -dno-unique-ids";
+
+   {
+    setup-ocamlopt.byte-build-env;
+    ocamlopt.byte;
+    check-ocamlopt.byte-output;
+   }
+   {
+    setup-ocamlopt.byte-build-env;
+    flags += " -O3";
+    ocamlopt.byte;
+    check-ocamlopt.byte-output;
+   }
+*)

--- a/testsuite/tests/atomic-locs/optimized.ml
+++ b/testsuite/tests/atomic-locs/optimized.ml
@@ -1,0 +1,77 @@
+(* TEST
+ reference = "${test_source_directory}/optimized.reference";
+ flambda2;
+ {
+   native;
+ } {
+   flags = "-O3";
+   native;
+ } {
+   flags = "-Oclassic";
+   native;
+ } {
+   bytecode;
+ }
+*)
+
+type ('a : value_or_null) atomic = { mutable contents : 'a [@atomic] }
+
+let print_string_atomic prefix x = Printf.printf "%s: %s\n" prefix x.contents
+let print_int_atomic prefix x = Printf.printf "%s: %d\n" prefix x.contents
+let print_float_atomic prefix x = Printf.printf "%s: %.2f\n" prefix x.contents
+let print_int_or_null_atomic prefix x = match x.contents with
+  | Null -> Printf.printf "%s: Null\n" prefix
+  | This n -> Printf.printf "%s: This %d\n" prefix n
+
+let print_float_or_null_atomic prefix x = match x.contents with
+  | Null -> Printf.printf "%s: Null\n" prefix
+  | This n -> Printf.printf "%s: This %.2f\n" prefix n
+
+(* Test getting and setting int atomic fields *)
+let test_int_atomic () =
+  let x = { contents = 42 } in
+  print_int_atomic "Int atomic get initial" x;
+  x.contents <- 100;
+  print_int_atomic "Int atomic get after set" x;
+;;
+
+let () = test_int_atomic ()
+
+(* Test getting and setting string atomic fields *)
+let test_string_atomic () =
+  let x = { contents = "hello" } in
+  print_string_atomic "String atomic get initial" x;
+  x.contents <- "world";
+  print_string_atomic "String atomic get after set" x;
+;;
+
+let () = test_string_atomic ()
+
+(* Test getting and setting float atomic fields *)
+let test_float_atomic () =
+  let x = { contents = 3.14 } in
+  print_float_atomic "Float atomic get initial" x;
+  x.contents <- 2.71;
+  print_float_atomic "Float atomic get after set" x;
+;;
+
+let () = test_float_atomic ()
+
+(* Test getting and setting or_null atomic fields *)
+let test_or_null_atomic () =
+  let x = { contents = This 123 } in
+  print_int_or_null_atomic "Or_null atomic get initial" x;
+  x.contents <- Null;
+  print_int_or_null_atomic "Or_null atomic get after set to Null" x;
+  x.contents <- This 456;
+  print_int_or_null_atomic "Or_null atomic get after set to This" x;
+
+  let y = { contents = This 1.23 } in
+  print_float_or_null_atomic "Float or_null atomic get initial" y;
+  y.contents <- Null;
+  print_float_or_null_atomic "Float or_null atomic get after set to Null" y;
+  y.contents <- This 4.56;
+  print_float_or_null_atomic "Float or_null atomic get after set to This" y;
+;;
+
+let () = test_or_null_atomic ()

--- a/testsuite/tests/atomic-locs/optimized.reference
+++ b/testsuite/tests/atomic-locs/optimized.reference
@@ -1,0 +1,12 @@
+Int atomic get initial: 42
+Int atomic get after set: 100
+String atomic get initial: hello
+String atomic get after set: world
+Float atomic get initial: 3.14
+Float atomic get after set: 2.71
+Or_null atomic get initial: This 123
+Or_null atomic get after set to Null: Null
+Or_null atomic get after set to This: This 456
+Float or_null atomic get initial: This 1.23
+Float or_null atomic get after set to Null: Null
+Float or_null atomic get after set to This: This 4.56

--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -1,0 +1,387 @@
+(* TEST
+   flags = "-dlambda -dno-locations -dno-unique-ids";
+   expect;
+*)
+
+(* Atomic fields must be mutable. *)
+module Error1 = struct
+  type t = { x : int [@atomic] }
+end
+[%%expect{|
+Line 2, characters 13-30:
+2 |   type t = { x : int [@atomic] }
+                 ^^^^^^^^^^^^^^^^^
+Error: The label "x" must be mutable to be declared atomic.
+|}];;
+
+
+(* Check module interface checking: it is not allowed to remove or add
+   atomic attributes. *)
+
+module Wrong1 = (struct
+  type t = { mutable x : int }
+end : sig
+  (* adding an 'atomic' attribute missing in the implementation: invalid. *)
+  type t = { mutable x : int [@atomic] }
+end)
+[%%expect{|
+Lines 1-3, characters 17-3:
+1 | .................struct
+2 |   type t = { mutable x : int }
+3 | end......
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = { mutable x : int; } end
+       is not included in
+         sig type t = { mutable x : int [@atomic]; } end
+       Type declarations do not match:
+         type t = { mutable x : int; }
+       is not included in
+         type t = { mutable x : int [@atomic]; }
+       Fields do not match:
+         "mutable x : int;"
+       is not the same as:
+         "mutable x : int [@atomic];"
+       The second is atomic and the first is not.
+|}];;
+
+module Wrong2 = (struct
+  type t = { mutable x : int [@atomic] }
+end : sig
+  (* removing an 'atomic' attribute present in the implementation: invalid. *)
+  type t = { mutable x : int }
+end)
+[%%expect{|
+Lines 1-3, characters 17-3:
+1 | .................struct
+2 |   type t = { mutable x : int [@atomic] }
+3 | end......
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = { mutable x : int [@atomic]; } end
+       is not included in
+         sig type t = { mutable x : int; } end
+       Type declarations do not match:
+         type t = { mutable x : int [@atomic]; }
+       is not included in
+         type t = { mutable x : int; }
+       Fields do not match:
+         "mutable x : int [@atomic];"
+       is not the same as:
+         "mutable x : int;"
+       The first is atomic and the second is not.
+|}];;
+
+module Ok = (struct
+  type t = { mutable x : int [@atomic] }
+end : sig
+  type t = { mutable x : int [@atomic] }
+end)
+[%%expect{|
+(apply (field_imm 1 (global Toploop!)) "Ok/305" (makeblock 0))
+module Ok : sig type t = { mutable x : int [@atomic]; } end
+|}];;
+
+(* Inline records are supported, including in extensions. *)
+
+module Inline_record = struct
+  type t = A of { mutable x : int [@atomic] }
+
+  let test : t -> int = fun (A r) -> r.x
+end
+[%%expect{|
+(apply (field_imm 1 (global Toploop!)) "Inline_record/313"
+  (let
+    (test =
+       (function {nlocal = 0} param : int (atomic_load_field_imm param 0)))
+    (makeblock 0 test)))
+module Inline_record :
+  sig type t = A of { mutable x : int [@atomic]; } val test : t -> int end
+|}];;
+
+module Extension_with_inline_record = struct
+  type t = ..
+  type t += A of { mutable x : int [@atomic] }
+
+  (* one should see in the -dlambda output below that the field offset is not 0
+     as one could expect, but 1, due to an extra argument in extensible variants. *)
+  let test : t -> int = function
+    | A r -> r.x
+    | _ -> 0
+
+  let () = assert (test (A { x = 42 }) = 42)
+end
+
+[%%expect{|
+(apply (field_imm 1 (global Toploop!)) "Extension_with_inline_record/321"
+  (let
+    (A =
+       (makeblock_unique 248 "Extension_with_inline_record.A"
+         (caml_fresh_oo_id 0))
+     test =
+       (function {nlocal = 0} param : int
+         (if (== (field_imm 0 param) A) (atomic_load_field_imm param 1) 0))
+     *match* =[value<int>]
+       (if (== (apply test (makemutable 0 (?,value<int>) A 42)) 42) 0
+         (raise (makeblock 0 (getpredef Assert_failure!!) [0: "" 11 11]))))
+    (makeblock 0 A test)))
+module Extension_with_inline_record :
+  sig
+    type t = ..
+    type t += A of { mutable x : int [@atomic]; }
+    val test : t -> int
+  end
+|}]
+
+(* Marking a field [@atomic] in a float-only record disables the unboxing optimization. *)
+module Float_records = struct
+  type flat = { x : float; mutable y : float }
+  type t = { x : float; mutable y : float [@atomic] }
+
+  let mk_flat x y : flat = { x; y }
+  let mk_t x y : t = { x; y }
+  let get v = v.y
+end
+[%%expect{|
+Line 3, characters 2-53:
+3 |   type t = { x : float; mutable y : float [@atomic] }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 214 [atomic-float-record-boxed]: This record contains atomic
+float fields, which prevents the float record optimization. The
+fields of this record will be boxed instead of being
+represented as a flat float array.
+(apply (field_imm 1 (global Toploop!)) "Float_records/347"
+  (let
+    (mk_flat =
+       (function {nlocal = 0} x[value<float>] y[value<float>]
+         (makefloatblock Mutable x y))
+     mk_t =
+       (function {nlocal = 0} x[value<float>] y[value<float>]
+         (makemutable 0 (value<float>,value<float>) x y))
+     get = (function {nlocal = 0} v : float (atomic_load_field_ptr v 1)))
+    (makeblock 0 mk_flat mk_t get)))
+
+module Float_records :
+  sig
+    type flat = { x : float; mutable y : float; }
+    type t = { x : float; mutable y : float [@atomic]; }
+    val mk_flat : float -> float -> flat
+    val mk_t : float -> float -> t
+    val get : t -> float
+  end
+|}]
+
+(* Tests for Warning 214: Atomic float record boxing *)
+
+(* This should trigger warning 214 - all atomic float fields *)
+type all_atomic_floats = {
+  mutable x : float [@atomic];
+  mutable y : float [@atomic];
+  mutable z : float [@atomic];
+}
+[%%expect{|
+Lines 1-5, characters 0-1:
+1 | type all_atomic_floats = {
+2 |   mutable x : float [@atomic];
+3 |   mutable y : float [@atomic];
+4 |   mutable z : float [@atomic];
+5 | }
+Warning 214 [atomic-float-record-boxed]: This record contains atomic
+float fields, which prevents the float record optimization. The
+fields of this record will be boxed instead of being
+represented as a flat float array.
+0
+
+type all_atomic_floats = {
+  mutable x : float [@atomic];
+  mutable y : float [@atomic];
+  mutable z : float [@atomic];
+}
+|}]
+
+(* This should trigger warning 214 - mix of atomic and non-atomic float fields *)
+type mixed_atomic_floats = {
+  mutable a : float;
+  mutable b : float [@atomic];
+  mutable c : float;
+  mutable d : float [@atomic];
+}
+[%%expect{|
+Lines 1-6, characters 0-1:
+1 | type mixed_atomic_floats = {
+2 |   mutable a : float;
+3 |   mutable b : float [@atomic];
+4 |   mutable c : float;
+5 |   mutable d : float [@atomic];
+6 | }
+Warning 214 [atomic-float-record-boxed]: This record contains atomic
+float fields, which prevents the float record optimization. The
+fields of this record will be boxed instead of being
+represented as a flat float array.
+0
+
+type mixed_atomic_floats = {
+  mutable a : float;
+  mutable b : float [@atomic];
+  mutable c : float;
+  mutable d : float [@atomic];
+}
+|}]
+
+(* This should NOT trigger warning 214 - has non-float fields *)
+type atomic_float_with_int = {
+  mutable f : float [@atomic];
+  mutable i : int;
+  mutable g : float;
+}
+[%%expect{|
+0
+type atomic_float_with_int = {
+  mutable f : float [@atomic];
+  mutable i : int;
+  mutable g : float;
+}
+|}]
+
+(* This should NOT trigger warning 214 - no atomic fields *)
+type regular_float_record = {
+  mutable p : float;
+  mutable q : float;
+  mutable r : float;
+}
+[%%expect{|
+0
+type regular_float_record = {
+  mutable p : float;
+  mutable q : float;
+  mutable r : float;
+}
+|}]
+
+(* This should NOT trigger warning 214 - immutable float fields (can't be atomic) *)
+type immutable_float_record = {
+  x : float;
+  y : float;
+  z : float;
+}
+[%%expect{|
+0
+type immutable_float_record = { x : float; y : float; z : float; }
+|}]
+
+(* This should trigger warning 214 - single atomic float field *)
+type single_atomic_float = {
+  mutable value : float [@atomic];
+}
+[%%expect{|
+Lines 1-3, characters 0-1:
+1 | type single_atomic_float = {
+2 |   mutable value : float [@atomic];
+3 | }
+Warning 214 [atomic-float-record-boxed]: This record contains atomic
+float fields, which prevents the float record optimization. The
+fields of this record will be boxed instead of being
+represented as a flat float array.
+0
+
+type single_atomic_float = { mutable value : float [@atomic]; }
+|}]
+
+(* Test warning suppression with [@@@warning "-214"] *)
+[@@@warning "-214"]
+type suppressed_atomic_float = {
+  mutable x : float [@atomic];
+  mutable y : float [@atomic];
+}
+[%%expect{|
+0
+0
+type suppressed_atomic_float = {
+  mutable x : float [@atomic];
+  mutable y : float [@atomic];
+}
+|}]
+
+(* Re-enable the warning *)
+[@@@warning "+214"]
+type not_suppressed_atomic_float = {
+  mutable a : float [@atomic];
+}
+[%%expect{|
+0
+Lines 2-4, characters 0-1:
+2 | type not_suppressed_atomic_float = {
+3 |   mutable a : float [@atomic];
+4 | }
+Warning 214 [atomic-float-record-boxed]: This record contains atomic
+float fields, which prevents the float record optimization. The
+fields of this record will be boxed instead of being
+represented as a flat float array.
+0
+
+type not_suppressed_atomic_float = { mutable a : float [@atomic]; }
+|}]
+
+type suppressed_directly = { mutable a : float [@atomic] }
+[@@warning "-214"]
+[%%expect{|
+0
+type suppressed_directly = { mutable a : float [@atomic]; }
+|}]
+
+
+type suppressed_via_mnemonic = { mutable a : float [@atomic] }
+[@@warning "-atomic-float-record-boxed"]
+[%%expect{|
+0
+type suppressed_via_mnemonic = { mutable a : float [@atomic]; }
+|}]
+
+(* Pattern-matching on atomic record fields is disallowed. *)
+module Pattern_matching = struct
+  type t = { x : int; mutable y : int [@atomic] }
+
+  let forbidden { x; y } = x + y
+end
+[%%expect{|
+Line 4, characters 16-24:
+4 |   let forbidden { x; y } = x + y
+                    ^^^^^^^^
+Error: Atomic fields (here "y") are forbidden in patterns,
+       as it is difficult to reason about when the atomic read
+       will happen during pattern matching: the field may be read
+       zero, one or several times depending on the patterns around it.
+|}]
+
+(* ... except for wildcards, to allow exhaustive record patterns. *)
+module Pattern_matching_wildcard = struct
+  type t = { x : int; mutable y : int [@atomic] }
+
+  [@@@warning "+missing-record-field-pattern"]
+  let warning { x } = x
+
+  let allowed { x; y = _ } = x
+  let also_allowed { x; _ } = x
+end
+[%%expect{|
+Line 5, characters 14-19:
+5 |   let warning { x } = x
+                  ^^^^^
+Warning 9 [missing-record-field-pattern]: the following labels are not bound in this record pattern:
+y
+Either bind these labels explicitly or add '; _' to the pattern.
+(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/430"
+  (let
+    (warning = (function {nlocal = 0} param : int (field_int 0 param))
+     allowed = (function {nlocal = 0} param : int (field_int 0 param))
+     also_allowed = (function {nlocal = 0} param : int (field_int 0 param)))
+    (makeblock 0 warning allowed also_allowed)))
+
+module Pattern_matching_wildcard :
+  sig
+    type t = { x : int; mutable y : int [@atomic]; }
+    val warning : t -> int
+    val allowed : t -> int
+    val also_allowed : t -> int
+  end
+|}]

--- a/testsuite/tests/compiler-libs/test_untypeast.ml
+++ b/testsuite/tests/compiler-libs/test_untypeast.ml
@@ -8,17 +8,28 @@ let run s =
   let pe = Parse.expression (Lexing.from_string s) in
   let te = Typecore.type_expression (Lazy.force Env.initial) pe in
   let ute = Untypeast.untype_expression te in
-  Format.asprintf "%a" Pprintast.expression ute
+  Format.printf "%a@." Pprintast.expression ute
 ;;
 
 [%%expect{|
-val run : string -> string = <fun>
+val run : string -> unit = <fun>
 |}];;
 
 run {| match None with Some (Some _) -> () | _ -> () |};;
 
 [%%expect{|
-- : string = "match None with | Some (Some _) -> () | _ -> ()"
+match None with | Some (Some _) -> () | _ -> ()
+- : unit = ()
+|}];;
+
+run {| let open struct type t = { mutable x : int [@atomic] } end in
+       let _ = fun (v : t) -> v.x in () |};;
+
+[%%expect{|
+let open struct type t = {
+                  mutable x: int [@atomic ]} end in
+  let _ = fun (v : t) -> v.x in ()
+- : unit = ()
 |}];;
 
 (***********************************)
@@ -28,20 +39,23 @@ run {| match None with Some (Some _) -> () | _ -> () |};;
 run {| fun x y z -> function w -> x y z w |};;
 
 [%%expect{|
-- : string = "fun x y z -> function | w -> x y z w"
+fun x y z -> function | w -> x y z w
+- : unit = ()
 |}];;
 
 (* 3-ary function returning a 1-ary function *)
 run {| fun x y z -> (function w -> x y z w) |};;
 
 [%%expect{|
-- : string = "fun x y z -> (function | w -> x y z w)"
+fun x y z -> (function | w -> x y z w)
+- : unit = ()
 |}];;
 
 run {| match None with Some (Some _) -> () | _ -> () |};;
 
 [%%expect{|
-- : string = "match None with | Some (Some _) -> () | _ -> ()"
+match None with | Some (Some _) -> () | _ -> ()
+- : unit = ()
 |}];;
 
 (***********************************)
@@ -51,14 +65,16 @@ run {| match None with Some (Some _) -> () | _ -> () |};;
 run {| fun x y z -> function w -> x y z w |};;
 
 [%%expect{|
-- : string = "fun x y z -> function | w -> x y z w"
+fun x y z -> function | w -> x y z w
+- : unit = ()
 |}];;
 
 (* 3-ary function returning a 1-ary function *)
 run {| fun x y z -> (function w -> x y z w) |};;
 
 [%%expect{|
-- : string = "fun x y z -> (function | w -> x y z w)"
+fun x y z -> (function | w -> x y z w)
+- : unit = ()
 |}];;
 
 (***********************************)
@@ -67,14 +83,16 @@ run {| fun x y z -> (function w -> x y z w) |};;
 run {| let foo : 'a. 'a -> 'a = fun x -> x in foo |}
 
 [%%expect{|
-- : string = "let foo : ('a : value) . 'a -> 'a = fun x -> x in foo"
+let foo : ('a : value) . 'a -> 'a = fun x -> x in foo
+- : unit = ()
 |}];;
 
 run {| let foo : type a . a -> a = fun x -> x in foo |}
 
 [%%expect{|
-- : string =
-"let foo : ('a : value) . 'a -> 'a = fun (type a) -> ( (fun x -> x : a -> a)) in\nfoo"
+let foo : ('a : value) . 'a -> 'a = fun (type a) -> ( (fun x -> x : a -> a)) in
+foo
+- : unit = ()
 |}];;
 
 (* CR: untypeast/pprintast are totally busted on programs with modes in value
@@ -82,12 +100,13 @@ run {| let foo : type a . a -> a = fun x -> x in foo |}
 run {| let foo : ('a -> 'a) @ portable = fun x -> x in foo |}
 
 [%%expect{|
-- : string =
-"let (foo : 'a -> 'a) = ((fun x -> x : 'a -> 'a) : _ @ portable) in foo"
+let (foo : 'a -> 'a) = ((fun x -> x : 'a -> 'a) : _ @ portable) in foo
+- : unit = ()
 |}];;
 
 run {| let foo : 'a . ('a -> 'a) @ portable = fun x -> x in foo |}
 
 [%%expect{|
-- : string = "let foo : ('a : value) . 'a -> 'a = fun x -> x in foo"
+let foo : ('a : value) . 'a -> 'a = fun x -> x in foo
+- : unit = ()
 |}];;

--- a/testsuite/tests/typing-deprecated/deprecated.ml
+++ b/testsuite/tests/typing-deprecated/deprecated.ml
@@ -638,6 +638,11 @@ Line 3, characters 21-36:
                          ^^^^^^^^^^^^^^^
 Warning 22 [preprocessor]: Pp warning 2!
 
+Line 4, characters 21-36:
+4 |   [@@ocaml.ppwarning "Pp warning 3!"]
+                         ^^^^^^^^^^^^^^^
+Warning 22 [preprocessor]: Pp warning 3!
+
 type t = unit
 |}]
 

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -63,6 +63,7 @@ type kind_mismatch = type_kind * type_kind
 type label_mismatch =
   | Type of Errortrace.equality_error
   | Mutability of position
+  | Atomicity of position
   | Modality of Mode.Modality.Value.equate_error
 
 type record_change =

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -605,19 +605,24 @@ and print_typargs ppf =
       pp_print_space ppf ()
 and print_out_label ppf (name, mut, arg, gbl) =
   (* See the notes [NON-LEGACY MODES] *)
-  let mut =
+  let mut, atomic =
     match mut with
-    | Om_immutable -> ""
-    | Om_mutable None -> "mutable "
-    | Om_mutable (Some s) -> "mutable(" ^ s ^ ") "
+    | Om_immutable -> "", Nonatomic
+    | Om_mutable (None, atomic) -> "mutable ", atomic
+    | Om_mutable (Some s, atomic) -> "mutable(" ^ s ^ ") ", atomic
+  in
+  let print_atomic ppf atomic = match atomic with
+    | Nonatomic -> ()
+    | Atomic -> fprintf ppf " [@@atomic]"
   in
   let m_legacy, m_new = partition_modalities gbl in
-  fprintf ppf "@[<2>%s%a%a :@ %a%a@];"
+  fprintf ppf "@[<2>%s%a%a :@ %a%a%a@];"
     mut
     print_out_modalities_legacy m_legacy
     print_lident name
     print_out_type arg
     print_out_modalities_new m_new
+    print_atomic atomic
 
 and print_out_jkind_const ppf ojkind =
   let rec pp_element ~nested ppf (ojkind : Outcometree.out_jkind_const) =

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -68,9 +68,13 @@ type out_modality =
   | Ogf_legacy of out_modality_legacy
   | Ogf_new of out_modality_new
 
+type out_atomicity =
+  | Atomic
+  | Nonatomic
+
 type out_mutability =
   | Om_immutable
-  | Om_mutable of string option
+  | Om_mutable of string option * out_atomicity
 
 
 

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1838,12 +1838,17 @@ let param_jkind ty =
 let tree_of_label l =
   let mut =
     match l.ld_mutable with
-    | Mutable m ->
+    | Mutable { mode; atomic } ->
+        let atomic =
+          match atomic with
+          | Atomic -> Atomic
+          | Nonatomic -> Nonatomic
+        in
         let mut =
           let open Value.Comonadic in
-          match equate m legacy with
-          | Ok () -> Om_mutable None
-          | Error _ -> Om_mutable (Some "<non-legacy>")
+          match equate mode legacy with
+          | Ok () -> Om_mutable (None, atomic)
+          | Error _ -> Om_mutable (Some "<non-legacy>", atomic)
         in
         mut
     | Immutable -> Om_immutable

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -91,8 +91,10 @@ let fmt_mutable_flag f x =
 let fmt_mutable_mode_flag f (x : Types.mutability) =
   match x with
   | Immutable -> fprintf f "Immutable"
-  | Mutable m ->
-    fprintf f "Mutable(%a)" (Mode.Value.Comonadic.print ()) m
+  | Mutable { mode; atomic = Nonatomic } ->
+    fprintf f "Mutable(%a)" (Mode.Value.Comonadic.print ()) mode
+  | Mutable { mode; atomic = Atomic } ->
+    fprintf f "Atomic(%a)" (Mode.Value.Comonadic.print ()) mode
 
 let fmt_virtual_flag f x =
   match x with

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -244,6 +244,7 @@ type error =
   | Probe_name_undefined of string
   | Probe_is_enabled_format
   | Extension_not_enabled : _ Language_extension.t -> error
+  | Atomic_in_pattern of Longident.t
   | Literal_overflow of string
   | Unknown_literal of string * char
   | Float32_literal of string
@@ -1021,7 +1022,7 @@ let apply_mode_annots ~loc ~env (m : Alloc.Const.Option.t) mode =
 let check_construct_mutability ~loc ~env mutability ?ty ?modalities block_mode =
   match mutability with
   | Immutable -> ()
-  | Mutable m0 ->
+  | Mutable { mode = m0; _ } ->
       let m0 = m0 |> mutable_mode |> Value.disallow_right in
       let m0 = match ty with
       | Some ty -> cross_left env ty ?modalities m0
@@ -1037,7 +1038,8 @@ let mutvar_mode ~loc ~env m0 exp_mode =
   let mode = mode_default m in
   let modalities = Typemode.let_mutable_modalities m0 in
   submode ~loc ~env exp_mode (mode_modality modalities mode);
-  check_construct_mutability ~loc ~env (Mutable m0) ~modalities mode;
+  check_construct_mutability ~loc ~env
+    (Mutable { mode = m0; atomic = Nonatomic}) ~modalities mode;
   m |> Value.disallow_right
 
 (** The [expected_mode] of the record when projecting a mutable field. *)
@@ -2664,6 +2666,17 @@ let as_comp_pattern
 let components_have_label (labeled_components : (string option * 'a) list) =
   List.exists (function Some _, _ -> true | _ -> false) labeled_components
 
+let forbid_atomic_field_patterns loc penv (label_lid, label, pat) =
+  (* Pattern-matching under atomic record fields is not allowed. We
+     still allow wildcard patterns, so that it is valid to list all
+     record fields exhaustively. *)
+  let wildcard pat = match pat.pat_desc with
+    | Tpat_any -> true
+    | _ -> false
+  in
+  if Types.is_atomic label.lbl_mut && not (wildcard pat) then
+    raise (Error (loc, !!penv, Atomic_in_pattern label_lid.txt))
+
 (** [type_pat] propagates the expected type, and
     unification may update the typing environment. *)
 let rec type_pat
@@ -2837,6 +2850,7 @@ and type_pat_aux
       let make_record_pat
             (lbl_pat_list : (_ * rep gen_label_description * _) list) =
         check_recordpat_labels loc lbl_pat_list closed record_form;
+        List.iter (forbid_atomic_field_patterns loc penv) lbl_pat_list;
         let pat_desc = match record_form with
           | Legacy -> Tpat_record (lbl_pat_list, closed)
           | Unboxed_product ->
@@ -3110,7 +3124,11 @@ and type_pat_aux
   | Ppat_array (mut, spl) ->
       let mut =
         match mut with
-        | Mutable -> Mutable Value.Comonadic.legacy
+        | Mutable  -> Mutable {
+          mode = Value.Comonadic.legacy;
+          (* CR aspsmith: Revisit once we support atomic arrays *)
+          atomic = Nonatomic
+        }
         | Immutable ->
             Language_extension.assert_enabled ~loc Immutable_arrays ();
             Immutable
@@ -6322,7 +6340,8 @@ and type_expect_
       in
       let (label_loc, label, newval) =
         match label.lbl_mut with
-        | Mutable m0 ->
+        | Mutable { mode = m0; atomic } ->
+          ignore atomic;  (* CR aspsmith: TODO *)
           submode ~loc:record.exp_loc ~env rmode mode_mutate_mutable;
           let mode = mutable_mode m0 |> mode_default in
           let mode = mode_modality label.lbl_modalities mode in
@@ -6344,7 +6363,11 @@ and type_expect_
   | Pexp_array(mut, sargl) ->
       let mutability =
         match mut with
-        | Mutable -> Mutable Value.Comonadic.legacy
+        | Mutable -> Mutable {
+          mode = Value.Comonadic.legacy;
+          (* CR aspsmith: Revisit once we support atomic arrays *)
+          atomic = Nonatomic;
+        }
         | Immutable ->
             Language_extension.assert_enabled ~loc Immutable_arrays ();
             Immutable
@@ -9971,10 +9994,15 @@ and type_comprehension_expr ~loc ~env ~ty_expected ~attributes cexpr =
         Predef.list_argument_jkind
     | Pcomp_array_comprehension (amut, comp) ->
         let container_type, mut = match amut with
-          | Mutable   -> Predef.type_array, Mutable Value.Comonadic.legacy
-          | Immutable ->
-              Language_extension.assert_enabled ~loc Immutable_arrays ();
-              Predef.type_iarray, Immutable
+        | Mutable   ->
+          Predef.type_array, Mutable {
+            mode = Value.Comonadic.legacy;
+            (* CR aspsmith: Revisit once we support atomic arrays *)
+            atomic = Nonatomic
+          }
+        | Immutable ->
+          Language_extension.assert_enabled ~loc Immutable_arrays ();
+          Predef.type_iarray, Immutable
         in
         (Array_comprehension mut : comprehension_type),
         container_type,
@@ -11064,6 +11092,13 @@ let report_error ~loc env =
     let name = Language_extension.to_string ext in
     Location.errorf ~loc
         "Extension %s must be enabled to use this feature." name
+  | Atomic_in_pattern lid ->
+      Location.errorf ~loc
+        "Atomic fields (here %a) are forbidden in patterns,@ \
+         as it is difficult to reason about when the atomic read@ \
+         will happen during pattern matching:@ the field may be read@ \
+         zero, one or several times depending on the patterns around it."
+        (Style.as_inline_code longident) lid
   | Literal_overflow ty ->
       Location.errorf ~loc
         "Integer literal exceeds the range of representable integers of type %a"

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -293,6 +293,7 @@ type error =
   (* CR-soon mshinwell: Use an inlined record *)
   | Probe_is_enabled_format
   | Extension_not_enabled : _ Language_extension.t -> error
+  | Atomic_in_pattern of Longident.t
   | Literal_overflow of string
   | Unknown_literal of string * char
   | Float32_literal of string

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -141,6 +141,7 @@ type error =
   | Unsafe_mode_crossing_on_invalid_type_kind
   | Illegal_baggage of jkind_l
   | No_unboxed_version of Path.t
+  | Atomic_field_must_be_mutable of string
 
 open Typedtree
 
@@ -481,12 +482,18 @@ let transl_labels (type rep) ~(record_form : rep record_form) ~new_var_jkind
           pld_type=arg;pld_loc=loc;pld_attributes=attrs} =
     Builtin_attributes.warning_scope attrs
       (fun () ->
+         let is_atomic = Builtin_attributes.has_atomic attrs in
          let mut : mutability =
-          match mut with
-          | Immutable -> Immutable
-          | Mutable ->
+          match mut, is_atomic with
+          | Immutable, false -> Immutable
+          | Immutable, true ->
+            raise (Error (loc, Atomic_field_must_be_mutable name.txt))
+          | Mutable, is_atomic ->
               match record_form with
-              | Legacy -> Mutable Mode.Value.Comonadic.legacy
+              | Legacy -> Mutable {
+                mode = Mode.Value.Comonadic.legacy;
+                atomic = if is_atomic then Atomic else Nonatomic
+              }
               | Unboxed_product -> raise(Error(loc, Unboxed_mutable_label))
          in
          let modalities =
@@ -1668,8 +1675,9 @@ module Element_repr = struct
        don't give us enough information to do this reliably, and you could just
        use unboxed floats instead. *)
 
-  let classify env ty jkind =
-    if is_float env ty then Float_element
+  let classify env  ty jkind =
+    if is_float env ty
+    then Float_element
     else
       let layout = Jkind.get_layout_defaulting_to_value jkind in
       let sort =
@@ -1749,15 +1757,16 @@ let update_constructor_representation
     | Cstr_tuple arg_types_and_modes ->
         let arg_reprs =
           List.map2 (fun {Types.ca_type=arg_type; _} arg_jkind ->
-            Element_repr.classify env arg_type arg_jkind, arg_type)
+            Element_repr.classify env arg_type arg_jkind,
+            arg_type)
             arg_types_and_modes arg_jkinds
         in
         Element_repr.mixed_product_shape loc arg_reprs Cstr_tuple
     | Cstr_record fields ->
         let arg_reprs =
           List.map2 (fun ld arg_jkind ->
-              Element_repr.classify env ld.Types.ld_type arg_jkind,
-              ld.Types.ld_type)
+            Element_repr.classify env ld.Types.ld_type arg_jkind,
+            ld.Types.ld_type)
             fields arg_jkinds
         in
         Element_repr.mixed_product_shape loc arg_reprs Cstr_record
@@ -1807,6 +1816,7 @@ let rec update_decl_jkind env dpath decl =
          (* For purposes of this record, [floats] tracks whether any field
             has layout value and is known to be a float.
          *)
+         mutable atomic_floats : bool;
          mutable float64s : bool;
          mutable non_float64_unboxed_fields : bool;
          (* Includes product containing void *)
@@ -1836,18 +1846,23 @@ let rec update_decl_jkind env dpath decl =
         List.map2
           (fun lbl jkind ->
              Element_repr.classify env lbl.Types.ld_type jkind,
-             lbl.Types.ld_type)
+             lbl.Types.ld_type )
           lbls jkinds
       in
       let repr_summary =
-        { values = false; floats = false; float64s = false;
-          non_float64_unboxed_fields = false; voids = false;
+        { values = false; floats = false; atomic_floats = false;
+          float64s = false; non_float64_unboxed_fields = false;
+          voids = false;
         }
       in
-      List.iter
-        (fun ((repr : Element_repr.t), _lbl) ->
+      List.iter2
+        (fun ((repr : Element_repr.t), _) lbl ->
            match repr with
-           | Float_element -> repr_summary.floats <- true
+           | Float_element ->
+               repr_summary.floats <- true;
+               (* Check if this float field is atomic *)
+               if Types.is_atomic lbl.Types.ld_mutable
+               then repr_summary.atomic_floats <- true;
            | Unboxed_element Float64 -> repr_summary.float64s <- true
            | Unboxed_element ( Float32 | Bits8 | Bits16 | Bits32 | Bits64
                              | Vec128 | Vec256 | Vec512 | Word | Product _ ) ->
@@ -1855,13 +1870,13 @@ let rec update_decl_jkind env dpath decl =
            | Value_element -> repr_summary.values <- true
            | Void ->
                repr_summary.voids <- true)
-        reprs;
+        reprs lbls;
       let rep =
         (* CR layouts: improve the readability of this match *)
         match repr_summary with
         (* We store floats flatly in mixed records if all fields are
            float/float64/void. *)
-        | { values = false; floats = true;
+        | { values = false; floats = true; atomic_floats = false;
             float64s = true; non_float64_unboxed_fields = false }
            ->
             let shape =
@@ -1902,17 +1917,26 @@ let rec update_decl_jkind env dpath decl =
         | { values = true; float64s = false; non_float64_unboxed_fields = false;
             voids = false }
           -> rep
-        (* All-float and all-float64 records are stored as flat float records.
+        (* All-nonatomic-float and all-nonatomic-float64 records are stored as
+           flat float records.
         *)
-        | { values = false; floats = true ; float64s = false;
-            non_float64_unboxed_fields = false; voids = false } ->
+        | { values = false; floats = true ; atomic_floats = false;
+            float64s = false; non_float64_unboxed_fields = false;
+            voids = false } ->
           Record_float
-        | { values = false; floats = false; float64s = true;
-            non_float64_unboxed_fields = false; voids = false } ->
+        | { values = false; floats = false; atomic_floats = false;
+            float64s = true; non_float64_unboxed_fields = false;
+            voids = false } ->
           Record_ufloat
-        | { values = false; floats = false; float64s = false;
-            non_float64_unboxed_fields = false; voids = _ }  ->
-          (* CR layouts v5: support all-void records *)
+        (* Records with atomic float fields cannot use flat representation *)
+        | { atomic_floats = true; floats; values; _ } ->
+          if floats && not values
+          then Location.prerr_warning loc Warnings.Atomic_float_record_boxed;
+          rep
+        | { values = false; floats = false; atomic_floats = false;
+            float64s = false; non_float64_unboxed_fields = false;
+            voids = _ }
+          [@warning "+9"] ->
           Misc.fatal_error "Typedecl.update_record_kind: empty record"
       in
       lbls, rep, jkind
@@ -2091,22 +2115,24 @@ let update_decls_jkind_reason env decls =
 let update_decls_jkind env decls =
   List.map
     (fun (id, decl) ->
-       let allow_any_crossing =
-         Builtin_attributes.has_unsafe_allow_any_mode_crossing
-           decl.type_attributes
-       in
+       Builtin_attributes.warning_scope decl.type_attributes (fun () ->
+         let allow_any_crossing =
+           Builtin_attributes.has_unsafe_allow_any_mode_crossing
+             decl.type_attributes
+         in
 
-       (* Check that the attribute is valid, if set (unconditionally, for
-          consistency). *)
-       if allow_any_crossing then begin
-         match decl.type_kind with
-         | Type_abstract _ | Type_open ->
-           raise(
-             Error(decl.type_loc, Unsafe_mode_crossing_on_invalid_type_kind))
-         | _ -> ()
-       end;
+         (* Check that the attribute is valid, if set (unconditionally, for
+            consistency). *)
+         if allow_any_crossing then begin
+           match decl.type_kind with
+           | Type_abstract _ | Type_open ->
+             raise(Error(
+               decl.type_loc, Unsafe_mode_crossing_on_invalid_type_kind))
+           | _ -> ()
+         end;
 
-       (id, decl, allow_any_crossing, update_decl_jkind env (Pident id) decl))
+         (id, decl, allow_any_crossing,
+          update_decl_jkind env (Pident id) decl)))
     decls
 
 (* See Note [Typechecking unboxed versions of types]. *)
@@ -4750,6 +4776,10 @@ let report_error ppf = function
   | No_unboxed_version p ->
       fprintf ppf "@[The type %a@ has no unboxed version.@]"
         (Style.as_inline_code Printtyp.path) p
+  | Atomic_field_must_be_mutable name ->
+      fprintf ppf
+        "@[The label %a must be mutable to be declared atomic.@]"
+        Style.inline_code name
 
 let () =
   Location.register_error_of_exn

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -176,6 +176,7 @@ type error =
   | Unsafe_mode_crossing_on_invalid_type_kind
   | Illegal_baggage of jkind_l
   | No_unboxed_version of Path.t
+  | Atomic_field_must_be_mutable of string
 
 exception Error of Location.t * error
 

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -580,7 +580,9 @@ let transl_modalities ~maturity mut modalities =
     mut_modalities modalities
 
 let let_mutable_modalities m0 =
-  mutable_implied_modalities (Mutable m0) ~for_mutable_variable:true
+  mutable_implied_modalities
+    (Mutable { mode = m0; atomic = Nonatomic })
+    ~for_mutable_variable:true
 
 let untransl_modalities mut t =
   t

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -18,13 +18,25 @@
 open Allowance
 open Asttypes
 
+type atomic =
+  | Nonatomic
+  | Atomic
+
 type mutability =
   | Immutable
-  | Mutable of Mode.Value.Comonadic.lr
+  | Mutable of
+      { mode : Mode.Value.Comonadic.lr
+      ; atomic : atomic
+      }
 
 let is_mutable = function
   | Immutable -> false
   | Mutable _ -> true
+
+let is_atomic = function
+  | Immutable -> false
+  | Mutable { atomic = Atomic; mode = _ } -> true
+  | Mutable { atomic = Nonatomic; mode = _ } -> false
 
 (** Takes [m0] which is the parameter of [let mutable], returns the
     mode of new values in future writes. *)

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -26,15 +26,27 @@ open Allowance
 (** Asttypes exposes basic definitions shared both by Parsetree and Types. *)
 open Asttypes
 
+(** Whether or not a mutable field is atomic *)
+type atomic =
+  | Nonatomic
+  | Atomic
+
 (** Describes a mutable field/element. *)
 type mutability =
   | Immutable
-  | Mutable of Mode.Value.Comonadic.lr
-  (** Mode of new field value in mutation. *)
+  | Mutable of
+      { mode : Mode.Value.Comonadic.lr
+        (** Mode of new field value in mutation. *)
+      ; atomic : atomic
+      }
 
-(** Returns [true] is the [mutable_flag] is mutable. Should be called if not
-    interested in the payload of [Mutable]. *)
+(** Returns [true] is the [mutable_flag] is mutable or atomic. Should be called
+    if not interested in the payload of [Mutable]. *)
 val is_mutable : mutability -> bool
+
+(** Returns [true] is the [mutable_flag] is atomic. Should be called
+    if not interested in the payload of [Mutable]. *)
+val is_atomic : mutability -> bool
 
 (** Given the parameter [m0] on mutable, return the mode of future writes. *)
 val mutable_mode : ('l * 'r) Mode.Value.Comonadic.t -> ('l * 'r) Mode.Value.t

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -273,9 +273,9 @@ let constructor_declaration sub cd =
 let mutable_ (mut : Types.mutability) : mutable_flag =
   match mut with
   | Immutable -> Immutable
-  | Mutable m ->
+  | Mutable { mode; atomic = _ } ->
       let open Mode.Value.Comonadic in
-      equate_exn m legacy;
+      equate_exn mode legacy;
       Mutable
 
 let label_declaration sub ld =

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -139,6 +139,7 @@ type t =
     { axis : string;
       overriden_by : string;
     } (* 213 *)
+  | Atomic_float_record_boxed               (* 214 *)
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
    the numbers of existing warnings.
@@ -230,6 +231,7 @@ let number = function
   | Unboxing_impossible -> 210
   | Mod_by_top _ -> 211
   | Modal_axis_specified_twice _ -> 213
+  | Atomic_float_record_boxed -> 214
 ;;
 (* DO NOT REMOVE the ;; above: it is used by
    the testsuite/ests/warnings/mnemonics.mll test to determine where
@@ -615,6 +617,11 @@ let descriptions = [
   { number = 211;
     names = ["mod-by-top"];
     description = "Including the top-most element of an axis in a kind's modifiers is a no-op.";
+    since = since 4 14 };
+  { number = 214;
+    names = ["atomic-float-record-boxed"];
+    description = "Record contains atomic float fields, preventing the flat\n\
+                   float record optimization.";
     since = since 4 14 };
 ]
 
@@ -1287,6 +1294,12 @@ let message = function
     Printf.sprintf
       "This %s is overriden by %s later."
       axis overriden_by
+  | Atomic_float_record_boxed ->
+    Printf.sprintf
+      "This record contains atomic\n\
+       float fields, which prevents the float record optimization. The\n\
+       fields of this record will be boxed instead of being\n\
+       represented as a flat float array."
 ;;
 
 let nerrors = ref 0

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -144,6 +144,7 @@ type t =
       axis : string;
       overriden_by : string;
     }                                       (* 213 *)
+  | Atomic_float_record_boxed               (* 214 *)
 
 type alert = {kind:string; message:string; def:loc; use:loc}
 


### PR DESCRIPTION
Reverts oxcaml/oxcaml#4414

Now that the `[@atomic]` attribute is out of the way, we can try to land this again.