### PR TITLE
Shrink-wrapping: place epilogues earlier

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -399,6 +399,8 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
   ++ cfg_with_infos_profile ~accumulate:true "cfg_prologue" Cfg_prologue.run
   ++ cfg_with_infos_profile ~accumulate:true "cfg_prologue_validate"
        Cfg_prologue.validate
+  ++ cfg_with_infos_profile ~accumulate:true "cfg_prologue_count"
+       Cfg_prologue.count
   ++ Cfg_with_infos.cfg_with_layout
   ++ pass_dump_cfg_if ppf_dump Oxcaml_flags.dump_cfg "After cfg_prologue"
   ++ Profile.record ~accumulate:true "cfg_invariants" (cfg_invariants ppf_dump)

--- a/backend/cfg/cfg_prologue.mli
+++ b/backend/cfg/cfg_prologue.mli
@@ -3,3 +3,5 @@
 val run : Cfg_with_infos.t -> Cfg_with_infos.t
 
 val validate : Cfg_with_infos.t -> Cfg_with_infos.t
+
+val count : Cfg_with_infos.t -> Cfg_with_infos.t


### PR DESCRIPTION
Sometimes we can't shrink-wrap effectively because we have the condition that an epilogue is dominated by a prologue. To optimize how often the condition is met, we need to first move epilogues as far up as we can.

Previously, a set of "epilogue blocks" was computed for each block, which represented the subset of blocks where we would place an epilogue, if a prologue was placed there. This was computed by traversing the CFG and collecting all returns/tailcalls. Now, we instead do a dataflow analysis to figure out where a prologue stops being required, to find the earliest place on each path where we can place the epilogue, and we move the epilogue there.

This now may increase the code size, because an epilogue might be duplicated while it's being moved up.