### PR TITLE
Eliminate dependency of `typedecl` on `typeopt` and `lambda`

### DIFF
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2661,6 +2661,17 @@ let check_type_externality env ty ext =
   | Ok () -> true
   | Error _ -> false
 
+let is_always_gc_ignorable env ty =
+  let ext : Jkind_axis.Externality.t =
+    (* We check that we're compiling to (64-bit) native code before counting
+       External64 types as gc_ignorable, because bytecode is intended to be
+       platform independent. *)
+    if !Clflags.native_code && Sys.word_size = 64
+    then External64
+    else External
+  in
+  check_type_externality env ty ext
+
 let check_type_nullability env ty null =
   let upper_bound =
     Jkind.set_nullability_upper_bound (Jkind.Builtin.any ~why:Dummy_jkind) null

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -666,6 +666,10 @@ val constrain_type_jkind :
 val check_type_externality :
   Env.t -> type_expr -> Jkind_axis.Externality.t -> bool
 
+(* Check whether a type is gc ignorable based on its externality and the target
+   platform. *)
+val is_always_gc_ignorable : Env.t -> type_expr -> bool
+
 (* Check whether a type's nullability is less than some target.
    Uses get_nullability which is potentially cheaper than calling type_jkind
    if all with-bounds are irrelevant. *)


### PR DESCRIPTION
`Typedecl` shouldn't depend on `Typeopt` and `Lambda`. This seems pretty clear - those are later bits of compilation.  The only other module in the typechecker with a dependency on `Typeopt` is `Value_rec_check`.

It did so because `Typeopt` exposed a helper function for checking for immediacy and nullability that `Typedecl` wanted to use.  That functionality was just a thin wrapper around functions exposed from `Ctype`. So I've moved a little code from `Typeopt` to `Ctype` and now `Typedecl` just uses `Ctype` directly. I think the new typedecl code is clearer, and as a bonus we skip an unnecessary `scrape_ty` (which is needed when this check happens from `Typeopt` because it corrects levels).

This dependency is also present upstream. I may submit a patch there too, but the code is very different because we have a totally different system for immediacy, and upstream doesn't have nullability.

(I noticed this because it caused an unrelated dependency I added for something else I'm doing to create a cycle)