### PR TITLE
flambda2-types: Use Or_unknown.t for function types

### DIFF
--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -589,8 +589,7 @@ let simplify_set_of_closures0 outer_dacc context set_of_closures
         match old_code_id with
         | Deleted _ ->
           ( ( result_code_ids_to_never_delete_this_set,
-              Function_slot.Map.add function_slot Or_unknown_or_bottom.Unknown
-                fun_types,
+              Function_slot.Map.add function_slot Or_unknown.Unknown fun_types,
               outer_dacc ),
             old_code_id )
         | Code_id { code_id = old_code_id; only_full_applications } ->

--- a/middle_end/flambda2/simplify/simplify_set_of_closures_context.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures_context.ml
@@ -28,7 +28,7 @@ type t =
 
 let function_decl_type ?new_code_id ~rec_info old_code_id =
   let code_id = Option.value new_code_id ~default:old_code_id in
-  Or_unknown_or_bottom.Ok (T.Function_type.create code_id ~rec_info)
+  Or_unknown.Known (T.Function_type.create code_id ~rec_info)
 
 let create_for_stub dacc ~all_code ~simplify_function_body =
   let dacc_inside_functions =
@@ -113,7 +113,7 @@ let compute_closure_types_inside_functions ~denv ~all_sets_of_closures
                  (old_code_id :
                    Function_declarations.code_id_in_function_declaration) ->
               match old_code_id with
-              | Deleted _ -> Or_unknown_or_bottom.Unknown
+              | Deleted _ -> Or_unknown.Unknown
               | Code_id { code_id = old_code_id; only_full_applications = _ } ->
                 let code_or_metadata = DE.find_code_exn denv old_code_id in
                 let new_code_id =

--- a/middle_end/flambda2/simplify/simplify_set_of_closures_context.mli
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures_context.mli
@@ -59,4 +59,4 @@ val function_decl_type :
   ?new_code_id:Code_id.t ->
   rec_info:T.t ->
   Code_id.t ->
-  Function_type.t Or_unknown_or_bottom.t
+  Function_type.t Or_unknown.t

--- a/middle_end/flambda2/types/equal_types_for_debug.ml
+++ b/middle_end/flambda2/types/equal_types_for_debug.ml
@@ -195,7 +195,7 @@ let equal_function_type ~equal_type env (t1 : TG.function_type)
 let equal_closures_entry ~equal_type env (t1 : TG.closures_entry)
     (t2 : TG.closures_entry) =
   Function_slot.Map.equal
-    (Or_unknown_or_bottom.equal (equal_function_type ~equal_type env))
+    (Or_unknown.equal (equal_function_type ~equal_type env))
     t1.function_types t2.function_types
   && equal_function_slot_indexed_product ~equal_type env t1.closure_types
        t2.closure_types

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -529,8 +529,7 @@ val mutable_string : size:int -> t
 
 val exactly_this_closure :
   Function_slot.t ->
-  all_function_slots_in_set:
-    Function_type.t Or_unknown_or_bottom.t Function_slot.Map.t ->
+  all_function_slots_in_set:Function_type.t Or_unknown.t Function_slot.Map.t ->
   all_closure_types_in_set:t Function_slot.Map.t ->
   all_value_slots_in_set:flambda_type Value_slot.Map.t ->
   Alloc_mode.For_types.t ->

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -316,7 +316,7 @@ let static_closure_with_this_code ~this_function_slot ~closure_symbol ~code_id =
         ~rec_info:(TG.this_rec_info Rec_info_expr.initial)
     in
     Function_slot.Map.singleton this_function_slot
-      (Or_unknown_or_bottom.Ok function_type)
+      (Or_unknown.Known function_type)
   in
   let closure_types =
     let closure_type =
@@ -351,7 +351,7 @@ let closure_with_at_least_these_function_slots ~this_function_slot
   in
   let function_types =
     Function_slot.Map.map
-      (fun _ -> Or_unknown_or_bottom.Unknown)
+      (fun _ -> Or_unknown.Unknown)
       function_slots_and_bindings
   in
   let closure_types =

--- a/middle_end/flambda2/types/grammar/more_type_creators.mli
+++ b/middle_end/flambda2/types/grammar/more_type_creators.mli
@@ -149,7 +149,7 @@ val variant :
 val exactly_this_closure :
   Function_slot.t ->
   all_function_slots_in_set:
-    Type_grammar.function_type Or_unknown_or_bottom.t Function_slot.Map.t ->
+    Type_grammar.function_type Or_unknown.t Function_slot.Map.t ->
   all_closure_types_in_set:Type_grammar.t Function_slot.Map.t ->
   all_value_slots_in_set:Type_grammar.t Value_slot.Map.t ->
   Alloc_mode.For_types.t ->

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -153,7 +153,7 @@ and row_like_for_closures = private
   }
 
 and closures_entry = private
-  { function_types : function_type Or_unknown_or_bottom.t Function_slot.Map.t;
+  { function_types : function_type Or_unknown.t Function_slot.Map.t;
     closure_types : function_slot_indexed_product;
     value_slot_types : value_slot_indexed_product
   }
@@ -475,7 +475,7 @@ module Closures_entry : sig
   type t = closures_entry
 
   val create :
-    function_types:Function_type.t Or_unknown_or_bottom.t Function_slot.Map.t ->
+    function_types:Function_type.t Or_unknown.t Function_slot.Map.t ->
     closure_types:Product.Function_slot_indexed.t ->
     value_slot_types:Product.Value_slot_indexed.t ->
     t

--- a/middle_end/flambda2/types/meet_and_n_way_join.ml
+++ b/middle_end/flambda2/types/meet_and_n_way_join.ml
@@ -1678,21 +1678,21 @@ and meet_array_of_types env fields1 fields2 ~length =
   meet_mapping ~meet_data:meet ~fold2 ~env ~left:fields1 ~right:fields2 ~rebuild
 
 and meet_function_type (env : ME.t)
-    (func_type1 : TG.Function_type.t Or_unknown_or_bottom.t)
-    (func_type2 : TG.Function_type.t Or_unknown_or_bottom.t) :
-    TG.Function_type.t Or_unknown_or_bottom.t meet_result =
+    (func_type1 : TG.Function_type.t Or_unknown.t)
+    (func_type2 : TG.Function_type.t Or_unknown.t) :
+    TG.Function_type.t Or_unknown.t meet_result =
   match func_type1, func_type2 with
-  | Bottom, Bottom | Unknown, Unknown -> Ok (Both_inputs, env)
-  | Bottom, _ | _, Unknown -> Ok (Left_input, env)
-  | _, Bottom | Unknown, _ -> Ok (Right_input, env)
-  | ( Ok { code_id = code_id1; rec_info = rec_info1 },
-      Ok { code_id = code_id2; rec_info = rec_info2 } ) ->
+  | Unknown, Unknown -> Ok (Both_inputs, env)
+  | _, Unknown -> Ok (Left_input, env)
+  | Unknown, _ -> Ok (Right_input, env)
+  | ( Known { code_id = code_id1; rec_info = rec_info1 },
+      Known { code_id = code_id2; rec_info = rec_info2 } ) ->
     let rebuild code_id rec_info =
       (* It's possible that [code_id] corresponds to deleted code. In that case,
          any attempt to inline will fail, as the code will not be found in the
          simplifier's environment -- see
          [Simplify_apply_expr.simplify_direct_function_call]. *)
-      Or_unknown_or_bottom.Ok (TG.Function_type.create code_id ~rec_info)
+      Or_unknown.Known (TG.Function_type.create code_id ~rec_info)
     in
     combine_results2 env ~rebuild ~meet_a:meet_code_id ~left_a:code_id1
       ~right_a:code_id2 ~meet_b:meet ~left_b:rec_info1 ~right_b:rec_info2
@@ -2807,22 +2807,23 @@ and n_way_join_int_indexed_product env shape
   TG.Product.Int_indexed.create_from_array fields, env
 
 and n_way_join_function_type (env : Join_env.t)
-    (func_types :
-      TG.Function_type.t Or_unknown_or_bottom.t Join_env.join_arg list) :
-    TG.Function_type.t Or_unknown_or_bottom.t * _ =
+    (func_types : TG.Function_type.t Or_unknown.t Join_env.join_arg list) :
+    TG.Function_type.t Or_unknown.t * _ =
   let exception Unknown_result in
   try
     let func_types =
       List.fold_left
         (fun func_types (id2, func_type2) ->
-          match (func_type2 : TG.Function_type.t Or_unknown_or_bottom.t) with
-          | Bottom -> func_types
+          match (func_type2 : TG.Function_type.t Or_unknown.t) with
           | Unknown -> raise Unknown_result
-          | Ok func_type2 -> (id2, func_type2) :: func_types)
+          | Known func_type2 -> (id2, func_type2) :: func_types)
         [] func_types
     in
     match func_types with
-    | [] -> Bottom, env
+    | [] ->
+      if Flambda_features.check_light_invariants ()
+      then Misc.fatal_error "Join of zero function types";
+      Unknown, env
     | (id1, { code_id = code_id1; rec_info = rec_info1 }) :: func_types -> (
       let target_code_age_relation = Join_env.code_age_relation env in
       let target_code_age_relation_resolver =
@@ -2855,7 +2856,7 @@ and n_way_join_function_type (env : Join_env.t)
       in
       match n_way_join env rec_infos with
       | Known rec_info, env ->
-        Ok (TG.Function_type.create code_id ~rec_info), env
+        Known (TG.Function_type.create code_id ~rec_info), env
       | Unknown, env -> Unknown, env)
   with Unknown_result -> Unknown, env
 


### PR DESCRIPTION
It is not possible to create `Bottom` entries for function types, so we don't need the added complexity. This also fixes an old CR.