### PR TITLE
Expose the fact that Atomic.t is an atomic ref

### DIFF
--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -12,7 +12,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type (!'a : value_or_null) t : mutable_data with 'a
+type (!'a : value_or_null) t : mutable_data with 'a =
+  { mutable contents : 'a [@atomic] }
 
 external make
   : ('a : value_or_null).

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -24,7 +24,8 @@
   @since 4.12 *)
 
 (** An atomic (mutable) reference to a value of type ['a]. *)
-type (!'a : value_or_null) t : mutable_data with 'a
+type (!'a : value_or_null) t : mutable_data with 'a =
+  { mutable contents : 'a [@atomic] }
 
 (** Create an atomic reference. *)
 external make : ('a : value_or_null). 'a -> ('a t[@local_opt]) = "%makemutable"

--- a/testsuite/tests/lib-atomic/test_atomic.ml
+++ b/testsuite/tests/lib-atomic/test_atomic.ml
@@ -51,6 +51,14 @@ let () =
   ignore (Atomic.incr r, Atomic.decr r);
   assert (Atomic.get r = cur)
 
+(* Test operations on the contents field of the atomic *)
+
+let () = assert (Atomic.Loc.get [%atomic.loc r.contents] = 1)
+
+let () = assert ((Atomic.Loc.set [%atomic.loc r.contents] 5; Atomic.get r) = 5)
+
+let () = assert ((Atomic.Loc.incr [%atomic.loc r.contents]; Atomic.get r) = 6)
+
 (* Test primitives with non-immediate types *)
 
 let a = ref 1


### PR DESCRIPTION
Define ['a Atomic.t] as a record with a single mutable atomic field of type ['a], since that's effectively what it is now. Most notably, this allows creating an atomic loc to the contents of the atomic with `[%atomic.loc t.contents]`