### PR TITLE
Add Gc.Memprof.participate.

### DIFF
--- a/runtime4/memprof.c
+++ b/runtime4/memprof.c
@@ -1090,6 +1090,11 @@ CAMLprim value caml_memprof_stop(value unit)
   return Val_unit;
 }
 
+CAMLprim value caml_memprof_participate(value profile)
+{
+  caml_failwith("Gc.Memprof.participate: not implemented in runtime4");
+}
+
 CAMLprim value caml_memprof_discard(value profile)
 {
   caml_failwith("Gc.Memprof.discard: not implemented in runtime4");

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -213,6 +213,8 @@ module Memprof =
         c_start sampling_rate callstack_size tracker
     end
 
+    external participate : t -> unit @@ portable = "caml_memprof_participate"
+
     external stop : unit -> unit @@ portable = "caml_memprof_stop"
 
     external discard : t -> unit @@ portable = "caml_memprof_discard"

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -717,6 +717,12 @@ module (Memprof @@ nonportable) :
        called on a profile which has not been stopped.
        *)
 
+    val participate : t -> unit
+    (** Cause the current domain to participate in the specified profile.
+        Raises an exception if the current domain is currently sampling for
+        any profile, or if the specified profile has been stopped or
+        discarded. *)
+
     (** Submodule containing non-backwards-compatible functions which enforce thread
         safety via modes. *)
     module Safe : sig

--- a/testsuite/tests/statmemprof/participate.ml
+++ b/testsuite/tests/statmemprof/participate.ml
@@ -1,0 +1,53 @@
+(* TEST
+ flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
+ include systhreads;
+ runtime5;
+ multidomain;
+ { bytecode; }
+ { native; }
+*)
+
+module M = Gc.Memprof
+
+let start alloc_minor = M.start ~sampling_rate:1. { M.null_tracker with alloc_minor }
+
+let alloc_some () =
+  let rec f n =
+    if n = 0 then [] else (ref 0) :: (f (n-1))
+  in
+  ignore (Sys.opaque_identity (f 100))
+
+let counts = [| 0 ; 0 |]
+
+let alloc_minor _ =
+  let id = (Domain.self() :> int) in
+  counts.(id) <- (counts.(id) + 1); None
+
+let print_counts () =
+  Array.iteri (fun i n -> Printf.printf "Domain %d allocated %d words.\n" i n) counts
+
+(* `trigger ()` is `(wait, go)`, where `wait()` will wait until `go()` is called.
+    and resets the trigger (so go() can be meaningfully called more than once). *)
+
+let trigger () =
+  let t = Atomic.make false in
+  ((fun () -> (while not (Atomic.get t) do Thread.yield () done; Atomic.set t false)),
+   (fun () -> Atomic.set t true))
+
+let _ =
+  let wait, go = trigger () in
+  let r = ref None in
+  let d = Domain.spawn (fun () ->
+    wait ();
+    M.participate (Option.get (!r)) ;
+    alloc_some ())
+  in
+  r := Some (start alloc_minor);
+  go ();
+  ignore (alloc_some ()) ;
+  Domain.join d ;
+  M.stop ();
+  assert (counts.(0) >= 200);
+  assert (counts.(0) < 205); (* some headroom for e.g. closures in bytecode *)
+  assert (counts.(1) >= 200);
+  assert (counts.(1) < 205) (* some headroom for e.g. closures in bytecode *)


### PR DESCRIPTION
In order to dynamically start memory profiling in a running process, it is necessary for several live domains to join the same profile. This new function enables that.

This new function would naturally be called `Gc.Memprof.join`, except that `join` has acquired a distinct meaning here. Obviously `Domain.join` (for example) should be called `Domain.wait`, after `wait(2)`, but that ship sailed long ago. So `participate` it is.