### PR TITLE
Remove transl_store compilation pipeline

### DIFF
--- a/asmcomp/asmpackager.ml
+++ b/asmcomp/asmpackager.ml
@@ -119,7 +119,7 @@ let make_package_object unix ~ppf_dump members target coercion
     let prefixname = Filename.remove_extension objtemp in
     let required_globals = Compilation_unit.Set.empty in
     let main_module_block_size, code =
-      Translmod.transl_package components compilation_unit coercion
+      Translmod.transl_package components coercion
     in
     let code = Simplif.simplify_lambda code in
     let main_module_block_format : Lambda.main_module_block_format =

--- a/asmcomp/asmpackager.ml
+++ b/asmcomp/asmpackager.ml
@@ -119,8 +119,7 @@ let make_package_object unix ~ppf_dump members target coercion
     let prefixname = Filename.remove_extension objtemp in
     let required_globals = Compilation_unit.Set.empty in
     let transl_style : Translmod.compilation_unit_style =
-      if Config.flambda || Config.flambda2 then Plain_block
-      else Set_individual_fields
+      Plain_block
     in
     let main_module_block_size, code =
       Translmod.transl_package components compilation_unit coercion

--- a/asmcomp/asmpackager.ml
+++ b/asmcomp/asmpackager.ml
@@ -118,12 +118,8 @@ let make_package_object unix ~ppf_dump members target coercion
     let compilation_unit = Unit_info.Artifact.modname target in
     let prefixname = Filename.remove_extension objtemp in
     let required_globals = Compilation_unit.Set.empty in
-    let transl_style : Translmod.compilation_unit_style =
-      Plain_block
-    in
     let main_module_block_size, code =
       Translmod.transl_package components compilation_unit coercion
-        ~style:transl_style
     in
     let code = Simplif.simplify_lambda code in
     let main_module_block_format : Lambda.main_module_block_format =

--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -1119,4 +1119,8 @@ and make_unsigned_comparison size signed_comparison x y =
    (pop)
 *)
 
-let blambda_of_lambda x = comp_expr x
+let blambda_of_lambda ~compilation_unit x = 
+  let blam = comp_expr x in
+  match compilation_unit with
+  | None -> blam
+  | Some cu -> Blambda.Prim (Blambda.Setglobal cu, [blam])

--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -1119,7 +1119,7 @@ and make_unsigned_comparison size signed_comparison x y =
    (pop)
 *)
 
-let blambda_of_lambda ~compilation_unit x = 
+let blambda_of_lambda ~compilation_unit x =
   let blam = comp_expr x in
   match compilation_unit with
   | None -> blam

--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -494,7 +494,6 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
       pseudo_event (variadic (Makeblock { tag }))
     | Pmake_unboxed_product _ -> pseudo_event (variadic (Makeblock { tag = 0 }))
     | Pgetglobal cu -> nullary (Getglobal cu)
-    | Psetglobal cu -> unary (Setglobal cu)
     | Pgetpredef id -> nullary (Getpredef id)
     | Pfield (n, _, _) | Punboxed_product_field (n, _) -> unary (Getfield n)
     | Parray_element_size_in_bytes _array_kind -> (

--- a/bytecomp/blambda_of_lambda.mli
+++ b/bytecomp/blambda_of_lambda.mli
@@ -12,6 +12,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val blambda_of_lambda : 
+val blambda_of_lambda :
   compilation_unit:Compilation_unit.t option -> Lambda.lambda -> Blambda.blambda
 (* If compilation_unit is Some cu, wrap the result in Setglobal *)

--- a/bytecomp/blambda_of_lambda.mli
+++ b/bytecomp/blambda_of_lambda.mli
@@ -12,4 +12,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val blambda_of_lambda : Lambda.lambda -> Blambda.blambda
+val blambda_of_lambda : 
+  compilation_unit:Compilation_unit.t option -> Lambda.lambda -> Blambda.blambda
+(* If compilation_unit is Some cu, wrap the result in Setglobal *)

--- a/bytecomp/blambda_of_lambda.mli
+++ b/bytecomp/blambda_of_lambda.mli
@@ -12,6 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** Convert Lambda to Blambda for bytecode compilation.
+    If compilation_unit is [Some cu], wrap the result in Setglobal. *)
 val blambda_of_lambda :
   compilation_unit:Compilation_unit.t option -> Lambda.lambda -> Blambda.blambda
-(* If compilation_unit is Some cu, wrap the result in Setglobal *)

--- a/bytecomp/bytepackager.ml
+++ b/bytecomp/bytepackager.ml
@@ -218,7 +218,7 @@ let build_global_target ~ppf_dump oc ~packed_compilation_unit state members
       members
   in
   let main_module_block_size, lam =
-    Translmod.transl_package components packed_compilation_unit coercion
+    Translmod.transl_package components coercion
   in
   if !Clflags.dump_rawlambda then
     Format.fprintf ppf_dump "%a@." Printlambda.lambda lam;

--- a/bytecomp/bytepackager.ml
+++ b/bytecomp/bytepackager.ml
@@ -227,6 +227,10 @@ let build_global_target ~ppf_dump oc ~packed_compilation_unit state members
   if !Clflags.dump_lambda then
     Format.fprintf ppf_dump "%a@." Printlambda.lambda lam;
   let blam = Blambda_of_lambda.blambda_of_lambda lam in
+  let blam = 
+    (* Wrap the packed module in Setglobal for bytecode compilation *)
+    Blambda.Prim (Blambda.Setglobal packed_compilation_unit, [blam])
+  in
   if !Clflags.dump_blambda then
     Format.fprintf ppf_dump "%a@." Printblambda.blambda blam;
   let instrs = Bytegen.compile_implementation packed_compilation_unit blam in

--- a/bytecomp/bytepackager.ml
+++ b/bytecomp/bytepackager.ml
@@ -225,8 +225,8 @@ let build_global_target ~ppf_dump oc ~packed_compilation_unit state members
   let lam = Simplif.simplify_lambda lam in
   if !Clflags.dump_lambda then
     Format.fprintf ppf_dump "%a@." Printlambda.lambda lam;
-  let blam = 
-    Blambda_of_lambda.blambda_of_lambda 
+  let blam =
+    Blambda_of_lambda.blambda_of_lambda
       ~compilation_unit:(Some packed_compilation_unit) lam in
   if !Clflags.dump_blambda then
     Format.fprintf ppf_dump "%a@." Printblambda.blambda blam;

--- a/bytecomp/bytepackager.ml
+++ b/bytecomp/bytepackager.ml
@@ -225,7 +225,9 @@ let build_global_target ~ppf_dump oc ~packed_compilation_unit state members
   let lam = Simplif.simplify_lambda lam in
   if !Clflags.dump_lambda then
     Format.fprintf ppf_dump "%a@." Printlambda.lambda lam;
-  let blam = Blambda_of_lambda.blambda_of_lambda ~compilation_unit:(Some packed_compilation_unit) lam in
+  let blam = 
+    Blambda_of_lambda.blambda_of_lambda 
+      ~compilation_unit:(Some packed_compilation_unit) lam in
   if !Clflags.dump_blambda then
     Format.fprintf ppf_dump "%a@." Printblambda.blambda blam;
   let instrs = Bytegen.compile_implementation packed_compilation_unit blam in

--- a/bytecomp/bytepackager.ml
+++ b/bytecomp/bytepackager.ml
@@ -219,18 +219,13 @@ let build_global_target ~ppf_dump oc ~packed_compilation_unit state members
   in
   let main_module_block_size, lam =
     Translmod.transl_package components packed_compilation_unit coercion
-      ~style:Set_global_to_block
   in
   if !Clflags.dump_rawlambda then
     Format.fprintf ppf_dump "%a@." Printlambda.lambda lam;
   let lam = Simplif.simplify_lambda lam in
   if !Clflags.dump_lambda then
     Format.fprintf ppf_dump "%a@." Printlambda.lambda lam;
-  let blam = Blambda_of_lambda.blambda_of_lambda lam in
-  let blam = 
-    (* Wrap the packed module in Setglobal for bytecode compilation *)
-    Blambda.Prim (Blambda.Setglobal packed_compilation_unit, [blam])
-  in
+  let blam = Blambda_of_lambda.blambda_of_lambda ~compilation_unit:(Some packed_compilation_unit) lam in
   if !Clflags.dump_blambda then
     Format.fprintf ppf_dump "%a@." Printblambda.blambda blam;
   let instrs = Bytegen.compile_implementation packed_compilation_unit blam in

--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -52,6 +52,9 @@ let raw_lambda_to_bytecode i raw_lambda ~as_arg_for =
        |> Simplif.simplify_lambda
        |> print_if i.ppf_dump Clflags.dump_lambda Printlambda.lambda
        |> Blambda_of_lambda.blambda_of_lambda
+       |> (fun blam -> 
+            (* Wrap the module in Setglobal for bytecode compilation *)
+            Blambda.Prim (Blambda.Setglobal i.module_name, [blam]))
        |> print_if i.ppf_dump Clflags.dump_blambda Printblambda.blambda
        |> Bytegen.compile_implementation i.module_name
        |> print_if i.ppf_dump Clflags.dump_instr Printinstr.instrlist

--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -51,7 +51,7 @@ let raw_lambda_to_bytecode i raw_lambda ~as_arg_for =
        |> print_if i.ppf_dump Clflags.dump_rawlambda Printlambda.lambda
        |> Simplif.simplify_lambda
        |> print_if i.ppf_dump Clflags.dump_lambda Printlambda.lambda
-       |> Blambda_of_lambda.blambda_of_lambda 
+       |> Blambda_of_lambda.blambda_of_lambda
             ~compilation_unit:(Some i.module_name)
        |> print_if i.ppf_dump Clflags.dump_blambda Printblambda.blambda
        |> Bytegen.compile_implementation i.module_name

--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -51,7 +51,8 @@ let raw_lambda_to_bytecode i raw_lambda ~as_arg_for =
        |> print_if i.ppf_dump Clflags.dump_rawlambda Printlambda.lambda
        |> Simplif.simplify_lambda
        |> print_if i.ppf_dump Clflags.dump_lambda Printlambda.lambda
-       |> Blambda_of_lambda.blambda_of_lambda ~compilation_unit:(Some i.module_name)
+       |> Blambda_of_lambda.blambda_of_lambda 
+            ~compilation_unit:(Some i.module_name)
        |> print_if i.ppf_dump Clflags.dump_blambda Printblambda.blambda
        |> Bytegen.compile_implementation i.module_name
        |> print_if i.ppf_dump Clflags.dump_instr Printinstr.instrlist

--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -51,10 +51,7 @@ let raw_lambda_to_bytecode i raw_lambda ~as_arg_for =
        |> print_if i.ppf_dump Clflags.dump_rawlambda Printlambda.lambda
        |> Simplif.simplify_lambda
        |> print_if i.ppf_dump Clflags.dump_lambda Printlambda.lambda
-       |> Blambda_of_lambda.blambda_of_lambda
-       |> (fun blam -> 
-            (* Wrap the module in Setglobal for bytecode compilation *)
-            Blambda.Prim (Blambda.Setglobal i.module_name, [blam]))
+       |> Blambda_of_lambda.blambda_of_lambda ~compilation_unit:(Some i.module_name)
        |> print_if i.ppf_dump Clflags.dump_blambda Printblambda.blambda
        |> Bytegen.compile_implementation i.module_name
        |> print_if i.ppf_dump Clflags.dump_instr Printinstr.instrlist
@@ -72,7 +69,7 @@ let to_bytecode i Typedtree.{structure; coercion; argument_interface; _} =
   in
   (structure, coercion, argument_coercion)
   |> Profile.(record transl)
-    (Translmod.transl_implementation i.module_name ~style:Set_global_to_block)
+    (Translmod.transl_implementation i.module_name)
   |> raw_lambda_to_bytecode i
 
 let emit_bytecode i
@@ -141,7 +138,7 @@ let implementation_aux ~start_from ~source_file ~output_prefix
     in
     let impl =
       Translmod.transl_instance info.module_name ~runtime_args
-        ~main_module_block_size ~arg_block_idx ~style:Set_global_to_block
+        ~main_module_block_size ~arg_block_idx
     in
     let bytecode = raw_lambda_to_bytecode info impl ~as_arg_for in
     emit_bytecode info bytecode

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -73,10 +73,10 @@ let compile_from_raw_lambda i raw_lambda ~unix ~pipeline ~as_arg_for =
                ~arg_descr
            end))
 
-let compile_from_typed i typed ~transl_style ~unix ~pipeline ~as_arg_for =
+let compile_from_typed i typed ~unix ~pipeline ~as_arg_for =
   typed
   |> Profile.(record transl)
-    (Translmod.transl_implementation i.module_name ~style:transl_style)
+    (Translmod.transl_implementation i.module_name)
   |> compile_from_raw_lambda i ~unix ~pipeline ~as_arg_for
 
 type flambda2 =
@@ -112,9 +112,6 @@ let starting_point_of_compiler_pass start_from  =
 let implementation_aux unix ~(flambda2 : flambda2) ~start_from
       ~source_file ~output_prefix ~keep_symbol_tables
       ~(compilation_unit : Compile_common.compilation_unit_or_inferred) =
-  let transl_style : Translmod.compilation_unit_style =
-    Plain_block
-  in
   let pipeline : Asmgen.pipeline =
     Direct_to_cmm (flambda2 ~keep_symbol_tables)
   in
@@ -140,7 +137,7 @@ let implementation_aux unix ~(flambda2 : flambda2) ~start_from
         |> Option.map Global_module.Parameter_name.of_string
       in
       if not (Config.flambda || Config.flambda2) then Clflags.set_oclassic ();
-      compile_from_typed info typed ~unix ~transl_style ~pipeline ~as_arg_for
+      compile_from_typed info typed ~unix ~pipeline ~as_arg_for
     in
     Compile_common.implementation
       ~hook_parse_tree:(Compiler_hooks.execute Compiler_hooks.Parse_tree_impl)
@@ -165,7 +162,7 @@ let implementation_aux unix ~(flambda2 : flambda2) ~start_from
     in
     let impl =
       Translmod.transl_instance info.module_name ~runtime_args
-        ~main_module_block_size ~arg_block_idx ~style:transl_style
+        ~main_module_block_size ~arg_block_idx
     in
     if not (Config.flambda || Config.flambda2) then Clflags.set_oclassic ();
     compile_from_raw_lambda info impl ~unix ~pipeline ~as_arg_for

--- a/driver/optcompile.ml
+++ b/driver/optcompile.ml
@@ -113,8 +113,7 @@ let implementation_aux unix ~(flambda2 : flambda2) ~start_from
       ~source_file ~output_prefix ~keep_symbol_tables
       ~(compilation_unit : Compile_common.compilation_unit_or_inferred) =
   let transl_style : Translmod.compilation_unit_style =
-    if Config.flambda || Config.flambda2 then Plain_block
-    else Set_individual_fields
+    Plain_block
   in
   let pipeline : Asmgen.pipeline =
     Direct_to_cmm (flambda2 ~keep_symbol_tables)

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -138,7 +138,6 @@ type primitive =
   | Pignore
     (* Globals *)
   | Pgetglobal of Compilation_unit.t
-  | Psetglobal of Compilation_unit.t
   | Pgetpredef of Ident.t
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape * locality_mode
@@ -1921,7 +1920,7 @@ let primitive_may_allocate : primitive -> locality_mode option = function
   | Pbytes_to_string | Pbytes_of_string
   | Parray_to_iarray | Parray_of_iarray
   | Pignore -> None
-  | Pgetglobal _ | Psetglobal _ | Pgetpredef _ -> None
+  | Pgetglobal _ | Pgetpredef _ -> None
   | Pmakeblock (_, _, _, m) -> Some m
   | Pmakefloatblock (_, m) -> Some m
   | Pmakeufloatblock (_, m) -> Some m
@@ -2119,7 +2118,7 @@ let primitive_can_raise prim =
   | Pbigarrayset (_, _, _, Pbigarray_unknown_layout) ->
     true
   | Pbytes_to_string | Pbytes_of_string | Parray_of_iarray | Parray_to_iarray
-  | Pignore | Pgetglobal _ | Psetglobal _ | Pgetpredef _ | Pmakeblock _
+  | Pignore | Pgetglobal _ | Pgetpredef _ | Pmakeblock _
   | Pmakefloatblock _ | Pfield _ | Pfield_computed _ | Psetfield _
   | Psetfield_computed _ | Pfloatfield _ | Psetfloatfield _ | Pduprecord _
   | Pmakeufloatblock _ | Pufloatfield _ | Psetufloatfield _ | Psequand | Psequor
@@ -2404,7 +2403,7 @@ let primitive_result_layout (p : primitive) =
   | Punboxed_nativeint_array_set_vec _
   | Parrayblit _
     -> layout_unit
-  | Pgetglobal _ | Psetglobal _ | Pgetpredef _ -> layout_module_field
+  | Pgetglobal _ | Pgetpredef _ -> layout_module_field
   | Pmakeblock _ | Pmakefloatblock _ | Pmakearray _ | Pmakearray_dynamic _
   | Pduprecord _ | Pmakeufloatblock _ | Pmakemixedblock _ | Pmakelazyblock _
   | Pduparray _ | Pbigarraydim _ | Pobj_dup -> layout_block

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -122,7 +122,6 @@ type primitive =
   | Pignore
   (* Globals *)
   | Pgetglobal of Compilation_unit.t
-  | Psetglobal of Compilation_unit.t
   | Pgetpredef of Ident.t
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape * locality_mode

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -397,7 +397,6 @@ let primitive ppf = function
   | Pbytes_of_string -> fprintf ppf "bytes_of_string"
   | Pignore -> fprintf ppf "ignore"
   | Pgetglobal cu -> fprintf ppf "global %a!" Compilation_unit.print cu
-  | Psetglobal cu -> fprintf ppf "setglobal %a!" Compilation_unit.print cu
   | Pgetpredef id -> fprintf ppf "getpredef %a!" Ident.print id
   | Pmakeblock(tag, Immutable, shape, mode) ->
       fprintf ppf "make%sblock %i%a"
@@ -868,7 +867,6 @@ let name_of_primitive = function
   | Pbytes_to_string -> "Pbytes_to_string"
   | Pignore -> "Pignore"
   | Pgetglobal _ -> "Pgetglobal"
-  | Psetglobal _ -> "Psetglobal"
   | Pgetpredef _ -> "Pgetpredef"
   | Pmakeblock _ -> "Pmakeblock"
   | Pmakefloatblock _ -> "Pmakefloatblock"

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -881,7 +881,7 @@ let rec choice ctx t =
        considered constructions someday *)
     | Pbytes_to_string | Pbytes_of_string
     | Parray_to_iarray | Parray_of_iarray
-    | Pgetglobal _ | Psetglobal _ | Pgetpredef _
+    | Pgetglobal _ | Pgetpredef _
     | Pfield _ | Pfield_computed _
     | Psetfield _ | Psetfield_computed _
     | Pfloatfield _ | Psetfloatfield _

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -994,7 +994,6 @@ let wrap_toplevel_functor_in_struct code =
 
 (* Compile an implementation *)
 
-
 let has_parameters () =
   Env.parameters () <> []
 
@@ -1253,7 +1252,7 @@ let get_component = function
     None -> Lconst const_unit
   | Some id -> Lprim(Pgetglobal id, [], Loc_unknown)
 
-let transl_package component_names _target_name coercion =
+let transl_package component_names coercion =
   let size =
     match coercion with
     | Tcoerce_none -> List.length component_names

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -1409,7 +1409,6 @@ let () =
         None
     )
 
-
 let reset () =
   primitive_declarations := [];
   aliased_idents := Ident.empty;

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -901,7 +901,7 @@ let scan_used_globals lam =
   let rec scan lam =
     Lambda.iter_head_constructor scan lam;
     match lam with
-      Lprim ((Pgetglobal cu | Psetglobal cu), _, _) ->
+      Lprim ((Pgetglobal cu), _, _) ->
         globals := Compilation_unit.Set.add cu !globals
     | _ -> ()
   in
@@ -996,8 +996,7 @@ let wrap_toplevel_functor_in_struct code =
 
 let wrap_in_setglobal implementation =
   let code =
-    Lprim (Psetglobal implementation.compilation_unit, [implementation.code],
-           Loc_unknown)
+    implementation.code
   in
   { implementation with code }
 
@@ -1006,7 +1005,6 @@ let wrap_in_setglobal implementation =
 type compilation_unit_style =
   | Plain_block
   | Set_global_to_block
-  | Set_individual_fields
 
 let has_parameters () =
   Env.parameters () <> []
@@ -1068,688 +1066,10 @@ let transl_implementation_set_global module_name impl =
   transl_implementation_plain_block module_name impl
   |> wrap_in_setglobal
 
-(* Build the list of value identifiers defined by a toplevel structure
-   (excluding primitive declarations). *)
-
-let rec defined_idents = function
-    [] -> []
-  | item :: rem ->
-    match item.str_desc with
-    | Tstr_eval _ -> defined_idents rem
-    | Tstr_value(_rec_flag, pat_expr_list) ->
-      let_bound_idents pat_expr_list @ defined_idents rem
-    | Tstr_primitive _ -> defined_idents rem
-    | Tstr_type _ -> defined_idents rem
-    | Tstr_typext tyext ->
-      List.map (fun ext -> ext.ext_id) tyext.tyext_constructors
-      @ defined_idents rem
-    | Tstr_exception ext -> ext.tyexn_constructor.ext_id :: defined_idents rem
-    | Tstr_module {mb_id = Some id; mb_presence=Mp_present} ->
-      id :: defined_idents rem
-    | Tstr_module ({mb_id = None}
-                  |{mb_presence=Mp_absent}) -> defined_idents rem
-    | Tstr_recmodule decls ->
-      List.filter_map (fun mb -> mb.mb_id) decls @ defined_idents rem
-    | Tstr_modtype _ -> defined_idents rem
-    | Tstr_open od ->
-      bound_value_identifiers od.open_bound_items @ defined_idents rem
-    | Tstr_class cl_list ->
-      List.map (fun (ci, _) -> ci.ci_id_class) cl_list @ defined_idents rem
-    | Tstr_class_type _ -> defined_idents rem
-    | Tstr_include incl ->
-      bound_value_identifiers incl.incl_type @ defined_idents rem
-    | Tstr_attribute _ -> defined_idents rem
-
-(* second level idents (module M = struct ... let id = ... end),
-   and all sub-levels idents *)
-let rec more_idents = function
-    [] -> []
-  | item :: rem ->
-    match item.str_desc with
-    | Tstr_eval _ -> more_idents rem
-    | Tstr_value _ -> more_idents rem
-    | Tstr_primitive _ -> more_idents rem
-    | Tstr_type _ -> more_idents rem
-    | Tstr_typext _ -> more_idents rem
-    | Tstr_exception _ -> more_idents rem
-    | Tstr_recmodule _ -> more_idents rem
-    | Tstr_modtype _ -> more_idents rem
-    | Tstr_open od ->
-        let rest = more_idents rem in
-        begin match od.open_expr.mod_desc with
-        | Tmod_structure str -> all_idents str.str_items @ rest
-        | _ -> rest
-        end
-    | Tstr_class _ -> more_idents rem
-    | Tstr_class_type _ -> more_idents rem
-    | Tstr_include{incl_mod={mod_desc =
-                             Tmod_constraint ({mod_desc = Tmod_structure str},
-                                              _, _, _)
-                            | Tmod_structure str }} ->
-        all_idents str.str_items @ more_idents rem
-    | Tstr_include _ -> more_idents rem
-    | Tstr_module
-        {mb_presence=Mp_present; mb_expr={mod_desc = Tmod_structure str}}
-    | Tstr_module
-        {mb_presence=Mp_present;
-         mb_expr={mod_desc=
-           Tmod_constraint ({mod_desc = Tmod_structure str}, _, _, _)}} ->
-        all_idents str.str_items @ more_idents rem
-    | Tstr_module _ -> more_idents rem
-    | Tstr_attribute _ -> more_idents rem
-
-and all_idents = function
-    [] -> []
-  | item :: rem ->
-    match item.str_desc with
-    | Tstr_eval _ -> all_idents rem
-    | Tstr_value(_rec_flag, pat_expr_list) ->
-      let_bound_idents pat_expr_list @ all_idents rem
-    | Tstr_primitive _ -> all_idents rem
-    | Tstr_type _ -> all_idents rem
-    | Tstr_typext tyext ->
-      List.map (fun ext -> ext.ext_id) tyext.tyext_constructors
-      @ all_idents rem
-    | Tstr_exception ext -> ext.tyexn_constructor.ext_id :: all_idents rem
-    | Tstr_recmodule decls ->
-      List.filter_map (fun mb -> mb.mb_id) decls @ all_idents rem
-    | Tstr_modtype _ -> all_idents rem
-    | Tstr_open od ->
-        let rest = all_idents rem in
-        begin match od.open_expr.mod_desc with
-        | Tmod_structure str ->
-          bound_value_identifiers od.open_bound_items
-          @ all_idents str.str_items
-          @ rest
-        | _ -> bound_value_identifiers od.open_bound_items @ rest
-        end
-    | Tstr_class cl_list ->
-      List.map (fun (ci, _) -> ci.ci_id_class) cl_list @ all_idents rem
-    | Tstr_class_type _ -> all_idents rem
-
-    | Tstr_include{incl_type;
-                   incl_mod={mod_desc =
-                     ( Tmod_constraint({mod_desc=Tmod_structure str}, _, _, _)
-                     | Tmod_structure str )}} ->
-        bound_value_identifiers incl_type
-        @ all_idents str.str_items
-        @ all_idents rem
-    | Tstr_include incl ->
-      bound_value_identifiers incl.incl_type @ all_idents rem
-
-    | Tstr_module
-        { mb_id = Some id;
-          mb_presence=Mp_present;
-          mb_expr={mod_desc = Tmod_structure str} }
-    | Tstr_module
-        { mb_id = Some id;
-          mb_presence = Mp_present;
-          mb_expr =
-            {mod_desc =
-               Tmod_constraint ({mod_desc = Tmod_structure str}, _, _, _)}} ->
-        id :: all_idents str.str_items @ all_idents rem
-    | Tstr_module {mb_id = Some id;mb_presence=Mp_present} ->
-        id :: all_idents rem
-    | Tstr_module ({mb_id = None} | {mb_presence=Mp_absent}) -> all_idents rem
-    | Tstr_attribute _ -> all_idents rem
-
-
-(* A variant of transl_structure used to compile toplevel structure definitions
-   for the native-code compiler. Store the defined values in the fields
-   of the global as soon as they are defined, in order to reduce register
-   pressure.  Also rewrites the defining expressions so that they
-   refer to earlier fields of the structure through the fields of
-   the global, not by their names.
-   "map" is a table from defined idents to (pos in global block, coercion).
-   "prim" is a list of (pos in global block, primitive declaration). *)
-
-let transl_store_subst = ref Ident.Map.empty
-  (** In the native toplevel, this reference is threaded through successive
-      calls of transl_store_structure *)
-
-let nat_toplevel_name id =
-  try match Ident.Map.find id !transl_store_subst with
-    | Lprim(Pfield (pos, _, _),
-            [Lprim(Pgetglobal glob, [], _)], _) -> (glob,pos)
-    | _ -> raise Not_found
-  with Not_found ->
-    fatal_error("Translmod.nat_toplevel_name: " ^ Ident.unique_name id)
-
-let field_of_str loc str =
-  let ids = Array.of_list (defined_idents str.str_items) in
-  fun (pos, cc) ->
-    match cc with
-    | Tcoerce_primitive { pc_desc; pc_env; pc_type; pc_poly_mode; pc_poly_sort } ->
-        Translprim.transl_primitive loc pc_desc pc_env pc_type
-          ~poly_mode:pc_poly_mode
-          ~poly_sort:pc_poly_sort
-          None
-    | Tcoerce_alias (env, path, cc) ->
-        let lam = transl_module_path loc env path in
-        apply_coercion loc Alias cc lam
-    | _ -> apply_coercion loc Strict cc (Lvar ids.(pos))
-
-
-let transl_store_structure ~scopes glob map prims aliases str =
-  let no_env_update _ _ env = env in
-  let rec transl_store ~scopes rootpath subst cont = function
-    [] ->
-      transl_store_subst := subst;
-      Lambda.subst no_env_update subst cont
-    | item :: rem ->
-        match item.str_desc with
-        | Tstr_eval (expr, sort, _attrs) ->
-            let sort = Jkind.Sort.default_for_transl_and_get sort in
-            Lsequence(Lambda.subst no_env_update subst
-                        (transl_exp ~scopes sort expr),
-                      transl_store ~scopes rootpath subst cont rem)
-        | Tstr_value(rec_flag, pat_expr_list) ->
-            let ids = let_bound_idents pat_expr_list in
-            let lam =
-              transl_let ~scopes ~return_layout:Lambda.layout_unit
-                ~in_structure:true rec_flag pat_expr_list
-                (store_idents Loc_unknown ids)
-            in
-            Lsequence(Lambda.subst no_env_update subst lam,
-                      transl_store ~scopes rootpath
-                        (add_idents false ids subst) cont rem)
-        | Tstr_primitive descr ->
-            record_primitive descr.val_val;
-            transl_store ~scopes rootpath subst cont rem
-        | Tstr_type _ ->
-            transl_store ~scopes rootpath subst cont rem
-        | Tstr_typext(tyext) ->
-            let ids =
-              List.map (fun ext -> ext.ext_id) tyext.tyext_constructors
-            in
-            let lam =
-              transl_type_extension ~scopes item.str_env rootpath tyext
-                                    (store_idents Loc_unknown ids)
-            in
-            Lsequence(Lambda.subst no_env_update subst lam,
-                      transl_store ~scopes rootpath
-                        (add_idents false ids subst) cont rem)
-        | Tstr_exception ext ->
-            let id = ext.tyexn_constructor.ext_id in
-            let id_duid = Lambda.debug_uid_none in
-            (* CR sspies: Can we find a better [debug_uid] here? *)
-            let path = field_path rootpath id in
-            let loc = of_location ~scopes ext.tyexn_constructor.ext_loc in
-            let lam =
-              transl_extension_constructor ~scopes
-                                           item.str_env
-                                           path
-                                           ext.tyexn_constructor
-            in
-            Lsequence(Llet(Strict, Lambda.layout_block, id, id_duid,
-                           Lambda.subst no_env_update subst lam,
-                           store_ident loc id),
-                      transl_store ~scopes rootpath
-                        (add_ident false id subst) cont rem)
-        | Tstr_module
-            {mb_id=None; mb_name; mb_presence=Mp_present; mb_expr=modl;
-             mb_loc=loc; mb_attributes} ->
-            let lam =
-              Translattribute.add_inline_attribute
-                (transl_module ~scopes Tcoerce_none None modl)
-                loc mb_attributes
-            in
-            Lsequence(
-              Lprim(Pignore,[Lambda.subst no_env_update subst lam],
-                    of_location ~scopes mb_name.loc),
-              transl_store ~scopes rootpath subst cont rem
-            )
-        | Tstr_module{mb_id=Some id;mb_loc=loc;mb_presence=Mp_present;
-                      mb_expr={mod_desc = Tmod_structure str}} ->
-            let id_duid = Lambda.debug_uid_none in
-            (* CR sspies: Can we find a better [debug_uid] here? *)
-            let loc = of_location ~scopes loc in
-            let lam =
-              transl_store
-                ~scopes:(enter_module_definition ~scopes id)
-                (field_path rootpath id) subst
-                lambda_unit str.str_items
-            in
-            (* Careful: see next case *)
-            let subst = !transl_store_subst in
-            Lsequence(lam,
-                      Llet(Strict, Lambda.layout_module, id, id_duid,
-                           Lambda.subst no_env_update subst
-                             (Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
-                                    List.map (fun id -> Lvar id)
-                                      (defined_idents str.str_items), loc)),
-                           Lsequence(store_ident loc id,
-                                     transl_store ~scopes rootpath
-                                                  (add_ident true id subst)
-                                                  cont rem)))
-        | Tstr_module{
-            mb_id=Some id;mb_loc=loc;mb_presence=Mp_present;
-            mb_expr= {
-              mod_desc = Tmod_constraint (
-                  {mod_desc = Tmod_structure str}, _, _,
-                  (Tcoerce_structure (map, _) as _cc))}
-          } ->
-            (*    Format.printf "coerc id %s: %a@." (Ident.unique_name id)
-                                Includemod.print_coercion cc; *)
-            let id_duid = Lambda.debug_uid_none in
-            (* CR sspies: Can we find a better [debug_uid] here? *)
-            let loc = of_location ~scopes loc in
-            let lam =
-              transl_store
-                ~scopes:(enter_module_definition ~scopes id)
-                (field_path rootpath id) subst
-                lambda_unit str.str_items
-            in
-            (* Careful: see next case *)
-            let subst = !transl_store_subst in
-            let field = field_of_str loc str in
-            Lsequence(lam,
-                      Llet(Strict, Lambda.layout_module, id, id_duid,
-                           Lambda.subst no_env_update subst
-                             (Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
-                                    List.map field map, loc)),
-                           Lsequence(store_ident loc id,
-                                     transl_store ~scopes rootpath
-                                                  (add_ident true id subst)
-                                                  cont rem)))
-        | Tstr_module
-            {mb_id=Some id; mb_presence=Mp_present; mb_expr=modl;
-             mb_loc=loc; mb_attributes} ->
-            let id_duid = Lambda.debug_uid_none in
-            (* CR sspies: Can we find a better [debug_uid] here? *)
-            let lam =
-              Translattribute.add_inline_attribute
-                (transl_module
-                   ~scopes:(enter_module_definition ~scopes id)
-                   Tcoerce_none (field_path rootpath id) modl)
-                loc mb_attributes
-            in
-            (* Careful: the module value stored in the global may be different
-               from the local module value, in case a coercion is applied.
-               If so, keep using the local module value (id) in the remainder of
-               the compilation unit (add_ident true returns subst unchanged).
-               If not, we can use the value from the global
-               (add_ident true adds id -> Pgetglobal... to subst). *)
-            Llet(Strict, Lambda.layout_module, id, id_duid,
-                 Lambda.subst no_env_update subst lam,
-                 Lsequence(store_ident (of_location ~scopes loc) id,
-                           transl_store ~scopes rootpath
-                             (add_ident true id subst)
-                             cont rem))
-        | Tstr_module ({mb_presence=Mp_absent}) ->
-            transl_store ~scopes rootpath subst cont rem
-        | Tstr_recmodule bindings ->
-            let ids = List.filter_map (fun mb -> mb.mb_id) bindings in
-            compile_recmodule ~scopes
-              (fun id modl ->
-                 Lambda.subst no_env_update subst
-                   (match id with
-                    | None ->
-                      transl_module ~scopes Tcoerce_none None modl
-                    | Some id ->
-                      transl_module
-                        ~scopes:(enter_module_definition ~scopes id)
-                        Tcoerce_none (field_path rootpath id) modl))
-              bindings
-              (Lsequence(store_idents Loc_unknown ids,
-                         transl_store ~scopes rootpath
-                           (add_idents true ids subst) cont rem))
-        | Tstr_class cl_list ->
-            let (ids, class_bindings) = transl_class_bindings ~scopes cl_list in
-            let body = store_idents Loc_unknown ids in
-            let lam =
-              Value_rec_compiler.compile_letrec class_bindings body
-            in
-            Lsequence(Lambda.subst no_env_update subst lam,
-                      transl_store ~scopes rootpath (add_idents false ids subst)
-                        cont rem)
-
-        | Tstr_include({
-            incl_loc=loc;
-            incl_mod= {
-              mod_desc = Tmod_constraint (
-                  ({mod_desc = Tmod_structure str}), _, _,
-                  (Tcoerce_structure _ | Tcoerce_none))}
-            | ({ mod_desc = Tmod_structure str});
-            incl_type;
-          } as incl) ->
-            let lam =
-              transl_store ~scopes None subst lambda_unit str.str_items
-                (* It is tempting to pass rootpath instead of None
-                   in order to give a more precise name to exceptions
-                   in the included structured, but this would introduce
-                   a difference of behavior compared to bytecode. *)
-            in
-            let subst = !transl_store_subst in
-            let field = field_of_str (of_location ~scopes loc) str in
-            let ids0 = bound_value_identifiers incl_type in
-            let rec loop ids args =
-              match ids, args with
-              | [], [] ->
-                  transl_store ~scopes rootpath (add_idents true ids0 subst)
-                    cont rem
-              | id :: ids, arg :: args ->
-                  Llet(Alias, Lambda.layout_module_field, id,
-                       Lambda.debug_uid_none,
-                       (* CR sspies: Can we find a better [debug_uid] here? *)
-                       Lambda.subst no_env_update subst (field arg),
-                       Lsequence(store_ident (of_location ~scopes loc) id,
-                                 loop ids args))
-              | _ -> assert false
-            in
-            let map =
-              match incl.incl_mod.mod_desc with
-              | Tmod_constraint (_, _, _, Tcoerce_structure (map, _)) ->
-                 map
-              | Tmod_structure _
-              | Tmod_constraint (_, _, _, Tcoerce_none) ->
-                 List.init (List.length ids0) (fun i -> i, Tcoerce_none)
-              | _ -> assert false
-            in
-            Lsequence(lam, loop ids0 map)
-
-        | Tstr_include incl ->
-            let ids = bound_value_identifiers incl.incl_type in
-            let modl = incl.incl_mod in
-            let mid = Ident.create_local "include" in
-            let mid_duid = Lambda.debug_uid_none in
-            let loc = of_location ~scopes incl.incl_loc in
-            let rec store_idents pos = function
-              | [] -> transl_store
-                        ~scopes rootpath (add_idents true ids subst) cont rem
-              | id :: idl ->
-                  let id_duid = Lambda.debug_uid_none in
-                  (* CR sspies: Can we find a better [debug_uid] here? *)
-                  Llet(Alias, Lambda.layout_module_field, id, id_duid,
-                      Lprim(mod_field pos, [Lvar mid],
-                                                 loc),
-                       Lsequence(store_ident loc id,
-                                 store_idents (pos + 1) idl))
-            in
-            let modl =
-              match incl.incl_kind with
-              | Tincl_structure -> transl_module ~scopes Tcoerce_none None modl
-              | Tincl_functor ccs ->
-                  transl_include_functor ~generative:false modl ccs scopes loc
-              | Tincl_gen_functor ccs ->
-                  transl_include_functor ~generative:true modl ccs scopes loc
-            in
-            Llet(Strict, Lambda.layout_module, mid, mid_duid,
-                 Lambda.subst no_env_update subst modl,
-                 store_idents 0 ids)
-        | Tstr_open od ->
-            begin match od.open_expr.mod_desc with
-            | Tmod_structure str ->
-                let lam =
-                  transl_store ~scopes rootpath subst lambda_unit str.str_items
-                in
-                let loc = of_location ~scopes od.open_loc in
-                let ids = Array.of_list (defined_idents str.str_items) in
-                let ids0 = bound_value_identifiers od.open_bound_items in
-                let subst = !transl_store_subst in
-                let rec store_idents pos = function
-                  | [] -> transl_store ~scopes rootpath
-                            (add_idents true ids0 subst) cont rem
-                  | id :: idl ->
-                      let id_duid = Lambda.debug_uid_none in
-                      (* CR sspies: Can we find a better [debug_uid] here? *)
-                      Llet(Alias, Lambda.layout_module_field, id, id_duid,
-                           Lvar ids.(pos),
-                           Lsequence(store_ident loc id,
-                                     store_idents (pos + 1) idl))
-                in
-                Lsequence(lam, Lambda.subst no_env_update subst
-                                 (store_idents 0 ids0))
-            | _ ->
-                let pure = pure_module od.open_expr in
-                (* this optimization shouldn't be needed because Simplif would
-                   actually remove the [Llet] when it's not used.
-                   But since [scan_used_globals] runs before Simplif, we need to
-                   do it. *)
-                match od.open_bound_items with
-                | [] when pure = Alias ->
-                  transl_store ~scopes rootpath subst cont rem
-                | _ ->
-                    let ids = bound_value_identifiers od.open_bound_items in
-                    let mid = Ident.create_local "open" in
-                    let mid_duid = Lambda.debug_uid_none in
-                    let loc = of_location ~scopes od.open_loc in
-                    let rec store_idents pos = function
-                        [] -> transl_store ~scopes rootpath
-                                (add_idents true ids subst) cont rem
-                      | id :: idl ->
-                        (* CR sspies: Can we find a better [debug_uid] here? *)
-                          let id_duid = Lambda.debug_uid_none in
-                          Llet(Alias, Lambda.layout_module_field, id, id_duid,
-                               Lprim(mod_field pos,
-                                     [Lvar mid], loc),
-                               Lsequence(store_ident loc id,
-                                         store_idents (pos + 1) idl))
-                    in
-                    Llet(
-                      pure, Lambda.layout_module, mid, mid_duid,
-                      Lambda.subst no_env_update subst
-                        (transl_module ~scopes Tcoerce_none None od.open_expr),
-                      store_idents 0 ids)
-          end
-        | Tstr_modtype _
-        | Tstr_class_type _
-        | Tstr_attribute _ ->
-            transl_store ~scopes rootpath subst cont rem
-
-  and store_ident loc id =
-    try
-      let (pos, cc) = Ident.find_same id map in
-      let init_val = apply_coercion loc Alias cc (Lvar id) in
-      Lprim(mod_setfield pos,
-            [Lprim(Pgetglobal glob, [], loc); init_val],
-            loc)
-    with Not_found ->
-      fatal_error("Translmod.store_ident: " ^ Ident.unique_name id)
-
-  and store_idents loc idlist =
-    make_sequence (store_ident loc) idlist
-
-  and add_ident may_coerce id subst =
-    try
-      let (pos, cc) = Ident.find_same id map in
-      match cc with
-        Tcoerce_none ->
-          Ident.Map.add id
-            (Lprim(mod_field pos,
-                   [Lprim(Pgetglobal glob, [], Loc_unknown)],
-                   Loc_unknown))
-            subst
-      | _ ->
-          if may_coerce then subst else assert false
-    with Not_found ->
-      assert false
-
-  and add_idents may_coerce idlist subst =
-    List.fold_right (add_ident may_coerce) idlist subst
-
-  and store_primitive (pos, prim) cont =
-    Lsequence(Lprim(mod_setfield pos,
-                    [Lprim(Pgetglobal glob, [], Loc_unknown);
-                     Translprim.transl_primitive Loc_unknown
-                       prim.pc_desc prim.pc_env prim.pc_type
-                       ~poly_mode:prim.pc_poly_mode
-                       ~poly_sort:prim.pc_poly_sort
-                       None],
-                    Loc_unknown),
-              cont)
-
-  and store_alias (pos, env, path, cc) =
-    let path_lam = transl_module_path Loc_unknown env path in
-    let init_val = apply_coercion Loc_unknown Strict cc path_lam in
-    Lprim(mod_setfield pos,
-          [Lprim(Pgetglobal glob, [], Loc_unknown);
-           init_val],
-          Loc_unknown)
-  in
-  let aliases = make_sequence store_alias aliases in
-  List.fold_right store_primitive prims
-    (transl_store ~scopes (global_path glob) !transl_store_subst aliases str)
-
-(* Transform a coercion and the list of value identifiers defined by
-   a toplevel structure into a table [id -> (pos, coercion)],
-   with [pos] being the position in the global block where the value of
-   [id] must be stored, and [coercion] the coercion to be applied to it.
-   A given identifier may appear several times
-   in the coercion (if it occurs several times in the signature); remember
-   to assign it the position of its last occurrence.
-   Identifiers that are not exported are assigned positions at the
-   end of the block (beyond the positions of all exported idents).
-   Also compute the total size of the global block,
-   and the list of all primitives exported as values. *)
-
-let build_ident_map restr idlist more_ids =
-  let rec natural_map pos map prims aliases = function
-    | [] ->
-        (map, prims, aliases, pos)
-    | id :: rem ->
-        natural_map (pos+1)
-          (Ident.add id (pos, Tcoerce_none) map) prims aliases rem
-  in
-  let (map, prims, aliases, pos) =
-    match restr with
-    | Tcoerce_none ->
-        natural_map 0 Ident.empty [] [] idlist
-    | Tcoerce_structure (pos_cc_list, _id_pos_list) ->
-        (* ignore _id_pos_list as the ids are already bound *)
-        let idarray = Array.of_list idlist in
-        let rec export_map pos map prims aliases undef = function
-          | [] ->
-              natural_map pos map prims aliases undef
-          | (_source_pos, Tcoerce_primitive p) :: rem ->
-              export_map (pos + 1) map
-                ((pos, p) :: prims) aliases undef rem
-          | (_source_pos, Tcoerce_alias(env, path, cc)) :: rem ->
-              export_map (pos + 1) map prims
-                ((pos, env, path, cc) :: aliases) undef rem
-          | (source_pos, cc) :: rem ->
-              let id = idarray.(source_pos) in
-              export_map (pos + 1) (Ident.add id (pos, cc) map)
-                prims aliases (list_remove id undef) rem
-        in
-        export_map 0 Ident.empty [] [] idlist pos_cc_list
-    | _ ->
-        fatal_error "Translmod.build_ident_map"
-  in
-  natural_map pos map prims aliases more_ids
-
-let store_arg_block_with_module_block
-    module_name set_primary_fields restr size =
-  let glob = Lprim(Pgetglobal module_name, [], Loc_unknown) in
-  let primary_block_id = Ident.create_local "*primary-block*" in
-  let primary_block_id_duid = Lambda.debug_uid_none in
-  let primary_block_lam =
-    (* We could just access the global, but if [restr] is the trivial coercion,
-       that would end up storing the global in itself as a circular reference,
-       which we might be able to get working but doesn't seem worth the
-       hassle. Instead, we access each field of the global and repackage it as a
-       new block (which will be optimised away if not needed). *)
-    let get_field i = Lprim (mod_field i, [glob], Loc_unknown) in
-    let fields = List.init size get_field in
-    Lprim(Pmakeblock(0, Immutable, None, alloc_heap), fields, Loc_unknown)
-  in
-  let arg_block_id = Ident.create_local "*arg-block*" in
-  let arg_block_duid = Lambda.debug_uid_none in
-  let arg_block_lam =
-    apply_coercion Loc_unknown Strict restr (Lvar primary_block_id)
-  in
-  let arg_field = size in
-  let new_size = size + 1 in
-  let set_arg_block =
-    Lprim(mod_setfield arg_field, [glob; Lvar arg_block_id], Loc_unknown)
-  in
-  let lam =
-    Lsequence(set_primary_fields,
-              Llet(Strict, layout_module, primary_block_id,
-                   primary_block_id_duid, primary_block_lam,
-                   Llet(Strict, layout_module, arg_block_id, arg_block_duid,
-                        arg_block_lam, set_arg_block)))
-  in
-  new_size, lam, Some arg_field
-
-(* Compile an implementation using transl_store_structure
-   (for the native-code compiler). *)
-
-let transl_store_gen_init () =
-  reset_labels ();
-  primitive_declarations := [];
-  Translcore.clear_probe_handlers ();
-  Translprim.clear_used_primitives ()
-
-let transl_store_structure_gen
-      ~scopes module_name ({ str_items = str }, restr, restr2) topl =
-  let (map, prims, aliases, size) =
-    build_ident_map restr (defined_idents str) (more_idents str) in
-  let f str =
-    let expr =
-      match str with
-      | [ { str_desc = Tstr_eval (expr, sort, _attrs) } ] when topl ->
-        assert (size = 0);
-        let sort = Jkind.Sort.default_for_transl_and_get sort in
-        Lambda.subst (fun _ _ env -> env) !transl_store_subst
-          (transl_exp ~scopes sort expr)
-      | str ->
-        transl_store_structure ~scopes module_name map prims aliases str
-    in
-    Translcore.declare_probe_handlers expr
-  in
-  let size, expr =
-    transl_store_label_init module_name size f str
-  in
-  match restr2 with
-  | None -> size, expr, None
-  | Some restr2 ->
-      store_arg_block_with_module_block module_name expr restr2 size
-  (*size, transl_label_init (transl_store_structure module_id map prims str)*)
-
-let transl_store_implementation_as_functor
-    ~scopes:_ _module_id _impl =
-  Misc.fatal_error "Parameterised modules only supported with flambda2"
-
-let transl_store_phrases module_name str =
-  transl_store_gen_init ();
-  let scopes =
-    enter_compilation_unit ~scopes:empty_scopes module_name
-  in
-  let size, lam, _arg_block_field =
-    transl_store_structure_gen ~scopes module_name (str,Tcoerce_none,None) true
-  in
-  size, lam
-
-let transl_store_gen module_name impl topl =
-  transl_store_gen_init ();
-  match has_parameters () with
-  | false ->
-      transl_store_structure_gen module_name impl topl
-  | true ->
-      transl_store_implementation_as_functor module_name impl
-
-let transl_implementation_set_fields compilation_unit impl =
-  let s = !transl_store_subst in
-  transl_store_subst := Ident.Map.empty;
-  let scopes = enter_compilation_unit ~scopes:empty_scopes compilation_unit in
-  let i, code, arg_block_idx =
-    transl_store_gen ~scopes compilation_unit impl false
-  in
-  transl_store_subst := s;
-  { Lambda.main_module_block_format = Mb_struct { mb_size = i };
-    arg_block_idx;
-    code;
-    (* compilation_unit is not used by closure, but this allow to share
-       the type with the flambda version *)
-    compilation_unit;
-    required_globals = required_globals ~flambda:true code }
-
 let transl_implementation compilation_unit impl ~style =
   match style with
   | Plain_block -> transl_implementation_plain_block compilation_unit impl
   | Set_global_to_block -> transl_implementation_set_global compilation_unit impl
-  | Set_individual_fields -> transl_implementation_set_fields compilation_unit impl
 
 (* Compile a toplevel phrase *)
 
@@ -1967,9 +1287,9 @@ let transl_package_plain_block component_names coercion =
            List.map get_component component_names,
            Loc_unknown))
 
-let transl_package_set_global component_names target_name coercion =
+let transl_package_set_global component_names _target_name coercion =
   let size, block = transl_package_plain_block component_names coercion in
-  size, Lprim(Psetglobal target_name, [block], Loc_unknown)
+  size, block
   (*
   let components =
     match coercion with
@@ -1983,54 +1303,8 @@ let transl_package_set_global component_names target_name coercion =
           pos_cc_list
     | _ ->
         assert false in
-  Lprim(Psetglobal target_name, [Lprim(Pmakeblock(0, Immutable), components)])
+  Lprim(Pmakeblock(0, Immutable), components)
    *)
-
-let transl_package_set_fields component_names target_name coercion =
-  let rec make_sequence fn pos arg =
-    match arg with
-      [] -> lambda_unit
-    | hd :: tl -> Lsequence(fn pos hd, make_sequence fn (pos + 1) tl) in
-  match coercion with
-    Tcoerce_none ->
-      (List.length component_names,
-       make_sequence
-         (fun pos id ->
-           Lprim(mod_setfield pos,
-                 [Lprim(Pgetglobal target_name, [], Loc_unknown);
-                  get_component id],
-                 Loc_unknown))
-         0 component_names)
-  | Tcoerce_structure (pos_cc_list, _id_pos_list) ->
-      let components =
-        Lprim(Pmakeblock(0, Immutable, None, alloc_heap),
-              List.map get_component component_names,
-              Loc_unknown)
-      in
-      let blk = Ident.create_local "block" in
-      let blk_duid = Lambda.debug_uid_none in
-      (List.length pos_cc_list,
-       Llet (Strict, Lambda.layout_module, blk, blk_duid,
-             apply_coercion Loc_unknown Strict coercion components,
-             make_sequence
-               (fun pos _id ->
-                 Lprim(mod_setfield pos,
-                       [Lprim(Pgetglobal target_name, [], Loc_unknown);
-                        Lprim(mod_field pos, [Lvar blk], Loc_unknown)],
-                       Loc_unknown))
-               0 pos_cc_list))
-  (*
-              (* ignore id_pos_list as the ids are already bound *)
-      let id = Array.of_list component_names in
-      (List.length pos_cc_list,
-       make_sequence
-         (fun dst (src, cc) ->
-           Lprim(Psetfield(dst, false),
-                 [Lprim(Pgetglobal target_name, []);
-                  apply_coercion Strict cc (get_component id.(src))]))
-         0 pos_cc_list)
-  *)
-  | _ -> assert false
 
 let transl_package component_names target_name coercion ~style =
   match style with
@@ -2038,8 +1312,6 @@ let transl_package component_names target_name coercion ~style =
       transl_package_plain_block component_names coercion
   | Set_global_to_block ->
       transl_package_set_global component_names target_name coercion
-  | Set_individual_fields ->
-      transl_package_set_fields component_names target_name coercion
 
 type runtime_arg =
   | Argument_block of {
@@ -2115,11 +1387,6 @@ let transl_instance_set_global
     ~main_module_block_size ~arg_block_idx
   |> wrap_in_setglobal
 
-let transl_instance_set_fields
-      _compilation_unit ~runtime_args:_ ~main_module_block_size:_
-      ~arg_block_idx:_ =
-  Misc.fatal_error "Parameterised modules not supported in Closure"
-
 let transl_instance instance_unit ~runtime_args ~main_module_block_size
       ~arg_block_idx ~style =
   assert (Compilation_unit.is_instance instance_unit);
@@ -2131,9 +1398,6 @@ let transl_instance instance_unit ~runtime_args ~main_module_block_size
         ~main_module_block_size ~arg_block_idx
   | Set_global_to_block ->
       transl_instance_set_global instance_unit ~runtime_args
-        ~main_module_block_size ~arg_block_idx
-  | Set_individual_fields ->
-      transl_instance_set_fields instance_unit ~runtime_args
         ~main_module_block_size ~arg_block_idx
 
 (* Error report *)
@@ -2201,9 +1465,9 @@ let () =
         None
     )
 
+
 let reset () =
   primitive_declarations := [];
-  transl_store_subst := Ident.Map.empty;
   aliased_idents := Ident.empty;
   Env.reset_required_globals ();
   Translprim.clear_used_primitives ()

--- a/lambda/translmod.mli
+++ b/lambda/translmod.mli
@@ -29,7 +29,8 @@ type compilation_unit_style =
    [argument_interface.ai_coercion_from_primary] fields from
    [Typedtree.implementation].)*)
 (* CR lmaurer: This should just be taking [Typedtree.implementation]. But it
-   can't, because [Opttoploop] calls it and doesn't have a full implementation. *)
+   can't, because [Opttoploop] calls it and doesn't have a
+   full implementation. *)
 val transl_implementation:
       Compilation_unit.t -> structure * module_coercion * module_coercion option
         -> style:compilation_unit_style -> Lambda.program

--- a/lambda/translmod.mli
+++ b/lambda/translmod.mli
@@ -22,7 +22,6 @@ open Lambda
 type compilation_unit_style =
   | Plain_block (* Flambda *)
   | Set_global_to_block (* Bytecode *)
-  | Set_individual_fields (* Closure *)
 
 (* The triple here is the structure, the coercion from the raw structure to
    the main signature, and the coercion from the main signature to the argument
@@ -30,14 +29,10 @@ type compilation_unit_style =
    [argument_interface.ai_coercion_from_primary] fields from
    [Typedtree.implementation].)*)
 (* CR lmaurer: This should just be taking [Typedtree.implementation]. But it
-   can't, because [Opttoploop] calls it and doesn't have a full implementation.
-   But [Opttoploop] _shouldn't_ be calling it, it should be calling
-   [transl_store_phrases], because it's only storing phrases. But [Opttoploop]
-   _should not exist anymore_, since upstream refactored the toplevel code. *)
+   can't, because [Opttoploop] calls it and doesn't have a full implementation. *)
 val transl_implementation:
       Compilation_unit.t -> structure * module_coercion * module_coercion option
         -> style:compilation_unit_style -> Lambda.program
-val transl_store_phrases: Compilation_unit.t -> structure -> int * lambda
 
 val transl_toplevel_definition: structure -> lambda
 
@@ -63,7 +58,6 @@ val transl_instance:
         -> style:compilation_unit_style -> Lambda.program
 
 val toplevel_name: Ident.t -> string
-val nat_toplevel_name: Ident.t -> Compilation_unit.t * int
 
 val primitive_declarations: Primitive.description list ref
 

--- a/lambda/translmod.mli
+++ b/lambda/translmod.mli
@@ -19,10 +19,6 @@
 open Typedtree
 open Lambda
 
-type compilation_unit_style =
-  | Plain_block (* Flambda *)
-  | Set_global_to_block (* Bytecode *)
-
 (* The triple here is the structure, the coercion from the raw structure to
    the main signature, and the coercion from the main signature to the argument
    signature (corresponding to the [structure], [coercion], and
@@ -33,13 +29,13 @@ type compilation_unit_style =
    full implementation. *)
 val transl_implementation:
       Compilation_unit.t -> structure * module_coercion * module_coercion option
-        -> style:compilation_unit_style -> Lambda.program
+        -> Lambda.program
 
 val transl_toplevel_definition: structure -> lambda
 
 val transl_package:
       Compilation_unit.t option list -> Compilation_unit.t -> module_coercion
-        -> style:compilation_unit_style -> int * lambda
+        -> int * lambda
 
 type runtime_arg =
   | (* A module from which we need to project out the argument block *)
@@ -56,7 +52,7 @@ type runtime_arg =
 val transl_instance:
       Compilation_unit.t -> runtime_args:runtime_arg list
         -> main_module_block_size:int -> arg_block_idx:int option
-        -> style:compilation_unit_style -> Lambda.program
+        -> Lambda.program
 
 val toplevel_name: Ident.t -> string
 

--- a/lambda/translmod.mli
+++ b/lambda/translmod.mli
@@ -25,8 +25,11 @@ open Lambda
    [argument_interface.ai_coercion_from_primary] fields from
    [Typedtree.implementation].)*)
 (* CR lmaurer: This should just be taking [Typedtree.implementation]. But it
-   can't, because [Opttoploop] calls it and doesn't have a
-   full implementation. *)
+   can't, because [Opttoploop] calls it and doesn't have a full implementation.
+   But [Opttoploop] _shouldn't_ be calling it, it should be calling
+   [transl_store_phrases], because it's only storing phrases. But [Opttoploop]
+   _should not exist anymore_, since upstream refactored the toplevel code.
+   mshinwell: PR4527 has now removed transl_store* *)
 val transl_implementation:
       Compilation_unit.t -> structure * module_coercion * module_coercion option
         -> Lambda.program

--- a/lambda/translmod.mli
+++ b/lambda/translmod.mli
@@ -34,8 +34,7 @@ val transl_implementation:
 val transl_toplevel_definition: structure -> lambda
 
 val transl_package:
-      Compilation_unit.t option list -> Compilation_unit.t -> module_coercion
-        -> int * lambda
+      Compilation_unit.t option list -> module_coercion -> int * lambda
 
 type runtime_arg =
   | (* A module from which we need to project out the argument block *)

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -2238,7 +2238,7 @@ let lambda_primitive_needs_event_after = function
   | Pphys_equal _
   | Pbytes_to_string | Pbytes_of_string
   | Parray_to_iarray | Parray_of_iarray
-  | Pignore | Psetglobal _
+  | Pignore
   | Pgetglobal _ | Pgetpredef _ | Pmakeblock _ | Pmakefloatblock _
   | Pmakeufloatblock _ | Pmakemixedblock _ | Pmakelazyblock _
   | Pmake_unboxed_product _ | Punboxed_product_field _

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -287,7 +287,6 @@ let compute_static_size lam =
     | Pbytes_to_string
     | Pbytes_of_string
     | Pgetglobal _
-    | Psetglobal _
     | Pfield _
     | Pfield_computed _
     | Pfloatfield _

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1099,7 +1099,7 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
         Misc.fatal_error "Closure_conversion.close_primitive: unimplemented"
       | Pmakearray_dynamic _ | Pbytes_to_string | Pbytes_of_string
       | Parray_of_iarray | Parray_to_iarray | Pignore | Pgetglobal _
-      | Psetglobal _ | Pgetpredef _ | Pfield _ | Pfield_computed _ | Psetfield _
+      | Pgetpredef _ | Pfield _ | Pfield_computed _ | Psetfield _
       | Psetfield_computed _ | Pfloatfield _ | Psetfloatfield _ | Pduprecord _
       | Pccall _ | Praise _ | Pufloatfield _ | Psetufloatfield _ | Psequand
       | Psequor | Pnot | Pmixedfield _ | Psetmixedfield _ | Poffsetref _

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -2909,7 +2909,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
         kinds offsets new_values
     in
     [H.Sequence writes]
-  | (Psetglobal _ | Praise _ | Pccall _), _ ->
+  | (Praise _ | Pccall _), _ ->
     Misc.fatal_errorf
       "Closure_conversion.convert_primitive: Primitive %a (%a) shouldn't be \
        here, either a bug in [Closure_conversion] or the wrong number of \

--- a/testsuite/tests/basic-modules/anonymous.ocamlc.reference
+++ b/testsuite/tests/basic-modules/anonymous.ocamlc.reference
@@ -1,38 +1,35 @@
-(setglobal Anonymous!
-  (seq
-    (ignore
-      (let
-        (x =[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>]
-           [0: 13 37])
-        (makeblock 0 x)))
+(seq
+  (ignore
     (let
-      (A =
-         (apply (field_imm 0 (global CamlinternalMod!))
-           [0: "anonymous.ml" 25 6] [0: [0]])
-       B =
-         (apply (field_imm 0 (global CamlinternalMod!))
-           [0: "anonymous.ml" 35 6] [0: [0]]))
-      (seq
-        (ignore
-          (let
-            (x =[value<
-                  (consts ()) (non_consts ([0: value<int>, value<int>]))>]
-               [0: 4 2])
-            (makeblock 0 x)))
-        (apply (field_imm 1 (global CamlinternalMod!)) [0: [0]] A A)
-        (apply (field_imm 1 (global CamlinternalMod!)) [0: [0]] B
-          (let
-            (x =[value<(consts ()) (non_consts ([0: *, *]))>]
-               [0: "foo" "bar"])
-            (makeblock 0)))
+      (x =[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>]
+         [0: 13 37])
+      (makeblock 0 x)))
+  (let
+    (A =
+       (apply (field_imm 0 (global CamlinternalMod!))
+         [0: "anonymous.ml" 25 6] [0: [0]])
+     B =
+       (apply (field_imm 0 (global CamlinternalMod!))
+         [0: "anonymous.ml" 35 6] [0: [0]]))
+    (seq
+      (ignore
         (let
-          (f = (function {nlocal = 0} param : int 0)
-           s = (makemutable 0 (*) ""))
-          (seq
-            (ignore
-              (let (*match* =[value<int>] (setfield_ptr 0 s "Hello World!"))
-                (makeblock 0)))
-            (let
-              (drop = (function {nlocal = 0} param? : int 0)
-               *match* =[value<int>] (apply drop (field_mut 0 s)))
-              (makeblock 0 A B f s drop))))))))
+          (x =[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>]
+             [0: 4 2])
+          (makeblock 0 x)))
+      (apply (field_imm 1 (global CamlinternalMod!)) [0: [0]] A A)
+      (apply (field_imm 1 (global CamlinternalMod!)) [0: [0]] B
+        (let
+          (x =[value<(consts ()) (non_consts ([0: *, *]))>] [0: "foo" "bar"])
+          (makeblock 0)))
+      (let
+        (f = (function {nlocal = 0} param : int 0)
+         s = (makemutable 0 (*) ""))
+        (seq
+          (ignore
+            (let (*match* =[value<int>] (setfield_ptr 0 s "Hello World!"))
+              (makeblock 0)))
+          (let
+            (drop = (function {nlocal = 0} param? : int 0)
+             *match* =[value<int>] (apply drop (field_mut 0 s)))
+            (makeblock 0 A B f s drop)))))))

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -179,17 +179,16 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
     ]
 ]
 
-(setglobal Test_locations!
-  (letrec
-    (fib
-       (function {nlocal = 0} n[value<int>] : int
-         (funct-body Test_locations.fib test_locations.ml(17):548-606
-           (if (isout 1 n)
-             (before Test_locations.fib test_locations.ml(19):581-606
-               (%int_add
-                 (after Test_locations.fib test_locations.ml(19):581-592
-                   (apply fib (%int_sub n 1)))
-                 (after Test_locations.fib test_locations.ml(19):595-606
-                   (apply fib (%int_sub n 2)))))
-             (before Test_locations.fib test_locations.ml(18):570-571 1)))))
-    (pseudo <unknown location> (makeblock 0 fib))))
+(letrec
+  (fib
+     (function {nlocal = 0} n[value<int>] : int
+       (funct-body Test_locations.fib test_locations.ml(17):548-606
+         (if (isout 1 n)
+           (before Test_locations.fib test_locations.ml(19):581-606
+             (%int_add
+               (after Test_locations.fib test_locations.ml(19):581-592
+                 (apply fib (%int_sub n 1)))
+               (after Test_locations.fib test_locations.ml(19):595-606
+                 (apply fib (%int_sub n 2)))))
+           (before Test_locations.fib test_locations.ml(18):570-571 1)))))
+  (pseudo <unknown location> (makeblock 0 fib)))

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -179,11 +179,9 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
     ]
 ]
 
-(setglobal Test_locations!
-  (letrec
-    (fib
-       (function {nlocal = 0} n[value<int>] : int
-         (if (isout 1 n)
-           (%int_add (apply fib (%int_sub n 1)) (apply fib (%int_sub n 2)))
-           1)))
-    (makeblock 0 fib)))
+(letrec
+  (fib
+     (function {nlocal = 0} n[value<int>] : int
+       (if (isout 1 n)
+         (%int_add (apply fib (%int_sub n 1)) (apply fib (%int_sub n 2))) 1)))
+  (makeblock 0 fib))

--- a/testsuite/tests/functors/functors.compilers.reference
+++ b/testsuite/tests/functors/functors.compilers.reference
@@ -1,64 +1,63 @@
-(setglobal Functors!
-  (let
-    (O =
-       (function {nlocal = 0} X is_a_functor always_inline never_loop
-         (let
-           (cow =
-              (function {nlocal = 0} x[value<int>] : int
-                (apply (field_imm 0 X) x))
-            sheep =
-              (function {nlocal = 0} x[value<int>] : int
-                (%int_add 1 (apply cow x))))
-           (makeblock 0 cow sheep)))
-     F =
-       (function {nlocal = 0} X Y is_a_functor always_inline never_loop
-         (let
-           (cow =
-              (function {nlocal = 0} x[value<int>] : int
-                (apply (field_imm 0 Y) (apply (field_imm 0 X) x)))
-            sheep =
-              (function {nlocal = 0} x[value<int>] : int
-                (%int_add 1 (apply cow x))))
-           (makeblock 0 cow sheep)))
-     F1 =
-       (function {nlocal = 0} X Y is_a_functor always_inline never_loop
-         (let
-           (cow =
-              (function {nlocal = 0} x[value<int>] : int
-                (apply (field_imm 0 Y) (apply (field_imm 0 X) x)))
-            sheep =
-              (function {nlocal = 0} x[value<int>] : int
-                (%int_add 1 (apply cow x))))
-           (makeblock 0 sheep)))
-     F2 =
-       (function {nlocal = 0} X Y is_a_functor always_inline never_loop
-         (let
-           (X =a (makeblock 0 (field_imm 1 X))
-            Y =a (makeblock 0 (field_imm 1 Y))
-            cow =
-              (function {nlocal = 0} x[value<int>] : int
-                (apply (field_imm 0 Y) (apply (field_imm 0 X) x)))
-            sheep =
-              (function {nlocal = 0} x[value<int>] : int
-                (%int_add 1 (apply cow x))))
-           (makeblock 0 sheep)))
-     M =
+(let
+  (O =
+     (function {nlocal = 0} X is_a_functor always_inline never_loop
        (let
-         (F =
-            (function {nlocal = 0} X Y is_a_functor always_inline never_loop
-              (let
-                (cow =
-                   (function {nlocal = 0} x[value<int>] : int
-                     (apply (field_imm 0 Y) (apply (field_imm 0 X) x)))
-                 sheep =
-                   (function {nlocal = 0} x[value<int>] : int
-                     (%int_add 1 (apply cow x))))
-                (makeblock 0 cow sheep))))
-         (makeblock 0
-           (function {nlocal = 0} funarg funarg is_a_functor stub
-             (let
-               (let =
-                  (apply F (makeblock 0 (field_imm 1 funarg))
-                    (makeblock 0 (field_imm 1 funarg))))
-               (makeblock 0 (field_imm 1 let)))))))
-    (makeblock 0 O F F1 F2 M)))
+         (cow =
+            (function {nlocal = 0} x[value<int>] : int
+              (apply (field_imm 0 X) x))
+          sheep =
+            (function {nlocal = 0} x[value<int>] : int
+              (%int_add 1 (apply cow x))))
+         (makeblock 0 cow sheep)))
+   F =
+     (function {nlocal = 0} X Y is_a_functor always_inline never_loop
+       (let
+         (cow =
+            (function {nlocal = 0} x[value<int>] : int
+              (apply (field_imm 0 Y) (apply (field_imm 0 X) x)))
+          sheep =
+            (function {nlocal = 0} x[value<int>] : int
+              (%int_add 1 (apply cow x))))
+         (makeblock 0 cow sheep)))
+   F1 =
+     (function {nlocal = 0} X Y is_a_functor always_inline never_loop
+       (let
+         (cow =
+            (function {nlocal = 0} x[value<int>] : int
+              (apply (field_imm 0 Y) (apply (field_imm 0 X) x)))
+          sheep =
+            (function {nlocal = 0} x[value<int>] : int
+              (%int_add 1 (apply cow x))))
+         (makeblock 0 sheep)))
+   F2 =
+     (function {nlocal = 0} X Y is_a_functor always_inline never_loop
+       (let
+         (X =a (makeblock 0 (field_imm 1 X))
+          Y =a (makeblock 0 (field_imm 1 Y))
+          cow =
+            (function {nlocal = 0} x[value<int>] : int
+              (apply (field_imm 0 Y) (apply (field_imm 0 X) x)))
+          sheep =
+            (function {nlocal = 0} x[value<int>] : int
+              (%int_add 1 (apply cow x))))
+         (makeblock 0 sheep)))
+   M =
+     (let
+       (F =
+          (function {nlocal = 0} X Y is_a_functor always_inline never_loop
+            (let
+              (cow =
+                 (function {nlocal = 0} x[value<int>] : int
+                   (apply (field_imm 0 Y) (apply (field_imm 0 X) x)))
+               sheep =
+                 (function {nlocal = 0} x[value<int>] : int
+                   (%int_add 1 (apply cow x))))
+              (makeblock 0 cow sheep))))
+       (makeblock 0
+         (function {nlocal = 0} funarg funarg is_a_functor stub
+           (let
+             (let =
+                (apply F (makeblock 0 (field_imm 1 funarg))
+                  (makeblock 0 (field_imm 1 funarg))))
+             (makeblock 0 (field_imm 1 let)))))))
+  (makeblock 0 O F F1 F2 M))

--- a/testsuite/tests/ppx-empty-cases/test.compilers.reference
+++ b/testsuite/tests/ppx-empty-cases/test.compilers.reference
@@ -1,40 +1,39 @@
-(setglobal Test!
-  (let
-    (empty_cases_returning_string/275 =
-       (function {nlocal = 0} param/277?
-         (raise
-           (makeblock 0 (getpredef Match_failure/45!!) [0: "test.ml" 28 50])))
-     empty_cases_returning_float64/278 =
-       (function {nlocal = 0} param/280? : unboxed_float
-         (raise
-           (makeblock 0 (getpredef Match_failure/45!!) [0: "test.ml" 29 50])))
-     empty_cases_accepting_string/281 =
-       (function {nlocal = 0} param/283?
-         (raise
-           (makeblock 0 (getpredef Match_failure/45!!) [0: "test.ml" 30 50])))
-     empty_cases_accepting_float64/284 =
-       (function {nlocal = 0} param/286[float]
-         (raise
-           (makeblock 0 (getpredef Match_failure/45!!) [0: "test.ml" 31 50])))
-     non_empty_cases_returning_string/287 =
-       (function {nlocal = 0} param/289
-         (raise
-           (makeblock 0 (getpredef Assert_failure/55!!) [0: "test.ml" 32 68])))
-     non_empty_cases_returning_float64/290 =
-       (function {nlocal = 0} param/292 : unboxed_float
-         (raise
-           (makeblock 0 (getpredef Assert_failure/55!!) [0: "test.ml" 33 68])))
-     non_empty_cases_accepting_string/293 =
-       (function {nlocal = 0} param/295
-         (raise
-           (makeblock 0 (getpredef Assert_failure/55!!) [0: "test.ml" 34 68])))
-     non_empty_cases_accepting_float64/296 =
-       (function {nlocal = 0} param/298[float]
-         (raise
-           (makeblock 0 (getpredef Assert_failure/55!!) [0: "test.ml" 35 68]))))
-    (makeblock 0 empty_cases_returning_string/275
-      empty_cases_returning_float64/278 empty_cases_accepting_string/281
-      empty_cases_accepting_float64/284 non_empty_cases_returning_string/287
-      non_empty_cases_returning_float64/290
-      non_empty_cases_accepting_string/293
-      non_empty_cases_accepting_float64/296)))
+(let
+  (empty_cases_returning_string/275 =
+     (function {nlocal = 0} param/277?
+       (raise
+         (makeblock 0 (getpredef Match_failure/45!!) [0: "test.ml" 28 50])))
+   empty_cases_returning_float64/278 =
+     (function {nlocal = 0} param/280? : unboxed_float
+       (raise
+         (makeblock 0 (getpredef Match_failure/45!!) [0: "test.ml" 29 50])))
+   empty_cases_accepting_string/281 =
+     (function {nlocal = 0} param/283?
+       (raise
+         (makeblock 0 (getpredef Match_failure/45!!) [0: "test.ml" 30 50])))
+   empty_cases_accepting_float64/284 =
+     (function {nlocal = 0} param/286[float]
+       (raise
+         (makeblock 0 (getpredef Match_failure/45!!) [0: "test.ml" 31 50])))
+   non_empty_cases_returning_string/287 =
+     (function {nlocal = 0} param/289
+       (raise
+         (makeblock 0 (getpredef Assert_failure/55!!) [0: "test.ml" 32 68])))
+   non_empty_cases_returning_float64/290 =
+     (function {nlocal = 0} param/292 : unboxed_float
+       (raise
+         (makeblock 0 (getpredef Assert_failure/55!!) [0: "test.ml" 33 68])))
+   non_empty_cases_accepting_string/293 =
+     (function {nlocal = 0} param/295
+       (raise
+         (makeblock 0 (getpredef Assert_failure/55!!) [0: "test.ml" 34 68])))
+   non_empty_cases_accepting_float64/296 =
+     (function {nlocal = 0} param/298[float]
+       (raise
+         (makeblock 0 (getpredef Assert_failure/55!!) [0: "test.ml" 35 68]))))
+  (makeblock 0 empty_cases_returning_string/275
+    empty_cases_returning_float64/278 empty_cases_accepting_string/281
+    empty_cases_accepting_float64/284 non_empty_cases_returning_string/287
+    non_empty_cases_returning_float64/290
+    non_empty_cases_accepting_string/293
+    non_empty_cases_accepting_float64/296))

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_lambda.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_lambda.compilers.reference
@@ -1,2 +1,1 @@
-(setglobal Stop_after_lambda!
-  (let (*match*/7 =[value<int>] ( 1)) (makeblock 0)))
+(let (*match*/7 =[value<int>] ( 1)) (makeblock 0))

--- a/testsuite/tests/translprim/array_spec.stack.flat.reference
+++ b/testsuite/tests/translprim/array_spec.stack.flat.reference
@@ -1,102 +1,99 @@
-(setglobal Array_spec!
-  (let
-    (int_a =[value<intarray>] (makearray[int] 1 2 3)
-     float_a =[value<floatarray>] (makearray[float] 1. 2. 3.)
-     addr_a =[value<addrarray>] (makearray[addr] "a" "b" "c"))
-    (seq (array.length[int] int_a) (array.length[float] float_a)
-      (array.length[addr] addr_a)
-      (function {nlocal = 0} a[value<genarray>] : int (array.length[gen] a))
-      (array.get[int indexed by int] int_a 0)
-      (array.get[float indexed by int] float_a 0)
-      (array.get[addr indexed by int] addr_a 0)
-      (function {nlocal = 0} a[value<genarray>]
-        (array.get[gen indexed by int] a 0))
-      (array.unsafe_get[int indexed by int] int_a 0)
-      (array.unsafe_get[float indexed by int] float_a 0)
-      (array.unsafe_get[addr indexed by int] addr_a 0)
-      (function {nlocal = 0} a[value<genarray>]
-        (array.unsafe_get[gen indexed by int] a 0))
-      (array.set[int indexed by int] int_a 0 1)
-      (array.set[float indexed by int] float_a 0 1.)
-      (array.set[addr indexed by int] addr_a 0 "a")
-      (function {nlocal = 2} a[value<genarray>] x : int
-        (array.set[gen indexed by int] a 0 x))
-      (array.unsafe_set[int indexed by int] int_a 0 1)
-      (array.unsafe_set[float indexed by int] float_a 0 1.)
-      (array.unsafe_set[addr indexed by int] addr_a 0 "a")
-      (function {nlocal = 2} a[value<genarray>] x : int
-        (array.unsafe_set[gen indexed by int] a 0 x))
-      (let
-        (eta_gen_len =
-           (function {nlocal = 0} prim[value<genarray>] stub : int
-             (array.length[gen] prim))
-         eta_gen_safe_get =
-           (function {nlocal = 0} prim[value<genarray>] prim[value<int>] stub
-             (array.get[gen indexed by int] prim prim))
-         eta_gen_unsafe_get =
-           (function {nlocal = 0} prim[value<genarray>] prim[value<int>] stub
-             (array.unsafe_get[gen indexed by int] prim prim))
-         eta_gen_safe_set =
-           (function {nlocal = 0} prim[value<genarray>] prim[value<int>] prim
-             stub : int (array.set[gen indexed by int] prim prim prim))
-         eta_gen_unsafe_set =
-           (function {nlocal = 0} prim[value<genarray>] prim[value<int>] prim
-             stub : int
-             (array.unsafe_set[gen indexed by int] prim prim prim))
-         eta_int_len =
-           (function {nlocal = 0} prim[value<intarray>] stub : int
-             (array.length[int] prim))
-         eta_int_safe_get =
-           (function {nlocal = 0} prim[value<intarray>] prim[value<int>] stub
-             : int (array.get[int indexed by int] prim prim))
-         eta_int_unsafe_get =
-           (function {nlocal = 0} prim[value<intarray>] prim[value<int>] stub
-             : int (array.unsafe_get[int indexed by int] prim prim))
-         eta_int_safe_set =
-           (function {nlocal = 0} prim[value<intarray>] prim[value<int>]
-             prim[value<int>] stub : int
-             (array.set[int indexed by int] prim prim prim))
-         eta_int_unsafe_set =
-           (function {nlocal = 0} prim[value<intarray>] prim[value<int>]
-             prim[value<int>] stub : int
-             (array.unsafe_set[int indexed by int] prim prim prim))
-         eta_float_len =
-           (function {nlocal = 0} prim[value<floatarray>] stub : int
-             (array.length[float] prim))
-         eta_float_safe_get =
-           (function {nlocal = 0} prim[value<floatarray>] prim[value<int>]
-             stub : float (array.get[float indexed by int] prim prim))
-         eta_float_unsafe_get =
-           (function {nlocal = 0} prim[value<floatarray>] prim[value<int>]
-             stub : float (array.unsafe_get[float indexed by int] prim prim))
-         eta_float_safe_set =
-           (function {nlocal = 0} prim[value<floatarray>] prim[value<int>]
-             prim[value<float>] stub : int
-             (array.set[float indexed by int] prim prim prim))
-         eta_float_unsafe_set =
-           (function {nlocal = 0} prim[value<floatarray>] prim[value<int>]
-             prim[value<float>] stub : int
-             (array.unsafe_set[float indexed by int] prim prim prim))
-         eta_addr_len =
-           (function {nlocal = 0} prim[value<addrarray>] stub : int
-             (array.length[addr] prim))
-         eta_addr_safe_get =
-           (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
-             stub (array.get[addr indexed by int] prim prim))
-         eta_addr_unsafe_get =
-           (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
-             stub (array.unsafe_get[addr indexed by int] prim prim))
-         eta_addr_safe_set =
-           (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
-             prim stub : int (array.set[addr indexed by int] prim prim prim))
-         eta_addr_unsafe_set =
-           (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
-             prim stub : int
-             (array.unsafe_set[addr indexed by int] prim prim prim)))
-        (makeblock 0 int_a float_a addr_a eta_gen_len eta_gen_safe_get
-          eta_gen_unsafe_get eta_gen_safe_set eta_gen_unsafe_set eta_int_len
-          eta_int_safe_get eta_int_unsafe_get eta_int_safe_set
-          eta_int_unsafe_set eta_float_len eta_float_safe_get
-          eta_float_unsafe_get eta_float_safe_set eta_float_unsafe_set
-          eta_addr_len eta_addr_safe_get eta_addr_unsafe_get
-          eta_addr_safe_set eta_addr_unsafe_set)))))
+(let
+  (int_a =[value<intarray>] (makearray[int] 1 2 3)
+   float_a =[value<floatarray>] (makearray[float] 1. 2. 3.)
+   addr_a =[value<addrarray>] (makearray[addr] "a" "b" "c"))
+  (seq (array.length[int] int_a) (array.length[float] float_a)
+    (array.length[addr] addr_a)
+    (function {nlocal = 0} a[value<genarray>] : int (array.length[gen] a))
+    (array.get[int indexed by int] int_a 0)
+    (array.get[float indexed by int] float_a 0)
+    (array.get[addr indexed by int] addr_a 0)
+    (function {nlocal = 0} a[value<genarray>]
+      (array.get[gen indexed by int] a 0))
+    (array.unsafe_get[int indexed by int] int_a 0)
+    (array.unsafe_get[float indexed by int] float_a 0)
+    (array.unsafe_get[addr indexed by int] addr_a 0)
+    (function {nlocal = 0} a[value<genarray>]
+      (array.unsafe_get[gen indexed by int] a 0))
+    (array.set[int indexed by int] int_a 0 1)
+    (array.set[float indexed by int] float_a 0 1.)
+    (array.set[addr indexed by int] addr_a 0 "a")
+    (function {nlocal = 2} a[value<genarray>] x : int
+      (array.set[gen indexed by int] a 0 x))
+    (array.unsafe_set[int indexed by int] int_a 0 1)
+    (array.unsafe_set[float indexed by int] float_a 0 1.)
+    (array.unsafe_set[addr indexed by int] addr_a 0 "a")
+    (function {nlocal = 2} a[value<genarray>] x : int
+      (array.unsafe_set[gen indexed by int] a 0 x))
+    (let
+      (eta_gen_len =
+         (function {nlocal = 0} prim[value<genarray>] stub : int
+           (array.length[gen] prim))
+       eta_gen_safe_get =
+         (function {nlocal = 0} prim[value<genarray>] prim[value<int>] stub
+           (array.get[gen indexed by int] prim prim))
+       eta_gen_unsafe_get =
+         (function {nlocal = 0} prim[value<genarray>] prim[value<int>] stub
+           (array.unsafe_get[gen indexed by int] prim prim))
+       eta_gen_safe_set =
+         (function {nlocal = 0} prim[value<genarray>] prim[value<int>] prim
+           stub : int (array.set[gen indexed by int] prim prim prim))
+       eta_gen_unsafe_set =
+         (function {nlocal = 0} prim[value<genarray>] prim[value<int>] prim
+           stub : int (array.unsafe_set[gen indexed by int] prim prim prim))
+       eta_int_len =
+         (function {nlocal = 0} prim[value<intarray>] stub : int
+           (array.length[int] prim))
+       eta_int_safe_get =
+         (function {nlocal = 0} prim[value<intarray>] prim[value<int>] stub
+           : int (array.get[int indexed by int] prim prim))
+       eta_int_unsafe_get =
+         (function {nlocal = 0} prim[value<intarray>] prim[value<int>] stub
+           : int (array.unsafe_get[int indexed by int] prim prim))
+       eta_int_safe_set =
+         (function {nlocal = 0} prim[value<intarray>] prim[value<int>]
+           prim[value<int>] stub : int
+           (array.set[int indexed by int] prim prim prim))
+       eta_int_unsafe_set =
+         (function {nlocal = 0} prim[value<intarray>] prim[value<int>]
+           prim[value<int>] stub : int
+           (array.unsafe_set[int indexed by int] prim prim prim))
+       eta_float_len =
+         (function {nlocal = 0} prim[value<floatarray>] stub : int
+           (array.length[float] prim))
+       eta_float_safe_get =
+         (function {nlocal = 0} prim[value<floatarray>] prim[value<int>] stub
+           : float (array.get[float indexed by int] prim prim))
+       eta_float_unsafe_get =
+         (function {nlocal = 0} prim[value<floatarray>] prim[value<int>] stub
+           : float (array.unsafe_get[float indexed by int] prim prim))
+       eta_float_safe_set =
+         (function {nlocal = 0} prim[value<floatarray>] prim[value<int>]
+           prim[value<float>] stub : int
+           (array.set[float indexed by int] prim prim prim))
+       eta_float_unsafe_set =
+         (function {nlocal = 0} prim[value<floatarray>] prim[value<int>]
+           prim[value<float>] stub : int
+           (array.unsafe_set[float indexed by int] prim prim prim))
+       eta_addr_len =
+         (function {nlocal = 0} prim[value<addrarray>] stub : int
+           (array.length[addr] prim))
+       eta_addr_safe_get =
+         (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+           (array.get[addr indexed by int] prim prim))
+       eta_addr_unsafe_get =
+         (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+           (array.unsafe_get[addr indexed by int] prim prim))
+       eta_addr_safe_set =
+         (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] prim
+           stub : int (array.set[addr indexed by int] prim prim prim))
+       eta_addr_unsafe_set =
+         (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] prim
+           stub : int (array.unsafe_set[addr indexed by int] prim prim prim)))
+      (makeblock 0 int_a float_a addr_a eta_gen_len eta_gen_safe_get
+        eta_gen_unsafe_get eta_gen_safe_set eta_gen_unsafe_set eta_int_len
+        eta_int_safe_get eta_int_unsafe_get eta_int_safe_set
+        eta_int_unsafe_set eta_float_len eta_float_safe_get
+        eta_float_unsafe_get eta_float_safe_set eta_float_unsafe_set
+        eta_addr_len eta_addr_safe_get eta_addr_unsafe_get eta_addr_safe_set
+        eta_addr_unsafe_set))))

--- a/testsuite/tests/translprim/comparison_table.stack.reference
+++ b/testsuite/tests/translprim/comparison_table.stack.reference
@@ -1,423 +1,425 @@
-(setglobal Comparison_table!
-  (let
-    (gen_cmp = (function {nlocal = 0} x y : int (caml_compare x y))
-     int_cmp =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int
-         (%int_compare x y))
-     bool_cmp =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int
-         (%int_compare x y))
-     intlike_cmp =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int
-         (%int_compare x y))
-     float_cmp =
-       (function {nlocal = 0} x[value<float>] y[value<float>] : int
-         (%float_compare x y))
-     string_cmp = (function {nlocal = 0} x y : int (caml_string_compare x y))
-     int32_cmp =
-       (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
-         (%int32_compare x y))
-     int64_cmp =
-       (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
-         (%int64_compare x y))
-     nativeint_cmp =
-       (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
-         (%nativeint_compare x y))
-     gen_eq = (function {nlocal = 0} x y : int (caml_equal x y))
-     int_eq =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int (%eq x y))
-     bool_eq =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int (%eq x y))
-     intlike_eq =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int (%eq x y))
-     float_eq =
-       (function {nlocal = 0} x[value<float>] y[value<float>] : int
-         (%float_ordered_and_equal x y))
-     string_eq = (function {nlocal = 0} x y : int (caml_string_equal x y))
-     int32_eq =
-       (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
-         (%int32_equal x y))
-     int64_eq =
-       (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
-         (%int64_equal x y))
-     nativeint_eq =
-       (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
-         (%nativeint_equal x y))
-     gen_ne = (function {nlocal = 0} x y : int (caml_notequal x y))
-     int_ne =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int (%noteq x y))
-     bool_ne =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int (%noteq x y))
-     intlike_ne =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int (%noteq x y))
-     float_ne =
-       (function {nlocal = 0} x[value<float>] y[value<float>] : int
-         (%float_unordered_or_notequal x y))
-     string_ne = (function {nlocal = 0} x y : int (caml_string_notequal x y))
-     int32_ne =
-       (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
-         (%int32_notequal x y))
-     int64_ne =
-       (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
-         (%int64_notequal x y))
-     nativeint_ne =
-       (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
-         (%nativeint_notequal x y))
-     gen_lt = (function {nlocal = 0} x y : int (caml_lessthan x y))
-     int_lt =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int
-         (%int_lessthan x y))
-     bool_lt =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int
-         (%int_lessthan x y))
-     intlike_lt =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int
-         (%int_lessthan x y))
-     float_lt =
-       (function {nlocal = 0} x[value<float>] y[value<float>] : int
-         (%float_ordered_and_lessthan x y))
-     string_lt = (function {nlocal = 0} x y : int (caml_string_lessthan x y))
-     int32_lt =
-       (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
-         (%int32_lessthan x y))
-     int64_lt =
-       (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
-         (%int64_lessthan x y))
-     nativeint_lt =
-       (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
-         (%nativeint_lessthan x y))
-     gen_gt = (function {nlocal = 0} x y : int (caml_greaterthan x y))
-     int_gt =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int
-         (%int_greaterthan x y))
-     bool_gt =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int
-         (%int_greaterthan x y))
-     intlike_gt =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int
-         (%int_greaterthan x y))
-     float_gt =
-       (function {nlocal = 0} x[value<float>] y[value<float>] : int
-         (%float_ordered_and_greaterthan x y))
-     string_gt =
-       (function {nlocal = 0} x y : int (caml_string_greaterthan x y))
-     int32_gt =
-       (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
-         (%int32_greaterthan x y))
-     int64_gt =
-       (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
-         (%int64_greaterthan x y))
-     nativeint_gt =
-       (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
-         (%nativeint_greaterthan x y))
-     gen_le = (function {nlocal = 0} x y : int (caml_lessequal x y))
-     int_le =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int
-         (%int_lessequal x y))
-     bool_le =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int
-         (%int_lessequal x y))
-     intlike_le =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int
-         (%int_lessequal x y))
-     float_le =
-       (function {nlocal = 0} x[value<float>] y[value<float>] : int
-         (%float_ordered_and_lessequal x y))
-     string_le =
-       (function {nlocal = 0} x y : int (caml_string_lessequal x y))
-     int32_le =
-       (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
-         (%int32_lessequal x y))
-     int64_le =
-       (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
-         (%int64_lessequal x y))
-     nativeint_le =
-       (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
-         (%nativeint_lessequal x y))
-     gen_ge = (function {nlocal = 0} x y : int (caml_greaterequal x y))
-     int_ge =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int
-         (%int_greaterequal x y))
-     bool_ge =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int
-         (%int_greaterequal x y))
-     intlike_ge =
-       (function {nlocal = 0} x[value<int>] y[value<int>] : int
-         (%int_greaterequal x y))
-     float_ge =
-       (function {nlocal = 0} x[value<float>] y[value<float>] : int
-         (%float_ordered_and_greaterequal x y))
-     string_ge =
-       (function {nlocal = 0} x y : int (caml_string_greaterequal x y))
-     int32_ge =
-       (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
-         (%int32_greaterequal x y))
-     int64_ge =
-       (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
-         (%int64_greaterequal x y))
-     nativeint_ge =
-       (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
-         (%nativeint_greaterequal x y))
-     eta_gen_cmp =
-       (function {nlocal = 0} prim prim stub : int (caml_compare prim prim))
-     eta_int_cmp =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%int_compare prim prim))
-     eta_bool_cmp =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%int_compare prim prim))
-     eta_intlike_cmp =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%int_compare prim prim))
-     eta_float_cmp =
-       (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
-         : int (%float_compare prim prim))
-     eta_string_cmp =
-       (function {nlocal = 0} prim prim stub : int
-         (caml_string_compare prim prim))
-     eta_int32_cmp =
-       (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
-         : int (%int32_compare prim prim))
-     eta_int64_cmp =
-       (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
-         : int (%int64_compare prim prim))
-     eta_nativeint_cmp =
-       (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
-         stub : int (%nativeint_compare prim prim))
-     eta_gen_eq =
-       (function {nlocal = 0} prim prim stub : int (caml_equal prim prim))
-     eta_int_eq =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%eq prim prim))
-     eta_bool_eq =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%eq prim prim))
-     eta_intlike_eq =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%eq prim prim))
-     eta_float_eq =
-       (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
-         : int (%float_ordered_and_equal prim prim))
-     eta_string_eq =
-       (function {nlocal = 0} prim prim stub : int
-         (caml_string_equal prim prim))
-     eta_int32_eq =
-       (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
-         : int (%int32_equal prim prim))
-     eta_int64_eq =
-       (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
-         : int (%int64_equal prim prim))
-     eta_nativeint_eq =
-       (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
-         stub : int (%nativeint_equal prim prim))
-     eta_gen_ne =
-       (function {nlocal = 0} prim prim stub : int (caml_notequal prim prim))
-     eta_int_ne =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%noteq prim prim))
-     eta_bool_ne =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%noteq prim prim))
-     eta_intlike_ne =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%noteq prim prim))
-     eta_float_ne =
-       (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
-         : int (%float_unordered_or_notequal prim prim))
-     eta_string_ne =
-       (function {nlocal = 0} prim prim stub : int
-         (caml_string_notequal prim prim))
-     eta_int32_ne =
-       (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
-         : int (%int32_notequal prim prim))
-     eta_int64_ne =
-       (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
-         : int (%int64_notequal prim prim))
-     eta_nativeint_ne =
-       (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
-         stub : int (%nativeint_notequal prim prim))
-     eta_gen_lt =
-       (function {nlocal = 0} prim prim stub : int (caml_lessthan prim prim))
-     eta_int_lt =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%int_lessthan prim prim))
-     eta_bool_lt =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%int_lessthan prim prim))
-     eta_intlike_lt =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%int_lessthan prim prim))
-     eta_float_lt =
-       (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
-         : int (%float_ordered_and_lessthan prim prim))
-     eta_string_lt =
-       (function {nlocal = 0} prim prim stub : int
-         (caml_string_lessthan prim prim))
-     eta_int32_lt =
-       (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
-         : int (%int32_lessthan prim prim))
-     eta_int64_lt =
-       (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
-         : int (%int64_lessthan prim prim))
-     eta_nativeint_lt =
-       (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
-         stub : int (%nativeint_lessthan prim prim))
-     eta_gen_gt =
-       (function {nlocal = 0} prim prim stub : int
-         (caml_greaterthan prim prim))
-     eta_int_gt =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%int_greaterthan prim prim))
-     eta_bool_gt =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%int_greaterthan prim prim))
-     eta_intlike_gt =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%int_greaterthan prim prim))
-     eta_float_gt =
-       (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
-         : int (%float_ordered_and_greaterthan prim prim))
-     eta_string_gt =
-       (function {nlocal = 0} prim prim stub : int
-         (caml_string_greaterthan prim prim))
-     eta_int32_gt =
-       (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
-         : int (%int32_greaterthan prim prim))
-     eta_int64_gt =
-       (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
-         : int (%int64_greaterthan prim prim))
-     eta_nativeint_gt =
-       (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
-         stub : int (%nativeint_greaterthan prim prim))
-     eta_gen_le =
-       (function {nlocal = 0} prim prim stub : int
-         (caml_lessequal prim prim))
-     eta_int_le =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%int_lessequal prim prim))
-     eta_bool_le =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%int_lessequal prim prim))
-     eta_intlike_le =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%int_lessequal prim prim))
-     eta_float_le =
-       (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
-         : int (%float_ordered_and_lessequal prim prim))
-     eta_string_le =
-       (function {nlocal = 0} prim prim stub : int
-         (caml_string_lessequal prim prim))
-     eta_int32_le =
-       (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
-         : int (%int32_lessequal prim prim))
-     eta_int64_le =
-       (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
-         : int (%int64_lessequal prim prim))
-     eta_nativeint_le =
-       (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
-         stub : int (%nativeint_lessequal prim prim))
-     eta_gen_ge =
-       (function {nlocal = 0} prim prim stub : int
-         (caml_greaterequal prim prim))
-     eta_int_ge =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%int_greaterequal prim prim))
-     eta_bool_ge =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%int_greaterequal prim prim))
-     eta_intlike_ge =
-       (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-         (%int_greaterequal prim prim))
-     eta_float_ge =
-       (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
-         : int (%float_ordered_and_greaterequal prim prim))
-     eta_string_ge =
-       (function {nlocal = 0} prim prim stub : int
-         (caml_string_greaterequal prim prim))
-     eta_int32_ge =
-       (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
-         : int (%int32_greaterequal prim prim))
-     eta_int64_ge =
-       (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
-         : int (%int64_greaterequal prim prim))
-     eta_nativeint_ge =
-       (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
-         stub : int (%nativeint_greaterequal prim prim))
-     int_vec =[value<
+(let
+  (gen_cmp = (function {nlocal = 0} x y : int (caml_compare x y))
+   int_cmp =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int
+       (%int_compare x y))
+   bool_cmp =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int
+       (%int_compare x y))
+   intlike_cmp =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int
+       (%int_compare x y))
+   float_cmp =
+     (function {nlocal = 0} x[value<float>] y[value<float>] : int
+       (%float_compare x y))
+   string_cmp = (function {nlocal = 0} x y : int (caml_string_compare x y))
+   int32_cmp =
+     (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
+       (%int32_compare x y))
+   int64_cmp =
+     (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
+       (%int64_compare x y))
+   nativeint_cmp =
+     (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
+       (%nativeint_compare x y))
+   gen_eq = (function {nlocal = 0} x y : int (caml_equal x y))
+   int_eq =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int (%eq x y))
+   bool_eq =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int (%eq x y))
+   intlike_eq =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int (%eq x y))
+   float_eq =
+     (function {nlocal = 0} x[value<float>] y[value<float>] : int
+       (%float_ordered_and_equal x y))
+   string_eq = (function {nlocal = 0} x y : int (caml_string_equal x y))
+   int32_eq =
+     (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
+       (%int32_equal x y))
+   int64_eq =
+     (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
+       (%int64_equal x y))
+   nativeint_eq =
+     (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
+       (%nativeint_equal x y))
+   gen_ne = (function {nlocal = 0} x y : int (caml_notequal x y))
+   int_ne =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int (%noteq x y))
+   bool_ne =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int (%noteq x y))
+   intlike_ne =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int (%noteq x y))
+   float_ne =
+     (function {nlocal = 0} x[value<float>] y[value<float>] : int
+       (%float_unordered_or_notequal x y))
+   string_ne = (function {nlocal = 0} x y : int (caml_string_notequal x y))
+   int32_ne =
+     (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
+       (%int32_notequal x y))
+   int64_ne =
+     (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
+       (%int64_notequal x y))
+   nativeint_ne =
+     (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
+       (%nativeint_notequal x y))
+   gen_lt = (function {nlocal = 0} x y : int (caml_lessthan x y))
+   int_lt =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int
+       (%int_lessthan x y))
+   bool_lt =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int
+       (%int_lessthan x y))
+   intlike_lt =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int
+       (%int_lessthan x y))
+   float_lt =
+     (function {nlocal = 0} x[value<float>] y[value<float>] : int
+       (%float_ordered_and_lessthan x y))
+   string_lt = (function {nlocal = 0} x y : int (caml_string_lessthan x y))
+   int32_lt =
+     (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
+       (%int32_lessthan x y))
+   int64_lt =
+     (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
+       (%int64_lessthan x y))
+   nativeint_lt =
+     (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
+       (%nativeint_lessthan x y))
+   gen_gt = (function {nlocal = 0} x y : int (caml_greaterthan x y))
+   int_gt =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int
+       (%int_greaterthan x y))
+   bool_gt =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int
+       (%int_greaterthan x y))
+   intlike_gt =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int
+       (%int_greaterthan x y))
+   float_gt =
+     (function {nlocal = 0} x[value<float>] y[value<float>] : int
+       (%float_ordered_and_greaterthan x y))
+   string_gt =
+     (function {nlocal = 0} x y : int (caml_string_greaterthan x y))
+   int32_gt =
+     (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
+       (%int32_greaterthan x y))
+   int64_gt =
+     (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
+       (%int64_greaterthan x y))
+   nativeint_gt =
+     (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
+       (%nativeint_greaterthan x y))
+   gen_le = (function {nlocal = 0} x y : int (caml_lessequal x y))
+   int_le =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int
+       (%int_lessequal x y))
+   bool_le =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int
+       (%int_lessequal x y))
+   intlike_le =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int
+       (%int_lessequal x y))
+   float_le =
+     (function {nlocal = 0} x[value<float>] y[value<float>] : int
+       (%float_ordered_and_lessequal x y))
+   string_le = (function {nlocal = 0} x y : int (caml_string_lessequal x y))
+   int32_le =
+     (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
+       (%int32_lessequal x y))
+   int64_le =
+     (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
+       (%int64_lessequal x y))
+   nativeint_le =
+     (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
+       (%nativeint_lessequal x y))
+   gen_ge = (function {nlocal = 0} x y : int (caml_greaterequal x y))
+   int_ge =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int
+       (%int_greaterequal x y))
+   bool_ge =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int
+       (%int_greaterequal x y))
+   intlike_ge =
+     (function {nlocal = 0} x[value<int>] y[value<int>] : int
+       (%int_greaterequal x y))
+   float_ge =
+     (function {nlocal = 0} x[value<float>] y[value<float>] : int
+       (%float_ordered_and_greaterequal x y))
+   string_ge =
+     (function {nlocal = 0} x y : int (caml_string_greaterequal x y))
+   int32_ge =
+     (function {nlocal = 0} x[value<int32>] y[value<int32>] : int
+       (%int32_greaterequal x y))
+   int64_ge =
+     (function {nlocal = 0} x[value<int64>] y[value<int64>] : int
+       (%int64_greaterequal x y))
+   nativeint_ge =
+     (function {nlocal = 0} x[value<nativeint>] y[value<nativeint>] : int
+       (%nativeint_greaterequal x y))
+   eta_gen_cmp =
+     (function {nlocal = 0} prim prim stub : int (caml_compare prim prim))
+   eta_int_cmp =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%int_compare prim prim))
+   eta_bool_cmp =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%int_compare prim prim))
+   eta_intlike_cmp =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%int_compare prim prim))
+   eta_float_cmp =
+     (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+       (%float_compare prim prim))
+   eta_string_cmp =
+     (function {nlocal = 0} prim prim stub : int
+       (caml_string_compare prim prim))
+   eta_int32_cmp =
+     (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+       (%int32_compare prim prim))
+   eta_int64_cmp =
+     (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+       (%int64_compare prim prim))
+   eta_nativeint_cmp =
+     (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+       stub : int (%nativeint_compare prim prim))
+   eta_gen_eq =
+     (function {nlocal = 0} prim prim stub : int (caml_equal prim prim))
+   eta_int_eq =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%eq prim prim))
+   eta_bool_eq =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%eq prim prim))
+   eta_intlike_eq =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%eq prim prim))
+   eta_float_eq =
+     (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+       (%float_ordered_and_equal prim prim))
+   eta_string_eq =
+     (function {nlocal = 0} prim prim stub : int
+       (caml_string_equal prim prim))
+   eta_int32_eq =
+     (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+       (%int32_equal prim prim))
+   eta_int64_eq =
+     (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+       (%int64_equal prim prim))
+   eta_nativeint_eq =
+     (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+       stub : int (%nativeint_equal prim prim))
+   eta_gen_ne =
+     (function {nlocal = 0} prim prim stub : int (caml_notequal prim prim))
+   eta_int_ne =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%noteq prim prim))
+   eta_bool_ne =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%noteq prim prim))
+   eta_intlike_ne =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%noteq prim prim))
+   eta_float_ne =
+     (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+       (%float_unordered_or_notequal prim prim))
+   eta_string_ne =
+     (function {nlocal = 0} prim prim stub : int
+       (caml_string_notequal prim prim))
+   eta_int32_ne =
+     (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+       (%int32_notequal prim prim))
+   eta_int64_ne =
+     (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+       (%int64_notequal prim prim))
+   eta_nativeint_ne =
+     (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+       stub : int (%nativeint_notequal prim prim))
+   eta_gen_lt =
+     (function {nlocal = 0} prim prim stub : int (caml_lessthan prim prim))
+   eta_int_lt =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%int_lessthan prim prim))
+   eta_bool_lt =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%int_lessthan prim prim))
+   eta_intlike_lt =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%int_lessthan prim prim))
+   eta_float_lt =
+     (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+       (%float_ordered_and_lessthan prim prim))
+   eta_string_lt =
+     (function {nlocal = 0} prim prim stub : int
+       (caml_string_lessthan prim prim))
+   eta_int32_lt =
+     (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+       (%int32_lessthan prim prim))
+   eta_int64_lt =
+     (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+       (%int64_lessthan prim prim))
+   eta_nativeint_lt =
+     (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+       stub : int (%nativeint_lessthan prim prim))
+   eta_gen_gt =
+     (function {nlocal = 0} prim prim stub : int
+       (caml_greaterthan prim prim))
+   eta_int_gt =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%int_greaterthan prim prim))
+   eta_bool_gt =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%int_greaterthan prim prim))
+   eta_intlike_gt =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%int_greaterthan prim prim))
+   eta_float_gt =
+     (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+       (%float_ordered_and_greaterthan prim prim))
+   eta_string_gt =
+     (function {nlocal = 0} prim prim stub : int
+       (caml_string_greaterthan prim prim))
+   eta_int32_gt =
+     (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+       (%int32_greaterthan prim prim))
+   eta_int64_gt =
+     (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+       (%int64_greaterthan prim prim))
+   eta_nativeint_gt =
+     (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+       stub : int (%nativeint_greaterthan prim prim))
+   eta_gen_le =
+     (function {nlocal = 0} prim prim stub : int (caml_lessequal prim prim))
+   eta_int_le =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%int_lessequal prim prim))
+   eta_bool_le =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%int_lessequal prim prim))
+   eta_intlike_le =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%int_lessequal prim prim))
+   eta_float_le =
+     (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+       (%float_ordered_and_lessequal prim prim))
+   eta_string_le =
+     (function {nlocal = 0} prim prim stub : int
+       (caml_string_lessequal prim prim))
+   eta_int32_le =
+     (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+       (%int32_lessequal prim prim))
+   eta_int64_le =
+     (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+       (%int64_lessequal prim prim))
+   eta_nativeint_le =
+     (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+       stub : int (%nativeint_lessequal prim prim))
+   eta_gen_ge =
+     (function {nlocal = 0} prim prim stub : int
+       (caml_greaterequal prim prim))
+   eta_int_ge =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%int_greaterequal prim prim))
+   eta_bool_ge =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%int_greaterequal prim prim))
+   eta_intlike_ge =
+     (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+       (%int_greaterequal prim prim))
+   eta_float_ge =
+     (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+       (%float_ordered_and_greaterequal prim prim))
+   eta_string_ge =
+     (function {nlocal = 0} prim prim stub : int
+       (caml_string_greaterequal prim prim))
+   eta_int32_ge =
+     (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+       (%int32_greaterequal prim prim))
+   eta_int64_ge =
+     (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+       (%int64_greaterequal prim prim))
+   eta_nativeint_ge =
+     (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+       stub : int (%nativeint_greaterequal prim prim))
+   int_vec =[value<
+              (consts (0))
+               (non_consts ([0: ?,
+                             value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+     [0: [0: 1 1] [0: [0: 1 2] [0: [0: 2 1] 0]]]
+   bool_vec =[value<
+               (consts (0))
+                (non_consts ([0: ?,
+                              value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+     [0: [0: 0 0] [0: [0: 0 1] [0: [0: 1 0] 0]]]
+   intlike_vec =[value<
+                  (consts (0))
+                   (non_consts ([0: ?,
+                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+     [0: [0: 0 0] [0: [0: 0 1] [0: [0: 1 0] 0]]]
+   float_vec =[value<
                 (consts (0))
                  (non_consts ([0: ?,
                                value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
-       [0: [0: 1 1] [0: [0: 1 2] [0: [0: 2 1] 0]]]
-     bool_vec =[value<
+     [0: [0: 1. 1.] [0: [0: 1. 2.] [0: [0: 2. 1.] 0]]]
+   string_vec =[value<
                  (consts (0))
                   (non_consts ([0: ?,
                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
-       [0: [0: 0 0] [0: [0: 0 1] [0: [0: 1 0] 0]]]
-     intlike_vec =[value<
+     [0: [0: "1" "1"] [0: [0: "1" "2"] [0: [0: "2" "1"] 0]]]
+   int32_vec =[value<
+                (consts (0))
+                 (non_consts ([0: ?,
+                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+     [0: [0: 1l 1l] [0: [0: 1l 2l] [0: [0: 2l 1l] 0]]]
+   int64_vec =[value<
+                (consts (0))
+                 (non_consts ([0: ?,
+                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+     [0: [0: 1L 1L] [0: [0: 1L 2L] [0: [0: 2L 1L] 0]]]
+   nativeint_vec =[value<
                     (consts (0))
                      (non_consts ([0: ?,
                                    value<
                                     (consts (0)) (non_consts ([0: ?, *]))>]))>]
-       [0: [0: 0 0] [0: [0: 0 1] [0: [0: 1 0] 0]]]
-     float_vec =[value<
-                  (consts (0))
-                   (non_consts ([0: ?,
-                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
-       [0: [0: 1. 1.] [0: [0: 1. 2.] [0: [0: 2. 1.] 0]]]
-     string_vec =[value<
-                   (consts (0))
-                    (non_consts ([0: ?,
-                                  value<
-                                   (consts (0)) (non_consts ([0: ?, *]))>]))>]
-       [0: [0: "1" "1"] [0: [0: "1" "2"] [0: [0: "2" "1"] 0]]]
-     int32_vec =[value<
-                  (consts (0))
-                   (non_consts ([0: ?,
-                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
-       [0: [0: 1l 1l] [0: [0: 1l 2l] [0: [0: 2l 1l] 0]]]
-     int64_vec =[value<
-                  (consts (0))
-                   (non_consts ([0: ?,
-                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
-       [0: [0: 1L 1L] [0: [0: 1L 2L] [0: [0: 2L 1L] 0]]]
-     nativeint_vec =[value<
-                      (consts (0))
-                       (non_consts ([0: ?,
-                                     value<
-                                      (consts (0)) (non_consts ([0: ?, *]))>]))>]
-       [0: [0: 1n 1n] [0: [0: 1n 2n] [0: [0: 2n 1n] 0]]]
-     test_vec =
-       (function {nlocal = 0} cmp eq ne lt gt le ge
-         vec[value<
-              (consts (0))
-               (non_consts ([0: ?,
-                             value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
-         : (consts ())
-            (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>,
-                          value<(consts (0)) (non_consts ([0: ?, *]))>]))
-         (let
-           (uncurry =
-              (function {nlocal = 0} f
-                param[value<(consts ()) (non_consts ([0: ?, ?]))>]
-                (apply f (field_imm 0 param) (field_imm 1 param)))
-            map =
-              (function {nlocal = 2} f
-                l[value<
-                   (consts (0))
-                    (non_consts ([0: ?,
-                                  value<
-                                   (consts (0)) (non_consts ([0: ?, *]))>]))>]
-                : (consts (0))
-                   (non_consts ([0: ?,
-                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))
-                (apply (field_imm 19 (global Stdlib__List!))
-                  (apply uncurry f) l)))
+     [0: [0: 1n 1n] [0: [0: 1n 2n] [0: [0: 2n 1n] 0]]]
+   test_vec =
+     (function {nlocal = 0} cmp eq ne lt gt le ge
+       vec[value<
+            (consts (0))
+             (non_consts ([0: ?,
+                           value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+       : (consts ())
+          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>,
+                        value<(consts (0)) (non_consts ([0: ?, *]))>]))
+       (let
+         (uncurry =
+            (function {nlocal = 0} f
+              param[value<(consts ()) (non_consts ([0: ?, ?]))>]
+              (apply f (field_imm 0 param) (field_imm 1 param)))
+          map =
+            (function {nlocal = 2} f
+              l[value<
+                 (consts (0))
+                  (non_consts ([0: ?,
+                                value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+              : (consts (0))
+                 (non_consts ([0: ?,
+                               value<(consts (0)) (non_consts ([0: ?, *]))>]))
+              (apply (field_imm 19 (global Stdlib__List!)) (apply uncurry f)
+                l)))
+         (makeblock 0 (value<
+                        (consts ())
+                         (non_consts ([0:
+                                       value<
+                                        (consts (0)) (non_consts ([0: ?, *]))>,
+                                       value<
+                                        (consts (0)) (non_consts ([0: ?, *]))>]))>,
+           value<
+            (consts (0))
+             (non_consts ([0: ?,
+                           value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
            (makeblock 0 (value<
-                          (consts ())
-                           (non_consts ([0:
-                                         value<
-                                          (consts (0))
-                                           (non_consts ([0: ?, *]))>,
+                          (consts (0))
+                           (non_consts ([0: ?,
                                          value<
                                           (consts (0))
                                            (non_consts ([0: ?, *]))>]))>,
@@ -425,134 +427,16 @@
               (consts (0))
                (non_consts ([0: ?,
                              value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
-             (makeblock 0 (value<
-                            (consts (0))
-                             (non_consts ([0: ?,
-                                           value<
-                                            (consts (0))
-                                             (non_consts ([0: ?, *]))>]))>,
-               value<
-                (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
-               (apply map gen_cmp vec) (apply map cmp vec))
-             (apply map
-               (function {nlocal = 2} gen spec
-                 : (consts ())
-                    (non_consts ([0:
-                                  value<
-                                   (consts (0)) (non_consts ([0: ?, *]))>,
-                                  value<
-                                   (consts (0)) (non_consts ([0: ?, *]))>]))
-                 (makeblock 0 (value<
-                                (consts (0))
-                                 (non_consts ([0: ?,
-                                               value<
-                                                (consts (0))
-                                                 (non_consts ([0: ?, *]))>]))>,
-                   value<
-                    (consts (0))
-                     (non_consts ([0: ?,
-                                   value<
-                                    (consts (0)) (non_consts ([0: ?, *]))>]))>)
-                   (apply map gen vec) (apply map spec vec)))
-               (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
-                 value<
-                  (consts (0))
-                   (non_consts ([0: ?,
-                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
-                 (makeblock 0 (*,*) gen_eq eq)
-                 (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
-                   value<
-                    (consts (0))
-                     (non_consts ([0: ?,
-                                   value<
-                                    (consts (0)) (non_consts ([0: ?, *]))>]))>)
-                   (makeblock 0 (*,*) gen_ne ne)
-                   (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
-                     value<
-                      (consts (0))
-                       (non_consts ([0: ?,
-                                     value<
-                                      (consts (0)) (non_consts ([0: ?, *]))>]))>)
-                     (makeblock 0 (*,*) gen_lt lt)
-                     (makeblock 0 (value<
-                                    (consts ()) (non_consts ([0: *, *]))>,
-                       value<
-                        (consts (0))
-                         (non_consts ([0: ?,
-                                       value<
-                                        (consts (0)) (non_consts ([0: ?, *]))>]))>)
-                       (makeblock 0 (*,*) gen_gt gt)
-                       (makeblock 0 (value<
-                                      (consts ()) (non_consts ([0: *, *]))>,
-                         value<
-                          (consts (0))
-                           (non_consts ([0: ?,
-                                         value<
-                                          (consts (0))
-                                           (non_consts ([0: ?, *]))>]))>)
-                         (makeblock 0 (*,*) gen_le le)
-                         (makeblock 0 (value<
-                                        (consts ()) (non_consts ([0: *, *]))>,
-                           value<
-                            (consts (0))
-                             (non_consts ([0: ?,
-                                           value<
-                                            (consts (0))
-                                             (non_consts ([0: ?, *]))>]))>)
-                           (makeblock 0 (*,*) gen_ge ge) 0)))))))))))
-    (seq
-      (apply test_vec int_cmp int_eq int_ne int_lt int_gt int_le int_ge
-        int_vec)
-      (apply test_vec bool_cmp bool_eq bool_ne bool_lt bool_gt bool_le
-        bool_ge bool_vec)
-      (apply test_vec intlike_cmp intlike_eq intlike_ne intlike_lt intlike_gt
-        intlike_le intlike_ge intlike_vec)
-      (apply test_vec float_cmp float_eq float_ne float_lt float_gt float_le
-        float_ge float_vec)
-      (apply test_vec string_cmp string_eq string_ne string_lt string_gt
-        string_le string_ge string_vec)
-      (apply test_vec int32_cmp int32_eq int32_ne int32_lt int32_gt int32_le
-        int32_ge int32_vec)
-      (apply test_vec int64_cmp int64_eq int64_ne int64_lt int64_gt int64_le
-        int64_ge int64_vec)
-      (apply test_vec nativeint_cmp nativeint_eq nativeint_ne nativeint_lt
-        nativeint_gt nativeint_le nativeint_ge nativeint_vec)
-      (let
-        (eta_test_vec =
-           (function {nlocal = 0} cmp eq ne lt gt le ge
-             vec[value<
-                  (consts (0))
-                   (non_consts ([0: ?,
-                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
-             : (consts ())
-                (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>,
-                              value<(consts (0)) (non_consts ([0: ?, *]))>]))
-             (let
-               (uncurry =
-                  (function {nlocal = 0} f
-                    param[value<(consts ()) (non_consts ([0: ?, ?]))>]
-                    (apply f (field_imm 0 param) (field_imm 1 param)))
-                map =
-                  (function {nlocal = 2} f
-                    l[value<
-                       (consts (0))
-                        (non_consts ([0: ?,
-                                      value<
-                                       (consts (0)) (non_consts ([0: ?, *]))>]))>]
-                    : (consts (0))
-                       (non_consts ([0: ?,
-                                     value<
-                                      (consts (0)) (non_consts ([0: ?, *]))>]))
-                    (apply (field_imm 19 (global Stdlib__List!))
-                      (apply uncurry f) l)))
+             (apply map gen_cmp vec) (apply map cmp vec))
+           (apply map
+             (function {nlocal = 2} gen spec
+               : (consts ())
+                  (non_consts ([0:
+                                value<(consts (0)) (non_consts ([0: ?, *]))>,
+                                value<(consts (0)) (non_consts ([0: ?, *]))>]))
                (makeblock 0 (value<
-                              (consts ())
-                               (non_consts ([0:
-                                             value<
-                                              (consts (0))
-                                               (non_consts ([0: ?, *]))>,
+                              (consts (0))
+                               (non_consts ([0: ?,
                                              value<
                                               (consts (0))
                                                (non_consts ([0: ?, *]))>]))>,
@@ -560,45 +444,33 @@
                   (consts (0))
                    (non_consts ([0: ?,
                                  value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
-                 (makeblock 0 (value<
-                                (consts (0))
-                                 (non_consts ([0: ?,
-                                               value<
-                                                (consts (0))
-                                                 (non_consts ([0: ?, *]))>]))>,
+                 (apply map gen vec) (apply map spec vec)))
+             (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
+               value<
+                (consts (0))
+                 (non_consts ([0: ?,
+                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+               (makeblock 0 (*,*) gen_eq eq)
+               (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
+                 value<
+                  (consts (0))
+                   (non_consts ([0: ?,
+                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+                 (makeblock 0 (*,*) gen_ne ne)
+                 (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                    value<
                     (consts (0))
                      (non_consts ([0: ?,
                                    value<
                                     (consts (0)) (non_consts ([0: ?, *]))>]))>)
-                   (apply map eta_gen_cmp vec) (apply map cmp vec))
-                 (apply map
-                   (function {nlocal = 2} gen spec
-                     : (consts ())
-                        (non_consts ([0:
-                                      value<
-                                       (consts (0)) (non_consts ([0: ?, *]))>,
-                                      value<
-                                       (consts (0)) (non_consts ([0: ?, *]))>]))
-                     (makeblock 0 (value<
-                                    (consts (0))
-                                     (non_consts ([0: ?,
-                                                   value<
-                                                    (consts (0))
-                                                     (non_consts ([0: ?, *]))>]))>,
-                       value<
-                        (consts (0))
-                         (non_consts ([0: ?,
-                                       value<
-                                        (consts (0)) (non_consts ([0: ?, *]))>]))>)
-                       (apply map gen vec) (apply map spec vec)))
+                   (makeblock 0 (*,*) gen_lt lt)
                    (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                      value<
                       (consts (0))
                        (non_consts ([0: ?,
                                      value<
                                       (consts (0)) (non_consts ([0: ?, *]))>]))>)
-                     (makeblock 0 (*,*) eta_gen_eq eq)
+                     (makeblock 0 (*,*) gen_gt gt)
                      (makeblock 0 (value<
                                     (consts ()) (non_consts ([0: *, *]))>,
                        value<
@@ -606,7 +478,7 @@
                          (non_consts ([0: ?,
                                        value<
                                         (consts (0)) (non_consts ([0: ?, *]))>]))>)
-                       (makeblock 0 (*,*) eta_gen_ne ne)
+                       (makeblock 0 (*,*) gen_le le)
                        (makeblock 0 (value<
                                       (consts ()) (non_consts ([0: *, *]))>,
                          value<
@@ -615,7 +487,127 @@
                                          value<
                                           (consts (0))
                                            (non_consts ([0: ?, *]))>]))>)
-                         (makeblock 0 (*,*) eta_gen_lt lt)
+                         (makeblock 0 (*,*) gen_ge ge) 0)))))))))))
+  (seq
+    (apply test_vec int_cmp int_eq int_ne int_lt int_gt int_le int_ge
+      int_vec)
+    (apply test_vec bool_cmp bool_eq bool_ne bool_lt bool_gt bool_le bool_ge
+      bool_vec)
+    (apply test_vec intlike_cmp intlike_eq intlike_ne intlike_lt intlike_gt
+      intlike_le intlike_ge intlike_vec)
+    (apply test_vec float_cmp float_eq float_ne float_lt float_gt float_le
+      float_ge float_vec)
+    (apply test_vec string_cmp string_eq string_ne string_lt string_gt
+      string_le string_ge string_vec)
+    (apply test_vec int32_cmp int32_eq int32_ne int32_lt int32_gt int32_le
+      int32_ge int32_vec)
+    (apply test_vec int64_cmp int64_eq int64_ne int64_lt int64_gt int64_le
+      int64_ge int64_vec)
+    (apply test_vec nativeint_cmp nativeint_eq nativeint_ne nativeint_lt
+      nativeint_gt nativeint_le nativeint_ge nativeint_vec)
+    (let
+      (eta_test_vec =
+         (function {nlocal = 0} cmp eq ne lt gt le ge
+           vec[value<
+                (consts (0))
+                 (non_consts ([0: ?,
+                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+           : (consts ())
+              (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>,
+                            value<(consts (0)) (non_consts ([0: ?, *]))>]))
+           (let
+             (uncurry =
+                (function {nlocal = 0} f
+                  param[value<(consts ()) (non_consts ([0: ?, ?]))>]
+                  (apply f (field_imm 0 param) (field_imm 1 param)))
+              map =
+                (function {nlocal = 2} f
+                  l[value<
+                     (consts (0))
+                      (non_consts ([0: ?,
+                                    value<
+                                     (consts (0)) (non_consts ([0: ?, *]))>]))>]
+                  : (consts (0))
+                     (non_consts ([0: ?,
+                                   value<
+                                    (consts (0)) (non_consts ([0: ?, *]))>]))
+                  (apply (field_imm 19 (global Stdlib__List!))
+                    (apply uncurry f) l)))
+             (makeblock 0 (value<
+                            (consts ())
+                             (non_consts ([0:
+                                           value<
+                                            (consts (0))
+                                             (non_consts ([0: ?, *]))>,
+                                           value<
+                                            (consts (0))
+                                             (non_consts ([0: ?, *]))>]))>,
+               value<
+                (consts (0))
+                 (non_consts ([0: ?,
+                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+               (makeblock 0 (value<
+                              (consts (0))
+                               (non_consts ([0: ?,
+                                             value<
+                                              (consts (0))
+                                               (non_consts ([0: ?, *]))>]))>,
+                 value<
+                  (consts (0))
+                   (non_consts ([0: ?,
+                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+                 (apply map eta_gen_cmp vec) (apply map cmp vec))
+               (apply map
+                 (function {nlocal = 2} gen spec
+                   : (consts ())
+                      (non_consts ([0:
+                                    value<
+                                     (consts (0)) (non_consts ([0: ?, *]))>,
+                                    value<
+                                     (consts (0)) (non_consts ([0: ?, *]))>]))
+                   (makeblock 0 (value<
+                                  (consts (0))
+                                   (non_consts ([0: ?,
+                                                 value<
+                                                  (consts (0))
+                                                   (non_consts ([0: ?, *]))>]))>,
+                     value<
+                      (consts (0))
+                       (non_consts ([0: ?,
+                                     value<
+                                      (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                     (apply map gen vec) (apply map spec vec)))
+                 (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
+                   value<
+                    (consts (0))
+                     (non_consts ([0: ?,
+                                   value<
+                                    (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                   (makeblock 0 (*,*) eta_gen_eq eq)
+                   (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
+                     value<
+                      (consts (0))
+                       (non_consts ([0: ?,
+                                     value<
+                                      (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                     (makeblock 0 (*,*) eta_gen_ne ne)
+                     (makeblock 0 (value<
+                                    (consts ()) (non_consts ([0: *, *]))>,
+                       value<
+                        (consts (0))
+                         (non_consts ([0: ?,
+                                       value<
+                                        (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                       (makeblock 0 (*,*) eta_gen_lt lt)
+                       (makeblock 0 (value<
+                                      (consts ()) (non_consts ([0: *, *]))>,
+                         value<
+                          (consts (0))
+                           (non_consts ([0: ?,
+                                         value<
+                                          (consts (0))
+                                           (non_consts ([0: ?, *]))>]))>)
+                         (makeblock 0 (*,*) eta_gen_gt gt)
                          (makeblock 0 (value<
                                         (consts ()) (non_consts ([0: *, *]))>,
                            value<
@@ -624,7 +616,7 @@
                                            value<
                                             (consts (0))
                                              (non_consts ([0: ?, *]))>]))>)
-                           (makeblock 0 (*,*) eta_gen_gt gt)
+                           (makeblock 0 (*,*) eta_gen_le le)
                            (makeblock 0 (value<
                                           (consts ())
                                            (non_consts ([0: *, *]))>,
@@ -634,60 +626,48 @@
                                              value<
                                               (consts (0))
                                                (non_consts ([0: ?, *]))>]))>)
-                             (makeblock 0 (*,*) eta_gen_le le)
-                             (makeblock 0 (value<
-                                            (consts ())
-                                             (non_consts ([0: *, *]))>,
-                               value<
-                                (consts (0))
-                                 (non_consts ([0: ?,
-                                               value<
-                                                (consts (0))
-                                                 (non_consts ([0: ?, *]))>]))>)
-                               (makeblock 0 (*,*) eta_gen_ge ge) 0)))))))))))
-        (seq
-          (apply eta_test_vec eta_int_cmp eta_int_eq eta_int_ne eta_int_lt
-            eta_int_gt eta_int_le eta_int_ge int_vec)
-          (apply eta_test_vec eta_bool_cmp eta_bool_eq eta_bool_ne
-            eta_bool_lt eta_bool_gt eta_bool_le eta_bool_ge bool_vec)
-          (apply eta_test_vec eta_intlike_cmp eta_intlike_eq eta_intlike_ne
-            eta_intlike_lt eta_intlike_gt eta_intlike_le eta_intlike_ge
-            intlike_vec)
-          (apply eta_test_vec eta_float_cmp eta_float_eq eta_float_ne
-            eta_float_lt eta_float_gt eta_float_le eta_float_ge float_vec)
-          (apply eta_test_vec eta_string_cmp eta_string_eq eta_string_ne
-            eta_string_lt eta_string_gt eta_string_le eta_string_ge
-            string_vec)
-          (apply eta_test_vec eta_int32_cmp eta_int32_eq eta_int32_ne
-            eta_int32_lt eta_int32_gt eta_int32_le eta_int32_ge int32_vec)
-          (apply eta_test_vec eta_int64_cmp eta_int64_eq eta_int64_ne
-            eta_int64_lt eta_int64_gt eta_int64_le eta_int64_ge int64_vec)
-          (apply eta_test_vec eta_nativeint_cmp eta_nativeint_eq
-            eta_nativeint_ne eta_nativeint_lt eta_nativeint_gt
-            eta_nativeint_le eta_nativeint_ge nativeint_vec)
-          (makeblock 0 gen_cmp int_cmp bool_cmp intlike_cmp float_cmp
-            string_cmp int32_cmp int64_cmp nativeint_cmp gen_eq int_eq
-            bool_eq intlike_eq float_eq string_eq int32_eq int64_eq
-            nativeint_eq gen_ne int_ne bool_ne intlike_ne float_ne string_ne
-            int32_ne int64_ne nativeint_ne gen_lt int_lt bool_lt intlike_lt
-            float_lt string_lt int32_lt int64_lt nativeint_lt gen_gt int_gt
-            bool_gt intlike_gt float_gt string_gt int32_gt int64_gt
-            nativeint_gt gen_le int_le bool_le intlike_le float_le string_le
-            int32_le int64_le nativeint_le gen_ge int_ge bool_ge intlike_ge
-            float_ge string_ge int32_ge int64_ge nativeint_ge eta_gen_cmp
-            eta_int_cmp eta_bool_cmp eta_intlike_cmp eta_float_cmp
-            eta_string_cmp eta_int32_cmp eta_int64_cmp eta_nativeint_cmp
-            eta_gen_eq eta_int_eq eta_bool_eq eta_intlike_eq eta_float_eq
-            eta_string_eq eta_int32_eq eta_int64_eq eta_nativeint_eq
-            eta_gen_ne eta_int_ne eta_bool_ne eta_intlike_ne eta_float_ne
-            eta_string_ne eta_int32_ne eta_int64_ne eta_nativeint_ne
-            eta_gen_lt eta_int_lt eta_bool_lt eta_intlike_lt eta_float_lt
-            eta_string_lt eta_int32_lt eta_int64_lt eta_nativeint_lt
-            eta_gen_gt eta_int_gt eta_bool_gt eta_intlike_gt eta_float_gt
-            eta_string_gt eta_int32_gt eta_int64_gt eta_nativeint_gt
-            eta_gen_le eta_int_le eta_bool_le eta_intlike_le eta_float_le
-            eta_string_le eta_int32_le eta_int64_le eta_nativeint_le
-            eta_gen_ge eta_int_ge eta_bool_ge eta_intlike_ge eta_float_ge
-            eta_string_ge eta_int32_ge eta_int64_ge eta_nativeint_ge int_vec
-            bool_vec intlike_vec float_vec string_vec int32_vec int64_vec
-            nativeint_vec test_vec eta_test_vec))))))
+                             (makeblock 0 (*,*) eta_gen_ge ge) 0)))))))))))
+      (seq
+        (apply eta_test_vec eta_int_cmp eta_int_eq eta_int_ne eta_int_lt
+          eta_int_gt eta_int_le eta_int_ge int_vec)
+        (apply eta_test_vec eta_bool_cmp eta_bool_eq eta_bool_ne eta_bool_lt
+          eta_bool_gt eta_bool_le eta_bool_ge bool_vec)
+        (apply eta_test_vec eta_intlike_cmp eta_intlike_eq eta_intlike_ne
+          eta_intlike_lt eta_intlike_gt eta_intlike_le eta_intlike_ge
+          intlike_vec)
+        (apply eta_test_vec eta_float_cmp eta_float_eq eta_float_ne
+          eta_float_lt eta_float_gt eta_float_le eta_float_ge float_vec)
+        (apply eta_test_vec eta_string_cmp eta_string_eq eta_string_ne
+          eta_string_lt eta_string_gt eta_string_le eta_string_ge string_vec)
+        (apply eta_test_vec eta_int32_cmp eta_int32_eq eta_int32_ne
+          eta_int32_lt eta_int32_gt eta_int32_le eta_int32_ge int32_vec)
+        (apply eta_test_vec eta_int64_cmp eta_int64_eq eta_int64_ne
+          eta_int64_lt eta_int64_gt eta_int64_le eta_int64_ge int64_vec)
+        (apply eta_test_vec eta_nativeint_cmp eta_nativeint_eq
+          eta_nativeint_ne eta_nativeint_lt eta_nativeint_gt eta_nativeint_le
+          eta_nativeint_ge nativeint_vec)
+        (makeblock 0 gen_cmp int_cmp bool_cmp intlike_cmp float_cmp
+          string_cmp int32_cmp int64_cmp nativeint_cmp gen_eq int_eq bool_eq
+          intlike_eq float_eq string_eq int32_eq int64_eq nativeint_eq gen_ne
+          int_ne bool_ne intlike_ne float_ne string_ne int32_ne int64_ne
+          nativeint_ne gen_lt int_lt bool_lt intlike_lt float_lt string_lt
+          int32_lt int64_lt nativeint_lt gen_gt int_gt bool_gt intlike_gt
+          float_gt string_gt int32_gt int64_gt nativeint_gt gen_le int_le
+          bool_le intlike_le float_le string_le int32_le int64_le
+          nativeint_le gen_ge int_ge bool_ge intlike_ge float_ge string_ge
+          int32_ge int64_ge nativeint_ge eta_gen_cmp eta_int_cmp eta_bool_cmp
+          eta_intlike_cmp eta_float_cmp eta_string_cmp eta_int32_cmp
+          eta_int64_cmp eta_nativeint_cmp eta_gen_eq eta_int_eq eta_bool_eq
+          eta_intlike_eq eta_float_eq eta_string_eq eta_int32_eq eta_int64_eq
+          eta_nativeint_eq eta_gen_ne eta_int_ne eta_bool_ne eta_intlike_ne
+          eta_float_ne eta_string_ne eta_int32_ne eta_int64_ne
+          eta_nativeint_ne eta_gen_lt eta_int_lt eta_bool_lt eta_intlike_lt
+          eta_float_lt eta_string_lt eta_int32_lt eta_int64_lt
+          eta_nativeint_lt eta_gen_gt eta_int_gt eta_bool_gt eta_intlike_gt
+          eta_float_gt eta_string_gt eta_int32_gt eta_int64_gt
+          eta_nativeint_gt eta_gen_le eta_int_le eta_bool_le eta_intlike_le
+          eta_float_le eta_string_le eta_int32_le eta_int64_le
+          eta_nativeint_le eta_gen_ge eta_int_ge eta_bool_ge eta_intlike_ge
+          eta_float_ge eta_string_ge eta_int32_ge eta_int64_ge
+          eta_nativeint_ge int_vec bool_vec intlike_vec float_vec string_vec
+          int32_vec int64_vec nativeint_vec test_vec eta_test_vec)))))

--- a/testsuite/tests/translprim/module_coercion.compilers.flat.reference
+++ b/testsuite/tests/translprim/module_coercion.compilers.flat.reference
@@ -1,163 +1,162 @@
-(setglobal Module_coercion!
-  (let (M = (makeblock 0))
-    (makeblock 0 M
-      (makeblock 0
-        (function {nlocal = 0} prim[value<intarray>] stub : int
-          (array.length[int] prim))
-        (function {nlocal = 0} prim[value<intarray>] prim[value<int>] stub
-          : int (array.get[int indexed by int] prim prim))
-        (function {nlocal = 0} prim[value<intarray>] prim[value<int>] stub
-          : int (array.unsafe_get[int indexed by int] prim prim))
-        (function {nlocal = 0} prim[value<intarray>] prim[value<int>]
-          prim[value<int>] stub : int
-          (array.set[int indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[value<intarray>] prim[value<int>]
-          prim[value<int>] stub : int
-          (array.unsafe_set[int indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-          (%int_compare prim prim))
-        (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-          (%eq prim prim))
-        (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-          (%noteq prim prim))
-        (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-          (%int_lessthan prim prim))
-        (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-          (%int_greaterthan prim prim))
-        (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-          (%int_lessequal prim prim))
-        (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
-          (%int_greaterequal prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[value<floatarray>] stub : int
-          (array.length[float] prim))
-        (function {nlocal = 0} prim[value<floatarray>] prim[value<int>] stub
-          : float (array.get[float indexed by int] prim prim))
-        (function {nlocal = 0} prim[value<floatarray>] prim[value<int>] stub
-          : float (array.unsafe_get[float indexed by int] prim prim))
-        (function {nlocal = 0} prim[value<floatarray>] prim[value<int>]
-          prim[value<float>] stub : int
-          (array.set[float indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[value<floatarray>] prim[value<int>]
-          prim[value<float>] stub : int
-          (array.unsafe_set[float indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
-          : int (%float_compare prim prim))
-        (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
-          : int (%float_ordered_and_equal prim prim))
-        (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
-          : int (%float_unordered_or_notequal prim prim))
-        (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
-          : int (%float_ordered_and_lessthan prim prim))
-        (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
-          : int (%float_ordered_and_greaterthan prim prim))
-        (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
-          : int (%float_ordered_and_lessequal prim prim))
-        (function {nlocal = 0} prim[value<float>] prim[value<float>] stub
-          : int (%float_ordered_and_greaterequal prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[value<addrarray>] stub : int
-          (array.length[addr] prim))
-        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
-          (array.get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
-          (array.unsafe_get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] prim
-          stub : int (array.set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] prim
-          stub : int (array.unsafe_set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim prim stub : int
-          (caml_string_compare prim prim))
-        (function {nlocal = 0} prim prim stub : int
-          (caml_string_equal prim prim))
-        (function {nlocal = 0} prim prim stub : int
-          (caml_string_notequal prim prim))
-        (function {nlocal = 0} prim prim stub : int
-          (caml_string_lessthan prim prim))
-        (function {nlocal = 0} prim prim stub : int
-          (caml_string_greaterthan prim prim))
-        (function {nlocal = 0} prim prim stub : int
-          (caml_string_lessequal prim prim))
-        (function {nlocal = 0} prim prim stub : int
-          (caml_string_greaterequal prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[value<addrarray>] stub : int
-          (array.length[addr] prim))
-        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
-          : int32 (array.get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
-          : int32 (array.unsafe_get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
-          prim[value<int32>] stub : int
-          (array.set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
-          prim[value<int32>] stub : int
-          (array.unsafe_set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
-          : int (%int32_compare prim prim))
-        (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
-          : int (%int32_equal prim prim))
-        (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
-          : int (%int32_notequal prim prim))
-        (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
-          : int (%int32_lessthan prim prim))
-        (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
-          : int (%int32_greaterthan prim prim))
-        (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
-          : int (%int32_lessequal prim prim))
-        (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub
-          : int (%int32_greaterequal prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[value<addrarray>] stub : int
-          (array.length[addr] prim))
-        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
-          : int64 (array.get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
-          : int64 (array.unsafe_get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
-          prim[value<int64>] stub : int
-          (array.set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
-          prim[value<int64>] stub : int
-          (array.unsafe_set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
-          : int (%int64_compare prim prim))
-        (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
-          : int (%int64_equal prim prim))
-        (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
-          : int (%int64_notequal prim prim))
-        (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
-          : int (%int64_lessthan prim prim))
-        (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
-          : int (%int64_greaterthan prim prim))
-        (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
-          : int (%int64_lessequal prim prim))
-        (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub
-          : int (%int64_greaterequal prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[value<addrarray>] stub : int
-          (array.length[addr] prim))
-        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
-          : nativeint (array.get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
-          : nativeint (array.unsafe_get[addr indexed by int] prim prim))
-        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
-          prim[value<nativeint>] stub : int
-          (array.set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
-          prim[value<nativeint>] stub : int
-          (array.unsafe_set[addr indexed by int] prim prim prim))
-        (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
-          stub : int (%nativeint_compare prim prim))
-        (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
-          stub : int (%nativeint_equal prim prim))
-        (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
-          stub : int (%nativeint_notequal prim prim))
-        (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
-          stub : int (%nativeint_lessthan prim prim))
-        (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
-          stub : int (%nativeint_greaterthan prim prim))
-        (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
-          stub : int (%nativeint_lessequal prim prim))
-        (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
-          stub : int (%nativeint_greaterequal prim prim))))))
+(let (M = (makeblock 0))
+  (makeblock 0 M
+    (makeblock 0
+      (function {nlocal = 0} prim[value<intarray>] stub : int
+        (array.length[int] prim))
+      (function {nlocal = 0} prim[value<intarray>] prim[value<int>] stub
+        : int (array.get[int indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<intarray>] prim[value<int>] stub
+        : int (array.unsafe_get[int indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<intarray>] prim[value<int>]
+        prim[value<int>] stub : int
+        (array.set[int indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<intarray>] prim[value<int>]
+        prim[value<int>] stub : int
+        (array.unsafe_set[int indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+        (%int_compare prim prim))
+      (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+        (%eq prim prim))
+      (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+        (%noteq prim prim))
+      (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+        (%int_lessthan prim prim))
+      (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+        (%int_greaterthan prim prim))
+      (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+        (%int_lessequal prim prim))
+      (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+        (%int_greaterequal prim prim)))
+    (makeblock 0
+      (function {nlocal = 0} prim[value<floatarray>] stub : int
+        (array.length[float] prim))
+      (function {nlocal = 0} prim[value<floatarray>] prim[value<int>] stub
+        : float (array.get[float indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<floatarray>] prim[value<int>] stub
+        : float (array.unsafe_get[float indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<floatarray>] prim[value<int>]
+        prim[value<float>] stub : int
+        (array.set[float indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<floatarray>] prim[value<int>]
+        prim[value<float>] stub : int
+        (array.unsafe_set[float indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+        (%float_compare prim prim))
+      (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+        (%float_ordered_and_equal prim prim))
+      (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+        (%float_unordered_or_notequal prim prim))
+      (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+        (%float_ordered_and_lessthan prim prim))
+      (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+        (%float_ordered_and_greaterthan prim prim))
+      (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+        (%float_ordered_and_lessequal prim prim))
+      (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+        (%float_ordered_and_greaterequal prim prim)))
+    (makeblock 0
+      (function {nlocal = 0} prim[value<addrarray>] stub : int
+        (array.length[addr] prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+        (array.get[addr indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+        (array.unsafe_get[addr indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] prim
+        stub : int (array.set[addr indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] prim
+        stub : int (array.unsafe_set[addr indexed by int] prim prim prim))
+      (function {nlocal = 0} prim prim stub : int
+        (caml_string_compare prim prim))
+      (function {nlocal = 0} prim prim stub : int
+        (caml_string_equal prim prim))
+      (function {nlocal = 0} prim prim stub : int
+        (caml_string_notequal prim prim))
+      (function {nlocal = 0} prim prim stub : int
+        (caml_string_lessthan prim prim))
+      (function {nlocal = 0} prim prim stub : int
+        (caml_string_greaterthan prim prim))
+      (function {nlocal = 0} prim prim stub : int
+        (caml_string_lessequal prim prim))
+      (function {nlocal = 0} prim prim stub : int
+        (caml_string_greaterequal prim prim)))
+    (makeblock 0
+      (function {nlocal = 0} prim[value<addrarray>] stub : int
+        (array.length[addr] prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+        : int32 (array.get[addr indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+        : int32 (array.unsafe_get[addr indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+        prim[value<int32>] stub : int
+        (array.set[addr indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+        prim[value<int32>] stub : int
+        (array.unsafe_set[addr indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+        (%int32_compare prim prim))
+      (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+        (%int32_equal prim prim))
+      (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+        (%int32_notequal prim prim))
+      (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+        (%int32_lessthan prim prim))
+      (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+        (%int32_greaterthan prim prim))
+      (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+        (%int32_lessequal prim prim))
+      (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+        (%int32_greaterequal prim prim)))
+    (makeblock 0
+      (function {nlocal = 0} prim[value<addrarray>] stub : int
+        (array.length[addr] prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+        : int64 (array.get[addr indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+        : int64 (array.unsafe_get[addr indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+        prim[value<int64>] stub : int
+        (array.set[addr indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+        prim[value<int64>] stub : int
+        (array.unsafe_set[addr indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+        (%int64_compare prim prim))
+      (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+        (%int64_equal prim prim))
+      (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+        (%int64_notequal prim prim))
+      (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+        (%int64_lessthan prim prim))
+      (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+        (%int64_greaterthan prim prim))
+      (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+        (%int64_lessequal prim prim))
+      (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+        (%int64_greaterequal prim prim)))
+    (makeblock 0
+      (function {nlocal = 0} prim[value<addrarray>] stub : int
+        (array.length[addr] prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+        : nativeint (array.get[addr indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+        : nativeint (array.unsafe_get[addr indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+        prim[value<nativeint>] stub : int
+        (array.set[addr indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+        prim[value<nativeint>] stub : int
+        (array.unsafe_set[addr indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+        stub : int (%nativeint_compare prim prim))
+      (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+        stub : int (%nativeint_equal prim prim))
+      (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+        stub : int (%nativeint_notequal prim prim))
+      (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+        stub : int (%nativeint_lessthan prim prim))
+      (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+        stub : int (%nativeint_greaterthan prim prim))
+      (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+        stub : int (%nativeint_lessequal prim prim))
+      (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+        stub : int (%nativeint_greaterequal prim prim)))))

--- a/testsuite/tests/translprim/ref_spec.stack.reference
+++ b/testsuite/tests/translprim/ref_spec.stack.reference
@@ -1,51 +1,49 @@
-(setglobal Ref_spec!
-  (let
-    (int_ref = (makemutable 0 (value<int>) 1)
-     var_ref = (makemutable 0 (value<int>) 65)
-     vargen_ref = (makemutable 0 (*) 65)
-     cst_ref = (makemutable 0 (value<int>) 0)
-     gen_ref = (makemutable 0 (value<(consts (0)) (non_consts ([0: *]))>) 0)
-     flt_ref = (makemutable 0 (value<float>) 0.))
-    (seq (setfield_imm 0 int_ref 2) (setfield_imm 0 var_ref 66)
-      (setfield_ptr 0 vargen_ref [0: 66 0]) (setfield_ptr 0 vargen_ref 67)
-      (setfield_imm 0 cst_ref 1) (setfield_ptr 0 gen_ref [0: "foo"])
-      (setfield_ptr 0 gen_ref 0) (setfield_ptr 0 flt_ref 1.)
-      (let
-        (int_rec = (makemutable 0 (value<int>,value<int>) 0 1)
-         var_rec = (makemutable 0 (value<int>,value<int>) 0 65)
-         vargen_rec = (makemutable 0 (value<int>,*) 0 65)
-         cst_rec = (makemutable 0 (value<int>,value<int>) 0 0)
-         gen_rec =
-           (makemutable 0 (value<int>,value<
-                                       (consts (0)) (non_consts ([0: *]))>)
-             0 0)
-         flt_rec = (makemutable 0 (value<int>,value<float>) 0 0.)
-         flt_rec' = (makefloatblock Mutable 0. 0.))
-        (seq (setfield_imm 1 int_rec 2) (setfield_imm 1 var_rec 66)
-          (setfield_ptr 1 vargen_rec [0: 66 0])
-          (setfield_ptr 1 vargen_rec 67) (setfield_imm 1 cst_rec 1)
-          (setfield_ptr 1 gen_rec [0: "foo"]) (setfield_ptr 1 gen_rec 0)
-          (setfield_ptr 1 flt_rec 1.) (setfloatfield 1 flt_rec' 1.)
-          (let
-            (set_open_poly =
-               (function {nlocal = 2} r y : int (setfield_ptr 0 r y))
-             set_open_poly =
-               (function {nlocal = 2} r y[value<int>] : int
-                 (setfield_imm 0 r y))
-             set_open_poly =
-               (function {nlocal = 2} r y[value<int>] : int
-                 (setfield_imm 0 r y))
-             set_open_poly =
-               (function {nlocal = 2} r y[value<int>] : int
-                 (setfield_imm 0 r y))
-             set_open_poly =
-               (function {nlocal = 2} r y : int (setfield_ptr 0 r y))
-             set_open_poly =
-               (function {nlocal = 2} r y : int (setfield_ptr 0 r y))
-             set_open_poly =
-               (function {nlocal = 2} r y : int (setfield_ptr 0 r y))
-             set_open_poly =
-               (function {nlocal = 0} r y : int (setfield_ptr 0 r y)))
-            (makeblock 0 int_ref var_ref vargen_ref cst_ref gen_ref flt_ref
-              int_rec var_rec vargen_rec cst_rec gen_rec flt_rec flt_rec'
-              set_open_poly)))))))
+(let
+  (int_ref = (makemutable 0 (value<int>) 1)
+   var_ref = (makemutable 0 (value<int>) 65)
+   vargen_ref = (makemutable 0 (*) 65)
+   cst_ref = (makemutable 0 (value<int>) 0)
+   gen_ref = (makemutable 0 (value<(consts (0)) (non_consts ([0: *]))>) 0)
+   flt_ref = (makemutable 0 (value<float>) 0.))
+  (seq (setfield_imm 0 int_ref 2) (setfield_imm 0 var_ref 66)
+    (setfield_ptr 0 vargen_ref [0: 66 0]) (setfield_ptr 0 vargen_ref 67)
+    (setfield_imm 0 cst_ref 1) (setfield_ptr 0 gen_ref [0: "foo"])
+    (setfield_ptr 0 gen_ref 0) (setfield_ptr 0 flt_ref 1.)
+    (let
+      (int_rec = (makemutable 0 (value<int>,value<int>) 0 1)
+       var_rec = (makemutable 0 (value<int>,value<int>) 0 65)
+       vargen_rec = (makemutable 0 (value<int>,*) 0 65)
+       cst_rec = (makemutable 0 (value<int>,value<int>) 0 0)
+       gen_rec =
+         (makemutable 0 (value<int>,value<(consts (0)) (non_consts ([0: *]))>)
+           0 0)
+       flt_rec = (makemutable 0 (value<int>,value<float>) 0 0.)
+       flt_rec' = (makefloatblock Mutable 0. 0.))
+      (seq (setfield_imm 1 int_rec 2) (setfield_imm 1 var_rec 66)
+        (setfield_ptr 1 vargen_rec [0: 66 0]) (setfield_ptr 1 vargen_rec 67)
+        (setfield_imm 1 cst_rec 1) (setfield_ptr 1 gen_rec [0: "foo"])
+        (setfield_ptr 1 gen_rec 0) (setfield_ptr 1 flt_rec 1.)
+        (setfloatfield 1 flt_rec' 1.)
+        (let
+          (set_open_poly =
+             (function {nlocal = 2} r y : int (setfield_ptr 0 r y))
+           set_open_poly =
+             (function {nlocal = 2} r y[value<int>] : int
+               (setfield_imm 0 r y))
+           set_open_poly =
+             (function {nlocal = 2} r y[value<int>] : int
+               (setfield_imm 0 r y))
+           set_open_poly =
+             (function {nlocal = 2} r y[value<int>] : int
+               (setfield_imm 0 r y))
+           set_open_poly =
+             (function {nlocal = 2} r y : int (setfield_ptr 0 r y))
+           set_open_poly =
+             (function {nlocal = 2} r y : int (setfield_ptr 0 r y))
+           set_open_poly =
+             (function {nlocal = 2} r y : int (setfield_ptr 0 r y))
+           set_open_poly =
+             (function {nlocal = 0} r y : int (setfield_ptr 0 r y)))
+          (makeblock 0 int_ref var_ref vargen_ref cst_ref gen_ref flt_ref
+            int_rec var_rec vargen_rec cst_rec gen_rec flt_rec flt_rec'
+            set_open_poly))))))

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -71,7 +71,7 @@ let load_lambda ppf lam =
   if !Clflags.dump_rawlambda then fprintf ppf "%a@." Printlambda.lambda lam;
   let slam = Simplif.simplify_lambda lam in
   if !Clflags.dump_lambda then fprintf ppf "%a@." Printlambda.lambda slam;
-  let blam = Blambda_of_lambda.blambda_of_lambda slam in
+  let blam = Blambda_of_lambda.blambda_of_lambda ~compilation_unit:None slam in
   if !Clflags.dump_blambda then fprintf ppf "%a@." Printblambda.blambda blam;
   let instrs, can_free = Bytegen.compile_phrase blam in
   if !Clflags.dump_instr then

--- a/toplevel/native/opttoploop.ml
+++ b/toplevel/native/opttoploop.ml
@@ -430,7 +430,6 @@ let execute_phrase print_outcome ppf phr =
               required_globals; code = res } =
           Translmod.transl_implementation compilation_unit
             (str, coercion, None)
-            ~style:Plain_block
         in
         remember compilation_unit sg';
         let size =

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -213,7 +213,6 @@ let execute_phrase print_outcome ppf phr =
               required_globals; code = res } =
           Translmod.transl_implementation phrase_comp_unit
             (str, Tcoerce_none, None)
-            ~style:Plain_block
         in
         remember compilation_unit sg';
         compilation_unit, close_phrase res, required_globals, size

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -68,9 +68,7 @@ let close_phrase lam =
   ) (free_variables lam) lam
 
 let toplevel_value id =
-  let glob, pos =
-    if Config.flambda then toplevel_value id else Translmod.nat_toplevel_name id
-  in
+  let glob, pos = toplevel_value id in
   (Obj.magic (global_symbol glob)).(pos)
 
 (* Return the value referred to by a path *)
@@ -211,18 +209,14 @@ let execute_phrase print_outcome ppf phr =
          | None -> str, sg', false
       in
       let compilation_unit, res, required_globals, size =
-        if Config.flambda then
-          let { Lambda.compilation_unit; main_module_block_size = size;
-                required_globals; code = res } =
-            Translmod.transl_implementation phrase_comp_unit
-              (str, Tcoerce_none, None)
-              ~style:Plain_block
-          in
-          remember compilation_unit sg';
-          compilation_unit, close_phrase res, required_globals, size
-        else
-          let size, res = Translmod.transl_store_phrases phrase_comp_unit str in
-          phrase_comp_unit, res, Compilation_unit.Set.empty, size
+        let { Lambda.compilation_unit; main_module_block_size = size;
+              required_globals; code = res } =
+          Translmod.transl_implementation phrase_comp_unit
+            (str, Tcoerce_none, None)
+            ~style:Plain_block
+        in
+        remember compilation_unit sg';
+        compilation_unit, close_phrase res, required_globals, size
       in
       Warnings.check_fatal ();
       begin try
@@ -234,12 +228,9 @@ let execute_phrase print_outcome ppf phr =
         let out_phr =
           match res with
           | Result _ ->
-              if Config.flambda then
-                (* CR-someday trefis: *)
-                Env.register_import_as_opaque
-                  (Compilation_unit.name compilation_unit)
-              else
-                Compilenv.record_global_approx_toplevel ();
+              (* CR-someday trefis: *)
+              Env.register_import_as_opaque
+                (Compilation_unit.name compilation_unit);
               if print_outcome then
                 Printtyp.wrap_printing_env ~error:false oldenv (fun () ->
                 match str.str_items with


### PR DESCRIPTION
## Summary
- Removes the obsolete `transl_store` compilation pipeline and `Psetglobal` constructor from Lambda IR
- Rewrites native toplevel to use modern translation mechanism
- Unifies compilation approach across native and bytecode backends

## Details

The `transl_store` compilation pipeline was a legacy mechanism for setting individual fields in module globals, used only by:
1. The native toplevel (now fixed to use modern translation)
2. The old Closure middle-end (deleted long ago)

This PR removes approximately 750 lines of unused code from `translmod.ml`, including:
- `transl_store_*` functions for the old compilation pipeline
- `Psetglobal` constructor from Lambda IR
- Related pattern matching and helper functions

### Key Changes

**Native Toplevel**: Previously used `transl_store_phrases` when not using Flambda. Now always uses `transl_implementation` with `Plain_block` style, matching the Flambda approach.

**Bytecode Compilation**: Fixed to wrap modules with `Blambda.Setglobal` at the Blambda level to maintain module registration.

## Test plan
- [x] `make boot-compiler` - builds successfully
- [x] `make test` - all tests pass
- [x] Native toplevel works correctly with the new translation

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>