### PR TITLE
Extend modality wrappers

### DIFF
--- a/stdlib/modes.ml
+++ b/stdlib/modes.ml
@@ -37,3 +37,11 @@ end
 module Shared = struct
   type ('a : value_or_null) t = { shared : 'a @@ shared } [@@unboxed]
 end
+
+module Many = struct
+  type ('a : value_or_null) t = { many : 'a @@ many } [@@unboxed]
+end
+
+module Unyielding = struct
+  type ('a : value_or_null) t = { unyielding : 'a @@ unyielding } [@@unboxed]
+end

--- a/stdlib/modes.mli
+++ b/stdlib/modes.mli
@@ -46,3 +46,11 @@ end
 module Shared : sig
   type ('a : value_or_null) t = { shared : 'a @@ shared } [@@unboxed]
 end
+
+module Many : sig
+  type ('a : value_or_null) t = { many : 'a @@ many } [@@unboxed]
+end
+
+module Unyielding : sig
+  type ('a : value_or_null) t = { unyielding : 'a @@ unyielding } [@@unboxed]
+end


### PR DESCRIPTION
This changes the previously existing modality wrappers to allow `value_or_null` contents and adds `Many` and `Unyielding` wrappers.