### PR TITLE
Two sides of mode error are printed separately for easier integration into the caller's error

### DIFF
--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -692,7 +692,7 @@ Line 2, characters 30-31:
 Error: The value "x" is "local" but is expected to be "global"
        because it is used inside a lazy expression
        which is expected to be "global"
-       because it is a lazy expression and thus always needs to be allocated on the heap.
+       because lazy expressions always need to be allocated on the heap.
 |}]
 
 (* Don't escape through a functor *)
@@ -709,7 +709,7 @@ Line 3, characters 27-28:
                                ^
 Error: The value "x" is "local" but is expected to be "global"
        because it is used inside a functor which is expected to be "global"
-       because it is a module and thus always needs to be allocated on the heap.
+       because modules always need to be allocated on the heap.
 |}]
 
 (* Don't escape through a functor with underscore parameter *)
@@ -726,7 +726,7 @@ Line 3, characters 27-28:
                                ^
 Error: The value "x" is "local" but is expected to be "global"
        because it is used inside a functor which is expected to be "global"
-       because it is a module and thus always needs to be allocated on the heap.
+       because modules always need to be allocated on the heap.
 |}]
 
 (* Don't escape through a generative functor *)
@@ -743,7 +743,7 @@ Line 3, characters 27-28:
                                ^
 Error: The value "x" is "local" but is expected to be "global"
        because it is used inside a functor which is expected to be "global"
-       because it is a module and thus always needs to be allocated on the heap.
+       because modules always need to be allocated on the heap.
 |}]
 
 (* Don't escape through a functor with underscore parameter *)
@@ -760,7 +760,7 @@ Line 3, characters 27-28:
                                ^
 Error: The value "x" is "local" but is expected to be "global"
        because it is used inside a functor which is expected to be "global"
-       because it is a module and thus always needs to be allocated on the heap.
+       because modules always need to be allocated on the heap.
 |}]
 
 (* Don't escape through a generative functor *)
@@ -777,7 +777,7 @@ Line 3, characters 27-28:
                                ^
 Error: The value "x" is "local" but is expected to be "global"
        because it is used inside a functor which is expected to be "global"
-       because it is a module and thus always needs to be allocated on the heap.
+       because modules always need to be allocated on the heap.
 |}]
 
 (* Don't escape through a class method *)

--- a/testsuite/tests/typing-modes/class.ml
+++ b/testsuite/tests/typing-modes/class.ml
@@ -175,7 +175,7 @@ Line 3, characters 17-20:
 Error: This value is "nonportable"
        because it closes over the class "cla" (at Line 2, characters 21-24)
        which is "nonportable"
-       because it is a class and thus always at the legacy modes.
+       because classes are always at the legacy modes.
        However, the highlighted expression is expected to be "portable".
 |}]
 

--- a/testsuite/tests/typing-modes/hint.ml
+++ b/testsuite/tests/typing-modes/hint.ml
@@ -23,7 +23,7 @@ Error: The value "bar" is "nonportable"
        which is "nonportable"
        because it closes over the value "x" (at Line 4, characters 8-9)
        which is expected to be "uncontended".
-       However, the highlighted is expected to be "portable"
+       However, the highlighted value "bar" is expected to be "portable"
        because it is used inside a function which is expected to be "portable".
 |}]
 
@@ -44,6 +44,6 @@ Error: The value "bar" is "nonportable"
        which is "nonportable"
        because it closes over the value "x" (at Line 4, characters 17-18)
        which is expected to be "uncontended".
-       However, the highlighted is expected to be "portable"
+       However, the highlighted value "bar" is expected to be "portable"
        because it is used inside a function which is expected to be "portable".
 |}]

--- a/testsuite/tests/typing-modes/hint.ml
+++ b/testsuite/tests/typing-modes/hint.ml
@@ -23,7 +23,7 @@ Error: The value "bar" is "nonportable"
        which is "nonportable"
        because it closes over the value "x" (at Line 4, characters 8-9)
        which is expected to be "uncontended".
-       However, the highlighted expression is expected to be "portable"
+       However, the highlighted is expected to be "portable"
        because it is used inside a function which is expected to be "portable".
 |}]
 
@@ -44,6 +44,6 @@ Error: The value "bar" is "nonportable"
        which is "nonportable"
        because it closes over the value "x" (at Line 4, characters 17-18)
        which is expected to be "uncontended".
-       However, the highlighted expression is expected to be "portable"
+       However, the highlighted is expected to be "portable"
        because it is used inside a function which is expected to be "portable".
 |}]

--- a/testsuite/tests/typing-modes/lazy.ml
+++ b/testsuite/tests/typing-modes/lazy.ml
@@ -16,7 +16,7 @@ Line 2, characters 37-38:
 2 |     lazy (let x @ local = "hello" in x)
                                          ^
 Error: This value is "local" but is expected to be "global"
-       because it is a lazy expression and thus always needs to be allocated on the heap.
+       because it is a lazy expression and thus needs to be allocated on the heap.
 |}]
 
 let foo (local_ x) =
@@ -28,7 +28,7 @@ Line 2, characters 18-19:
 Error: The value "x" is "local" but is expected to be "global"
        because it is used inside a lazy expression
        which is expected to be "global"
-       because it is a lazy expression and thus always needs to be allocated on the heap.
+       because lazy expressions always need to be allocated on the heap.
 |}]
 
 (* For simplicity, we also require them to be [unyielding]. *)
@@ -41,7 +41,7 @@ Line 2, characters 18-19:
 Error: The value "x" is "yielding" but is expected to be "unyielding"
        because it is used inside a lazy expression
        which is expected to be "unyielding"
-       because it is a lazy expression and thus always needs to be allocated on the heap.
+       because lazy expressions always need to be allocated on the heap.
 |}]
 
 (* lazy expression is constructed as global *)

--- a/testsuite/tests/typing-modes/module.ml
+++ b/testsuite/tests/typing-modes/module.ml
@@ -520,6 +520,6 @@ module type S = sig
     @@ portable
 end
 [%%expect{|
-Uncaught exception: File "typing/env.ml", line 2126, characters 13-19: Assertion failed
+Uncaught exception: File "typing/env.ml", line 2124, characters 13-19: Assertion failed
 
 |}]

--- a/testsuite/tests/typing-modes/stack.ml
+++ b/testsuite/tests/typing-modes/stack.ml
@@ -38,7 +38,7 @@ Line 2, characters 18-26:
                       ^^^^^^^^
 Error: The allocation is "local"
        because it is "stack_"-allocated.
-       However, the highlighted is expected to be "global".
+       However, the highlighted allocation is expected to be "global".
 |}]
 
 let f () =
@@ -62,7 +62,7 @@ Line 2, characters 18-30:
                       ^^^^^^^^^^^^
 Error: The allocation is "local"
        because it is "stack_"-allocated.
-       However, the highlighted is expected to be "global".
+       However, the highlighted allocation is expected to be "global".
 |}]
 
 let f () =

--- a/testsuite/tests/typing-modes/stack.ml
+++ b/testsuite/tests/typing-modes/stack.ml
@@ -36,9 +36,9 @@ let f () =
 Line 2, characters 18-26:
 2 |   let g = stack_ ((42, 42) : _ @ global ) in
                       ^^^^^^^^
-Error: This value is "local"
+Error: The allocation is "local"
        because it is "stack_"-allocated.
-       However, the highlighted expression is expected to be "global".
+       However, the highlighted is expected to be "global".
 |}]
 
 let f () =
@@ -60,9 +60,9 @@ let f () =
 Line 2, characters 18-30:
 2 |   let g = stack_ (fun x y -> x : 'a -> 'a -> 'a) in
                       ^^^^^^^^^^^^
-Error: This value is "local"
+Error: The allocation is "local"
        because it is "stack_"-allocated.
-       However, the highlighted expression is expected to be "global".
+       However, the highlighted is expected to be "global".
 |}]
 
 let f () =

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -253,8 +253,6 @@ type lookup_error =
   | Cannot_scrape_alias of Longident.t * Path.t
   | Local_value_escaping of Mode.Hint.lock_item * Longident.t * escaping_context
   | Once_value_used_in of Mode.Hint.lock_item * Longident.t * shared_context
-  | Value_used_in_closure of Mode.Hint.lock_item * Longident.t *
-      Mode.Value.Comonadic.error
   | Local_value_used_in_exclave of Mode.Hint.lock_item * Longident.t
   | Non_value_used_in_object of Longident.t * type_expr * Jkind.Violation.t
   | No_unboxed_version of Longident.t * type_declaration
@@ -521,7 +519,9 @@ val add_escape_lock : escaping_context -> t -> t
     `unique` variables beyond the lock can still be accessed, but will be
     relaxed to `shared` *)
 val add_share_lock : shared_context -> t -> t
-val add_closure_lock : Mode.Hint.closure_context
+(* CR-soon zqian: require [pinpoint] instead of [pinpoint_desc] to include
+   location of the closure. *)
+val add_closure_lock : Mode.Hint.pinpoint_desc
   -> ('l * Mode.allowed) Mode.Value.Comonadic.t -> t -> t
 val add_region_lock : t -> t
 val add_exclave_lock : t -> t

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2263,13 +2263,21 @@ module Error = struct
     let loc, desc = pp in
     let print ppf () =
       let print_desc = Report.print_pinpoint_desc desc in
-      (match print_desc with
-      | None -> fprintf ppf "This is "
-      | Some print_desc -> fprintf ppf "The %t is " print_desc);
+      (let print_desc =
+         match print_desc with
+         | None -> dprintf "This"
+         | Some print_desc -> dprintf "The %t" print_desc
+       in
+       fprintf ppf "%t is " print_desc);
       let ({ left; right } : print_error) = print_packed pp packed in
       (match left ppf with
       | Mode_with_hint ->
-        fprintf ppf ".@\nHowever, the highlighted is expected to be "
+        let print_desc =
+          match print_desc with
+          | None -> dprintf "the highlighted"
+          | Some print_desc -> dprintf "the highlighted %t" print_desc
+        in
+        fprintf ppf ".@\nHowever, %t is expected to be " print_desc
       | Mode -> fprintf ppf "@ but is expected to be ");
       ignore (right ppf);
       pp_print_string ppf "."

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -21,6 +21,12 @@ open Mode_intf
 module Hint = Mode_hint
 
 module Hint_for_solver (* : Solver_intf.Hint *) = struct
+  module Pinpoint = struct
+    type t = Hint.pinpoint
+
+    let unknown : t = Location.none, Unknown
+  end
+
   module Morph = struct
     type 'd t = 'd Hint.morph
 
@@ -28,23 +34,35 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
 
     let id : _ t = Skip
 
-    let left_adjoint : type l. (l * allowed) t -> (allowed * disallowed) t =
-      function
-      | Skip -> Skip
-      | Unknown -> Unknown
-      | Is_closed_by x -> Close_over x
-      | Captured_by_partial_application -> Adj_captured_by_partial_application
-      | Crossing -> Crossing
-      | Unknown_non_rigid -> Unknown_non_rigid
+    let left_adjoint :
+        type l.
+        Hint.pinpoint ->
+        (l * allowed) t ->
+        Hint.pinpoint * (allowed * disallowed) t =
+     fun pp t ->
+      match t with
+      | Skip -> pp, Skip
+      | Is_closed_by co -> (Location.none, co.closure), Close_over co
+      | Captured_by_partial_application ->
+        (Location.none, Expression), Adj_captured_by_partial_application
+      | Crossing -> pp, Crossing
+      | Unknown_non_rigid -> (Location.none, Unknown), Unknown_non_rigid
+      | Unknown -> (Location.none, Unknown), Unknown
 
-    let right_adjoint : type r. (allowed * r) t -> (disallowed * allowed) t =
-      function
-      | Skip -> Skip
-      | Unknown -> Unknown
-      | Close_over x -> Is_closed_by x
-      | Adj_captured_by_partial_application -> Captured_by_partial_application
-      | Crossing -> Crossing
-      | Unknown_non_rigid -> Unknown_non_rigid
+    let right_adjoint :
+        type r.
+        Hint.pinpoint ->
+        (allowed * r) t ->
+        Hint.pinpoint * (disallowed * allowed) t =
+     fun pp t ->
+      match t with
+      | Skip -> pp, Skip
+      | Close_over co -> co.closed, Is_closed_by co
+      | Adj_captured_by_partial_application ->
+        (Location.none, Expression), Captured_by_partial_application
+      | Crossing -> pp, Crossing
+      | Unknown_non_rigid -> (Location.none, Unknown), Unknown_non_rigid
+      | Unknown -> (Location.none, Unknown), Unknown
 
     include Magic_allow_disallow (struct
       type (_, _, 'd) sided = 'd t constraint 'd = 'l * 'r
@@ -1830,8 +1848,6 @@ type 'a comonadic_with = 'a C.comonadic_with =
 
 module Axis = C.Axis
 
-type 'a error = 'a S.error_raw
-
 type nonrec 'a simple_error = 'a simple_error
 
 let print_longident =
@@ -1961,7 +1977,15 @@ module Report = struct
       let left = ahint_prod obj axis left in
       let right = ahint_prod obj axis right in
       { left; right }
+
+    let error_axis : type a. a C.obj -> a S.error -> a t =
+     fun obj { left; right } ->
+      let left = ahint_axis obj left in
+      let right = ahint_axis obj right in
+      { left; right }
   end
+
+  [@@@warning "-4"]
 
   open Format
 
@@ -1969,14 +1993,24 @@ module Report = struct
     | Record_field s -> fprintf ppf "mutable field %a" Misc.Style.inline_code s
     | Array_elements -> fprintf ppf "array elements"
 
-  let print_const (type l r) ppf : (l * r) const -> unit = function
+  (** Given a pinpoint and a const, where the pinpoint has been expressed,
+  prints the const to explain the mode on the pinpoint. *)
+  let print_const (type l r) (_, pp_desc) ppf : (l * r) const -> unit = function
     | Unknown -> Misc.fatal_error "Unknown hint should not be printed"
     | Lazy_allocated_on_heap ->
-      pp_print_string ppf
-        "it is a lazy expression and thus always needs to be allocated on the \
-         heap"
+      (match pp_desc with
+      | Lazy ->
+        (* if we already said it's a lazy, we don't need to emphasize it again. *)
+        pp_print_string ppf "lazy expressions always need"
+      | _ -> pp_print_string ppf "it is a lazy expression and thus needs");
+      pp_print_string ppf " to be allocated on the heap"
     | Class_legacy_monadic | Class_legacy_comonadic ->
-      pp_print_string ppf "it is a class and thus always at the legacy modes"
+      (match pp_desc with
+      | Ident { category = Class; _ } ->
+        (* if we already said it's a class, we don't need to emphasize it again. *)
+        pp_print_string ppf "classes are always"
+      | _ -> pp_print_string ppf "it is a class and thus");
+      pp_print_string ppf " at the legacy modes"
     | Tailcall_function ->
       pp_print_string ppf "it is the function in a tail call"
     | Tailcall_argument ->
@@ -1984,7 +2018,12 @@ module Report = struct
     | Mutable_read m -> fprintf ppf "its %a is being read" print_mutable_part m
     | Mutable_write m ->
       fprintf ppf "its %a is being written" print_mutable_part m
-    | Lazy_forced -> pp_print_string ppf "it is a lazy value being forced"
+    | Lazy_forced -> (
+      match pp_desc with
+      | Lazy ->
+        (* if we already said it's a lazy, we don't need to emphasize it again. *)
+        pp_print_string ppf "it is being forced"
+      | _ -> pp_print_string ppf "it is a lazy value being forced")
     | Function_return ->
       fprintf ppf
         "it is a function return value.@\n\
@@ -1992,8 +2031,12 @@ module Report = struct
     | Stack_expression ->
       fprintf ppf "it is %a-allocated" Misc.Style.inline_code "stack_"
     | Module_allocated_on_heap ->
-      pp_print_string ppf
-        "it is a module and thus always needs to be allocated on the heap"
+      (match pp_desc with
+      | Ident { category = Module; _ } | Functor ->
+        (* if we already said it's a module, we don't need to emphasize it again. *)
+        pp_print_string ppf "modules always need"
+      | _ -> pp_print_string ppf "it is a module and thus needs");
+      pp_print_string ppf " to be allocated on the heap"
 
   let print_lock_item ppf = function
     | Module -> fprintf ppf "module"
@@ -2001,32 +2044,52 @@ module Report = struct
     | Value -> fprintf ppf "value"
     | Constructor -> fprintf ppf "constructor"
 
-  let print_closure_context ppf = function
-    | Function -> fprintf ppf "function"
-    | Functor -> fprintf ppf "functor"
-    | Lazy -> fprintf ppf "lazy expression"
-
-  let print_morph : type l r. (l * r) morph -> (formatter -> unit) option =
+  let print_pinpoint_desc : pinpoint_desc -> (formatter -> unit) option =
     function
+    | Unknown -> None
+    | Ident { category; lid } ->
+      Some
+        (dprintf "%a %a" print_lock_item category
+           (Misc.Style.as_inline_code !print_longident)
+           lid)
+    | Function -> Some (dprintf "function")
+    | Functor -> Some (dprintf "functor")
+    | Lazy -> Some (dprintf "lazy expression")
+    | Expression -> Some (dprintf "expression")
+    | Allocation -> Some (dprintf "allocation")
+
+  let print_pinpoint : pinpoint -> (formatter -> unit) option =
+   fun (loc, desc) ->
+    print_pinpoint_desc desc
+    |> Option.map (fun print_desc ppf ->
+           if not (Location.is_none loc)
+           then fprintf ppf "the %t (at %a)" print_desc Location.print_loc loc
+           else fprintf ppf "a %t" print_desc)
+
+  (** Given a pinpoint and a morph, where the pinpoint is the destination of the
+      morph and have been expressed already, print the morph and gives the source pinpoint. *)
+  let print_morph :
+      type l r.
+      pinpoint -> (l * r) morph -> ((formatter -> unit) * pinpoint) option =
+   fun pp -> function
     | Skip -> Misc.fatal_error "Skip hint should not be printed"
     | Unknown | Unknown_non_rigid -> None
-    | Close_over closure ->
-      (* CR-someday pdsouza: in the future, we should print out the code at the mentioned
-         location, instead of just the location *)
-      Some
-        (dprintf "closes over the %a %a (at %a)" print_lock_item
-           closure.value_item
-           (Misc.Style.as_inline_code !print_longident)
-           closure.value_lid Location.print_loc closure.value_loc)
-    | Is_closed_by closure ->
-      Some
-        (dprintf "is used inside a %a" print_closure_context
-           closure.closure_context)
+    | Close_over { closed = pp; _ } ->
+      print_pinpoint pp
+      |> Option.map (fun print_pp -> dprintf "closes over %t" print_pp, pp)
+    | Is_closed_by { closure; _ } ->
+      let pp = Location.none, closure in
+      print_pinpoint pp
+      |> Option.map (fun print_pp -> dprintf "is used inside %t" print_pp, pp)
     | Captured_by_partial_application ->
-      Some (dprintf "is captured by a partial application")
+      Some
+        ( dprintf "is captured by a partial application",
+          (Location.none, Expression) )
     | Adj_captured_by_partial_application ->
-      Some (dprintf "has a partial application capturing a value")
-    | Crossing -> Some (dprintf "crosses with something")
+      Some
+        ( dprintf "has a partial application capturing a value",
+          (Location.none, Expression) )
+    | Crossing -> Some (dprintf "crosses with something", pp)
 
   let print_mode :
       type a. [`Actual | `Expected] -> a C.obj -> formatter -> a -> unit =
@@ -2066,10 +2129,12 @@ module Report = struct
       sub:bool -> [`Left | `Right] -> a C.obj -> Format.formatter -> a -> unit =
    fun ~sub side obj ppf a ->
     let side = adjust_side obj side in
-    if sub then Format.pp_print_string ppf "which ";
-    (match side with
-    | `Actual -> pp_print_string ppf "is "
-    | `Expected -> pp_print_string ppf "is expected to be ");
+    if sub
+    then (
+      Format.pp_print_string ppf "which ";
+      match side with
+      | `Actual -> pp_print_string ppf "is "
+      | `Expected -> pp_print_string ppf "is expected to be ");
     print_mode side obj ppf a
 
   (** Some morph hints are said to be "non-rigid", because they should be printed only
@@ -2087,47 +2152,43 @@ module Report = struct
     | Some Refl -> Misc.Le_result.equal ~le:(C.le a_obj) a b
     | None -> false
 
-  type print_ahint_result =
-    | Mode_with_hint
-    | Mode
-    | Nothing
-
   let rec print_ahint :
       type a l r.
       ?sub:bool ->
       [`Left | `Right] ->
+      pinpoint ->
       a C.obj ->
       Format.formatter ->
       (a, l * r) ahint ->
-      print_ahint_result =
-   fun ?(sub = false) side (obj : a C.obj) ppf (a, hint) ->
+      print_error_result option =
+   fun ?(sub = false) side pp (obj : a C.obj) ppf (a, hint) ->
     match hint with
     | Apply (morph_hint, src, ahint)
       when (not (is_rigid morph_hint)) && eq_mode obj src a (fst ahint) ->
-      print_ahint ~sub side src ppf ahint
+      print_ahint ~sub side pp src ppf ahint
     | Apply (morph_hint, src, ahint) -> (
       print_mode_with_side ~sub side obj ppf a;
-      match print_morph morph_hint with
-      | None -> Mode
-      | Some t ->
+      match print_morph pp morph_hint with
+      | None -> Some Mode
+      | Some (t, pp) ->
         fprintf ppf "@ because it %t@ " t;
-        ignore (print_ahint ~sub:true side src ppf ahint);
-        Mode_with_hint)
+        ignore (print_ahint ~sub:true side pp src ppf ahint);
+        Some Mode_with_hint)
     | Const Unknown ->
       print_mode_with_side ~sub side obj ppf a;
-      Mode
+      Some Mode
     | Irrelevant ->
       if not sub
       then
         Misc.fatal_error
           "the current mode is not responsible for the error, so must be \
            inside a responsible morphism";
-      Nothing
+      None
     | Const c ->
       fprintf ppf "%a@ because %a"
         (print_mode_with_side ~sub side obj)
-        a print_const c;
-      Mode_with_hint
+        a (print_const pp) c;
+      Some Mode_with_hint
    [@@ocaml.warning "-4"]
 
   type 'a ahint_sided =
@@ -2135,35 +2196,27 @@ module Report = struct
     | Right of ('a, right_only) ahint
 
   let print_ahint_sided :
-      type a. a C.obj -> Format.formatter -> a ahint_sided -> print_ahint_result
-      =
-   fun obj ppf ahint_sided ->
-    match ahint_sided with
-    | Left ahint -> print_ahint `Left obj ppf ahint
-    | Right ahint -> print_ahint `Right obj ppf ahint
-
-  let print :
       type a.
-      ?target:_ -> a Lattices_mono.obj -> Format.formatter -> a t -> unit =
-   fun ?target obj ppf { left; right } ->
+      pinpoint ->
+      a C.obj ->
+      Format.formatter ->
+      a ahint_sided ->
+      print_error_result option =
+   fun pp obj ppf ahint_sided ->
+    match ahint_sided with
+    | Left ahint -> print_ahint `Left pp obj ppf ahint
+    | Right ahint -> print_ahint `Right pp obj ppf ahint
+
+  let print : type a. pinpoint -> a C.obj -> a t -> print_error =
+   fun pp obj { left; right } ->
     let actual, expected =
       if C.is_opposite obj
       then Right right, Left left
       else Left left, Right right
     in
-    let open Format in
-    (match target with
-    | None -> fprintf ppf "This value "
-    | Some (target_item, target_lid) ->
-      fprintf ppf "The %a %a " print_lock_item target_item
-        (Misc.Style.as_inline_code !print_longident)
-        target_lid);
-    (match print_ahint_sided obj ppf actual with
-    | Mode_with_hint -> fprintf ppf ".@\nHowever, the highlighted expression "
-    | Mode -> fprintf ppf "@ but "
-    | Nothing -> assert false);
-    ignore (print_ahint_sided obj ppf expected);
-    fprintf ppf "."
+    let left ppf = Option.get (print_ahint_sided pp obj ppf actual) in
+    let right ppf = Option.get (print_ahint_sided pp obj ppf expected) in
+    { left; right }
 end
 
 type changes = S.changes
@@ -2177,6 +2230,61 @@ let set_append_changes f = append_changes := f
 
 type ('a, 'd) mode = ('a, 'd) S.mode
 
+module Error = struct
+  type 'a t = 'a S.error_raw
+
+  type packed =
+    | Product : 'r C.obj * ('r, 'a) Axis.t * 'r t -> packed
+    | Axis : 'a C.obj * 'a t -> packed
+
+  let print_product :
+      type r a. Hint.pinpoint -> r C.obj -> (r, a) Axis.t -> r t -> print_error
+      =
+   fun pp obj ax err ->
+    let err = S.populate_error obj err in
+    let err = Report.Of_solver.error_prod obj ax err in
+    let obj = C.proj_obj ax obj in
+    Report.print pp obj err
+
+  let print_axis : type a. Hint.pinpoint -> a C.obj -> a t -> print_error =
+   fun pp obj err ->
+    let err = S.populate_error obj err in
+    let err = Report.Of_solver.error_axis obj err in
+    Report.print pp obj err
+
+  let print_packed : Hint.pinpoint -> packed -> print_error =
+   fun pp -> function
+    | Product (obj, ax, err) -> print_product pp obj ax err
+    | Axis (obj, err) -> print_axis pp obj err
+
+  let print_packed_simple_context : Hint.pinpoint -> packed -> Location.error =
+   fun pp packed ->
+    let open Format in
+    let loc, desc = pp in
+    let print ppf () =
+      let print_desc = Report.print_pinpoint_desc desc in
+      (match print_desc with
+      | None -> fprintf ppf "This is "
+      | Some print_desc -> fprintf ppf "The %t is " print_desc);
+      let ({ left; right } : print_error) = print_packed pp packed in
+      (match left ppf with
+      | Mode_with_hint ->
+        fprintf ppf ".@\nHowever, the highlighted is expected to be "
+      | Mode -> fprintf ppf "@ but is expected to be ");
+      ignore (right ppf);
+      pp_print_string ppf "."
+    in
+    Location.error_of_printer ~loc print ()
+end
+
+exception Submode_error_simple_context of Hint.pinpoint * Error.packed
+
+let () =
+  Location.register_error_of_exn (function
+    | Submode_error_simple_context (pp, err) ->
+      Some (Error.print_packed_simple_context pp err)
+    | _ -> None)
+
 module type Common_axis_pos = sig
   module Const : Lattice
 
@@ -2184,7 +2292,6 @@ module type Common_axis_pos = sig
     Common_axis
       with module Const := Const
        and type 'd t = (Const.t, 'd pos) mode
-       and type error = Const.t error
        and type 'd hint_const := 'd pos_hint_const
 end
 
@@ -2195,7 +2302,6 @@ module type Common_axis_neg = sig
     Common_axis
       with module Const := Const
        and type 'd t = (Const.t, 'd neg) mode
-       and type error = Const.t error
        and type 'd hint_const := 'd neg_hint_const
 end
 
@@ -2257,7 +2363,7 @@ module Comonadic_gen (Obj : Obj) = struct
 
   type nonrec simple_error = const simple_error
 
-  type nonrec error = const error
+  type nonrec error = const Error.t
 
   type equate_error = equate_step * error
 
@@ -2281,12 +2387,20 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let newvar_below m = Solver.newvar_below obj m
 
-  let submode_log a b ~log = Solver.submode obj a b ~log
+  let submode_log ?(pp = (Location.none, Unknown : Hint.pinpoint)) a b ~log =
+    Solver.submode pp obj a b ~log
 
   let to_simple_error ({ left; right; _ } : error) : simple_error =
     { left; right }
 
-  let submode a b = try_with_log (submode_log a b)
+  let submode ?pp a b = try_with_log (submode_log ?pp a b)
+
+  let submode_err pp a b =
+    match submode ~pp a b with
+    | Ok () -> ()
+    | Error e -> raise (Submode_error_simple_context (pp, Axis (obj, e)))
+
+  let print_error pp err = Error.print_axis pp obj err
 
   let join l = Solver.join obj l
 
@@ -2294,7 +2408,7 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let submode_exn m0 m1 = submode m0 m1 |> Result.get_ok
 
-  let equate a b = try_with_log (equate_from_submode submode_log a b)
+  let equate a b = try_with_log (equate_from_submode (submode_log ?pp:None) a b)
 
   let equate_exn m0 m1 = equate m0 m1 |> Result.get_ok
 
@@ -2349,7 +2463,7 @@ module Monadic_gen (Obj : Obj) = struct
 
   type nonrec simple_error = const simple_error
 
-  type nonrec error = const error
+  type nonrec error = const Error.t
 
   type equate_error = equate_step * error
 
@@ -2373,12 +2487,20 @@ module Monadic_gen (Obj : Obj) = struct
 
   let newvar_below m = Solver.newvar_above obj m
 
-  let submode_log a b ~log = Solver.submode obj b a ~log
+  let submode_log ?(pp = (Location.none, Unknown : Hint.pinpoint)) a b ~log =
+    Solver.submode pp obj b a ~log
 
   let to_simple_error ({ left; right; _ } : error) : simple_error =
     { left = right; right = left }
 
-  let submode a b = try_with_log (submode_log a b)
+  let submode ?pp a b = try_with_log (submode_log ?pp a b)
+
+  let submode_err pp a b =
+    match submode ~pp a b with
+    | Ok () -> ()
+    | Error e -> raise (Submode_error_simple_context (pp, Axis (obj, e)))
+
+  let print_error pp err = Error.print_axis pp obj err
 
   let join l = Solver.meet obj l
 
@@ -2386,7 +2508,7 @@ module Monadic_gen (Obj : Obj) = struct
 
   let submode_exn m0 m1 = submode m0 m1 |> Result.get_ok
 
-  let equate a b = try_with_log (equate_from_submode submode_log a b)
+  let equate a b = try_with_log (equate_from_submode (submode_log ?pp:None) a b)
 
   let equate_exn m0 m1 = equate m0 m1 |> Result.get_ok
 
@@ -2773,12 +2895,16 @@ module Comonadic_with (Areality : Areality) = struct
   (* overriding to report the offending axis *)
   let to_simple_error ({ left; right; _ } : error) = axis_of_error left right
 
-  let report_error ?target ppf err =
+  let submode_err pp a b =
+    match submode ~pp a b with
+    | Ok () -> ()
+    | Error e ->
+      let (Error (ax, _)) = to_simple_error e in
+      raise (Submode_error_simple_context (pp, Product (Obj.obj, ax, e)))
+
+  let print_error pp err =
     let (Error (ax, _)) = to_simple_error err in
-    let err = S.populate_error Obj.obj err in
-    let err = Report.Of_solver.error_prod Obj.obj ax err in
-    let obj = proj_obj ax in
-    Report.print ?target obj ppf err
+    Error.print_product pp Obj.obj ax err
 end
 [@@inline]
 
@@ -2899,12 +3025,16 @@ module Monadic = struct
     (* monadic fragment is flipped *)
     axis_of_error right left
 
-  let report_error ?target ppf err =
+  let submode_err pp a b =
+    match submode ~pp a b with
+    | Ok () -> ()
+    | Error e ->
+      let (Error (ax, _)) = to_simple_error e in
+      raise (Submode_error_simple_context (pp, Product (Obj.obj, ax, e)))
+
+  let print_error pp err =
     let (Error (ax, _)) = to_simple_error err in
-    let err = S.populate_error Obj.obj err in
-    let err = Report.Of_solver.error_prod Obj.obj ax err in
-    let obj = proj_obj ax in
-    Report.print ?target obj ppf err
+    Error.print_product pp Obj.obj ax err
 end
 
 type ('mo, 'como) monadic_comonadic =
@@ -3325,24 +3455,28 @@ module Value_with (Areality : Areality) = struct
       let (Error (ax, e)) = Comonadic.to_simple_error e in
       Error (Comonadic ax, e)
 
-  let report_error ppf = function
-    | Monadic e -> Monadic.report_error ppf e
-    | Comonadic e -> Comonadic.report_error ppf e
+  let print_error pp = function
+    | Monadic e -> Monadic.print_error pp e
+    | Comonadic e -> Comonadic.print_error pp e
 
-  let submode_log { monadic = monadic0; comonadic = comonadic0 }
+  let submode_log ?pp { monadic = monadic0; comonadic = comonadic0 }
       { monadic = monadic1; comonadic = comonadic1 } ~log : (_, error) result =
     (* comonadic before monadic, so that locality errors dominate
        (error message backward compatibility) *)
-    match Comonadic.submode_log comonadic0 comonadic1 ~log with
+    match Comonadic.submode_log ?pp comonadic0 comonadic1 ~log with
     | Error e -> Error (Comonadic e)
     | Ok () -> (
-      match Monadic.submode_log monadic0 monadic1 ~log with
+      match Monadic.submode_log ?pp monadic0 monadic1 ~log with
       | Error e -> Error (Monadic e)
       | Ok () -> Ok ())
 
-  let submode a b = try_with_log (submode_log a b)
+  let submode ?pp a b = try_with_log (submode_log ?pp a b)
 
-  let equate a b = try_with_log (equate_from_submode submode_log a b)
+  let submode_err pp a b =
+    Comonadic.submode_err pp a.comonadic b.comonadic;
+    Monadic.submode_err pp a.monadic b.monadic
+
+  let equate a b = try_with_log (equate_from_submode (submode_log ?pp:None) a b)
 
   let submode_exn m0 m1 =
     match submode m0 m1 with

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -69,10 +69,24 @@ type 'a simple_error =
     right : 'a
   }
 
+type print_error_result =
+  | Mode  (** A mode constant is printed *)
+  | Mode_with_hint  (** A mode constant with hints is printed *)
+
+type print_error = (Format.formatter -> print_error_result) simple_error
+
 module type Common = sig
   module Const : Lattice
 
   type error
+
+  (** Takes a submode [error] accompanied by a [pinpoint] of the original
+  submode, returns an explaining printer for each side. Each printer prints
+  either a mode constant name, or "[mode] because ...". The function assumes
+  [pinpoint] is already printed, which allows simplifying its own printing. The
+  caller is responsible for printing [pinpoint] and placing the result of this
+  function in a suitable linguistic context. *)
+  val print_error : Mode_hint.pinpoint -> error -> print_error
 
   type equate_error = equate_step * error
 
@@ -104,17 +118,50 @@ module type Common = sig
 
   val newvar : unit -> ('l * 'r) t
 
-  (* CR-soon zqian: The following [submode] is currently abused at callsites
-     where the two modes should be linked via some morph hint, instead of being
-     linked directly. *)
+  (* How to submode
 
-  (** Constrain the first mode lower than the second mode. It also assumes the
-  submode is trivial and links the two modes directly, without inserting an
-  [Unknown] morph hint. *)
-  val submode : (allowed * 'r) t -> ('l * allowed) t -> (unit, error) result
+     Naively, mode constraints need to be justified by some explanation (e.g. a
+     location in the source code). For example, for function application [f e],
+     we check that the mode of [e] is less than the mode of the parameter of
+     [f], and this mode constraint can be justified by pointing to the location
+     of [e] in the application. Such explanation should be made into an
+     adjunction pair in [Mode_hint.morph] and applied to either modes, such that
+     both modes are about the argument (or equivalently, both modes are about
+     the parameter) . After the adjustment, the submode itself becomes
+     self-evident and doesn't require any mode-related hint.
+
+     However, while both modes can self-explain why they are high or low, they
+     don't always know what the "thing" that they both describe is. This
+     information is best known by the caller of submode, and encoded in the
+     [pinpoint] argument passed to submode. *)
+
+  (** Takes the actual and expected mode of something, check that the actual
+    mode is less than the expected mode. In case of error, the error is returned
+    and no mutation is done.
+
+    The two modes should be hinted sufficently that the submode is self-evident.
+    In particular, the two modes should be about the "same thing". See the notes
+    [How to submode] for details. *)
+  val submode :
+    ?pp:Mode_hint.pinpoint ->
+    (allowed * 'r) t ->
+    ('l * allowed) t ->
+    (unit, error) result
+  (* CR-soon zqian: make [pp] mandatory *)
+
+  (** Similar to [submode], but instead of returning an error, raise
+    user-friendly errors directly, with [pinpoint] describing the thing
+    whose actual and expected modes are being checked.
+
+    If you need more than [pinpoint] as the context in the error message,
+    consider [submode]. *)
+  val submode_err :
+    Mode_hint.pinpoint -> (allowed * 'r) t -> ('l * allowed) t -> unit
 
   val equate : lr -> lr -> (unit, equate_error) result
 
+  (** Similiar to [submode], but crashes the compiler if errors. Use this
+    function if the submode is guaranteed to succeed. *)
   val submode_exn : (allowed * 'r) t -> ('l * allowed) t -> unit
 
   val equate_exn : lr -> lr -> unit
@@ -175,17 +222,6 @@ module type Common_product = sig
   include
     Common with type simple_error := simple_error and module Const := Const
 
-  (* CR-soon zqian: Move [?target] into hints, and let [report_error] extract this
-     information. *)
-
-  (** Takes an optional [lock_item] and identifier of the offending value, and report the
-      submode error with hints. *)
-  val report_error :
-    ?target:Mode_hint.lock_item * Longident.t ->
-    Format.formatter ->
-    error ->
-    unit
-
   type 'd hint_const constraint 'd = 'l * 'r
 
   val of_const : ?hint:'d hint_const -> Const.t -> 'd t
@@ -211,9 +247,6 @@ module type S = sig
   module Hint = Mode_hint
 
   type nonrec 'a simple_error = 'a simple_error
-
-  (** Rich mode error specific to axis whose carrier type is ['a]. *)
-  type 'a error
 
   type changes
 
@@ -241,7 +274,6 @@ module type S = sig
       Common_axis
         with module Const := Const
          and type 'd t = (Const.t, 'd pos) mode
-         and type error = Const.t error
          and type 'd hint_const := 'd pos_hint_const
   end
 
@@ -252,7 +284,6 @@ module type S = sig
       Common_axis
         with module Const := Const
          and type 'd t = (Const.t, 'd neg) mode
-         and type error = Const.t error
          and type 'd hint_const := 'd neg_hint_const
   end
 
@@ -459,7 +490,6 @@ module type S = sig
       include
         Common_product
           with type Const.t = monadic
-           and type error = monadic error
            and type 'a Axis.t = (monadic, 'a) Axis.t
            and type 'd hint_morph := 'd neg_hint_morph
            and type 'd hint_const := 'd neg_hint_const
@@ -473,7 +503,6 @@ module type S = sig
       include
         Common_product
           with type Const.t = Areality.Const.t comonadic_with
-           and type error = Areality.Const.t comonadic_with error
            and type 'a Axis.t = (Areality.Const.t comonadic_with, 'a) Axis.t
            and type 'd hint_morph := 'd pos_hint_morph
            and type 'd hint_const := 'd pos_hint_const
@@ -568,8 +597,6 @@ module type S = sig
     type error =
       | Monadic of Monadic.error
       | Comonadic of Comonadic.error
-
-    val report_error : Format.formatter -> error -> unit
 
     type 'a simple_axerror := 'a simple_error
 

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -61,45 +61,51 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         constraint 'd = _ * _
       [@@ocaml.warning "-62"]
 
-      let left_adjoint =
-        let rec aux :
-            type a b l.
-            b C.obj ->
-            (a, b, l * allowed) t ->
-            a C.obj * (b, a, allowed * disallowed) t =
-         fun b_obj -> function
-          | Id -> b_obj, Id
-          | Base (small_morph_hint, morph) ->
-            ( C.src b_obj morph,
-              Base
-                ( H.Morph.left_adjoint small_morph_hint,
-                  C.left_adjoint b_obj morph ) )
-          | Compose (f_morph_hint, g_morph_hint) ->
-            let mid, f_morph_hint_adj = aux b_obj f_morph_hint in
-            let src, g_morph_hint_adj = aux mid g_morph_hint in
-            src, Compose (g_morph_hint_adj, f_morph_hint_adj)
-        in
-        fun b_obj h -> snd (aux b_obj h)
+      let rec left_adjoint :
+          type a b l.
+          H.Pinpoint.t ->
+          b C.obj ->
+          (a, b, l * allowed) t ->
+          H.Pinpoint.t * a C.obj * (b, a, allowed * disallowed) t =
+       fun pp b_obj -> function
+        | Id -> pp, b_obj, Id
+        | Base (small_morph_hint, morph) ->
+          let pp, small_morph_hint = H.Morph.left_adjoint pp small_morph_hint in
+          ( pp,
+            C.src b_obj morph,
+            Base (small_morph_hint, C.left_adjoint b_obj morph) )
+        | Compose (f_morph_hint, g_morph_hint) ->
+          let mid_pp, mid, f_morph_hint_adj =
+            left_adjoint pp b_obj f_morph_hint
+          in
+          let src_pp, src, g_morph_hint_adj =
+            left_adjoint mid_pp mid g_morph_hint
+          in
+          src_pp, src, Compose (g_morph_hint_adj, f_morph_hint_adj)
 
-      let right_adjoint =
-        let rec aux :
-            type a b r.
-            b C.obj ->
-            (a, b, allowed * r) t ->
-            a C.obj * (b, a, disallowed * allowed) t =
-         fun b_obj -> function
-          | Id -> b_obj, Id
-          | Base (small_morph_hint, morph) ->
-            ( C.src b_obj morph,
-              Base
-                ( H.Morph.right_adjoint small_morph_hint,
-                  C.right_adjoint b_obj morph ) )
-          | Compose (f_morph_hint, g_morph_hint) ->
-            let mid, f_morph_hint_adj = aux b_obj f_morph_hint in
-            let src, g_morph_hint_adj = aux mid g_morph_hint in
-            src, Compose (g_morph_hint_adj, f_morph_hint_adj)
-        in
-        fun b_obj h -> snd (aux b_obj h)
+      let rec right_adjoint :
+          type a b r.
+          H.Pinpoint.t ->
+          b C.obj ->
+          (a, b, allowed * r) t ->
+          H.Pinpoint.t * a C.obj * (b, a, disallowed * allowed) t =
+       fun pp b_obj -> function
+        | Id -> pp, b_obj, Id
+        | Base (small_morph_hint, morph) ->
+          let pp, small_morph_hint =
+            H.Morph.right_adjoint pp small_morph_hint
+          in
+          ( pp,
+            C.src b_obj morph,
+            Base (small_morph_hint, C.right_adjoint b_obj morph) )
+        | Compose (f_morph_hint, g_morph_hint) ->
+          let mid_pp, mid, f_morph_hint_adj =
+            right_adjoint pp b_obj f_morph_hint
+          in
+          let src_pp, src, g_morph_hint_adj =
+            right_adjoint mid_pp mid g_morph_hint
+          in
+          src_pp, src, Compose (g_morph_hint_adj, f_morph_hint_adj)
 
       include Magic_allow_disallow (struct
         type ('a, 'b, 'd) sided = ('a, 'b, 'd) t constraint 'd = 'l * 'r
@@ -638,12 +644,13 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let submode_cv :
       type a.
       log:_ ->
+      H.Pinpoint.t ->
       a C.obj ->
       a ->
       (a, left_only) Comp_hint.t ->
       a var ->
       (unit, a * (a, right_only) Comp_hint.t) Result.t =
-    fun (type a) ~log (obj : a C.obj) a' a'_hint v ->
+    fun (type a) ~log _pp (obj : a C.obj) a' a'_hint v ->
      if C.le obj a' v.lower
      then Ok ()
      else if not (C.le obj a' v.upper)
@@ -656,12 +663,13 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let submode_cmv :
       type a l.
       log:_ ->
+      H.Pinpoint.t ->
       a C.obj ->
       a ->
       (a, left_only) Comp_hint.t ->
       (a, l * allowed) morphvar ->
       (unit, a * (a, right_only) Comp_hint.t) Result.t =
-   fun ~log obj a a_hint (Amorphvar (v, f, f_hint) as mv) ->
+   fun ~log pp obj a a_hint (Amorphvar (v, f, f_hint) as mv) ->
     let mlower = mlower obj mv in
     let mupper = mupper obj mv in
     let mupper_hint = mupper_hint mv in
@@ -674,11 +682,12 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
          closure of [f]'s image. Therefore, asking [a <= f v] is equivalent to
          asking [f' a <= v]. *)
       let f' = C.left_adjoint obj f in
-      let f'_hint = Comp_hint.Morph_hint.left_adjoint obj f_hint in
-      let src = C.src obj f in
+      let src_pp, src, f'_hint =
+        Comp_hint.Morph_hint.left_adjoint pp obj f_hint
+      in
       let a' = C.apply src f' a in
       let a'_hint = Comp_hint.Apply (f'_hint, a_hint) in
-      submode_cv ~log src a' a'_hint v |> Result.get_ok;
+      submode_cv ~log src_pp src a' a'_hint v |> Result.get_ok;
       Ok ()
 
   (** Returns [Ok ()] if success; [Error x] if failed, and [x] is the next best
@@ -687,12 +696,13 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let rec submode_vc :
       type a.
       log:_ ->
+      H.Pinpoint.t ->
       a C.obj ->
       a var ->
       a ->
       (a, right_only) Comp_hint.t ->
       (unit, a * (a, left_only) Comp_hint.t) Result.t =
-    fun (type a) ~log (obj : a C.obj) v a' a'_hint ->
+    fun (type a) ~log pp (obj : a C.obj) v a' a'_hint ->
      if C.le obj v.upper a'
      then Ok ()
      else if not (C.le obj v.lower a')
@@ -702,7 +712,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
        let r =
          v.vlower
          |> find_error (fun mu ->
-                let r = submode_mvc ~log obj mu a' a'_hint in
+                let r = submode_mvc ~log pp obj mu a' a'_hint in
                 (if Result.is_ok r
                 then
                   (* Optimization: update [v.lower] based on [mlower u].*)
@@ -718,12 +728,13 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   and submode_mvc :
         'a 'r.
         log:change list ref option ->
+        H.Pinpoint.t ->
         'a C.obj ->
         ('a, allowed * 'r) morphvar ->
         'a ->
         ('a, right_only) Comp_hint.t ->
         (unit, 'a * ('a, left_only) Comp_hint.t) Result.t =
-   fun ~log obj (Amorphvar (v, f, f_hint) as mv) a a_hint ->
+   fun ~log pp obj (Amorphvar (v, f, f_hint) as mv) a a_hint ->
     (* See [submode_cmv] for why we need the following seemingly redundant
        lines. *)
     let mupper = mupper obj mv in
@@ -735,15 +746,16 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     then Error (mlower, mlower_hint)
     else
       let f' = C.right_adjoint obj f in
-      let f'_hint = Comp_hint.Morph_hint.right_adjoint obj f_hint in
-      let src = C.src obj f in
+      let src_pp, src, f'_hint =
+        Comp_hint.Morph_hint.right_adjoint pp obj f_hint
+      in
       let a' = C.apply src f' a in
       let a'_hint = Comp_hint.Apply (f'_hint, a_hint) in
       (* If [mlower] was precise, then the check
          [not (C.le obj (mlower obj mv) a)] should guarantee the following call
          to return [Ok ()]. However, [mlower] is not precise *)
       (* not using [Result.map_error] to avoid allocating closure *)
-      match submode_vc ~log src v a' a'_hint with
+      match submode_vc ~log src_pp src v a' a'_hint with
       | Ok () -> Ok ()
       | Error (e, e_hint) ->
         Error
@@ -761,7 +773,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       disallow_left (disallow_right mv0) == disallow_left (disallow_right mv1))
     || match C.eq_morph f0 f1 with None -> false | Some Refl -> v0 == v1
 
-  let submode_mvmv (type a) ~log (dst : a C.obj)
+  let submode_mvmv (type a) ~log (pp : H.Pinpoint.t) (dst : a C.obj)
       (Amorphvar (v, f, f_hint) as mv) (Amorphvar (u, g, g_hint) as mu) =
     if C.le dst (mupper dst mv) (mlower dst mu)
     then Ok ()
@@ -775,20 +787,21 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
          2. f v.lower <= g u
          3. adding g' (f v) to the u.vlower, where g' is the left adjoint of g.
       *)
-      match submode_mvc ~log dst mv muupper muupper_hint with
+      match submode_mvc ~log pp dst mv muupper muupper_hint with
       | Error (a, a_hint) -> Error (a, a_hint, muupper, muupper_hint)
       | Ok () -> (
         let mvlower = mlower dst mv in
         let mvlower_hint = mlower_hint mv in
-        match submode_cmv ~log dst mvlower mvlower_hint mu with
+        match submode_cmv ~log pp dst mvlower mvlower_hint mu with
         | Error (a, a_hint) -> Error (mvlower, mvlower_hint, a, a_hint)
         | Ok () ->
           (* At this point, we know that [f v <= g u.upper], which means [f v]
              lies within the downward closure of [g]'s image. Therefore, asking [f
              v <= g u] is equivalent to asking [g' f v <= u] *)
           let g' = C.left_adjoint dst g in
-          let g'_hint = Comp_hint.Morph_hint.left_adjoint dst g_hint in
-          let src = C.src dst g in
+          let _, src, g'_hint =
+            Comp_hint.Morph_hint.left_adjoint pp dst g_hint
+          in
           let g'f = C.compose src g' (C.disallow_right f) in
           let g'f_hint =
             Comp_hint.Morph_hint.Compose
@@ -831,75 +844,81 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       right_hint : ('a, right_only) hint_raw
     }
 
-  let submode (type a r l) (obj : a C.obj) (a : (a, allowed * r) mode)
-      (b : (a, l * allowed) mode) ~log =
-    let submode_cc ~log:_ obj left left_hint right right_hint =
+  let submode (type a r l) (pp : H.Pinpoint.t) (obj : a C.obj)
+      (a : (a, allowed * r) mode) (b : (a, l * allowed) mode) ~log =
+    let submode_cc ~log:_ _pp obj left left_hint right right_hint =
       if C.le obj left right
       then Ok ()
       else Error { left; left_hint; right; right_hint }
     in
-    let submode_mvc ~log obj v right right_hint =
+    let submode_mvc ~log pp obj v right right_hint =
       Result.map_error
         (fun (left, left_hint) -> { left; left_hint; right; right_hint })
-        (submode_mvc ~log obj v right right_hint)
+        (submode_mvc ~log pp obj v right right_hint)
     in
-    let submode_cmv ~log obj left left_hint v =
+    let submode_cmv ~log pp obj left left_hint v =
       Result.map_error
         (fun (right, right_hint) -> { left; left_hint; right; right_hint })
-        (submode_cmv ~log obj left left_hint v)
+        (submode_cmv ~log pp obj left left_hint v)
     in
-    let submode_mvmv ~log obj v u =
+    let submode_mvmv ~log pp obj v u =
       Result.map_error
         (fun (left, left_hint, right, right_hint) ->
           { left; left_hint; right; right_hint })
-        (submode_mvmv ~log obj v u)
+        (submode_mvmv ~log pp obj v u)
     in
     match a, b with
     | ( Amode (left, left_hint_lower, _left_hint_upper),
         Amode (right, _right_hint_lower, right_hint_upper) ) ->
-      submode_cc ~log obj left
+      submode_cc ~log pp obj left
         (Comp_hint.disallow_right left_hint_lower)
         right
         (Comp_hint.disallow_left right_hint_upper)
     | Amodevar v, Amode (right, _right_hint_lower, right_hint_upper) ->
-      submode_mvc ~log obj v right (Comp_hint.disallow_left right_hint_upper)
+      submode_mvc ~log pp obj v right (Comp_hint.disallow_left right_hint_upper)
     | Amode (left, left_hint_lower, _left_hint_upper), Amodevar v ->
-      submode_cmv ~log obj left (Comp_hint.disallow_right left_hint_lower) v
-    | Amodevar v, Amodevar u -> submode_mvmv ~log obj v u
+      submode_cmv ~log pp obj left (Comp_hint.disallow_right left_hint_lower) v
+    | Amodevar v, Amodevar u -> submode_mvmv ~log pp obj v u
     | Amode (a, a_hint_lower, _a_hint_upper), Amodemeet (b, b_hint, mvs) ->
       Result.bind
-        (submode_cc ~log obj a (Comp_hint.disallow_right a_hint_lower) b b_hint)
+        (submode_cc ~log pp obj a
+           (Comp_hint.disallow_right a_hint_lower)
+           b b_hint)
         (fun () ->
           find_error
             (fun mv ->
-              submode_cmv ~log obj a (Comp_hint.disallow_right a_hint_lower) mv)
+              submode_cmv ~log pp obj a
+                (Comp_hint.disallow_right a_hint_lower)
+                mv)
             mvs)
     | Amodevar mv, Amodemeet (b, b_hint, mvs) ->
-      Result.bind (submode_mvc ~log obj mv b b_hint) (fun () ->
-          find_error (fun mv' -> submode_mvmv ~log obj mv mv') mvs)
+      Result.bind (submode_mvc ~log pp obj mv b b_hint) (fun () ->
+          find_error (fun mv' -> submode_mvmv ~log pp obj mv mv') mvs)
     | Amodejoin (a, a_hint, mvs), Amode (b, _b_hint_lower, b_hint_upper) ->
       Result.bind
-        (submode_cc ~log obj a a_hint b (Comp_hint.disallow_left b_hint_upper))
+        (submode_cc ~log pp obj a a_hint b
+           (Comp_hint.disallow_left b_hint_upper))
         (fun () ->
           find_error
             (fun mv' ->
-              submode_mvc ~log obj mv' b (Comp_hint.disallow_left b_hint_upper))
+              submode_mvc ~log pp obj mv' b
+                (Comp_hint.disallow_left b_hint_upper))
             mvs)
     | Amodejoin (a, a_hint, mvs), Amodevar mv ->
-      Result.bind (submode_cmv ~log obj a a_hint mv) (fun () ->
-          find_error (fun mv' -> submode_mvmv ~log obj mv' mv) mvs)
+      Result.bind (submode_cmv ~log pp obj a a_hint mv) (fun () ->
+          find_error (fun mv' -> submode_mvmv ~log pp obj mv' mv) mvs)
     | Amodejoin (a, a_hint, mvs), Amodemeet (b, b_hint, mus) ->
       (* TODO: mabye create a intermediate variable? *)
-      Result.bind (submode_cc ~log obj a a_hint b b_hint) (fun () ->
+      Result.bind (submode_cc ~log pp obj a a_hint b b_hint) (fun () ->
           Result.bind
-            (find_error (fun mv -> submode_mvc ~log obj mv b b_hint) mvs)
+            (find_error (fun mv -> submode_mvc ~log pp obj mv b b_hint) mvs)
             (fun () ->
               Result.bind
-                (find_error (fun mu -> submode_cmv ~log obj a a_hint mu) mus)
+                (find_error (fun mu -> submode_cmv ~log pp obj a a_hint mu) mus)
                 (fun () ->
                   find_error
                     (fun mu ->
-                      find_error (fun mv -> submode_mvmv ~log obj mv mu) mvs)
+                      find_error (fun mv -> submode_mvmv ~log pp obj mv mu) mvs)
                     mus)))
 
   let populate_hint obj a hint =
@@ -1020,7 +1039,9 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     let ceil = get_ceil obj m in
     (* We want a hint to explain why [ceil] is high. However, we only have hint
        for why [ceil] is low. There is no good hint to use. *)
-    submode obj (Amode (ceil, Unknown ceil, Unknown ceil)) m ~log
+    submode H.Pinpoint.unknown obj
+      (Amode (ceil, Unknown ceil, Unknown ceil))
+      m ~log
     |> Result.get_ok;
     ceil
 
@@ -1044,7 +1065,10 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       let log = ref empty_changes in
       (* We want a hint for why [lower] is low, but we only have hint for why [lower] is
          high. There is no good hint to use. *)
-      let r = submode_mvc ~log:(Some log) obj mv lower (Unknown lower) in
+      let r =
+        submode_mvc ~log:(Some log) H.Pinpoint.unknown obj mv lower
+          (Unknown lower)
+      in
       match r with
       | Ok () -> !log, lower
       | Error (a, _) ->
@@ -1080,7 +1104,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         (fun _ mv ->
           (* We want a hint for why [floor] is low. However, we only have hint
              for why [floor] is high. There is no hint to use. *)
-          submode_mvc obj mv floor (Unknown floor) ~log |> Result.get_ok)
+          submode_mvc H.Pinpoint.unknown obj mv floor (Unknown floor) ~log
+          |> Result.get_ok)
         mvs;
       floor
 
@@ -1156,14 +1181,15 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | Amodevar mv ->
       let u = fresh obj in
       let mu = Amorphvar (u, C.id, Id) in
-      submode_mvmv obj ~log:None mu mv |> Result.get_ok;
+      submode_mvmv H.Pinpoint.unknown obj ~log:None mu mv |> Result.get_ok;
       allow_left (Amodevar mu), true
     | Amodemeet (a, a_hint, mvs) ->
       let u = fresh obj in
       let mu = Amorphvar (u, C.id, Id) in
-      submode_mvc obj ~log:None mu a a_hint |> Result.get_ok;
+      submode_mvc H.Pinpoint.unknown obj ~log:None mu a a_hint |> Result.get_ok;
       VarMap.iter
-        (fun _ mv -> submode_mvmv obj ~log:None mu mv |> Result.get_ok)
+        (fun _ mv ->
+          submode_mvmv H.Pinpoint.unknown obj ~log:None mu mv |> Result.get_ok)
         mvs;
       allow_left (Amodevar mu), true
 end

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -180,6 +180,8 @@ module type Solver_mono = sig
   (** The object type from the [Lattices_mono] we're working with *)
   type 'a obj
 
+  type pinpoint
+
   type 'd hint_morph constraint 'd = 'l * 'r
 
   type 'd hint_const constraint 'd = 'l * 'r
@@ -248,8 +250,10 @@ module type Solver_mono = sig
       right_hint : ('a, right_only) hint_raw
     }
 
-  (** Try to constrain the first mode below the second mode. *)
+  (** Try to constrain the first mode below the second mode. [pinpoint]
+  describes the thing that has both modes. *)
   val submode :
+    pinpoint ->
     'a obj ->
     ('a, allowed * 'r) mode ->
     ('a, 'l * allowed) mode ->
@@ -364,6 +368,14 @@ end
 
 (** Hint module to be provided by the user of the solver. *)
 module type Hint = sig
+  module Pinpoint : sig
+    (** Descriptions of things that have modes. *)
+    type t
+
+    (** Something that have modes but not described. *)
+    val unknown : t
+  end
+
   module Morph : sig
     (** Hints that explain morphisms. The allowance ['d] describes if the morphism can be on
       the LHS or RHS of [submode]. *)
@@ -372,11 +384,15 @@ module type Hint = sig
     (** The hint for the identity morphism *)
     val id : 'd t
 
-    (** Given a hint for a mode morphism, return a hint for the left adjoint of the morphism *)
-    val left_adjoint : (_ * allowed) t -> (allowed * disallowed) t
+    (** Given a hint for a mode morphism with its destination pinpoint, return a
+    hint for the left adjoint of the morphism with the opposite pinpoint. *)
+    val left_adjoint :
+      Pinpoint.t -> (_ * allowed) t -> Pinpoint.t * (allowed * disallowed) t
 
-    (** Given a hint for a mode morphism, return a hint for the right adjoint of the morphism *)
-    val right_adjoint : (allowed * _) t -> (disallowed * allowed) t
+    (** Given a hint for a mode morphism with its destination pinpoint, return a
+    hint for the right adjoint of the morphism with the opposite pinpoint. *)
+    val right_adjoint :
+      Pinpoint.t -> (allowed * _) t -> Pinpoint.t * (disallowed * allowed) t
 
     (** The hint for unexplained morphs *)
     val unknown : 'd t
@@ -415,6 +431,7 @@ module type S = sig
     Solver_mono
       with type ('a, 'b, 'd) morph := ('a, 'b, 'd) C.morph
        and type 'a obj := 'a C.obj
+       and type pinpoint := Hint.Pinpoint.t
        and type 'd hint_morph := 'd Hint.Morph.t
        and type 'd hint_const := 'd Hint.Const.t
 end

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -271,7 +271,6 @@ type error =
   | Block_index_modality_mismatch of
       { mut : bool; err : Modality.equate_error }
   | Submode_failed of Value.error * submode_reason * Env.shared_context option
-  | Submode_failed_alloc of Alloc.error
   | Curried_application_complete of
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Param_mode_mismatch of Alloc.equate_error
@@ -7260,14 +7259,11 @@ and type_expect_
             Value.(of_const ~hint_comonadic:Stack_expression
               { Const.min with areality = Local })
             expected_mode;
-          match
-            Alloc.submode Alloc.(of_const ~hint_comonadic:Stack_expression
-              { Const.min with areality = Local }) alloc_mode
-          with
-          | Ok () -> ()
-          | Error err ->
-              raise (Error (exp.exp_loc, exp.exp_env,
-                Submode_failed_alloc err))
+          let local =
+            Alloc.(of_const ~hint_comonadic:Stack_expression
+              { Const.min with areality = Local })
+          in
+          Alloc.submode_err (exp.exp_loc, Allocation) local alloc_mode
         end
       | Texp_list_comprehension _ -> unsupported List_comprehension
       | Texp_array_comprehension _ -> unsupported Array_comprehension
@@ -11553,6 +11549,9 @@ let report_error ~loc env =
       (print_modality "not") actual
   | Submode_failed(e, submode_reason, shared_context) ->
     let Mode.Value.Error (ax, _) = Mode.Value.to_simple_error e in
+    (* CR-soon zqian: move the following hints into the new hint system, then
+      we can invoke [submode_err] instead of [submode], and remove this
+      exception. *)
     let sub =
       match ax with
         | Comonadic Linearity | Monadic Uniqueness ->
@@ -11573,8 +11572,19 @@ let report_error ~loc env =
           (Style.as_inline_code longident) name ]
       | Application _ | Other -> sub
     in
-    Location.errorf ~loc ~sub "%a" Value.report_error e
-  | Submode_failed_alloc e -> Location.errorf ~loc "%a" Alloc.report_error e
+    Location.error_of_printer ~loc ~sub (fun ppf e ->
+      let open Format in
+      let {left; right} : Mode_intf.print_error =
+        Value.print_error (loc, Expression) e
+      in
+      pp_print_string ppf "This value is ";
+    (match left ppf with
+    | Mode_with_hint ->
+      fprintf ppf ".@\nHowever, the highlighted expression is expected to be "
+    | Mode -> fprintf ppf "@ but is expected to be ");
+    ignore (right ppf);
+    pp_print_string ppf "."
+      ) e
   | Curried_application_complete (lbl, e, loc_kind) ->
       let Mode.Alloc.Error (ax, {left; _}) = Mode.Alloc.to_simple_error e in
       let sub =

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -317,7 +317,6 @@ type error =
       { mut : bool; err : Mode.Modality.equate_error }
   | Submode_failed of Mode.Value.error * submode_reason *
       Env.shared_context option
-  | Submode_failed_alloc of Mode.Alloc.error
   | Curried_application_complete of
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Param_mode_mismatch of Mode.Alloc.equate_error


### PR DESCRIPTION
This is needed for a better approach to https://github.com/oxcaml/oxcaml/pull/4634

This PR clarifies some points that weren't clear in #4471:
- When there is a mode error, the mode system has all the hints about the actual mode and the expected mode. However, it doesn't always know what the two modes are about (i.e., what's the value that the two modes are describing?) The caller of `submode` knows that.
- As a result, the `report_error` function which prints a whole mode error message, is replaced by `print_error` which prints the left and right mode hints seperately (for easier integration into the caller's error).