### PR TITLE
Dataflow analysis for prologue validation

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -469,6 +469,13 @@ let is_return_terminator desc =
   | Call _ | Prim _ ->
     false
 
+let is_nontail_call_terminator desc =
+  match (desc : terminator) with
+  | Call_no_return _ | Call _ -> true
+  | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
+  | Switch _ | Return | Raise _ | Tailcall_self _ | Tailcall_func _ | Prim _ ->
+    false
+
 let is_pure_basic : basic -> bool = function
   | Op op -> Operation.is_pure op
   | Reloadretaddr ->

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -202,6 +202,8 @@ val is_never_terminator : terminator -> bool
 
 val is_return_terminator : terminator -> bool
 
+val is_nontail_call_terminator : terminator -> bool
+
 val is_pure_basic : basic -> bool
 
 val is_noop_move : basic instruction -> bool

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -196,10 +196,13 @@ let run : Cfg_with_layout.t -> Cfg_with_layout.t =
   fun_name := Cfg.fun_name (Cfg_with_layout.cfg cfg_with_layout);
   let cfg_with_layout = add_prologue_if_required cfg_with_layout in
   let cfg = Cfg_with_layout.cfg cfg_with_layout in
-  match
-    Validator.run cfg
-      ~init:(Validator.State_set.singleton No_prologue_on_stack)
-      ~handlers_are_entry_points:false ()
-  with
-  | Ok _ -> cfg_with_layout
-  | Error () -> Misc.fatal_error "Cfg_prologue.run: dataflow analysis failed"
+  match !Oxcaml_flags.cfg_prologue_validate with
+  | true -> (
+    match
+      Validator.run cfg
+        ~init:(Validator.State_set.singleton No_prologue_on_stack)
+        ~handlers_are_entry_points:false ()
+    with
+    | Ok _ -> cfg_with_layout
+    | Error () -> Misc.fatal_error "Cfg_prologue.run: dataflow analysis failed")
+  | false -> cfg_with_layout

--- a/backend/cfg/cfg_stack_checks.ml
+++ b/backend/cfg/cfg_stack_checks.ml
@@ -31,27 +31,12 @@
 open! Int_replace_polymorphic_compare
 module DLL = Oxcaml_utils.Doubly_linked_list
 
-let is_nontail_call : Cfg.terminator -> bool =
- fun term_desc ->
-  (* CR-soon xclerc for xclerc: reconsider whether this predicate is generic and
-     well-defined enough to be moved to `Cfg` once the transitive checks are
-     implemented. *)
-  match term_desc with
-  | Call_no_return _ | Call _ -> true
-  | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-  | Switch _ | Return | Raise _ | Tailcall_self _ | Tailcall_func _ | Prim _ ->
-    false
-
 (* Returns the stack check info, and the max of seen instruction ids. *)
 let block_preproc_stack_check_result :
     Cfg.basic_block -> frame_size:int -> Emitaux.preproc_stack_check_result =
  fun block ~frame_size ->
   let contains_nontail_calls =
-    (* XCR mshinwell: move to a method in Cfg somewhere?
-
-       xclerc: I have extracted the match to a dedicated function, but I don't
-       think the predicate is generic enough to be moved to `Cfg`. *)
-    is_nontail_call block.terminator.desc
+    Cfg.is_nontail_call_terminator block.terminator.desc
   in
   let max_frame_size =
     DLL.fold_left block.body ~init:block.terminator.stack_offset

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -136,6 +136,12 @@ let mk_no_cfg_eliminate_dead_trap_handlers f =
     Arg.Unit f,
     " Do not eliminate dead trap handlers" )
 
+let mk_cfg_prologue_validate f =
+  ("-cfg-prologue-validate", Arg.Unit f, " Produce CFG at selection")
+
+let mk_no_cfg_prologue_validate f =
+  ("-no-cfg-prologue-validate", Arg.Unit f, " Do not produce CFG at selection")
+
 let mk_reorder_blocks_random f =
   ( "-reorder-blocks-random",
     Arg.Int f,
@@ -923,6 +929,8 @@ module type Oxcaml_options = sig
   val cfg_stack_checks_threshold : int -> unit
   val cfg_eliminate_dead_trap_handlers : unit -> unit
   val no_cfg_eliminate_dead_trap_handlers : unit -> unit
+  val cfg_prologue_validate : unit -> unit
+  val no_cfg_prologue_validate : unit -> unit
   val reorder_blocks_random : int -> unit
   val basic_block_sections : unit -> unit
   val module_entry_functions_section : unit -> unit
@@ -1050,6 +1058,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_cfg_eliminate_dead_trap_handlers F.cfg_eliminate_dead_trap_handlers;
       mk_no_cfg_eliminate_dead_trap_handlers
         F.no_cfg_eliminate_dead_trap_handlers;
+      mk_cfg_prologue_validate F.cfg_prologue_validate;
+      mk_no_cfg_prologue_validate F.no_cfg_prologue_validate;
       mk_reorder_blocks_random F.reorder_blocks_random;
       mk_basic_block_sections F.basic_block_sections;
       mk_module_entry_functions_section F.module_entry_functions_section;
@@ -1210,6 +1220,9 @@ module Oxcaml_options_impl = struct
 
   let no_cfg_eliminate_dead_trap_handlers =
     clear' Oxcaml_flags.cfg_eliminate_dead_trap_handlers
+
+  let cfg_prologue_validate = set' Oxcaml_flags.cfg_prologue_validate
+  let no_cfg_prologue_validate = clear' Oxcaml_flags.cfg_prologue_validate
 
   let reorder_blocks_random seed =
     Oxcaml_flags.reorder_blocks_random := Some seed
@@ -1610,6 +1623,7 @@ module Extra_params = struct
     | "cfg-stack-checks" -> set' Oxcaml_flags.cfg_stack_checks
     | "cfg-eliminate-dead-trap-handlers" ->
         set' Oxcaml_flags.cfg_eliminate_dead_trap_handlers
+    | "cfg-prologue-validate" -> set' Oxcaml_flags.cfg_prologue_validate
     | "dump-inlining-paths" -> set' Oxcaml_flags.dump_inlining_paths
     | "davail" -> set' Oxcaml_flags.davail
     | "dranges" -> set' Oxcaml_flags.dranges

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -45,6 +45,8 @@ module type Oxcaml_options = sig
   val cfg_stack_checks_threshold : int -> unit
   val cfg_eliminate_dead_trap_handlers : unit -> unit
   val no_cfg_eliminate_dead_trap_handlers : unit -> unit
+  val cfg_prologue_validate : unit -> unit
+  val no_cfg_prologue_validate : unit -> unit
   val reorder_blocks_random : int -> unit
   val basic_block_sections : unit -> unit
   val module_entry_functions_section : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -35,6 +35,8 @@ let cfg_stack_checks_threshold = ref 16384 (* -cfg-stack-threshold *)
 
 let cfg_eliminate_dead_trap_handlers = ref false  (* -cfg-eliminate-dead-trap-handlers *)
 
+let cfg_prologue_validate = ref false    (* -[no-]cfg-prologue-validate *)
+
 let reorder_blocks_random = ref None    (* -reorder-blocks-random seed *)
 let basic_block_sections = ref false    (* -basic-block-sections *)
 (* -module-entry-functions-section *)

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -36,6 +36,8 @@ val cfg_stack_checks_threshold : int ref
 
 val cfg_eliminate_dead_trap_handlers : bool ref
 
+val cfg_prologue_validate : bool ref
+
 val reorder_blocks_random : int option ref
 val basic_block_sections : bool ref
 val module_entry_functions_section : bool ref


### PR DESCRIPTION
Prior to changing the implementation of how prologues are added, we are adding a new dataflow analysis which checks that for any execution path, the following is true:

- A prologue instruction only occurs when there's no prologue on the stack
- An epilogue only occurs when there's a prologue on the stack
- An instruction which requires a prologue (i.e. uses stack slots/is a non-tailcall) only occurs when there's a prologue on the stack

This is placed behind the `-[no-]cfg-prologue-validate` flag. Tested that it currently doesn't fail when building the compiler with the flag enabled, and caught some bugs with the new prologue implementation.