### PR TITLE
Add _bytecode to primitives emitted by Lambda_to_lambda transforms in JSIR mode

### DIFF
--- a/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
@@ -246,7 +246,10 @@ let makearray_dynamic_singleton name (mode : L.locality_mode) ~length ~init loc
   let non_empty = String.length name > 0 in
   let name =
     Printf.sprintf "caml_make%s_%s%svect%s"
-      (match mode with Alloc_heap -> "" | Alloc_local -> "_local")
+      (match mode with
+      | Alloc_heap -> ""
+      | Alloc_local when !Clflags.jsir -> ""
+      | Alloc_local -> "_local")
       name
       (if non_empty then "_" else "")
       (if non_empty && !Clflags.jsir then "_bytecode" else "")


### PR DESCRIPTION
JSOO doesn't have the non-bytecode functions.