### PR TITLE
refactor epilogue into cfg and linear instructions

### DIFF
--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -609,7 +609,7 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
                   | Isextend32 | Izextend32
                   | Ilfence | Isfence | Imfence)
        | Name_for_debugger _ | Dls_get | Pause)
-  | Poptrap _ | Prologue ->
+  | Poptrap _ | Prologue | Epilogue ->
     if fp then [| rbp |] else [||]
   | Stack_check _ ->
     assert false (* the instruction is added after register allocation *)

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -282,7 +282,7 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
         | Ioffset_loc (_, _)
         | Ifloatarithmem (_, _, _)
         | Icldemote _ | Iprefetch _ | Ibswap _ ))
-  | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue ->
+  | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue ->
     (* no rewrite *)
     May_still_have_spilled_registers
   | Op (Intop_imm ((Ipopcnt | Iclz _ | Ictz _), _)) | Stack_check _ ->

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -899,18 +899,6 @@ let emit_stack_adjustment n =
   if ml <> 0 then DSL.ins instr [| DSL.sp; DSL.sp; DSL.imm ml |];
   if n <> 0 then D.cfi_adjust_cfa_offset ~bytes:(-n)
 
-(* Deallocate the stack frame and reload the return address before a return or
-   tail call *)
-
-let output_epilogue f =
-  let n = frame_size () in
-  if !contains_calls
-  then DSL.ins I.LDR [| DSL.reg_x_30; DSL.emit_mem_sp_offset (n - 8) |];
-  if n > 0 then emit_stack_adjustment n;
-  f ();
-  (* reset CFA back because function body may continue *)
-  if n > 0 then D.cfi_adjust_cfa_offset ~bytes:n
-
 (* Output add-immediate / sub-immediate / cmp-immediate instructions *)
 
 let rec emit_addimm rd rs n =
@@ -1073,8 +1061,8 @@ let num_call_gc_points instr =
         | Floatop (_, _)
         | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
         | Name_for_debugger _ )
-    | Lprologue | Lreloadretaddr | Lreturn | Lentertrap | Lpoptrap _
-    | Lcall_op _ | Llabel _ | Lbranch _
+    | Lprologue | Lepilogue_open | Lepilogue_close | Lreloadretaddr | Lreturn
+    | Lentertrap | Lpoptrap _ | Lcall_op _ | Llabel _ | Lbranch _
     | Lcondbranch (_, _)
     | Lcondbranch3 (_, _, _)
     | Lswitch _ | Ladjust_stack_offset _ | Lpushtrap _ | Lraise _
@@ -1142,9 +1130,10 @@ module BR = Branch_relaxation.Make (struct
           | Floatop (_, _)
           | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
           | Name_for_debugger _ )
-      | Lprologue | Lend | Lreloadretaddr | Lreturn | Lentertrap | Lpoptrap _
-      | Lcall_op _ | Llabel _ | Lbranch _ | Lswitch _ | Ladjust_stack_offset _
-      | Lpushtrap _ | Lraise _ | Lstackcheck _ ->
+      | Lprologue | Lepilogue_open | Lepilogue_close | Lend | Lreloadretaddr
+      | Lreturn | Lentertrap | Lpoptrap _ | Lcall_op _ | Llabel _ | Lbranch _
+      | Lswitch _ | Ladjust_stack_offset _ | Lpushtrap _ | Lraise _
+      | Lstackcheck _ ->
         None
       | Lop (Const_vec256 _ | Const_vec512 _) ->
         Misc.fatal_error "arm64: got 256/512 bit vector"
@@ -1173,6 +1162,8 @@ module BR = Branch_relaxation.Make (struct
   let instr_size = function
     | Lend -> 0
     | Lprologue -> prologue_size ()
+    | Lepilogue_open -> epilogue_size ()
+    | Lepilogue_close -> 0
     | Lop (Move | Spill | Reload) -> 1
     | Lop (Const_int n) -> num_instructions_for_intconst n
     | Lop (Const_float32 _) -> 2
@@ -1660,6 +1651,14 @@ let emit_instr i =
     then (
       D.cfi_offset ~reg:30 (* return address *) ~offset:(-8);
       DSL.ins I.STR [| DSL.reg_x_30; DSL.emit_mem_sp_offset (n - 8) |])
+  | Lepilogue_open ->
+    let n = frame_size () in
+    if !contains_calls
+    then DSL.ins I.LDR [| DSL.reg_x_30; DSL.emit_mem_sp_offset (n - 8) |];
+    if n > 0 then emit_stack_adjustment n
+  | Lepilogue_close ->
+    let n = frame_size () in
+    if n > 0 then D.cfi_adjust_cfa_offset ~bytes:n
   | Lop (Intop_atomic _) ->
     (* Never generated; builtins are not yet translated to atomics *)
     assert false
@@ -1723,8 +1722,7 @@ let emit_instr i =
   | Lcall_op (Lcall_imm { func }) ->
     DSL.ins I.BL [| DSL.emit_symbol (S.create func.sym_name) |];
     record_frame i.live (Dbg_other i.dbg)
-  | Lcall_op Ltailcall_ind ->
-    output_epilogue (fun () -> DSL.ins I.BR [| DSL.emit_reg i.arg.(0) |])
+  | Lcall_op Ltailcall_ind -> DSL.ins I.BR [| DSL.emit_reg i.arg.(0) |]
   | Lcall_op (Ltailcall_imm { func }) ->
     if String.equal func.sym_name !function_name
     then
@@ -1732,9 +1730,7 @@ let emit_instr i =
       | None -> Misc.fatal_error "jump to missing tailrec entry point"
       | Some tailrec_entry_point ->
         DSL.ins I.B [| DSL.emit_label tailrec_entry_point |]
-    else
-      output_epilogue (fun () ->
-          DSL.ins I.B [| DSL.emit_symbol (S.create func.sym_name) |])
+    else DSL.ins I.B [| DSL.emit_symbol (S.create func.sym_name) |]
   | Lcall_op (Lextcall { func; alloc; stack_ofs; _ }) ->
     if Config.runtime5 && stack_ofs > 0
     then (
@@ -2206,7 +2202,7 @@ let emit_instr i =
              DSL.cond EQ
           |])
   | Lreloadretaddr -> ()
-  | Lreturn -> output_epilogue (fun () -> DSL.ins I.RET [||])
+  | Lreturn -> DSL.ins I.RET [||]
   | Llabel { label = lbl; _ } ->
     let lbl = label_to_asm_label ~section:Text lbl in
     D.define_label lbl

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -337,7 +337,7 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
         | Intop_imm _ | Intop_atomic _
         | Name_for_debugger _ | Probe_is_enabled _ | Opaque | Pause
         | Begin_region | End_region | Dls_get)
-  | Poptrap _ | Prologue
+  | Poptrap _ | Prologue | Epilogue
   | Op (Reinterpret_cast (Int_of_value | Value_of_int | Float_of_float32 |
                           Float32_of_float | Float_of_int64 | Int64_of_float |
                           Float32_of_int32 | Int32_of_float32 |

--- a/backend/arm64/regalloc_stack_operands.ml
+++ b/backend/arm64/regalloc_stack_operands.ml
@@ -41,7 +41,8 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
       | Floatop (_, _)
       | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
       | Name_for_debugger _ | Alloc _ )
-  | Reloadretaddr | Prologue | Pushtrap _ | Poptrap _ | Stack_check _ ->
+  | Reloadretaddr | Prologue | Epilogue | Pushtrap _ | Poptrap _ | Stack_check _
+    ->
     (* no rewrite *)
     May_still_have_spilled_registers
 

--- a/backend/branch_relaxation.ml
+++ b/backend/branch_relaxation.ml
@@ -28,8 +28,8 @@ module Make (T : Branch_relaxation_intf.S) = struct
       | Llabel { label = lbl; _ } ->
         Hashtbl.add map lbl pc;
         fill_map pc instr.next
-      | ( Lprologue | Lreloadretaddr | Lreturn | Lentertrap | Lpoptrap _ | Lop _
-        | Lcall_op _ | Lbranch _
+      | ( Lprologue | Lepilogue | Lreloadretaddr | Lreturn | Lentertrap
+        | Lpoptrap _ | Lop _ | Lcall_op _ | Lbranch _
         | Lcondbranch (_, _)
         | Lcondbranch3 (_, _, _)
         | Lswitch _ | Ladjust_stack_offset _ | Lpushtrap _ | Lraise _
@@ -81,9 +81,9 @@ module Make (T : Branch_relaxation_intf.S) = struct
           | Floatop (_, _)
           | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
           | Name_for_debugger _ )
-      | Lprologue | Lend | Lreloadretaddr | Lreturn | Lentertrap | Lpoptrap _
-      | Lcall_op _ | Llabel _ | Lbranch _ | Lswitch _ | Ladjust_stack_offset _
-      | Lpushtrap _ | Lraise _ | Lstackcheck _ ->
+      | Lprologue | Lepilogue | Lend | Lreloadretaddr | Lreturn | Lentertrap
+      | Lpoptrap _ | Lcall_op _ | Llabel _ | Lbranch _ | Lswitch _
+      | Ladjust_stack_offset _ | Lpushtrap _ | Lraise _ | Lstackcheck _ ->
         Misc.fatal_error "Unsupported instruction for branch relaxation")
 
   let fixup_branches ~code_size ~max_out_of_line_code_offset map code =
@@ -98,8 +98,8 @@ module Make (T : Branch_relaxation_intf.S) = struct
     let rec fixup did_fix pc instr =
       match instr.desc with
       | Lend -> did_fix
-      | Lprologue | Lreloadretaddr | Lreturn | Lentertrap | Lpoptrap _ | Lop _
-      | Lcall_op _ | Llabel _ | Lbranch _
+      | Lprologue | Lepilogue | Lreloadretaddr | Lreturn | Lentertrap
+      | Lpoptrap _ | Lop _ | Lcall_op _ | Llabel _ | Lbranch _
       | Lcondbranch (_, _)
       | Lcondbranch3 (_, _, _)
       | Lswitch _ | Ladjust_stack_offset _ | Lpushtrap _ | Lraise _
@@ -138,7 +138,7 @@ module Make (T : Branch_relaxation_intf.S) = struct
             instr.desc <- cont.desc;
             instr.next <- cont.next;
             fixup true pc instr
-          | Lprologue | Lend | Lreloadretaddr | Lreturn | Lentertrap
+          | Lprologue | Lepilogue | Lend | Lreloadretaddr | Lreturn | Lentertrap
           | Lpoptrap _ | Lcall_op _ | Llabel _ | Lbranch _ | Lswitch _
           | Ladjust_stack_offset _ | Lpushtrap _ | Lraise _ | Lstackcheck _
           | Lop

--- a/backend/branch_relaxation.ml
+++ b/backend/branch_relaxation.ml
@@ -28,8 +28,8 @@ module Make (T : Branch_relaxation_intf.S) = struct
       | Llabel { label = lbl; _ } ->
         Hashtbl.add map lbl pc;
         fill_map pc instr.next
-      | ( Lprologue | Lepilogue | Lreloadretaddr | Lreturn | Lentertrap
-        | Lpoptrap _ | Lop _ | Lcall_op _ | Lbranch _
+      | ( Lprologue | Lepilogue_open | Lepilogue_close | Lreloadretaddr
+        | Lreturn | Lentertrap | Lpoptrap _ | Lop _ | Lcall_op _ | Lbranch _
         | Lcondbranch (_, _)
         | Lcondbranch3 (_, _, _)
         | Lswitch _ | Ladjust_stack_offset _ | Lpushtrap _ | Lraise _
@@ -81,9 +81,10 @@ module Make (T : Branch_relaxation_intf.S) = struct
           | Floatop (_, _)
           | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
           | Name_for_debugger _ )
-      | Lprologue | Lepilogue | Lend | Lreloadretaddr | Lreturn | Lentertrap
-      | Lpoptrap _ | Lcall_op _ | Llabel _ | Lbranch _ | Lswitch _
-      | Ladjust_stack_offset _ | Lpushtrap _ | Lraise _ | Lstackcheck _ ->
+      | Lprologue | Lepilogue_open | Lepilogue_close | Lend | Lreloadretaddr
+      | Lreturn | Lentertrap | Lpoptrap _ | Lcall_op _ | Llabel _ | Lbranch _
+      | Lswitch _ | Ladjust_stack_offset _ | Lpushtrap _ | Lraise _
+      | Lstackcheck _ ->
         Misc.fatal_error "Unsupported instruction for branch relaxation")
 
   let fixup_branches ~code_size ~max_out_of_line_code_offset map code =
@@ -98,8 +99,8 @@ module Make (T : Branch_relaxation_intf.S) = struct
     let rec fixup did_fix pc instr =
       match instr.desc with
       | Lend -> did_fix
-      | Lprologue | Lepilogue | Lreloadretaddr | Lreturn | Lentertrap
-      | Lpoptrap _ | Lop _ | Lcall_op _ | Llabel _ | Lbranch _
+      | Lprologue | Lepilogue_open | Lepilogue_close | Lreloadretaddr | Lreturn
+      | Lentertrap | Lpoptrap _ | Lop _ | Lcall_op _ | Llabel _ | Lbranch _
       | Lcondbranch (_, _)
       | Lcondbranch3 (_, _, _)
       | Lswitch _ | Ladjust_stack_offset _ | Lpushtrap _ | Lraise _
@@ -138,9 +139,10 @@ module Make (T : Branch_relaxation_intf.S) = struct
             instr.desc <- cont.desc;
             instr.next <- cont.next;
             fixup true pc instr
-          | Lprologue | Lepilogue | Lend | Lreloadretaddr | Lreturn | Lentertrap
-          | Lpoptrap _ | Lcall_op _ | Llabel _ | Lbranch _ | Lswitch _
-          | Ladjust_stack_offset _ | Lpushtrap _ | Lraise _ | Lstackcheck _
+          | Lprologue | Lepilogue_open | Lepilogue_close | Lend | Lreloadretaddr
+          | Lreturn | Lentertrap | Lpoptrap _ | Lcall_op _ | Llabel _
+          | Lbranch _ | Lswitch _ | Ladjust_stack_offset _ | Lpushtrap _
+          | Lraise _ | Lstackcheck _
           | Lop
               ( Move | Spill | Reload | Opaque | Pause | Begin_region
               | End_region | Dls_get | Const_int _ | Const_float32 _

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -277,6 +277,7 @@ let dump_basic ppf (basic : basic) =
   | Poptrap { lbl_handler } ->
     fprintf ppf "Poptrap handler=%a" Label.format lbl_handler
   | Prologue -> fprintf ppf "Prologue"
+  | Epilogue -> fprintf ppf "Epilogue"
   | Stack_check { max_frame_size_bytes } ->
     fprintf ppf "Stack_check size=%d" max_frame_size_bytes
 
@@ -479,7 +480,7 @@ let is_pure_basic : basic -> bool = function
     (* Those instructions modify the trap stack which actually modifies the
        stack pointer. *)
     false
-  | Prologue ->
+  | Prologue | Epilogue ->
     (* [Prologue] grows the stack when entering a function and therefore
        modifies the stack pointer. [Prologue] can be considered pure if it's
        ensured that it wouldn't modify the stack pointer (e.g. there are no used
@@ -511,7 +512,8 @@ let is_noop_move instr =
       | Opaque | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
       | Specific _ | Name_for_debugger _ | Begin_region | End_region | Dls_get
       | Poll | Alloc _ | Pause )
-  | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ ->
+  | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue | Stack_check _
+    ->
     false
 
 let set_stack_offset (instr : _ instruction) stack_offset =
@@ -593,7 +595,7 @@ let make_empty_block ?label terminator : basic_block =
 let is_poll (instr : basic instruction) =
   match instr.desc with
   | Op Poll -> true
-  | Reloadretaddr | Prologue | Pushtrap _ | Poptrap _ | Stack_check _
+  | Reloadretaddr | Prologue | Epilogue | Pushtrap _ | Poptrap _ | Stack_check _
   | Op
       ( Alloc _ | Move | Spill | Reload | Opaque | Pause | Begin_region
       | End_region | Dls_get | Const_int _ | Const_float32 _ | Const_float _
@@ -611,7 +613,7 @@ let is_poll (instr : basic instruction) =
 let is_alloc (instr : basic instruction) =
   match instr.desc with
   | Op (Alloc _) -> true
-  | Reloadretaddr | Prologue | Pushtrap _ | Poptrap _ | Stack_check _
+  | Reloadretaddr | Prologue | Epilogue | Pushtrap _ | Poptrap _ | Stack_check _
   | Op
       ( Poll | Move | Spill | Reload | Opaque | Begin_region | End_region
       | Dls_get | Pause | Const_int _ | Const_float32 _ | Const_float _
@@ -629,7 +631,7 @@ let is_alloc (instr : basic instruction) =
 let is_end_region (b : basic) =
   match b with
   | Op End_region -> true
-  | Reloadretaddr | Prologue | Pushtrap _ | Poptrap _ | Stack_check _
+  | Reloadretaddr | Prologue | Epilogue | Pushtrap _ | Poptrap _ | Stack_check _
   | Op
       ( Alloc _ | Poll | Move | Spill | Reload | Opaque | Begin_region | Dls_get
       | Pause | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
@@ -720,7 +722,7 @@ let remove_trap_instructions t removed_trap_handlers =
         | Csel _ | Static_cast _ | Reinterpret_cast _ | Probe_is_enabled _
         | Opaque | Begin_region | End_region | Specific _ | Name_for_debugger _
         | Dls_get | Poll | Alloc _ | Pause )
-    | Reloadretaddr | Prologue | Stack_check _ ->
+    | Reloadretaddr | Prologue | Epilogue | Stack_check _ ->
       update_basic_next (DLL.Cursor.next cursor) ~stack_offset
   and update_body r ~stack_offset =
     match r with

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -484,7 +484,8 @@ let is_pure_basic : basic -> bool = function
     (* [Prologue] grows the stack when entering a function and therefore
        modifies the stack pointer. [Prologue] can be considered pure if it's
        ensured that it wouldn't modify the stack pointer (e.g. there are no used
-       local stack slots nor calls). *)
+       local stack slots nor calls). [Epilogue] shrinks the stack when leaving a
+       function, and can also be considered pure under the same conditions. *)
     false
   | Stack_check _ ->
     (* May reallocate the stack. *)

--- a/backend/cfg/cfg_available_regs.ml
+++ b/backend/cfg/cfg_available_regs.ml
@@ -312,7 +312,8 @@ module Transfer = struct
             | Floatop _ | Csel _ | Reinterpret_cast _ | Static_cast _
             | Probe_is_enabled _ | Opaque | Begin_region | End_region
             | Specific _ | Dls_get | Poll | Alloc _ | Pause )
-        | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ ->
+        | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
+        | Stack_check _ ->
           let is_op_end_region = Cfg.is_end_region in
           common ~avail_before ~destroyed_at:Proc.destroyed_at_basic
             ~is_interesting_constructor:is_op_end_region
@@ -379,7 +380,7 @@ module Analysis = Cfg_dataflow.Forward (Domain) (Transfer)
 let get_name_for_debugger_regs (b : Cfg.basic) =
   match b with
   | Op (Name_for_debugger { regs; _ }) -> Some regs
-  | Reloadretaddr | Prologue | Pushtrap _ | Poptrap _ | Stack_check _
+  | Reloadretaddr | Prologue | Epilogue | Pushtrap _ | Poptrap _ | Stack_check _
   | Op
       ( Move | Spill | Reload | Opaque | Begin_region | End_region | Dls_get
       | Poll | Pause | Const_int _ | Const_float32 _ | Const_float _

--- a/backend/cfg/cfg_comballoc.ml
+++ b/backend/cfg/cfg_comballoc.ml
@@ -40,7 +40,8 @@ let rec find_next_allocation : cell option -> allocation option =
         | Static_cast _ | Probe_is_enabled _ | Opaque | Begin_region
         | End_region | Specific _ | Name_for_debugger _ | Dls_get | Poll | Pause
           )
-    | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ ->
+    | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
+    | Stack_check _ ->
       find_next_allocation (DLL.next cell))
 
 (* [find_compatible_allocations cell ~curr_mode ~curr_size] returns the
@@ -81,7 +82,8 @@ let find_compatible_allocations :
         | Local -> return ()
         | Heap -> loop allocations (DLL.next cell) ~curr_mode ~curr_size)
       | Op Poll -> return ()
-      | Reloadretaddr | Poptrap _ | Prologue | Pushtrap _ | Stack_check _ ->
+      | Reloadretaddr | Poptrap _ | Prologue | Epilogue | Pushtrap _
+      | Stack_check _ ->
         (* CR-soon xclerc for xclerc: is it too conservative? (note: only the
            `Pushtrap` case may be too conservative) *)
         { allocations = List.rev allocations; next_cell = Some cell }

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -351,7 +351,9 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
    fun state n cell ->
     let i = DLL.value cell in
     match i.desc with
-    | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ -> n
+    | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
+    | Stack_check _ ->
+      n
     | Op (Move | Spill | Reload) ->
       (* For moves, we associate the same value number to the result reg as to
          the argument reg. *)

--- a/backend/cfg/cfg_deadcode.ml
+++ b/backend/cfg/cfg_deadcode.ml
@@ -22,7 +22,8 @@ let remove_deadcode (body : Cfg.basic_instruction_list) changed liveness
         match instr.desc with
         | Op _ as op ->
           Cfg.is_pure_basic op && Reg.disjoint_set_array !used_after instr.res
-        | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ ->
+        | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
+        | Stack_check _ ->
           false
       in
       used_after := before;

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -119,6 +119,7 @@ module S = struct
     | Pushtrap of { lbl_handler : Label.t }
     | Poptrap of { lbl_handler : Label.t }
     | Prologue
+    | Epilogue
     | Stack_check of { max_frame_size_bytes : int }
 
   type 'a with_label_after =

--- a/backend/cfg/cfg_invariants.ml
+++ b/backend/cfg/cfg_invariants.ml
@@ -245,7 +245,7 @@ let check_stack_offset t label (block : Cfg.basic_block) =
             | Reinterpret_cast _ | Probe_is_enabled _ | Opaque | Begin_region
             | End_region | Specific _ | Name_for_debugger _ | Dls_get | Poll
             | Pause | Alloc _ )
-        | Reloadretaddr | Prologue | Stack_check _ ->
+        | Reloadretaddr | Prologue | Epilogue | Stack_check _ ->
           cur_stack_offset)
   in
   if not (Int.equal stack_offset_after_body terminator_stack_offset)

--- a/backend/cfg/cfg_liveness.ml
+++ b/backend/cfg/cfg_liveness.ml
@@ -55,8 +55,8 @@ module Transfer :
     Result.ok
     @@
     match instr.desc with
-    | Op _ | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _
-      ->
+    | Op _ | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
+    | Stack_check _ ->
       if Cfg.is_pure_basic instr.desc && Reg.disjoint_set_array before instr.res
       then
         (* If the operation is without side-effects and the result is unused

--- a/backend/cfg/cfg_polling.ml
+++ b/backend/cfg/cfg_polling.ml
@@ -198,7 +198,8 @@ module Polls_before_prtc_transfer = struct
         | Floatop (_, _)
         | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
         | Specific _ | Name_for_debugger _ )
-    | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ ->
+    | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
+    | Stack_check _ ->
       Ok dom
 
   let terminator :
@@ -360,7 +361,9 @@ let add_poll_or_alloc_basic :
       points
     | Poll -> (Poll, instr.dbg) :: points
     | Alloc _ -> (Alloc, instr.dbg) :: points)
-  | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ -> points
+  | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue | Stack_check _
+    ->
+    points
 
 let add_calls_terminator :
     Cfg.terminator Cfg.instruction -> polling_points -> polling_points =

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -9,8 +9,8 @@ let add_prologue_if_required : Cfg_with_layout.t -> Cfg_with_layout.t =
     Proc.prologue_required ~fun_contains_calls:cfg.fun_contains_calls
       ~fun_num_stack_slots:cfg.fun_num_stack_slots
   in
-  (if prologue_required
-  then
+  if prologue_required
+  then (
     let entry_block = Cfg.get_block_exn cfg cfg.entry_label in
     let next_instr =
       Option.value (DLL.hd entry_block.body)
@@ -19,7 +19,24 @@ let add_prologue_if_required : Cfg_with_layout.t -> Cfg_with_layout.t =
     DLL.add_begin entry_block.body
       (Cfg.make_instruction_from_copy next_instr ~desc:Cfg.Prologue
          ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
-         ()));
+         ());
+    let add_epilogue (block : Cfg.basic_block) =
+      DLL.add_end block.body
+        (Cfg.make_instruction_from_copy next_instr ~desc:Cfg.Epilogue
+           ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
+           ())
+    in
+    Cfg.iter_blocks cfg ~f:(fun _label block ->
+        match block.terminator.desc with
+        | Cfg.Return | Tailcall_func Indirect -> add_epilogue block
+        | Tailcall_func (Direct func)
+          when not (String.equal func.sym_name cfg.fun_name) ->
+          add_epilogue block
+        | Tailcall_func (Direct _)
+        | Tailcall_self _ | Never | Always _ | Parity_test _ | Truth_test _
+        | Float_test _ | Int_test _ | Switch _ | Raise _ | Call_no_return _
+        | Prim _ | Call _ ->
+          ()));
   cfg_with_layout
 
 let run : Cfg_with_layout.t -> Cfg_with_layout.t =

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -11,18 +11,22 @@ let add_prologue_if_required : Cfg_with_layout.t -> Cfg_with_layout.t =
   in
   if prologue_required
   then (
+    let terminator_as_basic terminator =
+      { terminator with Cfg.desc = Cfg.Prologue }
+    in
     let entry_block = Cfg.get_block_exn cfg cfg.entry_label in
     let next_instr =
       Option.value (DLL.hd entry_block.body)
-        ~default:{ entry_block.terminator with desc = Cfg.Prologue }
+        ~default:(terminator_as_basic entry_block.terminator)
     in
     DLL.add_begin entry_block.body
       (Cfg.make_instruction_from_copy next_instr ~desc:Cfg.Prologue
          ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
          ());
     let add_epilogue (block : Cfg.basic_block) =
+      let terminator = terminator_as_basic block.terminator in
       DLL.add_end block.body
-        (Cfg.make_instruction_from_copy next_instr ~desc:Cfg.Epilogue
+        (Cfg.make_instruction_from_copy terminator ~desc:Cfg.Epilogue
            ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
            ())
     in

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -117,7 +117,8 @@ let cross_section cfg_with_layout src dst =
 
 let linearize_terminator cfg_with_layout (func : string) start
     (terminator : Cfg.terminator Cfg.instruction)
-    ~(next : Linear_utils.labelled_insn) : L.instruction * Label.t option =
+    ~(next : Linear_utils.labelled_insn) ~has_epilogue :
+    L.instruction * Label.t option =
   (* CR-someday gyorsh: refactor, a lot of redundant code for different cases *)
   (* CR-someday gyorsh: for successor labels that are not fallthrough, order of
      branch instructions should depend on perf data and possibly the relative
@@ -330,10 +331,24 @@ let linearize_terminator cfg_with_layout (func : string) start
             None )
       | _ -> assert false)
   in
-  ( List.fold_left
-      (fun next desc -> to_linear_instr ~like:terminator desc ~next)
-      next.insn (List.rev desc_list),
-    tailrec_label )
+  let desc_list =
+    match has_epilogue with
+    | true -> desc_list @ [L.Lepilogue_close]
+    | false -> desc_list
+  in
+  let instr =
+    List.fold_left
+      (fun next desc ->
+        let instr = to_linear_instr desc ~next ~like:terminator in
+        match has_epilogue with
+        (* In order to match the debug info generated when the epilogue was not
+           a linear instruction, we need to explicitly remove debug info, as
+           they were already added to Lepilogue_open. *)
+        | true -> { instr with L.dbg = Debuginfo.none }
+        | false -> instr)
+      next.insn (List.rev desc_list)
+  in
+  instr, tailrec_label
 
 let need_starting_label (cfg_with_layout : CL.t) (block : Cfg.basic_block)
     ~(prev_block : Cfg.basic_block) =
@@ -399,16 +414,9 @@ let run cfg_with_layout =
               | Cfg.Epilogue -> true
               | _ -> false)
         in
-        if has_epilogue
-        then
-          next
-            := { Linear_utils.label = Label.none;
-                 insn = to_linear_instr Lepilogue_close ~next:!next.insn
-               }
-        else ();
         let terminator, terminator_tailrec_label =
           linearize_terminator cfg_with_layout cfg.fun_name block.start
-            block.terminator ~next:!next
+            block.terminator ~next:!next ~has_epilogue
         in
         (match !tailrec_label, terminator_tailrec_label with
         | (Some _ | None), None -> ()

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -333,7 +333,12 @@ let linearize_terminator cfg_with_layout (func : string) start
   in
   let desc_list =
     match has_epilogue with
-    | true -> desc_list @ [L.Lepilogue_close]
+    | true ->
+      (* The corresponding [Lepilogue_open] was already added when converting
+         the body of the block, replacing a [Cfg.Epilogue] instruction. The
+         [Lepilogue_open] should be the last instruction in the block body,
+         immediately preceding the terminator. *)
+      desc_list @ [L.Lepilogue_close]
     | false -> desc_list
   in
   let instr =

--- a/backend/cfg/cfg_to_linear_desc.ml
+++ b/backend/cfg/cfg_to_linear_desc.ml
@@ -6,6 +6,10 @@ open! Int_replace_polymorphic_compare [@@warning "-66"]
 let from_basic (basic : basic) : Linear.instruction_desc =
   match basic with
   | Prologue -> Lprologue
+  (* [Epilogue] is changed into [Lepilogue_open], which is not complete. The
+     corresponding [Lepilogue_close] is added in
+     [Cfg_to_linear.linearize_terminator], as it needs to come after the
+     terminator instruction. *)
   | Epilogue -> Lepilogue_open
   | Reloadretaddr -> Lreloadretaddr
   | Pushtrap { lbl_handler } -> Lpushtrap { lbl_handler }

--- a/backend/cfg/cfg_to_linear_desc.ml
+++ b/backend/cfg/cfg_to_linear_desc.ml
@@ -6,6 +6,7 @@ open! Int_replace_polymorphic_compare [@@warning "-66"]
 let from_basic (basic : basic) : Linear.instruction_desc =
   match basic with
   | Prologue -> Lprologue
+  | Epilogue -> Lepilogue
   | Reloadretaddr -> Lreloadretaddr
   | Pushtrap { lbl_handler } -> Lpushtrap { lbl_handler }
   | Poptrap { lbl_handler } -> Lpoptrap { lbl_handler }

--- a/backend/cfg/cfg_to_linear_desc.ml
+++ b/backend/cfg/cfg_to_linear_desc.ml
@@ -6,7 +6,7 @@ open! Int_replace_polymorphic_compare [@@warning "-66"]
 let from_basic (basic : basic) : Linear.instruction_desc =
   match basic with
   | Prologue -> Lprologue
-  | Epilogue -> Lepilogue
+  | Epilogue -> Lepilogue_open
   | Reloadretaddr -> Lreloadretaddr
   | Pushtrap { lbl_handler } -> Lpushtrap { lbl_handler }
   | Poptrap { lbl_handler } -> Lpoptrap { lbl_handler }

--- a/backend/cfg/linear_utils.ml
+++ b/backend/cfg/linear_utils.ml
@@ -38,7 +38,7 @@ let rec defines_label (i : Linear.instruction) =
   match i.desc with
   | Lend | Llabel _ -> true
   | Ladjust_stack_offset _ -> defines_label i.next
-  | Lprologue | Lop _ | Lcall_op _ | Lreloadretaddr | Lreturn | Lbranch _
-  | Lcondbranch _ | Lcondbranch3 _ | Lswitch _ | Lentertrap | Lpushtrap _
-  | Lpoptrap _ | Lraise _ | Lstackcheck _ ->
+  | Lprologue | Lepilogue | Lop _ | Lcall_op _ | Lreloadretaddr | Lreturn
+  | Lbranch _ | Lcondbranch _ | Lcondbranch3 _ | Lswitch _ | Lentertrap
+  | Lpushtrap _ | Lpoptrap _ | Lraise _ | Lstackcheck _ ->
     false

--- a/backend/cfg/linear_utils.ml
+++ b/backend/cfg/linear_utils.ml
@@ -38,7 +38,8 @@ let rec defines_label (i : Linear.instruction) =
   match i.desc with
   | Lend | Llabel _ -> true
   | Ladjust_stack_offset _ -> defines_label i.next
-  | Lprologue | Lepilogue | Lop _ | Lcall_op _ | Lreloadretaddr | Lreturn
-  | Lbranch _ | Lcondbranch _ | Lcondbranch3 _ | Lswitch _ | Lentertrap
-  | Lpushtrap _ | Lpoptrap _ | Lraise _ | Lstackcheck _ ->
+  | Lprologue | Lepilogue_open | Lepilogue_close | Lop _ | Lcall_op _
+  | Lreloadretaddr | Lreturn | Lbranch _ | Lcondbranch _ | Lcondbranch3 _
+  | Lswitch _ | Lentertrap | Lpushtrap _ | Lpoptrap _ | Lraise _ | Lstackcheck _
+    ->
     false

--- a/backend/cfg/llvmize.ml
+++ b/backend/cfg/llvmize.ml
@@ -986,7 +986,7 @@ module F = struct
     pp_dbg_instr_basic t.ppf i;
     match i.desc with
     | Op op -> basic_op t i op
-    | Prologue | Reloadretaddr -> ()
+    | Prologue | Epilogue | Reloadretaddr -> ()
     | Poptrap _ | Pushtrap _ | Stack_check _ -> not_implemented_basic i
 
   (* == Cfg data items == *)

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -131,7 +131,8 @@ let is_last_instruction_const_int (body : C.basic C.instruction Dll.t) :
   | Some { desc = Op (Const_int const); res = [| reg |]; _ } -> Some (const, reg)
   | Some
       { desc =
-          ( Reloadretaddr | Prologue | Pushtrap _ | Poptrap _ | Stack_check _
+          ( Reloadretaddr | Prologue | Epilogue | Pushtrap _ | Poptrap _
+          | Stack_check _
           | Op
               ( Const_int _ | Move | Spill | Reload | Opaque | Begin_region
               | End_region | Dls_get | Poll | Pause | Const_float _

--- a/backend/cfg/vectorize.ml
+++ b/backend/cfg/vectorize.ml
@@ -226,7 +226,8 @@ end = struct
       let desc = basic_instruction.desc in
       match desc with
       | Op op -> Some op
-      | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ ->
+      | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
+      | Stack_check _ ->
         None)
     | Terminator _ -> None
 

--- a/backend/debug/available_ranges_vars.ml
+++ b/backend/debug/available_ranges_vars.ml
@@ -72,9 +72,10 @@ module Vars = struct
         | Lpushtrap _ -> t.stack_offset + Proc.trap_frame_size_in_bytes
         | Lpoptrap _ -> t.stack_offset - Proc.trap_frame_size_in_bytes
         | Ladjust_stack_offset { delta_bytes } -> t.stack_offset + delta_bytes
-        | Lend | Lprologue | Lepilogue | Lop _ | Lcall_op _ | Lreloadretaddr
-        | Lreturn | Llabel _ | Lbranch _ | Lcondbranch _ | Lcondbranch3 _
-        | Lswitch _ | Lentertrap | Lraise _ | Lstackcheck _ ->
+        | Lend | Lprologue | Lepilogue_open | Lepilogue_close | Lop _
+        | Lcall_op _ | Lreloadretaddr | Lreturn | Llabel _ | Lbranch _
+        | Lcondbranch _ | Lcondbranch3 _ | Lswitch _ | Lentertrap | Lraise _
+        | Lstackcheck _ ->
           t.stack_offset
       in
       { stack_offset }

--- a/backend/debug/available_ranges_vars.ml
+++ b/backend/debug/available_ranges_vars.ml
@@ -72,9 +72,9 @@ module Vars = struct
         | Lpushtrap _ -> t.stack_offset + Proc.trap_frame_size_in_bytes
         | Lpoptrap _ -> t.stack_offset - Proc.trap_frame_size_in_bytes
         | Ladjust_stack_offset { delta_bytes } -> t.stack_offset + delta_bytes
-        | Lend | Lprologue | Lop _ | Lcall_op _ | Lreloadretaddr | Lreturn
-        | Llabel _ | Lbranch _ | Lcondbranch _ | Lcondbranch3 _ | Lswitch _
-        | Lentertrap | Lraise _ | Lstackcheck _ ->
+        | Lend | Lprologue | Lepilogue | Lop _ | Lcall_op _ | Lreloadretaddr
+        | Lreturn | Llabel _ | Lbranch _ | Lcondbranch _ | Lcondbranch3 _
+        | Lswitch _ | Lentertrap | Lraise _ | Lstackcheck _ ->
           t.stack_offset
       in
       { stack_offset }

--- a/backend/debug/compute_ranges.ml
+++ b/backend/debug/compute_ranges.ml
@@ -513,10 +513,10 @@ module Make (S : Compute_ranges_intf.S_functor) = struct
               KS.print should_be_open KS.print currently_open_subranges));
     match insn.desc with
     | Lend -> first_insn
-    | Lprologue | Lepilogue | Lop _ | Lcall_op _ | Lreloadretaddr | Lreturn
-    | Llabel _ | Lbranch _ | Lcondbranch _ | Lcondbranch3 _ | Lswitch _
-    | Lentertrap | Lpushtrap _ | Lpoptrap _ | Ladjust_stack_offset _ | Lraise _
-    | Lstackcheck _ ->
+    | Lprologue | Lepilogue_open | Lepilogue_close | Lop _ | Lcall_op _
+    | Lreloadretaddr | Lreturn | Llabel _ | Lbranch _ | Lcondbranch _
+    | Lcondbranch3 _ | Lswitch _ | Lentertrap | Lpushtrap _ | Lpoptrap _
+    | Ladjust_stack_offset _ | Lraise _ | Lstackcheck _ ->
       let subrange_state =
         Subrange_state.advance_over_instruction subrange_state insn
       in

--- a/backend/debug/compute_ranges.ml
+++ b/backend/debug/compute_ranges.ml
@@ -513,9 +513,9 @@ module Make (S : Compute_ranges_intf.S_functor) = struct
               KS.print should_be_open KS.print currently_open_subranges));
     match insn.desc with
     | Lend -> first_insn
-    | Lprologue | Lop _ | Lcall_op _ | Lreloadretaddr | Lreturn | Llabel _
-    | Lbranch _ | Lcondbranch _ | Lcondbranch3 _ | Lswitch _ | Lentertrap
-    | Lpushtrap _ | Lpoptrap _ | Ladjust_stack_offset _ | Lraise _
+    | Lprologue | Lepilogue | Lop _ | Lcall_op _ | Lreloadretaddr | Lreturn
+    | Llabel _ | Lbranch _ | Lcondbranch _ | Lcondbranch3 _ | Lswitch _
+    | Lentertrap | Lpushtrap _ | Lpoptrap _ | Ladjust_stack_offset _ | Lraise _
     | Lstackcheck _ ->
       let subrange_state =
         Subrange_state.advance_over_instruction subrange_state insn

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -525,7 +525,7 @@ let preproc_stack_check ~fun_body ~frame_size ~trap_size =
       let s = fs + n in
       loop i.next s (max s max_fs) nontail_flag
     | Lcall_op (Lcall_ind | Lcall_imm _) -> loop i.next fs max_fs true
-    | Lprologue
+    | Lprologue | Lepilogue
     | Lop
         ( Move | Spill | Reload | Opaque | Begin_region | End_region | Dls_get
         | Poll | Pause | Const_int _ | Const_float32 _ | Const_float _

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -525,7 +525,7 @@ let preproc_stack_check ~fun_body ~frame_size ~trap_size =
       let s = fs + n in
       loop i.next s (max s max_fs) nontail_flag
     | Lcall_op (Lcall_ind | Lcall_imm _) -> loop i.next fs max_fs true
-    | Lprologue | Lepilogue
+    | Lprologue | Lepilogue_open | Lepilogue_close
     | Lop
         ( Move | Spill | Reload | Opaque | Begin_region | End_region | Dls_get
         | Poll | Pause | Const_int _ | Const_float32 _ | Const_float _

--- a/backend/linear.ml
+++ b/backend/linear.ml
@@ -35,7 +35,8 @@ type instruction =
 
 and instruction_desc =
   | Lprologue
-  | Lepilogue
+  | Lepilogue_open
+  | Lepilogue_close
   | Lend
   | Lop of Operation.t
   | Lcall_op of call_operation
@@ -79,10 +80,11 @@ and call_operation =
 let has_fallthrough = function
   | Lreturn | Lbranch _ | Lswitch _ | Lraise _
   | Lcall_op Ltailcall_ind
-  | Lcall_op (Ltailcall_imm _) ->
+  | Lcall_op (Ltailcall_imm _)
+  | Lepilogue_close ->
     false
   | Lcall_op (Lcall_ind | Lcall_imm _ | Lextcall _ | Lprobe _)
-  | Lprologue | Lepilogue | Lend | Lreloadretaddr | Lentertrap | Lpoptrap _
+  | Lprologue | Lepilogue_open | Lend | Lreloadretaddr | Lentertrap | Lpoptrap _
   | Lop _ | Llabel _
   | Lcondbranch (_, _)
   | Lcondbranch3 (_, _, _)

--- a/backend/linear.ml
+++ b/backend/linear.ml
@@ -35,6 +35,7 @@ type instruction =
 
 and instruction_desc =
   | Lprologue
+  | Lepilogue
   | Lend
   | Lop of Operation.t
   | Lcall_op of call_operation
@@ -81,8 +82,8 @@ let has_fallthrough = function
   | Lcall_op (Ltailcall_imm _) ->
     false
   | Lcall_op (Lcall_ind | Lcall_imm _ | Lextcall _ | Lprobe _)
-  | Lprologue | Lend | Lreloadretaddr | Lentertrap | Lpoptrap _ | Lop _
-  | Llabel _
+  | Lprologue | Lepilogue | Lend | Lreloadretaddr | Lentertrap | Lpoptrap _
+  | Lop _ | Llabel _
   | Lcondbranch (_, _)
   | Lcondbranch3 (_, _, _)
   | Ladjust_stack_offset _ | Lpushtrap _ | Lstackcheck _ ->

--- a/backend/linear.mli
+++ b/backend/linear.mli
@@ -35,6 +35,7 @@ type instruction =
 
 and instruction_desc =
   | Lprologue
+  | Lepilogue
   | Lend
   | Lop of Operation.t
   | Lcall_op of call_operation

--- a/backend/linear.mli
+++ b/backend/linear.mli
@@ -35,7 +35,8 @@ type instruction =
 
 and instruction_desc =
   | Lprologue
-  | Lepilogue
+  | Lepilogue_open
+  | Lepilogue_close
   | Lend
   | Lop of Operation.t
   | Lcall_op of call_operation

--- a/backend/linear.mli
+++ b/backend/linear.mli
@@ -35,6 +35,17 @@ type instruction =
 
 and instruction_desc =
   | Lprologue
+    (* [Lepilogue_open] and [Lepilogue_close] shrink the stack on exiting a
+       function. They are split so that the terminator can be emitted between
+       them, to maintain the correct debug information.
+
+       [Lepilogue_open] reverts the stack pointer and adjusts the CFA offset in
+       preparation for the function ending, and [Lepilogue_close] adjusts the
+       CFA offset back in case the function continues.
+
+       The two instructions should be paired together, with the terminator
+       between them. Any additional instructions between them that affect the
+       stack pointer and/or CFA will likely cause incorrect results. *)
   | Lepilogue_open
   | Lepilogue_close
   | Lend

--- a/backend/printlinear.ml
+++ b/backend/printlinear.ml
@@ -81,6 +81,7 @@ let instr' ?(print_reg = Printreg.reg) ppf i =
   (match i.desc with
   | Lend -> ()
   | Lprologue -> fprintf ppf "prologue"
+  | Lepilogue -> fprintf ppf "epilogue"
   | Lop op ->
     (match[@warning "-4"] op with
     | Alloc _ | Poll -> fprintf ppf "@[<1>{%a}@]@," regsetaddr i.live

--- a/backend/printlinear.ml
+++ b/backend/printlinear.ml
@@ -81,7 +81,8 @@ let instr' ?(print_reg = Printreg.reg) ppf i =
   (match i.desc with
   | Lend -> ()
   | Lprologue -> fprintf ppf "prologue"
-  | Lepilogue -> fprintf ppf "epilogue"
+  | Lepilogue_open -> fprintf ppf "epilogue_open"
+  | Lepilogue_close -> fprintf ppf "epilogue_close"
   | Lop op ->
     (match[@warning "-4"] op with
     | Alloc _ | Poll -> fprintf ppf "@[<1>{%a}@]@," regsetaddr i.live

--- a/backend/regalloc/regalloc_invariants.ml
+++ b/backend/regalloc/regalloc_invariants.ml
@@ -22,7 +22,9 @@ let precondition : Cfg_with_layout.t -> unit =
       | Opaque | Begin_region | End_region | Specific _ | Name_for_debugger _
       | Dls_get | Poll | Pause | Alloc _ ->
         ())
-    | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ -> ()
+    | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
+    | Stack_check _ ->
+      ()
   in
   let register_must_not_be_on_stack (id : InstructionId.t) (reg : Reg.t) : unit
       =
@@ -97,7 +99,8 @@ let postcondition_layout : Cfg_with_layout.t -> unit =
         then
           fatal "instruction %a is a move and refers to %d spilling slots"
             InstructionId.format id num_locals
-      | Reloadretaddr | Prologue | Pushtrap _ | Poptrap _ | Stack_check _
+      | Reloadretaddr | Prologue | Epilogue | Pushtrap _ | Poptrap _
+      | Stack_check _
       | Op
           ( Move | Opaque | Begin_region | End_region | Dls_get | Poll | Pause
           | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _

--- a/backend/regalloc/regalloc_irc_utils.ml
+++ b/backend/regalloc/regalloc_irc_utils.ml
@@ -173,7 +173,9 @@ let is_move_basic : Cfg.basic -> bool =
     | Poll -> false
     | Pause -> false
     | Alloc _ -> false)
-  | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Stack_check _ -> false
+  | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue | Stack_check _
+    ->
+    false
 
 let is_move_instruction : Cfg.basic Cfg.instruction -> bool =
  fun instr -> is_move_basic instr.desc

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -85,7 +85,8 @@ let coalesce_temp_spills_and_reloads (block : Cfg.basic_block)
       match Reg.Tbl.find_opt var_to_block_temp var with
       | None -> Reg.Tbl.add var_to_block_temp var temp
       | Some block_temp -> replace temp block_temp)
-    | Reloadretaddr | Prologue | Pushtrap _ | Poptrap _ | Stack_check _
+    | Reloadretaddr | Prologue | Epilogue | Pushtrap _ | Poptrap _
+    | Stack_check _
     | Op
         ( Move | Opaque | Begin_region | End_region | Dls_get | Poll | Pause
         | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -489,14 +489,7 @@ end = struct
     with
     (* The instruction was present before. *)
     | Some { instr = old_instr; successor_id = old_successor_id }, false ->
-      (* CR cfalas: clean this up *)
-      let successor_instr = Hashtbl.find_opt t.instructions old_successor_id in
-      if not
-           (InstructionId.equal old_successor_id successor_id
-           ||
-           match successor_instr with
-           | Some { instr = { desc = Epilogue; _ }; _ } -> true
-           | _ -> false)
+      if not (InstructionId.equal old_successor_id successor_id)
       then
         Regalloc_utils.fatal
           "The instruction's no. %a successor id has changed. Before \

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -489,7 +489,14 @@ end = struct
     with
     (* The instruction was present before. *)
     | Some { instr = old_instr; successor_id = old_successor_id }, false ->
-      if not (InstructionId.equal old_successor_id successor_id)
+      (* CR cfalas: clean this up *)
+      let successor_instr = Hashtbl.find_opt t.instructions old_successor_id in
+      if not
+           (InstructionId.equal old_successor_id successor_id
+           ||
+           match successor_instr with
+           | Some { instr = { desc = Epilogue; _ }; _ } -> true
+           | _ -> false)
       then
         Regalloc_utils.fatal
           "The instruction's no. %a successor id has changed. Before \

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -545,7 +545,7 @@ module Stack_offset_and_exn = struct
         | Csel _ | Static_cast _ | Reinterpret_cast _ | Probe_is_enabled _
         | Opaque | Begin_region | End_region | Specific _ | Name_for_debugger _
         | Dls_get | Poll | Pause | Alloc _ )
-    | Reloadretaddr | Prologue ->
+    | Reloadretaddr | Prologue | Epilogue ->
       stack_offset, traps
     | Stack_check _ ->
       Misc.fatal_error

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -2625,7 +2625,7 @@ end = struct
           (* treated as no-op here, flow and handling of exceptions is
              incorporated into the blocks and edges of the CFG *)
           Ok next
-        | Reloadretaddr | Prologue | Stack_check _ -> Ok next
+        | Reloadretaddr | Prologue | Epilogue | Stack_check _ -> Ok next
 
       let terminator next ~exn (i : Cfg.terminator Cfg.instruction) t =
         let dbg = i.dbg in


### PR DESCRIPTION
Currently, epilogues are only added when instructions are being emitted. This PR creates an `Epilogue` Cfg basic instruction and `Lepilogue_open` and `Lepilogue_closed` linear instructions, to facilitate shrink-wrapping at the CFG level.

Tested that on x86 there is no diff when running `tools/diff_compiler_version.sh` against 56c7b45c00b3589c06f29cb40d700e4a26d892e8, but haven't tested on arm.