### PR TITLE
Do not ignore nullable when printing param jkinds

### DIFF
--- a/testsuite/tests/tool-toplevel/show.ml
+++ b/testsuite/tests/tool-toplevel/show.ml
@@ -55,12 +55,12 @@ exception Invalid_argument of string
 
 #show Some;;
 [%%expect {|
-type 'a option = None | Some of 'a
+type ('a : value_or_null) option = None | Some of 'a
 |}];;
 
 #show option;;
 [%%expect {|
-type 'a option = None | Some of 'a
+type ('a : value_or_null) option = None | Some of 'a
 |}];;
 
 #show Open_binary;;

--- a/testsuite/tests/tool-toplevel/show_short_paths.ml
+++ b/testsuite/tests/tool-toplevel/show_short_paths.ml
@@ -8,7 +8,7 @@
 
 #show list;;
 [%%expect {|
-type 'a list = [] | (::) of 'a * 'a list
+type ('a : value_or_null) list = [] | (::) of 'a * 'a list
 |}];;
 
 type 'a t;;

--- a/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -132,7 +132,7 @@ type ('a : bits64) id_bits64 = 'a
 [%%expect{|
 type ('a : any) id_any = 'a
 type ('a : any_non_null) id_any_non_null = 'a
-type 'a id_value_or_null = 'a
+type ('a : value_or_null) id_value_or_null = 'a
 type 'a id_value = 'a
 type ('a : bits64) id_bits64 = 'a
 |}]

--- a/testsuite/tests/typing-layouts-or-null/immediate.ml
+++ b/testsuite/tests/typing-layouts-or-null/immediate.ml
@@ -68,7 +68,7 @@ type ('a : value_or_null) accept_value_or_null
 
 type should_work = t_immediate_or_null accept_value_or_null
 [%%expect{|
-type 'a accept_value_or_null
+type ('a : value_or_null) accept_value_or_null
 type should_work = t_immediate_or_null accept_value_or_null
 |}]
 

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -738,7 +738,7 @@ type ('a : value_or_null) record : value mod non_float =
   { x : 'a; y : int or_null; z : float }
 
 [%%expect{|
-type 'a record = { x : 'a; y : int or_null; z : float; }
+type ('a : value_or_null) record = { x : 'a; y : int or_null; z : float; }
 |}]
 
 type ('a : value_or_null) smth : immediate with 'a
@@ -750,11 +750,11 @@ type ('a : immediate) bounded
 type works = int or_null smth bounded
 
 [%%expect{|
-type 'a smth : immediate with 'a
+type ('a : value_or_null) smth : immediate with 'a
 type ('a : immediate) bounded
 type works = int or_null smth bounded
 |}, Principal{|
-type 'a smth : immediate with 'a
+type ('a : value_or_null) smth : immediate with 'a
 type ('a : immediate) bounded
 Line 7, characters 13-29:
 7 | type works = int or_null smth bounded

--- a/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -404,7 +404,7 @@ Error: This type "'a or_null" should be an instance of type "('b : value)"
 type (_, _ : value_or_null) gadt = Gadt : 'a or_null -> ('a, 'a or_null) gadt [@@unboxed]
 
 [%%expect{|
-type (_, _) gadt = Gadt : 'a or_null -> ('a, 'a or_null) gadt [@@unboxed]
+type (_, _ : value_or_null) gadt = Gadt : 'a or_null -> ('a, 'a or_null) gadt [@@unboxed]
 |}]
 
 let gadt_null = Gadt Null

--- a/testsuite/tests/typing-layouts-or-null/variables.ml
+++ b/testsuite/tests/typing-layouts-or-null/variables.ml
@@ -7,7 +7,7 @@ type ('a : value_or_null) id_value_or_null = 'a
 
 [%%expect{|
 type t_value_or_null : value_or_null
-type 'a id_value_or_null = 'a
+type ('a : value_or_null) id_value_or_null = 'a
 |}]
 
 (* Type parameters default to [value] and need
@@ -81,11 +81,11 @@ Error: Signature mismatch:
        Modules do not match:
          sig type 'a t = 'a X.t end
        is not included in
-         sig type 'a t end
+         sig type ('a : value_or_null) t end
        Type declarations do not match:
          type 'a t = 'a X.t
        is not included in
-         type 'a t
+         type ('a : value_or_null) t
        The problem is in the kinds of a parameter:
        The kind of 'a is value_or_null
          because of the definition of t at line 1, characters 39-66.
@@ -303,7 +303,7 @@ type (!'a : value_or_null) dummy
 type t = Packed : 'a dummy -> t
 
 [%%expect{|
-type !'a dummy
+type (!'a : value_or_null) dummy
 type t = Packed : 'a dummy -> t
 |}]
 

--- a/testsuite/tests/typing-layouts-products/basics_implicit_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/basics_implicit_unboxed_records.ml
@@ -553,7 +553,7 @@ val update_t : t# -> unit = <fun>
 
 type ('a : any) t = { x : int; y : 'a }
 [%%expect{|
-type 'a t = { x : int; y : 'a; }
+type ('a : value_or_null) t = { x : int; y : 'a; }
 |}]
 
 (* CR layouts v7.2: once we allow record declarations with unknown kind (right

--- a/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
@@ -696,7 +696,7 @@ val update_t : t -> unit = <fun>
 
 type ('a : any) t = #{ x : int; y : 'a }
 [%%expect{|
-type 'a t = #{ x : int; y : 'a; }
+type ('a : value_or_null) t = #{ x : int; y : 'a; }
 |}]
 
 (* CR layouts v7.2: once we allow record declarations with unknown kind (right

--- a/testsuite/tests/typing-layouts/basics.ml
+++ b/testsuite/tests/typing-layouts/basics.ml
@@ -609,7 +609,7 @@ type ('a : void) void4 = Void4 of 'a
 
 type ('a : any) any4 = Any4 of 'a
 [%%expect{|
-type 'a any4 = Any4 of 'a
+type ('a : value_or_null) any4 = Any4 of 'a
 |}];;
 
 (************************************************************)


### PR DESCRIPTION
`Printtyp` avoids printing `: value_or_null` for type variables, whether as parameters (e.g. `type 'a t = ...`) or quantifiers (e.g. `'a. 'a -> ...`). There's a CR explaining that this is intentional, to avoid cluttering cluttering output when it's irrelevant.

However, this has a sad interaction with `Base`. In order to ensure that it shadows everything from `Stdlib`, we [generate](https://github.com/janestreet/base/blob/master/shadow-stdlib/gen/gen.ml) a file [`shadow_stdlib.mli`](https://github.com/janestreet/base/blob/master/shadow-stdlib/src/dune) which has the same interface as `Stdlib`, except with a `[@@deprecated]` alert slapped on each item. However, we do this by reading `stdlib.cmi`, running it through `Printtyp.signature`, and then mapping the resulting text. This process loses the `: value_or_null` annotations on the re-export of the `result` type. Files in `Base` then effectively `open Shadow_stdlib`, causing constructor disambiguation to pick a `value` layout for the argument to `Ok` and `Error` constructors. To use them with `value_or_null` layouts, we must spell out the module path i.e. `Result.Ok` and `Result.Error`.

To fix this, we can simply prevent `Printtyp` from omitting `: value_or_null` annotations on type parameters. This is the less common case, in which the layout is often relevant, and arguably makes error messages clearer, as evidenced by the test changes in this PR.

We _could_ include `: value_or_null` annotations on quantified variables as well, but this is the far more common case, in which the layout annotation is often irrelevant, and would mostly serve clutter error messages. I tried making that change to see what would break, and nearly 150 additional test files would have changes. It's also orthogonal to the problem with `Shadow_stdlib`. So, for now, I propose we only make this change for type parameters.