### PR TITLE
Document need for stdlib_stable to use iarray

### DIFF
--- a/jane/doc/extensions/_11-miscellaneous-extensions/immutable-arrays.md
+++ b/jane/doc/extensions/_11-miscellaneous-extensions/immutable-arrays.md
@@ -35,4 +35,7 @@ type `super`, then `sub iarray` is a subtype of `super iarray`, as though you ha
 You can also have *immutable array comprehensions*: `[: x, y for x = 1
 to 3 and y in [: "some"; "thing" :] :]`.
 
-*This extension will appear in OCaml 5.4 as the `Iarray` module. See [ocaml/ocaml#13097](https://github.com/ocaml/ocaml/pull/13097).*
+*This extension will appear in OCaml 5.4 as the `Iarray` module. See
+[ocaml/ocaml#13097](https://github.com/ocaml/ocaml/pull/13097).* To use this
+extension with the current OxCaml release, you must add `stdlib_stable` as a
+library dependency.


### PR DESCRIPTION
It took me some time digging thru the source code to figure out why I couldn't access the functions in `Iarray`.