### PR TITLE
Fix dwarf availability of parameters on function entry

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -400,6 +400,7 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
   ++ cfg_with_layout_profile ~accumulate:true "cfg_prologue" Cfg_prologue.run
   ++ cfg_with_layout_profile ~accumulate:true "cfg_prologue_validate"
        Cfg_prologue.validate
+  ++ pass_dump_cfg_if ppf_dump Oxcaml_flags.dump_cfg "After cfg_prologue"
   ++ Profile.record ~accumulate:true "cfg_invariants" (cfg_invariants ppf_dump)
   ++ cfg_with_layout_profile ~accumulate:true "cfg_simplify"
        Regalloc_utils.simplify_cfg

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -255,6 +255,40 @@ let find_prologue_and_epilogues_at_entry (cfg : Cfg.t) =
     Some (cfg.entry_label, epilogue_blocks)
   else None
 
+(* Add prologue at the start of the block, but after all the [Name_for_debugger]
+   instructions that refer to function parameters. Such operations always come
+   in a contiguous block (see selectgen). *)
+let add_prologue ~prologue_label (cfg : Cfg.t) =
+  let prologue_block = Cfg.get_block_exn cfg prologue_label in
+  let make_prologue_instruction ~(like : _ Cfg.instruction) =
+    Cfg.make_instruction_from_copy like ~desc:Cfg.Prologue
+      ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
+      ()
+  in
+  let is_param_name_for_debugger (basic : Cfg.basic) =
+    match[@warning "-4"] basic with
+    | Op (Name_for_debugger { which_parameter; _ }) ->
+      Option.is_some which_parameter
+    | _ -> false
+  in
+  let not_param_name_for_debugger (i : Cfg.basic Cfg.instruction) =
+    not (is_param_name_for_debugger i.desc)
+  in
+  let next_instr =
+    DLL.find_cell_opt ~f:not_param_name_for_debugger prologue_block.body
+  in
+  match next_instr with
+  | None ->
+    let prologue_instruction =
+      make_prologue_instruction ~like:prologue_block.terminator
+    in
+    DLL.add_end prologue_block.body prologue_instruction
+  | Some next_instr ->
+    let prologue_instruction =
+      make_prologue_instruction ~like:(DLL.value next_instr)
+    in
+    DLL.insert_before next_instr prologue_instruction
+
 let add_prologue_if_required (cfg : Cfg.t) ~f =
   let prologue_and_epilogue_blocks = f cfg in
   match prologue_and_epilogue_blocks with
@@ -263,16 +297,7 @@ let add_prologue_if_required (cfg : Cfg.t) ~f =
     let terminator_as_basic terminator =
       { terminator with Cfg.desc = Cfg.Prologue }
     in
-    let prologue_block = Cfg.get_block_exn cfg prologue_label in
-    let next_instr =
-      Option.value
-        (DLL.hd prologue_block.body)
-        ~default:(terminator_as_basic prologue_block.terminator)
-    in
-    DLL.add_begin prologue_block.body
-      (Cfg.make_instruction_from_copy next_instr ~desc:Cfg.Prologue
-         ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
-         ());
+    add_prologue ~prologue_label cfg;
     Label.Set.iter
       (fun label ->
         let block = Cfg.get_block_exn cfg label in

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -294,16 +294,12 @@ let add_prologue_if_required (cfg : Cfg.t) ~f =
   match prologue_and_epilogue_blocks with
   | None -> ()
   | Some (prologue_label, epilogue_blocks) ->
-    let terminator_as_basic terminator =
-      { terminator with Cfg.desc = Cfg.Prologue }
-    in
     add_prologue ~prologue_label cfg;
     Label.Set.iter
       (fun label ->
         let block = Cfg.get_block_exn cfg label in
-        let terminator = terminator_as_basic block.terminator in
         DLL.add_end block.body
-          (Cfg.make_instruction_from_copy terminator ~desc:Cfg.Epilogue
+          (Cfg.make_instruction_from_copy block.terminator ~desc:Cfg.Epilogue
              ~id:(InstructionId.get_and_incr cfg.next_instruction_id)
              ()))
       epilogue_blocks


### PR DESCRIPTION
CFG instructions `Name_for_debugger` that describe function parameters should appear before `Prologue`. 

Currently, this is not the case. `Name_for_debugger` instructions are inserted  into the `tailrec_entry` block during `cfg_selectgen`.    Prologue is inserted at the start of the entry block unconditionally in a later pass that doesn't take into account `Name_for_debugger` instructions. With shrink-wrapping, prolgoue can be pushed down to another block but will always be the first instruction in that block.

This problem can be observed during debugging of any ocaml function in lldb or gdb for example, the values of function parameters are not available when stopping at a breakpoint of the function symbol (i.e., the first address in a function). After stepping past the prologue in a debugger, the values become available.

This is actually handled correctly [upstream](https://github.com/gretay-js/ocaml/blob/b667fec2e7f78d68cbf0ef012f34c41f5ad40b08/asmcomp/linearize.ml#L264) but there are no tests for it and the special handling of this case was probably lost during our transition to cfg.

This PR restores the old behavior. Confirmed manually. 

I'll add tests separately. Both upstream and this PR don't handle parameters correctly after a tailrec call in the same function, I'll make a separate PR to fix it.

This PR is probably easier to review commit by commit. 