### PR TITLE
Unsigned decimal literals

### DIFF
--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -554,8 +554,11 @@ let oct_literal =
   '0' ['o' 'O'] ['0'-'7'] ['0'-'7' '_']*
 let bin_literal =
   '0' ['b' 'B'] ['0'-'1'] ['0'-'1' '_']*
+let unsigned_decimal_literal =
+  '0' ['u' 'U'] ['0'-'9'] ['0'-'9' '_']*
 let int_literal =
-  decimal_literal | hex_literal | oct_literal | bin_literal
+  decimal_literal | hex_literal | oct_literal | bin_literal |
+  unsigned_decimal_literal
 let float_literal =
   ['0'-'9'] ['0'-'9' '_']*
   ('.' ['0'-'9' '_']* )?

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1381,6 +1381,28 @@ val x : float32 = 3.1400001s
 val x : unit -> float32# = <fun>
 |}]
 
+(*****************************)
+(* unsigned decimal literals *)
+
+let x = 0u42
+let x = 0U42
+let x = 0u9223372036854775807
+let x = -0u9223372036854775807
+let x = 0u18446744073709551615L
+let x = -0u18446744073709551615L
+let x () = #0u18446744073709551615L
+let x () = -#0u18446744073709551615L
+[%%expect{|
+val x : int = 42
+val x : int = 42
+val x : int = -1
+val x : int = 1
+val x : int64 = -1L
+val x : int64 = 1L
+val x : unit -> int64# = <fun>
+val x : unit -> int64# = <fun>
+|}]
+
 (********)
 (* simd *)
 (* CR mslater: Move documentation to GitHub *)

--- a/testsuite/tests/typing-layouts/literals.ml
+++ b/testsuite/tests/typing-layouts/literals.ml
@@ -169,6 +169,56 @@ Line 1, characters 36-51:
 Error: Integer literal exceeds the range of representable integers of type "int32#"
 |}]
 
+(*****************************)
+(* Unsigned decimal literals *)
+
+let x = 0u42
+let x = 0U42
+let x = 0u9223372036854775807
+let x = -0u9223372036854775807
+let x = 0u4294967295l
+let x = -0u4294967295l
+let x = 0u18446744073709551615L
+let x = -0u18446744073709551615L
+let x () = #0u18446744073709551615L
+let x () = -#0u18446744073709551615L
+[%%expect{|
+val x : int = 42
+val x : int = 42
+val x : int = -1
+val x : int = 1
+val x : int32 = -1l
+val x : int32 = 1l
+val x : int64 = -1L
+val x : int64 = 1L
+val x : unit -> int64# = <fun>
+val x : unit -> int64# = <fun>
+|}]
+
+let x = 0u9223372036854775808
+[%%expect{|
+Line 1, characters 8-29:
+1 | let x = 0u9223372036854775808
+            ^^^^^^^^^^^^^^^^^^^^^
+Error: Integer literal exceeds the range of representable integers of type "int"
+|}]
+
+let x = 0u18446744073709551616L
+[%%expect{|
+Line 1, characters 8-31:
+1 | let x = 0u18446744073709551616L
+            ^^^^^^^^^^^^^^^^^^^^^^^
+Error: Integer literal exceeds the range of representable integers of type "int64"
+|}]
+
+let x = 0u4294967296l
+[%%expect{|
+Line 1, characters 8-21:
+1 | let x = 0u4294967296l
+            ^^^^^^^^^^^^^
+Error: Integer literal exceeds the range of representable integers of type "int32"
+|}]
+
 (*****************************************)
 (* Patterns *)
 


### PR DESCRIPTION
Add unsigned decimal literals, prefixed with `0u`. This operates much like the `0x`, `0o`, and `0b` prefixes in that `0u` does not change the type of the literal, but does allow a wider range of values. See examples in `source_jane_street.ml`.