### PR TITLE
Add objcopy configure option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -98,7 +98,6 @@ AC_ARG_ENABLE([dev],
 
 AC_SUBST([prefix])
 AC_SUBST([middle_end])
-AC_SUBST([dune])
 
 coverage="$enable_coverage"
 AC_SUBST([coverage])
@@ -477,12 +476,6 @@ AC_ARG_VAR([ASPP], [which assembler (with preprocessor) to use])
 AC_ARG_VAR([PARTIALLD], [how to build partial (relocatable) object files])
 
 # Command-line arguments to configure
-
-AC_PATH_PROG([dune], [dune], [])
-AC_ARG_WITH([dune],
-  [AS_HELP_STRING([--with-dune],
-    [Path to dune executable (otherwise PATH is searched)])],
-  [dune=$with_dune])
 
 AC_ARG_ENABLE([debug-runtime],
   [AS_HELP_STRING([--disable-debug-runtime],

--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,23 @@ AX_COMPARE_VERSION([$dune_version], [le], [$DUNE_MAX_VERSION],
 
 AC_MSG_NOTICE([Using dune executable: $dune])
 
+dnl Prefer llvm-objcopy. If llvm-objcopy is not found, use objcopy.
+dnl GNU objcopy 2.35.2 sometimes modifies .relro_padding and .init_array
+dnl sections incorrectly, llvm-copy does not.
+default_objcopy="llvm-objcopy objcopy"
+AC_PATH_PROGS([objcopy], [$default_objcopy], [])
+
+AC_ARG_WITH([objcopy],
+  [AS_HELP_STRING([--with-objcopy],
+    [Path to objcopy executable (otherwise PATH is searched for 'llvm-objcopy' or
+    'objcopy')])],
+  [objcopy=$with_objcopy])
+
+AS_IF([test x"$objcopy" = "x"],
+  [AC_MSG_ERROR([objcopy not found on PATH; install, or use --with-objcopy])])
+
+AC_MSG_NOTICE([Using objcopy executable: $objcopy])
+
 AC_ARG_ENABLE([middle-end],
   [AS_HELP_STRING([--enable-middle-end],
     [Deprecated: must provide 'flambda2'])],
@@ -367,6 +384,7 @@ AC_SUBST([stack_allocation])
 AC_SUBST([poll_insertion])
 AC_SUBST([enable_multidomain])
 AC_SUBST([dune])
+AC_SUBST([objcopy])
 AC_SUBST([ocaml_bindir])
 AC_SUBST([ocaml_libdir])
 AC_SUBST([QS])

--- a/utils/config.generated.ml.in
+++ b/utils/config.generated.ml.in
@@ -132,5 +132,6 @@ let has_avx2 = "@has_avx2@" = "yes"
 let as_compress_debug_sections_flag = {@QS@|@as_compress_debug_sections_flag@|@QS@}
 let cc_compress_debug_sections_flag = {@QS@|@cc_compress_debug_sections_flag@|@QS@}
 let objcopy_compress_debug_sections_flag = {@QS@|@objcopy_compress_debug_sections_flag@|@QS@}
+let objcopy = {@QS@|@objcopy@|@QS@}
 
 let oxcaml_dwarf = "@enable_oxcaml_dwarf@" = "yes"

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -56,6 +56,10 @@ val cc_compress_debug_sections_flag : string
 val objcopy_compress_debug_sections_flag : string
 (** The flag to use for objcopy debug section compression ("" if none) *)
 
+val objcopy : string
+(** The objcopy command (and flags) to use for split debug enabled by
+    [Clflags.dwarf_fission]. *)
+
 val ocamlc_cflags : string
 (** The flags ocamlc should pass to the C compiler *)
 


### PR DESCRIPTION
Detect or specify the path to `objcopy` in configure.

This PR is a follow up on https://github.com/oxcaml/oxcaml/pull/4420 that introduced a call to `objcopy` for creating split debug.

This PRs add `Config.objcopy` and updates configure script to set it as follows:
- By default, use `llvm-obcopy` or `objcopy` if found during `configure` on the `PATH`. Prefer `llvm-objcopy` because of possible bugs on `objcopy` w.r.t. `.relro_padding` and `init_array` sections.
- Add configure flag `--with-objcopy <path>` to specify an alternative location.