### PR TITLE
flambda2: Recognize affine switches

### DIFF
--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -389,6 +389,92 @@ let rebuild_switch_with_single_arg_to_same_destination uacc ~dacc_before_switch
   in
   expr, uacc
 
+let recognize_affine_switch_to_same_destination consts =
+  match consts with
+  | [] | [_] -> None
+  | const0 :: const1 :: other_consts ->
+    let slope = TI.sub const1 const0 in
+    let rec check offset slope index = function
+      | [] -> Some (offset, slope)
+      | const :: _ when not TI.(equal const (add (mul index slope) offset)) ->
+        None
+      | _ :: consts -> check offset slope TI.(add index one) consts
+    in
+    check const0 slope (TI.of_int 2) other_consts
+
+(* Tiny DSL to preserve sanity while rebuilding expressions. *)
+
+let bound_prim name kind prim dbg = name, kind, prim, dbg
+
+let ( let$ ) (name, kind, prim, dbg) k uacc ~dacc_before_switch =
+  match
+    find_cse_simple ~required:false dacc_before_switch (UA.required_names uacc)
+      prim
+  with
+  | Some simple -> k simple uacc ~dacc_before_switch
+  | None ->
+    let named = Named.create_prim prim dbg in
+    let var = Variable.create name kind in
+    let uacc = UA.add_free_names uacc (NO.singleton_variable var NM.normal) in
+    let body, uacc = k (Simple.var var) uacc ~dacc_before_switch in
+    let duid = Flambda_debug_uid.none in
+    let binding : EB.binding_to_place =
+      { let_bound = BPt.singleton (BV.create var duid NM.normal);
+        simplified_defining_expr = Simplified_named.create named;
+        original_defining_expr = None
+      }
+    in
+    EB.make_new_let_bindings uacc ~bindings_outermost_first:[binding] ~body
+
+let return ~code_size ~free_names expr uacc ~dacc_before_switch:_ =
+  let uacc = UA.notify_added ~code_size uacc in
+  let uacc = UA.add_free_names uacc free_names in
+  expr, uacc
+
+let run uacc ~dacc_before_switch k = k uacc ~dacc_before_switch
+
+let rebuild_affine_switch_to_same_destination uacc ~dacc_before_switch ~original
+    ~scrutinee ~tagged_scrutinee ~dest ~offset ~slope
+    ~must_untag_lookup_table_result dbg =
+  (* We are creating the following fragment: *)
+  (* let scaled = x * slope in
+   * let final = scaled + offset in
+   * apply_cont k final
+   *)
+  let scrutinee, kind, standard_int, const =
+    match must_untag_lookup_table_result with
+    | Must_untag ->
+      ( scrutinee,
+        K.naked_immediate,
+        K.Standard_int.Naked_immediate,
+        Reg_width_const.naked_immediate )
+    | Leave_as_tagged_immediate ->
+      ( tagged_scrutinee,
+        K.value,
+        K.Standard_int.Tagged_immediate,
+        Reg_width_const.tagged_immediate )
+  in
+  run ~dacc_before_switch uacc
+    (let mul_prim : P.t =
+       Binary
+         (Int_arith (standard_int, Mul), scrutinee, Simple.const (const slope))
+     in
+     let$ scaled_arg = bound_prim "scaled_arg" kind mul_prim dbg in
+     let prim : P.t =
+       Binary
+         (Int_arith (standard_int, Add), scaled_arg, Simple.const (const offset))
+     in
+     let$ final_arg = bound_prim "final_arg" kind prim dbg in
+     let apply_cont = Apply_cont.create dest ~args:[final_arg] ~dbg in
+     let free_names = Apply_cont.free_names apply_cont in
+     let increase_in_code_size =
+       Code_size.( - )
+         (Code_size.apply_cont apply_cont)
+         (Code_size.switch original)
+     in
+     return ~code_size:increase_in_code_size ~free_names
+       (RE.create_apply_cont apply_cont))
+
 let rebuild_switch ~original ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
     ~dacc_before_switch uacc ~after_rebuild =
   let new_let_conts, arms, mergeable_arms, identity_arms, not_arms =
@@ -469,10 +555,16 @@ let rebuild_switch ~original ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
               tagging_prim
           with
           | None -> normal_case0 uacc
-          | Some tagged_scrutinee ->
-            rebuild_switch_with_single_arg_to_same_destination uacc
-              ~dacc_before_switch ~original ~tagged_scrutinee ~dest ~consts
-              ~must_untag_lookup_table_result dbg)
+          | Some tagged_scrutinee -> (
+            match recognize_affine_switch_to_same_destination consts with
+            | None ->
+              rebuild_switch_with_single_arg_to_same_destination uacc
+                ~dacc_before_switch ~original ~tagged_scrutinee ~dest ~consts
+                ~must_untag_lookup_table_result dbg
+            | Some (offset, slope) ->
+              rebuild_affine_switch_to_same_destination uacc ~dacc_before_switch
+                ~original ~scrutinee ~tagged_scrutinee ~dest ~offset ~slope
+                ~must_untag_lookup_table_result dbg))
       in
       match switch_merged with
       | Some (dest, args) ->


### PR DESCRIPTION
The middle-end (flambda2) recognizes and transforms identity switches, boolean not switches, and constant switches that get transformed into table lookups.

Unlike other parts of the compiler that implement these transformations, affine switches are not recognized. This means that when flambda2 transforms a switch into a lookup table, later passes are prevented from using an affine switch instead.

This patch implements the recognition of affine switches in flambda2.

Fixes #4474