### PR TITLE
Trigger minor GCs less enthusiastically when making arrays

### DIFF
--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -85,6 +85,8 @@ struct caml_minor_tables {
 CAMLextern void caml_minor_collection (void);
 
 #ifdef CAML_INTERNALS
+#include <stdbool.h>
+
 extern void caml_set_minor_heap_size (asize_t); /* size in bytes */
 extern void caml_empty_minor_heap_no_major_slice_from_stw
   (caml_domain_state* domain, void* unused, int participating_count,
@@ -102,6 +104,11 @@ extern void caml_realloc_dependent_table (struct caml_dependent_table *);
 struct caml_minor_tables* caml_alloc_minor_tables(void);
 void caml_free_minor_tables(struct caml_minor_tables*);
 void caml_empty_minor_heap_setup(caml_domain_state* domain, void*);
+
+/* We are about to write `count` fields on the major heap, with values
+ * currently on the minor heap. We may wish to do a minor GC
+ * first. Returns `true` if a minor GC was done. */
+bool caml_maybe_minor_gc_before_writes(mlsize_t count);
 
 #ifdef DEBUG
 extern int caml_debug_is_minor(value val);

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -154,6 +154,26 @@ void caml_set_minor_heap_size (asize_t wsize)
   reset_minor_tables(r);
 }
 
+/* We are about to write `count` ref table entries. We may wish to
+ * avoid them all by doing a minor GC first. Heuristic is that if we
+ * are going to use a significant chunk of the available remembered
+ * set space, without growing the remembered set, then do the GC. */
+
+#define WRITE_PERCENT_TO_TRIGGER_MINOR_GC 10
+
+bool caml_maybe_minor_gc_before_writes(mlsize_t count)
+{
+  struct caml_ref_table *table = &Caml_state->minor_tables->major_ref;
+  size_t space = table->base ? (table->limit - table->ptr) : table->size;
+  if (count > (space * WRITE_PERCENT_TO_TRIGGER_MINOR_GC) / 100) {
+    CAML_EV_COUNTER(EV_C_FORCE_MINOR_MAKE_VECT, 1);
+    caml_minor_collection();
+    return true;
+  }
+  return false;
+}
+
+
 /*****************************************************************************/
 
 struct oldify_state {


### PR DESCRIPTION
Whenever we make an array of more than 256 entries, each initialized to a value on the minor heap, we do a minor GC, to avoid writing the remembered set entries and then processing them on the next minor GC. This violates POLA, especially if the system is configured with a very large minor heap (recently observed with `s=8G`: a 64 GiB minor heap!). Also, writing a few hundred remembered set entries (and then processing them on the next minor GC) may be much cheaper than doing a minor GC, which has to synchronize all the domains etc.

This PR:
  (a) moves the policy decision of whether to do a minor GC from `array.c` into `minor_gc.c` (in a new function `caml_maybe_minor_gc_before_writes()`;
  (b) changes the decision to a heuristic: if the writes will use up more than 10% of the available remembered set, then do the GC.
  
So if the remembered set is close to full, we'll do a minor GC, but otherwise we will take the hit of the remembered set entries.