### PR TITLE
Eliminate some unnecessary `caml_modify`s when writing through a block index

### DIFF
--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -2329,6 +2329,24 @@ let rec mixed_block_element_of_layout (layout : layout) :
   | Punboxed_vector Unboxed_vec512 -> Vec512
   | Punboxed_or_untagged_integer Untagged_int -> Untagged_immediate
 
+let rec layout_of_mixed_block_element (mbe : _ mixed_block_element) : layout =
+  match mbe with
+  | Product mbes ->
+    Punboxed_product
+      (Array.to_list (Array.map layout_of_mixed_block_element mbes))
+  | Value value_kind -> Pvalue value_kind
+  | Float64 | Float_boxed _ -> Punboxed_float Unboxed_float64
+  | Float32 -> Punboxed_float Unboxed_float32
+  | Bits64 -> Punboxed_or_untagged_integer Unboxed_int64
+  | Bits32 -> Punboxed_or_untagged_integer Unboxed_int32
+  | Bits16 -> Punboxed_or_untagged_integer Untagged_int16
+  | Bits8 -> Punboxed_or_untagged_integer Untagged_int8
+  | Word -> Punboxed_or_untagged_integer Unboxed_nativeint
+  | Vec128 -> Punboxed_vector Unboxed_vec128
+  | Vec256 -> Punboxed_vector Unboxed_vec256
+  | Vec512 -> Punboxed_vector Unboxed_vec512
+  | Untagged_immediate -> Punboxed_or_untagged_integer Untagged_int
+
 let rec mixed_block_element_leaves (el : _ mixed_block_element)
   : _ mixed_block_element list =
   match el with

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -2329,11 +2329,12 @@ let rec mixed_block_element_of_layout (layout : layout) :
   | Punboxed_vector Unboxed_vec512 -> Vec512
   | Punboxed_or_untagged_integer Untagged_int -> Untagged_immediate
 
-let rec layout_of_mixed_block_element (mbe : _ mixed_block_element) : layout =
+let rec layout_of_mixed_block_element_for_idx_set (mbe : _ mixed_block_element)
+  : layout =
   match mbe with
   | Product mbes ->
     Punboxed_product
-      (Array.to_list (Array.map layout_of_mixed_block_element mbes))
+      (Array.to_list (Array.map layout_of_mixed_block_element_for_idx_set mbes))
   | Value value_kind -> Pvalue value_kind
   | Float64 | Float_boxed _ -> Punboxed_float Unboxed_float64
   | Float32 -> Punboxed_float Unboxed_float32

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -1218,7 +1218,7 @@ val mixed_block_element_of_layout : layout -> unit mixed_block_element
 
 (* Translates [Float_boxed] as [Punboxed_float Unboxed_float64], for
    compatibility with block indices. *)
-val layout_of_mixed_block_element : _ mixed_block_element -> layout
+val layout_of_mixed_block_element_for_idx_set : _ mixed_block_element -> layout
 
 val mixed_block_element_leaves
   : 'a mixed_block_element -> 'a mixed_block_element list

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -1216,6 +1216,10 @@ val structured_constant_layout : structured_constant -> layout
 
 val mixed_block_element_of_layout : layout -> unit mixed_block_element
 
+(* Translates [Float_boxed] as [Punboxed_float Unboxed_float64], for
+   compatibility with block indices. *)
+val layout_of_mixed_block_element : _ mixed_block_element -> layout
+
 val mixed_block_element_leaves
   : 'a mixed_block_element -> 'a mixed_block_element list
 

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -1646,7 +1646,9 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
     let jkind = Ctype.type_jkind env p3 in
     let mbe = Typedecl.mixed_block_element env p3 jkind in
     let mbe = transl_mixed_block_element env (to_location loc) p3 mbe in
-    Some (Primitive (Pset_idx (layout_of_mixed_block_element mbe, m), arity))
+    Some (Primitive
+            (Pset_idx (layout_of_mixed_block_element_for_idx_set mbe, m),
+             arity))
   | _ -> None
 
 let caml_equal =

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -1415,7 +1415,7 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
       | Some (p2, rhs) ->
         match is_function_type env rhs with
         | None -> [p1;p2], rhs
-        | Some (p3, rhs) -> 
+        | Some (p3, rhs) ->
           match is_function_type env rhs with
           | None -> [p1;p2;p3], rhs
           | Some (p4, rhs) -> [p1;p2;p3;p4], rhs
@@ -1608,17 +1608,17 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
   | Atomic (Load, (Ref | Loc as kind), Pointer), _ ->
     (match is_function_type env ty with
     | None -> None
-    | Some (_, rhs) -> 
+    | Some (_, rhs) ->
       match fst (maybe_pointer_type env rhs) with
       | Pointer -> None
       | Immediate -> Some (Atomic (Load, kind, Immediate)))
   | Atomic (Load, Field, Pointer), _ ->
     (match is_function_type env ty with
     | None -> None
-    | Some (_, ty) -> 
+    | Some (_, ty) ->
       match is_function_type env ty with
       | None -> None
-      | Some (_, rhs) -> 
+      | Some (_, rhs) ->
         match fst (maybe_pointer_type env rhs) with
         | Pointer -> None
         | Immediate -> Some (Atomic (Load, Field, Immediate)))
@@ -1634,6 +1634,19 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
     (match fst (maybe_pointer_type env v) with
     | Pointer -> None
     | Immediate -> Some (Atomic (op, kind, Immediate)))
+  | Primitive (Pset_idx (_, m), arity), (_ :: _ :: p3 :: _) ->
+    (* CR layouts: This is gross - particularly the call to [type_jkind] and the
+       conversion to and from [mixed_block_element]! The slightly less gross
+       thing would be to change [layout_of_const_sort_generic] in the same way
+       that we have changed [transl_mixed_block_element] to desecend into
+       products. But that's a big change that (a) will have substantial
+       performance impacts for lots of cases that don't matter, and (b) will
+       become obsolete when we do complex values. So for now, the gross
+       thing. *)
+    let jkind = Ctype.type_jkind env p3 in
+    let mbe = Typedecl.mixed_block_element env p3 jkind in
+    let mbe = transl_mixed_block_element env (to_location loc) p3 mbe in
+    Some (Primitive (Pset_idx (layout_of_mixed_block_element mbe, m), arity))
   | _ -> None
 
 let caml_equal =

--- a/testsuite/tests/typing-layouts-caml-modify/basics.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/basics.ml
@@ -2,7 +2,9 @@
  modules = "replace_caml_modify.c";
  {
    not-macos;
-   flags = "-cclib -Xlinker -cclib --wrap -cclib -Xlinker -cclib caml_modify \
+   (* Remove layout_beta here when block indices are out of beta *)
+   flags = "-extension layouts_beta \
+            -cclib -Xlinker -cclib --wrap -cclib -Xlinker -cclib caml_modify \
             -cclib -Xlinker -cclib --wrap -cclib -Xlinker -cclib caml_modify_local";
    native;
  }
@@ -326,3 +328,77 @@ let () =
     outer.y <- U inner4_2;
     ignore (Sys.opaque_identity outer)
   )
+
+(* Setting an immediate or non-value block index should give only the needed
+   number of caml_modifies *)
+
+(* First layout poly versions *)
+external unsafe_set : ('a : value) ('b : any).
+  'a -> ('a, 'b) idx_mut -> 'b -> unit = "%unsafe_set_idx"
+[@@layout_poly]
+
+let () =
+  let open struct
+    type t = { x : string; mutable y : int }
+  end in
+  let t = { x = "x"; y = 0 } in
+  let idx = (.y) in
+  test ~expect_caml_modifies:1 (* should be 0 *)
+    (fun () -> unsafe_set t idx 1; ignore (Sys.opaque_identity t))
+
+let () =
+  let open struct
+    type t = { x : string; mutable y : int64# }
+  end in
+  let t = { x = "x"; y = #0L } in
+  let idx = (.y) in
+  test ~expect_caml_modifies:0
+    (fun () -> unsafe_set t idx #1L; ignore (Sys.opaque_identity t))
+
+let () =
+  let open struct
+    type t = { x : string; mutable y : #(int64# * string * bool)}
+  end in
+  let t = { x = "x"; y = #(#0L, "a", true) } in
+  let idx = (.y) in
+  test ~expect_caml_modifies:2 (* should be 1 *)
+    (fun () -> unsafe_set t idx #(#1L, "b", false);
+               ignore (Sys.opaque_identity t))
+
+(* Second, specialized versions *)
+external unsafe_set_imm : ('a : value) ('b : immediate).
+  'a -> ('a, 'b) idx_mut -> 'b -> unit = "%unsafe_set_idx"
+
+let () =
+  let open struct
+    type t = { x : string; mutable y : int }
+  end in
+  let t = { x = "x"; y = 0 } in
+  let idx = (.y) in
+  test ~expect_caml_modifies:1 (* should be 0 *)
+    (fun () -> unsafe_set_imm t idx 1; ignore (Sys.opaque_identity t))
+
+external unsafe_set_i64 : ('a : value) ('b : bits64).
+  'a -> ('a, 'b) idx_mut -> 'b -> unit = "%unsafe_set_idx"
+
+let () =
+  let open struct
+    type t = { x : string; mutable y : int64# }
+  end in
+  let t = { x = "x"; y = #0L } in
+  let idx = (.y) in
+  test ~expect_caml_modifies:0
+    (fun () -> unsafe_set_i64 t idx #1L; ignore (Sys.opaque_identity t))
+
+external unsafe_set_prod : ('a : value) ('b : bits64 & value & immediate).
+  'a -> ('a, 'b) idx_mut -> 'b -> unit = "%unsafe_set_idx"
+
+let () =
+  let open struct
+    type t = { x : string; mutable y : #(int64# * string * bool)}
+  end in
+  let t = { x = "x"; y = #(#0L, "a", true) } in
+  let idx = (.y) in
+  test ~expect_caml_modifies:3 (* should be 1 *)
+    (fun () -> unsafe_set_prod t idx #(#1L, "b", false);
+               ignore (Sys.opaque_identity t))

--- a/testsuite/tests/typing-layouts-caml-modify/basics.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/basics.ml
@@ -343,7 +343,7 @@ let () =
   end in
   let t = { x = "x"; y = 0 } in
   let idx = (.y) in
-  test ~expect_caml_modifies:1 (* should be 0 *)
+  test ~expect_caml_modifies:0
     (fun () -> unsafe_set t idx 1; ignore (Sys.opaque_identity t))
 
 let () =
@@ -361,7 +361,7 @@ let () =
   end in
   let t = { x = "x"; y = #(#0L, "a", true) } in
   let idx = (.y) in
-  test ~expect_caml_modifies:2 (* should be 1 *)
+  test ~expect_caml_modifies:1
     (fun () -> unsafe_set t idx #(#1L, "b", false);
                ignore (Sys.opaque_identity t))
 
@@ -375,7 +375,7 @@ let () =
   end in
   let t = { x = "x"; y = 0 } in
   let idx = (.y) in
-  test ~expect_caml_modifies:1 (* should be 0 *)
+  test ~expect_caml_modifies:0
     (fun () -> unsafe_set_imm t idx 1; ignore (Sys.opaque_identity t))
 
 external unsafe_set_i64 : ('a : value) ('b : bits64).
@@ -399,6 +399,6 @@ let () =
   end in
   let t = { x = "x"; y = #(#0L, "a", true) } in
   let idx = (.y) in
-  test ~expect_caml_modifies:3 (* should be 1 *)
+  test ~expect_caml_modifies:1
     (fun () -> unsafe_set_prod t idx #(#1L, "b", false);
                ignore (Sys.opaque_identity t))

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -67,6 +67,8 @@ val check_coherence:
 (* for fixed types *)
 val is_fixed_type : Parsetree.type_declaration -> bool
 
+val mixed_block_element : Env.t -> type_expr -> _ jkind -> mixed_block_element
+
 type native_repr_kind = Unboxed | Untagged
 
 (* Records reason for a jkind representability requirement in errors. *)


### PR DESCRIPTION
This improves the perf of block indices. It builds on the approach from #4553, but is a bit grosser because the types don't work out as well - see my comment and feel free to complain.

There are two commits, the first adds a test showing the unnecessary `caml_modify`s, and the second fixes it.