### PR TITLE
Make atomic fields sync_data

### DIFF
--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -12,7 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type (!'a : value_or_null) t : mutable_data with 'a =
+type (!'a : value_or_null) t : mutable_data mod contended with 'a =
   { mutable contents : 'a [@atomic] }
 
 external make
@@ -58,42 +58,42 @@ external compare_exchange
   = "%atomic_compare_exchange"
 
 external fetch_and_add
-  :  int t @ contended local
+  :  int t @ local
   -> int
   -> int
   @@ portable
   = "%atomic_fetch_add"
 
 external add
-  :  int t @ contended local
+  :  int t @ local
   -> int
   -> unit
   @@ portable
   = "%atomic_add"
 
 external sub
-  :  int t @ contended local
+  :  int t @ local
   -> int
   -> unit
   @@ portable
   = "%atomic_sub"
 
 external logand
-  :  int t @ contended local
+  :  int t @ local
   -> int
   -> unit
   @@ portable
   = "%atomic_land"
 
 external logor
-  :  int t @ contended local
+  :  int t @ local
   -> int
   -> unit
   @@ portable
   = "%atomic_lor"
 
 external logxor
-  :  int t @ contended local
+  :  int t @ local
   -> int
   -> unit
   @@ portable
@@ -135,7 +135,7 @@ module Contended = struct
 end
 
 module Loc = struct
-  type ('a : value_or_null) t : mutable_data with 'a = 'a atomic_loc
+  type ('a : value_or_null) t : sync_data with 'a = 'a atomic_loc
   external get : ('a : value_or_null).
     'a t @ local -> 'a @@ portable = "%atomic_load_loc"
   external set : ('a : value_or_null).
@@ -148,23 +148,23 @@ module Loc = struct
     'a t @ local -> 'a -> 'a -> 'a @@ portable = "%atomic_compare_exchange_loc"
 
   external fetch_and_add
-    : int t @ contended local -> int -> int @@ portable
+    : int t @ local -> int -> int @@ portable
     = "%atomic_fetch_add_loc"
 
   external add
-    : int t @ contended local -> int -> unit @@ portable = "%atomic_add_loc"
+    : int t @ local -> int -> unit @@ portable = "%atomic_add_loc"
 
   external sub
-    : int t @ contended local -> int -> unit @@ portable = "%atomic_sub_loc"
+    : int t @ local -> int -> unit @@ portable = "%atomic_sub_loc"
 
   external logand
-    : int t @ contended local -> int -> unit @@ portable = "%atomic_land_loc"
+    : int t @ local -> int -> unit @@ portable = "%atomic_land_loc"
 
   external logor
-    : int t @ contended local -> int -> unit @@ portable = "%atomic_lor_loc"
+    : int t @ local -> int -> unit @@ portable = "%atomic_lor_loc"
 
   external logxor
-    : int t @ contended local -> int -> unit @@ portable = "%atomic_lxor_loc"
+    : int t @ local -> int -> unit @@ portable = "%atomic_lxor_loc"
 
   let incr t = add t 1
   let decr t = sub t 1

--- a/stdlib/atomic.ml
+++ b/stdlib/atomic.ml
@@ -12,7 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type (!'a : value_or_null) t : mutable_data mod contended with 'a =
+type (!'a : value_or_null) t : sync_data with 'a =
   { mutable contents : 'a [@atomic] }
 
 external make

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -24,7 +24,7 @@
   @since 4.12 *)
 
 (** An atomic (mutable) reference to a value of type ['a]. *)
-type (!'a : value_or_null) t : mutable_data mod contended with 'a =
+type (!'a : value_or_null) t : sync_data with 'a =
   { mutable contents : 'a [@atomic] }
 
 (** Create an atomic reference. *)

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -24,7 +24,7 @@
   @since 4.12 *)
 
 (** An atomic (mutable) reference to a value of type ['a]. *)
-type (!'a : value_or_null) t : mutable_data with 'a =
+type (!'a : value_or_null) t : mutable_data mod contended with 'a =
   { mutable contents : 'a [@atomic] }
 
 (** Create an atomic reference. *)
@@ -79,28 +79,28 @@ external compare_exchange
 
 (** [fetch_and_add r n] atomically increments the value of [r] by [n], and
     returns the current value (before the increment). *)
-val fetch_and_add : int t @ contended local -> int -> int
+val fetch_and_add : int t @ local -> int -> int
 
 (** [add r i] atomically adds [i] onto [r]. *)
-val add : int t @ contended local -> int -> unit
+val add : int t @ local -> int -> unit
 
 (** [sub r i] atomically subtracts [i] onto [r]. *)
-val sub : int t @ contended local -> int -> unit
+val sub : int t @ local -> int -> unit
 
 (** [logand r i] atomically bitwise-ands [i] onto [r]. *)
-val logand : int t @ contended local -> int -> unit
+val logand : int t @ local -> int -> unit
 
 (** [logor r i] atomically bitwise-ors [i] onto [r]. *)
-val logor : int t @ contended local -> int -> unit
+val logor : int t @ local -> int -> unit
 
 (** [logxor r i] atomically bitwise-xors [i] onto [r]. *)
-val logxor : int t @ contended local -> int -> unit
+val logxor : int t @ local -> int -> unit
 
 (** [incr r] atomically increments the value of [r] by [1]. *)
-val incr : int t @ contended local -> unit
+val incr : int t @ local -> unit
 
 (** [decr r] atomically decrements the value of [r] by [1]. *)
-val decr : int t @ contended local -> unit
+val decr : int t @ local -> unit
 
 (** Operations that act over contended atomics. This imposes some extra mode
     constraints for safety. *)
@@ -149,7 +149,7 @@ module Loc : sig
 
       The API below mirrors the API to access {{!t}atomic references},
       see the documentation above for more information. *)
-  type ('a : value_or_null) t : mutable_data with 'a = 'a atomic_loc
+  type ('a : value_or_null) t : sync_data with 'a = 'a atomic_loc
 
   external get : ('a : value_or_null). 'a t @ local -> 'a = "%atomic_load_loc"
 
@@ -166,25 +166,25 @@ module Loc : sig
     'a t @ local -> 'a -> 'a -> 'a = "%atomic_compare_exchange_loc"
 
   external fetch_and_add
-    : int t @ contended local -> int -> int = "%atomic_fetch_add_loc"
+    : int t @ local -> int -> int = "%atomic_fetch_add_loc"
 
   external add
-    : int t @ contended local -> int -> unit = "%atomic_add_loc"
+    : int t @ local -> int -> unit = "%atomic_add_loc"
 
   external sub
-    : int t @ contended local -> int -> unit = "%atomic_sub_loc"
+    : int t @ local -> int -> unit = "%atomic_sub_loc"
 
   external logand
-    : int t @ contended local -> int -> unit = "%atomic_land_loc"
+    : int t @ local -> int -> unit = "%atomic_land_loc"
 
   external logor
-    : int t @ contended local -> int -> unit = "%atomic_lor_loc"
+    : int t @ local -> int -> unit = "%atomic_lor_loc"
 
   external logxor
-    : int t @ contended local -> int -> unit = "%atomic_lxor_loc"
+    : int t @ local -> int -> unit = "%atomic_lxor_loc"
 
-  val incr : int t @ contended local -> unit
-  val decr : int t @ contended local -> unit
+  val incr : int t @ local -> unit
+  val decr : int t @ local -> unit
 
   module Contended : sig
     external get : ('a : value_or_null mod portable).

--- a/testsuite/tests/typing-jkind-bounds/gadt.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt.ml
@@ -307,6 +307,36 @@ Error: The kind of type "cell" is value mod non_float
          because of the annotation on the declaration of the type cell.
 |}]
 
+type 'a cell : sync_data with 'a =
+  | Nil : 'a cell
+  | Cons of { value : 'a; mutable next: 'a cell [@atomic] }
+(* CR layouts v2.8: This should be accepted *)
+[%%expect{|
+Lines 1-3, characters 0-59:
+1 | type 'a cell : sync_data with 'a =
+2 |   | Nil : 'a cell
+3 |   | Cons of { value : 'a; mutable next: 'a cell [@atomic] }
+Error: The kind of type "cell" is value mod non_float
+         because it's a boxed variant type.
+       But the kind of type "cell" must be a subkind of sync_data with 'a
+         because of the annotation on the declaration of the type cell.
+|}]
+
+type 'a cell : sync_data with 'a =
+  | Nil
+  | Cons : { value : 'b; mutable next: 'b cell [@atomic] } -> 'b cell
+(* CR layouts v2.8: This should be accepted *)
+[%%expect{|
+Lines 1-3, characters 0-69:
+1 | type 'a cell : sync_data with 'a =
+2 |   | Nil
+3 |   | Cons : { value : 'b; mutable next: 'b cell [@atomic] } -> 'b cell
+Error: The kind of type "cell" is value mod non_float
+         because it's a boxed variant type.
+       But the kind of type "cell" must be a subkind of sync_data with 'a
+         because of the annotation on the declaration of the type cell.
+|}]
+
 (* Existentials that are the type arguments to abstract types should end up as [type :
    kind] in the with-bounds.
 

--- a/testsuite/tests/typing-jkind-bounds/records.ml
+++ b/testsuite/tests/typing-jkind-bounds/records.ml
@@ -69,12 +69,31 @@ type t = { x : int option; }
 type ('a : immutable_data) t = { x : 'a option; }
 |}]
 
+(* atomic or immutable records annotated as sync *)
+type t : sync_data = { mutable x : int [@atomic] }
+type t : sync_data = { x : int; y : int; mutable z : int [@atomic] }
+type t : sync_data = { x : int; mutable y : int [@atomic]; mutable z : int [@atomic] }
+type nonrec t : sync_data = { t : t }
+type ('a : sync_data) t : sync_data = { x : 'a }
+type ('a : immutable_data) t : sync_data = { x : 'a }
+[%%expect {|
+type t = { mutable x : int [@atomic]; }
+type t = { x : int; y : int; mutable z : int [@atomic]; }
+type t = { x : int; mutable y : int [@atomic]; mutable z : int [@atomic]; }
+type nonrec t = { t : t; }
+type ('a : sync_data) t = { x : 'a; }
+type ('a : immutable_data) t = { x : 'a; }
+|}]
+
 (* mutable or immutable records annotated as mutable *)
 type t : mutable_data = { mutable x : int }
 type t : mutable_data = { x : int; y : int; mutable z : int }
 type t : mutable_data = { mutable x : int ref }
 type t : mutable_data = { x : int }
+type t : mutable_data = { mutable x : int [@atomic] }
+type t : mutable_data = { mutable x : int ref [@atomic] }
 type ('a : mutable_data) t : mutable_data = { x : 'a }
+type ('a : sync_data) t : mutable_data = { x : 'a }
 type ('a : immutable_data) t : mutable_data = { x : 'a }
 type t : mutable_data = { x : int ref; y : string }
 type ('a : mutable_data) t : mutable_data = { x : 'a option }
@@ -83,13 +102,16 @@ type t = { mutable x : int; }
 type t = { x : int; y : int; mutable z : int; }
 type t = { mutable x : int ref; }
 type t = { x : int; }
+type t = { mutable x : int [@atomic]; }
+type t = { mutable x : int ref [@atomic]; }
 type ('a : mutable_data) t = { x : 'a; }
+type ('a : sync_data) t = { x : 'a; }
 type ('a : immutable_data) t = { x : 'a; }
 type t = { x : int ref; y : string; }
 type ('a : mutable_data) t = { x : 'a option; }
 |}]
 
-(* annotations that aren't mutable_data or immutable_data *)
+(* annotations that aren't mutable_data, sync_data, or immutable_data *)
 type t : value mod contended = { x : unit -> unit }
 type 'a t : value mod contended = { x : 'a -> 'a }
 type ('a : value mod contended portable, 'b : value mod portable) t : value mod portable
@@ -239,9 +261,35 @@ Error: The kind of type "t" is immutable_data with 'a
          because of the annotation on the declaration of the type t.
 |}]
 
+type t : sync_data = { mutable x : int ref [@atomic] }
+[%%expect {|
+Line 1, characters 0-54:
+1 | type t : sync_data = { mutable x : int ref [@atomic] }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is mutable_data
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of sync_data
+         because of the annotation on the declaration of the type t.
+|}]
+
+type ('a : mutable_data) t : sync_data = { mutable x : 'a [@atomic] }
+[%%expect {|
+Line 1, characters 0-69:
+1 | type ('a : mutable_data) t : sync_data = { mutable x : 'a [@atomic] }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is sync_data with 'a @@ unyielding many
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of sync_data
+         because of the annotation on the declaration of the type t.
+
+       The first mode-crosses less than the second along:
+         contention: mod contended with 'a ≰ mod contended
+|}]
+
 (**** Test 2: Annotations with "with" are accepted when appropriate ****)
 type 'a t : immutable_data with 'a = { x : int }
 type 'a t : immutable_data with 'a = { x : 'a }
+type 'a t : sync_data with 'a = { mutable x : 'a [@atomic] }
 type 'a t : mutable_data with 'a = { mutable x : 'a }
 type 'a t : mutable_data with 'a = { x : 'a ref }
 type ('a, 'b) t : immutable_data with 'a with 'b = { x : 'a; y : 'b; z : 'a }
@@ -254,6 +302,7 @@ type 'a t : immutable_data with 'a -> 'a = { x : 'a -> 'a }
 [%%expect {|
 type 'a t = { x : int; }
 type 'a t = { x : 'a; }
+type 'a t = { mutable x : 'a [@atomic]; }
 type 'a t = { mutable x : 'a; }
 type 'a t = { x : 'a ref; }
 type ('a, 'b) t = { x : 'a; y : 'b; z : 'a; }

--- a/testsuite/tests/typing-jkind-bounds/records.ml
+++ b/testsuite/tests/typing-jkind-bounds/records.ml
@@ -72,17 +72,21 @@ type ('a : immutable_data) t = { x : 'a option; }
 (* atomic or immutable records annotated as sync *)
 type t : sync_data = { mutable x : int [@atomic] }
 type t : sync_data = { x : int; y : int; mutable z : int [@atomic] }
-type t : sync_data = { x : int; mutable y : int [@atomic]; mutable z : int [@atomic] }
-type nonrec t : sync_data = { t : t }
+type t : sync_data = { mutable x : int Atomic.t [@atomic] }
+type t : sync_data = { x : int }
 type ('a : sync_data) t : sync_data = { x : 'a }
 type ('a : immutable_data) t : sync_data = { x : 'a }
+type t : sync_data = { x : int Atomic.t; y : string }
+type ('a : sync_data) t : sync_data = { x : 'a option }
 [%%expect {|
 type t = { mutable x : int [@atomic]; }
 type t = { x : int; y : int; mutable z : int [@atomic]; }
-type t = { x : int; mutable y : int [@atomic]; mutable z : int [@atomic]; }
-type nonrec t = { t : t; }
+type t = { mutable x : int Atomic.t [@atomic]; }
+type t = { x : int; }
 type ('a : sync_data) t = { x : 'a; }
 type ('a : immutable_data) t = { x : 'a; }
+type t = { x : int Atomic.t; y : string; }
+type ('a : sync_data) t = { x : 'a option; }
 |}]
 
 (* mutable or immutable records annotated as mutable *)

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2489,11 +2489,20 @@ let of_type_decl_default ~context ~transl_type ~default
   | Some (t, _) -> t
   | None -> default
 
-let has_mutable_label lbls =
-  List.exists
-    (fun (lbl : Types.label_declaration) ->
-      match lbl.ld_mutable with Immutable -> false | Mutable _ -> true)
-    lbls
+let combine_mutability mut1 mut2 =
+  match mut1, mut2 with
+  | (Mutable { atomic = Nonatomic; mode = _ } as x), _
+  | _, (Mutable { atomic = Nonatomic; mode = _ } as x) -> x
+  | (Mutable { atomic = Atomic; mode = _ } as x), _
+  | _, (Mutable { atomic = Atomic; mode = _ } as x) -> x
+  | (Immutable as x), Immutable -> x
+
+let jkind_of_mutability mutability ~why =
+  (match mutability with
+   | Immutable -> Builtin.immutable_data
+   | Mutable { atomic = Atomic; _ } -> Builtin.sync_data
+   | Mutable { atomic = Nonatomic; _ } -> Builtin.mutable_data)
+    ~why
 
 let all_void_labels lbls =
   List.for_all
@@ -2510,10 +2519,11 @@ let for_boxed_record lbls =
   if all_void_labels lbls
   then Builtin.immediate ~why:Empty_record
   else
-    let is_mutable = has_mutable_label lbls in
     let base =
-      (if is_mutable then Builtin.mutable_data else Builtin.immutable_data)
-        ~why:Boxed_record
+      lbls
+      |> List.map (fun (ld : Types.label_declaration) -> ld.ld_mutable)
+      |> List.fold_left combine_mutability Immutable
+      |> jkind_of_mutability ~why:Boxed_record
       |> mark_best
     in
     add_labels_as_with_bounds lbls base
@@ -2623,17 +2633,15 @@ let for_boxed_variant ~loc cstrs =
             (Warnings.Incompatible_with_upstream Warnings.Immediate_void_variant);
         Builtin.immediate ~why:Enumeration)
       else
-        let is_mutable =
-          List.exists
-            (fun cstr ->
-              match cstr.cd_args with
-              | Cstr_tuple _ -> false
-              | Cstr_record lbls -> has_mutable_label lbls)
-            cstrs
-        in
-        if is_mutable
-        then Builtin.mutable_data ~why:Boxed_variant
-        else Builtin.immutable_data ~why:Boxed_variant
+        List.concat_map
+          (fun cstr ->
+             match cstr.cd_args with
+             | Cstr_tuple _ -> [ Immutable ]
+             | Cstr_record lbls ->
+               List.map (fun (ld : Types.label_declaration) -> ld.ld_mutable) lbls)
+          cstrs
+        |> List.fold_left combine_mutability Immutable
+        |> jkind_of_mutability ~why:Boxed_variant
     in
     let base = mark_best base in
     let add_cstr_args cstr jkind =

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2492,16 +2492,18 @@ let of_type_decl_default ~context ~transl_type ~default
 let combine_mutability mut1 mut2 =
   match mut1, mut2 with
   | (Mutable { atomic = Nonatomic; mode = _ } as x), _
-  | _, (Mutable { atomic = Nonatomic; mode = _ } as x) -> x
+  | _, (Mutable { atomic = Nonatomic; mode = _ } as x) ->
+    x
   | (Mutable { atomic = Atomic; mode = _ } as x), _
-  | _, (Mutable { atomic = Atomic; mode = _ } as x) -> x
+  | _, (Mutable { atomic = Atomic; mode = _ } as x) ->
+    x
   | (Immutable as x), Immutable -> x
 
 let jkind_of_mutability mutability ~why =
   (match mutability with
-   | Immutable -> Builtin.immutable_data
-   | Mutable { atomic = Atomic; _ } -> Builtin.sync_data
-   | Mutable { atomic = Nonatomic; _ } -> Builtin.mutable_data)
+  | Immutable -> Builtin.immutable_data
+  | Mutable { atomic = Atomic; _ } -> Builtin.sync_data
+  | Mutable { atomic = Nonatomic; _ } -> Builtin.mutable_data)
     ~why
 
 let all_void_labels lbls =
@@ -2635,10 +2637,12 @@ let for_boxed_variant ~loc cstrs =
       else
         List.concat_map
           (fun cstr ->
-             match cstr.cd_args with
-             | Cstr_tuple _ -> [ Immutable ]
-             | Cstr_record lbls ->
-               List.map (fun (ld : Types.label_declaration) -> ld.ld_mutable) lbls)
+            match cstr.cd_args with
+            | Cstr_tuple _ -> [Immutable]
+            | Cstr_record lbls ->
+              List.map
+                (fun (ld : Types.label_declaration) -> ld.ld_mutable)
+                lbls)
           cstrs
         |> List.fold_left combine_mutability Immutable
         |> jkind_of_mutability ~why:Boxed_variant

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -653,7 +653,7 @@ let build_initial_env add_type add_extension empty_env =
        ~param_jkind:(
          Jkind.Builtin.value_or_null ~why:(Primitive ident_atomic_loc))
        ~jkind:(fun param ->
-         Jkind.Builtin.mutable_data ~why:(Primitive ident_atomic_loc) |>
+         Jkind.Builtin.sync_data ~why:(Primitive ident_atomic_loc) |>
          Jkind.add_with_bounds
            ~modality:Mode.Modality.Const.id
            ~type_expr:param)


### PR DESCRIPTION
We were overly conservative with treating atomic mutable fields as mutable_data instead of sync_data. Improve this.