### PR TITLE
Ban generic optional argument usage in type classes

### DIFF
--- a/testsuite/tests/generic-optional-arguments/test_classes_comprehensive.ml
+++ b/testsuite/tests/generic-optional-arguments/test_classes_comprehensive.ml
@@ -16,15 +16,15 @@ class test_method_only = object
     | MySome n -> n
 end
 [%%expect{|
-type 'a my_option = MyNone | MySome of 'a [@@option_like]
+type 'a my_option = MyNone | MySome of 'a
 class test_method_only :
-  object method process : (?x : int my_option) -> unit -> int end
+  object method process : (?x):int my_option -> unit -> int end
 |}]
 
 (* Test 2: Use the class with method *)
 let obj1 = new test_method_only
 let v1 = obj1#process ()
-let v2 = obj1#process ~x:(MySome 42) ()
+let v2 = obj1#process ?x:(MySome 42) ()
 [%%expect{|
 val obj1 : test_method_only = <obj>
 val v1 : int = 0
@@ -44,7 +44,8 @@ class type interface = object
   method m : (?x):int my_option -> unit -> int
 end
 [%%expect{|
-class type interface = object method m : (?x):int my_option -> unit -> int end
+class type interface =
+  object method m : (?x):int my_option -> unit -> int end
 |}]
 
 (* Test 5: Class implementing the interface *)
@@ -59,7 +60,7 @@ class implementation : interface
 (* Test 5a: Use implementation class *)
 let obj_impl = new implementation
 let v_impl1 = obj_impl#m ()
-let v_impl2 = obj_impl#m ~x:(MySome 99) ()
+let v_impl2 = obj_impl#m ?x:(MySome 99) ()
 [%%expect{|
 val obj_impl : implementation = <obj>
 val v_impl1 : int = 0
@@ -78,7 +79,7 @@ end
 class mixed_args :
   int ->
   object
-    method use_generic : (?opt : string my_option) -> unit -> string
+    method use_generic : (?opt):string my_option -> unit -> string
     method use_regular : int
   end
 |}]
@@ -97,7 +98,7 @@ val v_gen2 : string = "test"
 
 (* Test 7: Inheritance with generic optional methods *)
 class base = object
-  method virtual process : (?x : int my_option) -> unit -> int
+  method virtual process : (?x) : int my_option -> unit -> int
 end
 [%%expect{|
 class base : object method virtual process : (?x : int my_option) -> unit -> int end
@@ -115,7 +116,7 @@ class derived : object method process : (?x : int my_option) -> unit -> int end
 (* Test 7a: Use the derived class *)
 let obj_derived = new derived
 let v3 = obj_derived#process ()
-let v4 = obj_derived#process ~x:(MySome 100) ()
+let v4 = obj_derived#process ?x:(MySome 100) ()
 [%%expect{|
 val obj_derived : derived = <obj>
 val v3 : int = -1
@@ -133,16 +134,16 @@ end
 class multiple_optionals :
   object
     method multi :
-      (?x : int my_option) -> (?y : string my_option) -> unit -> int * string
+      (?x):int my_option -> (?y):string my_option -> unit -> int * string
   end
 |}]
 
 (* Test 8a: Use multiple optionals *)
 let obj_multi = new multiple_optionals
 let v5 = obj_multi#multi ()
-let v6 = obj_multi#multi ~x:(MySome 5) ()
+let v6 = obj_multi#multi ?x:(MySome 5) ()
 let v7 = obj_multi#multi ~y:(MySome "hello") ()
-let v8 = obj_multi#multi ~x:(MySome 10) ~y:(MySome "world") ()
+let v8 = obj_multi#multi ?x:(MySome 10) ~y:(MySome "world") ()
 [%%expect{|
 val obj_multi : multiple_optionals = <obj>
 val v5 : int * string = (0, "")
@@ -163,7 +164,7 @@ end
 class with_state :
   object
     val mutable count : int
-    method increment : (?by : int my_option) -> unit -> int
+    method increment : (?by):int my_option -> unit -> int
   end
 |}]
 
@@ -181,7 +182,7 @@ val v11 : int = 7
 
 (* Test 10: Using generic optional with polymorphic method *)
 class poly_optional = object
-  method poly : 'a. (?x : 'a my_option) -> unit -> 'a option =
+  method poly : 'a. (?x) : 'a my_option -> unit -> 'a option =
     fun ?(x : 'a my_option) () ->
       match x with
       | MyNone -> None
@@ -195,8 +196,8 @@ class poly_optional :
 (* Test 10a: Use polymorphic optional *)
 let obj_poly = new poly_optional
 let v12 = obj_poly#poly ()
-let v13 = obj_poly#poly ~x:(MySome 42) ()
-let v14 = obj_poly#poly ~x:(MySome "poly") ()
+let v13 = obj_poly#poly ?x:(MySome 42) ()
+let v14 = obj_poly#poly ?x:(MySome "poly") ()
 [%%expect{|
 val obj_poly : poly_optional = <obj>
 val v12 : '_weak1 option = None

--- a/testsuite/tests/generic-optional-arguments/test_classes_comprehensive.ml
+++ b/testsuite/tests/generic-optional-arguments/test_classes_comprehensive.ml
@@ -1,0 +1,205 @@
+(* TEST
+ flags = "-extension-universe alpha";
+ expect;
+*)
+
+type 'a my_option =
+  | MyNone
+  | MySome of 'a
+[@@option_like]
+
+(* Test 1: Class with method having generic optional argument - should work *)
+class test_method_only = object
+  method process (?x : int my_option) () =
+    match x with
+    | MyNone -> 0
+    | MySome n -> n
+end
+[%%expect{|
+type 'a my_option = MyNone | MySome of 'a [@@option_like]
+class test_method_only :
+  object method process : (?x : int my_option) -> unit -> int end
+|}]
+
+(* Test 2: Use the class with method *)
+let obj1 = new test_method_only
+let v1 = obj1#process ()
+let v2 = obj1#process ~x:(MySome 42) ()
+[%%expect{|
+val obj1 : test_method_only = <obj>
+val v1 : int = 0
+val v2 : int = 42
+|}]
+
+(* Test 3: Class with generic optional constructor argument - should fail *)
+class test_constructor_arg (?x : int my_option) = object
+  method get = match x with MyNone -> 0 | MySome n -> n
+end
+[%%expect{|
+Exception: Failure "Cannot create fresh generic optional without existing type".
+|}]
+
+(* Test 4: Class type with generic optional in method signature *)
+class type interface = object
+  method m : (?x):int my_option -> unit -> int
+end
+[%%expect{|
+class type interface = object method m : (?x):int my_option -> unit -> int end
+|}]
+
+(* Test 5: Class implementing the interface *)
+class implementation : interface = object
+  method m (?x : int my_option) () =
+    match x with MyNone -> 0 | MySome n -> n
+end
+[%%expect{|
+class implementation : interface
+|}]
+
+(* Test 5a: Use implementation class *)
+let obj_impl = new implementation
+let v_impl1 = obj_impl#m ()
+let v_impl2 = obj_impl#m ~x:(MySome 99) ()
+[%%expect{|
+val obj_impl : implementation = <obj>
+val v_impl1 : int = 0
+val v_impl2 : int = 99
+|}]
+
+(* Test 6: Class with both regular and generic optional arguments *)
+class mixed_args (regular : int) = object
+  method use_regular = regular
+  method use_generic (?opt : string my_option) () =
+    match opt with
+    | MyNone -> "none"
+    | MySome s -> s
+end
+[%%expect{|
+class mixed_args :
+  int ->
+  object
+    method use_generic : (?opt : string my_option) -> unit -> string
+    method use_regular : int
+  end
+|}]
+
+(* Test 6a: Use mixed args class *)
+let obj_mixed = new mixed_args 42
+let v_reg = obj_mixed#use_regular
+let v_gen1 = obj_mixed#use_generic ()
+let v_gen2 = obj_mixed#use_generic ~opt:(MySome "test") ()
+[%%expect{|
+val obj_mixed : mixed_args = <obj>
+val v_reg : int = 42
+val v_gen1 : string = "none"
+val v_gen2 : string = "test"
+|}]
+
+(* Test 7: Inheritance with generic optional methods *)
+class base = object
+  method virtual process : (?x : int my_option) -> unit -> int
+end
+[%%expect{|
+class base : object method virtual process : (?x : int my_option) -> unit -> int end
+|}]
+
+class derived = object
+  inherit base
+  method process (?x : int my_option) () =
+    match x with MyNone -> -1 | MySome n -> n
+end
+[%%expect{|
+class derived : object method process : (?x : int my_option) -> unit -> int end
+|}]
+
+(* Test 7a: Use the derived class *)
+let obj_derived = new derived
+let v3 = obj_derived#process ()
+let v4 = obj_derived#process ~x:(MySome 100) ()
+[%%expect{|
+val obj_derived : derived = <obj>
+val v3 : int = -1
+val v4 : int = 100
+|}]
+
+(* Test 8: Multiple generic optional arguments in method *)
+class multiple_optionals = object
+  method multi (?x : int my_option) (?y : string my_option) () =
+    let x_val = match x with MyNone -> 0 | MySome n -> n in
+    let y_val = match y with MyNone -> "" | MySome s -> s in
+    (x_val, y_val)
+end
+[%%expect{|
+class multiple_optionals :
+  object
+    method multi :
+      (?x : int my_option) -> (?y : string my_option) -> unit -> int * string
+  end
+|}]
+
+(* Test 8a: Use multiple optionals *)
+let obj_multi = new multiple_optionals
+let v5 = obj_multi#multi ()
+let v6 = obj_multi#multi ~x:(MySome 5) ()
+let v7 = obj_multi#multi ~y:(MySome "hello") ()
+let v8 = obj_multi#multi ~x:(MySome 10) ~y:(MySome "world") ()
+[%%expect{|
+val obj_multi : multiple_optionals = <obj>
+val v5 : int * string = (0, "")
+val v6 : int * string = (5, "")
+val v7 : int * string = (0, "hello")
+val v8 : int * string = (10, "world")
+|}]
+
+(* Test 9: Class with mutable field and generic optional method *)
+class with_state = object
+  val mutable count = 0
+  method increment (?by : int my_option) () =
+    let inc = match by with MyNone -> 1 | MySome n -> n in
+    count <- count + inc;
+    count
+end
+[%%expect{|
+class with_state :
+  object
+    val mutable count : int
+    method increment : (?by : int my_option) -> unit -> int
+  end
+|}]
+
+(* Test 9a: Use stateful class *)
+let obj_state = new with_state
+let v9 = obj_state#increment ()
+let v10 = obj_state#increment ~by:(MySome 5) ()
+let v11 = obj_state#increment ()
+[%%expect{|
+val obj_state : with_state = <obj>
+val v9 : int = 1
+val v10 : int = 6
+val v11 : int = 7
+|}]
+
+(* Test 10: Using generic optional with polymorphic method *)
+class poly_optional = object
+  method poly : 'a. (?x : 'a my_option) -> unit -> 'a option =
+    fun ?(x : 'a my_option) () ->
+      match x with
+      | MyNone -> None
+      | MySome v -> Some v
+end
+[%%expect{|
+class poly_optional :
+  object method poly : (?x : 'a my_option) -> unit -> 'a option end
+|}]
+
+(* Test 10a: Use polymorphic optional *)
+let obj_poly = new poly_optional
+let v12 = obj_poly#poly ()
+let v13 = obj_poly#poly ~x:(MySome 42) ()
+let v14 = obj_poly#poly ~x:(MySome "poly") ()
+[%%expect{|
+val obj_poly : poly_optional = <obj>
+val v12 : '_weak1 option = None
+val v13 : int option = Some 42
+val v14 : string option = Some "poly"
+|}]

--- a/testsuite/tests/generic-optional-arguments/test_classes_simple.ml
+++ b/testsuite/tests/generic-optional-arguments/test_classes_simple.ml
@@ -38,12 +38,16 @@ end
 [%%expect{| |}]
 
 (* Test usage *)
-let () =
-  let obj1 = new without_constructor_arg in
-  let _ = obj1#process MyNone in
-  let _ = obj1#process (MySome 42) in
+let obj1 = new without_constructor_arg
+let _ = obj1#process MyNone
+let _ = obj1#process (MySome 42)
 
-  let obj2 = new with_regular_arg 100 in
-  let _ = obj2#process_optional () in
-  ()
-[%%expect{| |}]
+let obj2 = new with_regular_arg 100
+let _ = obj2#process_optional ()
+[%%expect{|
+val obj1 : without_constructor_arg = <obj>
+- : int = 0
+- : int = 42
+val obj2 : with_regular_arg = <obj>
+- : int = 100
+|}]

--- a/testsuite/tests/generic-optional-arguments/test_classes_simple.ml
+++ b/testsuite/tests/generic-optional-arguments/test_classes_simple.ml
@@ -1,0 +1,49 @@
+(* TEST
+ flags = "-extension-universe alpha";
+ expect;
+*)
+
+type 'a my_option =
+  | MyNone
+  | MySome of 'a
+[@@option_like]
+
+(* Test 1: Class with generic optional as constructor argument - SHOULD FAIL *)
+class with_optional_arg (?x : int my_option) = object
+     method get = match x with MyNone -> 0 | MySome n -> n
+   end
+[%%expect{| |}]
+
+(* Test 2: Class with NO constructor arguments, but method has generic optional - SHOULD WORK *)
+class without_constructor_arg = object
+  method process (x : int my_option) =
+    match x with
+    | MyNone -> 0
+    | MySome n -> n
+end
+[%%expect{| |}]
+
+(* Test 3: Class with regular (non-optional) constructor argument - SHOULD WORK *)
+class with_regular_arg (x : int) = object
+  method get = x
+  method process_optional (?y : int my_option) () =
+    match y with MyNone -> x | MySome n -> n
+end
+[%%expect{| |}]
+
+(* Test 4: Class type with generic optional in method signature - SHOULD WORK *)
+class type interface = object
+  method m : (?x):int my_option -> unit -> int
+end
+[%%expect{| |}]
+
+(* Test usage *)
+let () =
+  let obj1 = new without_constructor_arg in
+  let _ = obj1#process MyNone in
+  let _ = obj1#process (MySome 42) in
+
+  let obj2 = new with_regular_arg 100 in
+  let _ = obj2#process_optional () in
+  ()
+[%%expect{| |}]

--- a/testsuite/tests/generic-optional-arguments/test_classes_simple.ml
+++ b/testsuite/tests/generic-optional-arguments/test_classes_simple.ml
@@ -18,6 +18,24 @@ class with_optional_arg :
   (?x):int my_option -> unit -> object method get : int end
 |}]
 
+(* Test 1: Class with generic optional as constructor argument - SHOULD FAIL *)
+class with_optional_arg_2 (name: string) (?x : int my_option) () = object
+  method get = match x with MyNone -> 0 | MySome n -> n
+end
+[%%expect{|
+class with_optional_arg_2 :
+  string -> (?x):int my_option -> unit -> object method get : int end
+|}]
+
+(* Test 1b: Class with generic optional as constructor argument - SHOULD FAIL *)
+class with_vanilla_optional_arg_default ?(x : int = 2) () = object
+  method get : int = x
+end
+[%%expect{|
+class with_vanilla_optional_arg_default :
+  ?x:int -> unit -> object method get : int end
+|}]
+
 
 (* Test 1b: Class with generic optional as constructor argument - SHOULD FAIL *)
 class with_optional_arg_default (?(x = 2) : int my_option) () = object
@@ -116,4 +134,17 @@ val obj1 : without_constructor_arg = <obj>
 - : int = 42
 val obj2 : with_regular_arg = <obj>
 - : int = 100
+|}]
+
+
+class obj_class = with_optional_arg_2 "hello" ()
+[%%expect{|
+Uncaught exception: Failure("TRIGGER GEN-OPT 2")
+
+|}]
+
+class obj_class = with_optional_arg_2 "hello" ~x:2 ()
+[%%expect{|
+Uncaught exception: Failure("TRIGGER GEN-OPT 1")
+
 |}]

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1573,10 +1573,9 @@ let rec approx_declaration cl =
       let arg =
         match l with
         | Optional _ -> Ctype.instance var_option
-        | Generic_optional _ ->
-            Misc.fatal_error "Generic optional not supported"
           (* CR generic-optional: Handle this case *)
         | Position _ -> Ctype.instance Predef.type_lexing_position
+        | Generic_optional _ (* we approximate most general types *)
         | Labelled _ | Nolabel ->
           Ctype.newvar (Jkind.Builtin.value ~why:Class_term_argument)
           (* CR layouts: use of value here may be relaxed when we update
@@ -1600,7 +1599,7 @@ let rec approx_description ct =
         match Btype.classify_optionality l with
         | Vanilla_optional_arg -> Ctype.instance var_option
         | Generic_optional_arg ->
-            Misc.fatal_error "Generic optional not supported"
+            Misc.fatal_error "Generic optional not supported 2 "
         | Required_or_position_arg ->
             Ctype.newvar (Jkind.Builtin.value ~why:Class_term_argument)
         (* CR layouts: use of value here may be relaxed when we

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1377,11 +1377,17 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                   let arg = Typecore.type_argument val_env sarg ty ty0 in
                   arg, Jkind.Sort.value
                 else
+                  (let _ = failwith "TRIGGER GEN-OPT 1" in
+                  (* here fun type (l) is optional &&
+                     arg type is not optional (l'), we need to wrap things in
+                     Some *)
                   Typecore.type_option_some val_env sarg ty ty0,
                       Jkind.Sort.value
+                  )
               )
             in
             let eliminate_optional_arg _lbl =
+              let _ = failwith "TRIGGER GEN-OPT 2" in
               (* CR generic-optional: Handle the case of generic-optional *)
               Arg (Typecore.type_option_none val_env ty0 Location.none,
                 (* CR generic-optional: Change the sort when options can hold

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -167,6 +167,10 @@ val extract_optional_tp_from_pattern_constraint_exn:
         Env.t -> Parsetree.pattern ->
         (Btype.generic_optional_type_path * type_declaration) *
         Parsetree.core_type * Parsetree.pattern
+val get_some_constructor:
+        Env.t -> Btype.generic_optional_type_path -> constructor_description
+val get_none_constructor:
+        Env.t -> Btype.generic_optional_type_path -> constructor_description
 
 val type_option_some:
         Env.t -> Parsetree.expression ->


### PR DESCRIPTION
Ban the usage of generic optional arguments as class arguments. 

A partial implementation (with bugs) is stashed at `zchenb/gen-opt-type-class-fix-stashed-changes`.