### PR TITLE
Fix soundness issue with recursive abstract with bounds

### DIFF
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2283,6 +2283,30 @@ let type_equal' = ref (fun _ _ _ -> Misc.fatal_error "type_equal")
 let type_jkind_purely_if_principal' =
   ref (fun _ _ -> Misc.fatal_error "type_jkind_purely_if_principal")
 
+(* Helper functions for creating jkind contexts *)
+let mk_is_abstract env p =
+  let decl = 
+    try Env.find_type p env 
+    with Not_found ->
+      Misc.fatal_errorf "mk_is_abstract: type %a not found in environment" 
+        Path.print p
+  in
+  match decl.type_kind with
+  | Type_abstract _ -> 
+    (* Check if it's truly abstract (no manifest) or just an abbreviation *)
+    begin match decl.type_manifest with
+    | None -> true  (* Truly abstract - no manifest *)
+    | Some _ -> false  (* Type abbreviation - has manifest *)
+    end
+  | Type_variant _ | Type_record _ | Type_open | Type_record_unboxed_product _ -> false
+
+let mk_jkind_context env jkind_of_type =
+  { Jkind.jkind_of_type; is_abstract = mk_is_abstract env }
+
+(* This uses the forward ref - only needed inside estimate_type_jkind *)
+let mk_jkind_context_principal_ref env =
+  mk_jkind_context env (!type_jkind_purely_if_principal' env)
+
 (* We parameterize [estimate_type_jkind] by a function
    [expand_component] because some callers want expansion of types and others
    don't. *)
@@ -2340,7 +2364,7 @@ let rec estimate_type_jkind ~expand_component env ty =
      else Jkind.Builtin.immediate ~why:Immediate_polymorphic_variant
   | Tunivar { jkind } -> Jkind.disallow_right jkind
   | Tpoly (ty, _) ->
-    let jkind_of_type = !type_jkind_purely_if_principal' env in
+    let context = mk_jkind_context_principal_ref env in
     estimate_type_jkind ~expand_component env ty |>
     (* The jkind of [ty] might mention the variables bound in this [Tpoly]
        node, and so just returning it here would be wrong. Instead, we need
@@ -2349,7 +2373,7 @@ let rec estimate_type_jkind ~expand_component env ty =
        variables bound in this [Tpoly]. *)
     (* CR layouts v2.8: Consider doing better -- but only once we can write
        down a test case that cares. *)
-    Jkind.round_up ~jkind_of_type |>
+    Jkind.round_up ~context |>
     Jkind.disallow_right
   | Tof_kind jkind -> Jkind.mark_best jkind
   | Tpackage _ -> Jkind.for_non_float ~why:First_class_module
@@ -2360,10 +2384,8 @@ and close_open_jkind ~expand_component ~is_open env jkind =
     (* CR layouts v2.8: Do better, by tracking the actual free variables and
        rounding only those variables up. *)
   then
-    let jkind_of_type ty =
-      Some (estimate_type_jkind ~expand_component env ty)
-    in
-    Jkind.round_up ~jkind_of_type jkind |> Jkind.disallow_right
+    let context = mk_jkind_context env (fun ty -> Some (estimate_type_jkind ~expand_component env ty)) in
+    Jkind.round_up ~context jkind |> Jkind.disallow_right
   else jkind
 
 let estimate_type_jkind_unwrapped
@@ -2402,6 +2424,14 @@ let () = type_jkind_purely_if_principal' := type_jkind_purely_if_principal
 let estimate_type_jkind =
   estimate_type_jkind ~expand_component:mk_unwrapped_type_expr
 
+(* After type_jkind_purely_if_principal is defined, we can use it directly *)
+let mk_jkind_context_principal env =
+  mk_jkind_context env (type_jkind_purely_if_principal env)
+
+(* For cases where we always want Some (type_jkind_purely env ty) *)
+let mk_jkind_context_purely env =
+  mk_jkind_context env (fun ty -> Some (type_jkind_purely env ty))
+
 (**** checking jkind relationships ****)
 
 (* The ~fixed argument controls what effects this may have on `ty`.  If false,
@@ -2409,7 +2439,7 @@ let estimate_type_jkind =
    possible.  If true, we won't (but will still instantiate sort variables). *)
 let constrain_type_jkind ~fixed env ty jkind =
   let type_equal = !type_equal' env in
-  let jkind_of_type = type_jkind_purely_if_principal env in
+  let context = mk_jkind_context_principal env in
   (* The [expanded] argument says whether we've already tried [expand_head_opt].
 
      The "fuel" argument is used because we're duplicating the loop of
@@ -2441,7 +2471,7 @@ let constrain_type_jkind ~fixed env ty jkind =
     if Jkind.is_obviously_max jkind then Ok () else
     if fuel < 0 then
       Error (
-        Jkind.Violation.of_ ~jkind_of_type (
+        Jkind.Violation.of_ ~context (
           Not_a_subjkind (ty's_jkind, jkind, [Constrain_ran_out_of_fuel])))
     else
     match get_desc ty with
@@ -2470,7 +2500,7 @@ let constrain_type_jkind ~fixed env ty jkind =
           it first.
         *)
        let jkind_inter =
-         Jkind.intersection_or_error ~type_equal ~jkind_of_type
+         Jkind.intersection_or_error ~type_equal ~context
            ~reason:Tyvar_refinement_intersection ty's_jkind jkind
        in
        Result.map (set_var_jkind ty) jkind_inter
@@ -2483,7 +2513,7 @@ let constrain_type_jkind ~fixed env ty jkind =
 
     | _ ->
        match
-         Jkind.sub_or_intersect ~type_equal ~jkind_of_type ty's_jkind jkind
+         Jkind.sub_or_intersect ~type_equal ~context ty's_jkind jkind
        with
        | Sub -> Ok ()
        | Disjoint sub_failure_reasons ->
@@ -2495,7 +2525,7 @@ let constrain_type_jkind ~fixed env ty jkind =
              arbitrary amounts of expansion and looking through [@@unboxed]
              types. So we don't, settling for the slightly worse error
              message. *)
-          Error (Jkind.Violation.of_ ~jkind_of_type
+          Error (Jkind.Violation.of_ ~context
             (Not_a_subjkind (ty's_jkind, jkind, Nonempty_list.to_list sub_failure_reasons)))
        | Has_intersection sub_failure_reasons ->
            let sub_failure_reasons = Nonempty_list.to_list sub_failure_reasons in
@@ -2513,7 +2543,7 @@ let constrain_type_jkind ~fixed env ty jkind =
                in
                if List.for_all Result.is_ok results
                then Ok ()
-               else Error (Jkind.Violation.of_ ~jkind_of_type
+               else Error (Jkind.Violation.of_ ~context
                       (Not_a_subjkind (ty's_jkind, jkind, sub_failure_reasons)))
              in
              begin match Jkind.decompose_product ty's_jkind,
@@ -2532,13 +2562,13 @@ let constrain_type_jkind ~fixed env ty jkind =
                (* Products don't line up. This is only possible if [ty] was
                   given a jkind annotation of the wrong product arity.
                *)
-               Error (Jkind.Violation.of_ ~jkind_of_type
+               Error (Jkind.Violation.of_ ~context
                   (Not_a_subjkind (ty's_jkind, jkind, sub_failure_reasons)))
              end
           in
           let or_null ~fuel ty is_open modality =
             let error () =
-              Error (Jkind.Violation.of_ ~jkind_of_type
+              Error (Jkind.Violation.of_ ~context
                 (Not_a_subjkind (ty's_jkind, jkind, sub_failure_reasons)))
             in
             let jkind = Jkind.apply_modality_r modality jkind in
@@ -2574,12 +2604,12 @@ let constrain_type_jkind ~fixed env ty jkind =
              else
                begin match unbox_once env ty with
                | Missing path -> Error (Jkind.Violation.of_
-                                          ~jkind_of_type ~missing_cmi:path
+                                          ~context ~missing_cmi:path
                                           (Not_a_subjkind (ty's_jkind, jkind,
                                                            sub_failure_reasons)))
                | Final_result ->
                  Error
-                   (Jkind.Violation.of_ ~jkind_of_type
+                   (Jkind.Violation.of_ ~context
                       (Not_a_subjkind (ty's_jkind, jkind, sub_failure_reasons)))
                | Stepped { ty; is_open = is_open2; modality } ->
                  let is_open = is_open || is_open2 in
@@ -2599,7 +2629,7 @@ let constrain_type_jkind ~fixed env ty jkind =
             product ~fuel (List.map (fun (_, ty) ->
               mk_unwrapped_type_expr ty) ltys)
           | _ ->
-            Error (Jkind.Violation.of_ ~jkind_of_type
+            Error (Jkind.Violation.of_ ~context
                 (Not_a_subjkind (ty's_jkind, jkind, sub_failure_reasons)))
   in
   loop ~fuel:100 ~expanded:false ty ~is_open:false
@@ -2678,15 +2708,15 @@ let rec intersect_type_jkind ~reason env ty1 jkind2 =
        to avoid this call as in [constrain_type_jkind] *)
     let type_equal = !type_equal' env in
     let jkind1 = type_jkind env ty1 in
-    let jkind_of_type = type_jkind_purely_if_principal env in
-    let jkind1 = Jkind.round_up ~jkind_of_type jkind1 in
-    let jkind2 = Jkind.round_up ~jkind_of_type jkind2 in
+    let context = mk_jkind_context_principal env in
+    let jkind1 = Jkind.round_up ~context jkind1 in
+    let jkind2 = Jkind.round_up ~context jkind2 in
     (* This is strange, in that we're rounding up and then computing an
        intersection. So we might find an intersection where there isn't really
        one. See the comment above this function arguing why this is OK here. *)
     (* CR layouts v2.8: Think about doing better, but it's probably not worth
        it. *)
-    Jkind.intersection_or_error ~type_equal ~jkind_of_type ~reason jkind1 jkind2
+    Jkind.intersection_or_error ~type_equal ~context ~reason jkind1 jkind2
 
 (* See comment on [jkind_unification_mode] *)
 let unification_jkind_check uenv ty jkind =
@@ -2705,8 +2735,8 @@ let check_and_update_generalized_ty_jkind ?name ~loc env ty =
       (* Just check externality and layout, because that's what actually matters
          for upstream code. We check both for a known value and something that
          might turn out later to be value. This is the conservative choice. *)
-      let jkind_of_type = type_jkind_purely_if_principal env in
-      let ext = Jkind.get_externality_upper_bound ~jkind_of_type jkind in
+      let context = mk_jkind_context_principal env in
+      let ext = Jkind.get_externality_upper_bound ~context jkind in
       Jkind_axis.Externality.le ext External64 &&
       match Jkind.get_layout jkind with
       | Some (Base Value) | None -> true
@@ -5105,8 +5135,8 @@ let zap_modalities_to_floor_if_at_least level =
     else Mode.Modality.Value.zap_to_id
 
 let crossing_of_jkind env jkind =
-  let jkind_of_type = type_jkind_purely_if_principal env in
-  Jkind.get_mode_crossing ~jkind_of_type jkind
+  let context = mk_jkind_context_principal env in
+  Jkind.get_mode_crossing ~context jkind
 
 let crossing_of_ty env ?modalities ty =
   let crossing =
@@ -7088,8 +7118,8 @@ let rec nondep_type_decl env mid is_covariant decl =
       try Jkind.map_type_expr (nondep_type_rec env mid) decl.type_jkind
       (* CR layouts v2.8: This should be done with a proper nondep_jkind. *)
       with Nondep_cannot_erase _ when is_covariant ->
-        let jkind_of_type = type_jkind_purely_if_principal env in
-        Jkind.round_up ~jkind_of_type decl.type_jkind |>
+        let context = mk_jkind_context_principal env in
+        Jkind.round_up ~context decl.type_jkind |>
         Jkind.disallow_right
     in
     clear_hash ();
@@ -7294,7 +7324,7 @@ let check_decl_jkind env decl jkind =
      and so we leave this optimization for later. *)
   let type_equal = type_equal env in
   let type_jkind_purely = type_jkind_purely env in
-  let jkind_of_type ty = Some (type_jkind_purely ty) in
+  let context = mk_jkind_context_purely env in
   (* CR layouts v2.8: When we have [layout_of], this logic should move to the
      place where [type_jkind] is set. But for now, it has to be here, because we
      want this in module inclusion but not other places (because substitutions
@@ -7325,7 +7355,7 @@ let check_decl_jkind env decl jkind =
       Jkind.for_abbreviation ~type_jkind_purely ~modality inner_ty
     | _ -> decl.type_jkind
   in
-  match Jkind.sub_jkind_l ~type_equal ~jkind_of_type decl_jkind jkind with
+  match Jkind.sub_jkind_l ~type_equal ~context decl_jkind jkind with
   | Ok () -> Ok ()
   | Error _ as err ->
     match decl.type_manifest with
@@ -7334,7 +7364,7 @@ let check_decl_jkind env decl jkind =
       (* CR layouts v2.8: Should this use [type_jkind_purely_if_principal]? I
          think not. *)
       let ty_jkind = type_jkind env ty in
-      match Jkind.sub_jkind_l ~type_equal ~jkind_of_type ty_jkind jkind with
+      match Jkind.sub_jkind_l ~type_equal ~context ty_jkind jkind with
       | Ok () -> Ok ()
       | Error _ as err -> err
 
@@ -7347,9 +7377,9 @@ let constrain_decl_jkind env decl jkind =
   | None -> check_decl_jkind env decl jkind
   | Some jkind ->
     let type_equal = type_equal env in
-    let jkind_of_type ty = Some (type_jkind_purely env ty) in
+    let context = mk_jkind_context_purely env in
     match
-      Jkind.sub_or_error ~type_equal ~jkind_of_type decl.type_jkind jkind
+      Jkind.sub_or_error ~type_equal ~context decl.type_jkind jkind
     with
     | Ok () as ok -> ok
     | Error _ as err ->

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -624,6 +624,11 @@ val type_jkind_purely : Env.t -> type_expr -> jkind_l
    functions exported by [Jkind]. *)
 val type_jkind_purely_if_principal : Env.t -> type_expr -> jkind_l option
 
+(* Helper functions for creating jkind contexts *)
+val mk_jkind_context : Env.t -> (type_expr -> jkind_l option) -> Jkind.jkind_context
+val mk_jkind_context_principal : Env.t -> Jkind.jkind_context
+val mk_jkind_context_purely : Env.t -> Jkind.jkind_context
+
 (* Find a type's sort (if fixed is false: constraining it to be an
    arbitrary sort variable, if needed) *)
 val type_sort :

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -1479,9 +1479,9 @@ let type_declarations ?(equality = false) ~loc env ~mark name
          (match name with None -> "_" | Some n -> "'" ^ n)
          Printtyp.type_expr ty
   | Jkind_mismatch { original_jkind; inferred_jkind; ty } ->
-     let jkind_of_type ty = Some (Ctype.type_jkind_purely env ty) in
+     let context = Ctype.mk_jkind_context_purely env in
      Some (Parameter_jkind
-             (ty, Jkind.Violation.of_ ~jkind_of_type
+             (ty, Jkind.Violation.of_ ~context
                     (Not_a_subjkind (Jkind.disallow_right original_jkind,
                                      Jkind.disallow_left inferred_jkind,
                                      []))))

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -798,6 +798,14 @@ module With_bounds = struct
           type_exprs)
 end
 
+(******************************)
+(* context *)
+
+type jkind_context = {
+  jkind_of_type : Types.type_expr -> Types.jkind_l option;
+  is_abstract : Path.t -> bool;
+}
+
 module Layout_and_axes = struct
   module Allow_disallow = Allowance.Magic_allow_disallow (struct
     type (_, 'layout, 'd) sided = ('layout, 'd) layout_and_axes
@@ -886,7 +894,7 @@ module Layout_and_axes = struct
      of this function for these axes is undefined; do *not* look at the results for these
      axes.
   *)
-  let normalize (type layout l r1 r2) ~jkind_of_type ~(mode : r2 normalize_mode)
+  let normalize (type layout l r1 r2) ~context ~(mode : r2 normalize_mode)
       ~skip_axes
       ?(map_type_info :
          (type_expr -> With_bounds_type_info.t -> With_bounds_type_info.t)
@@ -990,6 +998,7 @@ module Layout_and_axes = struct
                      TransientTypeOps.equal (Transient_expr.repr ty1)
                        (Transient_expr.repr ty2))
                    seen_args args
+                 && not (context.is_abstract p)
               then Skip
               else if fuel > 0
               then
@@ -1132,7 +1141,7 @@ module Layout_and_axes = struct
                 Not_best [@nontail]
             | Skip -> loop ctl bounds_so_far relevant_axes bs (* skip [b] *)
             | Continue ctl_after_unpacking_b -> (
-              match jkind_of_type ty with
+              match context.jkind_of_type ty with
               | Some b_jkind ->
                 found_jkind_for_ty ctl_after_unpacking_b
                   b_jkind.jkind.mod_bounds b_jkind.jkind.with_bounds
@@ -2122,7 +2131,7 @@ module Jkind_desc = struct
   let equate_or_equal ~allow_mutation t1 t2 =
     Layout_and_axes.equal (Layout.equate_or_equal ~allow_mutation) t1 t2
 
-  let sub (type l r) ~type_equal:_ ~jkind_of_type
+  let sub (type l r) ~type_equal:_ ~context
       (sub : (allowed * r) jkind_desc)
       ({ layout = lay2; mod_bounds = bounds2; with_bounds = No_with_bounds } :
         (l * allowed) jkind_desc) =
@@ -2135,7 +2144,7 @@ module Jkind_desc = struct
             (_ * allowed) jkind_desc),
           _ ) =
       Layout_and_axes.normalize ~skip_axes:axes_max_on_right ~mode:Ignore_best
-        ~jkind_of_type sub
+        ~context sub
     in
     let layout = Layout.sub lay1 lay2 in
     let bounds = Mod_bounds.less_or_equal bounds1 bounds2 in
@@ -2674,12 +2683,12 @@ type normalize_mode =
   | Require_best
   | Ignore_best
 
-let[@inline] normalize ~mode ~jkind_of_type t =
+let[@inline] normalize ~mode ~context t =
   let mode : _ Layout_and_axes.normalize_mode =
     match mode with Require_best -> Require_best | Ignore_best -> Ignore_best
   in
   let jkind, fuel_result =
-    Layout_and_axes.normalize ~jkind_of_type ~skip_axes:Axis_set.empty ~mode
+    Layout_and_axes.normalize ~context ~skip_axes:Axis_set.empty ~mode
       t.jkind
   in
   { t with
@@ -2718,12 +2727,12 @@ let get_layout jk : Layout.Const.t option = Layout.get_const jk.jkind.layout
 
 let extract_layout jk = jk.jkind.layout
 
-let get_modal_bounds (type l r) ~jkind_of_type (jk : (l * r) jkind) =
+let get_modal_bounds (type l r) ~context (jk : (l * r) jkind) =
   let ( ({ layout = _; mod_bounds; with_bounds = No_with_bounds } :
           (_ * allowed) jkind_desc),
         _ ) =
     Layout_and_axes.normalize ~mode:Ignore_best
-      ~skip_axes:Axis_set.all_nonmodal_axes ~jkind_of_type jk.jkind
+      ~skip_axes:Axis_set.all_nonmodal_axes ~context jk.jkind
   in
   Mod_bounds.
     { comonadic =
@@ -2740,8 +2749,8 @@ let get_modal_bounds (type l r) ~jkind_of_type (jk : (l * r) jkind) =
         }
     }
 
-let get_mode_crossing (type l r) ~jkind_of_type (jk : (l * r) jkind) =
-  let bounds = get_modal_bounds ~jkind_of_type jk in
+let get_mode_crossing (type l r) ~context (jk : (l * r) jkind) =
+  let bounds = get_modal_bounds ~context jk in
   Mode.Crossing.of_bounds bounds
 
 let to_unsafe_mode_crossing jkind =
@@ -2752,12 +2761,12 @@ let to_unsafe_mode_crossing jkind =
 let all_except_externality =
   Axis_set.singleton (Nonmodal Externality) |> Axis_set.complement
 
-let get_externality_upper_bound ~jkind_of_type jk =
+let get_externality_upper_bound ~context jk =
   let ( ({ layout = _; mod_bounds; with_bounds = No_with_bounds } :
           (_ * allowed) jkind_desc),
         _ ) =
     Layout_and_axes.normalize ~mode:Ignore_best
-      ~skip_axes:all_except_externality ~jkind_of_type jk.jkind
+      ~skip_axes:all_except_externality ~context jk.jkind
   in
   Mod_bounds.get mod_bounds ~axis:(Nonmodal Externality)
 
@@ -2773,7 +2782,7 @@ let set_externality_upper_bound jk externality_upper_bound =
 let all_except_nullability =
   Axis_set.singleton (Nonmodal Nullability) |> Axis_set.complement
 
-let get_nullability ~jkind_of_type jk =
+let get_nullability ~context jk =
   (* Optimization: Usually, no with-bounds are relevant to nullability. If we check for
      this case, we can avoid calling normalize. *)
   let all_with_bounds_are_irrelevant =
@@ -2788,7 +2797,7 @@ let get_nullability ~jkind_of_type jk =
     let ( ({ layout = _; mod_bounds; with_bounds = No_with_bounds } :
             (_ * allowed) jkind_desc),
           _ ) =
-      Layout_and_axes.normalize ~mode:Ignore_best ~jkind_of_type
+      Layout_and_axes.normalize ~mode:Ignore_best ~context
         ~skip_axes:all_except_nullability jk.jkind
     in
     Mod_bounds.get mod_bounds ~axis:(Nonmodal Nullability)
@@ -3283,21 +3292,21 @@ module Violation = struct
      the choice of error message. (Though the [Path.t] payload *is*
      indeed just about the payload.) *)
 
-  let of_ ~jkind_of_type ?missing_cmi violation =
+  let of_ ~context ?missing_cmi violation =
     (* Normalize for better printing *)
     let violation =
       match violation with
       | Not_a_subjkind (jkind1, jkind2, reasons) ->
         let jkind1 =
-          normalize ~mode:Require_best ~jkind_of_type (disallow_right jkind1)
+          normalize ~mode:Require_best ~context (disallow_right jkind1)
         in
         let jkind2 =
-          normalize ~mode:Require_best ~jkind_of_type (disallow_right jkind2)
+          normalize ~mode:Require_best ~context (disallow_right jkind2)
         in
         Not_a_subjkind (jkind1, jkind2, reasons)
       | No_intersection (jkind1, jkind2) ->
         let jkind1 =
-          normalize ~mode:Require_best ~jkind_of_type (disallow_right jkind1)
+          normalize ~mode:Require_best ~context (disallow_right jkind1)
         in
         (* jkind2 can't have with-bounds, by its type *)
         No_intersection (jkind1, jkind2)
@@ -3543,7 +3552,7 @@ let score_reason = function
   | Creation (Concrete_creation _ | Concrete_legacy_creation _) -> -1
   | _ -> 0
 
-let combine_histories ~type_equal ~jkind_of_type reason (Pack_jkind k1)
+let combine_histories ~type_equal ~context reason (Pack_jkind k1)
     (Pack_jkind k2) =
   if flattened_histories
   then
@@ -3553,7 +3562,7 @@ let combine_histories ~type_equal ~jkind_of_type reason (Pack_jkind k1)
       else history_b
     in
     let choose_subjkind_history k_a history_a k_b history_b =
-      match Jkind_desc.sub ~type_equal ~jkind_of_type k_a k_b with
+      match Jkind_desc.sub ~type_equal ~context k_a k_b with
       | Less -> history_a
       | Not_le _ ->
         (* CR layouts: this will be wrong if we ever have a non-trivial meet in
@@ -3582,15 +3591,15 @@ let has_intersection t1 t2 =
   (* Need to check only the layouts: all the axes have bottom elements. *)
   Option.is_some (Layout.intersection t1.jkind.layout t2.jkind.layout)
 
-let intersection_or_error ~type_equal ~jkind_of_type ~reason t1 t2 =
+let intersection_or_error ~type_equal ~context ~reason t1 t2 =
   match Jkind_desc.intersection t1.jkind t2.jkind with
-  | None -> Error (Violation.of_ ~jkind_of_type (No_intersection (t1, t2)))
+  | None -> Error (Violation.of_ ~context (No_intersection (t1, t2)))
   | Some jkind ->
     Ok
       { jkind;
         annotation = None;
         history =
-          combine_histories ~type_equal ~jkind_of_type reason (Pack_jkind t1)
+          combine_histories ~type_equal ~context reason (Pack_jkind t1)
             (Pack_jkind t2);
         has_warned = t1.has_warned || t2.has_warned;
         ran_out_of_fuel_during_normalize =
@@ -3600,10 +3609,10 @@ let intersection_or_error ~type_equal ~jkind_of_type ~reason t1 t2 =
           Not_best (* As required by the fact that this is a [jkind_r] *)
       }
 
-let round_up (type l r) ~jkind_of_type (t : (allowed * r) jkind) :
+let round_up (type l r) ~context (t : (allowed * r) jkind) :
     (l * allowed) jkind =
   let normalized =
-    normalize ~mode:Ignore_best ~jkind_of_type (t |> disallow_right)
+    normalize ~mode:Ignore_best ~context (t |> disallow_right)
   in
   { t with
     jkind = { normalized.jkind with with_bounds = No_with_bounds };
@@ -3616,35 +3625,35 @@ let map_type_expr f t =
   else t (* short circuit this common case *)
 
 (* this is hammered on; it must be fast! *)
-let check_sub ~jkind_of_type sub super =
-  Jkind_desc.sub ~jkind_of_type sub.jkind super.jkind
+let check_sub ~context sub super =
+  Jkind_desc.sub ~context sub.jkind super.jkind
 
-let sub_with_reason ~type_equal ~jkind_of_type sub super =
-  Sub_result.require_le (check_sub ~type_equal ~jkind_of_type sub super)
+let sub_with_reason ~type_equal ~context sub super =
+  Sub_result.require_le (check_sub ~type_equal ~context sub super)
 
-let sub ~type_equal ~jkind_of_type sub super =
-  Result.is_ok (sub_with_reason ~type_equal ~jkind_of_type sub super)
+let sub ~type_equal ~context sub super =
+  Result.is_ok (sub_with_reason ~type_equal ~context sub super)
 
 type sub_or_intersect =
   | Sub
   | Disjoint of Violation.Sub_failure_reason.t Nonempty_list.t
   | Has_intersection of Violation.Sub_failure_reason.t Nonempty_list.t
 
-let sub_or_intersect ~type_equal ~jkind_of_type t1 t2 =
-  match sub_with_reason ~type_equal ~jkind_of_type t1 t2 with
+let sub_or_intersect ~type_equal ~context t1 t2 =
+  match sub_with_reason ~type_equal ~context t1 t2 with
   | Ok () -> Sub
   | Error reason ->
     if has_intersection t1 t2 then Has_intersection reason else Disjoint reason
 
-let sub_or_error ~type_equal ~jkind_of_type t1 t2 =
-  match sub_or_intersect ~type_equal ~jkind_of_type t1 t2 with
+let sub_or_error ~type_equal ~context t1 t2 =
+  match sub_or_intersect ~type_equal ~context t1 t2 with
   | Sub -> Ok ()
   | Disjoint reason | Has_intersection reason ->
     Error
-      (Violation.of_ ~jkind_of_type
+      (Violation.of_ ~context
          (Not_a_subjkind (t1, t2, Nonempty_list.to_list reason)))
 
-let sub_jkind_l ~type_equal ~jkind_of_type ?(allow_any_crossing = false) sub
+let sub_jkind_l ~type_equal ~context ?(allow_any_crossing = false) sub
     super =
   (* This function implements the "SUB" judgement from kind-inference.md. *)
   let open Misc.Stdlib.Monad.Result.Syntax in
@@ -3660,8 +3669,8 @@ let sub_jkind_l ~type_equal ~jkind_of_type ?(allow_any_crossing = false) sub
            (* CR layouts v2.8: It would be useful report to the user why this
               violation occurred, specifically which axes the violation is
               along. *)
-           let best_sub = normalize ~mode:Require_best ~jkind_of_type sub in
-           Violation.of_ ~jkind_of_type
+           let best_sub = normalize ~mode:Require_best ~context sub in
+           Violation.of_ ~context
              (Not_a_subjkind (best_sub, super, Nonempty_list.to_list reasons)))
   in
   let* () =
@@ -3673,7 +3682,7 @@ let sub_jkind_l ~type_equal ~jkind_of_type ?(allow_any_crossing = false) sub
   | false ->
     let best_super =
       (* MB_EXPAND_R *)
-      normalize ~mode:Require_best ~jkind_of_type super
+      normalize ~mode:Require_best ~context super
     in
     let right_bounds =
       With_bounds.to_best_eff_map best_super.jkind.with_bounds
@@ -3710,7 +3719,7 @@ let sub_jkind_l ~type_equal ~jkind_of_type ?(allow_any_crossing = false) sub
          joining.  [map_type_info] handles looking for [ty] on the right and
          removing irrelevant axes. *)
       Layout_and_axes.normalize sub.jkind ~skip_axes:axes_max_on_right
-        ~jkind_of_type ~mode:Ignore_best
+        ~context ~mode:Ignore_best
         ~map_type_info:(fun ty { relevant_axes = left_relevant_axes } ->
           let right_relevant_axes =
             (* Look for [ty] on the right. There may be multiple occurrences of

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -175,6 +175,15 @@ module History : sig
 end
 
 (******************************)
+(* context *)
+
+(** Context for jkind operations. *)
+type jkind_context = {
+  jkind_of_type : Types.type_expr -> Types.jkind_l option;
+  is_abstract : Path.t -> bool;  (* Check if a type path refers to an abstract type *)
+}
+
+(******************************)
 (* errors *)
 
 module Violation : sig
@@ -194,7 +203,7 @@ module Violation : sig
   (** Set [?missing_cmi] to mark [t] as having arisen from a missing cmi *)
 
   val of_ :
-    jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
+    context:jkind_context ->
     ?missing_cmi:Path.t ->
     violation ->
     t
@@ -623,14 +632,14 @@ val extract_layout : 'd Types.jkind -> Sort.t Layout.t
 
 (** Gets the mode crossing for types of this jkind. *)
 val get_mode_crossing :
-  jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
+  context:jkind_context ->
   'd Types.jkind ->
   Mode.Crossing.t
 
 val to_unsafe_mode_crossing : Types.jkind_l -> Types.unsafe_mode_crossing
 
 val get_externality_upper_bound :
-  jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
+  context:jkind_context ->
   'd Types.jkind ->
   Jkind_axis.Externality.t
 
@@ -641,7 +650,7 @@ val set_externality_upper_bound :
 
 (** Gets the nullability from a jkind. *)
 val get_nullability :
-  jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
+  context:jkind_context ->
   Types.jkind_l ->
   Jkind_axis.Nullability.t
 
@@ -702,7 +711,7 @@ type normalize_mode =
 
 val normalize :
   mode:normalize_mode ->
-  jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
+  context:jkind_context ->
   Types.jkind_l ->
   Types.jkind_l
 
@@ -771,7 +780,7 @@ val has_intersection : 'd1 Types.jkind -> 'd2 Types.jkind -> bool
     intersection of the two, not something that modifies the second jkind. *)
 val intersection_or_error :
   type_equal:(Types.type_expr -> Types.type_expr -> bool) ->
-  jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
+  context:jkind_context ->
   reason:History.interact_reason ->
   ('l1 * allowed) Types.jkind ->
   ('l2 * allowed) Types.jkind ->
@@ -781,7 +790,7 @@ val intersection_or_error :
     either [t1] or [t2] to make their layouts equal.*)
 val sub :
   type_equal:(Types.type_expr -> Types.type_expr -> bool) ->
-  jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
+  context:jkind_context ->
   Types.jkind_l ->
   Types.jkind_r ->
   bool
@@ -798,7 +807,7 @@ type sub_or_intersect =
     see comments there for more info. *)
 val sub_or_intersect :
   type_equal:(Types.type_expr -> Types.type_expr -> bool) ->
-  jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
+  context:jkind_context ->
   (allowed * 'r) Types.jkind ->
   ('l * allowed) Types.jkind ->
   sub_or_intersect
@@ -807,7 +816,7 @@ val sub_or_intersect :
     [Violation.t] upon failure. *)
 val sub_or_error :
   type_equal:(Types.type_expr -> Types.type_expr -> bool) ->
-  jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
+  context:jkind_context ->
   (allowed * 'r) Types.jkind ->
   ('l * allowed) Types.jkind ->
   (unit, Violation.t) result
@@ -818,7 +827,7 @@ val sub_or_error :
 *)
 val sub_jkind_l :
   type_equal:(Types.type_expr -> Types.type_expr -> bool) ->
-  jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
+  context:jkind_context ->
   ?allow_any_crossing:bool ->
   Types.jkind_l ->
   Types.jkind_l ->
@@ -827,7 +836,7 @@ val sub_jkind_l :
 (** "round up" a [jkind_l] to a [jkind_r] such that the input is less than the
     output. *)
 val round_up :
-  jkind_of_type:(Types.type_expr -> Types.jkind_l option) ->
+  context:jkind_context ->
   (allowed * 'r) Types.jkind ->
   ('l * allowed) Types.jkind
 

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1298,9 +1298,9 @@ let rec check_constraints_rec env loc visited ty =
         | Unification_failure err ->
           raise (Error(loc, Constraint_failed (env, err)))
         | Jkind_mismatch { original_jkind; inferred_jkind; ty } ->
-          let jkind_of_type ty = Some (Ctype.type_jkind_purely env ty) in
+          let context = Ctype.mk_jkind_context_purely env in
           let violation =
-            Jkind.Violation.of_ ~jkind_of_type
+            Jkind.Violation.of_ ~context
               (Not_a_subjkind (Jkind.disallow_right original_jkind,
                                Jkind.disallow_left inferred_jkind,
                                []))
@@ -1472,9 +1472,9 @@ let narrow_to_manifest_jkind env loc decl =
     begin match Jkind.try_allow_r decl.type_jkind with
     | None -> begin
         let type_equal = Ctype.type_equal env in
-        let jkind_of_type ty = Some (Ctype.type_jkind_purely env ty) in
+        let context = Ctype.mk_jkind_context_purely env in
         match
-          Jkind.sub_jkind_l ~type_equal ~jkind_of_type
+          Jkind.sub_jkind_l ~type_equal ~context
             manifest_jkind decl.type_jkind
         with
         | Ok () -> ()
@@ -2061,12 +2061,12 @@ let rec update_decl_jkind env dpath decl =
     Jkind.Layout.sub new_decl.type_jkind.jkind.layout decl.type_jkind.jkind.layout
   with
   | Not_le reason ->
-    let jkind_of_type ty = Some (Ctype.type_jkind_purely env ty) in
+    let context = Ctype.mk_jkind_context_purely env in
     raise (Error (
       decl.type_loc,
       Jkind_mismatch_of_path (
         dpath,
-        Jkind.Violation.of_ ~jkind_of_type (
+        Jkind.Violation.of_ ~context (
           Not_a_subjkind (
             new_decl.type_jkind, decl.type_jkind, Nonempty_list.to_list reason)))))
   | Less | Equal -> new_decl
@@ -2683,7 +2683,7 @@ let normalize_decl_jkinds env shapes decls =
     let normalized_jkind =
       Jkind.normalize
         ~mode:Require_best
-        ~jkind_of_type:(fun ty -> Some (Ctype.type_jkind env ty))
+        ~context:(Ctype.mk_jkind_context env (fun ty -> Some (Ctype.type_jkind env ty)))
         decl.type_jkind
     in
     let decl =
@@ -2698,14 +2698,14 @@ let normalize_decl_jkinds env shapes decls =
          the new jkind (we really only want this check here to check against the
          user-written annotation). We might be able to do a better job here and save
          some work. *)
-      let jkind_of_type ty = Some (Ctype.type_jkind_purely env ty) in
+      let context = Ctype.mk_jkind_context_purely env in
       let type_equal = Ctype.type_equal env in
       match
         (* CR layouts v2.8: Consider making a function that doesn't compute
            histories for this use-case, which doesn't need it. *)
         Jkind.sub_jkind_l
           ~type_equal
-          ~jkind_of_type
+          ~context
           ~allow_any_crossing
           decl.type_jkind
           original_decl.type_jkind

--- a/typing/typedecl_separability.ml
+++ b/typing/typedecl_separability.ml
@@ -485,9 +485,9 @@ let msig_of_external_type env decl =
     Result.is_error (Ctype.check_decl_jkind env decl
                         (Jkind.Builtin.value_or_null ~why:Separability_check))
   in
-  let jkind_of_type = Ctype.type_jkind_purely_if_principal env in
+  let context = Ctype.mk_jkind_context_principal env in
   let is_external =
-    match Jkind.get_externality_upper_bound ~jkind_of_type decl.type_jkind with
+    match Jkind.get_externality_upper_bound ~context decl.type_jkind with
     | Internal -> false
     | External | External64 -> true
   in

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -403,8 +403,8 @@ let value_kind_of_value_jkind env jkind =
   let layout = Jkind.get_layout_defaulting_to_value jkind in
   (* In other places, we use [Ctype.type_jkind_purely_if_principal]. Here, we omit
      the principality check, as we're just trying to compute optimizations. *)
-  let jkind_of_type ty = Some (Ctype.type_jkind_purely env ty) in
-  let externality_upper_bound = Jkind.get_externality_upper_bound ~jkind_of_type jkind in
+  let context = Ctype.mk_jkind_context_purely env in
+  let externality_upper_bound = Jkind.get_externality_upper_bound ~context jkind in
   match layout, externality_upper_bound with
   | Base Value, External -> Pintval
   | Base Value, External64 ->
@@ -494,9 +494,9 @@ let nullable raw_kind = { raw_kind; nullable = Nullable }
    have a jkind. We should pick one, or rationalize why there are two.
 *)
 let add_nullability_from_jkind env jkind raw_kind =
-  let jkind_of_type ty = Some (Ctype.type_jkind_purely env ty) in
+  let context = Ctype.mk_jkind_context_purely env in
   let nullable =
-    match Jkind.get_nullability ~jkind_of_type jkind with
+    match Jkind.get_nullability ~context jkind with
     | Non_null -> Non_nullable
     | Maybe_null -> Nullable
   in


### PR DESCRIPTION
The bug was found by Benjamin Peters.

Example of the bug:
    module type X = sig
      type t : value mod contended with t
    end
    module Xm : X = struct
      type t = int ref
    end
    type q : value mod contended = Xm.t  (* unsoundly accepted *)

The cause of the bug is that the mechanism to compute recursive jkinds optimistically interacted poorly with abstract types. For recursive concrete kinds, we want to pick the best kind we can. For recursive abstract kinds, we need to pessimistically assume that the implementor of the signature chooses the worst possible kind. The previous code chose optimistically in both cases.

This commit fixes the issue and rejects the code above as kind-incorrect.