### PR TITLE
Print the value of "objcopy" configuration

### DIFF
--- a/utils/config.common.ml.in
+++ b/utils/config.common.ml.in
@@ -150,6 +150,7 @@ let configuration_variables () =
   p_bool "poll_insertion" poll_insertion;
   p_bool "ox" oxcaml;
   p_bool "oxcaml_dwarf" oxcaml_dwarf;
+  p "objcopy" objcopy;
 ]
 
 let print_config_value oc = function


### PR DESCRIPTION
Add "objcopy" to configuration variables that can be printed so that it shows up in `ocamlopt -config`. 

How do we decide what to include in that list? Why are we not printing all configuration variables?