### PR TITLE
Defer prologue addition until after regalloc

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -397,6 +397,7 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
          ++ Cfg_with_infos.cfg_with_layout
          ++ cfg_with_layout_profile ~accumulate:true "cfg_validate_description"
               (Regalloc_validate.run cfg_description))
+  ++ cfg_with_layout_profile ~accumulate:true "cfg_prologue" Cfg_prologue.run
   ++ Profile.record ~accumulate:true "cfg_available_regs"
        (available_regs
           ~stack_slots:(fun x ->

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -557,6 +557,22 @@ let make_instruction ~desc ?(arg = [||]) ?(res = [||]) ?(dbg = Debuginfo.none)
     available_across
   }
 
+let make_instruction_from_copy (copy : _ instruction) ~desc ~id ?(arg = [||])
+    ?(res = [||]) ?(irc_work_list = Unknown_list) ?(ls_order = -1) () =
+  { desc;
+    arg;
+    res;
+    dbg = copy.dbg;
+    fdo = copy.fdo;
+    live = copy.live;
+    stack_offset = copy.stack_offset;
+    id;
+    irc_work_list;
+    ls_order;
+    available_before = copy.available_before;
+    available_across = copy.available_across
+  }
+
 let invalid_stack_offset = -1
 
 let make_empty_block ?label terminator : basic_block =

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -238,6 +238,19 @@ val make_instruction :
   unit ->
   'a instruction
 
+(** Make sure that the default parameter values of [irc_work_list] and [ls_order] are
+    reasonable before using. *)
+val make_instruction_from_copy :
+  'a instruction ->
+  desc:'b ->
+  id:InstructionId.t ->
+  ?arg:Reg.t array ->
+  ?res:Reg.t array ->
+  ?irc_work_list:irc_work_list ->
+  ?ls_order:int ->
+  unit ->
+  'b instruction
+
 val make_empty_block : ?label:Label.t -> terminator instruction -> basic_block
 
 (** "Contains calls" in the traditional sense as used in upstream [Selectgen]. *)

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -2,29 +2,6 @@
 
 module DLL = Oxcaml_utils.Doubly_linked_list
 
-let make_instr_with_copy :
-    Cfg.basic ->
-    id:InstructionId.t ->
-    copy:_ Cfg.instruction ->
-    arg:Reg.t array ->
-    res:Reg.t array ->
-    Cfg.basic Cfg.instruction =
- fun desc ~id ~copy ~arg ~res ->
-  { desc;
-    arg;
-    res;
-    dbg = copy.dbg;
-    fdo = copy.fdo;
-    live = copy.live;
-    (* note: recomputed anyway *)
-    stack_offset = copy.stack_offset;
-    id;
-    irc_work_list = Unknown_list;
-    ls_order = -1;
-    available_before = copy.available_before;
-    available_across = copy.available_across
-  }
-
 let add_prologue_if_required : Cfg_with_layout.t -> Cfg_with_layout.t =
  fun cfg_with_layout ->
   let cfg = Cfg_with_layout.cfg cfg_with_layout in
@@ -40,9 +17,9 @@ let add_prologue_if_required : Cfg_with_layout.t -> Cfg_with_layout.t =
         ~default:{ entry_block.terminator with desc = Cfg.Prologue }
     in
     DLL.add_begin entry_block.body
-      (make_instr_with_copy Cfg.Prologue
+      (Cfg.make_instruction_from_copy next_instr ~desc:Cfg.Prologue
          ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
-         ~copy:next_instr ~arg:[||] ~res:[||]));
+         ()));
   cfg_with_layout
 
 let run : Cfg_with_layout.t -> Cfg_with_layout.t =

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -1,0 +1,49 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+module DLL = Oxcaml_utils.Doubly_linked_list
+
+let make_instr_with_copy :
+    Cfg.basic ->
+    id:InstructionId.t ->
+    copy:_ Cfg.instruction ->
+    arg:Reg.t array ->
+    res:Reg.t array ->
+    Cfg.basic Cfg.instruction =
+ fun desc ~id ~copy ~arg ~res ->
+  { desc;
+    arg;
+    res;
+    dbg = copy.dbg;
+    fdo = copy.fdo;
+    live = copy.live;
+    (* note: recomputed anyway *)
+    stack_offset = copy.stack_offset;
+    id;
+    irc_work_list = Unknown_list;
+    ls_order = -1;
+    available_before = copy.available_before;
+    available_across = copy.available_across
+  }
+
+let add_prologue_if_required : Cfg_with_layout.t -> Cfg_with_layout.t =
+ fun cfg_with_layout ->
+  let cfg = Cfg_with_layout.cfg cfg_with_layout in
+  let prologue_required =
+    Proc.prologue_required ~fun_contains_calls:cfg.fun_contains_calls
+      ~fun_num_stack_slots:cfg.fun_num_stack_slots
+  in
+  (if prologue_required
+  then
+    let entry_block = Cfg.get_block_exn cfg cfg.entry_label in
+    let next_instr =
+      Option.value (DLL.hd entry_block.body)
+        ~default:{ entry_block.terminator with desc = Cfg.Prologue }
+    in
+    DLL.add_begin entry_block.body
+      (make_instr_with_copy Cfg.Prologue
+         ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
+         ~copy:next_instr ~arg:[||] ~res:[||]));
+  cfg_with_layout
+
+let run : Cfg_with_layout.t -> Cfg_with_layout.t =
+ fun cfg_with_layout -> add_prologue_if_required cfg_with_layout

--- a/backend/cfg/cfg_prologue.mli
+++ b/backend/cfg/cfg_prologue.mli
@@ -1,0 +1,3 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+val run : Cfg_with_layout.t -> Cfg_with_layout.t

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -1512,8 +1512,6 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       Cfg.make_empty_block ~label:(Cfg.entry_label cfg)
         (Sub_cfg.make_instr (Cfg.Always tailrec_label) [||] [||] Debuginfo.none)
     in
-    DLL.add_begin entry_block.body
-      (Sub_cfg.make_instr Cfg.Prologue [||] [||] Debuginfo.none);
     Cfg.add_block_exn cfg entry_block;
     DLL.add_end layout entry_block.start;
     let tailrec_block =

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -441,7 +441,6 @@ let postlude :
         Utils.log "stack_slots[%a]=%d" Stack_class.print stack_class
           num_stack_slots);
     Utils.dedent ());
-  remove_prologue_if_not_required cfg_with_layout;
   update_live_fields cfg_with_layout (Cfg_with_infos.liveness cfg_with_infos);
   f ();
   if debug && Lazy.force invariants

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -251,21 +251,10 @@ module Move = struct
       from:Reg.t ->
       to_:Reg.t ->
       Instruction.t =
-   fun move ~id ~copy:instr ~from ~to_ ->
-    { desc = Op (op_of_move move);
-      arg = [| from |];
-      res = [| to_ |];
-      dbg = instr.dbg;
-      fdo = instr.fdo;
-      live = instr.live;
-      (* note: recomputed anyway *)
-      stack_offset = instr.stack_offset;
-      id;
-      irc_work_list = Unknown_list;
-      ls_order = -1;
-      available_before = instr.available_before;
-      available_across = instr.available_across
-    }
+   fun move ~id ~copy ~from ~to_ ->
+    Cfg.make_instruction_from_copy copy
+      ~desc:(Cfg.Op (op_of_move move))
+      ~arg:[| from |] ~res:[| to_ |] ~id ()
 
   let to_string = function Plain -> "move" | Load -> "load" | Store -> "store"
 end

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -302,42 +302,6 @@ let save_cfg : string -> Cfg_with_layout.t -> unit =
       Printf.sprintf "%s->%s" (Label.to_string lbl1) (Label.to_string lbl2))
     str
 
-let remove_prologue : Cfg.basic_block -> bool =
- fun block ->
-  let removed = ref false in
-  DLL.filter_left block.body ~f:(fun instr ->
-      match[@ocaml.warning "-4"] instr.Cfg.desc with
-      | Cfg.Prologue ->
-        removed := true;
-        false
-      | _ -> true);
-  !removed
-
-let remove_prologue_if_not_required : Cfg_with_layout.t -> unit =
- fun cfg_with_layout ->
-  let cfg = Cfg_with_layout.cfg cfg_with_layout in
-  let prologue_required =
-    Proc.prologue_required ~fun_contains_calls:cfg.fun_contains_calls
-      ~fun_num_stack_slots:cfg.fun_num_stack_slots
-  in
-  if not prologue_required
-  then
-    (* note: `Cfgize` has put the prologue in the entry block or its
-       successor. *)
-    let entry_block = Cfg.get_block_exn cfg cfg.entry_label in
-    let removed = remove_prologue entry_block in
-    if not removed
-    then
-      match entry_block.terminator.desc with
-      | Always label ->
-        let block = Cfg.get_block_exn cfg label in
-        let removed = remove_prologue block in
-        assert removed
-      | Never | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-      | Switch _ | Return | Raise _ | Tailcall_self _ | Tailcall_func _
-      | Call_no_return _ | Call _ | Prim _ ->
-        assert false
-
 let update_live_fields : Cfg_with_layout.t -> liveness -> unit =
  fun cfg_with_layout liveness ->
   (* CR xclerc for xclerc: partial duplicate of

--- a/backend/regalloc/regalloc_utils.mli
+++ b/backend/regalloc/regalloc_utils.mli
@@ -105,8 +105,6 @@ val simplify_cfg : Cfg_with_layout.t -> Cfg_with_layout.t
 
 val save_cfg : string -> Cfg_with_layout.t -> unit
 
-val remove_prologue_if_not_required : Cfg_with_layout.t -> unit
-
 val update_live_fields : Cfg_with_layout.t -> liveness -> unit
 
 module SpillCosts : sig

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -297,11 +297,11 @@ module Description : sig
       instructions within or between basic blocks.
 
       The validator checks that the register allocator does not remove
-      instructions except Prologue (whenever it's allowed to do so), and does
-      not add any new instructions except Spill and Reload. The unique IDs of
-      instructions are sufficient to determine this, and the description does
-      not need to record the block an instruction belongs to. It is possible to
-      reconstruct some information about the CFG structure from the description.
+      instructions, and does not add any new instructions except Spill and 
+      Reload. The unique IDs of instructions are sufficient to determine this, 
+      and the description does not need to record the block an instruction 
+      belongs to. It is possible to reconstruct some information about the CFG 
+      structure from the description. 
       For example, successors of a block can be reconstructed from the labels
       that appear in terminator's [desc]. It also checks that all [fun_args]
       were preassigned before allocation and that they haven't changed after. *)
@@ -707,18 +707,8 @@ end = struct
         ignore (first_instruction_id : InstructionId.t))
       (Cfg_with_layout.cfg cfg).Cfg.blocks;
     Hashtbl.iter
-      (fun id { instr; _ } ->
-        let can_be_removed =
-          match instr.Instruction.desc with
-          | Prologue ->
-            let ({ fun_contains_calls; fun_num_stack_slots; _ } : Cfg.t) =
-              Cfg_with_layout.cfg cfg
-            in
-            not
-              (Proc.prologue_required ~fun_contains_calls ~fun_num_stack_slots)
-          | _ -> false
-        in
-        if (not (Hashtbl.mem seen_ids id)) && not can_be_removed
+      (fun id _ ->
+        if not (Hashtbl.mem seen_ids id)
         then
           Regalloc_utils.fatal
             "Instruction no. %a was deleted by register allocator"

--- a/dune
+++ b/dune
@@ -539,6 +539,7 @@
   cfg_stack_checks
   cfg_polling
   cfg_simplify
+  cfg_prologue
   extra_debug
   label
   linear_utils


### PR DESCRIPTION
Currently, function prologues are being added to functions eagerly ([at CFG generation](https://github.com/oxcaml/oxcaml/blob/b028c0cbe66f7313ca6269e99820a1102009e592/backend/cfg_selectgen.ml#L1515-L1516)), and later removed if they are not needed [at register allocation](https://github.com/oxcaml/oxcaml/blob/b028c0cbe66f7313ca6269e99820a1102009e592/backend/regalloc/regalloc_utils.ml#L316-L339). 

This PR simplifies this so that prologues are only added after we already know if they are needed or not, during register allocation.

The code being generated should be identical to before. Tested using the script in `tools/diff_compiler_versions.sh` against the commit 940e1a7a125fe1442b671f5bfca655d54a0b42ba and the assembly being generated is identical as expected.