### PR TITLE
Unzip `Mode.Modality.Value`

### DIFF
--- a/chamelon/compat.ox.ml
+++ b/chamelon/compat.ox.ml
@@ -414,7 +414,7 @@ let mk_value_description ~val_type ~val_kind ~val_attributes =
     val_type;
     val_kind;
     val_loc = Location.none;
-    val_modalities = Mode.Modality.Value.id;
+    val_modalities = Mode.Modality.id;
     val_attributes;
     val_uid = Uid.internal_not_actually_unique;
     val_zero_alloc = Zero_alloc.default;

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -1619,7 +1619,7 @@ let build_substs update_env ?(freshen_bound_variables = false) s =
                to be [max] for conservative soundness. [new_env] is only used
                for printing in debugger. *)
             let vd = Env.find_value (Path.Pident id) old_env in
-            let vd = {vd with val_modalities = Mode.Modality.Value.id} in
+            let vd = {vd with val_modalities = Mode.Modality.id} in
             let mode = Mode.Value.max |> Mode.Value.disallow_right in
             (vd, mode)
           in

--- a/ocamldoc/odoc_sig.ml
+++ b/ocamldoc/odoc_sig.ml
@@ -495,7 +495,7 @@ module Analyser =
       let record comments
           { Typedtree.ld_id; ld_mutable; ld_type; ld_loc; ld_attributes } =
         get_field env comments @@
-        {Types.ld_id; ld_mutable; ld_modalities = Mode.Modality.Value.Const.id;
+        {Types.ld_id; ld_mutable; ld_modalities = Mode.Modality.Const.id;
          ld_sort=Jkind.Sort.Const.void (* ignored *);
          ld_type=ld_type.Typedtree.ctyp_type;
          ld_loc; ld_attributes; ld_uid=Types.Uid.internal_not_actually_unique} in

--- a/tools/debug_printers.ml
+++ b/tools/debug_printers.ml
@@ -24,4 +24,4 @@ let layout = Jkind.Layout.Debug_printers.t Jkind.Sort.Debug_printers.t
 let mod_bounds ppf m = Types.Jkind_mod_bounds.debug_print ppf m
 let with_bounds ppf w = Jkind.With_bounds.debug_print ppf w
 let with_bounds_types ppf w = Jkind.With_bounds.debug_print_types ppf w
-let modalities = Mode.Modality.Value.Const.print
+let modalities = Mode.Modality.Const.print

--- a/toplevel/native/opttoploop.ml
+++ b/toplevel/native/opttoploop.ml
@@ -347,7 +347,7 @@ let name_expression ~loc ~attrs sort exp =
       val_loc = loc;
       val_attributes = attrs;
       val_zero_alloc = Zero_alloc.default;
-      val_modalities = Mode.Modality.Value.id;
+      val_modalities = Mode.Modality.id;
       val_uid = Uid.internal_not_actually_unique; }
   in
   let sg = [Sig_value(id, vd, Exported)] in

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2156,10 +2156,10 @@ let is_principal ty =
 type unwrapped_type_expr =
   { ty : type_expr
   ; is_open : bool
-  ; modality : Mode.Modality.Value.Const.t }
+  ; modality : Mode.Modality.Const.t }
 
 let mk_unwrapped_type_expr ty =
-  { ty; is_open = false; modality = Mode.Modality.Value.Const.id }
+  { ty; is_open = false; modality = Mode.Modality.Const.id }
 
 type unbox_result =
   (* unboxing process made a step: either an unboxing or removal of a [Tpoly] *)
@@ -2225,7 +2225,7 @@ let unbox_once env ty =
   | Tpoly (ty, bound_vars) ->
     Stepped { ty;
               is_open = not (Misc.Stdlib.List.is_empty bound_vars);
-              modality = Mode.Modality.Value.Const.id }
+              modality = Mode.Modality.Const.id }
   | _ -> Final_result
 
 let contained_without_boxing env ty =
@@ -2258,7 +2258,7 @@ let rec get_unboxed_type_representation
     | Stepped { ty = ty2; is_open = is_open2; modality = modality2 } ->
       let is_open = is_open || is_open2 in
       let modality =
-        Mode.Modality.Value.Const.concat modality ~then_:modality2
+        Mode.Modality.Const.concat modality ~then_:modality2
       in
       get_unboxed_type_representation
         ~is_open ~modality env ty ty2 (fuel - 1)
@@ -2269,7 +2269,7 @@ let rec get_unboxed_type_representation
 let get_unboxed_type_representation env ty =
   (* Do not give too much fuel: PR#7424 *)
   get_unboxed_type_representation
-    ~is_open:false ~modality:Mode.Modality.Value.Const.id env ty ty 100
+    ~is_open:false ~modality:Mode.Modality.Const.id env ty ty 100
 
 let get_unboxed_type_approximation env ty =
   match get_unboxed_type_representation env ty with
@@ -5082,8 +5082,8 @@ let relevant_pairs pairs v =
 
 let zap_modalities_to_floor_if_modes_enabled_at level =
   if Language_extension.(is_at_least Mode level)
-    then Mode.Modality.Value.zap_to_floor
-    else Mode.Modality.Value.zap_to_id
+    then Mode.Modality.zap_to_floor
+    else Mode.Modality.zap_to_id
 
 
 (** The mode crossing of the memory block of a structure. *)
@@ -5126,8 +5126,8 @@ let mode_crossing_module = Mode.Crossing.max
 
 let zap_modalities_to_floor_if_at_least level =
   if Language_extension.(is_at_least Mode level)
-    then Mode.Modality.Value.zap_to_floor
-    else Mode.Modality.Value.zap_to_id
+    then Mode.Modality.zap_to_floor
+    else Mode.Modality.zap_to_id
 
 let crossing_of_jkind env jkind =
   let context = mk_jkind_context_check_principal env in
@@ -7331,7 +7331,7 @@ let check_decl_jkind env decl jkind =
   let decl_jkind = match decl.type_kind, decl.type_manifest with
     | Type_abstract _, Some inner_ty ->
       Jkind.for_abbreviation ~type_jkind_purely
-        ~modality:Mode.Modality.Value.Const.id inner_ty
+        ~modality:Mode.Modality.Const.id inner_ty
     (* These next cases are more properly rule TK_UNBOXED from kind-inference.md
        (not rule FIND_ABBREV, as documented with [Jkind.for_abbreviation]), but
        they should be fine here. This will all get fixed up later with the

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -584,7 +584,7 @@ val mcomp : Env.t -> type_expr -> type_expr -> unit
 type unwrapped_type_expr =
   { ty : type_expr
   ; is_open : bool  (* are there any unbound variables in this type? *)
-  ; modality : Mode.Modality.Value.Const.t }
+  ; modality : Mode.Modality.Const.t }
 
 val get_unboxed_type_representation :
   Env.t ->
@@ -740,7 +740,7 @@ val crossing_of_jkind : Env.t -> 'd Types.jkind -> Mode.Crossing.t
     trivial crossing. *)
 val crossing_of_ty :
   Env.t ->
-  ?modalities:Mode.Modality.Value.Const.t ->
+  ?modalities:Mode.Modality.Const.t ->
   Types.type_expr ->
   Mode.Crossing.t
 
@@ -748,7 +748,7 @@ val crossing_of_ty :
     types don't cross. *)
 val cross_right :
   Env.t ->
-  ?modalities:Mode.Modality.Value.Const.t ->
+  ?modalities:Mode.Modality.Const.t ->
   Types.type_expr ->
   Mode.Value.r ->
   Mode.Value.r
@@ -757,7 +757,7 @@ val cross_right :
     types don't cross. *)
 val cross_left :
   Env.t ->
-  ?modalities:Mode.Modality.Value.Const.t ->
+  ?modalities:Mode.Modality.Const.t ->
   Types.type_expr ->
   Mode.Value.l ->
   Mode.Value.l
@@ -765,7 +765,7 @@ val cross_left :
 (** Similar to [cross_right] but for [Mode.Alloc]  *)
 val cross_right_alloc :
   Env.t ->
-  ?modalities:Mode.Modality.Value.Const.t ->
+  ?modalities:Mode.Modality.Const.t ->
   Types.type_expr ->
   Mode.Alloc.r ->
   Mode.Alloc.r
@@ -773,7 +773,7 @@ val cross_right_alloc :
 (** Similar to [cross_left] but for [Mode.Alloc]  *)
 val cross_left_alloc :
   Env.t ->
-  ?modalities:Mode.Modality.Value.Const.t ->
+  ?modalities:Mode.Modality.Const.t ->
   Types.type_expr ->
   Mode.Alloc.l ->
   Mode.Alloc.l
@@ -782,8 +782,8 @@ val cross_left_alloc :
     immature than the given one. Zap to id otherwise. *)
 val zap_modalities_to_floor_if_modes_enabled_at :
   Language_extension.maturity ->
-  Mode.Modality.Value.t ->
-  Mode.Modality.Value.Const.t
+  Mode.Modality.t ->
+  Mode.Modality.Const.t
 
 (** The mode crossing of the memory block of a structure. *)
 val mode_crossing_structure_memaddr : Mode.Crossing.t
@@ -797,8 +797,8 @@ val mode_crossing_module : Mode.Crossing.t
 (** Zap a modality to floor if maturity allows, zap to id otherwise. *)
 val zap_modalities_to_floor_if_at_least :
   Language_extension.maturity ->
-  Mode.Modality.Value.t ->
-  Mode.Modality.Value.Const.t
+  Mode.Modality.t ->
+  Mode.Modality.Const.t
 
 val check_constructor_crossing_creation :
   Env.t -> Longident.t loc

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -99,7 +99,7 @@ let constructor_args ~current_unit priv cd_args cd_res path rep =
         {
           ca_type = newgenconstr path type_params;
           ca_sort = Jkind.Sort.Const.value;
-          ca_modalities = Mode.Modality.Value.Const.id;
+          ca_modalities = Mode.Modality.Const.id;
           ca_loc = Location.none
         }
       ],
@@ -238,7 +238,7 @@ let dummy_label (type rep) (record_form : rep record_form)
   | Unboxed_product -> Record_unboxed_product
   in
   { lbl_name = ""; lbl_res = none; lbl_arg = none;
-    lbl_mut = Immutable; lbl_modalities = Mode.Modality.Value.Const.id;
+    lbl_mut = Immutable; lbl_modalities = Mode.Modality.Const.id;
     lbl_sort = Jkind.Sort.Const.void;
     lbl_pos = -1; lbl_all = [||];
     lbl_repres = repres;

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1025,18 +1025,18 @@ let scrape_alias =
         t -> Subst.Lazy.module_type -> Subst.Lazy.module_type)
 
 let md md_type =
-  {md_type; md_modalities = Mode.Modality.Value.id; md_attributes=[];
+  {md_type; md_modalities = Mode.Modality.id; md_attributes=[];
    md_loc=Location.none; md_uid = Uid.internal_not_actually_unique}
 
 (** The caller is not interested in modes, and thus [val_modalities] is
 invalidated. *)
 let vda_description vda =
   let vda_description = vda.vda_description in
-  {vda_description with val_modalities = Mode.Modality.Value.undefined}
+  {vda_description with val_modalities = Mode.Modality.undefined}
 
 let normalize_mode modality mode =
-  let vda_mode = Mode.Modality.Value.apply modality mode in
-  Mode.Modality.Value.id, vda_mode
+  let vda_mode = Mode.Modality.apply modality mode in
+  Mode.Modality.id, vda_mode
 
 let normalize_vda_mode vda =
   let vda_description = vda.vda_description in
@@ -1177,7 +1177,7 @@ let read_sign_of_cmi sign name uid ~shape ~address:addr ~flags =
   in
   let md =
     { Subst.Lazy.md_type = Mty_signature sign;
-      md_modalities = Mode.Modality.Value.id;
+      md_modalities = Mode.Modality.id;
       md_loc = Location.none;
       md_attributes = [];
       md_uid = uid;
@@ -2767,7 +2767,7 @@ and add_cltype ?shape id ty env =
 
 let add_module_lazy ~update_summary id presence mty ?mode env =
   let md = Subst.Lazy.{md_type = mty;
-                       md_modalities = Mode.Modality.Value.id;
+                       md_modalities = Mode.Modality.id;
                        md_attributes = [];
                        md_loc = Location.none;
                        md_uid = Uid.internal_not_actually_unique}
@@ -4264,7 +4264,7 @@ let lookup_settable_variable ?(use=true) ~loc name env =
           let mode =
             m0
             |> walk_locks_for_mutable_mode ~errors:true ~loc ~env locks
-            |> Mode.Modality.Value.Const.apply
+            |> Mode.Modality.Const.apply
                 Typemode.let_mutable_modalities
           in
           mutate_value ~use ~loc path vda;

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -42,7 +42,7 @@ type value_mismatch =
   | Not_a_primitive
   | Type of Errortrace.moregen_error
   | Zero_alloc of Zero_alloc.error
-  | Modality of Mode.Modality.Value.error
+  | Modality of Mode.Modality.error
   | Mode of Mode.Value.error
 
 exception Dont_match of value_mismatch
@@ -66,13 +66,13 @@ let child_modes id = function
 
 let child_modes_with_modalities id ~modalities:(moda0, moda1) = function
   | All ->
-    begin match Mode.Modality.Value.sub moda0 moda1 with
+    begin match Mode.Modality.sub moda0 moda1 with
       | Ok () -> Ok All
       | Error e -> Error e
     end
   | Specific (m0, m1, c) ->
     let c = child_close_over_coercion_opt id c in
-    begin match Mode.Modality.Value.to_const_opt moda1 with
+    begin match Mode.Modality.to_const_opt moda1 with
     | None ->
       (* [wrap_constraint_with_shape] invokes inclusion check with
           identical modes and inferred modalities, which we workaround *)
@@ -81,8 +81,8 @@ let child_modes_with_modalities id ~modalities:(moda0, moda1) = function
       (* For children, we only check modality inclusion *)
       Ok All
     | Some moda1 ->
-      let m0 = Mode.Modality.Value.apply moda0 m0 in
-      let m1 = Mode.Modality.Value.Const.apply moda1 m1 in
+      let m0 = Mode.Modality.apply moda0 m0 in
+      let m1 = Mode.Modality.Const.apply moda1 m1 in
       Ok (Specific (m0, m1, c))
     end
 
@@ -266,7 +266,7 @@ type label_mismatch =
   | Type of Errortrace.equality_error
   | Mutability of position
   | Atomicity of position
-  | Modality of Modality.Value.equate_error
+  | Modality of Modality.equate_error
 
 type record_change =
   (Types.label_declaration, Types.label_declaration, label_mismatch)
@@ -286,7 +286,7 @@ type constructor_mismatch =
   | Inline_record of record_change list
   | Kind of position
   | Explicit_return_type of position
-  | Modality of int * Modality.Value.equate_error
+  | Modality of int * Modality.equate_error
 
 type extension_constructor_mismatch =
   | Constructor_privacy
@@ -336,7 +336,7 @@ let report_modality_sub_error first second ppf e =
   let print_modality id ppf m =
     Printtyp.modality ~id:(fun ppf -> Format.pp_print_string ppf id) ppf m
   in
-  let Modality.Value.Error {left; right} = e in
+  let Modality.Error {left; right} = e in
   Format.fprintf ppf "%s is %a and %s is %a."
     (String.capitalize_ascii second)
     (print_modality "empty") right
@@ -354,7 +354,7 @@ let report_mode_sub_error got expected ppf e =
       expected
       (Misc.Style.as_inline_code (Value.Const.print_axis ax)) right
 
-let report_modality_equate_error first second ppf ((equate_step, sub_error) : Modality.Value.equate_error) =
+let report_modality_equate_error first second ppf ((equate_step, sub_error) : Modality.equate_error) =
   match equate_step with
   | Left_le_right -> report_modality_sub_error first second ppf sub_error
   | Right_le_left -> report_modality_sub_error second first ppf sub_error
@@ -744,7 +744,7 @@ module Record_diffing = struct
         | Some err -> Some err
         | None ->
           match
-            Modality.Value.Const.equate ld1.ld_modalities ld2.ld_modalities
+            Modality.Const.equate ld1.ld_modalities ld2.ld_modalities
           with
           | Ok () ->
             let tl1 = params1 @ [ld1.ld_type] in
@@ -955,7 +955,7 @@ module Variant_diffing = struct
           | exception Ctype.Equality err -> Some (Type err)
           | () -> List.combine arg1_gfs arg2_gfs
                   |> find_map_idx
-                    (fun (x,y) -> get_error @@ Modality.Value.Const.equate x y)
+                    (fun (x,y) -> get_error @@ Modality.Const.equate x y)
                   |> Option.map (fun (i, err) -> Modality (i, err))
         end
     | Types.Cstr_record l1, Types.Cstr_record l2 ->

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -37,7 +37,7 @@ type value_mismatch =
   | Not_a_primitive
   | Type of Errortrace.moregen_error
   | Zero_alloc of Zero_alloc.error
-  | Modality of Mode.Modality.Value.error
+  | Modality of Mode.Modality.error
   | Mode of Mode.Value.error
 
 exception Dont_match of value_mismatch
@@ -64,7 +64,7 @@ type label_mismatch =
   | Type of Errortrace.equality_error
   | Mutability of position
   | Atomicity of position
-  | Modality of Mode.Modality.Value.equate_error
+  | Modality of Mode.Modality.equate_error
 
 type record_change =
   (Types.label_declaration as 'ld, 'ld, label_mismatch) Diffing_with_keys.change
@@ -83,7 +83,7 @@ type constructor_mismatch =
   | Inline_record of record_change list
   | Kind of position
   | Explicit_return_type of position
-  | Modality of int * Mode.Modality.Value.equate_error
+  | Modality of int * Mode.Modality.equate_error
 
 type extension_constructor_mismatch =
   | Constructor_privacy
@@ -158,8 +158,8 @@ val child_modes: string -> mmodes -> mmodes
     modes suitable for the inclusion check of the parent item, and both hands'
     modalities between the parent and the child. *)
 val child_modes_with_modalities:
-  string -> modalities:(Mode.Modality.Value.t * Mode.Modality.Value.t) ->
-  mmodes -> (mmodes, Mode.Modality.Value.error) Result.t
+  string -> modalities:(Mode.Modality.t * Mode.Modality.t) ->
+  mmodes -> (mmodes, Mode.Modality.error) Result.t
 
 (** Claim the current item is included by the RHS and its mode checked. *)
 val check_modes : Env.t -> ?crossing:Mode.Crossing.t -> item:Env.lock_item ->
@@ -196,7 +196,7 @@ val report_type_mismatch :
   Format.formatter -> type_mismatch -> unit
 
 val report_modality_sub_error :
-  string -> string -> Format.formatter -> Mode.Modality.Value.error -> unit
+  string -> string -> Format.formatter -> Mode.Modality.error -> unit
 
 val report_mode_sub_error :
   string -> string -> Format.formatter -> Mode.Value.error -> unit

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -72,7 +72,7 @@ module Error = struct
         (class_type_declaration, Ctype.class_match_failure list) diff
     | Class_declarations of
         (class_declaration, class_declaration_symptom) mdiff
-    | Modalities of Mode.Modality.Value.error
+    | Modalities of Mode.Modality.error
 
   type core_module_type_symptom =
     | Not_an_alias

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -58,7 +58,7 @@ module Error: sig
         (Types.class_type_declaration, Ctype.class_match_failure list) diff
     | Class_declarations of
         (Types.class_declaration, class_declaration_symptom) mdiff
-    | Modalities of Mode.Modality.Value.error
+    | Modalities of Mode.Modality.error
 
   type core_module_type_symptom =
     | Not_an_alias

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -413,7 +413,7 @@ let relevant_axes_of_modality ~relevant_for_shallow ~modality =
   Axis_set.create ~f:(fun ~axis:(Pack axis) ->
       match axis with
       | Modal axis ->
-        let modality = Mode.Modality.Value.Const.proj axis modality in
+        let modality = Mode.Modality.Const.proj axis modality in
         not (Mode.Modality.Atom.is_constant modality)
       (* The kind-inference.md document (in the repo) discusses both constant
          modalities and identity modalities. Of course, reality has modalities
@@ -1896,11 +1896,11 @@ module Const = struct
                 Comonadic
                   (ax, Meet_with (Mode.Value.Comonadic.Const.Per_axis.min ax))
             in
-            Modality.Value.Const.set t acc
+            Modality.Const.set t acc
           | Nonmodal _ ->
             (* TODO: don't know how to print *)
             acc)
-        Modality.Value.Const.id
+        Modality.Const.id
         (Axis_set.to_list axes_to_ignore)
 
     (** Write [actual] in terms of [base] *)
@@ -2651,7 +2651,7 @@ let for_boxed_variant ~loc cstrs =
 let for_boxed_tuple elts =
   List.fold_right
     (fun (_, type_expr) ->
-      add_with_bounds ~modality:Mode.Modality.Value.Const.id ~type_expr)
+      add_with_bounds ~modality:Mode.Modality.Const.id ~type_expr)
     elts
     (Builtin.immutable_data ~why:Tuple |> mark_best)
 
@@ -2679,8 +2679,7 @@ let for_boxed_row row =
       let base = Builtin.immutable_data ~why:Polymorphic_variant in
       Btype.fold_row
         (fun jkind type_expr ->
-          add_with_bounds ~modality:Mode.Modality.Value.Const.id ~type_expr
-            jkind)
+          add_with_bounds ~modality:Mode.Modality.Const.id ~type_expr jkind)
         base row
       |> mark_best
   else Builtin.immediate ~why:Immediate_polymorphic_variant

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -413,7 +413,7 @@ module Builtin : sig
       are represented in the with-bounds. *)
   val product :
     why:History.product_creation_reason ->
-    (Types.type_expr * Mode.Modality.Value.Const.t) list ->
+    (Types.type_expr * Mode.Modality.Const.t) list ->
     Sort.t Layout.t list ->
     Types.jkind_l
 
@@ -430,7 +430,7 @@ val unsafely_set_bounds :
 
 (** Take an existing [jkind_l] and add some with-bounds. *)
 val add_with_bounds :
-  modality:Mode.Modality.Value.Const.t ->
+  modality:Mode.Modality.Const.t ->
   type_expr:Types.type_expr ->
   Types.jkind_l ->
   Types.jkind_l
@@ -578,7 +578,7 @@ val for_or_null_argument : Ident.t -> 'd Types.jkind
 *)
 val for_abbreviation :
   type_jkind_purely:(Types.type_expr -> Types.jkind_l) ->
-  modality:Mode.Modality.Value.Const.t ->
+  modality:Mode.Modality.Const.t ->
   Types.type_expr ->
   Types.jkind_l
 
@@ -671,13 +671,13 @@ val set_layout : 'd Types.jkind -> Sort.t Layout.t -> 'd Types.jkind
     modified by the modality, by setting the mod-bounds appropriately
     and propagating the modality into any with-bounds. *)
 val apply_modality_l :
-  Mode.Modality.Value.Const.t -> (allowed * 'r) Types.jkind -> Types.jkind_l
+  Mode.Modality.Const.t -> (allowed * 'r) Types.jkind -> Types.jkind_l
 
 (** Change a jkind to be appropriate for an expectation of a type under
     a modality. This means that the jkind's axes affected by the modality
     will all be top. The with-bounds are left unchanged. *)
 val apply_modality_r :
-  Mode.Modality.Value.Const.t -> ('l * allowed) Types.jkind -> Types.jkind_r
+  Mode.Modality.Const.t -> ('l * allowed) Types.jkind -> Types.jkind_r
 
 (** Change a jkind to be appropriate for an expectation of a type passed to
     the [or_null] constructor. Adjusts nullability to be [Non_null], and
@@ -718,9 +718,7 @@ val normalize :
 val set_outcometree_of_type : (Types.type_expr -> Outcometree.out_type) -> unit
 
 val set_outcometree_of_modalities_new :
-  (Types.mutability ->
-  Mode.Modality.Value.Const.t ->
-  Outcometree.out_mode_new list) ->
+  (Types.mutability -> Mode.Modality.Const.t -> Outcometree.out_mode_new list) ->
   unit
 
 (** Provides the [Printtyp.path] formatter back up the dependency chain to

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -305,7 +305,7 @@ let option_argument_jkind = Jkind.Builtin.value_or_null ~why:(
 let list_jkind param =
   Jkind.Builtin.immutable_data ~why:Boxed_variant |>
   Jkind.add_with_bounds
-    ~modality:Mode.Modality.Value.Const.id
+    ~modality:Mode.Modality.Const.id
     ~type_expr:param |>
   Jkind.mark_best
 
@@ -460,7 +460,7 @@ let mk_add_extension add_extension id args =
               {
                 ca_type;
                 ca_sort;
-                ca_modalities=Mode.Modality.Value.Const.id;
+                ca_modalities=Mode.Modality.Const.id;
                 ca_loc=Location.none
               })
             args);
@@ -493,7 +493,7 @@ let variant constrs =
 let unrestricted tvar ca_sort =
   {ca_type=tvar;
    ca_sort;
-   ca_modalities=Mode.Modality.Value.Const.id;
+   ca_modalities=Mode.Modality.Const.id;
    ca_loc=Location.none}
 
 (* CR layouts: Changes will be needed here as we add support for the built-ins
@@ -512,7 +512,7 @@ let build_initial_env add_type add_extension empty_env =
        ~jkind:(fun param ->
          Jkind.Builtin.mutable_data ~why:(Primitive ident_array) |>
          Jkind.add_with_bounds
-           ~modality:Mode.Modality.Value.Const.id
+           ~modality:Mode.Modality.Const.id
            ~type_expr:param)
   |> add_type1 ident_iarray
        ~variance:Variance.covariant
@@ -521,7 +521,7 @@ let build_initial_env add_type add_extension empty_env =
        ~jkind:(fun param ->
          Jkind.Builtin.immutable_data ~why:(Primitive ident_iarray) |>
          Jkind.add_with_bounds
-           ~modality:Mode.Modality.Value.Const.id
+           ~modality:Mode.Modality.Const.id
            ~type_expr:param)
   |> add_type ident_bool
        ~kind:(variant [ cstr ident_false []; cstr ident_true []])
@@ -571,7 +571,7 @@ let build_initial_env add_type add_extension empty_env =
        ~jkind:(fun param ->
          Jkind.Builtin.immutable_data ~why:Boxed_variant |>
          Jkind.add_with_bounds
-           ~modality:Mode.Modality.Value.Const.id
+           ~modality:Mode.Modality.Const.id
            ~type_expr:param)
   |> add_type2 ident_idx_imm
        ~param1_jkind:(
@@ -616,7 +616,7 @@ let build_initial_env add_type add_extension empty_env =
              {
                ld_id=id;
                ld_mutable=Immutable;
-               ld_modalities=Mode.Modality.Value.Const.id;
+               ld_modalities=Mode.Modality.Const.id;
                ld_type=field_type;
                ld_sort=Jkind.Sort.Const.value;
                ld_loc=Location.none;
@@ -641,10 +641,10 @@ let build_initial_env add_type add_extension empty_env =
        ~jkind:Jkind.(
          of_builtin Const.Builtin.immutable_data
            ~why:(Primitive ident_lexing_position) |>
-         add_with_bounds ~modality:Mode.Modality.Value.Const.id ~type_expr:type_int |>
-         add_with_bounds ~modality:Mode.Modality.Value.Const.id ~type_expr:type_int |>
-         add_with_bounds ~modality:Mode.Modality.Value.Const.id ~type_expr:type_int |>
-         add_with_bounds ~modality:Mode.Modality.Value.Const.id ~type_expr:type_string)
+         add_with_bounds ~modality:Mode.Modality.Const.id ~type_expr:type_int |>
+         add_with_bounds ~modality:Mode.Modality.Const.id ~type_expr:type_int |>
+         add_with_bounds ~modality:Mode.Modality.Const.id ~type_expr:type_int |>
+         add_with_bounds ~modality:Mode.Modality.Const.id ~type_expr:type_string)
   |> add_type ident_string ~jkind:Jkind.Const.Builtin.immutable_data
   |> add_type ident_bytes ~jkind:Jkind.Const.Builtin.mutable_data
   |> add_type ident_unit
@@ -746,7 +746,7 @@ let or_null_jkind param =
   Jkind.Const.Builtin.value_or_null_mod_everything
   |> Jkind.of_builtin ~why:(Primitive ident_or_null)
   |> Jkind.add_with_bounds
-    ~modality:Mode.Modality.Value.Const.id
+    ~modality:Mode.Modality.Const.id
     ~type_expr:param
   |> Jkind.mark_best
 

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -490,7 +490,7 @@ let enter_ancestor_met ~loc name ~sign ~meths ~cl_num ~ty ~attrs met_env =
   let check s = Warnings.Unused_ancestor s in
   let kind = Val_anc (sign, meths, cl_num) in
   let desc =
-    { val_type = ty; val_modalities = Modality.Value.id; val_kind = kind;
+    { val_type = ty; val_modalities = Modality.id; val_kind = kind;
       val_attributes = attrs;
       val_zero_alloc = Zero_alloc.default;
       Types.val_loc = loc;
@@ -506,7 +506,7 @@ let add_self_met loc id sign self_var_kind vars cl_num
   in
   let kind = Val_self (sign, self_var_kind, vars, cl_num) in
   let desc =
-    { val_type = ty; val_modalities = Modality.Value.id; val_kind = kind;
+    { val_type = ty; val_modalities = Modality.id; val_kind = kind;
       val_attributes = attrs;
       val_zero_alloc = Zero_alloc.default;
       Types.val_loc = loc;
@@ -522,7 +522,7 @@ let add_instance_var_met loc label id sign cl_num attrs met_env =
   in
   let kind = Val_ivar (mut, cl_num) in
   let desc =
-    { val_type = ty; val_modalities = Modality.Value.id; val_kind = kind;
+    { val_type = ty; val_modalities = Modality.id; val_kind = kind;
       val_attributes = attrs;
       Types.val_loc = loc;
       val_zero_alloc = Zero_alloc.default;
@@ -1468,7 +1468,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
              in
              let desc =
                {val_type = expr.exp_type;
-                val_modalities = Modality.Value.id;
+                val_modalities = Modality.id;
                 val_kind = Val_ivar (Immutable, cl_num);
                 val_attributes = [];
                 val_zero_alloc = Zero_alloc.default;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -96,7 +96,7 @@ let record_form_to_wrong_kind_sort
 
 type type_block_access_result =
   { ba : block_access; base_ty: type_expr; el_ty: type_expr; flat_float : bool;
-    modality : Modality.Value.Const.t }
+    modality : Modality.Const.t }
 
 type contains_gadt =
   | Contains_gadt
@@ -272,7 +272,7 @@ type error =
   | Block_access_record_unboxed
   | Block_access_private_record
   | Block_index_modality_mismatch of
-      { mut : bool; err : Modality.Value.equate_error }
+      { mut : bool; err : Modality.equate_error }
   | Submode_failed of
       Value.error * submode_reason *
       Env.locality_context option *
@@ -527,7 +527,7 @@ let mode_morph f expected_mode =
 
 let mode_modality modality expected_mode =
   as_single_mode expected_mode
-  |> Modality.Value.Const.apply modality
+  |> Modality.Const.apply modality
   |> mode_default
 
 (* used when entering a function;
@@ -1303,7 +1303,7 @@ let add_pattern_variables ?check ?check_as env pv =
        let check = if pv_as_var then check_as else check in
        Env.add_value ?check ~mode:pv_mode pv_id
          {val_type = pv_type; val_kind = pv_kind; Types.val_loc = pv_loc;
-          val_attributes = pv_attributes; val_modalities = Modality.Value.id;
+          val_attributes = pv_attributes; val_modalities = Modality.id;
           val_zero_alloc = Zero_alloc.default;
           val_uid = pv_uid
          } env
@@ -1340,7 +1340,7 @@ let add_module_variables env module_variables =
       in
       let md =
         { md_type = modl.mod_type; md_attributes = [];
-          md_modalities = Mode.Modality.Value.id;
+          md_modalities = Mode.Modality.id;
           md_loc = mv_name.loc;
           md_uid = mv_uid; }
       in
@@ -2741,7 +2741,7 @@ and type_pat_aux
       Typemode.transl_modalities ~maturity:Stable mutability []
     in
     check_project_mutability ~loc ~env:!!penv mutability alloc_mode.mode;
-    let alloc_mode = Modality.Value.Const.apply modalities alloc_mode.mode in
+    let alloc_mode = Modality.Const.apply modalities alloc_mode.mode in
     let alloc_mode = simple_pat_mode alloc_mode in
     let pl = List.map (fun p -> type_pat ~alloc_mode tps Value p ty_elt) spl in
     rvp {
@@ -2855,7 +2855,7 @@ and type_pat_aux
             record_ty record_form in
         check_project_mutability ~loc ~env:!!penv label.lbl_mut alloc_mode.mode;
         let mode =
-          Modality.Value.Const.apply label.lbl_modalities alloc_mode.mode
+          Modality.Const.apply label.lbl_modalities alloc_mode.mode
         in
         let alloc_mode = simple_pat_mode mode in
         (label_lid, label, type_pat tps Value ~alloc_mode sarg ty_arg)
@@ -3108,7 +3108,7 @@ and type_pat_aux
         List.map2
           (fun p (arg : Types.constructor_argument) ->
              let alloc_mode =
-              Modality.Value.Const.apply arg.ca_modalities alloc_mode.mode
+              Modality.Const.apply arg.ca_modalities alloc_mode.mode
              in
              let alloc_mode =
               Mode.Value.join [ alloc_mode; constructor_mode ]
@@ -3351,7 +3351,7 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
             ; val_kind = Val_reg
             ; val_attributes = pv_attributes
             ; val_zero_alloc = Zero_alloc.default
-            ; val_modalities = Modality.Value.id
+            ; val_modalities = Modality.id
             ; val_loc = pv_loc
             ; val_uid = pv_uid
             }
@@ -3363,7 +3363,7 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
             ; val_kind = Val_ivar (Immutable, cl_num)
             ; val_attributes = pv_attributes
             ; val_zero_alloc = Zero_alloc.default
-            ; val_modalities = Modality.Value.id
+            ; val_modalities = Modality.id
             ; val_loc = pv_loc
             ; val_uid = pv_uid
             }
@@ -5729,7 +5729,7 @@ and type_expect_
         assign_label_children (List.length lbl_a_list)
           (fun _loc ty mode -> (* only change mode here, see type_label_exp *)
              List.map (fun (_, label, _) ->
-               let mode = Modality.Value.Const.apply label.lbl_modalities mode in
+               let mode = Modality.Const.apply label.lbl_modalities mode in
                Overwrite_label(ty, mode))
                lbl_a_list)
           overwrite
@@ -5767,7 +5767,7 @@ and type_expect_
               with_explanation (fun () ->
                 unify_exp_types record_loc env (instance ty_expected) ty_res2);
               check_project_mutability ~loc:extended_expr_loc ~env lbl.lbl_mut mode;
-              let mode = Modality.Value.Const.apply lbl.lbl_modalities mode in
+              let mode = Modality.Const.apply lbl.lbl_modalities mode in
               check_construct_mutability ~loc:record_loc ~env lbl.lbl_mut
                 ~ty:lbl.lbl_arg ~modalities:lbl.lbl_modalities record_mode;
               let argument_mode =
@@ -5888,7 +5888,7 @@ and type_expect_
             | Path.Pident id ->
               let modalities = Typemode.let_mutable_modalities in
               let mode =
-                Modality.Value.Const.apply modalities actual_mode.mode
+                Modality.Const.apply modalities actual_mode.mode
               in
               submode ~loc ~env mode expected_mode;
               Texp_mutvar {loc = lid.loc; txt = id}
@@ -6324,7 +6324,7 @@ and type_expect_
         end ~post:generalize_structure
       in
       check_project_mutability ~loc:record.exp_loc ~env label.lbl_mut rmode;
-      let mode = Modality.Value.Const.apply label.lbl_modalities rmode in
+      let mode = Modality.Const.apply label.lbl_modalities rmode in
       let boxing : texp_field_boxing =
         let is_float_boxing =
           match label.lbl_repres with
@@ -6380,7 +6380,7 @@ and type_expect_
       if Types.is_mutable label.lbl_mut then
         fatal_error
           "Typecore.type_expect_: unboxed record labels are never mutable";
-      let mode = Modality.Value.Const.apply label.lbl_modalities rmode in
+      let mode = Modality.Const.apply label.lbl_modalities rmode in
       let mode = cross_left env ty_arg mode in
       submode ~loc ~env mode expected_mode;
       let uu = unique_use ~loc ~env mode (as_single_mode expected_mode) in
@@ -6497,7 +6497,7 @@ and type_expect_
                   type_unboxed_access env loc el_ty ua
                 in
                 let modality =
-                  Modality.Value.Const.concat modality ~then_:ua_modality in
+                  Modality.Const.concat modality ~then_:ua_modality in
                 (el_ty, modality), ua
              ))
         (el_ty, modality)
@@ -6505,7 +6505,7 @@ and type_expect_
     in
     let expected_modality = Typemode.idx_expected_modalities ~mut in
     begin
-      match Modality.Value.Const.equate modality expected_modality with
+      match Modality.Const.equate modality expected_modality with
       | Ok () -> ()
       | Error err ->
         raise (Error(loc, env, Block_index_modality_mismatch { mut; err }))
@@ -6808,7 +6808,7 @@ and type_expect_
               let md_shape = Shape.set_uid_if_none md_shape md_uid in
               let md =
                 { md_type = modl.mod_type; md_attributes = [];
-                  md_modalities = Modality.Value.id;
+                  md_modalities = Modality.id;
                   md_loc = name.loc;
                   md_uid; }
               in
@@ -8519,7 +8519,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
           { val_type = ty; val_kind = Val_reg;
             val_attributes = [];
             val_zero_alloc = Zero_alloc.default;
-            val_modalities = Modality.Value.id;
+            val_modalities = Modality.id;
             val_loc = Location.none;
             val_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
           }
@@ -9047,7 +9047,7 @@ and type_construct ~overwrite env (expected_mode : expected_mode) loc lid sarg
       (fun loc ty mode ->
          let ty_args, _, _ = unify_as_construct ty in
          List.map (fun ty_arg ->
-           let mode = Modality.Value.Const.apply ty_arg.Types.ca_modalities mode in
+           let mode = Modality.Const.apply ty_arg.Types.ca_modalities mode in
            match recarg with
            | Required -> Overwriting(loc, ty_arg.Types.ca_type, mode)
            | Allowed | Rejected -> Assigning(ty_arg.Types.ca_type, mode)
@@ -11508,7 +11508,7 @@ let report_error ~loc env =
     Location.error ~loc
       "Block indices do not support private records."
   | Block_index_modality_mismatch { mut; err } ->
-    let step, Modality.Value.Error({ left; right }) = err in
+    let step, Modality.Error({ left; right }) = err in
     let print_modality id ppf m =
       Printtyp.modality ~id:(fun ppf -> Format.pp_print_string ppf id) ppf m
     in

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -316,7 +316,7 @@ type error =
   | Block_access_record_unboxed
   | Block_access_private_record
   | Block_index_modality_mismatch of
-      { mut : bool; err : Mode.Modality.Value.equate_error }
+      { mut : bool; err : Mode.Modality.equate_error }
   | Submode_failed of
       Mode.Value.error * submode_reason *
       Env.locality_context option *

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -35,7 +35,7 @@ val transl_type_extension:
     Typedtree.type_extension * Env.t * Shape.t list
 
 val transl_value_decl:
-    Env.t -> modalities:Mode.Modality.Value.t -> Location.t ->
+    Env.t -> modalities:Mode.Modality.t -> Location.t ->
     Parsetree.value_description -> Typedtree.value_description * Env.t
 
 (* If the [fixed_row_path] optional argument is provided,

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -620,7 +620,7 @@ and primitive_coercion =
 
 and signature = {
   sig_items : signature_item list;
-  sig_modalities : Mode.Modality.Value.Const.t;
+  sig_modalities : Mode.Modality.Const.t;
   sig_type : Types.signature;
   sig_final_env : Env.t;
   sig_sloc : Location.t;
@@ -643,7 +643,7 @@ and signature_item_desc =
   | Tsig_modtype of module_type_declaration
   | Tsig_modtypesubst of module_type_declaration
   | Tsig_open of open_description
-  | Tsig_include of include_description * Mode.Modality.Value.Const.t
+  | Tsig_include of include_description * Mode.Modality.Const.t
   | Tsig_class of class_description list
   | Tsig_class_type of class_type_declaration list
   | Tsig_attribute of attribute
@@ -655,7 +655,7 @@ and module_declaration =
      md_uid: Uid.t;
      md_presence: module_presence;
      md_type: module_type;
-     md_modalities: Mode.Modality.Value.t;
+     md_modalities: Mode.Modality.t;
      md_attributes: attribute list;
      md_loc: Location.t;
     }
@@ -812,7 +812,7 @@ and label_declaration =
      ld_name: string loc;
      ld_uid: Uid.t;
      ld_mutable: mutability;
-     ld_modalities: Modality.Value.Const.t;
+     ld_modalities: Modality.Const.t;
      ld_type: core_type;
      ld_loc: Location.t;
      ld_attributes: attribute list;
@@ -832,7 +832,7 @@ and constructor_declaration =
 
 and constructor_argument =
   {
-    ca_modalities: Modality.Value.Const.t;
+    ca_modalities: Modality.Const.t;
     ca_type: core_type;
     ca_loc: Location.t;
   }

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -898,7 +898,7 @@ and primitive_coercion =
 
 and signature = {
   sig_items : signature_item list;
-  sig_modalities : Mode.Modality.Value.Const.t;
+  sig_modalities : Mode.Modality.Const.t;
   sig_type : Types.signature;
   sig_final_env : Env.t;
   sig_sloc : Location.t;
@@ -921,7 +921,7 @@ and signature_item_desc =
   | Tsig_modtype of module_type_declaration
   | Tsig_modtypesubst of module_type_declaration
   | Tsig_open of open_description
-  | Tsig_include of include_description * Mode.Modality.Value.Const.t
+  | Tsig_include of include_description * Mode.Modality.Const.t
   | Tsig_class of class_description list
   | Tsig_class_type of class_type_declaration list
   | Tsig_attribute of attribute
@@ -933,7 +933,7 @@ and module_declaration =
      md_uid: Uid.t;
      md_presence: Types.module_presence;
      md_type: module_type;
-     md_modalities: Mode.Modality.Value.t;
+     md_modalities: Mode.Modality.t;
      md_attributes: attributes;
      md_loc: Location.t;
     }
@@ -1095,7 +1095,7 @@ and label_declaration =
      ld_name: string loc;
      ld_uid: Uid.t;
      ld_mutable: Types.mutability;
-     ld_modalities: Mode.Modality.Value.Const.t;
+     ld_modalities: Mode.Modality.Const.t;
      ld_type: core_type;
      ld_loc: Location.t;
      ld_attributes: attributes;
@@ -1115,7 +1115,7 @@ and constructor_declaration =
 
 and constructor_argument =
   {
-    ca_modalities: Mode.Modality.Value.Const.t;
+    ca_modalities: Mode.Modality.Const.t;
     ca_type: core_type;
     ca_loc: Location.t;
   }

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -622,7 +622,7 @@ let rec remove_modality_and_zero_alloc_variables_sg env ~zap_modality sg =
     | Sig_value (id, desc, vis) ->
         let val_modalities =
           desc.val_modalities
-          |> zap_modality |> Mode.Modality.Value.of_const
+          |> zap_modality |> Mode.Modality.of_const
         in
         let val_zero_alloc =
           Zero_alloc.create_const (Zero_alloc.get desc.val_zero_alloc)
@@ -635,7 +635,7 @@ let rec remove_modality_and_zero_alloc_variables_sg env ~zap_modality sg =
             md.md_type
         in
         let md_modalities =
-          md.md_modalities |> zap_modality |> Mode.Modality.Value.of_const
+          md.md_modalities |> zap_modality |> Mode.Modality.of_const
         in
         let md = {md with md_type; md_modalities} in
         Sig_module (id, pres, md, re, vis)
@@ -657,7 +657,7 @@ and remove_modality_and_zero_alloc_variables_mty env ~zap_modality mty =
       | Named (id, mty) ->
           let mty =
             remove_modality_and_zero_alloc_variables_mty env
-              ~zap_modality:Mode.Modality.Value.to_const_exn mty
+              ~zap_modality:Mode.Modality.to_const_exn mty
           in
           Named (id, mty)
       | Unit -> Unit
@@ -669,7 +669,7 @@ and remove_modality_and_zero_alloc_variables_mty env ~zap_modality mty =
   | Mty_strengthen (mty, path, alias) ->
       let mty =
         remove_modality_and_zero_alloc_variables_mty env
-        ~zap_modality:Mode.Modality.Value.to_const_exn mty
+        ~zap_modality:Mode.Modality.to_const_exn mty
       in
       Mty_strengthen (mty, path, alias)
 
@@ -806,7 +806,7 @@ module Merge = struct
         let newsg =
           if destructive then
             remove_modality_and_zero_alloc_variables_sg sig_env
-              ~zap_modality:Mode.Modality.Value.zap_to_id newsg
+              ~zap_modality:Mode.Modality.zap_to_id newsg
           else
             newsg
         in
@@ -1013,7 +1013,7 @@ module Merge = struct
             let mty = Mtype.scrape_for_type_of ~remove_aliases sig_env mty in
             let mty =
               remove_modality_and_zero_alloc_variables_mty sig_env
-                ~zap_modality:Mode.Modality.Value.zap_to_id mty
+                ~zap_modality:Mode.Modality.zap_to_id mty
             in
             let md'' = { md' with md_type = mty } in
             let newmd =
@@ -1173,9 +1173,9 @@ let rec apply_modalities_signature ~recursive env modalities sg =
   | Sig_value (id, vd, vis) ->
       let val_modalities =
         vd.val_modalities
-        |> Mode.Modality.Value.to_const_exn
-        |> (fun then_ -> Mode.Modality.Value.Const.concat ~then_ modalities)
-        |> Mode.Modality.Value.of_const
+        |> Mode.Modality.to_const_exn
+        |> (fun then_ -> Mode.Modality.Const.concat ~then_ modalities)
+        |> Mode.Modality.of_const
       in
       let vd = {vd with val_modalities} in
       Sig_value (id, vd, vis)
@@ -1219,7 +1219,7 @@ let check_unsupported_modal_module ~env reason modes =
   | None -> ()
   | Some loc -> raise(Error(loc, env, Unsupported_modal_module reason))
 
-let transl_modalities ?(default_modalities = Mode.Modality.Value.Const.id)
+let transl_modalities ?(default_modalities = Mode.Modality.Const.id)
   modalities =
   match modalities with
   | [] -> default_modalities
@@ -1248,10 +1248,10 @@ let apply_pmd_modalities env ~default_modalities pmd_modalities mty =
 
   We still don't support [pmd_modalities] on functors.
   *)
-  match Mode.Modality.Value.Const.is_id modalities with
-  | true -> mty, Mode.Modality.Value.id
+  match Mode.Modality.Const.is_id modalities with
+  | true -> mty, Mode.Modality.id
   | false ->
-      apply_modalities_module_type env modalities mty, Mode.Modality.Value.id
+      apply_modalities_module_type env modalities mty, Mode.Modality.id
 
 (* Auxiliary for translating recursively-defined module types.
    Return a module type that approximates the shape of the given module
@@ -1334,7 +1334,7 @@ let rec approx_modtype env smty =
 and approx_module_declaration env pmd =
   {
     Types.md_type = approx_modtype env pmd.pmd_type;
-    md_modalities = Mode.Modality.Value.id;
+    md_modalities = Mode.Modality.id;
     md_attributes = pmd.pmd_attributes;
     md_loc = pmd.pmd_loc;
     md_uid = Uid.internal_not_actually_unique;
@@ -1865,7 +1865,7 @@ and transl_modtype_aux env smty =
               let id, newenv =
                 let arg_md =
                   { md_type = arg.mty_type;
-                    md_modalities = Mode.Modality.Value.id;
+                    md_modalities = Mode.Modality.id;
                     md_attributes = [];
                     md_loc = param.loc;
                     md_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
@@ -1993,7 +1993,7 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
         sincl.pincl_attributes
     in
     let sg =
-      match Mode.Modality.Value.Const.is_id modalities with
+      match Mode.Modality.Const.is_id modalities with
       | true -> sg
       | false -> apply_modalities_signature ~recursive env modalities sg
     in
@@ -2022,7 +2022,7 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
           | [] -> sig_modalities
           | l -> Typemode.transl_modalities ~maturity:Stable Immutable l
         in
-        let modalities = Mode.Modality.Value.of_const modalities in
+        let modalities = Mode.Modality.of_const modalities in
         let (tdesc, newenv) =
           Typedecl.transl_value_decl env ~modalities item.psig_loc sdesc
         in
@@ -2155,7 +2155,7 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
             md
           else
             { md_type = Mty_alias path;
-              md_modalities = Mode.Modality.Value.id;
+              md_modalities = Mode.Modality.id;
               md_attributes = pms.pms_attributes;
               md_loc = pms.pms_loc;
               md_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
@@ -2857,7 +2857,7 @@ let infer_modalities ~loc ~env ~md_mode ~mode =
           raise (Error (loc, env, Item_weaker_than_structure
             (Error (Comonadic ax, e))))
     end;
-    Mode.Modality.Value.infer ~md_mode ~mode
+    Mode.Modality.infer ~md_mode ~mode
 
 (** Given a signature [sg] to be included in a structure. The signature contains
   modalities relative to [mode], this function returns a signature with
@@ -2865,12 +2865,12 @@ let infer_modalities ~loc ~env ~md_mode ~mode =
 let rebase_modalities ~loc ~env ~md_mode ~mode sg =
   List.map (function
     | Sig_value (id, vd, vis) ->
-        let mode = Mode.Modality.Value.apply vd.val_modalities mode in
+        let mode = Mode.Modality.apply vd.val_modalities mode in
         let val_modalities = infer_modalities ~loc ~env ~md_mode ~mode in
         let vd = {vd with val_modalities} in
         Sig_value (id, vd, vis)
     | Sig_module (id, pres, md, rec_, vis) ->
-        let mode = Mode.Modality.Value.apply md.md_modalities mode in
+        let mode = Mode.Modality.apply md.md_modalities mode in
         let md_modalities = infer_modalities ~loc ~env ~md_mode ~mode in
         let md = {md with md_modalities} in
         Sig_module (id, pres, md, rec_, vis)
@@ -2942,7 +2942,7 @@ and type_module_aux ~alias ~hold_locks sttn funct_body anchor env
               let md_uid =  Uid.mk ~current_unit:(Env.get_unit_name ()) in
               let arg_md =
                 { md_type = mty.mty_type;
-                  md_modalities = Modality.Value.id;
+                  md_modalities = Modality.id;
                   md_attributes = [];
                   md_loc = param.loc;
                   md_uid;
@@ -3634,7 +3634,7 @@ and type_structure ?(toplevel = None) funct_body anchor env ?expected_mode
         in
         let (decls, newenv) =
           transl_recmodule_modtypes env
-            ~sig_modalities:Mode.Modality.Value.Const.id
+            ~sig_modalities:Mode.Modality.Const.id
             (List.map (fun (name, smty, smode, _smodl, attrs, loc) ->
                  ({pmd_name=name; pmd_type=smty;
                    pmd_attributes=attrs; pmd_loc=loc; pmd_modalities=[]}
@@ -3670,7 +3670,7 @@ and type_structure ?(toplevel = None) funct_body anchor env ?expected_mode
                    let mdecl =
                      {
                        md_type = mty.mty_type;
-                       md_modalities = Modality.Value.id;
+                       md_modalities = Modality.id;
                        md_attributes = attrs;
                        md_loc = loc;
                        md_uid = uid;
@@ -4391,7 +4391,7 @@ let package_signatures units =
       let sg = Subst.signature Make_local subst sg in
       let md =
         { md_type=Mty_signature sg;
-          md_modalities=Modality.Value.id;
+          md_modalities=Modality.id;
           md_attributes=[];
           md_loc=Location.none;
           md_uid = Uid.mk ~current_unit:(Env.get_unit_name ());

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -418,8 +418,8 @@ let mutable_implied_modalities ~for_mutable_variable mut =
 let mutable_implied_modalities ~for_mutable_variable mut =
   let l = mutable_implied_modalities ~for_mutable_variable mut in
   List.fold_left
-    (fun t (Modality.Atom.P a) -> Modality.Value.Const.set a t)
-    Modality.Value.Const.id l
+    (fun t (Modality.Atom.P a) -> Modality.Const.set a t)
+    Modality.Const.id l
 
 let idx_expected_modalities ~(mut : bool) =
   (* There are two design constraints on what modalities we allow in an index
@@ -431,8 +431,8 @@ let idx_expected_modalities ~(mut : bool) =
          primitives (see [idx_imm.mli] and [idx_mut.mli] in [Stdlib_beta]). *)
   let modality_of_list l =
     List.fold_left
-      (fun t (Modality.Atom.P a) -> Modality.Value.Const.set a t)
-      Modality.Value.Const.id l
+      (fun t (Modality.Atom.P a) -> Modality.Const.set a t)
+      Modality.Const.id l
   in
   let expected1 = mutable_implied_modalities mut ~for_mutable_variable:false in
   let expected2 =
@@ -445,11 +445,11 @@ let idx_expected_modalities ~(mut : bool) =
           P (Comonadic (Linearity, Meet_with Linearity.Const.legacy));
           P (Comonadic (Yielding, Meet_with Yielding.Const.legacy));
           P (Monadic (Uniqueness, Join_with Uniqueness.Const.legacy)) ]
-    else Mode.Modality.Value.Const.id
+    else Mode.Modality.Const.id
   in
   (* CR layouts v8: only perform this check at most twice: for [mut = true] and
      [mut = false] *)
-  match Mode.Modality.Value.Const.equate expected1 expected2 with
+  match Mode.Modality.Const.equate expected1 expected2 with
   | Ok () -> expected1
   | Error _ ->
     Misc.fatal_error
@@ -486,12 +486,12 @@ let implied_modalities (P a : Modality.Atom.packed) : Modality.Atom.packed list
     [P (Comonadic (Portability, Meet_with b))]
   | _ -> []
 
-let least_modalities_implying mut (t : Modality.Value.Const.t) =
+let least_modalities_implying mut (t : Modality.Const.t) =
   let baseline =
     mutable_implied_modalities ~for_mutable_variable:false
       (Types.is_mutable mut)
   in
-  let annotated = Modality.Value.Const.(diff baseline t) in
+  let annotated = Modality.Const.(diff baseline t) in
   let implied = List.concat_map implied_modalities annotated in
   let exclude_implied =
     List.filter (fun x -> not @@ List.mem x implied) annotated
@@ -500,7 +500,7 @@ let least_modalities_implying mut (t : Modality.Value.Const.t) =
     List.filter_map
       (fun (Modality.Atom.P m_implied) ->
         let m_projected =
-          Modality.Value.Const.proj (Modality.Atom.axis m_implied) t
+          Modality.Const.proj (Modality.Atom.axis m_implied) t
         in
         if m_projected <> m_implied
         then Some (Modality.Atom.P m_projected)
@@ -552,9 +552,9 @@ let transl_modalities ~maturity mut modalities =
      - For the same axis, later modalities overrides earlier modalities. *)
   List.fold_left
     (fun m (Atom.P a as t) ->
-      let m = Value.Const.set a m in
+      let m = Const.set a m in
       List.fold_left
-        (fun m (Atom.P a) -> Value.Const.set a m)
+        (fun m (Atom.P a) -> Const.set a m)
         m (implied_modalities t))
     mut_modalities modalities
 

--- a/typing/typemode.mli
+++ b/typing/typemode.mli
@@ -15,9 +15,9 @@ val transl_modalities :
   maturity:Language_extension.maturity ->
   Types.mutability ->
   Parsetree.modalities ->
-  Mode.Modality.Value.Const.t
+  Mode.Modality.Const.t
 
-val let_mutable_modalities : Mode.Modality.Value.Const.t
+val let_mutable_modalities : Mode.Modality.Const.t
 
 val untransl_modality :
   'a Mode.Modality.Atom.t -> Parsetree.modality Location.loc
@@ -26,9 +26,9 @@ val untransl_modality :
     attributes on the field and remove mutable-implied modalities accordingly.
     *)
 val untransl_modalities :
-  Types.mutability -> Mode.Modality.Value.Const.t -> Parsetree.modalities
+  Types.mutability -> Mode.Modality.Const.t -> Parsetree.modalities
 
 (** Interpret a mod-bounds. *)
 val transl_mod_bounds : Parsetree.modes -> Types.Jkind_mod_bounds.t
 
-val idx_expected_modalities : mut:bool -> Mode.Modality.Value.Const.t
+val idx_expected_modalities : mut:bool -> Mode.Modality.Const.t

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -706,7 +706,7 @@ and label_declaration =
   {
     ld_id: Ident.t;
     ld_mutable: mutability;
-    ld_modalities: Mode.Modality.Value.Const.t;
+    ld_modalities: Mode.Modality.Const.t;
     ld_type: type_expr;
     ld_sort: Jkind_types.Sort.Const.t;
     ld_loc: Location.t;
@@ -726,7 +726,7 @@ and constructor_declaration =
 
 and constructor_argument =
   {
-    ca_modalities: Mode.Modality.Value.Const.t;
+    ca_modalities: Mode.Modality.Const.t;
     ca_type: type_expr;
     ca_sort: Jkind_types.Sort.Const.t;
     ca_loc: Location.t;
@@ -826,7 +826,7 @@ module type Wrapped = sig
 
   type value_description =
     { val_type: type_expr wrapped;                (* Type of the value *)
-      val_modalities : Mode.Modality.Value.t;     (* Modalities on the value *)
+      val_modalities : Mode.Modality.t;     (* Modalities on the value *)
       val_kind: value_kind;
       val_loc: Location.t;
       val_zero_alloc: Zero_alloc.t;
@@ -861,7 +861,7 @@ module type Wrapped = sig
   and module_declaration =
   {
     md_type: module_type;
-    md_modalities: Mode.Modality.Value.t;
+    md_modalities: Mode.Modality.t;
     md_attributes: Parsetree.attributes;
     md_loc: Location.t;
     md_uid: Uid.t;
@@ -1114,7 +1114,7 @@ type 'a gen_label_description =
     lbl_res: type_expr;                 (* Type of the result *)
     lbl_arg: type_expr;                 (* Type of the argument *)
     lbl_mut: mutability;                (* Is this a mutable field? *)
-    lbl_modalities: Mode.Modality.Value.Const.t;(* Modalities on the field *)
+    lbl_modalities: Mode.Modality.Const.t;(* Modalities on the field *)
     lbl_sort: Jkind_types.Sort.Const.t; (* Sort of the argument *)
     lbl_pos: int;                       (* Position in type *)
     lbl_all: 'a gen_label_description array;   (* All the labels in this type *)

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -915,7 +915,7 @@ and label_declaration =
   {
     ld_id: Ident.t;
     ld_mutable: mutability;
-    ld_modalities: Mode.Modality.Value.Const.t;
+    ld_modalities: Mode.Modality.Const.t;
     ld_type: type_expr;
     ld_sort: Jkind_types.Sort.Const.t;
     ld_loc: Location.t;
@@ -935,7 +935,7 @@ and constructor_declaration =
 
 and constructor_argument =
   {
-    ca_modalities: Mode.Modality.Value.Const.t;
+    ca_modalities: Mode.Modality.Const.t;
     ca_type: type_expr;
     ca_sort: Jkind_types.Sort.Const.t;
     ca_loc: Location.t;
@@ -948,7 +948,7 @@ and constructor_arguments =
 val tys_of_constr_args : constructor_arguments -> type_expr list
 
 (* Returns the inner type and its modalities, if unboxed. *)
-val find_unboxed_type : type_declaration -> (type_expr * Mode.Modality.Value.Const.t) option
+val find_unboxed_type : type_declaration -> (type_expr * Mode.Modality.Const.t) option
 
 type extension_constructor =
   {
@@ -1036,7 +1036,7 @@ module type Wrapped = sig
 
   type value_description =
     { val_type: type_expr wrapped;                (* Type of the value *)
-      val_modalities: Mode.Modality.Value.t;      (* Modalities on the value *)
+      val_modalities: Mode.Modality.t;      (* Modalities on the value *)
       val_kind: value_kind;
       val_loc: Location.t;
       val_zero_alloc: Zero_alloc.t;
@@ -1071,7 +1071,7 @@ module type Wrapped = sig
   and module_declaration =
   {
     md_type: module_type;
-    md_modalities : Mode.Modality.Value.t;
+    md_modalities : Mode.Modality.t;
     md_attributes: Parsetree.attributes;
     md_loc: Location.t;
     md_uid: Uid.t;
@@ -1162,7 +1162,7 @@ type 'a gen_label_description =
     lbl_res: type_expr;                 (* Type of the result *)
     lbl_arg: type_expr;                 (* Type of the argument *)
     lbl_mut: mutability;                (* Is this a mutable field? *)
-    lbl_modalities: Mode.Modality.Value.Const.t;
+    lbl_modalities: Mode.Modality.Const.t;
                                         (* Modalities on the field *)
     lbl_sort: Jkind_types.Sort.Const.t; (* Sort of the argument *)
     lbl_pos: int;                       (* Position in type *)

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -1516,22 +1516,22 @@ module Paths : sig
 
   (** [modal_child gf proj t] is [child prof t] when [gf] is [Unrestricted]
       and is [untracked] otherwise. *)
-  val modal_child : Modality.Value.Const.t -> Projection.t -> t -> t
+  val modal_child : Modality.Const.t -> Projection.t -> t -> t
 
   (** [tuple_field i t] is [child (Projection.Tuple_field i) t]. *)
   val tuple_field : int -> t -> t
 
   (** [record_field gf s t] is
       [modal_child gf (Projection.Record_field s) t]. *)
-  val record_field : Modality.Value.Const.t -> string -> t -> t
+  val record_field : Modality.Const.t -> string -> t -> t
 
   (** [record_unboxed_product_field gf s t] is
       [modal_child gf (Projection.Record_unboxed_product_field s) t]. *)
-  val record_unboxed_product_field : Modality.Value.Const.t -> string -> t -> t
+  val record_unboxed_product_field : Modality.Const.t -> string -> t -> t
 
   (** [construct_field gf s i t] is
       [modal_child gf (Projection.Construct_field(s, i)) t]. *)
-  val construct_field : Modality.Value.Const.t -> string -> int -> t -> t
+  val construct_field : Modality.Const.t -> string -> int -> t -> t
 
   (** [variant_field s t] is [child (Projection.Variant_field s) t]. *)
   val variant_field : string -> t -> t
@@ -1573,8 +1573,8 @@ end = struct
   let modal_child modalities proj t =
     (* CR zqian: Instead of just ignoring such children, we should add modality
        to [Projection.t] and add corresponding logic in [UsageTree]. *)
-    let uni = Modality.Value.Const.proj (Monadic Uniqueness) modalities in
-    let lin = Modality.Value.Const.proj (Comonadic Linearity) modalities in
+    let uni = Modality.Const.proj (Monadic Uniqueness) modalities in
+    let lin = Modality.Const.proj (Comonadic Linearity) modalities in
     match uni, lin with
     | Monadic (_, Join_with Aliased), Comonadic (_, Meet_with Many) -> untracked
     | _ -> child proj t
@@ -1652,12 +1652,11 @@ module Value : sig
       are the paths of [t] and [o] is [t]'s occurrence. This is used for the
       implicit record field values for kept fields in a [{ foo with ... }]
       expression. *)
-  val implicit_record_field :
-    Modality.Value.Const.t -> string -> t -> unique_use -> t
+  val implicit_record_field : Modality.Const.t -> string -> t -> unique_use -> t
 
   (** Analogous to [implicit_record_field], but for unboxed records *)
   val implicit_record_unboxed_product_field :
-    Modality.Value.Const.t -> string -> t -> unique_use -> t
+    Modality.Const.t -> string -> t -> unique_use -> t
 
   (** Mark the value as aliased_or_unique   *)
   val mark_maybe_unique : t -> UF.t


### PR DESCRIPTION
This PR moves everything in `Mode.Modality.Value` to `Mode.Modality`, since modalities always act on `Mode.Value.t` anyway.