### PR TITLE
Basic shrink wrapping implementation

### DIFF
--- a/backend/cfg/cfg_loop_infos.ml
+++ b/backend/cfg/cfg_loop_infos.ml
@@ -171,3 +171,9 @@ let build : Cfg.t -> Cfg_dominators.t -> t =
             Format.eprintf "  \n"))
       header_map);
   { back_edges; loops; header_map; loop_depths }
+
+let is_in_loop : t -> Label.t -> bool =
+ fun loops label ->
+  Cfg_edge.Map.exists
+    (fun _ (loop : loop) -> Label.Set.mem label loop)
+    loops.loops

--- a/backend/cfg/cfg_loop_infos.mli
+++ b/backend/cfg/cfg_loop_infos.mli
@@ -39,3 +39,5 @@ type t = private
   }
 
 val build : Cfg.t -> Cfg_dominators.t -> t
+
+val is_in_loop : t -> Label.t -> bool

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -104,6 +104,8 @@ module Instruction_requirements = struct
 end
 
 let prologue_needed_block (block : Cfg.basic_block) ~fun_name =
+  (* CR-soon cfalas: Move to [Proc] so that it's arch-dependent and
+     frame_pointers only affects the output for amd64. *)
   Config.with_frame_pointers || block.is_trap_handler
   || DLL.exists block.Cfg.body ~f:(fun instr ->
          match Instruction_requirements.basic instr with

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -134,8 +134,7 @@ let can_place_prologue (prologue_label : Label.t) (cfg : Cfg.t)
     (doms : Cfg_dominators.t) (loop_infos : Cfg_loop_infos.t) =
   let prologue_block = Cfg.get_block_exn cfg prologue_label in
   (* Moving a prologue to a loop might cause it to execute multiple times, which
-     is both inefficient as well as makes handling the epilogue tricky to handle
-     (as we would have to know how many times the prologue was added).
+     is both inefficient as well as possibly incorrect.
 
      Having a non-zero stack offset means that the prologue is added after a
      [Pushtrap] or [Stackoffset] which shouldn't be allowed. *)

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -183,8 +183,6 @@ let rec find_prologue_and_epilogue_blocks (tree : Cfg_dominators.dominator_tree)
         (fun tree -> find_prologue_and_epilogue_blocks tree cfg doms loop_infos)
         tree.children
     in
-    (* let children_prologue_block = List.filter (fun x -> Option.is_some x)
-       children_prologue_block in *)
     match children_prologue_block with
     | [] -> None
     | [(child, child_epilogue_blocks)] ->

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -168,12 +168,10 @@ let can_place_prologue (prologue_label : Label.t) (cfg : Cfg.t)
        If we try to place the prologue in block B, the prologue would not
        dominate the epilogue in block C, so in some cases the epilogue would be
        executed without a prologue on the stack, which would be illegal. *)
-    Label.Set.fold
-      (fun epilogue_label acc ->
-        if Cfg_dominators.is_dominating doms prologue_label epilogue_label
-        then acc
-        else false)
-      epilogue_blocks true
+    Label.Set.for_all
+      (fun epilogue_label ->
+        Cfg_dominators.is_dominating doms prologue_label epilogue_label)
+      epilogue_blocks
 
 let rec find_prologue_block (tree : Cfg_dominators.dominator_tree) (cfg : Cfg.t)
     (doms : Cfg_dominators.t) (loop_infos : Cfg_loop_infos.t) =

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -103,24 +103,131 @@ module Instruction_requirements = struct
         Requirements No_requirements
 end
 
+let prologue_needed_block (block : Cfg.basic_block) ~fun_name =
+  block.is_trap_handler
+  || DLL.exists block.Cfg.body ~f:(fun instr ->
+         match Instruction_requirements.basic instr with
+         | Requirements Requires_prologue -> true
+         | Prologue | Epilogue
+         | Requirements (No_requirements | Requires_no_prologue) ->
+           false)
+  ||
+  match Instruction_requirements.terminator block.terminator fun_name with
+  | Requires_prologue -> true
+  | No_requirements | Requires_no_prologue -> false
+
+let descendants (cfg : Cfg.t) (block : Cfg.basic_block) : Label.Set.t =
+  let visited = ref Label.Set.empty in
+  let rec collect label =
+    if not (Label.Set.mem label !visited)
+    then (
+      visited := Label.Set.add label !visited;
+      let block = Cfg.get_block_exn cfg label in
+      Label.Set.iter
+        (fun succ_label -> collect succ_label)
+        (Cfg.successor_labels ~normal:true ~exn:true block))
+  in
+  collect block.start;
+  !visited
+
+(* CR cfalas: move to Cfg_loop_infos? *)
+let is_in_loop : Cfg_loop_infos.t -> Label.t -> bool =
+ fun loops label ->
+  Cfg_edge.Map.exists
+    (fun _ (loop : Cfg_loop_infos.loop) -> Label.Set.mem label loop)
+    loops.loops
+
+let can_place_prologue (prologue_label : Label.t) (cfg : Cfg.t)
+    (doms : Cfg_dominators.t) (loop_infos : Cfg_loop_infos.t) =
+  let prologue_block = Cfg.get_block_exn cfg prologue_label in
+  (* Moving a prologue to a loop might cause it to execute multiple times, which
+     is both inefficient as well as makes handling the epilogue tricky to handle
+     (as we would have to know how many times the prologue was added).
+
+     Having a non-zero stack offset means that the prologue is added after a
+     [Pushtrap] or [Stackoffset] which shouldn't be allowed. *)
+  if is_in_loop loop_infos prologue_label || prologue_block.stack_offset <> 0
+  then false
+  else
+    let epilogue_blocks =
+      Label.Set.filter
+        (fun label ->
+          let block = Cfg.get_block_exn cfg label in
+          let fun_name = Cfg.fun_name cfg in
+          match
+            Instruction_requirements.terminator block.terminator fun_name
+          with
+          | Requires_no_prologue -> true
+          | No_requirements | Requires_prologue -> false)
+        (descendants cfg prologue_block)
+    in
+    (* Check that the blocks requiring an epilogue are dominated by the prologue
+       block. Consider the following CFG:
+
+     *  Block A: Condition with branch to Block B / C
+     *  Block B: Contains an instruction requiring a prologue, with 
+        terminator that jumps to Block C
+     *  Block C: Return
+
+       We have the choice of putting the prologue in Block A or B, and we would
+       place an epilogue in Block C.
+
+       If we try to place the prologue in block B, the prologue would not
+       dominate the epilogue in block C, so in some cases the epilogue would be
+       executed without a prologue on the stack, which would be illegal. *)
+    Label.Set.fold
+      (fun epilogue_label acc ->
+        if Cfg_dominators.is_dominating doms prologue_label epilogue_label
+        then acc
+        else false)
+      epilogue_blocks true
+
+let rec find_prologue_block (tree : Cfg_dominators.dominator_tree) (cfg : Cfg.t)
+    (doms : Cfg_dominators.t) (loop_infos : Cfg_loop_infos.t) =
+  let block = Cfg.get_block_exn cfg tree.label in
+  if prologue_needed_block block ~fun_name:cfg.fun_name
+  then Some tree.label
+  else
+    let children_prologue_block =
+      List.filter_map
+        (fun tree -> find_prologue_block tree cfg doms loop_infos)
+        tree.children
+    in
+    match children_prologue_block with
+    | [] -> None
+    | [child] ->
+      (* Only a single child needs a prologue, so will consider moving the
+         prologue to that child *)
+      if can_place_prologue child cfg doms loop_infos
+      then Some child
+      else Some tree.label
+    | _ ->
+      (* Multiple children need a prologue. We keep the prologue at the parent
+         to avoid duplication of the prologue. *)
+      Some tree.label
+
 let add_prologue_if_required : Cfg_with_layout.t -> Cfg_with_layout.t =
  fun cfg_with_layout ->
   let cfg = Cfg_with_layout.cfg cfg_with_layout in
-  let prologue_required =
-    Proc.prologue_required ~fun_contains_calls:cfg.fun_contains_calls
-      ~fun_num_stack_slots:cfg.fun_num_stack_slots
-  in
-  if prologue_required
-  then (
+  let doms = Cfg_dominators.build cfg in
+  (* note: the other entries in the forest are dead code *)
+  let tree = Cfg_dominators.dominator_tree_for_entry_point doms in
+  let loop_infos = Cfg_loop_infos.build cfg doms in
+  let prologue_block = find_prologue_block tree cfg doms loop_infos in
+  match prologue_block with
+  | None -> cfg_with_layout
+  | Some prologue_block ->
+    assert (can_place_prologue prologue_block cfg doms loop_infos);
     let terminator_as_basic terminator =
       { terminator with Cfg.desc = Cfg.Prologue }
     in
-    let entry_block = Cfg.get_block_exn cfg cfg.entry_label in
+    let prologue_block = Cfg.get_block_exn cfg prologue_block in
     let next_instr =
-      Option.value (DLL.hd entry_block.body)
-        ~default:(terminator_as_basic entry_block.terminator)
+      Option.value
+        (DLL.hd prologue_block.body)
+        ~default:(terminator_as_basic prologue_block.terminator)
     in
-    DLL.add_begin entry_block.body
+    DLL.add_begin prologue_block.body
       (Cfg.make_instruction_from_copy next_instr ~desc:Cfg.Prologue
          ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
          ());
@@ -131,13 +238,16 @@ let add_prologue_if_required : Cfg_with_layout.t -> Cfg_with_layout.t =
            ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
            ())
     in
-    Cfg.iter_blocks cfg ~f:(fun _label block ->
+    Label.Set.iter
+      (fun label ->
+        let block = Cfg.get_block_exn cfg label in
         match
           Instruction_requirements.terminator block.terminator cfg.fun_name
         with
         | Requires_no_prologue -> add_epilogue block
-        | No_requirements | Requires_prologue -> ()));
-  cfg_with_layout
+        | No_requirements | Requires_prologue -> ())
+      (descendants cfg prologue_block);
+    cfg_with_layout
 
 module Validator = struct
   type state =

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -130,13 +130,6 @@ let descendants (cfg : Cfg.t) (block : Cfg.basic_block) : Label.Set.t =
   collect block.start;
   !visited
 
-(* CR cfalas: move to Cfg_loop_infos? *)
-let is_in_loop : Cfg_loop_infos.t -> Label.t -> bool =
- fun loops label ->
-  Cfg_edge.Map.exists
-    (fun _ (loop : Cfg_loop_infos.loop) -> Label.Set.mem label loop)
-    loops.loops
-
 let can_place_prologue (prologue_label : Label.t) (cfg : Cfg.t)
     (doms : Cfg_dominators.t) (loop_infos : Cfg_loop_infos.t) =
   let prologue_block = Cfg.get_block_exn cfg prologue_label in
@@ -146,7 +139,8 @@ let can_place_prologue (prologue_label : Label.t) (cfg : Cfg.t)
 
      Having a non-zero stack offset means that the prologue is added after a
      [Pushtrap] or [Stackoffset] which shouldn't be allowed. *)
-  if is_in_loop loop_infos prologue_label || prologue_block.stack_offset <> 0
+  if Cfg_loop_infos.is_in_loop loop_infos prologue_label
+     || prologue_block.stack_offset <> 0
   then false
   else
     let epilogue_blocks =

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -104,7 +104,7 @@ module Instruction_requirements = struct
 end
 
 let prologue_needed_block (block : Cfg.basic_block) ~fun_name =
-  block.is_trap_handler
+  Config.with_frame_pointers || block.is_trap_handler
   || DLL.exists block.Cfg.body ~f:(fun instr ->
          match Instruction_requirements.basic instr with
          | Requirements Requires_prologue -> true

--- a/backend/regalloc/regalloc_split_state.ml
+++ b/backend/regalloc/regalloc_split_state.ml
@@ -468,13 +468,6 @@ module RemoveDominatedSpillsForConstants : sig
     destructions_at_end:destructions_at_end ->
     destructions_at_end
 end = struct
-  (* CR-someday xclerc for xclerc: move to Cfg_loop_infos? *)
-  let is_in_loop : Cfg_loop_infos.t -> Label.t -> bool =
-   fun loops label ->
-    Cfg_edge.Map.exists
-      (fun _ (loop : Cfg_loop_infos.loop) -> Label.Set.mem label loop)
-      loops.loops
-
   type set =
     | At_most_once
     | Maybe_more_than_once
@@ -597,7 +590,7 @@ end = struct
     let num_sets =
       Cfg_with_infos.fold_blocks cfg_with_infos ~init:(Reg.Tbl.create 123)
         ~f:(fun label block acc ->
-          let in_loop : bool = is_in_loop loops label in
+          let in_loop : bool = Cfg_loop_infos.is_in_loop loops label in
           if debug then log "block %a in_loop? %B" Label.format label in_loop;
           incr_set acc block.terminator.res ~in_loop;
           DLL.iter block.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -144,6 +144,17 @@ let mk_no_cfg_prologue_validate f =
     Arg.Unit f,
     " Do not validate prologues added to CFG" )
 
+let mk_cfg_prologue_shrink_wrap f =
+  ( "-cfg-prologue-shrink-wrap",
+    Arg.Unit f,
+    " Place prologues optimally in the CFG to minimise unnecessary prologue \
+     executions" )
+
+let mk_no_cfg_prologue_shrink_wrap f =
+  ( "-no-cfg-prologue-shrink-wrap",
+    Arg.Unit f,
+    " Place prologues at the entrypoint of the CFG" )
+
 let mk_reorder_blocks_random f =
   ( "-reorder-blocks-random",
     Arg.Int f,
@@ -933,6 +944,8 @@ module type Oxcaml_options = sig
   val no_cfg_eliminate_dead_trap_handlers : unit -> unit
   val cfg_prologue_validate : unit -> unit
   val no_cfg_prologue_validate : unit -> unit
+  val cfg_prologue_shrink_wrap : unit -> unit
+  val no_cfg_prologue_shrink_wrap : unit -> unit
   val reorder_blocks_random : int -> unit
   val basic_block_sections : unit -> unit
   val module_entry_functions_section : unit -> unit
@@ -1062,6 +1075,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
         F.no_cfg_eliminate_dead_trap_handlers;
       mk_cfg_prologue_validate F.cfg_prologue_validate;
       mk_no_cfg_prologue_validate F.no_cfg_prologue_validate;
+      mk_cfg_prologue_shrink_wrap F.cfg_prologue_shrink_wrap;
+      mk_no_cfg_prologue_shrink_wrap F.no_cfg_prologue_shrink_wrap;
       mk_reorder_blocks_random F.reorder_blocks_random;
       mk_basic_block_sections F.basic_block_sections;
       mk_module_entry_functions_section F.module_entry_functions_section;
@@ -1225,6 +1240,8 @@ module Oxcaml_options_impl = struct
 
   let cfg_prologue_validate = set' Oxcaml_flags.cfg_prologue_validate
   let no_cfg_prologue_validate = clear' Oxcaml_flags.cfg_prologue_validate
+  let cfg_prologue_shrink_wrap = set' Oxcaml_flags.cfg_prologue_shrink_wrap
+  let no_cfg_prologue_shrink_wrap = clear' Oxcaml_flags.cfg_prologue_shrink_wrap
 
   let reorder_blocks_random seed =
     Oxcaml_flags.reorder_blocks_random := Some seed
@@ -1626,6 +1643,7 @@ module Extra_params = struct
     | "cfg-eliminate-dead-trap-handlers" ->
         set' Oxcaml_flags.cfg_eliminate_dead_trap_handlers
     | "cfg-prologue-validate" -> set' Oxcaml_flags.cfg_prologue_validate
+    | "cfg-prologue-shrink-wrap" -> set' Oxcaml_flags.cfg_prologue_shrink_wrap
     | "dump-inlining-paths" -> set' Oxcaml_flags.dump_inlining_paths
     | "davail" -> set' Oxcaml_flags.davail
     | "dranges" -> set' Oxcaml_flags.dranges

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -155,6 +155,11 @@ let mk_no_cfg_prologue_shrink_wrap f =
     Arg.Unit f,
     " Place prologues at the entrypoint of the CFG" )
 
+let mk_cfg_prologue_shrink_wrap_threshold f =
+  ( "-cfg-prologue-shrink-wrap-threshold",
+    Arg.Int f,
+    "<n>  Only CFGs with fewer than n blocks will be shrink-wrapped" )
+
 let mk_reorder_blocks_random f =
   ( "-reorder-blocks-random",
     Arg.Int f,
@@ -946,6 +951,7 @@ module type Oxcaml_options = sig
   val no_cfg_prologue_validate : unit -> unit
   val cfg_prologue_shrink_wrap : unit -> unit
   val no_cfg_prologue_shrink_wrap : unit -> unit
+  val cfg_prologue_shrink_wrap_threshold : int -> unit
   val reorder_blocks_random : int -> unit
   val basic_block_sections : unit -> unit
   val module_entry_functions_section : unit -> unit
@@ -1077,6 +1083,7 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_no_cfg_prologue_validate F.no_cfg_prologue_validate;
       mk_cfg_prologue_shrink_wrap F.cfg_prologue_shrink_wrap;
       mk_no_cfg_prologue_shrink_wrap F.no_cfg_prologue_shrink_wrap;
+      mk_cfg_prologue_shrink_wrap_threshold F.cfg_prologue_shrink_wrap_threshold;
       mk_reorder_blocks_random F.reorder_blocks_random;
       mk_basic_block_sections F.basic_block_sections;
       mk_module_entry_functions_section F.module_entry_functions_section;
@@ -1231,6 +1238,9 @@ module Oxcaml_options_impl = struct
 
   let cfg_stack_checks_threshold n =
     Oxcaml_flags.cfg_stack_checks_threshold := n
+
+  let cfg_prologue_shrink_wrap_threshold n =
+    Oxcaml_flags.cfg_prologue_shrink_wrap_threshold := n
 
   let cfg_eliminate_dead_trap_handlers =
     set' Oxcaml_flags.cfg_eliminate_dead_trap_handlers

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -49,6 +49,7 @@ module type Oxcaml_options = sig
   val no_cfg_prologue_validate : unit -> unit
   val cfg_prologue_shrink_wrap : unit -> unit
   val no_cfg_prologue_shrink_wrap : unit -> unit
+  val cfg_prologue_shrink_wrap_threshold : int -> unit
   val reorder_blocks_random : int -> unit
   val basic_block_sections : unit -> unit
   val module_entry_functions_section : unit -> unit

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -47,6 +47,8 @@ module type Oxcaml_options = sig
   val no_cfg_eliminate_dead_trap_handlers : unit -> unit
   val cfg_prologue_validate : unit -> unit
   val no_cfg_prologue_validate : unit -> unit
+  val cfg_prologue_shrink_wrap : unit -> unit
+  val no_cfg_prologue_shrink_wrap : unit -> unit
   val reorder_blocks_random : int -> unit
   val basic_block_sections : unit -> unit
   val module_entry_functions_section : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -37,7 +37,8 @@ let cfg_eliminate_dead_trap_handlers = ref false  (* -cfg-eliminate-dead-trap-ha
 
 let cfg_prologue_validate = ref false    (* -[no-]cfg-prologue-validate *)
 let cfg_prologue_shrink_wrap = ref false    (* -[no-]cfg-prologue-shrink-wrap *)
-let cfg_prologue_shrink_wrap_threshold = ref 16384 (* -cfg-prologue-shrink-wrap-threshold *)
+let cfg_prologue_shrink_wrap_threshold = ref 16384 
+                                       (* -cfg-prologue-shrink-wrap-threshold *)
 
 let reorder_blocks_random = ref None    (* -reorder-blocks-random seed *)
 let basic_block_sections = ref false    (* -basic-block-sections *)

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -37,6 +37,7 @@ let cfg_eliminate_dead_trap_handlers = ref false  (* -cfg-eliminate-dead-trap-ha
 
 let cfg_prologue_validate = ref false    (* -[no-]cfg-prologue-validate *)
 let cfg_prologue_shrink_wrap = ref false    (* -[no-]cfg-prologue-shrink-wrap *)
+let cfg_prologue_shrink_wrap_threshold = ref 16384 (* -cfg-prologue-shrink-wrap-threshold *)
 
 let reorder_blocks_random = ref None    (* -reorder-blocks-random seed *)
 let basic_block_sections = ref false    (* -basic-block-sections *)

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -36,6 +36,7 @@ let cfg_stack_checks_threshold = ref 16384 (* -cfg-stack-threshold *)
 let cfg_eliminate_dead_trap_handlers = ref false  (* -cfg-eliminate-dead-trap-handlers *)
 
 let cfg_prologue_validate = ref false    (* -[no-]cfg-prologue-validate *)
+let cfg_prologue_shrink_wrap = ref false    (* -[no-]cfg-prologue-shrink-wrap *)
 
 let reorder_blocks_random = ref None    (* -reorder-blocks-random seed *)
 let basic_block_sections = ref false    (* -basic-block-sections *)

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -38,6 +38,7 @@ val cfg_eliminate_dead_trap_handlers : bool ref
 
 val cfg_prologue_validate : bool ref
 val cfg_prologue_shrink_wrap : bool ref
+val cfg_prologue_shrink_wrap_threshold : int ref
 
 val reorder_blocks_random : int option ref
 val basic_block_sections : bool ref

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -37,6 +37,7 @@ val cfg_stack_checks_threshold : int ref
 val cfg_eliminate_dead_trap_handlers : bool ref
 
 val cfg_prologue_validate : bool ref
+val cfg_prologue_shrink_wrap : bool ref
 
 val reorder_blocks_random : int option ref
 val basic_block_sections : bool ref


### PR DESCRIPTION
Currently whenever a function prologue is required, it is emitted at the beginning of the entry block. This PR moves the function prologue as late in the CFG as possible without needing to duplicate it.

The process by which the position of the prologue is found is similar to the one used for stack-checks. Specifically, we traverse the dominator tree recursively, and move the prologue to a child if the following conditions hold:

- The parent node has precisely one child node which requires a prologue
- The child node is not in a loop
- The child node doesn't have a stack offset (a nonzero stack offset implies that we passed through a Pushtrap)
- The child node dominates all blocks where we would place an epilogue (see comment in `Cfg_prologue.can_place_prologue` for explanation)

### Testing

The validator introduced in #4521 passes when compiling a few large bodies of code. Additionally, as expected the number of prologues emitted when building the compiler is the same as when the change is not enabled (and the nuber of epilogues is less, as moving a prologue later will cause some of the epilogues to be removed):

```
   52067 prologues_shrink_off.txt
   52067 prologues_shrink_on.txt
  100919 epilogues_shrink_off.txt
   93734 epilogues_shrink_on.txt
```

These were counted with the patch at this commit c310187c60798cfecb254355cac1559d9556a5d0, and running a clean make install with and without `-cfg-prologue-shrink-wrap`