### PR TITLE
Improve invalid expression handling in JSIR

### DIFF
--- a/middle_end/flambda2/to_jsir/to_jsir.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir.ml
@@ -632,10 +632,14 @@ and switch ~env ~res e =
   in
   env, To_jsir_result.end_block_with_last_exn res last
 
-and invalid ~env ~res _msg =
+and invalid ~env ~res msg =
   let res =
     To_jsir_result.add_instr_exn res
-      (Let (Jsir.Var.fresh (), Prim (Extern "caml_invalid_primitive", [])))
+      (Let
+         ( Jsir.Var.fresh (),
+           Prim
+             ( Extern "caml_invalid_expr",
+               [Pc (NativeString (Jsir.Native_string.of_string msg))] ) ))
   in
   env, To_jsir_result.end_block_with_last_exn res Stop
 


### PR DESCRIPTION
Instead of reusing `caml_invalid_primitive`, we define a new runtime function `caml_invalid_expr` which accepts a message to be displayed.