### PR TITLE
Support dynamic integer width selection for JavaScript backend

### DIFF
--- a/asmcomp/asminstantiator.ml
+++ b/asmcomp/asminstantiator.ml
@@ -29,8 +29,9 @@ let read_unit_info file : Instantiator.unit_info =
   let { Cmx_format.ui_unit; ui_arg_descr; ui_format; _ } = unit_info in
   { Instantiator.ui_unit; ui_arg_descr; ui_format; }
 
-let instantiate unix ~src ~args targetcmx ~flambda2 =
+let instantiate ~machine_width unix ~src ~args targetcmx ~flambda2 =
   Instantiator.instantiate ~src ~args targetcmx
     ~expected_extension:".cmx"
     ~read_unit_info
-    ~compile:(Optcompile.instance unix ~flambda2 ~keep_symbol_tables:false)
+    ~compile:(Optcompile.instance ~machine_width unix ~flambda2
+      ~keep_symbol_tables:false)

--- a/asmcomp/asminstantiator.mli
+++ b/asmcomp/asminstantiator.mli
@@ -25,13 +25,15 @@
  **********************************************************************************)
 
 val instantiate
-  : (module Compiler_owee.Unix_intf.S)
+   : machine_width:Target_system.Machine_width.t
+  -> (module Compiler_owee.Unix_intf.S)
   -> src:string
   -> args:string list
   -> string
   -> flambda2:(
       ppf_dump:Format.formatter ->
       prefixname:string ->
+      machine_width:Target_system.Machine_width.t ->
       keep_symbol_tables:bool ->
       Lambda.program ->
       Cmm.phrase list)

--- a/asmcomp/asmpackager.ml
+++ b/asmcomp/asmpackager.ml
@@ -85,11 +85,12 @@ let check_units members =
 type flambda2 =
   ppf_dump:Format.formatter ->
   prefixname:string ->
+  machine_width:Target_system.Machine_width.t ->
   keep_symbol_tables:bool ->
   Lambda.program ->
   Cmm.phrase list
 
-let make_package_object unix ~ppf_dump members target coercion
+let make_package_object ~machine_width unix ~ppf_dump members target coercion
       ~(flambda2 : flambda2) =
   let pack_name =
     Printf.sprintf "pack(%s)"
@@ -139,7 +140,7 @@ let make_package_object unix ~ppf_dump members target coercion
       }
     in
     let pipeline : Asmgen.pipeline =
-      Direct_to_cmm (flambda2 ~keep_symbol_tables:true)
+      Direct_to_cmm (flambda2 ~machine_width ~keep_symbol_tables:true)
     in
     Asmgen.compile_implementation ~pipeline unix
       ~sourcefile:(Unit_info.Artifact.original_source_file target)
@@ -222,19 +223,21 @@ let build_package_cmx members cmxfile ~main_module_block_size =
 
 (* Make the .cmx and the .o for the package *)
 
-let package_object_files unix ~ppf_dump files target
+let package_object_files ~machine_width unix ~ppf_dump files target
                          targetcmx coercion ~flambda2 =
   let pack_path = Unit_info.Artifact.modname target in
   let members = map_left_right (read_member_info pack_path) files in
   check_units members;
   let main_module_block_size =
-    make_package_object unix ~ppf_dump members target coercion ~flambda2
+    make_package_object ~machine_width unix ~ppf_dump members target coercion
+      ~flambda2
   in
   build_package_cmx members targetcmx ~main_module_block_size
 
 (* The entry point *)
 
-let package_files unix ~ppf_dump initial_env files targetcmx ~flambda2 =
+let package_files ~machine_width unix ~ppf_dump initial_env files targetcmx
+      ~flambda2 =
   let files =
     List.map
       (fun f ->
@@ -256,7 +259,7 @@ let package_files unix ~ppf_dump initial_env files targetcmx ~flambda2 =
   Misc.try_finally (fun () ->
       let coercion =
         Typemod.package_units initial_env files cmi comp_unit in
-      package_object_files unix ~ppf_dump files obj targetcmx
+      package_object_files ~machine_width unix ~ppf_dump files obj targetcmx
         coercion ~flambda2
     )
     ~exceptionally:(fun () ->

--- a/asmcomp/asmpackager.mli
+++ b/asmcomp/asmpackager.mli
@@ -17,7 +17,8 @@
    original compilation units as sub-modules. *)
 
 val package_files
-   : (module Compiler_owee.Unix_intf.S)
+   : machine_width:Target_system.Machine_width.t
+  -> (module Compiler_owee.Unix_intf.S)
   -> ppf_dump:Format.formatter
   -> Env.t
   -> string list
@@ -25,6 +26,7 @@ val package_files
   -> flambda2:(
     ppf_dump:Format.formatter ->
     prefixname:string ->
+    machine_width:Target_system.Machine_width.t ->
     keep_symbol_tables:bool ->
     Lambda.program ->
     Cmm.phrase list)

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -41,11 +41,6 @@ let current_section_is_text () =
   | None -> not_initialized ()
   | Some section -> Asm_section.section_is_text section
 
-let _big_endian () =
-  match !big_endian_ref with
-  | None -> not_initialized ()
-  | Some big_endian -> big_endian
-
 let emit_comments () =
   let emit_assembly_comments =
     match !emit_assembly_comments_ref with
@@ -491,9 +486,6 @@ module Directive = struct
     | Space { bytes } -> bprintf buf "\tBYTE\t%d DUP (?)" bytes
     | New_label (label, Code) -> bprintf buf "%s:" label
     | New_label (label, Machine_width_data) ->
-      (* Only 64-bit supported in To_cmm match TS.machine_width () with |
-         Thirty_two | Thirty_two_no_gc_tag_bit -> bprintf buf "%s LABEL DWORD"
-         label | Sixty_four -> *)
       bprintf buf "%s LABEL QWORD" label
     | New_line -> ()
     | Cfi_adjust_cfa_offset _ -> unsupported "Cfi_adjust_cfa_offset"
@@ -663,11 +655,7 @@ let const ?comment constant
   let constant = Directive.Constant_with_width.create constant width in
   emit (Const { constant; comment })
 
-let const_machine_width ?comment constant =
-  (* Only 64-bit supported in To_cmm match TS.machine_width () with | Thirty_two
-     | Thirty_two_no_gc_tag_bit -> const ?comment constant Thirty_two |
-     Sixty_four -> *)
-  const ?comment constant Sixty_four
+let const_machine_width ?comment constant = const ?comment constant Sixty_four
 
 let float32_core f f_int32 =
   let comment =
@@ -680,21 +668,10 @@ let float32 f = float32_core f (Int32.bits_of_float f)
 let float32_from_bits f = float32_core (Int32.float_of_bits f) f
 
 let float64_core f f_int64 =
-  (* Only 64-bit supported in To_cmm match TS.machine_width () with | Sixty_four
-     -> *)
   let comment =
     if !Clflags.keep_asm_file then Some (Printf.sprintf "%.17g" f) else None
   in
   const ?comment (Signed_int f_int64) Sixty_four
-(* | Thirty_two | Thirty_two_no_gc_tag_bit -> let comment_lo = if
-   !Clflags.keep_asm_file then Some (Printf.sprintf "low part of %.17g" f) else
-   None in let comment_hi = if !Clflags.keep_asm_file then Some (Printf.sprintf
-   "high part of %.17g" f) else None in let lo = Signed_int (Int64.logand
-   f_int64 0xffff_ffffL) in let hi = Signed_int (Int64.shift_right_logical
-   f_int64 32) in if big_endian () then ( const ?comment:comment_hi hi
-   Thirty_two; const ?comment:comment_lo lo Thirty_two) else ( const
-   ?comment:comment_lo lo Thirty_two; const ?comment:comment_hi hi
-   Thirty_two) *)
 
 let float64 f = float64_core f (Int64.bits_of_float f)
 

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -41,7 +41,7 @@ let current_section_is_text () =
   | None -> not_initialized ()
   | Some section -> Asm_section.section_is_text section
 
-let big_endian () =
+let _big_endian () =
   match !big_endian_ref with
   | None -> not_initialized ()
   | Some big_endian -> big_endian
@@ -490,10 +490,11 @@ module Directive = struct
     | Section _ -> Misc.fatal_error "Unknown section name for MASM emitter"
     | Space { bytes } -> bprintf buf "\tBYTE\t%d DUP (?)" bytes
     | New_label (label, Code) -> bprintf buf "%s:" label
-    | New_label (label, Machine_width_data) -> (
-      match TS.machine_width () with
-      | Thirty_two -> bprintf buf "%s LABEL DWORD" label
-      | Sixty_four -> bprintf buf "%s LABEL QWORD" label)
+    | New_label (label, Machine_width_data) ->
+      (* Only 64-bit supported in To_cmm match TS.machine_width () with |
+         Thirty_two | Thirty_two_no_gc_tag_bit -> bprintf buf "%s LABEL DWORD"
+         label | Sixty_four -> *)
+      bprintf buf "%s LABEL QWORD" label
     | New_line -> ()
     | Cfi_adjust_cfa_offset _ -> unsupported "Cfi_adjust_cfa_offset"
     | Cfi_def_cfa_offset _ -> unsupported "Cfi_def_cfa_offset"
@@ -663,9 +664,10 @@ let const ?comment constant
   emit (Const { constant; comment })
 
 let const_machine_width ?comment constant =
-  match TS.machine_width () with
-  | Thirty_two -> const ?comment constant Thirty_two
-  | Sixty_four -> const ?comment constant Sixty_four
+  (* Only 64-bit supported in To_cmm match TS.machine_width () with | Thirty_two
+     | Thirty_two_no_gc_tag_bit -> const ?comment constant Thirty_two |
+     Sixty_four -> *)
+  const ?comment constant Sixty_four
 
 let float32_core f f_int32 =
   let comment =
@@ -678,32 +680,21 @@ let float32 f = float32_core f (Int32.bits_of_float f)
 let float32_from_bits f = float32_core (Int32.float_of_bits f) f
 
 let float64_core f f_int64 =
-  match TS.machine_width () with
-  | Sixty_four ->
-    let comment =
-      if !Clflags.keep_asm_file then Some (Printf.sprintf "%.17g" f) else None
-    in
-    const ?comment (Signed_int f_int64) Sixty_four
-  | Thirty_two ->
-    let comment_lo =
-      if !Clflags.keep_asm_file
-      then Some (Printf.sprintf "low part of %.17g" f)
-      else None
-    in
-    let comment_hi =
-      if !Clflags.keep_asm_file
-      then Some (Printf.sprintf "high part of %.17g" f)
-      else None
-    in
-    let lo = Signed_int (Int64.logand f_int64 0xffff_ffffL) in
-    let hi = Signed_int (Int64.shift_right_logical f_int64 32) in
-    if big_endian ()
-    then (
-      const ?comment:comment_hi hi Thirty_two;
-      const ?comment:comment_lo lo Thirty_two)
-    else (
-      const ?comment:comment_lo lo Thirty_two;
-      const ?comment:comment_hi hi Thirty_two)
+  (* Only 64-bit supported in To_cmm match TS.machine_width () with | Sixty_four
+     -> *)
+  let comment =
+    if !Clflags.keep_asm_file then Some (Printf.sprintf "%.17g" f) else None
+  in
+  const ?comment (Signed_int f_int64) Sixty_four
+(* | Thirty_two | Thirty_two_no_gc_tag_bit -> let comment_lo = if
+   !Clflags.keep_asm_file then Some (Printf.sprintf "low part of %.17g" f) else
+   None in let comment_hi = if !Clflags.keep_asm_file then Some (Printf.sprintf
+   "high part of %.17g" f) else None in let lo = Signed_int (Int64.logand
+   f_int64 0xffff_ffffL) in let hi = Signed_int (Int64.shift_right_logical
+   f_int64 32) in if big_endian () then ( const ?comment:comment_hi hi
+   Thirty_two; const ?comment:comment_lo lo Thirty_two) else ( const
+   ?comment:comment_lo lo Thirty_two; const ?comment:comment_hi hi
+   Thirty_two) *)
 
 let float64 f = float64_core f (Int64.bits_of_float f)
 

--- a/driver/jscompile.ml
+++ b/driver/jscompile.ml
@@ -51,7 +51,8 @@ let raw_lambda_to_jsir i raw_lambda ~as_arg_for =
            make_arg_descr ~param:as_arg_for ~arg_block_idx:program.arg_block_idx
          in
          lambda |> fun code ->
-         Flambda2.lambda_to_flambda ~ppf_dump:i.ppf_dump
+         Flambda2.lambda_to_flambda ~machine_width:Thirty_two_no_gc_tag_bit
+           ~ppf_dump:i.ppf_dump
            ~prefixname:(Unit_info.prefix i.target)
            { program with code }
          |> fun (flambda_result : Flambda2.flambda_result) ->

--- a/driver/optcompile.mli
+++ b/driver/optcompile.mli
@@ -18,10 +18,12 @@
 val interface: source_file:string -> output_prefix:string -> unit
 
 val implementation
-   : (module Compiler_owee.Unix_intf.S)
+   : machine_width:Target_system.Machine_width.t
+  -> (module Compiler_owee.Unix_intf.S)
   -> flambda2:(
     ppf_dump:Format.formatter ->
     prefixname:string ->
+    machine_width:Target_system.Machine_width.t ->
     keep_symbol_tables:bool ->
     Lambda.program ->
     Cmm.phrase list)
@@ -30,10 +32,12 @@ val implementation
   -> unit
 
 val instance
-   : (module Compiler_owee.Unix_intf.S)
+   : machine_width:Target_system.Machine_width.t
+  -> (module Compiler_owee.Unix_intf.S)
   -> flambda2:(
     ppf_dump:Format.formatter ->
     prefixname:string ->
+    machine_width:Target_system.Machine_width.t ->
     keep_symbol_tables:bool ->
     Lambda.program ->
     Cmm.phrase list)

--- a/driver/optmaindriver.mli
+++ b/driver/optmaindriver.mli
@@ -25,6 +25,7 @@ val main
   -> flambda2:(
     ppf_dump:Format.formatter ->
     prefixname:string ->
+    machine_width:Target_system.Machine_width.t ->
     keep_symbol_tables:bool ->
     Lambda.program ->
     Cmm.phrase list)

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -255,8 +255,8 @@ let prepare_cmx_file_contents ~final_typing_env ~module_symbol ~used_value_slots
     prepare_cmx ~module_symbol create_typing_env ~free_names_of_name
       ~used_value_slots ~canonicalise ~exported_offsets all_code
 
-let prepare_cmx_from_approx ~approxs ~module_symbol ~exported_offsets
-    ~used_value_slots all_code =
+let prepare_cmx_from_approx ~machine_width ~approxs ~module_symbol
+    ~exported_offsets ~used_value_slots all_code =
   if Flambda_features.opaque ()
   then Name_occurrences.singleton_symbol module_symbol Name_mode.normal, None
   else
@@ -266,7 +266,8 @@ let prepare_cmx_from_approx ~approxs ~module_symbol ~exported_offsets
           (fun sym _ -> Name_occurrences.mem_symbol reachable_names sym)
           approxs
       in
-      TE.Serializable.create_from_closure_conversion_approx approxs
+      TE.Serializable.create_from_closure_conversion_approx ~machine_width
+        approxs
     in
     let free_names_of_name name =
       let symbol = Name.must_be_symbol name in

--- a/middle_end/flambda2/cmx/flambda_cmx.mli
+++ b/middle_end/flambda2/cmx/flambda_cmx.mli
@@ -43,6 +43,7 @@ val prepare_cmx_file_contents :
   Name_occurrences.t * Flambda_cmx_format.t option
 
 val prepare_cmx_from_approx :
+  machine_width:Target_system.Machine_width.t ->
   approxs:Code_or_metadata.t Value_approximation.t Symbol.Map.t ->
   module_symbol:Symbol.t ->
   exported_offsets:Exported_offsets.t ->

--- a/middle_end/flambda2/flambda2.mli
+++ b/middle_end/flambda2/flambda2.mli
@@ -19,6 +19,7 @@
 val lambda_to_cmm :
   ppf_dump:Format.formatter ->
   prefixname:string ->
+  machine_width:Target_system.Machine_width.t ->
   keep_symbol_tables:bool ->
   Lambda.program ->
   Cmm.phrase list
@@ -35,6 +36,7 @@ type flambda_result =
 val lambda_to_flambda :
   ppf_dump:Format.formatter ->
   prefixname:string ->
+  machine_width:Target_system.Machine_width.t ->
   Lambda.program ->
   flambda_result
 

--- a/middle_end/flambda2/from_lambda/closure_conversion.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion.mli
@@ -100,6 +100,7 @@ type 'a close_program_result =
 
 val close_program :
   mode:'mode Flambda_features.mode ->
+  machine_width:Target_system.Machine_width.t ->
   big_endian:bool ->
   cmx_loader:Flambda_cmx.loader ->
   compilation_unit:Compilation_unit.t ->

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -229,7 +229,10 @@ module Acc : sig
 
   type t
 
-  val create : cmx_loader:Flambda_cmx.loader -> t
+  val create :
+    cmx_loader:Flambda_cmx.loader ->
+    machine_width:Target_system.Machine_width.t ->
+    t
 
   val manufacture_symbol_short_name : t -> t * Linkage_name.t
 
@@ -245,6 +248,8 @@ module Acc : sig
   val code_map : t -> Code.t Code_id.Map.t
 
   val free_names : t -> Name_occurrences.t
+
+  val machine_width : t -> Target_system.Machine_width.t
 
   val seen_a_function : t -> bool
 

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.mli
@@ -18,6 +18,7 @@
 
 val lambda_to_flambda :
   mode:'mode Flambda_features.mode ->
+  machine_width:Target_system.Machine_width.t ->
   big_endian:bool ->
   cmx_loader:Flambda_cmx.loader ->
   compilation_unit:Compilation_unit.t ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_env.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_env.ml
@@ -70,6 +70,7 @@ end
 
 type t =
   { current_unit : Compilation_unit.t;
+    machine_width : Target_system.Machine_width.t;
     current_values_of_mutables_in_scope :
       ((Ident.t * Flambda_debug_uid.t * Flambda_kind.With_subkind.full_kind)
        list
@@ -92,7 +93,8 @@ type t =
     ident_stamp_upon_starting : int
   }
 
-let create ~current_unit ~return_continuation ~exn_continuation ~my_region =
+let create ~current_unit ~machine_width ~return_continuation ~exn_continuation
+    ~my_region =
   let mutables_needed_by_continuations =
     Continuation.Map.of_list
       [return_continuation, Ident.Set.empty; exn_continuation, Ident.Set.empty]
@@ -100,6 +102,7 @@ let create ~current_unit ~return_continuation ~exn_continuation ~my_region =
   let id = Ident.create_local "unused" in
   let ident_stamp_upon_starting = Ident.stamp id in
   { current_unit;
+    machine_width;
     current_values_of_mutables_in_scope = Ident.Map.empty;
     mutables_needed_by_continuations;
     unboxed_product_components_in_scope = Ident.Map.empty;
@@ -116,6 +119,8 @@ let create ~current_unit ~return_continuation ~exn_continuation ~my_region =
   }
 
 let current_unit t = t.current_unit
+
+let machine_width t = t.machine_width
 
 let ident_stamp_upon_starting t = t.ident_stamp_upon_starting
 

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_env.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_env.mli
@@ -30,12 +30,15 @@ end
 
 val create :
   current_unit:Compilation_unit.t ->
+  machine_width:Target_system.Machine_width.t ->
   return_continuation:Continuation.t ->
   exn_continuation:Continuation.t ->
   my_region:Region_stack_element.t option ->
   t
 
 val current_unit : t -> Compilation_unit.t
+
+val machine_width : t -> Target_system.Machine_width.t
 
 val ident_stamp_upon_starting : t -> int
 

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1300,7 +1300,7 @@ let rec array_load_unsafe ~machine_width ~array ~index
     let index : H.expr_primitive =
       let multiplier =
         List.length unarized
-        |> Target_ocaml_int.of_int Target_system.Machine_width.Sixty_four
+        |> Target_ocaml_int.of_int machine_width
         |> Simple.const_int
       in
       Binary (Int_arith (Tagged_immediate, Mul), index, Simple multiplier)
@@ -1376,7 +1376,7 @@ let rec array_set_unsafe ~machine_width dbg ~array ~index array_kind
     let index : H.expr_primitive =
       let multiplier =
         List.length unarized
-        |> Target_ocaml_int.of_int Target_system.Machine_width.Sixty_four
+        |> Target_ocaml_int.of_int machine_width
         |> Simple.const_int
       in
       Binary (Int_arith (Tagged_immediate, Mul), index, Simple multiplier)

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -128,7 +128,7 @@ let convert_init_or_assign (i_or_a : L.initialization_or_assignment) :
   | Root_initialization ->
     Misc.fatal_error "[Root_initialization] should not appear in Flambda input"
 
-let convert_block_shape (shape : L.block_shape) ~num_fields =
+let convert_block_shape ~machine_width (shape : L.block_shape) ~num_fields =
   match shape with
   | None -> List.init num_fields (fun _field -> K.With_subkind.any_value)
   | Some shape ->
@@ -139,7 +139,7 @@ let convert_block_shape (shape : L.block_shape) ~num_fields =
         "Flambda_arity.of_block_shape: num_fields is %d yet the shape has %d \
          fields"
         num_fields shape_length;
-    List.map K.With_subkind.from_lambda_value_kind shape
+    List.map (K.With_subkind.from_lambda_value_kind ~machine_width) shape
 
 let check_float_array_optimisation_enabled name =
   if not (Flambda_features.flat_float_array ())
@@ -696,12 +696,13 @@ let check_bound ~(index_kind : Lambda.array_index_kind) ~(bound_kind : I.t)
    the target architecture.
 
    It is equivalent to the `max_or_zero` function in `cmm_helpers.ml` *)
-let max_with_zero ~size_int x =
+let max_with_zero ~machine_width x =
+  let size_int = Target_system.Machine_width.size_in_bytes machine_width in
   let register_bitsize_minus_one =
     H.Simple
       (Simple.const
          (Reg_width_const.naked_immediate
-            (Target_ocaml_int.of_int ((size_int * 8) - 1))))
+            (Target_ocaml_int.of_int machine_width ((size_int * 8) - 1))))
   in
   let sign =
     H.Prim
@@ -710,7 +711,8 @@ let max_with_zero ~size_int x =
   let minus_one =
     H.Simple
       (Simple.const
-         (Reg_width_const.naked_nativeint (Targetint_32_64.of_int (-1))))
+         (Reg_width_const.naked_nativeint
+            (Targetint_32_64.of_int machine_width (-1))))
   in
   let sign_negation =
     H.Prim (Binary (Int_arith (Naked_nativeint, Xor), sign, minus_one))
@@ -721,7 +723,7 @@ let max_with_zero ~size_int x =
   ret
 
 (* actual (strict) upper bound for an index in a string-like read/write *)
-let actual_max_length_for_string_like_access_as_nativeint ~size_int
+let actual_max_length_for_string_like_access_as_nativeint ~machine_width
     ~(access_size : Flambda_primitive.string_accessor_width) length =
   (* offset to subtract from the length depending on the size of the
      read/write *)
@@ -736,7 +738,7 @@ let actual_max_length_for_string_like_access_as_nativeint ~size_int
       | Two_fifty_six _ -> 31
       | Five_twelve _ -> 63
     in
-    Targetint_32_64.of_int offset
+    Targetint_32_64.of_int machine_width offset
   in
   (* We need to convert the length into a naked_nativeint because the optimised
      version of the max_with_zero function needs to be on machine-width integers
@@ -757,37 +759,39 @@ let actual_max_length_for_string_like_access_as_nativeint ~size_int
              length,
              Simple (Simple.const (Reg_width_const.naked_nativeint offset)) ))
     in
-    max_with_zero ~size_int reduced_length
+    max_with_zero ~machine_width reduced_length
 
 (* String-like validity conditions *)
 
-let string_like_access_validity_condition ~size_int ~access_size ~length
+let string_like_access_validity_condition ~machine_width ~access_size ~length
     ~index_kind index : H.expr_primitive =
   check_bound ~index_kind ~bound_kind:Naked_nativeint ~index
     ~bound:
-      (actual_max_length_for_string_like_access_as_nativeint ~size_int
+      (actual_max_length_for_string_like_access_as_nativeint ~machine_width
          ~access_size length)
 
-let string_or_bytes_access_validity_condition ~size_int str kind access_size
-    ~index_kind index : H.expr_primitive =
-  string_like_access_validity_condition ~index_kind index ~size_int ~access_size
+let string_or_bytes_access_validity_condition ~machine_width str kind
+    access_size ~index_kind index : H.expr_primitive =
+  string_like_access_validity_condition ~index_kind index ~machine_width
+    ~access_size
     ~length:(Prim (Unary (String_length kind, str)))
 
-let bigstring_access_validity_condition ~size_int big_str access_size
+let bigstring_access_validity_condition ~machine_width big_str access_size
     ~index_kind index : H.expr_primitive =
-  string_like_access_validity_condition ~index_kind index ~size_int ~access_size
+  string_like_access_validity_condition ~index_kind index ~machine_width
+    ~access_size
     ~length:(bigarray_dim_bound big_str 1)
 
-let bigstring_alignment_validity_condition bstr alignment tagged_index :
-    H.expr_primitive =
+let bigstring_alignment_validity_condition ~machine_width bstr alignment
+    tagged_index : H.expr_primitive =
   Binary
     ( Int_comp (I.Naked_immediate, Yielding_bool Eq),
       Prim
         (Binary (Bigarray_get_alignment alignment, bstr, untag_int tagged_index)),
-      Simple Simple.untagged_const_zero )
+      Simple (Simple.untagged_const_zero machine_width) )
 
-let checked_string_or_bytes_access ~dbg ~size_int ~access_size ~primitive kind
-    string ~index_kind index =
+let checked_string_or_bytes_access ~dbg ~machine_width ~access_size ~primitive
+    kind string ~index_kind index =
   (match (access_size : P.string_accessor_width) with
   | Eight | Sixteen | Thirty_two | Single | Sixty_four
   | One_twenty_eight { aligned = false }
@@ -801,27 +805,27 @@ let checked_string_or_bytes_access ~dbg ~size_int ~access_size ~primitive kind
       "flambda2 cannot yet check string/bytes aligned access safety");
   checked_access ~dbg ~primitive
     ~conditions:
-      [ string_or_bytes_access_validity_condition ~size_int string kind
+      [ string_or_bytes_access_validity_condition ~machine_width string kind
           access_size ~index_kind index ]
 
-let checked_bigstring_access ~dbg ~size_int ~access_size ~primitive arg1
+let checked_bigstring_access ~dbg ~machine_width ~access_size ~primitive arg1
     ~index_kind arg2 =
   let primitive =
     match (access_size : P.string_accessor_width) with
     | One_twenty_eight { aligned = true } ->
       checked_alignment ~dbg ~primitive
         ~conditions:
-          [ bigstring_alignment_validity_condition arg1 16
+          [ bigstring_alignment_validity_condition ~machine_width arg1 16
               (convert_index_to_tagged_int ~index:arg2 ~index_kind) ]
     | Two_fifty_six { aligned = true } ->
       checked_alignment ~dbg ~primitive
         ~conditions:
-          [ bigstring_alignment_validity_condition arg1 32
+          [ bigstring_alignment_validity_condition ~machine_width arg1 32
               (convert_index_to_tagged_int ~index:arg2 ~index_kind) ]
     | Five_twelve { aligned = true } ->
       checked_alignment ~dbg ~primitive
         ~conditions:
-          [ bigstring_alignment_validity_condition arg1 64
+          [ bigstring_alignment_validity_condition ~machine_width arg1 64
               (convert_index_to_tagged_int ~index:arg2 ~index_kind) ]
     | Eight | Sixteen | Thirty_two | Single | Sixty_four
     | One_twenty_eight { aligned = false }
@@ -831,12 +835,12 @@ let checked_bigstring_access ~dbg ~size_int ~access_size ~primitive arg1
   in
   checked_access ~dbg ~primitive
     ~conditions:
-      [ bigstring_access_validity_condition ~size_int arg1 access_size
+      [ bigstring_access_validity_condition ~machine_width arg1 access_size
           ~index_kind arg2 ]
 
 (* String-like loads *)
 let string_like_load ~dbg ~unsafe
-    ~(access_size : Flambda_primitive.string_accessor_width) ~size_int
+    ~(access_size : Flambda_primitive.string_accessor_width) ~machine_width
     (kind : P.string_like_value) mode ~boxed string ~index_kind index
     ~current_region =
   let unsafe_load =
@@ -875,7 +879,7 @@ let string_like_load ~dbg ~unsafe
       | Bytes -> checked_string_or_bytes_access Bytes
       | Bigstring -> checked_bigstring_access
     in
-    check_access ~dbg ~size_int ~access_size ~primitive:unsafe_load string
+    check_access ~dbg ~machine_width ~access_size ~primitive:unsafe_load string
       ~index_kind index
 
 let get_header obj mode ~current_region =
@@ -884,7 +888,7 @@ let get_header obj mode ~current_region =
 
 (* Bytes-like set *)
 let bytes_like_set ~dbg ~unsafe
-    ~(access_size : Flambda_primitive.string_accessor_width) ~size_int
+    ~(access_size : Flambda_primitive.string_accessor_width) ~machine_width
     (kind : P.bytes_like_value) ~boxed bytes ~index_kind index new_value =
   let unsafe_set =
     let index = convert_index_to_untagged_int ~index ~index_kind in
@@ -911,7 +915,7 @@ let bytes_like_set ~dbg ~unsafe
       | Bytes -> checked_string_or_bytes_access Bytes
       | Bigstring -> checked_bigstring_access
     in
-    check_access ~dbg ~size_int ~access_size ~primitive:unsafe_set bytes
+    check_access ~dbg ~machine_width ~access_size ~primitive:unsafe_set bytes
       ~index_kind index
 
 (* Array bounds checks *)
@@ -938,7 +942,7 @@ let bytes_like_set ~dbg ~unsafe
 
 (* CR mshinwell: When considering vectors and unboxed products, we should think
    again about whether the abstractions/concepts here can be improved. *)
-let multiple_word_array_access_validity_condition array ~size_int
+let multiple_word_array_access_validity_condition array ~machine_width
     array_length_kind (index_kind : L.array_index_kind)
     ~num_consecutive_elements_being_accessed ~index =
   let width_in_scalars_per_access =
@@ -976,7 +980,7 @@ let multiple_word_array_access_validity_condition array ~size_int
                length_untagged,
                Simple
                  (Simple.untagged_const_int
-                    (Target_ocaml_int.of_int
+                    (Target_ocaml_int.of_int machine_width
                        (num_consecutive_elements_being_accessed - 1))) ))
     in
     (* We need to convert the length into a naked_nativeint because the
@@ -989,7 +993,9 @@ let multiple_word_array_access_validity_condition array ~size_int
            ( Num_conv { src = Naked_immediate; dst = Naked_nativeint },
              reduced_length_untagged ))
     in
-    let nativeint_bound = max_with_zero ~size_int reduced_length_nativeint in
+    let nativeint_bound =
+      max_with_zero ~machine_width reduced_length_nativeint
+    in
     let nativeint_bound : H.simple_or_prim =
       if width_in_scalars_per_access = 1
       then nativeint_bound
@@ -1004,7 +1010,8 @@ let multiple_word_array_access_validity_condition array ~size_int
                Simple
                  (Simple.const
                     (Reg_width_const.naked_nativeint
-                       (Targetint_32_64.of_int width_in_scalars_per_access))) ))
+                       (Targetint_32_64.of_int machine_width
+                          width_in_scalars_per_access))) ))
     in
     check_bound ~index_kind ~bound_kind:Naked_nativeint ~index
       ~bound:nativeint_bound
@@ -1013,7 +1020,7 @@ let multiple_word_array_access_validity_condition array ~size_int
 (* CR mshinwell: it seems like these could be folded into the normal array
    load/store functions below *)
 
-let array_vector_access_validity_condition array ~size_int
+let array_vector_access_validity_condition array ~machine_width
     ~(vec_kind : Vector_types.Kind.t) (array_kind : P.Array_kind.t) index =
   let size_of_element =
     match array_kind with
@@ -1037,19 +1044,19 @@ let array_vector_access_validity_condition array ~size_int
   let num_consecutive_elements_being_accessed =
     (size_of_access + (size_of_element - 1)) / size_of_element
   in
-  multiple_word_array_access_validity_condition array ~size_int
+  multiple_word_array_access_validity_condition array ~machine_width
     (Array_kind array_kind) Ptagged_int_index
     ~num_consecutive_elements_being_accessed ~index
 
-let check_array_vector_access ~dbg ~size_int ~array array_kind ~index ~vec_kind
-    primitive : H.expr_primitive =
+let check_array_vector_access ~dbg ~machine_width ~array array_kind ~index
+    ~vec_kind primitive : H.expr_primitive =
   checked_access ~primitive
     ~conditions:
-      [ array_vector_access_validity_condition ~size_int ~vec_kind array
+      [ array_vector_access_validity_condition ~machine_width ~vec_kind array
           array_kind index ]
     ~dbg
 
-let array_like_load_vec ~dbg ~size_int ~unsafe ~mode ~boxed ~current_region
+let array_like_load_vec ~dbg ~machine_width ~unsafe ~mode ~boxed ~current_region
     ~(vec_kind : Vector_types.Kind.t) array_kind array ~index_kind index =
   let index = convert_index_to_tagged_int ~index ~index_kind in
   let load_kind, box =
@@ -1067,10 +1074,10 @@ let array_like_load_vec ~dbg ~size_int ~unsafe ~mode ~boxed ~current_region
   if unsafe
   then primitive
   else
-    check_array_vector_access ~dbg ~size_int ~array array_kind ~index ~vec_kind
-      primitive
+    check_array_vector_access ~dbg ~machine_width ~array array_kind ~index
+      ~vec_kind primitive
 
-let array_like_set_vec ~dbg ~size_int ~unsafe ~boxed
+let array_like_set_vec ~dbg ~machine_width ~unsafe ~boxed
     ~(vec_kind : Vector_types.Kind.t) array_kind array ~index_kind index
     new_value =
   let index = convert_index_to_tagged_int ~index ~index_kind in
@@ -1087,8 +1094,8 @@ let array_like_set_vec ~dbg ~size_int ~unsafe ~boxed
   if unsafe
   then primitive
   else
-    check_array_vector_access ~dbg ~size_int ~array array_kind ~index ~vec_kind
-      primitive
+    check_array_vector_access ~dbg ~machine_width ~array array_kind ~index
+      ~vec_kind primitive
 
 (* Bigarray accesses *)
 let bigarray_box_or_tag_raw_value_to_read kind alloc_mode =
@@ -1164,7 +1171,7 @@ let bigarray_unbox_or_untag_value_to_store kind =
    is done in the validity check, and one in the final offset computation,
    whereas cmmgen let-binds this access. It might matter for the performance,
    although the processor cache might make it not matter at all. *)
-let bigarray_indexing layout b args =
+let bigarray_indexing ~machine_width layout b args =
   let num_dim = List.length args in
   let rec aux dim delta_dim = function
     | [] -> assert false
@@ -1206,44 +1213,45 @@ let bigarray_indexing layout b args =
              (Binary
                 ( Int_arith (I.Tagged_immediate, Sub),
                   idx,
-                  H.Simple (Simple.const_int Target_ocaml_int.one) )))
+                  H.Simple
+                    (Simple.const_int (Target_ocaml_int.one machine_width)) )))
          args)
 
-let bigarray_access ~dbg ~unsafe ~access layout b indexes =
+let bigarray_access ~machine_width ~dbg ~unsafe ~access layout b indexes =
   let num_dim = List.length indexes in
-  let checks, offset = bigarray_indexing layout b indexes in
+  let checks, offset = bigarray_indexing ~machine_width layout b indexes in
   let primitive = access num_dim offset in
   if unsafe
   then primitive
   else checked_access ~dbg ~conditions:checks ~primitive
 
-let bigarray_load ~dbg ~unsafe kind layout b indexes =
+let bigarray_load ~machine_width ~dbg ~unsafe kind layout b indexes =
   let access num_dim offset =
     H.Binary (Bigarray_load (num_dim, kind, layout), b, offset)
   in
-  bigarray_access ~dbg ~unsafe ~access layout b indexes
+  bigarray_access ~machine_width ~dbg ~unsafe ~access layout b indexes
 
-let bigarray_set ~dbg ~unsafe kind layout b indexes value =
+let bigarray_set ~machine_width ~dbg ~unsafe kind layout b indexes value =
   let access num_dim offset =
     H.Ternary (Bigarray_set (num_dim, kind, layout), b, offset, value)
   in
-  bigarray_access ~dbg ~unsafe ~access layout b indexes
+  bigarray_access ~machine_width ~dbg ~unsafe ~access layout b indexes
 
 (* Array accesses *)
 let array_access_validity_condition array array_kind index
-    ~(index_kind : L.array_index_kind) ~size_int =
-  [ multiple_word_array_access_validity_condition array ~size_int array_kind
-      index_kind ~num_consecutive_elements_being_accessed:1 ~index ]
+    ~(index_kind : L.array_index_kind) ~machine_width =
+  [ multiple_word_array_access_validity_condition array ~machine_width
+      array_kind index_kind ~num_consecutive_elements_being_accessed:1 ~index ]
 
-let check_array_access ~dbg ~array array_kind ~index ~index_kind ~size_int
+let check_array_access ~dbg ~array array_kind ~index ~index_kind ~machine_width
     primitive : H.expr_primitive =
   checked_access ~primitive
     ~conditions:
       (array_access_validity_condition array array_kind index ~index_kind
-         ~size_int)
+         ~machine_width)
     ~dbg
 
-let compute_array_indexes ~index ~num_elts =
+let compute_array_indexes ~machine_width ~index ~num_elts =
   if num_elts <= 0 then Misc.fatal_errorf "Illegal num_elts value: %d" num_elts;
   List.init num_elts (fun offset ->
       assert (offset >= 0);
@@ -1254,11 +1262,13 @@ let compute_array_indexes ~index ~num_elts =
           (Binary
              ( Int_arith (Tagged_immediate, Add),
                index,
-               Simple (Simple.const_int (Target_ocaml_int.of_int offset)) )))
+               Simple
+                 (Simple.const_int
+                    (Target_ocaml_int.of_int machine_width offset)) )))
 
-let rec array_load_unsafe ~array ~index ~(mut : Lambda.mutable_flag) array_kind
-    (array_ref_kind : Array_ref_kind.t) ~current_region : H.expr_primitive list
-    =
+let rec array_load_unsafe ~machine_width ~array ~index
+    ~(mut : Lambda.mutable_flag) array_kind (array_ref_kind : Array_ref_kind.t)
+    ~current_region : H.expr_primitive list =
   (* CR mshinwell/ncourant: can we avoid taking [array_kind] here? *)
   let mut' : Mutability.t =
     match mut with
@@ -1289,18 +1299,21 @@ let rec array_load_unsafe ~array ~index ~(mut : Lambda.mutable_flag) array_kind
     let unarized = List.concat_map unarize_kind array_ref_kinds in
     let index : H.expr_primitive =
       let multiplier =
-        List.length unarized |> Target_ocaml_int.of_int |> Simple.const_int
+        List.length unarized
+        |> Target_ocaml_int.of_int Target_system.Machine_width.Sixty_four
+        |> Simple.const_int
       in
       Binary (Int_arith (Tagged_immediate, Mul), index, Simple multiplier)
     in
     let indexes =
       (* Reminder: all of the unarized components are machine word width. *)
-      compute_array_indexes ~index:(Prim index) ~num_elts:(List.length unarized)
+      compute_array_indexes ~machine_width ~index:(Prim index)
+        ~num_elts:(List.length unarized)
     in
     List.concat_map
       (fun (index, array_ref_kind) ->
-        array_load_unsafe ~array ~index ~mut array_kind array_ref_kind
-          ~current_region)
+        array_load_unsafe ~machine_width ~array ~index ~mut array_kind
+          array_ref_kind ~current_region)
       (List.combine indexes unarized)
   | No_float_array_opt
       (( Immediates | Values | Naked_floats | Naked_float32s | Naked_int32s
@@ -1322,13 +1335,13 @@ let rec array_load_unsafe ~array ~index ~(mut : Lambda.mutable_flag) array_kind
     in
     [Binary (Array_load (array_kind, array_load_kind, mut'), array, index)]
 
-let array_load_unsafe ~array ~index ~mut array_kind array_load_kind
-    ~current_region =
-  array_load_unsafe ~array ~index ~mut array_kind array_load_kind
+let array_load_unsafe ~machine_width ~array ~index ~mut array_kind
+    array_load_kind ~current_region =
+  array_load_unsafe ~machine_width ~array ~index ~mut array_kind array_load_kind
     ~current_region
   |> H.maybe_create_unboxed_product
 
-let rec array_set_unsafe dbg ~array ~index array_kind
+let rec array_set_unsafe ~machine_width dbg ~array ~index array_kind
     (array_set_kind : Array_set_kind.t) ~new_values : H.expr_primitive list =
   let[@local] normal_case array_set_kind new_values =
     match new_values with
@@ -1362,13 +1375,16 @@ let rec array_set_unsafe dbg ~array ~index array_kind
     let unarized = List.concat_map unarize_kind array_set_kinds in
     let index : H.expr_primitive =
       let multiplier =
-        List.length unarized |> Target_ocaml_int.of_int |> Simple.const_int
+        List.length unarized
+        |> Target_ocaml_int.of_int Target_system.Machine_width.Sixty_four
+        |> Simple.const_int
       in
       Binary (Int_arith (Tagged_immediate, Mul), index, Simple multiplier)
     in
     let indexes =
       (* Reminder: all of the unarized components are machine word width. *)
-      compute_array_indexes ~index:(Prim index) ~num_elts:(List.length unarized)
+      compute_array_indexes ~machine_width ~index:(Prim index)
+        ~num_elts:(List.length unarized)
     in
     if List.compare_lengths indexes new_values <> 0
     then
@@ -1379,8 +1395,8 @@ let rec array_set_unsafe dbg ~array ~index array_kind
     [ H.Sequence
         (List.concat_map
            (fun (index, (array_set_kind, new_value)) ->
-             array_set_unsafe dbg ~array ~index array_kind array_set_kind
-               ~new_values:[new_value])
+             array_set_unsafe ~machine_width dbg ~array ~index array_kind
+               array_set_kind ~new_values:[new_value])
            (List.combine indexes (List.combine unarized new_values))) ]
   | No_float_array_opt
       (( Immediates | Values _ | Naked_floats | Naked_float32s | Naked_int32s
@@ -1399,8 +1415,10 @@ let rec array_set_unsafe dbg ~array ~index array_kind
     | Naked_vec512s -> normal_case Naked_vec512s new_values
     | Unboxed_product _ -> assert false)
 
-let array_set_unsafe dbg ~array ~index array_kind array_set_kind ~new_values =
-  array_set_unsafe dbg ~array ~index array_kind array_set_kind ~new_values
+let array_set_unsafe ~machine_width dbg ~array ~index array_kind array_set_kind
+    ~new_values =
+  array_set_unsafe ~machine_width dbg ~array ~index array_kind array_set_kind
+    ~new_values
   |> H.maybe_create_unboxed_product
 
 let[@inline always] match_on_array_ref_kind ~array array_ref_kind f :
@@ -1441,10 +1459,11 @@ let[@inline always] match_on_array_set_kind ~array array_set_kind f :
            a singleton. *)
         [K.With_subkind.tagged_immediate] )
 
-let const width i = Simple.const_int_of_kind (I.to_kind width) i
+let const ~machine_width width i =
+  Simple.const_int_of_kind ~machine_width (I.to_kind width) i
 
-let check_zero_division width arg1 arg2 (operator : P.binary_int_arith_op) dbg :
-    H.expr_primitive =
+let check_zero_division ~machine_width width arg1 arg2
+    (operator : P.binary_int_arith_op) dbg : H.expr_primitive =
   (* CR gbury: try and avoid the unboxing duplication of arg2. (the simplifier
      might cse the duplication away, but it won't be the case for classic
      mode). *)
@@ -1452,14 +1471,18 @@ let check_zero_division width arg1 arg2 (operator : P.binary_int_arith_op) dbg :
     { primitive = Binary (Int_arith (width, operator), arg1, arg2);
       validity_conditions =
         [ Binary
-            (Int_comp (width, Yielding_bool Neq), arg2, Simple (const width 0))
-        ];
+            ( Int_comp (width, Yielding_bool Neq),
+              arg2,
+              Simple (const ~machine_width width 0) ) ];
       failure = Division_by_zero;
       dbg
     }
 
-let opaque layout arg ~middle_end_only : H.expr_primitive list =
-  let kinds = Flambda_arity.unarize (Flambda_arity.from_lambda_list [layout]) in
+let opaque ~machine_width layout arg ~middle_end_only : H.expr_primitive list =
+  let kinds =
+    Flambda_arity.unarize
+      (Flambda_arity.from_lambda_list [layout] ~machine_width)
+  in
   if List.compare_lengths kinds arg <> 0
   then
     Misc.fatal_error
@@ -1602,7 +1625,7 @@ let extract_block_index_offset idx =
 
 (* Given an index that points to data of some layout, produce the list of
    offsets needed to access each element *)
-let block_index_access_offsets layout idx =
+let block_index_access_offsets ~machine_width layout idx =
   assert (Target_system.is_64_bit ());
   let module MPB = Mixed_product_bytes in
   let mbe = L.mixed_block_element_of_layout layout in
@@ -1611,7 +1634,7 @@ let block_index_access_offsets layout idx =
   then
     let offset = extract_block_index_offset idx in
     let gap =
-      let shift = H.simple_untagged_int block_index_mask_size in
+      let shift = H.simple_untagged_int ~machine_width block_index_mask_size in
       H.Binary (Int_shift (Naked_int64, Lsr), idx, shift)
     in
     let f (to_left : MPB.t) (mbe : unit L.mixed_block_element) =
@@ -1652,17 +1675,15 @@ let block_index_access_offsets layout idx =
     snd (List.fold_left_map f MPB.zero (L.mixed_block_element_leaves mbe))
 
 (* Primitive conversion *)
-let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
-    (dbg : Debuginfo.t) ~current_region ~current_ghost_region :
-    H.expr_primitive list =
+let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
+    (prim : L.primitive) (args : Simple.t list list) (dbg : Debuginfo.t)
+    ~current_region ~current_ghost_region : H.expr_primitive list =
   let orig_args = args in
   let args =
     List.map (List.map (fun arg : H.simple_or_prim -> Simple arg)) args
   in
-  let size_int =
-    assert (Targetint_32_64.size mod 8 = 0);
-    Targetint_32_64.size / 8
-  in
+  let size_int = Target_system.Machine_width.size_in_bytes machine_width in
+  assert (size_int mod 8 = 0);
   match prim, args with
   | Pphys_equal eq, [[arg1]; [arg2]] ->
     let eq : P.equality_comparison = match eq with Eq -> Eq | Noteq -> Neq in
@@ -1671,7 +1692,9 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     let args = List.flatten args in
     let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in
     let tag = Tag.Scannable.create_exn tag in
-    let shape = convert_block_shape shape ~num_fields:(List.length args) in
+    let shape =
+      convert_block_shape ~machine_width shape ~num_fields:(List.length args)
+    in
     let mutability = Mutability.from_lambda mutability in
     [Variadic (Make_block (Values (tag, shape), mutability, mode), args)]
   | Pmakelazyblock lazy_tag, [[arg]] -> [Unary (Make_lazy lazy_tag, arg)]
@@ -1690,13 +1713,15 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     let field_arity_component =
       (* N.B. The arity of the field being projected may in itself be an unboxed
          product. *)
-      layouts_array.(n) |> Flambda_arity.Component_for_creation.from_lambda
+      layouts_array.(n)
+      |> Flambda_arity.Component_for_creation.from_lambda ~machine_width
     in
     let field_arity = Flambda_arity.create [field_arity_component] in
     let num_fields_prior_to_projected_fields =
       Misc.Stdlib.List.split_at n layouts
       |> fst
-      |> List.map Flambda_arity.Component_for_creation.from_lambda
+      |> List.map
+           (Flambda_arity.Component_for_creation.from_lambda ~machine_width)
       |> Flambda_arity.create |> Flambda_arity.cardinal_unarized
     in
     let num_projected_fields = Flambda_arity.cardinal_unarized field_arity in
@@ -1714,7 +1739,10 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     (* This is implemented as a unary primitive, but from our point of view it's
        actually nullary. *)
     let num_bytes = L.array_element_size_in_bytes array_kind in
-    [Simple (Simple.const_int (Target_ocaml_int.of_int num_bytes))]
+    [ Simple
+        (Simple.const_int
+           (Target_ocaml_int.of_int Target_system.Machine_width.Sixty_four
+              num_bytes)) ]
   | Pmake_idx_field pos, [] ->
     needs_64_bit_target prim dbg;
     let idx_raw_value = Int64.mul (Int64.of_int pos) 8L in
@@ -1828,7 +1856,9 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     | Mixed_product_to_all_flats ->
       (* offset += gap + left value + right value + left flat; gap = 0 *)
       let offset = extract_block_index_offset idx in
-      let shifter = H.simple_untagged_int block_index_mask_size in
+      let shifter =
+        H.simple_untagged_int block_index_mask_size ~machine_width
+      in
       let gap = H.Binary (Int_shift (Naked_int64, Lsr), idx, shifter) in
       let to_add =
         Int64.of_int
@@ -1940,18 +1970,21 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     Misc.fatal_error
       "Lambda_to_flambda_primitives.convert_lprim: Pmakearray_dynamic and \
        Parrayblit should have been expanded in [Lambda_to_lambda_transforms]"
-  | Popaque layout, [arg] -> opaque layout arg ~middle_end_only:false
-  | Pobj_magic layout, [arg] -> opaque layout arg ~middle_end_only:true
+  | Popaque layout, [arg] ->
+    opaque ~machine_width layout arg ~middle_end_only:false
+  | Pobj_magic layout, [arg] ->
+    opaque ~machine_width layout arg ~middle_end_only:true
   | Pduprecord (repr, num_fields), [[arg]] ->
     let kind : P.Duplicate_block_kind.t =
       match repr with
       | Record_boxed _ ->
         Values
           { tag = Tag.Scannable.zero;
-            length = Target_ocaml_int.of_int num_fields
+            length = Target_ocaml_int.of_int machine_width num_fields
           }
       | Record_float | Record_ufloat ->
-        Naked_floats { length = Target_ocaml_int.of_int num_fields }
+        Naked_floats
+          { length = Target_ocaml_int.of_int machine_width num_fields }
       | Record_inlined (_, Constructor_mixed _, _) | Record_mixed _ -> Mixed
       | Record_inlined
           ( Ordinary { runtime_tag; _ },
@@ -1959,7 +1992,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
             Variant_boxed _ ) ->
         Values
           { tag = Tag.Scannable.create_exn runtime_tag;
-            length = Target_ocaml_int.of_int num_fields
+            length = Target_ocaml_int.of_int machine_width num_fields
           }
       | Record_inlined (Extension _, shape, Variant_extensible) -> (
         match shape with
@@ -1968,7 +2001,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
             { tag = Tag.Scannable.zero;
               (* The "+1" is because there is an extra field containing the
                  hashed constructor. *)
-              length = Target_ocaml_int.of_int (num_fields + 1)
+              length = Target_ocaml_int.of_int machine_width (num_fields + 1)
             }
         | Constructor_mixed _ ->
           (* CR layouts v5.9: support this *)
@@ -2003,9 +2036,15 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
       let result : H.expr_primitive =
         match op with
         | Bswap -> Unary (Int_arith (width, Swap_byte_endianness), arg)
-        | Neg -> Binary (Int_arith (width, Sub), Simple (const width 0), arg)
-        | Succ -> Binary (Int_arith (width, Add), arg, Simple (const width 1))
-        | Pred -> Binary (Int_arith (width, Sub), arg, Simple (const width 1))
+        | Neg ->
+          Binary
+            (Int_arith (width, Sub), Simple (const ~machine_width width 0), arg)
+        | Succ ->
+          Binary
+            (Int_arith (width, Add), arg, Simple (const ~machine_width width 1))
+        | Pred ->
+          Binary
+            (Int_arith (width, Sub), arg, Simple (const ~machine_width width 1))
       in
       [to_expr (maybe_wrap (Prim result))]
     | Floating (outer, op) ->
@@ -2050,8 +2089,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
         | Xor -> Binary (Int_arith (width, Xor), arg1, arg2)
         | Div Unsafe -> Binary (Int_arith (width, Div), arg1, arg2)
         | Mod Unsafe -> Binary (Int_arith (width, Mod), arg1, arg2)
-        | Div Safe -> check_zero_division width arg1 arg2 Div dbg
-        | Mod Safe -> check_zero_division width arg1 arg2 Mod dbg
+        | Div Safe -> check_zero_division ~machine_width width arg1 arg2 Div dbg
+        | Mod Safe -> check_zero_division ~machine_width width arg1 arg2 Mod dbg
       in
       [to_expr (maybe_wrap (Prim result))]
     | Shift (outer, op, rhs) ->
@@ -2220,7 +2259,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
          flambda_primitive.mli). *)
       let divisor =
         P.Array_kind.width_in_scalars array_kind
-        |> Target_ocaml_int.of_int |> Simple.const_int
+        |> Target_ocaml_int.of_int machine_width
+        |> Simple.const_int
       in
       [Binary (Int_arith (Tagged_immediate, Div), Prim prim, Simple divisor)])
   | Pduparray (kind, mutability), [[arg]] -> (
@@ -2256,73 +2296,73 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
   | Pstringlength, [[arg]] -> [tag_int (Unary (String_length String, arg))]
   | Pbyteslength, [[arg]] -> [tag_int (Unary (String_length Bytes, arg))]
   | Pstringrefu, [[str]; [index]] ->
-    [ string_like_load ~unsafe:true ~dbg ~size_int ~access_size:Eight String
-        None ~boxed:false str ~index_kind:Ptagged_int_index index
+    [ string_like_load ~unsafe:true ~dbg ~machine_width ~access_size:Eight
+        String None ~boxed:false str ~index_kind:Ptagged_int_index index
         ~current_region ]
   | Pbytesrefu, [[bytes]; [index]] ->
-    [ string_like_load ~unsafe:true ~dbg ~size_int ~access_size:Eight Bytes None
-        ~boxed:false bytes ~index_kind:Ptagged_int_index index ~current_region
-    ]
+    [ string_like_load ~unsafe:true ~dbg ~machine_width ~access_size:Eight Bytes
+        None ~boxed:false bytes ~index_kind:Ptagged_int_index index
+        ~current_region ]
   | Pstringrefs, [[str]; [index]] ->
-    [ string_like_load ~unsafe:false ~dbg ~size_int ~access_size:Eight String
-        ~boxed:false None str ~index_kind:Ptagged_int_index index
+    [ string_like_load ~unsafe:false ~dbg ~machine_width ~access_size:Eight
+        String ~boxed:false None str ~index_kind:Ptagged_int_index index
         ~current_region ]
   | Pbytesrefs, [[bytes]; [index]] ->
-    [ string_like_load ~unsafe:false ~dbg ~size_int ~access_size:Eight Bytes
-        ~boxed:false None bytes ~index_kind:Ptagged_int_index index
+    [ string_like_load ~unsafe:false ~dbg ~machine_width ~access_size:Eight
+        Bytes ~boxed:false None bytes ~index_kind:Ptagged_int_index index
         ~current_region ]
   | Pstring_load_16 { unsafe; index_kind }, [[str]; [index]] ->
-    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Sixteen String
+    [ string_like_load ~unsafe ~dbg ~machine_width ~access_size:Sixteen String
         ~boxed:false None str ~index_kind index ~current_region ]
   | Pbytes_load_16 { unsafe; index_kind }, [[bytes]; [index]] ->
-    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Sixteen Bytes
+    [ string_like_load ~unsafe ~dbg ~machine_width ~access_size:Sixteen Bytes
         ~boxed:false None bytes ~index_kind index ~current_region ]
   | Pstring_load_32 { unsafe; index_kind; mode; boxed }, [[str]; [index]] ->
-    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Thirty_two String
-        ~boxed (Some mode) str ~index_kind index ~current_region ]
+    [ string_like_load ~unsafe ~dbg ~machine_width ~access_size:Thirty_two
+        String ~boxed (Some mode) str ~index_kind index ~current_region ]
   | Pstring_load_f32 { unsafe; index_kind; mode; boxed }, [[str]; [index]] ->
-    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Single String ~boxed
-        (Some mode) str ~index_kind index ~current_region ]
+    [ string_like_load ~unsafe ~dbg ~machine_width ~access_size:Single String
+        ~boxed (Some mode) str ~index_kind index ~current_region ]
   | Pbytes_load_32 { unsafe; index_kind; mode; boxed }, [[bytes]; [index]] ->
-    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Thirty_two Bytes
+    [ string_like_load ~unsafe ~dbg ~machine_width ~access_size:Thirty_two Bytes
         ~boxed (Some mode) bytes ~index_kind index ~current_region ]
   | Pbytes_load_f32 { unsafe; index_kind; mode; boxed }, [[bytes]; [index]] ->
-    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Single Bytes ~boxed
-        (Some mode) bytes ~index_kind index ~current_region ]
+    [ string_like_load ~unsafe ~dbg ~machine_width ~access_size:Single Bytes
+        ~boxed (Some mode) bytes ~index_kind index ~current_region ]
   | Pstring_load_64 { unsafe; index_kind; mode; boxed }, [[str]; [index]] ->
-    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Sixty_four String
-        ~boxed (Some mode) str ~index_kind index ~current_region ]
+    [ string_like_load ~unsafe ~dbg ~machine_width ~access_size:Sixty_four
+        String ~boxed (Some mode) str ~index_kind index ~current_region ]
   | Pbytes_load_64 { unsafe; index_kind; mode; boxed }, [[bytes]; [index]] ->
-    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Sixty_four Bytes
+    [ string_like_load ~unsafe ~dbg ~machine_width ~access_size:Sixty_four Bytes
         ~boxed (Some mode) bytes ~index_kind index ~current_region ]
   | Pstring_load_vec { size; unsafe; index_kind; mode; boxed }, [[str]; [index]]
     ->
-    [ string_like_load ~unsafe ~dbg ~size_int
+    [ string_like_load ~unsafe ~dbg ~machine_width
         ~access_size:(vec_accessor_width ~aligned:false size)
         String ~boxed (Some mode) str ~index_kind index ~current_region ]
   | Pbytes_load_vec { size; unsafe; index_kind; mode; boxed }, [[str]; [index]]
     ->
-    [ string_like_load ~unsafe ~dbg ~size_int
+    [ string_like_load ~unsafe ~dbg ~machine_width
         ~access_size:(vec_accessor_width ~aligned:false size)
         Bytes ~boxed (Some mode) str ~index_kind index ~current_region ]
   | Pbytes_set_16 { unsafe; index_kind }, [[bytes]; [index]; [new_value]] ->
-    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Sixteen Bytes
+    [ bytes_like_set ~unsafe ~dbg ~machine_width ~access_size:Sixteen Bytes
         ~boxed:false bytes ~index_kind index new_value ]
   | Pbytes_set_32 { unsafe; index_kind; boxed }, [[bytes]; [index]; [new_value]]
     ->
-    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Thirty_two Bytes ~boxed
-        bytes ~index_kind index new_value ]
+    [ bytes_like_set ~unsafe ~dbg ~machine_width ~access_size:Thirty_two Bytes
+        ~boxed bytes ~index_kind index new_value ]
   | Pbytes_set_f32 { unsafe; index_kind; boxed }, [[bytes]; [index]; [new_value]]
     ->
-    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Single Bytes ~boxed
-        bytes ~index_kind index new_value ]
+    [ bytes_like_set ~unsafe ~dbg ~machine_width ~access_size:Single Bytes
+        ~boxed bytes ~index_kind index new_value ]
   | Pbytes_set_64 { unsafe; index_kind; boxed }, [[bytes]; [index]; [new_value]]
     ->
-    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Sixty_four Bytes ~boxed
-        bytes ~index_kind index new_value ]
+    [ bytes_like_set ~unsafe ~dbg ~machine_width ~access_size:Sixty_four Bytes
+        ~boxed bytes ~index_kind index new_value ]
   | ( Pbytes_set_vec { size; unsafe; index_kind; boxed },
       [[bytes]; [index]; [new_value]] ) ->
-    [ bytes_like_set ~unsafe ~dbg ~size_int
+    [ bytes_like_set ~unsafe ~dbg ~machine_width
         ~access_size:(vec_accessor_width ~aligned:false size)
         Bytes ~boxed bytes ~index_kind index new_value ]
   | Pisint { variant_only }, [[arg]] ->
@@ -2336,7 +2376,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
              arg2 )) ]
   | Pfield (index, _int_or_ptr, sem), [[arg]] ->
     (* CR mshinwell: make use of the int-or-ptr flag (new in OCaml 5)? *)
-    let imm = Target_ocaml_int.of_int index in
+    let imm = Target_ocaml_int.of_int machine_width index in
     check_non_negative_imm imm "Pfield";
     let mutability = convert_field_read_semantics sem in
     let block_access : P.Block_access_kind.t =
@@ -2346,7 +2386,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
         (Block_load { kind = block_access; mut = mutability; field = imm }, arg)
     ]
   | Pfloatfield (field, sem, mode), [[arg]] ->
-    let imm = Target_ocaml_int.of_int field in
+    let imm = Target_ocaml_int.of_int machine_width field in
     check_non_negative_imm imm "Pfloatfield";
     let mutability = convert_field_read_semantics sem in
     let block_access : P.Block_access_kind.t =
@@ -2358,7 +2398,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
              arg ))
         ~current_region ]
   | Pufloatfield (field, sem), [[arg]] ->
-    let imm = Target_ocaml_int.of_int field in
+    let imm = Target_ocaml_int.of_int machine_width field in
     check_non_negative_imm imm "Pufloatfield";
     let mutability = convert_field_read_semantics sem in
     let block_access : P.Block_access_kind.t =
@@ -2383,7 +2423,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     in
     List.map
       (fun new_index ->
-        let imm = Target_ocaml_int.of_int new_index in
+        let imm = Target_ocaml_int.of_int machine_width new_index in
         check_non_negative_imm imm "Pmixedfield";
         let mutability = convert_field_read_semantics sem in
         let block_access : P.Block_access_kind.t =
@@ -2418,7 +2458,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
   | ( Psetfield (index, immediate_or_pointer, initialization_or_assignment),
       [[block]; [value]] ) ->
     let field_kind = convert_block_access_field_kind immediate_or_pointer in
-    let imm = Target_ocaml_int.of_int index in
+    let imm = Target_ocaml_int.of_int machine_width index in
     check_non_negative_imm imm "Psetfield";
     let init_or_assign = convert_init_or_assign initialization_or_assignment in
     let block_access : P.Block_access_kind.t =
@@ -2429,7 +2469,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
           block,
           value ) ]
   | Psetfloatfield (field, initialization_or_assignment), [[block]; [value]] ->
-    let imm = Target_ocaml_int.of_int field in
+    let imm = Target_ocaml_int.of_int machine_width field in
     check_non_negative_imm imm "Psetfloatfield";
     let block_access : P.Block_access_kind.t =
       Naked_floats { size = Unknown }
@@ -2440,7 +2480,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
           block,
           unbox_float value ) ]
   | Psetufloatfield (field, initialization_or_assignment), [[block]; [value]] ->
-    let imm = Target_ocaml_int.of_int field in
+    let imm = Target_ocaml_int.of_int machine_width field in
     check_non_negative_imm imm "Psetufloatfield";
     let block_access : P.Block_access_kind.t =
       Naked_floats { size = Unknown }
@@ -2474,7 +2514,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     let exprs =
       List.map2
         (fun new_index value : H.expr_primitive ->
-          let imm = Target_ocaml_int.of_int new_index in
+          let imm = Target_ocaml_int.of_int machine_width new_index in
           check_non_negative_imm imm "Psetmixedfield";
           let block_access : P.Block_access_kind.t =
             Mixed
@@ -2522,41 +2562,41 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
        CSE the two accesses to the array's header word in the [Pgenarray]
        case. *)
     [ match_on_array_ref_kind ~array array_ref_kind
-        (array_load_unsafe ~array ~mut
+        (array_load_unsafe ~machine_width ~array ~mut
            ~index:(convert_index_to_tagged_int ~index ~index_kind)
            ~current_region) ]
   | Parrayrefs (array_ref_kind, index_kind, mut), [[array]; [index]] ->
     let array_length_kind = convert_array_ref_kind_for_length array_ref_kind in
     [ check_array_access ~dbg ~array array_length_kind ~index ~index_kind
-        ~size_int
+        ~machine_width
         (match_on_array_ref_kind ~array array_ref_kind
-           (array_load_unsafe ~array ~mut
+           (array_load_unsafe ~machine_width ~array ~mut
               ~index:(convert_index_to_tagged_int ~index ~index_kind)
               ~current_region)) ]
   | Parraysetu (array_set_kind, index_kind), [[array]; [index]; new_values] ->
     [ match_on_array_set_kind ~array array_set_kind
-        (array_set_unsafe dbg ~array
+        (array_set_unsafe ~machine_width dbg ~array
            ~index:(convert_index_to_tagged_int ~index ~index_kind)
            ~new_values) ]
   | Parraysets (array_set_kind, index_kind), [[array]; [index]; new_values] ->
     let array_length_kind = convert_array_set_kind_for_length array_set_kind in
     [ check_array_access ~dbg ~array array_length_kind ~index ~index_kind
-        ~size_int
+        ~machine_width
         (match_on_array_set_kind ~array array_set_kind
-           (array_set_unsafe dbg ~array
+           (array_set_unsafe ~machine_width dbg ~array
               ~index:(convert_index_to_tagged_int ~index ~index_kind)
               ~new_values)) ]
   | Pbytessetu (* unsafe *), [[bytes]; [index]; [new_value]] ->
-    [ bytes_like_set ~unsafe:true ~dbg ~size_int ~access_size:Eight Bytes
+    [ bytes_like_set ~unsafe:true ~dbg ~machine_width ~access_size:Eight Bytes
         ~boxed:false bytes ~index_kind:Ptagged_int_index index new_value ]
   | Pbytessets, [[bytes]; [index]; [new_value]] ->
-    [ bytes_like_set ~unsafe:false ~dbg ~size_int ~access_size:Eight Bytes
+    [ bytes_like_set ~unsafe:false ~dbg ~machine_width ~access_size:Eight Bytes
         ~boxed:false bytes ~index_kind:Ptagged_int_index index new_value ]
   | Poffsetref n, [[block]] ->
     let block_access : P.Block_access_kind.t =
       Values
         { tag = Known Tag.Scannable.zero;
-          size = Known Target_ocaml_int.one;
+          size = Known (Target_ocaml_int.one machine_width);
           field_kind = Immediate
         }
     in
@@ -2566,7 +2606,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
            ( Block_load
                { kind = block_access;
                  mut = Mutable;
-                 field = Target_ocaml_int.zero
+                 field = Target_ocaml_int.zero machine_width
                },
              block ))
     in
@@ -2574,14 +2614,14 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
       H.Prim
         (Binary
            ( Int_arith (Tagged_immediate, Add),
-             Simple (Simple.const_int (Target_ocaml_int.of_int n)),
+             Simple (Simple.const_int (Target_ocaml_int.of_int machine_width n)),
              old_ref_value ))
     in
     [ Binary
         ( Block_set
             { kind = block_access;
               init = Assignment (Alloc_mode.For_assignments.local ());
-              field = Target_ocaml_int.zero
+              field = Target_ocaml_int.zero machine_width
             },
           block,
           new_ref_value ) ]
@@ -2594,28 +2634,37 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
         Printlambda.primitive prim Debuginfo.print_compact dbg
     | false -> (
       match const with
-      | Big_endian -> [Simple (Simple.const_bool big_endian)]
+      | Big_endian -> [Simple (Simple.const_bool machine_width big_endian)]
       | Word_size ->
-        [Simple (Simple.const_int (Target_ocaml_int.of_int (8 * size_int)))]
+        [ Simple
+            (Simple.const_int
+               (Target_ocaml_int.of_int machine_width (8 * size_int))) ]
       | Int_size ->
         [ Simple
-            (Simple.const_int (Target_ocaml_int.of_int ((8 * size_int) - 1))) ]
+            (Simple.const_int
+               (Target_ocaml_int.of_int machine_width ((8 * size_int) - 1))) ]
       | Max_wosize ->
         [ Simple
             (Simple.const_int
-               (Target_ocaml_int.of_int
+               (Target_ocaml_int.of_int machine_width
                   ((1 lsl ((8 * size_int) - (10 + Config.reserved_header_bits)))
                   - 1))) ]
       | Ostype_unix ->
-        [Simple (Simple.const_bool (String.equal Sys.os_type "Unix"))]
+        [ Simple
+            (Simple.const_bool machine_width (String.equal Sys.os_type "Unix"))
+        ]
       | Ostype_win32 ->
-        [Simple (Simple.const_bool (String.equal Sys.os_type "Win32"))]
+        [ Simple
+            (Simple.const_bool machine_width (String.equal Sys.os_type "Win32"))
+        ]
       | Ostype_cygwin ->
-        [Simple (Simple.const_bool (String.equal Sys.os_type "Cygwin"))]
+        [ Simple
+            (Simple.const_bool machine_width
+               (String.equal Sys.os_type "Cygwin")) ]
       | Backend_type ->
-        [Simple Simple.const_zero]
+        [Simple (Simple.const_zero machine_width)]
         (* constructor 0 is the same as Native here *)
-      | Runtime5 -> [Simple (Simple.const_bool Config.runtime5)]))
+      | Runtime5 -> [Simple (Simple.const_bool machine_width Config.runtime5)]))
   | Pint_as_pointer mode, [[arg]] ->
     (* This is not a stack allocation, but nonetheless has a region
        constraint. *)
@@ -2651,7 +2700,7 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
         bigarray_box_or_tag_raw_value_to_read kind
           Alloc_mode.For_allocations.heap
       in
-      [box (bigarray_load ~dbg ~unsafe kind layout b indexes)]
+      [box (bigarray_load ~machine_width ~dbg ~unsafe kind layout b indexes)]
     | None, _ ->
       Misc.fatal_errorf
         "Lambda_to_flambda_primitives.convert_lprim: Pbigarrayref primitives \
@@ -2685,7 +2734,8 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
         | [] -> Misc.fatal_errorf "Pbigarrayset is missing its arguments"
       in
       let unbox = bigarray_unbox_or_untag_value_to_store kind in
-      [bigarray_set ~dbg ~unsafe kind layout b indexes (unbox value)]
+      [ bigarray_set ~machine_width ~dbg ~unsafe kind layout b indexes
+          (unbox value) ]
     | None, _ ->
       Misc.fatal_errorf
         "Lambda_to_flambda_primitives.convert_lprim: Pbigarrayref primitives \
@@ -2697,121 +2747,138 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
   | Pbigarraydim dimension, [[arg]] ->
     [tag_int (Unary (Bigarray_length { dimension }, arg))]
   | Pbigstring_load_16 { unsafe; index_kind }, [[big_str]; [index]] ->
-    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Sixteen Bigstring
-        ~boxed:false None big_str ~index_kind index ~current_region ]
+    [ string_like_load ~unsafe ~dbg ~machine_width ~access_size:Sixteen
+        Bigstring ~boxed:false None big_str ~index_kind index ~current_region ]
   | Pbigstring_load_32 { unsafe; index_kind; mode; boxed }, [[big_str]; [index]]
     ->
-    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Thirty_two Bigstring
-        (Some mode) ~boxed big_str ~index_kind index ~current_region ]
+    [ string_like_load ~unsafe ~dbg ~machine_width ~access_size:Thirty_two
+        Bigstring (Some mode) ~boxed big_str ~index_kind index ~current_region
+    ]
   | Pbigstring_load_f32 { unsafe; index_kind; mode; boxed }, [[big_str]; [index]]
     ->
-    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Single Bigstring
+    [ string_like_load ~unsafe ~dbg ~machine_width ~access_size:Single Bigstring
         (Some mode) ~boxed big_str ~index_kind index ~current_region ]
   | Pbigstring_load_64 { unsafe; index_kind; mode; boxed }, [[big_str]; [index]]
     ->
-    [ string_like_load ~unsafe ~dbg ~size_int ~access_size:Sixty_four Bigstring
-        (Some mode) ~boxed big_str ~index_kind index ~current_region ]
+    [ string_like_load ~unsafe ~dbg ~machine_width ~access_size:Sixty_four
+        Bigstring (Some mode) ~boxed big_str ~index_kind index ~current_region
+    ]
   | ( Pbigstring_load_vec { size; unsafe; aligned; index_kind; mode; boxed },
       [[big_str]; [index]] ) ->
-    [ string_like_load ~unsafe ~dbg ~size_int
+    [ string_like_load ~unsafe ~dbg ~machine_width
         ~access_size:(vec_accessor_width ~aligned size)
         Bigstring (Some mode) ~boxed big_str ~index_kind index ~current_region
     ]
   | Pbigstring_set_16 { unsafe; index_kind }, [[bigstring]; [index]; [new_value]]
     ->
-    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Sixteen Bigstring
+    [ bytes_like_set ~unsafe ~dbg ~machine_width ~access_size:Sixteen Bigstring
         ~boxed:false bigstring ~index_kind index new_value ]
   | ( Pbigstring_set_32 { unsafe; index_kind; boxed },
       [[bigstring]; [index]; [new_value]] ) ->
-    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Thirty_two Bigstring
-        ~boxed bigstring ~index_kind index new_value ]
+    [ bytes_like_set ~unsafe ~dbg ~machine_width ~access_size:Thirty_two
+        Bigstring ~boxed bigstring ~index_kind index new_value ]
   | ( Pbigstring_set_f32 { unsafe; index_kind; boxed },
       [[bigstring]; [index]; [new_value]] ) ->
-    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Single Bigstring ~boxed
-        bigstring ~index_kind index new_value ]
+    [ bytes_like_set ~unsafe ~dbg ~machine_width ~access_size:Single Bigstring
+        ~boxed bigstring ~index_kind index new_value ]
   | ( Pbigstring_set_64 { unsafe; index_kind; boxed },
       [[bigstring]; [index]; [new_value]] ) ->
-    [ bytes_like_set ~unsafe ~dbg ~size_int ~access_size:Sixty_four Bigstring
-        ~boxed bigstring ~index_kind index new_value ]
+    [ bytes_like_set ~unsafe ~dbg ~machine_width ~access_size:Sixty_four
+        Bigstring ~boxed bigstring ~index_kind index new_value ]
   | ( Pbigstring_set_vec { size; unsafe; aligned; index_kind; boxed },
       [[bigstring]; [index]; [new_value]] ) ->
-    [ bytes_like_set ~unsafe ~dbg ~size_int
+    [ bytes_like_set ~unsafe ~dbg ~machine_width
         ~access_size:(vec_accessor_width ~aligned size)
         Bigstring ~boxed bigstring ~index_kind index new_value ]
   | ( Pfloat_array_load_vec { size; unsafe; index_kind; mode; boxed },
       [[array]; [index]] ) ->
     check_float_array_optimisation_enabled "Pfloat_array_load_vec";
-    [ array_like_load_vec ~dbg ~size_int ~current_region ~unsafe ~mode ~boxed
-        ~vec_kind:(vec_kind size) Naked_floats array ~index_kind index ]
+    [ array_like_load_vec ~dbg ~machine_width ~current_region ~unsafe ~mode
+        ~boxed ~vec_kind:(vec_kind size) Naked_floats array ~index_kind index ]
   | ( Pfloatarray_load_vec { size; unsafe; index_kind; mode; boxed },
       [[array]; [index]] )
   | ( Punboxed_float_array_load_vec { size; unsafe; index_kind; mode; boxed },
       [[array]; [index]] ) ->
-    [ array_like_load_vec ~dbg ~size_int ~current_region ~unsafe ~mode ~boxed
-        ~vec_kind:(vec_kind size) Naked_floats array ~index_kind index ]
+    [ array_like_load_vec ~dbg ~machine_width ~current_region ~unsafe ~mode
+        ~boxed ~vec_kind:(vec_kind size) Naked_floats array ~index_kind index ]
   | ( Punboxed_float32_array_load_vec { size; unsafe; index_kind; mode; boxed },
       [[array]; [index]] ) ->
-    [ array_like_load_vec ~dbg ~size_int ~current_region ~unsafe ~mode ~boxed
-        ~vec_kind:(vec_kind size) Naked_float32s array ~index_kind index ]
+    [ array_like_load_vec ~dbg ~machine_width ~current_region ~unsafe ~mode
+        ~boxed ~vec_kind:(vec_kind size) Naked_float32s array ~index_kind index
+    ]
   | ( Pint_array_load_vec { size; unsafe; index_kind; mode; boxed },
       [[array]; [index]] ) ->
-    if Targetint_32_64.size <> 64
-    then Misc.fatal_error "[Pint_array_load_vec]: immediates must be 64 bits.";
-    [ array_like_load_vec ~dbg ~size_int ~current_region ~unsafe ~mode ~boxed
-        ~vec_kind:(vec_kind size) Immediates array ~index_kind index ]
+    (match machine_width with
+    | Sixty_four -> ()
+    | Thirty_two | Thirty_two_no_gc_tag_bit ->
+      Misc.fatal_error "[Pint_array_load_vec]: immediates must be 64 bits.");
+    [ array_like_load_vec ~dbg ~machine_width ~current_region ~unsafe ~mode
+        ~boxed ~vec_kind:(vec_kind size) Immediates array ~index_kind index ]
   | ( Punboxed_int64_array_load_vec { size; unsafe; index_kind; mode; boxed },
       [[array]; [index]] ) ->
-    [ array_like_load_vec ~dbg ~size_int ~current_region ~unsafe ~mode ~boxed
-        ~vec_kind:(vec_kind size) Naked_int64s array ~index_kind index ]
+    [ array_like_load_vec ~dbg ~machine_width ~current_region ~unsafe ~mode
+        ~boxed ~vec_kind:(vec_kind size) Naked_int64s array ~index_kind index ]
   | ( Punboxed_nativeint_array_load_vec { size; unsafe; index_kind; mode; boxed },
       [[array]; [index]] ) ->
-    if Targetint_32_64.size <> 64
-    then
+    (match machine_width with
+    | Sixty_four -> ()
+    | Thirty_two | Thirty_two_no_gc_tag_bit ->
       Misc.fatal_error
-        "[Punboxed_nativeint_array_load_vec]: nativeint must be 64 bits.";
-    [ array_like_load_vec ~dbg ~size_int ~current_region ~unsafe ~mode ~boxed
-        ~vec_kind:(vec_kind size) Naked_nativeints array ~index_kind index ]
+        "[Punboxed_nativeint_array_load_vec]: nativeint must be 64 bits.");
+    [ array_like_load_vec ~dbg ~machine_width ~current_region ~unsafe ~mode
+        ~boxed ~vec_kind:(vec_kind size) Naked_nativeints array ~index_kind
+        index ]
   | ( Punboxed_int32_array_load_vec { size; unsafe; index_kind; mode; boxed },
       [[array]; [index]] ) ->
-    [ array_like_load_vec ~dbg ~size_int ~current_region ~unsafe ~mode ~boxed
-        ~vec_kind:(vec_kind size) Naked_int32s array ~index_kind index ]
+    [ array_like_load_vec ~dbg ~machine_width ~current_region ~unsafe ~mode
+        ~boxed ~vec_kind:(vec_kind size) Naked_int32s array ~index_kind index ]
   | ( Pfloat_array_set_vec { size; unsafe; index_kind; boxed },
       [[array]; [index]; [new_value]] ) ->
     check_float_array_optimisation_enabled "Pfloat_array_set_vec";
-    [ array_like_set_vec ~dbg ~size_int ~unsafe ~boxed ~vec_kind:(vec_kind size)
-        Naked_floats array ~index_kind index new_value ]
+    [ array_like_set_vec ~dbg ~machine_width ~unsafe ~boxed
+        ~vec_kind:(vec_kind size) Naked_floats array ~index_kind index new_value
+    ]
   | ( Pfloatarray_set_vec { size; unsafe; index_kind; boxed },
       [[array]; [index]; [new_value]] )
   | ( Punboxed_float_array_set_vec { size; unsafe; index_kind; boxed },
       [[array]; [index]; [new_value]] ) ->
-    [ array_like_set_vec ~dbg ~size_int ~unsafe ~boxed ~vec_kind:(vec_kind size)
-        Naked_floats array ~index_kind index new_value ]
+    [ array_like_set_vec ~dbg ~machine_width ~unsafe ~boxed
+        ~vec_kind:(vec_kind size) Naked_floats array ~index_kind index new_value
+    ]
   | ( Punboxed_float32_array_set_vec { size; unsafe; index_kind; boxed },
       [[array]; [index]; [new_value]] ) ->
-    [ array_like_set_vec ~dbg ~size_int ~unsafe ~boxed ~vec_kind:(vec_kind size)
-        Naked_float32s array ~index_kind index new_value ]
+    [ array_like_set_vec ~dbg ~machine_width ~unsafe ~boxed
+        ~vec_kind:(vec_kind size) Naked_float32s array ~index_kind index
+        new_value ]
   | ( Pint_array_set_vec { size; unsafe; index_kind; boxed },
       [[array]; [index]; [new_value]] ) ->
-    if Targetint_32_64.size <> 64
-    then Misc.fatal_error "[Pint_array_set_vec]: immediates must be 64 bits.";
-    [ array_like_set_vec ~dbg ~size_int ~unsafe ~boxed ~vec_kind:(vec_kind size)
-        Immediates array ~index_kind index new_value ]
+    (match machine_width with
+    | Sixty_four -> ()
+    | Thirty_two | Thirty_two_no_gc_tag_bit ->
+      Misc.fatal_error "[Pint_array_set_vec]: immediates must be 64 bits.");
+    [ array_like_set_vec ~dbg ~machine_width ~unsafe ~boxed
+        ~vec_kind:(vec_kind size) Immediates array ~index_kind index new_value
+    ]
   | ( Punboxed_int64_array_set_vec { size; unsafe; index_kind; boxed },
       [[array]; [index]; [new_value]] ) ->
-    [ array_like_set_vec ~dbg ~size_int ~unsafe ~boxed ~vec_kind:(vec_kind size)
-        Naked_int64s array ~index_kind index new_value ]
+    [ array_like_set_vec ~dbg ~machine_width ~unsafe ~boxed
+        ~vec_kind:(vec_kind size) Naked_int64s array ~index_kind index new_value
+    ]
   | ( Punboxed_nativeint_array_set_vec { size; unsafe; index_kind; boxed },
       [[array]; [index]; [new_value]] ) ->
-    if Targetint_32_64.size <> 64
-    then
+    (match machine_width with
+    | Sixty_four -> ()
+    | Thirty_two | Thirty_two_no_gc_tag_bit ->
       Misc.fatal_error
-        "[Punboxed_nativeint_array_set_vec]: nativeint must be 64 bits.";
-    [ array_like_set_vec ~dbg ~size_int ~unsafe ~boxed ~vec_kind:(vec_kind size)
-        Naked_nativeints array ~index_kind index new_value ]
+        "[Punboxed_nativeint_array_set_vec]: nativeint must be 64 bits.");
+    [ array_like_set_vec ~dbg ~machine_width ~unsafe ~boxed
+        ~vec_kind:(vec_kind size) Naked_nativeints array ~index_kind index
+        new_value ]
   | ( Punboxed_int32_array_set_vec { size; unsafe; index_kind; boxed },
       [[array]; [index]; [new_value]] ) ->
-    [ array_like_set_vec ~dbg ~size_int ~unsafe ~boxed ~vec_kind:(vec_kind size)
-        Naked_int32s array ~index_kind index new_value ]
+    [ array_like_set_vec ~dbg ~machine_width ~unsafe ~boxed
+        ~vec_kind:(vec_kind size) Naked_int32s array ~index_kind index new_value
+    ]
   | Pprobe_is_enabled { name }, [] ->
     [tag_int (Nullary (Probe_is_enabled { name }))]
   | Pobj_dup, [[v]] -> [Unary (Obj_dup, v)]
@@ -2893,9 +2960,10 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
     [Binary (Poke kind, ptr, new_value)]
   | Pget_idx (layout, mut), [[ptr]; [idx]] ->
     needs_64_bit_target prim dbg;
-    let offsets = block_index_access_offsets layout idx in
+    let offsets = block_index_access_offsets ~machine_width layout idx in
     let kinds =
-      Flambda_arity.unarize (Flambda_arity.from_lambda_list [layout])
+      Flambda_arity.unarize
+        (Flambda_arity.from_lambda_list [layout] ~machine_width)
     in
     let reads =
       List.map2
@@ -2907,9 +2975,10 @@ let convert_lprim ~big_endian (prim : L.primitive) (args : Simple.t list list)
   | Pset_idx (layout, mode), [[ptr]; [idx]; new_values] ->
     needs_64_bit_target prim dbg;
     let mode = Alloc_mode.For_assignments.from_lambda mode in
-    let offsets = block_index_access_offsets layout idx in
+    let offsets = block_index_access_offsets ~machine_width layout idx in
     let kinds =
-      Flambda_arity.unarize (Flambda_arity.from_lambda_list [layout])
+      Flambda_arity.unarize
+        (Flambda_arity.from_lambda_list [layout] ~machine_width)
     in
     let writes =
       Misc.Stdlib.List.map3
@@ -3053,8 +3122,9 @@ let convert_and_bind acc ~big_endian exn_cont ~register_const0
     ~current_region ~current_ghost_region
     (cont : Acc.t -> Flambda.Named.t list -> Expr_with_acc.t) : Expr_with_acc.t
     =
+  let machine_width = Acc.machine_width acc in
   let exprs =
-    convert_lprim ~big_endian prim args dbg ~current_region
+    convert_lprim ~machine_width ~big_endian prim args dbg ~current_region
       ~current_ghost_region
   in
   H.bind_recs acc exn_cont ~register_const0

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
@@ -58,7 +58,8 @@ and simple_or_prim =
   | Simple of Simple.t
   | Prim of expr_primitive
 
-val simple_untagged_int : int -> simple_or_prim
+val simple_untagged_int :
+  machine_width:Target_system.Machine_width.t -> int -> simple_or_prim
 
 val simple_i64 : Int64.t -> simple_or_prim
 

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -368,25 +368,32 @@ module Const = struct
 
   let naked_vec512 i = create (Naked_vec512 i)
 
-  let const_true = tagged_immediate Target_ocaml_int.bool_true
+  let const_true machine_width =
+    tagged_immediate (Target_ocaml_int.bool_true machine_width)
 
-  let const_false = tagged_immediate Target_ocaml_int.bool_false
+  let const_false machine_width =
+    tagged_immediate (Target_ocaml_int.bool_false machine_width)
 
-  let untagged_const_true = naked_immediate Target_ocaml_int.bool_true
+  let untagged_const_true machine_width =
+    naked_immediate (Target_ocaml_int.bool_true machine_width)
 
-  let untagged_const_false = naked_immediate Target_ocaml_int.bool_false
+  let untagged_const_false machine_width =
+    naked_immediate (Target_ocaml_int.bool_false machine_width)
 
-  let untagged_const_zero = naked_immediate Target_ocaml_int.zero
+  let untagged_const_zero machine_width =
+    naked_immediate (Target_ocaml_int.zero machine_width)
 
   let untagged_const_int i = naked_immediate i
 
   let const_int i = tagged_immediate i
 
-  let const_zero = tagged_immediate Target_ocaml_int.zero
+  let const_zero machine_width =
+    tagged_immediate (Target_ocaml_int.zero machine_width)
 
-  let const_one = tagged_immediate Target_ocaml_int.one
+  let const_one machine_width =
+    tagged_immediate (Target_ocaml_int.one machine_width)
 
-  let const_unit = const_zero
+  let const_unit machine_width = const_zero machine_width
 
   let const_null = create Null
 

--- a/middle_end/flambda2/identifiers/int_ids.mli
+++ b/middle_end/flambda2/identifiers/int_ids.mli
@@ -25,23 +25,23 @@ module Const : sig
 
   include Container_types.S with type t := t
 
-  val const_true : t
+  val const_true : Target_system.Machine_width.t -> t
 
-  val const_false : t
+  val const_false : Target_system.Machine_width.t -> t
 
-  val untagged_const_true : t
+  val untagged_const_true : Target_system.Machine_width.t -> t
 
-  val untagged_const_false : t
+  val untagged_const_false : Target_system.Machine_width.t -> t
 
-  val untagged_const_zero : t
+  val untagged_const_zero : Target_system.Machine_width.t -> t
 
   val untagged_const_int : Target_ocaml_int.t -> t
 
-  val const_zero : t
+  val const_zero : Target_system.Machine_width.t -> t
 
-  val const_one : t
+  val const_one : Target_system.Machine_width.t -> t
 
-  val const_unit : t
+  val const_unit : Target_system.Machine_width.t -> t
 
   val const_int : Target_ocaml_int.t -> t
 

--- a/middle_end/flambda2/identifiers/reg_width_const.ml
+++ b/middle_end/flambda2/identifiers/reg_width_const.ml
@@ -65,19 +65,21 @@ let kind t =
   | Naked_vec256 _ -> Flambda_kind.naked_vec256
   | Naked_vec512 _ -> Flambda_kind.naked_vec512
 
-let of_int_of_kind (kind : Flambda_kind.t) i =
+let of_int_of_kind machine_width (kind : Flambda_kind.t) i =
   match kind with
-  | Value -> tagged_immediate (Target_ocaml_int.of_int i)
+  | Value -> tagged_immediate (Target_ocaml_int.of_int machine_width i)
   | Naked_number Naked_float ->
     naked_float (Numeric_types.Float_by_bit_pattern.create (float_of_int i))
   | Naked_number Naked_float32 ->
     naked_float32 (Numeric_types.Float32_by_bit_pattern.create (float_of_int i))
-  | Naked_number Naked_immediate -> naked_immediate (Target_ocaml_int.of_int i)
+  | Naked_number Naked_immediate ->
+    naked_immediate (Target_ocaml_int.of_int machine_width i)
   | Naked_number Naked_int8 -> naked_int8 (Numeric_types.Int8.of_int i)
   | Naked_number Naked_int16 -> naked_int16 (Numeric_types.Int16.of_int i)
   | Naked_number Naked_int32 -> naked_int32 (Int32.of_int i)
   | Naked_number Naked_int64 -> naked_int64 (Int64.of_int i)
-  | Naked_number Naked_nativeint -> naked_nativeint (Targetint_32_64.of_int i)
+  | Naked_number Naked_nativeint ->
+    naked_nativeint (Targetint_32_64.of_int machine_width i)
   | Naked_number Naked_vec128 ->
     let i = Int64.of_int i in
     naked_vec128

--- a/middle_end/flambda2/identifiers/reg_width_const.mli
+++ b/middle_end/flambda2/identifiers/reg_width_const.mli
@@ -30,6 +30,6 @@ val is_tagged_immediate : t -> Target_ocaml_int.t option
 
 (** Create a numeric constant of the given kind ([Region] and [Rec_info] are
     forbidden). *)
-val of_int_of_kind : Flambda_kind.t -> int -> t
+val of_int_of_kind : Target_system.Machine_width.t -> Flambda_kind.t -> int -> t
 
 val kind : t -> Flambda_kind.t

--- a/middle_end/flambda2/kinds/flambda_arity.mli
+++ b/middle_end/flambda2/kinds/flambda_arity.mli
@@ -43,7 +43,8 @@ module Component_for_creation : sig
     | Unboxed_product : _ t list -> [`Complex] t
 
   (** Conversion from a Lambda layout, which might involve unboxed products. *)
-  val from_lambda : Lambda.layout -> [`Complex] t
+  val from_lambda :
+    Lambda.layout -> machine_width:Target_system.Machine_width.t -> [`Complex] t
 end
 
 (** One component per function or continuation parameter, for example. Each
@@ -102,7 +103,10 @@ val group_by_parameter : [`Complex] t -> 'a list -> 'a list list
 
 (** Take a list of Lambda layouts, one per parameter, and form the
     corresponding arity. *)
-val from_lambda_list : Lambda.layout list -> [`Complex] t
+val from_lambda_list :
+  Lambda.layout list ->
+  machine_width:Target_system.Machine_width.t ->
+  [`Complex] t
 
 (** Remove the first portion of an arity to correspond to a partial
     application (or other similar situation). *)

--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -327,10 +327,12 @@ module With_subkind : sig
   val boxed_of_boxable_number : Boxable_number.t -> t
 
   (* Nullability is taken from the Lambda value kind *)
-  val from_lambda_value_kind : Lambda.value_kind -> t
+  val from_lambda_value_kind :
+    Lambda.value_kind -> machine_width:Target_system.Machine_width.t -> t
 
   (* Nullability is taken from the Lambda value kind *)
-  val from_lambda_values_and_unboxed_numbers_only : Lambda.layout -> t
+  val from_lambda_values_and_unboxed_numbers_only :
+    Lambda.layout -> machine_width:Target_system.Machine_width.t -> t
 
   val compatible : t -> when_used_at:t -> bool
 

--- a/middle_end/flambda2/kinds/tag.ml
+++ b/middle_end/flambda2/kinds/tag.ml
@@ -40,9 +40,9 @@ let create_exn tag =
   then Misc.fatal_error (Printf.sprintf "Tag.create_exn %d" tag)
   else tag
 
-let create_from_targetint ti =
-  let min_tag = Target_ocaml_int.of_int min_tag in
-  let max_tag = Target_ocaml_int.of_int max_tag in
+let create_from_targetint machine_width ti =
+  let min_tag = Target_ocaml_int.of_int machine_width min_tag in
+  let max_tag = Target_ocaml_int.of_int machine_width max_tag in
   if Target_ocaml_int.compare ti min_tag >= 0
      && Target_ocaml_int.compare ti max_tag <= 0
   then Some (Target_ocaml_int.to_int ti)
@@ -50,7 +50,8 @@ let create_from_targetint ti =
 
 let to_int t = t
 
-let to_targetint_31_63 t = Target_ocaml_int.of_int (to_int t)
+let to_targetint_31_63 machine_width t =
+  Target_ocaml_int.of_int machine_width (to_int t)
 
 let zero = 0
 
@@ -88,7 +89,8 @@ module Scannable = struct
 
   let to_int t = t
 
-  let to_targetint t = Targetint_32_64.of_int (to_int t)
+  let to_targetint machine_width t =
+    Targetint_32_64.of_int machine_width (to_int t)
 
   let to_tag t = t
 

--- a/middle_end/flambda2/kinds/tag.mli
+++ b/middle_end/flambda2/kinds/tag.mli
@@ -22,11 +22,13 @@ type tag = t
 
 val create_exn : int -> t
 
-val create_from_targetint : Target_ocaml_int.t -> t option
+val create_from_targetint :
+  Target_system.Machine_width.t -> Target_ocaml_int.t -> t option
 
 val to_int : t -> int
 
-val to_targetint_31_63 : t -> Target_ocaml_int.t
+val to_targetint_31_63 :
+  Target_system.Machine_width.t -> t -> Target_ocaml_int.t
 
 val zero : t
 
@@ -71,7 +73,7 @@ module Scannable : sig
 
   val to_int : t -> int
 
-  val to_targetint : t -> Targetint_32_64.t
+  val to_targetint : Target_system.Machine_width.t -> t -> Targetint_32_64.t
 
   val to_tag : t -> tag
 

--- a/middle_end/flambda2/numbers/one_bit_fewer.ml
+++ b/middle_end/flambda2/numbers/one_bit_fewer.ml
@@ -23,19 +23,19 @@ module type S = sig
 
   val print : Format.formatter -> t -> unit
 
-  val min_value : t
+  val min_value : Target_system.Machine_width.t -> t
 
-  val max_value : t
+  val max_value : Target_system.Machine_width.t -> t
 
-  val minus_one : t
+  val minus_one : Target_system.Machine_width.t -> t
 
-  val zero : t
+  val zero : Target_system.Machine_width.t -> t
 
-  val one : t
+  val one : Target_system.Machine_width.t -> t
 
-  val ten : t
+  val ten : Target_system.Machine_width.t -> t
 
-  val hex_ff : t
+  val hex_ff : Target_system.Machine_width.t -> t
 
   val ( <= ) : t -> t -> bool
 
@@ -47,19 +47,22 @@ module type S = sig
 
   val bottom_byte_to_int : t -> int
 
-  val of_char : char -> t
+  val of_char : Target_system.Machine_width.t -> char -> t
 
-  val of_int : int -> t (* CR mshinwell: clarify semantics *)
+  val of_int :
+    Target_system.Machine_width.t ->
+    int ->
+    t (* CR mshinwell: clarify semantics *)
 
-  val of_int_option : int -> t option
+  val of_int_option : Target_system.Machine_width.t -> int -> t option
 
-  val of_int32 : int32 -> t
+  val of_int32 : Target_system.Machine_width.t -> int32 -> t
 
-  val of_int64 : int64 -> t
+  val of_int64 : Target_system.Machine_width.t -> int64 -> t
 
-  val of_targetint : Targetint_32_64.t -> t
+  val of_targetint : Target_system.Machine_width.t -> Targetint_32_64.t -> t
 
-  val of_float : float -> t
+  val of_float : Target_system.Machine_width.t -> float -> t
 
   val to_float : t -> float
 
@@ -73,7 +76,7 @@ module type S = sig
 
   val to_int64 : t -> int64
 
-  val to_targetint : t -> Targetint_32_64.t
+  val to_targetint : Target_system.Machine_width.t -> t -> Targetint_32_64.t
 
   val neg : t -> t
 
@@ -132,19 +135,19 @@ module Make (I : S) : S with type t = I.t = struct
      modulo 2^{n-2} bits. *)
   let sign_extend t = I.shift_right (I.shift_left t 1) 1
 
-  let min_value = I.shift_right I.min_value 1
+  let min_value machine_width = I.shift_right (I.min_value machine_width) 1
 
-  let max_value = I.shift_right I.max_value 1
+  let max_value machine_width = I.shift_right (I.max_value machine_width) 1
 
-  let minus_one = I.minus_one
+  let minus_one machine_width = I.minus_one machine_width
 
-  let zero = I.zero
+  let zero machine_width = I.zero machine_width
 
-  let one = I.one
+  let one machine_width = I.one machine_width
 
-  let ten = I.ten
+  let ten machine_width = I.ten machine_width
 
-  let hex_ff = I.hex_ff
+  let hex_ff machine_width = I.hex_ff machine_width
 
   let ( <= ) = I.( <= )
 
@@ -154,30 +157,32 @@ module Make (I : S) : S with type t = I.t = struct
 
   let ( > ) = I.( > )
 
-  let is_in_range n = I.( >= ) n min_value && I.( <= ) n max_value
+  let _is_in_range machine_width n =
+    I.( >= ) n (min_value machine_width) && I.( <= ) n (max_value machine_width)
 
   let bottom_byte_to_int = I.bottom_byte_to_int
 
-  let of_char = I.of_char
+  let of_char machine_width = I.of_char machine_width
 
-  let of_int t = sign_extend (I.of_int t)
+  let of_int machine_width t = sign_extend (I.of_int machine_width t)
 
-  let of_int_option t = Option.map sign_extend (I.of_int_option t)
+  let of_int_option machine_width t =
+    Option.map sign_extend (I.of_int_option machine_width t)
 
-  let of_int32 t =
-    let x = I.of_int32 t in
+  let of_int32 machine_width t =
+    let x = I.of_int32 machine_width t in
     sign_extend x
 
-  let of_int64 t =
-    let x = I.of_int64 t in
+  let of_int64 machine_width t =
+    let x = I.of_int64 machine_width t in
     sign_extend x
 
-  let of_targetint t =
-    let x = I.of_targetint t in
+  let of_targetint machine_width t =
+    let x = I.of_targetint machine_width t in
     sign_extend x
 
-  let of_float t =
-    let x = I.of_float t in
+  let of_float machine_width t =
+    let x = I.of_float machine_width t in
     sign_extend x
 
   let to_float = I.to_float
@@ -192,13 +197,16 @@ module Make (I : S) : S with type t = I.t = struct
 
   let to_int64 = I.to_int64
 
-  let to_targetint = I.to_targetint
+  let to_targetint machine_width = I.to_targetint machine_width
 
   let neg t = sign_extend (I.neg t)
 
   let get_least_significant_16_bits_then_byte_swap t =
     let res = I.get_least_significant_16_bits_then_byte_swap t in
-    assert (is_in_range res);
+    (* TODO: The range check would require machine_width, which is not available
+       here. The operation itself is safe as it only operates on the bottom 16
+       bits. *)
+    (* assert (is_in_range machine_width res); *)
     res
 
   let add x y = sign_extend (I.add x y)

--- a/middle_end/flambda2/numbers/one_bit_fewer.ml
+++ b/middle_end/flambda2/numbers/one_bit_fewer.ml
@@ -15,6 +15,8 @@
 module type S = sig
   type t
 
+  val machine_width : t -> Target_system.Machine_width.t
+
   val compare : t -> t -> int
 
   val equal : t -> t -> bool
@@ -121,6 +123,8 @@ module Make (I : S) : S with type t = I.t = struct
      range of numbers representable in {n-1} bits. *)
   type t = I.t
 
+  let machine_width = I.machine_width
+
   let compare = I.compare
 
   let equal = I.equal
@@ -157,7 +161,7 @@ module Make (I : S) : S with type t = I.t = struct
 
   let ( > ) = I.( > )
 
-  let _is_in_range machine_width n =
+  let is_in_range machine_width n =
     I.( >= ) n (min_value machine_width) && I.( <= ) n (max_value machine_width)
 
   let bottom_byte_to_int = I.bottom_byte_to_int
@@ -203,10 +207,7 @@ module Make (I : S) : S with type t = I.t = struct
 
   let get_least_significant_16_bits_then_byte_swap t =
     let res = I.get_least_significant_16_bits_then_byte_swap t in
-    (* TODO: The range check would require machine_width, which is not available
-       here. The operation itself is safe as it only operates on the bottom 16
-       bits. *)
-    (* assert (is_in_range machine_width res); *)
+    assert (is_in_range (machine_width t) res);
     res
 
   let add x y = sign_extend (I.add x y)

--- a/middle_end/flambda2/numbers/one_bit_fewer.mli
+++ b/middle_end/flambda2/numbers/one_bit_fewer.mli
@@ -9,19 +9,19 @@ module type S = sig
 
   val print : Format.formatter -> t -> unit
 
-  val min_value : t
+  val min_value : Target_system.Machine_width.t -> t
 
-  val max_value : t
+  val max_value : Target_system.Machine_width.t -> t
 
-  val minus_one : t
+  val minus_one : Target_system.Machine_width.t -> t
 
-  val zero : t
+  val zero : Target_system.Machine_width.t -> t
 
-  val one : t
+  val one : Target_system.Machine_width.t -> t
 
-  val ten : t
+  val ten : Target_system.Machine_width.t -> t
 
-  val hex_ff : t
+  val hex_ff : Target_system.Machine_width.t -> t
 
   val ( <= ) : t -> t -> bool
 
@@ -33,19 +33,19 @@ module type S = sig
 
   val bottom_byte_to_int : t -> int
 
-  val of_char : char -> t
+  val of_char : Target_system.Machine_width.t -> char -> t
 
-  val of_int : int -> t
+  val of_int : Target_system.Machine_width.t -> int -> t
 
-  val of_int_option : int -> t option
+  val of_int_option : Target_system.Machine_width.t -> int -> t option
 
-  val of_int32 : int32 -> t
+  val of_int32 : Target_system.Machine_width.t -> int32 -> t
 
-  val of_int64 : int64 -> t
+  val of_int64 : Target_system.Machine_width.t -> int64 -> t
 
-  val of_targetint : Targetint_32_64.t -> t
+  val of_targetint : Target_system.Machine_width.t -> Targetint_32_64.t -> t
 
-  val of_float : float -> t
+  val of_float : Target_system.Machine_width.t -> float -> t
 
   val to_float : t -> float
 
@@ -59,7 +59,7 @@ module type S = sig
 
   val to_int64 : t -> int64
 
-  val to_targetint : t -> Targetint_32_64.t
+  val to_targetint : Target_system.Machine_width.t -> t -> Targetint_32_64.t
 
   val neg : t -> t
 

--- a/middle_end/flambda2/numbers/one_bit_fewer.mli
+++ b/middle_end/flambda2/numbers/one_bit_fewer.mli
@@ -1,6 +1,8 @@
 module type S = sig
   type t
 
+  val machine_width : t -> Target_system.Machine_width.t
+
   val compare : t -> t -> int
 
   val equal : t -> t -> bool

--- a/middle_end/flambda2/numbers/target_ocaml_int.ml
+++ b/middle_end/flambda2/numbers/target_ocaml_int.ml
@@ -14,226 +14,566 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* CR-someday mshinwell/gbury: maybe we might want to consider adding some more
-   checks in some of the conversions functions to be more safe and more
-   consistent in the handling of overflows ? For instance One_bit_fewer.of_int
-   silently truncates the input int to make it fit, whereas we probably want to
-   make it produce an error ? *)
+module MW = Target_system.Machine_width
 
-module type S = sig
-  type t
+type t =
+  | Int31 of int32
+  | Int32 of int32
+  | Int63 of int64
 
-  include Container_types.S with type t := t
+(* Wrapper module for Int32 to work with One_bit_fewer *)
+module Int32_base = struct
+  type t = int32
 
-  val min_value : t
+  let compare = Int32.compare
 
-  val max_value : t
+  let equal = Int32.equal
 
-  val minus_one : t
+  let hash = Hashtbl.hash
 
-  val zero : t
+  let print ppf t = Format.fprintf ppf "%ld" t
 
-  val one : t
+  let min_value _machine_width = Int32.min_int
 
-  val ten : t
+  let max_value _machine_width = Int32.max_int
 
-  val hex_ff : t
+  let minus_one _machine_width = Int32.minus_one
 
-  val bool : bool -> t
+  let zero _machine_width = Int32.zero
 
-  val bool_true : t
+  let one _machine_width = Int32.one
 
-  val bool_false : t
+  let ten _machine_width = 10l
 
-  val ( <= ) : t -> t -> bool
+  let hex_ff _machine_width = 0xffl
 
-  val ( >= ) : t -> t -> bool
+  let ( <= ) x y = Int32.compare x y <= 0
 
-  val ( < ) : t -> t -> bool
+  let ( >= ) x y = Int32.compare x y >= 0
 
-  val bottom_byte_to_int : t -> int
+  let ( < ) x y = Int32.compare x y < 0
 
-  val of_char : char -> t
+  let ( > ) x y = Int32.compare x y > 0
 
-  val of_int : int -> t
+  let bottom_byte_to_int t = Int32.to_int (Int32.logand t 0xffl)
 
-  val of_int_option : int -> t option
+  let of_char _machine_width c = Int32.of_int (Char.code c)
 
-  val to_int : t -> int
+  let of_int _machine_width i = Int32.of_int i
 
-  val to_int_option : t -> int option
+  let of_int_option _machine_width i = Some (Int32.of_int i)
 
-  val to_int_exn : t -> int
+  let of_int32 _machine_width i = i
 
-  val of_int32 : int32 -> t
+  let of_int64 _machine_width i = Int64.to_int32 i
 
-  val to_int32 : t -> int32
+  let of_targetint _machine_width t =
+    match Targetint_32_64.repr t with
+    | Targetint_32_64.Int32 x -> x
+    | Targetint_32_64.Int64 x -> Int64.to_int32 x
 
-  val of_int64 : int64 -> t
+  let of_float _machine_width f = Int32.of_float f
 
-  val to_int64 : t -> int64
+  let to_float = Int32.to_float
 
-  val of_targetint : Targetint_32_64.t -> t
+  let to_int = Int32.to_int
 
-  val to_targetint : t -> Targetint_32_64.t
+  let to_int_exn = Int32.to_int
 
-  val of_float : float -> t
+  let to_int_option t = Some (Int32.to_int t)
 
-  val to_float : t -> float
+  let to_int32 t = t
 
-  val neg : t -> t
+  let to_int64 = Int64.of_int32
 
-  val get_least_significant_16_bits_then_byte_swap : t -> t
+  let to_targetint machine_width t = Targetint_32_64.of_int32 machine_width t
 
-  val add : t -> t -> t
-
-  val sub : t -> t -> t
-
-  val mul : t -> t -> t
-
-  val mod_ : t -> t -> t
-
-  val div : t -> t -> t
-
-  val and_ : t -> t -> t
-
-  val or_ : t -> t -> t
-
-  val xor : t -> t -> t
-
-  val shift_left : t -> int -> t
-
-  val shift_right : t -> int -> t
-
-  val shift_right_logical : t -> int -> t
-
-  val min : t -> t -> t
-
-  val max : t -> t -> t
-
-  val is_non_negative : t -> bool
-
-  val of_int8 : Numeric_types.Int8.t -> t
-
-  val of_int16 : Numeric_types.Int16.t -> t
-end
-
-module T0 = struct
-  include Targetint_32_64
-
-  let ten = Targetint_32_64.of_int 10
-
-  let hex_ff = Targetint_32_64.of_int 0xff
-
-  let bool_true = one
-
-  let bool_false = zero
-
-  let bool b = if b then bool_true else bool_false
-
-  let min_value = Targetint_32_64.min_int
-
-  let max_value = Targetint_32_64.max_int
-
-  let bottom_byte_to_int t =
-    Targetint_32_64.to_int (Targetint_32_64.logand t hex_ff)
-
-  let xor = Targetint_32_64.logxor
-
-  let or_ = Targetint_32_64.logor
-
-  let and_ = Targetint_32_64.logand
-
-  let mod_ = Targetint_32_64.rem
-
-  let of_char c = Targetint_32_64.of_int (Char.code c)
-
-  let of_int_option i = Some (of_int i)
-
-  let to_targetint t = t
-
-  let of_targetint t = t
-
-  let max t1 t2 = if Targetint_32_64.compare t1 t2 < 0 then t2 else t1
-
-  let min t1 t2 = if Targetint_32_64.compare t1 t2 < 0 then t1 else t2
-
-  let of_int8 i = Targetint_32_64.of_int (Numeric_types.Int8.to_int i)
-
-  let of_int16 i = Targetint_32_64.of_int (Numeric_types.Int16.to_int i)
-
-  let ( <= ) t1 t2 = Stdlib.( <= ) (Targetint_32_64.compare t1 t2) 0
-
-  let ( >= ) t1 t2 = Stdlib.( >= ) (Targetint_32_64.compare t1 t2) 0
-
-  let ( < ) t1 t2 = Stdlib.( < ) (Targetint_32_64.compare t1 t2) 0
-
-  let ( > ) t1 t2 = Stdlib.( > ) (Targetint_32_64.compare t1 t2) 0
-
-  let to_int_option t =
-    (* CR selee: maybe change to [to_int_in_range_option t ~min ~max] *)
-    let t_as_int64 = to_int64 t in
-    let min_int_as_int64 = Int64.of_int Stdlib.min_int in
-    let max_int_as_int64 = Int64.of_int Stdlib.max_int in
-    let le x y = Stdlib.( <= ) (Int64.compare x y) 0 in
-    if le min_int_as_int64 t_as_int64 && le t_as_int64 max_int_as_int64
-    then Some (to_int t)
-    else None
-
-  let to_int_exn t =
-    match to_int_option t with
-    | Some i -> i
-    | None ->
-      Misc.fatal_errorf "Targetint_31_63.to_int_exn: %a out of range"
-        Targetint_32_64.print t
+  let neg = Int32.neg
 
   let get_least_significant_16_bits_then_byte_swap t =
-    let least_significant_byte = Targetint_32_64.logand t hex_ff in
+    let least_significant_byte = Int32.logand t 0xffl in
     let second_to_least_significant_byte =
-      Targetint_32_64.shift_right_logical
-        (Targetint_32_64.logand t (Targetint_32_64.of_int 0xff00))
-        8
+      Int32.shift_right_logical (Int32.logand t 0xff00l) 8
     in
-    Targetint_32_64.logor second_to_least_significant_byte
-      (Targetint_32_64.shift_left least_significant_byte 8)
+    Int32.logor second_to_least_significant_byte
+      (Int32.shift_left least_significant_byte 8)
 
-  let is_non_negative t = t >= zero
+  let add = Int32.add
+
+  let sub = Int32.sub
+
+  let mul = Int32.mul
+
+  let mod_ = Int32.rem
+
+  let div = Int32.div
+
+  let and_ = Int32.logand
+
+  let or_ = Int32.logor
+
+  let xor = Int32.logxor
+
+  let shift_left = Int32.shift_left
+
+  let shift_right = Int32.shift_right
+
+  let shift_right_logical = Int32.shift_right_logical
+
+  let max x y = if Stdlib.( > ) (Int32.compare x y) 0 then x else y
+
+  let min x y = if Stdlib.( < ) (Int32.compare x y) 0 then x else y
 end
 
-module With_gc_bit = struct
-  include T0
+(* Wrapper module for Int64 to work with One_bit_fewer *)
+module Int64_base = struct
+  type t = int64
 
-  (* Note: the [include T0] must be first so that the [One_bit_fewer] functions
-     take precedence. *)
-  include One_bit_fewer.Make (T0)
-  include Container_types.Make (T0)
+  let compare = Int64.compare
+
+  let equal = Int64.equal
+
+  let hash = Hashtbl.hash
+
+  let print ppf t = Format.fprintf ppf "%Ld" t
+
+  let min_value _machine_width = Int64.min_int
+
+  let max_value _machine_width = Int64.max_int
+
+  let minus_one _machine_width = Int64.minus_one
+
+  let zero _machine_width = Int64.zero
+
+  let one _machine_width = Int64.one
+
+  let ten _machine_width = 10L
+
+  let hex_ff _machine_width = 0xffL
+
+  let ( <= ) x y = Int64.compare x y <= 0
+
+  let ( >= ) x y = Int64.compare x y >= 0
+
+  let ( < ) x y = Int64.compare x y < 0
+
+  let ( > ) x y = Int64.compare x y > 0
+
+  let bottom_byte_to_int t = Int64.to_int (Int64.logand t 0xffL)
+
+  let of_char _machine_width c = Int64.of_int (Char.code c)
+
+  let of_int _machine_width i = Int64.of_int i
+
+  let of_int_option _machine_width i = Some (Int64.of_int i)
+
+  let of_int32 _machine_width i = Int64.of_int32 i
+
+  let of_int64 _machine_width i = i
+
+  let of_targetint _machine_width t =
+    match Targetint_32_64.repr t with
+    | Targetint_32_64.Int32 x -> Int64.of_int32 x
+    | Targetint_32_64.Int64 x -> x
+
+  let of_float _machine_width f = Int64.of_float f
+
+  let to_float = Int64.to_float
+
+  let to_int = Int64.to_int
+
+  let to_int_exn = Int64.to_int
+
+  let to_int_option t = Some (Int64.to_int t)
+
+  let to_int32 = Int64.to_int32
+
+  let to_int64 t = t
+
+  let to_targetint machine_width t = Targetint_32_64.of_int64 machine_width t
+
+  let neg = Int64.neg
+
+  let get_least_significant_16_bits_then_byte_swap t =
+    let least_significant_byte = Int64.logand t 0xffL in
+    let second_to_least_significant_byte =
+      Int64.shift_right_logical (Int64.logand t 0xff00L) 8
+    in
+    Int64.logor second_to_least_significant_byte
+      (Int64.shift_left least_significant_byte 8)
+
+  let add = Int64.add
+
+  let sub = Int64.sub
+
+  let mul = Int64.mul
+
+  let mod_ = Int64.rem
+
+  let div = Int64.div
+
+  let and_ = Int64.logand
+
+  let or_ = Int64.logor
+
+  let xor = Int64.logxor
+
+  let shift_left = Int64.shift_left
+
+  let shift_right = Int64.shift_right
+
+  let shift_right_logical = Int64.shift_right_logical
+
+  let max x y = if Stdlib.( > ) (Int64.compare x y) 0 then x else y
+
+  let min x y = if Stdlib.( < ) (Int64.compare x y) 0 then x else y
 end
 
-module Without_gc_bit = struct
-  include T0
-  include Container_types.Make (T0)
+(* Create the One_bit_fewer versions for 31-bit and 63-bit *)
+module Int31 = One_bit_fewer.Make (Int32_base)
+module Int63 = One_bit_fewer.Make (Int64_base)
+
+let print ppf = function
+  | Int31 x -> Format.fprintf ppf "%ld" x
+  | Int32 x -> Format.fprintf ppf "%ld" x
+  | Int63 x -> Format.fprintf ppf "%Ld" x
+
+let machine_width = function
+  | Int31 _ -> MW.Thirty_two
+  | Int32 _ -> MW.Thirty_two_no_gc_tag_bit
+  | Int63 _ -> MW.Sixty_four
+
+let compare t1 t2 =
+  match t1, t2 with
+  | Int31 x1, Int31 x2 -> Int31.compare x1 x2
+  | Int32 x1, Int32 x2 -> Int32.compare x1 x2
+  | Int63 x1, Int63 x2 -> Int63.compare x1 x2
+  | Int31 _, (Int32 _ | Int63 _)
+  | Int32 _, (Int31 _ | Int63 _)
+  | Int63 _, (Int31 _ | Int32 _) ->
+    Misc.fatal_errorf "Target_ocaml_int.compare: incompatible types %a and %a"
+      print t1 print t2
+
+let equal t1 t2 = compare t1 t2 = 0
+
+let hash = function
+  | Int31 x -> Int31.hash x
+  | Int32 x -> Hashtbl.hash x
+  | Int63 x -> Int63.hash x
+
+let zero machine_width =
+  match machine_width with
+  | MW.Thirty_two -> Int31 (Int31.zero MW.Thirty_two)
+  | MW.Thirty_two_no_gc_tag_bit -> Int32 0l
+  | MW.Sixty_four -> Int63 (Int63.zero MW.Sixty_four)
+
+let one machine_width =
+  match machine_width with
+  | MW.Thirty_two -> Int31 (Int31.one MW.Thirty_two)
+  | MW.Thirty_two_no_gc_tag_bit -> Int32 1l
+  | MW.Sixty_four -> Int63 (Int63.one MW.Sixty_four)
+
+let minus_one machine_width =
+  match machine_width with
+  | MW.Thirty_two -> Int31 (Int31.minus_one MW.Thirty_two)
+  | MW.Thirty_two_no_gc_tag_bit -> Int32 (-1l)
+  | MW.Sixty_four -> Int63 (Int63.minus_one MW.Sixty_four)
+
+let ten machine_width =
+  match machine_width with
+  | MW.Thirty_two -> Int31 (Int31.ten MW.Thirty_two)
+  | MW.Thirty_two_no_gc_tag_bit -> Int32 10l
+  | MW.Sixty_four -> Int63 (Int63.ten MW.Sixty_four)
+
+let hex_ff machine_width =
+  match machine_width with
+  | MW.Thirty_two -> Int31 (Int31.hex_ff MW.Thirty_two)
+  | MW.Thirty_two_no_gc_tag_bit -> Int32 0xffl
+  | MW.Sixty_four -> Int63 (Int63.hex_ff MW.Sixty_four)
+
+let min_value machine_width =
+  match machine_width with
+  | MW.Thirty_two -> Int31 (Int31.min_value MW.Thirty_two)
+  | MW.Thirty_two_no_gc_tag_bit -> Int32 Int32.min_int
+  | MW.Sixty_four -> Int63 (Int63.min_value MW.Sixty_four)
+
+let max_value machine_width =
+  match machine_width with
+  | MW.Thirty_two -> Int31 (Int31.max_value MW.Thirty_two)
+  | MW.Thirty_two_no_gc_tag_bit -> Int32 Int32.max_int
+  | MW.Sixty_four -> Int63 (Int63.max_value MW.Sixty_four)
+
+let bool_true machine_width = one machine_width
+
+let bool_false machine_width = zero machine_width
+
+let bool machine_width b =
+  if b then bool_true machine_width else bool_false machine_width
+
+let ( <= ) t1 t2 = compare t1 t2 <= 0
+
+let ( >= ) t1 t2 = compare t1 t2 >= 0
+
+let ( < ) t1 t2 = compare t1 t2 < 0
+
+let bottom_byte_to_int = function
+  | Int31 x -> Int31.bottom_byte_to_int x
+  | Int32 x -> Int32.to_int (Int32.logand x 0xffl)
+  | Int63 x -> Int63.bottom_byte_to_int x
+
+let of_char machine_width c =
+  match machine_width with
+  | MW.Thirty_two -> Int31 (Int31.of_char MW.Thirty_two c)
+  | MW.Thirty_two_no_gc_tag_bit -> Int32 (Int32.of_int (Char.code c))
+  | MW.Sixty_four -> Int63 (Int63.of_char MW.Sixty_four c)
+
+let of_int machine_width i =
+  match machine_width with
+  | MW.Thirty_two -> Int31 (Int31.of_int MW.Thirty_two i)
+  | MW.Thirty_two_no_gc_tag_bit -> Int32 (Int32.of_int i)
+  | MW.Sixty_four -> Int63 (Int63.of_int MW.Sixty_four i)
+
+let of_int_option machine_width i = Some (of_int machine_width i)
+
+let of_int32 machine_width i =
+  match machine_width with
+  | MW.Thirty_two -> Int31 (Int31.of_int32 MW.Thirty_two i)
+  | MW.Thirty_two_no_gc_tag_bit -> Int32 i
+  | MW.Sixty_four -> Int63 (Int63.of_int32 MW.Sixty_four i)
+
+let of_int64 machine_width i =
+  match machine_width with
+  | MW.Thirty_two -> Int31 (Int31.of_int64 MW.Thirty_two i)
+  | MW.Thirty_two_no_gc_tag_bit -> Int32 (Int64.to_int32 i)
+  | MW.Sixty_four -> Int63 (Int63.of_int64 MW.Sixty_four i)
+
+let of_float machine_width f =
+  match machine_width with
+  | MW.Thirty_two -> Int31 (Int31.of_float MW.Thirty_two f)
+  | MW.Thirty_two_no_gc_tag_bit -> Int32 (Int32.of_float f)
+  | MW.Sixty_four -> Int63 (Int63.of_float MW.Sixty_four f)
+
+let to_float = function
+  | Int31 x -> Int31.to_float x
+  | Int32 x -> Int32.to_float x
+  | Int63 x -> Int63.to_float x
+
+let to_int = function
+  | Int31 x -> Int31.to_int x
+  | Int32 x -> Int32.to_int x
+  | Int63 x -> Int63.to_int x
+
+let to_int32 = function
+  | Int31 x -> Int31.to_int32 x
+  | Int32 x -> x
+  | Int63 x -> Int63.to_int32 x
+
+let to_int64 = function
+  | Int31 x -> Int31.to_int64 x
+  | Int32 x -> Int64.of_int32 x
+  | Int63 x -> Int63.to_int64 x
+
+let to_int_option t =
+  (* CR selee: maybe change to [to_int_in_range_option t ~min ~max] *)
+  let t_as_int64 = to_int64 t in
+  let min_int_as_int64 = Int64.of_int Stdlib.min_int in
+  let max_int_as_int64 = Int64.of_int Stdlib.max_int in
+  let le x y = Stdlib.( <= ) (Int64.compare x y) 0 in
+  if le min_int_as_int64 t_as_int64 && le t_as_int64 max_int_as_int64
+  then Some (to_int t)
+  else None
+
+let to_int_exn t =
+  match to_int_option t with
+  | Some i -> i
+  | None ->
+    Misc.fatal_errorf "Target_ocaml_int.to_int_exn: %a out of range" print t
+
+let of_targetint machine_width t =
+  match machine_width, Targetint_32_64.repr t with
+  | MW.Thirty_two, Targetint_32_64.Int32 x ->
+    Int31 (Int31.of_int32 MW.Thirty_two x)
+  | MW.Thirty_two_no_gc_tag_bit, Targetint_32_64.Int32 x -> Int32 x
+  | MW.Sixty_four, Targetint_32_64.Int64 x ->
+    Int63 (Int63.of_int64 MW.Sixty_four x)
+  | MW.Thirty_two, Targetint_32_64.Int64 _
+  | MW.Thirty_two_no_gc_tag_bit, Targetint_32_64.Int64 _
+  | MW.Sixty_four, Targetint_32_64.Int32 _ ->
+    Misc.fatal_errorf
+      "Target_ocaml_int.of_targetint: incompatible machine width and targetint"
+
+let to_targetint machine_width t =
+  match machine_width, t with
+  | MW.Thirty_two, Int31 x ->
+    Targetint_32_64.of_int32 MW.Thirty_two (Int31.to_int32 x)
+  | MW.Thirty_two_no_gc_tag_bit, Int32 x ->
+    Targetint_32_64.of_int32 MW.Thirty_two_no_gc_tag_bit x
+  | MW.Sixty_four, Int63 x ->
+    Targetint_32_64.of_int64 MW.Sixty_four (Int63.to_int64 x)
+  | MW.Thirty_two, (Int32 _ | Int63 _)
+  | MW.Thirty_two_no_gc_tag_bit, (Int31 _ | Int63 _)
+  | MW.Sixty_four, (Int31 _ | Int32 _) ->
+    Misc.fatal_errorf "Target_ocaml_int.to_targetint: mismatched machine width"
+
+let neg = function
+  | Int31 x -> Int31 (Int31.neg x)
+  | Int32 x -> Int32 (Int32.neg x)
+  | Int63 x -> Int63 (Int63.neg x)
+
+let add t1 t2 =
+  match t1, t2 with
+  | Int31 x1, Int31 x2 -> Int31 (Int31.add x1 x2)
+  | Int32 x1, Int32 x2 -> Int32 (Int32.add x1 x2)
+  | Int63 x1, Int63 x2 -> Int63 (Int63.add x1 x2)
+  | Int31 _, (Int32 _ | Int63 _)
+  | Int32 _, (Int31 _ | Int63 _)
+  | Int63 _, (Int31 _ | Int32 _) ->
+    Misc.fatal_errorf "Target_ocaml_int.add: incompatible types %a and %a" print
+      t1 print t2
+
+let sub t1 t2 =
+  match t1, t2 with
+  | Int31 x1, Int31 x2 -> Int31 (Int31.sub x1 x2)
+  | Int32 x1, Int32 x2 -> Int32 (Int32.sub x1 x2)
+  | Int63 x1, Int63 x2 -> Int63 (Int63.sub x1 x2)
+  | Int31 _, (Int32 _ | Int63 _)
+  | Int32 _, (Int31 _ | Int63 _)
+  | Int63 _, (Int31 _ | Int32 _) ->
+    Misc.fatal_errorf "Target_ocaml_int.sub: incompatible types %a and %a" print
+      t1 print t2
+
+let mul t1 t2 =
+  match t1, t2 with
+  | Int31 x1, Int31 x2 -> Int31 (Int31.mul x1 x2)
+  | Int32 x1, Int32 x2 -> Int32 (Int32.mul x1 x2)
+  | Int63 x1, Int63 x2 -> Int63 (Int63.mul x1 x2)
+  | Int31 _, (Int32 _ | Int63 _)
+  | Int32 _, (Int31 _ | Int63 _)
+  | Int63 _, (Int31 _ | Int32 _) ->
+    Misc.fatal_errorf "Target_ocaml_int.mul: incompatible types %a and %a" print
+      t1 print t2
+
+let div t1 t2 =
+  match t1, t2 with
+  | Int31 x1, Int31 x2 -> Int31 (Int31.div x1 x2)
+  | Int32 x1, Int32 x2 -> Int32 (Int32.div x1 x2)
+  | Int63 x1, Int63 x2 -> Int63 (Int63.div x1 x2)
+  | Int31 _, (Int32 _ | Int63 _)
+  | Int32 _, (Int31 _ | Int63 _)
+  | Int63 _, (Int31 _ | Int32 _) ->
+    Misc.fatal_errorf "Target_ocaml_int.div: incompatible types %a and %a" print
+      t1 print t2
+
+let mod_ t1 t2 =
+  match t1, t2 with
+  | Int31 x1, Int31 x2 -> Int31 (Int31.mod_ x1 x2)
+  | Int32 x1, Int32 x2 -> Int32 (Int32.rem x1 x2)
+  | Int63 x1, Int63 x2 -> Int63 (Int63.mod_ x1 x2)
+  | Int31 _, (Int32 _ | Int63 _)
+  | Int32 _, (Int31 _ | Int63 _)
+  | Int63 _, (Int31 _ | Int32 _) ->
+    Misc.fatal_errorf "Target_ocaml_int.mod_: incompatible types %a and %a"
+      print t1 print t2
+
+let and_ t1 t2 =
+  match t1, t2 with
+  | Int31 x1, Int31 x2 -> Int31 (Int31.and_ x1 x2)
+  | Int32 x1, Int32 x2 -> Int32 (Int32.logand x1 x2)
+  | Int63 x1, Int63 x2 -> Int63 (Int63.and_ x1 x2)
+  | Int31 _, (Int32 _ | Int63 _)
+  | Int32 _, (Int31 _ | Int63 _)
+  | Int63 _, (Int31 _ | Int32 _) ->
+    Misc.fatal_errorf "Target_ocaml_int.and_: incompatible types %a and %a"
+      print t1 print t2
+
+let or_ t1 t2 =
+  match t1, t2 with
+  | Int31 x1, Int31 x2 -> Int31 (Int31.or_ x1 x2)
+  | Int32 x1, Int32 x2 -> Int32 (Int32.logor x1 x2)
+  | Int63 x1, Int63 x2 -> Int63 (Int63.or_ x1 x2)
+  | Int31 _, (Int32 _ | Int63 _)
+  | Int32 _, (Int31 _ | Int63 _)
+  | Int63 _, (Int31 _ | Int32 _) ->
+    Misc.fatal_errorf "Target_ocaml_int.or_: incompatible types %a and %a" print
+      t1 print t2
+
+let xor t1 t2 =
+  match t1, t2 with
+  | Int31 x1, Int31 x2 -> Int31 (Int31.xor x1 x2)
+  | Int32 x1, Int32 x2 -> Int32 (Int32.logxor x1 x2)
+  | Int63 x1, Int63 x2 -> Int63 (Int63.xor x1 x2)
+  | Int31 _, (Int32 _ | Int63 _)
+  | Int32 _, (Int31 _ | Int63 _)
+  | Int63 _, (Int31 _ | Int32 _) ->
+    Misc.fatal_errorf "Target_ocaml_int.xor: incompatible types %a and %a" print
+      t1 print t2
+
+let shift_left t i =
+  match t with
+  | Int31 x -> Int31 (Int31.shift_left x i)
+  | Int32 x -> Int32 (Int32.shift_left x i)
+  | Int63 x -> Int63 (Int63.shift_left x i)
+
+let shift_right t i =
+  match t with
+  | Int31 x -> Int31 (Int31.shift_right x i)
+  | Int32 x -> Int32 (Int32.shift_right x i)
+  | Int63 x -> Int63 (Int63.shift_right x i)
+
+let shift_right_logical t i =
+  match t with
+  | Int31 x -> Int31 (Int31.shift_right_logical x i)
+  | Int32 x -> Int32 (Int32.shift_right_logical x i)
+  | Int63 x -> Int63 (Int63.shift_right_logical x i)
+
+let max t1 t2 = if Stdlib.( < ) (compare t1 t2) 0 then t2 else t1
+
+let min t1 t2 = if Stdlib.( < ) (compare t1 t2) 0 then t1 else t2
+
+let get_least_significant_16_bits_then_byte_swap t =
+  let mw = machine_width t in
+  let least_significant_byte = and_ t (hex_ff mw) in
+  let second_to_least_significant_byte =
+    shift_right_logical (and_ t (of_int mw 0xff00)) 8
+  in
+  or_ second_to_least_significant_byte (shift_left least_significant_byte 8)
+
+let is_non_negative t = t >= zero (machine_width t)
+
+let of_int8 machine_width i = of_int machine_width (Numeric_types.Int8.to_int i)
+
+let of_int16 machine_width i =
+  of_int machine_width (Numeric_types.Int16.to_int i)
+
+module Self = struct
+  type nonrec t = t
+
+  let print = print
+
+  let compare = compare
+
+  let equal = equal
+
+  let hash = hash
 end
 
-(* CR selee: this is extremely sad, and should be replaced with a proper config
-   variable in the future *)
-let has_gc_bit_in_int =
-  let compiler_name = Filename.basename Sys.argv.(0) in
-  match compiler_name with "ocamlj" | "ocamlj.opt" -> false | _ -> true
+include Container_types.Make (Self)
 
-module Self = (val if has_gc_bit_in_int
-                   then (module With_gc_bit)
-                   else (module Without_gc_bit) : S)
+let all_bools machine_width =
+  Set.of_list [bool_true machine_width; bool_false machine_width]
 
-include Self
-
-let all_bools = Set.of_list [bool_true; bool_false]
-
-let zero_one_and_minus_one = Set.of_list [zero; one; minus_one]
+let zero_one_and_minus_one machine_width =
+  Set.of_list [zero machine_width; one machine_width; minus_one machine_width]
 
 module Pair = struct
   type nonrec t = t * t
 
-  include Container_types.Make_pair (Self) (Self)
+  module T_pair = Container_types.Pair (Self) (Self)
+  include Container_types.Make (T_pair)
 end
 
-let cross_product = Pair.create_from_cross_product
+let cross_product set1 set2 =
+  Set.fold
+    (fun elt1 result ->
+      Set.fold (fun elt2 result -> Pair.Set.add (elt1, elt2) result) set2 result)
+    set1 Pair.Set.empty

--- a/middle_end/flambda2/numbers/target_ocaml_int.ml
+++ b/middle_end/flambda2/numbers/target_ocaml_int.ml
@@ -25,6 +25,8 @@ type t =
 module Int32_base = struct
   type t = int32
 
+  let machine_width _t = MW.Thirty_two
+
   let compare = Int32.compare
 
   let equal = Int32.equal
@@ -128,6 +130,8 @@ end
 (* Wrapper module for Int64 to work with One_bit_fewer *)
 module Int64_base = struct
   type t = int64
+
+  let machine_width _t = MW.Sixty_four
 
   let compare = Int64.compare
 

--- a/middle_end/flambda2/numbers/target_ocaml_int.ml
+++ b/middle_end/flambda2/numbers/target_ocaml_int.ml
@@ -80,9 +80,20 @@ module Int32_base = struct
 
   let to_int = Int32.to_int
 
-  let to_int_exn = Int32.to_int
+  let to_int_option t =
+    let t_as_int64 = Int64.of_int32 t in
+    let min_int64 = Int64.of_int Stdlib.min_int in
+    let max_int64 = Int64.of_int Stdlib.max_int in
+    if Stdlib.( >= ) (Int64.compare t_as_int64 min_int64) 0
+       && Stdlib.( <= ) (Int64.compare t_as_int64 max_int64) 0
+    then Some (Int32.to_int t)
+    else None
 
-  let to_int_option t = Some (Int32.to_int t)
+  let to_int_exn t =
+    match to_int_option t with
+    | Some i -> i
+    | None ->
+      Misc.fatal_errorf "Target_ocaml_int.to_int_exn: %ld out of range" t
 
   let to_int32 t = t
 
@@ -186,9 +197,19 @@ module Int64_base = struct
 
   let to_int = Int64.to_int
 
-  let to_int_exn = Int64.to_int
+  let to_int_option t =
+    let min_int64 = Int64.of_int Stdlib.min_int in
+    let max_int64 = Int64.of_int Stdlib.max_int in
+    if Stdlib.( >= ) (Int64.compare t min_int64) 0
+       && Stdlib.( <= ) (Int64.compare t max_int64) 0
+    then Some (Int64.to_int t)
+    else None
 
-  let to_int_option t = Some (Int64.to_int t)
+  let to_int_exn t =
+    match to_int_option t with
+    | Some i -> i
+    | None ->
+      Misc.fatal_errorf "Target_ocaml_int.to_int_exn: %Ld out of range" t
 
   let to_int32 = Int64.to_int32
 

--- a/middle_end/flambda2/numbers/target_ocaml_int.mli
+++ b/middle_end/flambda2/numbers/target_ocaml_int.mli
@@ -22,38 +22,40 @@ type t
 
 include Container_types.S with type t := t
 
+val machine_width : t -> Target_system.Machine_width.t
+
 (** The minimum integer representable on the target. *)
-val min_value : t
+val min_value : Target_system.Machine_width.t -> t
 
 (** The maximum integer representable on the target. *)
-val max_value : t
+val max_value : Target_system.Machine_width.t -> t
 
 (** The OCaml integer -1 *)
-val minus_one : t
+val minus_one : Target_system.Machine_width.t -> t
 
 (** The OCaml integer 0. *)
-val zero : t
+val zero : Target_system.Machine_width.t -> t
 
 (** The OCaml integer 1. *)
-val one : t
+val one : Target_system.Machine_width.t -> t
 
 (** The OCaml integer 10. *)
-val ten : t
+val ten : Target_system.Machine_width.t -> t
 
 (** The OCaml integer 0xff. *)
-val hex_ff : t
+val hex_ff : Target_system.Machine_width.t -> t
 
 (** The set {-1, 0, 1}. *)
-val zero_one_and_minus_one : Set.t
+val zero_one_and_minus_one : Target_system.Machine_width.t -> Set.t
 
 (** Boolean values. *)
-val bool : bool -> t
+val bool : Target_system.Machine_width.t -> bool -> t
 
-val bool_true : t
+val bool_true : Target_system.Machine_width.t -> t
 
-val bool_false : t
+val bool_false : Target_system.Machine_width.t -> t
 
-val all_bools : Set.t
+val all_bools : Target_system.Machine_width.t -> Set.t
 
 (** Comparison functions. *)
 val ( <= ) : t -> t -> bool
@@ -68,15 +70,15 @@ val bottom_byte_to_int : t -> int
 
 (** Returns the OCaml integer corresponding to the ASCII code of the given
     character. *)
-val of_char : char -> t
+val of_char : Target_system.Machine_width.t -> char -> t
 
 (** Convert the given integer (type [int]) to a OCaml integer (type [t]), modulo
     the target word size minus one (for the tag bit). *)
-val of_int : int -> t
+val of_int : Target_system.Machine_width.t -> int -> t
 
 (** Returns [None] iff the given [int] cannot be represented as a target
     "int"-width integer, else returns the same as {!of_int}. *)
-val of_int_option : int -> t option
+val of_int_option : Target_system.Machine_width.t -> int -> t option
 
 (** Convert the given OCaml integer (type [t]) to an integer (type [int]),
     modulo the [int] size, i.e. high-order bits are lost during the conversion. *)
@@ -94,7 +96,7 @@ val to_int_exn : t -> int
 
 (** Convert the given 32-bit integer (type [int32]) to a OCaml integer, modulo
     the size of a OCaml integer. *)
-val of_int32 : int32 -> t
+val of_int32 : Target_system.Machine_width.t -> int32 -> t
 
 (** Convert the given OCaml integer to a 32-bit integer (type [int32]). On
     64-bit platforms, the 64-bit native integer is taken modulo 2{^ 32}, i.e.
@@ -103,24 +105,24 @@ val to_int32 : t -> int32
 
 (** Convert the given 64-bit integer (type [int64]) to a target native integer,
     modulo the size of a OCaml integer. *)
-val of_int64 : int64 -> t
+val of_int64 : Target_system.Machine_width.t -> int64 -> t
 
 (** Convert the given OCaml integer to a 64-bit integer (type [int64]). *)
 val to_int64 : t -> int64
 
 (** Convert the given target native integer (type [Targetint_32_64.t]) to an
     OCaml integer, modulo the size of an OCaml integer. *)
-val of_targetint : Targetint_32_64.t -> t
+val of_targetint : Target_system.Machine_width.t -> Targetint_32_64.t -> t
 
 (** Convert the given OCaml integer (type [t]) to a target native integer (type
     [Targetint_32_64.t]). *)
-val to_targetint : t -> Targetint_32_64.t
+val to_targetint : Target_system.Machine_width.t -> t -> Targetint_32_64.t
 
 (** Convert the given floating-point number to an OCaml integer, discarding the
     fractional part (truncate towards 0). The result of the conversion is
     undefined if, after truncation, the number is outside the range
     \[{!Targetint_31_63.min_value}, {!Targetint_31_63.max_value}\]. *)
-val of_float : float -> t
+val of_float : Target_system.Machine_width.t -> float -> t
 
 (** Convert the given OCaml integer to a floating-point number. *)
 val to_float : t -> float
@@ -182,9 +184,9 @@ val max : t -> t -> t
 
 val is_non_negative : t -> bool
 
-val of_int8 : Numeric_types.Int8.t -> t
+val of_int8 : Target_system.Machine_width.t -> Numeric_types.Int8.t -> t
 
-val of_int16 : Numeric_types.Int16.t -> t
+val of_int16 : Target_system.Machine_width.t -> Numeric_types.Int16.t -> t
 
 module Pair : sig
   type nonrec t = t * t

--- a/middle_end/flambda2/numbers/targetint_32_64.ml
+++ b/middle_end/flambda2/numbers/targetint_32_64.ml
@@ -16,122 +16,20 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type repr =
+module MW = Target_system.Machine_width
+
+type t =
   | Int32 of int32
   | Int64 of int64
 
-type num_bits =
-  | Thirty_two
-  | Sixty_four
-
-module type S = sig
-  type t
-
-  type targetint = t
-
-  val num_bits : num_bits
-
-  val repr : t -> repr
-
-  include Container_types.S with type t := t
-
-  val zero : t
-
-  val one : t
-
-  val minus_one : t
-
-  val neg : t -> t
-
-  val add : t -> t -> t
-
-  val sub : t -> t -> t
-
-  val mul : t -> t -> t
-
-  val div : t -> t -> t
-
-  val shift_left : t -> int -> t
-
-  val shift_right : t -> int -> t
-
-  val shift_right_logical : t -> int -> t
-
-  val min : t -> t -> t
-
-  val max : t -> t -> t
-
-  val get_least_significant_16_bits_then_byte_swap : t -> t
-
-  module Pair : sig
-    type nonrec t = t * t
-
-    include Container_types.S with type t := t
-  end
-
-  val cross_product : Set.t -> Set.t -> Pair.Set.t
-
-  val max_int : t
-
-  val min_int : t
-
-  val rem : t -> t -> t
-
-  val succ : t -> t
-
-  val pred : t -> t
-
-  val abs : t -> t
-
-  val logand : t -> t -> t
-
-  val logor : t -> t -> t
-
-  val logxor : t -> t -> t
-
-  val lognot : t -> t
-
-  val swap_byte_endianness : t -> t
-
-  val of_int_exn : int -> t
-
-  val of_int : int -> t
-
-  val of_int32 : int32 -> t
-
-  val of_int64 : int64 -> t
-
-  val of_float : float -> t
-
-  val of_string : string -> t
-
-  val to_int : t -> int
-
-  val to_int32 : t -> int32
-
-  val to_int64 : t -> int64
-
-  val to_float : t -> float
-
-  val to_string : t -> string
-
-  val unsigned_div : t -> t -> t
-
-  val unsigned_rem : t -> t -> t
-
-  val unsigned_compare : t -> t -> int
-
-  module Targetint_set = Set
-end
+type targetint = t
 
 module Int32 = struct
   include Int32
 
-  type targetint = t
-
   let of_int_exn =
     match Sys.word_size with
-    (* size of [int] *)
+    (* size of [int] on the host *)
     | 32 -> Int32.of_int
     | 64 ->
       fun n ->
@@ -140,17 +38,7 @@ module Int32 = struct
         else Int32.of_int n
     | _ -> assert false
 
-  let num_bits = Thirty_two
-
-  let of_int32 x = x
-
-  let to_int32 x = x
-
-  let of_int64 = Int64.to_int32
-
   let to_int64 = Int64.of_int32
-
-  let repr x = Int32 x
 
   include Container_types.Make (struct
     type nonrec t = t
@@ -168,23 +56,6 @@ module Int32 = struct
 
   let max t1 t2 = if Int32.compare t1 t2 <= 0 then t2 else t1
 
-  module Targetint_set = Set
-
-  module Pair = struct
-    type nonrec t = t * t
-
-    module T_pair = Container_types.Pair (T) (T)
-    include Container_types.Make (T_pair)
-  end
-
-  let cross_product set1 set2 =
-    Set.fold
-      (fun elt1 result ->
-        Set.fold
-          (fun elt2 result -> Pair.Set.add (elt1, elt2) result)
-          set2 result)
-      set1 Pair.Set.empty
-
   let get_least_significant_16_bits_then_byte_swap t =
     let least_significant_byte = Int32.logand t 0xffl in
     let second_to_least_significant_byte =
@@ -199,21 +70,7 @@ end
 module Int64 = struct
   include Int64
 
-  type targetint = t
-
-  let num_bits = Sixty_four
-
   let of_int_exn = Int64.of_int
-
-  let of_int64 x = x
-
-  let to_int64 x = x
-
-  let repr x = Int64 x
-
-  let min t1 t2 = if Int64.compare t1 t2 <= 0 then t1 else t2
-
-  let max t1 t2 = if Int64.compare t1 t2 <= 0 then t2 else t1
 
   include Container_types.Make (struct
     type nonrec t = t
@@ -227,22 +84,9 @@ module Int64 = struct
     let [@ocamlformat "disable"] print ppf t = Format.fprintf ppf "%Ld" t
   end)
 
-  module Targetint_set = Set
+  let min t1 t2 = if Int64.compare t1 t2 <= 0 then t1 else t2
 
-  module Pair = struct
-    type nonrec t = t * t
-
-    module T_pair = Container_types.Pair (T) (T)
-    include Container_types.Make (T_pair)
-  end
-
-  let cross_product set1 set2 =
-    Set.fold
-      (fun elt1 result ->
-        Set.fold
-          (fun elt2 result -> Pair.Set.add (elt1, elt2) result)
-          set2 result)
-      set1 Pair.Set.empty
+  let max t1 t2 = if Int64.compare t1 t2 <= 0 then t2 else t1
 
   let get_least_significant_16_bits_then_byte_swap t =
     let least_significant_byte = Int64.logand t 0xffL in
@@ -255,22 +99,302 @@ module Int64 = struct
   external swap_byte_endianness : t -> t = "%bswap_int64"
 end
 
-(* CR selee: this is extremely sad, and should be replaced with a proper config
-   variable in the future *)
-let size =
-  let compiler_name = Filename.basename Sys.argv.(0) in
-  match compiler_name with "ocamlj" | "ocamlj.opt" -> 32 | _ -> Sys.word_size
+(* Helper function to extract machine width from a t value *)
+let machine_width t =
+  match t with
+  | Int32 _ ->
+    MW.Thirty_two
+    (* For targetint_32_64, Int32 always means traditional 32-bit *)
+  | Int64 _ -> MW.Sixty_four
 
-include (val match size with
-             | 32 -> (module Int32)
-             | 64 -> (module Int64)
-             | _ -> assert false : S)
+(* Print function *)
+let print ppf t =
+  match t with
+  | Int32 x -> Format.fprintf ppf "%ld" x
+  | Int64 x -> Format.fprintf ppf "%Ld" x
 
-let to_int_checked t =
+(* Creation functions *)
+let zero machine_width =
+  match machine_width with
+  | MW.Thirty_two | MW.Thirty_two_no_gc_tag_bit -> Int32 Int32.zero
+  | MW.Sixty_four -> Int64 Int64.zero
+
+let one machine_width =
+  match machine_width with
+  | MW.Thirty_two | MW.Thirty_two_no_gc_tag_bit -> Int32 Int32.one
+  | MW.Sixty_four -> Int64 Int64.one
+
+let minus_one machine_width =
+  match machine_width with
+  | MW.Thirty_two | MW.Thirty_two_no_gc_tag_bit -> Int32 Int32.minus_one
+  | MW.Sixty_four -> Int64 Int64.minus_one
+
+let max_int machine_width =
+  match machine_width with
+  | MW.Thirty_two | MW.Thirty_two_no_gc_tag_bit -> Int32 Int32.max_int
+  | MW.Sixty_four -> Int64 Int64.max_int
+
+let min_int machine_width =
+  match machine_width with
+  | MW.Thirty_two | MW.Thirty_two_no_gc_tag_bit -> Int32 Int32.min_int
+  | MW.Sixty_four -> Int64 Int64.min_int
+
+(* Unary operations *)
+let neg t =
+  match t with Int32 x -> Int32 (Int32.neg x) | Int64 x -> Int64 (Int64.neg x)
+
+let abs t =
+  match t with Int32 x -> Int32 (Int32.abs x) | Int64 x -> Int64 (Int64.abs x)
+
+let succ t =
+  match t with
+  | Int32 x -> Int32 (Int32.succ x)
+  | Int64 x -> Int64 (Int64.succ x)
+
+let pred t =
+  match t with
+  | Int32 x -> Int32 (Int32.pred x)
+  | Int64 x -> Int64 (Int64.pred x)
+
+let lognot t =
+  match t with
+  | Int32 x -> Int32 (Int32.lognot x)
+  | Int64 x -> Int64 (Int64.lognot x)
+
+(* Binary operations - need to check compatibility *)
+let add t1 t2 =
+  match t1, t2 with
+  | Int32 x1, Int32 x2 -> Int32 (Int32.add x1 x2)
+  | Int64 x1, Int64 x2 -> Int64 (Int64.add x1 x2)
+  | Int32 _, Int64 _ | Int64 _, Int32 _ ->
+    Misc.fatal_errorf "Targetint_32_64.add: incompatible types %a and %a" print
+      t1 print t2
+
+let sub t1 t2 =
+  match t1, t2 with
+  | Int32 x1, Int32 x2 -> Int32 (Int32.sub x1 x2)
+  | Int64 x1, Int64 x2 -> Int64 (Int64.sub x1 x2)
+  | Int32 _, Int64 _ | Int64 _, Int32 _ ->
+    Misc.fatal_errorf "Targetint_32_64.sub: incompatible types %a and %a" print
+      t1 print t2
+
+let mul t1 t2 =
+  match t1, t2 with
+  | Int32 x1, Int32 x2 -> Int32 (Int32.mul x1 x2)
+  | Int64 x1, Int64 x2 -> Int64 (Int64.mul x1 x2)
+  | Int32 _, Int64 _ | Int64 _, Int32 _ ->
+    Misc.fatal_errorf "Targetint_32_64.mul: incompatible types %a and %a" print
+      t1 print t2
+
+let div t1 t2 =
+  match t1, t2 with
+  | Int32 x1, Int32 x2 -> Int32 (Int32.div x1 x2)
+  | Int64 x1, Int64 x2 -> Int64 (Int64.div x1 x2)
+  | Int32 _, Int64 _ | Int64 _, Int32 _ ->
+    Misc.fatal_errorf "Targetint_32_64.div: incompatible types %a and %a" print
+      t1 print t2
+
+let unsigned_div t1 t2 =
+  match t1, t2 with
+  | Int32 x1, Int32 x2 -> Int32 (Int32.unsigned_div x1 x2)
+  | Int64 x1, Int64 x2 -> Int64 (Int64.unsigned_div x1 x2)
+  | Int32 _, Int64 _ | Int64 _, Int32 _ ->
+    Misc.fatal_errorf
+      "Targetint_32_64.unsigned_div: incompatible types %a and %a" print t1
+      print t2
+
+let rem t1 t2 =
+  match t1, t2 with
+  | Int32 x1, Int32 x2 -> Int32 (Int32.rem x1 x2)
+  | Int64 x1, Int64 x2 -> Int64 (Int64.rem x1 x2)
+  | Int32 _, Int64 _ | Int64 _, Int32 _ ->
+    Misc.fatal_errorf "Targetint_32_64.rem: incompatible types %a and %a" print
+      t1 print t2
+
+let unsigned_rem t1 t2 =
+  match t1, t2 with
+  | Int32 x1, Int32 x2 -> Int32 (Int32.unsigned_rem x1 x2)
+  | Int64 x1, Int64 x2 -> Int64 (Int64.unsigned_rem x1 x2)
+  | Int32 _, Int64 _ | Int64 _, Int32 _ ->
+    Misc.fatal_errorf
+      "Targetint_32_64.unsigned_rem: incompatible types %a and %a" print t1
+      print t2
+
+let logand t1 t2 =
+  match t1, t2 with
+  | Int32 x1, Int32 x2 -> Int32 (Int32.logand x1 x2)
+  | Int64 x1, Int64 x2 -> Int64 (Int64.logand x1 x2)
+  | Int32 _, Int64 _ | Int64 _, Int32 _ ->
+    Misc.fatal_errorf "Targetint_32_64.logand: incompatible types %a and %a"
+      print t1 print t2
+
+let logor t1 t2 =
+  match t1, t2 with
+  | Int32 x1, Int32 x2 -> Int32 (Int32.logor x1 x2)
+  | Int64 x1, Int64 x2 -> Int64 (Int64.logor x1 x2)
+  | Int32 _, Int64 _ | Int64 _, Int32 _ ->
+    Misc.fatal_errorf "Targetint_32_64.logor: incompatible types %a and %a"
+      print t1 print t2
+
+let logxor t1 t2 =
+  match t1, t2 with
+  | Int32 x1, Int32 x2 -> Int32 (Int32.logxor x1 x2)
+  | Int64 x1, Int64 x2 -> Int64 (Int64.logxor x1 x2)
+  | Int32 _, Int64 _ | Int64 _, Int32 _ ->
+    Misc.fatal_errorf "Targetint_32_64.logxor: incompatible types %a and %a"
+      print t1 print t2
+
+(* Shift operations *)
+let shift_left t n =
+  match t with
+  | Int32 x -> Int32 (Int32.shift_left x n)
+  | Int64 x -> Int64 (Int64.shift_left x n)
+
+let shift_right t n =
+  match t with
+  | Int32 x -> Int32 (Int32.shift_right x n)
+  | Int64 x -> Int64 (Int64.shift_right x n)
+
+let shift_right_logical t n =
+  match t with
+  | Int32 x -> Int32 (Int32.shift_right_logical x n)
+  | Int64 x -> Int64 (Int64.shift_right_logical x n)
+
+(* Comparison functions *)
+let compare t1 t2 =
+  match t1, t2 with
+  | Int32 x1, Int32 x2 -> Int32.compare x1 x2
+  | Int64 x1, Int64 x2 -> Int64.compare x1 x2
+  | Int32 _, Int64 _ -> -1
+  | Int64 _, Int32 _ -> 1
+
+let equal t1 t2 = compare t1 t2 = 0
+
+let unsigned_compare t1 t2 =
+  match t1, t2 with
+  | Int32 x1, Int32 x2 -> Int32.unsigned_compare x1 x2
+  | Int64 x1, Int64 x2 -> Int64.unsigned_compare x1 x2
+  | Int32 _, Int64 _ | Int64 _, Int32 _ ->
+    Misc.fatal_errorf
+      "Targetint_32_64.unsigned_compare: incompatible types %a and %a" print t1
+      print t2
+
+let min t1 t2 =
+  match t1, t2 with
+  | Int32 x1, Int32 x2 -> Int32 (Int32.min x1 x2)
+  | Int64 x1, Int64 x2 -> Int64 (Int64.min x1 x2)
+  | Int32 _, Int64 _ | Int64 _, Int32 _ ->
+    Misc.fatal_errorf "Targetint_32_64.min: incompatible types %a and %a" print
+      t1 print t2
+
+let max t1 t2 =
+  match t1, t2 with
+  | Int32 x1, Int32 x2 -> Int32 (Int32.max x1 x2)
+  | Int64 x1, Int64 x2 -> Int64 (Int64.max x1 x2)
+  | Int32 _, Int64 _ | Int64 _, Int32 _ ->
+    Misc.fatal_errorf "Targetint_32_64.max: incompatible types %a and %a" print
+      t1 print t2
+
+(* Conversion functions *)
+let of_int machine_width n =
+  match machine_width with
+  | MW.Thirty_two | MW.Thirty_two_no_gc_tag_bit -> Int32 (Int32.of_int n)
+  | MW.Sixty_four -> Int64 (Int64.of_int n)
+
+let of_int_exn machine_width n =
+  match machine_width with
+  | MW.Thirty_two | MW.Thirty_two_no_gc_tag_bit -> Int32 (Int32.of_int_exn n)
+  | MW.Sixty_four -> Int64 (Int64.of_int_exn n)
+
+let to_int t =
+  match t with Int32 x -> Int32.to_int x | Int64 x -> Int64.to_int x
+
+let of_int32 machine_width x =
+  match machine_width with
+  | MW.Thirty_two | MW.Thirty_two_no_gc_tag_bit -> Int32 x
+  | MW.Sixty_four -> Int64 (Int64.of_int32 x)
+
+let to_int32 t = match t with Int32 x -> x | Int64 x -> Int64.to_int32 x
+
+let of_int64 machine_width x =
+  match machine_width with
+  | MW.Thirty_two | MW.Thirty_two_no_gc_tag_bit -> Int32 (Int64.to_int32 x)
+  | MW.Sixty_four -> Int64 x
+
+let to_int64 t = match t with Int32 x -> Int32.to_int64 x | Int64 x -> x
+
+let of_float machine_width f =
+  match machine_width with
+  | MW.Thirty_two | MW.Thirty_two_no_gc_tag_bit -> Int32 (Int32.of_float f)
+  | MW.Sixty_four -> Int64 (Int64.of_float f)
+
+let to_float t =
+  match t with Int32 x -> Int32.to_float x | Int64 x -> Int64.to_float x
+
+let of_string machine_width s =
+  match machine_width with
+  | MW.Thirty_two | MW.Thirty_two_no_gc_tag_bit -> Int32 (Int32.of_string s)
+  | MW.Sixty_four -> Int64 (Int64.of_string s)
+
+let to_string t =
+  match t with Int32 x -> Int32.to_string x | Int64 x -> Int64.to_string x
+
+(* Other utility functions *)
+let get_least_significant_16_bits_then_byte_swap t =
+  match t with
+  | Int32 x -> Int32 (Int32.get_least_significant_16_bits_then_byte_swap x)
+  | Int64 x -> Int64 (Int64.get_least_significant_16_bits_then_byte_swap x)
+
+let swap_byte_endianness t =
+  match t with
+  | Int32 x -> Int32 (Int32.swap_byte_endianness x)
+  | Int64 x -> Int64 (Int64.swap_byte_endianness x)
+
+let hash t =
+  match t with Int32 x -> Hashtbl.hash x | Int64 x -> Hashtbl.hash x
+
+(* Container_types implementation *)
+module Self = struct
+  type nonrec t = t
+
+  let compare = compare
+
+  let equal = equal
+
+  let hash = hash
+
+  let print = print
+end
+
+include Container_types.Make (Self)
+module Targetint_set = Set
+
+module Pair = struct
+  type nonrec t = t * t
+
+  module T_pair = Container_types.Pair (Self) (Self)
+  include Container_types.Make (T_pair)
+end
+
+let cross_product set1 set2 =
+  Set.fold
+    (fun elt1 result ->
+      Set.fold (fun elt2 result -> Pair.Set.add (elt1, elt2) result) set2 result)
+    set1 Pair.Set.empty
+
+let to_int_checked machine_width t =
   let i = to_int t in
-  let t' = of_int i in
+  let t' = of_int machine_width i in
   if not (equal t t')
   then
     Misc.fatal_errorf "Cannot translate Targetint_32_64 %a to an OCaml integer"
       print t;
   i
+
+(* Define repr type and function at the very end to avoid constructor
+   shadowing *)
+type repr =
+  | Int32 of int32
+  | Int64 of int64
+
+let repr (t : t) : repr = match t with Int32 x -> Int32 x | Int64 x -> Int64 x

--- a/middle_end/flambda2/numbers/targetint_32_64.ml
+++ b/middle_end/flambda2/numbers/targetint_32_64.ml
@@ -99,14 +99,6 @@ module Int64 = struct
   external swap_byte_endianness : t -> t = "%bswap_int64"
 end
 
-(* Helper function to extract machine width from a t value *)
-let machine_width t =
-  match t with
-  | Int32 _ ->
-    MW.Thirty_two
-    (* For targetint_32_64, Int32 always means traditional 32-bit *)
-  | Int64 _ -> MW.Sixty_four
-
 (* Print function *)
 let print ppf t =
   match t with
@@ -118,6 +110,9 @@ let zero machine_width =
   match machine_width with
   | MW.Thirty_two | MW.Thirty_two_no_gc_tag_bit -> Int32 Int32.zero
   | MW.Sixty_four -> Int64 Int64.zero
+
+let zero_like t =
+  match t with Int32 _ -> Int32 Int32.zero | Int64 _ -> Int64 Int64.zero
 
 let one machine_width =
   match machine_width with

--- a/middle_end/flambda2/numbers/targetint_32_64.ml
+++ b/middle_end/flambda2/numbers/targetint_32_64.ml
@@ -28,10 +28,10 @@ module Int32 = struct
   include Int32
 
   let of_int_exn =
-    match Sys.word_size with
+    match Sys.int_size with
     (* size of [int] on the host *)
-    | 32 -> Int32.of_int
-    | 64 ->
+    | 31 -> Int32.of_int
+    | 63 ->
       fun n ->
         if n < Int32.to_int Int32.min_int || n > Int32.to_int Int32.max_int
         then Misc.fatal_errorf "Targetint_32_64.of_int_exn: 0x%x out of range" n

--- a/middle_end/flambda2/numbers/targetint_32_64.mli
+++ b/middle_end/flambda2/numbers/targetint_32_64.mli
@@ -33,10 +33,14 @@ type t
 
 type targetint = t
 
-val machine_width : t -> Target_system.Machine_width.t
-
 (** The target integer 0. *)
 val zero : Target_system.Machine_width.t -> t
+
+(** The target integer 0, taking the machine width from the argument.  (Note
+    that no function is provided to extract a [Machine_width] given a [t],
+    because we can't distinguish between the [Thirty_two] and
+    [Thirty_two_no_gc_bit] cases.) *)
+val zero_like : t -> t
 
 (** The target integer 1. *)
 val one : Target_system.Machine_width.t -> t

--- a/middle_end/flambda2/numbers/targetint_32_64.mli
+++ b/middle_end/flambda2/numbers/targetint_32_64.mli
@@ -33,14 +33,16 @@ type t
 
 type targetint = t
 
-(** The target integer 0.*)
-val zero : t
+val machine_width : t -> Target_system.Machine_width.t
 
-(** The target integer 1.*)
-val one : t
+(** The target integer 0. *)
+val zero : Target_system.Machine_width.t -> t
 
-(** The target integer -1.*)
-val minus_one : t
+(** The target integer 1. *)
+val one : Target_system.Machine_width.t -> t
+
+(** The target integer -1. *)
+val minus_one : Target_system.Machine_width.t -> t
 
 (** Unary negation. *)
 val neg : t -> t
@@ -85,25 +87,13 @@ val pred : t -> t
 (** Return the absolute value of its argument. *)
 val abs : t -> t
 
-(** The size in bits of a target native integer. *)
-val size : int
-
-(** The possible numbers of bits of a target native integer. *)
-type num_bits =
-  | Thirty_two
-  | Sixty_four
-(**)
-
-val num_bits : num_bits
-(* The number of bits of a target native integer. *)
-
 (** The greatest representable target integer, either 2{^31} - 1 on a 32-bit
     platform, or 2{^63} - 1 on a 64-bit platform. *)
-val max_int : t
+val max_int : Target_system.Machine_width.t -> t
 
 (** The smallest representable target integer, either -2{^31} on a 32-bit
     platform, or -2{^63} on a 64-bit platform. *)
-val min_int : t
+val min_int : Target_system.Machine_width.t -> t
 
 (** Bitwise logical and. *)
 val logand : t -> t -> t
@@ -142,18 +132,18 @@ val shift_right_logical : t -> int -> t
 
 (** Convert the given integer (type [int]) to a target integer (type [t]),
     modulo the target word size. *)
-val of_int : int -> t
+val of_int : Target_system.Machine_width.t -> int -> t
 
 (** Convert the given integer (type [int]) to a target integer (type [t]).
     Raises a fatal error if the conversion is not exact. *)
-val of_int_exn : int -> t
+val of_int_exn : Target_system.Machine_width.t -> int -> t
 
 (** Convert the given target integer (type [t]) to an integer (type [int]). The
     high-order bit is lost during the conversion. *)
 val to_int : t -> int
 
 (** Like [to_int] but will raise an exception if the integer doesn't fit. *)
-val to_int_checked : t -> int
+val to_int_checked : Target_system.Machine_width.t -> t -> int
 
 (** Convert the given floating-point number to a target integer, discarding the
     fractional part (truncate towards 0).
@@ -161,13 +151,13 @@ val to_int_checked : t -> int
     The result of the conversion is undefined if, after truncation, the number
     is outside the range \[{!Targetint_32_64.min_int},
     {!Targetint_32_64.max_int}\]. *)
-val of_float : float -> t
+val of_float : Target_system.Machine_width.t -> float -> t
 
 (** Convert the given target integer to a floating-point number. *)
 val to_float : t -> float
 
 (** Convert the given 32-bit integer (type [int32]) to a target integer. *)
-val of_int32 : int32 -> t
+val of_int32 : Target_system.Machine_width.t -> int32 -> t
 
 (** Convert the given target integer to a 32-bit integer (type [int32]).
 
@@ -177,7 +167,7 @@ val to_int32 : t -> int32
 
 (** Convert the given 64-bit integer (type [int64]) to a target integer, modulo
     the target word size. *)
-val of_int64 : int64 -> t
+val of_int64 : Target_system.Machine_width.t -> int64 -> t
 
 (** Convert the given target integer to a 64-bit integer (type [int64]). *)
 val to_int64 : t -> int64
@@ -190,7 +180,7 @@ val to_int64 : t -> int64
     Raise [Failure "int_of_string"] if the given string is not a valid
     representation of an integer, or if the integer represented exceeds the
     range of integers representable in type [nativeint]. *)
-val of_string : string -> t
+val of_string : Target_system.Machine_width.t -> string -> t
 
 (** Return the string representation of its argument, in decimal. *)
 val to_string : t -> string
@@ -199,7 +189,7 @@ val to_string : t -> string
     integers. *)
 val unsigned_compare : t -> t -> int
 
-type repr =
+type repr = private
   | Int32 of int32
   | Int64 of int64
 

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -244,11 +244,16 @@ let find_region env (r : Fexpr.region) =
 
 let find_code_id env code_id = fresh_or_existing_code_id env code_id
 
+(* TODO: This should not be hardcoded - machine_width should flow through
+   properly *)
+let machine_width = Target_system.Machine_width.Sixty_four
+
 let targetint (i : Fexpr.targetint) : Targetint_32_64.t =
-  Targetint_32_64.of_int64 i
+  Targetint_32_64.of_int64 machine_width i
 
 let targetint_31_63 (i : Fexpr.targetint) : Target_ocaml_int.t =
-  Target_ocaml_int.of_int64 i
+  (* TODO: machine_width should be passed through properly here *)
+  Target_ocaml_int.of_int64 Target_system.Machine_width.Sixty_four i
 
 let vec128 bits : Vector_types.Vec128.Bit_pattern.t =
   Vector_types.Vec128.Bit_pattern.of_bits bits
@@ -263,7 +268,11 @@ let tag_scannable (tag : Fexpr.tag_scannable) : Tag.Scannable.t =
   Tag.Scannable.create_exn tag
 
 let immediate i =
-  i |> Targetint_32_64.of_string |> Target_ocaml_int.of_targetint
+  (* TODO: This should not be hardcoded - machine_width should flow through
+     properly *)
+  i
+  |> Targetint_32_64.of_string machine_width
+  |> Target_ocaml_int.of_targetint machine_width
 
 let float32 f = f |> Numeric_types.Float32_by_bit_pattern.create
 
@@ -369,9 +378,10 @@ let field_of_block env (v : Fexpr.field_of_block) =
     match v with
     | Symbol s -> Simple.symbol (get_symbol env s)
     | Tagged_immediate i ->
-      let i = Targetint_32_64.of_string i in
+      let i = Targetint_32_64.of_string machine_width i in
       Simple.const
-        (Reg_width_const.tagged_immediate (Target_ocaml_int.of_targetint i))
+        (Reg_width_const.tagged_immediate
+           (Target_ocaml_int.of_targetint machine_width i))
     | Dynamically_computed var ->
       let var = find_var env var in
       Simple.var var
@@ -415,7 +425,10 @@ let block_access_kind (ak : Fexpr.block_access_kind) :
   let size s : _ Or_unknown.t =
     match s with
     | None -> Unknown
-    | Some s -> Known (s |> Target_ocaml_int.of_int64)
+    | Some s ->
+      (* TODO: Should get machine_width from fexpr context when available *)
+      Known
+        (s |> Target_ocaml_int.of_int64 Target_system.Machine_width.Sixty_four)
   in
   match ak with
   | Values { field_kind; tag; size = s } ->
@@ -730,7 +743,9 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
     let arms =
       List.map
         (fun (case, apply) ->
-          Target_ocaml_int.of_int case, apply_cont env apply)
+          (* TODO: Should get machine_width from fexpr context when available *)
+          ( Target_ocaml_int.of_int Target_system.Machine_width.Sixty_four case,
+            apply_cont env apply ))
         cases
       |> Target_ocaml_int.Map.of_list
     in

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -244,16 +244,16 @@ let find_region env (r : Fexpr.region) =
 
 let find_code_id env code_id = fresh_or_existing_code_id env code_id
 
-(* TODO: This should not be hardcoded - machine_width should flow through
-   properly *)
+(* CR mshinwell: This should not be hardcoded - machine_width should flow
+   through properly *)
 let machine_width = Target_system.Machine_width.Sixty_four
 
 let targetint (i : Fexpr.targetint) : Targetint_32_64.t =
   Targetint_32_64.of_int64 machine_width i
 
 let targetint_31_63 (i : Fexpr.targetint) : Target_ocaml_int.t =
-  (* TODO: machine_width should be passed through properly here *)
-  Target_ocaml_int.of_int64 Target_system.Machine_width.Sixty_four i
+  (* CR mshinwell: machine_width should be passed through properly here *)
+  Target_ocaml_int.of_int64 machine_width i
 
 let vec128 bits : Vector_types.Vec128.Bit_pattern.t =
   Vector_types.Vec128.Bit_pattern.of_bits bits
@@ -268,8 +268,8 @@ let tag_scannable (tag : Fexpr.tag_scannable) : Tag.Scannable.t =
   Tag.Scannable.create_exn tag
 
 let immediate i =
-  (* TODO: This should not be hardcoded - machine_width should flow through
-     properly *)
+  (* CR mshinwell: This should not be hardcoded - machine_width should flow
+     through properly *)
   i
   |> Targetint_32_64.of_string machine_width
   |> Target_ocaml_int.of_targetint machine_width
@@ -426,9 +426,9 @@ let block_access_kind (ak : Fexpr.block_access_kind) :
     match s with
     | None -> Unknown
     | Some s ->
-      (* TODO: Should get machine_width from fexpr context when available *)
-      Known
-        (s |> Target_ocaml_int.of_int64 Target_system.Machine_width.Sixty_four)
+      (* CR mshinwell: Should get machine_width from fexpr context when
+         available *)
+      Known (s |> Target_ocaml_int.of_int64 machine_width)
   in
   match ak with
   | Values { field_kind; tag; size = s } ->
@@ -743,9 +743,9 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
     let arms =
       List.map
         (fun (case, apply) ->
-          (* TODO: Should get machine_width from fexpr context when available *)
-          ( Target_ocaml_int.of_int Target_system.Machine_width.Sixty_four case,
-            apply_cont env apply ))
+          (* CR mshinwell: Should get machine_width from fexpr context when
+             available *)
+          Target_ocaml_int.of_int machine_width case, apply_cont env apply)
         cases
       |> Target_ocaml_int.Map.of_list
     in

--- a/middle_end/flambda2/parser/flambda_parser.ml
+++ b/middle_end/flambda2/parser/flambda_parser.ml
@@ -1036,7 +1036,7 @@ module Tables = struct
       (Fexpr.alloc_mode_for_allocations)
 # 1038 "flambda_parser_in.ml"
         ) = 
-# 530 "flambda_parser.mly"
+# 531 "flambda_parser.mly"
     ( Heap )
 # 1042 "flambda_parser_in.ml"
          in
@@ -1076,7 +1076,7 @@ module Tables = struct
       (Fexpr.alloc_mode_for_allocations)
 # 1078 "flambda_parser_in.ml"
         ) = 
-# 531 "flambda_parser.mly"
+# 532 "flambda_parser.mly"
                          ( Local { region } )
 # 1082 "flambda_parser_in.ml"
          in
@@ -1098,7 +1098,7 @@ module Tables = struct
       (Fexpr.alloc_mode_for_applications)
 # 1100 "flambda_parser_in.ml"
         ) = 
-# 534 "flambda_parser.mly"
+# 535 "flambda_parser.mly"
     ( Heap )
 # 1104 "flambda_parser_in.ml"
          in
@@ -1156,7 +1156,7 @@ module Tables = struct
       (Fexpr.alloc_mode_for_applications)
 # 1158 "flambda_parser_in.ml"
         ) = 
-# 535 "flambda_parser.mly"
+# 536 "flambda_parser.mly"
                                                      ( Local { region; ghost_region } )
 # 1162 "flambda_parser_in.ml"
          in
@@ -1199,7 +1199,7 @@ module Tables = struct
         let _startpos = _startpos_cont_ in
         let _endpos = _endpos_args_ in
         let _v : 'tv_apply_cont_expr = 
-# 941 "flambda_parser.mly"
+# 943 "flambda_parser.mly"
     ( { cont; args; trap_action } )
 # 1205 "flambda_parser_in.ml"
          in
@@ -1273,7 +1273,7 @@ module Tables = struct
         let _startpos = _startpos_call_kind_ in
         let _endpos = _endpos_e_ in
         let _v : 'tv_apply_expr = 
-# 867 "flambda_parser.mly"
+# 869 "flambda_parser.mly"
      ( let (func, arities) = func in {
        func;
           continuation = r;
@@ -1304,7 +1304,7 @@ module Tables = struct
       (Fexpr.array_kind)
 # 1306 "flambda_parser_in.ml"
         ) = 
-# 483 "flambda_parser.mly"
+# 484 "flambda_parser.mly"
     ( (Values : array_kind) )
 # 1310 "flambda_parser_in.ml"
          in
@@ -1333,7 +1333,7 @@ module Tables = struct
       (Fexpr.array_kind)
 # 1335 "flambda_parser_in.ml"
         ) = 
-# 484 "flambda_parser.mly"
+# 485 "flambda_parser.mly"
             ( (Immediates : array_kind) )
 # 1339 "flambda_parser_in.ml"
          in
@@ -1362,7 +1362,7 @@ module Tables = struct
       (Fexpr.array_kind)
 # 1364 "flambda_parser_in.ml"
         ) = 
-# 485 "flambda_parser.mly"
+# 486 "flambda_parser.mly"
               ( (Naked_floats : array_kind) )
 # 1368 "flambda_parser_in.ml"
          in
@@ -1395,7 +1395,7 @@ module Tables = struct
       (Fexpr.array_kind_for_length)
 # 1397 "flambda_parser_in.ml"
         ) = 
-# 488 "flambda_parser.mly"
+# 489 "flambda_parser.mly"
                       ( Array_kind kind )
 # 1401 "flambda_parser_in.ml"
          in
@@ -1424,7 +1424,7 @@ module Tables = struct
       (Fexpr.array_kind_for_length)
 # 1426 "flambda_parser_in.ml"
         ) = 
-# 489 "flambda_parser.mly"
+# 490 "flambda_parser.mly"
                 ( Float_array_opt_dynamic )
 # 1430 "flambda_parser_in.ml"
          in
@@ -1449,7 +1449,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_atomic_expr = 
-# 799 "flambda_parser.mly"
+# 801 "flambda_parser.mly"
             ( Invalid { message = "halt-and-catch-fire" } )
 # 1455 "flambda_parser_in.ml"
          in
@@ -1474,7 +1474,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_atomic_expr = 
-# 800 "flambda_parser.mly"
+# 802 "flambda_parser.mly"
                     ( Invalid { message =  "treat-as-unreachable" } )
 # 1480 "flambda_parser_in.ml"
          in
@@ -1510,7 +1510,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_message_ in
         let _v : 'tv_atomic_expr = 
-# 801 "flambda_parser.mly"
+# 803 "flambda_parser.mly"
                                   ( Invalid { message } )
 # 1516 "flambda_parser_in.ml"
          in
@@ -1542,7 +1542,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_ac_ in
         let _v : 'tv_atomic_expr = 
-# 802 "flambda_parser.mly"
+# 804 "flambda_parser.mly"
                                    ( Apply_cont ac )
 # 1548 "flambda_parser_in.ml"
          in
@@ -1581,7 +1581,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_cases_ in
         let _v : 'tv_atomic_expr = 
-# 803 "flambda_parser.mly"
+# 805 "flambda_parser.mly"
                                                    ( Switch {scrutinee; cases} )
 # 1587 "flambda_parser_in.ml"
          in
@@ -1613,7 +1613,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_e_ in
         let _v : 'tv_atomic_expr = 
-# 804 "flambda_parser.mly"
+# 806 "flambda_parser.mly"
                              ( Apply e )
 # 1619 "flambda_parser_in.ml"
          in
@@ -1652,7 +1652,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : 'tv_atomic_expr = 
-# 805 "flambda_parser.mly"
+# 807 "flambda_parser.mly"
                              ( e )
 # 1658 "flambda_parser_in.ml"
          in
@@ -1677,7 +1677,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_begin_region = 
-# 661 "flambda_parser.mly"
+# 663 "flambda_parser.mly"
                       ( Begin_region { ghost = false } )
 # 1683 "flambda_parser_in.ml"
          in
@@ -1702,7 +1702,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_begin_region = 
-# 662 "flambda_parser.mly"
+# 664 "flambda_parser.mly"
                             ( Begin_region { ghost = true } )
 # 1708 "flambda_parser_in.ml"
          in
@@ -1727,7 +1727,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_begin_region = 
-# 663 "flambda_parser.mly"
+# 665 "flambda_parser.mly"
                           ( Begin_try_region { ghost = false } )
 # 1733 "flambda_parser_in.ml"
          in
@@ -1752,7 +1752,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_begin_region = 
-# 664 "flambda_parser.mly"
+# 666 "flambda_parser.mly"
                                 ( Begin_try_region { ghost = true } )
 # 1758 "flambda_parser_in.ml"
          in
@@ -1781,7 +1781,7 @@ module Tables = struct
       (Fexpr.binary_float_arith_op)
 # 1783 "flambda_parser_in.ml"
         ) = 
-# 552 "flambda_parser.mly"
+# 553 "flambda_parser.mly"
             ( Add )
 # 1787 "flambda_parser_in.ml"
          in
@@ -1810,7 +1810,7 @@ module Tables = struct
       (Fexpr.binary_float_arith_op)
 # 1812 "flambda_parser_in.ml"
         ) = 
-# 553 "flambda_parser.mly"
+# 554 "flambda_parser.mly"
              ( Sub )
 # 1816 "flambda_parser_in.ml"
          in
@@ -1839,7 +1839,7 @@ module Tables = struct
       (Fexpr.binary_float_arith_op)
 # 1841 "flambda_parser_in.ml"
         ) = 
-# 554 "flambda_parser.mly"
+# 555 "flambda_parser.mly"
             ( Mul )
 # 1845 "flambda_parser_in.ml"
          in
@@ -1868,7 +1868,7 @@ module Tables = struct
       (Fexpr.binary_float_arith_op)
 # 1870 "flambda_parser_in.ml"
         ) = 
-# 555 "flambda_parser.mly"
+# 556 "flambda_parser.mly"
              ( Div )
 # 1874 "flambda_parser_in.ml"
          in
@@ -1897,7 +1897,7 @@ module Tables = struct
       (Fexpr.binary_int_arith_op)
 # 1899 "flambda_parser_in.ml"
         ) = 
-# 542 "flambda_parser.mly"
+# 543 "flambda_parser.mly"
          ( Add )
 # 1903 "flambda_parser_in.ml"
          in
@@ -1926,7 +1926,7 @@ module Tables = struct
       (Fexpr.binary_int_arith_op)
 # 1928 "flambda_parser_in.ml"
         ) = 
-# 543 "flambda_parser.mly"
+# 544 "flambda_parser.mly"
           ( Sub )
 # 1932 "flambda_parser_in.ml"
          in
@@ -1955,7 +1955,7 @@ module Tables = struct
       (Fexpr.binary_int_arith_op)
 # 1957 "flambda_parser_in.ml"
         ) = 
-# 544 "flambda_parser.mly"
+# 545 "flambda_parser.mly"
          ( Mul )
 # 1961 "flambda_parser_in.ml"
          in
@@ -1984,7 +1984,7 @@ module Tables = struct
       (Fexpr.binary_int_arith_op)
 # 1986 "flambda_parser_in.ml"
         ) = 
-# 545 "flambda_parser.mly"
+# 546 "flambda_parser.mly"
           ( Div )
 # 1990 "flambda_parser_in.ml"
          in
@@ -2013,7 +2013,7 @@ module Tables = struct
       (Fexpr.binary_int_arith_op)
 # 2015 "flambda_parser_in.ml"
         ) = 
-# 546 "flambda_parser.mly"
+# 547 "flambda_parser.mly"
             ( Mod )
 # 2019 "flambda_parser_in.ml"
          in
@@ -2042,7 +2042,7 @@ module Tables = struct
       (Fexpr.binary_int_arith_op)
 # 2044 "flambda_parser_in.ml"
         ) = 
-# 547 "flambda_parser.mly"
+# 548 "flambda_parser.mly"
              ( And )
 # 2048 "flambda_parser_in.ml"
          in
@@ -2071,7 +2071,7 @@ module Tables = struct
       (Fexpr.binary_int_arith_op)
 # 2073 "flambda_parser_in.ml"
         ) = 
-# 548 "flambda_parser.mly"
+# 549 "flambda_parser.mly"
             ( Or )
 # 2077 "flambda_parser_in.ml"
          in
@@ -2100,7 +2100,7 @@ module Tables = struct
       (Fexpr.binary_int_arith_op)
 # 2102 "flambda_parser_in.ml"
         ) = 
-# 549 "flambda_parser.mly"
+# 550 "flambda_parser.mly"
              ( Xor )
 # 2106 "flambda_parser_in.ml"
          in
@@ -2181,11 +2181,12 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_v_ in
         let _v : 'tv_binop_app = 
-# 589 "flambda_parser.mly"
-    ( let mw = Target_system.Machine_width.Sixty_four in
+# 590 "flambda_parser.mly"
+    ( (* CR mshinwell: pass machine width through properly *)
+      let mw = Target_system.Machine_width.Sixty_four in
       let field = Target_ocaml_int.of_int mw field in
       Binary (Block_set { kind; init; field }, block, v) )
-# 2189 "flambda_parser_in.ml"
+# 2190 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2243,9 +2244,9 @@ module Tables = struct
         let _startpos = _startpos_op_ in
         let _endpos = _endpos__6_ in
         let _v : 'tv_binop_app = 
-# 594 "flambda_parser.mly"
+# 596 "flambda_parser.mly"
     ( Binary (op, arg1, arg2) )
-# 2249 "flambda_parser_in.ml"
+# 2250 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2279,16 +2280,16 @@ module Tables = struct
         let op : (
 # 259 "flambda_parser.mly"
       (Fexpr.infix_binop)
-# 2283 "flambda_parser_in.ml"
+# 2284 "flambda_parser_in.ml"
         ) = Obj.magic op in
         let arg1 : 'tv_simple = Obj.magic arg1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_arg1_ in
         let _endpos = _endpos_arg2_ in
         let _v : 'tv_binop_app = 
-# 596 "flambda_parser.mly"
+# 598 "flambda_parser.mly"
     ( Binary (Infix op, arg1, arg2) )
-# 2292 "flambda_parser_in.ml"
+# 2293 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2356,19 +2357,19 @@ module Tables = struct
         let mut : (
 # 265 "flambda_parser.mly"
       (Fexpr.mutability)
-# 2360 "flambda_parser_in.ml"
+# 2361 "flambda_parser_in.ml"
         ) = Obj.magic mut in
         let ak : (
 # 244 "flambda_parser.mly"
       (Fexpr.array_kind)
-# 2365 "flambda_parser_in.ml"
+# 2366 "flambda_parser_in.ml"
         ) = Obj.magic ak in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__8_ in
         let _v : 'tv_binop_app = 
-# 600 "flambda_parser.mly"
+# 602 "flambda_parser.mly"
     (
     let array_load_kind : array_load_kind =
       match ak with
@@ -2386,7 +2387,7 @@ module Tables = struct
         Misc.fatal_error "Unboxed product array ops not supported"
     in
     Binary (Array_load (ak, array_load_kind, mut), arg1, arg2) )
-# 2390 "flambda_parser_in.ml"
+# 2391 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2432,22 +2433,22 @@ module Tables = struct
         let c : (
 # 248 "flambda_parser.mly"
       (Fexpr.binary_int_arith_op)
-# 2436 "flambda_parser_in.ml"
+# 2437 "flambda_parser_in.ml"
         ) = Obj.magic c in
         let arg1 : 'tv_simple = Obj.magic arg1 in
         let i : (
 # 272 "flambda_parser.mly"
       (Fexpr.standard_int)
-# 2442 "flambda_parser_in.ml"
+# 2443 "flambda_parser_in.ml"
         ) = Obj.magic i in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_arg2_ in
         let _v : 'tv_binop_app = 
-# 619 "flambda_parser.mly"
+# 621 "flambda_parser.mly"
     ( Binary (Int_arith (i, c), arg1, arg2) )
-# 2451 "flambda_parser_in.ml"
+# 2452 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2499,23 +2500,23 @@ module Tables = struct
         let c : (
 # 260 "flambda_parser.mly"
       (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
-# 2503 "flambda_parser_in.ml"
+# 2504 "flambda_parser_in.ml"
         ) = Obj.magic c in
         let arg1 : 'tv_simple = Obj.magic arg1 in
         let s : 'tv_signed_or_unsigned = Obj.magic s in
         let i : (
 # 272 "flambda_parser.mly"
       (Fexpr.standard_int)
-# 2510 "flambda_parser_in.ml"
+# 2511 "flambda_parser_in.ml"
         ) = Obj.magic i in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_arg2_ in
         let _v : 'tv_binop_app = 
-# 623 "flambda_parser.mly"
+# 625 "flambda_parser.mly"
     ( Binary (Int_comp (i, c s), arg1, arg2) )
-# 2519 "flambda_parser_in.ml"
+# 2520 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2563,16 +2564,16 @@ module Tables = struct
         let i : (
 # 272 "flambda_parser.mly"
       (Fexpr.standard_int)
-# 2567 "flambda_parser_in.ml"
+# 2568 "flambda_parser_in.ml"
         ) = Obj.magic i in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_arg2_ in
         let _v : 'tv_binop_app = 
-# 626 "flambda_parser.mly"
+# 628 "flambda_parser.mly"
     ( Binary (Int_shift (i, s), arg1, arg2) )
-# 2576 "flambda_parser_in.ml"
+# 2577 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2595,9 +2596,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_blank_or_kinds_with_subkinds_ = 
-# 1065 "flambda_parser.mly"
+# 1067 "flambda_parser.mly"
           ( None )
-# 2601 "flambda_parser_in.ml"
+# 2602 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2618,15 +2619,15 @@ module Tables = struct
         let a : (
 # 263 "flambda_parser.mly"
       (Fexpr.kind_with_subkind list)
-# 2622 "flambda_parser_in.ml"
+# 2623 "flambda_parser_in.ml"
         ) = Obj.magic a in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_a_ in
         let _endpos = _endpos_a_ in
         let _v : 'tv_blank_or_kinds_with_subkinds_ = 
-# 1066 "flambda_parser.mly"
+# 1068 "flambda_parser.mly"
           ( Some a )
-# 2630 "flambda_parser_in.ml"
+# 2631 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2649,9 +2650,9 @@ module Tables = struct
         let _startpos = _startpos_r_ in
         let _endpos = _endpos_r_ in
         let _v : 'tv_block = 
-# 668 "flambda_parser.mly"
+# 670 "flambda_parser.mly"
                      ( Variadic (r, []) )
-# 2655 "flambda_parser_in.ml"
+# 2656 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2711,13 +2712,13 @@ module Tables = struct
         let alloc : (
 # 242 "flambda_parser.mly"
       (Fexpr.alloc_mode_for_allocations)
-# 2715 "flambda_parser_in.ml"
+# 2716 "flambda_parser_in.ml"
         ) = Obj.magic alloc in
         let t : 'tv_tag = Obj.magic t in
         let m : (
 # 265 "flambda_parser.mly"
       (Fexpr.mutability)
-# 2721 "flambda_parser_in.ml"
+# 2722 "flambda_parser_in.ml"
         ) = Obj.magic m in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -2727,12 +2728,12 @@ module Tables = struct
           let elts = 
 # 241 "<standard.mly>"
     ( xs )
-# 2731 "flambda_parser_in.ml"
+# 2732 "flambda_parser_in.ml"
            in
           (
-# 671 "flambda_parser.mly"
+# 673 "flambda_parser.mly"
     ( Variadic (Make_block (t, m, alloc), elts) )
-# 2736 "flambda_parser_in.ml"
+# 2737 "flambda_parser_in.ml"
            : 'tv_block)
         in
         {
@@ -2751,11 +2752,11 @@ module Tables = struct
         let _v : (
 # 249 "flambda_parser.mly"
       (Fexpr.block_access_field_kind)
-# 2755 "flambda_parser_in.ml"
+# 2756 "flambda_parser_in.ml"
         ) = 
-# 502 "flambda_parser.mly"
+# 503 "flambda_parser.mly"
     ( Any_value )
-# 2759 "flambda_parser_in.ml"
+# 2760 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2780,11 +2781,11 @@ module Tables = struct
         let _v : (
 # 249 "flambda_parser.mly"
       (Fexpr.block_access_field_kind)
-# 2784 "flambda_parser_in.ml"
+# 2785 "flambda_parser_in.ml"
         ) = 
-# 503 "flambda_parser.mly"
+# 504 "flambda_parser.mly"
             ( Immediate )
-# 2788 "flambda_parser_in.ml"
+# 2789 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2819,15 +2820,15 @@ module Tables = struct
         let field_kind : (
 # 249 "flambda_parser.mly"
       (Fexpr.block_access_field_kind)
-# 2823 "flambda_parser_in.ml"
+# 2824 "flambda_parser_in.ml"
         ) = Obj.magic field_kind in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_field_kind_ in
         let _endpos = _endpos_size_ in
         let _v : 'tv_block_access_kind = 
-# 496 "flambda_parser.mly"
+# 497 "flambda_parser.mly"
     ( (Values { field_kind; tag; size } : block_access_kind) )
-# 2831 "flambda_parser_in.ml"
+# 2832 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2857,9 +2858,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_size_ in
         let _v : 'tv_block_access_kind = 
-# 498 "flambda_parser.mly"
+# 499 "flambda_parser.mly"
     ( (Naked_floats { size } : block_access_kind) )
-# 2863 "flambda_parser_in.ml"
+# 2864 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2877,7 +2878,7 @@ module Tables = struct
         let _v : 'tv_boption_KWD_LOCAL_ = 
 # 134 "<standard.mly>"
     ( false )
-# 2881 "flambda_parser_in.ml"
+# 2882 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2902,7 +2903,7 @@ module Tables = struct
         let _v : 'tv_boption_KWD_LOCAL_ = 
 # 137 "<standard.mly>"
     ( true )
-# 2906 "flambda_parser_in.ml"
+# 2907 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2920,7 +2921,7 @@ module Tables = struct
         let _v : 'tv_boption_KWD_NOALLOC_ = 
 # 134 "<standard.mly>"
     ( false )
-# 2924 "flambda_parser_in.ml"
+# 2925 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2945,7 +2946,7 @@ module Tables = struct
         let _v : 'tv_boption_KWD_NOALLOC_ = 
 # 137 "<standard.mly>"
     ( true )
-# 2949 "flambda_parser_in.ml"
+# 2950 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2963,7 +2964,7 @@ module Tables = struct
         let _v : 'tv_boption_KWD_TUPLED_ = 
 # 134 "<standard.mly>"
     ( false )
-# 2967 "flambda_parser_in.ml"
+# 2968 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2988,7 +2989,7 @@ module Tables = struct
         let _v : 'tv_boption_KWD_TUPLED_ = 
 # 137 "<standard.mly>"
     ( true )
-# 2992 "flambda_parser_in.ml"
+# 2993 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3011,9 +3012,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_bytes_or_bigstring_set = 
-# 630 "flambda_parser.mly"
+# 632 "flambda_parser.mly"
                    ( Bytes )
-# 3017 "flambda_parser_in.ml"
+# 3018 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3036,9 +3037,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_bytes_or_bigstring_set = 
-# 631 "flambda_parser.mly"
+# 633 "flambda_parser.mly"
                        ( Bigstring )
-# 3042 "flambda_parser_in.ml"
+# 3043 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3059,15 +3060,15 @@ module Tables = struct
         let alloc : (
 # 243 "flambda_parser.mly"
       (Fexpr.alloc_mode_for_applications)
-# 3063 "flambda_parser_in.ml"
+# 3064 "flambda_parser_in.ml"
         ) = Obj.magic alloc in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_alloc_ in
         let _endpos = _endpos_alloc_ in
         let _v : 'tv_call_kind = 
-# 880 "flambda_parser.mly"
+# 882 "flambda_parser.mly"
                                              ( Function (Indirect alloc) )
-# 3071 "flambda_parser_in.ml"
+# 3072 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3119,7 +3120,7 @@ module Tables = struct
         let alloc : (
 # 243 "flambda_parser.mly"
       (Fexpr.alloc_mode_for_applications)
-# 3123 "flambda_parser_in.ml"
+# 3124 "flambda_parser_in.ml"
         ) = Obj.magic alloc in
         let function_slot : 'tv_function_slot_opt = Obj.magic function_slot in
         let code_id : 'tv_code_id = Obj.magic code_id in
@@ -3129,9 +3130,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__6_ in
         let _v : 'tv_call_kind = 
-# 886 "flambda_parser.mly"
+# 888 "flambda_parser.mly"
     ( Function (Direct { code_id; function_slot; alloc }) )
-# 3135 "flambda_parser_in.ml"
+# 3136 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3161,9 +3162,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_noalloc_ in
         let _v : 'tv_call_kind = 
-# 888 "flambda_parser.mly"
+# 890 "flambda_parser.mly"
     ( C_call { alloc = not noalloc } )
-# 3167 "flambda_parser_in.ml"
+# 3168 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3281,7 +3282,7 @@ module Tables = struct
         params_and_body = { params; closure_var; region_var; ghost_region_var; depth_var;
                             ret_cont; exn_cont; body };
         code_size; is_tupled; loopify; result_mode; } )
-# 3285 "flambda_parser_in.ml"
+# 3286 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3371,7 +3372,7 @@ module Tables = struct
         let recursive : (
 # 281 "flambda_parser.mly"
       (Fexpr.is_recursive)
-# 3375 "flambda_parser_in.ml"
+# 3376 "flambda_parser_in.ml"
         ) = Obj.magic recursive in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -3380,7 +3381,7 @@ module Tables = struct
         let _v : 'tv_code_header = 
 # 366 "flambda_parser.mly"
     ( recursive, inline, loopify, id, newer_version_of, code_size, is_tupled )
-# 3384 "flambda_parser_in.ml"
+# 3385 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3403,9 +3404,9 @@ module Tables = struct
         let _startpos = _startpos_v_ in
         let _endpos = _endpos_v_ in
         let _v : 'tv_code_id = 
-# 1097 "flambda_parser.mly"
+# 1099 "flambda_parser.mly"
                  ( v )
-# 3409 "flambda_parser_in.ml"
+# 3410 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3428,9 +3429,9 @@ module Tables = struct
         let _startpos = _startpos_i_ in
         let _endpos = _endpos_i_ in
         let _v : 'tv_code_size = 
-# 1101 "flambda_parser.mly"
+# 1103 "flambda_parser.mly"
                   ( i )
-# 3434 "flambda_parser_in.ml"
+# 3435 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3453,9 +3454,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_coercion = 
-# 1077 "flambda_parser.mly"
+# 1079 "flambda_parser.mly"
            ( Id )
-# 3459 "flambda_parser_in.ml"
+# 3460 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3494,22 +3495,22 @@ module Tables = struct
         let to_ : (
 # 268 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 3498 "flambda_parser_in.ml"
+# 3499 "flambda_parser_in.ml"
         ) = Obj.magic to_ in
         let _3 : unit = Obj.magic _3 in
         let from : (
 # 268 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 3504 "flambda_parser_in.ml"
+# 3505 "flambda_parser_in.ml"
         ) = Obj.magic from in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_to__ in
         let _v : 'tv_coercion = 
-# 1079 "flambda_parser.mly"
+# 1081 "flambda_parser.mly"
     ( Change_depth { from; to_; } )
-# 3513 "flambda_parser_in.ml"
+# 3514 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3530,7 +3531,7 @@ module Tables = struct
         let c : (
 # 74 "flambda_parser.mly"
        (string * char option)
-# 3534 "flambda_parser_in.ml"
+# 3535 "flambda_parser_in.ml"
         ) = Obj.magic c in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_c_ in
@@ -3538,11 +3539,11 @@ module Tables = struct
         let _v : (
 # 250 "flambda_parser.mly"
       (Fexpr.const)
-# 3542 "flambda_parser_in.ml"
+# 3543 "flambda_parser_in.ml"
         ) = 
-# 1051 "flambda_parser.mly"
+# 1053 "flambda_parser.mly"
             ( make_const_int c )
-# 3546 "flambda_parser_in.ml"
+# 3547 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3563,7 +3564,7 @@ module Tables = struct
         let c : (
 # 68 "flambda_parser.mly"
        (float)
-# 3567 "flambda_parser_in.ml"
+# 3568 "flambda_parser_in.ml"
         ) = Obj.magic c in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_c_ in
@@ -3571,11 +3572,11 @@ module Tables = struct
         let _v : (
 # 250 "flambda_parser.mly"
       (Fexpr.const)
-# 3575 "flambda_parser_in.ml"
+# 3576 "flambda_parser_in.ml"
         ) = 
-# 1052 "flambda_parser.mly"
+# 1054 "flambda_parser.mly"
               ( Naked_float c )
-# 3579 "flambda_parser_in.ml"
+# 3580 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3593,11 +3594,11 @@ module Tables = struct
         let _v : (
 # 282 "flambda_parser.mly"
       (Fexpr.is_cont_recursive)
-# 3597 "flambda_parser_in.ml"
+# 3598 "flambda_parser_in.ml"
         ) = 
-# 958 "flambda_parser.mly"
+# 960 "flambda_parser.mly"
     ( Nonrecursive )
-# 3601 "flambda_parser_in.ml"
+# 3602 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3629,11 +3630,11 @@ module Tables = struct
         let _v : (
 # 282 "flambda_parser.mly"
       (Fexpr.is_cont_recursive)
-# 3633 "flambda_parser_in.ml"
+# 3634 "flambda_parser_in.ml"
         ) = 
-# 960 "flambda_parser.mly"
+# 962 "flambda_parser.mly"
     ( (Recursive params : Fexpr.is_cont_recursive) )
-# 3637 "flambda_parser_in.ml"
+# 3638 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3658,11 +3659,11 @@ module Tables = struct
         let _v : (
 # 251 "flambda_parser.mly"
       (Fexpr.continuation)
-# 3662 "flambda_parser_in.ml"
+# 3663 "flambda_parser_in.ml"
         ) = 
-# 1125 "flambda_parser.mly"
+# 1127 "flambda_parser.mly"
                         ( Named e )
-# 3666 "flambda_parser_in.ml"
+# 3667 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3683,7 +3684,7 @@ module Tables = struct
         let s : (
 # 271 "flambda_parser.mly"
       (Fexpr.special_continuation)
-# 3687 "flambda_parser_in.ml"
+# 3688 "flambda_parser_in.ml"
         ) = Obj.magic s in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_s_ in
@@ -3691,11 +3692,11 @@ module Tables = struct
         let _v : (
 # 251 "flambda_parser.mly"
       (Fexpr.continuation)
-# 3695 "flambda_parser_in.ml"
+# 3696 "flambda_parser_in.ml"
         ) = 
-# 1126 "flambda_parser.mly"
+# 1128 "flambda_parser.mly"
                              ( Special s )
-# 3699 "flambda_parser_in.ml"
+# 3700 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3743,16 +3744,16 @@ module Tables = struct
         let sort : (
 # 257 "flambda_parser.mly"
       (Fexpr.continuation_sort option)
-# 3747 "flambda_parser_in.ml"
+# 3748 "flambda_parser_in.ml"
         ) = Obj.magic sort in
         let name : 'tv_continuation_id = Obj.magic name in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_name_ in
         let _endpos = _endpos_handler_ in
         let _v : 'tv_continuation_binding = 
-# 972 "flambda_parser.mly"
+# 974 "flambda_parser.mly"
     ( { name; params; handler; sort } )
-# 3756 "flambda_parser_in.ml"
+# 3757 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3775,9 +3776,9 @@ module Tables = struct
         let _startpos = _startpos_l_ in
         let _endpos = _endpos_l_ in
         let _v : 'tv_continuation_body = 
-# 794 "flambda_parser.mly"
+# 796 "flambda_parser.mly"
                                     ( l )
-# 3781 "flambda_parser_in.ml"
+# 3782 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3800,9 +3801,9 @@ module Tables = struct
         let _startpos = _startpos_a_ in
         let _endpos = _endpos_a_ in
         let _v : 'tv_continuation_body = 
-# 795 "flambda_parser.mly"
+# 797 "flambda_parser.mly"
                     ( a )
-# 3806 "flambda_parser_in.ml"
+# 3807 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3823,7 +3824,7 @@ module Tables = struct
         let e : (
 # 73 "flambda_parser.mly"
        (string)
-# 3827 "flambda_parser_in.ml"
+# 3828 "flambda_parser_in.ml"
         ) = Obj.magic e in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_e_ in
@@ -3832,9 +3833,9 @@ module Tables = struct
           let _endpos = _endpos_e_ in
           let _startpos = _startpos_e_ in
           (
-# 1121 "flambda_parser.mly"
+# 1123 "flambda_parser.mly"
               ( make_located e (_startpos, _endpos) )
-# 3838 "flambda_parser_in.ml"
+# 3839 "flambda_parser_in.ml"
            : 'tv_continuation_id)
         in
         {
@@ -3853,69 +3854,69 @@ module Tables = struct
         let _v : (
 # 257 "flambda_parser.mly"
       (Fexpr.continuation_sort option)
-# 3857 "flambda_parser_in.ml"
-        ) = 
-# 964 "flambda_parser.mly"
-    ( None )
-# 3861 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 257 "flambda_parser.mly"
-      (Fexpr.continuation_sort option)
-# 3886 "flambda_parser_in.ml"
-        ) = 
-# 965 "flambda_parser.mly"
-            ( Some Exn )
-# 3890 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 257 "flambda_parser.mly"
-      (Fexpr.continuation_sort option)
-# 3915 "flambda_parser_in.ml"
+# 3858 "flambda_parser_in.ml"
         ) = 
 # 966 "flambda_parser.mly"
+    ( None )
+# 3862 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 257 "flambda_parser.mly"
+      (Fexpr.continuation_sort option)
+# 3887 "flambda_parser_in.ml"
+        ) = 
+# 967 "flambda_parser.mly"
+            ( Some Exn )
+# 3891 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 257 "flambda_parser.mly"
+      (Fexpr.continuation_sort option)
+# 3916 "flambda_parser_in.ml"
+        ) = 
+# 968 "flambda_parser.mly"
                            ( Some Define_root_symbol )
-# 3919 "flambda_parser_in.ml"
+# 3920 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3947,40 +3948,11 @@ module Tables = struct
         let _v : (
 # 252 "flambda_parser.mly"
       (Fexpr.standard_int_or_float)
-# 3951 "flambda_parser_in.ml"
-        ) = 
-# 517 "flambda_parser.mly"
-                       ( Tagged_immediate )
-# 3955 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 252 "flambda_parser.mly"
-      (Fexpr.standard_int_or_float)
-# 3980 "flambda_parser_in.ml"
+# 3952 "flambda_parser_in.ml"
         ) = 
 # 518 "flambda_parser.mly"
-            ( Naked_immediate )
-# 3984 "flambda_parser_in.ml"
+                       ( Tagged_immediate )
+# 3956 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4005,11 +3977,11 @@ module Tables = struct
         let _v : (
 # 252 "flambda_parser.mly"
       (Fexpr.standard_int_or_float)
-# 4009 "flambda_parser_in.ml"
+# 3981 "flambda_parser_in.ml"
         ) = 
 # 519 "flambda_parser.mly"
-              ( Naked_float )
-# 4013 "flambda_parser_in.ml"
+            ( Naked_immediate )
+# 3985 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4034,11 +4006,11 @@ module Tables = struct
         let _v : (
 # 252 "flambda_parser.mly"
       (Fexpr.standard_int_or_float)
-# 4038 "flambda_parser_in.ml"
+# 4010 "flambda_parser_in.ml"
         ) = 
 # 520 "flambda_parser.mly"
-              ( Naked_int32 )
-# 4042 "flambda_parser_in.ml"
+              ( Naked_float )
+# 4014 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4063,11 +4035,11 @@ module Tables = struct
         let _v : (
 # 252 "flambda_parser.mly"
       (Fexpr.standard_int_or_float)
-# 4067 "flambda_parser_in.ml"
+# 4039 "flambda_parser_in.ml"
         ) = 
 # 521 "flambda_parser.mly"
-              ( Naked_int64 )
-# 4071 "flambda_parser_in.ml"
+              ( Naked_int32 )
+# 4043 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4092,11 +4064,40 @@ module Tables = struct
         let _v : (
 # 252 "flambda_parser.mly"
       (Fexpr.standard_int_or_float)
-# 4096 "flambda_parser_in.ml"
+# 4068 "flambda_parser_in.ml"
         ) = 
 # 522 "flambda_parser.mly"
+              ( Naked_int64 )
+# 4072 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 252 "flambda_parser.mly"
+      (Fexpr.standard_int_or_float)
+# 4097 "flambda_parser_in.ml"
+        ) = 
+# 523 "flambda_parser.mly"
                   ( Naked_nativeint )
-# 4100 "flambda_parser_in.ml"
+# 4101 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4112,9 +4113,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_ctors = 
-# 741 "flambda_parser.mly"
+# 743 "flambda_parser.mly"
     ( [], [] )
-# 4118 "flambda_parser_in.ml"
+# 4119 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4137,9 +4138,9 @@ module Tables = struct
         let _startpos = _startpos_ctors_ in
         let _endpos = _endpos_ctors_ in
         let _v : 'tv_ctors = 
-# 742 "flambda_parser.mly"
+# 744 "flambda_parser.mly"
                            ( ctors )
-# 4143 "flambda_parser_in.ml"
+# 4144 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4162,9 +4163,9 @@ module Tables = struct
         let _startpos = _startpos_tag_ in
         let _endpos = _endpos_tag_ in
         let _v : 'tv_ctors_nonempty = 
-# 744 "flambda_parser.mly"
+# 746 "flambda_parser.mly"
                     ( [ tag ], [] )
-# 4168 "flambda_parser_in.ml"
+# 4169 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4201,9 +4202,9 @@ module Tables = struct
         let _startpos = _startpos_tag_ in
         let _endpos = _endpos_ctors_ in
         let _v : 'tv_ctors_nonempty = 
-# 746 "flambda_parser.mly"
+# 748 "flambda_parser.mly"
       ( let (c, nc) = ctors in (tag :: c, nc) )
-# 4207 "flambda_parser_in.ml"
+# 4208 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4226,9 +4227,9 @@ module Tables = struct
         let _startpos = _startpos_nonconsts_ in
         let _endpos = _endpos_nonconsts_ in
         let _v : 'tv_ctors_nonempty = 
-# 747 "flambda_parser.mly"
+# 749 "flambda_parser.mly"
                                         ( [], nonconsts )
-# 4232 "flambda_parser_in.ml"
+# 4233 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4267,7 +4268,7 @@ module Tables = struct
         let _v : 'tv_deleted_code = 
 # 330 "flambda_parser.mly"
                                              ( code_id )
-# 4271 "flambda_parser_in.ml"
+# 4272 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4285,11 +4286,11 @@ module Tables = struct
         let _v : (
 # 246 "flambda_parser.mly"
       (Fexpr.empty_array_kind)
-# 4289 "flambda_parser_in.ml"
+# 4290 "flambda_parser_in.ml"
         ) = 
-# 492 "flambda_parser.mly"
+# 493 "flambda_parser.mly"
     ( Values_or_immediates_or_naked_floats )
-# 4293 "flambda_parser_in.ml"
+# 4294 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4316,7 +4317,7 @@ module Tables = struct
         let cont : (
 # 251 "flambda_parser.mly"
       (Fexpr.continuation)
-# 4320 "flambda_parser_in.ml"
+# 4321 "flambda_parser_in.ml"
         ) = Obj.magic cont in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -4325,7 +4326,7 @@ module Tables = struct
         let _v : 'tv_exn_continuation = 
 # 308 "flambda_parser.mly"
                              ( cont )
-# 4329 "flambda_parser_in.ml"
+# 4330 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4357,7 +4358,7 @@ module Tables = struct
         let _v : 'tv_exn_continuation_id = 
 # 311 "flambda_parser.mly"
                                 ( cont )
-# 4361 "flambda_parser_in.ml"
+# 4362 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4403,11 +4404,11 @@ module Tables = struct
         let _v : (
 # 253 "flambda_parser.mly"
       (Fexpr.expect_test_spec)
-# 4407 "flambda_parser_in.ml"
+# 4408 "flambda_parser_in.ml"
         ) = 
 # 295 "flambda_parser.mly"
     ( { before; after } )
-# 4411 "flambda_parser_in.ml"
+# 4412 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4430,9 +4431,9 @@ module Tables = struct
         let _startpos = _startpos_l_ in
         let _endpos = _endpos_l_ in
         let _v : 'tv_expr = 
-# 773 "flambda_parser.mly"
+# 775 "flambda_parser.mly"
                        ( l )
-# 4436 "flambda_parser_in.ml"
+# 4437 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4455,9 +4456,9 @@ module Tables = struct
         let _startpos = _startpos_i_ in
         let _endpos = _endpos_i_ in
         let _v : 'tv_expr = 
-# 774 "flambda_parser.mly"
+# 776 "flambda_parser.mly"
                    ( i )
-# 4461 "flambda_parser_in.ml"
+# 4462 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4482,11 +4483,11 @@ module Tables = struct
         let _v : (
 # 254 "flambda_parser.mly"
       (Fexpr.field_of_block)
-# 4486 "flambda_parser_in.ml"
+# 4487 "flambda_parser_in.ml"
         ) = 
-# 1032 "flambda_parser.mly"
+# 1034 "flambda_parser.mly"
                ( Symbol s )
-# 4490 "flambda_parser_in.ml"
+# 4491 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4511,11 +4512,11 @@ module Tables = struct
         let _v : (
 # 254 "flambda_parser.mly"
       (Fexpr.field_of_block)
-# 4515 "flambda_parser_in.ml"
+# 4516 "flambda_parser_in.ml"
         ) = 
-# 1033 "flambda_parser.mly"
+# 1035 "flambda_parser.mly"
                  ( Dynamically_computed v )
-# 4519 "flambda_parser_in.ml"
+# 4520 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4536,7 +4537,7 @@ module Tables = struct
         let i : (
 # 74 "flambda_parser.mly"
        (string * char option)
-# 4540 "flambda_parser_in.ml"
+# 4541 "flambda_parser_in.ml"
         ) = Obj.magic i in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_i_ in
@@ -4545,13 +4546,13 @@ module Tables = struct
           let _endpos = _endpos_i_ in
           let _startpos = _startpos_i_ in
           (
-# 1034 "flambda_parser.mly"
+# 1036 "flambda_parser.mly"
             ( Tagged_immediate ( make_tagged_immediate ~loc:(_startpos, _endpos) i ) )
-# 4551 "flambda_parser_in.ml"
+# 4552 "flambda_parser_in.ml"
            : (
 # 254 "flambda_parser.mly"
       (Fexpr.field_of_block)
-# 4555 "flambda_parser_in.ml"
+# 4556 "flambda_parser_in.ml"
           ))
         in
         {
@@ -4584,11 +4585,11 @@ module Tables = struct
         let _v : (
 # 255 "flambda_parser.mly"
       (Fexpr.flambda_unit)
-# 4588 "flambda_parser_in.ml"
+# 4589 "flambda_parser_in.ml"
         ) = 
 # 290 "flambda_parser.mly"
     ( body )
-# 4592 "flambda_parser_in.ml"
+# 4593 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4613,40 +4614,11 @@ module Tables = struct
         let _v : (
 # 256 "flambda_parser.mly"
       (unit Fexpr.comparison_behaviour)
-# 4617 "flambda_parser_in.ml"
-        ) = 
-# 567 "flambda_parser.mly"
-             ( Yielding_bool Eq )
-# 4621 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 256 "flambda_parser.mly"
-      (unit Fexpr.comparison_behaviour)
-# 4646 "flambda_parser_in.ml"
+# 4618 "flambda_parser_in.ml"
         ) = 
 # 568 "flambda_parser.mly"
-                ( Yielding_bool Neq )
-# 4650 "flambda_parser_in.ml"
+             ( Yielding_bool Eq )
+# 4622 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4671,11 +4643,11 @@ module Tables = struct
         let _v : (
 # 256 "flambda_parser.mly"
       (unit Fexpr.comparison_behaviour)
-# 4675 "flambda_parser_in.ml"
+# 4647 "flambda_parser_in.ml"
         ) = 
 # 569 "flambda_parser.mly"
-            ( Yielding_bool ( Lt ()) )
-# 4679 "flambda_parser_in.ml"
+                ( Yielding_bool Neq )
+# 4651 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4700,11 +4672,11 @@ module Tables = struct
         let _v : (
 # 256 "flambda_parser.mly"
       (unit Fexpr.comparison_behaviour)
-# 4704 "flambda_parser_in.ml"
+# 4676 "flambda_parser_in.ml"
         ) = 
 # 570 "flambda_parser.mly"
-               ( Yielding_bool ( Gt ()) )
-# 4708 "flambda_parser_in.ml"
+            ( Yielding_bool ( Lt ()) )
+# 4680 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4729,11 +4701,11 @@ module Tables = struct
         let _v : (
 # 256 "flambda_parser.mly"
       (unit Fexpr.comparison_behaviour)
-# 4733 "flambda_parser_in.ml"
+# 4705 "flambda_parser_in.ml"
         ) = 
 # 571 "flambda_parser.mly"
-                 ( Yielding_bool (Le()) )
-# 4737 "flambda_parser_in.ml"
+               ( Yielding_bool ( Gt ()) )
+# 4709 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4758,11 +4730,11 @@ module Tables = struct
         let _v : (
 # 256 "flambda_parser.mly"
       (unit Fexpr.comparison_behaviour)
-# 4762 "flambda_parser_in.ml"
+# 4734 "flambda_parser_in.ml"
         ) = 
 # 572 "flambda_parser.mly"
-                    ( Yielding_bool (Ge ()) )
-# 4766 "flambda_parser_in.ml"
+                 ( Yielding_bool (Le()) )
+# 4738 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4787,11 +4759,40 @@ module Tables = struct
         let _v : (
 # 256 "flambda_parser.mly"
       (unit Fexpr.comparison_behaviour)
-# 4791 "flambda_parser_in.ml"
+# 4763 "flambda_parser_in.ml"
         ) = 
 # 573 "flambda_parser.mly"
+                    ( Yielding_bool (Ge ()) )
+# 4767 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 256 "flambda_parser.mly"
+      (unit Fexpr.comparison_behaviour)
+# 4792 "flambda_parser_in.ml"
+        ) = 
+# 574 "flambda_parser.mly"
              ( (Yielding_int_like_compare_functions ()) )
-# 4795 "flambda_parser_in.ml"
+# 4796 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4812,7 +4813,7 @@ module Tables = struct
         let f : (
 # 68 "flambda_parser.mly"
        (float)
-# 4816 "flambda_parser_in.ml"
+# 4817 "flambda_parser_in.ml"
         ) = Obj.magic f in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_f_ in
@@ -4820,11 +4821,11 @@ module Tables = struct
         let _v : (
 # 258 "flambda_parser.mly"
       (float Fexpr.or_variable)
-# 4824 "flambda_parser_in.ml"
+# 4825 "flambda_parser_in.ml"
         ) = 
-# 1012 "flambda_parser.mly"
+# 1014 "flambda_parser.mly"
               ( Const f )
-# 4828 "flambda_parser_in.ml"
+# 4829 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4849,11 +4850,11 @@ module Tables = struct
         let _v : (
 # 258 "flambda_parser.mly"
       (float Fexpr.or_variable)
-# 4853 "flambda_parser_in.ml"
+# 4854 "flambda_parser_in.ml"
         ) = 
-# 1013 "flambda_parser.mly"
+# 1015 "flambda_parser.mly"
                  ( Var v )
-# 4857 "flambda_parser_in.ml"
+# 4858 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4892,7 +4893,7 @@ module Tables = struct
         let alloc : (
 # 242 "flambda_parser.mly"
       (Fexpr.alloc_mode_for_allocations)
-# 4896 "flambda_parser_in.ml"
+# 4897 "flambda_parser_in.ml"
         ) = Obj.magic alloc in
         let function_slot : 'tv_function_slot_opt = Obj.magic function_slot in
         let code_id : 'tv_code_id = Obj.magic code_id in
@@ -4901,9 +4902,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_alloc_ in
         let _v : 'tv_fun_decl = 
-# 856 "flambda_parser.mly"
+# 858 "flambda_parser.mly"
     ( { code_id; function_slot; alloc; } )
-# 4907 "flambda_parser_in.ml"
+# 4908 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4926,9 +4927,9 @@ module Tables = struct
         let _startpos = _startpos_s_ in
         let _endpos = _endpos_s_ in
         let _v : 'tv_func_name_with_optional_arities = 
-# 1056 "flambda_parser.mly"
+# 1058 "flambda_parser.mly"
                ( s, None )
-# 4932 "flambda_parser_in.ml"
+# 4933 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4986,7 +4987,7 @@ module Tables = struct
         let ret_arity : (
 # 263 "flambda_parser.mly"
       (Fexpr.kind_with_subkind list)
-# 4990 "flambda_parser_in.ml"
+# 4991 "flambda_parser_in.ml"
         ) = Obj.magic ret_arity in
         let _5 : unit = Obj.magic _5 in
         let params_arity : 'tv_blank_or_kinds_with_subkinds_ = Obj.magic params_arity in
@@ -4997,9 +4998,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__7_ in
         let _v : 'tv_func_name_with_optional_arities = 
-# 1061 "flambda_parser.mly"
+# 1063 "flambda_parser.mly"
     ( s, Some ({ params_arity; ret_arity } : function_arities) )
-# 5003 "flambda_parser_in.ml"
+# 5004 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5022,9 +5023,9 @@ module Tables = struct
         let _startpos = _startpos_v_ in
         let _endpos = _endpos_v_ in
         let _v : 'tv_function_slot = 
-# 1104 "flambda_parser.mly"
+# 1106 "flambda_parser.mly"
                  ( v )
-# 5028 "flambda_parser_in.ml"
+# 5029 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5040,9 +5041,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_function_slot_opt = 
-# 1108 "flambda_parser.mly"
+# 1110 "flambda_parser.mly"
     ( None )
-# 5046 "flambda_parser_in.ml"
+# 5047 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5072,9 +5073,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_cid_ in
         let _v : 'tv_function_slot_opt = 
-# 1109 "flambda_parser.mly"
+# 1111 "flambda_parser.mly"
                             ( Some cid )
-# 5078 "flambda_parser_in.ml"
+# 5079 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5095,7 +5096,7 @@ module Tables = struct
         let o : (
 # 248 "flambda_parser.mly"
       (Fexpr.binary_int_arith_op)
-# 5099 "flambda_parser_in.ml"
+# 5100 "flambda_parser_in.ml"
         ) = Obj.magic o in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_o_ in
@@ -5103,11 +5104,11 @@ module Tables = struct
         let _v : (
 # 259 "flambda_parser.mly"
       (Fexpr.infix_binop)
-# 5107 "flambda_parser_in.ml"
+# 5108 "flambda_parser_in.ml"
         ) = 
-# 441 "flambda_parser.mly"
+# 442 "flambda_parser.mly"
                             ( Int_arith o )
-# 5111 "flambda_parser_in.ml"
+# 5112 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5128,7 +5129,7 @@ module Tables = struct
         let c : (
 # 260 "flambda_parser.mly"
       (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
-# 5132 "flambda_parser_in.ml"
+# 5133 "flambda_parser_in.ml"
         ) = Obj.magic c in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_c_ in
@@ -5136,11 +5137,11 @@ module Tables = struct
         let _v : (
 # 259 "flambda_parser.mly"
       (Fexpr.infix_binop)
-# 5140 "flambda_parser_in.ml"
+# 5141 "flambda_parser_in.ml"
         ) = 
-# 442 "flambda_parser.mly"
+# 443 "flambda_parser.mly"
                  ( Int_comp (c Signed) )
-# 5144 "flambda_parser_in.ml"
+# 5145 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5165,11 +5166,11 @@ module Tables = struct
         let _v : (
 # 259 "flambda_parser.mly"
       (Fexpr.infix_binop)
-# 5169 "flambda_parser_in.ml"
+# 5170 "flambda_parser_in.ml"
         ) = 
-# 443 "flambda_parser.mly"
+# 444 "flambda_parser.mly"
                   ( Int_shift s )
-# 5173 "flambda_parser_in.ml"
+# 5174 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5190,7 +5191,7 @@ module Tables = struct
         let o : (
 # 247 "flambda_parser.mly"
       (Fexpr.binary_float_arith_op)
-# 5194 "flambda_parser_in.ml"
+# 5195 "flambda_parser_in.ml"
         ) = Obj.magic o in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_o_ in
@@ -5198,11 +5199,11 @@ module Tables = struct
         let _v : (
 # 259 "flambda_parser.mly"
       (Fexpr.infix_binop)
-# 5202 "flambda_parser_in.ml"
+# 5203 "flambda_parser_in.ml"
         ) = 
-# 444 "flambda_parser.mly"
+# 445 "flambda_parser.mly"
                               ( Float_arith (Float64, o) )
-# 5206 "flambda_parser_in.ml"
+# 5207 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5223,7 +5224,7 @@ module Tables = struct
         let c : (
 # 256 "flambda_parser.mly"
       (unit Fexpr.comparison_behaviour)
-# 5227 "flambda_parser_in.ml"
+# 5228 "flambda_parser_in.ml"
         ) = Obj.magic c in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_c_ in
@@ -5231,36 +5232,11 @@ module Tables = struct
         let _v : (
 # 259 "flambda_parser.mly"
       (Fexpr.infix_binop)
-# 5235 "flambda_parser_in.ml"
+# 5236 "flambda_parser_in.ml"
         ) = 
-# 445 "flambda_parser.mly"
+# 446 "flambda_parser.mly"
                    ( Float_comp (Float64, c) )
-# 5239 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : 'tv_init_or_assign = 
-# 525 "flambda_parser.mly"
-          ( Initialization )
-# 5264 "flambda_parser_in.ml"
+# 5240 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5284,8 +5260,33 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : 'tv_init_or_assign = 
 # 526 "flambda_parser.mly"
+          ( Initialization )
+# 5265 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : 'tv_init_or_assign = 
+# 527 "flambda_parser.mly"
               ( Assignment Heap )
-# 5289 "flambda_parser_in.ml"
+# 5290 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5315,101 +5316,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : 'tv_init_or_assign = 
-# 527 "flambda_parser.mly"
+# 528 "flambda_parser.mly"
                   ( Assignment Local )
-# 5321 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _;
-          CamlinternalMenhirLib.EngineTypes.semv = _4;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__4_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__4_;
-          CamlinternalMenhirLib.EngineTypes.next = {
-            CamlinternalMenhirLib.EngineTypes.state = _;
-            CamlinternalMenhirLib.EngineTypes.semv = _3;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos__3_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos__3_;
-            CamlinternalMenhirLib.EngineTypes.next = {
-              CamlinternalMenhirLib.EngineTypes.state = _;
-              CamlinternalMenhirLib.EngineTypes.semv = _2;
-              CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
-              CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
-              CamlinternalMenhirLib.EngineTypes.next = {
-                CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-                CamlinternalMenhirLib.EngineTypes.semv = _1;
-                CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-                CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-                CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _4 : unit = Obj.magic _4 in
-        let _3 : unit = Obj.magic _3 in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__4_ in
-        let _v : 'tv_inline = 
-# 892 "flambda_parser.mly"
-                                        ( Always_inline )
-# 5367 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _;
-          CamlinternalMenhirLib.EngineTypes.semv = _4;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__4_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__4_;
-          CamlinternalMenhirLib.EngineTypes.next = {
-            CamlinternalMenhirLib.EngineTypes.state = _;
-            CamlinternalMenhirLib.EngineTypes.semv = _3;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos__3_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos__3_;
-            CamlinternalMenhirLib.EngineTypes.next = {
-              CamlinternalMenhirLib.EngineTypes.state = _;
-              CamlinternalMenhirLib.EngineTypes.semv = _2;
-              CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
-              CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
-              CamlinternalMenhirLib.EngineTypes.next = {
-                CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-                CamlinternalMenhirLib.EngineTypes.semv = _1;
-                CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-                CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-                CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _4 : unit = Obj.magic _4 in
-        let _3 : unit = Obj.magic _3 in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__4_ in
-        let _v : 'tv_inline = 
-# 893 "flambda_parser.mly"
-                                           ( Available_inline )
-# 5413 "flambda_parser_in.ml"
+# 5322 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5454,8 +5363,8 @@ module Tables = struct
         let _endpos = _endpos__4_ in
         let _v : 'tv_inline = 
 # 894 "flambda_parser.mly"
-                                       ( Never_inline )
-# 5459 "flambda_parser_in.ml"
+                                        ( Always_inline )
+# 5368 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5473,9 +5382,9 @@ module Tables = struct
           CamlinternalMenhirLib.EngineTypes.endp = _endpos__4_;
           CamlinternalMenhirLib.EngineTypes.next = {
             CamlinternalMenhirLib.EngineTypes.state = _;
-            CamlinternalMenhirLib.EngineTypes.semv = i;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos_i_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos_i_;
+            CamlinternalMenhirLib.EngineTypes.semv = _3;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos__3_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos__3_;
             CamlinternalMenhirLib.EngineTypes.next = {
               CamlinternalMenhirLib.EngineTypes.state = _;
               CamlinternalMenhirLib.EngineTypes.semv = _2;
@@ -5492,7 +5401,7 @@ module Tables = struct
           };
         } = _menhir_stack in
         let _4 : unit = Obj.magic _4 in
-        let i : 'tv_plain_int = Obj.magic i in
+        let _3 : unit = Obj.magic _3 in
         let _2 : unit = Obj.magic _2 in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -5500,8 +5409,8 @@ module Tables = struct
         let _endpos = _endpos__4_ in
         let _v : 'tv_inline = 
 # 895 "flambda_parser.mly"
-                                             ( Inline_attribute.Unroll i )
-# 5505 "flambda_parser_in.ml"
+                                           ( Available_inline )
+# 5414 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5546,100 +5455,100 @@ module Tables = struct
         let _endpos = _endpos__4_ in
         let _v : 'tv_inline = 
 # 896 "flambda_parser.mly"
+                                       ( Never_inline )
+# 5460 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _;
+          CamlinternalMenhirLib.EngineTypes.semv = _4;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__4_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__4_;
+          CamlinternalMenhirLib.EngineTypes.next = {
+            CamlinternalMenhirLib.EngineTypes.state = _;
+            CamlinternalMenhirLib.EngineTypes.semv = i;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos_i_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos_i_;
+            CamlinternalMenhirLib.EngineTypes.next = {
+              CamlinternalMenhirLib.EngineTypes.state = _;
+              CamlinternalMenhirLib.EngineTypes.semv = _2;
+              CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
+              CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
+              CamlinternalMenhirLib.EngineTypes.next = {
+                CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+                CamlinternalMenhirLib.EngineTypes.semv = _1;
+                CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+                CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+                CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _4 : unit = Obj.magic _4 in
+        let i : 'tv_plain_int = Obj.magic i in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__4_ in
+        let _v : 'tv_inline = 
+# 897 "flambda_parser.mly"
+                                             ( Inline_attribute.Unroll i )
+# 5506 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _;
+          CamlinternalMenhirLib.EngineTypes.semv = _4;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__4_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__4_;
+          CamlinternalMenhirLib.EngineTypes.next = {
+            CamlinternalMenhirLib.EngineTypes.state = _;
+            CamlinternalMenhirLib.EngineTypes.semv = _3;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos__3_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos__3_;
+            CamlinternalMenhirLib.EngineTypes.next = {
+              CamlinternalMenhirLib.EngineTypes.state = _;
+              CamlinternalMenhirLib.EngineTypes.semv = _2;
+              CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
+              CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
+              CamlinternalMenhirLib.EngineTypes.next = {
+                CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+                CamlinternalMenhirLib.EngineTypes.semv = _1;
+                CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+                CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+                CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _4 : unit = Obj.magic _4 in
+        let _3 : unit = Obj.magic _3 in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__4_ in
+        let _v : 'tv_inline = 
+# 898 "flambda_parser.mly"
                                          ( Default_inline )
-# 5551 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _;
-          CamlinternalMenhirLib.EngineTypes.semv = _4;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__4_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__4_;
-          CamlinternalMenhirLib.EngineTypes.next = {
-            CamlinternalMenhirLib.EngineTypes.state = _;
-            CamlinternalMenhirLib.EngineTypes.semv = _3;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos__3_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos__3_;
-            CamlinternalMenhirLib.EngineTypes.next = {
-              CamlinternalMenhirLib.EngineTypes.state = _;
-              CamlinternalMenhirLib.EngineTypes.semv = _2;
-              CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
-              CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
-              CamlinternalMenhirLib.EngineTypes.next = {
-                CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-                CamlinternalMenhirLib.EngineTypes.semv = _1;
-                CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-                CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-                CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _4 : unit = Obj.magic _4 in
-        let _3 : unit = Obj.magic _3 in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__4_ in
-        let _v : 'tv_inlined = 
-# 899 "flambda_parser.mly"
-                                         ( Always_inlined )
-# 5597 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _;
-          CamlinternalMenhirLib.EngineTypes.semv = _4;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__4_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__4_;
-          CamlinternalMenhirLib.EngineTypes.next = {
-            CamlinternalMenhirLib.EngineTypes.state = _;
-            CamlinternalMenhirLib.EngineTypes.semv = _3;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos__3_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos__3_;
-            CamlinternalMenhirLib.EngineTypes.next = {
-              CamlinternalMenhirLib.EngineTypes.state = _;
-              CamlinternalMenhirLib.EngineTypes.semv = _2;
-              CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
-              CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
-              CamlinternalMenhirLib.EngineTypes.next = {
-                CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-                CamlinternalMenhirLib.EngineTypes.semv = _1;
-                CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-                CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-                CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _4 : unit = Obj.magic _4 in
-        let _3 : unit = Obj.magic _3 in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__4_ in
-        let _v : 'tv_inlined = 
-# 900 "flambda_parser.mly"
-                                       ( Hint_inlined )
-# 5643 "flambda_parser_in.ml"
+# 5552 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5684,8 +5593,8 @@ module Tables = struct
         let _endpos = _endpos__4_ in
         let _v : 'tv_inlined = 
 # 901 "flambda_parser.mly"
-                                        ( Never_inlined )
-# 5689 "flambda_parser_in.ml"
+                                         ( Always_inlined )
+# 5598 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5703,9 +5612,9 @@ module Tables = struct
           CamlinternalMenhirLib.EngineTypes.endp = _endpos__4_;
           CamlinternalMenhirLib.EngineTypes.next = {
             CamlinternalMenhirLib.EngineTypes.state = _;
-            CamlinternalMenhirLib.EngineTypes.semv = i;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos_i_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos_i_;
+            CamlinternalMenhirLib.EngineTypes.semv = _3;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos__3_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos__3_;
             CamlinternalMenhirLib.EngineTypes.next = {
               CamlinternalMenhirLib.EngineTypes.state = _;
               CamlinternalMenhirLib.EngineTypes.semv = _2;
@@ -5722,7 +5631,7 @@ module Tables = struct
           };
         } = _menhir_stack in
         let _4 : unit = Obj.magic _4 in
-        let i : 'tv_plain_int = Obj.magic i in
+        let _3 : unit = Obj.magic _3 in
         let _2 : unit = Obj.magic _2 in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -5730,8 +5639,8 @@ module Tables = struct
         let _endpos = _endpos__4_ in
         let _v : 'tv_inlined = 
 # 902 "flambda_parser.mly"
-                                             ( Unroll i )
-# 5735 "flambda_parser_in.ml"
+                                       ( Hint_inlined )
+# 5644 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5776,8 +5685,100 @@ module Tables = struct
         let _endpos = _endpos__4_ in
         let _v : 'tv_inlined = 
 # 903 "flambda_parser.mly"
+                                        ( Never_inlined )
+# 5690 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _;
+          CamlinternalMenhirLib.EngineTypes.semv = _4;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__4_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__4_;
+          CamlinternalMenhirLib.EngineTypes.next = {
+            CamlinternalMenhirLib.EngineTypes.state = _;
+            CamlinternalMenhirLib.EngineTypes.semv = i;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos_i_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos_i_;
+            CamlinternalMenhirLib.EngineTypes.next = {
+              CamlinternalMenhirLib.EngineTypes.state = _;
+              CamlinternalMenhirLib.EngineTypes.semv = _2;
+              CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
+              CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
+              CamlinternalMenhirLib.EngineTypes.next = {
+                CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+                CamlinternalMenhirLib.EngineTypes.semv = _1;
+                CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+                CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+                CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _4 : unit = Obj.magic _4 in
+        let i : 'tv_plain_int = Obj.magic i in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__4_ in
+        let _v : 'tv_inlined = 
+# 904 "flambda_parser.mly"
+                                             ( Unroll i )
+# 5736 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _;
+          CamlinternalMenhirLib.EngineTypes.semv = _4;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__4_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__4_;
+          CamlinternalMenhirLib.EngineTypes.next = {
+            CamlinternalMenhirLib.EngineTypes.state = _;
+            CamlinternalMenhirLib.EngineTypes.semv = _3;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos__3_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos__3_;
+            CamlinternalMenhirLib.EngineTypes.next = {
+              CamlinternalMenhirLib.EngineTypes.state = _;
+              CamlinternalMenhirLib.EngineTypes.semv = _2;
+              CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
+              CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
+              CamlinternalMenhirLib.EngineTypes.next = {
+                CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+                CamlinternalMenhirLib.EngineTypes.semv = _1;
+                CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+                CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+                CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _4 : unit = Obj.magic _4 in
+        let _3 : unit = Obj.magic _3 in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__4_ in
+        let _v : 'tv_inlined = 
+# 905 "flambda_parser.mly"
                                           ( Default_inlined )
-# 5781 "flambda_parser_in.ml"
+# 5782 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5821,12 +5822,12 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : 'tv_inlining_state = 
-# 907 "flambda_parser.mly"
+# 909 "flambda_parser.mly"
     (
       (* CR poechsel: Parse the inlining arguments *)
       { depth }
     )
-# 5830 "flambda_parser_in.ml"
+# 5831 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5870,9 +5871,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : 'tv_inlining_state_depth = 
-# 913 "flambda_parser.mly"
+# 915 "flambda_parser.mly"
                                             ( i )
-# 5876 "flambda_parser_in.ml"
+# 5877 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5895,9 +5896,9 @@ module Tables = struct
         let _startpos = _startpos_w_ in
         let _endpos = _endpos_w_ in
         let _v : 'tv_inner_expr = 
-# 783 "flambda_parser.mly"
+# 785 "flambda_parser.mly"
                    ( w )
-# 5901 "flambda_parser_in.ml"
+# 5902 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5920,9 +5921,9 @@ module Tables = struct
         let _startpos = _startpos_a_ in
         let _endpos = _endpos_a_ in
         let _v : 'tv_inner_expr = 
-# 784 "flambda_parser.mly"
+# 786 "flambda_parser.mly"
                     ( a )
-# 5926 "flambda_parser_in.ml"
+# 5927 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5947,40 +5948,11 @@ module Tables = struct
         let _v : (
 # 260 "flambda_parser.mly"
       (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
-# 5951 "flambda_parser_in.ml"
-        ) = 
-# 558 "flambda_parser.mly"
-         ( fun s -> Yielding_bool (Lt s) )
-# 5955 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 260 "flambda_parser.mly"
-      (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
-# 5980 "flambda_parser_in.ml"
+# 5952 "flambda_parser_in.ml"
         ) = 
 # 559 "flambda_parser.mly"
-            ( fun s -> Yielding_bool (Gt s) )
-# 5984 "flambda_parser_in.ml"
+         ( fun s -> Yielding_bool (Lt s) )
+# 5956 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6005,11 +5977,11 @@ module Tables = struct
         let _v : (
 # 260 "flambda_parser.mly"
       (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
-# 6009 "flambda_parser_in.ml"
+# 5981 "flambda_parser_in.ml"
         ) = 
 # 560 "flambda_parser.mly"
-              ( fun s -> Yielding_bool (Le s) )
-# 6013 "flambda_parser_in.ml"
+            ( fun s -> Yielding_bool (Gt s) )
+# 5985 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6034,11 +6006,11 @@ module Tables = struct
         let _v : (
 # 260 "flambda_parser.mly"
       (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
-# 6038 "flambda_parser_in.ml"
+# 6010 "flambda_parser_in.ml"
         ) = 
 # 561 "flambda_parser.mly"
-                 ( fun s -> Yielding_bool (Ge s) )
-# 6042 "flambda_parser_in.ml"
+              ( fun s -> Yielding_bool (Le s) )
+# 6014 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6063,11 +6035,11 @@ module Tables = struct
         let _v : (
 # 260 "flambda_parser.mly"
       (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
-# 6067 "flambda_parser_in.ml"
+# 6039 "flambda_parser_in.ml"
         ) = 
 # 562 "flambda_parser.mly"
-          ( fun _ -> Yielding_bool Eq )
-# 6071 "flambda_parser_in.ml"
+                 ( fun s -> Yielding_bool (Ge s) )
+# 6043 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6092,11 +6064,11 @@ module Tables = struct
         let _v : (
 # 260 "flambda_parser.mly"
       (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
-# 6096 "flambda_parser_in.ml"
+# 6068 "flambda_parser_in.ml"
         ) = 
 # 563 "flambda_parser.mly"
-             ( fun _ -> Yielding_bool Neq )
-# 6100 "flambda_parser_in.ml"
+          ( fun _ -> Yielding_bool Eq )
+# 6072 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6121,11 +6093,11 @@ module Tables = struct
         let _v : (
 # 260 "flambda_parser.mly"
       (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
-# 6125 "flambda_parser_in.ml"
+# 6097 "flambda_parser_in.ml"
         ) = 
 # 564 "flambda_parser.mly"
-          ( fun s -> Yielding_int_like_compare_functions s )
-# 6129 "flambda_parser_in.ml"
+             ( fun _ -> Yielding_bool Neq )
+# 6101 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6147,10 +6119,14 @@ module Tables = struct
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
-        let _v : 'tv_int_shift = 
-# 577 "flambda_parser.mly"
-            ( Lsl )
-# 6154 "flambda_parser_in.ml"
+        let _v : (
+# 260 "flambda_parser.mly"
+      (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
+# 6126 "flambda_parser_in.ml"
+        ) = 
+# 565 "flambda_parser.mly"
+          ( fun s -> Yielding_int_like_compare_functions s )
+# 6130 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6174,8 +6150,8 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : 'tv_int_shift = 
 # 578 "flambda_parser.mly"
-            ( Lsr )
-# 6179 "flambda_parser_in.ml"
+            ( Lsl )
+# 6155 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6199,8 +6175,33 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : 'tv_int_shift = 
 # 579 "flambda_parser.mly"
+            ( Lsr )
+# 6180 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : 'tv_int_shift = 
+# 580 "flambda_parser.mly"
             ( Asr )
-# 6204 "flambda_parser_in.ml"
+# 6205 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6221,7 +6222,7 @@ module Tables = struct
         let nnk : (
 # 266 "flambda_parser.mly"
       (Flambda_kind.Naked_number_kind.t)
-# 6225 "flambda_parser_in.ml"
+# 6226 "flambda_parser_in.ml"
         ) = Obj.magic nnk in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_nnk_ in
@@ -6229,11 +6230,11 @@ module Tables = struct
         let _v : (
 # 262 "flambda_parser.mly"
       (Fexpr.kind_with_subkind)
-# 6233 "flambda_parser_in.ml"
+# 6234 "flambda_parser_in.ml"
         ) = 
-# 712 "flambda_parser.mly"
+# 714 "flambda_parser.mly"
                             ( Naked_number nnk )
-# 6237 "flambda_parser_in.ml"
+# 6238 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6254,7 +6255,7 @@ module Tables = struct
         let subkind : (
 # 275 "flambda_parser.mly"
       (Fexpr.subkind)
-# 6258 "flambda_parser_in.ml"
+# 6259 "flambda_parser_in.ml"
         ) = Obj.magic subkind in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_subkind_ in
@@ -6262,69 +6263,69 @@ module Tables = struct
         let _v : (
 # 262 "flambda_parser.mly"
       (Fexpr.kind_with_subkind)
-# 6266 "flambda_parser_in.ml"
-        ) = 
-# 713 "flambda_parser.mly"
-                      ( Value subkind )
-# 6270 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 262 "flambda_parser.mly"
-      (Fexpr.kind_with_subkind)
-# 6295 "flambda_parser_in.ml"
-        ) = 
-# 714 "flambda_parser.mly"
-               ( Region )
-# 6299 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 262 "flambda_parser.mly"
-      (Fexpr.kind_with_subkind)
-# 6324 "flambda_parser_in.ml"
+# 6267 "flambda_parser_in.ml"
         ) = 
 # 715 "flambda_parser.mly"
+                      ( Value subkind )
+# 6271 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 262 "flambda_parser.mly"
+      (Fexpr.kind_with_subkind)
+# 6296 "flambda_parser_in.ml"
+        ) = 
+# 716 "flambda_parser.mly"
+               ( Region )
+# 6300 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 262 "flambda_parser.mly"
+      (Fexpr.kind_with_subkind)
+# 6325 "flambda_parser_in.ml"
+        ) = 
+# 717 "flambda_parser.mly"
                  ( Rec_info )
-# 6328 "flambda_parser_in.ml"
+# 6329 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6340,9 +6341,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_kind_with_subkind_opt = 
-# 1042 "flambda_parser.mly"
+# 1044 "flambda_parser.mly"
     ( None )
-# 6346 "flambda_parser_in.ml"
+# 6347 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6369,16 +6370,16 @@ module Tables = struct
         let kind : (
 # 262 "flambda_parser.mly"
       (Fexpr.kind_with_subkind)
-# 6373 "flambda_parser_in.ml"
+# 6374 "flambda_parser_in.ml"
         ) = Obj.magic kind in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_kind_ in
         let _v : 'tv_kind_with_subkind_opt = 
-# 1043 "flambda_parser.mly"
+# 1045 "flambda_parser.mly"
                                     ( Some kind )
-# 6382 "flambda_parser_in.ml"
+# 6383 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6394,9 +6395,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_kinded_args = 
-# 976 "flambda_parser.mly"
+# 978 "flambda_parser.mly"
     ( [] )
-# 6400 "flambda_parser_in.ml"
+# 6401 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6433,9 +6434,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : 'tv_kinded_args = 
-# 977 "flambda_parser.mly"
+# 979 "flambda_parser.mly"
                                                                          ( vs )
-# 6439 "flambda_parser_in.ml"
+# 6440 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6465,9 +6466,9 @@ module Tables = struct
         let _startpos = _startpos_param_ in
         let _endpos = _endpos_kind_ in
         let _v : 'tv_kinded_variable = 
-# 1038 "flambda_parser.mly"
+# 1040 "flambda_parser.mly"
                                                    ( { param; kind } )
-# 6471 "flambda_parser_in.ml"
+# 6472 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6492,11 +6493,11 @@ module Tables = struct
         let _v : (
 # 263 "flambda_parser.mly"
       (Fexpr.kind_with_subkind list)
-# 6496 "flambda_parser_in.ml"
+# 6497 "flambda_parser_in.ml"
         ) = 
-# 718 "flambda_parser.mly"
+# 720 "flambda_parser.mly"
              ( [] )
-# 6500 "flambda_parser_in.ml"
+# 6501 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6521,11 +6522,11 @@ module Tables = struct
         let _v : (
 # 263 "flambda_parser.mly"
       (Fexpr.kind_with_subkind list)
-# 6525 "flambda_parser_in.ml"
+# 6526 "flambda_parser_in.ml"
         ) = 
-# 719 "flambda_parser.mly"
+# 721 "flambda_parser.mly"
                                                           ( ks )
-# 6529 "flambda_parser_in.ml"
+# 6530 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6550,11 +6551,11 @@ module Tables = struct
         let _v : (
 # 276 "flambda_parser.mly"
       (Fexpr.kind_with_subkind list)
-# 6554 "flambda_parser_in.ml"
+# 6555 "flambda_parser_in.ml"
         ) = 
-# 737 "flambda_parser.mly"
+# 739 "flambda_parser.mly"
                                                            ( sks )
-# 6558 "flambda_parser_in.ml"
+# 6559 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6598,9 +6599,9 @@ module Tables = struct
         let _startpos = _startpos_bindings_ in
         let _endpos = _endpos_body_ in
         let _v : 'tv_let__continuation_body_ = 
-# 832 "flambda_parser.mly"
+# 834 "flambda_parser.mly"
     ( ({ bindings; value_slots; body } : let_) )
-# 6604 "flambda_parser_in.ml"
+# 6605 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6644,9 +6645,9 @@ module Tables = struct
         let _startpos = _startpos_bindings_ in
         let _endpos = _endpos_body_ in
         let _v : 'tv_let__expr_ = 
-# 832 "flambda_parser.mly"
+# 834 "flambda_parser.mly"
     ( ({ bindings; value_slots; body } : let_) )
-# 6650 "flambda_parser_in.ml"
+# 6651 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6679,7 +6680,7 @@ module Tables = struct
         let defining_expr : (
 # 267 "flambda_parser.mly"
       (Fexpr.named)
-# 6683 "flambda_parser_in.ml"
+# 6684 "flambda_parser_in.ml"
         ) = Obj.magic defining_expr in
         let _2 : unit = Obj.magic _2 in
         let var : 'tv_variable = Obj.magic var in
@@ -6687,9 +6688,9 @@ module Tables = struct
         let _startpos = _startpos_var_ in
         let _endpos = _endpos_defining_expr_ in
         let _v : 'tv_let_binding = 
-# 837 "flambda_parser.mly"
+# 839 "flambda_parser.mly"
     ( { var; defining_expr } )
-# 6693 "flambda_parser_in.ml"
+# 6694 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6719,9 +6720,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_l_ in
         let _v : 'tv_let_expr_continuation_body_ = 
-# 778 "flambda_parser.mly"
+# 780 "flambda_parser.mly"
                            ( Let l )
-# 6725 "flambda_parser_in.ml"
+# 6726 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6744,9 +6745,9 @@ module Tables = struct
         let _startpos = _startpos_ls_ in
         let _endpos = _endpos_ls_ in
         let _v : 'tv_let_expr_continuation_body_ = 
-# 779 "flambda_parser.mly"
+# 781 "flambda_parser.mly"
                           ( Let_symbol ls )
-# 6750 "flambda_parser_in.ml"
+# 6751 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6776,9 +6777,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_l_ in
         let _v : 'tv_let_expr_expr_ = 
-# 778 "flambda_parser.mly"
+# 780 "flambda_parser.mly"
                            ( Let l )
-# 6782 "flambda_parser_in.ml"
+# 6783 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6801,9 +6802,9 @@ module Tables = struct
         let _startpos = _startpos_ls_ in
         let _endpos = _endpos_ls_ in
         let _v : 'tv_let_expr_expr_ = 
-# 779 "flambda_parser.mly"
+# 781 "flambda_parser.mly"
                           ( Let_symbol ls )
-# 6807 "flambda_parser_in.ml"
+# 6808 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6856,7 +6857,7 @@ module Tables = struct
         let _v : 'tv_let_symbol_continuation_body_ = 
 # 318 "flambda_parser.mly"
                          ( { bindings; value_slots; body } )
-# 6860 "flambda_parser_in.ml"
+# 6861 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6909,7 +6910,7 @@ module Tables = struct
         let _v : 'tv_let_symbol_expr_ = 
 # 318 "flambda_parser.mly"
                          ( { bindings; value_slots; body } )
-# 6913 "flambda_parser_in.ml"
+# 6914 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6934,69 +6935,69 @@ module Tables = struct
         let _v : (
 # 264 "flambda_parser.mly"
       (Fexpr.loopify_attribute)
-# 6938 "flambda_parser_in.ml"
-        ) = 
-# 922 "flambda_parser.mly"
-               ( Always_loopify )
-# 6942 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 264 "flambda_parser.mly"
-      (Fexpr.loopify_attribute)
-# 6967 "flambda_parser_in.ml"
-        ) = 
-# 923 "flambda_parser.mly"
-              ( Never_loopify )
-# 6971 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 264 "flambda_parser.mly"
-      (Fexpr.loopify_attribute)
-# 6996 "flambda_parser_in.ml"
+# 6939 "flambda_parser_in.ml"
         ) = 
 # 924 "flambda_parser.mly"
+               ( Always_loopify )
+# 6943 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 264 "flambda_parser.mly"
+      (Fexpr.loopify_attribute)
+# 6968 "flambda_parser_in.ml"
+        ) = 
+# 925 "flambda_parser.mly"
+              ( Never_loopify )
+# 6972 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 264 "flambda_parser.mly"
+      (Fexpr.loopify_attribute)
+# 6997 "flambda_parser_in.ml"
+        ) = 
+# 926 "flambda_parser.mly"
              ( Already_loopified )
-# 7000 "flambda_parser_in.ml"
+# 7001 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7028,11 +7029,11 @@ module Tables = struct
         let _v : (
 # 264 "flambda_parser.mly"
       (Fexpr.loopify_attribute)
-# 7032 "flambda_parser_in.ml"
+# 7033 "flambda_parser_in.ml"
         ) = 
-# 925 "flambda_parser.mly"
+# 927 "flambda_parser.mly"
                             ( Default_loopify_and_tailrec )
-# 7036 "flambda_parser_in.ml"
+# 7037 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7057,11 +7058,11 @@ module Tables = struct
         let _v : (
 # 264 "flambda_parser.mly"
       (Fexpr.loopify_attribute)
-# 7061 "flambda_parser_in.ml"
+# 7062 "flambda_parser_in.ml"
         ) = 
-# 926 "flambda_parser.mly"
+# 928 "flambda_parser.mly"
                 ( Default_loopify_and_not_tailrec )
-# 7065 "flambda_parser_in.ml"
+# 7066 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7077,9 +7078,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_loopify_opt = 
-# 917 "flambda_parser.mly"
+# 919 "flambda_parser.mly"
     ( None )
-# 7083 "flambda_parser_in.ml"
+# 7084 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7119,7 +7120,7 @@ module Tables = struct
         let l : (
 # 264 "flambda_parser.mly"
       (Fexpr.loopify_attribute)
-# 7123 "flambda_parser_in.ml"
+# 7124 "flambda_parser_in.ml"
         ) = Obj.magic l in
         let _2 : unit = Obj.magic _2 in
         let _1 : unit = Obj.magic _1 in
@@ -7127,9 +7128,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : 'tv_loopify_opt = 
-# 918 "flambda_parser.mly"
+# 920 "flambda_parser.mly"
                                             ( Some l )
-# 7133 "flambda_parser_in.ml"
+# 7134 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7147,7 +7148,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_COMMA_field_of_block__ = 
 # 145 "<standard.mly>"
     ( [] )
-# 7151 "flambda_parser_in.ml"
+# 7152 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7172,7 +7173,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_COMMA_field_of_block__ = 
 # 148 "<standard.mly>"
     ( x )
-# 7176 "flambda_parser_in.ml"
+# 7177 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7190,7 +7191,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_COMMA_float_or_variable__ = 
 # 145 "<standard.mly>"
     ( [] )
-# 7194 "flambda_parser_in.ml"
+# 7195 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7215,7 +7216,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_COMMA_float_or_variable__ = 
 # 148 "<standard.mly>"
     ( x )
-# 7219 "flambda_parser_in.ml"
+# 7220 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7233,7 +7234,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_COMMA_simple__ = 
 # 145 "<standard.mly>"
     ( [] )
-# 7237 "flambda_parser_in.ml"
+# 7238 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7258,7 +7259,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_COMMA_simple__ = 
 # 148 "<standard.mly>"
     ( x )
-# 7262 "flambda_parser_in.ml"
+# 7263 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7276,7 +7277,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_KWD_ANDWHERE_continuation_binding__ = 
 # 145 "<standard.mly>"
     ( [] )
-# 7280 "flambda_parser_in.ml"
+# 7281 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7301,7 +7302,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_KWD_ANDWHERE_continuation_binding__ = 
 # 148 "<standard.mly>"
     ( x )
-# 7305 "flambda_parser_in.ml"
+# 7306 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7319,7 +7320,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_PIPE_switch_case__ = 
 # 145 "<standard.mly>"
     ( [] )
-# 7323 "flambda_parser_in.ml"
+# 7324 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7344,7 +7345,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_PIPE_switch_case__ = 
 # 148 "<standard.mly>"
     ( x )
-# 7348 "flambda_parser_in.ml"
+# 7349 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7362,7 +7363,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_SEMICOLON_float_or_variable__ = 
 # 145 "<standard.mly>"
     ( [] )
-# 7366 "flambda_parser_in.ml"
+# 7367 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7387,7 +7388,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_SEMICOLON_float_or_variable__ = 
 # 148 "<standard.mly>"
     ( x )
-# 7391 "flambda_parser_in.ml"
+# 7392 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7405,7 +7406,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_SEMICOLON_value_slot__ = 
 # 145 "<standard.mly>"
     ( [] )
-# 7409 "flambda_parser_in.ml"
+# 7410 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7430,7 +7431,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_SEMICOLON_value_slot__ = 
 # 148 "<standard.mly>"
     ( x )
-# 7434 "flambda_parser_in.ml"
+# 7435 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7455,7 +7456,7 @@ module Tables = struct
         let _v : 'tv_module_ = 
 # 304 "flambda_parser.mly"
     ( { body } )
-# 7459 "flambda_parser_in.ml"
+# 7460 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7480,40 +7481,40 @@ module Tables = struct
         let _v : (
 # 265 "flambda_parser.mly"
       (Fexpr.mutability)
-# 7484 "flambda_parser_in.ml"
-        ) = 
-# 462 "flambda_parser.mly"
-                ( Mutable )
-# 7488 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 265 "flambda_parser.mly"
-      (Fexpr.mutability)
-# 7513 "flambda_parser_in.ml"
+# 7485 "flambda_parser_in.ml"
         ) = 
 # 463 "flambda_parser.mly"
+                ( Mutable )
+# 7489 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 265 "flambda_parser.mly"
+      (Fexpr.mutability)
+# 7514 "flambda_parser_in.ml"
+        ) = 
+# 464 "flambda_parser.mly"
                          ( Immutable_unique )
-# 7517 "flambda_parser_in.ml"
+# 7518 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7531,11 +7532,11 @@ module Tables = struct
         let _v : (
 # 265 "flambda_parser.mly"
       (Fexpr.mutability)
-# 7535 "flambda_parser_in.ml"
+# 7536 "flambda_parser_in.ml"
         ) = 
-# 464 "flambda_parser.mly"
+# 465 "flambda_parser.mly"
     ( Immutable )
-# 7539 "flambda_parser_in.ml"
+# 7540 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7560,69 +7561,11 @@ module Tables = struct
         let _v : (
 # 266 "flambda_parser.mly"
       (Flambda_kind.Naked_number_kind.t)
-# 7564 "flambda_parser_in.ml"
-        ) = 
-# 697 "flambda_parser.mly"
-            ( Naked_immediate )
-# 7568 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 266 "flambda_parser.mly"
-      (Flambda_kind.Naked_number_kind.t)
-# 7593 "flambda_parser_in.ml"
-        ) = 
-# 698 "flambda_parser.mly"
-              ( Naked_float )
-# 7597 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 266 "flambda_parser.mly"
-      (Flambda_kind.Naked_number_kind.t)
-# 7622 "flambda_parser_in.ml"
+# 7565 "flambda_parser_in.ml"
         ) = 
 # 699 "flambda_parser.mly"
-              ( Naked_int32 )
-# 7626 "flambda_parser_in.ml"
+            ( Naked_immediate )
+# 7569 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7647,11 +7590,11 @@ module Tables = struct
         let _v : (
 # 266 "flambda_parser.mly"
       (Flambda_kind.Naked_number_kind.t)
-# 7651 "flambda_parser_in.ml"
+# 7594 "flambda_parser_in.ml"
         ) = 
 # 700 "flambda_parser.mly"
-              ( Naked_int64 )
-# 7655 "flambda_parser_in.ml"
+              ( Naked_float )
+# 7598 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7676,11 +7619,69 @@ module Tables = struct
         let _v : (
 # 266 "flambda_parser.mly"
       (Flambda_kind.Naked_number_kind.t)
-# 7680 "flambda_parser_in.ml"
+# 7623 "flambda_parser_in.ml"
         ) = 
 # 701 "flambda_parser.mly"
+              ( Naked_int32 )
+# 7627 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 266 "flambda_parser.mly"
+      (Flambda_kind.Naked_number_kind.t)
+# 7652 "flambda_parser_in.ml"
+        ) = 
+# 702 "flambda_parser.mly"
+              ( Naked_int64 )
+# 7656 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 266 "flambda_parser.mly"
+      (Flambda_kind.Naked_number_kind.t)
+# 7681 "flambda_parser_in.ml"
+        ) = 
+# 703 "flambda_parser.mly"
                   ( Naked_nativeint )
-# 7684 "flambda_parser_in.ml"
+# 7685 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7705,11 +7706,11 @@ module Tables = struct
         let _v : (
 # 267 "flambda_parser.mly"
       (Fexpr.named)
-# 7709 "flambda_parser_in.ml"
+# 7710 "flambda_parser_in.ml"
         ) = 
-# 675 "flambda_parser.mly"
+# 677 "flambda_parser.mly"
                ( Simple s )
-# 7713 "flambda_parser_in.ml"
+# 7714 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7737,7 +7738,7 @@ module Tables = struct
         let u : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 7741 "flambda_parser_in.ml"
+# 7742 "flambda_parser_in.ml"
         ) = Obj.magic u in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_u_ in
@@ -7745,11 +7746,11 @@ module Tables = struct
         let _v : (
 # 267 "flambda_parser.mly"
       (Fexpr.named)
-# 7749 "flambda_parser_in.ml"
+# 7750 "flambda_parser_in.ml"
         ) = 
-# 676 "flambda_parser.mly"
+# 678 "flambda_parser.mly"
                         ( Prim (Unary (u, a)) )
-# 7753 "flambda_parser_in.ml"
+# 7754 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7774,11 +7775,11 @@ module Tables = struct
         let _v : (
 # 267 "flambda_parser.mly"
       (Fexpr.named)
-# 7778 "flambda_parser_in.ml"
+# 7779 "flambda_parser_in.ml"
         ) = 
-# 677 "flambda_parser.mly"
+# 679 "flambda_parser.mly"
                   ( Prim b )
-# 7782 "flambda_parser_in.ml"
+# 7783 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7803,11 +7804,11 @@ module Tables = struct
         let _v : (
 # 267 "flambda_parser.mly"
       (Fexpr.named)
-# 7807 "flambda_parser_in.ml"
+# 7808 "flambda_parser_in.ml"
         ) = 
-# 678 "flambda_parser.mly"
+# 680 "flambda_parser.mly"
                    ( Prim t )
-# 7811 "flambda_parser_in.ml"
+# 7812 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7832,11 +7833,11 @@ module Tables = struct
         let _v : (
 # 267 "flambda_parser.mly"
       (Fexpr.named)
-# 7836 "flambda_parser_in.ml"
+# 7837 "flambda_parser_in.ml"
         ) = 
-# 679 "flambda_parser.mly"
+# 681 "flambda_parser.mly"
               ( Prim b )
-# 7840 "flambda_parser_in.ml"
+# 7841 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7861,11 +7862,11 @@ module Tables = struct
         let _v : (
 # 267 "flambda_parser.mly"
       (Fexpr.named)
-# 7865 "flambda_parser_in.ml"
+# 7866 "flambda_parser_in.ml"
         ) = 
-# 680 "flambda_parser.mly"
+# 682 "flambda_parser.mly"
                  ( Closure c )
-# 7869 "flambda_parser_in.ml"
+# 7870 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7892,7 +7893,7 @@ module Tables = struct
         let ri : (
 # 269 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 7896 "flambda_parser_in.ml"
+# 7897 "flambda_parser_in.ml"
         ) = Obj.magic ri in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -7901,11 +7902,11 @@ module Tables = struct
         let _v : (
 # 267 "flambda_parser.mly"
       (Fexpr.named)
-# 7905 "flambda_parser_in.ml"
+# 7906 "flambda_parser_in.ml"
         ) = 
-# 686 "flambda_parser.mly"
+# 688 "flambda_parser.mly"
                                      ( Rec_info ri )
-# 7909 "flambda_parser_in.ml"
+# 7910 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7951,7 +7952,7 @@ module Tables = struct
         let _v : 'tv_newer_version_of = 
 # 370 "flambda_parser.mly"
                                                       ( id )
-# 7955 "flambda_parser_in.ml"
+# 7956 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7984,7 +7985,7 @@ module Tables = struct
         let kinds : (
 # 276 "flambda_parser.mly"
       (Fexpr.kind_with_subkind list)
-# 7988 "flambda_parser_in.ml"
+# 7989 "flambda_parser_in.ml"
         ) = Obj.magic kinds in
         let _2 : unit = Obj.magic _2 in
         let tag : 'tv_tag = Obj.magic tag in
@@ -7992,9 +7993,9 @@ module Tables = struct
         let _startpos = _startpos_tag_ in
         let _endpos = _endpos_kinds_ in
         let _v : 'tv_nonconst_ctor = 
-# 752 "flambda_parser.mly"
+# 754 "flambda_parser.mly"
                                                             ( tag, kinds )
-# 7998 "flambda_parser_in.ml"
+# 7999 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8017,9 +8018,9 @@ module Tables = struct
         let _startpos = _startpos_ctors_ in
         let _endpos = _endpos_ctors_ in
         let _v : 'tv_nonconst_ctors_nonempty = 
-# 749 "flambda_parser.mly"
+# 751 "flambda_parser.mly"
                                                          ( ctors )
-# 8023 "flambda_parser_in.ml"
+# 8024 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8037,7 +8038,7 @@ module Tables = struct
         let _v : 'tv_option_PIPE_ = 
 # 111 "<standard.mly>"
     ( None )
-# 8041 "flambda_parser_in.ml"
+# 8042 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8062,7 +8063,7 @@ module Tables = struct
         let _v : 'tv_option_PIPE_ = 
 # 114 "<standard.mly>"
     ( Some x )
-# 8066 "flambda_parser_in.ml"
+# 8067 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8080,7 +8081,7 @@ module Tables = struct
         let _v : 'tv_option_inline_ = 
 # 111 "<standard.mly>"
     ( None )
-# 8084 "flambda_parser_in.ml"
+# 8085 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8105,7 +8106,7 @@ module Tables = struct
         let _v : 'tv_option_inline_ = 
 # 114 "<standard.mly>"
     ( Some x )
-# 8109 "flambda_parser_in.ml"
+# 8110 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8123,7 +8124,7 @@ module Tables = struct
         let _v : 'tv_option_inlined_ = 
 # 111 "<standard.mly>"
     ( None )
-# 8127 "flambda_parser_in.ml"
+# 8128 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8148,7 +8149,7 @@ module Tables = struct
         let _v : 'tv_option_inlined_ = 
 # 114 "<standard.mly>"
     ( Some x )
-# 8152 "flambda_parser_in.ml"
+# 8153 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8166,7 +8167,7 @@ module Tables = struct
         let _v : 'tv_option_inlining_state_ = 
 # 111 "<standard.mly>"
     ( None )
-# 8170 "flambda_parser_in.ml"
+# 8171 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8191,7 +8192,7 @@ module Tables = struct
         let _v : 'tv_option_inlining_state_ = 
 # 114 "<standard.mly>"
     ( Some x )
-# 8195 "flambda_parser_in.ml"
+# 8196 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8209,7 +8210,7 @@ module Tables = struct
         let _v : 'tv_option_newer_version_of_ = 
 # 111 "<standard.mly>"
     ( None )
-# 8213 "flambda_parser_in.ml"
+# 8214 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8234,7 +8235,7 @@ module Tables = struct
         let _v : 'tv_option_newer_version_of_ = 
 # 114 "<standard.mly>"
     ( Some x )
-# 8238 "flambda_parser_in.ml"
+# 8239 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8252,7 +8253,7 @@ module Tables = struct
         let _v : 'tv_option_raise_kind_ = 
 # 111 "<standard.mly>"
     ( None )
-# 8256 "flambda_parser_in.ml"
+# 8257 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8277,7 +8278,7 @@ module Tables = struct
         let _v : 'tv_option_raise_kind_ = 
 # 114 "<standard.mly>"
     ( Some x )
-# 8281 "flambda_parser_in.ml"
+# 8282 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8295,7 +8296,7 @@ module Tables = struct
         let _v : 'tv_option_trap_action_ = 
 # 111 "<standard.mly>"
     ( None )
-# 8299 "flambda_parser_in.ml"
+# 8300 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8320,7 +8321,7 @@ module Tables = struct
         let _v : 'tv_option_trap_action_ = 
 # 114 "<standard.mly>"
     ( Some x )
-# 8324 "flambda_parser_in.ml"
+# 8325 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8341,15 +8342,15 @@ module Tables = struct
         let i : (
 # 74 "flambda_parser.mly"
        (string * char option)
-# 8345 "flambda_parser_in.ml"
+# 8346 "flambda_parser_in.ml"
         ) = Obj.magic i in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_i_ in
         let _endpos = _endpos_i_ in
         let _v : 'tv_plain_int = 
-# 1028 "flambda_parser.mly"
+# 1030 "flambda_parser.mly"
           ( make_plain_int i )
-# 8353 "flambda_parser_in.ml"
+# 8354 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8379,9 +8380,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_saw_ in
         let _v : 'tv_prefix_binop = 
-# 451 "flambda_parser.mly"
+# 452 "flambda_parser.mly"
     ( String_or_bigstring_load (Bigstring, saw) )
-# 8385 "flambda_parser_in.ml"
+# 8386 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8411,9 +8412,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_saw_ in
         let _v : 'tv_prefix_binop = 
-# 454 "flambda_parser.mly"
+# 455 "flambda_parser.mly"
     ( String_or_bigstring_load (Bytes, saw) )
-# 8417 "flambda_parser_in.ml"
+# 8418 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8442,35 +8443,10 @@ module Tables = struct
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_saw_ in
-        let _v : 'tv_prefix_binop = 
-# 457 "flambda_parser.mly"
-    ( String_or_bigstring_load (String, saw) )
-# 8449 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
         let _v : 'tv_prefix_binop = 
 # 458 "flambda_parser.mly"
-                 ( Phys_equal Eq )
-# 8474 "flambda_parser_in.ml"
+    ( String_or_bigstring_load (String, saw) )
+# 8450 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8494,58 +8470,33 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : 'tv_prefix_binop = 
 # 459 "flambda_parser.mly"
+                 ( Phys_equal Eq )
+# 8475 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : 'tv_prefix_binop = 
+# 460 "flambda_parser.mly"
                  ( Phys_equal Neq )
-# 8499 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : 'tv_raise_kind = 
-# 953 "flambda_parser.mly"
-                ( Regular )
-# 8524 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : 'tv_raise_kind = 
-# 954 "flambda_parser.mly"
-                ( Reraise )
-# 8549 "flambda_parser_in.ml"
+# 8500 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8569,8 +8520,58 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : 'tv_raise_kind = 
 # 955 "flambda_parser.mly"
+                ( Regular )
+# 8525 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : 'tv_raise_kind = 
+# 956 "flambda_parser.mly"
+                ( Reraise )
+# 8550 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : 'tv_raise_kind = 
+# 957 "flambda_parser.mly"
                 ( No_trace )
-# 8574 "flambda_parser_in.ml"
+# 8575 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8591,7 +8592,7 @@ module Tables = struct
         let ri : (
 # 269 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8595 "flambda_parser_in.ml"
+# 8596 "flambda_parser_in.ml"
         ) = Obj.magic ri in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_ri_ in
@@ -8599,11 +8600,11 @@ module Tables = struct
         let _v : (
 # 268 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8603 "flambda_parser_in.ml"
+# 8604 "flambda_parser_in.ml"
         ) = 
-# 1091 "flambda_parser.mly"
+# 1093 "flambda_parser.mly"
                        ( ri )
-# 8607 "flambda_parser_in.ml"
+# 8608 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8630,7 +8631,7 @@ module Tables = struct
         let ri : (
 # 269 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8634 "flambda_parser_in.ml"
+# 8635 "flambda_parser_in.ml"
         ) = Obj.magic ri in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -8639,11 +8640,11 @@ module Tables = struct
         let _v : (
 # 268 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8643 "flambda_parser_in.ml"
+# 8644 "flambda_parser_in.ml"
         ) = 
-# 1092 "flambda_parser.mly"
+# 1094 "flambda_parser.mly"
                                  ( Succ ri )
-# 8647 "flambda_parser_in.ml"
+# 8648 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8676,7 +8677,7 @@ module Tables = struct
         let ri : (
 # 269 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8680 "flambda_parser_in.ml"
+# 8681 "flambda_parser_in.ml"
         ) = Obj.magic ri in
         let d : 'tv_plain_int = Obj.magic d in
         let _1 : unit = Obj.magic _1 in
@@ -8686,11 +8687,11 @@ module Tables = struct
         let _v : (
 # 268 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8690 "flambda_parser_in.ml"
+# 8691 "flambda_parser_in.ml"
         ) = 
-# 1093 "flambda_parser.mly"
+# 1095 "flambda_parser.mly"
                                                   ( Unroll (d, ri) )
-# 8694 "flambda_parser_in.ml"
+# 8695 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8715,69 +8716,69 @@ module Tables = struct
         let _v : (
 # 269 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8719 "flambda_parser_in.ml"
-        ) = 
-# 1083 "flambda_parser.mly"
-                  ( Depth i )
-# 8723 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 269 "flambda_parser.mly"
-      (Fexpr.rec_info)
-# 8748 "flambda_parser_in.ml"
-        ) = 
-# 1084 "flambda_parser.mly"
-            ( Infinity )
-# 8752 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 269 "flambda_parser.mly"
-      (Fexpr.rec_info)
-# 8777 "flambda_parser_in.ml"
+# 8720 "flambda_parser_in.ml"
         ) = 
 # 1085 "flambda_parser.mly"
+                  ( Depth i )
+# 8724 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 269 "flambda_parser.mly"
+      (Fexpr.rec_info)
+# 8749 "flambda_parser_in.ml"
+        ) = 
+# 1086 "flambda_parser.mly"
+            ( Infinity )
+# 8753 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 269 "flambda_parser.mly"
+      (Fexpr.rec_info)
+# 8778 "flambda_parser_in.ml"
+        ) = 
+# 1087 "flambda_parser.mly"
                       ( Do_not_inline )
-# 8781 "flambda_parser_in.ml"
+# 8782 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8802,11 +8803,11 @@ module Tables = struct
         let _v : (
 # 269 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8806 "flambda_parser_in.ml"
+# 8807 "flambda_parser_in.ml"
         ) = 
-# 1086 "flambda_parser.mly"
+# 1088 "flambda_parser.mly"
                   ( Var dv )
-# 8810 "flambda_parser_in.ml"
+# 8811 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8840,7 +8841,7 @@ module Tables = struct
         let ri : (
 # 268 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8844 "flambda_parser_in.ml"
+# 8845 "flambda_parser_in.ml"
         ) = Obj.magic ri in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -8849,11 +8850,11 @@ module Tables = struct
         let _v : (
 # 269 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8853 "flambda_parser_in.ml"
+# 8854 "flambda_parser_in.ml"
         ) = 
-# 1087 "flambda_parser.mly"
+# 1089 "flambda_parser.mly"
                                   ( ri )
-# 8857 "flambda_parser_in.ml"
+# 8858 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8871,11 +8872,11 @@ module Tables = struct
         let _v : (
 # 281 "flambda_parser.mly"
       (Fexpr.is_recursive)
-# 8875 "flambda_parser_in.ml"
+# 8876 "flambda_parser_in.ml"
         ) = 
 # 385 "flambda_parser.mly"
     ( Nonrecursive )
-# 8879 "flambda_parser_in.ml"
+# 8880 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8900,11 +8901,11 @@ module Tables = struct
         let _v : (
 # 281 "flambda_parser.mly"
       (Fexpr.is_recursive)
-# 8904 "flambda_parser_in.ml"
+# 8905 "flambda_parser_in.ml"
         ) = 
 # 386 "flambda_parser.mly"
             ( Recursive )
-# 8908 "flambda_parser_in.ml"
+# 8909 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8929,11 +8930,11 @@ module Tables = struct
         let _v : (
 # 270 "flambda_parser.mly"
       (Fexpr.region)
-# 8933 "flambda_parser_in.ml"
+# 8934 "flambda_parser_in.ml"
         ) = 
-# 930 "flambda_parser.mly"
+# 932 "flambda_parser.mly"
                  ( Named v )
-# 8937 "flambda_parser_in.ml"
+# 8938 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8958,11 +8959,11 @@ module Tables = struct
         let _v : (
 # 270 "flambda_parser.mly"
       (Fexpr.region)
-# 8962 "flambda_parser_in.ml"
+# 8963 "flambda_parser_in.ml"
         ) = 
-# 931 "flambda_parser.mly"
+# 933 "flambda_parser.mly"
                  ( Toplevel )
-# 8966 "flambda_parser_in.ml"
+# 8967 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8983,15 +8984,15 @@ module Tables = struct
         let c : (
 # 251 "flambda_parser.mly"
       (Fexpr.continuation)
-# 8987 "flambda_parser_in.ml"
+# 8988 "flambda_parser_in.ml"
         ) = Obj.magic c in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_c_ in
         let _endpos = _endpos_c_ in
         let _v : 'tv_result_continuation = 
-# 935 "flambda_parser.mly"
+# 937 "flambda_parser.mly"
                      ( Return c )
-# 8995 "flambda_parser_in.ml"
+# 8996 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9014,9 +9015,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_result_continuation = 
-# 936 "flambda_parser.mly"
+# 938 "flambda_parser.mly"
               ( Never_returns )
-# 9020 "flambda_parser_in.ml"
+# 9021 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9032,9 +9033,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_return_arity = 
-# 755 "flambda_parser.mly"
+# 757 "flambda_parser.mly"
     ( None )
-# 9038 "flambda_parser_in.ml"
+# 9039 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9061,16 +9062,16 @@ module Tables = struct
         let k : (
 # 263 "flambda_parser.mly"
       (Fexpr.kind_with_subkind list)
-# 9065 "flambda_parser_in.ml"
+# 9066 "flambda_parser_in.ml"
         ) = Obj.magic k in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_k_ in
         let _v : 'tv_return_arity = 
-# 756 "flambda_parser.mly"
+# 758 "flambda_parser.mly"
                                   ( Some k )
-# 9074 "flambda_parser_in.ml"
+# 9075 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9091,7 +9092,7 @@ module Tables = struct
         let x : (
 # 254 "flambda_parser.mly"
       (Fexpr.field_of_block)
-# 9095 "flambda_parser_in.ml"
+# 9096 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9099,7 +9100,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_COMMA_field_of_block_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9103 "flambda_parser_in.ml"
+# 9104 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9134,7 +9135,7 @@ module Tables = struct
         let x : (
 # 254 "flambda_parser.mly"
       (Fexpr.field_of_block)
-# 9138 "flambda_parser_in.ml"
+# 9139 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9142,7 +9143,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_COMMA_field_of_block_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9146 "flambda_parser_in.ml"
+# 9147 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9163,7 +9164,7 @@ module Tables = struct
         let x : (
 # 258 "flambda_parser.mly"
       (float Fexpr.or_variable)
-# 9167 "flambda_parser_in.ml"
+# 9168 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9171,7 +9172,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_COMMA_float_or_variable_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9175 "flambda_parser_in.ml"
+# 9176 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9206,7 +9207,7 @@ module Tables = struct
         let x : (
 # 258 "flambda_parser.mly"
       (float Fexpr.or_variable)
-# 9210 "flambda_parser_in.ml"
+# 9211 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9214,7 +9215,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_COMMA_float_or_variable_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9218 "flambda_parser_in.ml"
+# 9219 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9239,7 +9240,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_COMMA_kinded_variable_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9243 "flambda_parser_in.ml"
+# 9244 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9278,7 +9279,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_COMMA_kinded_variable_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9282 "flambda_parser_in.ml"
+# 9283 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9303,7 +9304,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_COMMA_simple_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9307 "flambda_parser_in.ml"
+# 9308 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9342,7 +9343,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_COMMA_simple_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9346 "flambda_parser_in.ml"
+# 9347 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9367,7 +9368,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_KWD_AND_let_binding_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9371 "flambda_parser_in.ml"
+# 9372 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9406,7 +9407,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_KWD_AND_let_binding_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9410 "flambda_parser_in.ml"
+# 9411 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9431,7 +9432,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_KWD_AND_static_closure_binding_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9435 "flambda_parser_in.ml"
+# 9436 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9470,7 +9471,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_KWD_AND_static_closure_binding_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9474 "flambda_parser_in.ml"
+# 9475 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9491,7 +9492,7 @@ module Tables = struct
         let x : (
 # 278 "flambda_parser.mly"
       (Fexpr.symbol_binding)
-# 9495 "flambda_parser_in.ml"
+# 9496 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9499,7 +9500,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_KWD_AND_symbol_binding_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9503 "flambda_parser_in.ml"
+# 9504 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9534,7 +9535,7 @@ module Tables = struct
         let x : (
 # 278 "flambda_parser.mly"
       (Fexpr.symbol_binding)
-# 9538 "flambda_parser_in.ml"
+# 9539 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9542,7 +9543,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_KWD_AND_symbol_binding_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9546 "flambda_parser_in.ml"
+# 9547 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9567,7 +9568,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_KWD_ANDWHERE_continuation_binding_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9571 "flambda_parser_in.ml"
+# 9572 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9606,7 +9607,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_KWD_ANDWHERE_continuation_binding_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9610 "flambda_parser_in.ml"
+# 9611 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9631,7 +9632,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_PIPE_nonconst_ctor_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9635 "flambda_parser_in.ml"
+# 9636 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9670,7 +9671,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_PIPE_nonconst_ctor_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9674 "flambda_parser_in.ml"
+# 9675 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9695,7 +9696,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_PIPE_switch_case_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9699 "flambda_parser_in.ml"
+# 9700 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9734,7 +9735,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_PIPE_switch_case_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9738 "flambda_parser_in.ml"
+# 9739 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9755,7 +9756,7 @@ module Tables = struct
         let x : (
 # 258 "flambda_parser.mly"
       (float Fexpr.or_variable)
-# 9759 "flambda_parser_in.ml"
+# 9760 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9763,7 +9764,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_SEMICOLON_float_or_variable_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9767 "flambda_parser_in.ml"
+# 9768 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9798,7 +9799,7 @@ module Tables = struct
         let x : (
 # 258 "flambda_parser.mly"
       (float Fexpr.or_variable)
-# 9802 "flambda_parser_in.ml"
+# 9803 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9806,7 +9807,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_SEMICOLON_float_or_variable_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9810 "flambda_parser_in.ml"
+# 9811 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9831,7 +9832,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_SEMICOLON_value_slot_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9835 "flambda_parser_in.ml"
+# 9836 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9870,7 +9871,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_SEMICOLON_value_slot_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9874 "flambda_parser_in.ml"
+# 9875 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9891,7 +9892,7 @@ module Tables = struct
         let x : (
 # 262 "flambda_parser.mly"
       (Fexpr.kind_with_subkind)
-# 9895 "flambda_parser_in.ml"
+# 9896 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9899,7 +9900,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_STAR_kind_with_subkind_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9903 "flambda_parser_in.ml"
+# 9904 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9934,7 +9935,7 @@ module Tables = struct
         let x : (
 # 262 "flambda_parser.mly"
       (Fexpr.kind_with_subkind)
-# 9938 "flambda_parser_in.ml"
+# 9939 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9942,7 +9943,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_STAR_kind_with_subkind_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9946 "flambda_parser_in.ml"
+# 9947 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9958,9 +9959,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_signed_or_unsigned = 
-# 538 "flambda_parser.mly"
+# 539 "flambda_parser.mly"
     ( Signed )
-# 9964 "flambda_parser_in.ml"
+# 9965 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9983,9 +9984,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_signed_or_unsigned = 
-# 539 "flambda_parser.mly"
+# 540 "flambda_parser.mly"
                  ( Unsigned )
-# 9989 "flambda_parser_in.ml"
+# 9990 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10008,9 +10009,9 @@ module Tables = struct
         let _startpos = _startpos_s_ in
         let _endpos = _endpos_s_ in
         let _v : 'tv_simple = 
-# 1070 "flambda_parser.mly"
+# 1072 "flambda_parser.mly"
                ( Symbol s )
-# 10014 "flambda_parser_in.ml"
+# 10015 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10033,9 +10034,9 @@ module Tables = struct
         let _startpos = _startpos_v_ in
         let _endpos = _endpos_v_ in
         let _v : 'tv_simple = 
-# 1071 "flambda_parser.mly"
+# 1073 "flambda_parser.mly"
                  ( Var v )
-# 10039 "flambda_parser_in.ml"
+# 10040 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10056,15 +10057,15 @@ module Tables = struct
         let c : (
 # 250 "flambda_parser.mly"
       (Fexpr.const)
-# 10060 "flambda_parser_in.ml"
+# 10061 "flambda_parser_in.ml"
         ) = Obj.magic c in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_c_ in
         let _endpos = _endpos_c_ in
         let _v : 'tv_simple = 
-# 1072 "flambda_parser.mly"
+# 1074 "flambda_parser.mly"
               ( Const c )
-# 10068 "flambda_parser_in.ml"
+# 10069 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10101,9 +10102,9 @@ module Tables = struct
         let _startpos = _startpos_s_ in
         let _endpos = _endpos_c_ in
         let _v : 'tv_simple = 
-# 1073 "flambda_parser.mly"
+# 1075 "flambda_parser.mly"
                                     ( Coerce (s, c) )
-# 10107 "flambda_parser_in.ml"
+# 10108 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10119,9 +10120,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_simple_args = 
-# 1046 "flambda_parser.mly"
+# 1048 "flambda_parser.mly"
     ( [] )
-# 10125 "flambda_parser_in.ml"
+# 10126 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10158,9 +10159,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : 'tv_simple_args = 
-# 1047 "flambda_parser.mly"
+# 1049 "flambda_parser.mly"
                                                               ( s )
-# 10164 "flambda_parser_in.ml"
+# 10165 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10176,9 +10177,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_size_opt = 
-# 506 "flambda_parser.mly"
+# 507 "flambda_parser.mly"
     ( None )
-# 10182 "flambda_parser_in.ml"
+# 10183 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10222,9 +10223,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : 'tv_size_opt = 
-# 507 "flambda_parser.mly"
+# 508 "flambda_parser.mly"
                                                ( Some size )
-# 10228 "flambda_parser_in.ml"
+# 10229 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10249,11 +10250,11 @@ module Tables = struct
         let _v : (
 # 271 "flambda_parser.mly"
       (Fexpr.special_continuation)
-# 10253 "flambda_parser_in.ml"
+# 10254 "flambda_parser_in.ml"
         ) = 
-# 1130 "flambda_parser.mly"
+# 1132 "flambda_parser.mly"
              ( Done )
-# 10257 "flambda_parser_in.ml"
+# 10258 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10278,11 +10279,11 @@ module Tables = struct
         let _v : (
 # 271 "flambda_parser.mly"
       (Fexpr.special_continuation)
-# 10282 "flambda_parser_in.ml"
+# 10283 "flambda_parser_in.ml"
         ) = 
-# 1131 "flambda_parser.mly"
+# 1133 "flambda_parser.mly"
               ( Error )
-# 10286 "flambda_parser_in.ml"
+# 10287 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10300,40 +10301,11 @@ module Tables = struct
         let _v : (
 # 272 "flambda_parser.mly"
       (Fexpr.standard_int)
-# 10304 "flambda_parser_in.ml"
-        ) = 
-# 510 "flambda_parser.mly"
-    ( Tagged_immediate )
-# 10308 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 272 "flambda_parser.mly"
-      (Fexpr.standard_int)
-# 10333 "flambda_parser_in.ml"
+# 10305 "flambda_parser_in.ml"
         ) = 
 # 511 "flambda_parser.mly"
-            ( Naked_immediate )
-# 10337 "flambda_parser_in.ml"
+    ( Tagged_immediate )
+# 10309 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10358,11 +10330,11 @@ module Tables = struct
         let _v : (
 # 272 "flambda_parser.mly"
       (Fexpr.standard_int)
-# 10362 "flambda_parser_in.ml"
+# 10334 "flambda_parser_in.ml"
         ) = 
 # 512 "flambda_parser.mly"
-              ( Naked_int32 )
-# 10366 "flambda_parser_in.ml"
+            ( Naked_immediate )
+# 10338 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10387,11 +10359,11 @@ module Tables = struct
         let _v : (
 # 272 "flambda_parser.mly"
       (Fexpr.standard_int)
-# 10391 "flambda_parser_in.ml"
+# 10363 "flambda_parser_in.ml"
         ) = 
 # 513 "flambda_parser.mly"
-              ( Naked_int64 )
-# 10395 "flambda_parser_in.ml"
+              ( Naked_int32 )
+# 10367 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10416,11 +10388,40 @@ module Tables = struct
         let _v : (
 # 272 "flambda_parser.mly"
       (Fexpr.standard_int)
-# 10420 "flambda_parser_in.ml"
+# 10392 "flambda_parser_in.ml"
         ) = 
 # 514 "flambda_parser.mly"
+              ( Naked_int64 )
+# 10396 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 272 "flambda_parser.mly"
+      (Fexpr.standard_int)
+# 10421 "flambda_parser_in.ml"
+        ) = 
+# 515 "flambda_parser.mly"
                   ( Naked_nativeint )
-# 10424 "flambda_parser_in.ml"
+# 10425 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10459,7 +10460,7 @@ module Tables = struct
         let _v : 'tv_static_closure_binding = 
 # 374 "flambda_parser.mly"
     ( { symbol; fun_decl } )
-# 10463 "flambda_parser_in.ml"
+# 10464 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10514,7 +10515,7 @@ module Tables = struct
         let m : (
 # 265 "flambda_parser.mly"
       (Fexpr.mutability)
-# 10518 "flambda_parser_in.ml"
+# 10519 "flambda_parser_in.ml"
         ) = Obj.magic m in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -10524,16 +10525,16 @@ module Tables = struct
           let elements = 
 # 241 "<standard.mly>"
     ( xs )
-# 10528 "flambda_parser_in.ml"
+# 10529 "flambda_parser_in.ml"
            in
           (
-# 988 "flambda_parser.mly"
+# 990 "flambda_parser.mly"
     ( (Block { tag; mutability = m; elements } : static_data) )
-# 10533 "flambda_parser_in.ml"
+# 10534 "flambda_parser_in.ml"
            : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10537 "flambda_parser_in.ml"
+# 10538 "flambda_parser_in.ml"
           ))
         in
         {
@@ -10555,7 +10556,7 @@ module Tables = struct
         let f : (
 # 68 "flambda_parser.mly"
        (float)
-# 10559 "flambda_parser_in.ml"
+# 10560 "flambda_parser_in.ml"
         ) = Obj.magic f in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_f_ in
@@ -10563,11 +10564,11 @@ module Tables = struct
         let _v : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10567 "flambda_parser_in.ml"
+# 10568 "flambda_parser_in.ml"
         ) = 
-# 989 "flambda_parser.mly"
+# 991 "flambda_parser.mly"
               ( Boxed_float (Const f) )
-# 10571 "flambda_parser_in.ml"
+# 10572 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10588,7 +10589,7 @@ module Tables = struct
         let i : (
 # 74 "flambda_parser.mly"
        (string * char option)
-# 10592 "flambda_parser_in.ml"
+# 10593 "flambda_parser_in.ml"
         ) = Obj.magic i in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_i_ in
@@ -10596,11 +10597,11 @@ module Tables = struct
         let _v : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10600 "flambda_parser_in.ml"
+# 10601 "flambda_parser_in.ml"
         ) = 
-# 990 "flambda_parser.mly"
+# 992 "flambda_parser.mly"
             ( make_boxed_const_int i )
-# 10604 "flambda_parser_in.ml"
+# 10605 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10633,7 +10634,7 @@ module Tables = struct
         let k : (
 # 277 "flambda_parser.mly"
       (Fexpr.variable -> Fexpr.static_data)
-# 10637 "flambda_parser_in.ml"
+# 10638 "flambda_parser_in.ml"
         ) = Obj.magic k in
         let _2 : unit = Obj.magic _2 in
         let v : 'tv_variable = Obj.magic v in
@@ -10643,11 +10644,11 @@ module Tables = struct
         let _v : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10647 "flambda_parser_in.ml"
+# 10648 "flambda_parser_in.ml"
         ) = 
-# 991 "flambda_parser.mly"
+# 993 "flambda_parser.mly"
                                               ( k v )
-# 10651 "flambda_parser_in.ml"
+# 10652 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10694,16 +10695,16 @@ module Tables = struct
           let fs = 
 # 241 "<standard.mly>"
     ( xs )
-# 10698 "flambda_parser_in.ml"
+# 10699 "flambda_parser_in.ml"
            in
           (
-# 995 "flambda_parser.mly"
+# 997 "flambda_parser.mly"
     ( Immutable_float_block fs )
-# 10703 "flambda_parser_in.ml"
+# 10704 "flambda_parser_in.ml"
            : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10707 "flambda_parser_in.ml"
+# 10708 "flambda_parser_in.ml"
           ))
         in
         {
@@ -10751,16 +10752,16 @@ module Tables = struct
           let fs = 
 # 241 "<standard.mly>"
     ( xs )
-# 10755 "flambda_parser_in.ml"
+# 10756 "flambda_parser_in.ml"
            in
           (
-# 999 "flambda_parser.mly"
+# 1001 "flambda_parser.mly"
     ( Immutable_float_array fs )
-# 10760 "flambda_parser_in.ml"
+# 10761 "flambda_parser_in.ml"
            : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10764 "flambda_parser_in.ml"
+# 10765 "flambda_parser_in.ml"
           ))
         in
         {
@@ -10788,7 +10789,7 @@ module Tables = struct
         let kind : (
 # 246 "flambda_parser.mly"
       (Fexpr.empty_array_kind)
-# 10792 "flambda_parser_in.ml"
+# 10793 "flambda_parser_in.ml"
         ) = Obj.magic kind in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -10797,11 +10798,11 @@ module Tables = struct
         let _v : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10801 "flambda_parser_in.ml"
+# 10802 "flambda_parser_in.ml"
         ) = 
-# 1000 "flambda_parser.mly"
+# 1002 "flambda_parser.mly"
                                                    ( Empty_array kind )
-# 10805 "flambda_parser_in.ml"
+# 10806 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10828,7 +10829,7 @@ module Tables = struct
         let s : (
 # 104 "flambda_parser.mly"
       (string)
-# 10832 "flambda_parser_in.ml"
+# 10833 "flambda_parser_in.ml"
         ) = Obj.magic s in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -10837,11 +10838,11 @@ module Tables = struct
         let _v : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10841 "flambda_parser_in.ml"
+# 10842 "flambda_parser_in.ml"
         ) = 
-# 1001 "flambda_parser.mly"
+# 1003 "flambda_parser.mly"
                             ( Mutable_string { initial_value = s } )
-# 10845 "flambda_parser_in.ml"
+# 10846 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10862,7 +10863,7 @@ module Tables = struct
         let s : (
 # 104 "flambda_parser.mly"
       (string)
-# 10866 "flambda_parser_in.ml"
+# 10867 "flambda_parser_in.ml"
         ) = Obj.magic s in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_s_ in
@@ -10870,11 +10871,11 @@ module Tables = struct
         let _v : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10874 "flambda_parser_in.ml"
+# 10875 "flambda_parser_in.ml"
         ) = 
-# 1002 "flambda_parser.mly"
+# 1004 "flambda_parser.mly"
                ( Immutable_string s )
-# 10878 "flambda_parser_in.ml"
+# 10879 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10907,7 +10908,7 @@ module Tables = struct
         let sp : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10911 "flambda_parser_in.ml"
+# 10912 "flambda_parser_in.ml"
         ) = Obj.magic sp in
         let _2 : unit = Obj.magic _2 in
         let s : 'tv_symbol = Obj.magic s in
@@ -10917,11 +10918,11 @@ module Tables = struct
         let _v : (
 # 274 "flambda_parser.mly"
       (Fexpr.static_data_binding)
-# 10921 "flambda_parser_in.ml"
+# 10922 "flambda_parser_in.ml"
         ) = 
-# 982 "flambda_parser.mly"
+# 984 "flambda_parser.mly"
     ( { symbol = s; defining_expr = sp } )
-# 10925 "flambda_parser_in.ml"
+# 10926 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10953,83 +10954,11 @@ module Tables = struct
         let _v : (
 # 277 "flambda_parser.mly"
       (Fexpr.variable -> Fexpr.static_data)
-# 10957 "flambda_parser_in.ml"
-        ) = 
-# 1006 "flambda_parser.mly"
-                        ( fun v -> Boxed_float (Var v) )
-# 10961 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _;
-          CamlinternalMenhirLib.EngineTypes.semv = _2;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
-          CamlinternalMenhirLib.EngineTypes.next = {
-            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-            CamlinternalMenhirLib.EngineTypes.semv = _1;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-          };
-        } = _menhir_stack in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__2_ in
-        let _v : (
-# 277 "flambda_parser.mly"
-      (Fexpr.variable -> Fexpr.static_data)
-# 10993 "flambda_parser_in.ml"
-        ) = 
-# 1007 "flambda_parser.mly"
-                        ( fun v -> Boxed_int32 (Var v) )
-# 10997 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _;
-          CamlinternalMenhirLib.EngineTypes.semv = _2;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
-          CamlinternalMenhirLib.EngineTypes.next = {
-            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-            CamlinternalMenhirLib.EngineTypes.semv = _1;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-          };
-        } = _menhir_stack in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__2_ in
-        let _v : (
-# 277 "flambda_parser.mly"
-      (Fexpr.variable -> Fexpr.static_data)
-# 11029 "flambda_parser_in.ml"
+# 10958 "flambda_parser_in.ml"
         ) = 
 # 1008 "flambda_parser.mly"
-                        ( fun v -> Boxed_int64 (Var v) )
-# 11033 "flambda_parser_in.ml"
+                        ( fun v -> Boxed_float (Var v) )
+# 10962 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11061,11 +10990,83 @@ module Tables = struct
         let _v : (
 # 277 "flambda_parser.mly"
       (Fexpr.variable -> Fexpr.static_data)
-# 11065 "flambda_parser_in.ml"
+# 10994 "flambda_parser_in.ml"
         ) = 
 # 1009 "flambda_parser.mly"
+                        ( fun v -> Boxed_int32 (Var v) )
+# 10998 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _;
+          CamlinternalMenhirLib.EngineTypes.semv = _2;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
+          CamlinternalMenhirLib.EngineTypes.next = {
+            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+            CamlinternalMenhirLib.EngineTypes.semv = _1;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+          };
+        } = _menhir_stack in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__2_ in
+        let _v : (
+# 277 "flambda_parser.mly"
+      (Fexpr.variable -> Fexpr.static_data)
+# 11030 "flambda_parser_in.ml"
+        ) = 
+# 1010 "flambda_parser.mly"
+                        ( fun v -> Boxed_int64 (Var v) )
+# 11034 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _;
+          CamlinternalMenhirLib.EngineTypes.semv = _2;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
+          CamlinternalMenhirLib.EngineTypes.next = {
+            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+            CamlinternalMenhirLib.EngineTypes.semv = _1;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+          };
+        } = _menhir_stack in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__2_ in
+        let _v : (
+# 277 "flambda_parser.mly"
+      (Fexpr.variable -> Fexpr.static_data)
+# 11066 "flambda_parser_in.ml"
+        ) = 
+# 1011 "flambda_parser.mly"
                             ( fun v -> Boxed_nativeint (Var v) )
-# 11069 "flambda_parser_in.ml"
+# 11070 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11111,7 +11112,7 @@ module Tables = struct
         let _v : 'tv_static_set_of_closures = 
 # 382 "flambda_parser.mly"
     ( { bindings; elements } )
-# 11115 "flambda_parser_in.ml"
+# 11116 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11132,13 +11133,13 @@ module Tables = struct
         let i : (
 # 74 "flambda_parser.mly"
        (string * char option)
-# 11136 "flambda_parser_in.ml"
+# 11137 "flambda_parser_in.ml"
         ) = Obj.magic i in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_i_ in
         let _endpos = _endpos_i_ in
         let _v : 'tv_string_accessor_width = 
-# 468 "flambda_parser.mly"
+# 469 "flambda_parser.mly"
     ( let (i,c) = i in
       match int_of_string i, c with
       | 8, None -> Eight
@@ -11152,7 +11153,7 @@ module Tables = struct
       | 512, Some 'a' -> Five_twelve {aligned = true}
       | 512, Some 'u' -> Five_twelve {aligned = false}
       | _, _ -> Misc.fatal_error "invalid string accessor width" )
-# 11156 "flambda_parser_in.ml"
+# 11157 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11177,83 +11178,11 @@ module Tables = struct
         let _v : (
 # 275 "flambda_parser.mly"
       (Fexpr.subkind)
-# 11181 "flambda_parser_in.ml"
-        ) = 
-# 722 "flambda_parser.mly"
-            ( Anything )
-# 11185 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _;
-          CamlinternalMenhirLib.EngineTypes.semv = _2;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
-          CamlinternalMenhirLib.EngineTypes.next = {
-            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-            CamlinternalMenhirLib.EngineTypes.semv = _1;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-          };
-        } = _menhir_stack in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__2_ in
-        let _v : (
-# 275 "flambda_parser.mly"
-      (Fexpr.subkind)
-# 11217 "flambda_parser_in.ml"
-        ) = 
-# 723 "flambda_parser.mly"
-                        ( Boxed_float )
-# 11221 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _;
-          CamlinternalMenhirLib.EngineTypes.semv = _2;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
-          CamlinternalMenhirLib.EngineTypes.next = {
-            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-            CamlinternalMenhirLib.EngineTypes.semv = _1;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-          };
-        } = _menhir_stack in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__2_ in
-        let _v : (
-# 275 "flambda_parser.mly"
-      (Fexpr.subkind)
-# 11253 "flambda_parser_in.ml"
+# 11182 "flambda_parser_in.ml"
         ) = 
 # 724 "flambda_parser.mly"
-                        ( Boxed_int32 )
-# 11257 "flambda_parser_in.ml"
+            ( Anything )
+# 11186 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11285,11 +11214,11 @@ module Tables = struct
         let _v : (
 # 275 "flambda_parser.mly"
       (Fexpr.subkind)
-# 11289 "flambda_parser_in.ml"
+# 11218 "flambda_parser_in.ml"
         ) = 
 # 725 "flambda_parser.mly"
-                        ( Boxed_int64 )
-# 11293 "flambda_parser_in.ml"
+                        ( Boxed_float )
+# 11222 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11321,11 +11250,11 @@ module Tables = struct
         let _v : (
 # 275 "flambda_parser.mly"
       (Fexpr.subkind)
-# 11325 "flambda_parser_in.ml"
+# 11254 "flambda_parser_in.ml"
         ) = 
 # 726 "flambda_parser.mly"
-                            ( Boxed_nativeint )
-# 11329 "flambda_parser_in.ml"
+                        ( Boxed_int32 )
+# 11258 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11357,11 +11286,83 @@ module Tables = struct
         let _v : (
 # 275 "flambda_parser.mly"
       (Fexpr.subkind)
-# 11361 "flambda_parser_in.ml"
+# 11290 "flambda_parser_in.ml"
         ) = 
 # 727 "flambda_parser.mly"
+                        ( Boxed_int64 )
+# 11294 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _;
+          CamlinternalMenhirLib.EngineTypes.semv = _2;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
+          CamlinternalMenhirLib.EngineTypes.next = {
+            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+            CamlinternalMenhirLib.EngineTypes.semv = _1;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+          };
+        } = _menhir_stack in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__2_ in
+        let _v : (
+# 275 "flambda_parser.mly"
+      (Fexpr.subkind)
+# 11326 "flambda_parser_in.ml"
+        ) = 
+# 728 "flambda_parser.mly"
+                            ( Boxed_nativeint )
+# 11330 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _;
+          CamlinternalMenhirLib.EngineTypes.semv = _2;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
+          CamlinternalMenhirLib.EngineTypes.next = {
+            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+            CamlinternalMenhirLib.EngineTypes.semv = _1;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+          };
+        } = _menhir_stack in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__2_ in
+        let _v : (
+# 275 "flambda_parser.mly"
+      (Fexpr.subkind)
+# 11362 "flambda_parser_in.ml"
+        ) = 
+# 729 "flambda_parser.mly"
                        ( Tagged_immediate )
-# 11365 "flambda_parser_in.ml"
+# 11366 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11400,11 +11401,11 @@ module Tables = struct
         let _v : (
 # 275 "flambda_parser.mly"
       (Fexpr.subkind)
-# 11404 "flambda_parser_in.ml"
+# 11405 "flambda_parser_in.ml"
         ) = 
-# 728 "flambda_parser.mly"
+# 730 "flambda_parser.mly"
                                              ( Float_block { num_fields } )
-# 11408 "flambda_parser_in.ml"
+# 11409 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11443,83 +11444,11 @@ module Tables = struct
         let _v : (
 # 275 "flambda_parser.mly"
       (Fexpr.subkind)
-# 11447 "flambda_parser_in.ml"
-        ) = 
-# 730 "flambda_parser.mly"
-    ( let consts, non_consts = ctors in Variant { consts; non_consts; })
-# 11451 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _;
-          CamlinternalMenhirLib.EngineTypes.semv = _2;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
-          CamlinternalMenhirLib.EngineTypes.next = {
-            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-            CamlinternalMenhirLib.EngineTypes.semv = _1;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-          };
-        } = _menhir_stack in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__2_ in
-        let _v : (
-# 275 "flambda_parser.mly"
-      (Fexpr.subkind)
-# 11483 "flambda_parser_in.ml"
-        ) = 
-# 731 "flambda_parser.mly"
-                        ( Float_array )
-# 11487 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _;
-          CamlinternalMenhirLib.EngineTypes.semv = _2;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
-          CamlinternalMenhirLib.EngineTypes.next = {
-            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-            CamlinternalMenhirLib.EngineTypes.semv = _1;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-          };
-        } = _menhir_stack in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__2_ in
-        let _v : (
-# 275 "flambda_parser.mly"
-      (Fexpr.subkind)
-# 11519 "flambda_parser_in.ml"
+# 11448 "flambda_parser_in.ml"
         ) = 
 # 732 "flambda_parser.mly"
-                      ( Immediate_array )
-# 11523 "flambda_parser_in.ml"
+    ( let consts, non_consts = ctors in Variant { consts; non_consts; })
+# 11452 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11551,11 +11480,11 @@ module Tables = struct
         let _v : (
 # 275 "flambda_parser.mly"
       (Fexpr.subkind)
-# 11555 "flambda_parser_in.ml"
+# 11484 "flambda_parser_in.ml"
         ) = 
 # 733 "flambda_parser.mly"
-                      ( Value_array )
-# 11559 "flambda_parser_in.ml"
+                        ( Float_array )
+# 11488 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11587,11 +11516,83 @@ module Tables = struct
         let _v : (
 # 275 "flambda_parser.mly"
       (Fexpr.subkind)
-# 11591 "flambda_parser_in.ml"
+# 11520 "flambda_parser_in.ml"
         ) = 
 # 734 "flambda_parser.mly"
+                      ( Immediate_array )
+# 11524 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _;
+          CamlinternalMenhirLib.EngineTypes.semv = _2;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
+          CamlinternalMenhirLib.EngineTypes.next = {
+            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+            CamlinternalMenhirLib.EngineTypes.semv = _1;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+          };
+        } = _menhir_stack in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__2_ in
+        let _v : (
+# 275 "flambda_parser.mly"
+      (Fexpr.subkind)
+# 11556 "flambda_parser_in.ml"
+        ) = 
+# 735 "flambda_parser.mly"
+                      ( Value_array )
+# 11560 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _;
+          CamlinternalMenhirLib.EngineTypes.semv = _2;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
+          CamlinternalMenhirLib.EngineTypes.next = {
+            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+            CamlinternalMenhirLib.EngineTypes.semv = _1;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+          };
+        } = _menhir_stack in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__2_ in
+        let _v : (
+# 275 "flambda_parser.mly"
+      (Fexpr.subkind)
+# 11592 "flambda_parser_in.ml"
+        ) = 
+# 736 "flambda_parser.mly"
                       ( Generic_array )
-# 11595 "flambda_parser_in.ml"
+# 11596 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11624,12 +11625,12 @@ module Tables = struct
           let cs = 
 # 241 "<standard.mly>"
     ( xs )
-# 11628 "flambda_parser_in.ml"
+# 11629 "flambda_parser_in.ml"
            in
           (
-# 694 "flambda_parser.mly"
+# 696 "flambda_parser.mly"
                                                          ( cs )
-# 11633 "flambda_parser_in.ml"
+# 11634 "flambda_parser_in.ml"
            : 'tv_switch)
         in
         {
@@ -11667,9 +11668,9 @@ module Tables = struct
         let _startpos = _startpos_i_ in
         let _endpos = _endpos_ac_ in
         let _v : 'tv_switch_case = 
-# 690 "flambda_parser.mly"
+# 692 "flambda_parser.mly"
                                                 ( i,ac )
-# 11673 "flambda_parser_in.ml"
+# 11674 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11690,7 +11691,7 @@ module Tables = struct
         let e : (
 # 105 "flambda_parser.mly"
       (Fexpr.compilation_unit option * string)
-# 11694 "flambda_parser_in.ml"
+# 11695 "flambda_parser_in.ml"
         ) = Obj.magic e in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_e_ in
@@ -11699,9 +11700,9 @@ module Tables = struct
           let _endpos = _endpos_e_ in
           let _startpos = _startpos_e_ in
           (
-# 1113 "flambda_parser.mly"
+# 1115 "flambda_parser.mly"
                ( make_located e (_startpos, _endpos) )
-# 11705 "flambda_parser_in.ml"
+# 11706 "flambda_parser_in.ml"
            : 'tv_symbol)
         in
         {
@@ -11723,7 +11724,7 @@ module Tables = struct
         let s : (
 # 274 "flambda_parser.mly"
       (Fexpr.static_data_binding)
-# 11727 "flambda_parser_in.ml"
+# 11728 "flambda_parser_in.ml"
         ) = Obj.magic s in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_s_ in
@@ -11731,11 +11732,11 @@ module Tables = struct
         let _v : (
 # 278 "flambda_parser.mly"
       (Fexpr.symbol_binding)
-# 11735 "flambda_parser_in.ml"
+# 11736 "flambda_parser_in.ml"
         ) = 
 # 322 "flambda_parser.mly"
                             ( Data s )
-# 11739 "flambda_parser_in.ml"
+# 11740 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11760,11 +11761,11 @@ module Tables = struct
         let _v : (
 # 278 "flambda_parser.mly"
       (Fexpr.symbol_binding)
-# 11764 "flambda_parser_in.ml"
+# 11765 "flambda_parser_in.ml"
         ) = 
 # 323 "flambda_parser.mly"
                 ( Code code )
-# 11768 "flambda_parser_in.ml"
+# 11769 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11789,11 +11790,11 @@ module Tables = struct
         let _v : (
 # 278 "flambda_parser.mly"
       (Fexpr.symbol_binding)
-# 11793 "flambda_parser_in.ml"
+# 11794 "flambda_parser_in.ml"
         ) = 
 # 324 "flambda_parser.mly"
                            ( Deleted_code code_id )
-# 11797 "flambda_parser_in.ml"
+# 11798 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11818,11 +11819,11 @@ module Tables = struct
         let _v : (
 # 278 "flambda_parser.mly"
       (Fexpr.symbol_binding)
-# 11822 "flambda_parser_in.ml"
+# 11823 "flambda_parser_in.ml"
         ) = 
 # 325 "flambda_parser.mly"
                                ( Closure s )
-# 11826 "flambda_parser_in.ml"
+# 11827 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11847,11 +11848,11 @@ module Tables = struct
         let _v : (
 # 278 "flambda_parser.mly"
       (Fexpr.symbol_binding)
-# 11851 "flambda_parser_in.ml"
+# 11852 "flambda_parser_in.ml"
         ) = 
 # 326 "flambda_parser.mly"
                                ( Set_of_closures s )
-# 11855 "flambda_parser_in.ml"
+# 11856 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11872,7 +11873,7 @@ module Tables = struct
         let tag : (
 # 74 "flambda_parser.mly"
        (string * char option)
-# 11876 "flambda_parser_in.ml"
+# 11877 "flambda_parser_in.ml"
         ) = Obj.magic tag in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_tag_ in
@@ -11881,9 +11882,9 @@ module Tables = struct
           let _endpos = _endpos_tag_ in
           let _startpos = _startpos_tag_ in
           (
-# 1019 "flambda_parser.mly"
+# 1021 "flambda_parser.mly"
             ( make_tag ~loc:(make_loc (_startpos, _endpos)) tag )
-# 11887 "flambda_parser_in.ml"
+# 11888 "flambda_parser_in.ml"
            : 'tv_tag)
         in
         {
@@ -11928,9 +11929,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : 'tv_tag_opt = 
-# 1023 "flambda_parser.mly"
+# 1025 "flambda_parser.mly"
                                       ( Some tag )
-# 11934 "flambda_parser_in.ml"
+# 11935 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11946,9 +11947,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_tag_opt = 
-# 1024 "flambda_parser.mly"
+# 1026 "flambda_parser.mly"
     ( None )
-# 11952 "flambda_parser_in.ml"
+# 11953 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11969,15 +11970,15 @@ module Tables = struct
         let i : (
 # 74 "flambda_parser.mly"
        (string * char option)
-# 11973 "flambda_parser_in.ml"
+# 11974 "flambda_parser_in.ml"
         ) = Obj.magic i in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_i_ in
         let _endpos = _endpos_i_ in
         let _v : 'tv_targetint = 
-# 1016 "flambda_parser.mly"
+# 1018 "flambda_parser.mly"
           ( make_targetint i )
-# 11981 "flambda_parser_in.ml"
+# 11982 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12053,14 +12054,14 @@ module Tables = struct
         let ak : (
 # 244 "flambda_parser.mly"
       (Fexpr.array_kind)
-# 12057 "flambda_parser_in.ml"
+# 12058 "flambda_parser_in.ml"
         ) = Obj.magic ak in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_v_ in
         let _v : 'tv_ternop_app = 
-# 637 "flambda_parser.mly"
+# 639 "flambda_parser.mly"
     (
       let array_set_kind : array_set_kind =
         match ak with
@@ -12079,7 +12080,7 @@ module Tables = struct
       in
       Ternary (Array_set (ak, array_set_kind), arr, ix, v)
     )
-# 12083 "flambda_parser_in.ml"
+# 12084 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12151,9 +12152,9 @@ module Tables = struct
         let _startpos = _startpos_blv_ in
         let _endpos = _endpos_v_ in
         let _v : 'tv_ternop_app = 
-# 657 "flambda_parser.mly"
+# 659 "flambda_parser.mly"
     ( Ternary (Bytes_or_bigstring_set (blv, saw), block, ix, v) )
-# 12157 "flambda_parser_in.ml"
+# 12158 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12193,7 +12194,7 @@ module Tables = struct
         let exn_handler : (
 # 251 "flambda_parser.mly"
       (Fexpr.continuation)
-# 12197 "flambda_parser_in.ml"
+# 12198 "flambda_parser_in.ml"
         ) = Obj.magic exn_handler in
         let _2 : unit = Obj.magic _2 in
         let _1 : unit = Obj.magic _1 in
@@ -12201,9 +12202,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : 'tv_trap_action = 
-# 945 "flambda_parser.mly"
+# 947 "flambda_parser.mly"
                                                          ( Push { exn_handler } )
-# 12207 "flambda_parser_in.ml"
+# 12208 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12249,7 +12250,7 @@ module Tables = struct
         let exn_handler : (
 # 251 "flambda_parser.mly"
       (Fexpr.continuation)
-# 12253 "flambda_parser_in.ml"
+# 12254 "flambda_parser_in.ml"
         ) = Obj.magic exn_handler in
         let raise_kind : 'tv_option_raise_kind_ = Obj.magic raise_kind in
         let _2 : unit = Obj.magic _2 in
@@ -12258,9 +12259,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__5_ in
         let _v : 'tv_trap_action = 
-# 949 "flambda_parser.mly"
+# 951 "flambda_parser.mly"
     ( Pop { exn_handler; raise_kind } )
-# 12264 "flambda_parser_in.ml"
+# 12265 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12285,11 +12286,11 @@ module Tables = struct
         let _v : (
 # 279 "flambda_parser.mly"
       (Fexpr.unary_int_arith_op)
-# 12289 "flambda_parser_in.ml"
+# 12290 "flambda_parser_in.ml"
         ) = 
 # 390 "flambda_parser.mly"
               ( Swap_byte_endianness )
-# 12293 "flambda_parser_in.ml"
+# 12294 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12316,7 +12317,7 @@ module Tables = struct
         let kind : (
 # 245 "flambda_parser.mly"
       (Fexpr.array_kind_for_length)
-# 12320 "flambda_parser_in.ml"
+# 12321 "flambda_parser_in.ml"
         ) = Obj.magic kind in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -12325,11 +12326,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12329 "flambda_parser_in.ml"
+# 12330 "flambda_parser_in.ml"
         ) = 
 # 393 "flambda_parser.mly"
                                                     ( Array_length kind )
-# 12333 "flambda_parser_in.ml"
+# 12334 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12354,11 +12355,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12358 "flambda_parser_in.ml"
+# 12359 "flambda_parser_in.ml"
         ) = 
 # 394 "flambda_parser.mly"
                      ( Boolean_not )
-# 12362 "flambda_parser_in.ml"
+# 12363 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12385,7 +12386,7 @@ module Tables = struct
         let alloc : (
 # 242 "flambda_parser.mly"
       (Fexpr.alloc_mode_for_allocations)
-# 12389 "flambda_parser_in.ml"
+# 12390 "flambda_parser_in.ml"
         ) = Obj.magic alloc in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -12394,11 +12395,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12398 "flambda_parser_in.ml"
+# 12399 "flambda_parser_in.ml"
         ) = 
 # 396 "flambda_parser.mly"
     ( Box_number (Naked_float, alloc) )
-# 12402 "flambda_parser_in.ml"
+# 12403 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12425,7 +12426,7 @@ module Tables = struct
         let alloc : (
 # 242 "flambda_parser.mly"
       (Fexpr.alloc_mode_for_allocations)
-# 12429 "flambda_parser_in.ml"
+# 12430 "flambda_parser_in.ml"
         ) = Obj.magic alloc in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -12434,11 +12435,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12438 "flambda_parser_in.ml"
+# 12439 "flambda_parser_in.ml"
         ) = 
 # 398 "flambda_parser.mly"
     ( Box_number (Naked_int32, alloc) )
-# 12442 "flambda_parser_in.ml"
+# 12443 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12465,7 +12466,7 @@ module Tables = struct
         let alloc : (
 # 242 "flambda_parser.mly"
       (Fexpr.alloc_mode_for_allocations)
-# 12469 "flambda_parser_in.ml"
+# 12470 "flambda_parser_in.ml"
         ) = Obj.magic alloc in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -12474,11 +12475,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12478 "flambda_parser_in.ml"
+# 12479 "flambda_parser_in.ml"
         ) = 
 # 400 "flambda_parser.mly"
     ( Box_number (Naked_int64, alloc) )
-# 12482 "flambda_parser_in.ml"
+# 12483 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12505,7 +12506,7 @@ module Tables = struct
         let alloc : (
 # 242 "flambda_parser.mly"
       (Fexpr.alloc_mode_for_allocations)
-# 12509 "flambda_parser_in.ml"
+# 12510 "flambda_parser_in.ml"
         ) = Obj.magic alloc in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -12514,11 +12515,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12518 "flambda_parser_in.ml"
+# 12519 "flambda_parser_in.ml"
         ) = 
 # 402 "flambda_parser.mly"
     ( Box_number (Naked_nativeint, alloc) )
-# 12522 "flambda_parser_in.ml"
+# 12523 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12543,11 +12544,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12547 "flambda_parser_in.ml"
+# 12548 "flambda_parser_in.ml"
         ) = 
 # 403 "flambda_parser.mly"
                       ( String_length Bytes )
-# 12551 "flambda_parser_in.ml"
+# 12552 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12572,11 +12573,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12576 "flambda_parser_in.ml"
+# 12577 "flambda_parser_in.ml"
         ) = 
 # 404 "flambda_parser.mly"
                     ( End_region { ghost = false } )
-# 12580 "flambda_parser_in.ml"
+# 12581 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12601,11 +12602,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12605 "flambda_parser_in.ml"
+# 12606 "flambda_parser_in.ml"
         ) = 
 # 405 "flambda_parser.mly"
                           ( End_region { ghost = true } )
-# 12609 "flambda_parser_in.ml"
+# 12610 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12630,11 +12631,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12634 "flambda_parser_in.ml"
+# 12635 "flambda_parser_in.ml"
         ) = 
 # 406 "flambda_parser.mly"
                         ( End_try_region { ghost = false } )
-# 12638 "flambda_parser_in.ml"
+# 12639 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12659,11 +12660,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12663 "flambda_parser_in.ml"
+# 12664 "flambda_parser_in.ml"
         ) = 
 # 407 "flambda_parser.mly"
                               ( End_try_region { ghost = true } )
-# 12667 "flambda_parser_in.ml"
+# 12668 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12688,11 +12689,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12692 "flambda_parser_in.ml"
+# 12693 "flambda_parser_in.ml"
         ) = 
 # 408 "flambda_parser.mly"
                  ( Get_tag )
-# 12696 "flambda_parser_in.ml"
+# 12697 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12717,11 +12718,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12721 "flambda_parser_in.ml"
+# 12722 "flambda_parser_in.ml"
         ) = 
 # 409 "flambda_parser.mly"
                              ( Is_flat_float_array )
-# 12725 "flambda_parser_in.ml"
+# 12726 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12746,11 +12747,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12750 "flambda_parser_in.ml"
+# 12751 "flambda_parser_in.ml"
         ) = 
 # 410 "flambda_parser.mly"
                 ( Is_int )
-# 12754 "flambda_parser_in.ml"
+# 12755 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12783,12 +12784,12 @@ module Tables = struct
         let o : (
 # 279 "flambda_parser.mly"
       (Fexpr.unary_int_arith_op)
-# 12787 "flambda_parser_in.ml"
+# 12788 "flambda_parser_in.ml"
         ) = Obj.magic o in
         let i : (
 # 272 "flambda_parser.mly"
       (Fexpr.standard_int)
-# 12792 "flambda_parser_in.ml"
+# 12793 "flambda_parser_in.ml"
         ) = Obj.magic i in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -12797,11 +12798,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12801 "flambda_parser_in.ml"
+# 12802 "flambda_parser_in.ml"
         ) = 
 # 412 "flambda_parser.mly"
     ( Int_arith (i, o) )
-# 12805 "flambda_parser_in.ml"
+# 12806 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12853,13 +12854,13 @@ module Tables = struct
         let dst : (
 # 252 "flambda_parser.mly"
       (Fexpr.standard_int_or_float)
-# 12857 "flambda_parser_in.ml"
+# 12858 "flambda_parser_in.ml"
         ) = Obj.magic dst in
         let _4 : unit = Obj.magic _4 in
         let src : (
 # 252 "flambda_parser.mly"
       (Fexpr.standard_int_or_float)
-# 12863 "flambda_parser_in.ml"
+# 12864 "flambda_parser_in.ml"
         ) = Obj.magic src in
         let _2 : unit = Obj.magic _2 in
         let _1 : unit = Obj.magic _1 in
@@ -12869,11 +12870,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12873 "flambda_parser_in.ml"
+# 12874 "flambda_parser_in.ml"
         ) = 
 # 416 "flambda_parser.mly"
     ( Num_conv { src; dst } )
-# 12877 "flambda_parser_in.ml"
+# 12878 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12898,11 +12899,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12902 "flambda_parser_in.ml"
+# 12903 "flambda_parser_in.ml"
         ) = 
 # 417 "flambda_parser.mly"
                 ( Opaque_identity )
-# 12906 "flambda_parser_in.ml"
+# 12907 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12948,11 +12949,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12952 "flambda_parser_in.ml"
+# 12953 "flambda_parser_in.ml"
         ) = 
 # 419 "flambda_parser.mly"
     ( Project_value_slot { project_from; value_slot } )
-# 12956 "flambda_parser_in.ml"
+# 12957 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13012,11 +13013,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13016 "flambda_parser_in.ml"
+# 13017 "flambda_parser_in.ml"
         ) = 
 # 423 "flambda_parser.mly"
     ( Project_function_slot { move_from; move_to } )
-# 13020 "flambda_parser_in.ml"
+# 13021 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13041,11 +13042,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13045 "flambda_parser_in.ml"
+# 13046 "flambda_parser_in.ml"
         ) = 
 # 424 "flambda_parser.mly"
                        ( String_length String )
-# 13049 "flambda_parser_in.ml"
+# 13050 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13070,11 +13071,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13074 "flambda_parser_in.ml"
+# 13075 "flambda_parser_in.ml"
         ) = 
 # 425 "flambda_parser.mly"
                  ( Tag_immediate )
-# 13078 "flambda_parser_in.ml"
+# 13079 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13099,11 +13100,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13103 "flambda_parser_in.ml"
+# 13104 "flambda_parser_in.ml"
         ) = 
 # 426 "flambda_parser.mly"
                      ( Unbox_number Naked_float )
-# 13107 "flambda_parser_in.ml"
+# 13108 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13128,11 +13129,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13132 "flambda_parser_in.ml"
+# 13133 "flambda_parser_in.ml"
         ) = 
 # 427 "flambda_parser.mly"
                      ( Unbox_number Naked_int32 )
-# 13136 "flambda_parser_in.ml"
+# 13137 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13157,11 +13158,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13161 "flambda_parser_in.ml"
+# 13162 "flambda_parser_in.ml"
         ) = 
 # 428 "flambda_parser.mly"
                      ( Unbox_number Naked_int64 )
-# 13165 "flambda_parser_in.ml"
+# 13166 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13186,11 +13187,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13190 "flambda_parser_in.ml"
+# 13191 "flambda_parser_in.ml"
         ) = 
 # 429 "flambda_parser.mly"
                          ( Unbox_number Naked_nativeint )
-# 13194 "flambda_parser_in.ml"
+# 13195 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13215,11 +13216,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13219 "flambda_parser_in.ml"
+# 13220 "flambda_parser_in.ml"
         ) = 
 # 430 "flambda_parser.mly"
                       ( Unbox_number Naked_vec128 )
-# 13223 "flambda_parser_in.ml"
+# 13224 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13244,11 +13245,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13248 "flambda_parser_in.ml"
+# 13249 "flambda_parser_in.ml"
         ) = 
 # 431 "flambda_parser.mly"
                    ( Untag_immediate )
-# 13252 "flambda_parser_in.ml"
+# 13253 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13303,7 +13304,7 @@ module Tables = struct
         let mut : (
 # 265 "flambda_parser.mly"
       (Fexpr.mutability)
-# 13307 "flambda_parser_in.ml"
+# 13308 "flambda_parser_in.ml"
         ) = Obj.magic mut in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -13312,13 +13313,14 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13316 "flambda_parser_in.ml"
+# 13317 "flambda_parser_in.ml"
         ) = 
 # 436 "flambda_parser.mly"
-    ( (* TODO: Should get machine_width from fexpr context when available *)
+    ( (* CR mshinwell: Should get machine_width from fexpr context when
+         available *)
       let mw = Target_system.Machine_width.Sixty_four in
       Block_load { kind; mut; field = Target_ocaml_int.of_int mw field } )
-# 13322 "flambda_parser_in.ml"
+# 13324 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13355,9 +13357,9 @@ module Tables = struct
         let _startpos = _startpos_var_ in
         let _endpos = _endpos_value_ in
         let _v : 'tv_value_slot = 
-# 849 "flambda_parser.mly"
+# 851 "flambda_parser.mly"
                                                             ( { var; value; } )
-# 13361 "flambda_parser_in.ml"
+# 13363 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13378,7 +13380,7 @@ module Tables = struct
         let e : (
 # 73 "flambda_parser.mly"
        (string)
-# 13382 "flambda_parser_in.ml"
+# 13384 "flambda_parser_in.ml"
         ) = Obj.magic e in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_e_ in
@@ -13387,9 +13389,9 @@ module Tables = struct
           let _endpos = _endpos_e_ in
           let _startpos = _startpos_e_ in
           (
-# 1135 "flambda_parser.mly"
+# 1137 "flambda_parser.mly"
               ( make_located e (_startpos, _endpos) )
-# 13393 "flambda_parser_in.ml"
+# 13395 "flambda_parser_in.ml"
            : 'tv_value_slot_for_projection)
         in
         {
@@ -13411,7 +13413,7 @@ module Tables = struct
         let e : (
 # 73 "flambda_parser.mly"
        (string)
-# 13415 "flambda_parser_in.ml"
+# 13417 "flambda_parser_in.ml"
         ) = Obj.magic e in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_e_ in
@@ -13420,9 +13422,9 @@ module Tables = struct
           let _endpos = _endpos_e_ in
           let _startpos = _startpos_e_ in
           (
-# 1117 "flambda_parser.mly"
+# 1119 "flambda_parser.mly"
               ( make_located e (_startpos, _endpos) )
-# 13426 "flambda_parser_in.ml"
+# 13428 "flambda_parser_in.ml"
            : 'tv_variable)
         in
         {
@@ -13463,7 +13465,7 @@ module Tables = struct
         let recursive : (
 # 282 "flambda_parser.mly"
       (Fexpr.is_cont_recursive)
-# 13467 "flambda_parser_in.ml"
+# 13469 "flambda_parser_in.ml"
         ) = Obj.magic recursive in
         let _2 : unit = Obj.magic _2 in
         let body : 'tv_inner_expr = Obj.magic body in
@@ -13474,12 +13476,12 @@ module Tables = struct
           let bindings = 
 # 241 "<standard.mly>"
     ( xs )
-# 13478 "flambda_parser_in.ml"
+# 13480 "flambda_parser_in.ml"
            in
           (
-# 790 "flambda_parser.mly"
+# 792 "flambda_parser.mly"
     ( Let_cont { recursive; body; bindings } )
-# 13483 "flambda_parser_in.ml"
+# 13485 "flambda_parser_in.ml"
            : 'tv_where_expr)
         in
         {
@@ -13496,9 +13498,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_with_value_slots_opt = 
-# 841 "flambda_parser.mly"
+# 843 "flambda_parser.mly"
     ( None )
-# 13502 "flambda_parser_in.ml"
+# 13504 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13545,12 +13547,12 @@ module Tables = struct
           let elements = 
 # 241 "<standard.mly>"
     ( xs )
-# 13549 "flambda_parser_in.ml"
+# 13551 "flambda_parser_in.ml"
            in
           (
-# 845 "flambda_parser.mly"
+# 847 "flambda_parser.mly"
     ( Some elements )
-# 13554 "flambda_parser_in.ml"
+# 13556 "flambda_parser_in.ml"
            : 'tv_with_value_slots_opt)
         in
         {
@@ -13581,7 +13583,7 @@ let flambda_unit =
   fun lexer lexbuf : (
 # 255 "flambda_parser.mly"
       (Fexpr.flambda_unit)
-# 13585 "flambda_parser_in.ml"
+# 13587 "flambda_parser_in.ml"
   ) ->
     Obj.magic (MenhirInterpreter.entry `Legacy 621 lexer lexbuf)
 
@@ -13589,7 +13591,7 @@ and expect_test_spec =
   fun lexer lexbuf : (
 # 253 "flambda_parser.mly"
       (Fexpr.expect_test_spec)
-# 13593 "flambda_parser_in.ml"
+# 13595 "flambda_parser_in.ml"
   ) ->
     Obj.magic (MenhirInterpreter.entry `Legacy 0 lexer lexbuf)
 
@@ -13599,7 +13601,7 @@ module Incremental = struct
     fun initial_position : (
 # 255 "flambda_parser.mly"
       (Fexpr.flambda_unit)
-# 13603 "flambda_parser_in.ml"
+# 13605 "flambda_parser_in.ml"
     ) MenhirInterpreter.checkpoint ->
       Obj.magic (MenhirInterpreter.start 621 initial_position)
   
@@ -13607,13 +13609,13 @@ module Incremental = struct
     fun initial_position : (
 # 253 "flambda_parser.mly"
       (Fexpr.expect_test_spec)
-# 13611 "flambda_parser_in.ml"
+# 13613 "flambda_parser_in.ml"
     ) MenhirInterpreter.checkpoint ->
       Obj.magic (MenhirInterpreter.start 0 initial_position)
   
 end
 
-# 1138 "flambda_parser.mly"
+# 1140 "flambda_parser.mly"
   
 
-# 13620 "flambda_parser_in.ml"
+# 13622 "flambda_parser_in.ml"

--- a/middle_end/flambda2/parser/flambda_parser.ml
+++ b/middle_end/flambda2/parser/flambda_parser.ml
@@ -1036,7 +1036,7 @@ module Tables = struct
       (Fexpr.alloc_mode_for_allocations)
 # 1038 "flambda_parser_in.ml"
         ) = 
-# 528 "flambda_parser.mly"
+# 530 "flambda_parser.mly"
     ( Heap )
 # 1042 "flambda_parser_in.ml"
          in
@@ -1076,7 +1076,7 @@ module Tables = struct
       (Fexpr.alloc_mode_for_allocations)
 # 1078 "flambda_parser_in.ml"
         ) = 
-# 529 "flambda_parser.mly"
+# 531 "flambda_parser.mly"
                          ( Local { region } )
 # 1082 "flambda_parser_in.ml"
          in
@@ -1098,7 +1098,7 @@ module Tables = struct
       (Fexpr.alloc_mode_for_applications)
 # 1100 "flambda_parser_in.ml"
         ) = 
-# 532 "flambda_parser.mly"
+# 534 "flambda_parser.mly"
     ( Heap )
 # 1104 "flambda_parser_in.ml"
          in
@@ -1156,7 +1156,7 @@ module Tables = struct
       (Fexpr.alloc_mode_for_applications)
 # 1158 "flambda_parser_in.ml"
         ) = 
-# 533 "flambda_parser.mly"
+# 535 "flambda_parser.mly"
                                                      ( Local { region; ghost_region } )
 # 1162 "flambda_parser_in.ml"
          in
@@ -1199,7 +1199,7 @@ module Tables = struct
         let _startpos = _startpos_cont_ in
         let _endpos = _endpos_args_ in
         let _v : 'tv_apply_cont_expr = 
-# 936 "flambda_parser.mly"
+# 941 "flambda_parser.mly"
     ( { cont; args; trap_action } )
 # 1205 "flambda_parser_in.ml"
          in
@@ -1273,7 +1273,7 @@ module Tables = struct
         let _startpos = _startpos_call_kind_ in
         let _endpos = _endpos_e_ in
         let _v : 'tv_apply_expr = 
-# 862 "flambda_parser.mly"
+# 867 "flambda_parser.mly"
      ( let (func, arities) = func in {
        func;
           continuation = r;
@@ -1304,7 +1304,7 @@ module Tables = struct
       (Fexpr.array_kind)
 # 1306 "flambda_parser_in.ml"
         ) = 
-# 481 "flambda_parser.mly"
+# 483 "flambda_parser.mly"
     ( (Values : array_kind) )
 # 1310 "flambda_parser_in.ml"
          in
@@ -1333,7 +1333,7 @@ module Tables = struct
       (Fexpr.array_kind)
 # 1335 "flambda_parser_in.ml"
         ) = 
-# 482 "flambda_parser.mly"
+# 484 "flambda_parser.mly"
             ( (Immediates : array_kind) )
 # 1339 "flambda_parser_in.ml"
          in
@@ -1362,7 +1362,7 @@ module Tables = struct
       (Fexpr.array_kind)
 # 1364 "flambda_parser_in.ml"
         ) = 
-# 483 "flambda_parser.mly"
+# 485 "flambda_parser.mly"
               ( (Naked_floats : array_kind) )
 # 1368 "flambda_parser_in.ml"
          in
@@ -1395,7 +1395,7 @@ module Tables = struct
       (Fexpr.array_kind_for_length)
 # 1397 "flambda_parser_in.ml"
         ) = 
-# 486 "flambda_parser.mly"
+# 488 "flambda_parser.mly"
                       ( Array_kind kind )
 # 1401 "flambda_parser_in.ml"
          in
@@ -1424,7 +1424,7 @@ module Tables = struct
       (Fexpr.array_kind_for_length)
 # 1426 "flambda_parser_in.ml"
         ) = 
-# 487 "flambda_parser.mly"
+# 489 "flambda_parser.mly"
                 ( Float_array_opt_dynamic )
 # 1430 "flambda_parser_in.ml"
          in
@@ -1449,7 +1449,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_atomic_expr = 
-# 794 "flambda_parser.mly"
+# 799 "flambda_parser.mly"
             ( Invalid { message = "halt-and-catch-fire" } )
 # 1455 "flambda_parser_in.ml"
          in
@@ -1474,7 +1474,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_atomic_expr = 
-# 795 "flambda_parser.mly"
+# 800 "flambda_parser.mly"
                     ( Invalid { message =  "treat-as-unreachable" } )
 # 1480 "flambda_parser_in.ml"
          in
@@ -1510,7 +1510,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_message_ in
         let _v : 'tv_atomic_expr = 
-# 796 "flambda_parser.mly"
+# 801 "flambda_parser.mly"
                                   ( Invalid { message } )
 # 1516 "flambda_parser_in.ml"
          in
@@ -1542,7 +1542,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_ac_ in
         let _v : 'tv_atomic_expr = 
-# 797 "flambda_parser.mly"
+# 802 "flambda_parser.mly"
                                    ( Apply_cont ac )
 # 1548 "flambda_parser_in.ml"
          in
@@ -1581,7 +1581,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_cases_ in
         let _v : 'tv_atomic_expr = 
-# 798 "flambda_parser.mly"
+# 803 "flambda_parser.mly"
                                                    ( Switch {scrutinee; cases} )
 # 1587 "flambda_parser_in.ml"
          in
@@ -1613,7 +1613,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_e_ in
         let _v : 'tv_atomic_expr = 
-# 799 "flambda_parser.mly"
+# 804 "flambda_parser.mly"
                              ( Apply e )
 # 1619 "flambda_parser_in.ml"
          in
@@ -1652,7 +1652,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : 'tv_atomic_expr = 
-# 800 "flambda_parser.mly"
+# 805 "flambda_parser.mly"
                              ( e )
 # 1658 "flambda_parser_in.ml"
          in
@@ -1677,7 +1677,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_begin_region = 
-# 656 "flambda_parser.mly"
+# 661 "flambda_parser.mly"
                       ( Begin_region { ghost = false } )
 # 1683 "flambda_parser_in.ml"
          in
@@ -1702,7 +1702,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_begin_region = 
-# 657 "flambda_parser.mly"
+# 662 "flambda_parser.mly"
                             ( Begin_region { ghost = true } )
 # 1708 "flambda_parser_in.ml"
          in
@@ -1727,7 +1727,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_begin_region = 
-# 658 "flambda_parser.mly"
+# 663 "flambda_parser.mly"
                           ( Begin_try_region { ghost = false } )
 # 1733 "flambda_parser_in.ml"
          in
@@ -1752,7 +1752,7 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_begin_region = 
-# 659 "flambda_parser.mly"
+# 664 "flambda_parser.mly"
                                 ( Begin_try_region { ghost = true } )
 # 1758 "flambda_parser_in.ml"
          in
@@ -1781,7 +1781,7 @@ module Tables = struct
       (Fexpr.binary_float_arith_op)
 # 1783 "flambda_parser_in.ml"
         ) = 
-# 550 "flambda_parser.mly"
+# 552 "flambda_parser.mly"
             ( Add )
 # 1787 "flambda_parser_in.ml"
          in
@@ -1810,7 +1810,7 @@ module Tables = struct
       (Fexpr.binary_float_arith_op)
 # 1812 "flambda_parser_in.ml"
         ) = 
-# 551 "flambda_parser.mly"
+# 553 "flambda_parser.mly"
              ( Sub )
 # 1816 "flambda_parser_in.ml"
          in
@@ -1839,7 +1839,7 @@ module Tables = struct
       (Fexpr.binary_float_arith_op)
 # 1841 "flambda_parser_in.ml"
         ) = 
-# 552 "flambda_parser.mly"
+# 554 "flambda_parser.mly"
             ( Mul )
 # 1845 "flambda_parser_in.ml"
          in
@@ -1868,7 +1868,7 @@ module Tables = struct
       (Fexpr.binary_float_arith_op)
 # 1870 "flambda_parser_in.ml"
         ) = 
-# 553 "flambda_parser.mly"
+# 555 "flambda_parser.mly"
              ( Div )
 # 1874 "flambda_parser_in.ml"
          in
@@ -1897,7 +1897,7 @@ module Tables = struct
       (Fexpr.binary_int_arith_op)
 # 1899 "flambda_parser_in.ml"
         ) = 
-# 540 "flambda_parser.mly"
+# 542 "flambda_parser.mly"
          ( Add )
 # 1903 "flambda_parser_in.ml"
          in
@@ -1926,7 +1926,7 @@ module Tables = struct
       (Fexpr.binary_int_arith_op)
 # 1928 "flambda_parser_in.ml"
         ) = 
-# 541 "flambda_parser.mly"
+# 543 "flambda_parser.mly"
           ( Sub )
 # 1932 "flambda_parser_in.ml"
          in
@@ -1955,7 +1955,7 @@ module Tables = struct
       (Fexpr.binary_int_arith_op)
 # 1957 "flambda_parser_in.ml"
         ) = 
-# 542 "flambda_parser.mly"
+# 544 "flambda_parser.mly"
          ( Mul )
 # 1961 "flambda_parser_in.ml"
          in
@@ -1984,7 +1984,7 @@ module Tables = struct
       (Fexpr.binary_int_arith_op)
 # 1986 "flambda_parser_in.ml"
         ) = 
-# 543 "flambda_parser.mly"
+# 545 "flambda_parser.mly"
           ( Div )
 # 1990 "flambda_parser_in.ml"
          in
@@ -2013,7 +2013,7 @@ module Tables = struct
       (Fexpr.binary_int_arith_op)
 # 2015 "flambda_parser_in.ml"
         ) = 
-# 544 "flambda_parser.mly"
+# 546 "flambda_parser.mly"
             ( Mod )
 # 2019 "flambda_parser_in.ml"
          in
@@ -2042,7 +2042,7 @@ module Tables = struct
       (Fexpr.binary_int_arith_op)
 # 2044 "flambda_parser_in.ml"
         ) = 
-# 545 "flambda_parser.mly"
+# 547 "flambda_parser.mly"
              ( And )
 # 2048 "flambda_parser_in.ml"
          in
@@ -2071,7 +2071,7 @@ module Tables = struct
       (Fexpr.binary_int_arith_op)
 # 2073 "flambda_parser_in.ml"
         ) = 
-# 546 "flambda_parser.mly"
+# 548 "flambda_parser.mly"
             ( Or )
 # 2077 "flambda_parser_in.ml"
          in
@@ -2100,7 +2100,7 @@ module Tables = struct
       (Fexpr.binary_int_arith_op)
 # 2102 "flambda_parser_in.ml"
         ) = 
-# 547 "flambda_parser.mly"
+# 549 "flambda_parser.mly"
              ( Xor )
 # 2106 "flambda_parser_in.ml"
          in
@@ -2181,9 +2181,11 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_v_ in
         let _v : 'tv_binop_app = 
-# 587 "flambda_parser.mly"
-    ( Binary (Block_set { kind; init; field = Target_ocaml_int.of_int field }, block, v) )
-# 2187 "flambda_parser_in.ml"
+# 589 "flambda_parser.mly"
+    ( let mw = Target_system.Machine_width.Sixty_four in
+      let field = Target_ocaml_int.of_int mw field in
+      Binary (Block_set { kind; init; field }, block, v) )
+# 2189 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2241,9 +2243,9 @@ module Tables = struct
         let _startpos = _startpos_op_ in
         let _endpos = _endpos__6_ in
         let _v : 'tv_binop_app = 
-# 589 "flambda_parser.mly"
+# 594 "flambda_parser.mly"
     ( Binary (op, arg1, arg2) )
-# 2247 "flambda_parser_in.ml"
+# 2249 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2277,16 +2279,16 @@ module Tables = struct
         let op : (
 # 259 "flambda_parser.mly"
       (Fexpr.infix_binop)
-# 2281 "flambda_parser_in.ml"
+# 2283 "flambda_parser_in.ml"
         ) = Obj.magic op in
         let arg1 : 'tv_simple = Obj.magic arg1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_arg1_ in
         let _endpos = _endpos_arg2_ in
         let _v : 'tv_binop_app = 
-# 591 "flambda_parser.mly"
+# 596 "flambda_parser.mly"
     ( Binary (Infix op, arg1, arg2) )
-# 2290 "flambda_parser_in.ml"
+# 2292 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2354,19 +2356,19 @@ module Tables = struct
         let mut : (
 # 265 "flambda_parser.mly"
       (Fexpr.mutability)
-# 2358 "flambda_parser_in.ml"
+# 2360 "flambda_parser_in.ml"
         ) = Obj.magic mut in
         let ak : (
 # 244 "flambda_parser.mly"
       (Fexpr.array_kind)
-# 2363 "flambda_parser_in.ml"
+# 2365 "flambda_parser_in.ml"
         ) = Obj.magic ak in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__8_ in
         let _v : 'tv_binop_app = 
-# 595 "flambda_parser.mly"
+# 600 "flambda_parser.mly"
     (
     let array_load_kind : array_load_kind =
       match ak with
@@ -2384,7 +2386,7 @@ module Tables = struct
         Misc.fatal_error "Unboxed product array ops not supported"
     in
     Binary (Array_load (ak, array_load_kind, mut), arg1, arg2) )
-# 2388 "flambda_parser_in.ml"
+# 2390 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2430,22 +2432,22 @@ module Tables = struct
         let c : (
 # 248 "flambda_parser.mly"
       (Fexpr.binary_int_arith_op)
-# 2434 "flambda_parser_in.ml"
+# 2436 "flambda_parser_in.ml"
         ) = Obj.magic c in
         let arg1 : 'tv_simple = Obj.magic arg1 in
         let i : (
 # 272 "flambda_parser.mly"
       (Fexpr.standard_int)
-# 2440 "flambda_parser_in.ml"
+# 2442 "flambda_parser_in.ml"
         ) = Obj.magic i in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_arg2_ in
         let _v : 'tv_binop_app = 
-# 614 "flambda_parser.mly"
+# 619 "flambda_parser.mly"
     ( Binary (Int_arith (i, c), arg1, arg2) )
-# 2449 "flambda_parser_in.ml"
+# 2451 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2497,23 +2499,23 @@ module Tables = struct
         let c : (
 # 260 "flambda_parser.mly"
       (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
-# 2501 "flambda_parser_in.ml"
+# 2503 "flambda_parser_in.ml"
         ) = Obj.magic c in
         let arg1 : 'tv_simple = Obj.magic arg1 in
         let s : 'tv_signed_or_unsigned = Obj.magic s in
         let i : (
 # 272 "flambda_parser.mly"
       (Fexpr.standard_int)
-# 2508 "flambda_parser_in.ml"
+# 2510 "flambda_parser_in.ml"
         ) = Obj.magic i in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_arg2_ in
         let _v : 'tv_binop_app = 
-# 618 "flambda_parser.mly"
+# 623 "flambda_parser.mly"
     ( Binary (Int_comp (i, c s), arg1, arg2) )
-# 2517 "flambda_parser_in.ml"
+# 2519 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2561,16 +2563,16 @@ module Tables = struct
         let i : (
 # 272 "flambda_parser.mly"
       (Fexpr.standard_int)
-# 2565 "flambda_parser_in.ml"
+# 2567 "flambda_parser_in.ml"
         ) = Obj.magic i in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_arg2_ in
         let _v : 'tv_binop_app = 
-# 621 "flambda_parser.mly"
+# 626 "flambda_parser.mly"
     ( Binary (Int_shift (i, s), arg1, arg2) )
-# 2574 "flambda_parser_in.ml"
+# 2576 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2593,9 +2595,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_blank_or_kinds_with_subkinds_ = 
-# 1060 "flambda_parser.mly"
+# 1065 "flambda_parser.mly"
           ( None )
-# 2599 "flambda_parser_in.ml"
+# 2601 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2616,15 +2618,15 @@ module Tables = struct
         let a : (
 # 263 "flambda_parser.mly"
       (Fexpr.kind_with_subkind list)
-# 2620 "flambda_parser_in.ml"
+# 2622 "flambda_parser_in.ml"
         ) = Obj.magic a in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_a_ in
         let _endpos = _endpos_a_ in
         let _v : 'tv_blank_or_kinds_with_subkinds_ = 
-# 1061 "flambda_parser.mly"
+# 1066 "flambda_parser.mly"
           ( Some a )
-# 2628 "flambda_parser_in.ml"
+# 2630 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2647,9 +2649,9 @@ module Tables = struct
         let _startpos = _startpos_r_ in
         let _endpos = _endpos_r_ in
         let _v : 'tv_block = 
-# 663 "flambda_parser.mly"
+# 668 "flambda_parser.mly"
                      ( Variadic (r, []) )
-# 2653 "flambda_parser_in.ml"
+# 2655 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2709,13 +2711,13 @@ module Tables = struct
         let alloc : (
 # 242 "flambda_parser.mly"
       (Fexpr.alloc_mode_for_allocations)
-# 2713 "flambda_parser_in.ml"
+# 2715 "flambda_parser_in.ml"
         ) = Obj.magic alloc in
         let t : 'tv_tag = Obj.magic t in
         let m : (
 # 265 "flambda_parser.mly"
       (Fexpr.mutability)
-# 2719 "flambda_parser_in.ml"
+# 2721 "flambda_parser_in.ml"
         ) = Obj.magic m in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -2725,12 +2727,12 @@ module Tables = struct
           let elts = 
 # 241 "<standard.mly>"
     ( xs )
-# 2729 "flambda_parser_in.ml"
+# 2731 "flambda_parser_in.ml"
            in
           (
-# 666 "flambda_parser.mly"
+# 671 "flambda_parser.mly"
     ( Variadic (Make_block (t, m, alloc), elts) )
-# 2734 "flambda_parser_in.ml"
+# 2736 "flambda_parser_in.ml"
            : 'tv_block)
         in
         {
@@ -2749,11 +2751,11 @@ module Tables = struct
         let _v : (
 # 249 "flambda_parser.mly"
       (Fexpr.block_access_field_kind)
-# 2753 "flambda_parser_in.ml"
+# 2755 "flambda_parser_in.ml"
         ) = 
-# 500 "flambda_parser.mly"
+# 502 "flambda_parser.mly"
     ( Any_value )
-# 2757 "flambda_parser_in.ml"
+# 2759 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2778,11 +2780,11 @@ module Tables = struct
         let _v : (
 # 249 "flambda_parser.mly"
       (Fexpr.block_access_field_kind)
-# 2782 "flambda_parser_in.ml"
+# 2784 "flambda_parser_in.ml"
         ) = 
-# 501 "flambda_parser.mly"
+# 503 "flambda_parser.mly"
             ( Immediate )
-# 2786 "flambda_parser_in.ml"
+# 2788 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2817,15 +2819,15 @@ module Tables = struct
         let field_kind : (
 # 249 "flambda_parser.mly"
       (Fexpr.block_access_field_kind)
-# 2821 "flambda_parser_in.ml"
+# 2823 "flambda_parser_in.ml"
         ) = Obj.magic field_kind in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_field_kind_ in
         let _endpos = _endpos_size_ in
         let _v : 'tv_block_access_kind = 
-# 494 "flambda_parser.mly"
+# 496 "flambda_parser.mly"
     ( (Values { field_kind; tag; size } : block_access_kind) )
-# 2829 "flambda_parser_in.ml"
+# 2831 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2855,9 +2857,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_size_ in
         let _v : 'tv_block_access_kind = 
-# 496 "flambda_parser.mly"
+# 498 "flambda_parser.mly"
     ( (Naked_floats { size } : block_access_kind) )
-# 2861 "flambda_parser_in.ml"
+# 2863 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2875,7 +2877,7 @@ module Tables = struct
         let _v : 'tv_boption_KWD_LOCAL_ = 
 # 134 "<standard.mly>"
     ( false )
-# 2879 "flambda_parser_in.ml"
+# 2881 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2900,7 +2902,7 @@ module Tables = struct
         let _v : 'tv_boption_KWD_LOCAL_ = 
 # 137 "<standard.mly>"
     ( true )
-# 2904 "flambda_parser_in.ml"
+# 2906 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2918,7 +2920,7 @@ module Tables = struct
         let _v : 'tv_boption_KWD_NOALLOC_ = 
 # 134 "<standard.mly>"
     ( false )
-# 2922 "flambda_parser_in.ml"
+# 2924 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2943,7 +2945,7 @@ module Tables = struct
         let _v : 'tv_boption_KWD_NOALLOC_ = 
 # 137 "<standard.mly>"
     ( true )
-# 2947 "flambda_parser_in.ml"
+# 2949 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2961,7 +2963,7 @@ module Tables = struct
         let _v : 'tv_boption_KWD_TUPLED_ = 
 # 134 "<standard.mly>"
     ( false )
-# 2965 "flambda_parser_in.ml"
+# 2967 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -2986,7 +2988,7 @@ module Tables = struct
         let _v : 'tv_boption_KWD_TUPLED_ = 
 # 137 "<standard.mly>"
     ( true )
-# 2990 "flambda_parser_in.ml"
+# 2992 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3009,9 +3011,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_bytes_or_bigstring_set = 
-# 625 "flambda_parser.mly"
+# 630 "flambda_parser.mly"
                    ( Bytes )
-# 3015 "flambda_parser_in.ml"
+# 3017 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3034,9 +3036,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_bytes_or_bigstring_set = 
-# 626 "flambda_parser.mly"
+# 631 "flambda_parser.mly"
                        ( Bigstring )
-# 3040 "flambda_parser_in.ml"
+# 3042 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3057,15 +3059,15 @@ module Tables = struct
         let alloc : (
 # 243 "flambda_parser.mly"
       (Fexpr.alloc_mode_for_applications)
-# 3061 "flambda_parser_in.ml"
+# 3063 "flambda_parser_in.ml"
         ) = Obj.magic alloc in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_alloc_ in
         let _endpos = _endpos_alloc_ in
         let _v : 'tv_call_kind = 
-# 875 "flambda_parser.mly"
+# 880 "flambda_parser.mly"
                                              ( Function (Indirect alloc) )
-# 3069 "flambda_parser_in.ml"
+# 3071 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3117,7 +3119,7 @@ module Tables = struct
         let alloc : (
 # 243 "flambda_parser.mly"
       (Fexpr.alloc_mode_for_applications)
-# 3121 "flambda_parser_in.ml"
+# 3123 "flambda_parser_in.ml"
         ) = Obj.magic alloc in
         let function_slot : 'tv_function_slot_opt = Obj.magic function_slot in
         let code_id : 'tv_code_id = Obj.magic code_id in
@@ -3127,9 +3129,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__6_ in
         let _v : 'tv_call_kind = 
-# 881 "flambda_parser.mly"
+# 886 "flambda_parser.mly"
     ( Function (Direct { code_id; function_slot; alloc }) )
-# 3133 "flambda_parser_in.ml"
+# 3135 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3159,9 +3161,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_noalloc_ in
         let _v : 'tv_call_kind = 
-# 883 "flambda_parser.mly"
+# 888 "flambda_parser.mly"
     ( C_call { alloc = not noalloc } )
-# 3165 "flambda_parser_in.ml"
+# 3167 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3279,7 +3281,7 @@ module Tables = struct
         params_and_body = { params; closure_var; region_var; ghost_region_var; depth_var;
                             ret_cont; exn_cont; body };
         code_size; is_tupled; loopify; result_mode; } )
-# 3283 "flambda_parser_in.ml"
+# 3285 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3369,7 +3371,7 @@ module Tables = struct
         let recursive : (
 # 281 "flambda_parser.mly"
       (Fexpr.is_recursive)
-# 3373 "flambda_parser_in.ml"
+# 3375 "flambda_parser_in.ml"
         ) = Obj.magic recursive in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -3378,7 +3380,7 @@ module Tables = struct
         let _v : 'tv_code_header = 
 # 366 "flambda_parser.mly"
     ( recursive, inline, loopify, id, newer_version_of, code_size, is_tupled )
-# 3382 "flambda_parser_in.ml"
+# 3384 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3401,9 +3403,9 @@ module Tables = struct
         let _startpos = _startpos_v_ in
         let _endpos = _endpos_v_ in
         let _v : 'tv_code_id = 
-# 1092 "flambda_parser.mly"
+# 1097 "flambda_parser.mly"
                  ( v )
-# 3407 "flambda_parser_in.ml"
+# 3409 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3426,9 +3428,9 @@ module Tables = struct
         let _startpos = _startpos_i_ in
         let _endpos = _endpos_i_ in
         let _v : 'tv_code_size = 
-# 1096 "flambda_parser.mly"
+# 1101 "flambda_parser.mly"
                   ( i )
-# 3432 "flambda_parser_in.ml"
+# 3434 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3451,9 +3453,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_coercion = 
-# 1072 "flambda_parser.mly"
+# 1077 "flambda_parser.mly"
            ( Id )
-# 3457 "flambda_parser_in.ml"
+# 3459 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3492,22 +3494,22 @@ module Tables = struct
         let to_ : (
 # 268 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 3496 "flambda_parser_in.ml"
+# 3498 "flambda_parser_in.ml"
         ) = Obj.magic to_ in
         let _3 : unit = Obj.magic _3 in
         let from : (
 # 268 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 3502 "flambda_parser_in.ml"
+# 3504 "flambda_parser_in.ml"
         ) = Obj.magic from in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_to__ in
         let _v : 'tv_coercion = 
-# 1074 "flambda_parser.mly"
+# 1079 "flambda_parser.mly"
     ( Change_depth { from; to_; } )
-# 3511 "flambda_parser_in.ml"
+# 3513 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3528,7 +3530,7 @@ module Tables = struct
         let c : (
 # 74 "flambda_parser.mly"
        (string * char option)
-# 3532 "flambda_parser_in.ml"
+# 3534 "flambda_parser_in.ml"
         ) = Obj.magic c in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_c_ in
@@ -3536,11 +3538,11 @@ module Tables = struct
         let _v : (
 # 250 "flambda_parser.mly"
       (Fexpr.const)
-# 3540 "flambda_parser_in.ml"
+# 3542 "flambda_parser_in.ml"
         ) = 
-# 1046 "flambda_parser.mly"
+# 1051 "flambda_parser.mly"
             ( make_const_int c )
-# 3544 "flambda_parser_in.ml"
+# 3546 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3561,7 +3563,7 @@ module Tables = struct
         let c : (
 # 68 "flambda_parser.mly"
        (float)
-# 3565 "flambda_parser_in.ml"
+# 3567 "flambda_parser_in.ml"
         ) = Obj.magic c in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_c_ in
@@ -3569,11 +3571,11 @@ module Tables = struct
         let _v : (
 # 250 "flambda_parser.mly"
       (Fexpr.const)
-# 3573 "flambda_parser_in.ml"
+# 3575 "flambda_parser_in.ml"
         ) = 
-# 1047 "flambda_parser.mly"
+# 1052 "flambda_parser.mly"
               ( Naked_float c )
-# 3577 "flambda_parser_in.ml"
+# 3579 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3591,11 +3593,11 @@ module Tables = struct
         let _v : (
 # 282 "flambda_parser.mly"
       (Fexpr.is_cont_recursive)
-# 3595 "flambda_parser_in.ml"
+# 3597 "flambda_parser_in.ml"
         ) = 
-# 953 "flambda_parser.mly"
+# 958 "flambda_parser.mly"
     ( Nonrecursive )
-# 3599 "flambda_parser_in.ml"
+# 3601 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3627,11 +3629,11 @@ module Tables = struct
         let _v : (
 # 282 "flambda_parser.mly"
       (Fexpr.is_cont_recursive)
-# 3631 "flambda_parser_in.ml"
+# 3633 "flambda_parser_in.ml"
         ) = 
-# 955 "flambda_parser.mly"
+# 960 "flambda_parser.mly"
     ( (Recursive params : Fexpr.is_cont_recursive) )
-# 3635 "flambda_parser_in.ml"
+# 3637 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3656,11 +3658,11 @@ module Tables = struct
         let _v : (
 # 251 "flambda_parser.mly"
       (Fexpr.continuation)
-# 3660 "flambda_parser_in.ml"
+# 3662 "flambda_parser_in.ml"
         ) = 
-# 1120 "flambda_parser.mly"
+# 1125 "flambda_parser.mly"
                         ( Named e )
-# 3664 "flambda_parser_in.ml"
+# 3666 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3681,7 +3683,7 @@ module Tables = struct
         let s : (
 # 271 "flambda_parser.mly"
       (Fexpr.special_continuation)
-# 3685 "flambda_parser_in.ml"
+# 3687 "flambda_parser_in.ml"
         ) = Obj.magic s in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_s_ in
@@ -3689,11 +3691,11 @@ module Tables = struct
         let _v : (
 # 251 "flambda_parser.mly"
       (Fexpr.continuation)
-# 3693 "flambda_parser_in.ml"
+# 3695 "flambda_parser_in.ml"
         ) = 
-# 1121 "flambda_parser.mly"
+# 1126 "flambda_parser.mly"
                              ( Special s )
-# 3697 "flambda_parser_in.ml"
+# 3699 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3741,16 +3743,16 @@ module Tables = struct
         let sort : (
 # 257 "flambda_parser.mly"
       (Fexpr.continuation_sort option)
-# 3745 "flambda_parser_in.ml"
+# 3747 "flambda_parser_in.ml"
         ) = Obj.magic sort in
         let name : 'tv_continuation_id = Obj.magic name in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_name_ in
         let _endpos = _endpos_handler_ in
         let _v : 'tv_continuation_binding = 
-# 967 "flambda_parser.mly"
+# 972 "flambda_parser.mly"
     ( { name; params; handler; sort } )
-# 3754 "flambda_parser_in.ml"
+# 3756 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3773,9 +3775,9 @@ module Tables = struct
         let _startpos = _startpos_l_ in
         let _endpos = _endpos_l_ in
         let _v : 'tv_continuation_body = 
-# 789 "flambda_parser.mly"
+# 794 "flambda_parser.mly"
                                     ( l )
-# 3779 "flambda_parser_in.ml"
+# 3781 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3798,9 +3800,9 @@ module Tables = struct
         let _startpos = _startpos_a_ in
         let _endpos = _endpos_a_ in
         let _v : 'tv_continuation_body = 
-# 790 "flambda_parser.mly"
+# 795 "flambda_parser.mly"
                     ( a )
-# 3804 "flambda_parser_in.ml"
+# 3806 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3821,7 +3823,7 @@ module Tables = struct
         let e : (
 # 73 "flambda_parser.mly"
        (string)
-# 3825 "flambda_parser_in.ml"
+# 3827 "flambda_parser_in.ml"
         ) = Obj.magic e in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_e_ in
@@ -3830,9 +3832,9 @@ module Tables = struct
           let _endpos = _endpos_e_ in
           let _startpos = _startpos_e_ in
           (
-# 1116 "flambda_parser.mly"
+# 1121 "flambda_parser.mly"
               ( make_located e (_startpos, _endpos) )
-# 3836 "flambda_parser_in.ml"
+# 3838 "flambda_parser_in.ml"
            : 'tv_continuation_id)
         in
         {
@@ -3851,11 +3853,11 @@ module Tables = struct
         let _v : (
 # 257 "flambda_parser.mly"
       (Fexpr.continuation_sort option)
-# 3855 "flambda_parser_in.ml"
+# 3857 "flambda_parser_in.ml"
         ) = 
-# 959 "flambda_parser.mly"
+# 964 "flambda_parser.mly"
     ( None )
-# 3859 "flambda_parser_in.ml"
+# 3861 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3880,11 +3882,11 @@ module Tables = struct
         let _v : (
 # 257 "flambda_parser.mly"
       (Fexpr.continuation_sort option)
-# 3884 "flambda_parser_in.ml"
+# 3886 "flambda_parser_in.ml"
         ) = 
-# 960 "flambda_parser.mly"
+# 965 "flambda_parser.mly"
             ( Some Exn )
-# 3888 "flambda_parser_in.ml"
+# 3890 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3909,11 +3911,11 @@ module Tables = struct
         let _v : (
 # 257 "flambda_parser.mly"
       (Fexpr.continuation_sort option)
-# 3913 "flambda_parser_in.ml"
+# 3915 "flambda_parser_in.ml"
         ) = 
-# 961 "flambda_parser.mly"
+# 966 "flambda_parser.mly"
                            ( Some Define_root_symbol )
-# 3917 "flambda_parser_in.ml"
+# 3919 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -3945,69 +3947,11 @@ module Tables = struct
         let _v : (
 # 252 "flambda_parser.mly"
       (Fexpr.standard_int_or_float)
-# 3949 "flambda_parser_in.ml"
-        ) = 
-# 515 "flambda_parser.mly"
-                       ( Tagged_immediate )
-# 3953 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 252 "flambda_parser.mly"
-      (Fexpr.standard_int_or_float)
-# 3978 "flambda_parser_in.ml"
-        ) = 
-# 516 "flambda_parser.mly"
-            ( Naked_immediate )
-# 3982 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 252 "flambda_parser.mly"
-      (Fexpr.standard_int_or_float)
-# 4007 "flambda_parser_in.ml"
+# 3951 "flambda_parser_in.ml"
         ) = 
 # 517 "flambda_parser.mly"
-              ( Naked_float )
-# 4011 "flambda_parser_in.ml"
+                       ( Tagged_immediate )
+# 3955 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4032,11 +3976,11 @@ module Tables = struct
         let _v : (
 # 252 "flambda_parser.mly"
       (Fexpr.standard_int_or_float)
-# 4036 "flambda_parser_in.ml"
+# 3980 "flambda_parser_in.ml"
         ) = 
 # 518 "flambda_parser.mly"
-              ( Naked_int32 )
-# 4040 "flambda_parser_in.ml"
+            ( Naked_immediate )
+# 3984 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4061,11 +4005,11 @@ module Tables = struct
         let _v : (
 # 252 "flambda_parser.mly"
       (Fexpr.standard_int_or_float)
-# 4065 "flambda_parser_in.ml"
+# 4009 "flambda_parser_in.ml"
         ) = 
 # 519 "flambda_parser.mly"
-              ( Naked_int64 )
-# 4069 "flambda_parser_in.ml"
+              ( Naked_float )
+# 4013 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4090,11 +4034,69 @@ module Tables = struct
         let _v : (
 # 252 "flambda_parser.mly"
       (Fexpr.standard_int_or_float)
-# 4094 "flambda_parser_in.ml"
+# 4038 "flambda_parser_in.ml"
         ) = 
 # 520 "flambda_parser.mly"
+              ( Naked_int32 )
+# 4042 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 252 "flambda_parser.mly"
+      (Fexpr.standard_int_or_float)
+# 4067 "flambda_parser_in.ml"
+        ) = 
+# 521 "flambda_parser.mly"
+              ( Naked_int64 )
+# 4071 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 252 "flambda_parser.mly"
+      (Fexpr.standard_int_or_float)
+# 4096 "flambda_parser_in.ml"
+        ) = 
+# 522 "flambda_parser.mly"
                   ( Naked_nativeint )
-# 4098 "flambda_parser_in.ml"
+# 4100 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4110,9 +4112,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_ctors = 
-# 736 "flambda_parser.mly"
+# 741 "flambda_parser.mly"
     ( [], [] )
-# 4116 "flambda_parser_in.ml"
+# 4118 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4135,9 +4137,9 @@ module Tables = struct
         let _startpos = _startpos_ctors_ in
         let _endpos = _endpos_ctors_ in
         let _v : 'tv_ctors = 
-# 737 "flambda_parser.mly"
+# 742 "flambda_parser.mly"
                            ( ctors )
-# 4141 "flambda_parser_in.ml"
+# 4143 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4160,9 +4162,9 @@ module Tables = struct
         let _startpos = _startpos_tag_ in
         let _endpos = _endpos_tag_ in
         let _v : 'tv_ctors_nonempty = 
-# 739 "flambda_parser.mly"
+# 744 "flambda_parser.mly"
                     ( [ tag ], [] )
-# 4166 "flambda_parser_in.ml"
+# 4168 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4199,9 +4201,9 @@ module Tables = struct
         let _startpos = _startpos_tag_ in
         let _endpos = _endpos_ctors_ in
         let _v : 'tv_ctors_nonempty = 
-# 741 "flambda_parser.mly"
+# 746 "flambda_parser.mly"
       ( let (c, nc) = ctors in (tag :: c, nc) )
-# 4205 "flambda_parser_in.ml"
+# 4207 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4224,9 +4226,9 @@ module Tables = struct
         let _startpos = _startpos_nonconsts_ in
         let _endpos = _endpos_nonconsts_ in
         let _v : 'tv_ctors_nonempty = 
-# 742 "flambda_parser.mly"
+# 747 "flambda_parser.mly"
                                         ( [], nonconsts )
-# 4230 "flambda_parser_in.ml"
+# 4232 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4265,7 +4267,7 @@ module Tables = struct
         let _v : 'tv_deleted_code = 
 # 330 "flambda_parser.mly"
                                              ( code_id )
-# 4269 "flambda_parser_in.ml"
+# 4271 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4283,11 +4285,11 @@ module Tables = struct
         let _v : (
 # 246 "flambda_parser.mly"
       (Fexpr.empty_array_kind)
-# 4287 "flambda_parser_in.ml"
+# 4289 "flambda_parser_in.ml"
         ) = 
-# 490 "flambda_parser.mly"
+# 492 "flambda_parser.mly"
     ( Values_or_immediates_or_naked_floats )
-# 4291 "flambda_parser_in.ml"
+# 4293 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4314,7 +4316,7 @@ module Tables = struct
         let cont : (
 # 251 "flambda_parser.mly"
       (Fexpr.continuation)
-# 4318 "flambda_parser_in.ml"
+# 4320 "flambda_parser_in.ml"
         ) = Obj.magic cont in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -4323,7 +4325,7 @@ module Tables = struct
         let _v : 'tv_exn_continuation = 
 # 308 "flambda_parser.mly"
                              ( cont )
-# 4327 "flambda_parser_in.ml"
+# 4329 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4355,7 +4357,7 @@ module Tables = struct
         let _v : 'tv_exn_continuation_id = 
 # 311 "flambda_parser.mly"
                                 ( cont )
-# 4359 "flambda_parser_in.ml"
+# 4361 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4401,11 +4403,11 @@ module Tables = struct
         let _v : (
 # 253 "flambda_parser.mly"
       (Fexpr.expect_test_spec)
-# 4405 "flambda_parser_in.ml"
+# 4407 "flambda_parser_in.ml"
         ) = 
 # 295 "flambda_parser.mly"
     ( { before; after } )
-# 4409 "flambda_parser_in.ml"
+# 4411 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4428,9 +4430,9 @@ module Tables = struct
         let _startpos = _startpos_l_ in
         let _endpos = _endpos_l_ in
         let _v : 'tv_expr = 
-# 768 "flambda_parser.mly"
+# 773 "flambda_parser.mly"
                        ( l )
-# 4434 "flambda_parser_in.ml"
+# 4436 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4453,9 +4455,9 @@ module Tables = struct
         let _startpos = _startpos_i_ in
         let _endpos = _endpos_i_ in
         let _v : 'tv_expr = 
-# 769 "flambda_parser.mly"
+# 774 "flambda_parser.mly"
                    ( i )
-# 4459 "flambda_parser_in.ml"
+# 4461 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4480,11 +4482,11 @@ module Tables = struct
         let _v : (
 # 254 "flambda_parser.mly"
       (Fexpr.field_of_block)
-# 4484 "flambda_parser_in.ml"
+# 4486 "flambda_parser_in.ml"
         ) = 
-# 1027 "flambda_parser.mly"
+# 1032 "flambda_parser.mly"
                ( Symbol s )
-# 4488 "flambda_parser_in.ml"
+# 4490 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4509,11 +4511,11 @@ module Tables = struct
         let _v : (
 # 254 "flambda_parser.mly"
       (Fexpr.field_of_block)
-# 4513 "flambda_parser_in.ml"
+# 4515 "flambda_parser_in.ml"
         ) = 
-# 1028 "flambda_parser.mly"
+# 1033 "flambda_parser.mly"
                  ( Dynamically_computed v )
-# 4517 "flambda_parser_in.ml"
+# 4519 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4534,7 +4536,7 @@ module Tables = struct
         let i : (
 # 74 "flambda_parser.mly"
        (string * char option)
-# 4538 "flambda_parser_in.ml"
+# 4540 "flambda_parser_in.ml"
         ) = Obj.magic i in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_i_ in
@@ -4543,13 +4545,13 @@ module Tables = struct
           let _endpos = _endpos_i_ in
           let _startpos = _startpos_i_ in
           (
-# 1029 "flambda_parser.mly"
+# 1034 "flambda_parser.mly"
             ( Tagged_immediate ( make_tagged_immediate ~loc:(_startpos, _endpos) i ) )
-# 4549 "flambda_parser_in.ml"
+# 4551 "flambda_parser_in.ml"
            : (
 # 254 "flambda_parser.mly"
       (Fexpr.field_of_block)
-# 4553 "flambda_parser_in.ml"
+# 4555 "flambda_parser_in.ml"
           ))
         in
         {
@@ -4582,11 +4584,11 @@ module Tables = struct
         let _v : (
 # 255 "flambda_parser.mly"
       (Fexpr.flambda_unit)
-# 4586 "flambda_parser_in.ml"
+# 4588 "flambda_parser_in.ml"
         ) = 
 # 290 "flambda_parser.mly"
     ( body )
-# 4590 "flambda_parser_in.ml"
+# 4592 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4611,69 +4613,11 @@ module Tables = struct
         let _v : (
 # 256 "flambda_parser.mly"
       (unit Fexpr.comparison_behaviour)
-# 4615 "flambda_parser_in.ml"
-        ) = 
-# 565 "flambda_parser.mly"
-             ( Yielding_bool Eq )
-# 4619 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 256 "flambda_parser.mly"
-      (unit Fexpr.comparison_behaviour)
-# 4644 "flambda_parser_in.ml"
-        ) = 
-# 566 "flambda_parser.mly"
-                ( Yielding_bool Neq )
-# 4648 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 256 "flambda_parser.mly"
-      (unit Fexpr.comparison_behaviour)
-# 4673 "flambda_parser_in.ml"
+# 4617 "flambda_parser_in.ml"
         ) = 
 # 567 "flambda_parser.mly"
-            ( Yielding_bool ( Lt ()) )
-# 4677 "flambda_parser_in.ml"
+             ( Yielding_bool Eq )
+# 4621 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4698,11 +4642,11 @@ module Tables = struct
         let _v : (
 # 256 "flambda_parser.mly"
       (unit Fexpr.comparison_behaviour)
-# 4702 "flambda_parser_in.ml"
+# 4646 "flambda_parser_in.ml"
         ) = 
 # 568 "flambda_parser.mly"
-               ( Yielding_bool ( Gt ()) )
-# 4706 "flambda_parser_in.ml"
+                ( Yielding_bool Neq )
+# 4650 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4727,11 +4671,11 @@ module Tables = struct
         let _v : (
 # 256 "flambda_parser.mly"
       (unit Fexpr.comparison_behaviour)
-# 4731 "flambda_parser_in.ml"
+# 4675 "flambda_parser_in.ml"
         ) = 
 # 569 "flambda_parser.mly"
-                 ( Yielding_bool (Le()) )
-# 4735 "flambda_parser_in.ml"
+            ( Yielding_bool ( Lt ()) )
+# 4679 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4756,11 +4700,11 @@ module Tables = struct
         let _v : (
 # 256 "flambda_parser.mly"
       (unit Fexpr.comparison_behaviour)
-# 4760 "flambda_parser_in.ml"
+# 4704 "flambda_parser_in.ml"
         ) = 
 # 570 "flambda_parser.mly"
-                    ( Yielding_bool (Ge ()) )
-# 4764 "flambda_parser_in.ml"
+               ( Yielding_bool ( Gt ()) )
+# 4708 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4785,11 +4729,69 @@ module Tables = struct
         let _v : (
 # 256 "flambda_parser.mly"
       (unit Fexpr.comparison_behaviour)
-# 4789 "flambda_parser_in.ml"
+# 4733 "flambda_parser_in.ml"
         ) = 
 # 571 "flambda_parser.mly"
+                 ( Yielding_bool (Le()) )
+# 4737 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 256 "flambda_parser.mly"
+      (unit Fexpr.comparison_behaviour)
+# 4762 "flambda_parser_in.ml"
+        ) = 
+# 572 "flambda_parser.mly"
+                    ( Yielding_bool (Ge ()) )
+# 4766 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 256 "flambda_parser.mly"
+      (unit Fexpr.comparison_behaviour)
+# 4791 "flambda_parser_in.ml"
+        ) = 
+# 573 "flambda_parser.mly"
              ( (Yielding_int_like_compare_functions ()) )
-# 4793 "flambda_parser_in.ml"
+# 4795 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4810,7 +4812,7 @@ module Tables = struct
         let f : (
 # 68 "flambda_parser.mly"
        (float)
-# 4814 "flambda_parser_in.ml"
+# 4816 "flambda_parser_in.ml"
         ) = Obj.magic f in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_f_ in
@@ -4818,11 +4820,11 @@ module Tables = struct
         let _v : (
 # 258 "flambda_parser.mly"
       (float Fexpr.or_variable)
-# 4822 "flambda_parser_in.ml"
+# 4824 "flambda_parser_in.ml"
         ) = 
-# 1007 "flambda_parser.mly"
+# 1012 "flambda_parser.mly"
               ( Const f )
-# 4826 "flambda_parser_in.ml"
+# 4828 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4847,11 +4849,11 @@ module Tables = struct
         let _v : (
 # 258 "flambda_parser.mly"
       (float Fexpr.or_variable)
-# 4851 "flambda_parser_in.ml"
+# 4853 "flambda_parser_in.ml"
         ) = 
-# 1008 "flambda_parser.mly"
+# 1013 "flambda_parser.mly"
                  ( Var v )
-# 4855 "flambda_parser_in.ml"
+# 4857 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4890,7 +4892,7 @@ module Tables = struct
         let alloc : (
 # 242 "flambda_parser.mly"
       (Fexpr.alloc_mode_for_allocations)
-# 4894 "flambda_parser_in.ml"
+# 4896 "flambda_parser_in.ml"
         ) = Obj.magic alloc in
         let function_slot : 'tv_function_slot_opt = Obj.magic function_slot in
         let code_id : 'tv_code_id = Obj.magic code_id in
@@ -4899,9 +4901,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_alloc_ in
         let _v : 'tv_fun_decl = 
-# 851 "flambda_parser.mly"
+# 856 "flambda_parser.mly"
     ( { code_id; function_slot; alloc; } )
-# 4905 "flambda_parser_in.ml"
+# 4907 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4924,9 +4926,9 @@ module Tables = struct
         let _startpos = _startpos_s_ in
         let _endpos = _endpos_s_ in
         let _v : 'tv_func_name_with_optional_arities = 
-# 1051 "flambda_parser.mly"
+# 1056 "flambda_parser.mly"
                ( s, None )
-# 4930 "flambda_parser_in.ml"
+# 4932 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -4984,7 +4986,7 @@ module Tables = struct
         let ret_arity : (
 # 263 "flambda_parser.mly"
       (Fexpr.kind_with_subkind list)
-# 4988 "flambda_parser_in.ml"
+# 4990 "flambda_parser_in.ml"
         ) = Obj.magic ret_arity in
         let _5 : unit = Obj.magic _5 in
         let params_arity : 'tv_blank_or_kinds_with_subkinds_ = Obj.magic params_arity in
@@ -4995,9 +4997,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__7_ in
         let _v : 'tv_func_name_with_optional_arities = 
-# 1056 "flambda_parser.mly"
+# 1061 "flambda_parser.mly"
     ( s, Some ({ params_arity; ret_arity } : function_arities) )
-# 5001 "flambda_parser_in.ml"
+# 5003 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5020,9 +5022,9 @@ module Tables = struct
         let _startpos = _startpos_v_ in
         let _endpos = _endpos_v_ in
         let _v : 'tv_function_slot = 
-# 1099 "flambda_parser.mly"
+# 1104 "flambda_parser.mly"
                  ( v )
-# 5026 "flambda_parser_in.ml"
+# 5028 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5038,9 +5040,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_function_slot_opt = 
-# 1103 "flambda_parser.mly"
+# 1108 "flambda_parser.mly"
     ( None )
-# 5044 "flambda_parser_in.ml"
+# 5046 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5070,9 +5072,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_cid_ in
         let _v : 'tv_function_slot_opt = 
-# 1104 "flambda_parser.mly"
+# 1109 "flambda_parser.mly"
                             ( Some cid )
-# 5076 "flambda_parser_in.ml"
+# 5078 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5093,7 +5095,7 @@ module Tables = struct
         let o : (
 # 248 "flambda_parser.mly"
       (Fexpr.binary_int_arith_op)
-# 5097 "flambda_parser_in.ml"
+# 5099 "flambda_parser_in.ml"
         ) = Obj.magic o in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_o_ in
@@ -5101,11 +5103,11 @@ module Tables = struct
         let _v : (
 # 259 "flambda_parser.mly"
       (Fexpr.infix_binop)
-# 5105 "flambda_parser_in.ml"
+# 5107 "flambda_parser_in.ml"
         ) = 
-# 439 "flambda_parser.mly"
+# 441 "flambda_parser.mly"
                             ( Int_arith o )
-# 5109 "flambda_parser_in.ml"
+# 5111 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5126,7 +5128,7 @@ module Tables = struct
         let c : (
 # 260 "flambda_parser.mly"
       (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
-# 5130 "flambda_parser_in.ml"
+# 5132 "flambda_parser_in.ml"
         ) = Obj.magic c in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_c_ in
@@ -5134,11 +5136,11 @@ module Tables = struct
         let _v : (
 # 259 "flambda_parser.mly"
       (Fexpr.infix_binop)
-# 5138 "flambda_parser_in.ml"
+# 5140 "flambda_parser_in.ml"
         ) = 
-# 440 "flambda_parser.mly"
+# 442 "flambda_parser.mly"
                  ( Int_comp (c Signed) )
-# 5142 "flambda_parser_in.ml"
+# 5144 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5163,11 +5165,11 @@ module Tables = struct
         let _v : (
 # 259 "flambda_parser.mly"
       (Fexpr.infix_binop)
-# 5167 "flambda_parser_in.ml"
+# 5169 "flambda_parser_in.ml"
         ) = 
-# 441 "flambda_parser.mly"
+# 443 "flambda_parser.mly"
                   ( Int_shift s )
-# 5171 "flambda_parser_in.ml"
+# 5173 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5188,7 +5190,7 @@ module Tables = struct
         let o : (
 # 247 "flambda_parser.mly"
       (Fexpr.binary_float_arith_op)
-# 5192 "flambda_parser_in.ml"
+# 5194 "flambda_parser_in.ml"
         ) = Obj.magic o in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_o_ in
@@ -5196,11 +5198,11 @@ module Tables = struct
         let _v : (
 # 259 "flambda_parser.mly"
       (Fexpr.infix_binop)
-# 5200 "flambda_parser_in.ml"
+# 5202 "flambda_parser_in.ml"
         ) = 
-# 442 "flambda_parser.mly"
+# 444 "flambda_parser.mly"
                               ( Float_arith (Float64, o) )
-# 5204 "flambda_parser_in.ml"
+# 5206 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5221,7 +5223,7 @@ module Tables = struct
         let c : (
 # 256 "flambda_parser.mly"
       (unit Fexpr.comparison_behaviour)
-# 5225 "flambda_parser_in.ml"
+# 5227 "flambda_parser_in.ml"
         ) = Obj.magic c in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_c_ in
@@ -5229,11 +5231,11 @@ module Tables = struct
         let _v : (
 # 259 "flambda_parser.mly"
       (Fexpr.infix_binop)
-# 5233 "flambda_parser_in.ml"
+# 5235 "flambda_parser_in.ml"
         ) = 
-# 443 "flambda_parser.mly"
+# 445 "flambda_parser.mly"
                    ( Float_comp (Float64, c) )
-# 5237 "flambda_parser_in.ml"
+# 5239 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5256,9 +5258,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_init_or_assign = 
-# 523 "flambda_parser.mly"
+# 525 "flambda_parser.mly"
           ( Initialization )
-# 5262 "flambda_parser_in.ml"
+# 5264 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5281,9 +5283,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_init_or_assign = 
-# 524 "flambda_parser.mly"
+# 526 "flambda_parser.mly"
               ( Assignment Heap )
-# 5287 "flambda_parser_in.ml"
+# 5289 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5313,9 +5315,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__2_ in
         let _v : 'tv_init_or_assign = 
-# 525 "flambda_parser.mly"
+# 527 "flambda_parser.mly"
                   ( Assignment Local )
-# 5319 "flambda_parser_in.ml"
+# 5321 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5359,9 +5361,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : 'tv_inline = 
-# 887 "flambda_parser.mly"
+# 892 "flambda_parser.mly"
                                         ( Always_inline )
-# 5365 "flambda_parser_in.ml"
+# 5367 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5405,9 +5407,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : 'tv_inline = 
-# 888 "flambda_parser.mly"
+# 893 "flambda_parser.mly"
                                            ( Available_inline )
-# 5411 "flambda_parser_in.ml"
+# 5413 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5451,147 +5453,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : 'tv_inline = 
-# 889 "flambda_parser.mly"
-                                       ( Never_inline )
-# 5457 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _;
-          CamlinternalMenhirLib.EngineTypes.semv = _4;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__4_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__4_;
-          CamlinternalMenhirLib.EngineTypes.next = {
-            CamlinternalMenhirLib.EngineTypes.state = _;
-            CamlinternalMenhirLib.EngineTypes.semv = i;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos_i_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos_i_;
-            CamlinternalMenhirLib.EngineTypes.next = {
-              CamlinternalMenhirLib.EngineTypes.state = _;
-              CamlinternalMenhirLib.EngineTypes.semv = _2;
-              CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
-              CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
-              CamlinternalMenhirLib.EngineTypes.next = {
-                CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-                CamlinternalMenhirLib.EngineTypes.semv = _1;
-                CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-                CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-                CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _4 : unit = Obj.magic _4 in
-        let i : 'tv_plain_int = Obj.magic i in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__4_ in
-        let _v : 'tv_inline = 
-# 890 "flambda_parser.mly"
-                                             ( Inline_attribute.Unroll i )
-# 5503 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _;
-          CamlinternalMenhirLib.EngineTypes.semv = _4;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__4_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__4_;
-          CamlinternalMenhirLib.EngineTypes.next = {
-            CamlinternalMenhirLib.EngineTypes.state = _;
-            CamlinternalMenhirLib.EngineTypes.semv = _3;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos__3_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos__3_;
-            CamlinternalMenhirLib.EngineTypes.next = {
-              CamlinternalMenhirLib.EngineTypes.state = _;
-              CamlinternalMenhirLib.EngineTypes.semv = _2;
-              CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
-              CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
-              CamlinternalMenhirLib.EngineTypes.next = {
-                CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-                CamlinternalMenhirLib.EngineTypes.semv = _1;
-                CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-                CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-                CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _4 : unit = Obj.magic _4 in
-        let _3 : unit = Obj.magic _3 in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__4_ in
-        let _v : 'tv_inline = 
-# 891 "flambda_parser.mly"
-                                         ( Default_inline )
-# 5549 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _;
-          CamlinternalMenhirLib.EngineTypes.semv = _4;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__4_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__4_;
-          CamlinternalMenhirLib.EngineTypes.next = {
-            CamlinternalMenhirLib.EngineTypes.state = _;
-            CamlinternalMenhirLib.EngineTypes.semv = _3;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos__3_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos__3_;
-            CamlinternalMenhirLib.EngineTypes.next = {
-              CamlinternalMenhirLib.EngineTypes.state = _;
-              CamlinternalMenhirLib.EngineTypes.semv = _2;
-              CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
-              CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
-              CamlinternalMenhirLib.EngineTypes.next = {
-                CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-                CamlinternalMenhirLib.EngineTypes.semv = _1;
-                CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-                CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-                CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-              };
-            };
-          };
-        } = _menhir_stack in
-        let _4 : unit = Obj.magic _4 in
-        let _3 : unit = Obj.magic _3 in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__4_ in
-        let _v : 'tv_inlined = 
 # 894 "flambda_parser.mly"
-                                         ( Always_inlined )
-# 5595 "flambda_parser_in.ml"
+                                       ( Never_inline )
+# 5459 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5609,9 +5473,9 @@ module Tables = struct
           CamlinternalMenhirLib.EngineTypes.endp = _endpos__4_;
           CamlinternalMenhirLib.EngineTypes.next = {
             CamlinternalMenhirLib.EngineTypes.state = _;
-            CamlinternalMenhirLib.EngineTypes.semv = _3;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos__3_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos__3_;
+            CamlinternalMenhirLib.EngineTypes.semv = i;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos_i_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos_i_;
             CamlinternalMenhirLib.EngineTypes.next = {
               CamlinternalMenhirLib.EngineTypes.state = _;
               CamlinternalMenhirLib.EngineTypes.semv = _2;
@@ -5628,16 +5492,62 @@ module Tables = struct
           };
         } = _menhir_stack in
         let _4 : unit = Obj.magic _4 in
-        let _3 : unit = Obj.magic _3 in
+        let i : 'tv_plain_int = Obj.magic i in
         let _2 : unit = Obj.magic _2 in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
-        let _v : 'tv_inlined = 
+        let _v : 'tv_inline = 
 # 895 "flambda_parser.mly"
-                                       ( Hint_inlined )
-# 5641 "flambda_parser_in.ml"
+                                             ( Inline_attribute.Unroll i )
+# 5505 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _;
+          CamlinternalMenhirLib.EngineTypes.semv = _4;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__4_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__4_;
+          CamlinternalMenhirLib.EngineTypes.next = {
+            CamlinternalMenhirLib.EngineTypes.state = _;
+            CamlinternalMenhirLib.EngineTypes.semv = _3;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos__3_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos__3_;
+            CamlinternalMenhirLib.EngineTypes.next = {
+              CamlinternalMenhirLib.EngineTypes.state = _;
+              CamlinternalMenhirLib.EngineTypes.semv = _2;
+              CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
+              CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
+              CamlinternalMenhirLib.EngineTypes.next = {
+                CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+                CamlinternalMenhirLib.EngineTypes.semv = _1;
+                CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+                CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+                CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _4 : unit = Obj.magic _4 in
+        let _3 : unit = Obj.magic _3 in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__4_ in
+        let _v : 'tv_inline = 
+# 896 "flambda_parser.mly"
+                                         ( Default_inline )
+# 5551 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5681,9 +5591,101 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : 'tv_inlined = 
-# 896 "flambda_parser.mly"
+# 899 "flambda_parser.mly"
+                                         ( Always_inlined )
+# 5597 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _;
+          CamlinternalMenhirLib.EngineTypes.semv = _4;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__4_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__4_;
+          CamlinternalMenhirLib.EngineTypes.next = {
+            CamlinternalMenhirLib.EngineTypes.state = _;
+            CamlinternalMenhirLib.EngineTypes.semv = _3;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos__3_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos__3_;
+            CamlinternalMenhirLib.EngineTypes.next = {
+              CamlinternalMenhirLib.EngineTypes.state = _;
+              CamlinternalMenhirLib.EngineTypes.semv = _2;
+              CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
+              CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
+              CamlinternalMenhirLib.EngineTypes.next = {
+                CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+                CamlinternalMenhirLib.EngineTypes.semv = _1;
+                CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+                CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+                CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _4 : unit = Obj.magic _4 in
+        let _3 : unit = Obj.magic _3 in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__4_ in
+        let _v : 'tv_inlined = 
+# 900 "flambda_parser.mly"
+                                       ( Hint_inlined )
+# 5643 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _;
+          CamlinternalMenhirLib.EngineTypes.semv = _4;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__4_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__4_;
+          CamlinternalMenhirLib.EngineTypes.next = {
+            CamlinternalMenhirLib.EngineTypes.state = _;
+            CamlinternalMenhirLib.EngineTypes.semv = _3;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos__3_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos__3_;
+            CamlinternalMenhirLib.EngineTypes.next = {
+              CamlinternalMenhirLib.EngineTypes.state = _;
+              CamlinternalMenhirLib.EngineTypes.semv = _2;
+              CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
+              CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
+              CamlinternalMenhirLib.EngineTypes.next = {
+                CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+                CamlinternalMenhirLib.EngineTypes.semv = _1;
+                CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+                CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+                CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+              };
+            };
+          };
+        } = _menhir_stack in
+        let _4 : unit = Obj.magic _4 in
+        let _3 : unit = Obj.magic _3 in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__4_ in
+        let _v : 'tv_inlined = 
+# 901 "flambda_parser.mly"
                                         ( Never_inlined )
-# 5687 "flambda_parser_in.ml"
+# 5689 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5727,9 +5729,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : 'tv_inlined = 
-# 897 "flambda_parser.mly"
+# 902 "flambda_parser.mly"
                                              ( Unroll i )
-# 5733 "flambda_parser_in.ml"
+# 5735 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5773,9 +5775,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : 'tv_inlined = 
-# 898 "flambda_parser.mly"
+# 903 "flambda_parser.mly"
                                           ( Default_inlined )
-# 5779 "flambda_parser_in.ml"
+# 5781 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5819,12 +5821,12 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : 'tv_inlining_state = 
-# 902 "flambda_parser.mly"
+# 907 "flambda_parser.mly"
     (
       (* CR poechsel: Parse the inlining arguments *)
       { depth }
     )
-# 5828 "flambda_parser_in.ml"
+# 5830 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5868,9 +5870,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : 'tv_inlining_state_depth = 
-# 908 "flambda_parser.mly"
+# 913 "flambda_parser.mly"
                                             ( i )
-# 5874 "flambda_parser_in.ml"
+# 5876 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5893,9 +5895,9 @@ module Tables = struct
         let _startpos = _startpos_w_ in
         let _endpos = _endpos_w_ in
         let _v : 'tv_inner_expr = 
-# 778 "flambda_parser.mly"
+# 783 "flambda_parser.mly"
                    ( w )
-# 5899 "flambda_parser_in.ml"
+# 5901 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5918,9 +5920,9 @@ module Tables = struct
         let _startpos = _startpos_a_ in
         let _endpos = _endpos_a_ in
         let _v : 'tv_inner_expr = 
-# 779 "flambda_parser.mly"
+# 784 "flambda_parser.mly"
                     ( a )
-# 5924 "flambda_parser_in.ml"
+# 5926 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -5945,69 +5947,11 @@ module Tables = struct
         let _v : (
 # 260 "flambda_parser.mly"
       (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
-# 5949 "flambda_parser_in.ml"
-        ) = 
-# 556 "flambda_parser.mly"
-         ( fun s -> Yielding_bool (Lt s) )
-# 5953 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 260 "flambda_parser.mly"
-      (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
-# 5978 "flambda_parser_in.ml"
-        ) = 
-# 557 "flambda_parser.mly"
-            ( fun s -> Yielding_bool (Gt s) )
-# 5982 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 260 "flambda_parser.mly"
-      (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
-# 6007 "flambda_parser_in.ml"
+# 5951 "flambda_parser_in.ml"
         ) = 
 # 558 "flambda_parser.mly"
-              ( fun s -> Yielding_bool (Le s) )
-# 6011 "flambda_parser_in.ml"
+         ( fun s -> Yielding_bool (Lt s) )
+# 5955 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6032,11 +5976,11 @@ module Tables = struct
         let _v : (
 # 260 "flambda_parser.mly"
       (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
-# 6036 "flambda_parser_in.ml"
+# 5980 "flambda_parser_in.ml"
         ) = 
 # 559 "flambda_parser.mly"
-                 ( fun s -> Yielding_bool (Ge s) )
-# 6040 "flambda_parser_in.ml"
+            ( fun s -> Yielding_bool (Gt s) )
+# 5984 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6061,11 +6005,11 @@ module Tables = struct
         let _v : (
 # 260 "flambda_parser.mly"
       (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
-# 6065 "flambda_parser_in.ml"
+# 6009 "flambda_parser_in.ml"
         ) = 
 # 560 "flambda_parser.mly"
-          ( fun _ -> Yielding_bool Eq )
-# 6069 "flambda_parser_in.ml"
+              ( fun s -> Yielding_bool (Le s) )
+# 6013 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6090,11 +6034,11 @@ module Tables = struct
         let _v : (
 # 260 "flambda_parser.mly"
       (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
-# 6094 "flambda_parser_in.ml"
+# 6038 "flambda_parser_in.ml"
         ) = 
 # 561 "flambda_parser.mly"
-             ( fun _ -> Yielding_bool Neq )
-# 6098 "flambda_parser_in.ml"
+                 ( fun s -> Yielding_bool (Ge s) )
+# 6042 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6119,61 +6063,69 @@ module Tables = struct
         let _v : (
 # 260 "flambda_parser.mly"
       (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
-# 6123 "flambda_parser_in.ml"
+# 6067 "flambda_parser_in.ml"
         ) = 
 # 562 "flambda_parser.mly"
+          ( fun _ -> Yielding_bool Eq )
+# 6071 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 260 "flambda_parser.mly"
+      (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
+# 6096 "flambda_parser_in.ml"
+        ) = 
+# 563 "flambda_parser.mly"
+             ( fun _ -> Yielding_bool Neq )
+# 6100 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 260 "flambda_parser.mly"
+      (Fexpr.signed_or_unsigned -> Fexpr.signed_or_unsigned Fexpr.comparison_behaviour)
+# 6125 "flambda_parser_in.ml"
+        ) = 
+# 564 "flambda_parser.mly"
           ( fun s -> Yielding_int_like_compare_functions s )
-# 6127 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : 'tv_int_shift = 
-# 575 "flambda_parser.mly"
-            ( Lsl )
-# 6152 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : 'tv_int_shift = 
-# 576 "flambda_parser.mly"
-            ( Lsr )
-# 6177 "flambda_parser_in.ml"
+# 6129 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6197,8 +6149,58 @@ module Tables = struct
         let _endpos = _endpos__1_ in
         let _v : 'tv_int_shift = 
 # 577 "flambda_parser.mly"
+            ( Lsl )
+# 6154 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : 'tv_int_shift = 
+# 578 "flambda_parser.mly"
+            ( Lsr )
+# 6179 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : 'tv_int_shift = 
+# 579 "flambda_parser.mly"
             ( Asr )
-# 6202 "flambda_parser_in.ml"
+# 6204 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6219,7 +6221,7 @@ module Tables = struct
         let nnk : (
 # 266 "flambda_parser.mly"
       (Flambda_kind.Naked_number_kind.t)
-# 6223 "flambda_parser_in.ml"
+# 6225 "flambda_parser_in.ml"
         ) = Obj.magic nnk in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_nnk_ in
@@ -6227,11 +6229,11 @@ module Tables = struct
         let _v : (
 # 262 "flambda_parser.mly"
       (Fexpr.kind_with_subkind)
-# 6231 "flambda_parser_in.ml"
+# 6233 "flambda_parser_in.ml"
         ) = 
-# 707 "flambda_parser.mly"
+# 712 "flambda_parser.mly"
                             ( Naked_number nnk )
-# 6235 "flambda_parser_in.ml"
+# 6237 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6252,7 +6254,7 @@ module Tables = struct
         let subkind : (
 # 275 "flambda_parser.mly"
       (Fexpr.subkind)
-# 6256 "flambda_parser_in.ml"
+# 6258 "flambda_parser_in.ml"
         ) = Obj.magic subkind in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_subkind_ in
@@ -6260,11 +6262,11 @@ module Tables = struct
         let _v : (
 # 262 "flambda_parser.mly"
       (Fexpr.kind_with_subkind)
-# 6264 "flambda_parser_in.ml"
+# 6266 "flambda_parser_in.ml"
         ) = 
-# 708 "flambda_parser.mly"
+# 713 "flambda_parser.mly"
                       ( Value subkind )
-# 6268 "flambda_parser_in.ml"
+# 6270 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6289,11 +6291,11 @@ module Tables = struct
         let _v : (
 # 262 "flambda_parser.mly"
       (Fexpr.kind_with_subkind)
-# 6293 "flambda_parser_in.ml"
+# 6295 "flambda_parser_in.ml"
         ) = 
-# 709 "flambda_parser.mly"
+# 714 "flambda_parser.mly"
                ( Region )
-# 6297 "flambda_parser_in.ml"
+# 6299 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6318,11 +6320,11 @@ module Tables = struct
         let _v : (
 # 262 "flambda_parser.mly"
       (Fexpr.kind_with_subkind)
-# 6322 "flambda_parser_in.ml"
+# 6324 "flambda_parser_in.ml"
         ) = 
-# 710 "flambda_parser.mly"
+# 715 "flambda_parser.mly"
                  ( Rec_info )
-# 6326 "flambda_parser_in.ml"
+# 6328 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6338,9 +6340,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_kind_with_subkind_opt = 
-# 1037 "flambda_parser.mly"
+# 1042 "flambda_parser.mly"
     ( None )
-# 6344 "flambda_parser_in.ml"
+# 6346 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6367,16 +6369,16 @@ module Tables = struct
         let kind : (
 # 262 "flambda_parser.mly"
       (Fexpr.kind_with_subkind)
-# 6371 "flambda_parser_in.ml"
+# 6373 "flambda_parser_in.ml"
         ) = Obj.magic kind in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_kind_ in
         let _v : 'tv_kind_with_subkind_opt = 
-# 1038 "flambda_parser.mly"
+# 1043 "flambda_parser.mly"
                                     ( Some kind )
-# 6380 "flambda_parser_in.ml"
+# 6382 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6392,9 +6394,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_kinded_args = 
-# 971 "flambda_parser.mly"
+# 976 "flambda_parser.mly"
     ( [] )
-# 6398 "flambda_parser_in.ml"
+# 6400 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6431,9 +6433,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : 'tv_kinded_args = 
-# 972 "flambda_parser.mly"
+# 977 "flambda_parser.mly"
                                                                          ( vs )
-# 6437 "flambda_parser_in.ml"
+# 6439 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6463,9 +6465,9 @@ module Tables = struct
         let _startpos = _startpos_param_ in
         let _endpos = _endpos_kind_ in
         let _v : 'tv_kinded_variable = 
-# 1033 "flambda_parser.mly"
+# 1038 "flambda_parser.mly"
                                                    ( { param; kind } )
-# 6469 "flambda_parser_in.ml"
+# 6471 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6490,11 +6492,11 @@ module Tables = struct
         let _v : (
 # 263 "flambda_parser.mly"
       (Fexpr.kind_with_subkind list)
-# 6494 "flambda_parser_in.ml"
+# 6496 "flambda_parser_in.ml"
         ) = 
-# 713 "flambda_parser.mly"
+# 718 "flambda_parser.mly"
              ( [] )
-# 6498 "flambda_parser_in.ml"
+# 6500 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6519,11 +6521,11 @@ module Tables = struct
         let _v : (
 # 263 "flambda_parser.mly"
       (Fexpr.kind_with_subkind list)
-# 6523 "flambda_parser_in.ml"
+# 6525 "flambda_parser_in.ml"
         ) = 
-# 714 "flambda_parser.mly"
+# 719 "flambda_parser.mly"
                                                           ( ks )
-# 6527 "flambda_parser_in.ml"
+# 6529 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6548,11 +6550,11 @@ module Tables = struct
         let _v : (
 # 276 "flambda_parser.mly"
       (Fexpr.kind_with_subkind list)
-# 6552 "flambda_parser_in.ml"
+# 6554 "flambda_parser_in.ml"
         ) = 
-# 732 "flambda_parser.mly"
+# 737 "flambda_parser.mly"
                                                            ( sks )
-# 6556 "flambda_parser_in.ml"
+# 6558 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6596,9 +6598,9 @@ module Tables = struct
         let _startpos = _startpos_bindings_ in
         let _endpos = _endpos_body_ in
         let _v : 'tv_let__continuation_body_ = 
-# 827 "flambda_parser.mly"
+# 832 "flambda_parser.mly"
     ( ({ bindings; value_slots; body } : let_) )
-# 6602 "flambda_parser_in.ml"
+# 6604 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6642,9 +6644,9 @@ module Tables = struct
         let _startpos = _startpos_bindings_ in
         let _endpos = _endpos_body_ in
         let _v : 'tv_let__expr_ = 
-# 827 "flambda_parser.mly"
+# 832 "flambda_parser.mly"
     ( ({ bindings; value_slots; body } : let_) )
-# 6648 "flambda_parser_in.ml"
+# 6650 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6677,7 +6679,7 @@ module Tables = struct
         let defining_expr : (
 # 267 "flambda_parser.mly"
       (Fexpr.named)
-# 6681 "flambda_parser_in.ml"
+# 6683 "flambda_parser_in.ml"
         ) = Obj.magic defining_expr in
         let _2 : unit = Obj.magic _2 in
         let var : 'tv_variable = Obj.magic var in
@@ -6685,9 +6687,9 @@ module Tables = struct
         let _startpos = _startpos_var_ in
         let _endpos = _endpos_defining_expr_ in
         let _v : 'tv_let_binding = 
-# 832 "flambda_parser.mly"
+# 837 "flambda_parser.mly"
     ( { var; defining_expr } )
-# 6691 "flambda_parser_in.ml"
+# 6693 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6717,9 +6719,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_l_ in
         let _v : 'tv_let_expr_continuation_body_ = 
-# 773 "flambda_parser.mly"
+# 778 "flambda_parser.mly"
                            ( Let l )
-# 6723 "flambda_parser_in.ml"
+# 6725 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6742,9 +6744,9 @@ module Tables = struct
         let _startpos = _startpos_ls_ in
         let _endpos = _endpos_ls_ in
         let _v : 'tv_let_expr_continuation_body_ = 
-# 774 "flambda_parser.mly"
+# 779 "flambda_parser.mly"
                           ( Let_symbol ls )
-# 6748 "flambda_parser_in.ml"
+# 6750 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6774,9 +6776,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_l_ in
         let _v : 'tv_let_expr_expr_ = 
-# 773 "flambda_parser.mly"
+# 778 "flambda_parser.mly"
                            ( Let l )
-# 6780 "flambda_parser_in.ml"
+# 6782 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6799,9 +6801,9 @@ module Tables = struct
         let _startpos = _startpos_ls_ in
         let _endpos = _endpos_ls_ in
         let _v : 'tv_let_expr_expr_ = 
-# 774 "flambda_parser.mly"
+# 779 "flambda_parser.mly"
                           ( Let_symbol ls )
-# 6805 "flambda_parser_in.ml"
+# 6807 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6854,7 +6856,7 @@ module Tables = struct
         let _v : 'tv_let_symbol_continuation_body_ = 
 # 318 "flambda_parser.mly"
                          ( { bindings; value_slots; body } )
-# 6858 "flambda_parser_in.ml"
+# 6860 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6907,7 +6909,7 @@ module Tables = struct
         let _v : 'tv_let_symbol_expr_ = 
 # 318 "flambda_parser.mly"
                          ( { bindings; value_slots; body } )
-# 6911 "flambda_parser_in.ml"
+# 6913 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6932,11 +6934,11 @@ module Tables = struct
         let _v : (
 # 264 "flambda_parser.mly"
       (Fexpr.loopify_attribute)
-# 6936 "flambda_parser_in.ml"
+# 6938 "flambda_parser_in.ml"
         ) = 
-# 917 "flambda_parser.mly"
+# 922 "flambda_parser.mly"
                ( Always_loopify )
-# 6940 "flambda_parser_in.ml"
+# 6942 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6961,11 +6963,11 @@ module Tables = struct
         let _v : (
 # 264 "flambda_parser.mly"
       (Fexpr.loopify_attribute)
-# 6965 "flambda_parser_in.ml"
+# 6967 "flambda_parser_in.ml"
         ) = 
-# 918 "flambda_parser.mly"
+# 923 "flambda_parser.mly"
               ( Never_loopify )
-# 6969 "flambda_parser_in.ml"
+# 6971 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -6990,11 +6992,11 @@ module Tables = struct
         let _v : (
 # 264 "flambda_parser.mly"
       (Fexpr.loopify_attribute)
-# 6994 "flambda_parser_in.ml"
+# 6996 "flambda_parser_in.ml"
         ) = 
-# 919 "flambda_parser.mly"
+# 924 "flambda_parser.mly"
              ( Already_loopified )
-# 6998 "flambda_parser_in.ml"
+# 7000 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7026,11 +7028,11 @@ module Tables = struct
         let _v : (
 # 264 "flambda_parser.mly"
       (Fexpr.loopify_attribute)
-# 7030 "flambda_parser_in.ml"
+# 7032 "flambda_parser_in.ml"
         ) = 
-# 920 "flambda_parser.mly"
+# 925 "flambda_parser.mly"
                             ( Default_loopify_and_tailrec )
-# 7034 "flambda_parser_in.ml"
+# 7036 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7055,11 +7057,11 @@ module Tables = struct
         let _v : (
 # 264 "flambda_parser.mly"
       (Fexpr.loopify_attribute)
-# 7059 "flambda_parser_in.ml"
+# 7061 "flambda_parser_in.ml"
         ) = 
-# 921 "flambda_parser.mly"
+# 926 "flambda_parser.mly"
                 ( Default_loopify_and_not_tailrec )
-# 7063 "flambda_parser_in.ml"
+# 7065 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7075,9 +7077,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_loopify_opt = 
-# 912 "flambda_parser.mly"
+# 917 "flambda_parser.mly"
     ( None )
-# 7081 "flambda_parser_in.ml"
+# 7083 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7117,7 +7119,7 @@ module Tables = struct
         let l : (
 # 264 "flambda_parser.mly"
       (Fexpr.loopify_attribute)
-# 7121 "flambda_parser_in.ml"
+# 7123 "flambda_parser_in.ml"
         ) = Obj.magic l in
         let _2 : unit = Obj.magic _2 in
         let _1 : unit = Obj.magic _1 in
@@ -7125,9 +7127,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : 'tv_loopify_opt = 
-# 913 "flambda_parser.mly"
+# 918 "flambda_parser.mly"
                                             ( Some l )
-# 7131 "flambda_parser_in.ml"
+# 7133 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7145,7 +7147,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_COMMA_field_of_block__ = 
 # 145 "<standard.mly>"
     ( [] )
-# 7149 "flambda_parser_in.ml"
+# 7151 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7170,7 +7172,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_COMMA_field_of_block__ = 
 # 148 "<standard.mly>"
     ( x )
-# 7174 "flambda_parser_in.ml"
+# 7176 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7188,7 +7190,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_COMMA_float_or_variable__ = 
 # 145 "<standard.mly>"
     ( [] )
-# 7192 "flambda_parser_in.ml"
+# 7194 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7213,7 +7215,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_COMMA_float_or_variable__ = 
 # 148 "<standard.mly>"
     ( x )
-# 7217 "flambda_parser_in.ml"
+# 7219 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7231,7 +7233,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_COMMA_simple__ = 
 # 145 "<standard.mly>"
     ( [] )
-# 7235 "flambda_parser_in.ml"
+# 7237 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7256,7 +7258,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_COMMA_simple__ = 
 # 148 "<standard.mly>"
     ( x )
-# 7260 "flambda_parser_in.ml"
+# 7262 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7274,7 +7276,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_KWD_ANDWHERE_continuation_binding__ = 
 # 145 "<standard.mly>"
     ( [] )
-# 7278 "flambda_parser_in.ml"
+# 7280 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7299,7 +7301,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_KWD_ANDWHERE_continuation_binding__ = 
 # 148 "<standard.mly>"
     ( x )
-# 7303 "flambda_parser_in.ml"
+# 7305 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7317,7 +7319,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_PIPE_switch_case__ = 
 # 145 "<standard.mly>"
     ( [] )
-# 7321 "flambda_parser_in.ml"
+# 7323 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7342,7 +7344,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_PIPE_switch_case__ = 
 # 148 "<standard.mly>"
     ( x )
-# 7346 "flambda_parser_in.ml"
+# 7348 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7360,7 +7362,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_SEMICOLON_float_or_variable__ = 
 # 145 "<standard.mly>"
     ( [] )
-# 7364 "flambda_parser_in.ml"
+# 7366 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7385,7 +7387,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_SEMICOLON_float_or_variable__ = 
 # 148 "<standard.mly>"
     ( x )
-# 7389 "flambda_parser_in.ml"
+# 7391 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7403,7 +7405,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_SEMICOLON_value_slot__ = 
 # 145 "<standard.mly>"
     ( [] )
-# 7407 "flambda_parser_in.ml"
+# 7409 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7428,7 +7430,7 @@ module Tables = struct
         let _v : 'tv_loption_separated_nonempty_list_SEMICOLON_value_slot__ = 
 # 148 "<standard.mly>"
     ( x )
-# 7432 "flambda_parser_in.ml"
+# 7434 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7453,7 +7455,7 @@ module Tables = struct
         let _v : 'tv_module_ = 
 # 304 "flambda_parser.mly"
     ( { body } )
-# 7457 "flambda_parser_in.ml"
+# 7459 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7478,11 +7480,11 @@ module Tables = struct
         let _v : (
 # 265 "flambda_parser.mly"
       (Fexpr.mutability)
-# 7482 "flambda_parser_in.ml"
+# 7484 "flambda_parser_in.ml"
         ) = 
-# 460 "flambda_parser.mly"
+# 462 "flambda_parser.mly"
                 ( Mutable )
-# 7486 "flambda_parser_in.ml"
+# 7488 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7507,11 +7509,11 @@ module Tables = struct
         let _v : (
 # 265 "flambda_parser.mly"
       (Fexpr.mutability)
-# 7511 "flambda_parser_in.ml"
+# 7513 "flambda_parser_in.ml"
         ) = 
-# 461 "flambda_parser.mly"
+# 463 "flambda_parser.mly"
                          ( Immutable_unique )
-# 7515 "flambda_parser_in.ml"
+# 7517 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7529,11 +7531,11 @@ module Tables = struct
         let _v : (
 # 265 "flambda_parser.mly"
       (Fexpr.mutability)
-# 7533 "flambda_parser_in.ml"
+# 7535 "flambda_parser_in.ml"
         ) = 
-# 462 "flambda_parser.mly"
+# 464 "flambda_parser.mly"
     ( Immutable )
-# 7537 "flambda_parser_in.ml"
+# 7539 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7558,11 +7560,11 @@ module Tables = struct
         let _v : (
 # 266 "flambda_parser.mly"
       (Flambda_kind.Naked_number_kind.t)
-# 7562 "flambda_parser_in.ml"
+# 7564 "flambda_parser_in.ml"
         ) = 
-# 692 "flambda_parser.mly"
+# 697 "flambda_parser.mly"
             ( Naked_immediate )
-# 7566 "flambda_parser_in.ml"
+# 7568 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7587,11 +7589,11 @@ module Tables = struct
         let _v : (
 # 266 "flambda_parser.mly"
       (Flambda_kind.Naked_number_kind.t)
-# 7591 "flambda_parser_in.ml"
+# 7593 "flambda_parser_in.ml"
         ) = 
-# 693 "flambda_parser.mly"
+# 698 "flambda_parser.mly"
               ( Naked_float )
-# 7595 "flambda_parser_in.ml"
+# 7597 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7616,11 +7618,11 @@ module Tables = struct
         let _v : (
 # 266 "flambda_parser.mly"
       (Flambda_kind.Naked_number_kind.t)
-# 7620 "flambda_parser_in.ml"
+# 7622 "flambda_parser_in.ml"
         ) = 
-# 694 "flambda_parser.mly"
+# 699 "flambda_parser.mly"
               ( Naked_int32 )
-# 7624 "flambda_parser_in.ml"
+# 7626 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7645,11 +7647,11 @@ module Tables = struct
         let _v : (
 # 266 "flambda_parser.mly"
       (Flambda_kind.Naked_number_kind.t)
-# 7649 "flambda_parser_in.ml"
+# 7651 "flambda_parser_in.ml"
         ) = 
-# 695 "flambda_parser.mly"
+# 700 "flambda_parser.mly"
               ( Naked_int64 )
-# 7653 "flambda_parser_in.ml"
+# 7655 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7674,11 +7676,11 @@ module Tables = struct
         let _v : (
 # 266 "flambda_parser.mly"
       (Flambda_kind.Naked_number_kind.t)
-# 7678 "flambda_parser_in.ml"
+# 7680 "flambda_parser_in.ml"
         ) = 
-# 696 "flambda_parser.mly"
+# 701 "flambda_parser.mly"
                   ( Naked_nativeint )
-# 7682 "flambda_parser_in.ml"
+# 7684 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7703,11 +7705,11 @@ module Tables = struct
         let _v : (
 # 267 "flambda_parser.mly"
       (Fexpr.named)
-# 7707 "flambda_parser_in.ml"
+# 7709 "flambda_parser_in.ml"
         ) = 
-# 670 "flambda_parser.mly"
+# 675 "flambda_parser.mly"
                ( Simple s )
-# 7711 "flambda_parser_in.ml"
+# 7713 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7735,7 +7737,7 @@ module Tables = struct
         let u : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 7739 "flambda_parser_in.ml"
+# 7741 "flambda_parser_in.ml"
         ) = Obj.magic u in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_u_ in
@@ -7743,11 +7745,11 @@ module Tables = struct
         let _v : (
 # 267 "flambda_parser.mly"
       (Fexpr.named)
-# 7747 "flambda_parser_in.ml"
+# 7749 "flambda_parser_in.ml"
         ) = 
-# 671 "flambda_parser.mly"
+# 676 "flambda_parser.mly"
                         ( Prim (Unary (u, a)) )
-# 7751 "flambda_parser_in.ml"
+# 7753 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7772,11 +7774,11 @@ module Tables = struct
         let _v : (
 # 267 "flambda_parser.mly"
       (Fexpr.named)
-# 7776 "flambda_parser_in.ml"
+# 7778 "flambda_parser_in.ml"
         ) = 
-# 672 "flambda_parser.mly"
+# 677 "flambda_parser.mly"
                   ( Prim b )
-# 7780 "flambda_parser_in.ml"
+# 7782 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7801,11 +7803,11 @@ module Tables = struct
         let _v : (
 # 267 "flambda_parser.mly"
       (Fexpr.named)
-# 7805 "flambda_parser_in.ml"
+# 7807 "flambda_parser_in.ml"
         ) = 
-# 673 "flambda_parser.mly"
+# 678 "flambda_parser.mly"
                    ( Prim t )
-# 7809 "flambda_parser_in.ml"
+# 7811 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7830,11 +7832,11 @@ module Tables = struct
         let _v : (
 # 267 "flambda_parser.mly"
       (Fexpr.named)
-# 7834 "flambda_parser_in.ml"
+# 7836 "flambda_parser_in.ml"
         ) = 
-# 674 "flambda_parser.mly"
+# 679 "flambda_parser.mly"
               ( Prim b )
-# 7838 "flambda_parser_in.ml"
+# 7840 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7859,11 +7861,11 @@ module Tables = struct
         let _v : (
 # 267 "flambda_parser.mly"
       (Fexpr.named)
-# 7863 "flambda_parser_in.ml"
+# 7865 "flambda_parser_in.ml"
         ) = 
-# 675 "flambda_parser.mly"
+# 680 "flambda_parser.mly"
                  ( Closure c )
-# 7867 "flambda_parser_in.ml"
+# 7869 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7890,7 +7892,7 @@ module Tables = struct
         let ri : (
 # 269 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 7894 "flambda_parser_in.ml"
+# 7896 "flambda_parser_in.ml"
         ) = Obj.magic ri in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -7899,11 +7901,11 @@ module Tables = struct
         let _v : (
 # 267 "flambda_parser.mly"
       (Fexpr.named)
-# 7903 "flambda_parser_in.ml"
+# 7905 "flambda_parser_in.ml"
         ) = 
-# 681 "flambda_parser.mly"
+# 686 "flambda_parser.mly"
                                      ( Rec_info ri )
-# 7907 "flambda_parser_in.ml"
+# 7909 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7949,7 +7951,7 @@ module Tables = struct
         let _v : 'tv_newer_version_of = 
 # 370 "flambda_parser.mly"
                                                       ( id )
-# 7953 "flambda_parser_in.ml"
+# 7955 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -7982,7 +7984,7 @@ module Tables = struct
         let kinds : (
 # 276 "flambda_parser.mly"
       (Fexpr.kind_with_subkind list)
-# 7986 "flambda_parser_in.ml"
+# 7988 "flambda_parser_in.ml"
         ) = Obj.magic kinds in
         let _2 : unit = Obj.magic _2 in
         let tag : 'tv_tag = Obj.magic tag in
@@ -7990,9 +7992,9 @@ module Tables = struct
         let _startpos = _startpos_tag_ in
         let _endpos = _endpos_kinds_ in
         let _v : 'tv_nonconst_ctor = 
-# 747 "flambda_parser.mly"
+# 752 "flambda_parser.mly"
                                                             ( tag, kinds )
-# 7996 "flambda_parser_in.ml"
+# 7998 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8015,9 +8017,9 @@ module Tables = struct
         let _startpos = _startpos_ctors_ in
         let _endpos = _endpos_ctors_ in
         let _v : 'tv_nonconst_ctors_nonempty = 
-# 744 "flambda_parser.mly"
+# 749 "flambda_parser.mly"
                                                          ( ctors )
-# 8021 "flambda_parser_in.ml"
+# 8023 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8035,7 +8037,7 @@ module Tables = struct
         let _v : 'tv_option_PIPE_ = 
 # 111 "<standard.mly>"
     ( None )
-# 8039 "flambda_parser_in.ml"
+# 8041 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8060,7 +8062,7 @@ module Tables = struct
         let _v : 'tv_option_PIPE_ = 
 # 114 "<standard.mly>"
     ( Some x )
-# 8064 "flambda_parser_in.ml"
+# 8066 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8078,7 +8080,7 @@ module Tables = struct
         let _v : 'tv_option_inline_ = 
 # 111 "<standard.mly>"
     ( None )
-# 8082 "flambda_parser_in.ml"
+# 8084 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8103,7 +8105,7 @@ module Tables = struct
         let _v : 'tv_option_inline_ = 
 # 114 "<standard.mly>"
     ( Some x )
-# 8107 "flambda_parser_in.ml"
+# 8109 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8121,7 +8123,7 @@ module Tables = struct
         let _v : 'tv_option_inlined_ = 
 # 111 "<standard.mly>"
     ( None )
-# 8125 "flambda_parser_in.ml"
+# 8127 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8146,7 +8148,7 @@ module Tables = struct
         let _v : 'tv_option_inlined_ = 
 # 114 "<standard.mly>"
     ( Some x )
-# 8150 "flambda_parser_in.ml"
+# 8152 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8164,7 +8166,7 @@ module Tables = struct
         let _v : 'tv_option_inlining_state_ = 
 # 111 "<standard.mly>"
     ( None )
-# 8168 "flambda_parser_in.ml"
+# 8170 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8189,7 +8191,7 @@ module Tables = struct
         let _v : 'tv_option_inlining_state_ = 
 # 114 "<standard.mly>"
     ( Some x )
-# 8193 "flambda_parser_in.ml"
+# 8195 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8207,7 +8209,7 @@ module Tables = struct
         let _v : 'tv_option_newer_version_of_ = 
 # 111 "<standard.mly>"
     ( None )
-# 8211 "flambda_parser_in.ml"
+# 8213 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8232,7 +8234,7 @@ module Tables = struct
         let _v : 'tv_option_newer_version_of_ = 
 # 114 "<standard.mly>"
     ( Some x )
-# 8236 "flambda_parser_in.ml"
+# 8238 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8250,7 +8252,7 @@ module Tables = struct
         let _v : 'tv_option_raise_kind_ = 
 # 111 "<standard.mly>"
     ( None )
-# 8254 "flambda_parser_in.ml"
+# 8256 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8275,7 +8277,7 @@ module Tables = struct
         let _v : 'tv_option_raise_kind_ = 
 # 114 "<standard.mly>"
     ( Some x )
-# 8279 "flambda_parser_in.ml"
+# 8281 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8293,7 +8295,7 @@ module Tables = struct
         let _v : 'tv_option_trap_action_ = 
 # 111 "<standard.mly>"
     ( None )
-# 8297 "flambda_parser_in.ml"
+# 8299 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8318,7 +8320,7 @@ module Tables = struct
         let _v : 'tv_option_trap_action_ = 
 # 114 "<standard.mly>"
     ( Some x )
-# 8322 "flambda_parser_in.ml"
+# 8324 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8339,15 +8341,15 @@ module Tables = struct
         let i : (
 # 74 "flambda_parser.mly"
        (string * char option)
-# 8343 "flambda_parser_in.ml"
+# 8345 "flambda_parser_in.ml"
         ) = Obj.magic i in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_i_ in
         let _endpos = _endpos_i_ in
         let _v : 'tv_plain_int = 
-# 1023 "flambda_parser.mly"
+# 1028 "flambda_parser.mly"
           ( make_plain_int i )
-# 8351 "flambda_parser_in.ml"
+# 8353 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8377,9 +8379,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_saw_ in
         let _v : 'tv_prefix_binop = 
-# 449 "flambda_parser.mly"
+# 451 "flambda_parser.mly"
     ( String_or_bigstring_load (Bigstring, saw) )
-# 8383 "flambda_parser_in.ml"
+# 8385 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8409,9 +8411,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_saw_ in
         let _v : 'tv_prefix_binop = 
-# 452 "flambda_parser.mly"
+# 454 "flambda_parser.mly"
     ( String_or_bigstring_load (Bytes, saw) )
-# 8415 "flambda_parser_in.ml"
+# 8417 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8440,60 +8442,60 @@ module Tables = struct
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_saw_ in
-        let _v : 'tv_prefix_binop = 
-# 455 "flambda_parser.mly"
-    ( String_or_bigstring_load (String, saw) )
-# 8447 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : 'tv_prefix_binop = 
-# 456 "flambda_parser.mly"
-                 ( Phys_equal Eq )
-# 8472 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
         let _v : 'tv_prefix_binop = 
 # 457 "flambda_parser.mly"
+    ( String_or_bigstring_load (String, saw) )
+# 8449 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : 'tv_prefix_binop = 
+# 458 "flambda_parser.mly"
+                 ( Phys_equal Eq )
+# 8474 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : 'tv_prefix_binop = 
+# 459 "flambda_parser.mly"
                  ( Phys_equal Neq )
-# 8497 "flambda_parser_in.ml"
+# 8499 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8516,9 +8518,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_raise_kind = 
-# 948 "flambda_parser.mly"
+# 953 "flambda_parser.mly"
                 ( Regular )
-# 8522 "flambda_parser_in.ml"
+# 8524 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8541,9 +8543,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_raise_kind = 
-# 949 "flambda_parser.mly"
+# 954 "flambda_parser.mly"
                 ( Reraise )
-# 8547 "flambda_parser_in.ml"
+# 8549 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8566,9 +8568,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_raise_kind = 
-# 950 "flambda_parser.mly"
+# 955 "flambda_parser.mly"
                 ( No_trace )
-# 8572 "flambda_parser_in.ml"
+# 8574 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8589,7 +8591,7 @@ module Tables = struct
         let ri : (
 # 269 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8593 "flambda_parser_in.ml"
+# 8595 "flambda_parser_in.ml"
         ) = Obj.magic ri in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_ri_ in
@@ -8597,11 +8599,11 @@ module Tables = struct
         let _v : (
 # 268 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8601 "flambda_parser_in.ml"
+# 8603 "flambda_parser_in.ml"
         ) = 
-# 1086 "flambda_parser.mly"
+# 1091 "flambda_parser.mly"
                        ( ri )
-# 8605 "flambda_parser_in.ml"
+# 8607 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8628,7 +8630,7 @@ module Tables = struct
         let ri : (
 # 269 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8632 "flambda_parser_in.ml"
+# 8634 "flambda_parser_in.ml"
         ) = Obj.magic ri in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -8637,11 +8639,11 @@ module Tables = struct
         let _v : (
 # 268 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8641 "flambda_parser_in.ml"
+# 8643 "flambda_parser_in.ml"
         ) = 
-# 1087 "flambda_parser.mly"
+# 1092 "flambda_parser.mly"
                                  ( Succ ri )
-# 8645 "flambda_parser_in.ml"
+# 8647 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8674,7 +8676,7 @@ module Tables = struct
         let ri : (
 # 269 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8678 "flambda_parser_in.ml"
+# 8680 "flambda_parser_in.ml"
         ) = Obj.magic ri in
         let d : 'tv_plain_int = Obj.magic d in
         let _1 : unit = Obj.magic _1 in
@@ -8684,11 +8686,11 @@ module Tables = struct
         let _v : (
 # 268 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8688 "flambda_parser_in.ml"
+# 8690 "flambda_parser_in.ml"
         ) = 
-# 1088 "flambda_parser.mly"
+# 1093 "flambda_parser.mly"
                                                   ( Unroll (d, ri) )
-# 8692 "flambda_parser_in.ml"
+# 8694 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8713,11 +8715,11 @@ module Tables = struct
         let _v : (
 # 269 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8717 "flambda_parser_in.ml"
+# 8719 "flambda_parser_in.ml"
         ) = 
-# 1078 "flambda_parser.mly"
+# 1083 "flambda_parser.mly"
                   ( Depth i )
-# 8721 "flambda_parser_in.ml"
+# 8723 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8742,11 +8744,11 @@ module Tables = struct
         let _v : (
 # 269 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8746 "flambda_parser_in.ml"
+# 8748 "flambda_parser_in.ml"
         ) = 
-# 1079 "flambda_parser.mly"
+# 1084 "flambda_parser.mly"
             ( Infinity )
-# 8750 "flambda_parser_in.ml"
+# 8752 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8771,11 +8773,11 @@ module Tables = struct
         let _v : (
 # 269 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8775 "flambda_parser_in.ml"
+# 8777 "flambda_parser_in.ml"
         ) = 
-# 1080 "flambda_parser.mly"
+# 1085 "flambda_parser.mly"
                       ( Do_not_inline )
-# 8779 "flambda_parser_in.ml"
+# 8781 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8800,11 +8802,11 @@ module Tables = struct
         let _v : (
 # 269 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8804 "flambda_parser_in.ml"
+# 8806 "flambda_parser_in.ml"
         ) = 
-# 1081 "flambda_parser.mly"
+# 1086 "flambda_parser.mly"
                   ( Var dv )
-# 8808 "flambda_parser_in.ml"
+# 8810 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8838,7 +8840,7 @@ module Tables = struct
         let ri : (
 # 268 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8842 "flambda_parser_in.ml"
+# 8844 "flambda_parser_in.ml"
         ) = Obj.magic ri in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -8847,11 +8849,11 @@ module Tables = struct
         let _v : (
 # 269 "flambda_parser.mly"
       (Fexpr.rec_info)
-# 8851 "flambda_parser_in.ml"
+# 8853 "flambda_parser_in.ml"
         ) = 
-# 1082 "flambda_parser.mly"
+# 1087 "flambda_parser.mly"
                                   ( ri )
-# 8855 "flambda_parser_in.ml"
+# 8857 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8869,11 +8871,11 @@ module Tables = struct
         let _v : (
 # 281 "flambda_parser.mly"
       (Fexpr.is_recursive)
-# 8873 "flambda_parser_in.ml"
+# 8875 "flambda_parser_in.ml"
         ) = 
 # 385 "flambda_parser.mly"
     ( Nonrecursive )
-# 8877 "flambda_parser_in.ml"
+# 8879 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8898,11 +8900,11 @@ module Tables = struct
         let _v : (
 # 281 "flambda_parser.mly"
       (Fexpr.is_recursive)
-# 8902 "flambda_parser_in.ml"
+# 8904 "flambda_parser_in.ml"
         ) = 
 # 386 "flambda_parser.mly"
             ( Recursive )
-# 8906 "flambda_parser_in.ml"
+# 8908 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8927,11 +8929,11 @@ module Tables = struct
         let _v : (
 # 270 "flambda_parser.mly"
       (Fexpr.region)
-# 8931 "flambda_parser_in.ml"
+# 8933 "flambda_parser_in.ml"
         ) = 
-# 925 "flambda_parser.mly"
+# 930 "flambda_parser.mly"
                  ( Named v )
-# 8935 "flambda_parser_in.ml"
+# 8937 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8956,11 +8958,11 @@ module Tables = struct
         let _v : (
 # 270 "flambda_parser.mly"
       (Fexpr.region)
-# 8960 "flambda_parser_in.ml"
+# 8962 "flambda_parser_in.ml"
         ) = 
-# 926 "flambda_parser.mly"
+# 931 "flambda_parser.mly"
                  ( Toplevel )
-# 8964 "flambda_parser_in.ml"
+# 8966 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -8981,15 +8983,15 @@ module Tables = struct
         let c : (
 # 251 "flambda_parser.mly"
       (Fexpr.continuation)
-# 8985 "flambda_parser_in.ml"
+# 8987 "flambda_parser_in.ml"
         ) = Obj.magic c in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_c_ in
         let _endpos = _endpos_c_ in
         let _v : 'tv_result_continuation = 
-# 930 "flambda_parser.mly"
+# 935 "flambda_parser.mly"
                      ( Return c )
-# 8993 "flambda_parser_in.ml"
+# 8995 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9012,9 +9014,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_result_continuation = 
-# 931 "flambda_parser.mly"
+# 936 "flambda_parser.mly"
               ( Never_returns )
-# 9018 "flambda_parser_in.ml"
+# 9020 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9030,9 +9032,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_return_arity = 
-# 750 "flambda_parser.mly"
+# 755 "flambda_parser.mly"
     ( None )
-# 9036 "flambda_parser_in.ml"
+# 9038 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9059,16 +9061,16 @@ module Tables = struct
         let k : (
 # 263 "flambda_parser.mly"
       (Fexpr.kind_with_subkind list)
-# 9063 "flambda_parser_in.ml"
+# 9065 "flambda_parser_in.ml"
         ) = Obj.magic k in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_k_ in
         let _v : 'tv_return_arity = 
-# 751 "flambda_parser.mly"
+# 756 "flambda_parser.mly"
                                   ( Some k )
-# 9072 "flambda_parser_in.ml"
+# 9074 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9089,7 +9091,7 @@ module Tables = struct
         let x : (
 # 254 "flambda_parser.mly"
       (Fexpr.field_of_block)
-# 9093 "flambda_parser_in.ml"
+# 9095 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9097,7 +9099,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_COMMA_field_of_block_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9101 "flambda_parser_in.ml"
+# 9103 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9132,7 +9134,7 @@ module Tables = struct
         let x : (
 # 254 "flambda_parser.mly"
       (Fexpr.field_of_block)
-# 9136 "flambda_parser_in.ml"
+# 9138 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9140,7 +9142,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_COMMA_field_of_block_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9144 "flambda_parser_in.ml"
+# 9146 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9161,7 +9163,7 @@ module Tables = struct
         let x : (
 # 258 "flambda_parser.mly"
       (float Fexpr.or_variable)
-# 9165 "flambda_parser_in.ml"
+# 9167 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9169,7 +9171,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_COMMA_float_or_variable_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9173 "flambda_parser_in.ml"
+# 9175 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9204,7 +9206,7 @@ module Tables = struct
         let x : (
 # 258 "flambda_parser.mly"
       (float Fexpr.or_variable)
-# 9208 "flambda_parser_in.ml"
+# 9210 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9212,7 +9214,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_COMMA_float_or_variable_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9216 "flambda_parser_in.ml"
+# 9218 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9237,7 +9239,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_COMMA_kinded_variable_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9241 "flambda_parser_in.ml"
+# 9243 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9276,7 +9278,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_COMMA_kinded_variable_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9280 "flambda_parser_in.ml"
+# 9282 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9301,7 +9303,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_COMMA_simple_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9305 "flambda_parser_in.ml"
+# 9307 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9340,7 +9342,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_COMMA_simple_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9344 "flambda_parser_in.ml"
+# 9346 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9365,7 +9367,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_KWD_AND_let_binding_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9369 "flambda_parser_in.ml"
+# 9371 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9404,7 +9406,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_KWD_AND_let_binding_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9408 "flambda_parser_in.ml"
+# 9410 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9429,7 +9431,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_KWD_AND_static_closure_binding_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9433 "flambda_parser_in.ml"
+# 9435 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9468,7 +9470,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_KWD_AND_static_closure_binding_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9472 "flambda_parser_in.ml"
+# 9474 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9489,7 +9491,7 @@ module Tables = struct
         let x : (
 # 278 "flambda_parser.mly"
       (Fexpr.symbol_binding)
-# 9493 "flambda_parser_in.ml"
+# 9495 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9497,7 +9499,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_KWD_AND_symbol_binding_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9501 "flambda_parser_in.ml"
+# 9503 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9532,7 +9534,7 @@ module Tables = struct
         let x : (
 # 278 "flambda_parser.mly"
       (Fexpr.symbol_binding)
-# 9536 "flambda_parser_in.ml"
+# 9538 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9540,7 +9542,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_KWD_AND_symbol_binding_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9544 "flambda_parser_in.ml"
+# 9546 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9565,7 +9567,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_KWD_ANDWHERE_continuation_binding_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9569 "flambda_parser_in.ml"
+# 9571 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9604,7 +9606,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_KWD_ANDWHERE_continuation_binding_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9608 "flambda_parser_in.ml"
+# 9610 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9629,7 +9631,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_PIPE_nonconst_ctor_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9633 "flambda_parser_in.ml"
+# 9635 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9668,7 +9670,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_PIPE_nonconst_ctor_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9672 "flambda_parser_in.ml"
+# 9674 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9693,7 +9695,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_PIPE_switch_case_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9697 "flambda_parser_in.ml"
+# 9699 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9732,7 +9734,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_PIPE_switch_case_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9736 "flambda_parser_in.ml"
+# 9738 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9753,7 +9755,7 @@ module Tables = struct
         let x : (
 # 258 "flambda_parser.mly"
       (float Fexpr.or_variable)
-# 9757 "flambda_parser_in.ml"
+# 9759 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9761,7 +9763,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_SEMICOLON_float_or_variable_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9765 "flambda_parser_in.ml"
+# 9767 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9796,7 +9798,7 @@ module Tables = struct
         let x : (
 # 258 "flambda_parser.mly"
       (float Fexpr.or_variable)
-# 9800 "flambda_parser_in.ml"
+# 9802 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9804,7 +9806,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_SEMICOLON_float_or_variable_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9808 "flambda_parser_in.ml"
+# 9810 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9829,7 +9831,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_SEMICOLON_value_slot_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9833 "flambda_parser_in.ml"
+# 9835 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9868,7 +9870,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_SEMICOLON_value_slot_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9872 "flambda_parser_in.ml"
+# 9874 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9889,7 +9891,7 @@ module Tables = struct
         let x : (
 # 262 "flambda_parser.mly"
       (Fexpr.kind_with_subkind)
-# 9893 "flambda_parser_in.ml"
+# 9895 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9897,7 +9899,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_STAR_kind_with_subkind_ = 
 # 250 "<standard.mly>"
     ( [ x ] )
-# 9901 "flambda_parser_in.ml"
+# 9903 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9932,7 +9934,7 @@ module Tables = struct
         let x : (
 # 262 "flambda_parser.mly"
       (Fexpr.kind_with_subkind)
-# 9936 "flambda_parser_in.ml"
+# 9938 "flambda_parser_in.ml"
         ) = Obj.magic x in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_x_ in
@@ -9940,7 +9942,7 @@ module Tables = struct
         let _v : 'tv_separated_nonempty_list_STAR_kind_with_subkind_ = 
 # 253 "<standard.mly>"
     ( x :: xs )
-# 9944 "flambda_parser_in.ml"
+# 9946 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9956,9 +9958,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_signed_or_unsigned = 
-# 536 "flambda_parser.mly"
+# 538 "flambda_parser.mly"
     ( Signed )
-# 9962 "flambda_parser_in.ml"
+# 9964 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -9981,9 +9983,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__1_ in
         let _v : 'tv_signed_or_unsigned = 
-# 537 "flambda_parser.mly"
+# 539 "flambda_parser.mly"
                  ( Unsigned )
-# 9987 "flambda_parser_in.ml"
+# 9989 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10006,9 +10008,9 @@ module Tables = struct
         let _startpos = _startpos_s_ in
         let _endpos = _endpos_s_ in
         let _v : 'tv_simple = 
-# 1065 "flambda_parser.mly"
+# 1070 "flambda_parser.mly"
                ( Symbol s )
-# 10012 "flambda_parser_in.ml"
+# 10014 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10031,9 +10033,9 @@ module Tables = struct
         let _startpos = _startpos_v_ in
         let _endpos = _endpos_v_ in
         let _v : 'tv_simple = 
-# 1066 "flambda_parser.mly"
+# 1071 "flambda_parser.mly"
                  ( Var v )
-# 10037 "flambda_parser_in.ml"
+# 10039 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10054,15 +10056,15 @@ module Tables = struct
         let c : (
 # 250 "flambda_parser.mly"
       (Fexpr.const)
-# 10058 "flambda_parser_in.ml"
+# 10060 "flambda_parser_in.ml"
         ) = Obj.magic c in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_c_ in
         let _endpos = _endpos_c_ in
         let _v : 'tv_simple = 
-# 1067 "flambda_parser.mly"
+# 1072 "flambda_parser.mly"
               ( Const c )
-# 10066 "flambda_parser_in.ml"
+# 10068 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10099,9 +10101,9 @@ module Tables = struct
         let _startpos = _startpos_s_ in
         let _endpos = _endpos_c_ in
         let _v : 'tv_simple = 
-# 1068 "flambda_parser.mly"
+# 1073 "flambda_parser.mly"
                                     ( Coerce (s, c) )
-# 10105 "flambda_parser_in.ml"
+# 10107 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10117,9 +10119,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_simple_args = 
-# 1041 "flambda_parser.mly"
+# 1046 "flambda_parser.mly"
     ( [] )
-# 10123 "flambda_parser_in.ml"
+# 10125 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10156,9 +10158,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__3_ in
         let _v : 'tv_simple_args = 
-# 1042 "flambda_parser.mly"
+# 1047 "flambda_parser.mly"
                                                               ( s )
-# 10162 "flambda_parser_in.ml"
+# 10164 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10174,9 +10176,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_size_opt = 
-# 504 "flambda_parser.mly"
+# 506 "flambda_parser.mly"
     ( None )
-# 10180 "flambda_parser_in.ml"
+# 10182 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10220,9 +10222,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : 'tv_size_opt = 
-# 505 "flambda_parser.mly"
+# 507 "flambda_parser.mly"
                                                ( Some size )
-# 10226 "flambda_parser_in.ml"
+# 10228 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10247,11 +10249,11 @@ module Tables = struct
         let _v : (
 # 271 "flambda_parser.mly"
       (Fexpr.special_continuation)
-# 10251 "flambda_parser_in.ml"
+# 10253 "flambda_parser_in.ml"
         ) = 
-# 1125 "flambda_parser.mly"
+# 1130 "flambda_parser.mly"
              ( Done )
-# 10255 "flambda_parser_in.ml"
+# 10257 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10276,11 +10278,11 @@ module Tables = struct
         let _v : (
 # 271 "flambda_parser.mly"
       (Fexpr.special_continuation)
-# 10280 "flambda_parser_in.ml"
+# 10282 "flambda_parser_in.ml"
         ) = 
-# 1126 "flambda_parser.mly"
+# 1131 "flambda_parser.mly"
               ( Error )
-# 10284 "flambda_parser_in.ml"
+# 10286 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10298,69 +10300,11 @@ module Tables = struct
         let _v : (
 # 272 "flambda_parser.mly"
       (Fexpr.standard_int)
-# 10302 "flambda_parser_in.ml"
-        ) = 
-# 508 "flambda_parser.mly"
-    ( Tagged_immediate )
-# 10306 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 272 "flambda_parser.mly"
-      (Fexpr.standard_int)
-# 10331 "flambda_parser_in.ml"
-        ) = 
-# 509 "flambda_parser.mly"
-            ( Naked_immediate )
-# 10335 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = _1;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        } = _menhir_stack in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__1_ in
-        let _v : (
-# 272 "flambda_parser.mly"
-      (Fexpr.standard_int)
-# 10360 "flambda_parser_in.ml"
+# 10304 "flambda_parser_in.ml"
         ) = 
 # 510 "flambda_parser.mly"
-              ( Naked_int32 )
-# 10364 "flambda_parser_in.ml"
+    ( Tagged_immediate )
+# 10308 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10385,11 +10329,11 @@ module Tables = struct
         let _v : (
 # 272 "flambda_parser.mly"
       (Fexpr.standard_int)
-# 10389 "flambda_parser_in.ml"
+# 10333 "flambda_parser_in.ml"
         ) = 
 # 511 "flambda_parser.mly"
-              ( Naked_int64 )
-# 10393 "flambda_parser_in.ml"
+            ( Naked_immediate )
+# 10337 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10414,11 +10358,69 @@ module Tables = struct
         let _v : (
 # 272 "flambda_parser.mly"
       (Fexpr.standard_int)
-# 10418 "flambda_parser_in.ml"
+# 10362 "flambda_parser_in.ml"
         ) = 
 # 512 "flambda_parser.mly"
+              ( Naked_int32 )
+# 10366 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 272 "flambda_parser.mly"
+      (Fexpr.standard_int)
+# 10391 "flambda_parser_in.ml"
+        ) = 
+# 513 "flambda_parser.mly"
+              ( Naked_int64 )
+# 10395 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = _1;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        } = _menhir_stack in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__1_ in
+        let _v : (
+# 272 "flambda_parser.mly"
+      (Fexpr.standard_int)
+# 10420 "flambda_parser_in.ml"
+        ) = 
+# 514 "flambda_parser.mly"
                   ( Naked_nativeint )
-# 10422 "flambda_parser_in.ml"
+# 10424 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10457,7 +10459,7 @@ module Tables = struct
         let _v : 'tv_static_closure_binding = 
 # 374 "flambda_parser.mly"
     ( { symbol; fun_decl } )
-# 10461 "flambda_parser_in.ml"
+# 10463 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10512,7 +10514,7 @@ module Tables = struct
         let m : (
 # 265 "flambda_parser.mly"
       (Fexpr.mutability)
-# 10516 "flambda_parser_in.ml"
+# 10518 "flambda_parser_in.ml"
         ) = Obj.magic m in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -10522,16 +10524,16 @@ module Tables = struct
           let elements = 
 # 241 "<standard.mly>"
     ( xs )
-# 10526 "flambda_parser_in.ml"
+# 10528 "flambda_parser_in.ml"
            in
           (
-# 983 "flambda_parser.mly"
+# 988 "flambda_parser.mly"
     ( (Block { tag; mutability = m; elements } : static_data) )
-# 10531 "flambda_parser_in.ml"
+# 10533 "flambda_parser_in.ml"
            : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10535 "flambda_parser_in.ml"
+# 10537 "flambda_parser_in.ml"
           ))
         in
         {
@@ -10553,7 +10555,7 @@ module Tables = struct
         let f : (
 # 68 "flambda_parser.mly"
        (float)
-# 10557 "flambda_parser_in.ml"
+# 10559 "flambda_parser_in.ml"
         ) = Obj.magic f in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_f_ in
@@ -10561,11 +10563,11 @@ module Tables = struct
         let _v : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10565 "flambda_parser_in.ml"
+# 10567 "flambda_parser_in.ml"
         ) = 
-# 984 "flambda_parser.mly"
+# 989 "flambda_parser.mly"
               ( Boxed_float (Const f) )
-# 10569 "flambda_parser_in.ml"
+# 10571 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10586,7 +10588,7 @@ module Tables = struct
         let i : (
 # 74 "flambda_parser.mly"
        (string * char option)
-# 10590 "flambda_parser_in.ml"
+# 10592 "flambda_parser_in.ml"
         ) = Obj.magic i in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_i_ in
@@ -10594,11 +10596,11 @@ module Tables = struct
         let _v : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10598 "flambda_parser_in.ml"
+# 10600 "flambda_parser_in.ml"
         ) = 
-# 985 "flambda_parser.mly"
+# 990 "flambda_parser.mly"
             ( make_boxed_const_int i )
-# 10602 "flambda_parser_in.ml"
+# 10604 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10631,7 +10633,7 @@ module Tables = struct
         let k : (
 # 277 "flambda_parser.mly"
       (Fexpr.variable -> Fexpr.static_data)
-# 10635 "flambda_parser_in.ml"
+# 10637 "flambda_parser_in.ml"
         ) = Obj.magic k in
         let _2 : unit = Obj.magic _2 in
         let v : 'tv_variable = Obj.magic v in
@@ -10641,11 +10643,11 @@ module Tables = struct
         let _v : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10645 "flambda_parser_in.ml"
+# 10647 "flambda_parser_in.ml"
         ) = 
-# 986 "flambda_parser.mly"
+# 991 "flambda_parser.mly"
                                               ( k v )
-# 10649 "flambda_parser_in.ml"
+# 10651 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10692,16 +10694,16 @@ module Tables = struct
           let fs = 
 # 241 "<standard.mly>"
     ( xs )
-# 10696 "flambda_parser_in.ml"
+# 10698 "flambda_parser_in.ml"
            in
           (
-# 990 "flambda_parser.mly"
+# 995 "flambda_parser.mly"
     ( Immutable_float_block fs )
-# 10701 "flambda_parser_in.ml"
+# 10703 "flambda_parser_in.ml"
            : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10705 "flambda_parser_in.ml"
+# 10707 "flambda_parser_in.ml"
           ))
         in
         {
@@ -10749,16 +10751,16 @@ module Tables = struct
           let fs = 
 # 241 "<standard.mly>"
     ( xs )
-# 10753 "flambda_parser_in.ml"
+# 10755 "flambda_parser_in.ml"
            in
           (
-# 994 "flambda_parser.mly"
+# 999 "flambda_parser.mly"
     ( Immutable_float_array fs )
-# 10758 "flambda_parser_in.ml"
+# 10760 "flambda_parser_in.ml"
            : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10762 "flambda_parser_in.ml"
+# 10764 "flambda_parser_in.ml"
           ))
         in
         {
@@ -10786,7 +10788,7 @@ module Tables = struct
         let kind : (
 # 246 "flambda_parser.mly"
       (Fexpr.empty_array_kind)
-# 10790 "flambda_parser_in.ml"
+# 10792 "flambda_parser_in.ml"
         ) = Obj.magic kind in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -10795,11 +10797,11 @@ module Tables = struct
         let _v : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10799 "flambda_parser_in.ml"
+# 10801 "flambda_parser_in.ml"
         ) = 
-# 995 "flambda_parser.mly"
+# 1000 "flambda_parser.mly"
                                                    ( Empty_array kind )
-# 10803 "flambda_parser_in.ml"
+# 10805 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10826,7 +10828,7 @@ module Tables = struct
         let s : (
 # 104 "flambda_parser.mly"
       (string)
-# 10830 "flambda_parser_in.ml"
+# 10832 "flambda_parser_in.ml"
         ) = Obj.magic s in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -10835,11 +10837,11 @@ module Tables = struct
         let _v : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10839 "flambda_parser_in.ml"
+# 10841 "flambda_parser_in.ml"
         ) = 
-# 996 "flambda_parser.mly"
+# 1001 "flambda_parser.mly"
                             ( Mutable_string { initial_value = s } )
-# 10843 "flambda_parser_in.ml"
+# 10845 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10860,7 +10862,7 @@ module Tables = struct
         let s : (
 # 104 "flambda_parser.mly"
       (string)
-# 10864 "flambda_parser_in.ml"
+# 10866 "flambda_parser_in.ml"
         ) = Obj.magic s in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_s_ in
@@ -10868,11 +10870,11 @@ module Tables = struct
         let _v : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10872 "flambda_parser_in.ml"
+# 10874 "flambda_parser_in.ml"
         ) = 
-# 997 "flambda_parser.mly"
+# 1002 "flambda_parser.mly"
                ( Immutable_string s )
-# 10876 "flambda_parser_in.ml"
+# 10878 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10905,7 +10907,7 @@ module Tables = struct
         let sp : (
 # 273 "flambda_parser.mly"
       (Fexpr.static_data)
-# 10909 "flambda_parser_in.ml"
+# 10911 "flambda_parser_in.ml"
         ) = Obj.magic sp in
         let _2 : unit = Obj.magic _2 in
         let s : 'tv_symbol = Obj.magic s in
@@ -10915,11 +10917,11 @@ module Tables = struct
         let _v : (
 # 274 "flambda_parser.mly"
       (Fexpr.static_data_binding)
-# 10919 "flambda_parser_in.ml"
+# 10921 "flambda_parser_in.ml"
         ) = 
-# 977 "flambda_parser.mly"
+# 982 "flambda_parser.mly"
     ( { symbol = s; defining_expr = sp } )
-# 10923 "flambda_parser_in.ml"
+# 10925 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10951,11 +10953,11 @@ module Tables = struct
         let _v : (
 # 277 "flambda_parser.mly"
       (Fexpr.variable -> Fexpr.static_data)
-# 10955 "flambda_parser_in.ml"
+# 10957 "flambda_parser_in.ml"
         ) = 
-# 1001 "flambda_parser.mly"
+# 1006 "flambda_parser.mly"
                         ( fun v -> Boxed_float (Var v) )
-# 10959 "flambda_parser_in.ml"
+# 10961 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -10987,11 +10989,11 @@ module Tables = struct
         let _v : (
 # 277 "flambda_parser.mly"
       (Fexpr.variable -> Fexpr.static_data)
-# 10991 "flambda_parser_in.ml"
+# 10993 "flambda_parser_in.ml"
         ) = 
-# 1002 "flambda_parser.mly"
+# 1007 "flambda_parser.mly"
                         ( fun v -> Boxed_int32 (Var v) )
-# 10995 "flambda_parser_in.ml"
+# 10997 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11023,11 +11025,11 @@ module Tables = struct
         let _v : (
 # 277 "flambda_parser.mly"
       (Fexpr.variable -> Fexpr.static_data)
-# 11027 "flambda_parser_in.ml"
+# 11029 "flambda_parser_in.ml"
         ) = 
-# 1003 "flambda_parser.mly"
+# 1008 "flambda_parser.mly"
                         ( fun v -> Boxed_int64 (Var v) )
-# 11031 "flambda_parser_in.ml"
+# 11033 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11059,11 +11061,11 @@ module Tables = struct
         let _v : (
 # 277 "flambda_parser.mly"
       (Fexpr.variable -> Fexpr.static_data)
-# 11063 "flambda_parser_in.ml"
+# 11065 "flambda_parser_in.ml"
         ) = 
-# 1004 "flambda_parser.mly"
+# 1009 "flambda_parser.mly"
                             ( fun v -> Boxed_nativeint (Var v) )
-# 11067 "flambda_parser_in.ml"
+# 11069 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11109,7 +11111,7 @@ module Tables = struct
         let _v : 'tv_static_set_of_closures = 
 # 382 "flambda_parser.mly"
     ( { bindings; elements } )
-# 11113 "flambda_parser_in.ml"
+# 11115 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11130,13 +11132,13 @@ module Tables = struct
         let i : (
 # 74 "flambda_parser.mly"
        (string * char option)
-# 11134 "flambda_parser_in.ml"
+# 11136 "flambda_parser_in.ml"
         ) = Obj.magic i in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_i_ in
         let _endpos = _endpos_i_ in
         let _v : 'tv_string_accessor_width = 
-# 466 "flambda_parser.mly"
+# 468 "flambda_parser.mly"
     ( let (i,c) = i in
       match int_of_string i, c with
       | 8, None -> Eight
@@ -11150,7 +11152,7 @@ module Tables = struct
       | 512, Some 'a' -> Five_twelve {aligned = true}
       | 512, Some 'u' -> Five_twelve {aligned = false}
       | _, _ -> Misc.fatal_error "invalid string accessor width" )
-# 11154 "flambda_parser_in.ml"
+# 11156 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11175,191 +11177,191 @@ module Tables = struct
         let _v : (
 # 275 "flambda_parser.mly"
       (Fexpr.subkind)
-# 11179 "flambda_parser_in.ml"
-        ) = 
-# 717 "flambda_parser.mly"
-            ( Anything )
-# 11183 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _;
-          CamlinternalMenhirLib.EngineTypes.semv = _2;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
-          CamlinternalMenhirLib.EngineTypes.next = {
-            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-            CamlinternalMenhirLib.EngineTypes.semv = _1;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-          };
-        } = _menhir_stack in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__2_ in
-        let _v : (
-# 275 "flambda_parser.mly"
-      (Fexpr.subkind)
-# 11215 "flambda_parser_in.ml"
-        ) = 
-# 718 "flambda_parser.mly"
-                        ( Boxed_float )
-# 11219 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _;
-          CamlinternalMenhirLib.EngineTypes.semv = _2;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
-          CamlinternalMenhirLib.EngineTypes.next = {
-            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-            CamlinternalMenhirLib.EngineTypes.semv = _1;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-          };
-        } = _menhir_stack in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__2_ in
-        let _v : (
-# 275 "flambda_parser.mly"
-      (Fexpr.subkind)
-# 11251 "flambda_parser_in.ml"
-        ) = 
-# 719 "flambda_parser.mly"
-                        ( Boxed_int32 )
-# 11255 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _;
-          CamlinternalMenhirLib.EngineTypes.semv = _2;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
-          CamlinternalMenhirLib.EngineTypes.next = {
-            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-            CamlinternalMenhirLib.EngineTypes.semv = _1;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-          };
-        } = _menhir_stack in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__2_ in
-        let _v : (
-# 275 "flambda_parser.mly"
-      (Fexpr.subkind)
-# 11287 "flambda_parser_in.ml"
-        ) = 
-# 720 "flambda_parser.mly"
-                        ( Boxed_int64 )
-# 11291 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _;
-          CamlinternalMenhirLib.EngineTypes.semv = _2;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
-          CamlinternalMenhirLib.EngineTypes.next = {
-            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-            CamlinternalMenhirLib.EngineTypes.semv = _1;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-          };
-        } = _menhir_stack in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__2_ in
-        let _v : (
-# 275 "flambda_parser.mly"
-      (Fexpr.subkind)
-# 11323 "flambda_parser_in.ml"
-        ) = 
-# 721 "flambda_parser.mly"
-                            ( Boxed_nativeint )
-# 11327 "flambda_parser_in.ml"
-         in
-        {
-          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
-          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-        });
-      (fun _menhir_env ->
-        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
-        let {
-          CamlinternalMenhirLib.EngineTypes.state = _;
-          CamlinternalMenhirLib.EngineTypes.semv = _2;
-          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
-          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
-          CamlinternalMenhirLib.EngineTypes.next = {
-            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
-            CamlinternalMenhirLib.EngineTypes.semv = _1;
-            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
-            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
-            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
-          };
-        } = _menhir_stack in
-        let _2 : unit = Obj.magic _2 in
-        let _1 : unit = Obj.magic _1 in
-        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
-        let _startpos = _startpos__1_ in
-        let _endpos = _endpos__2_ in
-        let _v : (
-# 275 "flambda_parser.mly"
-      (Fexpr.subkind)
-# 11359 "flambda_parser_in.ml"
+# 11181 "flambda_parser_in.ml"
         ) = 
 # 722 "flambda_parser.mly"
+            ( Anything )
+# 11185 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _;
+          CamlinternalMenhirLib.EngineTypes.semv = _2;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
+          CamlinternalMenhirLib.EngineTypes.next = {
+            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+            CamlinternalMenhirLib.EngineTypes.semv = _1;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+          };
+        } = _menhir_stack in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__2_ in
+        let _v : (
+# 275 "flambda_parser.mly"
+      (Fexpr.subkind)
+# 11217 "flambda_parser_in.ml"
+        ) = 
+# 723 "flambda_parser.mly"
+                        ( Boxed_float )
+# 11221 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _;
+          CamlinternalMenhirLib.EngineTypes.semv = _2;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
+          CamlinternalMenhirLib.EngineTypes.next = {
+            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+            CamlinternalMenhirLib.EngineTypes.semv = _1;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+          };
+        } = _menhir_stack in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__2_ in
+        let _v : (
+# 275 "flambda_parser.mly"
+      (Fexpr.subkind)
+# 11253 "flambda_parser_in.ml"
+        ) = 
+# 724 "flambda_parser.mly"
+                        ( Boxed_int32 )
+# 11257 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _;
+          CamlinternalMenhirLib.EngineTypes.semv = _2;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
+          CamlinternalMenhirLib.EngineTypes.next = {
+            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+            CamlinternalMenhirLib.EngineTypes.semv = _1;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+          };
+        } = _menhir_stack in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__2_ in
+        let _v : (
+# 275 "flambda_parser.mly"
+      (Fexpr.subkind)
+# 11289 "flambda_parser_in.ml"
+        ) = 
+# 725 "flambda_parser.mly"
+                        ( Boxed_int64 )
+# 11293 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _;
+          CamlinternalMenhirLib.EngineTypes.semv = _2;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
+          CamlinternalMenhirLib.EngineTypes.next = {
+            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+            CamlinternalMenhirLib.EngineTypes.semv = _1;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+          };
+        } = _menhir_stack in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__2_ in
+        let _v : (
+# 275 "flambda_parser.mly"
+      (Fexpr.subkind)
+# 11325 "flambda_parser_in.ml"
+        ) = 
+# 726 "flambda_parser.mly"
+                            ( Boxed_nativeint )
+# 11329 "flambda_parser_in.ml"
+         in
+        {
+          CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+          CamlinternalMenhirLib.EngineTypes.semv = Obj.repr _v;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos;
+          CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+        });
+      (fun _menhir_env ->
+        let _menhir_stack = _menhir_env.CamlinternalMenhirLib.EngineTypes.stack in
+        let {
+          CamlinternalMenhirLib.EngineTypes.state = _;
+          CamlinternalMenhirLib.EngineTypes.semv = _2;
+          CamlinternalMenhirLib.EngineTypes.startp = _startpos__2_;
+          CamlinternalMenhirLib.EngineTypes.endp = _endpos__2_;
+          CamlinternalMenhirLib.EngineTypes.next = {
+            CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
+            CamlinternalMenhirLib.EngineTypes.semv = _1;
+            CamlinternalMenhirLib.EngineTypes.startp = _startpos__1_;
+            CamlinternalMenhirLib.EngineTypes.endp = _endpos__1_;
+            CamlinternalMenhirLib.EngineTypes.next = _menhir_stack;
+          };
+        } = _menhir_stack in
+        let _2 : unit = Obj.magic _2 in
+        let _1 : unit = Obj.magic _1 in
+        let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
+        let _startpos = _startpos__1_ in
+        let _endpos = _endpos__2_ in
+        let _v : (
+# 275 "flambda_parser.mly"
+      (Fexpr.subkind)
+# 11361 "flambda_parser_in.ml"
+        ) = 
+# 727 "flambda_parser.mly"
                        ( Tagged_immediate )
-# 11363 "flambda_parser_in.ml"
+# 11365 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11398,11 +11400,11 @@ module Tables = struct
         let _v : (
 # 275 "flambda_parser.mly"
       (Fexpr.subkind)
-# 11402 "flambda_parser_in.ml"
+# 11404 "flambda_parser_in.ml"
         ) = 
-# 723 "flambda_parser.mly"
+# 728 "flambda_parser.mly"
                                              ( Float_block { num_fields } )
-# 11406 "flambda_parser_in.ml"
+# 11408 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11441,11 +11443,11 @@ module Tables = struct
         let _v : (
 # 275 "flambda_parser.mly"
       (Fexpr.subkind)
-# 11445 "flambda_parser_in.ml"
+# 11447 "flambda_parser_in.ml"
         ) = 
-# 725 "flambda_parser.mly"
+# 730 "flambda_parser.mly"
     ( let consts, non_consts = ctors in Variant { consts; non_consts; })
-# 11449 "flambda_parser_in.ml"
+# 11451 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11477,11 +11479,11 @@ module Tables = struct
         let _v : (
 # 275 "flambda_parser.mly"
       (Fexpr.subkind)
-# 11481 "flambda_parser_in.ml"
+# 11483 "flambda_parser_in.ml"
         ) = 
-# 726 "flambda_parser.mly"
+# 731 "flambda_parser.mly"
                         ( Float_array )
-# 11485 "flambda_parser_in.ml"
+# 11487 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11513,11 +11515,11 @@ module Tables = struct
         let _v : (
 # 275 "flambda_parser.mly"
       (Fexpr.subkind)
-# 11517 "flambda_parser_in.ml"
+# 11519 "flambda_parser_in.ml"
         ) = 
-# 727 "flambda_parser.mly"
+# 732 "flambda_parser.mly"
                       ( Immediate_array )
-# 11521 "flambda_parser_in.ml"
+# 11523 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11549,11 +11551,11 @@ module Tables = struct
         let _v : (
 # 275 "flambda_parser.mly"
       (Fexpr.subkind)
-# 11553 "flambda_parser_in.ml"
+# 11555 "flambda_parser_in.ml"
         ) = 
-# 728 "flambda_parser.mly"
+# 733 "flambda_parser.mly"
                       ( Value_array )
-# 11557 "flambda_parser_in.ml"
+# 11559 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11585,11 +11587,11 @@ module Tables = struct
         let _v : (
 # 275 "flambda_parser.mly"
       (Fexpr.subkind)
-# 11589 "flambda_parser_in.ml"
+# 11591 "flambda_parser_in.ml"
         ) = 
-# 729 "flambda_parser.mly"
+# 734 "flambda_parser.mly"
                       ( Generic_array )
-# 11593 "flambda_parser_in.ml"
+# 11595 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11622,12 +11624,12 @@ module Tables = struct
           let cs = 
 # 241 "<standard.mly>"
     ( xs )
-# 11626 "flambda_parser_in.ml"
+# 11628 "flambda_parser_in.ml"
            in
           (
-# 689 "flambda_parser.mly"
+# 694 "flambda_parser.mly"
                                                          ( cs )
-# 11631 "flambda_parser_in.ml"
+# 11633 "flambda_parser_in.ml"
            : 'tv_switch)
         in
         {
@@ -11665,9 +11667,9 @@ module Tables = struct
         let _startpos = _startpos_i_ in
         let _endpos = _endpos_ac_ in
         let _v : 'tv_switch_case = 
-# 685 "flambda_parser.mly"
+# 690 "flambda_parser.mly"
                                                 ( i,ac )
-# 11671 "flambda_parser_in.ml"
+# 11673 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11688,7 +11690,7 @@ module Tables = struct
         let e : (
 # 105 "flambda_parser.mly"
       (Fexpr.compilation_unit option * string)
-# 11692 "flambda_parser_in.ml"
+# 11694 "flambda_parser_in.ml"
         ) = Obj.magic e in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_e_ in
@@ -11697,9 +11699,9 @@ module Tables = struct
           let _endpos = _endpos_e_ in
           let _startpos = _startpos_e_ in
           (
-# 1108 "flambda_parser.mly"
+# 1113 "flambda_parser.mly"
                ( make_located e (_startpos, _endpos) )
-# 11703 "flambda_parser_in.ml"
+# 11705 "flambda_parser_in.ml"
            : 'tv_symbol)
         in
         {
@@ -11721,7 +11723,7 @@ module Tables = struct
         let s : (
 # 274 "flambda_parser.mly"
       (Fexpr.static_data_binding)
-# 11725 "flambda_parser_in.ml"
+# 11727 "flambda_parser_in.ml"
         ) = Obj.magic s in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_s_ in
@@ -11729,11 +11731,11 @@ module Tables = struct
         let _v : (
 # 278 "flambda_parser.mly"
       (Fexpr.symbol_binding)
-# 11733 "flambda_parser_in.ml"
+# 11735 "flambda_parser_in.ml"
         ) = 
 # 322 "flambda_parser.mly"
                             ( Data s )
-# 11737 "flambda_parser_in.ml"
+# 11739 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11758,11 +11760,11 @@ module Tables = struct
         let _v : (
 # 278 "flambda_parser.mly"
       (Fexpr.symbol_binding)
-# 11762 "flambda_parser_in.ml"
+# 11764 "flambda_parser_in.ml"
         ) = 
 # 323 "flambda_parser.mly"
                 ( Code code )
-# 11766 "flambda_parser_in.ml"
+# 11768 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11787,11 +11789,11 @@ module Tables = struct
         let _v : (
 # 278 "flambda_parser.mly"
       (Fexpr.symbol_binding)
-# 11791 "flambda_parser_in.ml"
+# 11793 "flambda_parser_in.ml"
         ) = 
 # 324 "flambda_parser.mly"
                            ( Deleted_code code_id )
-# 11795 "flambda_parser_in.ml"
+# 11797 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11816,11 +11818,11 @@ module Tables = struct
         let _v : (
 # 278 "flambda_parser.mly"
       (Fexpr.symbol_binding)
-# 11820 "flambda_parser_in.ml"
+# 11822 "flambda_parser_in.ml"
         ) = 
 # 325 "flambda_parser.mly"
                                ( Closure s )
-# 11824 "flambda_parser_in.ml"
+# 11826 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11845,11 +11847,11 @@ module Tables = struct
         let _v : (
 # 278 "flambda_parser.mly"
       (Fexpr.symbol_binding)
-# 11849 "flambda_parser_in.ml"
+# 11851 "flambda_parser_in.ml"
         ) = 
 # 326 "flambda_parser.mly"
                                ( Set_of_closures s )
-# 11853 "flambda_parser_in.ml"
+# 11855 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11870,7 +11872,7 @@ module Tables = struct
         let tag : (
 # 74 "flambda_parser.mly"
        (string * char option)
-# 11874 "flambda_parser_in.ml"
+# 11876 "flambda_parser_in.ml"
         ) = Obj.magic tag in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_tag_ in
@@ -11879,9 +11881,9 @@ module Tables = struct
           let _endpos = _endpos_tag_ in
           let _startpos = _startpos_tag_ in
           (
-# 1014 "flambda_parser.mly"
+# 1019 "flambda_parser.mly"
             ( make_tag ~loc:(make_loc (_startpos, _endpos)) tag )
-# 11885 "flambda_parser_in.ml"
+# 11887 "flambda_parser_in.ml"
            : 'tv_tag)
         in
         {
@@ -11926,9 +11928,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : 'tv_tag_opt = 
-# 1018 "flambda_parser.mly"
+# 1023 "flambda_parser.mly"
                                       ( Some tag )
-# 11932 "flambda_parser_in.ml"
+# 11934 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11944,9 +11946,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_tag_opt = 
-# 1019 "flambda_parser.mly"
+# 1024 "flambda_parser.mly"
     ( None )
-# 11950 "flambda_parser_in.ml"
+# 11952 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -11967,15 +11969,15 @@ module Tables = struct
         let i : (
 # 74 "flambda_parser.mly"
        (string * char option)
-# 11971 "flambda_parser_in.ml"
+# 11973 "flambda_parser_in.ml"
         ) = Obj.magic i in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_i_ in
         let _endpos = _endpos_i_ in
         let _v : 'tv_targetint = 
-# 1011 "flambda_parser.mly"
+# 1016 "flambda_parser.mly"
           ( make_targetint i )
-# 11979 "flambda_parser_in.ml"
+# 11981 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12051,14 +12053,14 @@ module Tables = struct
         let ak : (
 # 244 "flambda_parser.mly"
       (Fexpr.array_kind)
-# 12055 "flambda_parser_in.ml"
+# 12057 "flambda_parser_in.ml"
         ) = Obj.magic ak in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos__1_ in
         let _endpos = _endpos_v_ in
         let _v : 'tv_ternop_app = 
-# 632 "flambda_parser.mly"
+# 637 "flambda_parser.mly"
     (
       let array_set_kind : array_set_kind =
         match ak with
@@ -12077,7 +12079,7 @@ module Tables = struct
       in
       Ternary (Array_set (ak, array_set_kind), arr, ix, v)
     )
-# 12081 "flambda_parser_in.ml"
+# 12083 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12149,9 +12151,9 @@ module Tables = struct
         let _startpos = _startpos_blv_ in
         let _endpos = _endpos_v_ in
         let _v : 'tv_ternop_app = 
-# 652 "flambda_parser.mly"
+# 657 "flambda_parser.mly"
     ( Ternary (Bytes_or_bigstring_set (blv, saw), block, ix, v) )
-# 12155 "flambda_parser_in.ml"
+# 12157 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12191,7 +12193,7 @@ module Tables = struct
         let exn_handler : (
 # 251 "flambda_parser.mly"
       (Fexpr.continuation)
-# 12195 "flambda_parser_in.ml"
+# 12197 "flambda_parser_in.ml"
         ) = Obj.magic exn_handler in
         let _2 : unit = Obj.magic _2 in
         let _1 : unit = Obj.magic _1 in
@@ -12199,9 +12201,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__4_ in
         let _v : 'tv_trap_action = 
-# 940 "flambda_parser.mly"
+# 945 "flambda_parser.mly"
                                                          ( Push { exn_handler } )
-# 12205 "flambda_parser_in.ml"
+# 12207 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12247,7 +12249,7 @@ module Tables = struct
         let exn_handler : (
 # 251 "flambda_parser.mly"
       (Fexpr.continuation)
-# 12251 "flambda_parser_in.ml"
+# 12253 "flambda_parser_in.ml"
         ) = Obj.magic exn_handler in
         let raise_kind : 'tv_option_raise_kind_ = Obj.magic raise_kind in
         let _2 : unit = Obj.magic _2 in
@@ -12256,9 +12258,9 @@ module Tables = struct
         let _startpos = _startpos__1_ in
         let _endpos = _endpos__5_ in
         let _v : 'tv_trap_action = 
-# 944 "flambda_parser.mly"
+# 949 "flambda_parser.mly"
     ( Pop { exn_handler; raise_kind } )
-# 12262 "flambda_parser_in.ml"
+# 12264 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12283,11 +12285,11 @@ module Tables = struct
         let _v : (
 # 279 "flambda_parser.mly"
       (Fexpr.unary_int_arith_op)
-# 12287 "flambda_parser_in.ml"
+# 12289 "flambda_parser_in.ml"
         ) = 
 # 390 "flambda_parser.mly"
               ( Swap_byte_endianness )
-# 12291 "flambda_parser_in.ml"
+# 12293 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12314,7 +12316,7 @@ module Tables = struct
         let kind : (
 # 245 "flambda_parser.mly"
       (Fexpr.array_kind_for_length)
-# 12318 "flambda_parser_in.ml"
+# 12320 "flambda_parser_in.ml"
         ) = Obj.magic kind in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -12323,11 +12325,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12327 "flambda_parser_in.ml"
+# 12329 "flambda_parser_in.ml"
         ) = 
 # 393 "flambda_parser.mly"
                                                     ( Array_length kind )
-# 12331 "flambda_parser_in.ml"
+# 12333 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12352,11 +12354,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12356 "flambda_parser_in.ml"
+# 12358 "flambda_parser_in.ml"
         ) = 
 # 394 "flambda_parser.mly"
                      ( Boolean_not )
-# 12360 "flambda_parser_in.ml"
+# 12362 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12383,7 +12385,7 @@ module Tables = struct
         let alloc : (
 # 242 "flambda_parser.mly"
       (Fexpr.alloc_mode_for_allocations)
-# 12387 "flambda_parser_in.ml"
+# 12389 "flambda_parser_in.ml"
         ) = Obj.magic alloc in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -12392,11 +12394,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12396 "flambda_parser_in.ml"
+# 12398 "flambda_parser_in.ml"
         ) = 
 # 396 "flambda_parser.mly"
     ( Box_number (Naked_float, alloc) )
-# 12400 "flambda_parser_in.ml"
+# 12402 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12423,7 +12425,7 @@ module Tables = struct
         let alloc : (
 # 242 "flambda_parser.mly"
       (Fexpr.alloc_mode_for_allocations)
-# 12427 "flambda_parser_in.ml"
+# 12429 "flambda_parser_in.ml"
         ) = Obj.magic alloc in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -12432,11 +12434,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12436 "flambda_parser_in.ml"
+# 12438 "flambda_parser_in.ml"
         ) = 
 # 398 "flambda_parser.mly"
     ( Box_number (Naked_int32, alloc) )
-# 12440 "flambda_parser_in.ml"
+# 12442 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12463,7 +12465,7 @@ module Tables = struct
         let alloc : (
 # 242 "flambda_parser.mly"
       (Fexpr.alloc_mode_for_allocations)
-# 12467 "flambda_parser_in.ml"
+# 12469 "flambda_parser_in.ml"
         ) = Obj.magic alloc in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -12472,11 +12474,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12476 "flambda_parser_in.ml"
+# 12478 "flambda_parser_in.ml"
         ) = 
 # 400 "flambda_parser.mly"
     ( Box_number (Naked_int64, alloc) )
-# 12480 "flambda_parser_in.ml"
+# 12482 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12503,7 +12505,7 @@ module Tables = struct
         let alloc : (
 # 242 "flambda_parser.mly"
       (Fexpr.alloc_mode_for_allocations)
-# 12507 "flambda_parser_in.ml"
+# 12509 "flambda_parser_in.ml"
         ) = Obj.magic alloc in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -12512,11 +12514,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12516 "flambda_parser_in.ml"
+# 12518 "flambda_parser_in.ml"
         ) = 
 # 402 "flambda_parser.mly"
     ( Box_number (Naked_nativeint, alloc) )
-# 12520 "flambda_parser_in.ml"
+# 12522 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12541,11 +12543,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12545 "flambda_parser_in.ml"
+# 12547 "flambda_parser_in.ml"
         ) = 
 # 403 "flambda_parser.mly"
                       ( String_length Bytes )
-# 12549 "flambda_parser_in.ml"
+# 12551 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12570,11 +12572,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12574 "flambda_parser_in.ml"
+# 12576 "flambda_parser_in.ml"
         ) = 
 # 404 "flambda_parser.mly"
                     ( End_region { ghost = false } )
-# 12578 "flambda_parser_in.ml"
+# 12580 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12599,11 +12601,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12603 "flambda_parser_in.ml"
+# 12605 "flambda_parser_in.ml"
         ) = 
 # 405 "flambda_parser.mly"
                           ( End_region { ghost = true } )
-# 12607 "flambda_parser_in.ml"
+# 12609 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12628,11 +12630,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12632 "flambda_parser_in.ml"
+# 12634 "flambda_parser_in.ml"
         ) = 
 # 406 "flambda_parser.mly"
                         ( End_try_region { ghost = false } )
-# 12636 "flambda_parser_in.ml"
+# 12638 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12657,11 +12659,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12661 "flambda_parser_in.ml"
+# 12663 "flambda_parser_in.ml"
         ) = 
 # 407 "flambda_parser.mly"
                               ( End_try_region { ghost = true } )
-# 12665 "flambda_parser_in.ml"
+# 12667 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12686,11 +12688,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12690 "flambda_parser_in.ml"
+# 12692 "flambda_parser_in.ml"
         ) = 
 # 408 "flambda_parser.mly"
                  ( Get_tag )
-# 12694 "flambda_parser_in.ml"
+# 12696 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12715,11 +12717,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12719 "flambda_parser_in.ml"
+# 12721 "flambda_parser_in.ml"
         ) = 
 # 409 "flambda_parser.mly"
                              ( Is_flat_float_array )
-# 12723 "flambda_parser_in.ml"
+# 12725 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12744,11 +12746,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12748 "flambda_parser_in.ml"
+# 12750 "flambda_parser_in.ml"
         ) = 
 # 410 "flambda_parser.mly"
                 ( Is_int )
-# 12752 "flambda_parser_in.ml"
+# 12754 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12781,12 +12783,12 @@ module Tables = struct
         let o : (
 # 279 "flambda_parser.mly"
       (Fexpr.unary_int_arith_op)
-# 12785 "flambda_parser_in.ml"
+# 12787 "flambda_parser_in.ml"
         ) = Obj.magic o in
         let i : (
 # 272 "flambda_parser.mly"
       (Fexpr.standard_int)
-# 12790 "flambda_parser_in.ml"
+# 12792 "flambda_parser_in.ml"
         ) = Obj.magic i in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -12795,11 +12797,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12799 "flambda_parser_in.ml"
+# 12801 "flambda_parser_in.ml"
         ) = 
 # 412 "flambda_parser.mly"
     ( Int_arith (i, o) )
-# 12803 "flambda_parser_in.ml"
+# 12805 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12851,13 +12853,13 @@ module Tables = struct
         let dst : (
 # 252 "flambda_parser.mly"
       (Fexpr.standard_int_or_float)
-# 12855 "flambda_parser_in.ml"
+# 12857 "flambda_parser_in.ml"
         ) = Obj.magic dst in
         let _4 : unit = Obj.magic _4 in
         let src : (
 # 252 "flambda_parser.mly"
       (Fexpr.standard_int_or_float)
-# 12861 "flambda_parser_in.ml"
+# 12863 "flambda_parser_in.ml"
         ) = Obj.magic src in
         let _2 : unit = Obj.magic _2 in
         let _1 : unit = Obj.magic _1 in
@@ -12867,11 +12869,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12871 "flambda_parser_in.ml"
+# 12873 "flambda_parser_in.ml"
         ) = 
 # 416 "flambda_parser.mly"
     ( Num_conv { src; dst } )
-# 12875 "flambda_parser_in.ml"
+# 12877 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12896,11 +12898,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12900 "flambda_parser_in.ml"
+# 12902 "flambda_parser_in.ml"
         ) = 
 # 417 "flambda_parser.mly"
                 ( Opaque_identity )
-# 12904 "flambda_parser_in.ml"
+# 12906 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -12946,11 +12948,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 12950 "flambda_parser_in.ml"
+# 12952 "flambda_parser_in.ml"
         ) = 
 # 419 "flambda_parser.mly"
     ( Project_value_slot { project_from; value_slot } )
-# 12954 "flambda_parser_in.ml"
+# 12956 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13010,11 +13012,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13014 "flambda_parser_in.ml"
+# 13016 "flambda_parser_in.ml"
         ) = 
 # 423 "flambda_parser.mly"
     ( Project_function_slot { move_from; move_to } )
-# 13018 "flambda_parser_in.ml"
+# 13020 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13039,11 +13041,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13043 "flambda_parser_in.ml"
+# 13045 "flambda_parser_in.ml"
         ) = 
 # 424 "flambda_parser.mly"
                        ( String_length String )
-# 13047 "flambda_parser_in.ml"
+# 13049 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13068,11 +13070,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13072 "flambda_parser_in.ml"
+# 13074 "flambda_parser_in.ml"
         ) = 
 # 425 "flambda_parser.mly"
                  ( Tag_immediate )
-# 13076 "flambda_parser_in.ml"
+# 13078 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13097,11 +13099,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13101 "flambda_parser_in.ml"
+# 13103 "flambda_parser_in.ml"
         ) = 
 # 426 "flambda_parser.mly"
                      ( Unbox_number Naked_float )
-# 13105 "flambda_parser_in.ml"
+# 13107 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13126,11 +13128,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13130 "flambda_parser_in.ml"
+# 13132 "flambda_parser_in.ml"
         ) = 
 # 427 "flambda_parser.mly"
                      ( Unbox_number Naked_int32 )
-# 13134 "flambda_parser_in.ml"
+# 13136 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13155,11 +13157,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13159 "flambda_parser_in.ml"
+# 13161 "flambda_parser_in.ml"
         ) = 
 # 428 "flambda_parser.mly"
                      ( Unbox_number Naked_int64 )
-# 13163 "flambda_parser_in.ml"
+# 13165 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13184,11 +13186,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13188 "flambda_parser_in.ml"
+# 13190 "flambda_parser_in.ml"
         ) = 
 # 429 "flambda_parser.mly"
                          ( Unbox_number Naked_nativeint )
-# 13192 "flambda_parser_in.ml"
+# 13194 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13213,11 +13215,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13217 "flambda_parser_in.ml"
+# 13219 "flambda_parser_in.ml"
         ) = 
 # 430 "flambda_parser.mly"
                       ( Unbox_number Naked_vec128 )
-# 13221 "flambda_parser_in.ml"
+# 13223 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13242,11 +13244,11 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13246 "flambda_parser_in.ml"
+# 13248 "flambda_parser_in.ml"
         ) = 
 # 431 "flambda_parser.mly"
                    ( Untag_immediate )
-# 13250 "flambda_parser_in.ml"
+# 13252 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13301,7 +13303,7 @@ module Tables = struct
         let mut : (
 # 265 "flambda_parser.mly"
       (Fexpr.mutability)
-# 13305 "flambda_parser_in.ml"
+# 13307 "flambda_parser_in.ml"
         ) = Obj.magic mut in
         let _1 : unit = Obj.magic _1 in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
@@ -13310,11 +13312,13 @@ module Tables = struct
         let _v : (
 # 280 "flambda_parser.mly"
       (Fexpr.unop)
-# 13314 "flambda_parser_in.ml"
+# 13316 "flambda_parser_in.ml"
         ) = 
 # 436 "flambda_parser.mly"
-    ( Block_load { kind; mut; field = Target_ocaml_int.of_int field } )
-# 13318 "flambda_parser_in.ml"
+    ( (* TODO: Should get machine_width from fexpr context when available *)
+      let mw = Target_system.Machine_width.Sixty_four in
+      Block_load { kind; mut; field = Target_ocaml_int.of_int mw field } )
+# 13322 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13351,9 +13355,9 @@ module Tables = struct
         let _startpos = _startpos_var_ in
         let _endpos = _endpos_value_ in
         let _v : 'tv_value_slot = 
-# 844 "flambda_parser.mly"
+# 849 "flambda_parser.mly"
                                                             ( { var; value; } )
-# 13357 "flambda_parser_in.ml"
+# 13361 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13374,7 +13378,7 @@ module Tables = struct
         let e : (
 # 73 "flambda_parser.mly"
        (string)
-# 13378 "flambda_parser_in.ml"
+# 13382 "flambda_parser_in.ml"
         ) = Obj.magic e in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_e_ in
@@ -13383,9 +13387,9 @@ module Tables = struct
           let _endpos = _endpos_e_ in
           let _startpos = _startpos_e_ in
           (
-# 1130 "flambda_parser.mly"
+# 1135 "flambda_parser.mly"
               ( make_located e (_startpos, _endpos) )
-# 13389 "flambda_parser_in.ml"
+# 13393 "flambda_parser_in.ml"
            : 'tv_value_slot_for_projection)
         in
         {
@@ -13407,7 +13411,7 @@ module Tables = struct
         let e : (
 # 73 "flambda_parser.mly"
        (string)
-# 13411 "flambda_parser_in.ml"
+# 13415 "flambda_parser_in.ml"
         ) = Obj.magic e in
         let _endpos__0_ = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _startpos = _startpos_e_ in
@@ -13416,9 +13420,9 @@ module Tables = struct
           let _endpos = _endpos_e_ in
           let _startpos = _startpos_e_ in
           (
-# 1112 "flambda_parser.mly"
+# 1117 "flambda_parser.mly"
               ( make_located e (_startpos, _endpos) )
-# 13422 "flambda_parser_in.ml"
+# 13426 "flambda_parser_in.ml"
            : 'tv_variable)
         in
         {
@@ -13459,7 +13463,7 @@ module Tables = struct
         let recursive : (
 # 282 "flambda_parser.mly"
       (Fexpr.is_cont_recursive)
-# 13463 "flambda_parser_in.ml"
+# 13467 "flambda_parser_in.ml"
         ) = Obj.magic recursive in
         let _2 : unit = Obj.magic _2 in
         let body : 'tv_inner_expr = Obj.magic body in
@@ -13470,12 +13474,12 @@ module Tables = struct
           let bindings = 
 # 241 "<standard.mly>"
     ( xs )
-# 13474 "flambda_parser_in.ml"
+# 13478 "flambda_parser_in.ml"
            in
           (
-# 785 "flambda_parser.mly"
+# 790 "flambda_parser.mly"
     ( Let_cont { recursive; body; bindings } )
-# 13479 "flambda_parser_in.ml"
+# 13483 "flambda_parser_in.ml"
            : 'tv_where_expr)
         in
         {
@@ -13492,9 +13496,9 @@ module Tables = struct
         let _startpos = _menhir_stack.CamlinternalMenhirLib.EngineTypes.endp in
         let _endpos = _startpos in
         let _v : 'tv_with_value_slots_opt = 
-# 836 "flambda_parser.mly"
+# 841 "flambda_parser.mly"
     ( None )
-# 13498 "flambda_parser_in.ml"
+# 13502 "flambda_parser_in.ml"
          in
         {
           CamlinternalMenhirLib.EngineTypes.state = _menhir_s;
@@ -13541,12 +13545,12 @@ module Tables = struct
           let elements = 
 # 241 "<standard.mly>"
     ( xs )
-# 13545 "flambda_parser_in.ml"
+# 13549 "flambda_parser_in.ml"
            in
           (
-# 840 "flambda_parser.mly"
+# 845 "flambda_parser.mly"
     ( Some elements )
-# 13550 "flambda_parser_in.ml"
+# 13554 "flambda_parser_in.ml"
            : 'tv_with_value_slots_opt)
         in
         {
@@ -13577,7 +13581,7 @@ let flambda_unit =
   fun lexer lexbuf : (
 # 255 "flambda_parser.mly"
       (Fexpr.flambda_unit)
-# 13581 "flambda_parser_in.ml"
+# 13585 "flambda_parser_in.ml"
   ) ->
     Obj.magic (MenhirInterpreter.entry `Legacy 621 lexer lexbuf)
 
@@ -13585,7 +13589,7 @@ and expect_test_spec =
   fun lexer lexbuf : (
 # 253 "flambda_parser.mly"
       (Fexpr.expect_test_spec)
-# 13589 "flambda_parser_in.ml"
+# 13593 "flambda_parser_in.ml"
   ) ->
     Obj.magic (MenhirInterpreter.entry `Legacy 0 lexer lexbuf)
 
@@ -13595,7 +13599,7 @@ module Incremental = struct
     fun initial_position : (
 # 255 "flambda_parser.mly"
       (Fexpr.flambda_unit)
-# 13599 "flambda_parser_in.ml"
+# 13603 "flambda_parser_in.ml"
     ) MenhirInterpreter.checkpoint ->
       Obj.magic (MenhirInterpreter.start 621 initial_position)
   
@@ -13603,13 +13607,13 @@ module Incremental = struct
     fun initial_position : (
 # 253 "flambda_parser.mly"
       (Fexpr.expect_test_spec)
-# 13607 "flambda_parser_in.ml"
+# 13611 "flambda_parser_in.ml"
     ) MenhirInterpreter.checkpoint ->
       Obj.magic (MenhirInterpreter.start 0 initial_position)
   
 end
 
-# 1133 "flambda_parser.mly"
+# 1138 "flambda_parser.mly"
   
 
-# 13616 "flambda_parser_in.ml"
+# 13620 "flambda_parser_in.ml"

--- a/middle_end/flambda2/parser/flambda_parser.mly
+++ b/middle_end/flambda2/parser/flambda_parser.mly
@@ -433,7 +433,9 @@ unop:
     mut = mutability;
     kind = block_access_kind;
     LPAREN; field = tag; RPAREN;
-    { Block_load { kind; mut; field = Target_ocaml_int.of_int field } }
+    { (* TODO: Should get machine_width from fexpr context when available *)
+      let mw = Target_system.Machine_width.Sixty_four in
+      Block_load { kind; mut; field = Target_ocaml_int.of_int mw field } }
 
 infix_binop:
   | o = binary_int_arith_op { Int_arith o }
@@ -583,10 +585,11 @@ binop_app:
     block = simple; DOT;
     LPAREN; field = tag; RPAREN;
     init = init_or_assign;
-    v = simple
-    { Binary
-        (Block_set
-           { kind; init; field = Target_ocaml_int.of_int field }, block, v) }
+    v = simple;
+    { let mw = Target_system.Machine_width.Sixty_four in
+      let field = Target_ocaml_int.of_int mw field in
+      Binary (Block_set { kind; init; field }, block, v) }
+           (* TODO: Should get machine_width from fexpr context *)
   | op = prefix_binop; LPAREN; arg1 = simple; COMMA; arg2 = simple; RPAREN
     { Binary (op, arg1, arg2) }
   | arg1 = simple; op = infix_binop; arg2 = simple

--- a/middle_end/flambda2/parser/flambda_parser.mly
+++ b/middle_end/flambda2/parser/flambda_parser.mly
@@ -433,7 +433,8 @@ unop:
     mut = mutability;
     kind = block_access_kind;
     LPAREN; field = tag; RPAREN;
-    { (* TODO: Should get machine_width from fexpr context when available *)
+    { (* CR mshinwell: Should get machine_width from fexpr context when
+         available *)
       let mw = Target_system.Machine_width.Sixty_four in
       Block_load { kind; mut; field = Target_ocaml_int.of_int mw field } }
 
@@ -586,7 +587,8 @@ binop_app:
     LPAREN; field = tag; RPAREN;
     init = init_or_assign;
     v = simple;
-    { let mw = Target_system.Machine_width.Sixty_four in
+    { (* CR mshinwell: pass machine width through properly *)
+      let mw = Target_system.Machine_width.Sixty_four in
       let field = Target_ocaml_int.of_int mw field in
       Binary (Block_set { kind; init; field }, block, v) }
            (* TODO: Should get machine_width from fexpr context *)

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -368,10 +368,18 @@ let const c : Fexpr.const =
   match Reg_width_const.descr c with
   | Naked_immediate imm ->
     Naked_immediate
-      (imm |> Target_ocaml_int.to_targetint |> Targetint_32_64.to_string)
+      (* TODO: machine_width should be passed through properly here *)
+      (let machine_width = Target_system.Machine_width.Sixty_four in
+       imm
+       |> Target_ocaml_int.to_targetint machine_width
+       |> Targetint_32_64.to_string)
   | Tagged_immediate imm ->
     Tagged_immediate
-      (imm |> Target_ocaml_int.to_targetint |> Targetint_32_64.to_string)
+      (* TODO: machine_width should be passed through properly here *)
+      (let machine_width = Target_system.Machine_width.Sixty_four in
+       imm
+       |> Target_ocaml_int.to_targetint machine_width
+       |> Targetint_32_64.to_string)
   | Naked_float f -> Naked_float (f |> float)
   | Naked_float32 f -> Naked_float32 (f |> float32)
   | Naked_int32 i -> Naked_int32 i
@@ -742,7 +750,11 @@ let field_of_block env field =
       match[@ocaml.warning "-fragile-match"] Reg_width_const.descr cst with
       | Tagged_immediate imm ->
         Tagged_immediate
-          (imm |> Target_ocaml_int.to_targetint |> Targetint_32_64.to_string)
+          (* TODO: machine_width should be passed through properly here *)
+          (let machine_width = Target_system.Machine_width.Sixty_four in
+           imm
+           |> Target_ocaml_int.to_targetint machine_width
+           |> Targetint_32_64.to_string)
       | _ -> Misc.fatal_error "Mixed blocks not supported yet in fexpr")
 
 let or_variable f env (ov : _ Or_variable.t) : _ Fexpr.or_variable =
@@ -1195,7 +1207,11 @@ and switch_expr env switch : Fexpr.expr =
     List.map
       (fun (imm, app_cont) ->
         let tag =
-          imm |> Target_ocaml_int.to_targetint |> Targetint_32_64.to_int
+          (* TODO: machine_width should be passed through properly here *)
+          let machine_width = Target_system.Machine_width.Sixty_four in
+          imm
+          |> Target_ocaml_int.to_targetint machine_width
+          |> Targetint_32_64.to_int
         in
         let app_cont = apply_cont env app_cont in
         tag, app_cont)

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -368,14 +368,14 @@ let const c : Fexpr.const =
   match Reg_width_const.descr c with
   | Naked_immediate imm ->
     Naked_immediate
-      (* TODO: machine_width should be passed through properly here *)
+      (* CR mshinwell: machine_width should be passed through properly here *)
       (let machine_width = Target_system.Machine_width.Sixty_four in
        imm
        |> Target_ocaml_int.to_targetint machine_width
        |> Targetint_32_64.to_string)
   | Tagged_immediate imm ->
     Tagged_immediate
-      (* TODO: machine_width should be passed through properly here *)
+      (* CR mshinwell: machine_width should be passed through properly here *)
       (let machine_width = Target_system.Machine_width.Sixty_four in
        imm
        |> Target_ocaml_int.to_targetint machine_width
@@ -750,7 +750,8 @@ let field_of_block env field =
       match[@ocaml.warning "-fragile-match"] Reg_width_const.descr cst with
       | Tagged_immediate imm ->
         Tagged_immediate
-          (* TODO: machine_width should be passed through properly here *)
+          (* CR mshinwell: machine_width should be passed through properly
+             here *)
           (let machine_width = Target_system.Machine_width.Sixty_four in
            imm
            |> Target_ocaml_int.to_targetint machine_width

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -23,7 +23,7 @@ let unit_with_body (unit : Flambda_unit.t) (body : Flambda.Expr.t) =
     ~module_symbol:(Flambda_unit.module_symbol unit)
     ~used_value_slots:(Flambda_unit.used_value_slots unit)
 
-let run ~cmx_loader ~all_code (unit : Flambda_unit.t) =
+let run ~machine_width ~cmx_loader ~all_code (unit : Flambda_unit.t) =
   let debug_print = Flambda_features.dump_reaper () in
   let load_code = Flambda_cmx.get_imported_code cmx_loader in
   let get_code_metadata code_id =
@@ -50,8 +50,8 @@ let run ~cmx_loader ~all_code (unit : Flambda_unit.t) =
       Dot_printer.print_solved_dep solved_dep deps)
   in
   let Rebuild.{ body; free_names; all_code; slot_offsets } =
-    Rebuild.rebuild ~code_deps ~fixed_arity_continuations ~continuation_info
-      kinds solved_dep get_code_metadata holed
+    Rebuild.rebuild ~machine_width ~code_deps ~fixed_arity_continuations
+      ~continuation_info kinds solved_dep get_code_metadata holed
   in
   (* Is this what we really want? This keeps all the code that has not been
      deleted by this pass to be exported in the cmx. It looks like this does the

--- a/middle_end/flambda2/reaper/reaper.mli
+++ b/middle_end/flambda2/reaper/reaper.mli
@@ -14,6 +14,7 @@
 (**************************************************************************)
 
 val run :
+  machine_width:Target_system.Machine_width.t ->
   cmx_loader:Flambda_cmx.loader ->
   all_code:Exported_code.t ->
   Flambda_unit.t ->

--- a/middle_end/flambda2/reaper/rebuild.mli
+++ b/middle_end/flambda2/reaper/rebuild.mli
@@ -37,6 +37,7 @@ type result = private
   }
 
 val rebuild :
+  machine_width:Target_system.Machine_width.t ->
   code_deps:Traverse_acc.code_dep Code_id.Map.t ->
   continuation_info:Traverse_acc.continuation_info Continuation.Map.t ->
   fixed_arity_continuations:Continuation.Set.t ->

--- a/middle_end/flambda2/simplify/apply_cont_rewrite.ml
+++ b/middle_end/flambda2/simplify/apply_cont_rewrite.ml
@@ -152,7 +152,7 @@ let extra_args_list rewrite id =
          extra params were not empty for id %a"
         Apply_cont_rewrite_id.print id)
 
-let make_rewrite rewrite ~ctx id args : _ Or_invalid.t =
+let make_rewrite rewrite ~machine_width ~ctx id args : _ Or_invalid.t =
   let invariant_args, args =
     partition_used args rewrite.original_params_usage
   in
@@ -179,7 +179,7 @@ let make_rewrite rewrite ~ctx id args : _ Or_invalid.t =
               let temp_duid = Flambda_debug_uid.none in
               let extra_let =
                 ( Bound_var.create temp temp_duid Name_mode.normal,
-                  Code_size.prim prim,
+                  Code_size.prim ~machine_width prim,
                   Flambda.Named.create_prim prim Debuginfo.none )
               in
               ( Simple.var temp,
@@ -199,7 +199,7 @@ let make_rewrite rewrite ~ctx id args : _ Or_invalid.t =
               in
               let extra_let =
                 ( Bound_var.create temp temp_duid Name_mode.normal,
-                  Code_size.prim prim,
+                  Code_size.prim ~machine_width prim,
                   Flambda.Named.create_prim prim Debuginfo.none )
               in
               ( Simple.var temp,

--- a/middle_end/flambda2/simplify/apply_cont_rewrite.mli
+++ b/middle_end/flambda2/simplify/apply_cont_rewrite.mli
@@ -50,6 +50,7 @@ type rewrite_apply_cont_ctx =
 
 val make_rewrite :
   t ->
+  machine_width:Target_system.Machine_width.t ->
   ctx:rewrite_apply_cont_ctx ->
   Apply_cont_rewrite_id.t ->
   Simple.t list ->

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -32,6 +32,7 @@ val print : Format.formatter -> t -> unit
     unit. *)
 val create :
   round:int ->
+  machine_width:Target_system.Machine_width.t ->
   resolver:resolver ->
   get_imported_names:get_imported_names ->
   get_imported_code:get_imported_code ->
@@ -43,6 +44,8 @@ val create :
   t
 
 val all_code : t -> Code.t Code_id.Map.t
+
+val machine_width : t -> Target_system.Machine_width.t
 
 val resolver :
   t -> Compilation_unit.t -> Flambda2_types.Typing_env.Serializable.t option

--- a/middle_end/flambda2/simplify/env/upwards_env.ml
+++ b/middle_end/flambda2/simplify/env/upwards_env.ml
@@ -19,20 +19,24 @@ type t =
     continuation_shortcuts : Continuation_shortcut.t Continuation.Map.t;
     apply_cont_rewrites : Apply_cont_rewrite.t Continuation.Map.t;
     (* this [are_rebuilding_terms] is **only** used for printing *)
-    are_rebuilding_terms : Are_rebuilding_terms.t
+    are_rebuilding_terms : Are_rebuilding_terms.t;
+    machine_width : Target_system.Machine_width.t
   }
 
-let create are_rebuilding_terms =
+let create are_rebuilding_terms ~machine_width =
   { continuations = Continuation.Map.empty;
     continuation_shortcuts = Continuation.Map.empty;
     apply_cont_rewrites = Continuation.Map.empty;
-    are_rebuilding_terms
+    are_rebuilding_terms;
+    machine_width
   }
+
+let machine_width t = t.machine_width
 
 let [@ocamlformat "disable"] print ppf
     { continuations;
       apply_cont_rewrites; are_rebuilding_terms ;
-      continuation_shortcuts } =
+      continuation_shortcuts; machine_width = _ } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(continuations@ %a)@]@ \
       @[<hov 1>(continuation_shortcuts@ %a)@]@ \

--- a/middle_end/flambda2/simplify/env/upwards_env.mli
+++ b/middle_end/flambda2/simplify/env/upwards_env.mli
@@ -21,7 +21,10 @@ type t
 (** Create an upwards environment.
 
     The [are_rebuilding_terms] provided is only used for printing. *)
-val create : Are_rebuilding_terms.t -> t
+val create :
+  Are_rebuilding_terms.t -> machine_width:Target_system.Machine_width.t -> t
+
+val machine_width : t -> Target_system.Machine_width.t
 
 val print : Format.formatter -> t -> unit
 

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -555,9 +555,10 @@ let create_let_symbols uacc lifted_constant ~body =
             | Project_value_slot { project_from; value_slot } ->
               Unary (Project_value_slot { project_from; value_slot }, symbol)
           in
+          let machine_width = UE.machine_width (UA.uenv uacc) in
           ( Named.create_prim prim Debuginfo.none,
             coercion_from_proj_to_var,
-            Code_size.prim prim )
+            Code_size.prim ~machine_width prim )
       in
       (* It's possible that this might create duplicates of the same projection
          operation, but it's unlikely there will be a significant number, and
@@ -721,7 +722,8 @@ let no_rewrite_apply_cont uenv apply_cont =
 let rewrite_apply_cont0 uacc rewrite ~ctx id apply_cont :
     rewrite_apply_cont_result =
   let args = Apply_cont.args apply_cont in
-  match Apply_cont_rewrite.make_rewrite rewrite ~ctx id args with
+  let machine_width = UE.machine_width (UA.uenv uacc) in
+  match Apply_cont_rewrite.make_rewrite rewrite ~machine_width ~ctx id args with
   | Invalid -> Invalid { message = "" }
   | Ok (extra_lets, args) -> (
     let apply_cont = Apply_cont.update_args apply_cont ~args in

--- a/middle_end/flambda2/simplify/flow/flow.mli
+++ b/middle_end/flambda2/simplify/flow/flow.mli
@@ -105,6 +105,7 @@ module Analysis : sig
   val analyze :
     ?speculative:bool ->
     ?print_name:string ->
+    machine_width:Target_system.Machine_width.t ->
     return_continuation:Continuation.t ->
     exn_continuation:Continuation.t ->
     code_age_relation:Code_age_relation.t ->

--- a/middle_end/flambda2/simplify/flow/flow_analysis.ml
+++ b/middle_end/flambda2/simplify/flow/flow_analysis.ml
@@ -50,8 +50,8 @@ let print_graph ~print ~print_name ~lazy_ppf ~graph =
 
 (* analysis *)
 
-let analyze ?(speculative = false) ?print_name ~return_continuation
-    ~exn_continuation ~code_age_relation ~used_value_slots
+let analyze ?(speculative = false) ?print_name ~machine_width
+    ~return_continuation ~exn_continuation ~code_age_relation ~used_value_slots
     ~code_ids_to_never_delete ~specialization_map t : T.Flow_result.t =
   Profile.record_call ~accumulate:true "data_flow" (fun () ->
       if Flambda_features.dump_flow ()
@@ -94,8 +94,8 @@ let analyze ?(speculative = false) ?print_name ~return_continuation
       (* control flow graph *)
       let control = Control_flow_graph.create ~dummy_toplevel_cont t in
       let reference_analysis =
-        Mutable_unboxing.create ~dom:aliases ~dom_graph ~source_info:t
-          ~control_flow_graph:control
+        Mutable_unboxing.create ~machine_width ~dom:aliases ~dom_graph
+          ~source_info:t ~control_flow_graph:control
           ~required_names:dead_variable_result.required_names
           ~return_continuation ~exn_continuation
       in

--- a/middle_end/flambda2/simplify/flow/flow_analysis.mli
+++ b/middle_end/flambda2/simplify/flow/flow_analysis.mli
@@ -26,6 +26,7 @@
 val analyze :
   ?speculative:bool ->
   ?print_name:string ->
+  machine_width:Target_system.Machine_width.t ->
   return_continuation:Continuation.t ->
   exn_continuation:Continuation.t ->
   code_age_relation:Code_age_relation.t ->

--- a/middle_end/flambda2/simplify/flow/mutable_unboxing.mli
+++ b/middle_end/flambda2/simplify/flow/mutable_unboxing.mli
@@ -22,6 +22,7 @@ val create :
   required_names:Name.Set.t ->
   return_continuation:Continuation.t ->
   exn_continuation:Continuation.t ->
+  machine_width:Target_system.Machine_width.t ->
   t
 
 val make_result : t -> Flow_types.Mutable_unboxing_result.t * Simple.Set.t

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -97,14 +97,16 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
             ~specialization_map:(DA.specialization_map dacc)
             ~return_continuation:function_return_cont
             ~exn_continuation:(Exn_continuation.exn_handler exn_continuation)
+            ~machine_width:(DE.machine_width (DA.denv dacc))
         in
         let uenv =
           (* Note that we don't need to do anything special if the exception
              continuation takes extra arguments, since we are only simplifying
              the body of the function in question, not substituting it into an
              existing context. *)
+          let machine_width = DE.machine_width (DA.denv dacc) in
           UE.add_function_return_or_exn_continuation
-            (UE.create (DA.are_rebuilding_terms dacc))
+            (UE.create (DA.are_rebuilding_terms dacc) ~machine_width)
             (Exn_continuation.exn_handler exn_continuation)
             (Flambda_arity.create_singletons
                [Flambda_kind.With_subkind.any_value])

--- a/middle_end/flambda2/simplify/join_points.ml
+++ b/middle_end/flambda2/simplify/join_points.ml
@@ -158,7 +158,10 @@ let add_equations_on_params typing_env ~is_recursive ~params:params'
           if Flambda_kind.With_subkind.has_useful_subkind_info kind
           then
             let raw_kind = Flambda_kind.With_subkind.kind kind in
-            let type_from_kind = T.unknown_with_subkind kind in
+            let type_from_kind =
+              T.unknown_with_subkind kind
+                ~machine_width:(TE.machine_width typing_env)
+            in
             match T.meet typing_env type_from_kind param_type with
             | Bottom ->
               (* This should really replace the corresponding uses with

--- a/middle_end/flambda2/simplify/lifting/reification.ml
+++ b/middle_end/flambda2/simplify/lifting/reification.ml
@@ -134,7 +134,8 @@ let lift dacc ty ~bound_to static_const : _ Or_invalid.t * DA.t =
     DA.map_denv dacc ~f:(fun denv ->
         DE.add_equation_on_variable denv bound_to var_ty)
   in
-  Ok (Simplified_named.create term), dacc
+  let machine_width = DE.machine_width (DA.denv dacc) in
+  Ok (Simplified_named.create ~machine_width term), dacc
 
 let try_to_reify dacc dbg (term : Simplified_named.t) ~bound_to
     ~kind_of_bound_to ~allow_lifting : _ Or_invalid.t * DA.t =
@@ -175,6 +176,8 @@ let try_to_reify dacc dbg (term : Simplified_named.t) ~bound_to
       let denv = DE.add_equation_on_variable denv bound_to ty in
       DA.with_denv dacc denv
     in
-    Ok (Simplified_named.create (Named.create_simple simple)), dacc
+    let machine_width = DE.machine_width (DA.denv dacc) in
+    ( Ok (Simplified_named.create ~machine_width (Named.create_simple simple)),
+      dacc )
   | Cannot_reify -> Ok term, dacc
   | Invalid -> Invalid, dacc

--- a/middle_end/flambda2/simplify/number_adjuncts.ml
+++ b/middle_end/flambda2/simplify/number_adjuncts.ml
@@ -886,7 +886,7 @@ module For_nativeints : Boxable_int_number_kind = struct
     include Targetint_32_64
 
     let strictly_negative t =
-      let zero_val = zero (machine_width t) in
+      let zero_val = zero_like t in
       compare t zero_val < 0
 
     let compare_unsigned t1 t2 =
@@ -898,33 +898,24 @@ module For_nativeints : Boxable_int_number_kind = struct
 
     let and_ = logand
 
-    let div t1 t2 =
-      assert (
-        Target_system.Machine_width.equal (machine_width t1) (machine_width t2));
-      if equal t2 (zero (machine_width t1)) then None else Some (div t1 t2)
+    let div t1 t2 = if equal t2 (zero_like t1) then None else Some (div t1 t2)
 
-    let mod_ t1 t2 =
-      assert (
-        Target_system.Machine_width.equal (machine_width t1) (machine_width t2));
-      if equal t2 (zero (machine_width t1)) then None else Some (rem t1 t2)
+    let mod_ t1 t2 = if equal t2 (zero_like t1) then None else Some (rem t1 t2)
 
     let integer_bit_width = if Target_system.is_32_bit () then 32 else 64
 
     let shift_left t shift =
-      with_shift shift
-        (zero (machine_width t))
+      with_shift shift (zero_like t)
         (fun shift -> shift_left t shift)
         ~integer_bit_width
 
     let shift_right t shift =
-      with_shift shift
-        (zero (machine_width t))
+      with_shift shift (zero_like t)
         (fun shift -> shift_right t shift)
         ~integer_bit_width
 
     let shift_right_logical t shift =
-      with_shift shift
-        (zero (machine_width t))
+      with_shift shift (zero_like t)
         (fun shift -> shift_right_logical t shift)
         ~integer_bit_width
 

--- a/middle_end/flambda2/simplify/number_adjuncts.ml
+++ b/middle_end/flambda2/simplify/number_adjuncts.ml
@@ -58,11 +58,11 @@ module type Num_common = sig
 
   val cross_product : Set.t -> Set.t -> Pair.Set.t
 
-  val zero : t
+  val zero : Target_system.Machine_width.t -> t
 
-  val one : t
+  val one : Target_system.Machine_width.t -> t
 
-  val minus_one : t
+  val minus_one : Target_system.Machine_width.t -> t
 
   val add : t -> t -> t
 
@@ -76,7 +76,7 @@ module type Num_common = sig
 
   val to_const : t -> Reg_width_const.t
 
-  val to_immediate : t -> Target_ocaml_int.t
+  val to_immediate : t -> Target_system.Machine_width.t -> Target_ocaml_int.t
 
   val to_naked_float32 : t -> Numeric_types.Float32_by_bit_pattern.t
 
@@ -90,7 +90,8 @@ module type Num_common = sig
 
   val to_naked_int64 : t -> Numeric_types.Int64.t
 
-  val to_naked_nativeint : t -> Targetint_32_64.t
+  val to_naked_nativeint :
+    t -> Target_system.Machine_width.t -> Targetint_32_64.t
 end
 
 module type Number_kind_common = sig
@@ -191,18 +192,30 @@ module For_tagged_immediates : Int_number_kind = struct
   module Num = struct
     include Target_ocaml_int
 
-    let strictly_negative t = t < zero
+    let zero machine_width = Target_ocaml_int.zero machine_width
+
+    let one machine_width = Target_ocaml_int.one machine_width
+
+    let minus_one machine_width = Target_ocaml_int.minus_one machine_width
+
+    (* Shift functions inherit correct signature from Target_ocaml_int *)
+
+    let strictly_negative t = t < Target_ocaml_int.zero (machine_width t)
 
     let compare_unsigned t1 t2 =
       compare_unsigned_generic t1 t2 ~compare ~strictly_negative
 
     let div t1 t2 =
-      if Target_ocaml_int.equal t2 Target_ocaml_int.zero
+      assert (
+        Target_system.Machine_width.equal (machine_width t1) (machine_width t2));
+      if Target_ocaml_int.equal t2 (Target_ocaml_int.zero (machine_width t1))
       then None
       else Some (div t1 t2)
 
     let mod_ t1 t2 =
-      if Target_ocaml_int.equal t2 Target_ocaml_int.zero
+      assert (
+        Target_system.Machine_width.equal (machine_width t1) (machine_width t2));
+      if Target_ocaml_int.equal t2 (Target_ocaml_int.zero (machine_width t1))
       then None
       else Some (mod_ t1 t2)
 
@@ -211,16 +224,21 @@ module For_tagged_immediates : Int_number_kind = struct
     let integer_bit_width = if Target_system.is_32_bit () then 32 else 64
 
     let shift_left t shift =
-      with_shift shift zero (fun shift -> shift_left t shift) ~integer_bit_width
+      with_shift shift
+        (Target_ocaml_int.zero (machine_width t))
+        (fun shift_int -> Target_ocaml_int.shift_left t shift_int)
+        ~integer_bit_width
 
     let shift_right t shift =
-      with_shift shift zero
-        (fun shift -> shift_right t shift)
+      with_shift shift
+        (Target_ocaml_int.zero (machine_width t))
+        (fun shift_int -> Target_ocaml_int.shift_right t shift_int)
         ~integer_bit_width
 
     let shift_right_logical t shift =
-      with_shift shift zero
-        (fun shift -> shift_right_logical t shift)
+      with_shift shift
+        (Target_ocaml_int.zero (machine_width t))
+        (fun shift_int -> Target_ocaml_int.shift_right_logical t shift_int)
         ~integer_bit_width
 
     let swap_byte_endianness =
@@ -228,7 +246,7 @@ module For_tagged_immediates : Int_number_kind = struct
 
     let to_const t = Reg_width_const.tagged_immediate t
 
-    let to_immediate t = t
+    let to_immediate t _machine_width = t
 
     let to_naked_float32 t =
       Float32_by_bit_pattern.create (Target_ocaml_int.to_float t)
@@ -244,7 +262,8 @@ module For_tagged_immediates : Int_number_kind = struct
 
     let to_naked_int64 t = Target_ocaml_int.to_int64 t
 
-    let to_naked_nativeint t = Target_ocaml_int.to_targetint t
+    let to_naked_nativeint t machine_width =
+      Target_ocaml_int.to_targetint machine_width t
   end
 
   let standard_int_or_float_kind : K.Standard_int_or_float.t = Tagged_immediate
@@ -265,33 +284,51 @@ module For_naked_immediates : Int_number_kind = struct
   module Num = struct
     include Target_ocaml_int
 
-    let strictly_negative t = t < zero
+    let zero machine_width = Target_ocaml_int.zero machine_width
+
+    let one machine_width = Target_ocaml_int.one machine_width
+
+    let minus_one machine_width = Target_ocaml_int.minus_one machine_width
+
+    let strictly_negative t = t < Target_ocaml_int.zero (machine_width t)
 
     let compare_unsigned t1 t2 =
       compare_unsigned_generic t1 t2 ~compare ~strictly_negative
 
     let div t1 t2 =
-      if Target_ocaml_int.equal t2 Target_ocaml_int.zero
+      assert (
+        Target_system.Machine_width.equal (machine_width t1) (machine_width t2));
+      if Target_ocaml_int.equal t2 (Target_ocaml_int.zero (machine_width t1))
       then None
       else Some (div t1 t2)
 
     let mod_ t1 t2 =
-      if Target_ocaml_int.equal t2 Target_ocaml_int.zero
+      assert (
+        Target_system.Machine_width.equal (machine_width t1) (machine_width t2));
+      if Target_ocaml_int.equal t2 (Target_ocaml_int.zero (machine_width t1))
       then None
       else Some (mod_ t1 t2)
 
     let integer_bit_width = if Target_system.is_32_bit () then 31 else 63
 
     let shift_left t shift =
-      with_shift shift zero (fun shift -> shift_left t shift) ~integer_bit_width
+      let machine_width = Target_ocaml_int.machine_width t in
+      with_shift shift
+        (Target_ocaml_int.zero machine_width)
+        (fun shift -> shift_left t shift)
+        ~integer_bit_width
 
     let shift_right t shift =
-      with_shift shift zero
+      let machine_width = Target_ocaml_int.machine_width t in
+      with_shift shift
+        (Target_ocaml_int.zero machine_width)
         (fun shift -> shift_right t shift)
         ~integer_bit_width
 
     let shift_right_logical t shift =
-      with_shift shift zero
+      let machine_width = Target_ocaml_int.machine_width t in
+      with_shift shift
+        (Target_ocaml_int.zero machine_width)
         (fun shift -> shift_right_logical t shift)
         ~integer_bit_width
 
@@ -300,7 +337,7 @@ module For_naked_immediates : Int_number_kind = struct
 
     let to_const t = Reg_width_const.naked_immediate t
 
-    let to_immediate t = t
+    let to_immediate t _machine_width = t
 
     let to_naked_float32 t =
       Float32_by_bit_pattern.create (Target_ocaml_int.to_float t)
@@ -316,7 +353,8 @@ module For_naked_immediates : Int_number_kind = struct
 
     let to_naked_int64 = Target_ocaml_int.to_int64
 
-    let to_naked_nativeint = Target_ocaml_int.to_targetint
+    let to_naked_nativeint t machine_width =
+      Target_ocaml_int.to_targetint machine_width t
   end
 
   let standard_int_or_float_kind : K.Standard_int_or_float.t = Naked_immediate
@@ -337,6 +375,12 @@ module For_float32s : Boxable_number_kind = struct
   module Num = struct
     include Float32_by_bit_pattern
 
+    let zero _machine_width = Float32_by_bit_pattern.zero
+
+    let one _machine_width = Float32_by_bit_pattern.one
+
+    let minus_one _machine_width = Float32_by_bit_pattern.minus_one
+
     let add = IEEE_semantics.add
 
     let sub = IEEE_semantics.sub
@@ -349,7 +393,8 @@ module For_float32s : Boxable_number_kind = struct
 
     let to_const t = Reg_width_const.naked_float32 t
 
-    let to_immediate t = Target_ocaml_int.of_float (to_float t)
+    let to_immediate t machine_width =
+      Target_ocaml_int.of_float machine_width (to_float t)
 
     let to_naked_float32 t = t
 
@@ -363,7 +408,8 @@ module For_float32s : Boxable_number_kind = struct
 
     let to_naked_int64 t = Int64.of_float (to_float t)
 
-    let to_naked_nativeint t = Targetint_32_64.of_float (to_float t)
+    let to_naked_nativeint t machine_width =
+      Targetint_32_64.of_float machine_width (to_float t)
   end
 
   let standard_int_or_float_kind : K.Standard_int_or_float.t = Naked_float32
@@ -390,6 +436,12 @@ module For_floats : Boxable_number_kind = struct
   module Num = struct
     include Float_by_bit_pattern
 
+    let zero _machine_width = Float_by_bit_pattern.zero
+
+    let one _machine_width = Float_by_bit_pattern.one
+
+    let minus_one _machine_width = Float_by_bit_pattern.minus_one
+
     let add = IEEE_semantics.add
 
     let sub = IEEE_semantics.sub
@@ -402,7 +454,8 @@ module For_floats : Boxable_number_kind = struct
 
     let to_const t = Reg_width_const.naked_float t
 
-    let to_immediate t = Target_ocaml_int.of_float (to_float t)
+    let to_immediate t machine_width =
+      (Target_ocaml_int.of_float machine_width) (to_float t)
 
     let to_naked_float32 t = Float32_by_bit_pattern.create (to_float t)
 
@@ -416,7 +469,8 @@ module For_floats : Boxable_number_kind = struct
 
     let to_naked_int64 t = Int64.of_float (to_float t)
 
-    let to_naked_nativeint t = Targetint_32_64.of_float (to_float t)
+    let to_naked_nativeint t machine_width =
+      Targetint_32_64.of_float machine_width (to_float t)
   end
 
   let standard_int_or_float_kind : K.Standard_int_or_float.t = Naked_float
@@ -443,16 +497,16 @@ module For_int8s : Int_number_kind = struct
   module Num = struct
     include Int8
 
-    let strictly_negative t = compare t zero < 0
+    let strictly_negative t = compare t Int8.zero < 0
 
     let compare_unsigned t1 t2 =
       compare_unsigned_generic t1 t2 ~compare ~strictly_negative
 
-    let zero = of_int 0
+    let zero _machine_width = Int8.zero
 
-    let one = of_int 1
+    let one _machine_width = Int8.one
 
-    let minus_one = of_int (-1)
+    let minus_one _machine_width = Int8.of_int (-1)
 
     let neg x = of_int (Int.neg (to_int x))
 
@@ -485,28 +539,29 @@ module For_int8s : Int_number_kind = struct
 
     let and_ = logand
 
-    let div t1 t2 = if equal t2 zero then None else Some (div t1 t2)
+    let div t1 t2 = if equal t2 (of_int 0) then None else Some (div t1 t2)
 
-    let mod_ t1 t2 = if equal t2 zero then None else Some (rem t1 t2)
+    let mod_ t1 t2 = if equal t2 (of_int 0) then None else Some (rem t1 t2)
 
     let shift_left t shift =
-      with_shift shift zero
+      with_shift shift (of_int 0)
         (fun shift -> shift_left t shift)
         ~integer_bit_width:8
 
     let shift_right t shift =
-      with_shift shift zero
+      with_shift shift Int8.zero
         (fun shift -> shift_right t shift)
         ~integer_bit_width:8
 
     let shift_right_logical t shift =
-      with_shift shift zero
+      with_shift shift Int8.zero
         (fun shift -> shift_right_logical t shift)
         ~integer_bit_width:8
 
     let to_const t = Reg_width_const.naked_int8 t
 
-    let to_immediate t = Target_ocaml_int.of_int (to_int t)
+    let to_immediate t machine_width =
+      Target_ocaml_int.of_int machine_width (to_int t)
 
     let to_naked_float32 t = Float32_by_bit_pattern.create (to_float t)
 
@@ -520,7 +575,8 @@ module For_int8s : Int_number_kind = struct
 
     let to_naked_int64 t = Int64.of_int (to_int t)
 
-    let to_naked_nativeint t = Targetint_32_64.of_int (to_int t)
+    let to_naked_nativeint t machine_width =
+      Targetint_32_64.of_int machine_width (to_int t)
 
     module Pair = struct
       type nonrec t = t * t
@@ -551,16 +607,16 @@ module For_int16s : Int_number_kind = struct
   module Num = struct
     include Int16
 
-    let strictly_negative t = compare t zero < 0
+    let strictly_negative t = compare t Int16.zero < 0
 
     let compare_unsigned t1 t2 =
       compare_unsigned_generic t1 t2 ~compare ~strictly_negative
 
-    let zero = of_int 0
+    let zero _machine_width = Int16.zero
 
-    let one = of_int 1
+    let one _machine_width = Int16.one
 
-    let minus_one = of_int (-1)
+    let minus_one _machine_width = Int16.of_int (-1)
 
     let neg x = of_int (Int.neg (to_int x))
 
@@ -593,28 +649,29 @@ module For_int16s : Int_number_kind = struct
 
     let and_ = logand
 
-    let div t1 t2 = if equal t2 zero then None else Some (div t1 t2)
+    let div t1 t2 = if equal t2 Int16.zero then None else Some (div t1 t2)
 
-    let mod_ t1 t2 = if equal t2 zero then None else Some (rem t1 t2)
+    let mod_ t1 t2 = if equal t2 Int16.zero then None else Some (rem t1 t2)
 
     let shift_left t shift =
-      with_shift shift zero
+      with_shift shift Int16.zero
         (fun shift -> shift_left t shift)
         ~integer_bit_width:16
 
     let shift_right t shift =
-      with_shift shift zero
+      with_shift shift Int16.zero
         (fun shift -> shift_right t shift)
         ~integer_bit_width:16
 
     let shift_right_logical t shift =
-      with_shift shift zero
+      with_shift shift Int16.zero
         (fun shift -> shift_right_logical t shift)
         ~integer_bit_width:16
 
     let to_const t = Reg_width_const.naked_int16 t
 
-    let to_immediate t = Target_ocaml_int.of_int (to_int t)
+    let to_immediate t machine_width =
+      Target_ocaml_int.of_int machine_width (to_int t)
 
     let to_naked_float32 t = Float32_by_bit_pattern.create (to_float t)
 
@@ -628,7 +685,8 @@ module For_int16s : Int_number_kind = struct
 
     let to_naked_int64 t = Int64.of_int (to_int t)
 
-    let to_naked_nativeint t = Targetint_32_64.of_int (to_int t)
+    let to_naked_nativeint t machine_width =
+      Targetint_32_64.of_int machine_width (to_int t)
 
     module Pair = struct
       type nonrec t = t * t
@@ -663,10 +721,16 @@ module For_int32s : Boxable_int_number_kind = struct
   module Num = struct
     include Int32
 
-    let strictly_negative t = compare t zero < 0
+    let strictly_negative t = compare t Int32.zero < 0
 
     let compare_unsigned t1 t2 =
       compare_unsigned_generic t1 t2 ~compare ~strictly_negative
+
+    let zero _machine_width = Int32.zero
+
+    let one _machine_width = Int32.one
+
+    let minus_one _machine_width = Int32.minus_one
 
     let xor = logxor
 
@@ -674,28 +738,28 @@ module For_int32s : Boxable_int_number_kind = struct
 
     let and_ = logand
 
-    let div t1 t2 = if equal t2 zero then None else Some (div t1 t2)
+    let div t1 t2 = if equal t2 (of_int 0) then None else Some (div t1 t2)
 
-    let mod_ t1 t2 = if equal t2 zero then None else Some (rem t1 t2)
+    let mod_ t1 t2 = if equal t2 (of_int 0) then None else Some (rem t1 t2)
 
     let shift_left t shift =
-      with_shift shift zero
+      with_shift shift (of_int 0)
         (fun shift -> shift_left t shift)
         ~integer_bit_width:32
 
     let shift_right t shift =
-      with_shift shift zero
+      with_shift shift (of_int 0)
         (fun shift -> shift_right t shift)
         ~integer_bit_width:32
 
     let shift_right_logical t shift =
-      with_shift shift zero
+      with_shift shift (of_int 0)
         (fun shift -> shift_right_logical t shift)
         ~integer_bit_width:32
 
     let to_const t = Reg_width_const.naked_int32 t
 
-    let to_immediate t = Target_ocaml_int.of_int32 t
+    let to_immediate t machine_width = Target_ocaml_int.of_int32 machine_width t
 
     let to_naked_float32 t = Float32_by_bit_pattern.create (Int32.to_float t)
 
@@ -709,7 +773,8 @@ module For_int32s : Boxable_int_number_kind = struct
 
     let to_naked_int64 t = Int64.of_int32 t
 
-    let to_naked_nativeint t = Targetint_32_64.of_int32 t
+    let to_naked_nativeint t machine_width =
+      Targetint_32_64.of_int32 machine_width t
   end
 
   let standard_int_or_float_kind : K.Standard_int_or_float.t = Naked_int32
@@ -738,10 +803,16 @@ module For_int64s : Boxable_int_number_kind = struct
   module Num = struct
     include Int64
 
-    let strictly_negative t = compare t zero < 0
+    let strictly_negative t = compare t Int64.zero < 0
 
     let compare_unsigned t1 t2 =
       compare_unsigned_generic t1 t2 ~compare ~strictly_negative
+
+    let zero _machine_width = Int64.zero
+
+    let one _machine_width = Int64.one
+
+    let minus_one _machine_width = Int64.minus_one
 
     let xor = logxor
 
@@ -749,28 +820,28 @@ module For_int64s : Boxable_int_number_kind = struct
 
     let and_ = logand
 
-    let div t1 t2 = if equal t2 zero then None else Some (div t1 t2)
+    let div t1 t2 = if equal t2 Int64.zero then None else Some (div t1 t2)
 
-    let mod_ t1 t2 = if equal t2 zero then None else Some (rem t1 t2)
+    let mod_ t1 t2 = if equal t2 Int64.zero then None else Some (rem t1 t2)
 
     let shift_left t shift =
-      with_shift shift zero
+      with_shift shift Int64.zero
         (fun shift -> shift_left t shift)
         ~integer_bit_width:64
 
     let shift_right t shift =
-      with_shift shift zero
+      with_shift shift Int64.zero
         (fun shift -> shift_right t shift)
         ~integer_bit_width:64
 
     let shift_right_logical t shift =
-      with_shift shift zero
+      with_shift shift Int64.zero
         (fun shift -> shift_right_logical t shift)
         ~integer_bit_width:64
 
     let to_const t = Reg_width_const.naked_int64 t
 
-    let to_immediate t = Target_ocaml_int.of_int64 t
+    let to_immediate t machine_width = Target_ocaml_int.of_int64 machine_width t
 
     let to_naked_float32 t = Float32_by_bit_pattern.create (Int64.to_float t)
 
@@ -784,7 +855,8 @@ module For_int64s : Boxable_int_number_kind = struct
 
     let to_naked_int64 t = t
 
-    let to_naked_nativeint t = Targetint_32_64.of_int64 t
+    let to_naked_nativeint t machine_width =
+      Targetint_32_64.of_int64 machine_width t
   end
 
   let standard_int_or_float_kind : K.Standard_int_or_float.t = Naked_int64
@@ -813,7 +885,9 @@ module For_nativeints : Boxable_int_number_kind = struct
   module Num = struct
     include Targetint_32_64
 
-    let strictly_negative t = compare t zero < 0
+    let strictly_negative t =
+      let zero_val = zero (machine_width t) in
+      compare t zero_val < 0
 
     let compare_unsigned t1 t2 =
       compare_unsigned_generic t1 t2 ~compare ~strictly_negative
@@ -824,28 +898,40 @@ module For_nativeints : Boxable_int_number_kind = struct
 
     let and_ = logand
 
-    let div t1 t2 = if equal t2 zero then None else Some (div t1 t2)
+    let div t1 t2 =
+      assert (
+        Target_system.Machine_width.equal (machine_width t1) (machine_width t2));
+      if equal t2 (zero (machine_width t1)) then None else Some (div t1 t2)
 
-    let mod_ t1 t2 = if equal t2 zero then None else Some (rem t1 t2)
+    let mod_ t1 t2 =
+      assert (
+        Target_system.Machine_width.equal (machine_width t1) (machine_width t2));
+      if equal t2 (zero (machine_width t1)) then None else Some (rem t1 t2)
 
     let integer_bit_width = if Target_system.is_32_bit () then 32 else 64
 
     let shift_left t shift =
-      with_shift shift zero (fun shift -> shift_left t shift) ~integer_bit_width
+      with_shift shift
+        (zero (machine_width t))
+        (fun shift -> shift_left t shift)
+        ~integer_bit_width
 
     let shift_right t shift =
-      with_shift shift zero
+      with_shift shift
+        (zero (machine_width t))
         (fun shift -> shift_right t shift)
         ~integer_bit_width
 
     let shift_right_logical t shift =
-      with_shift shift zero
+      with_shift shift
+        (zero (machine_width t))
         (fun shift -> shift_right_logical t shift)
         ~integer_bit_width
 
     let to_const t = Reg_width_const.naked_nativeint t
 
-    let to_immediate t = Target_ocaml_int.of_targetint t
+    let to_immediate t machine_width =
+      Target_ocaml_int.of_targetint machine_width t
 
     let to_naked_float32 t =
       Float32_by_bit_pattern.create (Targetint_32_64.to_float t)
@@ -861,7 +947,7 @@ module For_nativeints : Boxable_int_number_kind = struct
 
     let to_naked_int64 t = Targetint_32_64.to_int64 t
 
-    let to_naked_nativeint t = t
+    let to_naked_nativeint t _machine_width = t
   end
 
   let standard_int_or_float_kind : K.Standard_int_or_float.t = Naked_nativeint

--- a/middle_end/flambda2/simplify/number_adjuncts.mli
+++ b/middle_end/flambda2/simplify/number_adjuncts.mli
@@ -29,11 +29,11 @@ module type Num_common = sig
 
   val cross_product : Set.t -> Set.t -> Pair.Set.t
 
-  val zero : t
+  val zero : Target_system.Machine_width.t -> t
 
-  val one : t
+  val one : Target_system.Machine_width.t -> t
 
-  val minus_one : t
+  val minus_one : Target_system.Machine_width.t -> t
 
   val add : t -> t -> t
 
@@ -47,7 +47,7 @@ module type Num_common = sig
 
   val to_const : t -> Reg_width_const.t
 
-  val to_immediate : t -> Target_ocaml_int.t
+  val to_immediate : t -> Target_system.Machine_width.t -> Target_ocaml_int.t
 
   val to_naked_float32 : t -> Numeric_types.Float32_by_bit_pattern.t
 
@@ -61,7 +61,8 @@ module type Num_common = sig
 
   val to_naked_int64 : t -> Numeric_types.Int64.t
 
-  val to_naked_nativeint : t -> Targetint_32_64.t
+  val to_naked_nativeint :
+    t -> Target_system.Machine_width.t -> Targetint_32_64.t
 end
 
 module type Number_kind_common = sig

--- a/middle_end/flambda2/simplify/simplified_named.ml
+++ b/middle_end/flambda2/simplify/simplified_named.ml
@@ -34,13 +34,14 @@ type t =
     free_names : Name_occurrences.t
   }
 
-let create (named : Named.t) =
+let create ~machine_width (named : Named.t) =
   let (simplified_named : simplified_named), cost_metrics =
     match named with
     | Simple simple ->
       Simple simple, Cost_metrics.from_size (Code_size.simple simple)
     | Prim (prim, dbg) ->
-      Prim (prim, dbg), Cost_metrics.from_size (Code_size.prim prim)
+      ( Prim (prim, dbg),
+        Cost_metrics.from_size (Code_size.prim ~machine_width prim) )
     | Set_of_closures _ ->
       Misc.fatal_errorf
         "Cannot use [Simplified_named.create] on [Set_of_closures];@ use \
@@ -58,14 +59,15 @@ let create (named : Named.t) =
     free_names = Named.free_names named
   }
 
-let create_with_known_free_names ~find_code_characteristics (named : Named.t)
-    ~free_names =
+let create_with_known_free_names ~machine_width ~find_code_characteristics
+    (named : Named.t) ~free_names =
   let (simplified_named : simplified_named), cost_metrics =
     match named with
     | Simple simple ->
       Simple simple, Cost_metrics.from_size (Code_size.simple simple)
     | Prim (prim, dbg) ->
-      Prim (prim, dbg), Cost_metrics.from_size (Code_size.prim prim)
+      ( Prim (prim, dbg),
+        Cost_metrics.from_size (Code_size.prim ~machine_width prim) )
     | Set_of_closures set ->
       ( Set_of_closures set,
         Cost_metrics.set_of_closures ~find_code_characteristics set )

--- a/middle_end/flambda2/simplify/simplified_named.mli
+++ b/middle_end/flambda2/simplify/simplified_named.mli
@@ -35,10 +35,11 @@ type t = private
 (** It is an error to pass [Set_of_closures] or [Static_consts] to this
     function. (Sets of closures are disallowed because computation of their free
     names might be expensive; use [reachable_with_known_free_names] instead.) *)
-val create : Named.t -> t
+val create : machine_width:Target_system.Machine_width.t -> Named.t -> t
 
 (** It is an error to pass [Static_consts] to this function. *)
 val create_with_known_free_names :
+  machine_width:Target_system.Machine_width.t ->
   find_code_characteristics:(Code_id.t -> Cost_metrics.code_characteristics) ->
   Named.t ->
   free_names:Name_occurrences.t ->

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -24,7 +24,7 @@ type simplify_result =
     unit : Flambda_unit.t
   }
 
-let run ~cmx_loader ~round ~code_slot_offsets unit =
+let run ~cmx_loader ~machine_width ~round ~code_slot_offsets unit =
   let return_continuation = FU.return_continuation unit in
   let exn_continuation = FU.exn_continuation unit in
   let toplevel_my_region = FU.toplevel_my_region unit in
@@ -34,7 +34,8 @@ let run ~cmx_loader ~round ~code_slot_offsets unit =
   let get_imported_names = Flambda_cmx.get_imported_names cmx_loader in
   let get_imported_code = Flambda_cmx.get_imported_code cmx_loader in
   let denv =
-    DE.create ~round ~resolver ~get_imported_names ~get_imported_code
+    DE.create ~round ~machine_width ~resolver ~get_imported_names
+      ~get_imported_code
       ~propagating_float_consts:(Flambda_features.float_const_prop ())
       ~unit_toplevel_return_continuation:return_continuation
       ~unit_toplevel_exn_continuation:exn_continuation ~toplevel_my_region

--- a/middle_end/flambda2/simplify/simplify.mli
+++ b/middle_end/flambda2/simplify/simplify.mli
@@ -30,6 +30,7 @@ type simplify_result = private
 
 val run :
   cmx_loader:Flambda_cmx.loader ->
+  machine_width:Target_system.Machine_width.t ->
   round:int ->
   code_slot_offsets:Slot_offsets.t Code_id.Map.t ->
   Flambda_unit.t ->

--- a/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
@@ -47,8 +47,10 @@ let inline_linearly_used_continuation uacc ~params:params' ~handler
           |> Bound_pattern.singleton
         in
         let named = Named.create_simple arg in
+        let machine_width = UE.machine_width (UA.uenv uacc) in
         { Expr_builder.let_bound;
-          simplified_defining_expr = Simplified_named.create named;
+          simplified_defining_expr =
+            Simplified_named.create ~machine_width named;
           original_defining_expr = Some named
         })
   in

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -79,17 +79,17 @@ let update_exn_continuation_extra_args uacc ~exn_cont_use_id apply =
          (Apply.exn_continuation apply))
 
 (* generate the projection of the i-th field of a n-tuple *)
-let project_tuple ~dbg ~size ~field tuple =
+let project_tuple ~machine_width ~dbg ~size ~field tuple =
   let module BAK = P.Block_access_kind in
   let bak : BAK.t =
     Values
       { field_kind = Any_value;
         tag = Known Tag.Scannable.zero;
-        size = Known (Target_ocaml_int.of_int size)
+        size = Known (Target_ocaml_int.of_int machine_width size)
       }
   in
   let mutability : Mutability.t = Immutable in
-  let field = Target_ocaml_int.of_int field in
+  let field = Target_ocaml_int.of_int machine_width field in
   let prim =
     P.Unary (Block_load { kind = bak; mut = mutability; field }, tuple)
   in
@@ -394,7 +394,7 @@ let patch_unused_exn_bucket uacc apply_cont =
       else
         (* The raise argument must be present, if it is unused, we replace it by
            a dummy value to avoid keeping a useless value alive *)
-        let dummy_value = Simple.const_zero in
+        let dummy_value = Simple.const_zero (UE.machine_width (UA.uenv uacc)) in
         AC.update_args ~args:(dummy_value :: other_args) apply_cont
   else apply_cont
 

--- a/middle_end/flambda2/simplify/simplify_common.mli
+++ b/middle_end/flambda2/simplify/simplify_common.mli
@@ -109,7 +109,12 @@ val update_exn_continuation_extra_args :
 (** Create a projection from a tuple (assumed to be a [size]-tuple of OCaml
     values). *)
 val project_tuple :
-  dbg:Debuginfo.t -> size:int -> field:int -> Simple.t -> Named.t
+  machine_width:Target_system.Machine_width.t ->
+  dbg:Debuginfo.t ->
+  size:int ->
+  field:int ->
+  Simple.t ->
+  Named.t
 
 (** Split a direct over-application into a full application followed by the
     application of the leftover arguments. *)

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -62,10 +62,13 @@ let simplify_toplevel_common dacc simplify ~params ~implicit_params
             ~code_ids_to_never_delete:(DA.code_ids_to_never_delete dacc)
             ~specialization_map:(DA.specialization_map dacc)
             ~return_continuation ~exn_continuation
+            ~machine_width:(DE.machine_width (DA.denv dacc))
         in
         let uenv =
           UE.add_function_return_or_exn_continuation
-            (UE.create (DA.are_rebuilding_terms dacc))
+            (UE.create
+               (DA.are_rebuilding_terms dacc)
+               ~machine_width:(DE.machine_width (DA.denv dacc)))
             return_continuation return_arity
         in
         let uenv =

--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -91,9 +91,11 @@ let rebuild_let simplify_named_result removed_operations ~rewrite_id
             with
             | None -> binding
             | Some dbg ->
+              let machine_width = UE.machine_width (UA.uenv uacc) in
               { binding with
                 simplified_defining_expr =
-                  Simplified_named.create (Named.create_prim prim dbg)
+                  Simplified_named.create ~machine_width
+                    (Named.create_prim prim dbg)
               }))
         | Simple _ | Set_of_closures _ | Rec_info _ -> binding)
       bindings
@@ -116,6 +118,7 @@ let rebuild_let simplify_named_result removed_operations ~rewrite_id
               ~operation:(Removed_operations.prim original_prim)
               uacc
           in
+          let machine_width = UE.machine_width (UA.uenv uacc) in
           let new_bindings =
             match prim_rewrite with
             | Remove_prim -> []
@@ -124,7 +127,8 @@ let rebuild_let simplify_named_result removed_operations ~rewrite_id
               let binding =
                 { binding with
                   simplified_defining_expr =
-                    Simplified_named.create (Named.create_prim prim dbg)
+                    Simplified_named.create ~machine_width
+                      (Named.create_prim prim dbg)
                 }
               in
               [binding]
@@ -135,7 +139,8 @@ let rebuild_let simplify_named_result removed_operations ~rewrite_id
               let binding =
                 { binding with
                   simplified_defining_expr =
-                    Simplified_named.create (Named.create_simple bound_to)
+                    Simplified_named.create ~machine_width
+                      (Named.create_simple bound_to)
                 }
               in
               [binding]

--- a/middle_end/flambda2/simplify/simplify_named.ml
+++ b/middle_end/flambda2/simplify/simplify_named.ml
@@ -74,10 +74,12 @@ let simplify_named0 dacc (bound_pattern : Bound_pattern.t) (named : Named.t)
     let min_name_mode = Bound_var.name_mode bound_var in
     let ty, new_simple = S.simplify_simple dacc simple ~min_name_mode in
     let dacc = DA.add_variable dacc bound_var ty in
+    let machine_width = DE.machine_width (DA.denv dacc) in
     let defining_expr =
       if simple == new_simple
-      then Simplified_named.create named
-      else Simplified_named.create (Named.create_simple new_simple)
+      then Simplified_named.create ~machine_width named
+      else
+        Simplified_named.create ~machine_width (Named.create_simple new_simple)
     in
     Ok
       (Simplify_named_result.create dacc
@@ -190,10 +192,13 @@ let simplify_named0 dacc (bound_pattern : Bound_pattern.t) (named : Named.t)
     in
     let ty = T.this_rec_info rec_info_expr in
     let dacc = DA.add_variable dacc bound_var ty in
+    let machine_width = DE.machine_width (DA.denv dacc) in
     let defining_expr =
       if rec_info_expr == new_rec_info_expr
-      then Simplified_named.create named
-      else Simplified_named.create (Named.create_rec_info new_rec_info_expr)
+      then Simplified_named.create ~machine_width named
+      else
+        Simplified_named.create ~machine_width
+          (Named.create_rec_info new_rec_info_expr)
     in
     Ok
       (Simplify_named_result.create dacc

--- a/middle_end/flambda2/simplify/simplify_named_result.ml
+++ b/middle_end/flambda2/simplify/simplify_named_result.ml
@@ -30,13 +30,15 @@ let create dacc bindings_to_place =
 let create_have_lifted_set_of_closures dacc bound_vars_to_symbols
     ~original_defining_expr =
   (* The benefit of lifting the set of closures is added in [Simplify_named]. *)
+  let machine_width = Downwards_env.machine_width (Downwards_acc.denv dacc) in
   { dacc;
     bindings_to_place =
       List.mapi
         (fun i (var, sym) ->
           { Expr_builder.let_bound = Bound_pattern.singleton var;
             simplified_defining_expr =
-              Simplified_named.create (Named.create_simple (Simple.symbol sym));
+              Simplified_named.create ~machine_width
+                (Named.create_simple (Simple.symbol sym));
             original_defining_expr =
               (if i = 0 then Some original_defining_expr else None)
           })

--- a/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
@@ -32,7 +32,9 @@ let simplify_nullary_primitive dacc original_prim (prim : P.nullary_primitive)
     Simplify_primitive_result.create named ~try_reify:false dacc
   | Probe_is_enabled { name = _ } ->
     let named = Named.create_prim original_prim dbg in
-    let ty = T.any_naked_bool in
+    let ty =
+      T.any_naked_bool ~machine_width:(DE.machine_width (DA.denv dacc))
+    in
     let dacc = DA.add_variable dacc result_var ty in
     Simplify_primitive_result.create named ~try_reify:false dacc
   | Enter_inlined_apply { dbg } ->
@@ -40,8 +42,9 @@ let simplify_nullary_primitive dacc original_prim (prim : P.nullary_primitive)
       DA.map_denv dacc ~f:(fun denv ->
           DE.merge_inlined_debuginfo denv ~from_apply_expr:dbg)
     in
-    let named = Named.create_simple Simple.const_unit in
-    let ty = T.this_tagged_immediate Target_ocaml_int.zero in
+    let machine_width = DE.machine_width (DA.denv dacc) in
+    let named = Named.create_simple (Simple.const_unit machine_width) in
+    let ty = T.this_tagged_immediate (Target_ocaml_int.zero machine_width) in
     let dacc = DA.add_variable dacc result_var ty in
     Simplify_primitive_result.create named ~try_reify:false dacc
   | Dls_get ->
@@ -51,11 +54,13 @@ let simplify_nullary_primitive dacc original_prim (prim : P.nullary_primitive)
     Simplify_primitive_result.create named ~try_reify:false dacc
   | Poll ->
     let named = Named.create_prim original_prim dbg in
-    let ty = T.this_tagged_immediate Target_ocaml_int.zero in
+    let machine_width = DE.machine_width (DA.denv dacc) in
+    let ty = T.this_tagged_immediate (Target_ocaml_int.zero machine_width) in
     let dacc = DA.add_variable dacc result_var ty in
     Simplify_primitive_result.create named ~try_reify:false dacc
   | Cpu_relax ->
     let named = Named.create_prim original_prim dbg in
-    let ty = T.this_tagged_immediate Target_ocaml_int.zero in
+    let machine_width = DE.machine_width (DA.denv dacc) in
+    let ty = T.this_tagged_immediate (Target_ocaml_int.zero machine_width) in
     let dacc = DA.add_variable dacc result_var ty in
     Simplify_primitive_result.create named ~try_reify:false dacc

--- a/middle_end/flambda2/simplify/simplify_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_primitive.ml
@@ -57,8 +57,9 @@ let try_cse dacc dbg ~original_prim ~min_name_mode ~result_var : cse_result =
             ~operation:(Removed_operations.prim original_prim)
             Cost_metrics.zero
         in
+        let machine_width = DE.machine_width (DA.denv dacc) in
         let simplified_named =
-          Simplified_named.create named
+          Simplified_named.create ~machine_width named
           |> Simplified_named.update_cost_metrics cost_metrics
         in
         Simplify_primitive_result.create_simplified simplified_named

--- a/middle_end/flambda2/simplify/simplify_primitive_result.ml
+++ b/middle_end/flambda2/simplify/simplify_primitive_result.ml
@@ -24,7 +24,8 @@ type t =
   }
 
 let create ?(extra_bindings = []) named ~try_reify dacc =
-  { simplified_named = Ok (Simplified_named.create named);
+  let machine_width = Downwards_env.machine_width (Downwards_acc.denv dacc) in
+  { simplified_named = Ok (Simplified_named.create ~machine_width named);
     try_reify;
     dacc;
     extra_bindings
@@ -43,7 +44,10 @@ let create_invalid dacc =
 let create_unit dacc ~result_var ~original_term =
   (* CR gbury: would it make sense to have a Flambda2_types.unit instead of this
      ? *)
-  let ty = Flambda2_types.this_tagged_immediate Target_ocaml_int.zero in
+  let machine_width = Downwards_env.machine_width (Downwards_acc.denv dacc) in
+  let ty =
+    Flambda2_types.this_tagged_immediate (Target_ocaml_int.zero machine_width)
+  in
   let dacc = Downwards_acc.add_variable dacc result_var ty in
   create original_term ~try_reify:false dacc
 

--- a/middle_end/flambda2/simplify/simplify_quaternary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_quaternary_primitive.ml
@@ -61,7 +61,10 @@ let simplify_atomic_compare_and_set_field
            desired ))
       dbg
   in
-  let dacc = DA.add_variable dacc result_var T.any_tagged_bool in
+  let dacc =
+    DA.add_variable dacc result_var
+      (T.any_tagged_bool ~machine_width:(DE.machine_width (DA.denv dacc)))
+  in
   SPR.create new_term ~try_reify:false dacc
 
 let simplify_atomic_compare_exchange_field

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -812,7 +812,9 @@ let simplify_non_lifted_set_of_closures0 dacc bound_vars ~closure_bound_vars
             Flambda_arity.num_params (Code_metadata.params_arity code_metadata)
         }
     in
-    Simplified_named.create_with_known_free_names ~find_code_characteristics
+    let machine_width = DE.machine_width (DA.denv dacc) in
+    Simplified_named.create_with_known_free_names ~machine_width
+      ~find_code_characteristics
       (Named.create_set_of_closures set_of_closures)
       ~free_names:(Named.free_names named)
   in

--- a/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_ternary_primitive.ml
@@ -54,7 +54,10 @@ let simplify_array_set (array_kind : P.Array_kind.t)
            (Array_set (array_kind, array_set_kind), array, index, new_value))
         dbg
     in
-    let unit_ty = Flambda2_types.this_tagged_immediate Target_ocaml_int.zero in
+    let machine_width = DE.machine_width (DA.denv dacc) in
+    let unit_ty =
+      Flambda2_types.this_tagged_immediate (Target_ocaml_int.zero machine_width)
+    in
     let dacc = DA.add_variable dacc result_var unit_ty in
     SPR.create named ~try_reify:false dacc
 

--- a/middle_end/flambda2/simplify/specialization_cost.ml
+++ b/middle_end/flambda2/simplify/specialization_cost.ml
@@ -58,8 +58,8 @@ let update_cost ~f = function
   | Can_specialize cost -> Can_specialize (f cost)
   | Cannot_specialize _ as res -> res
 
-let add_prim prim t =
-  let size = Code_size.to_int (Code_size.prim prim) in
+let add_prim ~machine_width prim t =
+  let size = Code_size.to_int (Code_size.prim ~machine_width prim) in
   update_cost t ~f:(fun { size_of_primitives = s } ->
       { size_of_primitives = size + s })
 

--- a/middle_end/flambda2/simplify/specialization_cost.mli
+++ b/middle_end/flambda2/simplify/specialization_cost.mli
@@ -71,7 +71,8 @@ val cannot_specialize : reason -> t
 (** {2 Updating Costs} *)
 
 (** Add a primitive of the given size to the cost of specialization *)
-val add_prim : Flambda_primitive.t -> t -> t
+val add_prim :
+  machine_width:Target_system.Machine_width.t -> Flambda_primitive.t -> t -> t
 
 (** Add a set of closure containing [~num] closures to the cost of specialization. *)
 val add_set_of_closures : Set_of_closures.t -> t -> t

--- a/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
+++ b/middle_end/flambda2/simplify/unboxing/build_unboxing_denv.ml
@@ -54,6 +54,7 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
     let shape =
       T.immutable_block ~is_unique:false tag ~shape ~fields:field_types
         (Alloc_mode.For_types.unknown ())
+        ~machine_width:(DE.machine_width denv)
     in
     let denv = add_equation_on_var denv param_var shape in
     List.fold_left
@@ -176,7 +177,9 @@ let rec denv_of_decision denv ~param_var (decision : U.decision) : DE.t =
         fields_by_tag
     in
     let shape =
-      T.variant ~const_ctors ~non_const_ctors (Alloc_mode.For_types.unknown ())
+      T.variant ~machine_width:(DE.machine_width denv) ~const_ctors
+        ~non_const_ctors
+        (Alloc_mode.For_types.unknown ())
     in
     let denv = add_equation_on_var denv param_var shape in
     (* Recurse on the fields *)

--- a/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
+++ b/middle_end/flambda2/simplify/unboxing/optimistic_unboxing_decision.ml
@@ -185,6 +185,7 @@ and make_optimistic_fields ~add_tag_to_name ~depth ~recursive tenv param_type
   let shape =
     T.immutable_block ~is_unique:false tag ~shape ~fields:field_types
       (Alloc_mode.For_types.unknown ())
+      ~machine_width:(TE.machine_width tenv)
   in
   match T.meet tenv param_type shape with
   | Bottom -> None

--- a/middle_end/flambda2/simplify/unboxing/unbox_continuation_params.mli
+++ b/middle_end/flambda2/simplify/unboxing/unbox_continuation_params.mli
@@ -36,6 +36,7 @@ val make_decisions :
   DE.t * Decisions.t
 
 val compute_extra_params_and_args :
+  machine_width:Target_system.Machine_width.t ->
   Decisions.t ->
   arg_types_by_use_id:Continuation_uses.arg_types_by_use_id ->
   EPA.t ->

--- a/middle_end/flambda2/simplify/unboxing/unboxers.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.ml
@@ -36,7 +36,7 @@ module type Number_S = sig
 
   val unboxing_prim : Simple.t -> P.t
 
-  val unboxer : unboxer
+  val unboxer : Target_system.Machine_width.t -> unboxer
 end
 
 module Immediate = struct
@@ -48,10 +48,11 @@ module Immediate = struct
 
   let unboxing_prim simple = P.(Unary (Untag_immediate, simple))
 
-  let unboxer =
+  let unboxer machine_width =
     { var_name = "naked_immediate";
       var_kind = K.naked_immediate;
-      poison_const = Const.naked_immediate (Target_ocaml_int.of_int 0xabcd);
+      poison_const =
+        Const.naked_immediate (Target_ocaml_int.of_int machine_width 0xabcd);
       unboxing_prim;
       prove_simple = T.meet_tagging_of_simple
     }
@@ -66,7 +67,7 @@ module Float32 = struct
 
   let unboxing_prim simple = P.(Unary (Unbox_number Naked_float32, simple))
 
-  let unboxer =
+  let unboxer _machine_width =
     { var_name = "unboxed_float32";
       var_kind = K.naked_float32;
       poison_const =
@@ -85,7 +86,7 @@ module Float = struct
 
   let unboxing_prim simple = P.(Unary (Unbox_number Naked_float, simple))
 
-  let unboxer =
+  let unboxer _machine_width =
     { var_name = "unboxed_float";
       var_kind = K.naked_float;
       poison_const = Const.naked_float Numeric_types.Float_by_bit_pattern.zero;
@@ -103,7 +104,7 @@ module Int32 = struct
 
   let unboxing_prim simple = P.(Unary (Unbox_number Naked_int32, simple))
 
-  let unboxer =
+  let unboxer _machine_width =
     { var_name = "unboxed_int32";
       var_kind = K.naked_int32;
       poison_const = Const.naked_int32 Int32.(div 0xabcd0l 2l);
@@ -121,7 +122,7 @@ module Int64 = struct
 
   let unboxing_prim simple = P.(Unary (Unbox_number Naked_int64, simple))
 
-  let unboxer =
+  let unboxer _machine_width =
     { var_name = "unboxed_int64";
       var_kind = K.naked_int64;
       poison_const = Const.naked_int64 Int64.(div 0xdcba0L 2L);
@@ -139,10 +140,10 @@ module Nativeint = struct
 
   let unboxing_prim simple = P.(Unary (Unbox_number Naked_nativeint, simple))
 
-  let unboxer =
+  let unboxer machine_width =
     { var_name = "unboxed_nativeint";
       var_kind = K.naked_nativeint;
-      poison_const = Const.naked_nativeint Targetint_32_64.zero;
+      poison_const = Const.naked_nativeint (Targetint_32_64.zero machine_width);
       unboxing_prim;
       prove_simple = T.meet_boxed_nativeint_containing_simple
     }
@@ -157,7 +158,7 @@ module Vec128 = struct
 
   let unboxing_prim simple = P.(Unary (Unbox_number Naked_vec128, simple))
 
-  let unboxer =
+  let unboxer _machine_width =
     { var_name = "unboxed_vec128";
       var_kind = K.naked_vec128;
       poison_const = Const.naked_vec128 Vector_types.Vec128.Bit_pattern.zero;
@@ -175,7 +176,7 @@ module Vec256 = struct
 
   let unboxing_prim simple = P.(Unary (Unbox_number Naked_vec256, simple))
 
-  let unboxer =
+  let unboxer _machine_width =
     { var_name = "unboxed_vec256";
       var_kind = K.naked_vec256;
       poison_const = Const.naked_vec256 Vector_types.Vec256.Bit_pattern.zero;
@@ -193,7 +194,7 @@ module Vec512 = struct
 
   let unboxing_prim simple = P.(Unary (Unbox_number Naked_vec512, simple))
 
-  let unboxer =
+  let unboxer _machine_width =
     { var_name = "unboxed_vec512";
       var_kind = K.naked_vec512;
       poison_const = Const.naked_vec512 Vector_types.Vec512.Bit_pattern.zero;
@@ -224,10 +225,11 @@ module Closure_field = struct
     P.Unary
       (Project_value_slot { project_from = function_slot; value_slot }, closure)
 
-  let unboxer function_slot value_slot =
+  let unboxer machine_width function_slot value_slot =
     { var_name = "closure_field_at_use";
       var_kind = Value_slot.kind value_slot;
-      poison_const = Const.of_int_of_kind (Value_slot.kind value_slot) 0;
+      poison_const =
+        Const.of_int_of_kind machine_width (Value_slot.kind value_slot) 0;
       unboxing_prim =
         (fun closure -> unboxing_prim function_slot ~closure value_slot);
       prove_simple =

--- a/middle_end/flambda2/simplify/unboxing/unboxers.mli
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.mli
@@ -45,7 +45,8 @@ end
 module Closure_field : sig
   val unboxing_prim : Function_slot.t -> closure:Simple.t -> Value_slot.t -> P.t
 
-  val unboxer : Function_slot.t -> Value_slot.t -> unboxer
+  val unboxer :
+    Target_system.Machine_width.t -> Function_slot.t -> Value_slot.t -> unboxer
 end
 
 (* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -58,7 +59,7 @@ module type Number_S = sig
 
   val unboxing_prim : Simple.t -> P.t
 
-  val unboxer : unboxer
+  val unboxer : Target_system.Machine_width.t -> unboxer
 end
 
 module Immediate : Number_S

--- a/middle_end/flambda2/simplify/unboxing/unboxing_epa.mli
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_epa.mli
@@ -29,6 +29,7 @@ val compute_extra_args_for_one_decision_and_use :
   pass:Unboxing_types.pass ->
   Apply_cont_rewrite_id.t ->
   typing_env_at_use:Flambda2_types.Typing_env.t ->
+  machine_width:Target_system.Machine_width.t ->
   unboxed_arg ->
   Unboxing_types.decision ->
   Unboxing_types.decision

--- a/middle_end/flambda2/term_basics/simple.ml
+++ b/middle_end/flambda2/term_basics/simple.ml
@@ -17,32 +17,40 @@
 module RWC = Reg_width_const
 include Int_ids.Simple
 
-let const_bool b = const (if b then RWC.const_true else RWC.const_false)
+let const_bool machine_width b =
+  const
+    (if b then RWC.const_true machine_width else RWC.const_false machine_width)
 
-let const_true = const_bool true
+let const_true machine_width = const_bool machine_width true
 
-let const_false = const_bool false
+let const_false machine_width = const_bool machine_width false
 
-let untagged_const_true = const RWC.untagged_const_true
+let untagged_const_true machine_width =
+  const (RWC.untagged_const_true machine_width)
 
-let untagged_const_false = const RWC.untagged_const_false
+let untagged_const_false machine_width =
+  const (RWC.untagged_const_false machine_width)
 
-let untagged_const_bool b =
-  if b then untagged_const_true else untagged_const_false
+let untagged_const_bool machine_width b =
+  if b
+  then untagged_const_true machine_width
+  else untagged_const_false machine_width
 
-let untagged_const_zero = const RWC.untagged_const_zero
+let untagged_const_zero machine_width =
+  const (RWC.untagged_const_zero machine_width)
 
 let untagged_const_int i = const (RWC.untagged_const_int i)
 
 let const_int i = const (RWC.const_int i)
 
-let const_zero = const RWC.const_zero
+let const_zero machine_width = const (RWC.const_zero machine_width)
 
-let const_one = const RWC.const_one
+let const_one machine_width = const (RWC.const_one machine_width)
 
-let const_unit = const RWC.const_unit
+let const_unit machine_width = const (RWC.const_unit machine_width)
 
-let const_int_of_kind kind i = const (RWC.of_int_of_kind kind i)
+let const_int_of_kind ~machine_width kind i =
+  const (RWC.of_int_of_kind machine_width kind i)
 
 let[@inline always] is_var t =
   pattern_match t

--- a/middle_end/flambda2/term_basics/simple.mli
+++ b/middle_end/flambda2/term_basics/simple.mli
@@ -43,36 +43,37 @@ val must_be_const : t -> Reg_width_const.t option
 val const_int : Target_ocaml_int.t -> t
 
 (** The constant representating the given boolean value. *)
-val const_bool : bool -> t
+val const_bool : Target_system.Machine_width.t -> bool -> t
 
 (** The naked immediate constant representating the given boolean value. *)
-val untagged_const_bool : bool -> t
+val untagged_const_bool : Target_system.Machine_width.t -> bool -> t
 
 (** The constant representating boolean true. *)
-val const_true : t
+val const_true : Target_system.Machine_width.t -> t
 
-val untagged_const_true : t
+val untagged_const_true : Target_system.Machine_width.t -> t
 
 (** The constant representating boolean false. *)
-val const_false : t
+val const_false : Target_system.Machine_width.t -> t
 
-val untagged_const_false : t
+val untagged_const_false : Target_system.Machine_width.t -> t
 
 (** The constant representating the number zero of type "int". *)
-val const_zero : t
+val const_zero : Target_system.Machine_width.t -> t
 
-val untagged_const_zero : t
+val untagged_const_zero : Target_system.Machine_width.t -> t
 
 val untagged_const_int : Target_ocaml_int.t -> t
 
-val const_one : t
+val const_one : Target_system.Machine_width.t -> t
 
 (** The constant representing the unit value. *)
-val const_unit : t
+val const_unit : Target_system.Machine_width.t -> t
 
 val const_from_descr : Reg_width_const.Descr.t -> t
 
-val const_int_of_kind : Flambda_kind.t -> int -> t
+val const_int_of_kind :
+  machine_width:Target_system.Machine_width.t -> Flambda_kind.t -> int -> t
 
 val is_const : t -> bool
 

--- a/middle_end/flambda2/term_basics/string_info.ml
+++ b/middle_end/flambda2/term_basics/string_info.ml
@@ -46,19 +46,20 @@ include Container_types.Make (struct
 
   let hash t = Hashtbl.hash t
 
-  let [@ocamlformat "disable"] print ppf { contents; size; } =
+  let print ppf { contents; size } =
     match contents with
     | Unknown_or_mutable ->
-      Format.fprintf ppf "(size %a)"
-        Target_ocaml_int.print size
+      Format.fprintf ppf "(size %a)" Target_ocaml_int.print size
     | Contents s ->
       let s, dots =
-        let max_size = Target_ocaml_int.ten in
+        let machine_width =
+          (* This value doesn't matter *)
+          Target_system.Machine_width.Sixty_four
+        in
+        let max_size = Target_ocaml_int.ten machine_width in
         let long = Target_ocaml_int.compare size max_size > 0 in
-        if long then String.sub s 0 8, "..."
-        else s, ""
+        if long then String.sub s 0 8, "..." else s, ""
       in
-      Format.fprintf ppf "(size %a) (contents \"%S\"%s)"
-        Target_ocaml_int.print size
-        s dots
+      Format.fprintf ppf "(size %a) (contents \"%S\"%s)" Target_ocaml_int.print
+        size s dots
 end)

--- a/middle_end/flambda2/terms/code_size.mli
+++ b/middle_end/flambda2/terms/code_size.mli
@@ -38,7 +38,8 @@ val equal : t -> t -> bool
 
 val print : Format.formatter -> t -> unit
 
-val prim : Flambda_primitive.t -> t
+val prim :
+  machine_width:Target_system.Machine_width.t -> Flambda_primitive.t -> t
 
 val simple : Simple.t -> t
 

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -1391,12 +1391,14 @@ module Named = struct
     | Static_consts _ -> true
     | Rec_info _ -> true
 
-  let dummy_value (kind : K.t) : t =
+  let dummy_value ~machine_width (kind : K.t) : t =
     let simple =
       match kind with
-      | Value -> Simple.const_zero
+      | Value -> Simple.const_zero machine_width
       | Naked_number Naked_immediate ->
-        Simple.const (Reg_width_const.naked_immediate Target_ocaml_int.zero)
+        Simple.const
+          (Reg_width_const.naked_immediate
+             (Target_ocaml_int.zero machine_width))
       | Naked_number Naked_float ->
         Simple.const
           (Reg_width_const.naked_float Numeric_types.Float_by_bit_pattern.zero)
@@ -1413,7 +1415,8 @@ module Named = struct
       | Naked_number Naked_int64 ->
         Simple.const (Reg_width_const.naked_int64 Int64.zero)
       | Naked_number Naked_nativeint ->
-        Simple.const (Reg_width_const.naked_nativeint Targetint_32_64.zero)
+        Simple.const
+          (Reg_width_const.naked_nativeint (Targetint_32_64.zero machine_width))
       | Naked_number Naked_vec128 ->
         Simple.const
           (Reg_width_const.naked_vec128 Vector_types.Vec128.Bit_pattern.zero)

--- a/middle_end/flambda2/terms/flambda.mli
+++ b/middle_end/flambda2/terms/flambda.mli
@@ -185,7 +185,8 @@ module Named : sig
 
   (** Return a defining expression for a [Let] which is kind-correct, but not
       necessarily type-correct, at the given kind. *)
-  val dummy_value : Flambda_kind.t -> t
+  val dummy_value :
+    machine_width:Target_system.Machine_width.t -> Flambda_kind.t -> t
 
   (** Return the kind of the expression. Must only be used on expressions
       bound to a singleton pattern (everything except sets of closures and static consts). *)

--- a/middle_end/flambda2/terms/switch_expr.ml
+++ b/middle_end/flambda2/terms/switch_expr.ml
@@ -71,11 +71,11 @@ let print ppf { condition_dbg; scrutinee; arms } =
 
 let create ~condition_dbg ~scrutinee ~arms = { condition_dbg; scrutinee; arms }
 
-let if_then_else ~condition_dbg ~scrutinee ~if_true ~if_false =
+let if_then_else ~machine_width ~condition_dbg ~scrutinee ~if_true ~if_false =
   let arms =
     Target_ocaml_int.Map.of_list
-      [ Target_ocaml_int.bool_true, if_true;
-        Target_ocaml_int.bool_false, if_false ]
+      [ Target_ocaml_int.bool_true machine_width, if_true;
+        Target_ocaml_int.bool_false machine_width, if_false ]
   in
   create ~condition_dbg ~scrutinee ~arms
 

--- a/middle_end/flambda2/terms/switch_expr.mli
+++ b/middle_end/flambda2/terms/switch_expr.mli
@@ -33,6 +33,7 @@ val create :
 
 (** Create a [Switch] corresponding to a traditional if-then-else. *)
 val if_then_else :
+  machine_width:Target_system.Machine_width.t ->
   condition_dbg:Debuginfo.t ->
   scrutinee:Simple.t ->
   if_true:Apply_cont_expr.t ->

--- a/middle_end/flambda2/tests/api_tests/extension_meet.ml
+++ b/middle_end/flambda2/tests/api_tests/extension_meet.ml
@@ -12,6 +12,7 @@ let _test_recursive_meet () =
     TE.create
       ~resolver:(fun _ -> None)
       ~get_imported_names:(fun () -> Name.Set.empty)
+      ~machine_width:Sixty_four
   in
   let var_x = Variable.create "x" Flambda_kind.value in
   let var_y = Variable.create "y" Flambda_kind.value in
@@ -35,6 +36,7 @@ let _test_recursive_meet () =
       ~shape:(Flambda_kind.Block_shape.Scannable Value_only)
       Alloc_mode.For_types.heap
       ~fields:[alias name]
+      ~machine_width:Sixty_four
   in
   let env = TE.add_equation env n_x (mk_block_type n_y) in
   let env = TE.add_equation env n_y (mk_block_type n_z) in
@@ -43,13 +45,13 @@ let _test_recursive_meet () =
     T.immutable_block ~is_unique:false Tag.zero
       ~shape:(Flambda_kind.Block_shape.Scannable Value_only)
       ~fields:[alias n_v; alias n_v]
-      Alloc_mode.For_types.heap
+      Alloc_mode.For_types.heap ~machine_width:Sixty_four
   in
   let ty2 =
     T.immutable_block ~is_unique:false Tag.zero
       ~shape:(Flambda_kind.Block_shape.Scannable Value_only)
       ~fields:[alias n_x; alias n_y]
-      Alloc_mode.For_types.heap
+      Alloc_mode.For_types.heap ~machine_width:Sixty_four
   in
   Format.eprintf "Environment: %a@." TE.print env;
   match T.meet env ty1 ty2 with
@@ -63,6 +65,7 @@ let _test_bottom_detection () =
     TE.create
       ~resolver:(fun _ -> None)
       ~get_imported_names:(fun () -> Name.Set.empty)
+      ~machine_width:Sixty_four
   in
   let var_x = Variable.create "x" Flambda_kind.value in
   let n_x = Name.var var_x in
@@ -71,19 +74,20 @@ let _test_bottom_detection () =
   let alias name = T.alias_type_of Flambda_kind.value (Simple.name name) in
   let const n =
     T.alias_type_of Flambda_kind.value
-      (Simple.const (Reg_width_const.const_int (Target_ocaml_int.of_int n)))
+      (Simple.const
+         (Reg_width_const.const_int (Target_ocaml_int.of_int Sixty_four n)))
   in
   let ty1 =
     T.immutable_block ~is_unique:false Tag.zero
       ~shape:(Flambda_kind.Block_shape.Scannable Value_only)
       ~fields:[alias n_x; alias n_x]
-      Alloc_mode.For_types.heap
+      Alloc_mode.For_types.heap ~machine_width:Sixty_four
   in
   let ty2 =
     T.immutable_block ~is_unique:false Tag.zero
       ~shape:(Flambda_kind.Block_shape.Scannable Value_only)
       ~fields:[const 0; const 1]
-      Alloc_mode.For_types.heap
+      Alloc_mode.For_types.heap ~machine_width:Sixty_four
   in
   Format.eprintf "Environment: %a@." TE.print env;
   match T.meet env ty1 ty2 with
@@ -97,6 +101,7 @@ let _test_bottom_recursive () =
     TE.create
       ~resolver:(fun _ -> None)
       ~get_imported_names:(fun () -> Name.Set.empty)
+      ~machine_width:Sixty_four
   in
   let var_x = Variable.create "x" Flambda_kind.value in
   let n_x = Name.var var_x in
@@ -105,26 +110,27 @@ let _test_bottom_recursive () =
   let alias name = T.alias_type_of Flambda_kind.value (Simple.name name) in
   let const n =
     T.alias_type_of Flambda_kind.value
-      (Simple.const (Reg_width_const.const_int (Target_ocaml_int.of_int n)))
+      (Simple.const
+         (Reg_width_const.const_int (Target_ocaml_int.of_int Sixty_four n)))
   in
   let ty_x =
     T.immutable_block ~is_unique:false Tag.zero
       ~shape:(Flambda_kind.Block_shape.Scannable Value_only)
       ~fields:[T.unknown Flambda_kind.value; alias n_x]
-      Alloc_mode.For_types.heap
+      Alloc_mode.For_types.heap ~machine_width:Sixty_four
   in
   let env = TE.add_equation env n_x ty_x in
   let ty_cell2 =
     T.immutable_block ~is_unique:false Tag.zero
       ~shape:(Flambda_kind.Block_shape.Scannable Value_only)
       ~fields:[const 1; T.unknown Flambda_kind.value]
-      Alloc_mode.For_types.heap
+      Alloc_mode.For_types.heap ~machine_width:Sixty_four
   in
   let ty_cell1 =
     T.immutable_block ~is_unique:false Tag.zero
       ~shape:(Flambda_kind.Block_shape.Scannable Value_only)
       ~fields:[const 0; ty_cell2]
-      Alloc_mode.For_types.heap
+      Alloc_mode.For_types.heap ~machine_width:Sixty_four
   in
   Format.eprintf "Environment: %a@." TE.print env;
   match T.meet env (alias n_x) ty_cell1 with
@@ -141,6 +147,7 @@ let test_double_recursion () =
     TE.create
       ~resolver:(fun _ -> None)
       ~get_imported_names:(fun () -> Name.Set.empty)
+      ~machine_width:Sixty_four
   in
   let var_x = Variable.create "x" Flambda_kind.value in
   let var_y = Variable.create "y" Flambda_kind.value in
@@ -159,19 +166,19 @@ let test_double_recursion () =
     T.immutable_block ~is_unique:false Tag.zero
       ~shape:(Flambda_kind.Block_shape.Scannable Value_only)
       ~fields:[alias n_x; alias n_y; alias n_z]
-      Alloc_mode.For_types.heap
+      Alloc_mode.For_types.heap ~machine_width:Sixty_four
   in
   let ty_y =
     T.immutable_block ~is_unique:false Tag.zero
       ~shape:(Flambda_kind.Block_shape.Scannable Value_only)
       ~fields:[alias n_y; alias n_z; alias n_x]
-      Alloc_mode.For_types.heap
+      Alloc_mode.For_types.heap ~machine_width:Sixty_four
   in
   let ty_z =
     T.immutable_block ~is_unique:false Tag.zero
       ~shape:(Flambda_kind.Block_shape.Scannable Value_only)
       ~fields:[alias n_z; alias n_x; alias n_y]
-      Alloc_mode.For_types.heap
+      Alloc_mode.For_types.heap ~machine_width:Sixty_four
   in
   let env = TE.add_equation env n_x ty_x in
   let env = TE.add_equation env n_y ty_y in

--- a/middle_end/flambda2/tests/tools/flexpect.ml
+++ b/middle_end/flambda2/tests/tools/flexpect.ml
@@ -45,7 +45,7 @@ let run_expect_test ~get_module_info ~extension ~filename
   (* CR ncourant: test reaper as well *)
   let ({ unit = actual_fl; _ } : Simplify.simplify_result) =
     Simplify.run ~cmx_loader ~round:0 before_fl
-      ~code_slot_offsets:Code_id.Map.empty
+      ~code_slot_offsets:Code_id.Map.empty ~machine_width:Sixty_four
   in
   let expected_fl = Fexpr_to_flambda.conv comp_unit expected in
   match Compare.flambda_units actual_fl expected_fl with

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -118,7 +118,7 @@ let unit0 ~offsets ~all_code ~reachable_names flambda_unit =
   (* CR mshinwell: This should at least be given a source file location. *)
   let dbg = Debuginfo.none in
   let body =
-    let unit_value = C.targetint ~dbg Targetint_32_64.one in
+    let unit_value = C.targetint ~dbg (Targetint_32_64.one Sixty_four) in
     C.create_ccatch ~rec_flag:false ~body
       ~handlers:
         [ C.handler ~dbg return_cont

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -1198,8 +1198,9 @@ and switch env res switch =
   in
   let wrap, env, res = Env.flush_delayed_lets ~mode:Branching_point env res in
   let prepare_discriminant ~must_tag d =
-    let targetint_d = Target_ocaml_int.to_targetint d in
-    Targetint_32_64.to_int_checked
+    let machine_width = Target_system.Machine_width.Sixty_four in
+    let targetint_d = Target_ocaml_int.to_targetint machine_width d in
+    Targetint_32_64.to_int_checked machine_width
       (if must_tag then C.tag_targetint targetint_d else targetint_d)
   in
   let make_arm ~must_tag_discriminant env res (d, action) =

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -385,7 +385,7 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     in
     env, res, updates
   | Block_like symbol, Boxed_nativeint v ->
-    let default = Targetint_32_64.zero in
+    let default = Targetint_32_64.zero Sixty_four in
     let transl = C.nativeint_of_targetint in
     let structured i = Cmmgen_state.Const_nativeint i in
     let res, env, updates =

--- a/middle_end/flambda2/to_jsir/to_jsir.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir.ml
@@ -621,7 +621,7 @@ and switch ~env ~res e =
           let res = To_jsir_result.end_block_with_last_exn res last in
           res, (addr, []))
       res
-      (Array.init (max + 1) Target_ocaml_int.of_int)
+      (Array.init (max + 1) (Target_ocaml_int.of_int Thirty_two_no_gc_tag_bit))
   in
   let last : Jsir.last =
     match Array.length arms with

--- a/middle_end/flambda2/to_jsir/to_jsir_shared.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_shared.ml
@@ -39,7 +39,10 @@ let bind_expr_to_var ~env ~res fvar expr =
   env, res
 
 let target_ocaml_int_to_jsir_const targetint : Jsir.constant =
-  let repr = Target_ocaml_int.to_targetint targetint |> Targetint_32_64.repr in
+  let repr =
+    Target_ocaml_int.to_targetint Thirty_two_no_gc_tag_bit targetint
+    |> Targetint_32_64.repr
+  in
   let targetint =
     match repr with
     | Int32 int32 -> Targetint.of_int32 int32

--- a/middle_end/flambda2/types/env/meet_env.ml
+++ b/middle_end/flambda2/types/env/meet_env.ml
@@ -52,7 +52,7 @@ let use_meet_env_strict t ~f : _ Or_bottom.t =
 let map_typing_env t ~f = with_typing_env t (f (typing_env t))
 
 let replace_concrete_equation t name ty =
-  match TG.must_be_singleton ty with
+  match TG.must_be_singleton ty ~machine_width:(TE.machine_width t) with
   | None ->
     (* [ty] must be a concrete type. *)
     (match TG.get_alias_opt ty with

--- a/middle_end/flambda2/types/env/typing_env.mli
+++ b/middle_end/flambda2/types/env/typing_env.mli
@@ -35,7 +35,9 @@ module Serializable : sig
   val create : Pre_serializable.t -> reachable_names:Name_occurrences.t -> t
 
   val create_from_closure_conversion_approx :
-    'a Value_approximation.t Symbol.Map.t -> t
+    machine_width:Target_system.Machine_width.t ->
+    'a Value_approximation.t Symbol.Map.t ->
+    t
 
   val predefined_exceptions : Symbol.Set.t -> t
 
@@ -80,9 +82,12 @@ end
 val print : Format.formatter -> t -> unit
 
 val create :
+  machine_width:Target_system.Machine_width.t ->
   resolver:(Compilation_unit.t -> Serializable.t option) ->
   get_imported_names:(unit -> Name.Set.t) ->
   t
+
+val machine_width : t -> Target_system.Machine_width.t
 
 val is_bottom : t -> bool
 

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -132,7 +132,9 @@ module Typing_env : sig
     val create : Pre_serializable.t -> reachable_names:Name_occurrences.t -> t
 
     val create_from_closure_conversion_approx :
-      'a Value_approximation.t Symbol.Map.t -> t
+      machine_width:Target_system.Machine_width.t ->
+      'a Value_approximation.t Symbol.Map.t ->
+      t
 
     val predefined_exceptions : Symbol.Set.t -> t
 
@@ -155,9 +157,12 @@ module Typing_env : sig
   val print : Format.formatter -> t -> unit
 
   val create :
+    machine_width:Target_system.Machine_width.t ->
     resolver:(Compilation_unit.t -> Serializable.t option) ->
     get_imported_names:(unit -> Name.Set.t) ->
     t
+
+  val machine_width : t -> Target_system.Machine_width.t
 
   val closure_env : t -> t
 
@@ -317,7 +322,10 @@ val bottom : Flambda_kind.t -> t
 val unknown : Flambda_kind.t -> t
 
 val unknown_with_subkind :
-  ?alloc_mode:Alloc_mode.For_types.t -> Flambda_kind.With_subkind.t -> t
+  ?alloc_mode:Alloc_mode.For_types.t ->
+  machine_width:Target_system.Machine_width.t ->
+  Flambda_kind.With_subkind.t ->
+  t
 
 (** Create an bottom type with the same kind as the given type. *)
 val bottom_like : t -> t
@@ -331,7 +339,7 @@ val any_tagged_immediate : t
 
 val any_tagged_immediate_or_null : t
 
-val any_tagged_bool : t
+val any_tagged_bool : machine_width:Target_system.Machine_width.t -> t
 
 val any_boxed_float32 : t
 
@@ -345,7 +353,7 @@ val any_boxed_nativeint : t
 
 val any_naked_immediate : t
 
-val any_naked_bool : t
+val any_naked_bool : machine_width:Target_system.Machine_width.t -> t
 
 val any_naked_float32 : t
 
@@ -454,9 +462,11 @@ val boxed_float32_alias_to :
 
 val boxed_float_alias_to : naked_float:Variable.t -> Alloc_mode.For_types.t -> t
 
-val tagged_int8_alias_to : naked_int8:Variable.t -> t
+val tagged_int8_alias_to :
+  naked_int8:Variable.t -> machine_width:Target_system.Machine_width.t -> t
 
-val tagged_int16_alias_to : naked_int16:Variable.t -> t
+val tagged_int16_alias_to :
+  naked_int16:Variable.t -> machine_width:Target_system.Machine_width.t -> t
 
 val boxed_int32_alias_to : naked_int32:Variable.t -> Alloc_mode.For_types.t -> t
 
@@ -498,6 +508,7 @@ val any_block : t
 
 (** The type of an immutable block with a known tag, size and field types. *)
 val immutable_block :
+  machine_width:Target_system.Machine_width.t ->
   is_unique:bool ->
   Tag.t ->
   shape:Flambda_kind.Block_shape.t ->
@@ -509,6 +520,7 @@ val immutable_block :
     The type of the [n - 1]th field is taken to be an [Equals] to the given
     variable. *)
 val immutable_block_with_size_at_least :
+  machine_width:Target_system.Machine_width.t ->
   tag:Tag.t Or_unknown.t ->
   n:Target_ocaml_int.t ->
   shape:Flambda_kind.Block_shape.t ->
@@ -518,14 +530,17 @@ val immutable_block_with_size_at_least :
 val mutable_block : Alloc_mode.For_types.t -> t
 
 val variant :
+  machine_width:Target_system.Machine_width.t ->
   const_ctors:t ->
   non_const_ctors:(Flambda_kind.Block_shape.t * t list) Tag.Scannable.Map.t ->
   Alloc_mode.For_types.t ->
   t
 
-val this_immutable_string : string -> t
+val this_immutable_string :
+  string -> machine_width:Target_system.Machine_width.t -> t
 
-val mutable_string : size:int -> t
+val mutable_string :
+  size:int -> machine_width:Target_system.Machine_width.t -> t
 
 val exactly_this_closure :
   Function_slot.t ->
@@ -568,6 +583,7 @@ val immutable_array :
   element_kind:Flambda_kind.With_subkind.t Or_unknown_or_bottom.t ->
   fields:flambda_type list ->
   Alloc_mode.For_types.t ->
+  machine_width:Target_system.Machine_width.t ->
   flambda_type
 
 (** Construct a type equal to the type of the given name. (The name must be
@@ -578,7 +594,10 @@ val alias_type_of : Flambda_kind.t -> Simple.t -> t
 val kind : t -> Flambda_kind.t
 
 (** For each of the kinds in an arity, create an "unknown" type. *)
-val unknown_types_from_arity : [`Unarized] Flambda_arity.t -> t list
+val unknown_types_from_arity :
+  machine_width:Target_system.Machine_width.t ->
+  [`Unarized] Flambda_arity.t ->
+  t list
 
 (** Whether the given type says that a term of that type can never be
     constructed (in other words, it is [Invalid]). *)

--- a/middle_end/flambda2/types/grammar/more_type_creators.mli
+++ b/middle_end/flambda2/types/grammar/more_type_creators.mli
@@ -59,9 +59,11 @@ val these_tagged_immediates0 : Target_ocaml_int.Set.t -> Type_grammar.t
 
 val these_tagged_immediates : Target_ocaml_int.Set.t -> Type_grammar.t
 
-val any_tagged_bool : Type_grammar.t
+val any_tagged_bool :
+  machine_width:Target_system.Machine_width.t -> Type_grammar.t
 
-val any_naked_bool : Type_grammar.t
+val any_naked_bool :
+  machine_width:Target_system.Machine_width.t -> Type_grammar.t
 
 val this_boxed_float32 :
   Numeric_types.Float32_by_bit_pattern.t ->
@@ -122,9 +124,13 @@ val any_block : Type_grammar.t
 
 (* Note this is only for blocks (variants, tuples, etc), not arrays! *)
 val blocks_with_these_tags :
-  Tag.Set.t -> Alloc_mode.For_types.t -> Type_grammar.t Or_unknown.t
+  machine_width:Target_system.Machine_width.t ->
+  Tag.Set.t ->
+  Alloc_mode.For_types.t ->
+  Type_grammar.t Or_unknown.t
 
 val immutable_block :
+  machine_width:Target_system.Machine_width.t ->
   is_unique:bool ->
   Tag.t ->
   shape:Flambda_kind.Block_shape.t ->
@@ -133,6 +139,7 @@ val immutable_block :
   Type_grammar.t
 
 val immutable_block_with_size_at_least :
+  machine_width:Target_system.Machine_width.t ->
   tag:Tag.t Or_unknown.t ->
   n:Target_ocaml_int.t ->
   shape:Flambda_kind.Block_shape.t ->
@@ -140,6 +147,7 @@ val immutable_block_with_size_at_least :
   Type_grammar.t
 
 val variant :
+  machine_width:Target_system.Machine_width.t ->
   const_ctors:Type_grammar.t ->
   non_const_ctors:
     (Flambda_kind.Block_shape.t * Type_grammar.t list) Tag.Scannable.Map.t ->
@@ -190,9 +198,12 @@ val arity_of_list : Type_grammar.t list -> [`Unarized] Flambda_arity.t
 
 val unknown_with_subkind :
   ?alloc_mode:Alloc_mode.For_types.t ->
+  machine_width:Target_system.Machine_width.t ->
   Flambda_kind.With_subkind.t ->
   Type_grammar.t
 
 (** For each of the kinds in an arity, create an "unknown" type. *)
 val unknown_types_from_arity :
-  [`Unarized] Flambda_arity.t -> Type_grammar.t list
+  machine_width:Target_system.Machine_width.t ->
+  [`Unarized] Flambda_arity.t ->
+  Type_grammar.t list

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -330,9 +330,11 @@ val boxed_float32_alias_to :
 
 val boxed_float_alias_to : naked_float:Variable.t -> Alloc_mode.For_types.t -> t
 
-val tagged_int8_alias_to : naked_int8:Variable.t -> t
+val tagged_int8_alias_to :
+  naked_int8:Variable.t -> machine_width:Target_system.Machine_width.t -> t
 
-val tagged_int16_alias_to : naked_int16:Variable.t -> t
+val tagged_int16_alias_to :
+  naked_int16:Variable.t -> machine_width:Target_system.Machine_width.t -> t
 
 val boxed_int32_alias_to : naked_int32:Variable.t -> Alloc_mode.For_types.t -> t
 
@@ -357,10 +359,10 @@ val box_float32 : t -> Alloc_mode.For_types.t -> t
 val box_float : t -> Alloc_mode.For_types.t -> t
 
 (** This function checks the kind of its argument. *)
-val tag_int8 : t -> t
+val tag_int8 : t -> machine_width:Target_system.Machine_width.t -> t
 
 (** This function checks the kind of its argument. *)
-val tag_int16 : t -> t
+val tag_int16 : t -> machine_width:Target_system.Machine_width.t -> t
 
 (** This function checks the kind of its argument. *)
 val box_int32 : t -> Alloc_mode.For_types.t -> t
@@ -403,9 +405,11 @@ val mutable_block : Alloc_mode.For_types.t -> t
 val create_closures : Alloc_mode.For_types.t -> row_like_for_closures -> t
 
 (** Note this assumes the allocation mode is [Heap] *)
-val this_immutable_string : string -> t
+val this_immutable_string :
+  string -> machine_width:Target_system.Machine_width.t -> t
 
-val mutable_string : size:int -> t
+val mutable_string :
+  size:int -> machine_width:Target_system.Machine_width.t -> t
 
 val array_of_length :
   element_kind:Flambda_kind.With_subkind.t Or_unknown_or_bottom.t ->
@@ -423,6 +427,7 @@ val immutable_array :
   element_kind:Flambda_kind.With_subkind.t Or_unknown_or_bottom.t ->
   fields:t list ->
   Alloc_mode.For_types.t ->
+  machine_width:Target_system.Machine_width.t ->
   t
 
 module Product : sig
@@ -433,7 +438,7 @@ module Product : sig
 
     val create : flambda_type Function_slot.Map.t -> t
 
-    val width : t -> Target_ocaml_int.t
+    val width : t -> int
   end
 
   module Value_slot_indexed : sig
@@ -443,7 +448,7 @@ module Product : sig
 
     val create : flambda_type Value_slot.Map.t -> t
 
-    val width : t -> Target_ocaml_int.t
+    val width : t -> int
   end
 
   module Int_indexed : sig
@@ -455,7 +460,7 @@ module Product : sig
 
     val create_from_array : flambda_type array -> t
 
-    val width : t -> Target_ocaml_int.t
+    val width : t -> int
 
     val components : t -> flambda_type list
   end
@@ -524,6 +529,7 @@ module Row_like_for_blocks : sig
     | Closed of Tag.t
 
   val create :
+    machine_width:Target_system.Machine_width.t ->
     shape:Flambda_kind.Block_shape.t ->
     field_tys:flambda_type list ->
     open_or_closed ->
@@ -531,11 +537,13 @@ module Row_like_for_blocks : sig
     t
 
   val create_blocks_with_these_tags :
+    machine_width:Target_system.Machine_width.t ->
     Flambda_kind.Block_shape.t Or_unknown.t Tag.Map.t ->
     Alloc_mode.For_types.t ->
     t
 
   val create_exactly_multiple :
+    machine_width:Target_system.Machine_width.t ->
     shape_and_field_tys_by_tag:
       (Flambda_kind.Block_shape.t * flambda_type list) Tag.Map.t ->
     Alloc_mode.For_types.t ->
@@ -550,6 +558,7 @@ module Row_like_for_blocks : sig
   val all_tags : t -> Tag.Set.t Or_unknown.t
 
   val all_tags_and_sizes :
+    machine_width:Target_system.Machine_width.t ->
     t ->
     (Target_ocaml_int.t * Flambda_kind.Block_shape.t) Tag.Map.t Or_unknown.t
 
@@ -949,4 +958,5 @@ module Head_of_kind_naked_vec512 :
     with type n = Vector_types.Vec512.Bit_pattern.t
     with type n_set = Vector_types.Vec512.Bit_pattern.Set.t
 
-val must_be_singleton : t -> Reg_width_const.t option
+val must_be_singleton :
+  t -> machine_width:Target_system.Machine_width.t -> Reg_width_const.t option

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -972,24 +972,32 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
       (match side with Left -> meet env ty shape | Right -> meet env shape ty)
   in
   let is_int_immediate ~is_int_ty ~immediates ~is_int_side =
-    if I.Set.is_empty immediates
-    then bottom_other_side is_int_side
-    else
+    match I.Set.choose_opt immediates with
+    | None -> bottom_other_side is_int_side
+    | Some arbitrary_int -> (
       let rebuild = TG.Head_of_kind_naked_immediate.create_is_int in
-      match I.Set.mem I.zero immediates, I.Set.mem I.one immediates with
+      let machine_width = I.machine_width arbitrary_int in
+      match
+        ( I.Set.mem (I.zero machine_width) immediates,
+          I.Set.mem (I.one machine_width) immediates )
+      with
       | false, false -> Bottom (New_result ())
       | true, true -> keep_side is_int_side
       | true, false ->
         meet_with_shape ~rebuild is_int_ty MTC.any_block is_int_side
       | false, true ->
-        meet_with_shape ~rebuild is_int_ty MTC.any_tagged_immediate is_int_side
+        meet_with_shape ~rebuild is_int_ty MTC.any_tagged_immediate is_int_side)
   in
   let is_null_immediate ~is_null_ty ~immediates ~is_null_side =
     if I.Set.is_empty immediates
     then bottom_other_side is_null_side
     else
       let rebuild = TG.Head_of_kind_naked_immediate.create_is_null in
-      match I.Set.mem I.zero immediates, I.Set.mem I.one immediates with
+      let machine_width = TE.machine_width (ME.typing_env env) in
+      match
+        ( I.Set.mem (I.zero machine_width) immediates,
+          I.Set.mem (I.one machine_width) immediates )
+      with
       | false, false -> Bottom (New_result ())
       | true, true -> keep_side is_null_side
       | true, false ->
@@ -997,13 +1005,14 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
       | false, true -> meet_with_shape ~rebuild is_null_ty TG.null is_null_side
   in
   let get_tag_immediate ~get_tag_ty ~immediates ~get_tag_side =
-    if I.Set.is_empty immediates
-    then bottom_other_side get_tag_side
-    else
+    match I.Set.choose_opt immediates with
+    | None -> bottom_other_side get_tag_side
+    | Some arbitrary_int -> (
       let tags =
         I.Set.fold
           (fun tag tags ->
-            match Tag.create_from_targetint tag with
+            let machine_width = I.machine_width arbitrary_int in
+            match Tag.create_from_targetint machine_width tag with
             | Some tag -> Tag.Set.add tag tags
             | None -> tags (* No blocks exist with this tag *))
           immediates Tag.Set.empty
@@ -1011,14 +1020,16 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
       if Tag.Set.is_empty tags
       then Bottom (New_result ())
       else
+        let machine_width = TE.machine_width (ME.typing_env env) in
         match
-          MTC.blocks_with_these_tags tags (Alloc_mode.For_types.unknown ())
+          MTC.blocks_with_these_tags ~machine_width tags
+            (Alloc_mode.For_types.unknown ())
         with
         | Known shape ->
           meet_with_shape
             ~rebuild:TG.Head_of_kind_naked_immediate.create_get_tag get_tag_ty
             shape get_tag_side
-        | Unknown -> keep_side get_tag_side
+        | Unknown -> keep_side get_tag_side)
   in
   match t1, t2 with
   | Naked_immediates is1, Naked_immediates is2 ->
@@ -1967,19 +1978,21 @@ and join_head_of_kind_naked_immediate env
      those) but this looks unlikely to be useful and could end up begin quite
      expensive. *)
   | Is_int ty, Naked_immediates is_int | Naked_immediates is_int, Is_int ty -> (
-    if I.Set.is_empty is_int
-    then Known (TG.Head_of_kind_naked_immediate.create_is_int ty)
-    else
+    match I.Set.choose_opt is_int with
+    | None -> Known (TG.Head_of_kind_naked_immediate.create_is_int ty)
+    | Some arbitrary_int -> (
+      let machine_width = I.machine_width arbitrary_int in
       (* Slightly better than Unknown *)
       let head =
         TG.Head_of_kind_naked_immediate.create_naked_immediates
-          (I.Set.add I.zero (I.Set.add I.one is_int))
+          (I.Set.add (I.zero machine_width)
+             (I.Set.add (I.one machine_width) is_int))
       in
       match head with
       | Ok head -> Known head
       | Bottom ->
         Misc.fatal_error
-          "Did not expect [Bottom] from [create_naked_immediates]")
+          "Did not expect [Bottom] from [create_naked_immediates]"))
   | Get_tag ty, Naked_immediates tags | Naked_immediates tags, Get_tag ty ->
     if I.Set.is_empty tags
     then Known (TG.Head_of_kind_naked_immediate.create_get_tag ty)
@@ -1992,7 +2005,9 @@ and join_head_of_kind_naked_immediate env
       (* Slightly better than Unknown *)
       let head =
         TG.Head_of_kind_naked_immediate.create_naked_immediates
-          (I.Set.add I.zero (I.Set.add I.one is_null))
+          (I.Set.add
+             (I.zero Target_system.Machine_width.Sixty_four)
+             (I.Set.add (I.one Target_system.Machine_width.Sixty_four) is_null))
       in
       match head with
       | Ok head -> Known head

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -229,23 +229,32 @@ let meet_is_null env t = as_meet_shortcut (prove_is_null_generic env t)
 
 let prove_naked_immediates_generic env t : Target_ocaml_int.Set.t generic_proof
     =
+  let machine_width = TE.machine_width env in
   match expand_head env t with
   | Naked_immediate (Ok (Naked_immediates is)) ->
     if Target_ocaml_int.Set.is_empty is then Invalid else Proved is
   | Naked_immediate (Ok (Is_int scrutinee_ty)) -> (
     match prove_is_int_generic ~variant_only:true env scrutinee_ty with
     | Proved true ->
-      Proved (Target_ocaml_int.Set.singleton Target_ocaml_int.bool_true)
+      Proved
+        (Target_ocaml_int.Set.singleton
+           (Target_ocaml_int.bool_true machine_width))
     | Proved false ->
-      Proved (Target_ocaml_int.Set.singleton Target_ocaml_int.bool_false)
+      Proved
+        (Target_ocaml_int.Set.singleton
+           (Target_ocaml_int.bool_false machine_width))
     | Unknown -> Unknown
     | Invalid -> Invalid)
   | Naked_immediate (Ok (Is_null scrutinee_ty)) -> (
     match prove_is_null_generic env scrutinee_ty with
     | Proved true ->
-      Proved (Target_ocaml_int.Set.singleton Target_ocaml_int.bool_true)
+      Proved
+        (Target_ocaml_int.Set.singleton
+           (Target_ocaml_int.bool_true machine_width))
     | Proved false ->
-      Proved (Target_ocaml_int.Set.singleton Target_ocaml_int.bool_false)
+      Proved
+        (Target_ocaml_int.Set.singleton
+           (Target_ocaml_int.bool_false machine_width))
     | Unknown -> Unknown
     | Invalid -> Invalid)
   | Naked_immediate (Ok (Get_tag block_ty)) -> (
@@ -254,7 +263,9 @@ let prove_naked_immediates_generic env t : Target_ocaml_int.Set.t generic_proof
       let is =
         Tag.Set.fold
           (fun tag is ->
-            Target_ocaml_int.Set.add (Tag.to_targetint_31_63 tag) is)
+            Target_ocaml_int.Set.add
+              (Tag.to_targetint_31_63 machine_width tag)
+              is)
           tags Target_ocaml_int.Set.empty
       in
       Proved is
@@ -475,7 +486,10 @@ let prove_variant_like_generic_value env
     match blocks_imms.blocks with
     | Unknown -> Unknown
     | Known blocks -> (
-      match TG.Row_like_for_blocks.all_tags_and_sizes blocks with
+      match
+        TG.Row_like_for_blocks.all_tags_and_sizes
+          ~machine_width:(TE.machine_width env) blocks
+      with
       | Unknown -> Unknown
       | Known non_const_ctors_with_sizes -> (
         let non_const_ctors_with_sizes =

--- a/middle_end/flambda2/types/reify.ml
+++ b/middle_end/flambda2/types/reify.ml
@@ -250,8 +250,8 @@ let reify ~allowed_if_free_vars_defined_in ~var_is_defined_at_toplevel
             try_canonical_simple ()
           | Some (tag, shape, size, field_types, alloc_mode) -> (
             assert (
-              Target_ocaml_int.equal size
-                (TG.Product.Int_indexed.width field_types));
+              Target_ocaml_int.to_int size
+              = TG.Product.Int_indexed.width field_types);
             let field_types = TG.Product.Int_indexed.components field_types in
             let field_types_and_expected_kinds =
               match shape with
@@ -605,7 +605,9 @@ let reify ~allowed_if_free_vars_defined_in ~var_is_defined_at_toplevel
           }) -> (
       match Provers.meet_equals_single_tagged_immediate env length with
       | Known_result length -> (
-        if not (Target_ocaml_int.equal length Target_ocaml_int.zero)
+        if not
+             (Target_ocaml_int.equal length
+                (Target_ocaml_int.zero (TE.machine_width env)))
         then try_canonical_simple ()
         else
           match element_kind with

--- a/toplevel/native/opttoploop.ml
+++ b/toplevel/native/opttoploop.ml
@@ -255,8 +255,11 @@ let default_load ppf (program : Lambda.program) =
     else Filename.temp_file ("caml" ^ !phrase_name) ext_dll
   in
   let filename = Filename.chop_extension dll in
+  (* TODO: Determine machine_width properly from target configuration *)
+  let machine_width = Target_system.Machine_width.Sixty_four in
   let pipeline : Asmgen.pipeline =
-    Direct_to_cmm (Flambda2.lambda_to_cmm ~keep_symbol_tables:true)
+    Direct_to_cmm
+      (Flambda2.lambda_to_cmm ~machine_width ~keep_symbol_tables:true)
   in
   Asmgen.compile_implementation
     (module Unix : Compiler_owee.Unix_intf.S)

--- a/utils/target_system.ml
+++ b/utils/target_system.ml
@@ -121,15 +121,36 @@ let assembler () =
   | Generic_BSD | Solaris | GNU | Dragonfly | BeOS | Unknown ->
     GAS_like
 
-type machine_width =
-  | Thirty_two
-  | Sixty_four
+module Machine_width = struct
+  type t =
+    | Thirty_two  (* Traditional 32-bit OCaml with GC tag bit *)
+    | Thirty_two_no_gc_tag_bit  (* JavaScript mode with full 32-bit integers *)
+    | Sixty_four  (* Traditional 64-bit OCaml with GC tag bit *)
 
-let machine_width () =
-  match Targetint.size with
-  | 32 -> Thirty_two
-  | 64 -> Sixty_four
-  | bits -> Misc.fatal_errorf "Unknown machine width: %d" bits
+  let print ppf = function
+    | Thirty_two -> Format.fprintf ppf "Thirty_two"
+    | Thirty_two_no_gc_tag_bit -> Format.fprintf ppf "Thirty_two_no_gc_tag_bit"
+    | Sixty_four -> Format.fprintf ppf "Sixty_four"
+
+  let equal t1 t2 =
+    match t1, t2 with
+    | Thirty_two, Thirty_two
+    | Thirty_two_no_gc_tag_bit, Thirty_two_no_gc_tag_bit
+    | Sixty_four, Sixty_four -> true
+    | _ -> false
+
+  let is_32_bit = function
+    | Thirty_two | Thirty_two_no_gc_tag_bit -> true
+    | Sixty_four -> false
+
+  let is_64_bit = function
+    | Thirty_two | Thirty_two_no_gc_tag_bit -> false
+    | Sixty_four -> true
+
+  let size_in_bytes = function
+    | Thirty_two | Thirty_two_no_gc_tag_bit -> 4
+    | Sixty_four -> 8
+end
 
 type windows_system =
   | Cygwin

--- a/utils/target_system.mli
+++ b/utils/target_system.mli
@@ -11,6 +11,7 @@ val architecture : unit -> architecture
 
 val is_64_bit : unit -> bool
 
+(* CR mshinwell: what happens about these functions for JSIR? *)
 val is_32_bit : unit -> bool
 
 type derived_system =
@@ -42,12 +43,22 @@ type assembler =
 
 val assembler : unit -> assembler
 
-type machine_width =
-  | Thirty_two
-  | Sixty_four
+module Machine_width : sig
+  type t =
+    | Thirty_two  (* Traditional 32-bit OCaml with GC tag bit *)
+    | Thirty_two_no_gc_tag_bit  (* JavaScript mode with full 32-bit integers *)
+    | Sixty_four  (* Traditional 64-bit OCaml with GC tag bit *)
 
-(** The natural machine width of the target system. *)
-val machine_width : unit -> machine_width
+  val print : Format.formatter -> t -> unit
+
+  val equal : t -> t -> bool
+
+  val is_32_bit : t -> bool
+
+  val is_64_bit : t -> bool
+
+  val size_in_bytes : t -> int
+end
 
 type windows_system = private
   | Cygwin


### PR DESCRIPTION
## Summary
This PR refactors `Targetint_32_64` and `Target_ocaml_int` modules to support dynamic integer width selection at runtime, preparing for the JavaScript backend (ocamlj) that will translate Flambda 2 to js_of_ocaml/wasm_of_ocaml intermediate representation.

## Motivation
The new JSIR work requires different integer width selections for:
- **ocamlopt**: Traditional behavior with GC tag bits (31-bit and 63-bit integers)
- **ocamlj**: JavaScript backend with full 32-bit integers (no GC tag bit)

## Implementation Approach
We chose runtime dispatch over functorization because:
1. **Less invasive**: Functorization would require extensive changes throughout the codebase
2. **Type safety**: Prevents accidental segfaults during demarshalling if wrong instantiation were used
3. **Simpler integration**: Easier to integrate with existing code that uses these modules

## Changes

### 1. Added new Machine_width variant
- `Thirty_two_no_gc_tag_bit`: Represents JavaScript mode with full 32-bit integers

### 2. Refactored Targetint_32_64
- Changed from first-class module approach to tagged union: `type t = Int32 of int32 | Int64 of int64`
- Creation functions now pattern match on `machine_width` parameter
- Binary operations check type compatibility at runtime

### 3. Refactored Target_ocaml_int  
- Three-way split for integer representations:
  - `Int31`: Traditional 32-bit OCaml with GC tag bit (31 bits usable)
  - `Int32`: JavaScript mode with full 32-bit integers (no GC tag bit)
  - `Int63`: Traditional 64-bit OCaml with GC tag bit (63 bits usable)
- Uses `One_bit_fewer` module for Int31 and Int63 cases

## Testing
The changes have been tested with `make boot-compiler` and pass all existing tests.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>