### PR TITLE
Annotate `Unix` write functions to accept shared buffers

### DIFF
--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -396,7 +396,7 @@ val read_bigarray :
 (** Same as {!read}, but read the data into a bigarray.
     @since 5.2 *)
 
-val write : file_descr -> bytes -> int -> int -> int
+val write : file_descr -> bytes @ shared -> int -> int -> int
 (** [write fd buf pos len] writes [len] bytes to descriptor [fd],
     taking them from byte sequence [buf], starting at position [pos]
     in [buff]. Return the number of bytes actually written.  [write]
@@ -405,12 +405,13 @@ val write : file_descr -> bytes -> int -> int -> int
 
 val write_bigarray :
   file_descr ->
-  (_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+  (_, Bigarray.int8_unsigned_elt, Bigarray.c_layout)
+    Bigarray.Array1.t @ shared ->
   int -> int -> int
 (** Same as {!write}, but take the data from a bigarray.
     @since 5.2 *)
 
-val single_write : file_descr -> bytes -> int -> int -> int
+val single_write : file_descr -> bytes @ shared -> int -> int -> int
 (** Same as {!write}, but attempts to write only once.
    Thus, if an error occurs, [single_write] guarantees that no data
    has been written. *)
@@ -428,7 +429,8 @@ val single_write_substring :
 
 val single_write_bigarray :
   file_descr ->
-  (_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+  (_, Bigarray.int8_unsigned_elt, Bigarray.c_layout)
+    Bigarray.Array1.t @ shared ->
   int -> int -> int
 (** Same as {!single_write}, but take the data from a bigarray.
     @since 5.2 *)
@@ -1559,7 +1561,7 @@ val recvfrom :
 (** Receive data from an unconnected socket. *)
 
 val send :
-  file_descr -> bytes -> int -> int -> msg_flag list -> int
+  file_descr -> bytes @ shared -> int -> int -> msg_flag list -> int
 (** Send data over a connected socket. *)
 
 val send_substring :
@@ -1569,7 +1571,7 @@ val send_substring :
     @since 4.02 *)
 
 val sendto :
-  file_descr -> bytes -> int -> int -> msg_flag list ->
+  file_descr -> bytes @ shared -> int -> int -> msg_flag list ->
     sockaddr -> int
 (** Send data over an unconnected socket. *)
 
@@ -1887,7 +1889,7 @@ type setattr_when =
   | TCSADRAIN
   | TCSAFLUSH
 
-val tcsetattr : file_descr -> setattr_when -> terminal_io -> unit
+val tcsetattr : file_descr -> setattr_when -> terminal_io @ shared -> unit
 (** Set the status of the terminal referred to by the given
    file descriptor. The second argument indicates when the
    status change takes place: immediately ([TCSANOW]),

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -393,7 +393,7 @@ val read_bigarray :
 (** Same as {!read}, but read the data into a bigarray.
     @since 5.2 *)
 
-val write : file_descr -> buf:bytes -> pos:int -> len:int -> int
+val write : file_descr -> buf:bytes @ shared -> pos:int -> len:int -> int
 (** [write fd ~buf ~pos ~len] writes [len] bytes to descriptor [fd],
     taking them from byte sequence [buf], starting at position [pos]
     in [buff]. Return the number of bytes actually written.  [write]
@@ -402,12 +402,13 @@ val write : file_descr -> buf:bytes -> pos:int -> len:int -> int
 
 val write_bigarray :
   file_descr ->
-  buf:(_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+  buf:(_, Bigarray.int8_unsigned_elt, Bigarray.c_layout)
+    Bigarray.Array1.t @ shared ->
   pos:int -> len:int -> int
 (** Same as {!write}, but take the data from a bigarray.
     @since 5.2 *)
 
-val single_write : file_descr -> buf:bytes -> pos:int -> len:int -> int
+val single_write : file_descr -> buf:bytes @ shared -> pos:int -> len:int -> int
 (** Same as {!write}, but attempts to write only once.
    Thus, if an error occurs, [single_write] guarantees that no data
    has been written. *)
@@ -425,7 +426,8 @@ val single_write_substring :
 
 val single_write_bigarray :
   file_descr ->
-  buf:(_, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t ->
+  buf:(_, Bigarray.int8_unsigned_elt, Bigarray.c_layout)
+    Bigarray.Array1.t @ shared ->
   pos:int -> len:int -> int
 (** Same as {!single_write}, but take the data from a bigarray.
     @since 5.2 *)
@@ -1556,7 +1558,8 @@ val recvfrom :
 (** Receive data from an unconnected socket. *)
 
 val send :
-  file_descr -> buf:bytes -> pos:int -> len:int -> mode:msg_flag list -> int
+  file_descr -> buf:bytes @ shared -> pos:int -> len:int ->
+    mode:msg_flag list -> int
 (** Send data over a connected socket. *)
 
 val send_substring :
@@ -1566,8 +1569,8 @@ val send_substring :
     @since 4.02 *)
 
 val sendto :
-  file_descr -> buf:bytes -> pos:int -> len:int -> mode:msg_flag list ->
-    addr:sockaddr -> int
+  file_descr -> buf:bytes @ shared -> pos:int -> len:int ->
+    mode:msg_flag list -> addr:sockaddr -> int
 (** Send data over an unconnected socket. *)
 
 val sendto_substring :
@@ -1885,7 +1888,7 @@ type setattr_when = Unix.setattr_when =
   | TCSADRAIN
   | TCSAFLUSH
 
-val tcsetattr : file_descr -> mode:setattr_when -> terminal_io -> unit
+val tcsetattr : file_descr -> mode:setattr_when -> terminal_io @ shared -> unit
 (** Set the status of the terminal referred to by the given
    file descriptor. The second argument indicates when the
    status change takes place: immediately ([TCSANOW]),

--- a/otherlibs/unix/unix_unix.ml
+++ b/otherlibs/unix/unix_unix.ml
@@ -261,13 +261,16 @@ external unsafe_read : file_descr -> bytes -> int -> int -> int @@ portable
 external unsafe_read_bigarray :
   file_descr -> _ Bigarray.Array1.t -> int -> int -> int @@ portable
   = "caml_unix_read_bigarray"
-external unsafe_write : file_descr -> bytes -> int -> int -> int @@ portable
-                      = "caml_unix_write"
+external unsafe_write :
+  file_descr -> bytes @ shared -> int -> int -> int @@ portable
+  = "caml_unix_write"
 external unsafe_write_bigarray :
-  file_descr -> _ Bigarray.Array1.t -> int -> int -> single: bool -> int @@ portable
+  file_descr -> _ Bigarray.Array1.t @ shared -> int -> int -> single: bool
+  -> int @@ portable
   = "caml_unix_write_bigarray"
-external unsafe_single_write : file_descr -> bytes -> int -> int -> int @@ portable
-   = "caml_unix_single_write"
+external unsafe_single_write :
+  file_descr -> bytes @ shared -> int -> int -> int @@ portable
+  = "caml_unix_single_write"
 
 let read fd buf ofs len =
   if ofs < 0 || len < 0 || ofs > Bytes.length buf - len
@@ -629,10 +632,11 @@ external unsafe_recvfrom :
   file_descr -> bytes -> int -> int -> msg_flag list -> int * sockaddr @@ portable
                                   = "caml_unix_recvfrom"
 external unsafe_send :
-  file_descr -> bytes -> int -> int -> msg_flag list -> int @@ portable
+  file_descr -> bytes @ shared -> int -> int -> msg_flag list -> int @@ portable
                                   = "caml_unix_send"
 external unsafe_sendto :
-  file_descr -> bytes -> int -> int -> msg_flag list -> sockaddr -> int @@ portable
+  file_descr -> bytes @ shared -> int -> int -> msg_flag list -> sockaddr
+  -> int @@ portable
                                   = "caml_unix_sendto" "caml_unix_sendto_native"
 
 let recv fd buf ofs len flags =
@@ -1226,8 +1230,9 @@ type setattr_when = TCSANOW | TCSADRAIN | TCSAFLUSH
 
 external tcgetattr: file_descr -> terminal_io @@ portable = "caml_unix_tcgetattr"
 
-external tcsetattr: file_descr -> setattr_when -> terminal_io -> unit @@ portable
-               = "caml_unix_tcsetattr"
+external tcsetattr:
+  file_descr -> setattr_when -> terminal_io @ shared -> unit @@ portable
+  = "caml_unix_tcsetattr"
 external tcsendbreak: file_descr -> int -> unit @@ portable = "caml_unix_tcsendbreak"
 external tcdrain: file_descr -> unit @@ portable = "caml_unix_tcdrain"
 

--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -26,7 +26,7 @@ open! Stdlib
    These functions have a "duplicated" comment above their definition.
 *)
 
-external length : bytes -> int @@ portable = "%bytes_length"
+external length : bytes @ immutable -> int @@ portable = "%bytes_length"
 external string_length : string -> int @@ portable = "%string_length"
 external get : bytes -> int -> char @@ portable = "%bytes_safe_get"
 external set : bytes -> int -> char -> unit @@ portable = "%bytes_safe_set"

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -59,7 +59,7 @@ open! Stdlib
 
    *)
 
-external length : bytes -> int = "%bytes_length"
+external length : bytes @ immutable -> int = "%bytes_length"
 (** Return the length (number of bytes) of the argument. *)
 
 external get : bytes -> int -> char = "%bytes_safe_get"

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -61,7 +61,7 @@ open! Stdlib
 
 [@@@ocaml.nolabels]
 
-external length : bytes -> int = "%bytes_length"
+external length : bytes @ immutable -> int = "%bytes_length"
 (** Return the length (number of bytes) of the argument. *)
 
 external get : bytes -> int -> char = "%bytes_safe_get"


### PR DESCRIPTION
It is safe for write/send functions to read from `@ shared` buffers, i.e. `Bytes.t` and `Bigarray.t`.