### PR TITLE
Cleaning Script

### DIFF
--- a/tools/clean-compiler-repo.sh
+++ b/tools/clean-compiler-repo.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+# clean-compiler-repo.sh - Clean the repository while preserving .claude and .vscode directories
+#
+# This script runs `git clean -dfX` while temporarily preserving the .claude
+# and .vscode directories, which contain project-specific configuration that
+# should not be removed during cleaning operations.
+
+set -eu
+
+# Get the top-level directory of the git repository
+TOPLEVEL=$(git rev-parse --show-toplevel)
+
+# Ensure we're in a git repository
+if [ -z "$TOPLEVEL" ] || [ ! -d "$TOPLEVEL" ]; then
+    echo "Error: Not in a git repository or could not determine repository root" >&2
+    exit 1
+fi
+
+# Track whether we moved the directories
+MOVED_CLAUDE=false
+MOVED_VSCODE=false
+
+# Check if .claude directory exists and move it temporarily
+if [ -d "$TOPLEVEL/.claude" ]; then
+    echo "Preserving .claude directory..."
+    mv "$TOPLEVEL/.claude" "$TOPLEVEL/.claude-tmp"
+    MOVED_CLAUDE=true
+fi
+
+# Check if .vscode directory exists and move it temporarily
+if [ -d "$TOPLEVEL/.vscode" ]; then
+    echo "Preserving .vscode directory..."
+    mv "$TOPLEVEL/.vscode" "$TOPLEVEL/.vscode-tmp"
+    MOVED_VSCODE=true
+fi
+
+# Run git clean and capture exit code
+EXIT_CODE=0
+git clean -dfX || EXIT_CODE=$?
+
+# Restore .claude directory if it was moved
+if [ "$MOVED_CLAUDE" = true ] && [ -d "$TOPLEVEL/.claude-tmp" ]; then
+    mv "$TOPLEVEL/.claude-tmp" "$TOPLEVEL/.claude"
+fi
+
+# Restore .vscode directory if it was moved
+if [ "$MOVED_VSCODE" = true ] && [ -d "$TOPLEVEL/.vscode-tmp" ]; then
+    mv "$TOPLEVEL/.vscode-tmp" "$TOPLEVEL/.vscode"
+fi
+
+exit $EXIT_CODE

--- a/tools/clean-compiler-repo.sh
+++ b/tools/clean-compiler-repo.sh
@@ -1,10 +1,13 @@
 #!/bin/sh
 
-# clean-compiler-repo.sh - Clean the repository while preserving .claude and .vscode directories
+# clean-compiler-repo.sh - Clean the repository while preserving specified
+# directories
 #
 # This script runs `git clean -dfX` while temporarily preserving the .claude
-# and .vscode directories, which contain project-specific configuration that
-# should not be removed during cleaning operations.
+# and .vscode directories (by default), plus any additional files/directories
+# specified as command-line arguments.
+#
+# Usage: clean-compiler-repo.sh [file1] [dir2] [...]
 
 set -eu
 
@@ -13,40 +16,52 @@ TOPLEVEL=$(git rev-parse --show-toplevel)
 
 # Ensure we're in a git repository
 if [ -z "$TOPLEVEL" ] || [ ! -d "$TOPLEVEL" ]; then
-    echo "Error: Not in a git repository or could not determine repository root" >&2
-    exit 1
+  echo "Error: Not in a git repository or could not determine repository root" >&2
+  exit 1
 fi
 
-# Track whether we moved the directories
-MOVED_CLAUDE=false
-MOVED_VSCODE=false
+# Build list of items to preserve: default ones + command-line arguments
+PRESERVE_ITEMS=".claude .vscode"
+for arg in "$@"; do
+    PRESERVE_ITEMS="$PRESERVE_ITEMS $arg"
+done
 
-# Check if .claude directory exists and move it temporarily
-if [ -d "$TOPLEVEL/.claude" ]; then
-    echo "Preserving .claude directory..."
-    mv "$TOPLEVEL/.claude" "$TOPLEVEL/.claude-tmp"
-    MOVED_CLAUDE=true
-fi
+# Array to track moved items and their temporary names
+MOVED_ITEMS=""
 
-# Check if .vscode directory exists and move it temporarily
-if [ -d "$TOPLEVEL/.vscode" ]; then
-    echo "Preserving .vscode directory..."
-    mv "$TOPLEVEL/.vscode" "$TOPLEVEL/.vscode-tmp"
-    MOVED_VSCODE=true
-fi
+# Function to get temporary name for an item
+get_temp_name() {
+  echo "$1-tmp-$$"
+}
+
+# Preserve each item by moving it temporarily
+for item in $PRESERVE_ITEMS; do
+  item_path="$TOPLEVEL/$item"
+  if [ -e "$item_path" ]; then
+    temp_name=$(get_temp_name "$item")
+    temp_path="$TOPLEVEL/$temp_name"
+    echo "Preserving $item..."
+    mv "$item_path" "$temp_path"
+    MOVED_ITEMS="$MOVED_ITEMS $item:$temp_name"
+  fi
+done
 
 # Run git clean and capture exit code
 EXIT_CODE=0
 git clean -dfX || EXIT_CODE=$?
 
-# Restore .claude directory if it was moved
-if [ "$MOVED_CLAUDE" = true ] && [ -d "$TOPLEVEL/.claude-tmp" ]; then
-    mv "$TOPLEVEL/.claude-tmp" "$TOPLEVEL/.claude"
-fi
+# Restore all moved items
+for moved_item in $MOVED_ITEMS; do
+  original_name=$(echo "$moved_item" | cut -d: -f1)
+  temp_name=$(echo "$moved_item" | cut -d: -f2)
+  temp_path="$TOPLEVEL/$temp_name"
+  original_path="$TOPLEVEL/$original_name"
 
-# Restore .vscode directory if it was moved
-if [ "$MOVED_VSCODE" = true ] && [ -d "$TOPLEVEL/.vscode-tmp" ]; then
-    mv "$TOPLEVEL/.vscode-tmp" "$TOPLEVEL/.vscode"
-fi
+  if [ -e "$temp_path" ]; then
+    mv "$temp_path" "$original_path"
+  else
+    echo "Warning: could not restore $original_name" >&2
+  fi
+done
 
 exit $EXIT_CODE


### PR DESCRIPTION
This PR adds a cleaning script for the compiler repo that preserves the `.claude` and `.vscode` directories. The preservation of the `.vscode` directory prepares for adding the directory to the `.gitignore` (#4186). 

The script can be run with `sh tools/clean-compiler-repo.sh`. This can be added to `git` as 
```
git config --global alias.cleanup '!sh tools/clean-compiler-repo.sh'
```
such that afterwards `git cleanup` will run the script.

**Preserved files.** By default, the script will preserve `.vscode` and `.claude`. Additional files and directories can be provided as arguments to the script.

