### PR TITLE
Fix unbound variable bug in JSIR

### DIFF
--- a/middle_end/flambda2/to_jsir/to_jsir_set_of_closures.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_set_of_closures.ml
@@ -33,6 +33,10 @@ let set_of_closures ~env ~res ~bindings ~add_to_env soc =
   let decls =
     Function_declarations.funs_in_order fun_decls |> Function_slot.Lmap.bindings
   in
+  (* JSOO is expects that variables are bound before they are used (statically),
+     except that closures can refer to themselves and consecutive closures can
+     refer to one-another. This means that we should bind the value slots before
+     defining the functions using those variables.*)
   let env, res =
     Value_slot.Map.fold
       (fun slot simple (env, res) ->

--- a/middle_end/flambda2/to_jsir/to_jsir_set_of_closures.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_set_of_closures.ml
@@ -34,44 +34,42 @@ let set_of_closures ~env ~res ~bindings ~add_to_env soc =
     Function_declarations.funs_in_order fun_decls |> Function_slot.Lmap.bindings
   in
   let env, res =
-    List.fold_left2
-      (fun (env, res) binding (slot, decl) ->
-        match
-          (decl : Function_declarations.code_id_in_function_declaration)
-        with
-        | Deleted _ -> env, res
-        | Code_id { code_id; only_full_applications = _ } ->
-          let ({ addr; params; closure = fn_var } : To_jsir_env.code_id) =
-            To_jsir_env.get_code_id_exn env code_id
-          in
-          let expr : Jsir.expr = Closure (params, (addr, []), None) in
-          (* If this function slot is used, its corresponding variable should've
-             already been added to the environment when the code using it was
-             translated. We should make sure that this matches up with our
-             preemptively declared closure variable for this closure. *)
-          let res =
-            match To_jsir_env.get_function_slot env slot with
-            | None -> res
-            | Some fn_var' ->
-              To_jsir_result.add_instr_exn res (Assign (fn_var', fn_var))
-          in
-          let res = To_jsir_result.add_instr_exn res (Let (fn_var, expr)) in
-          add_to_env ~env ~res binding fn_var)
-      (env, res) bindings decls
+    Value_slot.Map.fold
+      (fun slot simple (env, res) ->
+        match To_jsir_env.get_value_slot env slot with
+        | Some var ->
+          let simple_var, res = To_jsir_shared.simple ~env ~res simple in
+          (* This value slot has been used in the function body, so we should
+             set the used variable to be the appropriate [Simple.t] *)
+          env, To_jsir_result.add_instr_exn res (Assign (var, simple_var))
+        | None ->
+          (* This value slot is not used, so we don't need to do anything *)
+          env, res)
+      (Set_of_closures.value_slots soc)
+      (env, res)
   in
-  Value_slot.Map.fold
-    (fun slot simple (env, res) ->
-      match To_jsir_env.get_value_slot env slot with
-      | Some var ->
-        let simple_var, res = To_jsir_shared.simple ~env ~res simple in
-        (* This value slot has been used in the function body, so we should set
-           the used variable to be the appropriate [Simple.t] *)
-        env, To_jsir_result.add_instr_exn res (Assign (var, simple_var))
-      | None ->
-        (* This value slot is not used, so we don't need to do anything *)
-        env, res)
-    (Set_of_closures.value_slots soc)
-    (env, res)
+  List.fold_left2
+    (fun (env, res) binding (slot, decl) ->
+      match (decl : Function_declarations.code_id_in_function_declaration) with
+      | Deleted _ -> env, res
+      | Code_id { code_id; only_full_applications = _ } ->
+        let ({ addr; params; closure = fn_var } : To_jsir_env.code_id) =
+          To_jsir_env.get_code_id_exn env code_id
+        in
+        let expr : Jsir.expr = Closure (params, (addr, []), None) in
+        (* If this function slot is used, its corresponding variable should've
+           already been added to the environment when the code using it was
+           translated. We should make sure that this matches up with our
+           preemptively declared closure variable for this closure. *)
+        let res =
+          match To_jsir_env.get_function_slot env slot with
+          | None -> res
+          | Some fn_var' ->
+            To_jsir_result.add_instr_exn res (Assign (fn_var', fn_var))
+        in
+        let res = To_jsir_result.add_instr_exn res (Let (fn_var, expr)) in
+        add_to_env ~env ~res binding fn_var)
+    (env, res) bindings decls
 
 let dynamic_set_of_closures ~env ~res ~bound_vars soc =
   let vars = List.map Bound_var.var bound_vars in

--- a/middle_end/flambda2/to_jsir/to_jsir_set_of_closures.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_set_of_closures.ml
@@ -33,12 +33,6 @@ let set_of_closures ~env ~res ~bindings ~add_to_env soc =
   let decls =
     Function_declarations.funs_in_order fun_decls |> Function_slot.Lmap.bindings
   in
-  (* CR selee: It should be sufficient to have these variables bound before the
-     call site of the closures being defined, but it seems that having the
-     closure expression before the bindings interact badly with the JSOO
-     simplifier when self-recursive functions become tail-call optimised.
-     Swapping the order resolved the issue, but we should dig into the intended
-     semantics of JSIR more. *)
   let env, res =
     Value_slot.Map.fold
       (fun slot simple (env, res) ->

--- a/middle_end/flambda2/to_jsir/to_jsir_set_of_closures.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_set_of_closures.ml
@@ -36,7 +36,7 @@ let set_of_closures ~env ~res ~bindings ~add_to_env soc =
   (* JSOO is expects that variables are bound before they are used (statically),
      except that closures can refer to themselves and consecutive closures can
      refer to one-another. This means that we should bind the value slots before
-     defining the functions using those variables.*)
+     defining the functions that use those variables.*)
   let env, res =
     Value_slot.Map.fold
       (fun slot simple (env, res) ->

--- a/middle_end/flambda2/to_jsir/to_jsir_set_of_closures.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_set_of_closures.ml
@@ -33,6 +33,12 @@ let set_of_closures ~env ~res ~bindings ~add_to_env soc =
   let decls =
     Function_declarations.funs_in_order fun_decls |> Function_slot.Lmap.bindings
   in
+  (* CR selee: It should be sufficient to have these variables bound before the
+     call site of the closures being defined, but it seems that having the
+     closure expression before the bindings interact badly with the JSOO
+     simplifier when self-recursive functions become tail-call optimised.
+     Swapping the order resolved the issue, but we should dig into the intended
+     semantics of JSIR more. *)
   let env, res =
     Value_slot.Map.fold
       (fun slot simple (env, res) ->


### PR DESCRIPTION
Previously, the variable bindings for value slots were inserted after the closure let-instruction, since our assumption was that these variables only need to be bound by the time the function is called. It turned out that this interacts badly with the JSOO simplifier when self-recursive functions become tail call optimised, where some variables became bound after the call site. Reordering these resolved the issue; but perhaps this hints that we should look at the simplifier more carefully.