### PR TITLE
Refactor caml_send to avoid `Addr` arg

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3492,7 +3492,7 @@ let send_function (arity, result, mode) =
   let body = Clet (VP.create clos', clos, body) in
   let fun_name = send_function_name arity result mode in
   let fun_args =
-    [obj, typ_val; tag, typ_int; cache, typ_addr; pos, typ_int]
+    [obj, typ_val; tag, typ_int; cache, typ_val; pos, typ_int]
     @ List.combine (List.tl args) arity
   in
   let fun_dbg = placeholder_fun_dbg ~human_name:fun_name in


### PR DESCRIPTION
Currently, `caml_send*` functions take an argument of machtype `Addr` that holds "cache pointer". This PR refactors the code of `caml_send` to take two arguments that represent the "cache base address" and "position" instead of one "cache pointer", and compute "cache pointer" inside of `caml_send*`. 

This is currently tested with llvm backend, but the change is not guared by it.

Recommend reviewing with `patdiff`.