### PR TITLE
Bump dune version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,7 @@ jobs:
       id: cache
       with:
         path: ${{ github.workspace }}/ocaml-414/_install
-        key: ${{ matrix.os }}-cache-ocaml-414-patched-dune-3152-menhir-20231231-rev13
+        key: ${{ matrix.os }}-cache-ocaml-414-dune-3153-menhir-20231231-rev13
 
     - name: Checkout OCaml 4.14
       uses: actions/checkout@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,7 +193,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       with:
         repository: 'ocaml/dune'
-        ref: '3.15.2'
+        ref: '3.15.3'
         path: 'dune'
 
     - name: Build dune

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ One-time setup (you can also use other 4.14.x releases):
 ```
 $ opam switch 4.14.1  # or "opam switch create 4.14.1" if you haven't got that switch already
 $ eval $(opam env)
-$ opam install dune.3.15.2 menhir.20231231
+$ opam install dune.3.15.3 menhir.20231231
 ```
 
 You probably then want to fork the `oxcaml/oxcaml` repo to your own Github org.


### PR DESCRIPTION
As per title, because 3.15.2 is no longer
available from opam. The 3.15.2 tag still
exists in the dune repository, to the CI
job does not _need_ to be updated - I
just thought it would be more consistent.

(The renaming of the cache key is not
particularly useful, but suggested for
consistency.)