### PR TITLE
Clean up scalar `caml_simd` intrinsics

### DIFF
--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -122,7 +122,7 @@ let select_operation_sse ~dbg op args =
     sse_or_avx maxss vmaxss args
   | "caml_simd_float32_min" | "caml_sse_float32_min" ->
     sse_or_avx minss vminss args
-  | "caml_sse_cast_float32_int64" | "caml_simd_cast_float32_int64" ->
+  | "caml_simd_cast_float32_int64" | "caml_sse_cast_float32_int64" ->
     sse_or_avx cvtss2si_r64_Xm32 vcvtss2si_r64_Xm32 args
   | "caml_sse_float32x4_cmp" ->
     let i, args = extract_constant args ~max:7 op in
@@ -161,7 +161,7 @@ let select_operation_sse2 ~dbg op args =
     sse_or_avx maxsd vmaxsd args
   | "caml_simd_float64_min" | "caml_sse2_float64_min" ->
     sse_or_avx minsd vminsd args
-  | "caml_sse2_cast_float64_int64" ->
+  | "caml_simd_cast_float64_int64" | "caml_sse2_cast_float64_int64" ->
     sse_or_avx cvtsd2si_r64_Xm64 vcvtsd2si_r64_Xm64 args
   | "caml_sse2_float64x2_sqrt" -> sse_or_avx sqrtpd vsqrtpd_X_Xm128 args
   | "caml_sse2_int8x16_add" -> sse_or_avx paddb vpaddb_X_X_Xm128 args
@@ -476,10 +476,6 @@ let select_operation_sse41 ~dbg op args =
       seq_or_avx_zeroed ~dbg Seq.roundsd vroundsd
         ~i:(int_of_float_rounding RoundTruncate)
         args
-    | "caml_simd_float64_round_near" | "caml_sse41_float64_round_near" ->
-      seq_or_avx_zeroed ~dbg Seq.roundsd vroundsd
-        ~i:(int_of_float_rounding RoundNearest)
-        args
     | "caml_sse41_float32_round" ->
       let i, args = extract_constant args ~max:15 op in
       check_float_rounding i;
@@ -500,10 +496,6 @@ let select_operation_sse41 ~dbg op args =
     | "caml_sse41_float32_round_towards_zero" ->
       seq_or_avx_zeroed ~dbg Seq.roundss vroundss
         ~i:(int_of_float_rounding RoundTruncate)
-        args
-    | "caml_simd_float32_round_near" | "caml_sse41_float32_round_near" ->
-      seq_or_avx_zeroed ~dbg Seq.roundss vroundss
-        ~i:(int_of_float_rounding RoundNearest)
         args
     | "caml_sse41_int8x16_max" -> sse_or_avx pmaxsb vpmaxsb_X_X_Xm128 args
     | "caml_sse41_int32x4_max" -> sse_or_avx pmaxsd vpmaxsd_X_X_Xm128 args

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -377,6 +377,9 @@ end = struct
     | Rf32_to_Rs64 ->
       check_reg Float32 i.arg.(0);
       check_reg Int i.res.(0)
+    | Rf64_to_Rs64 ->
+      check_reg Float i.arg.(0);
+      check_reg Int i.res.(0)
     | Rs32x4_to_Rs32 _ | Rs64x2_to_Rs64 _ | Rs16x8_to_Rs16 _ | Rs8x16_to_Rs8 _
       ->
       check_reg Vec128 i.arg.(0);
@@ -470,7 +473,8 @@ end = struct
       |]
     | Rs16x8_to_Rs16x8 -> [| emit_reg_v8h i.res.(0); emit_reg_v8h i.arg.(0) |]
     | Rf32_Rf32_to_Rf32 | Rf64_Rf64_to_Rf64 -> emit_regs_binary i
-    | Rf64_to_Rf64 | Rf32_to_Rf32 | Rf32_to_Rs64 -> emit_regs_unary i
+    | Rf64_to_Rf64 | Rf32_to_Rf32 | Rf32_to_Rs64 | Rf64_to_Rs64 ->
+      emit_regs_unary i
     | Rs8x16_to_Rs8 { lane : int } ->
       [| emit_reg i.res.(0); emit_reglane_b i.arg.(0) ~lane |]
     | Rs16x8_to_Rs16 { lane : int } ->
@@ -515,36 +519,37 @@ end = struct
     | Min_scalar_f64 | Max_scalar_f64 -> 2
     | Min_scalar_f32 | Max_scalar_f32 -> 2
     | Round_f32 _ | Round_f64 _ | Roundq_f32 _ | Roundq_f64 _ | Round_f32_s64
-    | Zip1q_s8 | Zip2q_s8 | Zip1q_s16 | Zip2q_s16 | Zip1_f32 | Zip1q_f32
-    | Zip2q_f32 | Zip1q_f64 | Zip2q_f64 | Addq_f32 | Subq_f32 | Mulq_f32
-    | Divq_f32 | Minq_f32 | Maxq_f32 | Addq_f64 | Subq_f64 | Mulq_f64 | Divq_f64
-    | Minq_f64 | Maxq_f64 | Recpeq_f32 | Sqrtq_f32 | Rsqrteq_f32 | Sqrtq_f64
-    | Rsqrteq_f64 | Cvtq_s32_f32 | Cvtnq_s32_f32 | Cvtq_f32_s32 | Cvt_f64_f32
-    | Cvt_f32_f64 | Paddq_f32 | Fmin_f32 | Fmax_f32 | Fmin_f64 | Fmax_f64
-    | Addq_s64 | Subq_s64 | Cmp_f32 _ | Cmpz_f32 _ | Cmpz_s32 _ | Cmp_f64 _
-    | Cmpz_f64 _ | Cmp_s32 _ | Cmp_s64 _ | Cmpz_s64 _ | Mvnq_s32 | Orrq_s32
-    | Andq_s32 | Eorq_s32 | Negq_s32 | Getq_lane_s32 _ | Getq_lane_s64 _
-    | Mulq_s32 | Mulq_s16 | Addq_s32 | Subq_s32 | Minq_s32 | Maxq_s32 | Minq_u32
-    | Maxq_u32 | Absq_s32 | Absq_s64 | Paddq_f64 | Paddq_s32 | Paddq_s64
-    | Mvnq_s64 | Orrq_s64 | Andq_s64 | Eorq_s64 | Negq_s64 | Shlq_u32 | Shlq_u64
-    | Shlq_s32 | Shlq_s64 | Shlq_n_u32 _ | Shlq_n_u64 _ | Shrq_n_u32 _
-    | Shrq_n_u64 _ | Shrq_n_s32 _ | Shrq_n_s64 _ | Setq_lane_s32 _
-    | Setq_lane_s64 _ | Dupq_lane_s32 _ | Dupq_lane_s64 _ | Cvtq_f64_s64
-    | Cvtq_s64_f64 | Cvtnq_s64_f64 | Movl_s32 | Movl_u32 | Addq_s16 | Paddq_s16
-    | Qaddq_s16 | Qaddq_u16 | Subq_s16 | Qsubq_s16 | Qsubq_u16 | Absq_s16
-    | Minq_s16 | Maxq_s16 | Minq_u16 | Maxq_u16 | Mvnq_s16 | Orrq_s16 | Andq_s16
-    | Eorq_s16 | Negq_s16 | Cntq_u16 | Shlq_u16 | Shlq_s16 | Cmp_s16 _
-    | Cmpz_s16 _ | Shlq_n_u16 _ | Shrq_n_u16 _ | Shrq_n_s16 _ | Getq_lane_s16 _
-    | Setq_lane_s16 _ | Dupq_lane_s16 _ | Movn_s64 | Copyq_laneq_s64 _ | Addq_s8
-    | Paddq_s8 | Qaddq_s8 | Qaddq_u8 | Subq_s8 | Qsubq_s8 | Qsubq_u8 | Absq_s8
-    | Minq_s8 | Maxq_s8 | Minq_u8 | Maxq_u8 | Mvnq_s8 | Orrq_s8 | Andq_s8
-    | Eorq_s8 | Negq_s8 | Cntq_u8 | Shlq_u8 | Shlq_s8 | Cmp_s8 _ | Cmpz_s8 _
-    | Shlq_n_u8 _ | Shrq_n_u8 _ | Shrq_n_s8 _ | Getq_lane_s8 _ | Setq_lane_s8 _
-    | Dupq_lane_s8 _ | Extq_u8 _ | Qmovn_high_s64 | Qmovn_s64 | Qmovn_high_s32
-    | Qmovn_s32 | Qmovn_high_u32 | Qmovn_u32 | Qmovn_high_s16 | Qmovn_s16
-    | Qmovn_high_u16 | Qmovn_u16 | Movn_high_s64 | Movn_high_s32 | Movn_s32
-    | Movn_high_s16 | Movn_s16 | Mullq_s16 | Mullq_u16 | Mullq_high_s16
-    | Mullq_high_u16 | Movl_s16 | Movl_u16 | Movl_s8 | Movl_u8 ->
+    | Round_f64_s64 | Zip1q_s8 | Zip2q_s8 | Zip1q_s16 | Zip2q_s16 | Zip1_f32
+    | Zip1q_f32 | Zip2q_f32 | Zip1q_f64 | Zip2q_f64 | Addq_f32 | Subq_f32
+    | Mulq_f32 | Divq_f32 | Minq_f32 | Maxq_f32 | Addq_f64 | Subq_f64 | Mulq_f64
+    | Divq_f64 | Minq_f64 | Maxq_f64 | Recpeq_f32 | Sqrtq_f32 | Rsqrteq_f32
+    | Sqrtq_f64 | Rsqrteq_f64 | Cvtq_s32_f32 | Cvtnq_s32_f32 | Cvtq_f32_s32
+    | Cvt_f64_f32 | Cvt_f32_f64 | Paddq_f32 | Fmin_f32 | Fmax_f32 | Fmin_f64
+    | Fmax_f64 | Addq_s64 | Subq_s64 | Cmp_f32 _ | Cmpz_f32 _ | Cmpz_s32 _
+    | Cmp_f64 _ | Cmpz_f64 _ | Cmp_s32 _ | Cmp_s64 _ | Cmpz_s64 _ | Mvnq_s32
+    | Orrq_s32 | Andq_s32 | Eorq_s32 | Negq_s32 | Getq_lane_s32 _
+    | Getq_lane_s64 _ | Mulq_s32 | Mulq_s16 | Addq_s32 | Subq_s32 | Minq_s32
+    | Maxq_s32 | Minq_u32 | Maxq_u32 | Absq_s32 | Absq_s64 | Paddq_f64
+    | Paddq_s32 | Paddq_s64 | Mvnq_s64 | Orrq_s64 | Andq_s64 | Eorq_s64
+    | Negq_s64 | Shlq_u32 | Shlq_u64 | Shlq_s32 | Shlq_s64 | Shlq_n_u32 _
+    | Shlq_n_u64 _ | Shrq_n_u32 _ | Shrq_n_u64 _ | Shrq_n_s32 _ | Shrq_n_s64 _
+    | Setq_lane_s32 _ | Setq_lane_s64 _ | Dupq_lane_s32 _ | Dupq_lane_s64 _
+    | Cvtq_f64_s64 | Cvtq_s64_f64 | Cvtnq_s64_f64 | Movl_s32 | Movl_u32
+    | Addq_s16 | Paddq_s16 | Qaddq_s16 | Qaddq_u16 | Subq_s16 | Qsubq_s16
+    | Qsubq_u16 | Absq_s16 | Minq_s16 | Maxq_s16 | Minq_u16 | Maxq_u16
+    | Mvnq_s16 | Orrq_s16 | Andq_s16 | Eorq_s16 | Negq_s16 | Cntq_u16 | Shlq_u16
+    | Shlq_s16 | Cmp_s16 _ | Cmpz_s16 _ | Shlq_n_u16 _ | Shrq_n_u16 _
+    | Shrq_n_s16 _ | Getq_lane_s16 _ | Setq_lane_s16 _ | Dupq_lane_s16 _
+    | Movn_s64 | Copyq_laneq_s64 _ | Addq_s8 | Paddq_s8 | Qaddq_s8 | Qaddq_u8
+    | Subq_s8 | Qsubq_s8 | Qsubq_u8 | Absq_s8 | Minq_s8 | Maxq_s8 | Minq_u8
+    | Maxq_u8 | Mvnq_s8 | Orrq_s8 | Andq_s8 | Eorq_s8 | Negq_s8 | Cntq_u8
+    | Shlq_u8 | Shlq_s8 | Cmp_s8 _ | Cmpz_s8 _ | Shlq_n_u8 _ | Shrq_n_u8 _
+    | Shrq_n_s8 _ | Getq_lane_s8 _ | Setq_lane_s8 _ | Dupq_lane_s8 _ | Extq_u8 _
+    | Qmovn_high_s64 | Qmovn_s64 | Qmovn_high_s32 | Qmovn_s32 | Qmovn_high_u32
+    | Qmovn_u32 | Qmovn_high_s16 | Qmovn_s16 | Qmovn_high_u16 | Qmovn_u16
+    | Movn_high_s64 | Movn_high_s32 | Movn_s32 | Movn_high_s16 | Movn_s16
+    | Mullq_s16 | Mullq_u16 | Mullq_high_s16 | Mullq_high_u16 | Movl_s16
+    | Movl_u16 | Movl_s8 | Movl_u8 ->
       1
 
   let emit_rounding_mode (rm : Simd.Rounding_mode.t) : I.Rounding_mode.t =
@@ -594,6 +599,7 @@ end = struct
     | Round_f32 rm | Round_f64 rm | Roundq_f32 rm | Roundq_f64 rm ->
       ins (I.FRINT (emit_rounding_mode rm)) operands
     | Round_f32_s64 -> ins I.FCVTNS operands
+    | Round_f64_s64 -> ins I.FCVTNS operands
     | Fmin_f32 -> ins I.FMIN operands
     | Fmax_f32 -> ins I.FMAX operands
     | Fmin_f64 -> ins I.FMIN operands

--- a/backend/arm64/simd.ml
+++ b/backend/arm64/simd.ml
@@ -122,6 +122,7 @@ type operation =
   | Roundq_f32 of Rounding_mode.t
   | Roundq_f64 of Rounding_mode.t
   | Round_f32_s64
+  | Round_f64_s64
   (* [Min_scalar_f32/Max_scalar_f32] are emitted as a sequence of instructions
      that matches amd64 semantics of the same intrinsic
      [caml_simd_float32_min/max], regardless of the value of [FPCR.AH]. *)
@@ -313,6 +314,7 @@ let print_name op =
   | Roundq_f32 rm -> "Roundq_f32_" ^ Rounding_mode.instruction_suffix rm
   | Roundq_f64 rm -> "Roundq_f64_" ^ Rounding_mode.instruction_suffix rm
   | Round_f32_s64 -> "Round_f32_i"
+  | Round_f64_s64 -> "Round_f64_i"
   | Extq_u8 c -> "Extq_u8_" ^ Int.to_string c
   | Zip1_f32 -> "Zip1_f32"
   | Zip1q_s8 -> "Zip1q_s8"
@@ -505,6 +507,7 @@ let equal_operation op1 op2 =
   | Roundq_f64 mode, Roundq_f64 mode' ->
     Rounding_mode.equal mode mode'
   | Round_f32_s64, Round_f32_s64
+  | Round_f64_s64, Round_f64_s64
   | Min_scalar_f32, Min_scalar_f32
   | Max_scalar_f32, Max_scalar_f32
   | Min_scalar_f64, Min_scalar_f64
@@ -689,59 +692,61 @@ let equal_operation op1 op2 =
   | Cmpz_f64 c, Cmpz_f64 c' ->
     Float_cond.equal c c'
   | ( ( Round_f32 _ | Round_f64 _ | Roundq_f32 _ | Roundq_f64 _ | Round_f32_s64
-      | Min_scalar_f32 | Max_scalar_f32 | Min_scalar_f64 | Max_scalar_f64
-      | Fmin_f32 | Fmax_f32 | Fmin_f64 | Fmax_f64 | Extq_u8 _ | Zip1_f32
-      | Zip1q_s8 | Zip2q_s8 | Zip1q_s16 | Zip2q_s16 | Zip1q_f32 | Zip2q_f32
-      | Zip1q_f64 | Zip2q_f64 | Addq_s64 | Subq_s64 | Addq_f32 | Subq_f32
-      | Mulq_f32 | Divq_f32 | Minq_f32 | Maxq_f32 | Minq_f64 | Addq_f64
-      | Subq_f64 | Mulq_f64 | Divq_f64 | Maxq_f64 | Recpeq_f32 | Sqrtq_f32
-      | Rsqrteq_f32 | Sqrtq_f64 | Rsqrteq_f64 | Cvtq_s32_f32 | Cvtnq_s32_f32
-      | Cvtq_f32_s32 | Cvt_f64_f32 | Cvt_f32_f64 | Cvtq_f64_s64 | Cvtq_s64_f64
-      | Cvtnq_s64_f64 | Movl_s32 | Movl_u32 | Movl_s16 | Movl_u16 | Movl_s8
-      | Movl_u8 | Paddq_f32 | Cmp_f32 _ | Cmpz_f32 _ | Cmpz_s32 _ | Cmp_f64 _
-      | Cmpz_f64 _ | Cmp_s32 _ | Cmp_s64 _ | Cmpz_s64 _ | Mvnq_s32 | Orrq_s32
-      | Andq_s32 | Eorq_s32 | Negq_s32 | Getq_lane_s32 _ | Getq_lane_s64 _
-      | Dupq_lane_s32 _ | Dupq_lane_s64 _ | Mulq_s32 | Mulq_s16 | Addq_s32
-      | Subq_s32 | Minq_s32 | Maxq_s32 | Minq_u32 | Maxq_u32 | Absq_s32
-      | Absq_s64 | Paddq_f64 | Paddq_s32 | Paddq_s64 | Mvnq_s64 | Orrq_s64
-      | Andq_s64 | Eorq_s64 | Negq_s64 | Shlq_u32 | Shlq_u64 | Shlq_n_u32 _
-      | Shlq_n_u64 _ | Shrq_n_u32 _ | Shrq_n_u64 _ | Shrq_n_s32 _ | Shrq_n_s64 _
-      | Shlq_s32 | Shlq_s64 | Setq_lane_s32 _ | Setq_lane_s64 _ | Addq_s16
-      | Paddq_s16 | Qaddq_s16 | Qaddq_u16 | Subq_s16 | Qsubq_s16 | Qsubq_u16
-      | Absq_s16 | Minq_s16 | Maxq_s16 | Minq_u16 | Maxq_u16 | Mvnq_s16
-      | Orrq_s16 | Andq_s16 | Eorq_s16 | Negq_s16 | Cntq_u16 | Shlq_u16
-      | Shlq_s16 | Cmp_s16 _ | Cmpz_s16 _ | Shlq_n_u16 _ | Shrq_n_u16 _
-      | Shrq_n_s16 _ | Getq_lane_s16 _ | Setq_lane_s16 _ | Dupq_lane_s16 _
-      | Addq_s8 | Paddq_s8 | Qaddq_s8 | Qaddq_u8 | Subq_s8 | Qsubq_s8 | Qsubq_u8
-      | Absq_s8 | Minq_s8 | Maxq_s8 | Minq_u8 | Maxq_u8 | Mvnq_s8 | Orrq_s8
-      | Andq_s8 | Eorq_s8 | Negq_s8 | Cntq_u8 | Shlq_u8 | Shlq_s8 | Cmp_s8 _
-      | Cmpz_s8 _ | Shlq_n_u8 _ | Shrq_n_u8 _ | Shrq_n_s8 _ | Getq_lane_s8 _
-      | Setq_lane_s8 _ | Dupq_lane_s8 _ | Copyq_laneq_s64 _ | Qmovn_high_s64
-      | Qmovn_s64 | Qmovn_high_s32 | Qmovn_s32 | Qmovn_high_u32 | Qmovn_u32
-      | Qmovn_high_s16 | Qmovn_s16 | Qmovn_high_u16 | Qmovn_u16 | Movn_high_s64
-      | Movn_s64 | Movn_high_s32 | Movn_s32 | Movn_high_s16 | Movn_s16
-      | Mullq_s16 | Mullq_u16 | Mullq_high_s16 | Mullq_high_u16 ),
+      | Round_f64_s64 | Min_scalar_f32 | Max_scalar_f32 | Min_scalar_f64
+      | Max_scalar_f64 | Fmin_f32 | Fmax_f32 | Fmin_f64 | Fmax_f64 | Extq_u8 _
+      | Zip1_f32 | Zip1q_s8 | Zip2q_s8 | Zip1q_s16 | Zip2q_s16 | Zip1q_f32
+      | Zip2q_f32 | Zip1q_f64 | Zip2q_f64 | Addq_s64 | Subq_s64 | Addq_f32
+      | Subq_f32 | Mulq_f32 | Divq_f32 | Minq_f32 | Maxq_f32 | Minq_f64
+      | Addq_f64 | Subq_f64 | Mulq_f64 | Divq_f64 | Maxq_f64 | Recpeq_f32
+      | Sqrtq_f32 | Rsqrteq_f32 | Sqrtq_f64 | Rsqrteq_f64 | Cvtq_s32_f32
+      | Cvtnq_s32_f32 | Cvtq_f32_s32 | Cvt_f64_f32 | Cvt_f32_f64 | Cvtq_f64_s64
+      | Cvtq_s64_f64 | Cvtnq_s64_f64 | Movl_s32 | Movl_u32 | Movl_s16 | Movl_u16
+      | Movl_s8 | Movl_u8 | Paddq_f32 | Cmp_f32 _ | Cmpz_f32 _ | Cmpz_s32 _
+      | Cmp_f64 _ | Cmpz_f64 _ | Cmp_s32 _ | Cmp_s64 _ | Cmpz_s64 _ | Mvnq_s32
+      | Orrq_s32 | Andq_s32 | Eorq_s32 | Negq_s32 | Getq_lane_s32 _
+      | Getq_lane_s64 _ | Dupq_lane_s32 _ | Dupq_lane_s64 _ | Mulq_s32
+      | Mulq_s16 | Addq_s32 | Subq_s32 | Minq_s32 | Maxq_s32 | Minq_u32
+      | Maxq_u32 | Absq_s32 | Absq_s64 | Paddq_f64 | Paddq_s32 | Paddq_s64
+      | Mvnq_s64 | Orrq_s64 | Andq_s64 | Eorq_s64 | Negq_s64 | Shlq_u32
+      | Shlq_u64 | Shlq_n_u32 _ | Shlq_n_u64 _ | Shrq_n_u32 _ | Shrq_n_u64 _
+      | Shrq_n_s32 _ | Shrq_n_s64 _ | Shlq_s32 | Shlq_s64 | Setq_lane_s32 _
+      | Setq_lane_s64 _ | Addq_s16 | Paddq_s16 | Qaddq_s16 | Qaddq_u16
+      | Subq_s16 | Qsubq_s16 | Qsubq_u16 | Absq_s16 | Minq_s16 | Maxq_s16
+      | Minq_u16 | Maxq_u16 | Mvnq_s16 | Orrq_s16 | Andq_s16 | Eorq_s16
+      | Negq_s16 | Cntq_u16 | Shlq_u16 | Shlq_s16 | Cmp_s16 _ | Cmpz_s16 _
+      | Shlq_n_u16 _ | Shrq_n_u16 _ | Shrq_n_s16 _ | Getq_lane_s16 _
+      | Setq_lane_s16 _ | Dupq_lane_s16 _ | Addq_s8 | Paddq_s8 | Qaddq_s8
+      | Qaddq_u8 | Subq_s8 | Qsubq_s8 | Qsubq_u8 | Absq_s8 | Minq_s8 | Maxq_s8
+      | Minq_u8 | Maxq_u8 | Mvnq_s8 | Orrq_s8 | Andq_s8 | Eorq_s8 | Negq_s8
+      | Cntq_u8 | Shlq_u8 | Shlq_s8 | Cmp_s8 _ | Cmpz_s8 _ | Shlq_n_u8 _
+      | Shrq_n_u8 _ | Shrq_n_s8 _ | Getq_lane_s8 _ | Setq_lane_s8 _
+      | Dupq_lane_s8 _ | Copyq_laneq_s64 _ | Qmovn_high_s64 | Qmovn_s64
+      | Qmovn_high_s32 | Qmovn_s32 | Qmovn_high_u32 | Qmovn_u32 | Qmovn_high_s16
+      | Qmovn_s16 | Qmovn_high_u16 | Qmovn_u16 | Movn_high_s64 | Movn_s64
+      | Movn_high_s32 | Movn_s32 | Movn_high_s16 | Movn_s16 | Mullq_s16
+      | Mullq_u16 | Mullq_high_s16 | Mullq_high_u16 ),
       _ ) ->
     false
 
 let class_of_operation op =
   match op with
   | Round_f32 _ | Round_f64 _ | Roundq_f32 _ | Roundq_f64 _ | Round_f32_s64
-  | Min_scalar_f32 | Max_scalar_f32 | Min_scalar_f64 | Max_scalar_f64 | Fmin_f32
-  | Fmax_f32 | Fmin_f64 | Fmax_f64 | Extq_u8 _ | Zip1_f32 | Zip1q_s8 | Zip1q_s16
-  | Zip2q_s8 | Zip2q_s16 | Zip1q_f32 | Zip2q_f32 | Zip1q_f64 | Zip2q_f64
-  | Addq_s64 | Subq_s64 | Addq_f32 | Subq_f32 | Mulq_f32 | Divq_f32 | Minq_f32
-  | Maxq_f32 | Addq_f64 | Subq_f64 | Mulq_f64 | Divq_f64 | Minq_f64 | Maxq_f64
-  | Recpeq_f32 | Sqrtq_f32 | Rsqrteq_f32 | Sqrtq_f64 | Rsqrteq_f64
-  | Cvtq_s32_f32 | Cvtnq_s32_f32 | Cvtq_f32_s32 | Cvt_f64_f32 | Cvt_f32_f64
-  | Cvtq_f64_s64 | Cvtq_s64_f64 | Cvtnq_s64_f64 | Movl_s32 | Movl_u32 | Movl_s16
-  | Movl_u16 | Movl_s8 | Movl_u8 | Paddq_f32 | Cmp_f32 _ | Cmpz_f32 _
-  | Cmpz_s32 _ | Cmp_f64 _ | Cmpz_f64 _ | Cmp_s32 _ | Cmp_s64 _ | Cmpz_s64 _
-  | Mvnq_s32 | Orrq_s32 | Andq_s32 | Eorq_s32 | Negq_s32 | Getq_lane_s32 _
-  | Getq_lane_s64 _ | Dupq_lane_s32 _ | Dupq_lane_s64 _ | Mulq_s32 | Mulq_s16
-  | Addq_s32 | Subq_s32 | Minq_s32 | Maxq_s32 | Minq_u32 | Maxq_u32 | Absq_s32
-  | Absq_s64 | Paddq_f64 | Paddq_s32 | Paddq_s64 | Mvnq_s64 | Orrq_s64
-  | Andq_s64 | Eorq_s64 | Negq_s64 | Shlq_u32 | Shlq_u64 | Shlq_s32 | Shlq_s64
+  | Round_f64_s64 | Min_scalar_f32 | Max_scalar_f32 | Min_scalar_f64
+  | Max_scalar_f64 | Fmin_f32 | Fmax_f32 | Fmin_f64 | Fmax_f64 | Extq_u8 _
+  | Zip1_f32 | Zip1q_s8 | Zip1q_s16 | Zip2q_s8 | Zip2q_s16 | Zip1q_f32
+  | Zip2q_f32 | Zip1q_f64 | Zip2q_f64 | Addq_s64 | Subq_s64 | Addq_f32
+  | Subq_f32 | Mulq_f32 | Divq_f32 | Minq_f32 | Maxq_f32 | Addq_f64 | Subq_f64
+  | Mulq_f64 | Divq_f64 | Minq_f64 | Maxq_f64 | Recpeq_f32 | Sqrtq_f32
+  | Rsqrteq_f32 | Sqrtq_f64 | Rsqrteq_f64 | Cvtq_s32_f32 | Cvtnq_s32_f32
+  | Cvtq_f32_s32 | Cvt_f64_f32 | Cvt_f32_f64 | Cvtq_f64_s64 | Cvtq_s64_f64
+  | Cvtnq_s64_f64 | Movl_s32 | Movl_u32 | Movl_s16 | Movl_u16 | Movl_s8
+  | Movl_u8 | Paddq_f32 | Cmp_f32 _ | Cmpz_f32 _ | Cmpz_s32 _ | Cmp_f64 _
+  | Cmpz_f64 _ | Cmp_s32 _ | Cmp_s64 _ | Cmpz_s64 _ | Mvnq_s32 | Orrq_s32
+  | Andq_s32 | Eorq_s32 | Negq_s32 | Getq_lane_s32 _ | Getq_lane_s64 _
+  | Dupq_lane_s32 _ | Dupq_lane_s64 _ | Mulq_s32 | Mulq_s16 | Addq_s32
+  | Subq_s32 | Minq_s32 | Maxq_s32 | Minq_u32 | Maxq_u32 | Absq_s32 | Absq_s64
+  | Paddq_f64 | Paddq_s32 | Paddq_s64 | Mvnq_s64 | Orrq_s64 | Andq_s64
+  | Eorq_s64 | Negq_s64 | Shlq_u32 | Shlq_u64 | Shlq_s32 | Shlq_s64
   | Shlq_n_u32 _ | Shlq_n_u64 _ | Shrq_n_u32 _ | Shrq_n_u64 _ | Shrq_n_s32 _
   | Shrq_n_s64 _ | Setq_lane_s32 _ | Setq_lane_s64 _ | Addq_s16 | Paddq_s16
   | Qaddq_s16 | Qaddq_u16 | Subq_s16 | Qsubq_s16 | Qsubq_u16 | Absq_s16

--- a/backend/arm64/simd_proc.ml
+++ b/backend/arm64/simd_proc.ml
@@ -72,6 +72,7 @@ type register_behavior =
   | Rf32_to_Rf32
   | Rf64_to_Rf64
   | Rf32_to_Rs64
+  | Rf64_to_Rs64
   (* extract *)
   | Rs8x16_to_Rs8 of { lane : int }
   | Rs16x8_to_Rs16 of { lane : int }
@@ -96,6 +97,7 @@ let register_behavior (op : Simd.operation) =
   match op with
   (* unary *)
   | Round_f32_s64 -> Rf32_to_Rs64
+  | Round_f64_s64 -> Rf64_to_Rs64
   | Round_f32 _ -> Rf32_to_Rf32
   | Round_f64 _ -> Rf64_to_Rf64
   (* binary *)

--- a/backend/arm64/simd_selection.ml
+++ b/backend/arm64/simd_selection.ml
@@ -83,12 +83,10 @@ let select_simd_instr op args dbg =
     Some (Round_f32 Current, args)
   | "caml_simd_float64_round_current" | "caml_neon_float64_round_current" ->
     Some (Round_f64 Current, args)
-  | "caml_simd_float32_round_near" | "caml_neon_float32_round_near" ->
-    Some (Round_f32 Nearest, args)
-  | "caml_simd_float64_round_near" | "caml_neon_float64_round_near" ->
-    Some (Round_f64 Nearest, args)
   | "caml_simd_cast_float32_int64" | "caml_neon_cast_float32_int64" ->
     Some (Round_f32_s64, args)
+  | "caml_simd_cast_float64_int64" | "caml_neon_cast_float64_int64" ->
+    Some (Round_f64_s64, args)
   (* min/max that match amd64 behavior, regardless of the value of FPCR.AH.
      implemented as a sequence of instructions *)
   | "caml_simd_float32_min" -> Some (Min_scalar_f32, args)
@@ -425,7 +423,7 @@ let pseudoregs_for_operation (simd_op : Simd.operation) arg res =
   | Rf64x2_to_Rf32x2 | Rs8x16_to_Rs8x16 | Rs8x16_Rs8x16_to_Rs8x16
   | Rs64x2_to_Rs64x2 | Rf64x2_to_Rs64x2 | Rf64x2_Rf64x2_to_Rs64x2
   | Rs32x4_Rs32x4_to_Rs32x4 | Rf32_Rf32_to_Rf32 | Rf64_Rf64_to_Rf64
-  | Rf32_to_Rf32 | Rf64_to_Rf64 | Rf32_to_Rs64 | Rs64x2_to_Rs64 _
+  | Rf32_to_Rf32 | Rf64_to_Rf64 | Rf32_to_Rs64 | Rf64_to_Rs64 | Rs64x2_to_Rs64 _
   | Rs32x4_to_Rs32 _ | Rs32x4lane_to_Rs32x4 _ | Rs64x2lane_to_Rs64x2 _
   | Rf64x2_to_Rf64x2 | Rs64x2_to_Rf64x2 | Rs32x2_to_Rs64x2
   | Rs16x8_Rs16x8_to_Rs16x8 | Rs16x8_to_Rs16x8 | Rs16x8_to_Rs16 _

--- a/oxcaml/tests/simd/scalar_ops.ml
+++ b/oxcaml/tests/simd/scalar_ops.ml
@@ -22,6 +22,19 @@ let eq' x y = if x <> y then Printf.printf "%016Lx <> %016Lx\n" x y
 
 let eqi x y = if x <> y then Printf.printf "%d <> %d\n" x y
 
+let eq64 x y = if x <> y then Printf.printf "%Ld <> %Ld\n" x y
+
+let eqf x y =
+  if Float.is_nan x && Float.is_nan y then ()
+  else if x <> y then Printf.printf "%f <> %f\n" x y
+
+external f32_to_f64 : float32 -> float = "%floatoffloat32"
+
+let eqf32 x y =
+  let x, y = f32_to_f64 x, f32_to_f64 y in
+  if Float.is_nan x && Float.is_nan y then ()
+  else if x <> y then Printf.printf "%f <> %f\n" x y
+
 module Int = struct
   external count_leading_zeros : int -> (int[@untagged])
     = "caml_vec128_unreachable" "caml_int_clz_tagged_to_untagged"
@@ -211,4 +224,126 @@ module Int32 = struct
     check count_trailing_zeros ctz;
     check ~nonzero:true count_trailing_zeros_nonzero_arg ctz;
     check count_set_bits popcnt
+end
+
+module Float = struct
+
+  external max_f64 : float -> float -> float
+    = "caml_vec128_unreachable" "caml_simd_float64_max"
+  [@@noalloc] [@@builtin] [@@unboxed]
+
+  external max_f32 : float32 -> float32 -> float32
+    = "caml_vec128_unreachable" "caml_simd_float32_max"
+  [@@noalloc] [@@builtin] [@@unboxed]
+
+  external min_f64 : float -> float -> float
+    = "caml_vec128_unreachable" "caml_simd_float64_min"
+  [@@noalloc] [@@builtin] [@@unboxed]
+
+  external min_f32 : float32 -> float32 -> float32
+    = "caml_vec128_unreachable" "caml_simd_float32_min"
+  [@@noalloc] [@@builtin] [@@unboxed]
+
+  external iround_f64 : float -> int64
+    = "caml_vec128_unreachable" "caml_simd_cast_float64_int64"
+  [@@noalloc] [@@builtin] [@@unboxed]
+
+  external iround_f32 : float32 -> int64
+    = "caml_vec128_unreachable" "caml_simd_cast_float32_int64"
+  [@@noalloc] [@@builtin] [@@unboxed]
+
+  external round_current_f64 : float -> float
+    = "caml_vec128_unreachable" "caml_simd_float64_round_current"
+  [@@noalloc] [@@builtin] [@@unboxed]
+
+  external round_neg_inf_f64 : float -> float
+    = "caml_vec128_unreachable" "caml_simd_float64_round_neg_inf"
+  [@@noalloc] [@@builtin] [@@unboxed]
+
+  external round_pos_inf_f64 : float -> float
+    = "caml_vec128_unreachable" "caml_simd_float64_round_pos_inf"
+  [@@noalloc] [@@builtin] [@@unboxed]
+
+  external round_towards_zero_f64 : float -> float
+    = "caml_vec128_unreachable" "caml_simd_float64_round_towards_zero"
+  [@@noalloc] [@@builtin] [@@unboxed]
+
+  external round_current_f32 : float32 -> float32
+    = "caml_vec128_unreachable" "caml_simd_float32_round_current"
+  [@@noalloc] [@@builtin] [@@unboxed]
+
+  external round_neg_inf_f32 : float32 -> float32
+    = "caml_vec128_unreachable" "caml_simd_float32_round_neg_inf"
+  [@@noalloc] [@@builtin] [@@unboxed]
+
+  external round_pos_inf_f32 : float32 -> float32
+    = "caml_vec128_unreachable" "caml_simd_float32_round_pos_inf"
+  [@@noalloc] [@@builtin] [@@unboxed]
+
+  external round_towards_zero_f32 : float32 -> float32
+    = "caml_vec128_unreachable" "caml_simd_float32_round_towards_zero"
+  [@@noalloc] [@@builtin] [@@unboxed]
+
+  external float32_of_bits : int32 -> float32
+    = "caml_float32_of_bits_bytecode" "caml_float32_of_bits"
+    [@@unboxed] [@@noalloc]
+
+  let f32_nan = float32_of_bits 0x7fc00001l
+
+  let () =
+    eqf (round_current_f64 0.5) 0.;
+    eqf (round_neg_inf_f64 0.5) 0.;
+    eqf (round_pos_inf_f64 0.5) 1.;
+    eqf (round_towards_zero_f64 0.5) 0.;
+    eqf (round_current_f64 (-0.5)) 0.;
+    eqf (round_neg_inf_f64 (-0.5)) (-1.);
+    eqf (round_pos_inf_f64 (-0.5)) 0.;
+    eqf (round_towards_zero_f64 (-0.5)) 0.;
+    eqf32 (round_current_f32 0.5s) 0.s;
+    eqf32 (round_neg_inf_f32 0.5s) 0.s;
+    eqf32 (round_pos_inf_f32 0.5s) 1.s;
+    eqf32 (round_towards_zero_f32 0.5s) 0.s;
+    eqf32 (round_current_f32 (-0.5s)) 0.s;
+    eqf32 (round_neg_inf_f32 (-0.5s)) (-1.s);
+    eqf32 (round_pos_inf_f32 (-0.5s)) 0.s;
+    eqf32 (round_towards_zero_f32 (-0.5s)) 0.s
+
+  (* If either argument is nan, returns the second argument. *)
+  let () =
+    eqf (max_f64 (-1.) 1.) 1.;
+    eqf (max_f64 1. (-1.)) 1.;
+    eqf (max_f64 Float.nan 1.) 1.;
+    eqf (max_f64 1. Float.nan) Float.nan;
+    eqf (max_f64 Float.nan Float.nan) Float.nan;
+    eqf32 (max_f32 (-1.s) 1.s) 1.s;
+    eqf32 (max_f32 1.s (-1.s)) 1.s;
+    eqf32 (max_f32 f32_nan 1.s) 1.s;
+    eqf32 (max_f32 1.s f32_nan) f32_nan;
+    eqf32 (max_f32 f32_nan f32_nan) f32_nan;
+    eqf (min_f64 (-1.) 1.) (-1.);
+    eqf (min_f64 1. (-1.)) (-1.);
+    eqf (min_f64 Float.nan 1.) 1.;
+    eqf (min_f64 1. Float.nan) Float.nan;
+    eqf (min_f64 Float.nan Float.nan) Float.nan;
+    eqf32 (min_f32 (-1.s) 1.s) (-1.s);
+    eqf32 (min_f32 1.s (-1.s)) (-1.s);
+    eqf32 (min_f32 f32_nan 1.s) 1.s;
+    eqf32 (min_f32 1.s f32_nan) f32_nan;
+    eqf32 (min_f32 f32_nan f32_nan) f32_nan
+
+  (* In native code, the current mode should be half-to-even.
+     Result is unspecified for inf/nan/out-of-range values. *)
+  let () =
+    eq64 (iround_f64 0.) 0L;
+    eq64 (iround_f64 (-0.)) 0L;
+    eq64 (iround_f64 0.5) 0L;
+    eq64 (iround_f64 (-0.5)) 0L;
+    eq64 (iround_f64 1.5) 2L;
+    eq64 (iround_f64 (-1.5)) (-2L);
+    eq64 (iround_f32 0.s) 0L;
+    eq64 (iround_f32 (-0.s)) 0L;
+    eq64 (iround_f32 0.5s) 0L;
+    eq64 (iround_f32 (-0.5s)) 0L;
+    eq64 (iround_f32 1.5s) 2L;
+    eq64 (iround_f32 (-1.5s)) (-2L)
 end

--- a/oxcaml/tests/simd/stubs.c
+++ b/oxcaml/tests/simd/stubs.c
@@ -347,9 +347,6 @@ BUILTIN(caml_int_clz_tagged_to_untagged);
 
 BUILTIN(caml_simd_vec128_interleave_low_32)
 BUILTIN(caml_simd_vec128_interleave_low_64)
-BUILTIN(caml_simd_float64_max);
-BUILTIN(caml_simd_float64_min);
-
 
 #include <float.h>
 #include <math.h>

--- a/runtime/float32.c
+++ b/runtime/float32.c
@@ -848,7 +848,7 @@ static value caml_make_unboxed_float32_vect0(value len, int local)
   /* This is only used on 64-bit targets. */
 
   mlsize_t num_elements = Long_val(len);
-  if (num_elements > Max_unboxed_float32_array_wosize) 
+  if (num_elements > Max_unboxed_float32_array_wosize)
     caml_invalid_argument("Array.make");
 
   /* Empty arrays have tag 0 */
@@ -857,11 +857,11 @@ static value caml_make_unboxed_float32_vect0(value len, int local)
   }
 
   mlsize_t num_fields = num_elements / 2 + num_elements % 2;
-  
+
   /* Use appropriate unboxed array tag based on even/odd length */
-  tag_t tag = (num_elements % 2 == 0) 
+  tag_t tag = (num_elements % 2 == 0)
     ? Unboxed_float32_array_even_tag : Unboxed_float32_array_odd_tag;
-  
+
   /* Mixed block with no scannable fields */
   reserved_t reserved = Reserved_mixed_block_scannable_wosize_native(0);
 

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -1176,3 +1176,61 @@ CAMLprim value caml_classify_float(value vd)
 {
   return caml_classify_float_unboxed(Double_val(vd));
 }
+
+double caml_simd_float64_min(double x, double y) {
+  return x < y ? x : y;
+}
+
+CAMLprim value caml_simd_float64_min_bytecode(value x, value y) {
+  return Double_val(x) < Double_val(y) ? x : y;
+}
+
+double caml_simd_float64_max(double x, double y) {
+  return x > y ? x : y;
+}
+
+CAMLprim value caml_simd_float64_max_bytecode(value x, value y) {
+  return Double_val(x) > Double_val(y) ? x : y;
+}
+
+int64_t caml_simd_cast_float64_int64(double f)
+{
+  return llrint(f);
+}
+
+CAMLprim value caml_simd_cast_float64_int64_bytecode(value f)
+{
+  return caml_copy_int64(caml_simd_cast_float64_int64(Double_val(f)));
+}
+
+double caml_simd_float64_round_current(double f) {
+  return rint(f);
+}
+
+CAMLprim value caml_simd_float64_round_current_bytecode(value f) {
+  return caml_copy_double(caml_simd_float64_round_current(Double_val(f)));
+}
+
+double caml_simd_float64_round_neg_inf(double f) {
+  return floor(f);
+}
+
+CAMLprim value caml_simd_float64_round_neg_inf_bytecode(value f) {
+  return caml_copy_double(caml_simd_float64_round_neg_inf(Double_val(f)));
+}
+
+double caml_simd_float64_round_pos_inf(double f) {
+  return ceil(f);
+}
+
+CAMLprim value caml_simd_float64_round_pos_inf_bytecode(value f) {
+  return caml_copy_double(caml_simd_float64_round_pos_inf(Double_val(f)));
+}
+
+double caml_simd_float64_round_towards_zero(double f) {
+  return trunc(f);
+}
+
+CAMLprim value caml_simd_float64_round_towards_zero_bytecode(value f) {
+  return caml_copy_double(caml_simd_float64_round_towards_zero(Double_val(f)));
+}

--- a/runtime4/float32.c
+++ b/runtime4/float32.c
@@ -847,7 +847,7 @@ static value caml_make_unboxed_float32_vect0(value len, int local)
   /* This is only used on 64-bit targets. */
 
   mlsize_t num_elements = Long_val(len);
-  if (num_elements > Max_unboxed_float32_array_wosize) 
+  if (num_elements > Max_unboxed_float32_array_wosize)
     caml_invalid_argument("Array.make");
 
   /* Empty arrays have tag 0 */
@@ -856,11 +856,11 @@ static value caml_make_unboxed_float32_vect0(value len, int local)
   }
 
   mlsize_t num_fields = num_elements / 2 + num_elements % 2;
-  
+
   /* Use appropriate unboxed array tag based on even/odd length */
-  tag_t tag = (num_elements % 2 == 0) 
+  tag_t tag = (num_elements % 2 == 0)
     ? Unboxed_float32_array_even_tag : Unboxed_float32_array_odd_tag;
-  
+
   /* Mixed block with no scannable fields */
   reserved_t reserved = Reserved_mixed_block_scannable_wosize_native(0);
 

--- a/runtime4/floats.c
+++ b/runtime4/floats.c
@@ -1185,3 +1185,61 @@ CAMLprim value caml_classify_float(value vd)
 {
   return caml_classify_float_unboxed(Double_val(vd));
 }
+
+double caml_simd_float64_min(double x, double y) {
+  return x < y ? x : y;
+}
+
+CAMLprim value caml_simd_float64_min_bytecode(value x, value y) {
+  return Double_val(x) < Double_val(y) ? x : y;
+}
+
+double caml_simd_float64_max(double x, double y) {
+  return x > y ? x : y;
+}
+
+CAMLprim value caml_simd_float64_max_bytecode(value x, value y) {
+  return Double_val(x) > Double_val(y) ? x : y;
+}
+
+int64_t caml_simd_cast_float64_int64(double f)
+{
+  return llrint(f);
+}
+
+CAMLprim value caml_simd_cast_float64_int64_bytecode(value f)
+{
+  return caml_copy_int64(caml_simd_cast_float64_int64(Double_val(f)));
+}
+
+double caml_simd_float64_round_current(double f) {
+  return rint(f);
+}
+
+CAMLprim value caml_simd_float64_round_current_bytecode(value f) {
+  return caml_copy_double(caml_simd_float64_round_current(Double_val(f)));
+}
+
+double caml_simd_float64_round_neg_inf(double f) {
+  return floor(f);
+}
+
+CAMLprim value caml_simd_float64_round_neg_inf_bytecode(value f) {
+  return caml_copy_double(caml_simd_float64_round_neg_inf(Double_val(f)));
+}
+
+double caml_simd_float64_round_pos_inf(double f) {
+  return ceil(f);
+}
+
+CAMLprim value caml_simd_float64_round_pos_inf_bytecode(value f) {
+  return caml_copy_double(caml_simd_float64_round_pos_inf(Double_val(f)));
+}
+
+double caml_simd_float64_round_towards_zero(double f) {
+  return trunc(f);
+}
+
+CAMLprim value caml_simd_float64_round_towards_zero_bytecode(value f) {
+  return caml_copy_double(caml_simd_float64_round_towards_zero(Double_val(f)));
+}


### PR DESCRIPTION
Several of the `caml_simd_*` intrinsics were not fully implemented. This fixes that and tests them.
- Adds f64->i64 cast and implements it on arm
- Removes round-nearest, as it was unused and the `RoundNearest` x86 flag actually does half-to-even.