### PR TITLE
Remove first-class modules from `Jkind_axis`

### DIFF
--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -350,9 +350,9 @@ let report_mode_sub_error got expected ppf e =
   | _ ->
     Format.fprintf ppf "%s %a but %s %a."
       (String.capitalize_ascii got)
-      (Misc.Style.as_inline_code (Value.Const.print_axis ax)) left
+      (Misc.Style.as_inline_code (Value.Const.Per_axis.print ax)) left
       expected
-      (Misc.Style.as_inline_code (Value.Const.print_axis ax)) right
+      (Misc.Style.as_inline_code (Value.Const.Per_axis.print ax)) right
 
 let report_modality_equate_error first second ppf ((equate_step, sub_error) : Modality.Value.equate_error) =
   match equate_step with

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -289,11 +289,11 @@ let zap_axis_to_ceil
 let print_out_mode
 : type a. ?in_structure:_ -> a Mode.Value.Axis.t -> a -> _
 = fun ?(in_structure=true) ax mode ->
-  let (module L) = Mode.Value.Const.lattice_of_axis ax in
+  let print = Mode.Value.Const.Per_axis.print ax in
   if in_structure then
-    Format.dprintf " (* in a structure at %a *)" L.print mode
+    Format.dprintf " (* in a structure at %a *)" print mode
   else
-    Format.dprintf " (* at %a *)" L.print mode
+    Format.dprintf " (* at %a *)" print mode
 
 let maybe_print_mode_l ~is_modal (mode : Mode.Value.l) =
   match is_modal with

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -174,11 +174,6 @@ module Axis = struct
       | Externality : Externality.t t
       | Nullability : Nullability.t t
       | Separability : Separability.t t
-
-    let get (type a) : a t -> (module Axis_ops with type t = a) = function
-      | Externality -> (module Externality)
-      | Nullability -> (module Nullability)
-      | Separability -> (module Separability)
   end
 
   type 'a t =
@@ -186,24 +181,6 @@ module Axis = struct
     | Nonmodal : 'a Nonmodal.t -> 'a t
 
   type packed = Pack : 'a t -> packed [@@unboxed]
-
-  module Accent_lattice (M : Mode_intf.Lattice) = struct
-    (* A functor to add some convenient functions to modal axes *)
-    include M
-
-    let[@inline] less_or_equal a b : Misc.Le_result.t =
-      match le a b, le b a with
-      | true, true -> Equal
-      | true, false -> Less
-      | false, _ -> Not_le
-
-    let equal a b = Misc.Le_result.is_equal (less_or_equal a b)
-  end
-
-  let get (type a) : a t -> (module Axis_ops with type t = a) = function
-    | Modal axis ->
-      (module Accent_lattice ((val Mode.Value.Const.lattice_of_axis axis)))
-    | Nonmodal axis -> Nonmodal.get axis
 
   let all =
     [ Pack (Modal (Comonadic Areality));
@@ -223,6 +200,104 @@ module Axis = struct
     | Nonmodal Externality -> "externality"
     | Nonmodal Nullability -> "nullability"
     | Nonmodal Separability -> "separability"
+end
+
+module Per_axis = struct
+  open Axis
+
+  module Nonmodal = struct
+    open Axis.Nonmodal
+
+    let min : type a. a t -> a = function
+      | Externality -> Externality.min
+      | Nullability -> Nullability.min
+      | Separability -> Separability.min
+
+    let max : type a. a t -> a = function
+      | Externality -> Externality.max
+      | Nullability -> Nullability.max
+      | Separability -> Separability.max
+
+    let le : type a. a t -> a -> a -> bool =
+     fun ax a b ->
+      match ax with
+      | Externality -> Externality.le a b
+      | Nullability -> Nullability.le a b
+      | Separability -> Separability.le a b
+
+    let meet : type a. a t -> a -> a -> a =
+     fun ax a b ->
+      match ax with
+      | Externality -> Externality.meet a b
+      | Nullability -> Nullability.meet a b
+      | Separability -> Separability.meet a b
+
+    let join : type a. a t -> a -> a -> a =
+     fun ax a b ->
+      match ax with
+      | Externality -> Externality.join a b
+      | Nullability -> Nullability.join a b
+      | Separability -> Separability.join a b
+
+    let print : type a. a t -> Format.formatter -> a -> unit =
+     fun ax ppf a ->
+      match ax with
+      | Externality -> Externality.print ppf a
+      | Nullability -> Nullability.print ppf a
+      | Separability -> Separability.print ppf a
+
+    let eq_obj : type a b. a t -> b t -> (a, b) Misc.eq option =
+     fun a b ->
+      match a, b with
+      | Externality, Externality -> Some Refl
+      | Nullability, Nullability -> Some Refl
+      | Separability, Separability -> Some Refl
+      | _ -> None
+
+    let print_obj : type a. Format.formatter -> a t -> unit =
+     fun ppf -> function
+      | Externality -> Format.fprintf ppf "externality"
+      | Nullability -> Format.fprintf ppf "nullability"
+      | Separability -> Format.fprintf ppf "separability"
+  end
+
+  let min = function
+    | Modal ax -> Mode.Value.Const.Per_axis.min ax
+    | Nonmodal ax -> Nonmodal.min ax
+
+  let max = function
+    | Modal ax -> Mode.Value.Const.Per_axis.max ax
+    | Nonmodal ax -> Nonmodal.max ax
+
+  let le ax a b =
+    match ax with
+    | Modal ax -> Mode.Value.Const.Per_axis.le ax a b
+    | Nonmodal ax -> Nonmodal.le ax a b
+
+  let meet ax a b =
+    match ax with
+    | Modal ax -> Mode.Value.Const.Per_axis.meet ax a b
+    | Nonmodal ax -> Nonmodal.meet ax a b
+
+  let join ax a b =
+    match ax with
+    | Modal ax -> Mode.Value.Const.Per_axis.join ax a b
+    | Nonmodal ax -> Nonmodal.join ax a b
+
+  let print ax ppf a =
+    match ax with
+    | Modal ax -> Mode.Value.Const.Per_axis.print ax ppf a
+    | Nonmodal ax -> Nonmodal.print ax ppf a
+
+  let eq_obj a b =
+    match a, b with
+    | Modal ax0, Modal ax1 -> Mode.Value.Const.Per_axis.eq_obj ax0 ax1
+    | Nonmodal ax0, Nonmodal ax1 -> Nonmodal.eq_obj ax0 ax1
+    | _ -> None
+
+  let print_obj ppf = function
+    | Modal ax -> Mode.Value.Const.Per_axis.print_obj ppf ax
+    | Nonmodal ax -> Nonmodal.print_obj ppf ax
 end
 
 module Axis_set = struct

--- a/typing/jkind_axis.mli
+++ b/typing/jkind_axis.mli
@@ -55,8 +55,6 @@ module Axis : sig
       | Externality : Externality.t t
       | Nullability : Nullability.t t
       | Separability : Separability.t t
-
-    val get : 'a t -> (module Axis_ops with type t = 'a)
   end
 
   (** Represents an axis of a jkind *)
@@ -66,15 +64,13 @@ module Axis : sig
 
   type packed = Pack : 'a t -> packed [@@unboxed]
 
-  (* CR zqian: push ['a t] into the module to avoid first-class module. *)
-
-  (** Given a jkind axis, get its interface *)
-  val get : 'a t -> (module Axis_ops with type t = 'a)
-
   val all : packed list
 
   val name : _ t -> string
 end
+
+module Per_axis :
+  Solver_intf.Lattices with type 'a elt := 'a and type 'a obj := 'a Axis.t
 
 module Axis_set : sig
   (** A set of [Axis.t], represented as a bitfield for efficiency. *)

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2345,6 +2345,14 @@ module Value_with (Areality : Areality) = struct
           (fun (Comonadic.Axis.P ax) -> P (Comonadic ax))
           Comonadic.Axis.all
       |> List.sort (fun (P ax0) (P ax1) -> compare ax0 ax1)
+
+    let eq : type a b. a t -> b t -> (a, b) Misc.eq option =
+     fun ax0 ax1 ->
+      match ax0, ax1 with
+      | Monadic ax0, Monadic ax1 -> Axis.eq ax0 ax1
+      | Comonadic ax0, Comonadic ax1 -> Axis.eq ax0 ax1
+      | Monadic _, Comonadic _ -> None
+      | Comonadic _, Monadic _ -> None
   end
 
   let proj_obj : type a. a Axis.t -> a C.obj = function
@@ -2623,30 +2631,38 @@ module Value_with (Areality : Areality) = struct
       let monadic = Monadic.min in
       merge { comonadic; monadic }
 
-    let print_axis : type a. a Axis.t -> _ -> a -> unit =
-     fun ax ppf a ->
-      let obj = proj_obj ax in
-      C.print obj ppf a
+    module Per_axis = struct
+      let print : type a. a Axis.t -> _ -> a -> unit =
+       fun ax ppf a ->
+        let obj = proj_obj ax in
+        C.print obj ppf a
 
-    let le_axis : type a. a Axis.t -> a -> a -> bool =
-     fun ax m0 m1 ->
-      match ax with
-      | Comonadic ax -> Comonadic.Per_axis.le ax m0 m1
-      | Monadic ax -> Monadic.Per_axis.le ax m0 m1
+      let le : type a. a Axis.t -> a -> a -> bool =
+       fun ax m0 m1 ->
+        match ax with
+        | Comonadic ax -> Comonadic.Per_axis.le ax m0 m1
+        | Monadic ax -> Monadic.Per_axis.le ax m0 m1
 
-    let min_axis : type a. a Axis.t -> a = function
-      | Comonadic ax -> Comonadic.Per_axis.min ax
-      | Monadic ax -> Monadic.Per_axis.min ax
+      let min : type a. a Axis.t -> a = function
+        | Comonadic ax -> Comonadic.Per_axis.min ax
+        | Monadic ax -> Monadic.Per_axis.min ax
 
-    let max_axis : type a. a Axis.t -> a = function
-      | Comonadic ax -> Comonadic.Per_axis.max ax
-      | Monadic ax -> Monadic.Per_axis.max ax
+      let max : type a. a Axis.t -> a = function
+        | Comonadic ax -> Comonadic.Per_axis.max ax
+        | Monadic ax -> Monadic.Per_axis.max ax
 
-    let is_max : type a. a Axis.t -> a -> bool =
-     fun ax m -> le_axis ax (max_axis ax) m
+      let meet : type a. a Axis.t -> a -> a -> a = function
+        | Comonadic ax -> Comonadic.Per_axis.meet ax
+        | Monadic ax -> Monadic.Per_axis.meet ax
 
-    let is_min : type a. a Axis.t -> a -> bool =
-     fun ax m -> le_axis ax m (min_axis ax)
+      let join : type a. a Axis.t -> a -> a -> a = function
+        | Comonadic ax -> Comonadic.Per_axis.join ax
+        | Monadic ax -> Monadic.Per_axis.join ax
+
+      let eq_obj = Axis.eq
+
+      let print_obj = Axis.print
+    end
 
     let split = split
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2064,15 +2064,6 @@ module Comonadic_with (Areality : Areality) = struct
         let obj = proj_obj ax in
         C.print_obj ppf obj
     end
-
-    let lattice_of_axis (type a) (axis : a Axis.t) :
-        (module Lattice with type t = a) =
-      match axis with
-      | Areality -> (module Areality.Const)
-      | Linearity -> (module Linearity.Const)
-      | Portability -> (module Portability.Const)
-      | Yielding -> (module Yielding.Const)
-      | Statefulness -> (module Statefulness.Const)
   end
 
   let proj ax m = Solver.apply (proj_obj ax) (Proj (Obj.obj, ax)) m
@@ -2227,13 +2218,6 @@ module Monadic = struct
         let obj = proj_obj ax in
         C.print_obj ppf obj
     end
-
-    let lattice_of_axis (type a) (axis : a Axis.t) :
-        (module Lattice with type t = a) =
-      match axis with
-      | Uniqueness -> (module Uniqueness.Const_op)
-      | Contention -> (module Contention.Const_op)
-      | Visibility -> (module Visibility.Const_op)
   end
 
   module Const_op = C.Monadic_op
@@ -2465,12 +2449,6 @@ module Value_with (Areality : Areality) = struct
       let monadic = Monadic.join m0.monadic m1.monadic in
       let comonadic = Comonadic.join m0.comonadic m1.comonadic in
       merge { monadic; comonadic }
-
-    let lattice_of_axis (type a) (axis : a Axis.t) :
-        (module Lattice with type t = a) =
-      match axis with
-      | Comonadic ax -> Comonadic.lattice_of_axis ax
-      | Monadic ax -> Monadic.lattice_of_axis ax
 
     module Option = struct
       type some = t

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -458,10 +458,6 @@ module type S = sig
               Visibility.Const.t )
             modes
 
-      (** Gets the normal lattice for comonadic axes and the "op"ped lattice for
-        monadic ones. *)
-      val lattice_of_axis : 'a Axis.t -> (module Lattice with type t = 'a)
-
       module Option : sig
         type some = t
 

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -487,9 +487,8 @@ module type S = sig
         val set : 'a Axis.t -> 'a option -> t -> t
       end
 
-      val is_max : 'a Axis.t -> 'a -> bool
-
-      val is_min : 'a Axis.t -> 'a -> bool
+      module Per_axis :
+        Solver_intf.Lattices with type 'a elt := 'a and type 'a obj := 'a Axis.t
 
       val split : t -> (Monadic.Const.t, Comonadic.Const.t) monadic_comonadic
 
@@ -504,9 +503,6 @@ module type S = sig
 
       (** Similar to [Alloc.partial_apply] but for constants *)
       val partial_apply : t -> t
-
-      (** Prints a constant on any axis. *)
-      val print_axis : 'a Axis.t -> Format.formatter -> 'a -> unit
     end
 
     type error = Error : 'a Axis.t * 'a Solver.error -> error

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -11574,10 +11574,10 @@ let report_error ~loc env =
                     (Style.as_inline_code Contention.Const.print) Shared
                     (Style.as_inline_code Contention.Const.print) Uncontended
               | _, _ ->
-                  Style.as_inline_code (Value.Const.print_axis ax) ppf right
+                  Style.as_inline_code (Value.Const.Per_axis.print ax) ppf right
             in
             Format.dprintf "This value is %a but expected to be %a."
-              (Style.as_inline_code (Value.Const.print_axis ax)) left
+              (Style.as_inline_code (Value.Const.Per_axis.print ax)) left
               pp_expectation ()
         end
   | Curried_application_complete (lbl, Error (ax, {left; _}), loc_kind) ->
@@ -11603,7 +11603,7 @@ let report_error ~loc env =
       Location.errorf ~loc ~sub
         "@[This application is complete, but surplus arguments were provided afterwards.@ \
          When passing or calling %a values, extra arguments are passed in a separate application.@]"
-         (Alloc.Const.print_axis ax) left
+         (Alloc.Const.Per_axis.print ax) left
   | Param_mode_mismatch (s, Error (ax, {left; right})) ->
       let actual, expected =
         match s with
@@ -11613,8 +11613,8 @@ let report_error ~loc env =
       Location.errorf ~loc
         "@[This function takes a parameter which is %a,@ \
         but was expected to take a parameter which is %a.@]"
-        (Style.as_inline_code (Alloc.Const.print_axis ax)) actual
-        (Style.as_inline_code (Alloc.Const.print_axis ax)) expected
+        (Style.as_inline_code (Alloc.Const.Per_axis.print ax)) actual
+        (Style.as_inline_code (Alloc.Const.Per_axis.print ax)) expected
   | Uncurried_function_escapes e -> begin
       match e with
       | Error (Comonadic Areality, _) ->
@@ -11625,8 +11625,8 @@ let report_error ~loc env =
           Location.errorf ~loc
             "This function when partially applied returns a value which is %a,@ \
               but expected to be %a."
-            (Style.as_inline_code (Alloc.Const.print_axis ax)) left
-            (Style.as_inline_code (Alloc.Const.print_axis ax)) right
+            (Style.as_inline_code (Alloc.Const.Per_axis.print ax)) left
+            (Style.as_inline_code (Alloc.Const.Per_axis.print ax)) right
     end
   | Local_return_annotation_mismatch _ ->
       Location.errorf ~loc

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -4800,8 +4800,8 @@ let report_error ppf = function
   | Constructor_submode_failed (Error (ax, {left; right})) ->
       fprintf ppf "@[This constructor is at mode %a, \
         but expected to be at mode %a.@]"
-        (Style.as_inline_code (Mode.Value.Const.print_axis ax)) left
-        (Style.as_inline_code (Mode.Value.Const.print_axis ax)) right;
+        (Style.as_inline_code (Mode.Value.Const.Per_axis.print ax)) left
+        (Style.as_inline_code (Mode.Value.Const.Per_axis.print ax)) right;
       fprintf ppf "@[<hv>@[@{<hint>Hint@}: all argument types must \
         mode-cross for rebinding to succeed.@]"
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -4809,18 +4809,18 @@ let report_error ~loc _env = function
         | Comonadic Areality -> Format.dprintf "a structure"
         | _ ->
             Format.dprintf "a %a structure"
-              (Style.as_inline_code (Mode.Value.Const.print_axis ax)) right
+              (Style.as_inline_code (Mode.Value.Const.Per_axis.print ax)) right
       in
       Location.errorf ~loc
         "This is %a, but expected to be %a because it is inside %t."
-        (Style.as_inline_code (Mode.Value.Const.print_axis ax)) left
-        (Style.as_inline_code (Mode.Value.Const.print_axis ax)) right
+        (Style.as_inline_code (Mode.Value.Const.Per_axis.print ax)) left
+        (Style.as_inline_code (Mode.Value.Const.Per_axis.print ax)) right
         d
   | Submode_failed (Error (ax, {left; right})) ->
       Location.errorf ~loc
         "This is %a, but expected to be %a."
-        (Style.as_inline_code (Mode.Value.Const.print_axis ax)) left
-        (Style.as_inline_code (Mode.Value.Const.print_axis ax)) right
+        (Style.as_inline_code (Mode.Value.Const.Per_axis.print ax)) left
+        (Style.as_inline_code (Mode.Value.Const.Per_axis.print ax)) right
   | Unsupported_modal_module e ->
       Location.errorf ~loc
         "Mode annotations on %a are not supported yet."
@@ -4828,8 +4828,8 @@ let report_error ~loc _env = function
   | Legacy_module (reason, Error (ax, {left; right})) ->
       Location.errorf ~loc
         "This is %a, but expected to be %a because it is a %a."
-        (Style.as_inline_code (Mode.Value.Const.print_axis ax)) left
-        (Style.as_inline_code (Mode.Value.Const.print_axis ax)) right
+        (Style.as_inline_code (Mode.Value.Const.Per_axis.print ax)) left
+        (Style.as_inline_code (Mode.Value.Const.Per_axis.print ax)) right
         print_legacy_module reason
 
 let report_error env ~loc err =

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -151,8 +151,7 @@ let transl_mod_bounds annots =
   let step bounds_so_far { txt = Parsetree.Mode txt; loc } =
     match Axis_pair.of_string txt with
     | P (type a) ((axis, mode) : a Axis.t * a) ->
-      let (module A) = Axis.get axis in
-      let is_top = A.le A.max mode in
+      let is_top = Per_axis.le axis (Per_axis.max axis) mode in
       if is_top
       then
         (* CR layouts v2.8: This warning is disabled for now because transl_type_decl


### PR DESCRIPTION
This should improve inlining.

**Please review by commits:**
- The first and third commit: to be reviewed by @dkalinichenko-js 
- The second commit: to be reviewed by @glittershark 