### PR TITLE
Correct ocamltest multidomain messages

### DIFF
--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -1365,8 +1365,8 @@ let multidomain = Actions.make
   ~description:"Passes if multiple domains is enabled"
   ~does_something:false
   (Actions_helpers.predicate Config.multidomain
-    "Multidomain disabled"
-    "Multidomain enabled")
+    "Multidomain enabled"
+    "Multidomain disabled")
 
 let runtime4 = Actions.make
   ~name:"runtime4"


### PR DESCRIPTION
ocamltest was telling me "multidomain enabled" when it wasn't enabled, and vice versa. Looking at the other predicates alongside this one, I'm pretty sure these two strings are the wrong way around.