### PR TITLE
Import compilation unit for JSIR symbol imports, too

### DIFF
--- a/middle_end/flambda2/to_jsir/to_jsir_env.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_env.ml
@@ -141,7 +141,7 @@ let get_exn_handler_exn t cont = Continuation.Map.find cont t.exn_handlers
 
 let get_var_exn t fvar = Variable.Map.find fvar t.vars
 
-let get_symbol_from_global_data ~compilation_unit ~symbol_name ~res =
+let get_symbol_from_global_data ~symbol_name ~res =
   let res, global_data = To_jsir_result.global_data_var res in
   let symbol_name = Jsir.Native_string.of_string symbol_name in
   let var = Jsir.Var.fresh () in
@@ -164,9 +164,7 @@ let get_predef_exception ~res symbol =
       (String.length symbol_name - String.length caml_exn_)
   in
   (* jsoo already registers these in global data *)
-  get_symbol_from_global_data
-    ~compilation_unit:(Symbol.compilation_unit symbol)
-    ~symbol_name ~res
+  get_symbol_from_global_data ~symbol_name ~res
 
 let get_external_symbol ~res symbol =
   match Symbol.is_predefined_exception symbol with
@@ -179,8 +177,7 @@ let get_external_symbol ~res symbol =
       let compilation_unit_name =
         Compilation_unit.name_as_string compilation_unit
       in
-      get_symbol_from_global_data ~compilation_unit
-        ~symbol_name:compilation_unit_name ~res
+      get_symbol_from_global_data ~symbol_name:compilation_unit_name ~res
     | false ->
       let compilation_unit_name, symbol_name =
         symbol_to_native_strings symbol

--- a/middle_end/flambda2/to_jsir/to_jsir_env.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_env.ml
@@ -142,7 +142,6 @@ let get_exn_handler_exn t cont = Continuation.Map.find cont t.exn_handlers
 let get_var_exn t fvar = Variable.Map.find fvar t.vars
 
 let get_symbol_from_global_data ~compilation_unit ~symbol_name ~res =
-  let res = To_jsir_result.import_compilation_unit res compilation_unit in
   let res, global_data = To_jsir_result.global_data_var res in
   let symbol_name = Jsir.Native_string.of_string symbol_name in
   let var = Jsir.Var.fresh () in
@@ -176,6 +175,7 @@ let get_external_symbol ~res symbol =
     match symbol_is_for_compilation_unit symbol with
     | true ->
       let compilation_unit = Symbol.compilation_unit symbol in
+      let res = To_jsir_result.import_compilation_unit res compilation_unit in
       let compilation_unit_name =
         Compilation_unit.name_as_string compilation_unit
       in


### PR DESCRIPTION
This influences what is put in the `//Provides` stanza of the `Unit_info.t` header in each compiled (pre-linked) `.js` file.