### PR TITLE
Fix: Make `[@@unboxed]` void variants not `cstr_constant`

### DIFF
--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -507,7 +507,8 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       | Null, Variant_with_null -> Lconst Const_null
       | Null, (Variant_boxed _ | Variant_unboxed | Variant_extensible) ->
         assert false
-      | Ordinary {runtime_tag}, _ when cstr.cstr_constant ->
+      | Ordinary {runtime_tag},
+        (Variant_boxed _ | Variant_extensible) when cstr.cstr_constant ->
           assert (
             List.for_all
               (fun (_, s) -> Jkind.Sort.Const.all_void s) args_with_sorts);

--- a/testsuite/tests/typing-layouts-void/voids.ml
+++ b/testsuite/tests/typing-layouts-void/voids.ml
@@ -712,4 +712,18 @@ let test18 () =
 
 let _ = test18 ()
 
+(*********************************************)
+(* Test 19: unboxed variants containing void *)
+
+type t = P of void [@@unboxed]
+let create () = P (void ())
+
+let test19 () =
+  start_test "unboxed variants containing void";
+  let v = create () in
+  match v with
+  | P v -> assert (use_void v = 1)
+
+let _ = test19 ()
+
 let () = print_endline "All tests passed."

--- a/testsuite/tests/typing-layouts-void/voids.reference
+++ b/testsuite/tests/typing-layouts-void/voids.reference
@@ -19,4 +19,5 @@ Test 18: Obj.tag of records containing void
   Obj.tag of record with void: 0
   Obj.tag of record with multiple voids: 0
   Obj.tag of variant containing record with void: 0
+Test 19: unboxed variants containing void
 All tests passed.

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -966,7 +966,10 @@ type constructor_description =
     cstr_tag: tag;                      (* Tag for heap blocks *)
     cstr_repr: variant_representation;  (* Repr of the outer variant *)
     cstr_shape: constructor_representation; (* Repr of the constructor itself *)
-    cstr_constant: bool;                (* True if all args are void *)
+    cstr_constant: bool;
+    (* True if it's the constructor of a non-[@@unboxed] variant with 0 bits of
+       payload. (Or equivalently, if it's represented as either a tagged int or
+       the null pointer) *)
     cstr_consts: int;                   (* Number of constant constructors *)
     cstr_nonconsts: int;                (* Number of non-const constructors *)
     cstr_generalized: bool;             (* Constrained return type? *)


### PR DESCRIPTION
The introduction of void made it possible to have `[@@unboxed]` variants with 0 bits of payload. These constructors should have `cstr_constant=false`, as the translation to lambda assumes that `cstr_constant=true` constructors are represented as either tagged integers or the null pointer.

As those void constructors seem "constant," `cstr_constant` is now somewhat of a misnomer, but we leave refactoring/renaming for future PRs in order to get this fix in with minimal divergence from upstream. (We do add some clarifying comments.)

Representations of constructors:

|               | Boxed variant | `or_null`-like variant | `[@@unboxed]` variant             |
|---------------|---------------|------------------------|-----------------------------------|
| No args       | Tagged int         | Null pointer                  | N/A                         |
| Void args     | Tagged int         | N/A                    | Just the argument |
| Non-void args | Block     | Just the argument              | Just the argument                         |

Whether or not each constructor is `cstr_constant`:

|               | Boxed variant | `or_null`-like variant | `[@@unboxed]` variant             |
|---------------|---------------|------------------------|-----------------------------------|
| No args       | const         | const                  | N/A                         |
| Void args     | const         | N/A                    | non-const (before this PR: const) |
| Non-void args | non-const     | non-const              | non-const                         |

## Reviewing

The changes in `lambda/` are not necessary, but remove a [wildcard match](https://github.com/oxcaml/oxcaml/blob/ae5ce4357a652830bfff3072d52b80ea2f2dde89/lambda/translcore.ml#L510) that obscured this issue.

Without this patch, the regression test added to `testsuite/tests/typing-layouts-void/voids.ml` causes a fatal error.