### PR TITLE
Revert "`mutable` no longer implies several comonadic modalities"

### DIFF
--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -610,13 +610,13 @@ type t =
   | K2 : global_ string * (float -> float) @@ many * string -> t
 type t = {
   global_ x : string;
-  mutable y : float -> float @@ many;
+  mutable y : float -> float;
   z : string @@ global many;
 }
 type t1 = { mutable x : float; mutable f : float -> float; }
 type t2 = {
-  mutable x : float @@ local;
-  mutable f : float -> float @@ local;
+  mutable x : float @@ local once;
+  mutable f : float -> float @@ local once;
 }
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -990,7 +990,7 @@ type ('a : immediate) t : value mod global = { mutable x : 'a }
 Line 1, characters 0-63:
 1 | type ('a : immediate) t : value mod global = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ unyielding
+Error: The kind of type "t" is mutable_data with 'a @@ unyielding many
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod global
          because of the annotation on the declaration of the type t.
@@ -1004,7 +1004,7 @@ type ('a : immediate) t : value mod aliased = { mutable x : 'a }
 Line 1, characters 0-64:
 1 | type ('a : immediate) t : value mod aliased = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ unyielding
+Error: The kind of type "t" is mutable_data with 'a @@ unyielding many
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod aliased
          because of the annotation on the declaration of the type t.
@@ -1018,7 +1018,7 @@ type ('a : immediate) t : value mod contended = { mutable x : 'a }
 Line 1, characters 0-66:
 1 | type ('a : immediate) t : value mod contended = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ unyielding
+Error: The kind of type "t" is mutable_data with 'a @@ unyielding many
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod contended
          because of the annotation on the declaration of the type t.
@@ -1032,7 +1032,7 @@ type ('a : immediate) t : value mod external_ = { mutable x : 'a }
 Line 1, characters 0-66:
 1 | type ('a : immediate) t : value mod external_ = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ unyielding
+Error: The kind of type "t" is mutable_data with 'a @@ unyielding many
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod external_
          because of the annotation on the declaration of the type t.
@@ -1046,7 +1046,7 @@ type ('a : immediate) t : value mod external64 = { mutable x : 'a }
 Line 1, characters 0-67:
 1 | type ('a : immediate) t : value mod external64 = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ unyielding
+Error: The kind of type "t" is mutable_data with 'a @@ unyielding many
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod external64
          because of the annotation on the declaration of the type t.

--- a/testsuite/tests/typing-jkind-bounds/composite.ml
+++ b/testsuite/tests/typing-jkind-bounds/composite.ml
@@ -189,12 +189,11 @@ Line 1, characters 13-20:
 1 | let foo (t : int ref t @ contended) = use_uncontended t
                  ^^^^^^^
 Error: This type "int ref" should be an instance of type "('a : immutable_data)"
-       The kind of int ref is mutable_data with int @@ unyielding.
+       The kind of int ref is mutable_data with int @@ unyielding many.
        But the kind of int ref must be a subkind of immutable_data
          because of the definition of t at line 1, characters 0-46.
 
        The first mode-crosses less than the second along:
-         linearity: mod many with int ≰ mod many
          contention: mod uncontended ≰ mod contended
          portability: mod portable with int ≰ mod portable
          statefulness: mod stateless with int ≰ mod stateless
@@ -342,12 +341,11 @@ Line 1, characters 13-20:
 1 | let foo (t : int ref t @ contended) = use_uncontended t
                  ^^^^^^^
 Error: This type "int ref" should be an instance of type "('a : immutable_data)"
-       The kind of int ref is mutable_data with int @@ unyielding.
+       The kind of int ref is mutable_data with int @@ unyielding many.
        But the kind of int ref must be a subkind of immutable_data
          because of the definition of t at line 1, characters 0-73.
 
        The first mode-crosses less than the second along:
-         linearity: mod many with int ≰ mod many
          contention: mod uncontended ≰ mod contended
          portability: mod portable with int ≰ mod portable
          statefulness: mod stateless with int ≰ mod stateless

--- a/testsuite/tests/typing-jkind-bounds/predef.ml
+++ b/testsuite/tests/typing-jkind-bounds/predef.ml
@@ -176,12 +176,11 @@ type 'a t : mutable_data = 'a ref
 Line 1, characters 0-33:
 1 | type 'a t : mutable_data = 'a ref
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a ref" is mutable_data with 'a @@ unyielding.
+Error: The kind of type "'a ref" is mutable_data with 'a @@ unyielding many.
        But the kind of type "'a ref" must be a subkind of mutable_data
          because of the definition of t at line 1, characters 0-33.
 
        The first mode-crosses less than the second along:
-         linearity: mod many with 'a ≰ mod many
          portability: mod portable with 'a ≰ mod portable
          statefulness: mod stateless with 'a ≰ mod stateless
 |}]
@@ -200,7 +199,7 @@ Line 1, characters 14-21:
                   ^^^^^^^
 Error: This type "int ref" should be an instance of type
          "('a : value mod portable)"
-       The kind of int ref is mutable_data with int @@ unyielding.
+       The kind of int ref is mutable_data with int @@ unyielding many.
        But the kind of int ref must be a subkind of value mod portable
          because of the definition of require_portable at line 10, characters 0-47.
 
@@ -224,7 +223,7 @@ Line 1, characters 14-21:
                   ^^^^^^^
 Error: This type "int ref" should be an instance of type
          "('a : value mod contended)"
-       The kind of int ref is mutable_data with int @@ unyielding.
+       The kind of int ref is mutable_data with int @@ unyielding many.
        But the kind of int ref must be a subkind of value mod contended
          because of the definition of require_contended at line 9, characters 0-49.
 

--- a/testsuite/tests/typing-jkind-bounds/printing.ml
+++ b/testsuite/tests/typing-jkind-bounds/printing.ml
@@ -179,12 +179,11 @@ Line 3, characters 11-12:
                ^
 Error: This type "a" = "int ref" should be an instance of type
          "('a : immutable_data)"
-       The kind of a is mutable_data with int @@ unyielding.
+       The kind of a is mutable_data with int @@ unyielding many.
        But the kind of a must be a subkind of immutable_data
          because of the definition of t at line 2, characters 0-28.
 
        The first mode-crosses less than the second along:
-         linearity: mod many with int ≰ mod many
          contention: mod uncontended ≰ mod contended
          portability: mod portable with int ≰ mod portable
          statefulness: mod stateless with int ≰ mod stateless
@@ -344,18 +343,19 @@ Error: Signature mismatch:
        Modules do not match:
          sig type 'a t : mutable_data with 'a end
        is not included in
-         sig type 'a t : mutable_data with 'a @@ unyielding end
+         sig type 'a t : mutable_data with 'a @@ unyielding many end
        Type declarations do not match:
          type 'a t : mutable_data with 'a
        is not included in
-         type 'a t : mutable_data with 'a @@ unyielding
+         type 'a t : mutable_data with 'a @@ unyielding many
        The kind of the first is mutable_data with 'a
          because of the definition of t at line 4, characters 2-34.
        But the kind of the first must be a subkind of mutable_data
-         with 'a @@ unyielding
+         with 'a @@ unyielding many
          because of the definition of t at line 2, characters 2-40.
 
        The first mode-crosses less than the second along:
+         linearity: mod many with 'a ≰ mod many
          yielding: mod unyielding with 'a ≰ mod unyielding
 |}]
 
@@ -423,14 +423,14 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig type 'a t : mutable_data with 'a @@ unyielding end
+         sig type 'a t : mutable_data with 'a @@ unyielding many end
        is not included in
          sig type 'a t : immutable_data with 'a end
        Type declarations do not match:
-         type 'a t : mutable_data with 'a @@ unyielding
+         type 'a t : mutable_data with 'a @@ unyielding many
        is not included in
          type 'a t : immutable_data with 'a
-       The kind of the first is mutable_data with 'a @@ unyielding
+       The kind of the first is mutable_data with 'a @@ unyielding many
          because of the definition of t at line 4, characters 2-40.
        But the kind of the first must be a subkind of immutable_data with 'a
          because of the definition of t at line 2, characters 2-56.

--- a/testsuite/tests/typing-jkind-bounds/records.ml
+++ b/testsuite/tests/typing-jkind-bounds/records.ml
@@ -128,13 +128,12 @@ type 'a t : immutable_data = { mutable x : 'a }
 Line 1, characters 0-47:
 1 | type 'a t : immutable_data = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ unyielding
+Error: The kind of type "t" is mutable_data with 'a @@ unyielding many
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
 
        The first mode-crosses less than the second along:
-         linearity: mod many with 'a ≰ mod many
          contention: mod uncontended ≰ mod contended
          portability: mod portable with 'a ≰ mod portable
          statefulness: mod stateless with 'a ≰ mod stateless
@@ -271,7 +270,7 @@ type 'a t : immutable_data with 'a = { mutable x : 'a }
 Line 1, characters 0-55:
 1 | type 'a t : immutable_data with 'a = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ unyielding
+Error: The kind of type "t" is mutable_data with 'a @@ unyielding many
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data with 'a
          because of the annotation on the declaration of the type t.

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
@@ -181,18 +181,19 @@ Error: Signature mismatch:
        Modules do not match:
          sig type 'a t : mutable_data with 'a end
        is not included in
-         sig type 'a t : mutable_data with 'a @@ unyielding end
+         sig type 'a t : mutable_data with 'a @@ unyielding many end
        Type declarations do not match:
          type 'a t : mutable_data with 'a
        is not included in
-         type 'a t : mutable_data with 'a @@ unyielding
+         type 'a t : mutable_data with 'a @@ unyielding many
        The kind of the first is mutable_data with 'a
          because of the definition of t at line 4, characters 2-34.
        But the kind of the first must be a subkind of mutable_data
-         with 'a @@ unyielding
+         with 'a @@ unyielding many
          because of the definition of t at line 2, characters 2-40.
 
        The first mode-crosses less than the second along:
+         linearity: mod many with 'a ≰ mod many
          yielding: mod unyielding with 'a ≰ mod unyielding
 |}]
 
@@ -202,7 +203,7 @@ end = struct
   type 'a t : mutable_data with 'a @@ many unyielding
 end
 [%%expect {|
-module M : sig type 'a t : mutable_data with 'a @@ unyielding end
+module M : sig type 'a t : mutable_data with 'a @@ unyielding many end
 |}]
 
 (* CR layouts v2.8: 'a u's kind should get normalized to just immutable_data *)

--- a/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
@@ -141,7 +141,7 @@ Error: Signature mismatch:
          type 'a t = Foo of 'a constraint 'a = 'b ref
        is not included in
          type 'a t : immutable_data with 'b constraint 'a = 'b ref
-       The kind of the first is mutable_data with 'b @@ unyielding
+       The kind of the first is mutable_data with 'b @@ unyielding many
          because of the definition of t at line 4, characters 2-46.
        But the kind of the first must be a subkind of immutable_data with 'b
          because of the definition of t at line 2, characters 2-59.

--- a/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
@@ -86,7 +86,6 @@ Error: The kind of type "'a F(Ref).t" is mutable_data
          because of the definition of t at line 4, characters 0-38.
 
        The first mode-crosses less than the second along:
-         linearity: mod many with 'a ≰ mod many
          portability: mod portable with 'a ≰ mod portable
          statefulness: mod stateless with 'a ≰ mod stateless
 |}]

--- a/testsuite/tests/typing-jkind-bounds/variants.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants.ml
@@ -132,13 +132,12 @@ type 'a t : immutable_data = Foo of { mutable x : 'a }
 Line 1, characters 0-54:
 1 | type 'a t : immutable_data = Foo of { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ unyielding
+Error: The kind of type "t" is mutable_data with 'a @@ unyielding many
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
 
        The first mode-crosses less than the second along:
-         linearity: mod many with 'a ≰ mod many
          contention: mod uncontended ≰ mod contended
          portability: mod portable with 'a ≰ mod portable
          statefulness: mod stateless with 'a ≰ mod stateless
@@ -275,7 +274,7 @@ type 'a t : immutable_data with 'a = Foo of { mutable x : 'a }
 Line 1, characters 0-62:
 1 | type 'a t : immutable_data with 'a = Foo of { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ unyielding
+Error: The kind of type "t" is mutable_data with 'a @@ unyielding many
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data with 'a
          because of the annotation on the declaration of the type t.

--- a/testsuite/tests/typing-layouts/hash_types.ml
+++ b/testsuite/tests/typing-layouts/hash_types.ml
@@ -234,10 +234,10 @@ Error: This expression has type "r#" but an expression was expected of type "r2#
 
 (* Mutable fields imply modalities *)
 type r = { i : int ; mutable s : string }
-type u = r# = #{ i : int ; s : string @@ global aliased unyielding }
+type u = r# = #{ i : int ; s : string @@ global many aliased unyielding }
 [%%expect{|
 type r = { i : int; mutable s : string; }
-type u = r# = #{ i : int; s : string @@ global aliased; }
+type u = r# = #{ i : int; s : string @@ global many aliased; }
 |}]
 
 (*******************)

--- a/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/testsuite/tests/typing-modal-kinds/basics.ml
@@ -934,7 +934,7 @@ Line 1, characters 10-19:
               ^^^^^^^^^
 Error: This type "int t ref" should be an instance of type
          "('a : value mod contended)"
-       The kind of int t ref is mutable_data with int t @@ unyielding.
+       The kind of int t ref is mutable_data with int t @@ unyielding many.
        But the kind of int t ref must be a subkind of value mod contended
          because of the definition of require_contended at line 1, characters 0-49.
 

--- a/testsuite/tests/typing-modes/modes.ml
+++ b/testsuite/tests/typing-modes/modes.ml
@@ -391,10 +391,10 @@ type r = Foo of string @@ global aliased many
 type r = Foo of string @@ global many aliased
 |}]
 
-(* mutable implies [global] and [unyielding], and legacy modalities for monadic
-   axes. *)
+(* mutable implies global aliased many. No warnings are given since we imagine
+   that the coupling will be removed soon. *)
 type r = {
-  mutable x : string @@ global unyielding aliased
+  mutable x : string @@ global aliased many
 }
 [%%expect{|
 type r = { mutable x : string; }

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -460,20 +460,18 @@ let untransl_modality (a : Modality.t) : Parsetree.modality loc =
   in
   { txt = Modality s; loc = Location.none }
 
-(* For now, mutable implies:
-   1. [global] and [unyielding]. This is for compatibility with existing code
-      and will be removed in the future.
-   2. [many]. This is to remedy the coarse treatment of modalities in the
-      uniqueness analysis.
-   3. legacy modalities for all monadic axes. This will stay in the future.
-
-   Implied modalities can be overriden. *)
-(* CR zqian: remove [1] and [2] *)
+(* For now, mutable implies legacy modalities for both comonadic axes and
+   monadic axes. In the future, implications on the comonadic axes will be
+   removed. The implications on the monadic axes will stay. Implied modalities
+   can be overriden. *)
+(* CR zqian: decouple mutable and comonadic modalities *)
 let mutable_implied_modalities (mut : Types.mutability) =
   let comonadic : Modality.t list =
     [ Atom (Comonadic Areality, Meet_with Regionality.Const.legacy);
       Atom (Comonadic Linearity, Meet_with Linearity.Const.legacy);
-      Atom (Comonadic Yielding, Meet_with Yielding.Const.legacy) ]
+      Atom (Comonadic Portability, Meet_with Portability.Const.legacy);
+      Atom (Comonadic Yielding, Meet_with Yielding.Const.legacy);
+      Atom (Comonadic Statefulness, Meet_with Statefulness.Const.legacy) ]
   in
   let monadic : Modality.t list =
     [ Atom (Monadic Uniqueness, Join_with Uniqueness.Const.legacy);


### PR DESCRIPTION
Reverts oxcaml/oxcaml#4415