### PR TITLE
Remove bogus parameters leftover from an earlier dev branch.

### DIFF
--- a/stdlib/effect.ml
+++ b/stdlib/effect.ml
@@ -59,7 +59,6 @@ module Must_not_enter_gc = struct
     ('a -> 'b) ->
     (exn -> 'b) ->
     ('c t -> ('c, 'b) cont -> last_fiber -> 'b) ->
-    unit -> unit -> (* for dynamic bindings *)
     ('a, 'b) stack = "caml_alloc_stack"
 
   external runstack : ('a, 'b) stack -> ('c -> 'a) -> 'c -> 'b = "%runstack"
@@ -80,7 +79,7 @@ module Must_not_enter_gc = struct
      We must not enter the GC between [alloc_stack] and [runstack].
      [with_stack] is marked as [@inline never] to avoid reordering. *)
   let[@inline never] with_stack valuec exnc effc f x =
-    runstack (alloc_stack valuec exnc effc () ()) f x
+    runstack (alloc_stack valuec exnc effc) f x
 
   (* Retrieve the stack from a [cont]inuation and run [f x] using it.
      We must not enter the GC between [take_cont_noexc] and [resume].

--- a/testsuite/tests/backtrace/backtrace_effects.reference
+++ b/testsuite/tests/backtrace/backtrace_effects.reference
@@ -1,7 +1,7 @@
 (** get_callstack **)
 Raised by primitive operation at Backtrace_effects.bar in file "backtrace_effects.ml", line 20, characters 13-39
 Called from Backtrace_effects.foo in file "backtrace_effects.ml", line 27, characters 12-17
-Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 83, characters 4-53
+Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 82, characters 4-47
 Called from Backtrace_effects.baz in file "backtrace_effects.ml" (inlined), lines 31-41, characters 2-401
 Called from Backtrace_effects in file "backtrace_effects.ml", line 43, characters 8-14
 (** get_continuation_callstack **)
@@ -11,6 +11,6 @@ Called from Backtrace_effects.foo in file "backtrace_effects.ml", line 27, chara
 Fatal error: exception Stdlib.Exit
 Raised at Backtrace_effects.bar in file "backtrace_effects.ml", line 17, characters 4-14
 Re-raised at Backtrace_effects.baz.(fun) in file "backtrace_effects.ml", line 33, characters 21-28
-Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 83, characters 4-53
+Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 82, characters 4-47
 Called from Backtrace_effects.baz in file "backtrace_effects.ml" (inlined), lines 31-41, characters 2-401
 Called from Backtrace_effects in file "backtrace_effects.ml", line 43, characters 8-14

--- a/testsuite/tests/backtrace/backtrace_effects_nested.flambda.reference
+++ b/testsuite/tests/backtrace/backtrace_effects_nested.flambda.reference
@@ -1,5 +1,5 @@
 Raised by primitive operation at Backtrace_effects_nested.blorp in file "backtrace_effects_nested.ml", line 24, characters 2-11
-Called from Stdlib__Effect.Deep.continue in file "stdlib/effect.ml" (inlined), line 102, characters 21-64
+Called from Stdlib__Effect.Deep.continue in file "stdlib/effect.ml" (inlined), line 101, characters 21-64
 Called from Backtrace_effects_nested.baz.(fun) in file "backtrace_effects_nested.ml", line 32, characters 16-29
-Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 83, characters 4-53
+Called from Stdlib__Effect.Must_not_enter_gc.with_stack in file "stdlib/effect.ml", line 82, characters 4-47
 43

--- a/testsuite/tests/effects/backtrace.byte.reference
+++ b/testsuite/tests/effects/backtrace.byte.reference
@@ -2,5 +2,5 @@ Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace.foo in file "backtrace.ml", line 14, characters 11-27
 Called from Backtrace.bar in file "backtrace.ml", line 22, characters 4-9
 Called from Backtrace.task1 in file "backtrace.ml", line 31, characters 4-10
-Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 107, characters 44-78
+Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 106, characters 44-78
 Called from Backtrace.task2 in file "backtrace.ml", line 38, characters 4-16

--- a/testsuite/tests/effects/backtrace.reference
+++ b/testsuite/tests/effects/backtrace.reference
@@ -2,5 +2,5 @@ Raised at Stdlib.failwith in file "stdlib.ml" (inlined), line 39, characters 17-
 Called from Backtrace.foo in file "backtrace.ml", line 14, characters 11-27
 Called from Backtrace.bar in file "backtrace.ml", line 22, characters 4-9
 Called from Backtrace.task1 in file "backtrace.ml", line 31, characters 4-10
-Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 107, characters 44-78
+Re-raised at Stdlib__Effect.Deep.discontinue_with_backtrace.(fun) in file "stdlib/effect.ml", line 106, characters 44-78
 Called from Backtrace.task2 in file "backtrace.ml", line 38, characters 4-16


### PR DESCRIPTION
In an earlier version of #4239, the extra parameters of `caml_alloc_stack_bind` were simply added to `caml_alloc_stack`. This persisted in `stdlib/effect.ml`, which could never work.