### PR TITLE
Use 32-bit int types for ocamlj

### DIFF
--- a/middle_end/flambda2/numbers/targetint_31_63.ml
+++ b/middle_end/flambda2/numbers/targetint_31_63.ml
@@ -20,6 +20,100 @@
    silently truncates the input int to make it fit, whereas we probably want to
    make it produce an error ? *)
 
+module type S = sig
+  type t
+
+  include Container_types.S with type t := t
+
+  val min_value : t
+
+  val max_value : t
+
+  val minus_one : t
+
+  val zero : t
+
+  val one : t
+
+  val ten : t
+
+  val hex_ff : t
+
+  val bool : bool -> t
+
+  val bool_true : t
+
+  val bool_false : t
+
+  val ( <= ) : t -> t -> bool
+
+  val ( >= ) : t -> t -> bool
+
+  val ( < ) : t -> t -> bool
+
+  val bottom_byte_to_int : t -> int
+
+  val of_char : char -> t
+
+  val of_int : int -> t
+
+  val of_int_option : int -> t option
+
+  val to_int : t -> int
+
+  val to_int_option : t -> int option
+
+  val to_int_exn : t -> int
+
+  val of_int32 : int32 -> t
+
+  val to_int32 : t -> int32
+
+  val of_int64 : int64 -> t
+
+  val to_int64 : t -> int64
+
+  val of_targetint : Targetint_32_64.t -> t
+
+  val to_targetint : t -> Targetint_32_64.t
+
+  val of_float : float -> t
+
+  val to_float : t -> float
+
+  val neg : t -> t
+
+  val get_least_significant_16_bits_then_byte_swap : t -> t
+
+  val add : t -> t -> t
+
+  val sub : t -> t -> t
+
+  val mul : t -> t -> t
+
+  val mod_ : t -> t -> t
+
+  val div : t -> t -> t
+
+  val and_ : t -> t -> t
+
+  val or_ : t -> t -> t
+
+  val xor : t -> t -> t
+
+  val shift_left : t -> int -> t
+
+  val shift_right : t -> int -> t
+
+  val shift_right_logical : t -> int -> t
+
+  val min : t -> t -> t
+
+  val max : t -> t -> t
+
+  val is_non_negative : t -> bool
+end
+
 module T0 = struct
   include Targetint_32_64
 
@@ -98,7 +192,7 @@ module T0 = struct
   let is_non_negative t = t >= zero
 end
 
-module Self = struct
+module With_gc_bit = struct
   include T0
 
   (* Note: the [include T0] must be first so that the [One_bit_fewer] functions
@@ -106,6 +200,21 @@ module Self = struct
   include One_bit_fewer.Make (T0)
   include Container_types.Make (T0)
 end
+
+module Without_gc_bit = struct
+  include T0
+  include Container_types.Make (T0)
+end
+
+(* CR selee: this is extremely sad, and should be replaced with a proper config
+   variable in the future *)
+let has_gc_bit_in_int =
+  let compiler_name = Filename.basename Sys.argv.(0) in
+  match compiler_name with "ocamlj" | "ocamlj.opt" -> false | _ -> true
+
+module Self = (val if has_gc_bit_in_int
+                   then (module With_gc_bit)
+                   else (module Without_gc_bit) : S)
 
 include Self
 

--- a/middle_end/flambda2/numbers/targetint_32_64.ml
+++ b/middle_end/flambda2/numbers/targetint_32_64.ml
@@ -124,11 +124,6 @@ module type S = sig
   module Targetint_set = Set
 end
 
-(* CR selee: this is extremely sad *)
-let size =
-  let compiler_name = Filename.basename Sys.argv.(0) in
-  match compiler_name with "ocamlj" | "ocamlj.opt" -> 32 | _ -> Sys.word_size
-
 module Int32 = struct
   include Int32
 
@@ -259,6 +254,12 @@ module Int64 = struct
 
   external swap_byte_endianness : t -> t = "%bswap_int64"
 end
+
+(* CR selee: this is extremely sad, and should be replaced with a proper config
+   variable in the future *)
+let size =
+  let compiler_name = Filename.basename Sys.argv.(0) in
+  match compiler_name with "ocamlj" | "ocamlj.opt" -> 32 | _ -> Sys.word_size
 
 include (val match size with
              | 32 -> (module Int32)


### PR DESCRIPTION
Before, `Targetint_31_63` assumed that ocaml ints in javascript are 31-bits wide; it's actually 32. We use the same unfortunate hack as in `Targetint_32_64` to detect that we are running `ocamlj`, and switch to 32 bits instead. Note that `Targetint_31_63` was renamed to `Target_ocaml_int` in anticipation of this change, so the module name being `Targetint_31_63` is not a problem.