### PR TITLE
Replace several `Unknown` hints with `Unknown_non_rigid`

### DIFF
--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -853,9 +853,8 @@ Line 1, characters 23-36:
 1 | let make_tuple x y z = stack_ (x, y), z
                            ^^^^^^^^^^^^^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be "global".
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "global".
 |}]
 
 type u = A of unit | C of int | B of int * int | D

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -854,6 +854,7 @@ Line 1, characters 23-36:
                            ^^^^^^^^^^^^^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be "global".
 |}]
 

--- a/testsuite/tests/typing-local/let_mutable.ml
+++ b/testsuite/tests/typing-local/let_mutable.ml
@@ -265,7 +265,8 @@ Line 4, characters 2-3:
 4 |   x
       ^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       because it is a stack expression.
+       However, it is expected to be in the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -281,7 +282,8 @@ Line 4, characters 2-3:
 4 |   x
       ^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       because it is a stack expression.
+       However, it is expected to be in the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -490,7 +492,10 @@ let disallowed_13_6 =
 Line 4, characters 19-20:
 4 |   require_portable f
                        ^
-Error: This value is "nonportable" but is expected to be "portable".
+Error: This value is "nonportable"
+       because it closes over the value "x_13_3" (at Line 3, characters 17-23)
+       which is expected to be "uncontended".
+       However, it is expected to be "portable".
 |}]
 
 (* [f] remains non-portable even if a portable function is reassigned *)
@@ -503,7 +508,10 @@ let disallowed_13_7 =
 Line 5, characters 19-20:
 5 |   require_portable f
                        ^
-Error: This value is "nonportable" but is expected to be "portable".
+Error: This value is "nonportable"
+       because it closes over the value "x_13_3" (at Line 3, characters 17-23)
+       which is expected to be "uncontended".
+       However, it is expected to be "portable".
 |}]
 
 
@@ -633,7 +641,8 @@ Line 4, characters 2-3:
 4 |   x
       ^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       because it is a stack expression.
+       However, it is expected to be in the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]

--- a/testsuite/tests/typing-local/let_mutable.ml
+++ b/testsuite/tests/typing-local/let_mutable.ml
@@ -266,6 +266,7 @@ Line 4, characters 2-3:
       ^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be in the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
@@ -283,6 +284,7 @@ Line 4, characters 2-3:
       ^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be in the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
@@ -495,6 +497,7 @@ Line 4, characters 19-20:
 Error: This value is "nonportable"
        because it closes over the value "x_13_3" (at Line 3, characters 17-23)
        which is expected to be "uncontended".
+
        However, it is expected to be "portable".
 |}]
 
@@ -511,6 +514,7 @@ Line 5, characters 19-20:
 Error: This value is "nonportable"
        because it closes over the value "x_13_3" (at Line 3, characters 17-23)
        which is expected to be "uncontended".
+
        However, it is expected to be "portable".
 |}]
 
@@ -642,6 +646,7 @@ Line 4, characters 2-3:
       ^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be in the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.

--- a/testsuite/tests/typing-local/let_mutable.ml
+++ b/testsuite/tests/typing-local/let_mutable.ml
@@ -265,9 +265,8 @@ Line 4, characters 2-3:
 4 |   x
       ^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be in the parent region or "global"
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be in the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -283,9 +282,8 @@ Line 4, characters 2-3:
 4 |   x
       ^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be in the parent region or "global"
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be in the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -497,8 +495,7 @@ Line 4, characters 19-20:
 Error: This value is "nonportable"
        because it closes over the value "x_13_3" (at Line 3, characters 17-23)
        which is expected to be "uncontended".
-
-       However, it is expected to be "portable".
+       However, the highlighted expression is expected to be "portable".
 |}]
 
 (* [f] remains non-portable even if a portable function is reassigned *)
@@ -514,8 +511,7 @@ Line 5, characters 19-20:
 Error: This value is "nonportable"
        because it closes over the value "x_13_3" (at Line 3, characters 17-23)
        which is expected to be "uncontended".
-
-       However, it is expected to be "portable".
+       However, the highlighted expression is expected to be "portable".
 |}]
 
 
@@ -645,9 +641,8 @@ Line 4, characters 2-3:
 4 |   x
       ^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be in the parent region or "global"
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be in the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -441,8 +441,7 @@ Line 10, characters 24-26:
 Error: This value is "local"
        because it closes over the value "foo" (at Line 5, characters 25-28)
        which is "local".
-
-       However, it is expected to be "global".
+       However, the highlighted expression is expected to be "global".
 |}]
 
 let local_closure () =
@@ -693,7 +692,7 @@ Line 2, characters 30-31:
 Error: The value "x" is "local" but is expected to be "global"
        because it is used inside a lazy expression
        which is expected to be "global"
-       because it is a lazy expression and thus always allocated on the heap.
+       because it is a lazy expression and thus always needs to be allocated on the heap.
 |}]
 
 (* Don't escape through a functor *)
@@ -710,7 +709,7 @@ Line 3, characters 27-28:
                                ^
 Error: The value "x" is "local" but is expected to be "global"
        because it is used inside a functor which is expected to be "global"
-       because it is a module and thus always allocated on the heap.
+       because it is a module and thus always needs to be allocated on the heap.
 |}]
 
 (* Don't escape through a functor with underscore parameter *)
@@ -727,7 +726,7 @@ Line 3, characters 27-28:
                                ^
 Error: The value "x" is "local" but is expected to be "global"
        because it is used inside a functor which is expected to be "global"
-       because it is a module and thus always allocated on the heap.
+       because it is a module and thus always needs to be allocated on the heap.
 |}]
 
 (* Don't escape through a generative functor *)
@@ -744,7 +743,7 @@ Line 3, characters 27-28:
                                ^
 Error: The value "x" is "local" but is expected to be "global"
        because it is used inside a functor which is expected to be "global"
-       because it is a module and thus always allocated on the heap.
+       because it is a module and thus always needs to be allocated on the heap.
 |}]
 
 (* Don't escape through a functor with underscore parameter *)
@@ -761,7 +760,7 @@ Line 3, characters 27-28:
                                ^
 Error: The value "x" is "local" but is expected to be "global"
        because it is used inside a functor which is expected to be "global"
-       because it is a module and thus always allocated on the heap.
+       because it is a module and thus always needs to be allocated on the heap.
 |}]
 
 (* Don't escape through a generative functor *)
@@ -778,7 +777,7 @@ Line 3, characters 27-28:
                                ^
 Error: The value "x" is "local" but is expected to be "global"
        because it is used inside a functor which is expected to be "global"
-       because it is a module and thus always allocated on the heap.
+       because it is a module and thus always needs to be allocated on the heap.
 |}]
 
 (* Don't escape through a class method *)

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -438,7 +438,10 @@ let heap_closure () =
 Line 10, characters 24-26:
 10 |   let _force_heap = ref fn in
                              ^^
-Error: This value is "local" but is expected to be "global".
+Error: This value is "local"
+       because it closes over the value "foo" (at Line 5, characters 25-28)
+       which is "local".
+       However, it is expected to be "global".
 |}]
 
 let local_closure () =

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -441,6 +441,7 @@ Line 10, characters 24-26:
 Error: This value is "local"
        because it closes over the value "foo" (at Line 5, characters 25-28)
        which is "local".
+
        However, it is expected to be "global".
 |}]
 

--- a/testsuite/tests/typing-modes/class.ml
+++ b/testsuite/tests/typing-modes/class.ml
@@ -176,6 +176,7 @@ Error: This value is "nonportable"
        because it closes over the class "cla" (at Line 2, characters 21-24)
        which is "nonportable"
        because it is a class and thus always of legacy modes.
+
        However, it is expected to be "portable".
 |}]
 

--- a/testsuite/tests/typing-modes/class.ml
+++ b/testsuite/tests/typing-modes/class.ml
@@ -172,7 +172,11 @@ let u =
 Line 3, characters 17-20:
 3 |     portable_use foo
                      ^^^
-Error: This value is "nonportable" but is expected to be "portable".
+Error: This value is "nonportable"
+       because it closes over the class "cla" (at Line 2, characters 21-24)
+       which is "nonportable"
+       because it is a class and thus always of legacy modes.
+       However, it is expected to be "portable".
 |}]
 
 module type SC = sig

--- a/testsuite/tests/typing-modes/class.ml
+++ b/testsuite/tests/typing-modes/class.ml
@@ -175,9 +175,8 @@ Line 3, characters 17-20:
 Error: This value is "nonportable"
        because it closes over the class "cla" (at Line 2, characters 21-24)
        which is "nonportable"
-       because it is a class and thus always of legacy modes.
-
-       However, it is expected to be "portable".
+       because it is a class and thus always at the legacy modes.
+       However, the highlighted expression is expected to be "portable".
 |}]
 
 module type SC = sig

--- a/testsuite/tests/typing-modes/hint.ml
+++ b/testsuite/tests/typing-modes/hint.ml
@@ -18,7 +18,12 @@ let test () =
 Line 10, characters 16-19:
 10 |         let _ = bar in ()
                      ^^^
-Error: The value "bar" is "nonportable" but is expected to be "portable"
+Error: The value "bar" is "nonportable"
+       because it closes over the value "foo" (at Line 7, characters 17-20)
+       which is "nonportable"
+       because it closes over the value "x" (at Line 4, characters 8-9)
+       which is expected to be "uncontended".
+       However, it is expected to be "portable"
        because it is used inside a function which is expected to be "portable".
 |}]
 
@@ -34,6 +39,11 @@ end
 Line 6, characters 38-41:
 6 |     let (baz @ portable) () = let _ = bar in ()
                                           ^^^
-Error: The value "bar" is "nonportable" but is expected to be "portable"
+Error: The value "bar" is "nonportable"
+       because it closes over the value "foo" (at Line 5, characters 26-29)
+       which is "nonportable"
+       because it closes over the value "x" (at Line 4, characters 17-18)
+       which is expected to be "uncontended".
+       However, it is expected to be "portable"
        because it is used inside a function which is expected to be "portable".
 |}]

--- a/testsuite/tests/typing-modes/hint.ml
+++ b/testsuite/tests/typing-modes/hint.ml
@@ -23,8 +23,7 @@ Error: The value "bar" is "nonportable"
        which is "nonportable"
        because it closes over the value "x" (at Line 4, characters 8-9)
        which is expected to be "uncontended".
-
-       However, it is expected to be "portable"
+       However, the highlighted expression is expected to be "portable"
        because it is used inside a function which is expected to be "portable".
 |}]
 
@@ -45,7 +44,6 @@ Error: The value "bar" is "nonportable"
        which is "nonportable"
        because it closes over the value "x" (at Line 4, characters 17-18)
        which is expected to be "uncontended".
-
-       However, it is expected to be "portable"
+       However, the highlighted expression is expected to be "portable"
        because it is used inside a function which is expected to be "portable".
 |}]

--- a/testsuite/tests/typing-modes/hint.ml
+++ b/testsuite/tests/typing-modes/hint.ml
@@ -1,0 +1,39 @@
+(* TEST
+    expect;
+*)
+
+let test () =
+    let x = ref 42 in
+    let foo () =
+        x := 24
+    in
+    let bar () =
+        let _  = foo in ()
+    in
+    let (baz @ portable) () =
+        let _ = bar in ()
+    in
+    ()
+[%%expect{|
+Line 10, characters 16-19:
+10 |         let _ = bar in ()
+                     ^^^
+Error: The value "bar" is "nonportable" but is expected to be "portable"
+       because it is used inside a function which is expected to be "portable".
+|}]
+
+
+module M = struct
+    let x = ref 42
+
+    let foo () = x := 24
+    let bar () = let _  = foo in ()
+    let (baz @ portable) () = let _ = bar in ()
+end
+[%%expect{|
+Line 6, characters 38-41:
+6 |     let (baz @ portable) () = let _ = bar in ()
+                                          ^^^
+Error: The value "bar" is "nonportable" but is expected to be "portable"
+       because it is used inside a function which is expected to be "portable".
+|}]

--- a/testsuite/tests/typing-modes/hint.ml
+++ b/testsuite/tests/typing-modes/hint.ml
@@ -23,6 +23,7 @@ Error: The value "bar" is "nonportable"
        which is "nonportable"
        because it closes over the value "x" (at Line 4, characters 8-9)
        which is expected to be "uncontended".
+
        However, it is expected to be "portable"
        because it is used inside a function which is expected to be "portable".
 |}]
@@ -44,6 +45,7 @@ Error: The value "bar" is "nonportable"
        which is "nonportable"
        because it closes over the value "x" (at Line 4, characters 17-18)
        which is expected to be "uncontended".
+
        However, it is expected to be "portable"
        because it is used inside a function which is expected to be "portable".
 |}]

--- a/testsuite/tests/typing-modes/lazy.ml
+++ b/testsuite/tests/typing-modes/lazy.ml
@@ -16,7 +16,7 @@ Line 2, characters 37-38:
 2 |     lazy (let x @ local = "hello" in x)
                                          ^
 Error: This value is "local" but is expected to be "global"
-       because it is a lazy expression and thus always allocated on the heap.
+       because it is a lazy expression and thus always needs to be allocated on the heap.
 |}]
 
 let foo (local_ x) =
@@ -28,7 +28,7 @@ Line 2, characters 18-19:
 Error: The value "x" is "local" but is expected to be "global"
        because it is used inside a lazy expression
        which is expected to be "global"
-       because it is a lazy expression and thus always allocated on the heap.
+       because it is a lazy expression and thus always needs to be allocated on the heap.
 |}]
 
 (* For simplicity, we also require them to be [unyielding]. *)
@@ -41,7 +41,7 @@ Line 2, characters 18-19:
 Error: The value "x" is "yielding" but is expected to be "unyielding"
        because it is used inside a lazy expression
        which is expected to be "unyielding"
-       because it is a lazy expression and thus always allocated on the heap.
+       because it is a lazy expression and thus always needs to be allocated on the heap.
 |}]
 
 (* lazy expression is constructed as global *)

--- a/testsuite/tests/typing-modes/module.ml
+++ b/testsuite/tests/typing-modes/module.ml
@@ -42,7 +42,12 @@ let u =
 Line 10, characters 17-20:
 10 |     portable_use foo
                       ^^^
-Error: This value is "nonportable" but is expected to be "portable".
+Error: This value is "nonportable"
+       because it closes over the module "F" (at Line 7, characters 23-24)
+       which is "nonportable"
+       because it closes over the value "foo" (at Line 15, characters 12-15)
+       which is "nonportable".
+       However, it is expected to be "portable".
 |}]
 
 let u =

--- a/testsuite/tests/typing-modes/module.ml
+++ b/testsuite/tests/typing-modes/module.ml
@@ -47,6 +47,7 @@ Error: This value is "nonportable"
        which is "nonportable"
        because it closes over the value "foo" (at Line 15, characters 12-15)
        which is "nonportable".
+
        However, it is expected to be "portable".
 |}]
 

--- a/testsuite/tests/typing-modes/module.ml
+++ b/testsuite/tests/typing-modes/module.ml
@@ -47,8 +47,7 @@ Error: This value is "nonportable"
        which is "nonportable"
        because it closes over the value "foo" (at Line 15, characters 12-15)
        which is "nonportable".
-
-       However, it is expected to be "portable".
+       However, the highlighted expression is expected to be "portable".
 |}]
 
 let u =

--- a/testsuite/tests/typing-modes/portable-contend.ml
+++ b/testsuite/tests/typing-modes/portable-contend.ml
@@ -127,6 +127,7 @@ Line 4, characters 23-26:
 Error: This value is "nonportable"
        because it closes over the value "best_bytes" (at Line 3, characters 24-34)
        which is "nonportable".
+
        However, it is expected to be "portable".
 |}]
 
@@ -143,6 +144,7 @@ Line 4, characters 23-26:
 Error: This value is "nonportable"
        because it closes over the value "r" (at Line 3, characters 25-26)
        which is expected to be "shared" or "uncontended".
+
        However, it is expected to be "portable".
 |}]
 
@@ -158,6 +160,7 @@ Line 3, characters 23-26:
 Error: This value is "nonportable"
        because it closes over the value "r" (at Line 2, characters 25-26)
        which is expected to be "shared" or "uncontended".
+
        However, it is expected to be "portable".
 |}]
 
@@ -243,6 +246,7 @@ Line 4, characters 23-26:
 Error: This value is "nonportable"
        because it closes over the value "r" (at Line 3, characters 27-28)
        which is expected to be "uncontended".
+
        However, it is expected to be "portable".
 |}]
 
@@ -259,6 +263,7 @@ Line 4, characters 23-26:
 Error: This value is "nonportable"
        because it closes over the value "r" (at Line 3, characters 27-28)
        which is expected to be "uncontended".
+
        However, it is expected to be "portable".
 |}]
 
@@ -300,6 +305,7 @@ Line 4, characters 23-26:
 Error: This value is "nonportable"
        because it closes over the value "r" (at Line 3, characters 25-26)
        which is "nonportable".
+
        However, it is expected to be "portable".
 |}]
 

--- a/testsuite/tests/typing-modes/portable-contend.ml
+++ b/testsuite/tests/typing-modes/portable-contend.ml
@@ -127,8 +127,7 @@ Line 4, characters 23-26:
 Error: This value is "nonportable"
        because it closes over the value "best_bytes" (at Line 3, characters 24-34)
        which is "nonportable".
-
-       However, it is expected to be "portable".
+       However, the highlighted expression is expected to be "portable".
 |}]
 
 (* Closing over reading mutable field gives nonportable *)
@@ -144,8 +143,7 @@ Line 4, characters 23-26:
 Error: This value is "nonportable"
        because it closes over the value "r" (at Line 3, characters 25-26)
        which is expected to be "shared" or "uncontended".
-
-       However, it is expected to be "portable".
+       However, the highlighted expression is expected to be "portable".
 |}]
 
 (* Closing over reading mutable field from shared value is nonportable *)
@@ -160,8 +158,7 @@ Line 3, characters 23-26:
 Error: This value is "nonportable"
        because it closes over the value "r" (at Line 2, characters 25-26)
        which is expected to be "shared" or "uncontended".
-
-       However, it is expected to be "portable".
+       However, the highlighted expression is expected to be "portable".
 |}]
 
 (* Closing over reading immutable field is OK *)
@@ -246,8 +243,7 @@ Line 4, characters 23-26:
 Error: This value is "nonportable"
        because it closes over the value "r" (at Line 3, characters 27-28)
        which is expected to be "uncontended".
-
-       However, it is expected to be "portable".
+       However, the highlighted expression is expected to be "portable".
 |}]
 
 (* Closing over read gives nonportable *)
@@ -263,8 +259,7 @@ Line 4, characters 23-26:
 Error: This value is "nonportable"
        because it closes over the value "r" (at Line 3, characters 27-28)
        which is expected to be "uncontended".
-
-       However, it is expected to be "portable".
+       However, the highlighted expression is expected to be "portable".
 |}]
 
 (* Closing over Array.length doesn't force nonportable; but that needs a
@@ -305,8 +300,7 @@ Line 4, characters 23-26:
 Error: This value is "nonportable"
        because it closes over the value "r" (at Line 3, characters 25-26)
        which is "nonportable".
-
-       However, it is expected to be "portable".
+       However, the highlighted expression is expected to be "portable".
 |}]
 
 (* closing over nonportable gives nonportable *)

--- a/testsuite/tests/typing-modes/portable-contend.ml
+++ b/testsuite/tests/typing-modes/portable-contend.ml
@@ -124,7 +124,10 @@ let foo () =
 Line 4, characters 23-26:
 4 |     let _ @ portable = bar in
                            ^^^
-Error: This value is "nonportable" but is expected to be "portable".
+Error: This value is "nonportable"
+       because it closes over the value "best_bytes" (at Line 3, characters 24-34)
+       which is "nonportable".
+       However, it is expected to be "portable".
 |}]
 
 (* Closing over reading mutable field gives nonportable *)
@@ -137,7 +140,10 @@ let foo () =
 Line 4, characters 23-26:
 4 |     let _ @ portable = bar in
                            ^^^
-Error: This value is "nonportable" but is expected to be "portable".
+Error: This value is "nonportable"
+       because it closes over the value "r" (at Line 3, characters 25-26)
+       which is expected to be "shared" or "uncontended".
+       However, it is expected to be "portable".
 |}]
 
 (* Closing over reading mutable field from shared value is nonportable *)
@@ -149,7 +155,10 @@ let foo (r @ shared) =
 Line 3, characters 23-26:
 3 |     let _ @ portable = bar in
                            ^^^
-Error: This value is "nonportable" but is expected to be "portable".
+Error: This value is "nonportable"
+       because it closes over the value "r" (at Line 2, characters 25-26)
+       which is expected to be "shared" or "uncontended".
+       However, it is expected to be "portable".
 |}]
 
 (* Closing over reading immutable field is OK *)
@@ -231,7 +240,10 @@ let foo () =
 Line 4, characters 23-26:
 4 |     let _ @ portable = bar in
                            ^^^
-Error: This value is "nonportable" but is expected to be "portable".
+Error: This value is "nonportable"
+       because it closes over the value "r" (at Line 3, characters 27-28)
+       which is expected to be "uncontended".
+       However, it is expected to be "portable".
 |}]
 
 (* Closing over read gives nonportable *)
@@ -244,7 +256,10 @@ let foo () =
 Line 4, characters 23-26:
 4 |     let _ @ portable = bar in
                            ^^^
-Error: This value is "nonportable" but is expected to be "portable".
+Error: This value is "nonportable"
+       because it closes over the value "r" (at Line 3, characters 27-28)
+       which is expected to be "uncontended".
+       However, it is expected to be "portable".
 |}]
 
 (* Closing over Array.length doesn't force nonportable; but that needs a
@@ -282,7 +297,10 @@ let foo () =
 Line 4, characters 23-26:
 4 |     let _ @ portable = bar in
                            ^^^
-Error: This value is "nonportable" but is expected to be "portable".
+Error: This value is "nonportable"
+       because it closes over the value "r" (at Line 3, characters 25-26)
+       which is "nonportable".
+       However, it is expected to be "portable".
 |}]
 
 (* closing over nonportable gives nonportable *)

--- a/testsuite/tests/typing-modes/stack.ml
+++ b/testsuite/tests/typing-modes/stack.ml
@@ -16,6 +16,7 @@ Line 1, characters 12-31:
                 ^^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be "global".
 |}]
 
@@ -26,6 +27,7 @@ Line 1, characters 12-29:
                 ^^^^^^^^^^^^^^^^^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be "global".
 |}]
 
@@ -38,6 +40,7 @@ Line 2, characters 18-26:
                       ^^^^^^^^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be "global".
 |}]
 
@@ -50,6 +53,7 @@ Line 2, characters 14-47:
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be "global".
 |}]
 
@@ -62,6 +66,7 @@ Line 2, characters 18-30:
                       ^^^^^^^^^^^^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be "global".
 |}]
 
@@ -74,6 +79,7 @@ Line 2, characters 14-54:
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be "global".
 |}]
 
@@ -85,6 +91,7 @@ Line 1, characters 12-27:
                 ^^^^^^^^^^^^^^^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be "global".
 |}]
 
@@ -111,6 +118,7 @@ Line 1, characters 12-29:
                 ^^^^^^^^^^^^^^^^^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be "global".
 |}]
 
@@ -134,6 +142,7 @@ Line 1, characters 12-30:
                 ^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be "global".
 |}]
 
@@ -163,6 +172,7 @@ Line 3, characters 12-34:
                 ^^^^^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be "global".
 |}]
 
@@ -191,6 +201,7 @@ Line 2, characters 20-32:
                         ^^^^^^^^^^^^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be "global".
 |}]
 
@@ -206,6 +217,7 @@ Line 1, characters 12-33:
                 ^^^^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be "global".
 |}]
 
@@ -222,6 +234,7 @@ Line 1, characters 11-24:
                ^^^^^^^^^^^^^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be in the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
@@ -241,6 +254,7 @@ Line 3, characters 4-5:
         ^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be in the parent region or "global"
        because it is the function in a tail call.
 |}]
@@ -253,6 +267,7 @@ Line 2, characters 4-23:
         ^^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be in the parent region or "global"
        because it is the function in a tail call.
 |}]
@@ -265,6 +280,7 @@ Line 2, characters 16-34:
                     ^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be "global".
 |}]
 
@@ -277,6 +293,7 @@ Line 2, characters 24-42:
                             ^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be "global".
 |}]
 
@@ -289,6 +306,7 @@ Line 3, characters 6-24:
           ^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be in the parent region or "global"
        because it is an argument in a tail call.
 |}]
@@ -403,6 +421,7 @@ Line 3, characters 2-5:
       ^^^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be in the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.

--- a/testsuite/tests/typing-modes/stack.ml
+++ b/testsuite/tests/typing-modes/stack.ml
@@ -15,9 +15,8 @@ Line 1, characters 12-31:
 1 | let f = ref (stack_ fun x -> x)
                 ^^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be "global".
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "global".
 |}]
 
 let f = ref (stack_ (42, 42))
@@ -26,9 +25,8 @@ Line 1, characters 12-29:
 1 | let f = ref (stack_ (42, 42))
                 ^^^^^^^^^^^^^^^^^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be "global".
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "global".
 |}]
 
 let f () =
@@ -39,9 +37,8 @@ Line 2, characters 18-26:
 2 |   let g = stack_ ((42, 42) : _ @ global ) in
                       ^^^^^^^^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be "global".
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "global".
 |}]
 
 let f () =
@@ -52,9 +49,8 @@ Line 2, characters 14-47:
 2 |   let g = ref (stack_ ((42, 42) : _ @ global )) in
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be "global".
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "global".
 |}]
 
 let f () =
@@ -65,9 +61,8 @@ Line 2, characters 18-30:
 2 |   let g = stack_ (fun x y -> x : 'a -> 'a -> 'a) in
                       ^^^^^^^^^^^^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be "global".
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "global".
 |}]
 
 let f () =
@@ -78,9 +73,8 @@ Line 2, characters 14-54:
 2 |   let g = ref (stack_ (fun x y -> x : 'a -> 'a -> 'a)) in
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be "global".
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "global".
 |}]
 
 
@@ -90,9 +84,8 @@ Line 1, characters 12-27:
 1 | let f = ref (stack_ (2, 3))
                 ^^^^^^^^^^^^^^^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be "global".
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "global".
 |}]
 
 let f = ignore_local (stack_ (2, 3))
@@ -117,9 +110,8 @@ Line 1, characters 12-29:
 1 | let f = ref (stack_ (Bar 42))
                 ^^^^^^^^^^^^^^^^^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be "global".
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "global".
 |}]
 
 let f = ignore_local (stack_ (Bar 42))
@@ -141,9 +133,8 @@ Line 1, characters 12-30:
 1 | let f = ref (stack_ (`Bar 42))
                 ^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be "global".
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "global".
 |}]
 
 let f = ignore_local (stack_ (`Bar 42))
@@ -171,9 +162,8 @@ Line 3, characters 12-34:
 3 | let f = ref (stack_ {x = "hello"})
                 ^^^^^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be "global".
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "global".
 |}]
 
 let f = ignore_local (stack_ {x = "hello"})
@@ -200,9 +190,8 @@ Line 2, characters 20-32:
 2 | let f (r : r) = ref (stack_ r.x)
                         ^^^^^^^^^^^^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be "global".
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "global".
 |}]
 
 let f (r : r) = ignore_local (stack_ r.x) [@nontail]
@@ -216,9 +205,8 @@ Line 1, characters 12-33:
 1 | let f = ref (stack_ [| 42; 56 |])
                 ^^^^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be "global".
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "global".
 |}]
 
 let f = ignore_local (stack_ [| 42; 56 |])
@@ -233,9 +221,8 @@ Line 1, characters 11-24:
 1 | let f () = stack_ (3, 5)
                ^^^^^^^^^^^^^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be in the parent region or "global"
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be in the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -253,9 +240,8 @@ Line 3, characters 4-5:
 3 |     g 42
         ^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be in the parent region or "global"
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be in the parent region or "global"
        because it is the function in a tail call.
 |}]
 
@@ -266,9 +252,8 @@ Line 2, characters 4-23:
 2 |     (stack_ fun x -> x) 42
         ^^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be in the parent region or "global"
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be in the parent region or "global"
        because it is the function in a tail call.
 |}]
 
@@ -279,9 +264,8 @@ Line 2, characters 16-34:
 2 |     List.length (stack_ [1; 2; 3])
                     ^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be "global".
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "global".
 |}]
 
 let f2 () =
@@ -292,9 +276,8 @@ Line 2, characters 24-42:
 2 |     let _ = List.length (stack_ [1; 2; 3]) in
                             ^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be "global".
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "global".
 |}]
 
 let f3 () =
@@ -305,9 +288,8 @@ Line 3, characters 6-24:
 3 |     g (stack_ [1; 2; 3])
           ^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be in the parent region or "global"
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be in the parent region or "global"
        because it is an argument in a tail call.
 |}]
 
@@ -420,9 +402,8 @@ Line 3, characters 2-5:
 3 |   r.x
       ^^^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be in the parent region or "global"
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be in the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]

--- a/testsuite/tests/typing-modes/stack.ml
+++ b/testsuite/tests/typing-modes/stack.ml
@@ -240,7 +240,8 @@ Line 3, characters 4-5:
 3 |     g 42
         ^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       because it is a stack expression.
+       However, it is expected to be in the parent region or "global"
        because it is the function in a tail call.
 |}]
 
@@ -401,7 +402,8 @@ Line 3, characters 2-5:
 3 |   r.x
       ^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       because it is a stack expression.
+       However, it is expected to be in the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]

--- a/testsuite/tests/typing-modes/statefulness-visibility.ml
+++ b/testsuite/tests/typing-modes/statefulness-visibility.ml
@@ -394,7 +394,10 @@ let foo () =
 Line 4, characters 24-27:
 4 |     let _ @ stateless = bar in
                             ^^^
-Error: This value is "stateful" but is expected to be "stateless".
+Error: This value is "stateful"
+       because it closes over the value "a" (at Line 3, characters 28-29)
+       which is expected to be "read_write".
+       However, it is expected to be "stateless".
 |}]
 
 let foo : int Atomic.t @ read_write -> (unit -> unit) @ stateless =
@@ -479,7 +482,10 @@ let foo () =
 Line 4, characters 22-25:
 4 |   let _ @ stateless = bar in
                           ^^^
-Error: This value is "observing" but is expected to be "stateless".
+Error: This value is "observing"
+       because it closes over the value "a" (at Line 3, characters 26-27)
+       which is expected to be "read" or "read_write".
+       However, it is expected to be "stateless".
 |}]
 
 (* Closing over a observing value also gives observing. *)

--- a/testsuite/tests/typing-modes/statefulness-visibility.ml
+++ b/testsuite/tests/typing-modes/statefulness-visibility.ml
@@ -397,8 +397,7 @@ Line 4, characters 24-27:
 Error: This value is "stateful"
        because it closes over the value "a" (at Line 3, characters 28-29)
        which is expected to be "read_write".
-
-       However, it is expected to be "stateless".
+       However, the highlighted expression is expected to be "stateless".
 |}]
 
 let foo : int Atomic.t @ read_write -> (unit -> unit) @ stateless =
@@ -486,8 +485,7 @@ Line 4, characters 22-25:
 Error: This value is "observing"
        because it closes over the value "a" (at Line 3, characters 26-27)
        which is expected to be "read" or "read_write".
-
-       However, it is expected to be "stateless".
+       However, the highlighted expression is expected to be "stateless".
 |}]
 
 (* Closing over a observing value also gives observing. *)
@@ -692,8 +690,7 @@ Line 1, characters 42-43:
                                               ^
 Error: This value is "immutable" because it is used inside a lazy expression
        which is expected to be "stateless".
-
-       However, it is expected to be "read" or "read_write"
+       However, the highlighted expression is expected to be "read" or "read_write"
        because its mutable field "contents" is being read.
 |}]
 
@@ -704,8 +701,7 @@ Line 1, characters 42-43:
                                               ^
 Error: This value is "immutable" because it is used inside a lazy expression
        which is expected to be "stateless".
-
-       However, it is expected to be "read_write"
+       However, the highlighted expression is expected to be "read_write"
        because its mutable field "contents" is being written.
 |}]
 
@@ -718,8 +714,7 @@ Line 1, characters 42-43:
                                               ^
 Error: This value is "read" because it is used inside a lazy expression
        which is expected to be "observing".
-
-       However, it is expected to be "read_write"
+       However, the highlighted expression is expected to be "read_write"
        because its mutable field "contents" is being written.
 |}]
 

--- a/testsuite/tests/typing-modes/statefulness-visibility.ml
+++ b/testsuite/tests/typing-modes/statefulness-visibility.ml
@@ -397,6 +397,7 @@ Line 4, characters 24-27:
 Error: This value is "stateful"
        because it closes over the value "a" (at Line 3, characters 28-29)
        which is expected to be "read_write".
+
        However, it is expected to be "stateless".
 |}]
 
@@ -485,6 +486,7 @@ Line 4, characters 22-25:
 Error: This value is "observing"
        because it closes over the value "a" (at Line 3, characters 26-27)
        which is expected to be "read" or "read_write".
+
        However, it is expected to be "stateless".
 |}]
 
@@ -690,6 +692,7 @@ Line 1, characters 42-43:
                                               ^
 Error: This value is "immutable" because it is used inside a lazy expression
        which is expected to be "stateless".
+
        However, it is expected to be "read" or "read_write"
        because its mutable field "contents" is being read.
 |}]
@@ -701,6 +704,7 @@ Line 1, characters 42-43:
                                               ^
 Error: This value is "immutable" because it is used inside a lazy expression
        which is expected to be "stateless".
+
        However, it is expected to be "read_write"
        because its mutable field "contents" is being written.
 |}]
@@ -714,6 +718,7 @@ Line 1, characters 42-43:
                                               ^
 Error: This value is "read" because it is used inside a lazy expression
        which is expected to be "observing".
+
        However, it is expected to be "read_write"
        because its mutable field "contents" is being written.
 |}]

--- a/testsuite/tests/typing-unique/overwriting.ml
+++ b/testsuite/tests/typing-unique/overwriting.ml
@@ -143,9 +143,8 @@ Line 3, characters 13-14:
 3 |   overwrite_ r with { x }
                  ^
 Error: This value is "local"
-       because it is a stack expression.
-
-       However, it is expected to be in the parent region or "global".
+       because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be in the parent region or "global".
 |}]
 
 let returning_regional () x =

--- a/testsuite/tests/typing-unique/overwriting.ml
+++ b/testsuite/tests/typing-unique/overwriting.ml
@@ -144,6 +144,7 @@ Line 3, characters 13-14:
                  ^
 Error: This value is "local"
        because it is a stack expression.
+
        However, it is expected to be in the parent region or "global".
 |}]
 

--- a/testsuite/tests/typing-unique/overwriting.ml
+++ b/testsuite/tests/typing-unique/overwriting.ml
@@ -143,7 +143,8 @@ Line 3, characters 13-14:
 3 |   overwrite_ r with { x }
                  ^
 Error: This value is "local"
-       but is expected to be in the parent region or "global".
+       because it is a stack expression.
+       However, it is expected to be in the parent region or "global".
 |}]
 
 let returning_regional () x =

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2155,7 +2155,7 @@ module Report = struct
         (Misc.Style.as_inline_code !print_longident)
         target_lid);
     (match print_ahint_sided obj ppf actual with
-    | Mode_with_hint -> fprintf ppf ".@\nHowever, it "
+    | Mode_with_hint -> fprintf ppf ".@\n@\nHowever, it "
     | Mode -> fprintf ppf "@ but "
     | Nothing -> assert false);
     ignore (print_ahint_sided obj ppf expected);

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1972,9 +1972,10 @@ module Report = struct
     | Unknown -> Misc.fatal_error "Unknown hint should not be printed"
     | Lazy_allocated_on_heap ->
       pp_print_string ppf
-        "it is a lazy expression and thus always allocated on the heap"
+        "it is a lazy expression and thus always needs to be allocated on the \
+         heap"
     | Class_legacy_monadic | Class_legacy_comonadic ->
-      pp_print_string ppf "it is a class and thus always of legacy modes"
+      pp_print_string ppf "it is a class and thus always at the legacy modes"
     | Tailcall_function ->
       pp_print_string ppf "it is the function in a tail call"
     | Tailcall_argument ->
@@ -1987,9 +1988,11 @@ module Report = struct
       fprintf ppf
         "it is a function return value.@\n\
          Hint: Use exclave_ to return a local value"
-    | Stack_expression -> pp_print_string ppf "it is a stack expression"
+    | Stack_expression ->
+      fprintf ppf "it is %a-allocated" Misc.Style.inline_code "stack_"
     | Module_allocated_on_heap ->
-      pp_print_string ppf "it is a module and thus always allocated on the heap"
+      pp_print_string ppf
+        "it is a module and thus always needs to be allocated on the heap"
 
   let print_lock_item ppf = function
     | Module -> fprintf ppf "module"
@@ -2155,7 +2158,7 @@ module Report = struct
         (Misc.Style.as_inline_code !print_longident)
         target_lid);
     (match print_ahint_sided obj ppf actual with
-    | Mode_with_hint -> fprintf ppf ".@\n@\nHowever, it "
+    | Mode_with_hint -> fprintf ppf ".@\nHowever, the highlighted expression "
     | Mode -> fprintf ppf "@ but "
     | Nothing -> assert false);
     ignore (print_ahint_sided obj ppf expected);

--- a/typing/mode_hint.mli
+++ b/typing/mode_hint.mli
@@ -45,7 +45,12 @@ type closure_details =
 (** Hint for a morphism on bounds. See [Mode.Report.print_morph] for what each non-trivial
     constructor means. *)
 type 'd morph =
-  | Unknown : ('l * 'r) morph  (** The morphism is not explained.  *)
+  | Unknown : ('l * 'r) morph  (** The morphism is not explained. *)
+  | Unknown_non_rigid : ('l * 'r) morph
+      (** Similiar to [Unknown], but in the special case where the morph doesn't change the
+    bound, it can be skipped. *)
+  (* CR-soon zqian: usages of [Unknown_non_rigid] should be replaced with
+     corresponding proper hints *)
   | Skip : ('l * 'r) morph
       (** The morphism doesn't change the bound and should be skipped in printing. *)
   | Close_over : closure_details -> ('l * disallowed) morph

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -680,7 +680,7 @@ let register_allocation_mode alloc_mode =
 let register_allocation_value_mode mode =
   let alloc_mode = value_to_alloc_r2g mode in
   register_allocation_mode alloc_mode;
-  let mode = alloc_as_value alloc_mode in
+  let mode = value_r2g ~hint:Unknown_non_rigid mode in
   alloc_mode, mode
 
 (** Register as allocation the expression constrained by the given
@@ -5278,7 +5278,7 @@ let split_function_ty
     env (expected_mode : expected_mode) ty_expected loc ~arg_label ~has_poly
     ~mode_annots ~ret_mode_annots ~in_function ~is_first_val_param ~is_final_val_param
   =
-  let alloc_mode =
+  let alloc_mode, mode =
       (* Unlike most allocations which can be the highest mode allowed by
          [expected_mode] and their [alloc_mode] identical to [expected_mode] ,
          functions have more constraints. For example, an outer function needs
@@ -5286,7 +5286,7 @@ let split_function_ty
          function deserves a separate allocation mode.
       *)
       let mode, _ = Value.newvar_below (as_single_mode expected_mode) in
-      fst (register_allocation_value_mode mode)
+      register_allocation_value_mode mode
   in
   if expected_mode.strictly_local then
     Locality.submode_exn Locality.local
@@ -5336,7 +5336,7 @@ let split_function_ty
         let env =
           Env.add_closure_lock
             Function
-            (alloc_as_value alloc_mode).comonadic
+            mode.comonadic
             env
         in
         Env.add_region_lock env


### PR DESCRIPTION
This PR replaces several mode morphism applications that were hinted `Unknown` with `Unknown_non_rigid`, to avoid cutting-off during hint printing.

Please review by commits.