### PR TITLE
Tweak the register equality used by peephole rules

### DIFF
--- a/backend/peephole/peephole_utils.ml
+++ b/backend/peephole/peephole_utils.ml
@@ -1,8 +1,7 @@
 module DLL = Oxcaml_utils.Doubly_linked_list
 open! Int_replace_polymorphic_compare
 
-let are_equal_regs (reg1 : Reg.t) (reg2 : Reg.t) =
-  Reg.same_loc reg1 reg2 && Cmm.equal_machtype_component reg1.typ reg2.typ
+let are_equal_regs (reg1 : Reg.t) (reg2 : Reg.t) = Reg.same_loc reg1 reg2
 
 (* CR-soon gtulba-lecu: Delete this when implementing auto-generated rules. *)
 let go_back_const = 1


### PR DESCRIPTION
As investigated and discussed with @gretay-js,
this pull request consider register as equal in
the peephole rules if they have the same location.

Since we are post register allocation, and the
`same_loc` predicate checks register and
stack classes, we think asking for the mach
types to be equal is too strong.