### PR TITLE
Make `raw_backtrace` immutable_data

### DIFF
--- a/stdlib/printexc.mli
+++ b/stdlib/printexc.mli
@@ -116,7 +116,7 @@ val use_printers: exn -> string option
 
 (** {1 Raw backtraces} *)
 
-type raw_backtrace : mutable_data
+type raw_backtrace : immutable_data
 (** The type [raw_backtrace] stores a backtrace in a low-level format,
     which can be converted to usable form using [raw_backtrace_entries]
     and [backtrace_slots_of_raw_entry] below.


### PR DESCRIPTION
Changes the representation of `raw_backtrace` to an `iarray` instead of an `array`. 

This means `raw_backtrace_entries` now copies the backtrace, which is technically a breaking change, but as far as I can tell nothing relies on mutating the raw backtrace via this function.