### PR TITLE
Update default.nix with support for runtime quotations syntax

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,6 +13,7 @@
   warnError ? true,
   oxcamlClang ? false,
   oxcamlLldb ? false,
+  syntaxQuotations ? true,
 }:
 let
   pkgs = nixpkgs.pkgs or nixpkgs;
@@ -38,6 +39,7 @@ let
       (mkFlag stackChecks "stack-checks")
       (mkFlag warnError "warn-error")
       (mkFlag ocamltest "ocamltest")
+      (mkFlag syntaxQuotations "syntax-quotations")
     ];
 
   upstream = pkgs.ocaml-ng.ocamlPackages_4_14;

--- a/default.nix
+++ b/default.nix
@@ -13,7 +13,7 @@
   warnError ? true,
   oxcamlClang ? false,
   oxcamlLldb ? false,
-  syntaxQuotations ? true,
+  syntaxQuotations ? false,
 }:
 let
   pkgs = nixpkgs.pkgs or nixpkgs;


### PR DESCRIPTION
Configuring the compiler with `--enable-syntax-quotations` changes lexer behaviour: it emits tokens related to runtime metaprogramming when encountering `$`, `<[` and `]>`.

This pull requests adds the flag to `default.nix` and turns it on by default.