### PR TITLE
Apply heisenbug patch to system compiler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,7 @@ jobs:
       id: cache
       with:
         path: ${{ github.workspace }}/ocaml-414/_install
-        key: ${{ matrix.os }}-cache-ocaml-414-dune-3153-menhir-20231231-rev13
+        key: ${{ matrix.os }}-cache-ocaml-414-dune-3153-menhir-20231231-rev14
 
     - name: Checkout OCaml 4.14
       uses: actions/checkout@master
@@ -197,6 +197,7 @@ jobs:
       working-directory: ocaml-414
       run: |
         ./configure --prefix=$GITHUB_WORKSPACE/ocaml-414/_install
+        patch -p1 < $GITHUB_WORKSPACE/oxcaml/arm64-issue-debug-upstream.patch
         make -j $J world.opt
         make install
         # Remove unneeded parts to shrink cache file


### PR DESCRIPTION
I'm not sure why this got missed in #3960, but a patch to the system compiler is required to avoid the heisenbug, in addition to the fix in the oxcaml code.