### PR TITLE
Push initial prologue validation behind flag

### DIFF
--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -385,7 +385,8 @@ end
 
 let run : Cfg_with_layout.t -> Cfg_with_layout.t =
  fun cfg_with_layout ->
-  validate_no_prologue cfg_with_layout;
+  if !Oxcaml_flags.cfg_prologue_validate
+  then validate_no_prologue cfg_with_layout;
   let cfg = Cfg_with_layout.cfg cfg_with_layout in
   let fun_name = Cfg.fun_name cfg in
   (match !Oxcaml_flags.cfg_prologue_shrink_wrap with


### PR DESCRIPTION
Although the dataflow analysis was already behind a flag, we would always traverse the CFG at the beginning of the `cfg_prologue` pass to check if any of the previous passes accidentally added a prologue, which shouldn't happen in general, so shouldn't be necessary when we are not running with validation explicitly turned on.