### PR TITLE
Stop shrink-wrapping when all paths need a prologue

### DIFF
--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -267,7 +267,7 @@ let find_prologue_and_epilogues_shrink_wrapped (cfg : Cfg.t) =
           (fun tree -> visit tree cfg doms loop_infos reachable_epilogues)
           tree.children
       in
-      let prologue_blocks, epilogue_blocks =
+      let child_prologue_blocks, child_epilogue_blocks =
         List.fold_left
           (fun (child_prologues, child_epilogues) (all_prologues, all_epilogues) ->
             ( Label.Set.union all_prologues child_prologues,
@@ -275,8 +275,9 @@ let find_prologue_and_epilogues_shrink_wrapped (cfg : Cfg.t) =
           (Label.Set.empty, Label.Set.empty)
           children_prologue_block
       in
-      if can_place_prologues prologue_blocks cfg doms loop_infos epilogue_blocks
-      then Some (prologue_blocks, epilogue_blocks)
+      if can_place_prologues child_prologue_blocks cfg doms loop_infos
+           child_epilogue_blocks
+      then Some (child_prologue_blocks, child_epilogue_blocks)
       else Some (Label.Set.singleton tree.label, epilogue_blocks)
   in
   (* [Proc.prologue_required] is cheap and should provide an over-estimate of

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -118,6 +118,10 @@ let prologue_needed_block (block : Cfg.basic_block) ~fun_name =
   | Requires_prologue -> true
   | No_requirements | Requires_no_prologue -> false
 
+(* CR-someday cfalas: This implementation can take O(n^2) memory if there are
+   many blocks which need an epilogue. Ideally we should be able to re-use some
+   of the epilogues stored for the children instead of storing a fresh copy for
+   each block to bring this worst-case down. *)
 module Reachable_epilogues = struct
   type t = Label.Set.t Label.Tbl.t
 

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -167,6 +167,102 @@ let descendants (cfg : Cfg.t) (block : Cfg.basic_block) : Label.Set.t =
   collect block.start;
   !visited
 
+(* The dataflow analysis here is used to determine whether a block on any path
+   leading to a block in the CFG needs a prologue. This then allows us to check
+   whether we can stop shrink-wrapping if all descendant leaf blocks need a
+   prologue *)
+module Path_needs_prologue = struct
+  type state = bool
+
+  type context = { fun_name : string }
+
+  (* The domain represents whether the path leading to a specific block needs a
+     prologue or not. *)
+  module Domain : Cfg_dataflow.Domain_S with type t = state = struct
+    type t = bool
+
+    (* An empty block doesn't need a prologue. *)
+    let bot = false
+
+    (* If any of the predecessors of a block need a prologue, then we consider
+       the block to also need a prologue. *)
+    let join = ( || )
+
+    let less_equal a b = b || not a
+  end
+
+  module Transfer :
+    Cfg_dataflow.Forward_transfer
+      with type domain = bool
+       and type context = context = struct
+    type domain = bool
+
+    type nonrec context = context
+
+    type image =
+      { normal : domain;
+        exceptional : domain
+      }
+
+    let transfer : domain -> Instruction_requirements.t -> domain =
+     fun domain requirements ->
+      match domain, requirements with
+      | _, Requires_prologue -> true
+      | domain, (No_requirements | Requires_no_prologue) -> domain
+
+    let basic : domain -> Cfg.basic Cfg.instruction -> context -> domain =
+     fun domain instr _ ->
+      match domain, Instruction_requirements.basic instr with
+      | _, (Prologue | Epilogue) ->
+        Misc.fatal_error
+          "found prologue or epilogue instruction before prologue addition \
+           phase"
+      | domain, Requirements requirements -> transfer domain requirements
+
+    let terminator :
+        domain -> Cfg.terminator Cfg.instruction -> context -> image =
+     fun domain instr { fun_name } ->
+      let res =
+        transfer domain (Instruction_requirements.terminator instr fun_name)
+      in
+      { normal = res; exceptional = res }
+  end
+
+  module T = struct
+    include Cfg_dataflow.Forward (Domain) (Transfer)
+  end
+
+  include (T : module type of T with type context := context)
+
+  type t = bool Label.Tbl.t
+
+  let build (cfg : Cfg.t) : t =
+    match
+      run ~init:false ~handlers_are_entry_points:true cfg
+        { fun_name = cfg.fun_name }
+    with
+    | Ok res_at_entry ->
+      (* The result returned by the forward analysis is the state at the entry
+         of each block, but we want the state just before the terminator, i.e.
+         after the entire body of the block. *)
+      let res_at_exit = Label.Tbl.copy res_at_entry in
+      let context = { fun_name = cfg.fun_name } in
+      Label.Tbl.iter
+        (fun label at_entry ->
+          let block = Cfg.get_block_exn cfg label in
+          let at_exit =
+            DLL.fold_left
+              ~f:(fun acc instr -> Transfer.basic acc instr context)
+              ~init:at_entry block.body
+          in
+          Label.Tbl.replace res_at_exit label at_exit)
+        res_at_entry;
+      res_at_exit
+    | Error () -> Misc.fatal_error "Cfg_prologue: unreachable code"
+
+  let needs_prologue (t : t) (label : Label.t) = Label.Tbl.find t label
+end
+
 let can_place_prologues (prologue_labels : Label.Set.t) (cfg : Cfg.t)
     (doms : Cfg_dominators.t) (loop_infos : Cfg_loop_infos.t)
     (epilogue_blocks : Label.Set.t) =
@@ -240,31 +336,38 @@ let can_place_prologues (prologue_labels : Label.Set.t) (cfg : Cfg.t)
 let find_prologue_and_epilogues_shrink_wrapped (cfg : Cfg.t) =
   let rec visit (tree : Cfg_dominators.dominator_tree) (cfg : Cfg.t)
       (doms : Cfg_dominators.t) (loop_infos : Cfg_loop_infos.t)
-      (reachable_epilogues : Reachable_epilogues.t) :
+      (reachable_epilogues : Reachable_epilogues.t)
+      (path_needs_prologue : Path_needs_prologue.t) :
       (Label.Set.t * Label.Set.t) option =
     let block = Cfg.get_block_exn cfg tree.label in
     let epilogue_blocks =
       Reachable_epilogues.from_block reachable_epilogues tree.label
     in
     (* If the current block needs a prologue, we can't propagate the prologue
-       downwards. If it's cold or all paths lead to an exception, there's no
-       reason to do so, as performance is not important. *)
-    let all_exceptional_paths =
+       downwards. If all paths eventually need a prologue (i.e. all reachable
+       blocks where we would add an epilogue require a prologue at some point on
+       any path to that block), we can place it here without any disadvantages.
+
+       This also covers the case where all paths lead to an exception and/or are
+       cold. *)
+    (* CR-soon cfalas: this assumes that all descendants of a cold block are
+       also cold.*)
+    let all_need_prologue =
       Label.Set.for_all
         (fun label ->
           let block = Cfg.get_block_exn cfg label in
-          match[@ocaml.warning "-4"] block.terminator.desc with
-          | Raise _ -> true
-          | _ -> false)
+          block.cold
+          || Path_needs_prologue.needs_prologue path_needs_prologue label)
         epilogue_blocks
     in
-    if prologue_needed_block block ~fun_name:cfg.fun_name
-       || block.cold || all_exceptional_paths
+    if prologue_needed_block block ~fun_name:cfg.fun_name || all_need_prologue
     then Some (Label.Set.singleton tree.label, epilogue_blocks)
     else
       let children_prologue_block =
         List.filter_map
-          (fun tree -> visit tree cfg doms loop_infos reachable_epilogues)
+          (fun tree ->
+            visit tree cfg doms loop_infos reachable_epilogues
+              path_needs_prologue)
           tree.children
       in
       let child_prologue_blocks, child_epilogue_blocks =
@@ -293,7 +396,10 @@ let find_prologue_and_epilogues_shrink_wrapped (cfg : Cfg.t) =
     let tree = Cfg_dominators.dominator_tree_for_entry_point doms in
     let loop_infos = Cfg_loop_infos.build cfg doms in
     let reachable_epilogues = Reachable_epilogues.build cfg in
-    match visit tree cfg doms loop_infos reachable_epilogues with
+    let path_needs_prologue = Path_needs_prologue.build cfg in
+    match
+      visit tree cfg doms loop_infos reachable_epilogues path_needs_prologue
+    with
     | None -> None
     | Some (prologue_label, epilogue_blocks) ->
       assert (

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -153,6 +153,20 @@ module Reachable_epilogues = struct
   let from_block (t : t) (label : Label.t) = Label.Tbl.find t label
 end
 
+let descendants (cfg : Cfg.t) (block : Cfg.basic_block) : Label.Set.t =
+  let visited = ref Label.Set.empty in
+  let rec collect label =
+    if not (Label.Set.mem label !visited)
+    then (
+      visited := Label.Set.add label !visited;
+      let block = Cfg.get_block_exn cfg label in
+      Label.Set.iter
+        (fun succ_label -> collect succ_label)
+        (Cfg.successor_labels ~normal:true ~exn:true block))
+  in
+  collect block.start;
+  !visited
+
 let can_place_prologues (prologue_labels : Label.Set.t) (cfg : Cfg.t)
     (doms : Cfg_dominators.t) (loop_infos : Cfg_loop_infos.t)
     (epilogue_blocks : Label.Set.t) =
@@ -168,24 +182,40 @@ let can_place_prologues (prologue_labels : Label.Set.t) (cfg : Cfg.t)
          let block = Cfg.get_block_exn cfg label in
          Cfg_loop_infos.is_in_loop loop_infos label || block.stack_offset <> 0)
        prologue_labels
+  then
+    false
+    (* Check that there are no prologues which might execute after another
+       prologue has already executed.
+
+       This might happen when duplicating a prologue in the following CFG:
+
+     * Block A: Condition with branch to Block B / C
+     * Block B: Contains an instruction requiring a prologue, with terminator
+       that jumps to Block C
+     * Block C: Return
+
+       If we duplicate the prologue to both B and C (which are both children of
+       A), the prologue will execute twice on the A->B->C path. *)
+  else if Label.Set.exists
+            (fun prologue ->
+              let descendants =
+                descendants cfg (Cfg.get_block_exn cfg prologue)
+              in
+              let descendant_prologues =
+                Label.Set.inter prologue_labels descendants
+              in
+              let descendant_prologues =
+                Label.Set.remove prologue descendant_prologues
+              in
+              not (Label.Set.is_empty descendant_prologues))
+            prologue_labels
   then false
   else
     (* Check that the blocks requiring an epilogue are dominated by the prologue
-       block. Consider the following CFG:
-
-     *  Block A: Condition with branch to Block B / C
-     *  Block B: Contains an instruction requiring a prologue, with 
-        terminator that jumps to Block C
-     *  Block C: Return
-
-       We have the choice of putting the prologue in Block A or B, and we would
-       place an epilogue in Block C (or we could create a new block with the
-       epilogue).
-
-       If we try to place the prologue in block B, the prologue would not
-       dominate the epilogue in block C, so in some cases the epilogue would be
-       executed without a prologue on the stack, which would be illegal. *)
-
+       block. Consider the CFG from the example above. If we try to place the
+       prologue in block B, the prologue would not dominate the epilogue in
+       block C, so in some cases the epilogue would be executed without a
+       prologue on the stack, which would be illegal. *)
     (* CR-soon cfalas: This should be done using post-dominators (i.e. A->B is
        in the post-dominator tree if and only if executing A guarantees that we
        are also executing B). In cases where the prologue does not dominate one

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -216,7 +216,20 @@ let find_prologue_and_epilogues_shrink_wrapped (cfg : Cfg.t) =
     let epilogue_blocks =
       Reachable_epilogues.from_block reachable_epilogues tree.label
     in
+    (* If the current block needs a prologue, we can't propagate the prologue
+       downwards. If it's cold or all paths lead to an exception, there's no
+       reason to do so, as performance is not important. *)
+    let all_exceptional_paths =
+      Label.Set.for_all
+        (fun label ->
+          let block = Cfg.get_block_exn cfg label in
+          match[@ocaml.warning "-4"] block.terminator.desc with
+          | Raise _ -> true
+          | _ -> false)
+        epilogue_blocks
+    in
     if prologue_needed_block block ~fun_name:cfg.fun_name
+       || block.cold || all_exceptional_paths
     then Some (Label.Set.singleton tree.label, epilogue_blocks)
     else
       let children_prologue_block =

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -153,10 +153,9 @@ module Reachable_epilogues = struct
   let from_block (t : t) (label : Label.t) = Label.Tbl.find t label
 end
 
-let can_place_prologue (prologue_label : Label.t) (cfg : Cfg.t)
+let can_place_prologues (prologue_labels : Label.Set.t) (cfg : Cfg.t)
     (doms : Cfg_dominators.t) (loop_infos : Cfg_loop_infos.t)
     (epilogue_blocks : Label.Set.t) =
-  let prologue_block = Cfg.get_block_exn cfg prologue_label in
   (* Moving a prologue to a loop might cause it to execute multiple times, which
      is both inefficient as well as possibly incorrect.
 
@@ -164,8 +163,11 @@ let can_place_prologue (prologue_label : Label.t) (cfg : Cfg.t)
      [Pushtrap] or [Stackoffset] which shouldn't be allowed. This is because the
      prologue is added at the stack pointer, which would overlap with the
      handler pushed by a [Pushtrap]. *)
-  if Cfg_loop_infos.is_in_loop loop_infos prologue_label
-     || prologue_block.stack_offset <> 0
+  if Label.Set.exists
+       (fun label ->
+         let block = Cfg.get_block_exn cfg label in
+         Cfg_loop_infos.is_in_loop loop_infos label || block.stack_offset <> 0)
+       prologue_labels
   then false
   else
     (* Check that the blocks requiring an epilogue are dominated by the prologue
@@ -183,39 +185,56 @@ let can_place_prologue (prologue_label : Label.t) (cfg : Cfg.t)
        If we try to place the prologue in block B, the prologue would not
        dominate the epilogue in block C, so in some cases the epilogue would be
        executed without a prologue on the stack, which would be illegal. *)
+
+    (* CR-soon cfalas: This should be done using post-dominators (i.e. A->B is
+       in the post-dominator tree if and only if executing A guarantees that we
+       are also executing B). In cases where the prologue does not dominate one
+       of its epilogues, it might be the case that when "combined together", all
+       the prologues in the set dominate the epilogue (i.e. all execution paths
+       from the entry to the epilogue pass through precisely one of the
+       prologues.
+
+       The current implementation is stricter, i.e. checks that each epilogue is
+       dominated by at least one of the prologues. (note: this is at the same
+       time not strict enough, if the set of prologues contains one which
+       dominates another this will return true, but that should never happen
+       when computing the prologues. *)
     Label.Set.for_all
       (fun epilogue_label ->
-        Cfg_dominators.is_dominating doms prologue_label epilogue_label)
+        Label.Set.exists
+          (fun prologue_label ->
+            Cfg_dominators.is_dominating doms prologue_label epilogue_label)
+          prologue_labels)
       epilogue_blocks
 
 let find_prologue_and_epilogues_shrink_wrapped (cfg : Cfg.t) =
   let rec visit (tree : Cfg_dominators.dominator_tree) (cfg : Cfg.t)
       (doms : Cfg_dominators.t) (loop_infos : Cfg_loop_infos.t)
-      (reachable_epilogues : Reachable_epilogues.t) =
+      (reachable_epilogues : Reachable_epilogues.t) :
+      (Label.Set.t * Label.Set.t) option =
     let block = Cfg.get_block_exn cfg tree.label in
     let epilogue_blocks =
       Reachable_epilogues.from_block reachable_epilogues tree.label
     in
     if prologue_needed_block block ~fun_name:cfg.fun_name
-    then Some (tree.label, epilogue_blocks)
+    then Some (Label.Set.singleton tree.label, epilogue_blocks)
     else
       let children_prologue_block =
         List.filter_map
           (fun tree -> visit tree cfg doms loop_infos reachable_epilogues)
           tree.children
       in
-      match children_prologue_block with
-      | [] -> None
-      | [(child, child_epilogue_blocks)] ->
-        (* Only a single child needs a prologue, so will consider moving the
-           prologue to that child *)
-        if can_place_prologue child cfg doms loop_infos child_epilogue_blocks
-        then Some (child, child_epilogue_blocks)
-        else Some (tree.label, epilogue_blocks)
-      | _ ->
-        (* Multiple children need a prologue. We keep the prologue at the parent
-           to avoid duplication of the prologue. *)
-        Some (tree.label, epilogue_blocks)
+      let prologue_blocks, epilogue_blocks =
+        List.fold_left
+          (fun (child_prologues, child_epilogues) (all_prologues, all_epilogues) ->
+            ( Label.Set.union all_prologues child_prologues,
+              Label.Set.union all_epilogues child_epilogues ))
+          (Label.Set.empty, Label.Set.empty)
+          children_prologue_block
+      in
+      if can_place_prologues prologue_blocks cfg doms loop_infos epilogue_blocks
+      then Some (prologue_blocks, epilogue_blocks)
+      else Some (Label.Set.singleton tree.label, epilogue_blocks)
   in
   (* [Proc.prologue_required] is cheap and should provide an over-estimate of
      when we would need a prologue (in some cases [Proc.prologue_required] will
@@ -234,7 +253,7 @@ let find_prologue_and_epilogues_shrink_wrapped (cfg : Cfg.t) =
     | None -> None
     | Some (prologue_label, epilogue_blocks) ->
       assert (
-        can_place_prologue prologue_label cfg doms loop_infos epilogue_blocks);
+        can_place_prologues prologue_label cfg doms loop_infos epilogue_blocks);
       Some (prologue_label, epilogue_blocks))
   else None
 
@@ -252,27 +271,30 @@ let find_prologue_and_epilogues_at_entry (cfg : Cfg.t) =
           | No_requirements | Requires_prologue -> acc)
         ~init:Label.Set.empty
     in
-    Some (cfg.entry_label, epilogue_blocks)
+    Some (Label.Set.singleton cfg.entry_label, epilogue_blocks)
   else None
 
 let add_prologue_if_required (cfg : Cfg.t) ~f =
   let prologue_and_epilogue_blocks = f cfg in
   match prologue_and_epilogue_blocks with
   | None -> ()
-  | Some (prologue_label, epilogue_blocks) ->
+  | Some (prologue_labels, epilogue_blocks) ->
     let terminator_as_basic terminator =
       { terminator with Cfg.desc = Cfg.Prologue }
     in
-    let prologue_block = Cfg.get_block_exn cfg prologue_label in
-    let next_instr =
-      Option.value
-        (DLL.hd prologue_block.body)
-        ~default:(terminator_as_basic prologue_block.terminator)
-    in
-    DLL.add_begin prologue_block.body
-      (Cfg.make_instruction_from_copy next_instr ~desc:Cfg.Prologue
-         ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
-         ());
+    Label.Set.iter
+      (fun prologue_label ->
+        let prologue_block = Cfg.get_block_exn cfg prologue_label in
+        let next_instr =
+          Option.value
+            (DLL.hd prologue_block.body)
+            ~default:(terminator_as_basic prologue_block.terminator)
+        in
+        DLL.add_begin prologue_block.body
+          (Cfg.make_instruction_from_copy next_instr ~desc:Cfg.Prologue
+             ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
+             ()))
+      prologue_labels;
     Label.Set.iter
       (fun label ->
         let block = Cfg.get_block_exn cfg label in


### PR DESCRIPTION
Shrink wrapping is beneficial whenever a hot path is freed such that the entire path from the entry point of the function to a return runs without a prologue/epilogue pair. If the prologue will execute it roughly doesn't make a difference if the prologue is executed at the beginning or later. When we have duplication where we may have many prologues, stopping shrink-wrapping in such cases will avoid unnecessary prologues which will increase the size of the executable and therefore make cache locality (and possibly speculative execution) worse.

This is done by checking the following condition:

This is done by checking the following condition when considering moving a prologue from a parent to its children (either with or without duplication): If we were to place a prologue here (at the parent), find all places where we would need to add an epilogue. If for each of them, for all paths from the entrypoint of the function to the epilogue there exists an instruction which used the prologue, then there will be no benefit from further shrink-wrapping and we can place the prologue at the parent.

Checking whether all paths leading to an epilogue block need a prologue is done with a dataflow analysis.

This also covers the cases where all paths are exceptional (because raising requires a prologue) and also treats cold paths as "needing a prologue", because in those cases we don't mind having an extra prologue since performance is not important.