### PR TITLE
Refactor `Istore_int` (`amd64`) to use inline record

### DIFF
--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -32,7 +32,8 @@ let class_of_operation (op : Operation.t)
   | Specific spec ->
     begin match spec with
     | Ilea _ | Isextend32 | Izextend32 -> Class Op_pure
-    | Istore_int(_, _, is_asg) -> Class (Op_store is_asg)
+    | Istore_int { const = _; addr = _; is_assignment = is_asg } ->
+      Class (Op_store is_asg)
     | Ioffset_loc(_, _) -> Class (Op_store true)
     | Ifloatarithmem _ -> Class (Op_load Mutable)
     | Ibswap _ -> Use_default

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -233,7 +233,8 @@ type float_width = Cmm.float_width
 (* Specific operations, including [Simd], must not raise. *)
 type specific_operation =
     Ilea of addressing_mode            (* "lea" gives scaled adds *)
-  | Istore_int of nativeint * addressing_mode * bool
+  | Istore_int of
+      { const : nativeint; addr : addressing_mode; is_assignment : bool }
                                        (* Store an integer constant *)
   | Ioffset_loc of int * addressing_mode
                                        (* Add a constant to a location *)
@@ -366,7 +367,7 @@ let floatartith_name (width : float_width) op =
 let print_specific_operation printreg op ppf arg =
   match op with
   | Ilea addr -> print_addressing printreg addr ppf arg
-  | Istore_int(n, addr, is_assign) ->
+  | Istore_int { const = n; addr; is_assignment = is_assign } ->
       fprintf ppf "[%a] := %nd %s"
          (print_addressing printreg addr) arg n
          (if is_assign then "(assign)" else "(init)")
@@ -409,7 +410,8 @@ let print_specific_operation printreg op ppf arg =
 let specific_operation_name : specific_operation -> string = fun op ->
   match op with
   | Ilea _ -> "lea"
-  | Istore_int (n,_addr,_is_assign) -> "store_int "^ (Nativeint.to_string n)
+  | Istore_int { const = n; addr = _; is_assignment = _ } ->
+    "store_int "^ (Nativeint.to_string n)
   | Ioffset_loc (n,_addr) -> "offset_loc "^(string_of_int n)
   | Ifloatarithmem (width, op, _addr) -> floatartith_name width op
   | Ibswap { bitwidth } ->
@@ -441,7 +443,7 @@ let operation_is_pure = function
   | Ifloatarithmem _  -> true
   | Irdtsc | Irdpmc
   | Ilfence | Isfence | Imfence
-  | Istore_int (_, _, _) | Ioffset_loc (_, _)
+  | Istore_int { const = _; addr = _; is_assignment = _ } | Ioffset_loc (_, _)
   | Icldemote _ | Iprefetch _ -> false
   | Ipackf32 -> true
   | Isimd op -> Simd.is_pure_operation op
@@ -454,7 +456,7 @@ let operation_allocates = function
   | Irdtsc | Irdpmc  | Ipackf32
   | Isimd _ | Isimd_mem _
   | Ilfence | Isfence | Imfence
-  | Istore_int (_, _, _) | Ioffset_loc (_, _)
+  | Istore_int { const = _; addr = _; is_assignment = _ } | Ioffset_loc (_, _)
   | Icldemote _ | Iprefetch _ -> false
 
 open X86_ast
@@ -510,7 +512,8 @@ let equal_float_operation left right =
 let equal_specific_operation left right =
   match left, right with
   | Ilea x, Ilea y -> equal_addressing_mode x y
-  | Istore_int (x, x', x''), Istore_int (y, y', y'') ->
+  | ( Istore_int { const = x; addr = x'; is_assignment = x'' },
+      Istore_int { const = y; addr = y'; is_assignment = y'' } ) ->
     Nativeint.equal x y && equal_addressing_mode x' y' && Bool.equal x'' y''
   | Ioffset_loc (x, x'), Ioffset_loc (y, y') ->
     Int.equal x y && equal_addressing_mode x' y'
@@ -620,7 +623,8 @@ let addressing_offset_in_bytes
 let isomorphic_specific_operation op1 op2 =
   match op1, op2 with
   | Ilea a1, Ilea a2 -> equal_addressing_mode_without_displ a1 a2
-  | Istore_int (_n1, a1, is_assign1), Istore_int (_n2, a2, is_assign2) ->
+  | ( Istore_int { const = _; addr = a1; is_assignment = is_assign1 },
+      Istore_int { const = _; addr = a2; is_assignment = is_assign2 } ) ->
     equal_addressing_mode_without_displ a1 a2 && Bool.equal is_assign1 is_assign2
   | Ioffset_loc (_n1, a1), Ioffset_loc (_n2, a2) ->
     equal_addressing_mode_without_displ a1 a2

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -77,7 +77,8 @@ type float_width = Cmm.float_width
 
 type specific_operation =
     Ilea of addressing_mode             (* "lea" gives scaled adds *)
-  | Istore_int of nativeint * addressing_mode * bool
+  | Istore_int of
+      { const : nativeint; addr : addressing_mode; is_assignment : bool }
                                         (* Store an integer constant *)
   | Ioffset_loc of int * addressing_mode (* Add a constant to a location *)
   | Ifloatarithmem of float_width * float_operation * addressing_mode

--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -212,7 +212,7 @@ let pseudoregs_for_operation op arg res =
   | Intop_imm ((Imulh _ | Idiv | Imod | Icomp _ | Ipopcnt | Iclz _ | Ictz _), _)
   | Specific
       ( Isextend32 | Izextend32 | Ilea _
-      | Istore_int (_, _, _)
+      | Istore_int { const = _; addr = _; is_assignment = _ }
       | Ilfence | Isfence | Imfence
       | Ioffset_loc (_, _)
       | Irdtsc | Icldemote _ | Iprefetch _ )
@@ -277,9 +277,14 @@ let select_store ~is_assign addr (exp : Cmm.expression) :
   match exp with
   | Cconst_int (n, _dbg) when int_is_immediate n ->
     Rewritten
-      (Specific (Istore_int (Nativeint.of_int n, addr, is_assign)), Ctuple [])
+      ( Specific
+          (Istore_int
+             { const = Nativeint.of_int n; addr; is_assignment = is_assign }),
+        Ctuple [] )
   | Cconst_natint (n, _dbg) when is_immediate_natint n ->
-    Rewritten (Specific (Istore_int (n, addr, is_assign)), Ctuple [])
+    Rewritten
+      ( Specific (Istore_int { const = n; addr; is_assignment = is_assign }),
+        Ctuple [] )
   | Cconst_int _ | Cconst_vec128 _ | Cconst_vec256 _ | Cconst_vec512 _
   | Cconst_natint (_, _)
   | Cconst_float32 (_, _)

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -1974,7 +1974,8 @@ let emit_instr ~first ~fallthrough i =
       movss xmm15 address
     | Single { reg = Float32 } -> store REAL4 arg movss
     | Double -> store REAL8 arg movsd)
-  | Lop (Specific (Istore_int (n, addr, is_modify))) ->
+  | Lop (Specific (Istore_int { const = n; addr; is_assignment = is_modify }))
+    ->
     let address = addressing addr QWORD i 0 in
     let src = nat n in
     let memory_access : Address_sanitizer.memory_access =

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -278,7 +278,7 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
   | Op
       (Specific
         ( Isextend32 | Izextend32 | Ilea _
-        | Istore_int (_, _, _)
+        | Istore_int { const = _; addr = _; is_assignment = _ }
         | Ioffset_loc (_, _)
         | Ifloatarithmem (_, _, _)
         | Icldemote _ | Iprefetch _ | Ibswap _ ))

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -1357,13 +1357,14 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
       | W32 -> None (* See previous comment *)
       | W16 -> None
       | W8 -> None)
-    | Istore_int (_n, addressing_mode, is_assignment) -> (
+    | Istore_int { const = _n; addr = addressing_mode; is_assignment } -> (
       if not (Vectorize_utils.Width_in_bits.equal width_type W64)
       then None
       else
         let extract_store_int_imm (op : Operation.t) =
           match op with
-          | Specific (Istore_int (n, _addr, _is_assign)) -> Int64.of_nativeint n
+          | Specific (Istore_int { const = n; addr = _; is_assignment = _ }) ->
+            Int64.of_nativeint n
           | Specific
               ( Ifloatarithmem _ | Ioffset_loc _ | Iprefetch _ | Icldemote _
               | Irdtsc | Irdpmc | Ilfence | Isfence | Imfence | Ipackf32

--- a/backend/amd64/vectorize_specific.ml
+++ b/backend/amd64/vectorize_specific.ml
@@ -12,7 +12,7 @@ let memory_access : Arch.specific_operation -> Memory_access.t option =
     Some (Memory_access.create ?first_memory_arg_index desc)
   in
   match op with
-  | Istore_int (_n, addressing_mode, is_assignment) ->
+  | Istore_int { const = _n; addr = addressing_mode; is_assignment } ->
     let desc =
       Memory_access.Write
         { width_in_bits = W64;


### PR DESCRIPTION
Replace the tuple-based constructor `Istore_int of nativeint * addressing_mode * bool` with an inline record `Istore_int of { const : nativeint; addr : addressing_mode; is_assignment : bool }` for better code readability and field naming clarity.

The field names follow existing codebase conventions:
- `const`: the integer constant to store
- `addr`: the addressing mode (consistent with other constructors like Iprefetch)
- `is_assignment`: boolean indicating assignment vs initialization

🤖 Generated with [Claude Code](https://claude.ai/code)