### PR TITLE
Refactor modality atoms to decouple polarity from atom

### DIFF
--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -333,10 +333,10 @@ type type_mismatch =
   | Unsafe_mode_crossing of unsafe_mode_crossing_mismatch
 
 let report_modality_sub_error first second ppf e =
+  let Modality.Error (ax, {left; right}) = e in
   let print_modality id ppf m =
-    Printtyp.modality ~id:(fun ppf -> Format.pp_print_string ppf id) ppf m
+    Printtyp.modality ~id:(fun ppf -> Format.pp_print_string ppf id) ax ppf m
   in
-  let Modality.Error {left; right} = e in
   Format.fprintf ppf "%s is %a and %s is %a."
     (String.capitalize_ascii second)
     (print_modality "empty") right

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -413,8 +413,9 @@ let relevant_axes_of_modality ~relevant_for_shallow ~modality =
   Axis_set.create ~f:(fun ~axis:(Pack axis) ->
       match axis with
       | Modal axis ->
+        let (P axis) = Mode.Modality.Axis.of_value (P axis) in
         let modality = Mode.Modality.Const.proj axis modality in
-        not (Mode.Modality.Atom.is_constant modality)
+        not (Mode.Modality.Per_axis.is_constant axis modality)
       (* The kind-inference.md document (in the repo) discusses both constant
          modalities and identity modalities. Of course, reality has modalities
          (such as [shared]) that are neither constants nor identities. Here, we
@@ -1887,16 +1888,17 @@ module Const = struct
         (fun acc (Axis.Pack axis) ->
           match axis with
           | Modal axis ->
-            let t : _ Modality.Atom.t =
+            let (P (type a) (axis : a Mode.Modality.Axis.t)) =
+              Mode.Modality.Axis.of_value (P axis)
+            in
+            let t : a =
               match axis with
               | Monadic ax ->
-                Monadic
-                  (ax, Join_with (Mode.Value.Monadic.Const.Per_axis.max ax))
+                Join_with (Mode.Value.Monadic.Const.Per_axis.max ax)
               | Comonadic ax ->
-                Comonadic
-                  (ax, Meet_with (Mode.Value.Comonadic.Const.Per_axis.min ax))
+                Meet_with (Mode.Value.Comonadic.Const.Per_axis.min ax)
             in
-            Modality.Const.set t acc
+            Modality.Const.set axis t acc
           | Nonmodal _ ->
             (* TODO: don't know how to print *)
             acc)

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2994,9 +2994,6 @@ module Modality = struct
       let is_id ax (Join_with c) = Mode.Const.Per_axis.(le ax c (min ax))
 
       let is_constant ax (Join_with c) = Mode.Const.Per_axis.(le ax (max ax) c)
-
-      let print ax ppf (Join_with c) =
-        Format.fprintf ppf "join_with(%a)" (C.print (Mode.proj_obj ax)) c
     end
 
     type error = Error : 'a axis * 'a Atom.t Solver.error -> error
@@ -3135,9 +3132,6 @@ module Modality = struct
       let is_id ax (Meet_with c) = Mode.Const.Per_axis.(le ax (max ax) c)
 
       let is_constant ax (Meet_with c) = Mode.Const.Per_axis.(le ax c (min ax))
-
-      let print ax ppf (Meet_with c) =
-        Format.fprintf ppf "meet_with(%a)" (C.print (Mode.proj_obj ax)) c
     end
 
     type error = Error : 'a axis * 'a Atom.t Solver.error -> error
@@ -3289,36 +3283,40 @@ module Modality = struct
     let of_const c = Const c
   end
 
-  module Atom = struct
+  module Axis = struct
     type 'a t =
-      | Monadic of 'a Monadic.axis * 'a Monadic.Atom.t
-      | Comonadic of 'a Comonadic.axis * 'a Comonadic.Atom.t
+      | Monadic : 'a Monadic.axis -> 'a Monadic.Atom.t t
+      | Comonadic : 'a Comonadic.axis -> 'a Comonadic.Atom.t t
 
     type packed = P : 'a t -> packed
 
+    let of_value : Value.Axis.packed -> packed = function
+      | P (Monadic ax) -> P (Monadic ax)
+      | P (Comonadic ax) -> P (Comonadic ax)
+
+    let to_value : packed -> Value.Axis.packed = function
+      | P (Monadic ax) -> P (Monadic ax)
+      | P (Comonadic ax) -> P (Comonadic ax)
+  end
+
+  type atom = Atom : 'a Axis.t * 'a -> atom
+
+  module Per_axis = struct
     open struct
       module Monadic = Monadic.Atom
       module Comonadic = Comonadic.Atom
     end
 
-    let is_id = function
-      | Monadic (ax, a) -> Monadic.is_id ax a
-      | Comonadic (ax, a) -> Comonadic.is_id ax a
+    let is_id : type a. a Axis.t -> a -> bool = function
+      | Monadic ax -> Monadic.is_id ax
+      | Comonadic ax -> Comonadic.is_id ax
 
-    let is_constant = function
-      | Monadic (ax, a) -> Monadic.is_constant ax a
-      | Comonadic (ax, a) -> Comonadic.is_constant ax a
-
-    let axis : 'a t -> 'a Value.Axis.t = function
-      | Monadic (ax, _) -> Monadic ax
-      | Comonadic (ax, _) -> Comonadic ax
-
-    let print ppf = function
-      | Monadic (ax, a) -> Monadic.print ax ppf a
-      | Comonadic (ax, a) -> Comonadic.print ax ppf a
+    let is_constant : type a. a Axis.t -> a -> bool = function
+      | Monadic ax -> Monadic.is_constant ax
+      | Comonadic ax -> Comonadic.is_constant ax
   end
 
-  type error = Error : 'a Atom.t Solver.error -> error
+  type error = Error : 'a Axis.t * 'a Solver.error -> error
 
   type equate_error = equate_step * error
 
@@ -3335,15 +3333,11 @@ module Modality = struct
 
     let sub t0 t1 : (unit, error) Result.t =
       match Monadic.sub t0.monadic t1.monadic with
-      | Error (Error (ax, { left; right })) ->
-        Error (Error { left = Monadic (ax, left); right = Monadic (ax, right) })
+      | Error (Error (ax, e)) -> Error (Error (Monadic ax, e))
       | Ok () -> (
         match Comonadic.sub t0.comonadic t1.comonadic with
         | Ok () -> Ok ()
-        | Error (Error (ax, { left; right })) ->
-          Error
-            (Error
-               { left = Comonadic (ax, left); right = Comonadic (ax, right) }))
+        | Error (Error (ax, e)) -> Error (Error (Comonadic ax, e)))
 
     let equate = equate_from_submode' sub
 
@@ -3357,23 +3351,23 @@ module Modality = struct
       let comonadic = Comonadic.concat ~then_:then_.comonadic t.comonadic in
       { monadic; comonadic }
 
-    let proj (type a) (ax : a Value.Axis.t) { monadic; comonadic } : a Atom.t =
+    let proj (type a) (ax : a Axis.t) { monadic; comonadic } : a =
       match ax with
-      | Monadic ax -> Monadic (ax, Monadic.proj ax monadic)
-      | Comonadic ax -> Comonadic (ax, Comonadic.proj ax comonadic)
+      | Monadic ax -> Monadic.proj ax monadic
+      | Comonadic ax -> Comonadic.proj ax comonadic
 
-    let set (type a) (a : a Atom.t) { monadic; comonadic } : t =
-      match a with
-      | Monadic (ax, a) -> { monadic = Monadic.set ax a monadic; comonadic }
-      | Comonadic (ax, a) ->
-        { monadic; comonadic = Comonadic.set ax a comonadic }
+    let set (type a) (ax : a Axis.t) (a : a) { monadic; comonadic } : t =
+      match ax with
+      | Monadic ax -> { monadic = Monadic.set ax a monadic; comonadic }
+      | Comonadic ax -> { monadic; comonadic = Comonadic.set ax a comonadic }
 
     let diff t0 t1 =
       List.filter_map
-        (fun (P ax : Value.Axis.packed) : Atom.packed option ->
+        (fun ax : atom option ->
+          let (P ax) = Axis.of_value ax in
           let a0 = proj ax t0 in
           let a1 = proj ax t1 in
-          if a0 = a1 then None else Some (P a1))
+          if a0 = a1 then None else Some (Atom (ax, a1)))
         Value.Axis.all
 
     let print ppf { monadic; comonadic } =
@@ -3393,15 +3387,11 @@ module Modality = struct
 
   let sub_log t0 t1 ~log : (unit, error) Result.t =
     match Monadic.sub_log t0.monadic t1.monadic ~log with
-    | Error (Error (ax, { left; right })) ->
-      Error (Error { left = Monadic (ax, left); right = Monadic (ax, right) })
+    | Error (Error (ax, e)) -> Error (Error (Monadic ax, e))
     | Ok () -> (
       match Comonadic.sub_log t0.comonadic t1.comonadic ~log with
       | Ok () -> Ok ()
-      | Error (Error (ax, { left; right })) ->
-        Error
-          (Error { left = Comonadic (ax, left); right = Comonadic (ax, right) })
-      )
+      | Error (Error (ax, e)) -> Error (Error (Comonadic ax, e)))
 
   let sub l r = try_with_log (sub_log l r)
 
@@ -3617,17 +3607,20 @@ module Crossing = struct
   let equal t0 t1 = le t0 t1 && le t1 t0
 
   let print ppf t =
-    let print_atom ppf (Modality.Atom.P a) =
-      match a with
-      | Monadic (ax, Join_with c) -> Value.Monadic.Const.Per_axis.print ax ppf c
-      | Comonadic (ax, Meet_with c) ->
+    let print_atom ppf (Modality.Atom (ax, a)) =
+      match ax, a with
+      | Monadic ax, Join_with c -> Value.Monadic.Const.Per_axis.print ax ppf c
+      | Comonadic ax, Meet_with c ->
         Value.Comonadic.Const.Per_axis.print ax ppf c
     in
     let l =
       List.filter_map
-        (fun (Value.Axis.P ax) ->
+        (fun ax ->
+          let (P ax) = Modality.Axis.of_value ax in
           let a = Modality.Const.proj ax t in
-          if Modality.Atom.is_id a then None else Some (Modality.Atom.P a))
+          if Modality.Per_axis.is_id ax a
+          then None
+          else Some (Modality.Atom (ax, a)))
         Value.Axis.all
     in
     Format.(pp_print_list ~pp_sep:pp_print_space print_atom ppf l)

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -630,27 +630,29 @@ module type S = sig
       end
     end
 
-    module Atom : sig
+    module Axis : sig
       type 'a t =
-        | Monadic of 'a Value.Monadic.Axis.t * 'a Monadic.Atom.t
-        | Comonadic of 'a Value.Comonadic.Axis.t * 'a Comonadic.Atom.t
+        | Monadic : 'a Value.Monadic.Axis.t -> 'a Monadic.Atom.t t
+        | Comonadic : 'a Value.Comonadic.Axis.t -> 'a Comonadic.Atom.t t
 
       type packed = P : 'a t -> packed
 
-      (** Test if the given modality is the identity modality. *)
-      val is_id : 'a t -> bool
+      val of_value : Value.Axis.packed -> packed
 
-      (** Test if the given modality is a constant modality. *)
-      val is_constant : 'a t -> bool
-
-      (** Printing for debugging *)
-      val print : Format.formatter -> 'a t -> unit
-
-      (** Returns the axis that the atom modality belongs to. *)
-      val axis : 'a t -> 'a Value.Axis.t
+      val to_value : packed -> Value.Axis.packed
     end
 
-    type error = Error : 'a Atom.t Solver.error -> error
+    type atom = Atom : 'a Axis.t * 'a -> atom
+
+    module Per_axis : sig
+      (** Test if the given modality is the identity modality. *)
+      val is_id : 'a Axis.t -> 'a -> bool
+
+      (** Test if the given modality is a constant modality. *)
+      val is_constant : 'a Axis.t -> 'a -> bool
+    end
+
+    type error = Error : 'a Axis.t * 'a Solver.error -> error
 
     type nonrec equate_error = equate_step * error
 
@@ -668,8 +670,8 @@ module type S = sig
        [zap_to_id], [zap_to_floor], etc.. *)
 
     module Const : sig
-      (** A modality that acts on [Value] modes. Conceptually it is a sequnce
-            of [atom] that acts on individual axes. *)
+      (** A modality that acts on [Value] axes. Conceptually it is a record where
+        individual fields can be [set] or [proj]. *)
       type t
 
       (** The identity modality. *)
@@ -685,14 +687,14 @@ module type S = sig
       val concat : then_:t -> t -> t
 
       (** [set a t] overwrites an axis of [t] to be [a]. *)
-      val set : 'a Atom.t -> t -> t
+      val set : 'a Axis.t -> 'a -> t -> t
 
       (** [proj ax t] projects out the axis [ax] of [t]. *)
-      val proj : 'a Value.Axis.t -> t -> 'a Atom.t
+      val proj : 'a Axis.t -> t -> 'a
 
       (** [diff t0 t1] returns a list of atoms in [t1] that are different than
         [t0]. *)
-      val diff : t -> t -> Atom.packed list
+      val diff : t -> t -> atom list
 
       (** [equate t0 t1] checks that [t0 = t1].
             Definition: [t0 = t1] iff [t0 <= t1] and [t1 <= t0]. *)
@@ -702,8 +704,8 @@ module type S = sig
       val print : Format.formatter -> t -> unit
     end
 
-    (** A modality that acts on [Value] modes. Conceptually it is a sequnce of
-          [atom] that acts on individual axes. *)
+    (** A modality that acts on [Value] modes. Conceptually it is a record where
+      individual fields can be [set] or [proj]. *)
     type t
 
     (** The identity modality. *)

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1765,10 +1765,10 @@ let typexp mode ppf ty =
   !Oprint.out_type ppf (tree_of_typexp mode ty)
 
 (* Only used for printing a single modality in error message *)
-let modality ?(id = fun _ppf -> ()) ppf modality =
-  if Mode.Modality.Atom.is_id modality then id ppf
+let modality ?(id = fun _ppf -> ()) ax ppf modality =
+  if Mode.Modality.Per_axis.is_id ax modality then id ppf
   else
-    modality
+    Atom (ax, modality)
     |> Typemode.untransl_modality
     |> tree_of_modality_new
     |> !Oprint.out_modality ppf

--- a/typing/printtyp.mli
+++ b/typing/printtyp.mli
@@ -110,7 +110,7 @@ val type_expr: formatter -> type_expr -> unit
 (** Prints a modality. If it is the identity modality, prints [id], which
     defaults to nothing. *)
 val modality :
-  ?id:(formatter -> unit) -> formatter -> 'a Mode.Modality.Atom.t -> unit
+  ?id:(formatter -> unit) -> 'a Mode.Modality.Axis.t -> formatter -> 'a -> unit
 
 (** [prepare_for_printing] resets the global printing environment, a la [reset],
     and prepares the types for printing by reserving names and marking loops.

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -11598,16 +11598,16 @@ let report_error ~loc env =
     Location.error ~loc
       "Block indices do not support private records."
   | Block_index_modality_mismatch { mut; err } ->
-    let step, Modality.Error({ left; right }) = err in
+    let step, Modality.Error(ax, { left; right }) = err in
     let print_modality id ppf m =
-      Printtyp.modality ~id:(fun ppf -> Format.pp_print_string ppf id) ppf m
+      Printtyp.modality ~id:(fun ppf -> Format.pp_print_string ppf id) ax ppf m
     in
     let expected, actual = match step with
       | Left_le_right -> right, left
       | Right_le_left -> left, right
     in
     let what_element_must_do =
-      if Modality.Atom.is_id expected then
+      if Modality.Per_axis.is_id ax expected then
         "have the identity modality"
       else
         Format.asprintf "be %a" (print_modality "") expected

--- a/typing/typemode.mli
+++ b/typing/typemode.mli
@@ -22,8 +22,7 @@ val let_mutable_modalities : Mode.Modality.Const.t
 (** The (default) modalities for an atomic mutable field *)
 val atomic_mutable_modalities : Mode.Modality.Const.t
 
-val untransl_modality :
-  'a Mode.Modality.Atom.t -> Parsetree.modality Location.loc
+val untransl_modality : Mode.Modality.atom -> Parsetree.modality Location.loc
 
 (** Un-interpret modalities back to parsetree. Takes the mutability and
     attributes on the field and remove mutable-implied modalities accordingly.

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -1576,7 +1576,7 @@ end = struct
     let uni = Modality.Const.proj (Monadic Uniqueness) modalities in
     let lin = Modality.Const.proj (Comonadic Linearity) modalities in
     match uni, lin with
-    | Monadic (_, Join_with Aliased), Comonadic (_, Meet_with Many) -> untracked
+    | Join_with Aliased, Meet_with Many -> untracked
     | _ -> child proj t
 
   let tuple_field i t = child (Projection.Tuple_field i) t


### PR DESCRIPTION
Towards #4273 

This improves upon #4436 such that in the type `Modality.atom`, the actual modality is decoupled from the polarity. That is, in order to extract a `Meet_with` or `Join_with` from an `atom`, we are no longer forced to pattern match it with `Monadic` or `Comonadic`. This allows simpler code in #4273 .
