### PR TITLE
Fix sort variable defaulting in poly type schemes

### DIFF
--- a/testsuite/tests/typing-misc/variable_quantification_check.ml
+++ b/testsuite/tests/typing-misc/variable_quantification_check.ml
@@ -1,19 +1,16 @@
 (* TEST
- expect;
+ {
+   native;
+ }{
+   bytecode;
+ }
 *)
 
 module type Test1 = sig
     val unbound_variable : 'a . 'a -> 'b
 end
 
-[%%expect{|
-module type Test1 = sig val unbound_variable : 'a -> 'b end
-|}]
-
 module type Test2 = sig
     val wildcard : 'a . _ option -> 'a
 end
 
-[%%expect{|
-module type Test2 = sig val wildcard : 'b option -> 'a end
-|}]

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1432,6 +1432,7 @@ let transl_type_scheme_poly env attrs loc vars inner_type =
     ~post:(fun (_,_,typ) -> generalize_ctyp typ)
   in
   let _ : _ list = TyVarEnv.instance_poly_univars env loc univars in
+  remove_mode_and_jkind_variables typ.ctyp_type;
   { ctyp_desc = Ttyp_poly (typed_vars, typ);
     ctyp_type = typ.ctyp_type;
     ctyp_env = env;


### PR DESCRIPTION
Disabling the forall or none check surfaced an issue in `typetexp.ml` where we defaulted sort variables in monomorphic type schemes but not polymorphic ones. Fix. With the check enabled, unannotated-but-quantified type variables in polymorphic type schemes always started as `value` and we didn't hit this.

This error wasn't caught by `variable_quantification_check.ml` because it used the toplevel `expect` mode.
Change the test to call the whole-program compiler. Without this fix, test fails as:
```
> Error: Unconstrained layout variable detected when saving artifacts of compilation to disk.
>        Please report this error to the Jane Street compilers team. 
```