### PR TITLE
Silence shape related errors

### DIFF
--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -850,8 +850,8 @@ let rec shape_with_layout ~(layout : Layout.t) (sh : without_layout ts) :
       | Base
           ( Void | Untagged_immediate | Bits8 | Bits16 | Bits32 | Bits64 |
             Float64 | Float32 | Word | Vec128 | Vec256 | Vec512 ) ) ) ->
-    Misc.fatal_errorf "tuple shape must have layout value, but has layout %a"
-      Layout.format layout
+    (* CR sspies: silenced error, should be handled properly instead *)
+    Ts_other layout
   | Ts_unboxed_tuple shapes, Product lys
     when List.length shapes = List.length lys ->
     let shapes_and_layouts = List.combine shapes lys in
@@ -861,28 +861,26 @@ let rec shape_with_layout ~(layout : Layout.t) (sh : without_layout ts) :
         shapes_and_layouts
     in
     Ts_unboxed_tuple shapes_with_layout
-  | Ts_unboxed_tuple shapes, Product lys ->
-    Misc.fatal_errorf "unboxed tuple shape has %d shapes, but %d layouts"
-      (List.length shapes) (List.length lys)
+  | Ts_unboxed_tuple _, Product _ ->
+    (* CR sspies: silenced error, should be handled properly instead *)
+    Ts_other layout
   | ( Ts_unboxed_tuple _,
       Base
         ( Void | Value | Untagged_immediate | Float32 | Float64 | Word |
           Bits8 | Bits16 | Bits32 | Bits64 | Vec128 | Vec256 | Vec512 ) ) ->
-    Misc.fatal_errorf
-      "unboxed tuple must have unboxed product layout, but has layout %a"
-      Layout.format layout
+    (* CR sspies: silenced error, should be handled properly instead *)
+    Ts_other layout
   | Ts_var (name, Layout_to_be_determined), _ -> Ts_var (name, layout)
   | Ts_arrow (arg, ret), Base Value -> Ts_arrow (arg, ret)
   | Ts_arrow _, _ ->
-    Misc.fatal_errorf "function type shape must have layout value"
+    (* CR sspies: silenced error, should be handled properly instead *)
+    Ts_other layout
   | Ts_predef (predef, shapes), _
     when Layout.equal (Predef.to_layout predef) layout ->
     Ts_predef (predef, shapes)
-  | Ts_predef (predef, _), _ ->
-    Misc.fatal_errorf
-      "predef %s has layout %a, but is expected to have layout %a"
-      (Predef.to_string predef) Layout.format (Predef.to_layout predef)
-      Layout.format layout
+  | Ts_predef (_, _), _ ->
+    (* CR sspies: silenced error, should be handled properly instead *)
+    Ts_other layout
   | Ts_variant fields, Base Value ->
     let fields =
       poly_variant_constructors_map
@@ -891,7 +889,8 @@ let rec shape_with_layout ~(layout : Layout.t) (sh : without_layout ts) :
     in
     Ts_variant fields
   | Ts_variant _, _ ->
-    Misc.fatal_errorf "polymorphic variant must have layout value"
+    (* CR sspies: silenced error, should be handled properly instead *)
+    Ts_other layout
   | Ts_other Layout_to_be_determined, _ -> Ts_other layout
 
 (* CR sspies: This is a hacky "solution" to do type variable substitution in

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -128,7 +128,8 @@ module Type_shape = struct
         Shape.Ts_other Layout_to_be_determined
         (* Objects are currently not supported in the debugger. *)
       | Tlink _ | Tsubst _ ->
-        Misc.fatal_error "linking and substitution should not reach this stage."
+        (* CR sspies: silenced error, should be handled properly instead *)
+        Shape.Ts_other Layout_to_be_determined
       | Tvariant rd ->
         let row_fields = Types.row_fields rd in
         let row_fields =
@@ -216,10 +217,8 @@ module Type_decl_shape = struct
             let ly2 = mixed_block_shape_to_layout mix_shape in
             if not (Layout.equal ly ly2)
             then
-              Misc.fatal_errorf
-                "Type_shape: variant constructor with mismatched layout, has \
-                 %a but expected %a"
-                Layout.format ly Layout.format ly2)
+              (* CR sspies: silenced error, should be handled properly instead *)
+              ())
           (Array.to_list shapes) args;
         Array.map mixed_block_shape_to_layout shapes
       | Constructor_uniform_value ->
@@ -230,10 +229,8 @@ module Type_decl_shape = struct
                    (Layout.equal ly (Layout.Base Value)
                    || Layout.equal ly (Layout.Base Void))
               then
-                Misc.fatal_errorf
-                  "Type_shape: variant constructor with mismatched layout, has \
-                   %a but expected value or void."
-                  Layout.format ly
+                (* CR sspies: silenced error, should be handled properly instead *)
+                Layout.Base Value
               else ly)
             args
         in
@@ -338,7 +335,8 @@ module Type_decl_shape = struct
             in
             record_of_labels ~uid_of_path Record_floats lbl_list
           | Record_inlined _ ->
-            Misc.fatal_error "inlined records not allowed here"
+            (* CR sspies: silenced error, should be handled properly instead *)
+            Tds_other
             (* Inline records of this form should not occur as part of type
                declarations. They do not exist for top-level declarations, but
                they do exist temporarily such as inside of a match (e.g., [t] is


### PR DESCRIPTION
This PR silences the shape related errors in the DWARF emission (`dwarf_type.ml`) and shape generation (`type_shape.ml` and `shape.ml`). In the future, errors in these cases should become configurable via a flag to avoid disturbing compilation. See #4555. 

There is one notable exception: The fatal errors remain for `[@@unboxed]` records and variants. For these, an error is still raised if there is, for example, more than one argument. (The relevant code is in `type_shape.ml:288-308`, `dwarf_type.ml:1435-1439`, and `dwarf_type.ml:1596-1601`.)