### PR TITLE
Preserve levels in `Typeopt.value_kind`

### DIFF
--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -390,7 +390,8 @@ let _ =fun a b -> match a, b with
 (function {nlocal = 0} a/360[value<int>]
   b/361[value<
          (consts (0))
-          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+          (non_consts ([0:
+                        value<(consts ()) (non_consts ([0: value<int>, *]))>]))>]
   : (consts ())
      (non_consts ([0: value<int>, value<(consts (0)) (non_consts ([0: *]))>]))
   (catch
@@ -408,7 +409,8 @@ let _ =fun a b -> match a, b with
 (function {nlocal = 0} a/360[value<int>]
   b/361[value<
          (consts (0))
-          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+          (non_consts ([0:
+                        value<(consts ()) (non_consts ([0: value<int>, *]))>]))>]
   : (consts ())
      (non_consts ([0: value<int>, value<(consts (0)) (non_consts ([0: *]))>]))
   (catch (if a/360 (if b/361 (field_imm 0 b/361) (exit 12)) (exit 12))
@@ -424,7 +426,8 @@ let _ = fun a b -> match a, b with
 (function {nlocal = 0} a/364[value<int>]
   b/365[value<
          (consts (0))
-          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+          (non_consts ([0:
+                        value<(consts ()) (non_consts ([0: value<int>, *]))>]))>]
   : (consts ())
      (non_consts ([0: value<int>, value<(consts (0)) (non_consts ([0: *]))>]))
   (catch
@@ -449,7 +452,8 @@ let _ = fun a b -> match a, b with
 (function {nlocal = 0} a/364[value<int>]
   b/365[value<
          (consts (0))
-          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+          (non_consts ([0:
+                        value<(consts ()) (non_consts ([0: value<int>, *]))>]))>]
   : (consts ())
      (non_consts ([0: value<int>, value<(consts (0)) (non_consts ([0: *]))>]))
   (catch

--- a/testsuite/tests/flambda2/examples/array_specialisation_examples.simplify.reference
+++ b/testsuite/tests/flambda2/examples/array_specialisation_examples.simplify.reference
@@ -11,7 +11,7 @@ let code loopify(never) size(22) newer_version_of(f_0)
       f_0_1 (arr : val array)
         my_closure _region _ghost_region my_depth
         -> k * k1
-        : [ 0 | 0 of val ] =
+        : [ 0 | 0 of imm tagged ] =
   (let prim = %array_length.generic (arr) in
    let prim_1 = %int_comp.unsigned.lt (0, prim) in
    switch prim_1
@@ -25,10 +25,10 @@ let code loopify(never) size(22) newer_version_of(f_0)
 in
 let $camlArray_specialisation_examples__f_4 = closure f_0_1 @f in
 let code loopify(never) size(8) newer_version_of(g_1)
-      g_1_1 (x : [ 0 | 0 of val ])
+      g_1_1 (x : [ 0 | 0 of imm tagged ])
         my_closure _region _ghost_region my_depth
         -> k * k1
-        : [ 0 | 0 of val ] =
+        : [ 0 | 0 of imm tagged ] =
   let a = %array.mut (x) in
   let ifnot_result = %array_load.mut (a, 0) in
   cont k (ifnot_result)

--- a/testsuite/tests/flambda2/examples/from_odoc_texi.simplify.reference
+++ b/testsuite/tests/flambda2/examples/from_odoc_texi.simplify.reference
@@ -37,7 +37,7 @@ let $camlFrom_odoc_texi__foo_3 = closure foo_1_1 @foo in
           in
           let Pmakeblock_1 = %block.[`0`] (Pmakeblock, 0) in
           cont k (Pmakeblock_1)))
-  where k (y : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+  where k (y : [ 0 | 0 of [ 0 of val * val ] * [ 0 | 0 of val * val ] ]) =
     let $camlFrom_odoc_texi =
       Block 0 ($`camlFrom_odoc_texi__!_2`,
                esc_8bits,

--- a/testsuite/tests/flambda2/examples/partial_closure.simplify.reference
+++ b/testsuite/tests/flambda2/examples/partial_closure.simplify.reference
@@ -1,6 +1,8 @@
 let code foo_1 deleted in
 let code loopify(never) size(17) newer_version_of(foo_1)
-      foo_1_1 (x : imm tagged, y : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+      foo_1_1
+        (x : imm tagged,
+         y : [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ])
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =

--- a/testsuite/tests/flambda2/examples/tests.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests.raw.reference
@@ -10,8 +10,8 @@ let $camlTests__first_const = Block 0 () in
  let code size(79)
        f_1
          (c : imm tagged,
-          m : [ 0 | 0 of val ],
-          n : [ 0 | 0 of val ],
+          m : [ 0 | 0 of imm tagged ],
+          n : [ 0 | 0 of imm tagged ],
           x' : imm tagged,
           y' : imm tagged)
          my_closure _region _ghost_region my_depth

--- a/testsuite/tests/flambda2/examples/tests.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests.simplify.reference
@@ -11,8 +11,8 @@ let $camlTests__to_inline_2 = closure to_inline_0_1 @to_inline in
 let code loopify(never) size(22) newer_version_of(f_1)
       f_1_1
         (c : imm tagged,
-         m : [ 0 | 0 of val ],
-         n : [ 0 | 0 of val ],
+         m : [ 0 | 0 of imm tagged ],
+         n : [ 0 | 0 of imm tagged ],
          x' : imm tagged,
          y' : imm tagged)
         my_closure _region _ghost_region my_depth

--- a/testsuite/tests/flambda2/examples/unknown/alt_ergo.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/alt_ergo.simplify.reference
@@ -114,7 +114,7 @@ let code loopify(never) size(45) newer_version_of(inv_3) tupled
       inv_3_1 (param : [ 0 | 0 of val * val ], param_1, param_2)
         my_closure _region _ghost_region my_depth
         -> k * k1
-        : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
+        : [ 0 | 0 of [ 0 of val * val ] * [ 0 | 0 of val * val ] ] =
   let prim = %is_int (param) in
   switch prim
     | 0 -> k2
@@ -154,10 +154,13 @@ let code loopify(never) size(11) newer_version_of(div_4)
    let tuple_field_1 = %block_load.tag[`0`].`size`[`3`].[`1`] (i2) in
    let tuple_field_2 = %block_load.tag[`0`].`size`[`3`].[`2`] (i2) in
    apply direct(inv_3_1)
-     ($camlAlt_ergo__inv_8 : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+     ($camlAlt_ergo__inv_8
+      : _ -> [ 0 | 0 of [ 0 of val * val ] * [ 0 | 0 of val * val ] ])
        (tuple_field, tuple_field_1, tuple_field_2)
        -> k3 * k1
-     where k3 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+     where k3
+             (param :
+                [ 0 | 0 of [ 0 of val * val ] * [ 0 | 0 of val * val ] ]) =
        cont k2)
     where k2 =
       cont k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock106)

--- a/testsuite/tests/flambda2/examples/unknown/emitcode_repro.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/emitcode_repro.simplify.reference
@@ -58,12 +58,20 @@ let code loopify(never) size(50) newer_version_of(emit_instr_1)
 in
 let $camlEmitcode_repro__emit_instr_4 = closure emit_instr_1_1 @emit_instr in
 let code loopify(done) size(121) newer_version_of(emit_2)
-      emit_2_1 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+      emit_2_1
+        (param :
+           [ 0
+           | 0 of [ 0 |1 | 0 of imm tagged |1 of imm tagged ] *
+               [ 0 | 0 of val * val ] ])
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
   cont self (param)
-    where rec self (param_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+    where rec self
+                (param_1 :
+                   [ 0
+                   | 0 of [ 0 |1 | 0 of imm tagged |1 of imm tagged ] *
+                       [ 0 | 0 of val * val ] ]) =
       let `region` = %begin_region () in
       let ghost_region = %begin_ghost_region () in
       ((let prim = %is_int (param_1) in

--- a/testsuite/tests/flambda2/examples/unknown/eol_detect.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/eol_detect.simplify.reference
@@ -1,6 +1,6 @@
 let code f_0 deleted in
 let code loopify(never) size(48) newer_version_of(f_0)
-      f_0_1 (read : val, x : [ 0 | 0 of val ])
+      f_0_1 (read : val, x : [ 0 | 0 of imm tagged ])
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =

--- a/testsuite/tests/flambda2/examples/unknown/gadt_meet.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/gadt_meet.simplify.reference
@@ -40,7 +40,7 @@ let code loopify(never) size(44) newer_version_of(test_3)
       test_3_1 (x)
         my_closure _region _ghost_region my_depth
         -> k * k1
-        : [ 0 | 0 of val ] =
+        : [ 0 | 0 of [ 0 of val * val ] ] =
   apply direct(f_1_1)
     ($camlGadt_meet__f_6 : _ -> [ 0 of [ 0 of imm tagged ] |1 of imm tagged ]
      )
@@ -68,7 +68,7 @@ let code loopify(never) size(44) newer_version_of(test_3)
                      cont k (Pmakeblock_1))))
 in
 let $camlGadt_meet__test_8 = closure test_3_1 @test in
-let $camlGadt_meet__Pmakeblock146 =
+let $camlGadt_meet__Pmakeblock149 =
   Block 0 ($`*predef*`.caml_exn_Failure, $camlGadt_meet__immstring59)
 in
 let code loopify(never) size(17) newer_version_of(foo_4)
@@ -77,12 +77,14 @@ let code loopify(never) size(17) newer_version_of(foo_4)
         -> k * k1
         : [ 0 of imm tagged * [ 0 of val |1 of imm tagged ] ] =
   apply direct(test_3_1)
-    ($camlGadt_meet__test_8 : _ -> [ 0 | 0 of val ]) (0) -> k2 * k1
-    where k2 (`*match*` : [ 0 | 0 of val ]) =
+    ($camlGadt_meet__test_8 : _ -> [ 0 | 0 of [ 0 of imm tagged * val ] ])
+      (0)
+      -> k2 * k1
+    where k2 (`*match*` : [ 0 | 0 of [ 0 of imm tagged * val ] ]) =
       let prim = %is_int (`*match*`) in
       (switch prim
          | 0 -> k2
-         | 1 -> k1 pop(reraise k1) ($camlGadt_meet__Pmakeblock146)
+         | 1 -> k1 pop(reraise k1) ($camlGadt_meet__Pmakeblock149)
          where k2 =
            let Pfield = %block_load.[`0`] (`*match*`) in
            cont k (Pfield))

--- a/testsuite/tests/flambda2/examples/unknown/includecore_repro.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/includecore_repro.simplify.reference
@@ -11,7 +11,7 @@ let code inline(never) loopify(never) size(160) newer_version_of(f_0)
            [ 0 of [ 0 |1 | 0 of imm tagged * imm tagged |1 of imm tagged ] ])
         my_closure _region _ghost_region my_depth
         -> k * k1
-        : [ 0 | 0 of val ] =
+        : [ 0 | 0 of [ 0 of imm tagged * imm tagged ] ] =
   let `*match*` = %block_load.[`0`] (x) in
   let `*match*_1` = %block_load.[`0`] (y) in
   (let prim = %is_int (`*match*_1`) in
@@ -90,11 +90,12 @@ let code inline(never) loopify(never) size(160) newer_version_of(f_0)
 in
 let $camlIncludecore_repro__f_1 = closure f_0_1 @f in
 apply direct(f_0_1)
-  ($camlIncludecore_repro__f_1 : _ -> [ 0 | 0 of val ])
+  ($camlIncludecore_repro__f_1
+   : _ -> [ 0 | 0 of [ 0 of imm tagged * imm tagged ] ])
     ($camlIncludecore_repro__const_block61,
      $camlIncludecore_repro__const_block61)
     -> k1 * error
-  where k1 (param : [ 0 | 0 of val ]) =
+  where k1 (param : [ 0 | 0 of [ 0 of imm tagged * imm tagged ] ]) =
     cont k
   where k =
     let $camlIncludecore_repro = Block 0 ($camlIncludecore_repro__f_1) in

--- a/testsuite/tests/flambda2/examples/unknown/local.raw.reference
+++ b/testsuite/tests/flambda2/examples/unknown/local.raw.reference
@@ -5,7 +5,7 @@
        return_local_0 (param : imm tagged)
          my_closure my_region my_ghost_region my_depth
          -> k1 * k2
-         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
+         : [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ] local =
    let next_depth = rec_info (succ my_depth) in
    cont k1 ($camlLocal__const_block15)
  in
@@ -156,7 +156,7 @@
          (break_here : val, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
          my_closure my_region my_ghost_region my_depth
          -> k1 * k2
-         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
+         : [ 0 | 0 of [ 0 | 0 of val * val ] * [ 0 | 0 of val * val ] ] local =
    let next_depth = rec_info (succ my_depth) in
    let rev_app = %project_value_slot.[`spans`].[`rev_app`] (my_closure) in
    let find_span =
@@ -182,12 +182,17 @@
             ((let Pfield = %block_load.[`1`] (`*match*`) in
               apply direct(spans_5 &my_region &my_ghost_region)
                 (my_closure ~ depth my_depth -> next_depth
-                 : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+                 : _ ->
+                   [ 0 | 0 of [ 0 | 0 of val * val ] * [ 0 | 0 of val * val ]
+                   ]
+                 )
                   (break_here, Pfield)
                   -> k3 * k2)
                where k3
                        (apply_result :
-                          [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+                          [ 0
+                          | 0 of [ 0 | 0 of val * val ] *
+                              [ 0 | 0 of val * val ] ]) =
                  ((let Pfield = %block_load.[`0`] (`*match*`) in
                    apply direct(rev_app_4 &my_region &my_ghost_region)
                      (rev_app
@@ -266,10 +271,13 @@
      ((let `region` = %begin_region () in
        let ghost_region = %begin_ghost_region () in
        apply direct(return_local_0 &`region` &ghost_region)
-         (return_local : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+         (return_local
+          : _ -> [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ])
            (0)
            -> k5 * error
-         where k5 (apply_result : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+         where k5
+                 (apply_result :
+                    [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ]) =
            apply direct(length_2) unroll(3)
              (length : _ -> imm tagged) (apply_result) -> k4 * error
          where k4 (apply_result : imm tagged) =
@@ -291,20 +299,32 @@
           ((let `region` = %begin_region () in
             let ghost_region = %begin_ghost_region () in
             apply direct(return_local_0 &`region` &ghost_region)
-              (return_local : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+              (return_local
+               : _ -> [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ]
+               )
                 (0)
                 -> k3 * error
-              where k3 (ns : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+              where k3
+                      (ns :
+                         [ 0
+                         | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ]) =
                 ((let `fn[local.ml:32,27--43]` =
                     closure `fn[local.ml:32,27--43]_3`
                       @`fn[local.ml:32,27--43]`
                   in
                   apply direct(map_local_1 &`region` &ghost_region)
                     (map_local
-                     : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+                     : _ ->
+                       [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ]
+                       ]
+                     )
                       (`fn[local.ml:32,27--43]`, ns)
                       -> k3 * error)
-                   where k3 (ms : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+                   where k3
+                           (ms :
+                              [ 0
+                              | 0 of imm tagged *
+                                  [ 0 | 0 of imm tagged * val ] ]) =
                      (apply direct(length_2)
                         (length : _ -> imm tagged) (ms) -> k4 * error
                         where k4 (apply_result : imm tagged) =
@@ -334,12 +354,19 @@
                ((let `region` = %begin_region () in
                  let ghost_region = %begin_ghost_region () in
                  apply direct(spans_5 &`region` &ghost_region)
-                   (spans : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+                   (spans
+                    : _ ->
+                      [ 0
+                      | 0 of [ 0 | 0 of imm tagged * val ] *
+                          [ 0 | 0 of val * val ] ]
+                    )
                      (is_even, $camlLocal__const_block176)
                      -> k3 * error
                    where k3
                            (even_spans :
-                              [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+                              [ 0
+                              | 0 of [ 0 | 0 of imm tagged * val ] *
+                                  [ 0 | 0 of val * val ] ]) =
                      (apply direct(length_2)
                         (length : _ -> imm tagged) (even_spans) -> k4 * error
                         where k4 (apply_result : imm tagged) =

--- a/testsuite/tests/flambda2/examples/unknown/local.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/local.simplify.reference
@@ -36,7 +36,7 @@ let code loopify(never) size(1) newer_version_of(return_local_0)
       return_local_0_1 (param : imm tagged)
         my_closure my_region my_ghost_region my_depth
         -> k * k1
-        : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
+        : [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ] local =
   cont k ($camlLocal__const_block15)
 in
 let $camlLocal__return_local_8 = closure return_local_0_1 @return_local in
@@ -129,11 +129,14 @@ apply direct(length_2_1)
            in
            apply direct(map_local_1_1 &`region` &ghost_region)
              ($camlLocal__map_local_9
-              : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+              : _ -> [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ])
                ($`camlLocal__fn[local.ml:32,27--43]_11`,
                 $camlLocal__const_block15)
                -> k1 * error)
-            where k1 (ms : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+            where k1
+                    (ms :
+                       [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ]
+                       ]) =
               (apply direct(length_2_1)
                  ($camlLocal__length_10 : _ -> imm tagged) (ms) -> k1 * error
                  where k1 (apply_result : imm tagged) =
@@ -230,7 +233,9 @@ apply direct(length_2_1)
                        l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                       my_closure my_region my_ghost_region my_depth
                       -> k * k1
-                      : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
+                      : [ 0
+                        | 0 of [ 0 | 0 of val * val ] *
+                            [ 0 | 0 of val * val ] ] local =
                 let prim = %is_int (l) in
                 switch prim
                   | 0 -> k2
@@ -254,14 +259,17 @@ apply direct(length_2_1)
                                   &my_region &my_ghost_region)
                              ($camlLocal__spans_13 ~ depth my_depth -> succ my_depth
                               : _ ->
-                                [ 0 | 0 of val * [ 0 | 0 of val * val ] ]
+                                [ 0
+                                | 0 of [ 0 | 0 of val * val ] *
+                                    [ 0 | 0 of val * val ] ]
                               )
                                (break_here, Pfield)
                                -> k2 * k1)
                             where k2
                                     (apply_result :
                                        [ 0
-                                       | 0 of val * [ 0 | 0 of val * val ] ]) =
+                                       | 0 of [ 0 | 0 of val * val ] *
+                                           [ 0 | 0 of val * val ] ]) =
                               ((let Pfield = %block_load.[`0`] (`*match*`) in
                                 apply
                                        direct(rev_app_4_1
@@ -299,12 +307,18 @@ apply direct(length_2_1)
               let ghost_region_1 = %begin_ghost_region () in
               (apply direct(spans_5_1 &region_1 &ghost_region_1)
                  ($camlLocal__spans_13
-                  : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+                  : _ ->
+                    [ 0
+                    | 0 of [ 0 | 0 of imm tagged * val ] *
+                        [ 0 | 0 of val * val ] ]
+                  )
                    ($camlLocal__is_even_15, $camlLocal__const_block176)
                    -> k1 * error
                  where k1
                          (even_spans :
-                            [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+                            [ 0
+                            | 0 of [ 0 | 0 of imm tagged * val ] *
+                                [ 0 | 0 of val * val ] ]) =
                    (apply direct(length_2_1)
                       ($camlLocal__length_10 : _ -> imm tagged)
                         (even_spans)

--- a/testsuite/tests/flambda2/examples/unknown/protect_refs.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/protect_refs.simplify.reference
@@ -41,7 +41,8 @@ let $`camlProtect_refs__fn[protect_refs.ml:28,24--50]_8` =
 in
 let code loopify(never) size(11) newer_version_of(`fn[protect_refs.ml:29,2--43]_3`)
       `fn[protect_refs.ml:29,2--43]_3_1`
-        (refs : [ 0 | 0 of val * [ 0 | 0 of val * val ] ], f : val)
+        (refs : [ 0 | 0 of [ 0 of val * val ] * [ 0 | 0 of val * val ] ],
+         f : val)
         my_closure _region _ghost_region my_depth
         -> k * k1 =
   apply direct(iter_0_1) inlining_state(depth(10))

--- a/testsuite/tests/flambda2/examples/wrong/opt_flags.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/opt_flags.simplify.reference
@@ -21,6 +21,6 @@ let $camlOpt_flags__immstring26 = "foo" in
       | 0 -> k (99)
       | 1 -> k (-1)
   where k (y : imm tagged) =
-    let $camlOpt_flags__Pmakeblock138 = Block 0 (42, y, 1701) in
-    let $camlOpt_flags = Block 0 ($camlOpt_flags__Pmakeblock138) in
+    let $camlOpt_flags__Pmakeblock139 = Block 0 (42, y, 1701) in
+    let $camlOpt_flags = Block 0 ($camlOpt_flags__Pmakeblock139) in
     cont done ($camlOpt_flags)

--- a/testsuite/tests/flambda2/examples/wrong/static.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/static.simplify.reference
@@ -25,7 +25,9 @@ let code loopify(never) size(10) newer_version_of(h_2)
       cont k (int_add_1)
 in
 let code loopify(never) size(58) newer_version_of(f_0)
-      f_0_1 (x : imm tagged, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+      f_0_1
+        (x : imm tagged,
+         l : [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ])
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =

--- a/testsuite/tests/match-side-effects/partiality.ml
+++ b/testsuite/tests/match-side-effects/partiality.ml
@@ -89,7 +89,7 @@ let f r =
      (function {nlocal = 0} r/311 : int
        (region
          (let
-           (*match*/313 =[value<(consts (0)) (non_consts ([0: ?]))>]
+           (*match*/313 =[value<(consts (0)) (non_consts ([0: *]))>]
               (makelocalblock 0 (*) r/311))
            (catch
              (if *match*/313
@@ -125,8 +125,13 @@ type _ t = Int : int -> int t | Bool : bool -> bool t
 (let
   (test/321 =
      (function {nlocal = 0}
-       param/324[value<(consts (0)) (non_consts ([0: ?]))>] : int
-       (if param/324 (field_imm 0 (field_imm 0 param/324)) 0)))
+       param/324[value<
+                  (consts (0))
+                   (non_consts ([0:
+                                 value<
+                                  (consts ()) (non_consts ([1: value<int>]
+                                   [0: value<int>]))>]))>]
+       : int (if param/324 (field_imm 0 (field_imm 0 param/324)) 0)))
   (apply (field_imm 1 (global Toploop!)) "test" test/321))
 val test : int t option -> int = <fun>
 |}]
@@ -174,7 +179,12 @@ type _ t = Int : int -> int t | Bool : bool -> bool t
      (function {nlocal = 0} n/338? : int
        (region
          (let
-           (*match*/341 =[value<(consts (0)) (non_consts ([0: ?]))>]
+           (*match*/341 =[value<
+                           (consts (0))
+                            (non_consts ([0:
+                                          value<
+                                           (consts ())
+                                            (non_consts ([0: *, *]))>]))>]
               (makelocalblock 0 (value<
                                   (consts ())
                                    (non_consts ([0: *,

--- a/testsuite/tests/match-side-effects/test_contexts_code.ml
+++ b/testsuite/tests/match-side-effects/test_contexts_code.ml
@@ -33,13 +33,14 @@ let example_1 () =
 (let
   (example_1/305 =
      (function {nlocal = 0} param/329[value<int>]
-       : (consts ()) (non_consts ([1: ?] [0: ?]))
+       : (consts ()) (non_consts ([1: value<int>] [0: value<int>]))
        (region
          (let
            (input/307 =
               (makelocalmutable 0 (value<int>,value<
                                                (consts ())
-                                                (non_consts ([1: ?] [0: ?]))>)
+                                                (non_consts ([1: value<int>]
+                                                [0: value<int>]))>)
                 1 [0: 1]))
            (if (field_int 0 input/307)
              (let (*match*/332 =o? (field_mut 1 input/307))
@@ -82,14 +83,15 @@ let example_2 () =
 (let
   (example_2/344 =
      (function {nlocal = 0} param/348[value<int>]
-       : (consts ()) (non_consts ([1: ?] [0: ?]))
+       : (consts ()) (non_consts ([1: value<int>] [0: value<int>]))
        (region
          (let
            (input/346 =[value<(consts ()) (non_consts ([0: value<int>, *]))>]
               (makelocalblock 0 (value<int>,*) 1
                 (makelocalmutable 0 (value<
-                                      (consts ()) (non_consts ([1: ?]
-                                       [0: ?]))>)
+                                      (consts ())
+                                       (non_consts ([1: value<int>]
+                                       [0: value<int>]))>)
                   [0: 1])))
            (if (field_int 0 input/346)
              (let (*match*/352 =o? (field_mut 0 (field_imm 1 input/346)))
@@ -135,15 +137,16 @@ let example_3 () =
 (let
   (example_3/362 =
      (function {nlocal = 0} param/366[value<int>]
-       : (consts ()) (non_consts ([1: ?] [0: ?]))
+       : (consts ()) (non_consts ([1: value<int>] [0: value<int>]))
        (region
          (let
            (input/364 =mut[value<
                             (consts ())
                              (non_consts ([0: value<int>,
                                            value<
-                                            (consts ()) (non_consts (
-                                             [1: ?] [0: ?]))>]))>]
+                                            (consts ())
+                                             (non_consts ([1: value<int>]
+                                             [0: value<int>]))>]))>]
               [0: 1 [0: 1]]
             *match*/367 =o? *input/364)
            (if (field_imm 0 *match*/367)

--- a/testsuite/tests/tmc/readable_output.ml
+++ b/testsuite/tests/tmc/readable_output.ml
@@ -75,32 +75,50 @@ let[@tail_mod_cons] rec rec_map f = function
 (letrec
   (rec_map
      (function {nlocal = 0} f
-       param[value<(consts (0)) (non_consts ([0: ?]))>] tail_mod_cons
-       : (consts (0)) (non_consts ([0: ?]))
+       param[value<
+              (consts (0))
+               (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+       tail_mod_cons
+       : (consts (0))
+          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))
        (if param
          (let (*match* =a? (field_imm 0 param))
            (makeblock 0 (value<
                           (consts ())
                            (non_consts ([0: *,
                                          value<
-                                          (consts (0)) (non_consts ([0: ?]))>]))>)
+                                          (consts (0)) (non_consts ([0: *]))>]))>)
              (let
                (block =
-                  (makemutable 0 (*,value<(consts (0)) (non_consts ([0: ?]))>)
+                  (makemutable 0 (*,value<
+                                     (consts (0))
+                                      (non_consts ([0:
+                                                    value<
+                                                     (consts ())
+                                                      (non_consts ([0: *, *]))>]))>)
                     (apply f (field_imm 0 *match*)) 24029))
                (seq (apply rec_map_dps block 1 f (field_imm 1 *match*))
                  block))))
          0))
     rec_map_dps
       (function {nlocal = 0} dst offset[value<int>] f
-        param[value<(consts (0)) (non_consts ([0: ?]))>] tail_mod_cons
-        : (consts (0)) (non_consts ([0: ?]))
+        param[value<
+               (consts (0))
+                (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+        tail_mod_cons
+        : (consts (0))
+           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))
         (if param
           (let
             (*match* =a? (field_imm 0 param)
              block1_arg0 =? (apply f (field_imm 0 *match*))
              block =
-               (makemutable 0 (*,value<(consts (0)) (non_consts ([0: ?]))>)
+               (makemutable 0 (*,value<
+                                  (consts (0))
+                                   (non_consts ([0:
+                                                 value<
+                                                  (consts ())
+                                                   (non_consts ([0: *, *]))>]))>)
                  block1_arg0 24029))
             (seq
               (setfield_ptr(heap-init)_computed dst offset
@@ -109,7 +127,7 @@ let[@tail_mod_cons] rec rec_map f = function
                                 (non_consts ([0: *,
                                               value<
                                                (consts (0))
-                                                (non_consts ([0: ?]))>]))>)
+                                                (non_consts ([0: *]))>]))>)
                   block))
               (apply rec_map_dps block 1 f (field_imm 1 *match*) tailcall)))
           (setfield_ptr(heap-init)_computed dst offset 0))))
@@ -134,21 +152,27 @@ let[@tail_mod_cons] rec trip = function
                              value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
        tail_mod_cons
        : (consts (0))
-          (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))
+          (non_consts ([0:
+                        value<(consts ()) (non_consts ([0: ?, value<int>]))>,
+                        value<(consts (0)) (non_consts ([0: *, *]))>]))
        (if param
          (let (x =a? (field_imm 0 param))
            (makeblock 0 (value<(consts ()) (non_consts ([0: ?, value<int>]))>,
              value<
               (consts (0))
-               (non_consts ([0: ?,
-                             value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+               (non_consts ([0:
+                             value<
+                              (consts ()) (non_consts ([0: ?, value<int>]))>,
+                             value<(consts (0)) (non_consts ([0: *, *]))>]))>)
              (makeblock 0 (?,value<int>) x 0)
              (makeblock 0 (value<
                             (consts ()) (non_consts ([0: ?, value<int>]))>,
                value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+                 (non_consts ([0:
+                               value<
+                                (consts ()) (non_consts ([0: ?, value<int>]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>)
                (makeblock 0 (?,value<int>) x 1)
                (let
                  (block =
@@ -157,9 +181,12 @@ let[@tail_mod_cons] rec trip = function
                                       (non_consts ([0: ?, value<int>]))>,
                       value<
                        (consts (0))
-                        (non_consts ([0: ?,
+                        (non_consts ([0:
                                       value<
-                                       (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                       (consts ())
+                                        (non_consts ([0: ?, value<int>]))>,
+                                      value<
+                                       (consts (0)) (non_consts ([0: *, *]))>]))>)
                       (makeblock 0 (?,value<int>) x 2) 24029))
                  (seq (apply trip_dps block 1 (field_imm 1 param)) block)))))
          0))
@@ -171,7 +198,9 @@ let[@tail_mod_cons] rec trip = function
                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
         tail_mod_cons
         : (consts (0))
-           (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))
+           (non_consts ([0:
+                         value<(consts ()) (non_consts ([0: ?, value<int>]))>,
+                         value<(consts (0)) (non_consts ([0: *, *]))>]))
         (if param
           (let
             (x =a? (field_imm 0 param)
@@ -183,8 +212,11 @@ let[@tail_mod_cons] rec trip = function
                                 (consts ()) (non_consts ([0: ?, value<int>]))>,
                  value<
                   (consts (0))
-                   (non_consts ([0: ?,
-                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+                   (non_consts ([0:
+                                 value<
+                                  (consts ())
+                                   (non_consts ([0: ?, value<int>]))>,
+                                 value<(consts (0)) (non_consts ([0: *, *]))>]))>)
                  block2_arg0 24029))
             (seq
               (setfield_ptr(heap-init)_computed dst offset
@@ -192,18 +224,24 @@ let[@tail_mod_cons] rec trip = function
                                (consts ()) (non_consts ([0: ?, value<int>]))>,
                   value<
                    (consts (0))
-                    (non_consts ([0: ?,
+                    (non_consts ([0:
                                   value<
-                                   (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                   (consts ())
+                                    (non_consts ([0: ?, value<int>]))>,
+                                  value<
+                                   (consts (0)) (non_consts ([0: *, *]))>]))>)
                   block0_arg0
                   (makeblock 0 (value<
                                  (consts ())
                                   (non_consts ([0: ?, value<int>]))>,
                     value<
                      (consts (0))
-                      (non_consts ([0: ?,
+                      (non_consts ([0:
                                     value<
-                                     (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                     (consts ())
+                                      (non_consts ([0: ?, value<int>]))>,
+                                    value<
+                                     (consts (0)) (non_consts ([0: *, *]))>]))>)
                     block1_arg0 block)))
               (apply trip_dps block 1 (field_imm 1 param) tailcall)))
           (setfield_ptr(heap-init)_computed dst offset 0))))
@@ -224,8 +262,8 @@ let[@tail_mod_cons] rec effects f = function
      (function {nlocal = 0} f
        param[value<
               (consts (0))
-               (non_consts ([0: ?,
-                             value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+               (non_consts ([0: value<(consts ()) (non_consts ([0: ?, ?]))>,
+                             value<(consts (0)) (non_consts ([0: *, *]))>]))>]
        tail_mod_cons
        : (consts (0))
           (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))
@@ -253,8 +291,8 @@ let[@tail_mod_cons] rec effects f = function
       (function {nlocal = 0} dst offset[value<int>] f
         param[value<
                (consts (0))
-                (non_consts ([0: ?,
-                              value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                (non_consts ([0: value<(consts ()) (non_consts ([0: ?, ?]))>,
+                              value<(consts (0)) (non_consts ([0: *, *]))>]))>]
         tail_mod_cons
         : (consts (0))
            (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))

--- a/testsuite/tests/translprim/comparison_table.stack.reference
+++ b/testsuite/tests/translprim/comparison_table.stack.reference
@@ -342,54 +342,77 @@
        stub : int (%nativeint_greaterequal prim prim))
    int_vec =[value<
               (consts (0))
-               (non_consts ([0: ?,
-                             value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+               (non_consts ([0:
+                             value<
+                              (consts ())
+                               (non_consts ([0: value<int>, value<int>]))>,
+                             value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 1 1] [0: [0: 1 2] [0: [0: 2 1] 0]]]
    bool_vec =[value<
                (consts (0))
-                (non_consts ([0: ?,
-                              value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                (non_consts ([0:
+                              value<
+                               (consts ())
+                                (non_consts ([0: value<int>, value<int>]))>,
+                              value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 0 0] [0: [0: 0 1] [0: [0: 1 0] 0]]]
    intlike_vec =[value<
                   (consts (0))
-                   (non_consts ([0: ?,
-                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                   (non_consts ([0:
+                                 value<
+                                  (consts ())
+                                   (non_consts ([0: value<int>, value<int>]))>,
+                                 value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 0 0] [0: [0: 0 1] [0: [0: 1 0] 0]]]
    float_vec =[value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                 (non_consts ([0:
+                               value<
+                                (consts ())
+                                 (non_consts ([0: value<float>, value<float>]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 1. 1.] [0: [0: 1. 2.] [0: [0: 2. 1.] 0]]]
    string_vec =[value<
                  (consts (0))
-                  (non_consts ([0: ?,
-                                value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                  (non_consts ([0:
+                                value<(consts ()) (non_consts ([0: *, *]))>,
+                                value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: "1" "1"] [0: [0: "1" "2"] [0: [0: "2" "1"] 0]]]
    int32_vec =[value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                 (non_consts ([0:
+                               value<
+                                (consts ())
+                                 (non_consts ([0: value<int32>, value<int32>]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 1l 1l] [0: [0: 1l 2l] [0: [0: 2l 1l] 0]]]
    int64_vec =[value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                 (non_consts ([0:
+                               value<
+                                (consts ())
+                                 (non_consts ([0: value<int64>, value<int64>]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 1L 1L] [0: [0: 1L 2L] [0: [0: 2L 1L] 0]]]
    nativeint_vec =[value<
                     (consts (0))
-                     (non_consts ([0: ?,
+                     (non_consts ([0:
                                    value<
-                                    (consts (0)) (non_consts ([0: ?, *]))>]))>]
+                                    (consts ())
+                                     (non_consts ([0: value<nativeint>,
+                                                   value<nativeint>]))>,
+                                   value<
+                                    (consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 1n 1n] [0: [0: 1n 2n] [0: [0: 2n 1n] 0]]]
    test_vec =
      (function {nlocal = 0} cmp eq ne lt gt le ge
        vec[value<
             (consts (0))
-             (non_consts ([0: ?,
-                           value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+             (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>,
+                           value<(consts (0)) (non_consts ([0: *, *]))>]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>,
-                        value<(consts (0)) (non_consts ([0: ?, *]))>]))
+                        value<(consts (0)) (non_consts ([0: *, *]))>]))
        (let
          (uncurry =
             (function {nlocal = 0} f
@@ -399,8 +422,9 @@
             (function {nlocal = 2} f
               l[value<
                  (consts (0))
-                  (non_consts ([0: ?,
-                                value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                  (non_consts ([0:
+                                value<(consts ()) (non_consts ([0: ?, ?]))>,
+                                value<(consts (0)) (non_consts ([0: *, *]))>]))>]
               : (consts (0))
                  (non_consts ([0: ?,
                                value<(consts (0)) (non_consts ([0: ?, *]))>]))
@@ -410,19 +434,20 @@
                         (consts ())
                          (non_consts ([0:
                                        value<
-                                        (consts (0)) (non_consts ([0: ?, *]))>,
+                                        (consts (0))
+                                         (non_consts ([0: value<int>, *]))>,
                                        value<
                                         (consts (0)) (non_consts ([0: ?, *]))>]))>,
            value<
             (consts (0))
-             (non_consts ([0: ?,
-                           value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+             (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>,
+                           value<(consts (0)) (non_consts ([0: *, *]))>]))>)
            (makeblock 0 (value<
                           (consts (0))
-                           (non_consts ([0: ?,
+                           (non_consts ([0: value<int>,
                                          value<
                                           (consts (0))
-                                           (non_consts ([0: ?, *]))>]))>,
+                                           (non_consts ([0: value<int>, *]))>]))>,
              value<
               (consts (0))
                (non_consts ([0: ?,
@@ -432,14 +457,17 @@
              (function {nlocal = 2} gen spec
                : (consts ())
                   (non_consts ([0:
-                                value<(consts (0)) (non_consts ([0: ?, *]))>,
+                                value<
+                                 (consts (0))
+                                  (non_consts ([0: value<int>, *]))>,
                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))
                (makeblock 0 (value<
                               (consts (0))
-                               (non_consts ([0: ?,
+                               (non_consts ([0: value<int>,
                                              value<
                                               (consts (0))
-                                               (non_consts ([0: ?, *]))>]))>,
+                                               (non_consts ([0: value<int>,
+                                                             *]))>]))>,
                  value<
                   (consts (0))
                    (non_consts ([0: ?,
@@ -448,45 +476,56 @@
              (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+                 (non_consts ([0:
+                               value<(consts ()) (non_consts ([0: *, *]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>)
                (makeblock 0 (*,*) gen_eq eq)
                (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                  value<
                   (consts (0))
-                   (non_consts ([0: ?,
-                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+                   (non_consts ([0:
+                                 value<(consts ()) (non_consts ([0: *, *]))>,
+                                 value<(consts (0)) (non_consts ([0: *, *]))>]))>)
                  (makeblock 0 (*,*) gen_ne ne)
                  (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                    value<
                     (consts (0))
-                     (non_consts ([0: ?,
+                     (non_consts ([0:
                                    value<
-                                    (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                    (consts ()) (non_consts ([0: *, *]))>,
+                                   value<
+                                    (consts (0)) (non_consts ([0: *, *]))>]))>)
                    (makeblock 0 (*,*) gen_lt lt)
                    (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                      value<
                       (consts (0))
-                       (non_consts ([0: ?,
+                       (non_consts ([0:
                                      value<
-                                      (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                      (consts ()) (non_consts ([0: *, *]))>,
+                                     value<
+                                      (consts (0)) (non_consts ([0: *, *]))>]))>)
                      (makeblock 0 (*,*) gen_gt gt)
                      (makeblock 0 (value<
                                     (consts ()) (non_consts ([0: *, *]))>,
                        value<
                         (consts (0))
-                         (non_consts ([0: ?,
+                         (non_consts ([0:
                                        value<
-                                        (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                        (consts ()) (non_consts ([0: *, *]))>,
+                                       value<
+                                        (consts (0)) (non_consts ([0: *, *]))>]))>)
                        (makeblock 0 (*,*) gen_le le)
                        (makeblock 0 (value<
                                       (consts ()) (non_consts ([0: *, *]))>,
                          value<
                           (consts (0))
-                           (non_consts ([0: ?,
+                           (non_consts ([0:
+                                         value<
+                                          (consts ())
+                                           (non_consts ([0: *, *]))>,
                                          value<
                                           (consts (0))
-                                           (non_consts ([0: ?, *]))>]))>)
+                                           (non_consts ([0: *, *]))>]))>)
                          (makeblock 0 (*,*) gen_ge ge) 0)))))))))))
   (seq
     (apply test_vec int_cmp int_eq int_ne int_lt int_gt int_le int_ge
@@ -510,11 +549,12 @@
          (function {nlocal = 0} cmp eq ne lt gt le ge
            vec[value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                 (non_consts ([0:
+                               value<(consts ()) (non_consts ([0: *, *]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>]
            : (consts ())
               (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>,
-                            value<(consts (0)) (non_consts ([0: ?, *]))>]))
+                            value<(consts (0)) (non_consts ([0: *, *]))>]))
            (let
              (uncurry =
                 (function {nlocal = 0} f
@@ -524,9 +564,11 @@
                 (function {nlocal = 2} f
                   l[value<
                      (consts (0))
-                      (non_consts ([0: ?,
+                      (non_consts ([0:
                                     value<
-                                     (consts (0)) (non_consts ([0: ?, *]))>]))>]
+                                     (consts ()) (non_consts ([0: ?, ?]))>,
+                                    value<
+                                     (consts (0)) (non_consts ([0: *, *]))>]))>]
                   : (consts (0))
                      (non_consts ([0: ?,
                                    value<
@@ -538,20 +580,22 @@
                              (non_consts ([0:
                                            value<
                                             (consts (0))
-                                             (non_consts ([0: ?, *]))>,
+                                             (non_consts ([0: value<int>, *]))>,
                                            value<
                                             (consts (0))
                                              (non_consts ([0: ?, *]))>]))>,
                value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+                 (non_consts ([0:
+                               value<(consts ()) (non_consts ([0: *, *]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>)
                (makeblock 0 (value<
                               (consts (0))
-                               (non_consts ([0: ?,
+                               (non_consts ([0: value<int>,
                                              value<
                                               (consts (0))
-                                               (non_consts ([0: ?, *]))>]))>,
+                                               (non_consts ([0: value<int>,
+                                                             *]))>]))>,
                  value<
                   (consts (0))
                    (non_consts ([0: ?,
@@ -562,15 +606,18 @@
                    : (consts ())
                       (non_consts ([0:
                                     value<
-                                     (consts (0)) (non_consts ([0: ?, *]))>,
+                                     (consts (0))
+                                      (non_consts ([0: value<int>, *]))>,
                                     value<
                                      (consts (0)) (non_consts ([0: ?, *]))>]))
                    (makeblock 0 (value<
                                   (consts (0))
-                                   (non_consts ([0: ?,
+                                   (non_consts ([0: value<int>,
                                                  value<
                                                   (consts (0))
-                                                   (non_consts ([0: ?, *]))>]))>,
+                                                   (non_consts ([0:
+                                                                 value<int>,
+                                                                 *]))>]))>,
                      value<
                       (consts (0))
                        (non_consts ([0: ?,
@@ -580,52 +627,67 @@
                  (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                    value<
                     (consts (0))
-                     (non_consts ([0: ?,
+                     (non_consts ([0:
                                    value<
-                                    (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                    (consts ()) (non_consts ([0: *, *]))>,
+                                   value<
+                                    (consts (0)) (non_consts ([0: *, *]))>]))>)
                    (makeblock 0 (*,*) eta_gen_eq eq)
                    (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                      value<
                       (consts (0))
-                       (non_consts ([0: ?,
+                       (non_consts ([0:
                                      value<
-                                      (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                      (consts ()) (non_consts ([0: *, *]))>,
+                                     value<
+                                      (consts (0)) (non_consts ([0: *, *]))>]))>)
                      (makeblock 0 (*,*) eta_gen_ne ne)
                      (makeblock 0 (value<
                                     (consts ()) (non_consts ([0: *, *]))>,
                        value<
                         (consts (0))
-                         (non_consts ([0: ?,
+                         (non_consts ([0:
                                        value<
-                                        (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                        (consts ()) (non_consts ([0: *, *]))>,
+                                       value<
+                                        (consts (0)) (non_consts ([0: *, *]))>]))>)
                        (makeblock 0 (*,*) eta_gen_lt lt)
                        (makeblock 0 (value<
                                       (consts ()) (non_consts ([0: *, *]))>,
                          value<
                           (consts (0))
-                           (non_consts ([0: ?,
+                           (non_consts ([0:
+                                         value<
+                                          (consts ())
+                                           (non_consts ([0: *, *]))>,
                                          value<
                                           (consts (0))
-                                           (non_consts ([0: ?, *]))>]))>)
+                                           (non_consts ([0: *, *]))>]))>)
                          (makeblock 0 (*,*) eta_gen_gt gt)
                          (makeblock 0 (value<
                                         (consts ()) (non_consts ([0: *, *]))>,
                            value<
                             (consts (0))
-                             (non_consts ([0: ?,
+                             (non_consts ([0:
+                                           value<
+                                            (consts ())
+                                             (non_consts ([0: *, *]))>,
                                            value<
                                             (consts (0))
-                                             (non_consts ([0: ?, *]))>]))>)
+                                             (non_consts ([0: *, *]))>]))>)
                            (makeblock 0 (*,*) eta_gen_le le)
                            (makeblock 0 (value<
                                           (consts ())
                                            (non_consts ([0: *, *]))>,
                              value<
                               (consts (0))
-                               (non_consts ([0: ?,
+                               (non_consts ([0:
+                                             value<
+                                              (consts ())
+                                               (non_consts ([0: *, *]))>,
                                              value<
                                               (consts (0))
-                                               (non_consts ([0: ?, *]))>]))>)
+                                               (non_consts ([0: *, *]))>]))>)
                              (makeblock 0 (*,*) eta_gen_ge ge) 0)))))))))))
       (seq
         (apply eta_test_vec eta_int_cmp eta_int_eq eta_int_ne eta_int_lt

--- a/testsuite/tests/typing-layouts-caml-modify/immediate_or_null_record.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/immediate_or_null_record.ml
@@ -1,0 +1,39 @@
+(* TEST
+ modules = "replace_caml_modify.c";
+ {
+   not-macos;
+   flags = "-cclib -Xlinker -cclib --wrap -cclib -Xlinker -cclib caml_modify \
+            -cclib -Xlinker -cclib --wrap -cclib -Xlinker -cclib caml_modify_local";
+   native;
+ }
+*)
+
+(* This test verifies that setting an immediate_or_null field in a mixed record
+   calls [caml_modify]. See [basics.ml] for an explanation. *)
+
+external called_caml_modify : unit -> int
+  = "replace_caml_modify_called_modify" [@@noalloc]
+external reset : unit -> unit = "replace_caml_modify_reset" [@@noalloc]
+
+let test ~(call_pos : [%call_pos]) ~expect_caml_modifies f =
+  reset ();
+  f ();
+  let actual_modifies = called_caml_modify () in
+  if not (expect_caml_modifies = actual_modifies) then
+    failwith @@
+      Format.sprintf
+        "On line %d, expected %d calls to caml_modify, but saw %d"
+        call_pos.pos_lnum expect_caml_modifies actual_modifies
+
+type t =
+  { mutable a : int or_null
+  ; mutable b : int64#
+  }
+
+let set t ~a =
+  t.a <- a
+
+let () =
+  let t = { a = Null; b = #0L } in
+  test ~expect_caml_modifies:0
+    (fun () -> set t ~a:(This 5))

--- a/testsuite/tests/typing-layouts-scannable/external_array_operations.ml
+++ b/testsuite/tests/typing-layouts-scannable/external_array_operations.ml
@@ -13,7 +13,7 @@ external weird_id : ('a : any mod separable). 'a array -> int = "%identity"
 let weird_id' arr = weird_id arr
 [%%expect{|
 external weird_id : ('a : any separable). 'a array -> int = "%identity"
-val weird_id' : ('a : value maybe_null). 'a array -> int = <fun>
+val weird_id' : ('a : any separable). 'a array -> int = <fun>
 |}]
 
 (* This is not sound whenever 'a is not a value, but this is the kind of
@@ -31,6 +31,5 @@ let product_edge_case x = product_edge_case x
 [%%expect{|
 external product_edge_case : ('a : any separable). #('a * 'a) array -> int
   = "%identity"
-val product_edge_case : ('a : value maybe_null). #('a * 'a) array -> int =
-  <fun>
+val product_edge_case : ('a : any separable). #('a * 'a) array -> int = <fun>
 |}]

--- a/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/testsuite/tests/typing-layouts/layout_poly.ml
@@ -667,7 +667,7 @@ let id' x = id x
 
 [%%expect{|
 external id : ('a : any separable). 'a t -> int = "%identity"
-val id' : ('a : value maybe_null). 'a t -> int = <fun>
+val id' : ('a : any separable). 'a t -> int = <fun>
 |}]
 
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5559,6 +5559,11 @@ let rec filter_method_row env name priv ty =
   | _ ->
       raise Filter_method_row_failed
 
+let generic_instance_declaration_with_params env params decl =
+  let decl = generic_instance_declaration decl in
+  List.iter2 (unify_var env) decl.type_params params;
+  decl
+
 (* Operations on class signatures *)
 
 let new_class_signature () =

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -221,6 +221,13 @@ val instance_parameterized_type:
 val instance_declaration: type_declaration -> type_declaration
 val generic_instance_declaration: type_declaration -> type_declaration
         (* Same as instance_declaration, but new nodes at generic_level *)
+
+(** [generic_instance_declaration_with_params env params decl] calls
+    [generic_instance_declaration] on [decl] and then unifies passed
+    [params] with [decl.type_params].  *)
+val generic_instance_declaration_with_params:
+    Env.t -> type_expr list -> type_declaration -> type_declaration
+
 val instance_class:
         type_expr list -> class_type -> type_expr list * class_type
 

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -478,32 +478,6 @@ let bigarray_specialize_kind_and_layout env ~kind ~layout typ =
   | _ ->
       (kind, layout)
 
-let value_kind_of_scannable_jkind env jkind =
-  let layout = Jkind.get_layout_defaulting_to_scannable env jkind in
-  (* In other places, we use [Ctype.type_jkind_purely_if_principal]. Here, we omit
-     the principality check, as we're just trying to compute optimizations. *)
-  let context = Ctype.mk_jkind_context_always_principal env in
-  let externality_upper_bound =
-    Jkind.get_externality_upper_bound ~context env jkind
-  in
-  match layout with
-  | Some (Base (Scannable, { separability; _ })) -> (
-    (* use the better of the two [immediate_or_pointer]s *)
-    match pointerness_of_separability separability,
-          pointerness_of_scannable_with_externality externality_upper_bound with
-    | Immediate, Immediate | Immediate, Pointer | Pointer, Immediate -> Pintval
-    | Pointer, Pointer -> Pgenval)
-  | None
-  | Some ( Any _
-         | Product _
-         | Univar _
-         | Genvar _
-         | Base ( ( Void | Untagged_immediate | Float64 | Float32 | Word
-                  | Bits8 | Bits16 | Bits32 | Bits64 | Vec128 | Vec256
-                  | Vec512 ),
-                  _ )) ->
-    Misc.fatal_error "expected a layout of scannable"
-
 (* [value_kind] has a pre-condition that it is only called on values.  With the
    current set of sort restrictions, there are two reasons this invariant may
    be violated:
@@ -569,11 +543,12 @@ let non_nullable raw_kind = { raw_kind; nullable = Non_nullable }
 
 let nullable raw_kind = { raw_kind; nullable = Nullable }
 
-let add_nullability_from_ty env ty raw_kind =
-  let nullable =
-    match Ctype.check_type_nullability env ty Non_null with
-    | true -> Non_nullable
-    | false -> Nullable
+let estimate_value_kind_from_jkind env ty =
+  let immediate_or_pointer, nullable = maybe_pointer_type env ty in
+  let raw_kind =
+    match immediate_or_pointer with
+    | Immediate -> Pintval
+    | Pointer -> Pgenval
   in
   { raw_kind; nullable }
 
@@ -710,8 +685,7 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
       in
       if cannot_proceed () then
         num_nodes_visited,
-        add_nullability_from_ty env scty
-          (value_kind_of_scannable_jkind env decl.type_jkind)
+        estimate_value_kind_from_jkind env ty
       else
         let visited = Numbers.Int.Set.add (get_id ty) visited in
         (* Default of [Pgenval] is currently safe for the missing cmi fallback
@@ -743,8 +717,7 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
             "Typeopt.value_kind: non-unary unboxed record can't have kind value"
         | Type_abstract _ ->
           num_nodes_visited,
-          add_nullability_from_ty env scty
-            (value_kind_of_scannable_jkind env decl.type_jkind)
+          estimate_value_kind_from_jkind env ty
         | Type_open -> num_nodes_visited, non_nullable Pgenval
     end
   | Ttuple labeled_fields ->
@@ -776,7 +749,7 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
     else non_nullable Pintval
   | _ ->
     num_nodes_visited,
-    add_nullability_from_ty env scty Pgenval
+    estimate_value_kind_from_jkind env ty
 
 and value_kind_mixed_block_field env ~loc ~visited ~depth ~num_nodes_visited
       (field : Types.mixed_block_element) ty
@@ -1084,14 +1057,19 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
     end
 
 let value_kind env loc ty =
+  (* CR dkalinichenko: [value_kind] sometimes changes the levels
+     in the original type. Investigate why and fix. *)
+  let snap = Btype.snapshot () in
   try
     let (_num_nodes_visited, value_kind) =
       value_kind env ~loc ~visited:Numbers.Int.Set.empty ~depth:0
         ~num_nodes_visited:0 ty
     in
+    Btype.backtrack snap;
     value_kind
   with
   | Missing_cmi_fallback ->
+    Btype.backtrack snap;
     raise (Error (loc, Non_value_layout (env, ty, None)))
 
 let transl_mixed_block_element env loc ty mbe =

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -673,15 +673,17 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
           || Path.same p Predef.path_iarray) ->
     let ak = array_type_kind ~elt_ty:(Some arg) env loc ty in
     num_nodes_visited, non_nullable (Parrayval ak)
-  | Tconstr(p, _, _) -> begin
-      (* CR layouts v2.8: The uses of [decl.type_jkind] here are suspect:
-         with with-kinds, [decl.type_jkind] will mention variables bound
-         by the parameters of the declaration. The code below loses this
-         connection and will continue processing with e.g. ['a : value]
-         instead of [string] when looking at a [string list]. This should
-         probably just call a [type_jkind] function. Internal ticket 5101. *)
+  | Tconstr(p, params, _) -> begin
       let decl =
-        try Env.find_type p env with Not_found -> raise Missing_cmi_fallback
+        try
+          Env.find_type p env
+          (* CR dkalinichenko: this uses a [generic_instance_] function to
+             ensure that unification succeeds regardless of levels. It's unclear
+             why this is necessary (we can't even compile Stdlib otherwise),
+             and I haven't been able to determine the reason. At least,
+             I think this may be unnecessary after the rebase to 5.4. *)
+          |> Ctype.generic_instance_declaration_with_params env params
+        with Not_found -> raise Missing_cmi_fallback
       in
       if cannot_proceed () then
         num_nodes_visited,


### PR DESCRIPTION
Due to some implementation issue, `Typeopt.value_kind` can change the levels of a type, sometimes causing weird and difficult to debug errors in toplevel. Make a snapshot and backtrack the state of the typechecker to make `value_kind` pure. This fixes a principal typing difference for locals and a type variable being unnecessarily lowered to `value_or_null` from `any`.

Also, refactor neighboring nullability-related code in `Typeopt` to remove a CR.