### PR TITLE
Disable -gdwarf-may-alter-codegen

### DIFF
--- a/backend/cfg/cfg_available_regs.ml
+++ b/backend/cfg/cfg_available_regs.ml
@@ -13,7 +13,10 @@ module V = Backend_var
    to be seen in the debugger, for example when the last use of some variable is
    just before a call, and the debugger is standing in the callee. It may
    however affect the semantics of e.g. finalizers. *)
-let extend_live () = !Dwarf_flags.gdwarf_may_alter_codegen
+let extend_live () = false
+  (* CR sspies: This used to be set by [-gdwarf-may-alter-codegen]. But the
+  computation is currently broken, so we've disabled the flag. Fix the
+  compuation and re-enable the flag. *)
 
 (* CR xclerc for xclerc: consider passing this value through the context. *)
 let all_regs_that_might_be_named = ref Reg.Set.empty

--- a/backend/cfg/cfg_available_regs.ml
+++ b/backend/cfg/cfg_available_regs.ml
@@ -14,9 +14,9 @@ module V = Backend_var
    just before a call, and the debugger is standing in the callee. It may
    however affect the semantics of e.g. finalizers. *)
 let extend_live () = false
-  (* CR sspies: This used to be set by [-gdwarf-may-alter-codegen]. But the
-  computation is currently broken, so we've disabled the flag. Fix the
-  compuation and re-enable the flag. *)
+(* CR sspies: This used to be set by [-gdwarf-may-alter-codegen]. But the
+   computation is currently broken, so we've disabled the flag. Fix the
+   compuation and re-enable the flag. *)
 
 (* CR xclerc for xclerc: consider passing this value through the context. *)
 let all_regs_that_might_be_named = ref Reg.Set.empty


### PR DESCRIPTION
This PR disables the effect of `-gdwarf-may-alter-codegen`, since the current calculation of the live registers can be faulty. Once the computation is fixed, the flag should be used again.