### PR TITLE
Fix loop computation for back edge

### DIFF
--- a/backend/cfg/cfg_loop_infos.ml
+++ b/backend/cfg/cfg_loop_infos.ml
@@ -52,18 +52,7 @@ type loops = loop Cfg_edge.Map.t
 let compute_loops_of_back_edges cfg back_edges =
   Cfg_edge.Set.fold
     (fun edge acc ->
-      let loop = compute_loop_of_back_edge cfg edge in
-      Label.Set.iter
-        (fun loop_label ->
-          match Label.equal loop_label edge.dst with
-          | true -> ()
-          | false ->
-            let loop_block = Cfg.get_block_exn cfg loop_label in
-            List.iter (Cfg.predecessor_labels loop_block)
-              ~f:(fun loop_predecessor ->
-                if not (Label.Set.mem loop_predecessor loop) then fatal "XXX"))
-        loop;
-      Cfg_edge.Map.add edge loop acc)
+      Cfg_edge.Map.add edge (compute_loop_of_back_edge cfg edge) acc)
     back_edges Cfg_edge.Map.empty
 
 type header_map = loop list Label.Map.t

--- a/backend/cfg/cfg_loop_infos.ml
+++ b/backend/cfg/cfg_loop_infos.ml
@@ -44,9 +44,7 @@ let compute_loop_of_back_edge cfg dominators { Cfg_edge.src; dst } =
       in
       visit stack acc
   in
-  if Label.equal src dst
-  then Label.Set.singleton src
-  else visit [src] (Label.Set.add src (Label.Set.singleton dst))
+  visit [src] (Label.Set.add src (Label.Set.singleton dst))
 
 type loops = loop Cfg_edge.Map.t
 

--- a/backend/cfg/cfg_loop_infos.ml
+++ b/backend/cfg/cfg_loop_infos.ml
@@ -27,7 +27,7 @@ let compute_back_edges cfg dominators =
 
 type loop = Label.Set.t
 
-let compute_loop_of_back_edge cfg { Cfg_edge.src; dst } =
+let compute_loop_of_back_edge cfg dominators { Cfg_edge.src; dst } =
   let rec visit stack acc =
     match stack with
     | [] -> acc
@@ -37,20 +37,23 @@ let compute_loop_of_back_edge cfg { Cfg_edge.src; dst } =
       let stack, acc =
         List.fold_left predecessor_labels ~init:(tl, acc)
           ~f:(fun (stack, acc) predecessor_label ->
-            if not (Label.Set.mem predecessor_label acc)
+            if (not (Label.Set.mem predecessor_label acc))
+               && Cfg_dominators.is_dominating dominators dst predecessor_label
             then predecessor_label :: stack, Label.Set.add predecessor_label acc
             else stack, acc)
       in
       visit stack acc
   in
-  visit [src] (Label.Set.add src (Label.Set.singleton dst))
+  if Label.equal src dst
+  then Label.Set.singleton src
+  else visit [src] (Label.Set.add src (Label.Set.singleton dst))
 
 type loops = loop Cfg_edge.Map.t
 
-let compute_loops_of_back_edges cfg back_edges =
+let compute_loops_of_back_edges cfg dominators back_edges =
   Cfg_edge.Set.fold
     (fun edge acc ->
-      Cfg_edge.Map.add edge (compute_loop_of_back_edge cfg edge) acc)
+      Cfg_edge.Map.add edge (compute_loop_of_back_edge cfg dominators edge) acc)
     back_edges Cfg_edge.Map.empty
 
 type header_map = loop list Label.Map.t
@@ -135,7 +138,7 @@ type t =
 let build : Cfg.t -> Cfg_dominators.t -> t =
  fun cfg doms ->
   let back_edges = compute_back_edges cfg doms in
-  let loops = compute_loops_of_back_edges cfg back_edges in
+  let loops = compute_loops_of_back_edges cfg doms back_edges in
   let header_map = compute_header_map loops in
   if debug then invariant_header_map doms header_map;
   let loop_depths = compute_loop_depths cfg header_map in

--- a/backend/cfg/cfg_loop_infos.mli
+++ b/backend/cfg/cfg_loop_infos.mli
@@ -6,14 +6,13 @@ type loop = Label.Set.t
 (* Blocks in a loop; if a node is part of several/nested loops, it will appear
    in several sets. *)
 
-val compute_loop_of_back_edge : Cfg.t -> Cfg_dominators.t -> Cfg_edge.t -> loop
+val compute_loop_of_back_edge : Cfg.t -> Cfg_edge.t -> loop
 (* Assumes the passed edge is a back edge. *)
 
 type loops = loop Cfg_edge.Map.t
 (* Map from back edge to loop. *)
 
-val compute_loops_of_back_edges :
-  Cfg.t -> Cfg_dominators.t -> Cfg_edge.Set.t -> loops
+val compute_loops_of_back_edges : Cfg.t -> Cfg_edge.Set.t -> loops
 (* Assumes the passed edges are back edges. *)
 
 type header_map = loop list Label.Map.t

--- a/backend/cfg/cfg_loop_infos.mli
+++ b/backend/cfg/cfg_loop_infos.mli
@@ -6,13 +6,14 @@ type loop = Label.Set.t
 (* Blocks in a loop; if a node is part of several/nested loops, it will appear
    in several sets. *)
 
-val compute_loop_of_back_edge : Cfg.t -> Cfg_edge.t -> loop
+val compute_loop_of_back_edge : Cfg.t -> Cfg_dominators.t -> Cfg_edge.t -> loop
 (* Assumes the passed edge is a back edge. *)
 
 type loops = loop Cfg_edge.Map.t
 (* Map from back edge to loop. *)
 
-val compute_loops_of_back_edges : Cfg.t -> Cfg_edge.Set.t -> loops
+val compute_loops_of_back_edges :
+  Cfg.t -> Cfg_dominators.t -> Cfg_edge.Set.t -> loops
 (* Assumes the passed edges are back edges. *)
 
 type header_map = loop list Label.Map.t


### PR DESCRIPTION
While working on https://github.com/oxcaml/oxcaml/pull/4544, @cfalas stumbled on
a bug in the computation of a loop from a back
edge. The current code assumes that the destination
of the back edge dominates all predecessors of
the source of the back edge, but that is not always
true. A trivial counterexample is a loop reduced
to a single block.

I have checked the few uses of loop infos, and
don't think the bug can have very bad effects:
we may think more blocks are in a loop, but that
will essentially prevent some optimizations to
trigger. (The default computation of spilling
costs used by all register allocators does not
use the information about loops.)

The fix in this pull request is to move from
predecessor to predecessor only if the block
is dominated by the back edge's destination.
The condition checking whether it is a loop of
only one block is not strictly necessary, but the
shortcut does not hurt.
