### PR TITLE
Fix peephole rule about overwritten moves

### DIFF
--- a/backend/peephole/peephole_rules.ml
+++ b/backend/peephole/peephole_rules.ml
@@ -5,14 +5,14 @@ open! Int_replace_polymorphic_compare
 module DLL = Oxcaml_utils.Doubly_linked_list
 module U = Peephole_utils
 
-let delete_fst_if_redundant ~fst ~(fst_val : Cfg.basic Cfg.instruction)
+let delete_fst_if_redundant ~fst ~snd ~(fst_val : Cfg.basic Cfg.instruction)
     ~(snd_val : Cfg.basic Cfg.instruction) =
   let fst_dst = fst_val.res.(0) in
   let snd_dst = snd_val.res.(0) in
   if U.are_equal_regs fst_dst snd_dst
   then (
     DLL.delete_curr fst;
-    Some (U.prev_at_most U.go_back_const fst))
+    Some (U.prev_at_most U.go_back_const snd))
   else None
 
 (** Logical condition for simplifying the following case:
@@ -37,12 +37,12 @@ let remove_overwritten_mov (cell : Cfg.basic Cfg.instruction DLL.cell) =
           | Const_vec256 _ | Const_vec512 _ ) ) ->
       (* Removing the first instruction is okay here since it doesn't change the
          set of addresses we touch. *)
-      delete_fst_if_redundant ~fst ~fst_val ~snd_val
+      delete_fst_if_redundant ~fst ~snd ~fst_val ~snd_val
     | Op (Spill | Reload), Op (Move | Spill | Reload) ->
       (* We only consider the removal of spill and reload instructions because a
          move from/to an arbitrary memory location could fail because of memory
          protection. *)
-      delete_fst_if_redundant ~fst ~fst_val ~snd_val
+      delete_fst_if_redundant ~fst ~snd ~fst_val ~snd_val
     | _, _ -> None)
   | _ -> None
 


### PR DESCRIPTION
The bug was introduced by #3103. It is **not**
a correctness issue. If the rule triggers on the
first instruction of the block, that instruction
will be deleted from the list but we will restart
on the very instruction (still connected to the
list), over and over again until the fuel is
exhausted. Among other things, this means
that no other simplification will be applied in
the block.