### PR TITLE
Free dynamic bindings on domain terminate.

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -2156,6 +2156,9 @@ static void domain_terminate (void)
   caml_free_extern_state();
   caml_teardown_major_gc();
 
+  caml_dynamic_delete_thread(domain_state->dynamic_bindings);
+  domain_state->dynamic_bindings = NULL;
+
   caml_teardown_shared_heap(domain_state->shared_heap);
   domain_state->shared_heap = 0;
   caml_free_minor_tables(domain_state->minor_tables);


### PR DESCRIPTION
We were neglecting to free the dynamic binding data structure on domain termination. This was caused a slow leak when creating/terminating many domains, and a crash (a `CAMLassert` failure) when running the debug runtime.