### PR TITLE
`Mutex.protect` is `once`

### DIFF
--- a/stdlib/mutex.mli
+++ b/stdlib/mutex.mli
@@ -61,7 +61,7 @@ val unlock : t @ local -> unit
    @before 4.12 {!Sys_error} was not raised when unlocking an unlocked mutex
    or when unlocking a mutex from a different thread. *)
 
-val protect : t @ local -> (unit -> 'a) @ local -> 'a
+val protect : t @ local -> (unit -> 'a) @ local once -> 'a
 (** [protect mutex f] runs [f()] in a critical section where [mutex]
     is locked (using {!lock}); it then takes care of releasing [mutex],
     whether [f()] returned a value or raised an exception.


### PR DESCRIPTION
This just annotates `Mutex.protect` as calling the function once like it does.