### PR TITLE
Add claude md docs

### DIFF
--- a/oxcaml/tests/backend/llvmize/CLAUDE.md
+++ b/oxcaml/tests/backend/llvmize/CLAUDE.md
@@ -1,0 +1,195 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+# OxCaml LLVMIZE Test Suite
+
+This directory contains tests for the LLVM backend (llvmize) in the OxCaml compiler. The tests verify that OCaml programs compiled with the LLVM backend produce correct output and generate expected LLVM IR.
+
+## Prerequisites
+
+These tests require a custom LLVM/Clang build with OxCaml support. The path to this custom Clang must be provided via the `OXCAML_CLANG` environment variable when running tests.
+
+```bash
+export OXCAML_CLANG=/path/to/custom/clang
+```
+
+## Architecture
+
+**Test Components:**
+- `test_*.ml` - OCaml source files to compile with LLVM backend
+- `test_*_main.ml` - Main entry points that use the compiled modules
+- `test_*_data.ml` / `test_*_defn.ml` - Supporting modules with data/definitions
+- `test_*.output` - Expected program output
+- `test_*_ir.output` - Expected filtered LLVM IR output
+- `*.c` - C stubs for foreign function tests
+- `filter.sh` - Normalizes LLVM IR output for stable comparisons
+- `gen/gen_dune.ml` - Generates dune rules for all tests
+
+**Build System:**
+- `dune.inc` - Auto-generated from `gen/gen_dune.ml`, contains test rules
+- Tests compile with `-llvm-backend -llvm-path ${OXCAML_CLANG}`
+- IR output is filtered to remove volatile identifiers
+- Foreign C stubs compiled with clang
+
+## Commands
+
+```bash
+# Run all LLVMIZE tests from repository root
+# Note: Individual tests cannot be run separately - all LLVMIZE tests run together
+make runtest-llvmize
+
+# Regenerate dune.inc after modifying gen/gen_dune.ml
+# This happens automatically when running make runtest-llvmize
+make runtest-llvmize
+make promote
+
+# Update expected output after verifying changes
+make runtest-llvmize
+make promote
+```
+
+
+## Important Restrictions
+
+**NEVER manually build or run individual components:**
+- Do NOT run `dune build oxcaml/tests/backend/llvmize/dune.inc.gen`
+- Do NOT run `dune build oxcaml/tests/backend/llvmize/gen/gen_dune.exe`
+- Do NOT execute test executables directly (e.g., `./test_*.exe`)
+- Do NOT run LLVM or CLANG commands manually on test executables
+
+**All operations must go through `make runtest-llvm`** - this ensures proper build dependencies, environment setup, and test orchestration. The make target handles the build and test pipeline correctly.
+
+
+## Test Patterns
+
+### Simple IR Test (no execution)
+Tests that only verify LLVM IR generation:
+```ocaml
+(* id_fn.ml *)
+let id x = x
+```
+
+### IR Test with Execution
+Tests that verify both IR generation and program execution:
+```ocaml
+(* const_val.ml *)
+let x = 37
+
+(* const_val_main.ml *)
+let () = print_int Const_val.x; print_newline ()
+```
+
+### Test with Data Dependencies
+Tests with separate data modules:
+```ocaml
+(* gcd.ml - compiled with LLVM *)
+let rec gcd a b = ...
+
+(* gcd_data.ml - compiled normally *)
+let test_data = [(12, 8); (35, 14)]
+
+(* gcd_main.ml - compiled normally *)
+let () = List.iter test_gcd Gcd_data.test_data
+```
+
+### Test with C Stubs
+Tests with foreign C functions:
+```ocaml
+(* extcalls.ml - compiled with LLVM *)
+external my_function : int -> int = "stub_function"
+
+(* extcalls_defn.c - compiled with clang *)
+value stub_function(value x) { ... }
+```
+
+## Adding New Tests
+
+1. Create test files following naming conventions:
+   - `test_name.ml` - Main module for LLVM compilation
+   - `test_name_main.ml` - Entry point (if test should execute)
+   - `test_name.output` - Expected stdout (if test executes)
+
+2. Add test to `gen/gen_dune.ml`:
+   ```ocaml
+   print_test_ir_and_run "test_name";  (* For IR + execution *)
+   print_test_ir_only "test_name";     (* For IR only *)
+   ```
+
+3. Create empty output files:
+   ```bash
+   touch test_name.output
+   touch test_name_ir.output  # If applicable
+   ```
+
+4. Regenerate dune.inc and run tests:
+   ```bash
+   export OXCAML_CLANG=/path/to/custom/clang
+   # First run: regenerates and promotes the dune.inc file
+   make runtest-llvmize
+   make promote
+   # Second run: runs the actual tests and promotes the test output
+   make runtest-llvmize
+   make promote
+   ```
+
+## Test Writing Patterns
+
+**Preventing Optimization:**
+- Use `[@inline never] [@local never]` to ensure functions aren't optimized away
+- Keep test functions simple
+
+## Important Notes
+
+- Tests require AMD64 architecture
+- OXCAML_CLANG environment variable must be set
+- IR output is filtered to remove non-deterministic elements
+- All tests run with `-O3 -g` optimization flags
+- Poll insertion is currently disabled (`-disable-poll-insertion`)
+
+## Test Categories
+
+**Basic Operations:**
+- `const_val` - Integer constants
+- `float_ops` - Floating point operations
+- `int_ops` - Integer operations with C stubs
+
+**Control Flow:**
+- `gcd` - Recursive functions
+- `switch` - Pattern matching
+- `csel` - Conditional selection
+- `tailcall` - Tail call optimization
+
+**Data Structures:**
+- `array_rev` - Array operations
+- `alloc` - Allocation and boxing
+- `data_decl` - Data declarations
+
+**Function Calls:**
+- `indirect_call` - Indirect/higher-order functions
+- `many_args` - Functions with many arguments
+- `multi_ret` - Multiple return values
+- `extcalls` - External C calls
+
+**Exception Handling:**
+- `exn` - Exception raising and handling
+
+## Debugging Test Failures
+
+When tests fail, the diff shows expected vs actual output:
+
+```bash
+# View the generated LLVM IR
+cat _build/default/oxcaml/tests/backend/llvmize/test_name.ll
+
+# View the filtered IR output
+cat _build/default/oxcaml/tests/backend/llvmize/test_name_ir.output.corrected
+
+# View execution output
+cat _build/default/oxcaml/tests/backend/llvmize/test_name.output.corrected
+```
+
+Common issues:
+- Missing OXCAML_CLANG environment variable
+- Non-deterministic IR elements not properly filtered
+- Changes in LLVM IR format between versions

--- a/oxcaml/tests/backend/oxcaml_dwarf/CLAUDE.md
+++ b/oxcaml/tests/backend/oxcaml_dwarf/CLAUDE.md
@@ -1,0 +1,130 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+# OxCaml DWARF Test Suite
+
+This directory contains tests for DWARF debugging information in the OxCaml compiler. The tests verify that OCaml programs compiled with debugging flags produce correct DWARF output that debuggers can use.
+
+## Prerequisites
+
+These tests require a custom LLDB build with OCaml support. The path to this custom LLDB must be provided via the `OXCAML_LLDB` environment variable when running tests.
+
+## Architecture
+
+**Test Components:**
+- `test_*.ml` - OCaml source files with functions to debug
+- `test_*.lldb` - LLDB debugger commands (breakpoints, continue, etc.)
+- `test_*.output` - Expected filtered debugger output
+- `filter_for_function_call_only.sh` - Normalizes LLDB output for stable comparisons
+- `gen/gen_dune.ml` - Generates dune rules for all tests
+
+**Build System:**
+- `dune.inc` - Auto-generated from `gen/gen_dune.ml`, contains test rules
+- Tests compile with `-g -gno-upstream-dwarf -shape-format debugging-shapes`
+- Foreign C stubs compiled with SSE4.2/AVX2 support for SIMD tests
+
+## Commands
+
+```bash
+# Run all DWARF tests from repository root
+# Note: Individual tests cannot be run separately - all DWARF tests run together
+OXCAML_LLDB=/path/to/custom/lldb make runtest-dwarf
+
+# Regenerate dune.inc after modifying gen/gen_dune.ml (from repository root)
+OXCAML_LLDB=/path/to/custom/lldb make runtest-dwarf
+dune promote
+
+# Update expected output after verifying changes (from repository root)
+OXCAML_LLDB=/path/to/custom/lldb make runtest-dwarf
+dune promote
+```
+
+## Important Restrictions
+
+**NEVER manually build or run individual components:**
+- Do NOT run `dune build oxcaml/tests/backend/oxcaml_dwarf/dune.inc.gen`
+- Do NOT run `dune build oxcaml/tests/backend/oxcaml_dwarf/gen/gen_dune.exe`
+- Do NOT execute test executables directly (e.g., `./test_*.exe`)
+- Do NOT run LLDB commands manually on test executables
+
+**All operations must go through `make runtest-dwarf`** - this ensures proper build dependencies, environment setup, and test orchestration. The make target handles the build and test pipeline correctly.
+
+## Adding New Tests
+
+1. Create `test_yourtest_dwarf.ml` with functions using:
+   ```ocaml
+   let[@inline never] [@local never] f_start () = ()
+   let _ = f_start ()
+
+   let[@inline never] [@local never] f_example (x : type) = ...
+   let _ = f_example test_value
+   ```
+
+2. Create `test_yourtest_dwarf.lldb` with debugger commands:
+   ```
+   (lldb) b Test_yourtest_dwarf.f_start
+   (lldb) run
+   (lldb) b Test_yourtest_dwarf.f_example
+   (lldb) c
+   ```
+
+3. Add test to `gen/gen_dune.ml`:
+   ```ocaml
+   print_dwarf_test "test_yourtest_dwarf";
+   ```
+
+4. Create an empty output file:
+   ```bash
+   touch test_yourtest_dwarf.output
+   ```
+
+5. Regenerate dune.inc and create initial output:
+   ```bash
+   # First iteration: generates and promotes the dune.inc file
+   OXCAML_LLDB=/path/to/custom/lldb make runtest-dwarf
+   dune promote
+   # Second iteration: runs the actual tests and promotes the test output
+   OXCAML_LLDB=/path/to/custom/lldb make runtest-dwarf
+   dune promote
+   ```
+
+## Test Writing Patterns
+
+**Preventing Optimization:**
+- Use `[@inline never] [@local never]` to ensure functions aren't optimized away
+- Keep test functions simple to isolate debugging behavior
+
+**LLDB Script Format:**
+- Each command on its own line prefixed with `(lldb)`
+- Use module-qualified function names: `Test_module.function_name`
+- Current tests follow a pattern: start with `f_start` dummy function breakpoint, then `run`, then other function breakpoints with `c` (continue)
+- This pattern allows the `run` command to be issued once at the beginning, avoiding multiple runs
+- Future tests may use different patterns as needed
+
+**Output Filtering:**
+- Addresses, PIDs, and paths are normalized to `<ADDRESS>`, `<PID>`, `<PATH>`
+- LLDB prompts and thread information are removed
+- Only function call frames are preserved
+
+## Debugging Test Failures
+
+When tests fail, the diff shows expected vs actual output:
+```bash
+# First, preprocess the LLDB script (removes "(lldb) " prefixes and empty lines)
+sed -e 's/^(lldb) //' -e '/^[[:space:]]*$/d' test_name.lldb > test_name_clean.lldb
+
+# View the raw LLDB output before filtering
+/path/to/custom/lldb -s test_name_clean.lldb ./test_name.exe
+
+# Build and examine the corrected output
+OXCAML_LLDB=/path/to/custom/lldb dune build test_name.output.corrected
+cat _build/default/oxcaml/tests/backend/oxcaml_dwarf/test_name.output.corrected
+```
+
+
+## Finding Known Issues
+
+Known DWARF debugging issues are documented as CR (Code Review) comments in the test files themselves. These appear as OCaml comments near the relevant test code and describe current limitations.
+
+These CR comments provide context about current limitations and expected behavior when debugging OCaml programs with LLDB.


### PR DESCRIPTION
Add documentation for llvmize and oxcaml_dwarf test suites to guide AI assistants working with these tests. 

Initial version of CLAUDE.md for llvmize was created using Claude Code from Simon's CLAUDE.md for dwarf tests.

Co-authored-by: Simon Spies

🤖 Generated with [Claude Code](https://claude.ai/code)
