### PR TITLE
Use `Lambda.layout` for `transl_exp`

### DIFF
--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -1335,6 +1335,7 @@ let split_vectors =
     Misc.fatal_error "Only x86-64 and arm64 are supported"
 
 let layout_unit = non_null_value Pintval
+let layout_bool = non_null_value (Pvariant { consts = [0; 1]; non_consts = []})
 let layout_unboxed_unit = Punboxed_product []
 let layout_int = non_null_value Pintval
 let layout_int_or_null = nullable_value Pintval
@@ -1357,6 +1358,7 @@ let layout_variant_arg = nullable_value Pgenval
 let layout_exception = non_null_value Pgenval
 let layout_function = non_null_value Pgenval
 let layout_object = non_null_value Pgenval
+let layout_poly_variant = non_null_value Pgenval
 let layout_class = non_null_value Pgenval
 let layout_module = non_null_value Pgenval
 let layout_functor = non_null_value Pgenval
@@ -1417,7 +1419,14 @@ let layout_lazy = nullable_value Pgenval
 let layout_lazy_contents = nullable_value Pgenval
 let layout_any_value = nullable_value Pgenval
 let layout_letrec = layout_any_value
+let layout_instance_var = nullable_value Pgenval
+let layout_method = nullable_value Pgenval
+let layout_initializer = nullable_value Pgenval
+let layout_array_comprehension_element = nullable_value Pgenval
+let layout_list_element = nullable_value Pgenval
 let layout_probe_arg = nullable_value Pgenval
+let layout_block_idx = layout_unboxed_nativeint
+
 let layout_unboxed_product layouts = Punboxed_product layouts
 
 let unboxed_vector_of_boxed_vector = function

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -1161,6 +1161,7 @@ val of_bool : bool -> lambda
 val split_vectors : bool
 
 val layout_unit : layout
+val layout_bool : layout
 val layout_unboxed_unit : layout
 val layout_int : layout
 val layout_array : array_kind -> layout
@@ -1169,6 +1170,7 @@ val layout_list : layout
 val layout_exception : layout
 val layout_function : layout
 val layout_object : layout
+val layout_poly_variant : layout
 val layout_class : layout
 val layout_module : layout
 val layout_functor : layout
@@ -1198,8 +1200,14 @@ val layout_lazy_contents : layout
 val layout_any_value : layout
 (* A layout that is Pgenval because it is bound by a letrec *)
 val layout_letrec : layout
+val layout_instance_var : layout
+val layout_method : layout
+val layout_initializer : layout
+val layout_array_comprehension_element : layout
+val layout_list_element : layout
 (* The probe hack: Free vars in probes must have layout value. *)
 val layout_probe_arg : layout
+val layout_block_idx : layout
 
 val layout_unboxed_product : layout list -> layout
 

--- a/lambda/transl_array_comprehension.ml
+++ b/lambda/transl_array_comprehension.ml
@@ -463,7 +463,7 @@ let iterator ~transl_exp ~scopes ~loc :
       { ident; ident_debug_uid; pattern = _; start; stop; direction } ->
     let bound name debug_uid value =
       Let_binding.make (Immutable Strict) layout_int name debug_uid
-        (transl_exp ~scopes Jkind.Sort.Const.for_predef_scannable value)
+        (transl_exp ~scopes Lambda.layout_int value)
     in
     let start = bound "start" Lambda.debug_uid_none start in
     let stop = bound "stop" Lambda.debug_uid_none stop in
@@ -480,14 +480,15 @@ let iterator ~transl_exp ~scopes ~loc :
     in
     mk_iterator, Range { start; stop; direction }
   | Texp_comp_in { pattern; sequence = iter_arr_exp } ->
-    let iter_arr =
-      Let_binding.make (Immutable Strict) layout_any_value "iter_arr"
-        Lambda.debug_uid_none
-        (transl_exp ~scopes Jkind.Sort.Const.for_predef_scannable iter_arr_exp)
-    in
     let iter_arr_kind =
       Typeopt.array_type_kind ~elt_ty:(Some pattern.pat_type)
         iter_arr_exp.exp_env iter_arr_exp.exp_loc iter_arr_exp.exp_type
+    in
+    let iter_arr_layout = Lambda.layout_array iter_arr_kind in
+    let iter_arr =
+      Let_binding.make (Immutable Strict) iter_arr_layout "iter_arr"
+        Lambda.debug_uid_none
+        (transl_exp ~scopes iter_arr_layout iter_arr_exp)
     in
     let iter_arr_mut =
       Typeopt.array_type_mut iter_arr_exp.exp_env iter_arr_exp.exp_type
@@ -572,7 +573,7 @@ let clause ~transl_exp ~scopes ~loc = function
   | Texp_comp_when cond ->
     fun body ->
       Lifthenelse
-        ( transl_exp ~scopes Jkind.Sort.Const.for_predef_scannable cond,
+        ( transl_exp ~scopes Lambda.layout_bool cond,
           body,
           lambda_unit,
           layout_unit )
@@ -921,8 +922,8 @@ let comprehension ~transl_exp ~scopes ~loc ~(array_kind : Lambda.array_kind)
                   (* CR layouts v4: Ensure that the [transl_exp] here can cope
                      with non-values. *)
                 ~body:
-                  (transl_exp ~scopes
-                     Jkind.Sort.Const.for_array_comprehension_element comp_body)),
+                  (transl_exp ~scopes Lambda.layout_array_comprehension_element
+                     comp_body)),
            (* If it was dynamically grown, cut it down to size *)
            match array_sizing with
            | Fixed_size -> array.var

--- a/lambda/transl_array_comprehension.mli
+++ b/lambda/transl_array_comprehension.mli
@@ -22,7 +22,7 @@ open Debuginfo.Scoped_location
     so is parameterized by [Translcore.transl_exp], its [scopes] argument, and
     the [loc]ation. *)
 val comprehension :
-  transl_exp:(scopes:scopes -> Jkind.Sort.Const.t -> expression -> lambda) ->
+  transl_exp:(scopes:scopes -> Lambda.layout -> expression -> lambda) ->
   scopes:scopes ->
   loc:scoped_location ->
   array_kind:array_kind ->

--- a/lambda/transl_list_comprehension.ml
+++ b/lambda/transl_list_comprehension.ml
@@ -174,7 +174,7 @@ let iterator ~transl_exp ~scopes = function
        correct (i.e., left-to-right) order *)
     let transl_bound var debug_uid bound =
       Let_binding.make (Immutable Strict) layout_int var debug_uid
-        (transl_exp ~scopes Jkind.Sort.Const.for_predef_scannable bound)
+        (transl_exp ~scopes Lambda.layout_int bound)
     in
     let start = transl_bound "start" Lambda.debug_uid_none start in
     let stop = transl_bound "stop" Lambda.debug_uid_none stop in
@@ -190,9 +190,9 @@ let iterator ~transl_exp ~scopes = function
     }
   | Texp_comp_in { pattern; sequence } ->
     let iter_list =
-      Let_binding.make (Immutable Strict) layout_any_value "iter_list"
+      Let_binding.make (Immutable Strict) Lambda.layout_list "iter_list"
         Lambda.debug_uid_none
-        (transl_exp ~scopes Jkind.Sort.Const.for_predef_scannable sequence)
+        (transl_exp ~scopes Lambda.layout_list sequence)
     in
     (* Create a fresh variable to use as the function argument. The debug uid is
        [.debug_uid_none], because the variable is not visible to users. *)
@@ -306,7 +306,7 @@ let rec translate_clauses ~transl_exp ~scopes ~loc ~comprehension_body
       Let_binding.let_all arg_lets bindings
     | Texp_comp_when cond ->
       Lifthenelse
-        ( transl_exp ~scopes Jkind.Sort.Const.for_predef_scannable cond,
+        ( transl_exp ~scopes Lambda.layout_bool cond,
           body ~accumulator,
           accumulator,
           layout_any_value (* [list]s have the standard representation *) ))
@@ -317,7 +317,7 @@ let comprehension ~transl_exp ~scopes ~loc { comp_body; comp_clauses } =
     translate_clauses ~transl_exp ~scopes ~loc
       ~comprehension_body:(fun ~accumulator ->
         rev_list_snoc_local ~loc ~init:accumulator
-          ~last:(transl_exp ~scopes Jkind.Sort.Const.for_list_element comp_body))
+          ~last:(transl_exp ~scopes Lambda.layout_list_element comp_body))
       ~accumulator:rev_list_nil comp_clauses
   in
   Lambda_utils.apply ~loc ~mode:alloc_heap

--- a/lambda/transl_list_comprehension.mli
+++ b/lambda/transl_list_comprehension.mli
@@ -15,7 +15,7 @@ open Debuginfo.Scoped_location
     so is parameterized by [Translcore.transl_exp], its [scopes] argument, and
     the [loc]ation. *)
 val comprehension :
-  transl_exp:(scopes:scopes -> Jkind.Sort.Const.t -> expression -> lambda) ->
+  transl_exp:(scopes:scopes -> Lambda.layout -> expression -> lambda) ->
   scopes:scopes ->
   loc:scoped_location ->
   comprehension ->

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -274,7 +274,7 @@ let transl_meth_list lst =
 let set_inst_var ~scopes obj id expr =
   let ptr_or_imm, _ = Typeopt.maybe_pointer expr in
   Lprim(Psetfield_computed (ptr_or_imm, Assignment modify_heap),
-    [Lvar obj; Lvar id; transl_exp ~scopes Jkind.Sort.Const.for_instance_var expr],
+    [Lvar obj; Lvar id; transl_exp ~scopes Lambda.layout_instance_var expr],
         Loc_unknown)
 
 let transl_val tbl create name =
@@ -661,7 +661,8 @@ let rec build_class_init ~scopes cla cstr super inh_init cl_init msubst top cl =
             | Tcf_method (name, _, Tcfk_concrete (_, exp)) ->
                 let scopes = enter_method_definition ~scopes name.txt in
                 let met_code =
-                  msubst true (transl_scoped_exp ~scopes Jkind.Sort.Const.for_method exp)
+                  msubst true
+                    (transl_scoped_exp ~scopes Lambda.layout_method exp)
                 in
                 let met_code =
                   if !Clflags.native_code && List.length met_code = 1 then
@@ -679,7 +680,8 @@ let rec build_class_init ~scopes cla cstr super inh_init cl_init msubst top cl =
                  Lsequence(mkappl (oo_prim "add_initializer",
                                    Lvar cla :: msubst false
                                                  (transl_exp ~scopes
-                                                    Jkind.Sort.Const.for_initializer exp),
+                                                    Lambda.layout_initializer
+                                                    exp),
                                    layout_unit),
                            cl_init),
                  methods, values)

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -155,8 +155,6 @@ let maybe_region get_layout lam =
 let maybe_region_layout layout lam =
   maybe_region (fun () -> layout) lam
 
-let maybe_region_exp sort exp lam =
-  maybe_region (fun () -> layout_exp sort exp) lam
 
 let is_alloc_heap = function Alloc_heap -> true | Alloc_local -> false
 
@@ -368,8 +366,8 @@ let zero_alloc_of_application
     end
   | None, _ -> Zero_alloc_utils.Assume_info.none
 
-let rec transl_exp ~scopes sort e =
-  transl_exp1 ~scopes ~in_new_scope:false sort e
+let rec transl_exp ~scopes layout e =
+  transl_exp1 ~scopes ~in_new_scope:false layout e
 
 (* ~in_new_scope tracks whether we just opened a new scope.
 
@@ -378,17 +376,17 @@ let rec transl_exp ~scopes sort e =
    parsed as a let-bound Pexp_function node [let f = fun x -> ...].
    We give it f's scope.
 *)
-and transl_exp1 ~scopes ~in_new_scope sort e =
+and transl_exp1 ~scopes ~in_new_scope layout e =
   let eval_once =
     (* Whether classes for immediate objects must be cached *)
     match e.exp_desc with
       Texp_function _ | Texp_for _ | Texp_while _ -> false
     | _ -> true
   in
-  if eval_once then transl_exp0 ~scopes ~in_new_scope sort e else
-  Translobj.oo_wrap e.exp_env true (transl_exp0 ~scopes ~in_new_scope sort) e
+  if eval_once then transl_exp0 ~scopes ~in_new_scope layout e else
+  Translobj.oo_wrap e.exp_env true (transl_exp0 ~scopes ~in_new_scope layout) e
 
-and transl_exp0 ~in_new_scope ~scopes sort e =
+and transl_exp0 ~in_new_scope ~scopes layout e =
   match e.exp_desc with
   | Texp_ident { path; desc; kind; _ } ->
       transl_ident (of_location ~scopes e.exp_loc)
@@ -404,13 +402,11 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         sorts
   | Texp_constant cst -> Lconst (Const_base cst)
   | Texp_let(rec_flag, pat_expr_list, body) ->
-      let return_layout = layout_exp sort body in
-      transl_let ~scopes ~return_layout rec_flag pat_expr_list
-        (event_before ~scopes body (transl_exp ~scopes sort body))
+      transl_let ~scopes ~return_layout:layout rec_flag pat_expr_list
+        (event_before ~scopes body (transl_exp ~scopes layout body))
   | Texp_letmutable(pat_expr, body) ->
-      let return_layout = layout_exp sort body in
-      transl_letmutable ~scopes ~return_layout pat_expr
-        (event_before ~scopes body (transl_exp ~scopes sort body))
+      transl_letmutable ~scopes ~return_layout:layout pat_expr
+        (event_before ~scopes body (transl_exp ~scopes layout body))
   | Texp_function { params; body; ret_sort; ret_mode; alloc_mode;
                     zero_alloc } ->
       let ret_sort = Jkind.Sort.default_for_transl_and_get ret_sort in
@@ -468,19 +464,18 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         let specialised = Translattribute.get_specialised_attribute funct in
         let position = transl_apply_position pos in
         let mode = transl_locality_mode_l ap_mode in
-        let result_layout = layout_exp sort e in
         event_after ~scopes e
           (transl_apply ~scopes ~tailcall ~inlined ~specialised
              ~assume_zero_alloc
              ~position ~mode
-             ~result_layout lam extra_args (of_location ~scopes e.exp_loc))
+             ~result_layout:layout lam extra_args
+             (of_location ~scopes e.exp_loc))
       end
   | Texp_apply(funct, oargs, position, ap_mode, zero_alloc)
     ->
       let tailcall = Translattribute.get_tailcall_attribute funct in
       let inlined = Translattribute.get_inlined_attribute funct in
       let specialised = Translattribute.get_specialised_attribute funct in
-      let result_layout = layout_exp sort e in
       let position = transl_apply_position position in
       let mode = transl_locality_mode_l ap_mode in
       let assume_zero_alloc =
@@ -489,12 +484,12 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       event_after ~scopes e
         (transl_apply ~scopes ~tailcall ~inlined ~specialised
            ~assume_zero_alloc
-           ~result_layout
-           ~position ~mode (transl_exp ~scopes Jkind.Sort.Const.for_function funct)
+           ~result_layout:layout
+           ~position ~mode (transl_exp ~scopes Lambda.layout_function funct)
            oargs (of_location ~scopes e.exp_loc))
   | Texp_match(arg, arg_sort, pat_expr_list, [], partial) ->
       let arg_sort = Jkind.Sort.default_for_transl_and_get arg_sort in
-      transl_match ~scopes ~arg_sort ~return_sort:sort e arg pat_expr_list
+      transl_match ~scopes ~arg_sort ~return_layout:layout e arg pat_expr_list
         partial
   | Texp_match(arg, arg_sort, pat_expr_list, eff_pat_expr_list, partial) ->
       let arg_sort = Jkind.Sort.default_for_transl_and_get arg_sort in
@@ -517,20 +512,23 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         let x, y = List.fold_left split_case ([], []) pat_expr_list in
         List.rev x, List.rev y
       in
-      transl_handler ~scopes ~return_sort:sort ~body_sort:arg_sort e arg
-        (Some (pat_expr_list, partial)) exn_pat_expr_list eff_pat_expr_list
+      transl_handler ~scopes ~return_layout:layout
+        ~body_layout:(layout_exp arg_sort arg) e arg
+        (Some (pat_expr_list, partial, arg_sort)) exn_pat_expr_list
+        eff_pat_expr_list
   | Texp_try(body, pat_expr_list, []) ->
       let id, id_duid = Typecore.name_cases "exn" pat_expr_list in
-      let return_layout = layout_exp sort e in
-      Ltrywith(transl_exp ~scopes sort body, id, id_duid,
-               Matching.for_trywith ~scopes ~return_layout e.exp_loc (Lvar id)
-                 (transl_cases_try ~scopes sort pat_expr_list),
-               return_layout)
+      Ltrywith(transl_exp ~scopes layout body, id, id_duid,
+               Matching.for_trywith ~scopes ~return_layout:layout
+                 e.exp_loc (Lvar id)
+                 (transl_cases_try ~scopes layout pat_expr_list),
+               layout)
   | Texp_try(body, exn_pat_expr_list, eff_pat_expr_list) ->
-      transl_handler ~scopes ~return_sort:sort ~body_sort:sort e body
+      transl_handler ~scopes ~return_layout:layout ~body_layout:layout e body
         None exn_pat_expr_list eff_pat_expr_list
   | Texp_unboxed_unit ->
-      Lprim(Punbox_unit, [lambda_unit], of_location ~scopes e.exp_loc)
+      Lprim(Punbox_unit, [lambda_unit],
+            of_location ~scopes e.exp_loc)
   | Texp_unboxed_bool b ->
       Lconst(Const_base(Const_untagged_int8(Bool.to_int b)))
   | Texp_tuple (el, alloc_mode) ->
@@ -553,7 +551,9 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
             (l, e, Jkind.Sort.default_for_transl_and_get s)) el
       in
       let shape = List.map (fun (_, e, s) -> layout_exp s e) el in
-      let ll = List.map (fun (_, e, s) -> transl_exp ~scopes s e) el in
+      let ll = List.map (fun (_, e, s) ->
+        let layout = layout_exp s e in
+        transl_exp ~scopes layout e) el in
       Lprim(Pmake_unboxed_product shape,
             ll,
             of_location ~scopes e.exp_loc)
@@ -563,13 +563,16 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           (fun (sort, e) -> e, Jkind.Sort.default_for_transl_and_get sort)
           args
       in
-      let ll =
-        List.map (fun (e, sort) -> transl_exp ~scopes sort e) args_with_sorts
-      in
-      if cstr.cstr_inlined <> None then begin match ll with
-        | [x] -> x
+      if cstr.cstr_inlined <> None then begin match args_with_sorts with
+        | [arg, _] -> transl_exp ~scopes layout arg
         | _ -> assert false
-      end else begin match cstr.cstr_tag, cstr.cstr_repr with
+      end else begin
+        let ll =
+          List.map (fun (e, sort) ->
+            let layout = layout_exp sort e in
+            transl_exp ~scopes layout e) args_with_sorts
+        in
+        match cstr.cstr_tag, cstr.cstr_repr with
       | Null, Variant_with_null -> Lconst Const_null
       | Null, (Variant_boxed _ | Variant_unboxed | Variant_extensible) ->
         assert false
@@ -693,7 +696,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       begin match arg with
         None -> (tagged_immediate tag)
       | Some (arg, alloc_mode) ->
-          let lam = transl_exp ~scopes Jkind.Sort.Const.for_poly_variant arg in
+          let lam = transl_exp ~scopes Lambda.layout_poly_variant arg in
           try
             Lconst(Const_block(0, [const_int tag;
                                    extract_constant lam]))
@@ -726,7 +729,8 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
               lbl.lbl_name
         | repres -> repres
       in
-      let (arg, lbl) = transl_atomic_loc ~scopes arg arg_sort lbl repres in
+      let arg_layout = layout_exp arg_sort arg in
+      let (arg, lbl) = transl_atomic_loc ~scopes arg arg_layout lbl repres in
       let loc = of_location ~scopes e.exp_loc in
       Lprim (Pmakeblock (0, Immutable, shape, transl_alloc_mode alloc_mode),
              [arg; lbl], loc)
@@ -734,7 +738,8 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                  lid = _; label = lbl; boxing = float;
                  unique_barrier = ubr } ->
       let arg_sort = Jkind.Sort.default_for_transl_and_get arg_sort in
-      let targ = transl_exp ~scopes arg_sort arg in
+      let arg_layout = layout_exp arg_sort arg in
+      let targ = transl_exp ~scopes arg_layout arg in
       let sem =
         if Types.is_mutable lbl.lbl_mut then Reads_vary else Reads_agree
       in
@@ -825,7 +830,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         if l.lbl_pos = lbl.lbl_pos then
           (* This is the field being projected, so give it a precise value kind
              (by using the known type of the expression) *)
-          layout e.exp_env l.lbl_loc sort e.exp_type
+          Typeopt.layout e.exp_env l.lbl_loc sort e.exp_type
         else
           (* We don't necessarily know this field's precise value kind
              ([l.lbl_arg] may be an [any]) but for lambda's purposes the sort
@@ -834,7 +839,8 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       in
       let layouts = Array.map lbl_layout lbl.lbl_all |> Array.to_list in
       let arg_sort = Jkind.Sort.default_for_transl_and_get arg_sort in
-      let targ = transl_exp ~scopes arg_sort arg in
+      let arg_layout = layout_exp arg_sort arg in
+      let targ = transl_exp ~scopes arg_layout arg in
       if Array.length lbl.lbl_all == 1 then
         (* erase singleton unboxed records before lambda *)
         targ
@@ -862,9 +868,11 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         | `Sort s -> s
         | `Same_as_record_sort -> sort_arg
       in
-      let arg_lambda = transl_exp ~scopes sort_arg arg in
+      let arg_layout = layout_exp sort_arg arg in
+      let arg_lambda = transl_exp ~scopes arg_layout arg in
       let field_lambda = Lconst (Const_base (Const_int lbl.lbl_pos)) in
-      let newval_lambda = transl_exp ~scopes sort_newval newval in
+      let newval_layout = layout_exp sort_newval newval in
+      let newval_lambda = transl_exp ~scopes newval_layout newval in
       let prim, args =
         match record_repres with
           Record_boxed
@@ -1009,25 +1017,25 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       Transl_array_comprehension.comprehension
         ~transl_exp ~scopes ~loc ~array_kind comp
   | Texp_ifthenelse(cond, ifso, Some ifnot) ->
-      Lifthenelse(transl_exp ~scopes Jkind.Sort.Const.for_predef_scannable cond,
-                  event_before ~scopes ifso (transl_exp ~scopes sort ifso),
-                  event_before ~scopes ifnot (transl_exp ~scopes sort ifnot),
-                  layout_exp sort e)
+      Lifthenelse(transl_exp ~scopes Lambda.layout_bool cond,
+                  event_before ~scopes ifso (transl_exp ~scopes layout ifso),
+                  event_before ~scopes ifnot (transl_exp ~scopes layout ifnot),
+                  layout)
   | Texp_ifthenelse(cond, ifso, None) ->
-      Lifthenelse(transl_exp ~scopes Jkind.Sort.Const.for_predef_scannable cond,
-                  event_before ~scopes ifso (transl_exp ~scopes sort ifso),
+      Lifthenelse(transl_exp ~scopes Lambda.layout_bool cond,
+                  event_before ~scopes ifso (transl_exp ~scopes layout ifso),
                   lambda_unit,
                   Lambda.layout_unit)
   | Texp_sequence(expr1, sort', expr2) ->
       let sort' = Jkind.Sort.default_for_transl_and_get sort' in
-      Lsequence(transl_exp ~scopes sort' expr1,
-                event_before ~scopes expr2 (transl_exp ~scopes sort expr2))
+      let layout' = layout_exp sort' expr1 in
+      Lsequence(transl_exp ~scopes layout' expr1,
+                event_before ~scopes expr2 (transl_exp ~scopes layout expr2))
   | Texp_while {wh_body; wh_body_sort; wh_cond} ->
       let wh_body_sort = Jkind.Sort.default_for_transl_and_get wh_body_sort in
-      let cond =
-        transl_exp ~scopes Jkind.Sort.Const.for_predef_scannable wh_cond
-      in
-      let body = transl_exp ~scopes wh_body_sort wh_body in
+      let cond = transl_exp ~scopes Lambda.layout_bool wh_cond in
+      let wh_body_layout = layout_exp wh_body_sort wh_body in
+      let body = transl_exp ~scopes wh_body_layout wh_body in
       Lwhile {
         wh_cond = maybe_region_layout layout_int cond;
         wh_body = event_before ~scopes wh_body
@@ -1036,15 +1044,14 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
   | Texp_for {for_id; for_debug_uid; for_from; for_to; for_dir; for_body;
               for_body_sort} ->
       let for_body_sort = Jkind.Sort.default_for_transl_and_get for_body_sort in
-      let body = transl_exp ~scopes for_body_sort for_body in
+      let for_body_layout = layout_exp for_body_sort for_body in
+      let body = transl_exp ~scopes for_body_layout for_body in
       Lfor {
         for_id;
         for_debug_uid;
         for_loc = of_location ~scopes e.exp_loc;
-        for_from = transl_exp ~scopes
-                     Jkind.Sort.Const.for_predef_scannable for_from;
-        for_to = transl_exp ~scopes
-                   Jkind.Sort.Const.for_predef_scannable for_to;
+        for_from = transl_exp ~scopes Lambda.layout_int for_from;
+        for_to = transl_exp ~scopes Lambda.layout_int for_to;
         for_dir;
         for_body = event_before ~scopes for_body
                      (maybe_region_layout layout_unit body);
@@ -1054,13 +1061,12 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
         let pos = transl_apply_position pos in
         let mode = Lambda.alloc_heap in
         let loc = of_location ~scopes e.exp_loc in
-        let layout = layout_exp sort e in
         match met with
         | Tmeth_val id ->
-            let obj = transl_exp ~scopes Jkind.Sort.Const.for_object expr in
+            let obj = transl_exp ~scopes Lambda.layout_object expr in
             Lsend (Self, Lvar id, obj, [], pos, mode, loc, layout)
         | Tmeth_name nm ->
-            let obj = transl_exp ~scopes Jkind.Sort.Const.for_object expr in
+            let obj = transl_exp ~scopes Lambda.layout_object expr in
             let (tag, cache) = Translobj.meth obj nm in
             let kind = if cache = [] then Public else Cached in
             Lsend (kind, tag, obj, cache, pos, mode, loc, layout)
@@ -1087,7 +1093,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           Lprim(Pfield (0, Pointer, Reads_vary),
               [transl_class_path loc e.exp_env cl], loc);
         ap_args=[lambda_unit];
-        ap_result_layout=layout_exp sort e;
+        ap_result_layout=layout;
         ap_region_close=pos;
         ap_mode=alloc_heap;
         ap_tailcall=Default_tailcall;
@@ -1107,8 +1113,9 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       let var = transl_value_path loc e.exp_env path in
       transl_setinstvar ~scopes loc self var expr
   | Texp_setmutvar(id, expr_sort, expr) ->
-      Lassign(id.txt, transl_exp ~scopes
-        (Jkind.Sort.default_for_transl_and_get expr_sort) expr)
+      let expr_sort = Jkind.Sort.default_for_transl_and_get expr_sort in
+      let expr_layout = layout_exp expr_sort expr in
+      Lassign(id.txt, transl_exp ~scopes expr_layout expr)
   | Texp_override(path_self, modifs) ->
       let loc = of_location ~scopes e.exp_loc in
       let self = transl_value_path loc e.exp_env path_self in
@@ -1137,7 +1144,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       let mod_scopes = enter_anonymous_module ~scopes ~loc:loc.loc in
       let lam = !transl_module ~scopes:mod_scopes Tcoerce_none None modl in
       Lsequence(Lprim(Pignore, [lam], of_location ~scopes loc.loc),
-                transl_exp ~scopes sort body)
+                transl_exp ~scopes layout body)
   | Texp_letmodule(Some id, _loc, Mp_present, modl, body) ->
       let defining_expr =
         let mod_scopes = enter_module_definition ~scopes id in
@@ -1145,14 +1152,14 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       in
       (* CR sspies: Add a debug uid to [Texp_letmodule] for the binder. *)
       Llet(Strict, Lambda.layout_module, id, Lambda.debug_uid_none,
-          defining_expr, transl_exp ~scopes sort body)
+          defining_expr, transl_exp ~scopes layout body)
   | Texp_letmodule(_, _, Mp_absent, _, body) ->
-      transl_exp ~scopes sort body
+      transl_exp ~scopes layout body
   | Texp_letexception(cd, body) ->
       Llet(Strict, Lambda.layout_block,
            cd.ext_id,  Lambda.debug_uid_none,
            transl_extension_constructor ~scopes e.exp_env None cd,
-           transl_exp ~scopes sort body)
+           transl_exp ~scopes layout body)
   | Texp_pack modl ->
       !transl_module ~scopes Tcoerce_none None modl
   | Texp_assert ({exp_desc=Texp_construct(_, {cstr_name="false"}, _, _, _)},
@@ -1163,7 +1170,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       then lambda_unit
       else begin
         Lifthenelse
-          (transl_exp ~scopes Jkind.Sort.Const.for_predef_scannable cond,
+          (transl_exp ~scopes Lambda.layout_bool cond,
            lambda_unit,
            assert_failed loc ~scopes e,
            Lambda.layout_unit)
@@ -1176,14 +1183,14 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       | `Constant_or_function ->
         (* A constant expr (of type <> float if [Config.flat_float_array] is
            true) gets compiled as itself. *)
-         transl_exp ~scopes Jkind.Sort.Const.for_lazy_body e
+         transl_exp ~scopes Lambda.layout_lazy_contents e
       | `Float_that_cannot_be_shortcut
       | `Identifier `Forward_value ->
          Lprim(Pmakelazyblock Forward_tag,
-                [transl_exp ~scopes Jkind.Sort.Const.for_lazy_body e],
+                [transl_exp ~scopes Lambda.layout_lazy_contents e],
                 of_location ~scopes e.exp_loc)
       | `Identifier `Other ->
-         transl_exp ~scopes Jkind.Sort.Const.for_lazy_body e
+         transl_exp ~scopes Lambda.layout_lazy_contents e
       | `Other ->
          (* other cases compile to a lazy block holding a function.  The
             typechecker enforces that e has jkind value.  *)
@@ -1205,7 +1212,8 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                             ~ret_mode:alloc_heap
                             ~body:(maybe_region_layout
                                      Lambda.layout_lazy_contents
-                                     (transl_exp ~scopes Jkind.Sort.Const.for_lazy_body e))
+                                     (transl_exp ~scopes
+                                        Lambda.layout_lazy_contents e))
          in
           Lprim(Pmakelazyblock Lazy_tag, [fn],
                 of_location ~scopes e.exp_loc)
@@ -1235,7 +1243,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
           But since [scan_used_globals] runs before Simplif, we need to
           do it. *)
       begin match od.open_bound_items with
-      | [] when pure = Alias -> transl_exp ~scopes sort e
+      | [] when pure = Alias -> transl_exp ~scopes layout e
       | _ ->
           let oid = Ident.create_local "open" in
           let oid_duid = Lambda.debug_uid_none in
@@ -1247,7 +1255,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
                    Lprim(mod_field pos open_repr, [Lvar oid],
                          of_location ~scopes od.open_loc), body),
               pos + 1
-            ) (transl_exp ~scopes sort e, 0)
+            ) (transl_exp ~scopes layout e, 0)
               (bound_value_identifiers od.open_bound_items)
           in
           Llet(pure, Lambda.layout_module, oid, oid_duid,
@@ -1255,7 +1263,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       end
   | Texp_probe {name; handler=exp; enabled_at_init} ->
     if !Clflags.native_code && !Clflags.probes then begin
-      let lam = transl_exp ~scopes Jkind.Sort.Const.for_probe_body exp in
+      let lam = transl_exp ~scopes Lambda.layout_probe_arg exp in
       let map =
         Ident.Set.fold (fun v acc -> Ident.Map.add v (Ident.rename v) acc)
           (free_variables lam)
@@ -1404,7 +1412,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
     else
       lambda_unit
   | Texp_exclave e ->
-    let l = transl_exp ~scopes sort e in
+    let l = transl_exp ~scopes layout e in
     if Config.stack_allocation then Lexclave l
     else l
   | Texp_src_pos ->
@@ -1424,7 +1432,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       Location.todo_overwrite_not_implemented ~kind:"Translcore" e.exp_loc
   | Texp_quotation exp ->
       Translquote.transl_quote
-        ~scopes ~loc:e.exp_loc ~transl:(transl_exp ~scopes sort) exp
+        ~scopes ~loc:e.exp_loc ~transl:(transl_exp ~scopes layout) exp
   (* TODO: update scopes *)
   | Texp_antiquotation exp ->
       fatal_errorf
@@ -1439,31 +1447,33 @@ and pure_module m =
   | _ -> Strict
 
 and transl_list ~scopes expr_list =
-  List.map (fun (exp, sort) -> transl_exp ~scopes sort exp) expr_list
+  List.map (fun (exp, sort) ->
+    let layout = layout_exp sort exp in
+    transl_exp ~scopes layout exp) expr_list
 
 and transl_list_with_layout ~scopes expr_list =
-  List.map (fun (exp, sort) -> transl_exp ~scopes sort exp,
-                               sort,
-                               layout_exp sort exp)
+  List.map (fun (exp, sort) ->
+    let layout = layout_exp sort exp in
+    transl_exp ~scopes layout exp, sort, layout)
     expr_list
 
 (* Will raise if a list element has a non-value layout. *)
 and transl_value_list_with_shape ~scopes expr_list =
   let transl_with_shape (e, sort) =
-    let shape = Lambda.must_be_value (layout_exp sort e) in
-    transl_exp ~scopes sort e, shape
+    let layout = layout_exp sort e in
+    let shape = Lambda.must_be_value layout in
+    transl_exp ~scopes layout e, shape
   in
   List.split (List.map transl_with_shape expr_list)
 
-and transl_guard ~scopes guard rhs_sort rhs =
-  let layout = layout_exp rhs_sort rhs in
-  let expr = event_before ~scopes rhs (transl_exp ~scopes rhs_sort rhs) in
+and transl_guard ~scopes guard rhs_layout rhs =
+  let layout = rhs_layout in
+  let expr = event_before ~scopes rhs (transl_exp ~scopes rhs_layout rhs) in
   match guard with
   | None -> expr
   | Some cond ->
       event_before ~scopes cond
-        (Lifthenelse(transl_exp ~scopes
-                       Jkind.Sort.Const.for_predef_scannable cond,
+        (Lifthenelse(transl_exp ~scopes Lambda.layout_bool cond,
                      expr, staticfail, layout))
 
 and transl_cont cont c_cont body =
@@ -1475,33 +1485,34 @@ and transl_cont cont c_cont body =
   | Some _, None -> body
   | None, Some _ -> assert false
 
-and transl_case ~scopes ?cont rhs_sort {c_lhs; c_cont; c_guard; c_rhs} =
-  (c_lhs, transl_cont cont c_cont (transl_guard ~scopes c_guard rhs_sort c_rhs))
+and transl_case ~scopes ?cont rhs_layout {c_lhs; c_cont; c_guard; c_rhs} =
+  (c_lhs,
+   transl_cont cont c_cont (transl_guard ~scopes c_guard rhs_layout c_rhs))
 
-and transl_cases ~scopes ?cont rhs_sort cases =
+and transl_cases ~scopes ?cont rhs_layout cases =
   let cases =
     List.filter (fun c -> c.c_rhs.exp_desc <> Texp_unreachable) cases in
-  List.map (transl_case ~scopes ?cont rhs_sort) cases
+  List.map (transl_case ~scopes ?cont rhs_layout) cases
 
-and transl_case_try ~scopes rhs_sort {c_lhs; c_guard; c_rhs} =
+and transl_case_try ~scopes rhs_layout {c_lhs; c_guard; c_rhs} =
   iter_exn_names Translprim.add_exception_ident c_lhs;
   Misc.try_finally
-    (fun () -> c_lhs, transl_guard ~scopes c_guard rhs_sort c_rhs)
+    (fun () -> c_lhs, transl_guard ~scopes c_guard rhs_layout c_rhs)
     ~always:(fun () ->
         iter_exn_names Translprim.remove_exception_ident c_lhs)
 
-and transl_cases_try ~scopes rhs_sort cases =
+and transl_cases_try ~scopes rhs_layout cases =
   let cases =
     List.filter (fun c -> c.c_rhs.exp_desc <> Texp_unreachable) cases in
-  List.map (transl_case_try ~scopes rhs_sort) cases
+  List.map (transl_case_try ~scopes rhs_layout) cases
 
-and transl_tupled_cases ~scopes rhs_sort patl_expr_list =
+and transl_tupled_cases ~scopes rhs_layout patl_expr_list =
   let patl_expr_list =
     List.filter (fun (_,_,e) -> e.exp_desc <> Texp_unreachable)
       patl_expr_list in
   List.map
     (fun (patl, guard, expr) ->
-       (patl, transl_guard ~scopes guard rhs_sort expr))
+       (patl, transl_guard ~scopes guard rhs_layout expr))
     patl_expr_list
 
 and transl_apply ~scopes
@@ -1653,7 +1664,8 @@ and transl_apply ~scopes
          | Omitted _ as arg -> arg
          | Arg (exp, sort_arg) ->
            let sort_arg = Jkind.Sort.default_for_transl_and_get sort_arg in
-           Arg (transl_exp ~scopes sort_arg exp, layout_exp sort_arg exp))
+           let layout = layout_exp sort_arg exp in
+           Arg (transl_exp ~scopes layout exp, layout))
       sargs
   in
   build_apply lam [] loc position mode result_layout args
@@ -1679,15 +1691,15 @@ and transl_function_without_attributes
   in
   match
     transl_tupled_function ~scopes loc params body
-      ~return_sort ~return_mode ~return_layout ~mode ~region
+      ~return_mode ~return_layout ~mode ~region
   with
   | Some result -> result
   | None ->
       transl_curried_function ~scopes loc repr params body
-        ~return_sort ~return_mode ~return_layout ~mode ~region
+        ~return_mode ~return_layout ~mode ~region
 
 and transl_tupled_function
-      ~scopes ~return_sort ~return_mode ~return_layout ~mode ~region loc params body
+      ~scopes ~return_mode ~return_layout ~mode ~region loc params body
   =
   let eligible_cases =
     match params, body with
@@ -1752,7 +1764,7 @@ and transl_tupled_function
         let params = List.map (fun p -> p.name) tparams in
         let body =
           Matching.for_tupled_function ~scopes ~return_layout loc params
-            (transl_tupled_cases ~scopes return_sort pats_expr_list) partial
+            (transl_tupled_cases ~scopes return_layout pats_expr_list) partial
         in
         let region = region || not (may_allocate_in_region body) in
         add_type_shapes_of_cases cases;
@@ -1820,7 +1832,7 @@ and add_type_shapes_of_patterns patterns =
   List.iter add_case patterns
 
 and transl_curried_function ~scopes loc repr params body
-    ~return_sort ~return_layout ~return_mode ~region ~mode
+    ~return_layout ~return_mode ~region ~mode
   =
   let { nlocal } =
     let param_curries =
@@ -1837,7 +1849,7 @@ and transl_curried_function ~scopes loc repr params body
   let cases_param, body =
     match body with
     | Tfunction_body body ->
-        None, event_before ~scopes body (transl_exp ~scopes return_sort body)
+        None, event_before ~scopes body (transl_exp ~scopes return_layout body)
     | Tfunction_cases
         { fc_cases; fc_partial; fc_param; fc_param_debug_uid;
           fc_loc; fc_arg_sort; fc_arg_mode }
@@ -1871,7 +1883,7 @@ and transl_curried_function ~scopes loc repr params body
         let body =
           Matching.for_function ~scopes fc_loc repr (Lvar fc_param)
             ~arg_sort:fc_arg_sort ~arg_layout ~return_layout
-            (transl_cases ~scopes return_sort fc_cases) fc_partial
+            (transl_cases ~scopes return_layout fc_cases) fc_partial
         in
         Some param, body
   in
@@ -1908,9 +1920,12 @@ and transl_curried_function ~scopes loc repr params body
                 ~return_layout
           | Tparam_optional_default (pat, default_arg, default_arg_sort) ->
               let default_arg_sort = Jkind.Sort.default_for_transl_and_get default_arg_sort in
+              let default_arg_layout =
+                layout_exp default_arg_sort default_arg
+              in
               let default_arg =
                 event_before ~scopes default_arg
-                  (transl_exp ~scopes default_arg_sort default_arg)
+                  (transl_exp ~scopes default_arg_layout default_arg)
               in
               Matching.for_optional_arg_default ~return_layout
                 ~scopes fp_loc pat body ~default_arg ~default_arg_sort
@@ -2068,11 +2083,11 @@ and transl_function ~in_new_scope ~scopes e params body
   Translattribute.add_function_attributes lam e.exp_loc attrs
 
 (* Like transl_exp, but used when a new scope was just introduced. *)
-and transl_scoped_exp ~scopes sort expr =
-  transl_exp1 ~scopes ~in_new_scope:true sort expr
+and transl_scoped_exp ~scopes layout expr =
+  transl_exp1 ~scopes ~in_new_scope:true layout expr
 
 (* Decides whether a pattern binding should introduce a new scope. *)
-and transl_bound_exp ~scopes ~in_structure pat sort expr loc attrs =
+and transl_bound_exp ~scopes ~in_structure pat layout expr loc attrs =
   let should_introduce_scope =
     match expr.exp_desc with
     | Texp_function _ -> true
@@ -2085,8 +2100,8 @@ and transl_bound_exp ~scopes ~in_structure pat sort expr loc attrs =
       (* If this is a let-binding of a function, the scope will be updated
          with zero_alloc info in [transl_function]. *)
       let scopes = enter_value_definition ~scopes ~assume_zero_alloc id in
-      transl_scoped_exp ~scopes sort expr
-    | _ -> transl_exp ~scopes sort expr
+      transl_scoped_exp ~scopes layout expr
+    | _ -> transl_exp ~scopes layout expr
   in
   Translattribute.add_function_attributes lam loc attrs
 
@@ -2107,11 +2122,13 @@ and transl_let ~scopes ~return_layout ?(add_regions=false) ?(in_structure=false)
       | {vb_pat=pat; vb_expr=expr; vb_sort=sort; vb_rec_kind=_; vb_attributes; vb_loc}
         :: rem ->
           let sort = Jkind.Sort.default_for_transl_and_get sort in
+          let layout = layout_exp sort expr in
           let lam =
-            transl_bound_exp ~scopes ~in_structure pat sort expr vb_loc vb_attributes
+            transl_bound_exp ~scopes ~in_structure pat layout expr vb_loc
+              vb_attributes
           in
           let lam =
-            if add_regions then maybe_region_exp sort expr lam else lam
+            if add_regions then maybe_region_layout layout lam else lam
           in
           let mk_body = transl rem in
           fun body ->
@@ -2130,11 +2147,13 @@ and transl_let ~scopes ~return_layout ?(add_regions=false) ?(in_structure=false)
             {vb_expr=expr; vb_sort; vb_attributes; vb_rec_kind = rkind;
              vb_loc; vb_pat} (id, id_duid) =
         let vb_sort = Jkind.Sort.default_for_transl_and_get vb_sort in
+        let vb_layout = layout_exp vb_sort expr in
         let def =
-          transl_bound_exp ~scopes ~in_structure vb_pat vb_sort expr vb_loc vb_attributes
+          transl_bound_exp ~scopes ~in_structure vb_pat vb_layout expr
+            vb_loc vb_attributes
         in
         let def =
-          if add_regions then maybe_region_exp vb_sort expr def else def
+          if add_regions then maybe_region_layout vb_layout def else def
         in
         ( id, id_duid, rkind, def ) in
       let lam_bds = List.map2 transl_case pat_expr_list idlist in
@@ -2143,8 +2162,9 @@ and transl_let ~scopes ~return_layout ?(add_regions=false) ?(in_structure=false)
 and transl_letmutable ~scopes ~return_layout
       {vb_pat=pat; vb_expr=expr; vb_attributes=attr; vb_loc; vb_sort} body =
   let arg_sort = Jkind_types.Sort.default_to_scannable_and_get vb_sort in
+  let arg_layout = layout_exp arg_sort expr in
   let lam =
-    transl_bound_exp ~scopes ~in_structure:false pat arg_sort expr vb_loc attr
+    transl_bound_exp ~scopes ~in_structure:false pat arg_layout expr vb_loc attr
   in
   Matching.for_let ~scopes ~return_layout ~arg_sort pat.pat_loc lam Mutable
     pat body
@@ -2152,7 +2172,7 @@ and transl_letmutable ~scopes ~return_layout
 and transl_setinstvar ~scopes loc self var expr =
   let ptr_or_imm, _ = maybe_pointer expr in
   Lprim(Psetfield_computed (ptr_or_imm, Assignment modify_heap),
-    [self; var; transl_exp ~scopes Jkind.Sort.Const.for_instance_var expr], loc)
+    [self; var; transl_exp ~scopes Lambda.layout_instance_var expr], loc)
 
 (* CR layouts v5: Invariant - this is only called on values.  Relax that. *)
 and transl_record ~scopes loc env mode fields repres opt_init_expr =
@@ -2216,18 +2236,20 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
             | Record_variable ->
               fatal_error "transl_record: unexpected variable representation"
           in
+          let field_layout = layout_exp lbl_sort expr in
           Lsequence(Lprim(upd, [Lvar copy_id;
-                                transl_exp ~scopes lbl_sort expr],
+                                transl_exp ~scopes field_layout expr],
                           of_location ~scopes loc),
                     cont)
     in
     let init_expr_sort =
       Jkind.Sort.default_for_transl_and_get init_expr_sort
     in
+    let init_expr_layout = layout_exp init_expr_sort init_expr in
     assert (is_heap_mode (Option.get mode)); (* Pduprecord must be Alloc_heap and not unboxed *)
     Llet(Strict, Lambda.layout_block, copy_id, copy_id_duid,
          Lprim(Pduprecord (repres, size),
-               [transl_exp ~scopes init_expr_sort init_expr],
+               [transl_exp ~scopes init_expr_layout init_expr],
                of_location ~scopes loc),
          Array.fold_left update_field (Lvar copy_id) fields)
   | Some _ | None ->
@@ -2308,7 +2330,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                field_layout
            | Overridden (_lid, expr) ->
                let field_layout = layout_exp lbl_sort expr in
-               transl_exp ~scopes lbl_sort expr, field_layout)
+               transl_exp ~scopes field_layout expr, field_layout)
         fields
     in
     let ll, shape = List.split (Array.to_list lv) in
@@ -2427,8 +2449,9 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
         let init_expr_sort =
           Jkind.Sort.default_for_transl_and_get init_expr_sort
         in
+        let init_expr_layout = layout_exp init_expr_sort init_expr in
         Llet(Strict, Lambda.layout_block, init_id, init_id_duid,
-             transl_exp ~scopes init_expr_sort init_expr, lam)
+             transl_exp ~scopes init_expr_layout init_expr, lam)
     end
 
 and transl_record_unboxed_product ~scopes loc env fields repres opt_init_expr =
@@ -2458,7 +2481,8 @@ and transl_record_unboxed_product ~scopes loc env fields repres opt_init_expr =
               let access = Punboxed_product_field (i, shape) in
               Lprim (access, [Lvar init_id], of_location ~scopes loc)
             | Overridden (_lid, expr) ->
-              transl_exp ~scopes lbl_sort expr)
+              let field_layout = layout_exp lbl_sort expr in
+              transl_exp ~scopes field_layout expr)
         fields
       |> Array.to_list
     in
@@ -2473,7 +2497,7 @@ and transl_record_unboxed_product ~scopes loc env fields repres opt_init_expr =
         Jkind.Sort.default_for_transl_and_get init_expr_sort
       in
       let layout = layout_exp init_expr_sort init_expr in
-      let exp = transl_exp ~scopes init_expr_sort init_expr in
+      let exp = transl_exp ~scopes layout init_expr in
       Llet(Strict, layout, init_id, init_id_duid, exp, lam)
     end
 
@@ -2486,7 +2510,7 @@ and transl_idx ~scopes loc env ba uas =
   let uas_path = List.filter_map ua_to_pos uas in
   begin match ba with
   | Baccess_block (_, idx) ->
-    let idx = transl_exp ~scopes Jkind.Sort.Const.for_idx idx in
+    let idx = transl_exp ~scopes Lambda.layout_block_idx idx in
     begin match uas with
     | [] -> idx
     | Uaccess_unboxed_field (_, lbl, sorts) :: _ ->
@@ -2539,8 +2563,8 @@ and transl_idx ~scopes loc env ba uas =
     end
   end
 
-and transl_atomic_loc ~scopes arg arg_sort lbl repres =
-  let arg = transl_exp ~scopes arg_sort arg in
+and transl_atomic_loc ~scopes arg arg_layout lbl repres =
+  let arg = transl_exp ~scopes arg_layout arg in
   begin match repres with
   | Record_dummy _ ->
     Misc.fatal_error "transl_atomic_loc: unexpected dummy representation"
@@ -2561,8 +2585,7 @@ and transl_atomic_loc ~scopes arg arg_sort lbl repres =
   let lbl = Lconst (Const_base (Const_int field_offset)) in
   (arg, lbl)
 
-and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
-  let return_layout = layout_exp return_sort e in
+and transl_match ~scopes ~arg_sort ~return_layout e arg pat_expr_list partial =
   let rewrite_case (val_cases, exn_cases, static_handlers as acc)
         ({ c_lhs; c_guard; c_rhs } as case) =
     if c_rhs.exp_desc = Texp_unreachable then acc else
@@ -2571,12 +2594,12 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
     | None, None -> assert false
     | Some pv, None ->
         let val_case =
-          transl_case ~scopes return_sort { case with c_lhs = pv }
+          transl_case ~scopes return_layout { case with c_lhs = pv }
         in
         val_case :: val_cases, exn_cases, static_handlers
     | None, Some pe ->
         let exn_case =
-          transl_case_try ~scopes return_sort { case with c_lhs = pe }
+          transl_case_try ~scopes return_layout { case with c_lhs = pe }
         in
         val_cases, exn_case :: exn_cases, static_handlers
     | Some pv, Some pe ->
@@ -2601,7 +2624,7 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
         let rhs =
           Misc.try_finally
             (fun () -> event_before ~scopes c_rhs
-                         (transl_exp ~scopes return_sort c_rhs))
+                         (transl_exp ~scopes return_layout c_rhs))
             ~always:(fun () ->
                 iter_exn_names Translprim.remove_exception_ident pe)
         in
@@ -2678,14 +2701,14 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
       assert (static_handlers = []);
       let arg_layout = layout_exp arg_sort arg in
       Matching.for_function ~scopes ~arg_sort ~arg_layout ~return_layout
-        e.exp_loc None (transl_exp ~scopes arg_sort arg) val_cases partial
+        e.exp_loc None (transl_exp ~scopes arg_layout arg) val_cases partial
     | arg, _ :: _ ->
         let val_id, val_id_duid =
           Typecore.name_pattern "val" (List.map fst val_cases)
         in
         let arg_layout = layout_exp arg_sort arg in
         static_catch
-          [transl_exp ~scopes arg_sort arg]
+          [transl_exp ~scopes arg_layout arg]
           [val_id, val_id_duid, arg_layout]
           (Matching.for_function ~scopes ~arg_sort ~arg_layout ~return_layout
              e.exp_loc None (Lvar val_id) val_cases partial)
@@ -2717,20 +2740,22 @@ and transl_match ~scopes ~arg_sort ~return_sort e arg pat_expr_list partial =
    We always wrap the body as [body_fun = fun _ -> body] and [arg = 0].
 
    Effect handlers require all types to have layout [value]. *)
-and transl_handler ~scopes ~return_sort ~body_sort e body
+and transl_handler ~scopes ~return_layout ~body_layout e body
                    val_caselist exn_caselist eff_caselist =
-  if not (Jkind.Sort.Const.equal body_sort (Base Scannable)) then
-    Misc.fatal_errorf_doc "Matching with effect handlers is only supported for \
-                           scrutinees of kind [value], received %a at %a"
-                           Jkind.Sort.Const.format return_sort
-                           (Location.Doc.loc ~capitalize_first:false) e.exp_loc;
-  if not (Jkind.Sort.Const.equal return_sort (Base Scannable)) then
-    Misc.fatal_errorf_doc "Matching with effect handlers is only supported for \
-                           resulting types of kind [value], received %a at %a"
-                           Jkind.Sort.Const.format return_sort
-                           (Location.Doc.loc ~capitalize_first:false) e.exp_loc;
-  let return_layout = layout_exp return_sort e in
-  let body_layout = layout_exp body_sort body in
+  (match (body_layout : Lambda.layout) with
+   | Pvalue _ | Pbottom -> ()
+   | _ ->
+     Misc.fatal_errorf_doc "Matching with effect handlers is only supported \
+                            for scrutinees of kind [value] at %a"
+                           (Location.Doc.loc ~capitalize_first:false)
+                           e.exp_loc);
+  (match (return_layout : Lambda.layout) with
+   | Pvalue _ | Pbottom -> ()
+   | _ ->
+     Misc.fatal_errorf_doc "Matching with effect handlers is only supported \
+                            for resulting types of kind [value] at %a"
+                           (Location.Doc.loc ~capitalize_first:false)
+                           e.exp_loc);
   let mk_param name debug_uid layout =
     { name; debug_uid; layout;
       attributes = Lambda.default_param_attribute;
@@ -2745,8 +2770,8 @@ and transl_handler ~scopes ~return_sort ~body_sort e body
          ~return:return_layout ~body:(Lvar param)
          ~attr:default_function_attribute ~loc:Loc_unknown
          ~mode:alloc_heap ~ret_mode:alloc_heap
-    | Some (val_caselist, partial) ->
-        let val_cases = transl_cases ~scopes return_sort val_caselist in
+    | Some (val_caselist, partial, body_sort) ->
+        let val_cases = transl_cases ~scopes return_layout val_caselist in
         let param, param_duid = Typecore.name_cases "param" val_caselist in
         let body =
           maybe_region_layout return_layout
@@ -2760,7 +2785,7 @@ and transl_handler ~scopes ~return_sort ~body_sort e body
           ~loc:Loc_unknown ~body ~mode:alloc_heap ~ret_mode:alloc_heap
   in
   let exn_fun =
-    let exn_cases = transl_cases ~scopes return_sort exn_caselist in
+    let exn_cases = transl_cases ~scopes return_layout exn_caselist in
     let param, param_duid = Typecore.name_cases "exn" exn_caselist in
     let body =
       maybe_region_layout return_layout
@@ -2776,7 +2801,7 @@ and transl_handler ~scopes ~return_sort ~body_sort e body
     let param, param_duid = Typecore.name_cases "eff" eff_caselist in
     let cont = Ident.create_local "k" in
     let cont_tail = Ident.create_local "ktail" in
-    let eff_cases = transl_cases ~scopes ~cont return_sort eff_caselist in
+    let eff_cases = transl_cases ~scopes ~cont return_layout eff_caselist in
     let body =
       maybe_region_layout return_layout
         (Matching.for_handler ~scopes ~return_layout e.exp_loc (Lvar param)
@@ -2794,7 +2819,7 @@ and transl_handler ~scopes ~return_sort ~body_sort e body
      arg has layout [value] from [Lapply]. *)
   let (body_fun, arg) =
     let body =
-      maybe_region_layout body_layout (transl_exp ~scopes body_sort body)
+      maybe_region_layout body_layout (transl_exp ~scopes body_layout body)
     in
     let param = Ident.create_local "param" in
     (lfunction ~kind:(Curried {nlocal=0})
@@ -2826,8 +2851,8 @@ and transl_letop ~scopes loc env let_ ands param param_debug_uid param_sort case
         let and_bop_op_return_sort =
           Jkind.Sort.default_for_transl_and_get and_.bop_op_return_sort
         in
-        let exp = transl_exp ~scopes and_bop_exp_sort and_.bop_exp in
         let right_layout = layout_exp and_bop_exp_sort and_.bop_exp in
+        let exp = transl_exp ~scopes right_layout and_.bop_exp in
         let result_layout =
           function2_return_layout env and_.bop_loc and_bop_op_return_sort
             and_.bop_op_type
@@ -2860,9 +2885,10 @@ and transl_letop ~scopes loc env let_ ands param param_debug_uid param_sort case
   let let_bop_op_return_sort =
     Jkind.Sort.default_for_transl_and_get let_.bop_op_return_sort
   in
+  let let_bop_exp_layout = layout_exp let_bop_exp_sort let_.bop_exp in
   let exp =
-    loop (layout_exp let_bop_exp_sort let_.bop_exp)
-      (transl_exp ~scopes let_bop_exp_sort let_.bop_exp) ands
+    loop let_bop_exp_layout
+      (transl_exp ~scopes let_bop_exp_layout let_.bop_exp) ands
   in
   let func =
     let return_mode = alloc_heap (* XXX fixme: use result of is_function_type *) in
@@ -2907,15 +2933,15 @@ and transl_letop ~scopes loc env let_ ands param param_debug_uid param_sort case
 (* Wrapper for class/module compilation,
    that can only return global values *)
 
-let transl_exp ~scopes sort exp =
-  maybe_region_exp sort exp (transl_exp ~scopes sort exp)
+let transl_exp ~scopes layout exp =
+  maybe_region_layout layout (transl_exp ~scopes layout exp)
 
 let transl_let ~scopes ~return_layout ?in_structure rec_flag pat_expr_list =
   transl_let ~scopes ~return_layout ~add_regions:true ?in_structure rec_flag
     pat_expr_list
 
-let transl_scoped_exp ~scopes sort exp =
-  maybe_region_exp sort exp (transl_scoped_exp ~scopes sort exp)
+let transl_scoped_exp ~scopes layout exp =
+  maybe_region_layout layout (transl_scoped_exp ~scopes layout exp)
 
 let transl_apply
       ~scopes ?tailcall ?inlined ?specialised ?position ?mode ~result_layout fn

--- a/lambda/translcore.mli
+++ b/lambda/translcore.mli
@@ -24,7 +24,7 @@ open Debuginfo.Scoped_location
 val pure_module : module_expr -> let_kind
 
 (* Used for translating Alloc_heap values in classes and modules. *)
-val transl_exp: scopes:scopes -> Jkind.Sort.Const.t -> expression -> lambda
+val transl_exp: scopes:scopes -> Lambda.layout -> expression -> lambda
 val transl_apply: scopes:scopes
                   -> ?tailcall:tailcall_attribute
                   -> ?inlined:inlined_attribute
@@ -42,7 +42,7 @@ val transl_extension_constructor: scopes:scopes ->
   Env.t -> Longident.t option ->
   extension_constructor -> lambda
 
-val transl_scoped_exp : scopes:scopes -> Jkind.Sort.Const.t -> expression -> lambda
+val transl_scoped_exp : scopes:scopes -> Lambda.layout -> expression -> lambda
 
 type error =
     Free_super_var

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -648,7 +648,7 @@ and transl_module ~scopes cc rootpath mexp =
       transl_module ~scopes (compose_coercions cc ccarg) rootpath arg
   | Tmod_unpack(arg, _) ->
       apply_coercion loc Strict cc
-        (Translcore.transl_exp ~scopes Jkind.Sort.Const.for_module arg)
+        (Translcore.transl_exp ~scopes Lambda.layout_module arg)
 
 and transl_apply ~scopes ~loc ~cc mod_env funct translated_arg =
   let inlined_attribute =
@@ -754,7 +754,10 @@ and transl_structure ~scopes loc
             transl_structure ~scopes loc fields cc rootpath final_env rem
           in
           let sort = Jkind.Sort.default_for_transl_and_get sort in
-          Lsequence(transl_exp ~scopes sort expr, body), repr
+          let layout =
+            Typeopt.layout_of_sort expr.exp_loc sort
+          in
+          Lsequence(transl_exp ~scopes layout expr, body), repr
       | Tstr_value(rec_flag, pat_expr_list) ->
           (* Translate bindings first *)
           let mk_lam_let =
@@ -1251,12 +1254,14 @@ let transl_toplevel_item ~scopes item =
        unit. *)
     Tstr_eval (expr, sort, _) ->
       let sort = Jkind.Sort.default_for_transl_and_get sort in
-      transl_exp ~scopes sort expr
+      let layout = Typeopt.layout_of_sort expr.exp_loc sort in
+      transl_exp ~scopes layout expr
   | Tstr_value(Nonrecursive,
                [{vb_pat = {pat_desc=Tpat_any}; vb_expr = expr;
                  vb_sort = sort}]) ->
       let sort = Jkind.Sort.default_for_transl_and_get sort in
-      transl_exp ~scopes sort expr
+      let layout = Typeopt.layout_of_sort expr.exp_loc sort in
+      transl_exp ~scopes layout expr
   | Tstr_value(rec_flag, pat_expr_list) ->
       let idents = let_bound_idents pat_expr_list in
       transl_let ~scopes ~return_layout:Lambda.layout_unit ~in_structure:true

--- a/testsuite/tests/flambda/match_in_match_seq.raw.reference
+++ b/testsuite/tests/flambda/match_in_match_seq.raw.reference
@@ -111,7 +111,7 @@ let $camlMatch_in_match_seq__first_const = Block 0 () in
             let s' = %block_load.[`1`] (`*match*`) in
             let x = %block_load.[`0`] (`*match*`) in
             (apply f (x) -> k5 * k2
-               where k5 (apply_result : imm tagged) =
+               where k5 (apply_result : [ 0 |1 ]) =
                  ((let untagged = %untag_imm (apply_result) in
                    switch untagged
                      | 0 -> k5

--- a/testsuite/tests/flambda2/examples/is_int_2020_07_21.simplify.reference
+++ b/testsuite/tests/flambda2/examples/is_int_2020_07_21.simplify.reference
@@ -15,7 +15,7 @@ let code loopify(never) size(28) newer_version_of(test_1)
         my_closure _region _ghost_region my_depth
         -> k * k1 =
   apply f (0) -> k4 * k1
-    where k4 (param : imm tagged) =
+    where k4 (param : [ 0 |1 ]) =
       let unboxed_field = %untag_imm (param) in
       cont k3 (unboxed_field)
     where k3 (unboxed_field : imm) =

--- a/testsuite/tests/flambda2/examples/unknown/alt_ergo.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/alt_ergo.simplify.reference
@@ -53,7 +53,7 @@ let code loopify(never) size(86) newer_version_of(inv_borne_sup_1)
         let Popaque = %opaque (0) in
         let Pobj_magic = %opaque (Popaque) in
         apply Pobj_magic (Pfield_1) -> k3 * k1
-          where k3 (param : imm tagged) =
+          where k3 (param : [ 0 |1 ]) =
             let unboxed_field = %untag_imm (param) in
             cont k2 (unboxed_field))
          where k2 (unboxed_field : imm) =

--- a/testsuite/tests/flambda2/examples/unknown/get_tag_2020_07_21.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/get_tag_2020_07_21.simplify.reference
@@ -15,7 +15,7 @@ let code loopify(never) size(29) newer_version_of(test_1)
         my_closure _region _ghost_region my_depth
         -> k * k1 =
   apply f (0) -> k4 * k1
-    where k4 (param : imm tagged) =
+    where k4 (param : [ 0 |1 ]) =
       let unboxed_field = %untag_imm (param) in
       cont k3 (unboxed_field)
     where k3 (unboxed_field : imm) =

--- a/testsuite/tests/flambda2/examples/unknown/local.raw.reference
+++ b/testsuite/tests/flambda2/examples/unknown/local.raw.reference
@@ -125,7 +125,7 @@
        let a = %block_load.[`0`] (l) in
        let acc_1 = %block.[`0`].`local`[my_region] (a, acc) in
        (apply break_here (a) -> k6 * k2
-          where k6 (apply_result : imm tagged) =
+          where k6 (apply_result : [ 0 |1 ]) =
             ((let untagged = %untag_imm (apply_result) in
               switch untagged
                 | 0 -> k6

--- a/testsuite/tests/flambda2/examples/unknown/local.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/local.simplify.reference
@@ -197,7 +197,7 @@ apply direct(length_2_1)
                     let a = %block_load.[`0`] (l) in
                     let acc_1 = %block.[`0`].`local`[my_region] (a, acc) in
                     (apply break_here (a) -> k3 * k1
-                       where k3 (param : imm tagged) =
+                       where k3 (param : [ 0 |1 ]) =
                          let unboxed_field = %untag_imm (param) in
                          cont k2 (unboxed_field)
                        where k2 (unboxed_field : imm) =

--- a/testsuite/tests/flambda2/examples/wrong/local_exns_to_jumps.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/local_exns_to_jumps.simplify.reference
@@ -28,7 +28,7 @@ apply ccall noalloc
                   | 1 -> k4
                   where k4 =
                     (apply g (r_294_unboxed0) -> k6 * k2
-                       where k6 (param : imm tagged) =
+                       where k6 (param : [ 0 |1 ]) =
                          let unboxed_field = %untag_imm (param) in
                          cont k5 (unboxed_field)
                        where k5 (unboxed_field : imm) =
@@ -71,7 +71,7 @@ apply ccall noalloc
                    where k7 =
                      let r_299_unboxed0_1 = r_299_unboxed0 in
                      (apply g (r_299_unboxed0) -> k8 * k6
-                        where k8 (param : imm tagged) =
+                        where k8 (param : [ 0 |1 ]) =
                           let unboxed_field = %untag_imm (param) in
                           cont k7 (unboxed_field)
                         where k7 (unboxed_field : imm) =
@@ -118,7 +118,7 @@ apply ccall noalloc
                    where k7 =
                      let r_304_unboxed0_1 = r_304_unboxed0 in
                      (apply g (r_304_unboxed0) -> k8 * k6
-                        where k8 (param : imm tagged) =
+                        where k8 (param : [ 0 |1 ]) =
                           let unboxed_field = %untag_imm (param) in
                           cont k7 (unboxed_field)
                         where k7 (unboxed_field : imm) =
@@ -172,7 +172,7 @@ apply ccall noalloc
                         where k7 =
                           let r_310_unboxed0_1 = r_310_unboxed0 in
                           (apply g (r_310_unboxed0) -> k8 * k6
-                             where k8 (param : imm tagged) =
+                             where k8 (param : [ 0 |1 ]) =
                                let unboxed_field = %untag_imm (param) in
                                cont k7 (unboxed_field)
                              where k7 (unboxed_field : imm) =

--- a/testsuite/tests/flambda2/examples/wrong/unused_bucket_switch.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/unused_bucket_switch.simplify.reference
@@ -22,9 +22,7 @@ let ghost_region = %begin_ghost_region () in
              -> k3 * k4
              : imm tagged =
        apply direct(opaque_0_1)
-         ($camlUnused_bucket_switch__opaque_2 : _ -> imm tagged)
-           (1)
-           -> k6 * k4
+         ($camlUnused_bucket_switch__opaque_2 : _ -> [ 0 |1 ]) (1) -> k6 * k4
          where k6 (param_1) =
            let unboxed_field = %untag_imm (param_1) in
            cont k5 (unboxed_field)

--- a/testsuite/tests/typing-layouts-products/product_arrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_arrays.ml
@@ -227,9 +227,9 @@ val f_ignorable : #(float# * int * int64# * bool) array -> int = <fun>
 (* But not on the bad ones. *)
 let f_bad (x : #(string * float#) array) = len x
 [%%expect{|
-Line 1, characters 43-48:
+Line 1, characters 47-48:
 1 | let f_bad (x : #(string * float#) array) = len x
-                                               ^^^^^
+                                                   ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -260,9 +260,9 @@ external len_bad : #(string * float#) array -> int = "%array_length"
 let len_bad_app x = len_bad x
 [%%expect{|
 external len_bad : #(string * float#) array -> int = "%array_length"
-Line 2, characters 20-29:
+Line 2, characters 28-29:
 2 | let len_bad_app x = len_bad x
-                        ^^^^^^^^^
+                                ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -276,9 +276,9 @@ Error: An unboxed product array element must be formed from all
 (* Unboxed vectors are also rejected. *)
 let f_bad (x : #(int * int32x4#) array) = len x
 [%%expect{|
-Line 1, characters 42-47:
+Line 1, characters 46-47:
 1 | let f_bad (x : #(int * int32x4#) array) = len x
-                                              ^^^^^
+                                                  ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -289,9 +289,9 @@ let len_ignorable_with_vec_app x = len_ignorable_with_vec x
 [%%expect{|
 external len_ignorable_with_vec : #(int * int32x4#) array -> int
   = "%array_length"
-Line 3, characters 35-59:
+Line 3, characters 58-59:
 3 | let len_ignorable_with_vec_app x = len_ignorable_with_vec x
-                                       ^^^^^^^^^^^^^^^^^^^^^^^^
+                                                              ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -318,9 +318,9 @@ val f_ignorable :
 (* But not on the bad ones. *)
 let f_bad (x : #(string * float#) array) = get x 42
 [%%expect{|
-Line 1, characters 43-51:
+Line 1, characters 47-48:
 1 | let f_bad (x : #(string * float#) array) = get x 42
-                                               ^^^^^^^^
+                                                   ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -362,9 +362,9 @@ let get_bad_app a i = get_bad a i
 [%%expect{|
 external get_bad : #(string * float#) array -> int -> #(string * float#)
   = "%array_safe_get"
-Line 3, characters 22-33:
+Line 3, characters 30-31:
 3 | let get_bad_app a i = get_bad a i
-                          ^^^^^^^^^^^
+                                  ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -378,9 +378,9 @@ Error: An unboxed product array element must be formed from all
 (* Unboxed vectors are also rejected. *)
 let f_bad (x : #(int * int32x4#) array) = get x 42
 [%%expect{|
-Line 1, characters 42-50:
+Line 1, characters 46-47:
 1 | let f_bad (x : #(int * int32x4#) array) = get x 42
-                                              ^^^^^^^^
+                                                  ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -391,9 +391,9 @@ let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
 [%%expect{|
 external get_ignorable_with_vec :
   #(int * int32x4#) array -> int -> #(int * int32x4#) = "%array_safe_get"
-Line 3, characters 37-63:
+Line 3, characters 60-61:
 3 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
-                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -418,9 +418,9 @@ val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
 
 let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
 [%%expect{|
-Line 1, characters 43-64:
+Line 1, characters 47-48:
 1 | let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
-                                               ^^^^^^^^^^^^^^^^^^^^^
+                                                   ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -465,9 +465,9 @@ let set_bad_app a i x = set_bad a i x
 external set_bad :
   #(string * float#) array -> int -> #(string * float#) -> unit
   = "%array_safe_set"
-Line 4, characters 24-37:
+Line 4, characters 32-33:
 4 | let set_bad_app a i x = set_bad a i x
-                            ^^^^^^^^^^^^^
+                                    ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -481,9 +481,9 @@ Error: An unboxed product array element must be formed from all
 (* Unboxed vectors are also rejected. *)
 let f_bad (x : #(int * int32x4#) array) v = set x 42 #(1, v)
 [%%expect{|
-Line 1, characters 44-60:
+Line 1, characters 48-49:
 1 | let f_bad (x : #(int * int32x4#) array) v = set x 42 #(1, v)
-                                                ^^^^^^^^^^^^^^^^
+                                                    ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -496,9 +496,9 @@ let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
 external set_ignorable_with_vec :
   #(int * int32x4#) array -> int -> #(int * int32x4#) -> unit
   = "%array_safe_set"
-Line 4, characters 39-73:
+Line 4, characters 62-63:
 4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
-                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                  ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -525,9 +525,9 @@ val f_ignorable :
 (* But not on the bad ones. *)
 let f_bad (x : #(string * float#) array) = get x 42
 [%%expect{|
-Line 1, characters 43-51:
+Line 1, characters 47-48:
 1 | let f_bad (x : #(string * float#) array) = get x 42
-                                               ^^^^^^^^
+                                                   ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -569,9 +569,9 @@ let get_bad_app a i = get_bad a i
 [%%expect{|
 external get_bad : #(string * float#) array -> int -> #(string * float#)
   = "%array_unsafe_get"
-Line 3, characters 22-33:
+Line 3, characters 30-31:
 3 | let get_bad_app a i = get_bad a i
-                          ^^^^^^^^^^^
+                                  ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -585,9 +585,9 @@ Error: An unboxed product array element must be formed from all
 (* Unboxed vectors are also rejected. *)
 let f_bad (x : #(int * int32x4#) array) = get x 42
 [%%expect{|
-Line 1, characters 42-50:
+Line 1, characters 46-47:
 1 | let f_bad (x : #(int * int32x4#) array) = get x 42
-                                              ^^^^^^^^
+                                                  ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -599,9 +599,9 @@ let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
 [%%expect{|
 external get_ignorable_with_vec :
   #(int * int32x4#) array -> int -> #(int * int32x4#) = "%array_unsafe_get"
-Line 4, characters 37-63:
+Line 4, characters 60-61:
 4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
-                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -626,9 +626,9 @@ val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
 
 let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
 [%%expect{|
-Line 1, characters 43-64:
+Line 1, characters 47-48:
 1 | let f_bad (x : #(string * float#) array) = set x 42 #("1", #2.0)
-                                               ^^^^^^^^^^^^^^^^^^^^^
+                                                   ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -673,9 +673,9 @@ let set_bad_app a i x = set_bad a i x
 external set_bad :
   #(string * float#) array -> int -> #(string * float#) -> unit
   = "%array_unsafe_set"
-Line 4, characters 24-37:
+Line 4, characters 32-33:
 4 | let set_bad_app a i x = set_bad a i x
-                            ^^^^^^^^^^^^^
+                                    ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -689,9 +689,9 @@ Error: An unboxed product array element must be formed from all
 (* Unboxed vectors are also rejected. *)
 let f_bad (x : #(int * int32x4#) array) v = set x 42 #(1, v)
 [%%expect{|
-Line 1, characters 44-60:
+Line 1, characters 48-49:
 1 | let f_bad (x : #(int * int32x4#) array) v = set x 42 #(1, v)
-                                                ^^^^^^^^^^^^^^^^
+                                                    ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -704,9 +704,9 @@ let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
 external set_ignorable_with_vec :
   #(int * int32x4#) array -> int -> #(int * int32x4#) -> unit
   = "%array_unsafe_set"
-Line 4, characters 39-73:
+Line 4, characters 62-63:
 4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
-                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                  ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -733,9 +733,9 @@ val f_ignorable :
 (* But not on the bad ones. *)
 let f_bad (x : #(string * float#) array) = get x #42L
 [%%expect{|
-Line 1, characters 43-53:
+Line 1, characters 47-48:
 1 | let f_bad (x : #(string * float#) array) = get x #42L
-                                               ^^^^^^^^^^
+                                                   ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -778,9 +778,9 @@ let get_bad_app a i = get_bad a i
 [%%expect{|
 external get_bad : #(string * float#) array -> int64# -> #(string * float#)
   = "%array_safe_get_indexed_by_int64#"
-Line 3, characters 22-33:
+Line 3, characters 30-31:
 3 | let get_bad_app a i = get_bad a i
-                          ^^^^^^^^^^^
+                                  ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -794,9 +794,9 @@ Error: An unboxed product array element must be formed from all
 (* Unboxed vectors are also rejected. *)
 let f_bad (x : #(int * int32x4#) array) = get x #42L
 [%%expect{|
-Line 1, characters 42-52:
+Line 1, characters 46-47:
 1 | let f_bad (x : #(int * int32x4#) array) = get x #42L
-                                              ^^^^^^^^^^
+                                                  ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -809,9 +809,9 @@ let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
 external get_ignorable_with_vec :
   #(int * int32x4#) array -> int64# -> #(int * int32x4#)
   = "%array_safe_get_indexed_by_int64#"
-Line 4, characters 37-63:
+Line 4, characters 60-61:
 4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
-                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -838,9 +838,9 @@ val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
 (* But not on the bad ones. *)
 let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
 [%%expect{|
-Line 1, characters 43-66:
+Line 1, characters 47-48:
 1 | let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
-                                               ^^^^^^^^^^^^^^^^^^^^^^^
+                                                   ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -886,9 +886,9 @@ let set_bad_app a i x = set_bad a i x
 external set_bad :
   #(string * float#) array -> int64# -> #(string * float#) -> unit
   = "%array_safe_set_indexed_by_int64#"
-Line 4, characters 24-37:
+Line 4, characters 32-33:
 4 | let set_bad_app a i x = set_bad a i x
-                            ^^^^^^^^^^^^^
+                                    ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -902,9 +902,9 @@ Error: An unboxed product array element must be formed from all
 (* Unboxed vectors are also rejected. *)
 let f_bad (x : #(int * int32x4#) array) v = set x #42L #(1, v)
 [%%expect{|
-Line 1, characters 44-62:
+Line 1, characters 48-49:
 1 | let f_bad (x : #(int * int32x4#) array) v = set x #42L #(1, v)
-                                                ^^^^^^^^^^^^^^^^^^
+                                                    ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -917,9 +917,9 @@ let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
 external set_ignorable_with_vec :
   #(int * int32x4#) array -> int64# -> #(int * int32x4#) -> unit
   = "%array_safe_set_indexed_by_int64#"
-Line 4, characters 39-73:
+Line 4, characters 62-63:
 4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
-                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                  ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -946,9 +946,9 @@ val f_ignorable :
 (* But not on the bad ones. *)
 let f_bad (x : #(string * float#) array) = get x #42L
 [%%expect{|
-Line 1, characters 43-53:
+Line 1, characters 47-48:
 1 | let f_bad (x : #(string * float#) array) = get x #42L
-                                               ^^^^^^^^^^
+                                                   ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -991,9 +991,9 @@ let get_bad_app a i = get_bad a i
 [%%expect{|
 external get_bad : #(string * float#) array -> int64# -> #(string * float#)
   = "%array_unsafe_get_indexed_by_int64#"
-Line 3, characters 22-33:
+Line 3, characters 30-31:
 3 | let get_bad_app a i = get_bad a i
-                          ^^^^^^^^^^^
+                                  ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -1007,9 +1007,9 @@ Error: An unboxed product array element must be formed from all
 (* Unboxed vectors are also rejected. *)
 let f_bad (x : #(int * int32x4#) array) = get x #42L
 [%%expect{|
-Line 1, characters 42-52:
+Line 1, characters 46-47:
 1 | let f_bad (x : #(int * int32x4#) array) = get x #42L
-                                              ^^^^^^^^^^
+                                                  ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -1022,9 +1022,9 @@ let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
 external get_ignorable_with_vec :
   #(int * int32x4#) array -> int64# -> #(int * int32x4#)
   = "%array_unsafe_get_indexed_by_int64#"
-Line 4, characters 37-63:
+Line 4, characters 60-61:
 4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
-                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -1050,9 +1050,9 @@ val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
 (* But not on the bad ones. *)
 let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
 [%%expect{|
-Line 1, characters 43-66:
+Line 1, characters 47-48:
 1 | let f_bad (x : #(string * float#) array) = set x #42L #("1", #2.0)
-                                               ^^^^^^^^^^^^^^^^^^^^^^^
+                                                   ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -1098,9 +1098,9 @@ let set_bad_app a i x = set_bad a i x
 external set_bad :
   #(string * float#) array -> int64# -> #(string * float#) -> unit
   = "%array_unsafe_set_indexed_by_int64#"
-Line 4, characters 24-37:
+Line 4, characters 32-33:
 4 | let set_bad_app a i x = set_bad a i x
-                            ^^^^^^^^^^^^^
+                                    ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -1114,9 +1114,9 @@ Error: An unboxed product array element must be formed from all
 (* Unboxed vectors are also rejected. *)
 let f_bad (x : #(int * int32x4#) array) v = set x #42L #(1, v)
 [%%expect{|
-Line 1, characters 44-62:
+Line 1, characters 48-49:
 1 | let f_bad (x : #(int * int32x4#) array) v = set x #42L #(1, v)
-                                                ^^^^^^^^^^^^^^^^^^
+                                                    ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -1129,9 +1129,9 @@ let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
 external set_ignorable_with_vec :
   #(int * int32x4#) array -> int64# -> #(int * int32x4#) -> unit
   = "%array_unsafe_set_indexed_by_int64#"
-Line 4, characters 39-73:
+Line 4, characters 62-63:
 4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
-                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                  ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -1158,9 +1158,9 @@ val f_ignorable :
 (* But not on the bad ones. *)
 let f_bad (x : #(string * float#) array) = get x #42l
 [%%expect{|
-Line 1, characters 43-53:
+Line 1, characters 47-48:
 1 | let f_bad (x : #(string * float#) array) = get x #42l
-                                               ^^^^^^^^^^
+                                                   ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -1203,9 +1203,9 @@ let get_bad_app a i = get_bad a i
 [%%expect{|
 external get_bad : #(string * float#) array -> int32# -> #(string * float#)
   = "%array_safe_get_indexed_by_int32#"
-Line 3, characters 22-33:
+Line 3, characters 30-31:
 3 | let get_bad_app a i = get_bad a i
-                          ^^^^^^^^^^^
+                                  ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -1219,9 +1219,9 @@ Error: An unboxed product array element must be formed from all
 (* Unboxed vectors are also rejected. *)
 let f_bad (x : #(int * int32x4#) array) = get x #42l
 [%%expect{|
-Line 1, characters 42-52:
+Line 1, characters 46-47:
 1 | let f_bad (x : #(int * int32x4#) array) = get x #42l
-                                              ^^^^^^^^^^
+                                                  ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -1234,9 +1234,9 @@ let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
 external get_ignorable_with_vec :
   #(int * int32x4#) array -> int32# -> #(int * int32x4#)
   = "%array_safe_get_indexed_by_int32#"
-Line 4, characters 37-63:
+Line 4, characters 60-61:
 4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
-                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -1263,9 +1263,9 @@ val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
 (* But not on the bad ones. *)
 let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
 [%%expect{|
-Line 1, characters 43-66:
+Line 1, characters 47-48:
 1 | let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
-                                               ^^^^^^^^^^^^^^^^^^^^^^^
+                                                   ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -1311,9 +1311,9 @@ let set_bad_app a i x = set_bad a i x
 external set_bad :
   #(string * float#) array -> int32# -> #(string * float#) -> unit
   = "%array_safe_set_indexed_by_int32#"
-Line 4, characters 24-37:
+Line 4, characters 32-33:
 4 | let set_bad_app a i x = set_bad a i x
-                            ^^^^^^^^^^^^^
+                                    ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -1327,9 +1327,9 @@ Error: An unboxed product array element must be formed from all
 (* Unboxed vectors are also rejected. *)
 let f_bad (x : #(int * int32x4#) array) v = set x #42l #(1, v)
 [%%expect{|
-Line 1, characters 44-62:
+Line 1, characters 48-49:
 1 | let f_bad (x : #(int * int32x4#) array) v = set x #42l #(1, v)
-                                                ^^^^^^^^^^^^^^^^^^
+                                                    ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -1342,9 +1342,9 @@ let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
 external set_ignorable_with_vec :
   #(int * int32x4#) array -> int32# -> #(int * int32x4#) -> unit
   = "%array_safe_set_indexed_by_int32#"
-Line 4, characters 39-73:
+Line 4, characters 62-63:
 4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
-                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                  ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -1371,9 +1371,9 @@ val f_ignorable :
 (* But not on the bad ones. *)
 let f_bad (x : #(string * float#) array) = get x #42l
 [%%expect{|
-Line 1, characters 43-53:
+Line 1, characters 47-48:
 1 | let f_bad (x : #(string * float#) array) = get x #42l
-                                               ^^^^^^^^^^
+                                                   ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -1416,9 +1416,9 @@ let get_bad_app a i = get_bad a i
 [%%expect{|
 external get_bad : #(string * float#) array -> int32# -> #(string * float#)
   = "%array_unsafe_get_indexed_by_int32#"
-Line 3, characters 22-33:
+Line 3, characters 30-31:
 3 | let get_bad_app a i = get_bad a i
-                          ^^^^^^^^^^^
+                                  ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -1432,9 +1432,9 @@ Error: An unboxed product array element must be formed from all
 (* Unboxed vectors are also rejected. *)
 let f_bad (x : #(int * int32x4#) array) = get x #42l
 [%%expect{|
-Line 1, characters 42-52:
+Line 1, characters 46-47:
 1 | let f_bad (x : #(int * int32x4#) array) = get x #42l
-                                              ^^^^^^^^^^
+                                                  ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -1447,9 +1447,9 @@ let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
 external get_ignorable_with_vec :
   #(int * int32x4#) array -> int32# -> #(int * int32x4#)
   = "%array_unsafe_get_indexed_by_int32#"
-Line 4, characters 37-63:
+Line 4, characters 60-61:
 4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
-                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -1476,9 +1476,9 @@ val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
 (* But not on the bad ones. *)
 let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
 [%%expect{|
-Line 1, characters 43-66:
+Line 1, characters 47-48:
 1 | let f_bad (x : #(string * float#) array) = set x #42l #("1", #2.0)
-                                               ^^^^^^^^^^^^^^^^^^^^^^^
+                                                   ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -1524,9 +1524,9 @@ let set_bad_app a i x = set_bad a i x
 external set_bad :
   #(string * float#) array -> int32# -> #(string * float#) -> unit
   = "%array_unsafe_set_indexed_by_int32#"
-Line 4, characters 24-37:
+Line 4, characters 32-33:
 4 | let set_bad_app a i x = set_bad a i x
-                            ^^^^^^^^^^^^^
+                                    ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -1540,9 +1540,9 @@ Error: An unboxed product array element must be formed from all
 (* Unboxed vectors are also rejected. *)
 let f_bad (x : #(int * int32x4#) array) v = set x #42l #(1, v)
 [%%expect{|
-Line 1, characters 44-62:
+Line 1, characters 48-49:
 1 | let f_bad (x : #(int * int32x4#) array) v = set x #42l #(1, v)
-                                                ^^^^^^^^^^^^^^^^^^
+                                                    ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -1555,9 +1555,9 @@ let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
 external set_ignorable_with_vec :
   #(int * int32x4#) array -> int32# -> #(int * int32x4#) -> unit
   = "%array_unsafe_set_indexed_by_int32#"
-Line 4, characters 39-73:
+Line 4, characters 62-63:
 4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
-                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                  ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -1585,9 +1585,9 @@ val f_ignorable :
 (* But not on the bad ones. *)
 let f_bad (x : #(string * float#) array) = get x #42n
 [%%expect{|
-Line 1, characters 43-53:
+Line 1, characters 47-48:
 1 | let f_bad (x : #(string * float#) array) = get x #42n
-                                               ^^^^^^^^^^
+                                                   ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -1633,9 +1633,9 @@ let get_bad_app a i = get_bad a i
 external get_bad :
   #(string * float#) array -> nativeint# -> #(string * float#)
   = "%array_safe_get_indexed_by_nativeint#"
-Line 4, characters 22-33:
+Line 4, characters 30-31:
 4 | let get_bad_app a i = get_bad a i
-                          ^^^^^^^^^^^
+                                  ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -1649,9 +1649,9 @@ Error: An unboxed product array element must be formed from all
 (* Unboxed vectors are also rejected. *)
 let f_bad (x : #(int * int32x4#) array) = get x #42n
 [%%expect{|
-Line 1, characters 42-52:
+Line 1, characters 46-47:
 1 | let f_bad (x : #(int * int32x4#) array) = get x #42n
-                                              ^^^^^^^^^^
+                                                  ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -1664,9 +1664,9 @@ let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
 external get_ignorable_with_vec :
   #(int * int32x4#) array -> nativeint# -> #(int * int32x4#)
   = "%array_safe_get_indexed_by_nativeint#"
-Line 4, characters 37-63:
+Line 4, characters 60-61:
 4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
-                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -1693,9 +1693,9 @@ val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
 (* But not on the bad ones. *)
 let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
 [%%expect{|
-Line 1, characters 43-66:
+Line 1, characters 47-48:
 1 | let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
-                                               ^^^^^^^^^^^^^^^^^^^^^^^
+                                                   ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -1743,9 +1743,9 @@ let set_bad_app a i x = set_bad a i x
 external set_bad :
   #(string * float#) array -> nativeint# -> #(string * float#) -> unit
   = "%array_safe_set_indexed_by_nativeint#"
-Line 4, characters 24-37:
+Line 4, characters 32-33:
 4 | let set_bad_app a i x = set_bad a i x
-                            ^^^^^^^^^^^^^
+                                    ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -1759,9 +1759,9 @@ Error: An unboxed product array element must be formed from all
 (* Unboxed vectors are also rejected. *)
 let f_bad (x : #(int * int32x4#) array) v = set x #42n #(1, v)
 [%%expect{|
-Line 1, characters 44-62:
+Line 1, characters 48-49:
 1 | let f_bad (x : #(int * int32x4#) array) v = set x #42n #(1, v)
-                                                ^^^^^^^^^^^^^^^^^^
+                                                    ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -1774,9 +1774,9 @@ let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
 external set_ignorable_with_vec :
   #(int * int32x4#) array -> nativeint# -> #(int * int32x4#) -> unit
   = "%array_safe_set_indexed_by_nativeint#"
-Line 4, characters 39-73:
+Line 4, characters 62-63:
 4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
-                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                  ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -1804,9 +1804,9 @@ val f_ignorable :
 (* But not on the bad ones. *)
 let f_bad (x : #(string * float#) array) = get x #42n
 [%%expect{|
-Line 1, characters 43-53:
+Line 1, characters 47-48:
 1 | let f_bad (x : #(string * float#) array) = get x #42n
-                                               ^^^^^^^^^^
+                                                   ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -1852,9 +1852,9 @@ let get_bad_app a i = get_bad a i
 external get_bad :
   #(string * float#) array -> nativeint# -> #(string * float#)
   = "%array_unsafe_get_indexed_by_nativeint#"
-Line 4, characters 22-33:
+Line 4, characters 30-31:
 4 | let get_bad_app a i = get_bad a i
-                          ^^^^^^^^^^^
+                                  ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -1868,9 +1868,9 @@ Error: An unboxed product array element must be formed from all
 (* Unboxed vectors are also rejected. *)
 let f_bad (x : #(int * int32x4#) array) = get x #42n
 [%%expect{|
-Line 1, characters 42-52:
+Line 1, characters 46-47:
 1 | let f_bad (x : #(int * int32x4#) array) = get x #42n
-                                              ^^^^^^^^^^
+                                                  ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -1883,9 +1883,9 @@ let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
 external get_ignorable_with_vec :
   #(int * int32x4#) array -> nativeint# -> #(int * int32x4#)
   = "%array_unsafe_get_indexed_by_nativeint#"
-Line 4, characters 37-63:
+Line 4, characters 60-61:
 4 | let get_ignorable_with_vec_app x i = get_ignorable_with_vec x i
-                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -1912,9 +1912,9 @@ val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
 (* But not on the bad ones. *)
 let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
 [%%expect{|
-Line 1, characters 43-66:
+Line 1, characters 47-48:
 1 | let f_bad (x : #(string * float#) array) = set x #42n #("1", #2.0)
-                                               ^^^^^^^^^^^^^^^^^^^^^^^
+                                                   ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -1962,9 +1962,9 @@ let set_bad_app a i x = set_bad a i x
 external set_bad :
   #(string * float#) array -> nativeint# -> #(string * float#) -> unit
   = "%array_unsafe_set_indexed_by_nativeint#"
-Line 4, characters 24-37:
+Line 4, characters 32-33:
 4 | let set_bad_app a i x = set_bad a i x
-                            ^^^^^^^^^^^^^
+                                    ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -1978,9 +1978,9 @@ Error: An unboxed product array element must be formed from all
 (* Unboxed vectors are also rejected. *)
 let f_bad (x : #(int * int32x4#) array) v = set x #42n #(1, v)
 [%%expect{|
-Line 1, characters 44-62:
+Line 1, characters 48-49:
 1 | let f_bad (x : #(int * int32x4#) array) v = set x #42n #(1, v)
-                                                ^^^^^^^^^^^^^^^^^^
+                                                    ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -1993,9 +1993,9 @@ let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
 external set_ignorable_with_vec :
   #(int * int32x4#) array -> nativeint# -> #(int * int32x4#) -> unit
   = "%array_unsafe_set_indexed_by_nativeint#"
-Line 4, characters 39-73:
+Line 4, characters 62-63:
 4 | let set_ignorable_with_vec_app x i v = set_ignorable_with_vec x i #(1, v)
-                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                  ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -2022,9 +2022,9 @@ val f_ignorable : #(float# * int * int64# * bool) array -> unit = <fun>
 (* But not on the bad ones. *)
 let f_bad (x : #(string * float#) array) = blit x 0 x 2 3
 [%%expect{|
-Line 1, characters 43-57:
+Line 1, characters 48-49:
 1 | let f_bad (x : #(string * float#) array) = blit x 0 x 2 3
-                                               ^^^^^^^^^^^^^^
+                                                    ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -2072,9 +2072,9 @@ let blit_bad_app a1 i1 a2 i2 len = blit_bad a1 i1 a2 i2 len
 external blit_bad :
   #(string * float#) array ->
   int -> #(string * float#) array -> int -> int -> unit = "%arrayblit"
-Line 5, characters 35-59:
+Line 5, characters 44-46:
 5 | let blit_bad_app a1 i1 a2 i2 len = blit_bad a1 i1 a2 i2 len
-                                       ^^^^^^^^^^^^^^^^^^^^^^^^
+                                                ^^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -2088,9 +2088,9 @@ Error: An unboxed product array element must be formed from all
 (* Unboxed vectors are also rejected. *)
 let f_bad (x : #(int * int32x4#) array) = blit x 0 x 2 3
 [%%expect{|
-Line 1, characters 42-56:
+Line 1, characters 47-48:
 1 | let f_bad (x : #(int * int32x4#) array) = blit x 0 x 2 3
-                                              ^^^^^^^^^^^^^^
+                                                   ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]
@@ -2104,9 +2104,9 @@ let blit_ignorable_with_vec_app x = blit_ignorable_with_vec x 0 x 2 3
 external blit_ignorable_with_vec :
   #(int * int32x4#) array ->
   int -> #(int * int32x4#) array -> int -> int -> unit = "%arrayblit"
-Line 5, characters 36-69:
+Line 5, characters 60-61:
 5 | let blit_ignorable_with_vec_app x = blit_ignorable_with_vec x 0 x 2 3
-                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                ^
 Error: Unboxed vector types are not yet supported in arrays of unboxed
        products.
 |}]

--- a/testsuite/tests/typing-layouts-products/product_iarrays.ml
+++ b/testsuite/tests/typing-layouts-products/product_iarrays.ml
@@ -61,9 +61,9 @@ val length_ignorable : #(int * float#) iarray -> int = <fun>
 
 let length_bad (x : #(string * float#) iarray) = len x
 [%%expect{|
-Line 1, characters 49-54:
+Line 1, characters 53-54:
 1 | let length_bad (x : #(string * float#) iarray) = len x
-                                                     ^^^^^
+                                                         ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -92,9 +92,9 @@ val get_ignorable : #(int * float#) iarray -> #(int * float#) = <fun>
 
 let get_bad (x : #(string * float#) iarray) = get x 42
 [%%expect{|
-Line 1, characters 46-54:
+Line 1, characters 50-51:
 1 | let get_bad (x : #(string * float#) iarray) = get x 42
-                                                  ^^^^^^^^
+                                                      ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -123,9 +123,9 @@ val get_ignorable : #(int * float#) iarray -> #(int * float#) = <fun>
 
 let get_bad (x : #(string * float#) iarray) = get x 42
 [%%expect{|
-Line 1, characters 46-54:
+Line 1, characters 50-51:
 1 | let get_bad (x : #(string * float#) iarray) = get x 42
-                                                  ^^^^^^^^
+                                                      ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -154,9 +154,9 @@ val get_ignorable : #(int * float#) iarray -> #(int * float#) = <fun>
 
 let get_bad (x : #(string * float#) iarray) = get x #42L
 [%%expect{|
-Line 1, characters 46-56:
+Line 1, characters 50-51:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42L
-                                                  ^^^^^^^^^^
+                                                      ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -185,9 +185,9 @@ val get_ignorable : #(int * float#) iarray -> #(int * float#) = <fun>
 
 let get_bad (x : #(string * float#) iarray) = get x #42L
 [%%expect{|
-Line 1, characters 46-56:
+Line 1, characters 50-51:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42L
-                                                  ^^^^^^^^^^
+                                                      ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -216,9 +216,9 @@ val get_ignorable : #(int * float#) iarray -> #(int * float#) = <fun>
 
 let get_bad (x : #(string * float#) iarray) = get x #42l
 [%%expect{|
-Line 1, characters 46-56:
+Line 1, characters 50-51:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42l
-                                                  ^^^^^^^^^^
+                                                      ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -247,9 +247,9 @@ val get_ignorable : #(int * float#) iarray -> #(int * float#) = <fun>
 
 let get_bad (x : #(string * float#) iarray) = get x #42l
 [%%expect{|
-Line 1, characters 46-56:
+Line 1, characters 50-51:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42l
-                                                  ^^^^^^^^^^
+                                                      ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -279,9 +279,9 @@ val get_ignorable : #(int * float#) iarray -> #(int * float#) = <fun>
 
 let get_bad (x : #(string * float#) iarray) = get x #42n
 [%%expect{|
-Line 1, characters 46-56:
+Line 1, characters 50-51:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42n
-                                                  ^^^^^^^^^^
+                                                      ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose
@@ -311,9 +311,9 @@ val get_ignorable : #(int * float#) iarray -> #(int * float#) = <fun>
 
 let get_bad (x : #(string * float#) iarray) = get x #42n
 [%%expect{|
-Line 1, characters 46-56:
+Line 1, characters 50-51:
 1 | let get_bad (x : #(string * float#) iarray) = get x #42n
-                                                  ^^^^^^^^^^
+                                                      ^
 Error: An unboxed product array element must be formed from all
        external types (which are ignored by the gc) or all gc-scannable types.
        But this array operation is peformed for an array whose

--- a/testsuite/tests/typing-layouts-void/basics_void.ml
+++ b/testsuite/tests/typing-layouts-void/basics_void.ml
@@ -248,56 +248,56 @@ external get : ('a : any separable). 'a array -> int -> 'a
 
 let f (a : unit_u array) = length a
 [%%expect{|
-Line 1, characters 27-35:
+Line 1, characters 34-35:
 1 | let f (a : unit_u array) = length a
-                               ^^^^^^^^
+                                      ^
 Error: Types whose layout contains [void] are not yet supported in arrays.
 |}]
 
 let f (a : #(int * unit_u) array) = length a
 [%%expect{|
-Line 1, characters 36-44:
+Line 1, characters 43-44:
 1 | let f (a : #(int * unit_u) array) = length a
-                                        ^^^^^^^^
+                                               ^
 Error: Types whose layout contains [void] are not yet supported in arrays.
 |}]
 
 let f (a : unit_u array) i = get a i
 [%%expect{|
-Line 1, characters 29-36:
+Line 1, characters 33-34:
 1 | let f (a : unit_u array) i = get a i
-                                 ^^^^^^^
+                                     ^
 Error: Types whose layout contains [void] are not yet supported in arrays.
 |}]
 
 let f (a : #(int * unit_u) array) i = get a i
 [%%expect{|
-Line 1, characters 38-45:
+Line 1, characters 42-43:
 1 | let f (a : #(int * unit_u) array) i = get a i
-                                          ^^^^^^^
+                                              ^
 Error: Types whose layout contains [void] are not yet supported in arrays.
 |}]
 
 let f (a : u1 array) i = get a i
 [%%expect{|
-Line 1, characters 25-32:
+Line 1, characters 29-30:
 1 | let f (a : u1 array) i = get a i
-                             ^^^^^^^
+                                 ^
 Error: Types whose layout contains [void] are not yet supported in arrays.
 |}]
 
 let f (a : u2 array) i = get a i
 [%%expect{|
-Line 1, characters 25-32:
+Line 1, characters 29-30:
 1 | let f (a : u2 array) i = get a i
-                             ^^^^^^^
+                                 ^
 Error: Types whose layout contains [void] are not yet supported in arrays.
 |}]
 
 let f (a : u3 array) i = get a i
 [%%expect{|
-Line 1, characters 25-32:
+Line 1, characters 29-30:
 1 | let f (a : u3 array) i = get a i
-                             ^^^^^^^
+                                 ^
 Error: Types whose layout contains [void] are not yet supported in arrays.
 |}]

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -124,8 +124,6 @@ module type Sort = sig
 
     val for_block_element : t
 
-    val for_array_get_result : t
-
     val for_array_comprehension_element : t
 
     val for_list_element : t
@@ -135,15 +133,7 @@ module type Sort = sig
         make the code clearer. *)
     val for_function : t
 
-    val for_probe_body : t
-
-    val for_poly_variant : t
-
     val for_object : t
-
-    val for_initializer : t
-
-    val for_method : t
 
     val for_module : t
 
@@ -151,8 +141,6 @@ module type Sort = sig
     val for_predef_scannable : t
 
     val for_tuple : t
-
-    val for_idx : t
 
     val for_loop_index : t
 

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -256,10 +256,6 @@ module Sort = struct
 
     let for_block_element = scannable
 
-    let for_probe_body = scannable
-
-    let for_poly_variant = scannable
-
     let for_boxed_record = scannable
 
     let for_object = scannable
@@ -274,21 +270,13 @@ module Sort = struct
 
     let for_class_arg = scannable
 
-    let for_method = scannable
-
-    let for_initializer = scannable
-
     let for_module = scannable
 
     let for_tuple = scannable
 
-    let for_array_get_result = scannable
-
     let for_array_comprehension_element = scannable
 
     let for_list_element = scannable
-
-    let for_idx = bits64
 
     let for_loop_index = scannable
 


### PR DESCRIPTION
Change `transl_exp` and `transl_scoped_exp` in `Translcore` to take `Lambda.layout` instead of a `Jkind.Sort.Const.t`. This is needed for allowing functions to have the return layout `any`, and also eliminates some duplicate work we did when converting sorts to layouts. Add a few more layout constants to `Lambda` to be more precise in a few places.

Tested by existing tests; results in a slightly more precise locations in error messages.