### PR TITLE
Extend `Tpat_var` and `Tpat_alias` to contain a sort

### DIFF
--- a/chamelon/compat.ox.ml
+++ b/chamelon/compat.ox.ml
@@ -4,6 +4,7 @@ open Mode
 
 let dummy_jkind = Jkind.Builtin.value ~why:(Unknown "dummy_layout")
 let dummy_value_mode = Value.disallow_right Value.legacy
+let dummy_value_sort = Jkind.Sort.value
 
 let dummy_alloc_mode =
   { mode = Alloc.disallow_left Alloc.legacy; locality_context = None }
@@ -294,15 +295,16 @@ let mkpattern_data ~pat_desc ~pat_loc ~pat_extra ~pat_type ~pat_env
     pat_unique_barrier = Unique_barrier.not_computed ();
   }
 
-type tpat_var_identifier = Value.l
+type tpat_var_identifier = Jkind.Sort.t * Value.l
 
-let mkTpat_var ?id:(mode = dummy_value_mode) (ident, name) =
-  Tpat_var (ident, name, Uid.internal_not_actually_unique, mode)
+let mkTpat_var ?id:(sort, mode = (dummy_value_sort, dummy_value_mode))
+    (ident, name) =
+  Tpat_var (ident, name, Uid.internal_not_actually_unique, sort, mode)
 
-type tpat_alias_identifier = Value.l * Types.type_expr
+type tpat_alias_identifier = Jkind.Sort.t * Value.l * Types.type_expr
 
-let mkTpat_alias ~id:(mode, ty) (p, ident, name) =
-  Tpat_alias (p, ident, name, Uid.internal_not_actually_unique, mode, ty)
+let mkTpat_alias ~id:(sort, mode, ty) (p, ident, name) =
+  Tpat_alias (p, ident, name, Uid.internal_not_actually_unique, sort, mode, ty)
 
 type tpat_array_identifier = mutability * Jkind.sort
 
@@ -342,9 +344,10 @@ type 'a matched_pattern_desc =
 
 let view_tpat (type a) (p : a pattern_desc) : a matched_pattern_desc =
   match p with
-  | Tpat_var (ident, name, _uid, mode) -> Tpat_var (ident, name, mode)
-  | Tpat_alias (p, ident, name, _uid, mode, ty) ->
-      Tpat_alias (p, ident, name, (mode, ty))
+  | Tpat_var (ident, name, _uid, sort, mode) ->
+      Tpat_var (ident, name, (sort, mode))
+  | Tpat_alias (p, ident, name, _uid, sort, mode, ty) ->
+      Tpat_alias (p, ident, name, (sort, mode, ty))
   | Tpat_array (mut, arg_sort, l) -> Tpat_array (l, (mut, arg_sort))
   | Tpat_tuple pats ->
       let labels, pats = List.split pats in

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1682,7 +1682,7 @@ and precompile_or ~arg ~arg_sort (cls : Simple.clause list) ors args def k =
             let patbound_action_vars =
               (* variables bound in the or-pattern
                  that are used in the orpm actions *)
-              Typedtree.pat_bound_idents_full arg_sort orp
+              Typedtree.pat_bound_idents_full orp
               |> List.filter (fun (id, _, _, _, _) -> Ident.Set.mem id pm_fv)
               |> List.map (fun (id, _, ty, uid, id_sort) ->
                   (id, uid, Typeopt.layout orp.pat_env orp.pat_loc id_sort ty))
@@ -4300,7 +4300,7 @@ let for_let ~scopes ~arg_sort ~return_layout loc param mutable_flag pat body =
   | _ ->
       let opt = ref false in
       let nraise = next_raise_count () in
-      let catch_ids = pat_bound_idents_full arg_sort pat in
+      let catch_ids = pat_bound_idents_full pat in
       let ids_with_kinds =
         List.map
           (fun (id, _, typ, uid, sort) ->

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -222,9 +222,9 @@ end = struct
     | Tpat_any
     | Tpat_var _ ->
         p
-    | Tpat_alias (q, id, s, uid, mode, ty) ->
+    | Tpat_alias (q, id, s, uid, sort, mode, ty) ->
         { p with pat_desc =
-            Tpat_alias (simpl_under_orpat q, id, s, uid, mode, ty) }
+            Tpat_alias (simpl_under_orpat q, id, s, uid, sort, mode, ty) }
     | Tpat_or (p1, p2, o) ->
         let p1, p2 = (simpl_under_orpat p1, simpl_under_orpat p2) in
         if le_pat p1 p2 then
@@ -250,9 +250,9 @@ end = struct
       in
       match p.pat_desc with
       | `Any -> stop p `Any
-      | `Var (id, s, uid, mode) ->
-        continue p (`Alias (Patterns.omega, id, s, uid, mode, p.pat_type))
-      | `Alias (p, id, _, duid, _, _) ->
+      | `Var (id, s, uid, sort, mode) ->
+        continue p (`Alias (Patterns.omega, id, s, uid, sort, mode, p.pat_type))
+      | `Alias (p, id, _, duid, _, _, _) ->
           aux
             ( (General.view p, patl),
               bind_alias p id duid ~arg ~arg_sort ~action )
@@ -359,11 +359,11 @@ end = struct
       match p.pat_desc with
       | `Or (p1, p2, _) ->
           split_explode p1 aliases (split_explode p2 aliases rem)
-      | `Alias (p, id, _, _, _, _) -> split_explode p (id :: aliases) rem
-      | `Var (id, str, uid, mode) ->
+      | `Alias (p, id, _, _, _, _, _) -> split_explode p (id :: aliases) rem
+      | `Var (id, str, uid, sort, mode) ->
           explode
             { p with pat_desc =
-                `Alias (Patterns.omega, id, str, uid, mode, p.pat_type) }
+                `Alias (Patterns.omega, id, str, uid, sort, mode, p.pat_type) }
             aliases rem
       | #view as view ->
           (* We are doing two things here:
@@ -611,7 +611,7 @@ end = struct
           match p.pat_desc with
           | `Or (p1, p2, _) ->
               filter_rec ((left, p1, right) :: (left, p2, right) :: rem)
-          | `Alias (p, _, _, _, _, _) -> filter_rec ((left, p, right) :: rem)
+          | `Alias (p, _, _, _, _, _, _) -> filter_rec ((left, p, right) :: rem)
           | `Var _ -> filter_rec ((left, Patterns.omega, right) :: rem)
           | #Simple.view as view -> (
               let p = { p with pat_desc = view } in
@@ -661,7 +661,7 @@ let rec flatten_pat_line size p k =
   | Tpat_tuple args -> (List.map snd args) :: k
   | Tpat_or (p1, p2, _) ->
       flatten_pat_line size p1 (flatten_pat_line size p2 k)
-  | Tpat_alias (p, _, _, _, _, _) ->
+  | Tpat_alias (p, _, _, _, _, _, _) ->
       (* Note: we are only called from flatten_matrix,
          which is itself only ever used in places
          where variables do not matter (default environments,
@@ -739,7 +739,7 @@ end = struct
       | (p, ps) :: rem -> (
           let p = General.view p in
           match p.pat_desc with
-          | `Alias (p, _, _, _, _, _) -> filter_rec ((p, ps) :: rem)
+          | `Alias (p, _, _, _, _, _, _) -> filter_rec ((p, ps) :: rem)
           | `Var _ -> filter_rec ((Patterns.omega, ps) :: rem)
           | `Or (p1, p2, _) -> filter_rec_or p1 p2 ps rem
           | #Simple.view as view -> (
@@ -1289,7 +1289,7 @@ let rec omega_like p =
   | Tpat_any
   | Tpat_var _ ->
       true
-  | Tpat_alias (p, _, _, _, _, _) -> omega_like p
+  | Tpat_alias (p, _, _, _, _, _, _) -> omega_like p
   | Tpat_or (p1, p2, _) -> omega_like p1 || omega_like p2
   | _ -> false
 
@@ -3733,8 +3733,8 @@ let rec comp_match_handlers layout comp_fun partial ctx first_match next_matches
 let rec name_pattern default = function
   | ((pat, _), _) :: rem -> (
       match pat.pat_desc with
-      | Tpat_var (id, _, uid, _) -> id, uid
-      | Tpat_alias (_, id, _, uid, _, _) -> id, uid
+      | Tpat_var (id, _, uid, _, _) -> id, uid
+      | Tpat_alias (_, id, _, uid, _, _, _) -> id, uid
       | _ -> name_pattern default rem
     )
   | _ -> Ident.create_local default, Lambda.debug_uid_none
@@ -4283,8 +4283,8 @@ let for_let ~scopes ~arg_sort ~return_layout loc param mutable_flag pat body =
       (* This eliminates a useless variable (and stack slot in bytecode)
          for "let _ = ...". See #6865. *)
       Lsequence (param, body)
-  | Tpat_var (id, _, duid, _)
-  | Tpat_alias ({ pat_desc = Tpat_any }, id, _, duid, _, _) ->
+  | Tpat_var (id, _, duid, _, _)
+  | Tpat_alias ({ pat_desc = Tpat_any }, id, _, duid, _, _, _) ->
       (* Fast path, and keep track of simple bindings to unboxable numbers.
 
          Note: the (Tpat_alias (Tpat_any, id)) case needs to be

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -155,8 +155,8 @@ let create_object cl obj init =
 
 let name_pattern default p =
   match p.pat_desc with
-  | Tpat_var (id, _, _, _) -> id
-  | Tpat_alias(_, id, _, _, _, _) -> id
+  | Tpat_var (id, _, _, _, _) -> id
+  | Tpat_alias(_, id, _, _, _, _, _) -> id
   | _ -> Ident.create_local default
 
 let rec build_object_init ~scopes cl_table obj params inh_init obj_init cl =

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1655,7 +1655,7 @@ and transl_tupled_function
             (transl_tupled_cases ~scopes return_sort pats_expr_list) partial
         in
         let region = region || not (may_allocate_in_region body) in
-        add_type_shapes_of_cases arg_sort cases;
+        add_type_shapes_of_cases cases;
         Some
           ((Tupled, tparams, return_layout, region, return_mode), body)
     with Matching.Cannot_flatten -> None
@@ -1676,9 +1676,9 @@ and transl_tupled_function
    expression.
 *)
 
-and add_type_shapes_of_pattern ~env sort pattern =
+and add_type_shapes_of_pattern ~env pattern =
   if !Clflags.debug && !Clflags.shape_format = Clflags.Debugging_shapes then
-    let var_list = Typedtree.pat_bound_idents_full sort pattern in
+    let var_list = Typedtree.pat_bound_idents_full pattern in
     List.iter (fun (_ident, _loc, type_expr, var_uid, var_sort) ->
       let type_name = Format.asprintf "%a" Printtyp.type_expr type_expr in
       Type_shape.add_to_type_shapes var_uid type_expr var_sort ~name:type_name
@@ -1688,9 +1688,9 @@ and add_type_shapes_of_pattern ~env sort pattern =
 (** [add_type_shapes_of_cases] iterates through a given list of cases and
     associates for each case, the debugging UID of the variable with the type
     expression of the variable and its sort. *)
-and add_type_shapes_of_cases sort cases =
+and add_type_shapes_of_cases cases =
   let add_case (case : Typedtree.value Typedtree.case) =
-    add_type_shapes_of_pattern ~env:case.c_lhs.pat_env sort case.c_lhs
+    add_type_shapes_of_pattern ~env:case.c_lhs.pat_env case.c_lhs
   in
   List.iter add_case cases
 
@@ -1703,8 +1703,7 @@ and add_type_shapes_of_params params =
                     | Tparam_pat p -> p
                     | Tparam_optional_default (p, _, _) -> p
       in
-      let sort = Jkind.Sort.default_for_transl_and_get param.fp_sort in
-      add_type_shapes_of_pattern ~env:pattern.pat_env sort pattern
+      add_type_shapes_of_pattern ~env:pattern.pat_env pattern
     in
     List.iter add_param params
 
@@ -1713,8 +1712,7 @@ and add_type_shapes_of_params params =
     with the type expression of the variable. *)
 and add_type_shapes_of_patterns patterns =
   let add_case (value_binding : Typedtree.value_binding) =
-    let sort = Jkind.Sort.default_for_transl_and_get value_binding.vb_sort in
-    add_type_shapes_of_pattern ~env:value_binding.vb_expr.exp_env sort
+    add_type_shapes_of_pattern ~env:value_binding.vb_expr.exp_env
       value_binding.vb_pat
   in
   List.iter add_case patterns
@@ -1752,7 +1750,7 @@ and transl_curried_function ~scopes loc repr params body
               layout_of_sort fc_loc fc_arg_sort
         in
         let arg_mode = transl_alloc_mode_l fc_arg_mode in
-        add_type_shapes_of_cases fc_arg_sort fc_cases;
+        add_type_shapes_of_cases fc_cases;
         let attributes =
           match fc_cases with
           | [ { c_lhs }] -> Translattribute.transl_param_attributes c_lhs
@@ -2483,7 +2481,7 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
         in
         (* Simplif doesn't like it if binders are not uniq, so we make sure to
            use different names in the value and the exception branches. *)
-        let ids_full = Typedtree.pat_bound_idents_full arg_sort pv in
+        let ids_full = Typedtree.pat_bound_idents_full pv in
         let ids = List.map (fun (id, _, _, _, _) -> id) ids_full in
         let ids_kinds =
           List.map (fun (id, {Location.loc; _}, ty, duid, s) ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -305,8 +305,8 @@ let fuse_method_arity (parent : fusable_function) : fusable_function =
 
 let rec iter_exn_names f pat =
   match pat.pat_desc with
-  | Tpat_var (id, _, _, _) -> f id
-  | Tpat_alias (p, id, _, _, _, _) ->
+  | Tpat_var (id, _, _, _, _) -> f id
+  | Tpat_alias (p, id, _, _, _, _, _) ->
       f id;
       iter_exn_names f p
   | _ -> ()
@@ -2021,7 +2021,7 @@ and transl_let ~scopes ~return_layout ?(add_regions=false) ?(in_structure=false)
       let idlist =
         List.map
           (fun {vb_pat=pat} -> match pat.pat_desc with
-              Tpat_var (id,_,uid,_) -> id, uid
+              Tpat_var (id,_,uid,_,_) -> id, uid
             | _ -> assert false)
         pat_expr_list in
       let transl_case

--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -50,8 +50,9 @@ module Typedtree_search =
 
     let iter_val_pattern = function
       | Typedtree.Tpat_any -> None
-      | Typedtree.Tpat_var (name, _, _, _)
-      | Typedtree.Tpat_alias (_, name, _, _, _, _)  -> Some (Name.from_ident name)
+      | Typedtree.Tpat_var (name, _, _, _, _)
+      | Typedtree.Tpat_alias (_, name, _, _, _, _, _) ->
+        Some (Name.from_ident name)
       | Typedtree.Tpat_tuple _ -> None (* FIXME when we will handle tuples *)
       | _ -> None
 
@@ -251,14 +252,14 @@ module Analyser =
     let tt_param_info_from_pattern env f_desc pat =
       let rec iter_pattern pat =
         match pat.pat_desc with
-          Typedtree.Tpat_var (ident, _, _, _) ->
+          Typedtree.Tpat_var (ident, _, _, _, _) ->
             let name = Name.from_ident ident in
             Simple_name { sn_name = name ;
                           sn_text = f_desc name ;
                           sn_type = Odoc_env.subst_type env pat.pat_type
                         }
 
-        | Typedtree.Tpat_alias (pat, _, _, _, _, _) ->
+        | Typedtree.Tpat_alias (pat, _, _, _, _, _, _) ->
             iter_pattern pat
 
         | Typedtree.Tpat_tuple patlist ->
@@ -334,7 +335,7 @@ module Analyser =
        let (pat, exp) = pat_exp in
        let comment_opt = Odoc_sig.analyze_alerts comment_opt attrs in
        match (pat.pat_desc, exp.exp_desc) with
-         (Tpat_var (ident, _, _, _), Texp_function { params; body; _ }) ->
+         (Tpat_var (ident, _, _, _, _), Texp_function { params; body; _ }) ->
            (* a new function is defined *)
            let name_pre = Name.from_ident ident in
            let name = Name.parens_if_infix name_pre in
@@ -360,7 +361,7 @@ module Analyser =
            in
            [ new_value ]
 
-       | (Typedtree.Tpat_var (ident, _, _, _), _) ->
+       | (Typedtree.Tpat_var (ident, _, _, _, _), _) ->
            (* a new value is defined *)
            let name_pre = Name.from_ident ident in
            let name = Name.parens_if_infix name_pre in
@@ -669,12 +670,14 @@ module Analyser =
               a default value. In this case, we look for the good parameter pattern *)
            let (parameter, next_tt_class_exp) =
              match pat.Typedtree.pat_desc with
-               Typedtree.Tpat_var (ident, _, _, _) when String.starts_with (Name.from_ident ident) ~prefix:"*opt*" ->
+               Typedtree.Tpat_var (ident, _, _, _, _)
+               when String.starts_with (Name.from_ident ident) ~prefix:"*opt*" ->
                  (
                   (* there must be a Tcl_let just after *)
                   match tt_class_expr2.Typedtree.cl_desc with
-                    Typedtree.Tcl_let (_, {vb_pat={pat_desc = Typedtree.Tpat_var (id,_,_,_) };
-                                           vb_expr=exp} :: _, _, tt_class_expr3) ->
+                    Typedtree.Tcl_let (_,
+                      {vb_pat={pat_desc = Typedtree.Tpat_var (id,_,_,_,_) };
+                       vb_expr=exp} :: _, _, tt_class_expr3) ->
                       let name = Name.from_ident id in
                       let new_param = Simple_name
                           { sn_name = name ;

--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -671,7 +671,8 @@ module Analyser =
            let (parameter, next_tt_class_exp) =
              match pat.Typedtree.pat_desc with
                Typedtree.Tpat_var (ident, _, _, _, _)
-               when String.starts_with (Name.from_ident ident) ~prefix:"*opt*" ->
+               when String.starts_with (Name.from_ident ident) ~prefix:"*opt*"
+                ->
                  (
                   (* there must be a Tcl_let just after *)
                   match tt_class_expr2.Typedtree.cl_desc with

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -89,6 +89,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
       <def_rec>
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
+          sort value
           value_mode global,many,portable,unyielding,stateful;imply(unique,uncontended,read_write)(modevar#3[aliased,contended,immutable .. unique,uncontended,read_write])
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
@@ -110,6 +111,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
               <case>
                 pattern (test_locations.ml[19,572+4]..test_locations.ml[19,572+5])
                   Tpat_var "n"
+                  sort value
                   value_mode global,many,portable,unyielding,stateless;unique,uncontended,read_write
                 expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+34])
                   Texp_apply

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -89,6 +89,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
       <def_rec>
         pattern 
           Tpat_var "fib"
+          sort value
           value_mode global,many,portable,unyielding,stateful;imply(unique,uncontended,read_write)(modevar#3[aliased,contended,immutable .. unique,uncontended,read_write])
         expression 
           Texp_function
@@ -110,6 +111,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
               <case>
                 pattern 
                   Tpat_var "n"
+                  sort value
                   value_mode global,many,portable,unyielding,stateless;unique,uncontended,read_write
                 expression 
                   Texp_apply

--- a/toplevel/native/opttoploop.ml
+++ b/toplevel/native/opttoploop.ml
@@ -354,7 +354,7 @@ let name_expression ~loc ~attrs sort exp =
   let pat =
     { pat_desc =
         Tpat_var(id, mknoloc name, vd.val_uid,
-          Jkind.Sort.value, (* Will be changed soon *)
+          Jkind.Sort.(of_const Const.for_module_field),
           Mode.Value.disallow_right Mode.Value.legacy);
       pat_loc = loc;
       pat_extra = [];

--- a/toplevel/native/opttoploop.ml
+++ b/toplevel/native/opttoploop.ml
@@ -352,7 +352,10 @@ let name_expression ~loc ~attrs sort exp =
   in
   let sg = [Sig_value(id, vd, Exported)] in
   let pat =
-    { pat_desc = Tpat_var(id, mknoloc name, vd.val_uid, Mode.Value.disallow_right Mode.Value.legacy);
+    { pat_desc =
+        Tpat_var(id, mknoloc name, vd.val_uid,
+          Jkind.Sort.value, (* Will be changed soon *)
+          Mode.Value.disallow_right Mode.Value.legacy);
       pat_loc = loc;
       pat_extra = [];
       pat_type = exp.exp_type;

--- a/typing/cmt2annot.ml
+++ b/typing/cmt2annot.ml
@@ -23,7 +23,7 @@ let variables_iterator scope =
   let super = default_iterator in
   let pat sub (type k) (p : k general_pattern) =
     begin match p.pat_desc with
-    | Tpat_var (id, _, _, _) | Tpat_alias (_, id, _, _, _, _) ->
+    | Tpat_var (id, _, _, _, _) | Tpat_alias (_, id, _, _, _, _, _) ->
         Stypes.record (Stypes.An_ident (p.pat_loc,
                                         Ident.name id,
                                         Annot.Idef scope))

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -139,6 +139,8 @@ module type Sort = sig
     val for_module_field : t
 
     val for_boxed_variant : t
+
+    val for_exception : t
   end
 
   module Var : sig

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -135,6 +135,10 @@ module type Sort = sig
     val for_loop_index : t
 
     val for_constructor : t
+
+    val for_module_field : t
+
+    val for_boxed_variant : t
   end
 
   module Var : sig

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -133,6 +133,8 @@ module type Sort = sig
     val for_idx : t
 
     val for_loop_index : t
+
+    val for_constructor : t
   end
 
   module Var : sig

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -131,6 +131,8 @@ module type Sort = sig
     val for_tuple : t
 
     val for_idx : t
+
+    val for_loop_index : t
   end
 
   module Var : sig

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -197,6 +197,8 @@ module Sort = struct
     let for_idx = bits64
 
     let for_loop_index = value
+
+    let for_constructor = value
   end
 
   module Var = struct

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -203,6 +203,8 @@ module Sort = struct
     let for_module_field = value
 
     let for_boxed_variant = value
+
+    let for_exception = value
   end
 
   module Var = struct

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -199,6 +199,10 @@ module Sort = struct
     let for_loop_index = value
 
     let for_constructor = value
+
+    let for_module_field = value
+
+    let for_boxed_variant = value
   end
 
   module Var = struct

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -195,6 +195,8 @@ module Sort = struct
     let for_list_element = value
 
     let for_idx = bits64
+
+    let for_loop_index = value
   end
 
   module Var = struct

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -62,7 +62,10 @@ let omega_list = Patterns.omega_list
 let extra_pat =
   make_pat
     (Tpat_var (Ident.create_local "+", mknoloc "+",
-      Uid.internal_not_actually_unique, Mode.Value.disallow_right Mode.Value.max))
+      Uid.internal_not_actually_unique,
+      (* CR jrayman: should be [for_*] *)
+      Jkind.Sort.value,
+      Mode.Value.disallow_right Mode.Value.max))
     Ctype.none Env.empty
 
 
@@ -335,8 +338,8 @@ module Compat
   | ((Tpat_any|Tpat_var _),_)
   | (_,(Tpat_any|Tpat_var _)) -> true
 (* Structural induction *)
-  | Tpat_alias (p,_,_,_,_,_),_      -> compat p q
-  | _,Tpat_alias (q,_,_,_,_,_)      -> compat p q
+  | Tpat_alias (p,_,_,_,_,_,_),_      -> compat p q
+  | _,Tpat_alias (q,_,_,_,_,_,_)      -> compat p q
   | Tpat_or (p1,p2,_),_ ->
       (compat p1 q || compat p2 q)
   | _,Tpat_or (q1,q2,_) ->
@@ -1059,7 +1062,9 @@ let build_other ext env =
           make_pat
             (Tpat_var (Ident.create_local "*extension*",
                        {txt="*extension*"; loc = d.pat_loc},
-                       Uid.internal_not_actually_unique, Mode.Value.disallow_right Mode.Value.max))
+                       Uid.internal_not_actually_unique,
+                       Jkind.Sort.(of_const Const.for_constructor),
+                       Mode.Value.disallow_right Mode.Value.max))
             Ctype.none Env.empty
       | Construct _ ->
           begin match ext with
@@ -1216,7 +1221,7 @@ let build_other ext env =
 let rec has_instance p = match p.pat_desc with
   | Tpat_variant (l,_,r) when is_absent l r -> false
   | Tpat_any | Tpat_var _ | Tpat_constant _ | Tpat_variant (_,None,_) -> true
-  | Tpat_alias (p,_,_,_,_,_) | Tpat_variant (_,Some p,_) -> has_instance p
+  | Tpat_alias (p,_,_,_,_,_,_) | Tpat_variant (_,Some p,_) -> has_instance p
   | Tpat_or (p1,p2,_) -> has_instance p1 || has_instance p2
   | Tpat_construct (_,_,ps, _) | Tpat_array (_, _, ps) ->
       has_instances ps
@@ -1676,7 +1681,7 @@ let is_var_column rs =
 (* Standard or-args for left-to-right matching *)
 let rec or_args p = match p.pat_desc with
 | Tpat_or (p1,p2,_) -> p1,p2
-| Tpat_alias (p,_,_,_,_,_)  -> or_args p
+| Tpat_alias (p,_,_,_,_,_,_)  -> or_args p
 | _                 -> assert false
 
 (* Just remove current column *)
@@ -1856,8 +1861,8 @@ and every_both pss qs q1 q2 =
 let rec le_pat p q =
   match (p.pat_desc, q.pat_desc) with
   | (Tpat_var _|Tpat_any),_ -> true
-  | Tpat_alias(p,_,_,_,_,_), _ -> le_pat p q
-  | _, Tpat_alias(q,_,_,_,_,_) -> le_pat p q
+  | Tpat_alias(p,_,_,_,_,_,_), _ -> le_pat p q
+  | _, Tpat_alias(q,_,_,_,_,_,_) -> le_pat p q
   | Tpat_constant(c1), Tpat_constant(c2) -> const_compare c1 c2 = 0
   | Tpat_construct(_,c1,ps,_), Tpat_construct(_,c2,qs,_) ->
       Types.equal_tag c1.cstr_tag c2.cstr_tag && le_pats ps qs
@@ -1917,8 +1922,8 @@ let get_mins le ps =
 *)
 
 let rec lub p q = match p.pat_desc,q.pat_desc with
-| Tpat_alias (p,_,_,_,_,_),_      -> lub p q
-| _,Tpat_alias (q,_,_,_,_,_)      -> lub p q
+| Tpat_alias (p,_,_,_,_,_,_),_      -> lub p q
+| _,Tpat_alias (q,_,_,_,_,_,_)      -> lub p q
 | (Tpat_any|Tpat_var _),_ -> q
 | _,(Tpat_any|Tpat_var _) -> p
 | Tpat_or (p1,p2,_),_     -> orlub p1 p2 q
@@ -2059,7 +2064,7 @@ let rec initial_only_guarded = function
 let contains_extension pat =
   exists_pattern
     (function
-     | {pat_desc=Tpat_var (_, {txt="*extension*"}, _, _)} -> true
+     | {pat_desc=Tpat_var (_, {txt="*extension*"}, _, _, _)} -> true
      | _ -> false)
     pat
 
@@ -2150,7 +2155,7 @@ let rec collect_paths_from_pat r p = match p.pat_desc with
     List.fold_left
       (fun r (_, _, p) -> collect_paths_from_pat r p)
       r lps
-| Tpat_variant (_, Some p, _) | Tpat_alias (p,_,_,_,_,_) ->
+| Tpat_variant (_, Some p, _) | Tpat_alias (p,_,_,_,_,_,_) ->
     collect_paths_from_pat r p
 | Tpat_or (p1,p2,_) ->
     collect_paths_from_pat (collect_paths_from_pat r p1) p2
@@ -2290,7 +2295,7 @@ let inactive ~partial pat =
             List.for_all (fun (_,p,_) -> loop p) ps
         | Tpat_construct (_, _, ps, _) | Tpat_array (Immutable, _, ps) ->
             List.for_all (fun p -> loop p) ps
-        | Tpat_alias (p,_,_,_,_,_) | Tpat_variant (_, Some p, _) ->
+        | Tpat_alias (p,_,_,_,_,_,_) | Tpat_variant (_, Some p, _) ->
             loop p
         | Tpat_record (ldps,_) ->
             List.for_all
@@ -2419,9 +2424,9 @@ type amb_row = { row : pattern list ; varsets : Ident.Set.t list; }
 let simplify_head_amb_pat head_bound_variables varsets ~add_column p ps k =
   let rec simpl head_bound_variables varsets p ps k =
     match (Patterns.General.view p).pat_desc with
-    | `Alias (p,x,_,_,_,_) ->
+    | `Alias (p,x,_,_,_,_,_) ->
       simpl (Ident.Set.add x head_bound_variables) varsets p ps k
-    | `Var (x, _, _, _) ->
+    | `Var (x, _, _, _, _) ->
       simpl (Ident.Set.add x head_bound_variables) varsets Patterns.omega ps k
     | `Or (p1,p2,_) ->
       simpl head_bound_variables varsets p1 ps

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -63,8 +63,7 @@ let extra_pat =
   make_pat
     (Tpat_var (Ident.create_local "+", mknoloc "+",
       Uid.internal_not_actually_unique,
-      (* CR jrayman: should be [for_*] *)
-      Jkind.Sort.value,
+      Jkind.Sort.(of_const Const.for_boxed_variant),
       Mode.Value.disallow_right Mode.Value.max))
     Ctype.none Env.empty
 

--- a/typing/patterns.ml
+++ b/typing/patterns.ml
@@ -84,19 +84,19 @@ end
 module General = struct
   type view = [
     | Half_simple.view
-    | `Var of Ident.t * string loc * Uid.t * Mode.Value.l
+    | `Var of Ident.t * string loc * Uid.t * Jkind.Sort.t * Mode.Value.l
     | `Alias of pattern * Ident.t * string loc
-                * Uid.t * Mode.Value.l * Types.type_expr
+                * Uid.t * Jkind.Sort.t * Mode.Value.l * Types.type_expr
   ]
   type pattern = view pattern_data
 
   let view_desc = function
     | Tpat_any ->
        `Any
-    | Tpat_var (id, str, uid, mode) ->
-       `Var (id, str, uid, mode)
-    | Tpat_alias (p, id, str, uid, mode, ty) ->
-       `Alias (p, id, str, uid, mode, ty)
+    | Tpat_var (id, str, uid, sort, mode) ->
+       `Var (id, str, uid, sort, mode)
+    | Tpat_alias (p, id, str, uid, sort, mode, ty) ->
+       `Alias (p, id, str, uid, sort, mode, ty)
     | Tpat_constant cst ->
        `Constant cst
     | Tpat_tuple ps ->
@@ -120,9 +120,9 @@ module General = struct
 
   let erase_desc = function
     | `Any -> Tpat_any
-    | `Var (id, str, uid, mode) -> Tpat_var (id, str, uid, mode)
-    | `Alias (p, id, str, uid, mode, ty) ->
-       Tpat_alias (p, id, str, uid, mode, ty)
+    | `Var (id, str, uid, sort, mode) -> Tpat_var (id, str, uid, sort, mode)
+    | `Alias (p, id, str, uid, sort, mode, ty) ->
+       Tpat_alias (p, id, str, uid, sort, mode, ty)
     | `Constant cst -> Tpat_constant cst
     | `Tuple ps -> Tpat_tuple ps
     | `Unboxed_tuple ps -> Tpat_unboxed_tuple ps
@@ -143,7 +143,7 @@ module General = struct
 
   let rec strip_vars (p : pattern) : Half_simple.pattern =
     match p.pat_desc with
-    | `Alias (p, _, _, _, _, _) -> strip_vars (view p)
+    | `Alias (p, _, _, _, _, _, _) -> strip_vars (view p)
     | `Var _ -> { p with pat_desc = `Any }
     | #Half_simple.view as view -> { p with pat_desc = view }
 end

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -68,9 +68,9 @@ end
 module General : sig
   type view = [
     | Half_simple.view
-    | `Var of Ident.t * string loc * Uid.t * Mode.Value.l
+    | `Var of Ident.t * string loc * Uid.t * Jkind.Sort.t * Mode.Value.l
     | `Alias of pattern * Ident.t * string loc * Uid.t
-                * Mode.Value.l * Types.type_expr
+                * Jkind.Sort.t * Mode.Value.l * Types.type_expr
   ]
   type pattern = view pattern_data
 

--- a/typing/printpat.ml
+++ b/typing/printpat.ml
@@ -79,7 +79,7 @@ let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
   in
   match v.pat_desc with
   | Tpat_any -> fprintf ppf "_"
-  | Tpat_var (x,_,_,_) -> fprintf ppf "%s" (Ident.name x)
+  | Tpat_var (x,_,_,_,_) -> fprintf ppf "%s" (Ident.name x)
   | Tpat_constant c -> fprintf ppf "%s" (pretty_const c)
   | Tpat_tuple vs ->
       fprintf ppf "@[(%a)@]" (pretty_list pretty_labeled_val ",") vs
@@ -114,7 +114,7 @@ let rec pretty_val : type k . _ -> k general_pattern -> _ = fun ppf v ->
       fprintf ppf "@[[%c %a %c]@]" punct (pretty_vals " ;") vs punct
   | Tpat_lazy v ->
       fprintf ppf "@[<2>lazy@ %a@]" pretty_arg v
-  | Tpat_alias (v, x, _, _, _, _) ->
+  | Tpat_alias (v, x, _, _, _, _, _) ->
       fprintf ppf "@[(%a@ as %a)@]" pretty_val v Ident.print x
   | Tpat_value v ->
       fprintf ppf "%a" pretty_val (v :> pattern)

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -340,11 +340,13 @@ and pattern : type k . _ -> _ -> k general_pattern -> unit = fun i ppf x ->
   end;
   match x.pat_desc with
   | Tpat_any -> line i ppf "Tpat_any\n";
-  | Tpat_var (s,_,_,m) ->
+  | Tpat_var (s,_,_,sort,m) ->
       line i ppf "Tpat_var \"%a\"\n" fmt_ident s;
+      line i ppf "sort %a\n" Jkind.Sort.format sort;
       value_mode i ppf m
-  | Tpat_alias (p, s,_,_,m,_) ->
+  | Tpat_alias (p, s,_,_,sort,m,_) ->
       line i ppf "Tpat_alias \"%a\"\n" fmt_ident s;
+      line i ppf "sort %a\n" Jkind.Sort.format sort;
       value_mode i ppf m;
       pattern i ppf p;
   | Tpat_constant (c) -> line i ppf "Tpat_constant %a\n" fmt_constant c;

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -255,7 +255,7 @@ let pat
   List.iter (pat_extra sub) extra;
   match pat_desc with
   | Tpat_any  -> ()
-  | Tpat_var (_, s, _, _) -> iter_loc sub s
+  | Tpat_var (_, s, _, _, _) -> iter_loc sub s
   | Tpat_constant _ -> ()
   | Tpat_tuple l -> List.iter (fun (_, p) -> sub.pat sub p) l
   | Tpat_unboxed_tuple l -> List.iter (fun (_, p, _) -> sub.pat sub p) l
@@ -275,7 +275,7 @@ let pat
   | Tpat_record_unboxed_product (l, _) ->
       List.iter (fun (lid, _, i) -> iter_loc sub lid; sub.pat sub i) l
   | Tpat_array (_, _, l) -> List.iter (sub.pat sub) l
-  | Tpat_alias (p, _, s, _, _, _) -> sub.pat sub p; iter_loc sub s
+  | Tpat_alias (p, _, s, _, _, _, _) -> sub.pat sub p; iter_loc sub s
   | Tpat_lazy p -> sub.pat sub p
   | Tpat_value p -> sub.pat sub (p :> pattern)
   | Tpat_exception p -> sub.pat sub p

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -301,7 +301,8 @@ let pat
     match x.pat_desc with
     | Tpat_any
     | Tpat_constant _ -> x.pat_desc
-    | Tpat_var (id, s, uid, m) -> Tpat_var (id, map_loc sub s, uid, m)
+    | Tpat_var (id, s, uid, sort, m) ->
+      Tpat_var (id, map_loc sub s, uid, sort, m)
     | Tpat_tuple l ->
         Tpat_tuple (List.map (fun (label, p) -> label, sub.pat sub p) l)
     | Tpat_unboxed_tuple l ->
@@ -323,8 +324,8 @@ let pat
         Tpat_record_unboxed_product
           (List.map (tuple3 (map_loc sub) id (sub.pat sub)) l, closed)
     | Tpat_array (am, arg_sort, l) -> Tpat_array (am, arg_sort, List.map (sub.pat sub) l)
-    | Tpat_alias (p, id, s, uid, m, ty) ->
-        Tpat_alias (sub.pat sub p, id, map_loc sub s, uid, m, ty)
+    | Tpat_alias (p, id, s, uid, sort, m, ty) ->
+        Tpat_alias (sub.pat sub p, id, map_loc sub s, uid, sort, m, ty)
     | Tpat_lazy p -> Tpat_lazy (sub.pat sub p)
     | Tpat_value p ->
        (as_computation_pattern (sub.pat sub (p :> pattern))).pat_desc

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2705,21 +2705,21 @@ let rec type_pat
       no_existentials: existential_restriction option ->
       alloc_mode:expected_pat_mode -> mutable_flag:_ ->
       penv: Pattern_env.t -> Parsetree.pattern -> type_expr ->
-      k general_pattern
+      Jkind.Sort.t -> k general_pattern
   = fun tps category ~no_existentials ~alloc_mode ~mutable_flag ~penv sp
-      expected_ty ->
+      expected_ty sort ->
   Builtin_attributes.warning_scope sp.ppat_attributes
     (fun () ->
        type_pat_aux tps category ~no_existentials
-         ~alloc_mode ~mutable_flag ~penv sp expected_ty
+         ~alloc_mode ~mutable_flag ~penv sp expected_ty sort
     )
 
 and type_pat_aux
   : type k . type_pat_state -> k pattern_category -> no_existentials:_ ->
          alloc_mode:expected_pat_mode -> mutable_flag:mutable_flag -> penv:_ ->
-         _ -> _ -> k general_pattern
+         _ -> _ -> _ -> k general_pattern
   = fun tps category ~no_existentials ~alloc_mode ~mutable_flag ~penv sp
-        expected_ty ->
+        expected_ty sort ->
   let type_pat tps category ?(alloc_mode=alloc_mode) ?(penv=penv) =
     type_pat tps category ~no_existentials ~alloc_mode ~mutable_flag ~penv
   in
@@ -2751,7 +2751,9 @@ and type_pat_aux
     check_project_mutability ~loc ~env:!!penv mutability alloc_mode.mode;
     let alloc_mode = Modality.Value.Const.apply modalities alloc_mode.mode in
     let alloc_mode = simple_pat_mode alloc_mode in
-    let pl = List.map (fun p -> type_pat ~alloc_mode tps Value p ty_elt) spl in
+    let pl =
+      List.map (fun p -> type_pat ~alloc_mode tps Value p ty_elt arg_sort) spl
+    in
     rvp {
       pat_desc = Tpat_array (mutability, arg_sort, pl);
       pat_loc = loc; pat_extra=[];
@@ -2786,7 +2788,9 @@ and type_pat_aux
         Option.iter (fun _ ->
             Language_extension.assert_enabled ~loc Labeled_tuples ())
           lbl;
-        lbl, type_pat tps Value ~alloc_mode p t)
+        lbl,
+        type_pat tps Value ~alloc_mode p t
+          Jkind.Sort.(of_const Const.for_tuple_element))
         spl_ann
     in
     rvp {
@@ -2824,7 +2828,7 @@ and type_pat_aux
         Option.iter (fun _ ->
             Language_extension.assert_enabled ~loc Labeled_tuples ())
           lbl;
-        lbl, type_pat tps Value ~alloc_mode p t, sort)
+        lbl, type_pat tps Value ~alloc_mode p t sort, sort)
         spl_ann
     in
     let ty =
@@ -2866,7 +2870,8 @@ and type_pat_aux
           Modality.Value.Const.apply label.lbl_modalities alloc_mode.mode
         in
         let alloc_mode = simple_pat_mode mode in
-        (label_lid, label, type_pat tps Value ~alloc_mode sarg ty_arg)
+        (label_lid, label, type_pat tps Value ~alloc_mode sarg ty_arg
+          (Jkind.Sort.of_const label.lbl_sort))
       in
       let make_record_pat
             (lbl_pat_list : (_ * rep gen_label_description * _) list) =
@@ -2910,12 +2915,6 @@ and type_pat_aux
       let ty = instance expected_ty in
       let alloc_mode =
         cross_left !!penv expected_ty alloc_mode.mode
-      in
-      (* CR jrayman: set why *)
-      let sort =
-        match Ctype.type_sort !!penv ty ~why:Let_binding ~fixed:false with
-        | Error _ -> assert false
-        | Ok sort -> sort
       in
       let mode, kind =
         match mutable_flag with
@@ -2982,15 +2981,9 @@ and type_pat_aux
             pat_unique_barrier = Unique_barrier.not_computed () }
       end
   | Ppat_alias(sq, name) ->
-      let q = type_pat tps Value sq expected_ty in
+      let q = type_pat tps Value sq expected_ty sort in
       let ty_var, mode = solve_Ppat_alias ~mode:alloc_mode.mode !!penv q in
       let mode = cross_left !!penv expected_ty mode in
-      (* CR jrayman: set why *)
-      let sort =
-        match Ctype.type_sort !!penv ty_var ~why:Let_binding ~fixed:false with
-        | Error _ -> assert false
-        | Ok sort -> sort
-      in
       let id, uid =
         enter_variable ~is_as_variable:true ~kind:Val_reg tps name.loc name mode
           ty_var sp.ppat_attributes sort
@@ -3023,6 +3016,7 @@ and type_pat_aux
       let p = if c1 <= c2 then loop c1 c2 else loop c2 c1 in
       let p = {p with ppat_loc=loc} in
       type_pat tps category p expected_ty
+        Jkind.Sort.(of_const Const.for_predef_value)
         (* TODO: record 'extra' to remember about interval *)
   | Ppat_interval _ ->
       raise (Error (loc, !!penv, Invalid_interval))
@@ -3137,7 +3131,8 @@ and type_pat_aux
               Mode.Value.join [ alloc_mode; constructor_mode ]
              in
              let alloc_mode = simple_pat_mode alloc_mode in
-             type_pat ~alloc_mode tps Value p arg.ca_type)
+             type_pat ~alloc_mode tps Value p arg.ca_type
+               (Jkind.Sort.of_const arg.ca_sort))
           sargs args
       in
       rvp { pat_desc=Tpat_construct(lid, constr, args, existential_ctyp);
@@ -3154,8 +3149,11 @@ and type_pat_aux
       let arg =
         (* PR#6235: propagate type information *)
         match sarg, arg_type with
-          Some sp, [ty] -> Some (type_pat tps Value sp ty)
-        | _             -> None
+          Some sp, [ty] ->
+          Some
+            (type_pat tps Value sp ty
+              Jkind.Sort.(of_const Const.for_variant_arg))
+        | _ -> None
       in
       rvp {
         pat_desc = Tpat_variant(tag, arg, ref row);
@@ -3192,7 +3190,7 @@ and type_pat_aux
       let env1, p1, env2, p2 =
         with_local_level begin fun () ->
           let type_pat_rec tps penv sp =
-            type_pat tps category sp expected_ty ~penv
+            type_pat tps category sp expected_ty sort ~penv
           in
           let penv1 =
             Pattern_env.copy ~equations_scope:(get_current_level ()) penv in
@@ -3240,7 +3238,10 @@ and type_pat_aux
       submode ~loc ~env:!!penv alloc_mode.mode mode_force_lazy;
       let nv = solve_Ppat_lazy ~refine:false loc penv expected_ty in
       let alloc_mode = global_pat_mode alloc_mode in
-      let p1 = type_pat ~alloc_mode tps Value sp1 nv in
+      let p1 =
+        type_pat ~alloc_mode tps Value sp1 nv
+          Jkind.Sort.(of_const Const.for_lazy_body)
+      in
       rvp {
         pat_desc = Tpat_lazy p1;
         pat_loc = loc; pat_extra=[];
@@ -3256,11 +3257,13 @@ and type_pat_aux
           let type_modes = Typemode.transl_alloc_mode ms in
           solve_Ppat_constraint tps loc !!penv type_modes sty expected_ty
         in
-        let p = type_pat ~alloc_mode tps category sp_constrained expected_ty' in
+        let p =
+          type_pat ~alloc_mode tps category sp_constrained expected_ty' sort
+        in
         let extra = (Tpat_constraint cty, loc, sp_constrained.ppat_attributes) in
         { p with pat_type = ty; pat_extra = extra::p.pat_extra }
       | None ->
-        type_pat ~alloc_mode tps category sp_constrained expected_ty
+        type_pat ~alloc_mode tps category sp_constrained expected_ty sort
       end
   | Ppat_type lid ->
       let (path, p) = build_or_pat !!penv loc lid in
@@ -3271,7 +3274,7 @@ and type_pat_aux
       let path, new_env =
         !type_open Asttypes.Fresh !!penv sp.ppat_loc lid in
       Pattern_env.set_env penv new_env;
-      let p = type_pat tps category ~penv p expected_ty in
+      let p = type_pat tps category ~penv p expected_ty sort in
       let new_env = !!penv in
       begin match Env.remove_last_open path new_env with
       | None -> assert false
@@ -3281,7 +3284,10 @@ and type_pat_aux
                                 loc, sp.ppat_attributes) :: p.pat_extra }
   | Ppat_exception p ->
       let alloc_mode = simple_pat_mode Value.legacy in
-      let p_exn = type_pat tps Value ~alloc_mode p Predef.type_exn in
+      let p_exn =
+        type_pat tps Value ~alloc_mode p Predef.type_exn
+          Jkind.Sort.(of_const Const.for_exception)
+      in
       rcp {
         pat_desc = Tpat_exception p_exn;
         pat_loc = sp.ppat_loc;
@@ -3297,13 +3303,15 @@ and type_pat_aux
 let type_pat tps category ?no_existentials ~mutable_flag penv =
   type_pat tps category ~no_existentials ~mutable_flag ~penv
 
-let type_pattern category ~lev ~alloc_mode env spat expected_ty allow_modules =
+let type_pattern
+    category ~lev ~alloc_mode env spat expected_ty sort allow_modules
+  =
   let tps = create_type_pat_state allow_modules in
   let new_penv = Pattern_env.make env
       ~equations_scope:lev ~allow_recursive_equations:false in
   let pat =
       type_pat tps category ~alloc_mode ~mutable_flag:Immutable new_penv spat
-        expected_ty
+        expected_ty sort
   in
   let { tps_pattern_variables = pvs;
         tps_module_variables = mvs;
@@ -3312,22 +3320,23 @@ let type_pattern category ~lev ~alloc_mode env spat expected_ty allow_modules =
   (pat, !!new_penv, forces, pvs, mvs)
 
 let type_pattern_list
-    category no_existentials env mutable_flag spatl expected_tys allow_modules
+    category no_existentials env mutable_flag spatl expected_tys expected_sorts
+    allow_modules
   =
   let tps = create_type_pat_state allow_modules in
   let equations_scope = get_current_level () in
   let new_penv = Pattern_env.make env
       ~equations_scope ~allow_recursive_equations:false in
-  let type_pat (attrs, pat_mode, exp_mode, pat) ty =
+  let type_pat (attrs, pat_mode, exp_mode, pat) ty sort =
     Builtin_attributes.warning_scope ~ppwarning:false attrs
       (fun () ->
          exp_mode,
          type_pat tps category
            ~no_existentials ~alloc_mode:pat_mode ~mutable_flag
-           new_penv pat ty
+           new_penv pat ty sort
       )
   in
-  let patl = List.map2 type_pat spatl expected_tys in
+  let patl = Misc.Stdlib.List.map3 type_pat spatl expected_tys expected_sorts in
   let { tps_pattern_variables = pvs;
         tps_module_variables = mvs;
         tps_pattern_force = forces;
@@ -3345,7 +3354,9 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
           ~equations_scope ~allow_recursive_equations:false in
       let pat =
         type_pat tps Value ~no_existentials:In_class_args ~alloc_mode
-          ~mutable_flag:Immutable new_penv spat nv in
+          ~mutable_flag:Immutable new_penv spat nv
+          Jkind.Sort.(of_const Const.for_class_arg)
+      in
       if has_variants pat then begin
         Parmatch.pressure_variants val_env [pat];
         finalize_variants pat;
@@ -3408,7 +3419,9 @@ let type_self_pattern env spat =
       ~equations_scope ~allow_recursive_equations:false in
   let pat =
     type_pat tps Value ~no_existentials:In_self_pattern ~alloc_mode
-      ~mutable_flag:Immutable new_penv spat nv in
+      ~mutable_flag:Immutable new_penv spat nv
+      Jkind.Sort.(of_const Const.for_object)
+  in
   List.iter (fun f -> f()) tps.tps_pattern_force;
   pat, tps.tps_pattern_variables
 
@@ -6237,7 +6250,7 @@ and type_expect_
       in
       let cases, partial =
         type_cases Computation env arg_pat_mode expected_mode
-          arg.exp_type ty_expected_explained
+          arg.exp_type sort ty_expected_explained
           ~check_if_total:true loc caselist in
       if
         List.for_all (fun c -> pattern_needs_partial_application_check c.c_lhs)
@@ -6257,7 +6270,8 @@ and type_expect_
       let arg_mode = simple_pat_mode Value.legacy in
       let cases, _ =
         type_cases Value env arg_mode expected_mode
-          Predef.type_exn ty_expected_explained
+          Predef.type_exn Jkind.Sort.(of_const Const.for_exception)
+          ty_expected_explained
           ~check_if_total:false loc caselist in
       re {
         exp_desc = Texp_try(body, cases);
@@ -7090,7 +7104,7 @@ and type_expect_
       let cases, partial =
         type_cases Value body_env
           (simple_pat_mode Value.legacy) (mode_return Value.legacy)
-          ty_params (mk_expected ty_func_result)
+          ty_params param_sort (mk_expected ty_func_result)
           ~check_if_total:true loc [scase]
       in
       let body =
@@ -7820,9 +7834,9 @@ and type_function
          optional arguments with defaults, where the external [ty_arg_mono]
          is optional and the internal view is not optional.
       *)
-      let ty_arg_internal, default_arg =
+      let ty_arg_internal, default_arg, sort_arg_internal =
         match default_arg with
-        | None -> ty_arg_mono, None
+        | None -> ty_arg_mono, None, arg_sort
         | Some default ->
             let arg_label =
               match arg_label with
@@ -7853,12 +7867,13 @@ and type_function
             let default_arg =
               type_expect env mode_legacy default (mk_expected ty_default_arg)
             in
-            ty_default_arg, Some (default_arg, arg_label, default_arg_sort)
+            ty_default_arg, Some (default_arg, arg_label, default_arg_sort),
+              default_arg_sort
       in
       let (pat, params, body, ret_info, newtypes, contains_gadt, curry), partial =
         (* Check everything else in the scope of the parameter. *)
         map_half_typed_cases Value env expected_pat_mode
-          ty_arg_internal ty_ret pat.ppat_loc
+          ty_arg_internal sort_arg_internal ty_ret pat.ppat_loc
           ~check_if_total:true
           (* We don't make use of [case_data] here so we pass unit. *)
           [ { pattern = pat; has_guard = false; needs_refute = false }, () ]
@@ -9207,7 +9222,7 @@ and type_statement ?explanation ?(position=RNontail) env sexp =
 and map_half_typed_cases
   : type k ret case_data.
     ?additional_checks_for_split_cases:((_ * ret) list -> unit)
-    -> k pattern_category -> _ -> _ -> _ -> _ -> _
+    -> k pattern_category -> _ -> _ -> _ -> _ -> _ -> _
     -> (untyped_case * case_data) list
     -> type_body:(
         case_data
@@ -9221,7 +9236,7 @@ and map_half_typed_cases
     -> ret list * partial
   = fun ?additional_checks_for_split_cases
     category env pat_mode
-    ty_arg ty_res loc caselist ~type_body ~check_if_total ->
+    ty_arg sort_arg ty_res loc caselist ~type_body ~check_if_total ->
   (* ty_arg is _fully_ generalized *)
   let patterns = List.map (fun ((x : untyped_case), _) -> x.pattern) caselist in
   let contains_polyvars = List.exists contains_polymorphic_variant patterns in
@@ -9278,8 +9293,8 @@ and map_half_typed_cases
                   (fun () -> instance ?partial:take_partial_instance ty_arg)
               in
               let (pat, ext_env, force, pvs, mvs) =
-                type_pattern category ~lev ~alloc_mode:pat_mode env pattern ty_arg
-                allow_modules
+                type_pattern category ~lev ~alloc_mode:pat_mode env pattern
+                  ty_arg sort_arg allow_modules
               in
               pattern_force := force @ !pattern_force;
               { typed_pat = pat;
@@ -9524,10 +9539,10 @@ and type_newtype_expr
 (* Typing of match cases *)
 and type_cases
     : type k . k pattern_category ->
-           _ -> _ -> _ -> _ -> _ -> check_if_total:bool -> _ -> Parsetree.case list ->
-           k case list * partial
+           _ -> _ -> _ -> _ -> _ -> _ -> check_if_total:bool -> _ ->
+           Parsetree.case list -> k case list * partial
   = fun category env pat_mode expr_mode
-        ty_arg ty_res_explained ~check_if_total loc caselist ->
+        ty_arg sort_arg ty_res_explained ~check_if_total loc caselist ->
   let { ty = ty_res; explanation } = ty_res_explained in
   let caselist =
     List.map (fun case -> Parmatch.untyped_case case, case) caselist
@@ -9536,7 +9551,8 @@ and type_cases
      is to typecheck the guards and the cases, and then to check for some
      warnings that can fire in the presence of guards.
   *)
-  map_half_typed_cases category env pat_mode ty_arg ty_res loc caselist ~check_if_total
+  map_half_typed_cases category env pat_mode ty_arg sort_arg ty_res loc caselist
+    ~check_if_total
     ~type_body:begin
       fun { pc_guard; pc_rhs } pat ~ext_env ~ty_expected ~ty_infer
           ~contains_gadt:_ ->
@@ -9588,8 +9604,8 @@ and type_function_cases_expect
     in
     let cases, partial =
       type_cases Value env
-        expected_pat_mode expected_inner_mode ty_arg_mono (mk_expected ty_ret)
-        ~check_if_total:true loc cases
+        expected_pat_mode expected_inner_mode ty_arg_mono arg_sort
+        (mk_expected ty_ret) ~check_if_total:true loc cases
     in
     let ty_fun =
       instance
@@ -9663,7 +9679,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
           let (pat_list, _new_env, _force, pvs, _mvs as res) =
             with_local_level_if is_recursive (fun () ->
               type_pattern_list Value existential_context env mutable_flag spatl
-                nvs allow_modules
+                nvs sorts allow_modules
             ) ~post:(fun (_, _, _, pvs, _) ->
                        iter_pattern_variables_type generalize pvs)
           in
@@ -10510,6 +10526,7 @@ and type_comprehension_iterator
           penv
           pattern
           item_ty
+          Jkind.Sort.(of_const Const.for_loop_index)
       in
       Texp_comp_in { pattern; sequence }
 

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -70,6 +70,7 @@ type pattern_variable =
     pv_loc: Location.t;
     pv_as_var: bool;
     pv_attributes: Typedtree.attributes;
+    pv_sort: Jkind.Sort.t;
   }
 
 val mk_expected:

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -157,11 +157,13 @@ and 'k pattern_desc =
   (* value patterns *)
   | Tpat_any : value pattern_desc
         (** _ *)
-  | Tpat_var : Ident.t * string loc * Uid.t * Mode.Value.l -> value pattern_desc
+  | Tpat_var :
+      Ident.t * string loc * Uid.t * Jkind_types.Sort.t * Mode.Value.l ->
+      value pattern_desc
         (** x *)
   | Tpat_alias :
-      value general_pattern * Ident.t * string loc * Uid.t * Mode.Value.l
-      * Types.type_expr
+      value general_pattern * Ident.t * string loc * Uid.t * Jkind_types.Sort.t
+      * Mode.Value.l * Types.type_expr
         -> value pattern_desc
         (** P as a *)
   | Tpat_constant : constant -> value pattern_desc

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -1325,7 +1325,7 @@ val mkloc: 'a -> Location.t -> 'a Asttypes.loc
 
 val pat_bound_idents: 'k general_pattern -> Ident.t list
 val pat_bound_idents_full:
-  Jkind.Sort.Const.t -> 'k general_pattern
+  'k general_pattern
   -> (Ident.t * string loc * Types.type_expr * Types.Uid.t * Jkind.Sort.Const.t) list
 
 (** Splits an or pattern into its value (left) and exception (right) parts. *)

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -1963,8 +1963,8 @@ and pattern_match_single pat paths : Ienv.Extension.t * UF.t =
       let ext1, uf1 = pattern_match_single pat1 paths in
       Ienv.Extension.disjunct ext0 ext1, UF.choose uf0 uf1
     | Tpat_any -> Ienv.Extension.empty, UF.unused
-    | Tpat_var (id, _, _, _) -> Ienv.Extension.singleton id paths, UF.unused
-    | Tpat_alias (pat', id, _, _, _, _) ->
+    | Tpat_var (id, _, _, _, _) -> Ienv.Extension.singleton id paths, UF.unused
+    | Tpat_alias (pat', id, _, _, _, _, _) ->
       let ext0 = Ienv.Extension.singleton id paths in
       let ext1, uf = pattern_match_single pat' paths in
       Ienv.Extension.conjunct ext0 ext1, uf

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -324,7 +324,7 @@ let pattern : type k . _ -> k T.general_pattern -> _ = fun sub pat ->
       { pat_extra=[Tpat_unpack, loc, _attrs]; pat_desc = Tpat_any; _ } ->
         Ppat_unpack { txt = None; loc  }
     | { pat_extra=[Tpat_unpack, _, _attrs];
-        pat_desc = Tpat_var (_,name, _, _); _ } ->
+        pat_desc = Tpat_var (_,name, _, _, _); _ } ->
         Ppat_unpack { name with txt = Some name.txt }
     | { pat_extra=[Tpat_type (_path, lid), _, _attrs]; _ } ->
         Ppat_type (map_loc sub lid)
@@ -335,7 +335,7 @@ let pattern : type k . _ -> k T.general_pattern -> _ = fun sub pat ->
     | _ ->
     match pat.pat_desc with
       Tpat_any -> Ppat_any
-    | Tpat_var (id, name,_,_) ->
+    | Tpat_var (id, name,_,_,_) ->
         begin
           match (Ident.name id).[0] with
             'A'..'Z' ->
@@ -348,11 +348,12 @@ let pattern : type k . _ -> k T.general_pattern -> _ = fun sub pat ->
        The compiler transforms (x:t) into (_ as x : t).
        This avoids transforming a warning 27 into a 26.
      *)
-    | Tpat_alias ({pat_desc = Tpat_any; pat_loc}, _id, name, _uid, _mode, _ty)
+    | Tpat_alias
+      ({pat_desc = Tpat_any; pat_loc}, _id, name, _uid, _sort, _mode, _ty)
          when pat_loc = pat.pat_loc ->
        Ppat_var name
 
-    | Tpat_alias (pat, _id, name, _uid, _mode, _ty) ->
+    | Tpat_alias (pat, _id, name, _uid, _sort, _mode, _ty) ->
         Ppat_alias (sub.pat sub pat, name)
     | Tpat_constant cst -> Ppat_constant (constant cst)
     | Tpat_tuple list ->
@@ -1045,7 +1046,7 @@ let core_type sub ct =
 
 let class_structure sub cs =
   let rec remove_self = function
-    | { pat_desc = Tpat_alias (p, id, _s, _uid, _mode, _ty) }
+    | { pat_desc = Tpat_alias (p, id, _s, _uid, _sort, _mode, _ty) }
       when string_is_prefix "selfpat-" (Ident.name id) ->
         remove_self p
     | p -> p
@@ -1075,7 +1076,7 @@ let object_field sub {of_loc; of_desc; of_attributes;} =
   Of.mk ~loc ~attrs desc
 
 and is_self_pat = function
-  | { pat_desc = Tpat_alias(_pat, id, _, _uid, _mode, _ty) } ->
+  | { pat_desc = Tpat_alias(_pat, id, _, _uid, _sort, _mode, _ty) } ->
       string_is_prefix "self-" (Ident.name id)
   | _ -> false
 

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -291,7 +291,7 @@ let classify_expression : Typedtree.expression -> sd =
     let old_env = env in
     let add_value_binding env vb =
       match vb.vb_pat.pat_desc with
-      | Tpat_var (id, _loc, _uid, _mode) ->
+      | Tpat_var (id, _loc, _uid, _sort, _mode) ->
           let size = classify_expression old_env vb.vb_expr in
           Ident.add id size env
       | _ ->
@@ -1508,8 +1508,8 @@ and pattern : type k . k general_pattern -> Env.t -> mode = fun pat env ->
 and is_destructuring_pattern : type k . k general_pattern -> bool =
   fun pat -> match pat.pat_desc with
     | Tpat_any -> false
-    | Tpat_var (_, _, _, _) -> false
-    | Tpat_alias (pat, _, _, _, _, _) -> is_destructuring_pattern pat
+    | Tpat_var (_, _, _, _, _) -> false
+    | Tpat_alias (pat, _, _, _, _, _, _) -> is_destructuring_pattern pat
     | Tpat_constant _ -> true
     | Tpat_tuple _ -> true
     | Tpat_unboxed_tuple _ -> true


### PR DESCRIPTION
Also add `pv_sort` to `pattern_variable` in `typecore` and refactor pattern iterators that can now get sorts form pattern variables. This change is a precursor for mixed modules.