### PR TITLE
Don't enroll a new domain into major GC until it's ready

### DIFF
--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -17,6 +17,7 @@
 #define CAML_MAJOR_GC_H
 
 #ifdef CAML_INTERNALS
+#include <stdbool.h>
 
 typedef enum {
   Phase_sweep_main,
@@ -41,7 +42,11 @@ void caml_opportunistic_major_collection_slice (intnat);
 void caml_major_collection_slice (intnat);
 void caml_finish_sweeping(void);
 void caml_finish_marking (void);
-int caml_init_major_gc(caml_domain_state*);
+/* Allocate data structures for major GC for a given domain. Return false on failure. */
+bool caml_alloc_major_gc(caml_domain_state*);
+/* Enroll a given (new) domain in major GC activity. Cannot fail. */
+void caml_enroll_major_gc(caml_domain_state*);
+/* Free data structures for major GC for the current domain. */
 void caml_teardown_major_gc(void);
 void caml_darken(void*, value, volatile value* ignored);
 void caml_darken_cont(value);


### PR DESCRIPTION
In the existing code, domain creation can fail after its major GC state has been initialized, which includes "enrolling" it in the global major GC state (e.g. by incrementing `num_domains_to_mark`). This is then not torn down correctly in the failure path. Fixed by splitting `caml_init_major_gc` into `caml_alloc_major_gc` (which can fail, and now has the same failure control flow as other initialization functions) and `caml_enroll_major_gc` (which can not, and which can be called after domain creation is definitely going to succeed).
Also `caml_teardown_major_gc` did not free everything allocated in `caml_init_major_gc`. It does now.