### PR TITLE
Restore frontend specialization for atomics

### DIFF
--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -150,7 +150,7 @@ type prim =
   | Identity
   | Apply of Lambda.region_close * Lambda.layout
   | Revapply of Lambda.region_close * Lambda.layout
-  | Atomic of atomic_op * atomic_kind
+  | Atomic of atomic_op * atomic_kind * Lambda.immediate_or_pointer
   | Peek of Lambda.peek_or_poke option
   | Poke of Lambda.peek_or_poke option
     (* For [Peek] and [Poke] the [option] is [None] until the primitive
@@ -977,39 +977,39 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
     | "%unbox_vec512" -> Primitive(Punbox_vector Boxed_vec512, 1)
     | "%box_vec512" -> Primitive(Pbox_vector (Boxed_vec512, mode), 1)
     | "%get_header" -> Primitive (Pget_header mode, 1)
-    | "%atomic_load" -> Atomic(Load, Ref)
-    | "%atomic_load_field" -> Atomic(Load, Field)
-    | "%atomic_load_loc" -> Atomic(Load, Loc)
-    | "%atomic_set" -> Atomic(Set, Ref)
-    | "%atomic_set_field" -> Atomic(Set, Field)
-    | "%atomic_set_loc" -> Atomic(Set, Loc)
-    | "%atomic_exchange" -> Atomic(Exchange, Ref)
-    | "%atomic_exchange_field" -> Atomic(Exchange, Field)
-    | "%atomic_exchange_loc" -> Atomic(Exchange, Loc)
-    | "%atomic_compare_exchange" -> Atomic(Compare_exchange, Ref)
-    | "%atomic_compare_exchange_field" -> Atomic(Compare_exchange, Field)
-    | "%atomic_compare_exchange_loc" -> Atomic(Compare_exchange, Loc)
-    | "%atomic_cas" -> Atomic(Compare_and_set, Ref)
-    | "%atomic_cas_field" -> Atomic(Compare_and_set, Field)
-    | "%atomic_cas_loc" -> Atomic(Compare_and_set, Loc)
-    | "%atomic_fetch_add" -> Atomic(Fetch_add, Ref)
-    | "%atomic_fetch_add_field" -> Atomic(Fetch_add, Field)
-    | "%atomic_fetch_add_loc" -> Atomic(Fetch_add, Loc)
-    | "%atomic_add" -> Atomic(Add, Ref)
-    | "%atomic_add_field" -> Atomic(Add, Field)
-    | "%atomic_add_loc" -> Atomic(Add, Loc)
-    | "%atomic_sub" -> Atomic(Sub, Ref)
-    | "%atomic_sub_field" -> Atomic(Sub, Field)
-    | "%atomic_sub_loc" -> Atomic(Sub, Loc)
-    | "%atomic_land" -> Atomic(Land, Ref)
-    | "%atomic_land_field" -> Atomic(Land, Field)
-    | "%atomic_land_loc" -> Atomic(Land, Loc)
-    | "%atomic_lor" -> Atomic(Lor, Ref)
-    | "%atomic_lor_field" -> Atomic(Lor, Field)
-    | "%atomic_lor_loc" -> Atomic(Lor, Loc)
-    | "%atomic_lxor" -> Atomic(Lxor, Ref)
-    | "%atomic_lxor_field" -> Atomic(Lxor, Field)
-    | "%atomic_lxor_loc" -> Atomic(Lxor, Loc)
+    | "%atomic_load" -> Atomic(Load, Ref, Pointer)
+    | "%atomic_load_field" -> Atomic(Load, Field, Pointer)
+    | "%atomic_load_loc" -> Atomic(Load, Loc, Pointer)
+    | "%atomic_set" -> Atomic(Set, Ref, Pointer)
+    | "%atomic_set_field" -> Atomic(Set, Field, Pointer)
+    | "%atomic_set_loc" -> Atomic(Set, Loc, Pointer)
+    | "%atomic_exchange" -> Atomic(Exchange, Ref, Pointer)
+    | "%atomic_exchange_field" -> Atomic(Exchange, Field, Pointer)
+    | "%atomic_exchange_loc" -> Atomic(Exchange, Loc, Pointer)
+    | "%atomic_compare_exchange" -> Atomic(Compare_exchange, Ref, Pointer)
+    | "%atomic_compare_exchange_field" -> Atomic(Compare_exchange, Field, Pointer)
+    | "%atomic_compare_exchange_loc" -> Atomic(Compare_exchange, Loc, Pointer)
+    | "%atomic_cas" -> Atomic(Compare_and_set, Ref, Pointer)
+    | "%atomic_cas_field" -> Atomic(Compare_and_set, Field, Pointer)
+    | "%atomic_cas_loc" -> Atomic(Compare_and_set, Loc, Pointer)
+    | "%atomic_fetch_add" -> Atomic(Fetch_add, Ref, Immediate)
+    | "%atomic_fetch_add_field" -> Atomic(Fetch_add, Field, Immediate)
+    | "%atomic_fetch_add_loc" -> Atomic(Fetch_add, Loc, Immediate)
+    | "%atomic_add" -> Atomic(Add, Ref, Immediate)
+    | "%atomic_add_field" -> Atomic(Add, Field, Immediate)
+    | "%atomic_add_loc" -> Atomic(Add, Loc, Immediate)
+    | "%atomic_sub" -> Atomic(Sub, Ref, Immediate)
+    | "%atomic_sub_field" -> Atomic(Sub, Field, Immediate)
+    | "%atomic_sub_loc" -> Atomic(Sub, Loc, Immediate)
+    | "%atomic_land" -> Atomic(Land, Ref, Immediate)
+    | "%atomic_land_field" -> Atomic(Land, Field, Immediate)
+    | "%atomic_land_loc" -> Atomic(Land, Loc, Immediate)
+    | "%atomic_lor" -> Atomic(Lor, Ref, Immediate)
+    | "%atomic_lor_field" -> Atomic(Lor, Field, Immediate)
+    | "%atomic_lor_loc" -> Atomic(Lor, Loc, Immediate)
+    | "%atomic_lxor" -> Atomic(Lxor, Ref, Immediate)
+    | "%atomic_lxor_field" -> Atomic(Lxor, Field, Immediate)
+    | "%atomic_lxor_loc" -> Atomic(Lxor, Loc, Immediate)
     | "%cpu_relax" -> Primitive (Pcpu_relax, 1)
     | "%runstack" ->
       if runtime5 then Primitive (Prunstack, 3) else Unsupported Prunstack
@@ -1414,7 +1414,10 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
       | Some (p2, rhs) ->
         match is_function_type env rhs with
         | None -> [p1;p2], rhs
-        | Some (p3, rhs) -> [p1;p2;p3], rhs
+        | Some (p3, rhs) -> 
+          match is_function_type env rhs with
+          | None -> [p1;p2;p3], rhs
+          | Some (p4, rhs) -> [p1;p2;p3;p4], rhs
   in
   match prim, param_tys with
   | Primitive (Psetfield(n, Pointer, init), arity), [_; p2] -> begin
@@ -1556,57 +1559,6 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
         Some (Primitive (Pmakeblock(tag, mut, Some shape, mode),arity))
       else None
     end
-  | Primitive (Patomic_load_field { immediate_or_pointer = Pointer },
-               arity), _ ->begin
-      let is_int = match is_function_type env ty with
-        | None -> Pointer
-        | Some (_p1, rhs) -> fst (maybe_pointer_type env rhs) in
-      Some (
-        Primitive (Patomic_load_field {immediate_or_pointer = is_int}, arity))
-    end
-  | Primitive (Patomic_set_field { immediate_or_pointer = Pointer },
-               arity), [_; p2] -> begin
-      match fst (maybe_pointer_type env p2) with
-      | Pointer -> None
-      | Immediate ->
-        Some
-          (Primitive
-             (Patomic_set_field
-                {immediate_or_pointer = Immediate}, arity))
-    end
-  | Primitive (Patomic_exchange_field { immediate_or_pointer = Pointer },
-               arity), [_; p2] -> begin
-      match fst (maybe_pointer_type env p2) with
-      | Pointer -> None
-      | Immediate ->
-          Some
-            (Primitive
-               (Patomic_exchange_field
-                  {immediate_or_pointer = Immediate}, arity))
-    end
-  | Primitive (
-    Patomic_compare_exchange_field { immediate_or_pointer = Pointer },
-               arity), [_; p2; p3] -> begin
-      match fst (maybe_pointer_type env p2),
-            fst (maybe_pointer_type env p3) with
-      | Pointer, _ | _, Pointer -> None
-      | Immediate, Immediate ->
-          Some
-            (Primitive
-               (Patomic_compare_exchange_field
-                  {immediate_or_pointer = Immediate}, arity))
-    end
-  | Primitive (Patomic_compare_set_field { immediate_or_pointer = Pointer },
-               arity), [_; p2; p3] -> begin
-      match fst (maybe_pointer_type env p2),
-            fst (maybe_pointer_type env p3) with
-      | Pointer, _ | _, Pointer -> None
-      | Immediate, Immediate ->
-          Some
-            (Primitive
-               (Patomic_compare_set_field
-                  {immediate_or_pointer = Immediate}, arity))
-    end
   | Comparison(comp, Compare_generic), p1 :: _ ->
     if (has_constant_constructor
         && simplify_constant_constructor comp) then begin
@@ -1652,6 +1604,45 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
     | None -> None
     | Some contents_layout -> Some (Poke (Some contents_layout))
   )
+  | Atomic (Load, (Ref | Loc as kind), Pointer), _ ->
+    (match is_function_type env ty with
+    | None -> None
+    | Some (_, rhs) -> 
+      match fst (maybe_pointer_type env rhs) with
+      | Pointer -> None
+      | Immediate -> Some (Atomic (Load, kind, Immediate)))
+  | Atomic (Load, Field, Pointer), _ ->
+    (match is_function_type env ty with
+    | None -> None
+    | Some (_, ty) -> 
+      match is_function_type env ty with
+      | None -> None
+      | Some (_, rhs) -> 
+        match fst (maybe_pointer_type env rhs) with
+        | Pointer -> None
+        | Immediate -> Some (Atomic (Load, Field, Immediate)))
+  | Atomic (Set, (Ref | Loc as kind), Pointer), [_; set_to]
+  | Atomic (Set, (Field as kind), Pointer), [_; _; set_to] ->
+    (match fst (maybe_pointer_type env set_to) with
+    | Pointer -> None
+    | Immediate -> Some (Atomic (Set, kind, Immediate)))
+  | Atomic (Exchange, (Ref | Loc as kind), Pointer), [_; set_to]
+  | Atomic (Exchange, (Field as kind), Pointer), [_; _; set_to] ->
+    (match fst (maybe_pointer_type env set_to) with
+    | Pointer -> None
+    | Immediate -> Some (Atomic (Set, kind, Immediate)))
+  | Atomic (Compare_and_set, (Ref | Loc as kind), Pointer), [_; compare_with; set_to]
+  | Atomic (Compare_and_set, (Field as kind), Pointer), [_; _; compare_with; set_to] ->
+    (match fst (maybe_pointer_type env compare_with),
+           fst (maybe_pointer_type env set_to) with
+    | Pointer, _ | _, Pointer -> None
+    | Immediate, Immediate -> Some (Atomic (Compare_and_set, kind, Immediate)))
+  | Atomic (Compare_exchange, (Ref | Loc as kind), Pointer), [_; compare_with; set_to]
+  | Atomic (Compare_exchange, (Field as kind), Pointer), [_; _; compare_with; set_to] ->
+    (match fst (maybe_pointer_type env compare_with),
+           fst (maybe_pointer_type env set_to) with
+    | Pointer, _ | _, Pointer -> None
+    | Immediate, Immediate -> Some (Atomic (Compare_exchange, kind, Immediate)))
   | _ -> None
 
 let caml_equal =
@@ -1848,7 +1839,8 @@ let atomic_arity op (kind : atomic_kind) =
   in
   arity_of_op + extra_kind_arity
 
-let lambda_of_atomic prim_name loc op (kind : atomic_kind) args =
+let lambda_of_atomic prim_name loc op (kind : atomic_kind)
+                     immediate_or_pointer args =
   if List.length args <> atomic_arity op kind then
     raise (Error (to_location loc, Wrong_arity_builtin_primitive prim_name)) ;
   let split = function
@@ -1860,13 +1852,13 @@ let lambda_of_atomic prim_name loc op (kind : atomic_kind) args =
   in
   let prim =
     match op with
-    | Load -> Patomic_load_field { immediate_or_pointer = Pointer }
-    | Set -> Patomic_set_field { immediate_or_pointer = Pointer }
-    | Exchange -> Patomic_exchange_field { immediate_or_pointer = Pointer }
+    | Load -> Patomic_load_field { immediate_or_pointer }
+    | Set -> Patomic_set_field { immediate_or_pointer }
+    | Exchange -> Patomic_exchange_field { immediate_or_pointer }
     | Compare_exchange ->
-      Patomic_compare_exchange_field { immediate_or_pointer = Pointer }
+      Patomic_compare_exchange_field { immediate_or_pointer }
     | Compare_and_set ->
-      Patomic_compare_set_field { immediate_or_pointer = Pointer }
+      Patomic_compare_set_field { immediate_or_pointer }
     | Fetch_add -> Patomic_fetch_add_field
     | Add -> Patomic_add_field
     | Sub -> Patomic_sub_field
@@ -2029,8 +2021,8 @@ let lambda_of_prim prim_name prim loc args arg_exps =
           [exn; Lconst (Const_immstring msg)],
           loc)],
         loc)
-  | Atomic (op, kind), args ->
-      lambda_of_atomic prim_name loc op kind args
+  | Atomic (op, kind, imm_or_ptr), args ->
+      lambda_of_atomic prim_name loc op kind imm_or_ptr args
   | (Raise _ | Raise_with_backtrace
     | Lazy_force _ | Loc _ | Primitive _ | Sys_argv | Comparison _
     | Send _ | Send_self _ | Send_cache _ | Frame_pointers | Identity
@@ -2068,7 +2060,7 @@ let check_primitive_arity loc p =
     | Frame_pointers -> p.prim_arity = 0
     | Identity | Peek _ -> p.prim_arity = 1
     | Apply _ | Revapply _ | Poke _ -> p.prim_arity = 2
-    | Atomic (op, kind) -> p.prim_arity = atomic_arity op kind
+    | Atomic (op, kind, _) -> p.prim_arity = atomic_arity op kind
     | Unsupported _ -> true
   in
   if not ok then raise(Error(loc, Wrong_arity_builtin_primitive p.prim_name))
@@ -2286,7 +2278,7 @@ let primitive_needs_event_after = function
   | Lazy_force _ | Send _ | Send_self _ | Send_cache _
   | Apply _ | Revapply _ -> true
   | Raise _ | Raise_with_backtrace | Loc _ | Frame_pointers | Identity
-  | Peek _ | Poke _ | Atomic (_, _) | Unsupported _ -> false
+  | Peek _ | Poke _ | Atomic _ | Unsupported _ -> false
 
 let transl_primitive_application loc p env ty ~poly_mode ~stack ~poly_sort
     path exp args arg_exps pos =

--- a/stdlib/atomic.mli
+++ b/stdlib/atomic.mli
@@ -49,7 +49,7 @@ external make_contended
   = "caml_atomic_make_contended"
 
 (** Get the current value of the atomic reference. *)
-val get : ('a : value_or_null). 'a t @ local -> 'a
+external get : ('a : value_or_null). 'a t @ local -> 'a = "%atomic_load"
 
 (** Set a new value for the atomic reference. *)
 external set : ('a : value_or_null). 'a t @ local -> 'a -> unit = "%atomic_set"
@@ -79,22 +79,22 @@ external compare_exchange
 
 (** [fetch_and_add r n] atomically increments the value of [r] by [n], and
     returns the current value (before the increment). *)
-val fetch_and_add : int t @ local -> int -> int
+external fetch_and_add : int t @ local -> int -> int = "%atomic_fetch_add"
 
 (** [add r i] atomically adds [i] onto [r]. *)
-val add : int t @ local -> int -> unit
+external add : int t @ local -> int -> unit =  "%atomic_add"
 
 (** [sub r i] atomically subtracts [i] onto [r]. *)
-val sub : int t @ local -> int -> unit
+external sub : int t @ local -> int -> unit =  "%atomic_sub"
 
 (** [logand r i] atomically bitwise-ands [i] onto [r]. *)
-val logand : int t @ local -> int -> unit
+external logand : int t @ local -> int -> unit =  "%atomic_land"
 
 (** [logor r i] atomically bitwise-ors [i] onto [r]. *)
-val logor : int t @ local -> int -> unit
+external logor : int t @ local -> int -> unit =  "%atomic_lor"
 
 (** [logxor r i] atomically bitwise-xors [i] onto [r]. *)
-val logxor : int t @ local -> int -> unit
+external logxor : int t @ local -> int -> unit =  "%atomic_lxor"
 
 (** [incr r] atomically increments the value of [r] by [1]. *)
 val incr : int t @ local -> unit

--- a/testsuite/tests/lib-atomic/test_atomic_codegen.ml
+++ b/testsuite/tests/lib-atomic/test_atomic_codegen.ml
@@ -1,0 +1,256 @@
+(* TEST
+   flags = "-dlambda -dno-locations -dno-unique-ids";
+   expect;
+*)
+
+let a = Atomic.make 0
+let _ = Atomic.get a
+let _ = Atomic.set a 1
+let _ = Atomic.exchange a 2 
+let _ = Atomic.compare_and_set a 2 3
+let _ = Atomic.compare_exchange a 3 4
+let _ = Atomic.fetch_and_add a 1
+let _ = Atomic.add a 1
+let _ = Atomic.sub a 1
+let _ = Atomic.logand a 1
+let _ = Atomic.logor a 1
+let _ = Atomic.logxor a 1
+
+[%%expect{|
+(let (a = (makemutable 0 (value<int>) 0))
+  (apply (field_imm 1 (global Toploop!)) "a" a))
+val a : int Atomic.t = {Atomic.contents = 0}
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_load_field_imm a 0))
+- : int = 0
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_set_field_imm a 0 1))
+- : unit = ()
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_set_field_imm a 0 2))
+- : int = 0
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_compare_set_field_imm a 0 2 3))
+- : bool = true
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_compare_exchange_field_imm a 0 3 4))
+- : int = 3
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_fetch_add_field a 0 1))
+- : int = 4
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_add_field a 0 1))
+- : unit = ()
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_sub_field a 0 1))
+- : unit = ()
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_land_field a 0 1))
+- : unit = ()
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_lor_field a 0 1))
+- : unit = ()
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_lxor_field a 0 1))
+- : unit = ()
+|}]
+
+type 'a atomic = { mutable x : 'a [@atomic] }
+
+[%%expect{|
+0
+type 'a atomic = { mutable x : 'a [@atomic]; }
+|}]
+
+let a = {x = 0}
+let _ = a.x
+let _ = a.x <- 1
+
+[%%expect{|
+(let (a = (makemutable 0 (value<int>) 0))
+  (apply (field_imm 1 (global Toploop!)) "a" a))
+val a : int atomic = {x = 0}
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_load_field_imm a 0))
+- : int = 0
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_set_field_imm a 0 1))
+- : unit = ()
+|}]
+
+let a = {x = 0}
+let _ = Atomic.Loc.get [%atomic.loc a.x]
+let _ = Atomic.Loc.set [%atomic.loc a.x] 1
+let _ = Atomic.Loc.exchange [%atomic.loc a.x] 2 
+let _ = Atomic.Loc.compare_and_set [%atomic.loc a.x] 2 3
+let _ = Atomic.Loc.compare_exchange [%atomic.loc a.x] 3 4
+let _ = Atomic.Loc.fetch_and_add [%atomic.loc a.x] 1
+let _ = Atomic.Loc.add [%atomic.loc a.x] 1
+let _ = Atomic.Loc.sub [%atomic.loc a.x] 1
+let _ = Atomic.Loc.logand [%atomic.loc a.x] 1
+let _ = Atomic.Loc.logor [%atomic.loc a.x] 1
+let _ = Atomic.Loc.logxor [%atomic.loc a.x] 1
+
+[%%expect{|
+(let (a = (makemutable 0 (value<int>) 0))
+  (apply (field_imm 1 (global Toploop!)) "a" a))
+val a : int atomic = {x = 0}
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_load_field_imm a 0))
+- : int = 0
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_set_field_imm a 0 1))
+- : unit = ()
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_set_field_imm a 0 2))
+- : int = 0
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_compare_set_field_imm a 0 2 3))
+- : bool = true
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_compare_exchange_field_imm a 0 3 4))
+- : int = 3
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_fetch_add_field a 0 1))
+- : int = 4
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_add_field a 0 1))
+- : unit = ()
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_sub_field a 0 1))
+- : unit = ()
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_land_field a 0 1))
+- : unit = ()
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_lor_field a 0 1))
+- : unit = ()
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_lxor_field a 0 1))
+- : unit = ()
+|}]
+
+external atomic_get_field : 'a atomic -> int -> 'a = "%atomic_load_field"
+external atomic_set_field : 'a atomic -> int -> 'a -> unit = "%atomic_set_field"
+external atomic_exchange_field : 'a atomic -> int -> 'a -> 'a = "%atomic_exchange_field"
+external atomic_compare_exchange_field : 'a atomic -> int -> 'a -> 'a -> 'a = "%atomic_compare_exchange_field"
+external atomic_compare_and_set_field : 'a atomic -> int -> 'a -> 'a -> bool = "%atomic_cas_field"
+external atomic_fetch_and_add_field : int atomic -> int -> int -> int = "%atomic_fetch_add_field"
+external atomic_add_field : int atomic -> int -> int -> unit = "%atomic_add_field"
+external atomic_sub_field : int atomic -> int -> int -> unit = "%atomic_sub_field"
+external atomic_logand_field : int atomic -> int -> int -> unit = "%atomic_land_field"
+external atomic_logor_field : int atomic -> int -> int -> unit = "%atomic_lor_field"
+external atomic_logxor_field : int atomic -> int -> int -> unit = "%atomic_lxor_field"
+
+[%%expect{|
+0
+external atomic_get_field : 'a atomic -> int -> 'a = "%atomic_load_field"
+0
+external atomic_set_field : 'a atomic -> int -> 'a -> unit
+  = "%atomic_set_field"
+0
+external atomic_exchange_field : 'a atomic -> int -> 'a -> 'a
+  = "%atomic_exchange_field"
+0
+external atomic_compare_exchange_field : 'a atomic -> int -> 'a -> 'a -> 'a
+  = "%atomic_compare_exchange_field"
+0
+external atomic_compare_and_set_field : 'a atomic -> int -> 'a -> 'a -> bool
+  = "%atomic_cas_field"
+0
+external atomic_fetch_and_add_field : int atomic -> int -> int -> int
+  = "%atomic_fetch_add_field"
+0
+external atomic_add_field : int atomic -> int -> int -> unit
+  = "%atomic_add_field"
+0
+external atomic_sub_field : int atomic -> int -> int -> unit
+  = "%atomic_sub_field"
+0
+external atomic_logand_field : int atomic -> int -> int -> unit
+  = "%atomic_land_field"
+0
+external atomic_logor_field : int atomic -> int -> int -> unit
+  = "%atomic_lor_field"
+0
+external atomic_logxor_field : int atomic -> int -> int -> unit
+  = "%atomic_lxor_field"
+|}]
+
+let a = {x = 0}
+let _ = atomic_get_field a 0
+let _ = atomic_set_field a 0 1
+let _ = atomic_exchange_field a 0 2 
+let _ = atomic_compare_and_set_field a 0 2 3
+let _ = atomic_compare_exchange_field a 0 3 4
+let _ = atomic_fetch_and_add_field a 0 1
+let _ = atomic_add_field a 0 1
+let _ = atomic_sub_field a 0 1
+let _ = atomic_logand_field a 0 1
+let _ = atomic_logor_field a 0 1
+let _ = atomic_logxor_field a 0 1
+
+[%%expect{|
+(let (a = (makemutable 0 (value<int>) 0))
+  (apply (field_imm 1 (global Toploop!)) "a" a))
+val a : int atomic = {x = 0}
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_load_field_imm a 0))
+- : int = 0
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_set_field_imm a 0 1))
+- : unit = ()
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_set_field_imm a 0 2))
+- : int = 0
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_compare_set_field_imm a 0 2 3))
+- : bool = true
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_compare_exchange_field_imm a 0 3 4))
+- : int = 3
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_fetch_add_field a 0 1))
+- : int = 4
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_add_field a 0 1))
+- : unit = ()
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_sub_field a 0 1))
+- : unit = ()
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_land_field a 0 1))
+- : unit = ()
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_lor_field a 0 1))
+- : unit = ()
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_lxor_field a 0 1))
+- : unit = ()
+|}]
+
+(* Not specialized by the frontend, but should be specialized by flambda2.
+   On amd64, the assembly should not include any calls to [caml_atomic_*]. *)
+
+type maybe_imm = I | P of unit
+[%%expect{|
+0
+type maybe_imm = I | P of unit
+|}]
+
+let a = Atomic.make I
+let _ = Atomic.compare_and_set a I I
+let _ = Atomic.compare_exchange a I I
+
+[%%expect{|
+(let
+  (a = (makemutable 0 (value<(consts (0)) (non_consts ([0: value<int>]))>) 0))
+  (apply (field_imm 1 (global Toploop!)) "a" a))
+val a : maybe_imm Atomic.t = {Atomic.contents = I}
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_compare_set_field_ptr a 0 0 0))
+- : bool = true
+(let (a =? (apply (field_imm 0 (global Toploop!)) "a"))
+  (atomic_compare_exchange_field_ptr a 0 0 0))
+- : maybe_imm = I
+|}]


### PR DESCRIPTION
By introducing the extra indirection through `Atomic` instead of `Primitive (Patomic...)`, https://github.com/oxcaml/oxcaml/pull/4138 made the frontend stop specializing atomic primitives on immediates. 

This reimplements the specialization for the new constructors and adds a test.