### PR TITLE
Implement TLS (take 2)

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -109,6 +109,7 @@ static enum {
 #define Ident(v) Field(v, 0)
 #define Start_closure(v) Field(v, 1)
 #define Terminated(v) Field(v, 2)
+#define TLS_state(v) Field(v, 3)
 
 /* The infos on threads (allocated via caml_stat_alloc()) */
 
@@ -497,8 +498,8 @@ static value caml_thread_new_descriptor(value clos)
   /* Create and initialize the termination semaphore */
   mu = caml_threadstatus_new();
   /* Create a descriptor for the new thread */
-  descr = caml_alloc_3(0, Val_long(atomic_fetch_add(&thread_next_id, +1)),
-                       clos, mu);
+  descr = caml_alloc_4(0, Val_long(atomic_fetch_add(&thread_next_id, +1)),
+                       clos, mu, Val_unit);
   CAMLreturn(descr);
 }
 
@@ -657,13 +658,48 @@ static void caml_thread_domain_spawn_hook(void)
   domain_lockmode = LOCKMODE_DOMAINS;
 }
 
+static value caml_thread_init_current(value unit)
+{
+  if (This_thread != NULL) return Val_unit;
+  caml_thread_t new_thread =
+    (caml_thread_t) caml_stat_alloc(sizeof(struct caml_thread_struct));
+
+  new_thread->domain_id = Caml_state->id;
+  new_thread->descr = caml_thread_new_descriptor(Val_unit);
+  new_thread->next = new_thread;
+  new_thread->prev = new_thread;
+  new_thread->backtrace_last_exn = Val_unit;
+  new_thread->memprof = caml_memprof_main_thread(Caml_state);
+  new_thread->dynamic = Caml_state->dynamic_bindings;
+  CAMLassert(new_thread->dynamic);
+  new_thread->is_main = 1;
+  new_thread->signal_stack = NULL;
+
+  This_thread = new_thread;
+  return Val_unit;
+}
+
+static value caml_thread_init_main_thread(value unit)
+{
+  if (threads_initialized) return Val_unit;
+  caml_thread_init_current(unit);
+  caml_register_generational_global_root(&This_thread->descr);
+  return Val_unit;
+}
+
+static value caml_thread_destroy_main_thread(value unit)
+{
+  if (threads_initialized) return Val_unit;
+  caml_remove_generational_global_root(&This_thread->descr);
+  caml_stat_free(This_thread);
+  return Val_unit;
+}
+
 /* FIXME: this should return an encoded exception for use in
    domain_thread_func, but the latter is not ready to handle it
    yet. */
 static void caml_thread_domain_initialize_hook(void)
 {
-  caml_thread_t new_thread;
-
   atomic_store_release(&Tick_thread_stop, 0);
   /* OS-specific initialization */
   st_initialize();
@@ -683,24 +719,14 @@ static void caml_thread_domain_initialize_hook(void)
 
   Locking_scheme(Caml_state->id) = ls;
 
-  new_thread =
-    (caml_thread_t) caml_stat_alloc(sizeof(struct caml_thread_struct));
+  /* If This_thread was initialized by caml_thread_init_main_thread, we must
+     unregister the descr, which will now be scanned by caml_scan_roots_hook */
+  if(This_thread) caml_remove_generational_global_root(&This_thread->descr);
+  caml_thread_init_current(Val_unit);
 
-  new_thread->domain_id = Caml_state->id;
-  new_thread->descr = caml_thread_new_descriptor(Val_unit);
-  new_thread->next = new_thread;
-  new_thread->prev = new_thread;
-  new_thread->backtrace_last_exn = Val_unit;
-  new_thread->memprof = caml_memprof_main_thread(Caml_state);
-  new_thread->dynamic = Caml_state->dynamic_bindings;
-  CAMLassert(new_thread->dynamic);
-  new_thread->is_main = 1;
-  new_thread->signal_stack = NULL;
-
-  This_thread = new_thread;
-  Active_thread = new_thread;
-  caml_memprof_enter_thread(new_thread->memprof);
-  caml_dynamic_enter_thread(new_thread->dynamic);
+  Active_thread = This_thread;
+  caml_memprof_enter_thread(Active_thread->memprof);
+  caml_dynamic_enter_thread(Active_thread->dynamic);
 }
 
 static void thread_yield(void);
@@ -996,6 +1022,39 @@ CAMLexport int caml_c_thread_unregister(void)
 CAMLprim value caml_thread_self(value unit)
 {
   return This_thread->descr;
+}
+
+/* Thread-local storage */
+
+static value caml_thread_has_tls_state(value unit)
+{
+  return Val_true;
+}
+
+static value caml_thread_get_state(value unit)
+{
+  return TLS_state(caml_thread_self(unit));
+}
+
+static value caml_thread_set_state(value state)
+{
+  caml_modify(&TLS_state(caml_thread_self(Val_unit)), state);
+  return Val_unit;
+}
+
+extern value (*caml_thread_has_tls_state_stub)(value unit);
+extern value (*caml_thread_get_state_stub)(value unit);
+extern value (*caml_thread_set_state_stub)(value state);
+extern value (*caml_thread_init_main_thread_stub)(value unit);
+extern value (*caml_thread_destroy_main_thread_stub)(value unit);
+
+__attribute__((constructor))
+static void caml_install_tls_functions(void) {
+  caml_thread_has_tls_state_stub = &caml_thread_has_tls_state;
+  caml_thread_get_state_stub = &caml_thread_get_state;
+  caml_thread_set_state_stub = &caml_thread_set_state;
+  caml_thread_init_main_thread_stub = &caml_thread_init_main_thread;
+  caml_thread_destroy_main_thread_stub = &caml_thread_destroy_main_thread;
 }
 
 /* Return the identifier of a thread */

--- a/otherlibs/systhreads/thread.ml
+++ b/otherlibs/systhreads/thread.ml
@@ -1,5 +1,4 @@
 # 2 "thread.ml"
-
 (**************************************************************************)
 (*                                                                        *)
 (*                                 OCaml                                  *)
@@ -18,6 +17,8 @@
 (* User-level threads *)
 
 [@@@ocaml.flambda_o3]
+
+module TLS = Domain.Safe.TLS
 
 type t : value mod contended portable
 
@@ -47,8 +48,11 @@ let set_uncaught_exception_handler (fn @ portable) =
 exception Exit
 
 let create (fn @ once) arg =
+  let tls_keys = Domain.TLS.Private.get_initial_keys () in
   thread_new
     (fun () ->
+      Domain.TLS.Private.init ();
+      Domain.TLS.Private.set_initial_keys tls_keys;
       try
         fn arg;
         ignore (Sys.opaque_identity (check_memprof_cb ()))

--- a/otherlibs/systhreads/thread.mli
+++ b/otherlibs/systhreads/thread.mli
@@ -199,3 +199,24 @@ val use_domains : unit -> unit
     used by domains. This ensures that domains can be started from threads
     other than the initial one. It prevents the use of a custom locking
     scheme, such as the one used by pyocaml. *)
+
+(** Thread-local storage. Like {!Domain.DLS}, but stores a distinct value
+    for each thread. Domains contain multiple threads, so [TLS] should be
+    preferred in nearly all cases. *)
+module TLS : sig @@ portable
+
+   type 'a key : value mod portable contended
+   (** Type of a TLS key *)
+
+   val new_key
+   : ?split_from_parent:('a -> (unit -> 'a) @ portable once) @ portable
+   -> (unit -> 'a) @ portable
+   -> 'a key
+   (** Like {!DLS.new_key}, but represents a distinct value in every thread. *)
+
+   val get : ('a : value mod portable). 'a key -> 'a @ contended
+   (** Like {!DLS.get}, but reads the value for the current thread. *)
+
+   val set : ('a : value mod contended). 'a key -> 'a @ portable -> unit
+   (** Like {!DLS.set}, but sets the value for the current thread. *)
+end

--- a/otherlibs/systhreads4/thread.mli
+++ b/otherlibs/systhreads4/thread.mli
@@ -189,3 +189,24 @@ val set_uncaught_exception_handler : (exn -> unit) @ portable -> unit
 
     If the newly set uncaught exception handler raise an exception,
     {!default_uncaught_exception_handler} will be called. *)
+
+(** Thread-local storage. Like {!Domain.DLS}, but stores a distinct value
+    for each thread. Domains contain multiple threads, so [TLS] should be
+    preferred in nearly all cases. *)
+module TLS : sig @@ portable
+
+   type 'a key : value mod portable contended
+   (** Type of a TLS key *)
+
+   val new_key
+   : ?split_from_parent:('a -> (unit -> 'a) @ portable once) @ portable
+   -> (unit -> 'a) @ portable
+   -> 'a key
+   (** Like {!DLS.new_key}, but represents a distinct value in every thread. *)
+
+   val get : ('a : value mod portable). 'a key -> 'a @ contended
+   (** Like {!DLS.get}, but reads the value for the current thread. *)
+
+   val set : ('a : value mod contended). 'a key -> 'a @ portable -> unit
+   (** Like {!DLS.set}, but sets the value for the current thread. *)
+end

--- a/oxcaml/tests/backend/llvmize/data_decl_ir.output
+++ b/oxcaml/tests/backend/llvmize/data_decl_ir.output
@@ -344,7 +344,7 @@ L133:                                                ; preds = %L130
   store i64 %108, ptr %31
   store ptr @camlData_decl__const_block54, ptr %32
   store i64 1, ptr %33
-  store ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1451$2c4$2d$2d59$5d_521, ptr %34
+  store ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521, ptr %34
   %109 = load i64, ptr %34
   store i64 %109, ptr %2
   %110 = load i64, ptr %33
@@ -406,7 +406,7 @@ L136:                                                ; preds = %L135
   store i64 %140, ptr %42
   store ptr @camlData_decl__const_block67, ptr %43
   store i64 1, ptr %44
-  store ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1451$2c4$2d$2d59$5d_521, ptr %45
+  store ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521, ptr %45
   %141 = load i64, ptr %45
   store i64 %141, ptr %2
   %142 = load i64, ptr %44
@@ -475,7 +475,7 @@ declare cc 104 { { ptr }, { i64 } } @caml_apply2(ptr, i64, i64, i64)
 declare i64 @llvm.read_register.i64(metadata)
 declare void @llvm.write_register.i64(metadata, i64)
 
-@camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1451$2c4$2d$2d59$5d_521 = external global ptr
+@camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 = external global ptr
 @camlStdlib__print_endline_138 = external global ptr
 @caml_c_call = external global ptr
 @caml_curry2 = external global ptr

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -2232,6 +2232,43 @@ CAMLprim value caml_domain_dls_compare_and_set(value old, value new)
   }
 }
 
+/* Weak definitions overridden when linked against [threads]. */
+
+value (*caml_thread_has_tls_state_stub)(value unit);
+CAMLprim value caml_thread_has_tls_state(value unit)
+{
+  if(caml_thread_has_tls_state_stub) return caml_thread_has_tls_state_stub(unit);
+  return Val_false;
+}
+
+value (*caml_thread_get_state_stub)(value unit);
+CAMLprim value caml_thread_get_state(value unit)
+{
+  if(caml_thread_get_state_stub) return caml_thread_get_state_stub(unit);
+  caml_failwith("caml_thread_get_state: TLS is not supported without the [threads] library.");
+}
+
+value (*caml_thread_set_state_stub)(value state);
+CAMLprim value caml_thread_set_state(value state)
+{
+  if(caml_thread_set_state_stub) return caml_thread_set_state_stub(state);
+  caml_failwith("caml_thread_set_state: TLS is not supported without the [threads] library.");
+}
+
+value (*caml_thread_init_main_thread_stub)(value unit);
+CAMLprim value caml_thread_init_main_thread(value unit)
+{
+  if(caml_thread_init_main_thread_stub) return caml_thread_init_main_thread_stub(unit);
+  caml_failwith("caml_thread_init_main_thread: TLS is not supported without the [threads] library.");
+}
+
+value (*caml_thread_destroy_main_thread_stub)(value unit);
+CAMLprim value caml_thread_destroy_main_thread(value unit)
+{
+  if(caml_thread_destroy_main_thread_stub) return caml_thread_destroy_main_thread_stub(unit);
+  caml_failwith("caml_thread_destroy_main_thread: TLS is not supported without the [threads] library.");
+}
+
 CAMLprim value caml_recommended_domain_count(value unused)
 {
   intnat n = -1;

--- a/runtime4/domain.c
+++ b/runtime4/domain.c
@@ -107,6 +107,43 @@ CAMLprim value caml_ml_domain_cpu_relax(value unit)
   return caml_process_pending_actions_with_root(unit);
 }
 
+/* Weak definitions overridden when linked against [threads]. */
+
+value (*caml_thread_has_tls_state_stub)(value unit);
+CAMLprim value caml_thread_has_tls_state(value unit)
+{
+  if(caml_thread_has_tls_state_stub) return caml_thread_has_tls_state_stub(unit);
+  return Val_false;
+}
+
+value (*caml_thread_get_state_stub)(value unit);
+CAMLprim value caml_thread_get_state(value unit)
+{
+  if(caml_thread_get_state_stub) return caml_thread_get_state_stub(unit);
+  caml_failwith("caml_thread_get_state: TLS is not supported without the [threads] library.");
+}
+
+value (*caml_thread_set_state_stub)(value state);
+CAMLprim value caml_thread_set_state(value state)
+{
+  if(caml_thread_set_state_stub) return caml_thread_set_state_stub(state);
+  caml_failwith("caml_thread_set_state: TLS is not supported without the [threads] library.");
+}
+
+value (*caml_thread_init_main_thread_stub)(value unit);
+CAMLprim value caml_thread_init_main_thread(value unit)
+{
+  if(caml_thread_init_main_thread_stub) return caml_thread_init_main_thread_stub(unit);
+  caml_failwith("caml_thread_init_main_thread: TLS is not supported without the [threads] library.");
+}
+
+value (*caml_thread_destroy_main_thread_stub)(value unit);
+CAMLprim value caml_thread_destroy_main_thread(value unit)
+{
+  if(caml_thread_destroy_main_thread_stub) return caml_thread_destroy_main_thread_stub(unit);
+  caml_failwith("caml_thread_destroy_main_thread: TLS is not supported without the [threads] library.");
+}
+
 /* Dummy implementations to enable [Stdlib.Domain] to link. */
 
 CAMLprim value caml_recommended_domain_count(void)

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -483,13 +483,176 @@ let impl = if runtime5 () then runtime_5_impl else runtime_4_impl
 module M : S = (val impl)
 include M
 
+module TLS0 = struct
+  module Impl = struct
+    type tls_state = Obj_opt.t array
+
+    external get_tls_state
+      : unit -> tls_state @@ portable = "caml_thread_get_state"
+    [@@noalloc]
+    external set_tls_state
+      : tls_state -> unit @@ portable = "caml_thread_set_state"
+    [@@noalloc]
+
+    let init () =
+      let st = Obj_opt.fresh () in
+      set_tls_state st
+
+    type 'a key = 'a DLS.key
+
+    let key_counter = Atomic.make 0
+
+    type key_initializer : value mod contended portable =
+        KI : 'a key * ('a -> (unit -> 'a) @ portable once) @@ portable
+        -> key_initializer
+    [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
+
+    type key_initializer_list = key_initializer list
+
+    let parent_keys = Atomic.make ([] : key_initializer_list)
+
+    let rec add_parent_key ki =
+      let l = Atomic.get parent_keys in
+      if not (Atomic.compare_and_set parent_keys l (ki :: l))
+      then add_parent_key ki
+
+    let new_key ?split_from_parent init_orphan =
+      let idx = Atomic.fetch_and_add key_counter 1 in
+      let k = idx, { Modes.Portable.portable = init_orphan } in
+      begin match split_from_parent with
+      | None -> ()
+      | Some split -> add_parent_key (KI (k, split))
+      end;
+      k
+
+    (* If necessary, grow the current domain's local state array such that [idx]
+     * is a valid index in the array. *)
+    let[@inline] maybe_grow idx =
+      let st = get_tls_state () in
+      let size = Array.length st in
+      if idx < size then st
+      else begin
+        let new_st = Obj_opt.grow_array st idx size in
+        set_tls_state new_st;
+        new_st
+      end
+
+    let[@inline] set (type a) (idx, _init) (x : a) =
+      (* Assures [idx] is in range. *)
+      let st = maybe_grow idx in
+      Array.unsafe_set st idx (Obj_opt.some x)
+
+    let[@inline never] init_idx (type a) idx (init : _ -> a) =
+      let v : a = init () in
+      let new_obj = Obj_opt.some v in
+      let st = get_tls_state () in
+      Array.unsafe_set st idx new_obj;
+      v
+
+    let[@inline] get (type a) ((idx, init) : a key) : a =
+      (* Assures [idx] is in range. *)
+      let st = maybe_grow idx in
+      let obj = Array.unsafe_get st idx in
+      if Obj_opt.is_some obj
+      then (Obj_opt.unsafe_get obj : a)
+      else init_idx idx init.portable
+
+    type key_value : value mod portable contended =
+        KV : 'a key * (unit -> 'a) @@ portable -> key_value
+    [@@unsafe_allow_any_mode_crossing "CR with-kinds"]
+
+    let get_initial_keys () : key_value list =
+      List.map
+        (* [v] is applied exactly once in [set_initial_keys] *)
+        (fun (KI (k, split)) ->
+          let v = Obj.magic_many (split (get k)) |> Obj.magic_portable in
+          KV (k, v))
+        (Atomic.get parent_keys : key_initializer_list)
+
+    let set_initial_keys (l : key_value list) =
+      List.iter (fun (KV (k, v)) -> set k (v ())) l
+  end
+
+  type 'a key = 'a Impl.key
+
+  external has_tls_state
+    : unit -> bool @@ portable = "caml_thread_has_tls_state"
+  let has_tls_state = has_tls_state ()
+
+  let[@inline] new_key ?split_from_parent init =
+    if has_tls_state
+    then Impl.new_key ?split_from_parent init
+    else DLS.new_key ?split_from_parent init
+  let[@inline] get key =
+    if has_tls_state then Impl.get key else DLS.get key
+  let[@inline] set key v =
+    if has_tls_state then Impl.set key v else DLS.set key v
+
+  module Private = struct
+      type keys = Impl.key_value list
+
+      let[@inline] init () =
+        if has_tls_state then Impl.init ()
+      let[@inline] get_initial_keys () =
+        if has_tls_state then Impl.get_initial_keys () else []
+      let[@inline] set_initial_keys keys =
+        if has_tls_state then Impl.set_initial_keys keys
+
+      external init_main_thread
+        : unit -> unit @@ portable = "caml_thread_init_main_thread"
+      external destroy_main_thread
+        : unit -> unit @@ portable = "caml_thread_destroy_main_thread"
+
+      let[@inline] init_main_thread () =
+        if has_tls_state then (init_main_thread (); init ())
+      let[@inline] destroy_main_thread () =
+        if has_tls_state then destroy_main_thread ()
+
+      (* Initialize TLS state for the main thread, since [Thread] might never 
+         be loaded. We don't destroy it since existing exit fns may use TLS. *)
+      let () = init_main_thread ()
+  end
+end
+
 module Safe = struct
   (* Note the exposed signature of [get] and [set] add modes for safety. *)
   module DLS = DLS
-  
-  let spawn = spawn
+  module TLS = TLS0
+
+  let spawn f =
+    let tls_keys = TLS.Private.get_initial_keys () in
+    spawn (fun () ->
+      (* Initialize and destroy TLS state for the main thread, since [Thread] 
+         might never be loaded. *)
+      TLS.Private.init_main_thread ();
+      at_exit TLS.Private.destroy_main_thread;
+      TLS.Private.set_initial_keys tls_keys;
+      f ()) [@nontail]
+
   let at_exit = at_exit
 end
+
+module TLS = struct
+  type 'a key = 'a TLS0.key
+
+  let new_key ?split_from_parent f =
+    let split_from_parent =
+      match split_from_parent with
+      | None -> None
+      | Some split_from_parent ->
+        Some (Obj.magic_portable (fun x ->
+          Obj.magic_portable (fun () -> split_from_parent x)))
+    in
+    TLS0.new_key ?split_from_parent (Obj.magic_portable f)
+  ;;
+
+  let get = TLS0.get
+  let set = TLS0.set
+
+  module Private = TLS0.Private
+end
+
+let () = DLS.init ()
 
 module DLS = struct
   type 'a key = 'a Safe.DLS.key
@@ -507,12 +670,9 @@ module DLS = struct
 
   let get = DLS.get
   let set = DLS.set
-  let init = DLS.init
 end
 
 let spawn f = Safe.spawn (Obj.magic_portable f)
 let at_exit f = Safe.at_exit (Obj.magic_portable f)
-
-let () = DLS.init ()
 
 let _ = Stdlib.do_domain_local_at_exit := do_at_exit

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -105,7 +105,7 @@ module DLS : sig
     (** Type of a DLS key *)
 
     val new_key : ?split_from_parent:('a -> 'a) -> (unit -> 'a) -> 'a key
-      @@ nonportable
+        @@ nonportable
     [@@alert unsafe_multidomain "Use [Domain.Safe.DLS.new_key]."]
     (** [new_key f] returns a new key bound to initialiser [f] for accessing
 ,        domain-local variables.
@@ -162,6 +162,36 @@ module DLS : sig
         to [k], which cannot be restored later. *)
 end
 
+(** Thread-local storage. Like {!DLS}, but stores a distinct value for each
+    thread. Domains contain multiple threads, so [TLS] should be preferred
+    in nearly all cases. *)
+module TLS : sig
+
+    type 'a key : value mod portable contended
+    (** Type of a TLS key *)
+
+    val new_key : ?split_from_parent:('a -> 'a) -> (unit -> 'a) -> 'a key
+        @@ nonportable
+    [@@alert unsafe_multidomain "Use [Domain.Safe.TLS.new_key]."]
+    (** Like {!DLS.new_key}, but represents a distinct value in every thread. *)
+
+    val get : 'a key -> 'a @@ nonportable
+    [@@alert unsafe_multidomain "Use [Domain.Safe.TLS.get]."]
+    (** Like {!DLS.get}, but reads the value for the current thread. *)
+
+    val set : 'a key -> 'a -> unit @@ nonportable
+    [@@alert unsafe_multidomain "Use [Domain.Safe.TLS.set]."]
+    (** Like {!DLS.set}, but sets the value for the current thread. *)
+
+    (** For use by the threading library. *)
+    module Private : sig @@ portable
+        type keys
+        val init : unit -> unit
+        val get_initial_keys : unit -> keys
+        val set_initial_keys : keys -> unit
+    end
+end
+
 (** Submodule containing non-backwards-compatible functions which enforce thread safety
     via modes. *)
 module Safe : sig @@ portable
@@ -185,6 +215,27 @@ module Safe : sig @@ portable
 
     val set : ('a : value mod contended). 'a key -> 'a @ portable -> unit
     (** Like {!DLS.set}, but safe to use in the presence of multiple domains. *)
+  end
+
+  (** Like {!TLS}, but uses modes to enforce properties necessary for data-race
+      freedom. *)
+  module TLS : sig
+
+    type 'a key = 'a TLS.key
+    (** Type of a TLS key *)
+
+    val new_key
+      : ?split_from_parent:('a -> (unit -> 'a) @ portable once) @ portable
+      -> (unit -> 'a) @ portable
+      -> 'a key
+    (** Like {!TLS.new_key}, but safe to use in the presence of multiple
+        domains. *)
+
+    val get : ('a : value mod portable). 'a key -> 'a @ contended
+    (** Like {!TLS.get}, but safe to use in the presence of multiple domains. *)
+
+    val set : ('a : value mod contended). 'a key -> 'a @ portable -> unit
+    (** Like {!TLS.set}, but safe to use in the presence of multiple domains. *)
   end
 
   val spawn : (unit -> 'a) @ portable once -> 'a t

--- a/stdlib/ephemeron.ml
+++ b/stdlib/ephemeron.ml
@@ -417,10 +417,10 @@ module GenHashTable = struct
     module Rng : sig
       val bits : unit -> int
     end = struct
-      (* CR-soon mslater: switch to TLS to remove thread unsafety *)
-      (* CR-someday mslater: switch to FLS to remove magic *)
+      (* This is safe since [bits] is a C call that cannot be preempted, 
+         we do not yield, and we do not borrow the state. *)
       let key = Domain.Safe.DLS.new_key Random.State.make_self_init
-      let[@inline] bits () = 
+      let[@inline] bits () =
         Random.State.bits (Obj.magic_uncontended (Domain.Safe.DLS.get key))
     end
 

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -338,8 +338,8 @@ module DLS = Domain.Safe.DLS
 module Rng : sig
   val bits : unit -> int
 end = struct
-  (* CR-soon mslater: switch to TLS to remove thread unsafety *)
-  (* CR-someday mslater: switch to FLS to remove magic *)
+  (* This is safe since [bits] is a C call that cannot be preempted, 
+     we do not yield, and we do not borrow the state. *)
   let key = DLS.new_key Random.State.make_self_init
   let[@inline] bits () = Random.State.bits (Obj.magic_uncontended (DLS.get key))
 end

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -1033,7 +1033,6 @@ and str_formatter = formatter_of_buffer stdbuf
 (* Initialise domain local state *)
 
 (* CR-soon mslater: switch to TLS to remove thread unsafety *)
-(* CR-someday mslater: switch to FLS to remove magic *)
 module DLS = struct 
   let new_key = Domain.Safe.DLS.new_key
   let get = Obj.magic_portable Domain.DLS.get

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -65,8 +65,8 @@ let is_randomized () = Atomic.get randomized
 module Rng : sig
   val bits : unit -> int
 end = struct
-  (* CR-soon mslater: switch to TLS to remove thread unsafety *)
-  (* CR-someday mslater: switch to FLS to remove magic *)
+  (* This is safe since [bits] is a C call that cannot be preempted, 
+     we do not yield, and we do not borrow the state. *)
   let key = Domain.Safe.DLS.new_key Random.State.make_self_init
   let[@inline] bits () = 
     Random.State.bits (Obj.magic_uncontended (Domain.Safe.DLS.get key))

--- a/stdlib/random.ml
+++ b/stdlib/random.ml
@@ -342,8 +342,10 @@ let mk_default () =
            (-8591268803865043407L)
            6388613595849772044L
 
-(* CR-soon mslater: switch to TLS to remove thread unsafety *)
-(* CR-someday mslater: switch to FLS to remove magic *)
+(* CR-soon mslater: this is safe since the state is only updated by a C call
+   that cannot be preempted, we do not yield, and we do not borrow the state.
+   However, it will not be deterministic in the presence of threads, so it 
+   should be converted to TLS. *)
 let random_key =
   DLS.new_key
     ~split_from_parent:(fun s ->

--- a/testsuite/tests/backtrace/backtrace_systhreads.reference
+++ b/testsuite/tests/backtrace/backtrace_systhreads.reference
@@ -2,24 +2,24 @@ Thread 2 killed on uncaught exception Failure("0")
 Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 53, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 57, characters 8-14
 Thread 3 killed on uncaught exception Failure("1")
 Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 53, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 57, characters 8-14
 Thread 4 killed on uncaught exception Failure("2")
 Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 53, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 57, characters 8-14
 Thread 5 killed on uncaught exception Failure("3")
 Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 53, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 57, characters 8-14
 Thread 1 killed on uncaught exception Failure("backtrace")
 Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace_systhreads.thread_backtrace in file "backtrace_systhreads.ml", line 22, characters 6-27
 Re-raised at Backtrace_systhreads.thread_backtrace in file "backtrace_systhreads.ml", line 26, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 53, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 57, characters 8-14

--- a/testsuite/tests/lib-threads/uncaught_exception_handler.reference
+++ b/testsuite/tests/lib-threads/uncaught_exception_handler.reference
@@ -1,15 +1,15 @@
 Thread 1 killed on uncaught exception Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 30-31, characters 2-47
-Called from Thread.create.(fun) in file "thread.ml", line 53, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 57, characters 8-14
 [thread 2] caught Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 30-31, characters 2-79
-Called from Thread.create.(fun) in file "thread.ml", line 53, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 57, characters 8-14
 Thread 2 killed on uncaught exception Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 30-31, characters 2-79
-Called from Thread.create.(fun) in file "thread.ml", line 53, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 57, characters 8-14
 Thread 2 uncaught exception handler raised Uncaught_exception_handler.UncaughtHandlerExn
 Raised at Uncaught_exception_handler.handler in file "uncaught_exception_handler.ml", line 26, characters 2-17
-Called from Thread.create.(fun) in file "thread.ml", line 62, characters 10-62
+Called from Thread.create.(fun) in file "thread.ml", line 66, characters 10-62
 [thread 3] caught Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 30-31, characters 2-79
-Called from Thread.create.(fun) in file "thread.ml", line 53, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 57, characters 8-14

--- a/testsuite/tests/parallel/tls_multi_domain_multi_thread.ml
+++ b/testsuite/tests/parallel/tls_multi_domain_multi_thread.ml
@@ -1,0 +1,62 @@
+(* TEST
+ flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
+ include systhreads;
+ hassysthreads;
+ runtime5;
+ multidomain;
+ { bytecode; }
+ { native; }
+*)
+
+let k1 = Thread.TLS.new_key (fun () -> 10)
+let k2 = Thread.TLS.new_key (fun () -> 1.0)
+
+let check_tls () =
+  Thread.TLS.set k1 100;
+  Thread.TLS.set k2 200.0;
+  let v1 = Thread.TLS.get k1 in
+  let v2 = Thread.TLS.get k2 in
+  assert (v1 = 100);
+  assert (v2 = 200.0);
+  Gc.major ()
+
+let k1 = Thread.TLS.new_key (fun () -> 100)
+let k2 = Thread.TLS.new_key (fun () -> 200)
+
+let check_tls_domain_reuse () =
+  let domains = Array.init 4 (fun _ -> Thread.create(fun () ->
+    Thread.TLS.set k1 31415;
+    Thread.TLS.set k2 27182;
+    assert (Thread.TLS.get k1 = 31415);
+    assert (Thread.TLS.get k2 = 27182)) ()) in
+  Array.iter Thread.join domains;
+  Gc.full_major ();
+  let domains2 = Array.init 4 (fun _ -> Thread.create(fun () ->
+    assert(Thread.TLS.get k1 = 100);
+    assert(Thread.TLS.get k2 = 200)) ()) in
+  Array.iter Thread.join domains2
+
+let _ =
+  let domains = Array.init 3 (fun _ -> Domain.spawn(check_tls)) in
+  check_tls ();
+  Array.iter Domain.join domains;
+  let domains = Array.init 3 (fun _ -> Domain.spawn(check_tls_domain_reuse)) in
+  check_tls_domain_reuse ();
+  Array.iter Domain.join domains
+
+let k = Thread.TLS.new_key
+  ~split_from_parent:(fun i ->
+    let i = Atomic.fetch_and_add i 1 in
+    (fun () -> Atomic.make i))
+  (fun () -> Atomic.make 0)
+
+let check_tls_split dom_idx =
+  assert (Atomic.get (Thread.TLS.get k) = dom_idx);
+  let threads = Array.init 4 (fun thd_idx -> Thread.create(fun () ->
+    assert (Atomic.get (Thread.TLS.get k) = dom_idx + thd_idx)) ()) in
+  Array.iter Thread.join threads
+
+let _ =
+  let domains = Array.init 3 (fun idx -> Domain.spawn(fun () -> check_tls_split idx)) in
+  check_tls_split 3;
+  Array.iter Domain.join domains

--- a/testsuite/tests/parallel/tls_multi_domain_single_thread.ml
+++ b/testsuite/tests/parallel/tls_multi_domain_single_thread.ml
@@ -1,0 +1,53 @@
+(* TEST
+ flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
+ runtime5;
+ multidomain;
+ { bytecode; }
+ { native; }
+*)
+
+let check_tls () =
+  let k1 = Domain.TLS.new_key (fun () -> 10) in
+  let k2 = Domain.TLS.new_key (fun () -> 1.0) in
+  Domain.TLS.set k1 100;
+  Domain.TLS.set k2 200.0;
+  let v1 = Domain.TLS.get k1 in
+  let v2 = Domain.TLS.get k2 in
+  assert (v1 = 100);
+  assert (v2 = 200.0);
+  Gc.major ()
+
+let check_tls_domain_reuse () =
+  let k1 = Domain.TLS.new_key (fun () -> 100) in
+  let k2 = Domain.TLS.new_key (fun () -> 200) in
+  let domains = Array.init 4 (fun _ -> Domain.spawn(fun _ ->
+    Domain.TLS.set k1 31415;
+    Domain.TLS.set k2 27182;
+    assert (Domain.TLS.get k1 = 31415);
+    assert (Domain.TLS.get k2 = 27182))) in
+  Array.iter Domain.join domains;
+  Gc.full_major ();
+  let domains2 = Array.init 4 (fun _ -> Domain.spawn(fun _ ->
+    assert(Domain.TLS.get k1 = 100);
+    assert(Domain.TLS.get k2 = 200))) in
+  Array.iter Domain.join domains2
+
+let _ =
+  let domains = Array.init 3 (fun _ -> Domain.spawn(check_tls)) in
+  check_tls ();
+  Array.iter Domain.join domains;
+  check_tls_domain_reuse ()
+
+let k = Domain.Safe.TLS.new_key
+  ~split_from_parent:(fun i ->
+    let i = Atomic.fetch_and_add i 1 in
+    (fun () -> Atomic.make i))
+  (fun () -> Atomic.make 0)
+
+let check_tls_split dom_idx =
+  assert (Atomic.get (Domain.TLS.get k) = dom_idx)
+
+let _ =
+  let domains = Array.init 3 (fun idx -> Domain.spawn(fun () -> check_tls_split idx)) in
+  check_tls_split 3;
+  Array.iter Domain.join domains

--- a/testsuite/tests/parallel/tls_single_domain_multi_thread.ml
+++ b/testsuite/tests/parallel/tls_single_domain_multi_thread.ml
@@ -1,0 +1,49 @@
+(* TEST
+ include systhreads;
+ hassysthreads;
+ { bytecode; }
+ { native; }
+*)
+
+let check_tls () =
+  let k1 = Thread.TLS.new_key (fun () -> 10) in
+  let k2 = Thread.TLS.new_key (fun () -> 1.0) in
+  Thread.TLS.set k1 100;
+  Thread.TLS.set k2 200.0;
+  let v1 = Thread.TLS.get k1 in
+  let v2 = Thread.TLS.get k2 in
+  assert (v1 = 100);
+  assert (v2 = 200.0);
+  Gc.major ()
+
+let check_tls_reuse () =
+  let k1 = Thread.TLS.new_key (fun () -> 100) in
+  let k2 = Thread.TLS.new_key (fun () -> 200) in
+  let threads = Array.init 4 (fun _ -> Thread.create(fun () ->
+    Thread.TLS.set k1 31415;
+    Thread.TLS.set k2 27182;
+    assert (Thread.TLS.get k1 = 31415);
+    assert (Thread.TLS.get k2 = 27182)) ()) in
+  Array.iter Thread.join threads;
+  Gc.full_major ();
+  let threads2 = Array.init 4 (fun _ -> Thread.create(fun () ->
+    assert(Thread.TLS.get k1 = 100);
+    assert(Thread.TLS.get k2 = 200)) ()) in
+  Array.iter Thread.join threads2
+
+let check_tls_split () =
+  let k = Thread.TLS.new_key
+    ~split_from_parent:(fun i ->
+      let i = Atomic.fetch_and_add i 1 in
+      (fun () -> Atomic.make i))
+    (fun () -> Atomic.make 0) in
+  let threads = Array.init 4 (fun idx -> Thread.create(fun () ->
+    assert (Atomic.get (Thread.TLS.get k) = idx)) ()) in
+  Array.iter Thread.join threads
+
+let _ =
+  let threads = Array.init 3 (fun _ -> Thread.create(check_tls) ()) in
+  check_tls ();
+  Array.iter Thread.join threads;
+  check_tls_reuse ();
+  check_tls_split ()

--- a/testsuite/tests/parallel/tls_single_domain_single_thread.ml
+++ b/testsuite/tests/parallel/tls_single_domain_single_thread.ml
@@ -1,0 +1,18 @@
+(* TEST
+  flags += "-alert -unsafe_multidomain";
+ { bytecode; }
+ { native; }
+*)
+
+let check_tls () =
+  let k1 = Domain.TLS.new_key (fun () -> 10) in
+  let k2 = Domain.TLS.new_key (fun () -> 1.0) in
+  Domain.TLS.set k1 100;
+  Domain.TLS.set k2 200.0;
+  let v1 = Domain.TLS.get k1 in
+  let v2 = Domain.TLS.get k2 in
+  assert (v1 = 100);
+  assert (v2 = 200.0);
+  Gc.major ()
+
+let _ = check_tls ()


### PR DESCRIPTION
This is the implementation of TLS from #4671, but without any other changes to the stdlib (except for comments).

I should still switch the implementation to a domain_state field to avoid the hacky initialization logic, but this can be included in minus-19 if needed.