### PR TITLE
Fix JSIR float32 constants

### DIFF
--- a/middle_end/flambda2/to_jsir/to_jsir_shared.mli
+++ b/middle_end/flambda2/to_jsir/to_jsir_shared.mli
@@ -44,6 +44,20 @@ val bind_expr_to_var' :
   Jsir.expr ->
   Jsir.Var.t * To_jsir_env.t * To_jsir_result.t
 
+(** Convert various integer types into a [Jsir.constant]. *)
+val target_ocaml_int_to_jsir_const : Target_ocaml_int.t -> Jsir.constant
+
+val float32_to_jsir_const :
+  Numeric_types.Float32_by_bit_pattern.t -> Jsir.constant
+
+val float_to_jsir_const : Numeric_types.Float_by_bit_pattern.t -> Jsir.constant
+
+val int32_to_jsir_const : Int32.t -> Jsir.constant
+
+val int64_to_jsir_const : Int64.t -> Jsir.constant
+
+val nativeint_to_jsir_const : Targetint_32_64.t -> Jsir.constant
+
 (** Convert a Flambda [Reg_width_const.t] into a [Jsir.constant]. *)
 val reg_width_const : Reg_width_const.t -> Jsir.constant
 

--- a/middle_end/flambda2/to_jsir/to_jsir_static_const.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_static_const.ml
@@ -46,20 +46,6 @@ let const_or_var ~env ~res ~symbol ~to_jsir_const (x : 'a Or_variable.t) =
         let value_var = To_jsir_env.get_var_exn env v in
         env, To_jsir_result.add_instr_exn res (Assign (symbol_var, value_var)))
 
-let float32_to_jsir_const float32 : Jsir.constant =
-  Float32
-    (Numeric_types.Float32_by_bit_pattern.to_bits float32 |> Int64.of_int32)
-
-let float_to_jsir_const float : Jsir.constant =
-  Float32 (Numeric_types.Float_by_bit_pattern.to_bits float)
-
-let int32_to_jsir_const int32 : Jsir.constant = Int32 int32
-
-let int64_to_jsir_const int64 : Jsir.constant = Int64 int64
-
-let nativeint_to_jsir_const nativeint : Jsir.constant =
-  Int32 (Targetint_32_64.to_int32 nativeint)
-
 let block_or_array ~env ~res ~symbol ~tag ~mut ~array_or_not fields =
   let fields = List.map Simple.With_debuginfo.simple fields in
   let all_consts = List.for_all Simple.is_const fields in
@@ -128,15 +114,20 @@ let block_like ~env ~res symbol (const : Static_const.t) =
     let tag = Tag.Scannable.to_tag tag in
     block_or_array ~env ~res ~symbol ~tag ~mut ~array_or_not:NotArray fields
   | Boxed_float32 value ->
-    const_or_var ~env ~res ~symbol ~to_jsir_const:float32_to_jsir_const value
+    const_or_var ~env ~res ~symbol
+      ~to_jsir_const:To_jsir_shared.float32_to_jsir_const value
   | Boxed_float value ->
-    const_or_var ~env ~res ~symbol ~to_jsir_const:float_to_jsir_const value
+    const_or_var ~env ~res ~symbol
+      ~to_jsir_const:To_jsir_shared.float_to_jsir_const value
   | Boxed_int32 value ->
-    const_or_var ~env ~res ~symbol ~to_jsir_const:int32_to_jsir_const value
+    const_or_var ~env ~res ~symbol
+      ~to_jsir_const:To_jsir_shared.int32_to_jsir_const value
   | Boxed_int64 value ->
-    const_or_var ~env ~res ~symbol ~to_jsir_const:int64_to_jsir_const value
+    const_or_var ~env ~res ~symbol
+      ~to_jsir_const:To_jsir_shared.int64_to_jsir_const value
   | Boxed_nativeint value ->
-    const_or_var ~env ~res ~symbol ~to_jsir_const:nativeint_to_jsir_const value
+    const_or_var ~env ~res ~symbol
+      ~to_jsir_const:To_jsir_shared.nativeint_to_jsir_const value
   | Boxed_vec128 _ | Boxed_vec256 _ | Boxed_vec512 _ ->
     (* Need SIMD *)
     static_const_not_supported ()


### PR DESCRIPTION
We were wrongly looking at the int32 bit pattern and casting it to int64. What we should really do is look at the bit pattern of the corresponding double, since float32s are secretly just floats in the JSOO runtime.

Also some refactoring/deduping number -> const functions