### PR TITLE
Reaper: do not demote direct calls in zero-alloc functions

### DIFF
--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -105,7 +105,7 @@ let prepare_code ~denv acc (code_id : Code_id.t) (code : Code.t) =
      let param = Code_id_or_name.var param in Graph.add_propagate_dep (Acc.graph
      acc) ~if_used:indirect_call_witness ~from:le_monde_exterieur ~to_:param)
      params; *)
-  if has_unsafe_result_type
+  if has_unsafe_result_type || never_delete
   then (
     List.iter
       (fun var -> Acc.used ~denv (Simple.var var) acc)

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -669,9 +669,10 @@ and traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
        calls_are_not_pure } in Acc.add_apply apply_dep acc; if Option.is_some
        (Apply.callee apply) then add_call_widget function_call) else default_acc
        acc *)
-    if Option.is_some (Apply.callee apply)
-    then add_call_widget function_call;
-    if Compilation_unit.is_current (Code_id.get_compilation_unit code_id) && (Option.is_none (Apply.callee apply) || denv.should_preserve_direct_calls)
+    if Option.is_some (Apply.callee apply) then add_call_widget function_call;
+    if Compilation_unit.is_current (Code_id.get_compilation_unit code_id)
+       && (Option.is_none (Apply.callee apply)
+          || denv.should_preserve_direct_calls)
     then
       let apply_dep =
         { Traverse_acc.function_containing_apply_expr = denv.current_code_id;
@@ -684,7 +685,8 @@ and traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
         }
       in
       Acc.add_apply apply_dep acc
-    else if Option.is_none (Apply.callee apply) then default_acc acc
+    else if Option.is_none (Apply.callee apply)
+    then default_acc acc
   | Function
       { function_call =
           (Indirect_unknown_arity | Indirect_known_arity) as function_call;

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -105,7 +105,7 @@ let prepare_code ~denv acc (code_id : Code_id.t) (code : Code.t) =
      let param = Code_id_or_name.var param in Graph.add_propagate_dep (Acc.graph
      acc) ~if_used:indirect_call_witness ~from:le_monde_exterieur ~to_:param)
      params; *)
-  if has_unsafe_result_type || never_delete
+  if has_unsafe_result_type
   then (
     List.iter
       (fun var -> Acc.used ~denv (Simple.var var) acc)

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -248,6 +248,7 @@ and traverse_let denv acc let_expr : rev_expr =
     { parent = let_acc;
       conts = denv.conts;
       current_code_id = denv.current_code_id;
+      should_preserve_direct_calls = denv.should_preserve_direct_calls;
       le_monde_exterieur = denv.le_monde_exterieur;
       all_constants = denv.all_constants
     }
@@ -441,6 +442,7 @@ and traverse_let_cont_non_recursive denv acc cont ~body handler =
     let denv =
       { parent = Let_cont { cont; handler; parent = denv.parent };
         conts;
+        should_preserve_direct_calls = denv.should_preserve_direct_calls;
         current_code_id = denv.current_code_id;
         le_monde_exterieur = denv.le_monde_exterieur;
         all_constants = denv.all_constants
@@ -451,6 +453,7 @@ and traverse_let_cont_non_recursive denv acc cont ~body handler =
   traverse_cont_handler
     { parent = Hole;
       conts = denv.conts;
+      should_preserve_direct_calls = denv.should_preserve_direct_calls;
       current_code_id = denv.current_code_id;
       le_monde_exterieur = denv.le_monde_exterieur;
       all_constants = denv.all_constants
@@ -499,6 +502,7 @@ and traverse_let_cont_recursive denv acc ~invariant_params ~body handlers =
           traverse
             { parent = Hole;
               conts;
+              should_preserve_direct_calls = denv.should_preserve_direct_calls;
               current_code_id = denv.current_code_id;
               le_monde_exterieur = denv.le_monde_exterieur;
               all_constants = denv.all_constants
@@ -512,6 +516,7 @@ and traverse_let_cont_recursive denv acc ~invariant_params ~body handlers =
   let denv =
     { parent = Let_cont_rec { invariant_params; handlers; parent = denv.parent };
       conts;
+      should_preserve_direct_calls = denv.should_preserve_direct_calls;
       current_code_id = denv.current_code_id;
       le_monde_exterieur = denv.le_monde_exterieur;
       all_constants = denv.all_constants
@@ -665,8 +670,8 @@ and traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
        (Apply.callee apply) then add_call_widget function_call) else default_acc
        acc *)
     if Option.is_some (Apply.callee apply)
-    then add_call_widget function_call
-    else if Compilation_unit.is_current (Code_id.get_compilation_unit code_id)
+    then add_call_widget function_call;
+    if Compilation_unit.is_current (Code_id.get_compilation_unit code_id) && (Option.is_none (Apply.callee apply) || denv.should_preserve_direct_calls)
     then
       let apply_dep =
         { Traverse_acc.function_containing_apply_expr = denv.current_code_id;
@@ -679,7 +684,7 @@ and traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
         }
       in
       Acc.add_apply apply_dep acc
-    else default_acc acc
+    else if Option.is_none (Apply.callee apply) then default_acc acc
   | Function
       { function_call =
           (Indirect_unknown_arity | Indirect_known_arity) as function_call;
@@ -756,9 +761,19 @@ and traverse_function_params_and_body acc code_id code ~return_continuation
     };
   Acc.fixed_arity_continuation acc return_continuation;
   Acc.fixed_arity_continuation acc exn_continuation;
+  let check_zero_alloc =
+    match Code.zero_alloc_attribute code with
+    | Default_zero_alloc ->
+      (* The effect of [Clflags.zero_alloc_assert] has been compiled into
+         [Check] earlier. *)
+      false
+    | Assume _ -> false
+    | Check _ -> true
+  in
   let denv =
     { parent = Hole;
       conts;
+      should_preserve_direct_calls = check_zero_alloc;
       current_code_id = Some code_id;
       le_monde_exterieur;
       all_constants
@@ -875,6 +890,7 @@ let run ~get_code_metadata (unit : Flambda_unit.t) =
     traverse
       { parent = Hole;
         conts;
+        should_preserve_direct_calls = false;
         current_code_id = None;
         le_monde_exterieur = Name.symbol le_monde_exterieur;
         all_constants = Name.symbol all_constants

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -105,18 +105,17 @@ let prepare_code ~denv acc (code_id : Code_id.t) (code : Code.t) =
      let param = Code_id_or_name.var param in Graph.add_propagate_dep (Acc.graph
      acc) ~if_used:indirect_call_witness ~from:le_monde_exterieur ~to_:param)
      params; *)
-  if has_unsafe_result_type || never_delete
+  if has_unsafe_result_type
   then (
-    let opaque_params = if has_unsafe_result_type then my_closure :: params else params in
     List.iter
       (fun var -> Acc.used ~denv (Simple.var var) acc)
-      (opaque_params @ (exn :: return));
+      ((my_closure :: params) @ (exn :: return));
     let le_monde_exterieur = Code_id_or_name.name denv.le_monde_exterieur in
     List.iter
       (fun param ->
         let param = Code_id_or_name.var param in
         Graph.add_alias (Acc.graph acc) ~to_:param ~from:le_monde_exterieur)
-      opaque_params);
+      (my_closure :: params));
   if never_delete then Acc.used_code_id code_id acc;
   Acc.add_code code_id code_dep acc
 

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -105,17 +105,18 @@ let prepare_code ~denv acc (code_id : Code_id.t) (code : Code.t) =
      let param = Code_id_or_name.var param in Graph.add_propagate_dep (Acc.graph
      acc) ~if_used:indirect_call_witness ~from:le_monde_exterieur ~to_:param)
      params; *)
-  if has_unsafe_result_type
+  if has_unsafe_result_type || never_delete
   then (
+    let opaque_params = if has_unsafe_result_type then my_closure :: params else params in
     List.iter
       (fun var -> Acc.used ~denv (Simple.var var) acc)
-      ((my_closure :: params) @ (exn :: return));
+      (opaque_params @ (exn :: return));
     let le_monde_exterieur = Code_id_or_name.name denv.le_monde_exterieur in
     List.iter
       (fun param ->
         let param = Code_id_or_name.var param in
         Graph.add_alias (Acc.graph acc) ~to_:param ~from:le_monde_exterieur)
-      (my_closure :: params));
+      opaque_params);
   if never_delete then Acc.used_code_id code_id acc;
   Acc.add_code code_id code_dep acc
 

--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -28,6 +28,7 @@ module Env = struct
     { parent : Rev_expr.rev_expr_holed;
       conts : cont_kind Continuation.Map.t;
       current_code_id : Code_id.t option;
+      should_preserve_direct_calls : bool;
       le_monde_exterieur : Name.t;
       all_constants : Name.t
     }

--- a/middle_end/flambda2/reaper/traverse_acc.mli
+++ b/middle_end/flambda2/reaper/traverse_acc.mli
@@ -28,6 +28,7 @@ module Env : sig
     { parent : Rev_expr.rev_expr_holed;
       conts : cont_kind Continuation.Map.t;
       current_code_id : Code_id.t option;
+      should_preserve_direct_calls : bool;
       le_monde_exterieur : Name.t;
       all_constants : Name.t
     }


### PR DESCRIPTION
Do not merge as-is, this is likely to cause false negatives for zero_alloc checking.