### PR TITLE
Stop banning mixed blocks in JSIR translation

### DIFF
--- a/middle_end/flambda2/to_jsir/to_jsir_primitive.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_primitive.ml
@@ -589,8 +589,8 @@ let variadic ~env ~res (f : Flambda_primitive.variadic_primitive) xs =
     let tag =
       match kind with
       | Values (tag, _with_subkind) -> Tag.Scannable.to_tag tag
+      | Mixed (tag, _mixed_block_shape) -> Tag.Scannable.to_tag tag
       | Naked_floats -> Tag.double_array_tag
-      | Mixed _ -> failwith "unimplemented block kind"
     in
     let expr, env, res = To_jsir_shared.block ~env ~res ~tag ~mut ~fields:xs in
     let var = Jsir.Var.fresh () in


### PR DESCRIPTION
There is no reason why this should raise here.