### PR TITLE
Fix conversion of untagged char literals in flambda

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -153,8 +153,7 @@ let rec declare_const acc dbg (const : Lambda.structured_constant) =
   | Const_base (Const_untagged_char c) ->
     ( acc,
       reg_width
-        (RWC.naked_immediate
-           (Target_ocaml_int.of_char (Acc.machine_width acc) c)),
+        (RWC.naked_int8 (Numeric_types.Int8.unsigned_of_int_exn (Char.code c))),
       "untagged_char" )
   | Const_base (Const_untagged_int c) ->
     ( acc,

--- a/middle_end/flambda2/numbers/numeric_types.ml
+++ b/middle_end/flambda2/numbers/numeric_types.ml
@@ -56,12 +56,32 @@ struct
 
     let max_int64 = Int64.lognot min_int64
 
+    let unsigned_min_int64 = 0L
+
+    let unsigned_max_int64 =
+      Int64.shift_right_logical Int64.minus_one (64 - num_bits)
+
+    let () =
+      if num_bits = 8
+      then (
+        assert (Int64.equal min_int64 (-128L));
+        assert (Int64.equal max_int64 127L);
+        assert (Int64.equal unsigned_max_int64 255L))
+
     let of_int64_exn i =
       if Int64.compare i min_int64 < 0 || Int64.compare i max_int64 > 0
       then Misc.fatal_errorf "Int%d: %Ld is out of range" num_bits i
       else Int64.to_int i
 
+    let unsigned_of_int64_exn i =
+      if Int64.compare i unsigned_min_int64 < 0
+         || Int64.compare i unsigned_max_int64 > 0
+      then Misc.fatal_errorf "Int%d: %Ld is out of range" num_bits i
+      else Int64.to_int i
+
     let of_int_exn i = of_int64_exn (Int64.of_int i)
+
+    let unsigned_of_int_exn i = unsigned_of_int64_exn (Int64.of_int i)
 
     let of_int i =
       let extra_bits = Sys.int_size - num_bits in

--- a/middle_end/flambda2/numbers/numeric_types.mli
+++ b/middle_end/flambda2/numbers/numeric_types.mli
@@ -39,7 +39,11 @@ module Int8 : sig
 
   val of_int_exn : int -> t
 
+  val unsigned_of_int_exn : int -> t
+
   val of_int64_exn : Int64.t -> t
+
+  val unsigned_of_int64_exn : Int64.t -> t
 
   val to_int : t -> int
 
@@ -61,7 +65,11 @@ module Int16 : sig
 
   val of_int_exn : int -> t
 
+  val unsigned_of_int_exn : int -> t
+
   val of_int64_exn : Int64.t -> t
+
+  val unsigned_of_int64_exn : Int64.t -> t
 
   val to_int : t -> int
 

--- a/testsuite/tests/typing-layouts/literals_native.ml
+++ b/testsuite/tests/typing-layouts/literals_native.ml
@@ -18,6 +18,7 @@ module Int32_u = Stdlib_upstream_compatible.Int32_u
 module Int64_u = Stdlib_upstream_compatible.Int64_u
 module Nativeint_u = Stdlib_upstream_compatible.Nativeint_u
 module Int_u = Stdlib_stable.Int_u
+module Char_u = Stdlib_stable.Char_u
 
 let test_float s f =
   Format.printf "%s: %f\n" s (Float_u.to_float f); Format.print_flush ()
@@ -29,6 +30,8 @@ let test_nativeint s f =
   Format.printf "%s: %s\n" s (Nativeint_u.to_string f); Format.print_flush ()
 let test_int s f =
   Format.printf "%s: %d\n" s (Int_u.to_int f); Format.print_flush ()
+let test_char s f =
+  Format.printf "%s: %C\n" s (Char_u.to_char f); Format.print_flush ()
 
 (*****************************************)
 (* Expressions *)
@@ -55,6 +58,10 @@ let () = test_nativeint "two_fifty_five_in_hex" (#0xFFn)
 let () = test_int32 "twenty_five_in_octal" (#0o31l)
 let () = test_int64 "forty_two_in_binary" (#0b101010L)
 let () = test_int "max_int + 1" (#4611686018427387904m)
+let () = test_char "untagged char" #'c'
+let () = test_char "untagged octal char" #'\o000'
+let () = test_char "untagged hex char" #'\xFF'
+let () = test_char "untagged decimal char" #'\222'
 
 (*****************************************)
 (* Patterns *)

--- a/testsuite/tests/typing-layouts/literals_native.reference
+++ b/testsuite/tests/typing-layouts/literals_native.reference
@@ -19,6 +19,10 @@ two_fifty_five_in_hex: 255
 twenty_five_in_octal: 25
 forty_two_in_binary: 42
 max_int + 1: -4611686018427387904
+untagged char: 'c'
+untagged octal char: '\000'
+untagged hex char: '\255'
+untagged decimal char: '\222'
 result: 7.000000
 larger match result: 3.000000
 result: 7


### PR DESCRIPTION
This one is my fault for not testing char literals on native before merging.

Anyway, this fix should be quick to review. The main change is in `closure_conversion.ml`: untagged chars have layout `bits8`, not untagged immediate. I added `Short_int.unsigned_of_int_exn` since we need to convert an `int` in `0..255` to an `int8`.