### PR TITLE
Fix let mutable documentation

### DIFF
--- a/jane/doc/extensions/_11-miscellaneous-extensions/let-mutable.md
+++ b/jane/doc/extensions/_11-miscellaneous-extensions/let-mutable.md
@@ -52,5 +52,3 @@ let sum xs =
   List.iter xs ~f:(fun x -> total <- total + x);
   total
 ```
-
-Mutable variables may not contain unboxed products.


### PR DESCRIPTION
Deleted a line saying `let mutable` did not support unboxed products.