### PR TITLE
Provide linking information to Js_of_ocaml in .cmj and .cmja

### DIFF
--- a/driver/jscompile.mli
+++ b/driver/jscompile.mli
@@ -43,4 +43,4 @@ val to_jsir :
   Compile_common.info ->
   Typedtree.implementation ->
   as_arg_for:Global_module.Parameter_name.t option ->
-  Jsoo_imports.Code.program
+  Flambda2_to_jsir.To_jsir_result.program

--- a/driver/jslibrarian.ml
+++ b/driver/jslibrarian.ml
@@ -37,11 +37,7 @@ let copy_object_file oc name =
              (Filename.remove_extension (Filename.basename name)))
       in
       let compunit =
-        { cu_name;
-          cu_pos = compunit_pos;
-          cu_codesize = compunit_size;
-          cu_imports = [||]
-        }
+        { cu_name; cu_pos = compunit_pos; cu_codesize = compunit_size }
       in
       [compunit])
     else if buffer = cmja_magic_number

--- a/file_formats/cmj_format.mli
+++ b/file_formats/cmj_format.mli
@@ -1,8 +1,35 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                           Leo Lee, Jane Street                             *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
 type compilation_unit_descr =
   { cu_name: Compilation_unit.t;
     cu_pos: int;
-    cu_codesize: int;
-    cu_imports: Import_info.t array }
+    cu_codesize: int }
 
 type library =
   { lib_units: compilation_unit_descr list }

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -501,6 +501,8 @@ module Symbol = struct
 
   let compilation_unit t = Symbol0.compilation_unit (find_data t)
 
+  let for_compilation_unit t = Symbol0.for_compilation_unit t |> create_wrapped
+
   let linkage_name t = Symbol0.linkage_name (find_data t)
 
   let linkage_name_as_string t = Linkage_name.to_string (linkage_name t)

--- a/middle_end/flambda2/identifiers/int_ids.mli
+++ b/middle_end/flambda2/identifiers/int_ids.mli
@@ -136,6 +136,8 @@ module Symbol : sig
 
   val compilation_unit : t -> Compilation_unit.t
 
+  val for_compilation_unit : Compilation_unit.t -> t
+
   val linkage_name : t -> Linkage_name.t
 
   val linkage_name_as_string : t -> string

--- a/middle_end/flambda2/to_jsir/jsoo_imports/code.ml
+++ b/middle_end/flambda2/to_jsir/jsoo_imports/code.ml
@@ -484,7 +484,9 @@ type program =
 
 type cmj_body =
   { program : program;
-    last_var : Addr.t
+    last_var : Addr.t;
+    imported_compilation_units : Compilation_unit.t list;
+    exported_compilation_unit : Compilation_unit.t
   }
 
 let noloc = No

--- a/middle_end/flambda2/to_jsir/jsoo_imports/code.mli
+++ b/middle_end/flambda2/to_jsir/jsoo_imports/code.mli
@@ -231,10 +231,15 @@ type program =
 
 type cmj_body =
   { program : program;
-    last_var : Addr.t
+    last_var : Addr.t;
         (** Highest used variable in the translation, since it is kept track by a
         mutable state (in [Var]), and the [ocamlj] compiler and [js_of_ocaml]
         need to have these in sync *)
+    imported_compilation_units : Compilation_unit.t list;
+        (** Compilation units fetched from JSOO's global data table. Needed to fill in
+        [Unit_info.t] in JSOO*)
+    exported_compilation_unit : Compilation_unit.t
+        (** Current compilation unit. Needed to fill in [Unit_info.t] in JSOO *)
   }
 
 module Print : sig

--- a/middle_end/flambda2/to_jsir/to_jsir.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir.ml
@@ -585,5 +585,5 @@ let unit ~offsets:_ ~all_code:_ ~reachable_names:_ flambda_unit =
   let res, _addr = To_jsir_result.new_block res ~params:[] in
   let _env, res = expr ~env ~res (Flambda_unit.body flambda_unit) in
   let program = To_jsir_result.to_program_exn res in
-  Jsir.invariant program;
+  Jsir.invariant program.program;
   program

--- a/middle_end/flambda2/to_jsir/to_jsir.mli
+++ b/middle_end/flambda2/to_jsir/to_jsir.mli
@@ -34,4 +34,4 @@ val unit :
   all_code:Exported_code.t ->
   reachable_names:Name_occurrences.t ->
   Flambda_unit.t ->
-  Jsir.program
+  To_jsir_result.program

--- a/middle_end/flambda2/to_jsir/to_jsir_env.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_env.ml
@@ -90,11 +90,14 @@ let add_exn_handler t cont ~addr ~exn_param ~extra_args =
 
 let add_var t fvar jvar = { t with vars = Variable.Map.add fvar jvar t.vars }
 
-let symbol_to_native_strings symbol =
+let symbol_to_strings symbol =
   ( Symbol.compilation_unit symbol
-    |> Compilation_unit.name |> Compilation_unit.Name.to_string
-    |> Jsir.Native_string.of_string,
-    Symbol.linkage_name_as_string symbol |> Jsir.Native_string.of_string )
+    |> Compilation_unit.name |> Compilation_unit.Name.to_string,
+    Symbol.linkage_name_as_string symbol )
+
+let symbol_to_native_strings symbol =
+  let cu_name, symbol_name = symbol_to_strings symbol in
+  Jsir.Native_string.of_string cu_name, Jsir.Native_string.of_string symbol_name
 
 let register_symbol' ~res symbol var =
   let compilation_unit_name, symbol_name = symbol_to_native_strings symbol in
@@ -130,13 +133,21 @@ let get_exn_handler_exn t cont = Continuation.Map.find cont t.exn_handlers
 
 let get_var_exn t fvar = Variable.Map.find fvar t.vars
 
-let get_predef_exception ~res symbol =
-  (* jsoo already registers these in global data *)
+let get_symbol_from_global_data symbol_name ~res =
+  (* CR selee: only make this once *)
   let global_data = Jsir.Var.fresh () in
   let res =
     To_jsir_result.add_instr_exn res
       (Let (global_data, Prim (Extern "caml_get_global_data", [])))
   in
+  let symbol_name = Jsir.Native_string.of_string symbol_name in
+  let var = Jsir.Var.fresh () in
+  let expr : Jsir.expr =
+    Prim (Extern "caml_js_get", [Pv global_data; Pc (NativeString symbol_name)])
+  in
+  var, To_jsir_result.add_instr_exn res (Let (var, expr))
+
+let get_predef_exception ~res symbol =
   let symbol_name = Symbol.linkage_name_as_string symbol in
   (* Chop off caml_exn_ *)
   let caml_exn_ = "caml_exn_" in
@@ -148,27 +159,32 @@ let get_predef_exception ~res symbol =
   let symbol_name =
     String.sub symbol_name (String.length caml_exn_)
       (String.length symbol_name - String.length caml_exn_)
-    |> Jsir.Native_string.of_string
   in
-  let exn_var = Jsir.Var.fresh () in
-  let exn_expr : Jsir.expr =
-    Prim (Extern "caml_js_get", [Pv global_data; Pc (NativeString symbol_name)])
-  in
-  exn_var, To_jsir_result.add_instr_exn res (Let (exn_var, exn_expr))
+  (* jsoo already registers these in global data *)
+  get_symbol_from_global_data symbol_name ~res
 
 let get_external_symbol ~res symbol =
   match Symbol.is_predefined_exception symbol with
   | true -> get_predef_exception ~res symbol
-  | false ->
-    let compilation_unit_name, symbol_name = symbol_to_native_strings symbol in
-    let var = Jsir.Var.fresh () in
-    let expr : Jsir.expr =
-      Prim
-        ( Extern "caml_get_symbol",
-          [ Pc (NativeString compilation_unit_name);
-            Pc (NativeString symbol_name) ] )
+  | false -> (
+    let is_toplevel_module ~compilation_unit_name ~symbol_name =
+      String.equal symbol_name ("caml" ^ compilation_unit_name)
     in
-    var, To_jsir_result.add_instr_exn res (Let (var, expr))
+    let compilation_unit_name, symbol_name = symbol_to_strings symbol in
+    match is_toplevel_module ~compilation_unit_name ~symbol_name with
+    | true -> get_symbol_from_global_data compilation_unit_name ~res
+    | false ->
+      let compilation_unit_name, symbol_name =
+        symbol_to_native_strings symbol
+      in
+      let var = Jsir.Var.fresh () in
+      let expr : Jsir.expr =
+        Prim
+          ( Extern "caml_get_symbol",
+            [ Pc (NativeString compilation_unit_name);
+              Pc (NativeString symbol_name) ] )
+      in
+      var, To_jsir_result.add_instr_exn res (Let (var, expr)))
 
 let get_symbol t ~res symbol =
   match Symbol.compilation_unit symbol |> Compilation_unit.is_current with

--- a/middle_end/flambda2/to_jsir/to_jsir_env.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_env.ml
@@ -96,16 +96,27 @@ let symbol_to_native_strings symbol =
     |> Jsir.Native_string.of_string,
     Symbol.linkage_name_as_string symbol |> Jsir.Native_string.of_string )
 
+let symbol_is_for_compilation_unit symbol =
+  let compilation_unit = Symbol.compilation_unit symbol in
+  Symbol.equal (Symbol.for_compilation_unit compilation_unit) symbol
+
 let register_symbol' ~res symbol var =
-  let compilation_unit_name, symbol_name = symbol_to_native_strings symbol in
-  To_jsir_result.add_instr_exn res
-    (Let
-       ( Jsir.Var.fresh (),
-         Prim
-           ( Extern "caml_register_symbol",
-             [ Pc (NativeString compilation_unit_name);
-               Pc (NativeString symbol_name);
-               Pv var ] ) ))
+  match symbol_is_for_compilation_unit symbol with
+  | true ->
+    (* We don't need to add this symbol to our symbol table, because we will
+       instead fetch it from jsoo's global data table (see
+       [get_symbol_for_global_data]) *)
+    res
+  | false ->
+    let compilation_unit_name, symbol_name = symbol_to_native_strings symbol in
+    To_jsir_result.add_instr_exn res
+      (Let
+         ( Jsir.Var.fresh (),
+           Prim
+             ( Extern "caml_register_symbol",
+               [ Pc (NativeString compilation_unit_name);
+                 Pc (NativeString symbol_name);
+                 Pv var ] ) ))
 
 let add_symbol_without_registering t symbol jvar =
   { t with symbols = Symbol.Map.add symbol jvar t.symbols }
@@ -162,11 +173,9 @@ let get_external_symbol ~res symbol =
   match Symbol.is_predefined_exception symbol with
   | true -> get_predef_exception ~res symbol
   | false -> (
-    let compilation_unit = Symbol.compilation_unit symbol in
-    match
-      Symbol.equal (Symbol.for_compilation_unit compilation_unit) symbol
-    with
+    match symbol_is_for_compilation_unit symbol with
     | true ->
+      let compilation_unit = Symbol.compilation_unit symbol in
       let compilation_unit_name =
         Compilation_unit.name_as_string compilation_unit
       in

--- a/middle_end/flambda2/to_jsir/to_jsir_env.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_env.ml
@@ -132,12 +132,7 @@ let get_var_exn t fvar = Variable.Map.find fvar t.vars
 
 let get_symbol_from_global_data ~compilation_unit ~symbol_name ~res =
   let res = To_jsir_result.import_compilation_unit res compilation_unit in
-  (* CR selee: only make this once *)
-  let global_data = Jsir.Var.fresh () in
-  let res =
-    To_jsir_result.add_instr_exn res
-      (Let (global_data, Prim (Extern "caml_get_global_data", [])))
-  in
+  let res, global_data = To_jsir_result.global_data_var res in
   let symbol_name = Jsir.Native_string.of_string symbol_name in
   let var = Jsir.Var.fresh () in
   let expr : Jsir.expr =

--- a/middle_end/flambda2/to_jsir/to_jsir_env.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_env.ml
@@ -130,7 +130,8 @@ let get_exn_handler_exn t cont = Continuation.Map.find cont t.exn_handlers
 
 let get_var_exn t fvar = Variable.Map.find fvar t.vars
 
-let get_symbol_from_global_data symbol_name ~res =
+let get_symbol_from_global_data ~compilation_unit ~symbol_name ~res =
+  let res = To_jsir_result.import_compilation_unit res compilation_unit in
   (* CR selee: only make this once *)
   let global_data = Jsir.Var.fresh () in
   let res =
@@ -158,7 +159,9 @@ let get_predef_exception ~res symbol =
       (String.length symbol_name - String.length caml_exn_)
   in
   (* jsoo already registers these in global data *)
-  get_symbol_from_global_data symbol_name ~res
+  get_symbol_from_global_data
+    ~compilation_unit:(Symbol.compilation_unit symbol)
+    ~symbol_name ~res
 
 let get_external_symbol ~res symbol =
   match Symbol.is_predefined_exception symbol with
@@ -172,7 +175,8 @@ let get_external_symbol ~res symbol =
       let compilation_unit_name =
         Compilation_unit.name_as_string compilation_unit
       in
-      get_symbol_from_global_data compilation_unit_name ~res
+      get_symbol_from_global_data ~compilation_unit
+        ~symbol_name:compilation_unit_name ~res
     | false ->
       let compilation_unit_name, symbol_name =
         symbol_to_native_strings symbol

--- a/middle_end/flambda2/to_jsir/to_jsir_result.mli
+++ b/middle_end/flambda2/to_jsir/to_jsir_result.mli
@@ -86,6 +86,8 @@ val import_compilation_unit : t -> Compilation_unit.t -> t
 (* CR selee: Eventually this should also be used for symbols too, so that we
    don't put unused symbols in the symbol table. *)
 
+val global_data_var : t -> t * Jsir.Var.t
+
 type program =
   { program : Jsir.program;
     imported_compilation_units : Compilation_unit.Set.t

--- a/middle_end/flambda2/to_jsir/to_jsir_result.mli
+++ b/middle_end/flambda2/to_jsir/to_jsir_result.mli
@@ -71,11 +71,6 @@ val new_block_with_addr_exn :
     This function raises if there are no blocks being worked on. *)
 val end_block_with_last_exn : t -> Jsir.last -> t
 
-(** Create a [Jsir.program] with the blocks in the result, including the
-    current block. This function raises if there are still blocks being
-    worked on, or there is a reserved address that has not been used yet. *)
-val to_program_exn : t -> Jsir.program
-
 (** Returns the address for a special block for invalid switches, creating one if it
     doesn't exist already. *)
 val invalid_switch_block : t -> t * Jsir.Addr.t
@@ -83,3 +78,20 @@ val invalid_switch_block : t -> t * Jsir.Addr.t
 (** Get a public method and return the function. Increments the method cache ID. *)
 val get_public_method :
   t -> obj:Jsir.Var.t -> field:Jsir.Var.t -> t * Jsir.Var.t
+
+(** Register the fact that we import the (toplevel module of the) given compilation unit
+    from the JSOO global data table. This is used to inform Js_of_ocaml that it needs to
+    add this compilation unit to the global data table. *)
+val import_compilation_unit : t -> Compilation_unit.t -> t
+(* CR selee: Eventually this should also be used for symbols too, so that we
+   don't put unused symbols in the symbol table. *)
+
+type program =
+  { program : Jsir.program;
+    imported_compilation_units : Compilation_unit.Set.t
+  }
+
+(** Create a [program] with the blocks in the result, including the
+    current block. This function raises if there are still blocks being
+    worked on, or there is a reserved address that has not been used yet. *)
+val to_program_exn : t -> program

--- a/middle_end/flambda2/to_jsir/to_jsir_result.mli
+++ b/middle_end/flambda2/to_jsir/to_jsir_result.mli
@@ -83,8 +83,8 @@ val get_public_method :
     from the JSOO global data table. This is used to inform Js_of_ocaml that it needs to
     add this compilation unit to the global data table. *)
 val import_compilation_unit : t -> Compilation_unit.t -> t
-(* CR selee: Eventually this should also be used for symbols too, so that we
-   don't put unused symbols in the symbol table. *)
+(* CR selee: Eventually we should do something similar for symbols too, so that
+   we don't put unused symbols in the symbol table. *)
 
 val global_data_var : t -> t * Jsir.Var.t
 


### PR DESCRIPTION
We modify the .cmj file format to include any compilation units imported while translating the current unit, so that js_of_ocaml can provide this info to the linker via the `//Requires:` stanza. This change is accompanied by a change in js_of_ocaml. We are able to use the bytecode-compiled stdlib with JSIR-compiled files with this change.