### PR TITLE
Configure flag for emitting assembly on compiler

### DIFF
--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -174,7 +174,7 @@ _build/_bootinstall: Makefile.config $(dune_config_targets)
 
 # flags.sexp
 	echo '(:standard $(if $(filter true,$(FUNCTION_SECTIONS)),-function-sections,))' > ocamlopt_upstream_flags.sexp
-	echo '(:standard $(OXCAML_DWARF_FLAGS_FOR_COMPILER) $(if $(filter true,$(FUNCTION_SECTIONS)),-function-sections,))' > ocamlopt_oxcaml_flags.sexp
+	echo '(:standard $(OXCAML_DWARF_FLAGS_FOR_COMPILER) $(ASSEMBLY_FLAG_FOR_COMPILER) $(if $(filter true,$(FUNCTION_SECTIONS)),-function-sections,))' > ocamlopt_oxcaml_flags.sexp
 	echo '( )' > boot_oc_cflags.sexp
 	echo '( $(OC_CFLAGS) )' > oc_cflags.sexp
 	echo '( $(OC_CPPFLAGS) )' > oc_cppflags.sexp

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -223,6 +223,7 @@ AFL_INSTRUMENT=@afl@
 FLAT_FLOAT_ARRAY=@flat_float_array@
 FUNCTION_SECTIONS=@function_sections@
 OXCAML_DWARF_FLAGS_FOR_COMPILER=@oxcaml_dwarf_flags_for_compiler@
+ASSEMBLY_FLAG_FOR_COMPILER=@assembly_flag_for_compiler@
 PROBES=@probes@
 AWK=@AWK@
 STDLIB_MANPAGES=@stdlib_manpages@

--- a/configure.ac
+++ b/configure.ac
@@ -723,7 +723,7 @@ AC_ARG_ENABLE([keep-compiler-asm],
   [AS_HELP_STRING([--enable-keep-compiler-asm],
     [Configure the compiler to use -S during bootstrapping, which will produce .s assembly files for the files in the compiler tree. The files can be found in _build/main when building with dune])],
   [],
-  [enable_produce_and_keep_assembly_files_for_compiler=no])
+  [enable_keep_compiler_asm=no])
 
 AC_ARG_ENABLE([multidomain],
   [AS_HELP_STRING([--enable-multidomain],
@@ -2861,7 +2861,7 @@ AS_IF([test x"$enable_oxcaml_dwarf_on_compiler" = "xyes"],
     [AC_MSG_ERROR([--enable-oxcaml-dwarf-on-compiler requires --disable-function-sections to be passed])])])
 
 # Configure assembly emission flag for compiler
-AS_IF([test x"$enable_produce_and_keep_assembly_files_for_compiler" = "xyes"],
+AS_IF([test x"$enable_keep_compiler_asm" = "xyes"],
   [assembly_flag_for_compiler="-S"],
   [assembly_flag_for_compiler=""])
 

--- a/configure.ac
+++ b/configure.ac
@@ -719,11 +719,11 @@ AC_ARG_ENABLE([oxcaml-dwarf-on-compiler],
   [],
   [enable_oxcaml_dwarf_on_compiler=no])
 
-AC_ARG_ENABLE([emit-assembly-on-compiler],
-  [AS_HELP_STRING([--enable-emit-assembly-on-compiler],
-    [Emit assembly when compiling the compiler])],
+AC_ARG_ENABLE([produce-and-keep-assembly-files-for-compiler],
+  [AS_HELP_STRING([--enable-produce-and-keep-assembly-files-for-compiler],
+    [Configure the compiler to use -S during bootstrapping, which will produce .s assembly files for the files in the compiler tree. The files can be found in _build/main when building with dune])],
   [],
-  [enable_emit_assembly_on_compiler=no])
+  [enable_produce_and_keep_assembly_files_for_compiler=no])
 
 AC_ARG_ENABLE([multidomain],
   [AS_HELP_STRING([--enable-multidomain],
@@ -2861,7 +2861,7 @@ AS_IF([test x"$enable_oxcaml_dwarf_on_compiler" = "xyes"],
     [AC_MSG_ERROR([--enable-oxcaml-dwarf-on-compiler requires --disable-function-sections to be passed])])])
 
 # Configure assembly emission flag for compiler
-AS_IF([test x"$enable_emit_assembly_on_compiler" = "xyes"],
+AS_IF([test x"$enable_produce_and_keep_assembly_files_for_compiler" = "xyes"],
   [assembly_flag_for_compiler="-S"],
   [assembly_flag_for_compiler=""])
 

--- a/configure.ac
+++ b/configure.ac
@@ -720,7 +720,7 @@ AC_ARG_ENABLE([oxcaml-dwarf-on-compiler],
   [enable_oxcaml_dwarf_on_compiler=no])
 
 AC_ARG_ENABLE([produce-and-keep-assembly-files-for-compiler],
-  [AS_HELP_STRING([--enable-produce-and-keep-assembly-files-for-compiler],
+  [AS_HELP_STRING([--enable-keep-compiler-asm],
     [Configure the compiler to use -S during bootstrapping, which will produce .s assembly files for the files in the compiler tree. The files can be found in _build/main when building with dune])],
   [],
   [enable_produce_and_keep_assembly_files_for_compiler=no])

--- a/configure.ac
+++ b/configure.ac
@@ -719,7 +719,7 @@ AC_ARG_ENABLE([oxcaml-dwarf-on-compiler],
   [],
   [enable_oxcaml_dwarf_on_compiler=no])
 
-AC_ARG_ENABLE([produce-and-keep-assembly-files-for-compiler],
+AC_ARG_ENABLE([keep-compiler-asm],
   [AS_HELP_STRING([--enable-keep-compiler-asm],
     [Configure the compiler to use -S during bootstrapping, which will produce .s assembly files for the files in the compiler tree. The files can be found in _build/main when building with dune])],
   [],

--- a/configure.ac
+++ b/configure.ac
@@ -353,6 +353,7 @@ AC_SUBST([windows_unicode])
 AC_SUBST([flat_float_array])
 AC_SUBST([function_sections])
 AC_SUBST([oxcaml_dwarf_flags_for_compiler])
+AC_SUBST([assembly_flag_for_compiler])
 AC_SUBST([probes])
 AC_SUBST([oc_native_compflags])
 AC_SUBST([afl])
@@ -717,6 +718,12 @@ AC_ARG_ENABLE([oxcaml-dwarf-on-compiler],
     [Compile the compiler and standard library with OxCaml DWARF])],
   [],
   [enable_oxcaml_dwarf_on_compiler=no])
+
+AC_ARG_ENABLE([emit-assembly-on-compiler],
+  [AS_HELP_STRING([--enable-emit-assembly-on-compiler],
+    [Emit assembly when compiling the compiler])],
+  [],
+  [enable_emit_assembly_on_compiler=no])
 
 AC_ARG_ENABLE([multidomain],
   [AS_HELP_STRING([--enable-multidomain],
@@ -2852,6 +2859,11 @@ AS_IF([test x"$enable_oxcaml_dwarf_on_compiler" = "xyes"],
 AS_IF([test x"$enable_oxcaml_dwarf_on_compiler" = "xyes"],
   [AS_IF([test x"$enable_function_sections" != "xno"],
     [AC_MSG_ERROR([--enable-oxcaml-dwarf-on-compiler requires --disable-function-sections to be passed])])])
+
+# Configure assembly emission flag for compiler
+AS_IF([test x"$enable_emit_assembly_on_compiler" = "xyes"],
+  [assembly_flag_for_compiler="-S"],
+  [assembly_flag_for_compiler=""])
 
 # Enable debugging support
 # TODO: add a --disable-debug-info configure option that disables debugging

--- a/tools/diff_compiler_versions.sh
+++ b/tools/diff_compiler_versions.sh
@@ -87,16 +87,14 @@ git archive --format=tar --prefix=revision/ $REVISION | (cd $BUILDDIR && tar xf 
 
 # we first build the bootcompiler of the new compiler
 cd $REVISION_DIR
-sed -i.bak "s/echo '(:standard \$(if \$(filter true,\$(FUNCTION_SECTIONS)),-function-sections,))' > ocamlopt_flags.sexp/echo '(:standard -S \$(if \$(filter true,\$(FUNCTION_SECTIONS)),-function-sections,))' > ocamlopt_flags.sexp/g" Makefile.common-ox && rm Makefile.common-ox.bak
 $AUTOCONF
-./configure --enable-ocamltest --enable-warn-error --prefix="$INSTALL_PATH"
+./configure --enable-ocamltest --enable-warn-error --enable-emit-assembly-on-compiler --prefix="$INSTALL_PATH"
 make boot-compiler
 
 # we turn to the base line compiler and build the normal version
 cd $BASE_ORIGINAL_DIR
-sed -i.bak "s/echo '(:standard \$(if \$(filter true,\$(FUNCTION_SECTIONS)),-function-sections,))' > ocamlopt_flags.sexp/echo '(:standard -S \$(if \$(filter true,\$(FUNCTION_SECTIONS)),-function-sections,))' > ocamlopt_flags.sexp/g" Makefile.common-ox && rm Makefile.common-ox.bak
 $AUTOCONF
-./configure --enable-ocamltest --enable-warn-error --prefix="$INSTALL_PATH"
+./configure --enable-ocamltest --enable-warn-error --enable-emit-assembly-on-compiler --prefix="$INSTALL_PATH"
 make _install
 cp -R -f _install/. "$TARGETDIR/base-compiler-original/_install/"
 cp -R -f _build/. "$TARGETDIR/base-compiler-original/_build/"
@@ -104,9 +102,8 @@ cp -R -f _build/. "$TARGETDIR/base-compiler-original/_build/"
 
 # we build a version with the new compiler
 cd $BASE_REVISION_DIR
-sed -i.bak "s/echo '(:standard \$(if \$(filter true,\$(FUNCTION_SECTIONS)),-function-sections,))' > ocamlopt_flags.sexp/echo '(:standard -S \$(if \$(filter true,\$(FUNCTION_SECTIONS)),-function-sections,))' > ocamlopt_flags.sexp/g" Makefile.common-ox && rm Makefile.common-ox.bak
 $AUTOCONF
-./configure --enable-ocamltest --enable-warn-error --prefix="$INSTALL_PATH"
+./configure --enable-ocamltest --enable-warn-error --enable-emit-assembly-on-compiler --prefix="$INSTALL_PATH"
 make boot-compiler
 # hack: we copy over the boot compiler from the revision compiler
 cp -L -R -f "$REVISION_DIR/_build/_bootinstall/bin/ocamlopt.opt" _build/_bootinstall/bin/

--- a/tools/diff_compiler_versions.sh
+++ b/tools/diff_compiler_versions.sh
@@ -88,13 +88,13 @@ git archive --format=tar --prefix=revision/ $REVISION | (cd $BUILDDIR && tar xf 
 # we first build the bootcompiler of the new compiler
 cd $REVISION_DIR
 $AUTOCONF
-./configure --enable-ocamltest --enable-warn-error --enable-produce-and-keep-assembly-files-for-compiler --prefix="$INSTALL_PATH"
+./configure --enable-ocamltest --enable-warn-error --enable-keep-compiler-asm --prefix="$INSTALL_PATH"
 make boot-compiler
 
 # we turn to the base line compiler and build the normal version
 cd $BASE_ORIGINAL_DIR
 $AUTOCONF
-./configure --enable-ocamltest --enable-warn-error --enable-produce-and-keep-assembly-files-for-compiler --prefix="$INSTALL_PATH"
+./configure --enable-ocamltest --enable-warn-error --enable-keep-compiler-asm --prefix="$INSTALL_PATH"
 make _install
 cp -R -f _install/. "$TARGETDIR/base-compiler-original/_install/"
 cp -R -f _build/. "$TARGETDIR/base-compiler-original/_build/"
@@ -103,7 +103,7 @@ cp -R -f _build/. "$TARGETDIR/base-compiler-original/_build/"
 # we build a version with the new compiler
 cd $BASE_REVISION_DIR
 $AUTOCONF
-./configure --enable-ocamltest --enable-warn-error --enable-produce-and-keep-assembly-files-for-compiler --prefix="$INSTALL_PATH"
+./configure --enable-ocamltest --enable-warn-error --enable-keep-compiler-asm --prefix="$INSTALL_PATH"
 make boot-compiler
 # hack: we copy over the boot compiler from the revision compiler
 cp -L -R -f "$REVISION_DIR/_build/_bootinstall/bin/ocamlopt.opt" _build/_bootinstall/bin/

--- a/tools/diff_compiler_versions.sh
+++ b/tools/diff_compiler_versions.sh
@@ -88,13 +88,13 @@ git archive --format=tar --prefix=revision/ $REVISION | (cd $BUILDDIR && tar xf 
 # we first build the bootcompiler of the new compiler
 cd $REVISION_DIR
 $AUTOCONF
-./configure --enable-ocamltest --enable-warn-error --enable-emit-assembly-on-compiler --prefix="$INSTALL_PATH"
+./configure --enable-ocamltest --enable-warn-error --enable-produce-and-keep-assembly-files-for-compiler --prefix="$INSTALL_PATH"
 make boot-compiler
 
 # we turn to the base line compiler and build the normal version
 cd $BASE_ORIGINAL_DIR
 $AUTOCONF
-./configure --enable-ocamltest --enable-warn-error --enable-emit-assembly-on-compiler --prefix="$INSTALL_PATH"
+./configure --enable-ocamltest --enable-warn-error --enable-produce-and-keep-assembly-files-for-compiler --prefix="$INSTALL_PATH"
 make _install
 cp -R -f _install/. "$TARGETDIR/base-compiler-original/_install/"
 cp -R -f _build/. "$TARGETDIR/base-compiler-original/_build/"
@@ -103,7 +103,7 @@ cp -R -f _build/. "$TARGETDIR/base-compiler-original/_build/"
 # we build a version with the new compiler
 cd $BASE_REVISION_DIR
 $AUTOCONF
-./configure --enable-ocamltest --enable-warn-error --enable-emit-assembly-on-compiler --prefix="$INSTALL_PATH"
+./configure --enable-ocamltest --enable-warn-error --enable-produce-and-keep-assembly-files-for-compiler --prefix="$INSTALL_PATH"
 make boot-compiler
 # hack: we copy over the boot compiler from the revision compiler
 cp -L -R -f "$REVISION_DIR/_build/_bootinstall/bin/ocamlopt.opt" _build/_bootinstall/bin/


### PR DESCRIPTION
This PR adds a configuration flag `--enable-produce-and-keep-assembly-files-for-compiler` for emitting assembly files in the second phase of bootstrapping. In doing so, it can clean up a hack in the compiler diffing script.