### PR TITLE
Fix two wrongly-hardcoded machine_width values

### DIFF
--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -620,6 +620,8 @@ module Source_env : sig
 
   val create : TE.t -> t
 
+  val machine_width : t -> Target_system.Machine_width.t
+
   val code_age_relation : t -> Code_age_relation.t
 
   val code_age_relation_resolver :
@@ -652,6 +654,8 @@ end = struct
   type t = { source_env : TE.t } [@@unboxed]
 
   let create source_env = { source_env }
+
+  let machine_width { source_env } = TE.machine_width source_env
 
   let code_age_relation { source_env } = TE.code_age_relation source_env
 
@@ -1318,6 +1322,9 @@ let joined_env t index = Joined_envs.get_nth_joined_env t.joined_envs index
 
 let code_age_relation t =
   Source_env.code_age_relation (Bindings_in_target_env.source_env t.bindings)
+
+let machine_width t =
+  Source_env.machine_width (Bindings_in_target_env.source_env t.bindings)
 
 let code_age_relation_resolver t =
   Source_env.code_age_relation_resolver

--- a/middle_end/flambda2/types/env/join_env.mli
+++ b/middle_end/flambda2/types/env/join_env.mli
@@ -24,6 +24,8 @@ type n_way_join_type =
 
 val joined_env : t -> env_id -> Typing_env.t
 
+val machine_width : t -> Target_system.Machine_width.t
+
 val code_age_relation : t -> Code_age_relation.t
 
 val code_age_relation_resolver :

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -1999,21 +1999,21 @@ and join_head_of_kind_naked_immediate env
     else Unknown
   | Is_null ty, Naked_immediates is_null | Naked_immediates is_null, Is_null ty
     -> (
-    if I.Set.is_empty is_null
-    then Known (TG.Head_of_kind_naked_immediate.create_is_null ty)
-    else
+    match I.Set.choose_opt is_null with
+    | None -> Known (TG.Head_of_kind_naked_immediate.create_is_null ty)
+    | Some arbitrary_int -> (
+      let machine_width = I.machine_width arbitrary_int in
       (* Slightly better than Unknown *)
       let head =
         TG.Head_of_kind_naked_immediate.create_naked_immediates
-          (I.Set.add
-             (I.zero Target_system.Machine_width.Sixty_four)
-             (I.Set.add (I.one Target_system.Machine_width.Sixty_four) is_null))
+          (I.Set.add (I.zero machine_width)
+             (I.Set.add (I.one machine_width) is_null))
       in
       match head with
       | Ok head -> Known head
       | Bottom ->
         Misc.fatal_error
-          "Did not expect [Bottom] from [create_naked_immediates]")
+          "Did not expect [Bottom] from [create_naked_immediates]"))
   | (Is_int _ | Get_tag _ | Is_null _), (Is_int _ | Get_tag _ | Is_null _) ->
     Unknown
 

--- a/middle_end/flambda2/types/meet_and_n_way_join.ml
+++ b/middle_end/flambda2/types/meet_and_n_way_join.ml
@@ -2362,10 +2362,10 @@ and n_way_join_head_of_kind_naked_immediate env
   | _ :: _, [], _ | _, [], _ :: _ -> (
     (* Slightly better than Unknown *)
     let head =
+      let machine_width = Join_env.machine_width env in
       TG.Head_of_kind_naked_immediate.create_naked_immediates
-        (I.Set.add
-           (I.zero Target_system.Machine_width.Sixty_four)
-           (I.Set.add (I.one Target_system.Machine_width.Sixty_four) immediates))
+        (I.Set.add (I.zero machine_width)
+           (I.Set.add (I.one machine_width) immediates))
     in
     match head with
     | Ok head -> Known head, env


### PR DESCRIPTION
I missed these two.  The change in the new n-way meet/join code requires adding the machine width to the `Join_env`, which is fine, but doing this could probably have made the changes in the old meet/join code simpler.  I've just followed the existing pattern for the latter however, as we'll be changing to the n-way code in due course anyway.