### PR TITLE
Refactor modality atoms to make it smaller

### DIFF
--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -336,12 +336,12 @@ let report_modality_sub_error first second ppf e =
   let print_modality id ppf m =
     Printtyp.modality ~id:(fun ppf -> Format.pp_print_string ppf id) ppf m
   in
-  let Modality.Value.Error(ax, {left; right}) = e in
+  let Modality.Value.Error {left; right} = e in
   Format.fprintf ppf "%s is %a and %s is %a."
     (String.capitalize_ascii second)
-    (print_modality "empty") (Atom (ax, right) : Modality.t)
+    (print_modality "empty") right
     first
-    (print_modality "not") (Atom (ax, left) : Modality.t)
+    (print_modality "not") left
 
 let report_mode_sub_error got expected ppf e =
   let Mode.Value.Error(ax, {left; right}) = e in

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -411,7 +411,7 @@ let relevant_axes_of_modality ~relevant_for_shallow ~modality =
       match axis with
       | Modal axis ->
         let modality = Mode.Modality.Value.Const.proj axis modality in
-        not (Mode.Modality.is_constant (Atom (axis, modality)))
+        not (Mode.Modality.Atom.is_constant modality)
       (* The kind-inference.md document (in the repo) discusses both constant
          modalities and identity modalities. Of course, reality has modalities
          (such as [shared]) that are neither constants nor identities. Here, we
@@ -1870,18 +1870,16 @@ module Const = struct
         (fun acc (Axis.Pack axis) ->
           match axis with
           | Modal axis ->
-            let t : Modality.t =
+            let t : _ Modality.Atom.t =
               match axis with
-              | Monadic monadic ->
-                Atom
-                  (axis, Join_with (Mode.Value.Monadic.Const.max_axis monadic))
-              | Comonadic comonadic ->
-                Atom
-                  ( axis,
-                    Meet_with (Mode.Value.Comonadic.Const.min_axis comonadic) )
+              | Monadic ax ->
+                Monadic
+                  (ax, Join_with (Mode.Value.Monadic.Const.Per_axis.max ax))
+              | Comonadic ax ->
+                Comonadic
+                  (ax, Meet_with (Mode.Value.Comonadic.Const.Per_axis.min ax))
             in
-            let (Atom (axis, a)) = t in
-            Modality.Value.Const.set axis a acc
+            Modality.Value.Const.set t acc
           | Nonmodal _ ->
             (* TODO: don't know how to print *)
             acc)

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1731,7 +1731,7 @@ let typexp mode ppf ty =
 
 (* Only used for printing a single modality in error message *)
 let modality ?(id = fun _ppf -> ()) ppf modality =
-  if Mode.Modality.is_id modality then id ppf
+  if Mode.Modality.Atom.is_id modality then id ppf
   else
     modality
     |> Typemode.untransl_modality

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -109,7 +109,8 @@ val type_expr: formatter -> type_expr -> unit
 
 (** Prints a modality. If it is the identity modality, prints [id], which
     defaults to nothing. *)
-val modality : ?id:(formatter -> unit) -> formatter -> Mode.Modality.t -> unit
+val modality :
+  ?id:(formatter -> unit) -> formatter -> 'a Mode.Modality.Atom.t -> unit
 
 (** [prepare_for_printing] resets the global printing environment, a la [reset],
     and prepares the types for printing by reserving names and marking loops.

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -29,17 +29,20 @@ module type Lattices = sig
   (** Lattice identifers, indexed by ['a] the carrier type of that lattice *)
   type 'a obj
 
-  val min : 'a obj -> 'a
+  (** An element in a lattice whose carrier type is ['a]. *)
+  type 'a elt
 
-  val max : 'a obj -> 'a
+  val min : 'a obj -> 'a elt
 
-  val le : 'a obj -> 'a -> 'a -> bool
+  val max : 'a obj -> 'a elt
 
-  val join : 'a obj -> 'a -> 'a -> 'a
+  val le : 'a obj -> 'a elt -> 'a elt -> bool
 
-  val meet : 'a obj -> 'a -> 'a -> 'a
+  val join : 'a obj -> 'a elt -> 'a elt -> 'a elt
 
-  val print : 'a obj -> Format.formatter -> 'a -> unit
+  val meet : 'a obj -> 'a elt -> 'a elt -> 'a elt
+
+  val print : 'a obj -> Format.formatter -> 'a elt -> unit
 
   val eq_obj : 'a obj -> 'b obj -> ('a, 'b) Misc.eq option
 
@@ -50,7 +53,7 @@ end
    category. Among those monotone functions some will have left and right
    adjoints. *)
 module type Lattices_mono = sig
-  include Lattices
+  include Lattices with type 'a elt := 'a
 
   (** Morphism from object of base type ['a] to object of base type ['b] with
       allowance ['d]. See Note [Allowance] in allowance.mli.

--- a/typing/typemode.mli
+++ b/typing/typemode.mli
@@ -20,7 +20,8 @@ val transl_modalities :
 val let_mutable_modalities :
   Mode.Value.Comonadic.lr -> Mode.Modality.Value.Const.t
 
-val untransl_modality : Mode.Modality.t -> Parsetree.modality Location.loc
+val untransl_modality :
+  'a Mode.Modality.Atom.t -> Parsetree.modality Location.loc
 
 (** Un-interpret modalities back to parsetree. Takes the mutability and
     attributes on the field and remove mutable-implied modalities accordingly.

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -1538,7 +1538,7 @@ end = struct
     let uni = Modality.Value.Const.proj (Monadic Uniqueness) modalities in
     let lin = Modality.Value.Const.proj (Comonadic Linearity) modalities in
     match uni, lin with
-    | Join_with Aliased, Meet_with Many -> untracked
+    | Monadic (_, Join_with Aliased), Comonadic (_, Meet_with Many) -> untracked
     | _ -> child proj t
 
   let tuple_field i t = child (Projection.Tuple_field i) t


### PR DESCRIPTION
Based on #4427 

Towards #4273, we want mode crossing atoms to be small and fast. Ideally, it should just be an unboxed constant mode. Note that mode crossing atoms are secretly modality atoms (see #4314 ). Therefore, in this PR we make modalities atoms small: `Mode.Modality.Monadic.Atom.t` is just unboxed constant mode (instead of two constructors `Join_with` and `Meet_with`). `Mode.Modality.Atom.t` still requires boxing for the generality over monadic vs. comonadic, but functions on them are hopefully inlined and the boxing/unboxing pair hopefully canceled out.

We are also able to remove several `assert false`.

#4080 also attempted this but wasn't satisfactory. The current PR takes a different approach that avoids the problem in that PR.