### PR TITLE
Silence `cd` in `merge_dot_a_files.sh`

### DIFF
--- a/tools/merge_dot_a_files.sh
+++ b/tools/merge_dot_a_files.sh
@@ -11,7 +11,7 @@ fi
 absolute_path () {
   path=$1
   dir=$(dirname $path)
-  dir_abs=$(cd $dir && pwd)
+  dir_abs=$(cd $dir >/dev/null && pwd)
   file=$(basename $path)
   echo $dir_abs/$file
 }


### PR DESCRIPTION
When `$CDPATH` is set, `cd <relative-dir>` displays the absolute path of the entered directory, so that `$(cd $dir && pwd)` actually returns the absolute path twice (separated by an end-of-line). This patch silences that call to `cd`.

Without this patch, `merge_dot_a_files.sh` breaks as it feeds that directory to `ar` as a file, thus giving the following error:

```
File "dune", lines 705-742, characters 0-1841:
705 | (rule
706 |  (targets ocamloptcomp_with_flambda2.a)
707 |  (action
.....
740 |    %{dep:ocamloptcomp.a}
741 |    %{dep:middle_end/flambda2/to_cmm/flambda2_to_cmm.a}
742 |    %{dep:middle_end/flambda2/flambda2.a})))
Context: main
ar: .../_build/main/backend/debug/dwarf/dwarf_flags: file format not recognized
```