### PR TITLE
Revert "flambda2: Loosen assertion broken by match-in-match"

### DIFF
--- a/middle_end/flambda2/types/join_levels_old.ml
+++ b/middle_end/flambda2/types/join_levels_old.ml
@@ -100,24 +100,7 @@ let join_types ~env_at_fork envs_with_levels =
             (Name.compilation_unit name)
             (Compilation_unit.get_current_exn ())
         in
-        (* CR bclement: This assertion not holding for variables would be a
-           serious bug, because the [base_env] is created by adding in all the
-           variables that are defined in any of the joined environments.
-
-           However, it could fail for symbols if some of the lifted constants
-           from one of the joined environments are not inserted into the base
-           environment by [Simplify_expr]. This would normally be a bug in
-           [Simplify_expr], but it can currently happen in the presence of
-           (continuation) specialization where constants from the
-           not-specialized case can sometimes leak into the wrong environments.
-
-           The bug is tricky to fix, but otherwise harmless, as we can just
-           leave the equation for the symbol alone, so we restrict the assertion
-           to variables only for now.
-
-           Once the issue in [Simplify_expr] is fixed, we can drop the
-           [Name.is_var name] part of the check below again. *)
-        if same_unit && Name.is_var name && not (TE.mem base_env name)
+        if same_unit && not (TE.mem base_env name)
         then
           Misc.fatal_errorf "Name %a not defined in [base_env]:@ %a" Name.print
             name TE.print base_env;


### PR DESCRIPTION
This reverts commit f45dd01276cbef9de2496f9ec4dab4124d40aa11.

This patch was not enough as there are other places where we crash due to those leaking lifted constants. It is also no longer be needed since #4617 fixes the underlying problem in Simplify_expr.