### PR TITLE
Fix Stack_check assertion failures when emitting full DWARF info

### DIFF
--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -622,7 +622,10 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
   | Poptrap _ | Prologue | Epilogue ->
     if fp then [| rbp |] else [||]
   | Stack_check _ ->
-    assert false (* the instruction is added after register allocation *)
+    (* This case is used by [Cfg_available_regs].  r10 is actually saved and
+       restored by the sequence to which [Stack_check] is expanded, but it may
+       be clobbered in the middle. *)
+    [| r10 |]
 
 (* note: keep this function in sync with `is_destruction_point` below. *)
 let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -350,7 +350,9 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
                           Float32_of_int32 | Int32_of_float32 |
                           V128_of_vec Vec128))
     -> [||]
-  | Stack_check _ -> assert false (* not supported *)
+  | Stack_check _ ->
+    (* This case is used by [Cfg_available_regs] *)
+    [||]
   | Op (Const_vec256 _ | Const_vec512 _)
   | Op (Load
           {memory_chunk=(Twofiftysix_aligned|Twofiftysix_unaligned|


### PR DESCRIPTION
This is extracted from #4704 , as discussed previously with @xclerc 