### PR TITLE
Implement TLS (take 3)

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2318,7 +2318,7 @@ let emit_instr ~first ~fallthrough i =
     I.movzx (res8 i 0) (res i 0)
   | Lop Dls_get ->
     if Config.runtime5
-    then I.mov (domain_field Domainstate.Domain_dls_root) (res i 0)
+    then I.mov (domain_field Domainstate.Domain_dls_state) (res i 0)
     else Misc.fatal_error "Dls is not supported in runtime4."
   | Lreloadretaddr -> ()
   | Lreturn -> I.ret ()

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -2138,7 +2138,7 @@ let emit_instr i =
   | Lop Dls_get ->
     if Config.runtime5
     then
-      let offset = Domainstate.(idx_of_field Domain_dls_root) * 8 in
+      let offset = Domainstate.(idx_of_field Domain_dls_state) * 8 in
       DSL.ins I.LDR
         [| DSL.emit_reg i.res.(0);
            DSL.emit_addressing (Iindexed offset) reg_domain_state_ptr

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -117,6 +117,7 @@ struct caml_thread_struct {
   value descr;              /* The heap-allocated descriptor (root) */
   struct caml_thread_struct * next; /* Doubly-linked list of running threads */
   struct caml_thread_struct * prev;
+  value tls_state;    /* saved TLS value */
   int domain_id;      /* The id of the domain to which this thread belongs */
   struct stack_info* current_stack;      /* saved Caml_state->current_stack */
   struct c_stack_link* c_stack;          /* saved Caml_state->c_stack */
@@ -260,6 +261,7 @@ static void caml_thread_scan_roots(
   if (active != NULL) {
     do {
       (*action)(fdata, th->descr, &th->descr);
+      (*action)(fdata, th->tls_state, &th->tls_state);
       (*action)(fdata, th->backtrace_last_exn, &th->backtrace_last_exn);
       /* Don't rescan the stack of the current thread, it was done already */
       if (th != active) {
@@ -288,6 +290,7 @@ static void save_runtime_state(void)
   CAMLassert(th != NULL);
   th->current_stack = Caml_state->current_stack;
   th->current_stack->local_sp = Caml_state->local_sp;
+  th->tls_state = Caml_state->tls_state;
   th->c_stack = Caml_state->c_stack;
   th->gc_regs = Caml_state->gc_regs;
   th->gc_regs_buckets = Caml_state->gc_regs_buckets;
@@ -316,6 +319,7 @@ static void restore_runtime_state(caml_thread_t th)
   Active_thread = th;
   Caml_state->current_stack = th->current_stack;
   caml_use_local_arenas(th->current_stack->local_arenas, th->current_stack->local_sp);
+  Caml_state->tls_state = th->tls_state;
   Caml_state->c_stack = th->c_stack;
   Caml_state->gc_regs = th->gc_regs;
   Caml_state->gc_regs_buckets = th->gc_regs_buckets;
@@ -324,6 +328,8 @@ static void restore_runtime_state(caml_thread_t th)
   Caml_state->local_roots = th->local_roots;
   Caml_state->backtrace_pos = th->backtrace_pos;
   Caml_state->backtrace_buffer = th->backtrace_buffer;
+  caml_modify_generational_global_root
+    (&Caml_state->tls_state, th->tls_state);
   caml_modify_generational_global_root
     (&Caml_state->backtrace_last_exn, th->backtrace_last_exn);
 #ifndef NATIVE_CODE
@@ -408,6 +414,7 @@ static caml_thread_t caml_thread_new_info(caml_thread_t parent)
   if (th == NULL) return NULL;
 
   th->descr = Val_unit;
+  th->tls_state = Atom(0); /* Empty array */
   th->next = NULL;
   th->prev = NULL;
 
@@ -461,6 +468,7 @@ void caml_thread_free_info(caml_thread_t th)
      c_stack: stack-allocated
      local_roots: stack-allocated
      backtrace_last_exn: heap-allocated
+     tls_state: heap-allocated
      gc_regs:
        must be empty for a terminated thread
        (we assume that the C call stack must be empty at
@@ -690,7 +698,10 @@ static void caml_thread_domain_initialize_hook(void)
   new_thread->descr = caml_thread_new_descriptor(Val_unit);
   new_thread->next = new_thread;
   new_thread->prev = new_thread;
+  /* Initialize [backtrace_last_exn] and [tls_state] as they are accessed
+     by the GC via [caml_thread_scan_roots] */
   new_thread->backtrace_last_exn = Val_unit;
+  new_thread->tls_state = Atom(0); /* empty array */
   new_thread->memprof = caml_memprof_main_thread(Caml_state);
   new_thread->dynamic = Caml_state->dynamic_bindings;
   CAMLassert(new_thread->dynamic);

--- a/otherlibs/systhreads/thread.ml
+++ b/otherlibs/systhreads/thread.ml
@@ -1,5 +1,4 @@
 # 2 "thread.ml"
-
 (**************************************************************************)
 (*                                                                        *)
 (*                                 OCaml                                  *)
@@ -18,6 +17,8 @@
 (* User-level threads *)
 
 [@@@ocaml.flambda_o3]
+
+module TLS = Domain.Safe.TLS
 
 type t : value mod contended portable
 
@@ -47,8 +48,11 @@ let set_uncaught_exception_handler (fn @ portable) =
 exception Exit
 
 let create (fn @ once) arg =
+  let tls_keys = Domain.TLS.Private.get_initial_keys () in
   thread_new
     (fun () ->
+      Domain.TLS.Private.init ();
+      Domain.TLS.Private.set_initial_keys tls_keys;
       try
         fn arg;
         ignore (Sys.opaque_identity (check_memprof_cb ()))

--- a/otherlibs/systhreads/thread.mli
+++ b/otherlibs/systhreads/thread.mli
@@ -199,3 +199,24 @@ val use_domains : unit -> unit
     used by domains. This ensures that domains can be started from threads
     other than the initial one. It prevents the use of a custom locking
     scheme, such as the one used by pyocaml. *)
+
+(** Thread-local storage. Like {!Domain.DLS}, but stores a distinct value
+    for each thread. Domains can contain multiple threads, so [TLS] should be
+    preferred in nearly all cases. *)
+module TLS : sig @@ portable
+
+   type 'a key : value mod portable contended
+   (** Type of a TLS key *)
+
+   val new_key
+   : ?split_from_parent:('a -> (unit -> 'a) @ portable once) @ portable
+   -> (unit -> 'a) @ portable
+   -> 'a key
+   (** Like {!DLS.new_key}, but represents a distinct value in every thread. *)
+
+   val get : ('a : value mod portable). 'a key -> 'a @ contended
+   (** Like {!DLS.get}, but reads the value for the current thread. *)
+
+   val set : ('a : value mod contended). 'a key -> 'a @ portable -> unit
+   (** Like {!DLS.set}, but sets the value for the current thread. *)
+end

--- a/otherlibs/systhreads4/thread.mli
+++ b/otherlibs/systhreads4/thread.mli
@@ -189,3 +189,24 @@ val set_uncaught_exception_handler : (exn -> unit) @ portable -> unit
 
     If the newly set uncaught exception handler raise an exception,
     {!default_uncaught_exception_handler} will be called. *)
+
+(** Thread-local storage. Like {!Domain.DLS}, but stores a distinct value
+    for each thread. Domains can contain multiple threads, so [TLS] should be
+    preferred in nearly all cases. *)
+module TLS : sig @@ portable
+
+   type 'a key : value mod portable contended
+   (** Type of a TLS key *)
+
+   val new_key
+   : ?split_from_parent:('a -> (unit -> 'a) @ portable once) @ portable
+   -> (unit -> 'a) @ portable
+   -> 'a key
+   (** Like {!DLS.new_key}, but represents a distinct value in every thread. *)
+
+   val get : ('a : value mod portable). 'a key -> 'a @ contended
+   (** Like {!DLS.get}, but reads the value for the current thread. *)
+
+   val set : ('a : value mod contended). 'a key -> 'a @ portable -> unit
+   (** Like {!DLS.set}, but sets the value for the current thread. *)
+end

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -146,8 +146,11 @@ DOMAIN_STATE(int, id)
 
 DOMAIN_STATE(int, unique_id)
 
-DOMAIN_STATE(value, dls_root)
+DOMAIN_STATE(value, dls_state)
 /* Domain-local state */
+
+DOMAIN_STATE(value, tls_state)
+/* Thread-local state */
 
 /* How much external memory is currenty held by the minor heap. */
 DOMAIN_STATE(uintnat, minor_dependent_bsz)

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -2234,18 +2234,6 @@ static inline void domain_root_remove(value *root) {
   *root = Val_unit;
 }
 
-static inline value domain_root_compare_and_set(value *root, value old, value new)
-{
-  CAMLnoalloc;
-  value current = *root;
-  if (current == old) {
-    caml_modify_generational_global_root(root, new);
-    return Val_true;
-  } else {
-    return Val_false;
-  }
-}
-
 /* Domain-local state */
 
 CAMLprim value caml_domain_dls_set(value t)
@@ -2261,7 +2249,14 @@ CAMLprim value caml_domain_dls_get(value unused)
 
 CAMLprim value caml_domain_dls_compare_and_set(value old, value new)
 {
-  return domain_root_compare_and_set(&Caml_state->dls_state, old, new);
+  CAMLnoalloc;
+  value current = Caml_state->dls_state;
+  if (current == old) {
+    caml_modify_generational_global_root(&Caml_state->dls_state, new);
+    return Val_true;
+  } else {
+    return Val_false;
+  }
 }
 
 /* Thread-local state */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -557,6 +557,9 @@ static uintnat fresh_domain_unique_id(void) {
     return next;
 }
 
+static inline void domain_root_register(value *root, value t);
+static inline void domain_root_remove(value *root);
+
 /* must be run on the domain's thread */
 static void domain_create(uintnat initial_minor_heap_wsize,
                           caml_domain_state *parent)
@@ -704,9 +707,9 @@ static void domain_create(uintnat initial_minor_heap_wsize,
 
   domain_state->in_minor_collection = 0;
 
-  domain_state->dls_root = Val_unit;
   /* This call may fail, but fatally so we don't need an error path */
-  caml_register_generational_global_root(&domain_state->dls_root);
+  domain_root_register(&domain_state->dls_state, Atom(0) /* Empty array */);
+  domain_root_register(&domain_state->tls_state, Atom(0) /* Empty array */);
 
   domain_state->stack_cache = caml_alloc_stack_cache();
   if(domain_state->stack_cache == NULL) {
@@ -746,11 +749,9 @@ static void domain_create(uintnat initial_minor_heap_wsize,
   domain_state->local_roots = NULL;
 
   domain_state->backtrace_buffer = NULL;
-  domain_state->backtrace_last_exn = Val_unit;
-  domain_state->backtrace_active = 0;
-
   /* This call may fail, but fatally so we don't need an error path */
-  caml_register_generational_global_root(&domain_state->backtrace_last_exn);
+  domain_root_register(&domain_state->backtrace_last_exn, Val_unit);
+  domain_state->backtrace_active = 0;
 
   domain_state->local_sp = 0;
   domain_state->local_top = NULL;
@@ -788,7 +789,8 @@ static void domain_create(uintnat initial_minor_heap_wsize,
 fail_main_stack:
   caml_free_stack_cache(domain_state->stack_cache);
 fail_stack_cache:
-  caml_remove_generational_global_root(&domain_state->dls_root);
+  domain_root_remove(&domain_state->dls_state);
+  domain_root_remove(&domain_state->tls_state);
   free_minor_heap();
 fail_minor_heap:
   caml_teardown_major_gc();
@@ -2148,8 +2150,9 @@ static void domain_terminate (void)
 
   /* We can not touch domain_self->interruptor after here
      because it may be reused */
-  caml_remove_generational_global_root(&domain_state->dls_root);
-  caml_remove_generational_global_root(&domain_state->backtrace_last_exn);
+  domain_root_remove(&domain_state->dls_state);
+  domain_root_remove(&domain_state->tls_state);
+  domain_root_remove(&domain_state->backtrace_last_exn);
   caml_stat_free(domain_state->final_info);
   caml_stat_free(domain_state->ephe_info);
   caml_free_intern_state();
@@ -2207,29 +2210,71 @@ CAMLprim value caml_ml_domain_cpu_relax(value t)
 #endif
 }
 
-CAMLprim value caml_domain_dls_set(value t)
+/* OCaml values stored in the domain state. */
+
+static inline void domain_root_register(value *root, value t) {
+  CAMLnoalloc;
+  *root = t;
+  caml_register_generational_global_root(root);
+}
+
+static inline void domain_root_set(value *root, value t) {
+  CAMLnoalloc;
+  caml_modify_generational_global_root(root, t);
+}
+
+static inline value domain_root_get(value *root) {
+  CAMLnoalloc;
+  return *root;
+}
+
+static inline void domain_root_remove(value *root) {
+  CAMLnoalloc;
+  caml_remove_generational_global_root(root);
+  *root = Val_unit;
+}
+
+static inline value domain_root_compare_and_set(value *root, value old, value new)
 {
   CAMLnoalloc;
-  caml_modify_generational_global_root(&Caml_state->dls_root, t);
+  value current = *root;
+  if (current == old) {
+    caml_modify_generational_global_root(root, new);
+    return Val_true;
+  } else {
+    return Val_false;
+  }
+}
+
+/* Domain-local state */
+
+CAMLprim value caml_domain_dls_set(value t)
+{
+  domain_root_set(&Caml_state->dls_state, t);
   return Val_unit;
 }
 
 CAMLprim value caml_domain_dls_get(value unused)
 {
-  CAMLnoalloc;
-  return Caml_state->dls_root;
+  return domain_root_get(&Caml_state->dls_state);
 }
 
 CAMLprim value caml_domain_dls_compare_and_set(value old, value new)
 {
-  CAMLnoalloc;
-  value current = Caml_state->dls_root;
-  if (current == old) {
-    caml_modify_generational_global_root(&Caml_state->dls_root, new);
-    return Val_true;
-  } else {
-    return Val_false;
-  }
+  return domain_root_compare_and_set(&Caml_state->dls_state, old, new);
+}
+
+/* Thread-local state */
+
+CAMLprim value caml_domain_tls_set(value t)
+{
+  domain_root_set(&Caml_state->tls_state, t);
+  return Val_unit;
+}
+
+CAMLprim value caml_domain_tls_get(value unused)
+{
+  return domain_root_get(&Caml_state->tls_state);
 }
 
 CAMLprim value caml_recommended_domain_count(value unused)

--- a/runtime4/caml/domain_state.tbl
+++ b/runtime4/caml/domain_state.tbl
@@ -104,7 +104,10 @@ DOMAIN_STATE(void*, checking_pointer_pc)
 /* See major_gc.c */
 #endif
 
-DOMAIN_STATE(void*, dls_root)
+DOMAIN_STATE(value, tls_state)
+/* Thread-local storage */
+
+DOMAIN_STATE(void*, dls_state)
 DOMAIN_STATE(void*, c_stack)
 DOMAIN_STATE(void*, current_stack)
 /* Unused: compatibility with runtime5 */

--- a/runtime4/domain.c
+++ b/runtime4/domain.c
@@ -69,6 +69,9 @@ void caml_init_domain (void)
   Caml_state->last_return_address = 1; /* not in OCaml code initially */
   Caml_state->gc_regs = NULL;
 
+  Caml_state->tls_state = Val_unit;
+  caml_register_generational_global_root(&Caml_state->tls_state);
+
   Caml_state->stat_minor_words = 0.0;
   Caml_state->stat_promoted_words = 0.0;
   Caml_state->stat_major_words = 0.0;
@@ -137,4 +140,17 @@ CAMLprim value caml_domain_dls_set(void)
 CAMLprim value caml_domain_dls_get(void)
 {
   caml_failwith("Domains not supported on runtime4");
+}
+
+/* Thread-local state */
+
+CAMLprim value caml_domain_tls_set(value t)
+{
+  caml_modify_generational_global_root(&Caml_state->tls_state, t);
+  return Val_unit;
+}
+
+CAMLprim value caml_domain_tls_get(value unused)
+{
+  return Caml_state->tls_state;
 }

--- a/testsuite/tests/backtrace/backtrace_systhreads.reference
+++ b/testsuite/tests/backtrace/backtrace_systhreads.reference
@@ -2,24 +2,24 @@ Thread 2 killed on uncaught exception Failure("0")
 Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 53, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 57, characters 8-14
 Thread 3 killed on uncaught exception Failure("1")
 Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 53, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 57, characters 8-14
 Thread 4 killed on uncaught exception Failure("2")
 Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 53, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 57, characters 8-14
 Thread 5 killed on uncaught exception Failure("3")
 Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 53, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 57, characters 8-14
 Thread 1 killed on uncaught exception Failure("backtrace")
 Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace_systhreads.thread_backtrace in file "backtrace_systhreads.ml", line 22, characters 6-27
 Re-raised at Backtrace_systhreads.thread_backtrace in file "backtrace_systhreads.ml", line 26, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 53, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 57, characters 8-14

--- a/testsuite/tests/parallel/tls_multi_domain_multi_thread.ml
+++ b/testsuite/tests/parallel/tls_multi_domain_multi_thread.ml
@@ -1,0 +1,62 @@
+(* TEST
+ flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
+ include systhreads;
+ hassysthreads;
+ runtime5;
+ multidomain;
+ { bytecode; }
+ { native; }
+*)
+
+let k1 = Thread.TLS.new_key (fun () -> 10)
+let k2 = Thread.TLS.new_key (fun () -> 1.0)
+
+let check_tls () =
+  Thread.TLS.set k1 100;
+  Thread.TLS.set k2 200.0;
+  let v1 = Thread.TLS.get k1 in
+  let v2 = Thread.TLS.get k2 in
+  assert (v1 = 100);
+  assert (v2 = 200.0);
+  Gc.major ()
+
+let k1 = Thread.TLS.new_key (fun () -> 100)
+let k2 = Thread.TLS.new_key (fun () -> 200)
+
+let check_tls_domain_reuse () =
+  let domains = Array.init 4 (fun _ -> Thread.create(fun () ->
+    Thread.TLS.set k1 31415;
+    Thread.TLS.set k2 27182;
+    assert (Thread.TLS.get k1 = 31415);
+    assert (Thread.TLS.get k2 = 27182)) ()) in
+  Array.iter Thread.join domains;
+  Gc.full_major ();
+  let domains2 = Array.init 4 (fun _ -> Thread.create(fun () ->
+    assert(Thread.TLS.get k1 = 100);
+    assert(Thread.TLS.get k2 = 200)) ()) in
+  Array.iter Thread.join domains2
+
+let _ =
+  let domains = Array.init 3 (fun _ -> Domain.spawn(check_tls)) in
+  check_tls ();
+  Array.iter Domain.join domains;
+  let domains = Array.init 3 (fun _ -> Domain.spawn(check_tls_domain_reuse)) in
+  check_tls_domain_reuse ();
+  Array.iter Domain.join domains
+
+let k = Thread.TLS.new_key
+  ~split_from_parent:(fun i ->
+    let i = Atomic.fetch_and_add i 1 in
+    (fun () -> Atomic.make i))
+  (fun () -> Atomic.make 0)
+
+let check_tls_split dom_idx =
+  assert (Atomic.get (Thread.TLS.get k) = dom_idx);
+  let threads = Array.init 4 (fun thd_idx -> Thread.create(fun () ->
+    assert (Atomic.get (Thread.TLS.get k) = dom_idx + thd_idx)) ()) in
+  Array.iter Thread.join threads
+
+let _ =
+  let domains = Array.init 3 (fun idx -> Domain.spawn(fun () -> check_tls_split idx)) in
+  check_tls_split 3;
+  Array.iter Domain.join domains

--- a/testsuite/tests/parallel/tls_multi_domain_single_thread.ml
+++ b/testsuite/tests/parallel/tls_multi_domain_single_thread.ml
@@ -1,0 +1,53 @@
+(* TEST
+ flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
+ runtime5;
+ multidomain;
+ { bytecode; }
+ { native; }
+*)
+
+let check_tls () =
+  let k1 = Domain.TLS.new_key (fun () -> 10) in
+  let k2 = Domain.TLS.new_key (fun () -> 1.0) in
+  Domain.TLS.set k1 100;
+  Domain.TLS.set k2 200.0;
+  let v1 = Domain.TLS.get k1 in
+  let v2 = Domain.TLS.get k2 in
+  assert (v1 = 100);
+  assert (v2 = 200.0);
+  Gc.major ()
+
+let check_tls_domain_reuse () =
+  let k1 = Domain.TLS.new_key (fun () -> 100) in
+  let k2 = Domain.TLS.new_key (fun () -> 200) in
+  let domains = Array.init 4 (fun _ -> Domain.spawn(fun _ ->
+    Domain.TLS.set k1 31415;
+    Domain.TLS.set k2 27182;
+    assert (Domain.TLS.get k1 = 31415);
+    assert (Domain.TLS.get k2 = 27182))) in
+  Array.iter Domain.join domains;
+  Gc.full_major ();
+  let domains2 = Array.init 4 (fun _ -> Domain.spawn(fun _ ->
+    assert(Domain.TLS.get k1 = 100);
+    assert(Domain.TLS.get k2 = 200))) in
+  Array.iter Domain.join domains2
+
+let _ =
+  let domains = Array.init 3 (fun _ -> Domain.spawn(check_tls)) in
+  check_tls ();
+  Array.iter Domain.join domains;
+  check_tls_domain_reuse ()
+
+let k = Domain.Safe.TLS.new_key
+  ~split_from_parent:(fun i ->
+    let i = Atomic.fetch_and_add i 1 in
+    (fun () -> Atomic.make i))
+  (fun () -> Atomic.make 0)
+
+let check_tls_split dom_idx =
+  assert (Atomic.get (Domain.TLS.get k) = dom_idx)
+
+let _ =
+  let domains = Array.init 3 (fun idx -> Domain.spawn(fun () -> check_tls_split idx)) in
+  check_tls_split 3;
+  Array.iter Domain.join domains

--- a/testsuite/tests/parallel/tls_single_domain_multi_thread.ml
+++ b/testsuite/tests/parallel/tls_single_domain_multi_thread.ml
@@ -1,0 +1,49 @@
+(* TEST
+ include systhreads;
+ hassysthreads;
+ { bytecode; }
+ { native; }
+*)
+
+let check_tls () =
+  let k1 = Thread.TLS.new_key (fun () -> 10) in
+  let k2 = Thread.TLS.new_key (fun () -> 1.0) in
+  Thread.TLS.set k1 100;
+  Thread.TLS.set k2 200.0;
+  let v1 = Thread.TLS.get k1 in
+  let v2 = Thread.TLS.get k2 in
+  assert (v1 = 100);
+  assert (v2 = 200.0);
+  Gc.major ()
+
+let check_tls_reuse () =
+  let k1 = Thread.TLS.new_key (fun () -> 100) in
+  let k2 = Thread.TLS.new_key (fun () -> 200) in
+  let threads = Array.init 4 (fun _ -> Thread.create(fun () ->
+    Thread.TLS.set k1 31415;
+    Thread.TLS.set k2 27182;
+    assert (Thread.TLS.get k1 = 31415);
+    assert (Thread.TLS.get k2 = 27182)) ()) in
+  Array.iter Thread.join threads;
+  Gc.full_major ();
+  let threads2 = Array.init 4 (fun _ -> Thread.create(fun () ->
+    assert(Thread.TLS.get k1 = 100);
+    assert(Thread.TLS.get k2 = 200)) ()) in
+  Array.iter Thread.join threads2
+
+let check_tls_split () =
+  let k = Thread.TLS.new_key
+    ~split_from_parent:(fun i ->
+      let i = Atomic.fetch_and_add i 1 in
+      (fun () -> Atomic.make i))
+    (fun () -> Atomic.make 0) in
+  let threads = Array.init 4 (fun idx -> Thread.create(fun () ->
+    assert (Atomic.get (Thread.TLS.get k) = idx)) ()) in
+  Array.iter Thread.join threads
+
+let _ =
+  let threads = Array.init 3 (fun _ -> Thread.create(check_tls) ()) in
+  check_tls ();
+  Array.iter Thread.join threads;
+  check_tls_reuse ();
+  check_tls_split ()

--- a/testsuite/tests/parallel/tls_single_domain_single_thread.ml
+++ b/testsuite/tests/parallel/tls_single_domain_single_thread.ml
@@ -1,0 +1,18 @@
+(* TEST
+  flags += "-alert -unsafe_multidomain";
+ { bytecode; }
+ { native; }
+*)
+
+let check_tls () =
+  let k1 = Domain.TLS.new_key (fun () -> 10) in
+  let k2 = Domain.TLS.new_key (fun () -> 1.0) in
+  Domain.TLS.set k1 100;
+  Domain.TLS.set k2 200.0;
+  let v1 = Domain.TLS.get k1 in
+  let v2 = Domain.TLS.get k2 in
+  assert (v1 = 100);
+  assert (v2 = 200.0);
+  Gc.major ()
+
+let _ = check_tls ()


### PR DESCRIPTION
New implementation of TLS by adding a field to the domain state. Includes the same `stdlib` interface/implementation as #4671, but the runtime implementation is based on https://github.com/ocaml/ocaml/pull/13355 instead (and extended to runtime4).