### PR TITLE
Fix fatal error when deepening a block index from a mixed product to void

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1615,6 +1615,7 @@ let block_index_access_offsets layout idx =
       let offset_from_offset : H.simple_or_prim =
         match mbe with
         | Product _ ->
+          (* Products not produced by [L.mixed_block_element_leaves] *)
           Misc.fatal_errorf "Unexpected product in block index access: %a"
             Printlambda.layout layout
         (* Values are (values to left) beyond the offset *)
@@ -1771,6 +1772,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
         | Mixed_product_to_mixed_product
         | Mixed_product_to_all_values
         | Mixed_product_to_all_flats
+        | Mixed_product_to_empty
         | All_values_or_flats
     end in
     let deepening_type =
@@ -1786,9 +1788,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
         | false, false -> Mixed_product_to_mixed_product
         | false, true -> Mixed_product_to_all_values
         | true, false -> Mixed_product_to_all_flats
-        | true, true ->
-          Misc.fatal_errorf "Unexpected value=0 and flat=0 in %a@ %a"
-            Printlambda.primitive prim Debuginfo.print_compact dbg
+        | true, true -> Mixed_product_to_empty
       else All_values_or_flats
     in
     match deepening_type with
@@ -1836,7 +1836,10 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
           ( Int_arith (Naked_int64, Add),
             H.Prim
               (Binary (Int_arith (Naked_int64, Add), H.Prim offset, H.Prim gap)),
-            H.simple_i64 to_add ) ])
+            H.simple_i64 to_add ) ]
+    | Mixed_product_to_empty ->
+      (* Accesses to an index to a product of voids will not actually access *)
+      [Simple (Simple.const (Reg_width_const.naked_int64 Int64.zero))])
   | Pmakefloatblock (mutability, mode), _ ->
     let args = List.flatten args in
     let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in

--- a/testsuite/tests/typing-layouts-block-indices/block_indices.reference
+++ b/testsuite/tests/typing-layouts-block-indices/block_indices.reference
@@ -42,6 +42,11 @@ Mixed block record (nativeint# field)
 1
 2
 
+Mixed block record with unboxed record with value, flat, and void
+{ a 1.000000 #() }
+{ b 2.000000 #() }
+{ c 3.000000 #() }
+
 Nested product update and deepen mixed product to mixed product
 { 1 { a 2 } b }
 { 10 { aa 20 } bb }


### PR DESCRIPTION
A fatal error in deepening a block index from a mixed product to a layout with neither values nor flats became no-longer-unreachable with #4211.