### PR TITLE
Void for primitives

### DIFF
--- a/testsuite/tests/typing-layouts-void/void_upstream_compatible.ml
+++ b/testsuite/tests/typing-layouts-void/void_upstream_compatible.ml
@@ -8,18 +8,6 @@ type t : void
 external void_id : t -> t = "%identity"
 [%%expect{|
 type t : void
-Line 3, characters 19-20:
-3 | external void_id : t -> t = "%identity"
-                       ^
-Warning 187 [incompatible-with-upstream]: [@unboxed] attribute must be added to external declaration
-argument type with layout void for upstream compatibility.
-
-Line 3, characters 24-25:
-3 | external void_id : t -> t = "%identity"
-                            ^
-Warning 187 [incompatible-with-upstream]: [@unboxed] attribute must be added to external declaration
-argument type with layout void for upstream compatibility.
-
 external void_id : t -> t = "%identity" [@@unboxed]
 |}]
 

--- a/testsuite/tests/typing-layouts-void/void_upstream_compatible.ml
+++ b/testsuite/tests/typing-layouts-void/void_upstream_compatible.ml
@@ -1,0 +1,52 @@
+(* TEST
+   flags = "-extension-universe upstream_compatible";
+   expect;
+*)
+
+type t : void
+
+external void_id : t -> t = "%identity"
+[%%expect{|
+type t : void
+Line 3, characters 19-20:
+3 | external void_id : t -> t = "%identity"
+                       ^
+Warning 187 [incompatible-with-upstream]: [@unboxed] attribute must be added to external declaration
+argument type with layout void for upstream compatibility.
+
+Line 3, characters 24-25:
+3 | external void_id : t -> t = "%identity"
+                            ^
+Warning 187 [incompatible-with-upstream]: [@unboxed] attribute must be added to external declaration
+argument type with layout void for upstream compatibility.
+
+external void_id : t -> t = "%identity" [@@unboxed]
+|}]
+
+external void_id : t -> t = "%identity" [@@unboxed]
+[%%expect{|
+Line 1, characters 19-20:
+1 | external void_id : t -> t = "%identity" [@@unboxed]
+                       ^
+Warning 187 [incompatible-with-upstream]: External declaration here is not upstream compatible.
+The only types with non-value layouts allowed are float#,
+int32#, int64#, and nativeint#. Unknown type with layout
+void encountered.
+
+Line 1, characters 24-25:
+1 | external void_id : t -> t = "%identity" [@@unboxed]
+                            ^
+Warning 187 [incompatible-with-upstream]: External declaration here is not upstream compatible.
+The only types with non-value layouts allowed are float#,
+int32#, int64#, and nativeint#. Unknown type with layout
+void encountered.
+
+external void_id : t -> t = "%identity" [@@unboxed]
+|}]
+
+external[@layout_poly] poly_id : ('a : any). 'a -> 'a = "%identity"
+let void_id (x : t) = poly_id x
+[%%expect{|
+external poly_id : ('a : any). 'a -> 'a = "%identity" [@@layout_poly]
+val void_id : t -> t = <fun>
+|}]

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -3512,8 +3512,8 @@ let make_native_repr env core_type ty ~global_repr ~is_layout_poly ~why =
         sort_or_poly with
   | Native_repr_attr_absent, Poly ->
     Repr_poly
-  | Native_repr_attr_absent, Sort (Base Value) ->
-    Same_as_ocaml_repr (Base Value)
+  | Native_repr_attr_absent, Sort (Base (Value | Void) as base) ->
+    Same_as_ocaml_repr base
   | Native_repr_attr_absent, (Sort (Base sort as c)) ->
     (if Language_extension.erasable_extensions_only ()
     then


### PR DESCRIPTION
This PR eliminates the upstream compatibility warning when using `void` with a primitive. It's currently pretty busted - any attempt to use `void` with a primitive tells you that you have to label it `[@unboxed]`, but then if you do that you get a different warning saying `void` doesn't support `[@unboxed]`.

There are three cases to consider:

* Layout-polymorphic primitives like `%identity`.  These work fine on void values in upstream code via the usual erasure story.
* Void-specific primitives (`%unbox_unit`). This is not upstream compatible inherently, but we have a plan for fixing that with typical erasure mechanisms - see internal thread.
* Non-primitive externals (C stubs). Using void here is not upstream compatible (or at least not obviously so - we have to think about whether a C stub can observe that a void taking or returning function doesn't smash the relevant register to 1). But this is banned separately, and the existing test `void_stubs.ml` shows we haven't broken it.