### PR TITLE
Annotate `Array` and `Bigarray` pure accessors as `immutable`

### DIFF
--- a/stdlib/array.ml
+++ b/stdlib/array.ml
@@ -23,7 +23,7 @@ type 'a t = 'a array
 
 (* Array operations *)
 
-external length : ('a array[@local_opt]) @ contended -> int @@ portable
+external length : ('a array[@local_opt]) @ immutable -> int @@ stateless
   = "%array_length"
 external get : ('a array[@local_opt]) -> int -> 'a @@ portable
   = "%array_safe_get"
@@ -46,7 +46,7 @@ external create_float: int -> float array @@ portable = "caml_make_float_vect"
 
 module Floatarray = struct
   external create : int -> floatarray @@ portable = "caml_floatarray_create"
-  external length : (floatarray[@local_opt]) @ contended -> int @@ portable
+  external length : (floatarray[@local_opt]) @ immutable -> int @@ stateless
     = "%floatarray_length"
   external get
     : (floatarray[@local_opt]) @ shared -> int -> (float[@local_opt])

--- a/stdlib/array.mli
+++ b/stdlib/array.mli
@@ -35,7 +35,8 @@ open! Stdlib
 type 'a t = 'a array
 (** An alias for the type of arrays. *)
 
-external length : ('a array[@local_opt]) @ contended -> int = "%array_length"
+external length : ('a array[@local_opt]) @ immutable -> int @@ stateless
+  = "%array_length"
 (** Return the length (number of elements) of the given array. *)
 
 external get : ('a array[@local_opt]) -> int -> 'a = "%array_safe_get"
@@ -461,7 +462,7 @@ external unsafe_set : ('a array[@local_opt]) -> int -> 'a -> unit
 
 module Floatarray : sig
   external create : int -> floatarray = "caml_floatarray_create"
-  external length : (floatarray[@local_opt]) @ contended -> int
+  external length : (floatarray[@local_opt]) @ immutable -> int @@ stateless
     = "%floatarray_length"
   external get : (floatarray[@local_opt]) @ shared -> int -> (float[@local_opt])
     = "%floatarray_safe_get"

--- a/stdlib/arrayLabels.mli
+++ b/stdlib/arrayLabels.mli
@@ -37,7 +37,8 @@ open! Stdlib
 type 'a t = 'a array
 (** An alias for the type of arrays. *)
 
-external length : ('a array[@local_opt]) @ contended -> int = "%array_length"
+external length : ('a array[@local_opt]) @ immutable -> int @@ stateless
+  = "%array_length"
 (** Return the length (number of elements) of the given array. *)
 
 external get : ('a array[@local_opt]) -> int -> 'a = "%array_safe_get"
@@ -463,7 +464,7 @@ external unsafe_set : ('a array[@local_opt]) -> int -> 'a -> unit
 
 module Floatarray : sig
   external create : int -> floatarray = "caml_floatarray_create"
-  external length : (floatarray[@local_opt]) @ contended -> int
+  external length : (floatarray[@local_opt]) @ immutable -> int @@ stateless
     = "%floatarray_length"
   external get : (floatarray[@local_opt]) @ shared -> int -> (float[@local_opt])
     = "%floatarray_safe_get"

--- a/stdlib/bigarray.ml
+++ b/stdlib/bigarray.ml
@@ -135,10 +135,11 @@ module Genarray = struct
     | C_layout -> cloop arr (Array.make dlen 0) f 0 dims; arr
     | Fortran_layout -> floop arr (Array.make dlen 1) f (pred dlen) dims; arr
 
-  external num_dims: (('a, 'b, 'c) t[@local_opt]) @ contended -> int @@ portable
+  external num_dims
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> int @@ stateless
     = "caml_ba_num_dims"
   external nth_dim
-    : (('a, 'b, 'c) t[@local_opt]) @ contended -> int -> int @@ portable
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> int -> int @@ stateless
     = "caml_ba_dim"
   let dims a =
     let n = num_dims a in
@@ -147,10 +148,10 @@ module Genarray = struct
     d
 
   external kind
-    : (('a, 'b, 'c) t[@local_opt]) @ contended -> ('a, 'b) kind @@ portable
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> ('a, 'b) kind @@ stateless
     = "caml_ba_kind"
   external layout
-    : (('a, 'b, 'c) t[@local_opt]) @ contended -> 'c layout @@ portable
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> 'c layout @@ stateless
     = "caml_ba_layout"
   external change_layout: ('a, 'b, 'c) t -> 'd layout -> ('a, 'b, 'd) t @@ portable
      = "caml_ba_change_layout"
@@ -186,10 +187,10 @@ module Array0 = struct
   let get arr = Genarray.get arr [||]
   let set arr value = Genarray.set arr [||] value
   external kind
-    : (('a, 'b, 'c) t[@local_opt]) @ contended -> ('a, 'b) kind @@ portable
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> ('a, 'b) kind @@ stateless
     = "caml_ba_kind"
   external layout
-    : (('a, 'b, 'c) t[@local_opt]) @ contended -> 'c layout @@ portable
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> 'c layout @@ stateless
     = "caml_ba_layout"
 
   external change_layout: ('a, 'b, 'c) t -> 'd layout -> ('a, 'b, 'd) t @@ portable
@@ -233,13 +234,13 @@ module Array1 = struct
     : (('a, 'b, 'c) t[@local_opt]) -> int -> ('a[@local_opt]) -> unit
     @@ portable
     = "%caml_ba_unsafe_set_1"
-  external dim: (('a, 'b, 'c) t[@local_opt]) @ contended -> int @@ portable
+  external dim: (('a, 'b, 'c) t[@local_opt]) @ immutable -> int @@ stateless
     = "%caml_ba_dim_1"
   external kind
-    : (('a, 'b, 'c) t[@local_opt]) @ contended -> ('a, 'b) kind @@ portable
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> ('a, 'b) kind @@ stateless
     = "caml_ba_kind"
   external layout
-    : (('a, 'b, 'c) t[@local_opt]) @ contended -> 'c layout @@ portable
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> 'c layout @@ stateless
     = "caml_ba_layout"
 
   external change_layout: ('a, 'b, 'c) t -> 'd layout -> ('a, 'b, 'd) t @@ portable
@@ -301,15 +302,15 @@ module Array2 = struct
     : (('a, 'b, 'c) t[@local_opt]) -> int -> int -> ('a[@local_opt]) -> unit
     @@ portable
     = "%caml_ba_unsafe_set_2"
-  external dim1: (('a, 'b, 'c) t[@local_opt]) @ contended -> int @@ portable
+  external dim1: (('a, 'b, 'c) t[@local_opt]) @ immutable -> int @@ stateless
     = "%caml_ba_dim_1"
-  external dim2: (('a, 'b, 'c) t[@local_opt]) @ contended -> int @@ portable
+  external dim2: (('a, 'b, 'c) t[@local_opt]) @ immutable -> int @@ stateless
     = "%caml_ba_dim_2"
   external kind
-    : (('a, 'b, 'c) t[@local_opt]) @ contended -> ('a, 'b) kind @@ portable
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> ('a, 'b) kind @@ stateless
     = "caml_ba_kind"
   external layout
-    : (('a, 'b, 'c) t[@local_opt]) @ contended -> 'c layout @@ portable
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> 'c layout @@ stateless
     = "caml_ba_layout"
 
   external change_layout: ('a, 'b, 'c) t -> 'd layout -> ('a, 'b, 'd) t @@ portable
@@ -394,17 +395,17 @@ module Array3 = struct
        unit
      @@ portable
      = "%caml_ba_unsafe_set_3"
-  external dim1: (('a, 'b, 'c) t[@local_opt]) @ contended -> int @@ portable
+  external dim1: (('a, 'b, 'c) t[@local_opt]) @ immutable -> int @@ stateless
     = "%caml_ba_dim_1"
-  external dim2: (('a, 'b, 'c) t[@local_opt]) @ contended -> int @@ portable
+  external dim2: (('a, 'b, 'c) t[@local_opt]) @ immutable -> int @@ stateless
     = "%caml_ba_dim_2"
-  external dim3: (('a, 'b, 'c) t[@local_opt]) @ contended -> int @@ portable
+  external dim3: (('a, 'b, 'c) t[@local_opt]) @ immutable -> int @@ stateless
     = "%caml_ba_dim_3"
   external kind
-    : (('a, 'b, 'c) t[@local_opt]) @ contended -> ('a, 'b) kind @@ portable
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> ('a, 'b) kind @@ stateless
     = "caml_ba_kind"
   external layout
-    : (('a, 'b, 'c) t[@local_opt]) @ contended -> 'c layout @@ portable
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> 'c layout @@ stateless
     = "caml_ba_layout"
 
   external change_layout: ('a, 'b, 'c) t -> 'd layout -> ('a, 'b, 'd) t @@ portable

--- a/stdlib/bigarray.mli
+++ b/stdlib/bigarray.mli
@@ -346,15 +346,17 @@ module Genarray :
 
       @since 4.12 *)
 
-  external num_dims: (('a, 'b, 'c) t[@local_opt]) @ contended -> int
+  external num_dims
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> int @@ stateless
     = "caml_ba_num_dims"
   (** Return the number of dimensions of the given Bigarray. *)
 
-  val dims : ('a, 'b, 'c) t @ contended local -> int array
+  val dims : ('a, 'b, 'c) t @ immutable local -> int array
   (** [Genarray.dims a] returns all dimensions of the Bigarray [a],
      as an array of integers of length [Genarray.num_dims a]. *)
 
-  external nth_dim: (('a, 'b, 'c) t[@local_opt]) @ contended -> int -> int
+  external nth_dim
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> int -> int @@ stateless
     = "caml_ba_dim"
   (** [Genarray.nth_dim a n] returns the [n]-th dimension of the
      Bigarray [a].  The first dimension corresponds to [n = 0];
@@ -363,11 +365,13 @@ module Genarray :
      @raise Invalid_argument if [n] is less than 0 or greater or equal than
      [Genarray.num_dims a]. *)
 
-  external kind: (('a, 'b, 'c) t[@local_opt]) @ contended -> ('a, 'b) kind
+  external kind
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> ('a, 'b) kind @@ stateless
     = "caml_ba_kind"
   (** Return the kind of the given Bigarray. *)
 
-  external layout: (('a, 'b, 'c) t[@local_opt]) @ contended -> 'c layout
+  external layout
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> 'c layout @@ stateless
     = "caml_ba_layout"
   (** Return the layout of the given Bigarray. *)
 
@@ -383,7 +387,7 @@ module Genarray :
       @since 4.04
   *)
 
-  val size_in_bytes : ('a, 'b, 'c) t @ contended local -> int
+  val size_in_bytes : ('a, 'b, 'c) t @ immutable local -> int
   (** [size_in_bytes a] is the number of elements in [a] multiplied
     by [a]'s {!kind_size_in_bytes}.
 
@@ -552,11 +556,13 @@ module Array0 : sig
 
      @since 4.12 *)
 
-  external kind: (('a, 'b, 'c) t[@local_opt]) @ contended -> ('a, 'b) kind
+  external kind
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> ('a, 'b) kind @@ stateless
     = "caml_ba_kind"
   (** Return the kind of the given Bigarray. *)
 
-  external layout: (('a, 'b, 'c) t[@local_opt]) @ contended -> 'c layout
+  external layout
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> 'c layout @@ stateless
     = "caml_ba_layout"
   (** Return the layout of the given Bigarray. *)
 
@@ -569,7 +575,7 @@ module Array0 : sig
       @since 4.06
   *)
 
-  val size_in_bytes : ('a, 'b, 'c) t @ contended local -> int
+  val size_in_bytes : ('a, 'b, 'c) t @ immutable local -> int
   (** [size_in_bytes a] is [a]'s {!kind_size_in_bytes}. *)
 
   val get: ('a, 'b, 'c) t @ local shared -> 'a
@@ -633,16 +639,18 @@ module Array1 : sig
 
      @since 4.12 *)
 
-  external dim: (('a, 'b, 'c) t[@local_opt]) @ contended -> int
+  external dim: (('a, 'b, 'c) t[@local_opt]) @ immutable -> int @@ stateless
     = "%caml_ba_dim_1"
   (** Return the size (dimension) of the given one-dimensional
      Bigarray. *)
 
-  external kind: (('a, 'b, 'c) t[@local_opt]) @ contended -> ('a, 'b) kind
+  external kind
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> ('a, 'b) kind @@ stateless
     = "caml_ba_kind"
   (** Return the kind of the given Bigarray. *)
 
-  external layout: (('a, 'b, 'c) t[@local_opt]) @ contended -> 'c layout
+  external layout
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> 'c layout @@ stateless
     = "caml_ba_layout"
   (** Return the layout of the given Bigarray. *)
 
@@ -656,7 +664,7 @@ module Array1 : sig
   *)
 
 
-  val size_in_bytes : ('a, 'b, 'c) t @ contended -> int
+  val size_in_bytes : ('a, 'b, 'c) t @ immutable -> int
   (** [size_in_bytes a] is the number of elements in [a]
     multiplied by [a]'s {!kind_size_in_bytes}.
 
@@ -759,19 +767,21 @@ module Array2 :
 
      @since 4.12 *)
 
-  external dim1: (('a, 'b, 'c) t[@local_opt]) @ contended -> int
+  external dim1: (('a, 'b, 'c) t[@local_opt]) @ immutable -> int @@ stateless
     = "%caml_ba_dim_1"
   (** Return the first dimension of the given two-dimensional Bigarray. *)
 
-  external dim2: (('a, 'b, 'c) t[@local_opt]) @ contended -> int
+  external dim2: (('a, 'b, 'c) t[@local_opt]) @ immutable -> int @@ stateless
     = "%caml_ba_dim_2"
   (** Return the second dimension of the given two-dimensional Bigarray. *)
 
-  external kind: (('a, 'b, 'c) t[@local_opt]) @ contended -> ('a, 'b) kind
+  external kind
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> ('a, 'b) kind @@ stateless
     = "caml_ba_kind"
   (** Return the kind of the given Bigarray. *)
 
-  external layout: (('a, 'b, 'c) t[@local_opt]) @ contended -> 'c layout
+  external layout
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> 'c layout @@ stateless
     = "caml_ba_layout"
   (** Return the layout of the given Bigarray. *)
 
@@ -787,7 +797,7 @@ module Array2 :
   *)
 
 
-  val size_in_bytes : ('a, 'b, 'c) t @ contended -> int
+  val size_in_bytes : ('a, 'b, 'c) t @ immutable -> int
   (** [size_in_bytes a] is the number of elements in [a]
     multiplied by [a]'s {!kind_size_in_bytes}.
 
@@ -906,23 +916,25 @@ module Array3 :
 
      @since 4.12 *)
 
-  external dim1: (('a, 'b, 'c) t[@local_opt]) @ contended -> int
+  external dim1: (('a, 'b, 'c) t[@local_opt]) @ immutable -> int @@ stateless
     = "%caml_ba_dim_1"
   (** Return the first dimension of the given three-dimensional Bigarray. *)
 
-  external dim2: (('a, 'b, 'c) t[@local_opt]) @ contended -> int
+  external dim2: (('a, 'b, 'c) t[@local_opt]) @ immutable -> int @@ stateless
     = "%caml_ba_dim_2"
   (** Return the second dimension of the given three-dimensional Bigarray. *)
 
-  external dim3: (('a, 'b, 'c) t[@local_opt]) @ contended -> int
+  external dim3: (('a, 'b, 'c) t[@local_opt]) @ immutable -> int @@ stateless
     = "%caml_ba_dim_3"
   (** Return the third dimension of the given three-dimensional Bigarray. *)
 
-  external kind: (('a, 'b, 'c) t[@local_opt]) @ contended -> ('a, 'b) kind
+  external kind
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> ('a, 'b) kind @@ stateless
     = "caml_ba_kind"
   (** Return the kind of the given Bigarray. *)
 
-  external layout: (('a, 'b, 'c) t[@local_opt]) @ contended -> 'c layout
+  external layout
+    : (('a, 'b, 'c) t[@local_opt]) @ immutable -> 'c layout @@ stateless
     = "caml_ba_layout"
   (** Return the layout of the given Bigarray. *)
 
@@ -938,7 +950,7 @@ module Array3 :
       @since 4.06
   *)
 
-  val size_in_bytes : ('a, 'b, 'c) t @ contended -> int
+  val size_in_bytes : ('a, 'b, 'c) t @ immutable -> int
   (** [size_in_bytes a] is the number of elements in [a]
     multiplied by [a]'s {!kind_size_in_bytes}.
 


### PR DESCRIPTION
Previously accessors on `Array` and `Bigarray` that don't touch any mutable state were annotated as taking the array as `contended`, but `immutable` is preferable.