### PR TITLE
Teach ocamltest about stack checks, and use for test_issue_11094.ml.

### DIFF
--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -1368,6 +1368,14 @@ let multidomain = Actions.make
     "Multidomain enabled"
     "Multidomain disabled")
 
+let stack_checks = Actions.make
+  ~name:"stack-checks"
+  ~description:"Passes if stack checks are enabled"
+  ~does_something:false
+  (Actions_helpers.predicate (not Config.no_stack_checks)
+    "Stack checks enabled"
+    "Stack checks disabled")
+
 let runtime4 = Actions.make
   ~name:"runtime4"
   ~description:"Passes if the OCaml 4.x runtime is being used"
@@ -1600,6 +1608,7 @@ let init () =
     cc;
     ocamlobjinfo;
     multidomain;
+    stack_checks;
     runtime4;
     runtime5
   ]

--- a/testsuite/tests/parallel/test_issue_11094.ml
+++ b/testsuite/tests/parallel/test_issue_11094.ml
@@ -2,7 +2,7 @@
  flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
  runtime5;
  multidomain;
- set OCAMLRUNPARAM = "Xmain_stack_size=1000";
+ stack-checks;
  {
    bytecode;
  }{


### PR DESCRIPTION
The test-suite test `parallel/test_issue_11094.ml` fails if you `--enable-multidomain` but don't `--enable-stack-checks`, because it makes too many fiber stacks which are too large. This should probably be fixed---the test did have `OCAMLRUNPARAM = "Xmain_stack_size=1000"`, presumably to keep the fiber stacks small, but it was still failing. In the meantime, we should skip this test unless configured with`--enable-stack-checks`.