### PR TITLE
Fix race when restoring parent fiber from continuation after callback

### DIFF
--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -70,7 +70,7 @@ Caml_inline void restore_stack_parent(caml_domain_state* domain_state,
 {
   CAMLassert(Stack_parent(domain_state->current_stack) == NULL);
   if (Is_block(cont)) {
-    struct stack_info* parent_stack = Ptr_val(Op_val(cont)[0]);
+    struct stack_info* parent_stack = Ptr_val(caml_continuation_use(cont));
     Stack_parent(domain_state->current_stack) = parent_stack;
   }
 }

--- a/testsuite/tests/callback/callback_effects_domains_gc.ml
+++ b/testsuite/tests/callback/callback_effects_domains_gc.ml
@@ -1,0 +1,28 @@
+(* TEST
+ runtime5;
+ multidomain;
+ native;
+*)
+
+[@@@alert "-do_not_spawn_domains"]
+
+external caml_callback : ('a -> 'b) -> 'a -> 'b = "caml_callback"
+
+let callback_minor () = caml_callback Gc.minor ()
+
+let make_dead_cont () =
+  Effect.Deep.match_with callback_minor () {
+    retc = ignore;
+    exnc = raise;
+    effc = fun _ -> None
+  }
+
+let () =
+  let _ = Domain.Safe.spawn (fun () ->
+    while true do Gc.compact () done) in
+  let mutable state = "hello" in
+  for _ = 0 to 10_000 do
+    make_dead_cont ();
+    state <- "world";
+  done;
+  ignore state


### PR DESCRIPTION
`caml_callback` stashes the parent stack in a continuation for the duration of the callback, then restores it afterward. 

Currently, the following can occur:
- Domain 1 enters `caml_callback`, allocating a cont pointing to its parent stack
- A minor collection promotes the cont
- Domain 1 leaves `caml_callback`, dropping the cont and changing the retaddr on its stack
- Some domain starts doing compaction work and finds the cont unmarked. It traverses the stack, which has an arbitrary retaddr from domain 1. If the frametable indicates it should visit registers, it segfaults trying to dereference gc_regs.

When resuming a continuation, we call `caml_continuation_use`, which avoids this issue by explicitly darkening the cont if we're in a mark phase, then swapping out the stack pointer. We need to do the same thing when dropping the temporary cont in `callback.c`. This fixes the test I've added, which consistently segfaults without the change.

It might be OK to just clear the stack pointer instead of calling `caml_continuation_use` (the cont block isn't referenced from anywhere else), but I'm not entirely sure. Either way, the extra darken is only required when the cont is promoted, which should be fairly rare.