### PR TITLE
Default all new domains to recording backtraces

### DIFF
--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -377,6 +377,8 @@ module Runtime_5 = struct
 
     let body () =
       match
+        (* Always record backtraces, even on new domains *)
+        Printexc.record_backtrace true;
         DLS.create_dls ();
         DLS.set_initial_keys pk;
         let res = f () in


### PR DESCRIPTION
Recording backtraces seems like clearly a better default behavior than not recording backtraces, so just default all new domains to enabling backtrace recording. Users can disable it in their spawn functions if they want.