### PR TITLE
Bugfix: prevent arguments of indirect_unknown_arity calls to be unboxed

### DIFF
--- a/middle_end/flambda2/reaper/dep_solver.ml
+++ b/middle_end/flambda2/reaper/dep_solver.ml
@@ -1354,6 +1354,23 @@ let datalog_rules =
        constructor_rel call_witness code_id_of_witness codeid;
        cannot_change_calling_convention codeid ]
      ==> cannot_unbox0 allocation_id);
+    (* Cannot unbox parameters of [Indirect_unknown_arity] calls, even if they do not escape. *)
+    (let$ [ usage; allocation_id;
+            relation;
+            _v] =
+       [ "usage"; "allocation_id";
+         "relation";
+         "_v" ]
+     in
+     [ sources_rel usage allocation_id;
+       coaccessor_rel usage relation _v;
+       filter
+         (fun [f] ->
+           match[@ocaml.warning "-4"] CoField.decode f with
+           | Param (Indirect_code_pointer, _) -> true
+           | _ -> false)
+         [relation] ]
+     ==> cannot_unbox0 allocation_id);
     (let$ [alias; allocation_id; relation; to_] =
        ["alias"; "allocation_id"; "relation"; "to_"]
      in

--- a/middle_end/flambda2/reaper/dep_solver.ml
+++ b/middle_end/flambda2/reaper/dep_solver.ml
@@ -1354,13 +1354,10 @@ let datalog_rules =
        constructor_rel call_witness code_id_of_witness codeid;
        cannot_change_calling_convention codeid ]
      ==> cannot_unbox0 allocation_id);
-    (* Cannot unbox parameters of [Indirect_unknown_arity] calls, even if they do not escape. *)
-    (let$ [ usage; allocation_id;
-            relation;
-            _v] =
-       [ "usage"; "allocation_id";
-         "relation";
-         "_v" ]
+    (* Cannot unbox parameters of [Indirect_unknown_arity] calls, even if they
+       do not escape. *)
+    (let$ [usage; allocation_id; relation; _v] =
+       ["usage"; "allocation_id"; "relation"; "_v"]
      in
      [ sources_rel usage allocation_id;
        coaccessor_rel usage relation _v;

--- a/middle_end/flambda2/reaper/dep_solver.ml
+++ b/middle_end/flambda2/reaper/dep_solver.ml
@@ -1363,9 +1363,9 @@ let datalog_rules =
        coaccessor_rel usage relation _v;
        filter
          (fun [f] ->
-           match[@ocaml.warning "-4"] CoField.decode f with
+           match CoField.decode f with
            | Param (Indirect_code_pointer, _) -> true
-           | _ -> false)
+           | Param (Direct_code_pointer, _) -> false)
          [relation] ]
      ==> cannot_unbox0 allocation_id);
     (let$ [alias; allocation_id; relation; to_] =


### PR DESCRIPTION
In some cases, parameters of an `Indirect_unknown_arity` calls were unboxed, even though we do not change the arity of such calls for now. This fixes the bug by preventing the unboxing in such cases.