### PR TITLE
`include M` should not unfold with empty modalities

### DIFF
--- a/testsuite/tests/typing-modes/module.ml
+++ b/testsuite/tests/typing-modes/module.ml
@@ -456,8 +456,29 @@ module type S = sig
 
 end
 [%%expect{|
-Uncaught exception: File "typing/env.ml", line 2087, characters 13-19: Assertion failed
-
+module type S =
+  sig
+    module type S = sig end
+    module type Key = sig module M0 : S end
+    module L :
+      sig
+        module M : Key
+        module N :
+          sig
+            module Label : sig module M0 = M.M0 end
+            module Key : sig module M0 = M.M0 end
+          end
+      end
+    module L' :
+      sig
+        module M : sig module M0 : sig end end
+        module N :
+          sig
+            module Label : sig module M0 = M.M0 end
+            module Key : sig module M0 = M.M0 end
+          end
+      end
+  end
 |}]
 
 (* CR zqian: fix [make_aliases_absent]. *)
@@ -489,6 +510,6 @@ module type S = sig
     @@ portable
 end
 [%%expect{|
-Uncaught exception: File "typing/env.ml", line 2087, characters 13-19: Assertion failed
+Uncaught exception: File "typing/env.ml", line 2139, characters 13-19: Assertion failed
 
 |}]

--- a/testsuite/tests/typing-modes/module.ml
+++ b/testsuite/tests/typing-modes/module.ml
@@ -428,3 +428,67 @@ end
 [%%expect{|
 module rec Foo : sig val bar : unit -> unit end
 |}]
+
+module type S = sig
+    module type S = sig end
+
+    module type Key = sig
+    module M0 : S
+    end
+
+    module L : sig
+    module M : Key
+
+    module N : sig
+        module Label : Key with M
+
+        include sig
+            module Key : S
+        end
+        with module Key = Label
+    end
+    end
+
+    include sig
+        module L' : S
+    end
+    with module L' = L
+
+end
+[%%expect{|
+Uncaught exception: File "typing/env.ml", line 2087, characters 13-19: Assertion failed
+
+|}]
+
+(* CR zqian: fix [make_aliases_absent]. *)
+module type S = sig
+    module type S = sig end
+
+    module type Key = sig
+    module M0 : S
+    end
+
+    module L : sig
+    module M : Key
+
+    module N : sig
+        module Label : Key with M
+
+        include sig
+            module Key : S
+        end
+        with module Key = Label
+        @@ portable
+    end
+    end
+
+    include sig
+        module L' : S
+    end
+    with module L' = L
+    @@ portable
+end
+[%%expect{|
+Uncaught exception: File "typing/env.ml", line 2087, characters 13-19: Assertion failed
+
+|}]

--- a/testsuite/tests/typing-signatures/els.ocaml.reference
+++ b/testsuite/tests/typing-signatures/els.ocaml.reference
@@ -6,7 +6,7 @@ module type CORE0 =
   end
 module type CORE =
   sig
-    module V : sig type value type state type usert end
+    module V : VALUE
     val setglobal : V.state -> string -> V.value -> unit
     val apply : V.value -> V.state -> V.value list -> V.value
   end
@@ -31,7 +31,7 @@ module type EVALUATOR =
 module type PARSER = sig type chunk val parse : string -> chunk end
 module type INTERP =
   sig
-    module Value : sig type value type state type usert end
+    module Value : VALUE
     module Ast :
       sig type chunk type program val get_value : chunk -> Value.value end
     type state = Value.state

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1992,7 +1992,11 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
       not @@ Builtin_attributes.has_attribute "no_recursive_modalities"
         sincl.pincl_attributes
     in
-    let sg = apply_modalities_signature ~recursive env modalities sg in
+    let sg =
+      match Mode.Modality.Value.Const.is_id modalities with
+      | true -> sg
+      | false -> apply_modalities_signature ~recursive env modalities sg
+    in
     (* Assume the structure is legacy, for backward compatibility *)
     let sg, newenv = Env.enter_signature ~scope sg ~mode:Value.legacy env in
     Signature_group.iter


### PR DESCRIPTION
**_Please review by commits._**

What the title says. This should improve performance.

This also helps avoiding a bug in `Mtype.make_aliases_absent` when there is no modalities (tests added). A proper fix to that is  WIP.