### PR TITLE
Eliminate some unnecessary `caml_modify`s for nested unboxed product record updates.

### DIFF
--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
@@ -349,13 +349,7 @@ let flatten_fields_in_mixed_record ~(mixed_block_shapes : Layout.t array)
   let reordering =
     Mixed_block_shape.of_mixed_block_elements
       ~print_locality:(fun _ _ -> ())
-      (Lambda.transl_mixed_product_shape
-         ~get_value_kind:(fun _ -> Lambda.generic_value)
-         (* We don't care about the value kind of values, because it is dropped
-            again immediately afterwards. We only care about the layout
-            remapping: we only need the reordering to get the fields right
-            below. *)
-         mixed_block_shapes)
+      (Lambda.transl_mixed_product_shape mixed_block_shapes)
   in
   let fields =
     Array.init (Mixed_block_shape.new_block_length reordering) (fun i ->

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -1440,10 +1440,10 @@ let transl_prim mod_name name =
   | exception Not_found ->
       fatal_error ("Primitive " ^ name ^ " not found.")
 
-let rec transl_mixed_product_shape ~get_value_kind shape =
-  Array.mapi (fun i (elt : Types.mixed_block_element) ->
+let rec transl_mixed_product_shape shape =
+  Array.map (fun (elt : Types.mixed_block_element) ->
     match elt with
-    | Value -> Value (get_value_kind i)
+    | Value -> Value generic_value
     | Float_boxed -> Float_boxed ()
     | Float64 -> Float64
     | Float32 -> Float32
@@ -1457,10 +1457,7 @@ let rec transl_mixed_product_shape ~get_value_kind shape =
     | Word -> Word
     | Untagged_immediate -> Untagged_immediate
     | Product shapes ->
-      (* CR mshinwell: This [get_value_kind] override is a bit odd, maybe this
-         could be improved in the future (same below). *)
-      let get_value_kind _ = generic_value in
-      Product (transl_mixed_product_shape ~get_value_kind shapes)
+      Product (transl_mixed_product_shape shapes)
     | Void -> Product [||]
   ) shape
 

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -1098,9 +1098,7 @@ val transl_class_path: scoped_location -> Env.t -> Path.t -> lambda
 
 val transl_address : scoped_location -> Persistent_env.address -> lambda
 
-val transl_mixed_product_shape :
-  get_value_kind:(int -> value_kind)
-  -> Types.mixed_product_shape -> mixed_block_shape
+val transl_mixed_product_shape : Types.mixed_product_shape -> mixed_block_shape
 
 val transl_mixed_product_shape_for_read :
   get_value_kind:(int -> value_kind) -> get_mode:(int -> locality_mode)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1932,13 +1932,7 @@ let get_expr_args_constr ~scopes head (arg, _mut, sort, layout) rem =
       fatal_error
         "Matching.get_exr_args_constr: constant Constructor_uniform_value"
     | Constructor_mixed shape ->
-      let shape =
-        transl_mixed_product_shape
-          ~get_value_kind:
-            (fun _ ->
-                fatal_error "Matching.get_expr_args_constr: get_value_kind")
-          shape
-      in
+      let shape = transl_mixed_product_shape shape in
       let e, layout = lambda_void_of_el shape.(pos) in
       (e, binding_kind, sort, layout)
   in

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -552,11 +552,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                      constructors with all-void inline records, which are stored
                      as immediates *)
                   if !Clflags.native_code then
-                    let shape =
-                      Lambda.transl_mixed_product_shape
-                        ~get_value_kind:(fun _i -> Lambda.generic_value)
-                        shape
-                    in
+                    let shape = Lambda.transl_mixed_product_shape shape in
                     Some (Const_mixed_block(runtime_tag, shape, constants))
                   else
                     (* CR layouts v5.9: Structured constants for mixed blocks should
@@ -583,11 +579,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                     (* CR layouts v5: once all-void records are allowed, handle
                        constructors with all-void inline records, which are
                        stored as immediates *)
-                    let shape =
-                      Lambda.transl_mixed_product_shape
-                        ~get_value_kind:(fun _i -> Lambda.generic_value)
-                        shape
-                    in
+                    let shape = Lambda.transl_mixed_product_shape shape in
                     Pmakemixedblock(runtime_tag, Immutable, shape, alloc_mode)
               in
               Lprim (makeblock, ll, of_location ~scopes e.exp_loc)
@@ -621,11 +613,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                   (* CR layouts v5: once all-void records are allowed, handle
                      constructors with all-void inline records, which are stored
                      as immediates *)
-                  let shape =
-                    Lambda.transl_mixed_product_shape
-                      ~get_value_kind:(fun _i -> Lambda.generic_value)
-                      shape
-                  in
+                  let shape = Lambda.transl_mixed_product_shape shape in
                   let shape =
                     (* This corresponds to the poly variant hash.  This will
                        always stay in the same place because the reordering
@@ -822,23 +810,15 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
              constructors with all-void inline records, which are stored as
              immediates *)
         | Record_mixed shape ->
-          let shape =
-            Lambda.transl_mixed_product_shape
-              ~get_value_kind:(fun i ->
-                if i <> lbl.lbl_pos then Lambda.generic_value
-                else
-                  let pointerness, nullable =
-                    maybe_pointer newval
-                  in
-                  let raw_kind = match pointerness with
-                    | Pointer -> Pgenval
-                    | Immediate -> Pintval
-                  in
-                  Lambda.{ raw_kind; nullable })
-              shape
-            in
-            Psetmixedfield([lbl.lbl_pos], shape, mode),
-            [arg_lambda; newval_lambda]
+          let field_shape =
+            Typeopt.transl_mixed_block_element newval.exp_env newval.exp_loc
+              newval.exp_type shape.(lbl.lbl_pos)
+          in
+          let shape = Lambda.transl_mixed_product_shape shape in
+          (* Update the shape with details for the modified field. *)
+          shape.(lbl.lbl_pos) <- field_shape;
+          Psetmixedfield([lbl.lbl_pos], shape, mode),
+          [arg_lambda; newval_lambda]
         | Record_inlined (_, _, Variant_with_null) -> assert false
       in
       Lprim(prim, args, of_location ~scopes e.exp_loc)
@@ -2098,23 +2078,13 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                   constructors with all-void inline records, which are stored as
                   immediates *)
             | Record_mixed shape ->
-                let shape =
-                  Lambda.transl_mixed_product_shape
-                    ~get_value_kind:(fun i ->
-                      if i <> lbl.lbl_pos then Lambda.generic_value
-                      else
-                        let pointerness, nullable =
-                          maybe_pointer expr
-                        in
-                        let raw_kind = match pointerness with
-                          | Pointer -> Pgenval
-                          | Immediate -> Pintval
-                        in
-                        Lambda.{ raw_kind; nullable })
-                    shape
-                  in
-
-
+                let field_shape =
+                  Typeopt.transl_mixed_block_element expr.exp_env expr.exp_loc
+                    expr.exp_type shape.(lbl.lbl_pos)
+                in
+                let shape = Lambda.transl_mixed_product_shape shape in
+                (* Update the shape with details for the modified field. *)
+                shape.(lbl.lbl_pos) <- field_shape;
                 Psetmixedfield
                   ([lbl.lbl_pos], shape, Assignment modify_heap)
             | Record_inlined (_, _, Variant_with_null) -> assert false
@@ -2228,11 +2198,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
             Lconst(Const_float_block(List.map extract_float cl))
         | Record_mixed shape ->
             if !Clflags.native_code then
-              let shape =
-                Lambda.transl_mixed_product_shape
-                  ~get_value_kind:(fun _i -> Lambda.generic_value)
-                  shape
-              in
+              let shape = Lambda.transl_mixed_product_shape shape in
               Lconst(Const_mixed_block(0, shape, cl))
             else
               (* CR layouts v5.9: Structured constants for mixed blocks should
@@ -2283,22 +2249,14 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
         | Record_inlined (Ordinary _, _, Variant_extensible) ->
             assert false
         | Record_mixed shape ->
-            let shape =
-              Lambda.transl_mixed_product_shape
-                ~get_value_kind:(fun _i -> Lambda.generic_value)
-                shape
-            in
+            let shape = Lambda.transl_mixed_product_shape shape in
             Lprim (Pmakemixedblock (0, mut, shape, Option.get mode), ll, loc)
         | Record_inlined (Ordinary { runtime_tag },
                           Constructor_mixed shape, Variant_boxed _) ->
             (* CR layouts v5: once all-void records are allowed, handle
               constructors with all-void inline records, which are stored as
               immediates *)
-            let shape =
-              Lambda.transl_mixed_product_shape
-                ~get_value_kind:(fun _i -> Lambda.generic_value)
-                shape
-            in
+            let shape = Lambda.transl_mixed_product_shape shape in
             Lprim (Pmakemixedblock (runtime_tag, mut, shape, Option.get mode),
                    ll, loc)
         | Record_inlined (_, _, Variant_with_null) -> assert false
@@ -2409,10 +2367,7 @@ and transl_idx ~scopes loc env ba uas =
     | Record_inlined _ | Record_unboxed ->
       Misc.fatal_error "Texp_idx: unexpected unboxed/inlined record"
     | Record_mixed shape ->
-      let shape =
-        Lambda.transl_mixed_product_shape
-          ~get_value_kind:(fun _ -> Lambda.generic_value) shape
-      in
+      let shape = Lambda.transl_mixed_product_shape shape in
       (* Check to make sure the gap never overflows.
          See [jane/doc/extensions/_03-unboxed-types/03-block-indices.md]. *)
       let cts =

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -238,9 +238,7 @@ let compute_static_size lam =
         | Record_inlined (_, Constructor_mixed shape,
                           (Variant_boxed _ | Variant_extensible))
         | Record_mixed shape ->
-            Block (Mixed_record (Lambda.transl_mixed_product_shape
-              ~get_value_kind:(fun _i -> Lambda.generic_value)
-              shape))
+            Block (Mixed_record (Lambda.transl_mixed_product_shape shape))
         | Record_unboxed | Record_ufloat
         | Record_inlined (_, _, (Variant_unboxed | Variant_with_null)) ->
             Misc.fatal_error "size_of_primitive"

--- a/testsuite/tests/typing-layouts-caml-modify/basics.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/basics.ml
@@ -143,18 +143,12 @@ let () =
   test ~expect_caml_modifies (fun () -> f External_variant.make);
   test ~expect_caml_modifies (fun () -> f (Unboxed 10))
 
-(* Bug: Unboxed product updates in records result in one modify per product
-   element, even if that element is external.
-
-   To be fixed in a later commit.
-*)
-
 (* Record modification with shallow external product *)
 let () =
   let open struct
     type outer = { mutable x : #(int * int) }
   end in
-  test ~expect_caml_modifies:2 (* should be 0 *)
+  test ~expect_caml_modifies:0
   (fun () ->
     let outer = { x = #(1, 2) } in
     outer.x <- #(3, 4);
@@ -167,7 +161,7 @@ let () =
     type inner = #{ a : int; b : int }
     type outer = { mutable x : inner }
   end in
-  test ~expect_caml_modifies:2 (* should be 0 *)
+  test ~expect_caml_modifies:0
   (fun () ->
     let outer = { x = #{ a = 1; b = 2 } } in
     outer.x <- #{ a = 3; b = 4 };
@@ -179,7 +173,7 @@ let () =
     type inner = { a : int; b : int }
     type outer = { mutable x : inner# }
   end in
-  test ~expect_caml_modifies:2 (* should be 0 *)
+  test ~expect_caml_modifies:0
   (fun () ->
     let outer = { x = #{ a = 1; b = 2 } } in
     outer.x <- #{ a = 3; b = 4 };
@@ -191,7 +185,7 @@ let () =
   let open struct
     type outer = { mutable x : #(int * #(int * bool)) }
   end in
-  test ~expect_caml_modifies:3 (* should be 0 *)
+  test ~expect_caml_modifies:0
   (fun () ->
     let outer = { x = #(1, #(2, true)) } in
     outer.x <- #(3, #(4, false));
@@ -204,7 +198,7 @@ let () =
     type inner2 = #{ c : int; d : inner1 }
     type outer = { mutable x : inner2 }
   end in
-  test ~expect_caml_modifies:3 (* should be 0 *)
+  test ~expect_caml_modifies:0
   (fun () ->
     let outer = { x = #{ c = 1; d = #{ a = 2; b = 3 } } } in
     outer.x <- #{ c = 4; d = #{ a = 5; b = 6 } };
@@ -217,7 +211,7 @@ let () =
     type inner2 = { c : int; d : inner1# }
     type outer = { mutable x : inner2#}
   end in
-  test ~expect_caml_modifies:3 (* should be 0 *)
+  test ~expect_caml_modifies:0
   (fun () ->
     let outer = { x = #{ c = 1; d = #{ a = 2; b = 3 } } } in
     outer.x <- #{ c = 4; d = #{ a = 5; b = 6 } };
@@ -230,7 +224,7 @@ let () =
     type outer =
       { mutable x : #(int * #(int * #(string * bool) * #(bool option * char))) }
   end in
-  test ~expect_caml_modifies:6 (* should be 2 *)
+  test ~expect_caml_modifies:2
   (fun () ->
     let outer = { x = #(1, #(2, #("a", true), #(Some true, 'a'))) } in
     outer.x <- #(3, #(4, #("b", false), #(None, 'b')));
@@ -245,7 +239,7 @@ let () =
     type inner4 = #{ h : int; i : inner3 }
     type outer = { mutable x : inner4 }
   end in
-  test ~expect_caml_modifies:6 (* should be 2 *)
+  test ~expect_caml_modifies:2
   (fun () ->
     let outer =
       { x = #{ h = 1; i = #{ e = 2;
@@ -266,7 +260,7 @@ let () =
     type inner4 = { h : int; i : inner3# }
     type outer = { mutable x : inner4# }
   end in
-  test ~expect_caml_modifies:6 (* should be 2 *)
+  test ~expect_caml_modifies:2
   (fun () ->
     let outer =
       { x = #{ h = 1; i = #{ e = 2;

--- a/testsuite/tests/typing-layouts-caml-modify/basics.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/basics.ml
@@ -16,33 +16,35 @@
    Note: caml_modify is always called in bytecode, so this test is only performed on
    native *)
 
-external called_caml_modify : unit -> bool = "replace_caml_modify_called_modify" [@@noalloc]
+external called_caml_modify : unit -> int = "replace_caml_modify_called_modify" [@@noalloc]
 external reset : unit -> unit = "replace_caml_modify_reset" [@@noalloc]
 
 (* Test whether executing f results in caml_modify being called *)
-let test ~(call_pos : [%call_pos]) ~expect_caml_modify_call f =
+let test ~(call_pos : [%call_pos]) ~expect_caml_modifies f =
   reset ();
   f ();
-  let error =
-    match expect_caml_modify_call, called_caml_modify () with
-    | true, false -> Some "Expected a call to caml_modify but got none"
-    | false, true -> Some "Expected no call to caml_modify but got one"
-    | true, true | false, false -> None
-  in
-  match error with
-  | Some error ->
-    failwith @@ Format.sprintf "%s on line %d" error call_pos.pos_lnum
-  | None -> ()
+  let actual_modifies = called_caml_modify () in
+  if not (expect_caml_modifies = actual_modifies) then
+    failwith @@
+      Format.sprintf
+        "On line %d, expected %d calls to caml_modify, but saw %d"
+        call_pos.pos_lnum expect_caml_modifies actual_modifies
 
 (* Validate testing technique *)
 
 let () =
-  test ~expect_caml_modify_call:true (fun () ->
+  test ~expect_caml_modifies:1 (fun () ->
     let foo = Array.make 1 "hello" in
     foo.(0) <- "world")
 
 let () =
-  test ~expect_caml_modify_call:false (fun () ->
+  test ~expect_caml_modifies:2 (fun () ->
+    let foo = Array.make 1 "hello" in
+    foo.(0) <- "world";
+    foo.(0) <- "")
+
+let () =
+  test ~expect_caml_modifies:0 (fun () ->
     let foo = Array.make 1 0 in
     foo.(0) <- 0)
 
@@ -66,19 +68,19 @@ let () =
     let foo = Array.make 1 x in
     foo.(0) <- x
   in
-  let expect_caml_modify_call = true in
-  test ~expect_caml_modify_call (fun () -> f 10);
-  test ~expect_caml_modify_call (fun () -> f "hello");
-  test ~expect_caml_modify_call (fun () -> f true);
-  test ~expect_caml_modify_call (fun () -> f { boxed = 10 });
-  test ~expect_caml_modify_call (fun () -> f { boxed = "hello" });
-  test ~expect_caml_modify_call (fun () -> f { unboxed = 10 });
-  test ~expect_caml_modify_call (fun () -> f { unboxed = "hello" });
-  test ~expect_caml_modify_call (fun () -> f External_variant.make);
-  test ~expect_caml_modify_call (fun () -> f (Boxed 10));
-  test ~expect_caml_modify_call (fun () -> f (Boxed "hello"));
-  test ~expect_caml_modify_call (fun () -> f (Unboxed 10));
-  test ~expect_caml_modify_call (fun () -> f (Unboxed "hello"))
+  let expect_caml_modifies = 1 in
+  test ~expect_caml_modifies (fun () -> f 10);
+  test ~expect_caml_modifies (fun () -> f "hello");
+  test ~expect_caml_modifies (fun () -> f true);
+  test ~expect_caml_modifies (fun () -> f { boxed = 10 });
+  test ~expect_caml_modifies (fun () -> f { boxed = "hello" });
+  test ~expect_caml_modifies (fun () -> f { unboxed = 10 });
+  test ~expect_caml_modifies (fun () -> f { unboxed = "hello" });
+  test ~expect_caml_modifies (fun () -> f External_variant.make);
+  test ~expect_caml_modifies (fun () -> f (Boxed 10));
+  test ~expect_caml_modifies (fun () -> f (Boxed "hello"));
+  test ~expect_caml_modifies (fun () -> f (Unboxed 10));
+  test ~expect_caml_modifies (fun () -> f (Unboxed "hello"))
 
 (* External values result in no caml_modify calls *)
 let () =
@@ -86,12 +88,12 @@ let () =
     let foo = Array.make 1 x in
     foo.(0) <- x
   in
-  let expect_caml_modify_call = false in
-  test ~expect_caml_modify_call (fun () -> f 10);
-  test ~expect_caml_modify_call (fun () -> f true);
-  test ~expect_caml_modify_call (fun () -> f { unboxed = 10 });
-  test ~expect_caml_modify_call (fun () -> f External_variant.make);
-  test ~expect_caml_modify_call (fun () -> f (Unboxed 10))
+  let expect_caml_modifies = 0 in
+  test ~expect_caml_modifies (fun () -> f 10);
+  test ~expect_caml_modifies (fun () -> f true);
+  test ~expect_caml_modifies (fun () -> f { unboxed = 10 });
+  test ~expect_caml_modifies (fun () -> f External_variant.make);
+  test ~expect_caml_modifies (fun () -> f (Unboxed 10))
 
 (* Inlining a function that takes internal values should result in no caml_modify call
    for external values *)
@@ -100,24 +102,24 @@ let () =
     let foo = Array.make 1 x in
     foo.(0) <- x
   in
-  let expect_caml_modify_call = true in
+  let expect_caml_modifies = 1 in
   (* CR layouts v2.8: should have no caml_modify call *)
-  test ~expect_caml_modify_call (fun () -> f 10);
-  test ~expect_caml_modify_call (fun () -> f "hello");
+  test ~expect_caml_modifies (fun () -> f 10);
+  test ~expect_caml_modifies (fun () -> f "hello");
   (* CR layouts v2.8: should have no caml_modify call *)
-  test ~expect_caml_modify_call (fun () -> f true);
-  test ~expect_caml_modify_call (fun () -> f { boxed = 10 });
-  test ~expect_caml_modify_call (fun () -> f { boxed = "hello" });
+  test ~expect_caml_modifies (fun () -> f true);
+  test ~expect_caml_modifies (fun () -> f { boxed = 10 });
+  test ~expect_caml_modifies (fun () -> f { boxed = "hello" });
   (* CR layouts v2.8: should have no caml_modify call *)
-  test ~expect_caml_modify_call (fun () -> f { unboxed = 10 });
-  test ~expect_caml_modify_call (fun () -> f { unboxed = "hello" });
+  test ~expect_caml_modifies (fun () -> f { unboxed = 10 });
+  test ~expect_caml_modifies (fun () -> f { unboxed = "hello" });
   (* CR layouts v2.8: should have no caml_modify call *)
-  test ~expect_caml_modify_call (fun () -> f External_variant.make);
-  test ~expect_caml_modify_call (fun () -> f (Boxed 10));
-  test ~expect_caml_modify_call (fun () -> f (Boxed "hello"));
+  test ~expect_caml_modifies (fun () -> f External_variant.make);
+  test ~expect_caml_modifies (fun () -> f (Boxed 10));
+  test ~expect_caml_modifies (fun () -> f (Boxed "hello"));
   (* CR layouts v2.8: should have no caml_modify call *)
-  test ~expect_caml_modify_call (fun () -> f (Unboxed 10));
-  test ~expect_caml_modify_call (fun () -> f (Unboxed "hello"))
+  test ~expect_caml_modifies (fun () -> f (Unboxed 10));
+  test ~expect_caml_modifies (fun () -> f (Unboxed "hello"))
 
 (* External64 values result in no caml_modify calls iff the system is 64 bit *)
 let () =
@@ -134,9 +136,145 @@ let () =
       false
     | _ -> failwith "Expected word size of 32 or 64"
   in
-  let expect_caml_modify_call = not is_64_bit in
-  test ~expect_caml_modify_call (fun () -> f 10);
-  test ~expect_caml_modify_call (fun () -> f true);
-  test ~expect_caml_modify_call (fun () -> f { unboxed = 10 });
-  test ~expect_caml_modify_call (fun () -> f External_variant.make);
-  test ~expect_caml_modify_call (fun () -> f (Unboxed 10))
+  let expect_caml_modifies = if is_64_bit then 0 else 1 in
+  test ~expect_caml_modifies (fun () -> f 10);
+  test ~expect_caml_modifies (fun () -> f true);
+  test ~expect_caml_modifies (fun () -> f { unboxed = 10 });
+  test ~expect_caml_modifies (fun () -> f External_variant.make);
+  test ~expect_caml_modifies (fun () -> f (Unboxed 10))
+
+(* Bug: Unboxed product updates in records result in one modify per product
+   element, even if that element is external.
+
+   To be fixed in a later commit.
+*)
+
+(* Record modification with shallow external product *)
+let () =
+  let open struct
+    type outer = { mutable x : #(int * int) }
+  end in
+  test ~expect_caml_modifies:2 (* should be 0 *)
+  (fun () ->
+    let outer = { x = #(1, 2) } in
+    outer.x <- #(3, 4);
+    ignore (Sys.opaque_identity outer)
+  )
+
+
+let () =
+  let open struct
+    type inner = #{ a : int; b : int }
+    type outer = { mutable x : inner }
+  end in
+  test ~expect_caml_modifies:2 (* should be 0 *)
+  (fun () ->
+    let outer = { x = #{ a = 1; b = 2 } } in
+    outer.x <- #{ a = 3; b = 4 };
+    ignore (Sys.opaque_identity outer)
+  )
+
+let () =
+  let open struct
+    type inner = { a : int; b : int }
+    type outer = { mutable x : inner# }
+  end in
+  test ~expect_caml_modifies:2 (* should be 0 *)
+  (fun () ->
+    let outer = { x = #{ a = 1; b = 2 } } in
+    outer.x <- #{ a = 3; b = 4 };
+    ignore (Sys.opaque_identity outer)
+  )
+
+(* Record modification with nested external product *)
+let () =
+  let open struct
+    type outer = { mutable x : #(int * #(int * bool)) }
+  end in
+  test ~expect_caml_modifies:3 (* should be 0 *)
+  (fun () ->
+    let outer = { x = #(1, #(2, true)) } in
+    outer.x <- #(3, #(4, false));
+    ignore (Sys.opaque_identity outer)
+  )
+
+let () =
+  let open struct
+    type inner1 = #{ a : int; b : int }
+    type inner2 = #{ c : int; d : inner1 }
+    type outer = { mutable x : inner2 }
+  end in
+  test ~expect_caml_modifies:3 (* should be 0 *)
+  (fun () ->
+    let outer = { x = #{ c = 1; d = #{ a = 2; b = 3 } } } in
+    outer.x <- #{ c = 4; d = #{ a = 5; b = 6 } };
+    ignore (Sys.opaque_identity outer)
+  )
+
+let () =
+  let open struct
+    type inner1 = { a : int; b : int }
+    type inner2 = { c : int; d : inner1# }
+    type outer = { mutable x : inner2#}
+  end in
+  test ~expect_caml_modifies:3 (* should be 0 *)
+  (fun () ->
+    let outer = { x = #{ c = 1; d = #{ a = 2; b = 3 } } } in
+    outer.x <- #{ c = 4; d = #{ a = 5; b = 6 } };
+    ignore (Sys.opaque_identity outer)
+  )
+
+(* Record modification with nested mixed product *)
+let () =
+  let open struct
+    type outer =
+      { mutable x : #(int * #(int * #(string * bool) * #(bool option * char))) }
+  end in
+  test ~expect_caml_modifies:6 (* should be 2 *)
+  (fun () ->
+    let outer = { x = #(1, #(2, #("a", true), #(Some true, 'a'))) } in
+    outer.x <- #(3, #(4, #("b", false), #(None, 'b')));
+    ignore (Sys.opaque_identity outer)
+  )
+
+let () =
+  let open struct
+    type inner1 = #{ a : string; b : bool }
+    type inner2 = #{ c : bool option; d : char }
+    type inner3 = #{ e : int; f : inner1; g : inner2 }
+    type inner4 = #{ h : int; i : inner3 }
+    type outer = { mutable x : inner4 }
+  end in
+  test ~expect_caml_modifies:6 (* should be 2 *)
+  (fun () ->
+    let outer =
+      { x = #{ h = 1; i = #{ e = 2;
+                             f = #{ a = "a"; b = true };
+                             g = #{ c = Some true; d = 'a' } } } }
+    in
+    outer.x <- #{ h = 3; i = #{ e = 4;
+                                f = #{ a = "b"; b = false };
+                                g = #{ c = None; d = 'b' } } };
+    ignore (Sys.opaque_identity outer)
+  )
+
+let () =
+  let open struct
+    type inner1 = { a : string; b : bool }
+    type inner2 = { c : bool option; d : char }
+    type inner3 = { e : int; f : inner1#; g : inner2# }
+    type inner4 = { h : int; i : inner3# }
+    type outer = { mutable x : inner4# }
+  end in
+  test ~expect_caml_modifies:6 (* should be 2 *)
+  (fun () ->
+    let outer =
+      { x = #{ h = 1; i = #{ e = 2;
+                             f = #{ a = "a"; b = true };
+                             g = #{ c = Some true; d = 'a' } } } }
+    in
+    outer.x <- #{ h = 3; i = #{ e = 4;
+                                f = #{ a = "b"; b = false };
+                                g = #{ c = None; d = 'b' } } };
+    ignore (Sys.opaque_identity outer)
+  )

--- a/testsuite/tests/typing-layouts-caml-modify/replace_caml_modify.c
+++ b/testsuite/tests/typing-layouts-caml-modify/replace_caml_modify.c
@@ -1,17 +1,17 @@
 #include <caml/mlvalues.h>
 #include <stdbool.h>
 
-// Use this to track whether caml_modify has been called
-static bool called_modify = false;
+// Use this to track how many times caml_modify has been called
+static int called_modify = 0;
 
 CAMLprim value replace_caml_modify_called_modify()
 {
-  return Val_bool(called_modify);
+  return Val_int(called_modify);
 }
 
 CAMLprim value replace_caml_modify_reset()
 {
-  called_modify = false;
+  called_modify = 0;
   return Val_unit;
 }
 
@@ -22,7 +22,7 @@ CAMLextern void __real_caml_modify(value *fp, value v);
 CAMLprim void __wrap_caml_modify(value *fp, value v)
 {
   // Record that caml_modify was called and then call the actual caml_modify
-  called_modify = true;
+  called_modify += 1;
   __real_caml_modify(fp, v);
 }
 

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -756,6 +756,8 @@ and value_kind_mixed_block_field env ~loc ~visited ~depth ~num_nodes_visited
             Misc.Stdlib.Array.of_list_map (fun {Types.ld_type} -> Some ld_type)
               lbls
           | Type_variant _ | Type_record _ | Type_abstract _ | Type_open ->
+            (* We don't need to handle [@@unboxed] records/variants here,
+               because [scrape_ty] looks though them. *)
             unknown ()
           end
         | Tvar _ | Tarrow _ | Ttuple _ | Tobject _ | Tfield _ | Tnil

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -740,11 +740,36 @@ and value_kind_mixed_block_field env ~loc ~visited ~depth ~num_nodes_visited
   | Word -> num_nodes_visited, Word
   | Untagged_immediate -> num_nodes_visited, Untagged_immediate
   | Product fs ->
-    let num_nodes_visited, kinds =
-      Array.fold_left_map (fun num_nodes_visited field ->
-        value_kind_mixed_block_field env ~loc ~visited ~depth ~num_nodes_visited
-          field None
-      ) num_nodes_visited fs
+    let unknown () = Array.init (Array.length fs) (fun _ -> None) in
+    let types =
+      match ty with
+      | None -> unknown ()
+      | Some ty ->
+        let ty = scrape_ty env ty in
+        match get_desc ty with
+        | Tunboxed_tuple fields ->
+          Misc.Stdlib.Array.of_list_map (fun (_, field) -> Some field) fields
+        | Tconstr(p, _, _) ->
+          begin match (Env.find_type p env).type_kind with
+          | exception Not_found -> unknown ()
+          | Type_record_unboxed_product (lbls, _, _) ->
+            Misc.Stdlib.Array.of_list_map (fun {Types.ld_type} -> Some ld_type)
+              lbls
+          | Type_variant _ | Type_record _ | Type_abstract _ | Type_open ->
+            unknown ()
+          end
+        | Tvar _ | Tarrow _ | Ttuple _ | Tobject _ | Tfield _ | Tnil
+        | Tlink _ | Tsubst _ | Tvariant _ | Tunivar _ | Tpoly _ | Tpackage _
+        | Tof_kind _ -> unknown ()
+    in
+    let (_, num_nodes_visited), kinds =
+      Array.fold_left_map (fun (i, num_nodes_visited) field ->
+        let num_nodes_visited, kind =
+          value_kind_mixed_block_field env ~loc ~visited ~depth
+            ~num_nodes_visited field types.(i)
+        in
+        (i + 1, num_nodes_visited), kind
+      ) (0, num_nodes_visited) fs
     in
     num_nodes_visited, Product kinds
   | Void -> num_nodes_visited, Product [||]
@@ -981,6 +1006,16 @@ let value_kind env loc ty =
     let (_num_nodes_visited, value_kind) =
       value_kind env ~loc ~visited:Numbers.Int.Set.empty ~depth:0
         ~num_nodes_visited:0 ty
+    in
+    value_kind
+  with
+  | Missing_cmi_fallback -> raise (Error (loc, Non_value_layout (ty, None)))
+
+let transl_mixed_block_element env loc ty mbe =
+  try
+    let (_num_nodes_visited, value_kind) =
+      value_kind_mixed_block_field env ~loc ~visited:Numbers.Int.Set.empty
+        ~depth:0 ~num_nodes_visited:0 mbe (Some ty)
     in
     value_kind
   with

--- a/typing/typeopt.mli
+++ b/typing/typeopt.mli
@@ -78,6 +78,10 @@ val function_arg_layout :
 
 val value_kind : Env.t -> Location.t -> Types.type_expr -> Lambda.value_kind
 
+val transl_mixed_block_element :
+  Env.t -> Location.t -> Types.type_expr -> Types.mixed_block_element
+  -> unit Lambda.mixed_block_element
+
 val classify_lazy_argument : Typedtree.expression ->
                              [ `Constant_or_function
                              | `Float_that_cannot_be_shortcut


### PR DESCRIPTION
In this program, `set_mut_box` gets two calls to `caml_modify`, even though we know both things being updated are `int`s.
```ocaml
type record =
  { a : int
  ; b : int
  }
 
type mut_box = { mutable t : record# }

let set_mut_box r a b = r.t <- #{ a; b }
```

This happens because the compilation of `Texp_setfield` relies on `transl_mixed_product_shape`. That function has some logic that attempts to give an accurate value kind for the field being updated, but it is defeated by unboxed products. This PR fixes that by ditching the complicated logic within `transl_mixed_product_shape` and just separately calculating an accurate shape for the one field being updated.

To calculate that shape, we rely on `Typeopt.value_kind_mixed_block_field`, which already existed (and, confusingly computes a mixed block shape, not a value kind - it's called this because it's part of the big mutually recursive definition of `value_kind`).  That function also declined to descend into products, but it's the right place to do that, so we fix it. This means computing value kinds may get a little more expensive for mixed blocks containing unboxed products, but the issue this PR fixes shows that can be worth doing.

There are two commits: The first adds a test showing the bad behavior, the second makes the above changes and updates the test accordingly.