### PR TITLE
flambda2: Improve performance of free_names_transitive

### DIFF
--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1048,12 +1048,10 @@ let rec free_names_transitive_of_type_of_name t name ~result =
 
 and free_names_transitive0 t typ ~result =
   let free_names = TG.free_names typ in
-  let to_traverse = Name_occurrences.diff free_names ~without:result in
-  if Name_occurrences.is_empty to_traverse
-  then result
-  else
-    Name_occurrences.fold_names to_traverse ~init:result ~f:(fun result name ->
-        free_names_transitive_of_type_of_name t name ~result)
+  Name_occurrences.fold_names free_names ~init:result ~f:(fun result name ->
+      if Name_occurrences.mem_name result name
+      then result
+      else free_names_transitive_of_type_of_name t name ~result)
 
 let free_names_transitive t typ =
   free_names_transitive0 t typ ~result:Name_occurrences.empty


### PR DESCRIPTION
Currently, when processing a name, we first compute the free names of its type and then recurse into the free names we haven't seen yet.

If we have `a` with free names `b` and `c`, and `b` with free names `c`, this causes us to iterate on the free names of `c` twice (the first time where we will process them, and the second time in the computation of an empty `to_traverse`).

This patch instead checks if we have already processed a name immediately before processing it, ensuring we only compute the free names of a given name once.

This brings down the compilation of CFML's `parser.ml` (see #4674) to 1min14s on my machine, from over 10min (I killed it) before.