### PR TITLE
Fix the subsumption check for separability

### DIFF
--- a/testsuite/tests/typing-layouts-or-null/immediate.ml
+++ b/testsuite/tests/typing-layouts-or-null/immediate.ml
@@ -143,21 +143,5 @@ end = struct
 end
 
 [%%expect{|
-Lines 3-5, characters 6-3:
-3 | ......struct
-4 |   type t = int or_null
-5 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig type t = int or_null end
-       is not included in
-         sig type t : immediate_or_null end
-       Type declarations do not match:
-         type t = int or_null
-       is not included in
-         type t : immediate_or_null
-       The kind of the first is value_or_null mod everything
-         because it is the primitive type or_null.
-       But the kind of the first must be a subkind of immediate_or_null
-         because of the definition of t at line 2, characters 2-28.
+module M : sig type t : immediate_or_null end @@ stateless
 |}]

--- a/testsuite/tests/typing-layouts-or-null/immediate.ml
+++ b/testsuite/tests/typing-layouts-or-null/immediate.ml
@@ -135,3 +135,29 @@ val f : local_ int or_null -> ((int or_null -> unit) -> unit) = <fun>
 |}, Principal{|
 val f : local_ int or_null -> (int or_null -> unit) -> unit = <fun>
 |}]
+
+module M : sig
+  type t : immediate_or_null
+end = struct
+  type t = int or_null
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = int or_null
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = int or_null end
+       is not included in
+         sig type t : immediate_or_null end
+       Type declarations do not match:
+         type t = int or_null
+       is not included in
+         type t : immediate_or_null
+       The kind of the first is value_or_null mod everything
+         because it is the primitive type or_null.
+       But the kind of the first must be a subkind of immediate_or_null
+         because of the definition of t at line 2, characters 2-28.
+|}]

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -993,3 +993,53 @@ end
 [%%expect{|
 module M4 : S
 |}]
+
+module type S0 = sig
+  type t : value_or_null mod separable
+end
+
+[%%expect{|
+module type S0 = sig type t : value_or_null mod separable end
+|}]
+
+module M5 : S0 = struct
+  type t = int
+end
+
+[%%expect{|
+module M5 : S0
+|}]
+
+module M6 : S0 = struct
+  type t = string or_null
+end
+
+[%%expect{|
+module M6 : S0
+|}]
+
+module M7_fail : S0 = struct
+  type t = float or_null
+end
+
+[%%expect{|
+Lines 1-3, characters 22-3:
+1 | ......................struct
+2 |   type t = float or_null
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = float or_null end
+       is not included in
+         S0
+       Type declarations do not match:
+         type t = float or_null
+       is not included in
+         type t : value_or_null mod separable
+       The kind of the first is
+           value_or_null mod many unyielding stateless immutable
+         because it is the primitive type or_null.
+       But the kind of the first must be a subkind of
+           value_or_null mod separable
+         because of the definition of t at line 2, characters 2-38.
+|}]

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2842,7 +2842,20 @@ let apply_modality_r modality jk =
   in
   { jk with jkind = { jk.jkind with mod_bounds } } |> disallow_left
 
-let apply_or_null jkind =
+let apply_or_null_l jkind =
+  match Mod_bounds.nullability jkind.jkind.mod_bounds with
+  | Non_null ->
+    let jkind = set_nullability_upper_bound jkind Maybe_null in
+    let jkind =
+      match Mod_bounds.separability jkind.jkind.mod_bounds with
+      | Maybe_separable | Separable ->
+        set_separability_upper_bound jkind Maybe_separable
+      | Non_float -> jkind
+    in
+    Ok jkind
+  | Maybe_null -> Error ()
+
+let apply_or_null_r jkind =
   match Mod_bounds.nullability jkind.jkind.mod_bounds with
   | Maybe_null ->
     let jkind = set_nullability_upper_bound jkind Non_null in

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -671,11 +671,17 @@ val apply_modality_l :
 val apply_modality_r :
   Mode.Modality.Value.Const.t -> ('l * allowed) Types.jkind -> Types.jkind_r
 
+(** Change a jkind to be appropriate for ['a or_null] based on passed ['a].
+    Adjusts nullability to be [Maybe_null], and separability to be
+    [Maybe_separable] if it is already [Separable]. If the jkind is already
+    [Maybe_null], fails. *)
+val apply_or_null_l : Types.jkind_l -> (Types.jkind_l, unit) result
+
 (** Change a jkind to be appropriate for an expectation of a type passed to
     the [or_null] constructor. Adjusts nullability to be [Non_null], and
     separability to be [Non_float] if it is demanded to be [Separable].
     If the jkind is already [Non_null], fails. *)
-val apply_or_null : Types.jkind_r -> (Types.jkind_r, unit) result
+val apply_or_null_r : Types.jkind_r -> (Types.jkind_r, unit) result
 
 (** Extract out component jkinds from the product. Because there are no product
     jkinds, this is a bit of a lie: instead, this decomposes the layout but just


### PR DESCRIPTION
The magic interaction between `or_null` and separability is handled when checking l-kinds against r-kinds in `Ctype.constrain_type_jkind`. However, subsumption checks l-kinds against l-kinds, and instead calls `Ctype.check_decl_jkind`. We don't have a well-developed strategy here, so add another ad-hoc check accounting for separability and or_null.

This allows the following code to typecheck:

```
module M : sig
  type t : value_or_null mod non_float
end = struct
  type t = string or_null
end
```

Add tests.