### PR TITLE
Forkable axis

### DIFF
--- a/jane/doc/extensions/_05-modes/intro.md
+++ b/jane/doc/extensions/_05-modes/intro.md
@@ -246,10 +246,10 @@ Yielding is a future axis that tracks whether a function is permitted to perform
 effects that will be handled in its parent stack. See [the OCaml Manual entry
 for effect handlers](https://ocaml.org/manual/5.3/effects.html).
 
-Yielding has different defaults depending on the forkable (and hence locality) axes:
-*forkable* values are defaulted to *unyielding*, while *unforkable* values are
-defaulted to *yielding*. More documentation on mode implications is available
-[here](../../kinds/syntax).
+Yielding has different defaults depending on the locality axis: *global* values are
+defaulted to *yielding*, while *local* values are defaulted to *unyielding*.
+More documentation on mode implications is available [here](../../kinds/syntax).
+
 
 Yielding is irrelevant for types that do not contain functions, and values of such types
 *mode cross* on the yielding axis; they may be used as unyielding even

--- a/jane/doc/extensions/_05-modes/intro.md
+++ b/jane/doc/extensions/_05-modes/intro.md
@@ -151,6 +151,25 @@ Portability is irrelevant for types that do not contain functions. Values of
 such types *mode cross* on the portability axis; they may be used as portable
 even when they are nonportable.
 
+## Future modes: Forkable
+
+|----------------|
+| unforkable     |
+| `|`            |
+| **forkable**   |
+{: .table }
+
+Forkable is a future axis that tracks whether a function is permitted to access
+shared values in its parent stack. See [parallelism](../../parallelism/01-intro/).
+
+Forkable has different defaults depending on the locality axis: *global* values are
+defaulted to *forkable*, while *local* values are defaulted to *unforkable*.
+More documentation on mode implications is available [here](../../kinds/syntax).
+
+Forkable is irrelevant for types that do not contain functions, and values of such types
+*mode cross* on the forkable axis; they may be used as unforkable even
+when they are forkable.
+
 # Modes for aliasing {#uniqueness-linearity}
 
 ## Past modes: Uniqueness
@@ -227,9 +246,10 @@ Yielding is a future axis that tracks whether a function is permitted to perform
 effects that will be handled in its parent stack. See [the OCaml Manual entry
 for effect handlers](https://ocaml.org/manual/5.3/effects.html).
 
-Yielding has different defaults depending on the locality axis: *global* values are
-defaulted to *unyielding*, while *local* values are defaulted to *yielding*.
-More documentation on mode implications is available [here](../../kinds/syntax).
+Yielding has different defaults depending on the forkable (and hence locality) axes:
+*forkable* values are defaulted to *unyielding*, while *unforkable* values are
+defaulted to *yielding*. More documentation on mode implications is available
+[here](../../kinds/syntax).
 
 Yielding is irrelevant for types that do not contain functions, and values of such types
 *mode cross* on the yielding axis; they may be used as unyielding even

--- a/jane/doc/extensions/_05-modes/syntax.md
+++ b/jane/doc/extensions/_05-modes/syntax.md
@@ -289,9 +289,9 @@ and modalities, according to this table:
 | this          | implies this |
 |---------------|--------------|
 | `global`      | `forkable`   |
-| `forkable`    | `unyielding` |
 | `local`       | `unforkable` |
-| `unforkable`  | `yielding`   |
+| `global`      | `unyielding` |
+| `local`       | `yielding`   |
 | `stateless`   | `portable`   |
 | `immutable`   | `contended`  |
 | `read`        | `shared`     |

--- a/jane/doc/extensions/_05-modes/syntax.md
+++ b/jane/doc/extensions/_05-modes/syntax.md
@@ -19,6 +19,7 @@ linearity ::= `many` | `once`
 portability ::= `portable` | `nonportable`
 contention ::= `uncontended` | `shared` | `contended`
 yield ::= `unyielding` | `yielding`
+fork ::= `forkable` | `unforkable`
 statefulness ::= `stateless` | `observing` | `stateful`
 visibility ::= `read_write` | `read` | `immutable`
 
@@ -68,7 +69,7 @@ axes that are omitted, the so-called *legacy* modes are used instead. The legacy
 modes are as follows:
 
 ```ocaml
-global aliased many nonportable uncontended unyielding stateful read_write
+global aliased many nonportable uncontended forkable unyielding stateful read_write
 ```
 
 This means that `t1 -> t2` is actually equivalent to
@@ -164,7 +165,7 @@ Modalities are used to describe the relationship between a container and an
 element in that container; for example, if you have a record field `x` with
 a `portable` modality, then `r.x` is `portable` even if `r` is `nonportable`.
 We say that the `portable` modality applied to the `nonportable` record mode
-produces the `portable` mode of the field. 
+produces the `portable` mode of the field.
 
 Modalities work differently on future axes vs. past axes. On a future axis, the
 modality imposes an upper bound on the mode (thus always lowering that
@@ -180,7 +181,7 @@ as the mode of the record.) For future axes, this would be the top mode; for
 past axes, this would be the bottom mode. These are the identity modalities:
 
 ```ocaml
-local unique once nonportable uncontended unyielding stateless immutable
+local unique once nonportable uncontended unforkable yielding stateless immutable
 ```
 
 Note that a legacy mode might or might not be the same as the identity modality.
@@ -271,13 +272,14 @@ for modalities. For example, `local` implies `yielding`. Now consider
 type 'a glob = { g : 'a @@ global }
 let unglob (r : 'a glob @ local) : 'a = r.g
 ```
-Because of the mode implication, `r` has mode `local yielding`. The written
-`global` modality means that `r.g` will have mode `global` (corresponding to
-the unwritten legacy `global` on the return type of `'a`). But without a
-`unyielding` modality, then `r.g` will have mode `yielding`, which is not
-compatible with a return expecting the legacy `unyielding`. We thus extend
-implications to include modalities, such that `global` implies `unyielding`,
-thus getting `unglob` to type-check (because now `r.g` will be `unyielding`).
+Because of the mode implication, `r` has mode `local unforkable yielding`.
+The written `global` modality means that `r.g` will have mode `global`
+(corresponding to the unwritten legacy `global` on the return type of `'a`).
+But without a `unyielding` modality, then `r.g` will have mode `yielding`,
+which is not compatible with a return expecting the legacy `unyielding`.
+We thus extend implications to include modalities, such that `global`
+implies `unyielding`, thus getting `unglob` to type-check (because now
+`r.g` will be `unyielding`).
 
 Other implications
 exist, all to lower users' annotation burden, all applying both to modes
@@ -286,8 +288,10 @@ and modalities, according to this table:
 
 | this          | implies this |
 |---------------|--------------|
-| `global`      | `unyielding` |
-| `local`       | `yielding`   |
+| `global`      | `forkable`   |
+| `forkable`    | `unyielding` |
+| `local`       | `unforkable` |
+| `unforkable`  | `yielding`   |
 | `stateless`   | `portable`   |
 | `immutable`   | `contended`  |
 | `read`        | `shared`     |

--- a/jane/doc/extensions/_06-kinds/intro.md
+++ b/jane/doc/extensions/_06-kinds/intro.md
@@ -68,8 +68,8 @@ components, and includes both modal and non-modal bounds. The type `int` has all
 the bounds:
 
 ```
-value mod global contended portable aliased many unyielding immutable stateless
-          non_float external_
+value mod global contended portable aliased many forkable unyielding immutable
+          stateless non_float external_
 ```
 
 This kind indicates that `int` mode crosses on all eight of our modal axes. In
@@ -229,7 +229,7 @@ Here is the full kind of `'a list`:
 
 ```ocaml
 type 'a list
-  : value mod contended portable many immutable stateless unyielding with 'a
+  : value mod contended portable many immutable stateless forkable unyielding with 'a
 ```
 
 also written (see our [syntax page](../syntax) for details on `immutable_data`)

--- a/jane/doc/extensions/_06-kinds/syntax.md
+++ b/jane/doc/extensions/_06-kinds/syntax.md
@@ -103,15 +103,15 @@ their shallowness, are considered separately.
 
 The abbreviations defined in the language are as follows:
 
-* `everything = global aliased many contended portable unyielding immutable
-                stateless external_`
+* `everything = global aliased many contended portable forkable unyielding
+                immutable stateless external_`
 
     Values whose types have kinds that include `mod everything` do not...
 
     * ... allocate memory: this allows them to mode-cross to `global` and be
       `external_`.
     * ... contain functions: this allows them to mode-cross to `many portable
-      unyielding stateless` (all of which only affect functions).
+      forkable unyielding stateless` (all of which only affect functions).
     * ... support mutation: this allows them to mode-cross to `contended
       immutable`.
     * ... point anywhere: this allows mode-crossing to `aliased` (which would
@@ -137,8 +137,8 @@ The abbreviations defined in the language are as follows:
 
     This is the kind of `int or_null` and similar types.
 
-* `immediate64 = value mod global aliased many contended portable unyielding
-                 immutable stateless external64 non_float`
+* `immediate64 = value mod global aliased many contended portable forkable
+                 unyielding immutable stateless external64 non_float`
 
     This is just like `immediate`, but applies only on 64-bit machines. On a
     32-bit machine, value whose types are `immediate64` may be
@@ -154,7 +154,8 @@ The abbreviations defined in the language are as follows:
     * Something storable in 64 bits without indirection cannot support
       update-in-place, so mode-crossing to `aliased` is safe.
     * Something storable in 64 bits without indirection cannot contain
-      functions, so mode-crossing `many portable unyielding stateless` is safe.
+      functions, so mode-crossing `many portable forkable unyielding stateless`
+      is safe.
     * Something storable in 64 bits without indirection cannot support mutation
       (much like other unboxed types), so mode-crossing `contended immutable` is
       safe.
@@ -167,19 +168,20 @@ The abbreviations defined in the language are as follows:
     call to `caml_modify` (on 64-bit machines). See also the documentation on
     [externality][].
 
-* `immutable_data =
-     value mod many contended portable unyielding immutable stateless non_float`
+* `immutable_data = value mod many contended portable forkable unyielding immutable
+                    stateless non_float`
 
     This is a suitable kind for plain old data that is immutable. By "plain
     old data", we mean that values of types of this kind contain no pointers to
     functions. The type `string` has this kind.
 
-* `sync_data = value mod many contended portable unyielding stateless non_float`
+* `sync_data = value mod many contended portable forkable unyielding stateless
+               non_float`
 
    This is a suitable kind of plain old data that the type system guarantees can be mutated only
    safely in parallel, similar to the `Sync` trait in Rust.
 
-* `mutable_data = value mod many portable unyielding stateless non_float`
+* `mutable_data = value mod many portable forkable unyielding stateless non_float`
 
     This is a suitable kind for plain old data that may be mutable. The
     type `int ref` has this kind.

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -90,13 +90,13 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
           sort value
-          value_mode global,many,portable,unyielding,stateful;imply(unique,uncontended,read_write)(modevar#3[aliased,contended,immutable .. unique,uncontended,read_write])
+          value_mode global,many,portable,forkable,unyielding,stateful;imply(unique,uncontended,read_write)(modevar#3[aliased,contended,immutable .. unique,uncontended,read_write])
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
-          alloc_mode global,many,portable,unyielding,stateful;id(modevar#9[aliased,contended,immutable .. unique,uncontended,read_write])
+          alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#9[aliased,contended,immutable .. unique,uncontended,read_write])
           []
           Tfunction_cases (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
-          alloc_mode global,many,nonportable,unyielding,stateful;aliased,uncontended,read_write
+          alloc_mode global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write
           value
             [
               <case>
@@ -112,7 +112,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                 pattern (test_locations.ml[19,572+4]..test_locations.ml[19,572+5])
                   Tpat_var "n"
                   sort value
-                  value_mode global,many,portable,unyielding,stateless;unique,uncontended,read_write
+                  value_mode global,many,portable,forkable,unyielding,stateless;unique,uncontended,read_write
                 expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+34])
                   Texp_apply
                   apply_mode Tail

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -90,13 +90,13 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern 
           Tpat_var "fib"
           sort value
-          value_mode global,many,portable,unyielding,stateful;imply(unique,uncontended,read_write)(modevar#3[aliased,contended,immutable .. unique,uncontended,read_write])
+          value_mode global,many,portable,forkable,unyielding,stateful;imply(unique,uncontended,read_write)(modevar#3[aliased,contended,immutable .. unique,uncontended,read_write])
         expression 
           Texp_function
-          alloc_mode global,many,portable,unyielding,stateful;id(modevar#9[aliased,contended,immutable .. unique,uncontended,read_write])
+          alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#9[aliased,contended,immutable .. unique,uncontended,read_write])
           []
           Tfunction_cases 
-          alloc_mode global,many,nonportable,unyielding,stateful;aliased,uncontended,read_write
+          alloc_mode global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write
           value
             [
               <case>
@@ -112,7 +112,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                 pattern 
                   Tpat_var "n"
                   sort value
-                  value_mode global,many,portable,unyielding,stateless;unique,uncontended,read_write
+                  value_mode global,many,portable,forkable,unyielding,stateless;unique,uncontended,read_write
                 expression 
                   Texp_apply
                   apply_mode Tail

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -989,7 +989,7 @@ type ('a : immediate) t : value mod global = { mutable x : 'a }
 Line 1, characters 0-63:
 1 | type ('a : immediate) t : value mod global = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ unyielding many
+Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod global
          because of the annotation on the declaration of the type t.
@@ -1003,7 +1003,7 @@ type ('a : immediate) t : value mod aliased = { mutable x : 'a }
 Line 1, characters 0-64:
 1 | type ('a : immediate) t : value mod aliased = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ unyielding many
+Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod aliased
          because of the annotation on the declaration of the type t.
@@ -1017,7 +1017,7 @@ type ('a : immediate) t : value mod contended = { mutable x : 'a }
 Line 1, characters 0-66:
 1 | type ('a : immediate) t : value mod contended = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ unyielding many
+Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod contended
          because of the annotation on the declaration of the type t.
@@ -1031,7 +1031,7 @@ type ('a : immediate) t : value mod external_ = { mutable x : 'a }
 Line 1, characters 0-66:
 1 | type ('a : immediate) t : value mod external_ = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ unyielding many
+Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod external_
          because of the annotation on the declaration of the type t.
@@ -1045,7 +1045,7 @@ type ('a : immediate) t : value mod external64 = { mutable x : 'a }
 Line 1, characters 0-67:
 1 | type ('a : immediate) t : value mod external64 = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ unyielding many
+Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod external64
          because of the annotation on the declaration of the type t.
@@ -1253,7 +1253,7 @@ type 'a t : value mod global = { x : 'a @@ global }
 Line 1, characters 0-51:
 1 | type 'a t : value mod global = { x : 'a @@ global }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a @@ unyielding
+Error: The kind of type "t" is immutable_data with 'a @@ forkable unyielding
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod global
          because of the annotation on the declaration of the type t.

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -1167,7 +1167,7 @@ Error: The kind of type "t" is value
          because it instantiates an unannotated type parameter of t,
          chosen to have kind value.
        But the kind of type "t" must be a subkind of
-           immutable_data mod global aliased yielding
+           immutable_data mod global aliased yielding unforkable
          because of the annotation on the declaration of the type t.
 |}]
 (* CR layouts v2.8: this could be accepted, if we infer ('a : value mod

--- a/testsuite/tests/typing-jkind-bounds/composite.ml
+++ b/testsuite/tests/typing-jkind-bounds/composite.ml
@@ -189,7 +189,8 @@ Line 1, characters 13-20:
 1 | let foo (t : int ref t @ contended) = use_uncontended t
                  ^^^^^^^
 Error: This type "int ref" should be an instance of type "('a : immutable_data)"
-       The kind of int ref is mutable_data with int @@ unyielding many.
+       The kind of int ref is
+           mutable_data with int @@ forkable unyielding many.
        But the kind of int ref must be a subkind of immutable_data
          because of the definition of t at line 1, characters 0-46.
 
@@ -341,7 +342,8 @@ Line 1, characters 13-20:
 1 | let foo (t : int ref t @ contended) = use_uncontended t
                  ^^^^^^^
 Error: This type "int ref" should be an instance of type "('a : immutable_data)"
-       The kind of int ref is mutable_data with int @@ unyielding many.
+       The kind of int ref is
+           mutable_data with int @@ forkable unyielding many.
        But the kind of int ref must be a subkind of immutable_data
          because of the definition of t at line 1, characters 0-73.
 

--- a/testsuite/tests/typing-jkind-bounds/predef.ml
+++ b/testsuite/tests/typing-jkind-bounds/predef.ml
@@ -176,7 +176,8 @@ type 'a t : mutable_data = 'a ref
 Line 1, characters 0-33:
 1 | type 'a t : mutable_data = 'a ref
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a ref" is mutable_data with 'a @@ unyielding many.
+Error: The kind of type "'a ref" is
+           mutable_data with 'a @@ forkable unyielding many.
        But the kind of type "'a ref" must be a subkind of mutable_data
          because of the definition of t at line 1, characters 0-33.
 
@@ -199,7 +200,8 @@ Line 1, characters 14-21:
                   ^^^^^^^
 Error: This type "int ref" should be an instance of type
          "('a : value mod portable)"
-       The kind of int ref is mutable_data with int @@ unyielding many.
+       The kind of int ref is
+           mutable_data with int @@ forkable unyielding many.
        But the kind of int ref must be a subkind of value mod portable
          because of the definition of require_portable at line 10, characters 0-47.
 
@@ -223,7 +225,8 @@ Line 1, characters 14-21:
                   ^^^^^^^
 Error: This type "int ref" should be an instance of type
          "('a : value mod contended)"
-       The kind of int ref is mutable_data with int @@ unyielding many.
+       The kind of int ref is
+           mutable_data with int @@ forkable unyielding many.
        But the kind of int ref must be a subkind of value mod contended
          because of the definition of require_contended at line 9, characters 0-49.
 

--- a/testsuite/tests/typing-jkind-bounds/printing.ml
+++ b/testsuite/tests/typing-jkind-bounds/printing.ml
@@ -51,6 +51,7 @@ Error: The kind of type "t" is immutable_data with 'a @@ portable
        The first mode-crosses less than the second along:
          linearity: mod many with 'a ≰ mod many
          contention: mod contended with 'a ≰ mod contended
+         forkable: mod forkable with 'a ≰ mod forkable
          yielding: mod unyielding with 'a ≰ mod unyielding
          statefulness: mod stateless with 'a ≰ mod stateless
          visibility: mod immutable with 'a ≰ mod immutable
@@ -104,6 +105,7 @@ Error: Signature mismatch:
 
        The first mode-crosses less than the second along:
          portability: mod portable with 'a ≰ mod portable
+         forkable: mod forkable with 'a ≰ mod forkable
          yielding: mod unyielding with 'a ≰ mod unyielding
          statefulness: mod stateless with 'a ≰ mod stateless
          visibility: mod immutable with 'a ≰ mod immutable
@@ -222,6 +224,7 @@ Error: This type "(int -> int) u" should be an instance of type
        The first mode-crosses less than the second along:
          linearity: mod many with int -> int ≰ mod many
          contention: mod contended with int -> int ≰ mod contended
+         forkable: mod forkable with int -> int ≰ mod forkable
          yielding: mod unyielding with int -> int ≰ mod unyielding
          statefulness: mod stateless with int -> int ≰ mod stateless
          visibility: mod immutable with int -> int ≰ mod immutable
@@ -356,6 +359,7 @@ Error: Signature mismatch:
 
        The first mode-crosses less than the second along:
          linearity: mod many with 'a ≰ mod many
+         forkable: mod forkable with 'a ≰ mod forkable
          yielding: mod unyielding with 'a ≰ mod unyielding
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/printing.ml
+++ b/testsuite/tests/typing-jkind-bounds/printing.ml
@@ -181,7 +181,7 @@ Line 3, characters 11-12:
                ^
 Error: This type "a" = "int ref" should be an instance of type
          "('a : immutable_data)"
-       The kind of a is mutable_data with int @@ unyielding many.
+       The kind of a is mutable_data with int @@ forkable unyielding many.
        But the kind of a must be a subkind of immutable_data
          because of the definition of t at line 2, characters 0-28.
 
@@ -346,15 +346,15 @@ Error: Signature mismatch:
        Modules do not match:
          sig type 'a t : mutable_data with 'a end
        is not included in
-         sig type 'a t : mutable_data with 'a @@ unyielding many end
+         sig type 'a t : mutable_data with 'a @@ forkable unyielding many end
        Type declarations do not match:
          type 'a t : mutable_data with 'a
        is not included in
-         type 'a t : mutable_data with 'a @@ unyielding many
+         type 'a t : mutable_data with 'a @@ forkable unyielding many
        The kind of the first is mutable_data with 'a
          because of the definition of t at line 4, characters 2-34.
        But the kind of the first must be a subkind of
-           mutable_data with 'a @@ unyielding many
+           mutable_data with 'a @@ forkable unyielding many
          because of the definition of t at line 2, characters 2-40.
 
        The first mode-crosses less than the second along:
@@ -427,14 +427,15 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig type 'a t : mutable_data with 'a @@ unyielding many end
+         sig type 'a t : mutable_data with 'a @@ forkable unyielding many end
        is not included in
          sig type 'a t : immutable_data with 'a end
        Type declarations do not match:
-         type 'a t : mutable_data with 'a @@ unyielding many
+         type 'a t : mutable_data with 'a @@ forkable unyielding many
        is not included in
          type 'a t : immutable_data with 'a
-       The kind of the first is mutable_data with 'a @@ unyielding many
+       The kind of the first is
+           mutable_data with 'a @@ forkable unyielding many
          because of the definition of t at line 4, characters 2-40.
        But the kind of the first must be a subkind of immutable_data with 'a
          because of the definition of t at line 2, characters 2-56.

--- a/testsuite/tests/typing-jkind-bounds/records.ml
+++ b/testsuite/tests/typing-jkind-bounds/records.ml
@@ -154,7 +154,7 @@ type 'a t : immutable_data = { mutable x : 'a }
 Line 1, characters 0-47:
 1 | type 'a t : immutable_data = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ unyielding many
+Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -281,7 +281,7 @@ type ('a : mutable_data) t : sync_data = { mutable x : 'a [@atomic] }
 Line 1, characters 0-69:
 1 | type ('a : mutable_data) t : sync_data = { mutable x : 'a [@atomic] }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is sync_data with 'a @@ unyielding many
+Error: The kind of type "t" is sync_data with 'a @@ forkable unyielding many
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of sync_data
          because of the annotation on the declaration of the type t.
@@ -323,7 +323,7 @@ type 'a t : immutable_data with 'a = { mutable x : 'a }
 Line 1, characters 0-55:
 1 | type 'a t : immutable_data with 'a = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ unyielding many
+Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data with 'a
          because of the annotation on the declaration of the type t.

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
@@ -181,15 +181,15 @@ Error: Signature mismatch:
        Modules do not match:
          sig type 'a t : mutable_data with 'a end
        is not included in
-         sig type 'a t : mutable_data with 'a @@ unyielding many end
+         sig type 'a t : mutable_data with 'a @@ forkable unyielding many end
        Type declarations do not match:
          type 'a t : mutable_data with 'a
        is not included in
-         type 'a t : mutable_data with 'a @@ unyielding many
+         type 'a t : mutable_data with 'a @@ forkable unyielding many
        The kind of the first is mutable_data with 'a
          because of the definition of t at line 4, characters 2-34.
        But the kind of the first must be a subkind of
-           mutable_data with 'a @@ unyielding many
+           mutable_data with 'a @@ forkable unyielding many
          because of the definition of t at line 2, characters 2-40.
 
        The first mode-crosses less than the second along:
@@ -204,7 +204,8 @@ end = struct
   type 'a t : mutable_data with 'a @@ many unyielding forkable
 end
 [%%expect {|
-module M : sig type 'a t : mutable_data with 'a @@ unyielding many end
+module M :
+  sig type 'a t : mutable_data with 'a @@ forkable unyielding many end
 |}]
 
 (* CR layouts v2.8: 'a u's kind should get normalized to just immutable_data.

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
@@ -194,13 +194,14 @@ Error: Signature mismatch:
 
        The first mode-crosses less than the second along:
          linearity: mod many with 'a ≰ mod many
+         forkable: mod forkable with 'a ≰ mod forkable
          yielding: mod unyielding with 'a ≰ mod unyielding
 |}]
 
 module M : sig
   type 'a t : immutable_data with 'a ref
 end = struct
-  type 'a t : mutable_data with 'a @@ many unyielding
+  type 'a t : mutable_data with 'a @@ many unyielding forkable
 end
 [%%expect {|
 module M : sig type 'a t : mutable_data with 'a @@ unyielding many end

--- a/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
@@ -141,7 +141,8 @@ Error: Signature mismatch:
          type 'a t = Foo of 'a constraint 'a = 'b ref
        is not included in
          type 'a t : immutable_data with 'b constraint 'a = 'b ref
-       The kind of the first is mutable_data with 'b @@ unyielding many
+       The kind of the first is
+           mutable_data with 'b @@ forkable unyielding many
          because of the definition of t at line 4, characters 2-46.
        But the kind of the first must be a subkind of immutable_data with 'b
          because of the definition of t at line 2, characters 2-59.

--- a/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
@@ -59,7 +59,7 @@ Line 4, characters 0-48:
 4 | type 'a t : immutable_data with 'a = 'a F(Ref).t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "'a F(Ref).t" is
-           mutable_data with 'a @@ unyielding many
+           mutable_data with 'a @@ forkable unyielding many
          because of the definition of t at line 2, characters 2-40.
        But the kind of type "'a F(Ref).t" must be a subkind of
            immutable_data with 'a
@@ -80,7 +80,7 @@ Line 4, characters 0-38:
 4 | type 'a t : mutable_data = 'a F(Ref).t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "'a F(Ref).t" is
-           mutable_data with 'a @@ unyielding many
+           mutable_data with 'a @@ forkable unyielding many
          because of the definition of t at line 2, characters 2-40.
        But the kind of type "'a F(Ref).t" must be a subkind of mutable_data
          because of the definition of t at line 4, characters 0-38.

--- a/testsuite/tests/typing-jkind-bounds/variants.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants.ml
@@ -158,7 +158,7 @@ type 'a t : immutable_data = Foo of { mutable x : 'a }
 Line 1, characters 0-54:
 1 | type 'a t : immutable_data = Foo of { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ unyielding many
+Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -285,7 +285,7 @@ type ('a : mutable_data) t : sync_data = Foo of { mutable x : 'a [@atomic] }
 Line 1, characters 0-76:
 1 | type ('a : mutable_data) t : sync_data = Foo of { mutable x : 'a [@atomic] }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is sync_data with 'a @@ unyielding many
+Error: The kind of type "t" is sync_data with 'a @@ forkable unyielding many
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of sync_data
          because of the annotation on the declaration of the type t.
@@ -325,7 +325,7 @@ type 'a t : immutable_data with 'a = Foo of { mutable x : 'a }
 Line 1, characters 0-62:
 1 | type 'a t : immutable_data with 'a = Foo of { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ unyielding many
+Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data with 'a
          because of the annotation on the declaration of the type t.

--- a/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
+++ b/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
@@ -689,7 +689,8 @@ Line 1, characters 40-46:
                                             ^^^^^^
 Error: This expression has type "('a array, 'a) idx_mut"
        but an expression was expected of type "(float array, 'b) idx_mut"
-       The kind of float is value mod many unyielding stateless immutable
+       The kind of float is
+           value mod many forkable unyielding stateless immutable
          because it is the primitive type float.
        But the kind of float must be a subkind of value_or_null mod non_float
          because it's the element type (the second type parameter) for a
@@ -727,7 +728,8 @@ Line 1, characters 41-48:
                                              ^^^^^^^
 Error: This expression has type "('a iarray, 'a) idx_imm"
        but an expression was expected of type "(float iarray, 'b) idx_imm"
-       The kind of float is value mod many unyielding stateless immutable
+       The kind of float is
+           value mod many forkable unyielding stateless immutable
          because it is the primitive type float.
        But the kind of float must be a subkind of value_or_null mod non_float
          because it's the element type (the second type parameter) for a
@@ -744,7 +746,8 @@ Line 3, characters 23-24:
                            ^
 Error: This expression has type "('a array, 'a) idx_mut"
        but an expression was expected of type "(float array, 'b) idx_mut"
-       The kind of float is value mod many unyielding stateless immutable
+       The kind of float is
+           value mod many forkable unyielding stateless immutable
          because it is the primitive type float.
        But the kind of float must be a subkind of value_or_null mod non_float
          because of the definition of y at line 2, characters 10-17.

--- a/testsuite/tests/typing-layouts-or-null/containers.ml
+++ b/testsuite/tests/typing-layouts-or-null/containers.ml
@@ -77,7 +77,7 @@ Line 1, characters 19-32:
 Error: This type "float or_null" should be an instance of type
          "('a : any mod separable)"
        The kind of float or_null is
-           value_or_null mod many unyielding stateless immutable
+           value_or_null mod many forkable unyielding stateless immutable
          because it is the primitive type or_null.
        But the kind of float or_null must be a subkind of any mod separable
          because it's the type argument to the array type.
@@ -103,7 +103,8 @@ Line 1, characters 32-35:
                                     ^^^
 Error: This expression has type "float" but an expression was expected of type
          "('a : value mod non_float)"
-       The kind of float is value mod many unyielding stateless immutable
+       The kind of float is
+           value mod many forkable unyielding stateless immutable
          because it is the primitive type float.
        But the kind of float must be a subkind of value mod non_float
          because it's the type of an array element.
@@ -183,7 +184,7 @@ Line 1, characters 19-32:
 Error: This type "float or_null" should be an instance of type
          "('a : any mod separable)"
        The kind of float or_null is
-           value_or_null mod many unyielding stateless immutable
+           value_or_null mod many forkable unyielding stateless immutable
          because it is the primitive type or_null.
        But the kind of float or_null must be a subkind of any mod separable
          because it's the type argument to the array type.
@@ -208,7 +209,8 @@ Line 1, characters 39-42:
                                            ^^^
 Error: This expression has type "float" but an expression was expected of type
          "('a : value mod non_float)"
-       The kind of float is value mod many unyielding stateless immutable
+       The kind of float is
+           value mod many forkable unyielding stateless immutable
          because it is the primitive type float.
        But the kind of float must be a subkind of value mod non_float
          because it's the type of an array element.

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -383,7 +383,8 @@ Line 1, characters 13-18:
 1 | type fails = float accepts_nonfloat
                  ^^^^^
 Error: This type "float" should be an instance of type "('a : any mod non_float)"
-       The kind of float is value mod many unyielding stateless immutable
+       The kind of float is
+           value mod many forkable unyielding stateless immutable
          because it is the primitive type float.
        But the kind of float must be a subkind of any mod non_float
          because of the definition of accepts_nonfloat at line 3, characters 0-46.
@@ -560,7 +561,7 @@ Line 1, characters 13-26:
 Error: This type "float or_null" should be an instance of type
          "('a : any mod separable)"
        The kind of float or_null is
-           value_or_null mod many unyielding stateless immutable
+           value_or_null mod many forkable unyielding stateless immutable
          because it is the primitive type or_null.
        But the kind of float or_null must be a subkind of any mod separable
          because of the definition of accepts_sep at line 2, characters 0-41.
@@ -625,7 +626,7 @@ Line 1, characters 13-26:
 Error: This type "float or_null" should be an instance of type
          "('a : any mod separable)"
        The kind of float or_null is
-           value_or_null mod many unyielding stateless immutable
+           value_or_null mod many forkable unyielding stateless immutable
          because it is the primitive type or_null.
        But the kind of float or_null must be a subkind of any mod separable
          because it's the type argument to the array type.
@@ -814,7 +815,7 @@ Line 1, characters 13-37:
 Error: This type "float Or_null_reexport.t" = "float or_null"
        should be an instance of type "('a : any mod non_float)"
        The kind of float Or_null_reexport.t is
-           value_or_null mod many unyielding stateless immutable
+           value_or_null mod many forkable unyielding stateless immutable
          because it is the primitive type or_null.
        But the kind of float Or_null_reexport.t must be a subkind of
            any mod non_float
@@ -842,7 +843,7 @@ Line 1, characters 13-37:
 Error: This type "float Or_null_reexport.t" = "float or_null"
        should be an instance of type "('a : any mod separable)"
        The kind of float Or_null_reexport.t is
-           value_or_null mod many unyielding stateless immutable
+           value_or_null mod many forkable unyielding stateless immutable
          because it is the primitive type or_null.
        But the kind of float Or_null_reexport.t must be a subkind of
            any mod separable
@@ -886,7 +887,7 @@ Line 1, characters 13-31:
 Error: This type "float unbx or_null" should be an instance of type
          "('a : any mod separable)"
        The kind of float unbx or_null is
-           value_or_null mod many unyielding stateless immutable
+           value_or_null mod many forkable unyielding stateless immutable
          because it is the primitive type or_null.
        But the kind of float unbx or_null must be a subkind of
            any mod separable
@@ -928,7 +929,8 @@ Line 1, characters 30-32:
                                   ^^
 Error: This expression has type "float" but an expression was expected of type
          "('a : value mod non_float)"
-       The kind of float is value mod many unyielding stateless immutable
+       The kind of float is
+           value mod many forkable unyielding stateless immutable
          because it is the primitive type float.
        But the kind of float must be a subkind of value mod non_float
          because it's the layout polymorphic type in an external declaration
@@ -979,7 +981,7 @@ Error: Signature mismatch:
        is not included in
          type ('a : value mod non_float) t : value_or_null mod non_float
        The kind of the first is
-           value_or_null mod many unyielding stateless immutable
+           value_or_null mod many forkable unyielding stateless immutable
          because it is the primitive type or_null.
        But the kind of the first must be a subkind of
            value_or_null mod non_float
@@ -1037,7 +1039,7 @@ Error: Signature mismatch:
        is not included in
          type t : value_or_null mod separable
        The kind of the first is
-           value_or_null mod many unyielding stateless immutable
+           value_or_null mod many forkable unyielding stateless immutable
          because it is the primitive type or_null.
        But the kind of the first must be a subkind of
            value_or_null mod separable

--- a/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -210,7 +210,8 @@ Line 1, characters 26-28:
                               ^^
 Error: This expression has type "float" but an expression was expected of type
          "('a : value mod non_float)"
-       The kind of float is value mod many unyielding stateless immutable
+       The kind of float is
+           value mod many forkable unyielding stateless immutable
          because it is the primitive type float.
        But the kind of float must be a subkind of value mod non_float
          because it's the type of an array element.
@@ -231,7 +232,7 @@ Line 1, characters 19-32:
 Error: This type "float or_null" should be an instance of type
          "('a : any mod separable)"
        The kind of float or_null is
-           value_or_null mod many unyielding stateless immutable
+           value_or_null mod many forkable unyielding stateless immutable
          because it is the primitive type or_null.
        But the kind of float or_null must be a subkind of any mod separable
          because it's the type argument to the array type.
@@ -276,7 +277,8 @@ Line 1, characters 32-34:
                                     ^^
 Error: This expression has type "float" but an expression was expected of type
          "('a : value mod non_float)"
-       The kind of float is value mod many unyielding stateless immutable
+       The kind of float is
+           value mod many forkable unyielding stateless immutable
          because it is the primitive type float.
        But the kind of float must be a subkind of value mod non_float
          because it's the type of an array element.
@@ -297,7 +299,7 @@ Line 1, characters 19-32:
 Error: This type "float or_null" should be an instance of type
          "('a : any mod separable)"
        The kind of float or_null is
-           value_or_null mod many unyielding stateless immutable
+           value_or_null mod many forkable unyielding stateless immutable
          because it is the primitive type or_null.
        But the kind of float or_null must be a subkind of any mod separable
          because it's the type argument to the array type.

--- a/testsuite/tests/typing-layouts/allow_any.ml
+++ b/testsuite/tests/typing-layouts/allow_any.ml
@@ -384,10 +384,10 @@ Lines 1-2, characters 0-34:
 Error: This variant or record definition does not match that of type "'a t"
        They have different unsafe mode crossing behavior:
        Both specify [@@unsafe_allow_any_mode_crossing], but their bounds are not equal
-         the original has: mod unyielding many stateless portable immutable
-         contended with 'a
-         but this has: mod unyielding many stateless portable immutable
-         contended
+         the original has: mod forkable unyielding many stateless portable
+         immutable contended with 'a
+         but this has: mod forkable unyielding many stateless portable
+         immutable contended
 |}]
 
 type ('a, 'b) arity_2 : immutable_data with 'b = { x : 'a }
@@ -405,10 +405,10 @@ Error: This variant or record definition does not match that of type
          "('a, 'b) arity_2"
        They have different unsafe mode crossing behavior:
        Both specify [@@unsafe_allow_any_mode_crossing], but their bounds are not equal
-         the original has: mod unyielding many stateless portable immutable
-         contended with 'b
-         but this has: mod unyielding many stateless portable immutable
-         contended with 'a
+         the original has: mod forkable unyielding many stateless portable
+         immutable contended with 'b
+         but this has: mod forkable unyielding many stateless portable
+         immutable contended with 'a
 |}]
 
 (* mcomp *)

--- a/testsuite/tests/typing-layouts/datatypes.ml
+++ b/testsuite/tests/typing-layouts/datatypes.ml
@@ -335,7 +335,8 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type "float" but an expression was expected of type
          "('a : immediate)"
-       The kind of float is value mod many unyielding stateless immutable
+       The kind of float is
+           value mod many forkable unyielding stateless immutable
          because it is the primitive type float.
        But the kind of float must be a subkind of immediate
          because of the definition of s6 at line 2, characters 0-35.

--- a/testsuite/tests/typing-layouts/datatypes_alpha.ml
+++ b/testsuite/tests/typing-layouts/datatypes_alpha.ml
@@ -326,7 +326,8 @@ Line 8, characters 32-36:
                                     ^^^^
 Error: This expression has type "float" but an expression was expected of type
          "('a : immediate)"
-       The kind of float is value mod many unyielding stateless immutable
+       The kind of float is
+           value mod many forkable unyielding stateless immutable
          because it is the primitive type float.
        But the kind of float must be a subkind of immediate
          because of the definition of s6 at line 2, characters 0-35.

--- a/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/testsuite/tests/typing-modal-kinds/basics.ml
@@ -931,7 +931,8 @@ Line 1, characters 10-19:
               ^^^^^^^^^
 Error: This type "int t ref" should be an instance of type
          "('a : value mod contended)"
-       The kind of int t ref is mutable_data with int t @@ unyielding many.
+       The kind of int t ref is
+           mutable_data with int t @@ forkable unyielding many.
        But the kind of int t ref must be a subkind of value mod contended
          because of the definition of require_contended at line 1, characters 0-49.
 

--- a/testsuite/tests/typing-modes/forkable.ml
+++ b/testsuite/tests/typing-modes/forkable.ml
@@ -81,8 +81,6 @@ type 'a t3 = Mk3 of 'a @@ global forkable unyielding
 type 'a t4 = Mk4 of 'a @@ global forkable yielding
 type 'a t5 = Mk5 of 'a @@ global unforkable unyielding
 type 'a t6 = Mk6 of 'a @@ global unforkable yielding
-
-(* CR mslater: fix *)
 type 'a t7 = Mk7 of 'a @@ forkable unyielding
 type 'a t8 = Mk8 of 'a @@ forkable yielding
 type 'a t9 = Mk9 of 'a @@ unforkable unyielding
@@ -94,7 +92,7 @@ let with_global_unforkable : ((string -> unit) @ unforkable -> 'a) -> 'a =
 [%%expect{|
 type 'a t0 = Mk0 of global_ 'a
 type 'a t1 = Mk1 of global_ 'a
-type 'a t2 = Mk2 of 'a @@ global unforkable yielding
+type 'a t2 = Mk2 of 'a @@ global unforkable
 type 'a t3 = Mk3 of global_ 'a
 type 'a t4 = Mk4 of 'a @@ global yielding
 type 'a t5 = Mk5 of 'a @@ global unforkable
@@ -172,10 +170,7 @@ let _ = with_global_unforkable (fun k -> requires_unyielding k)
 external requires_unyielding : 'a @ local unyielding -> unit = "%ignore"
 - : unit = ()
 - : unit = ()
-Line 7, characters 61-62:
-7 | let _ = with_global_unforkable (fun k -> requires_unyielding k)
-                                                                 ^
-Error: This value is "yielding" but is expected to be "unyielding".
+- : unit = ()
 |}]
 
 external returns_unyielding : 'a -> 'a @ local unyielding = "%identity"

--- a/testsuite/tests/typing-modes/forkable.ml
+++ b/testsuite/tests/typing-modes/forkable.ml
@@ -1,0 +1,295 @@
+(* TEST
+ expect;
+*)
+
+let my_unforkable : (unit -> unit) @ unforkable = print_endline "Hello, world!"
+[%%expect{|
+Line 1, characters 4-79:
+1 | let my_unforkable : (unit -> unit) @ unforkable = print_endline "Hello, world!"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "unforkable" but is expected to be "forkable".
+|}]
+
+let storage = ref ""
+
+let with_unforkable : ((string -> unit) @ local unforkable -> 'a) -> 'a =
+  fun f -> f ((:=) storage)
+
+[%%expect{|
+val storage : string ref = {contents = ""}
+val with_unforkable : (local_ (string -> unit) -> 'a) -> 'a = <fun>
+|}]
+
+let () = with_unforkable (fun k -> k "Hello, world!")
+
+let _ = !storage
+
+[%%expect{|
+- : string = "Hello, world!"
+|}]
+
+let run_unforkable : (string -> unit) @ local unforkable -> unit = fun f -> f "my string"
+
+let () = with_unforkable (fun k -> run_unforkable k)
+
+let _ = !storage
+
+[%%expect{|
+val run_unforkable : local_ (string -> unit) -> unit = <fun>
+- : string = "my string"
+|}]
+
+let run_forkable : (string -> unit) @ local forkable -> unit = fun f -> f "another string"
+
+let () = with_unforkable (fun k -> run_forkable k)
+
+[%%expect{|
+val run_forkable : (string -> unit) @ local forkable -> unit = <fun>
+Line 3, characters 48-49:
+3 | let () = with_unforkable (fun k -> run_forkable k)
+                                                    ^
+Error: This value is "unforkable" but is expected to be "forkable".
+|}]
+
+let run_default : (string -> unit) @ local -> unit = fun f -> f "some string"
+
+let () = with_unforkable (fun k -> run_default k)
+
+[%%expect{|
+val run_default : local_ (string -> unit) -> unit = <fun>
+|}]
+
+(* A closure over a [unforkable] value must be [unforkable]. *)
+
+let () = with_unforkable (fun k ->
+  let closure @ local forkable = fun () -> k () in
+  run_forkable k)
+
+[%%expect{|
+Line 2, characters 43-44:
+2 |   let closure @ local forkable = fun () -> k () in
+                                               ^
+Error: The value "k" is "unforkable" but is expected to be "forkable"
+       because it is used inside a function which is expected to be "forkable".
+|}]
+
+
+type 'a t0 = Mk0 of 'a @@ global
+type 'a t1 = Mk1 of 'a @@ global forkable
+type 'a t2 = Mk2 of 'a @@ global unforkable
+type 'a t3 = Mk3 of 'a @@ global forkable unyielding
+type 'a t4 = Mk4 of 'a @@ global forkable yielding
+type 'a t5 = Mk5 of 'a @@ global unforkable unyielding
+type 'a t6 = Mk6 of 'a @@ global unforkable yielding
+
+(* CR mslater: fix *)
+type 'a t7 = Mk7 of 'a @@ forkable unyielding
+type 'a t8 = Mk8 of 'a @@ forkable yielding
+type 'a t9 = Mk9 of 'a @@ unforkable unyielding
+type 'a t10 = Mk10 of 'a @@ unforkable yielding
+
+let with_global_unforkable : ((string -> unit) @ unforkable -> 'a) -> 'a =
+  fun f -> f ((:=) storage)
+
+[%%expect{|
+type 'a t0 = Mk0 of global_ 'a
+type 'a t1 = Mk1 of global_ 'a
+type 'a t2 = Mk2 of 'a @@ global unforkable yielding
+type 'a t3 = Mk3 of global_ 'a
+type 'a t4 = Mk4 of 'a @@ global yielding
+type 'a t5 = Mk5 of 'a @@ global unforkable
+type 'a t6 = Mk6 of 'a @@ global unforkable yielding
+type 'a t7 = Mk7 of 'a @@ unyielding
+type 'a t8 = Mk8 of 'a
+type 'a t9 = Mk9 of 'a @@ unyielding
+type 'a t10 = Mk10 of 'a
+val with_global_unforkable : ((string -> unit) @ unforkable -> 'a) -> 'a =
+  <fun>
+|}]
+
+(* [global] modality implies [forkable]. *)
+let _ = with_global_unforkable (fun k -> let _ = Mk0 k in ())
+
+[%%expect{|
+Line 1, characters 53-54:
+1 | let _ = with_global_unforkable (fun k -> let _ = Mk0 k in ())
+                                                         ^
+Error: This value is "unforkable" but is expected to be "forkable".
+|}]
+
+(* [global unforkable] works: *)
+let _ = with_global_unforkable (fun k -> let _ = Mk2 k in ())
+
+[%%expect{|
+- : unit = ()
+|}]
+
+(* [unyielding] and [yielding] modalities: *)
+let _ = with_global_unforkable (fun k -> let _ = Mk3 k in ())
+
+[%%expect{|
+Line 1, characters 53-54:
+1 | let _ = with_global_unforkable (fun k -> let _ = Mk3 k in ())
+                                                         ^
+Error: This value is "unforkable" but is expected to be "forkable".
+|}]
+
+let _ = with_global_unforkable (fun k -> let _ = Mk4 k in ())
+
+[%%expect{|
+Line 1, characters 53-54:
+1 | let _ = with_global_unforkable (fun k -> let _ = Mk4 k in ())
+                                                         ^
+Error: This value is "unforkable" but is expected to be "forkable".
+|}]
+
+(* Externals and [yielding]: *)
+
+external ok_yielding : 'a @ local -> unit = "%ignore"
+
+let _ = ok_yielding 4
+
+let _ = ok_yielding (stack_ (Some "local string"))
+
+let _ = with_global_unforkable (fun k -> ok_yielding k)
+
+[%%expect{|
+external ok_yielding : local_ 'a -> unit = "%ignore"
+- : unit = ()
+- : unit = ()
+- : unit = ()
+|}]
+
+external requires_unyielding : 'a @ local unyielding -> unit = "%ignore"
+
+let _ = requires_unyielding 4
+
+let _ = requires_unyielding (stack_ (Some "local string"))
+
+let _ = with_global_unforkable (fun k -> requires_unyielding k)
+
+[%%expect{|
+external requires_unyielding : 'a @ local unyielding -> unit = "%ignore"
+- : unit = ()
+- : unit = ()
+Line 7, characters 61-62:
+7 | let _ = with_global_unforkable (fun k -> requires_unyielding k)
+                                                                 ^
+Error: This value is "yielding" but is expected to be "unyielding".
+|}]
+
+external returns_unyielding : 'a -> 'a @ local unyielding = "%identity"
+
+let _ = requires_unyielding (returns_unyielding "some string")
+
+[%%expect{|
+external returns_unyielding : 'a -> 'a @ local unyielding = "%identity"
+- : unit = ()
+|}]
+
+(* [@local_opt] and [yielding]: *)
+
+external id : ('a[@local_opt]) -> ('a[@local_opt]) = "%identity"
+
+let f1 x = id x
+let f2 (x @ local) = exclave_ id x
+let f3 (x @ yielding) = id x
+let f4 (x @ local unyielding) = exclave_ id x
+
+[%%expect{|
+external id : ('a [@local_opt]) -> ('a [@local_opt]) = "%identity"
+val f1 : 'a -> 'a = <fun>
+val f2 : local_ 'a -> local_ 'a = <fun>
+val f3 : 'a @ yielding -> 'a @ yielding = <fun>
+val f4 : 'a @ local unyielding -> local_ 'a = <fun>
+|}]
+
+(* Test [instance_prim] + mixed mode annots. *)
+external requires_unyielding : 'a @ local unyielding -> (unit [@local_opt]) = "%ignore"
+
+let f1 x = requires_unyielding x
+[%%expect{|
+external requires_unyielding : 'a @ local unyielding -> (unit [@local_opt])
+  = "%ignore"
+val f1 : 'a -> unit = <fun>
+|}]
+
+let f2 (x @ local) = exclave_ requires_unyielding x
+
+[%%expect{|
+Line 1, characters 50-51:
+1 | let f2 (x @ local) = exclave_ requires_unyielding x
+                                                      ^
+Error: This value is "yielding" but is expected to be "unyielding".
+|}]
+
+let f3 (x @ yielding) = requires_unyielding x
+[%%expect{|
+Line 1, characters 44-45:
+1 | let f3 (x @ yielding) = requires_unyielding x
+                                                ^
+Error: This value is "yielding" but is expected to be "unyielding".
+|}]
+
+let f4 (x @ local unyielding) = exclave_ requires_unyielding x
+[%%expect{|
+val f4 : 'a @ local unyielding -> local_ unit = <fun>
+|}]
+
+(* [@local_opt] overrides annotations. *)
+external overridden: ('a[@local_opt]) @ local unyielding -> unit = "%ignore"
+
+let succeeds (x @ local) = overridden x
+[%%expect{|
+external overridden : ('a [@local_opt]) @ local unyielding -> unit
+  = "%ignore"
+val succeeds : local_ 'a -> unit = <fun>
+|}]
+
+(* [mod global] implies [mod unyielding] by default. *)
+
+type ('a : value mod global) u1
+
+type ('a : value mod global yielding) u2
+
+type w1 : value mod global yielding
+
+type w2 : value mod global unyielding
+
+[%%expect{|
+type ('a : value mod global) u1
+type ('a : value mod global yielding) u2
+type w1 : value mod global yielding
+type w2 : value mod global
+|}]
+
+type _z1 = w1 u1
+
+[%%expect{|
+Line 1, characters 11-13:
+1 | type _z1 = w1 u1
+               ^^
+Error: This type "w1" should be an instance of type "('a : value mod global)"
+       The kind of w1 is value mod global yielding
+         because of the definition of w1 at line 5, characters 0-35.
+       But the kind of w1 must be a subkind of value mod global
+         because of the definition of u1 at line 1, characters 0-31.
+|}]
+
+type _z2 = w2 u1
+
+[%%expect{|
+type _z2 = w2 u1
+|}]
+
+type _z3 = w1 u2
+
+[%%expect{|
+type _z3 = w1 u2
+|}]
+
+type _z4 = w2 u2
+
+[%%expect{|
+type _z4 = w2 u2
+|}]

--- a/testsuite/tests/typing-modes/forkable.ml
+++ b/testsuite/tests/typing-modes/forkable.ml
@@ -73,7 +73,6 @@ Error: The value "k" is "unforkable" but is expected to be "forkable"
        because it is used inside a function which is expected to be "forkable".
 |}]
 
-
 type 'a t0 = Mk0 of 'a @@ global
 type 'a t1 = Mk1 of 'a @@ global forkable
 type 'a t2 = Mk2 of 'a @@ global unforkable
@@ -85,6 +84,8 @@ type 'a t7 = Mk7 of 'a @@ forkable unyielding
 type 'a t8 = Mk8 of 'a @@ forkable yielding
 type 'a t9 = Mk9 of 'a @@ unforkable unyielding
 type 'a t10 = Mk10 of 'a @@ unforkable yielding
+type 'a t11 = Mk11 of 'a @@ forkable
+type 'a t12 = Mk12 of 'a @@ unforkable
 
 let with_global_unforkable : ((string -> unit) @ unforkable -> 'a) -> 'a =
   fun f -> f ((:=) storage)
@@ -97,10 +98,12 @@ type 'a t3 = Mk3 of global_ 'a
 type 'a t4 = Mk4 of 'a @@ global yielding
 type 'a t5 = Mk5 of 'a @@ global unforkable
 type 'a t6 = Mk6 of 'a @@ global unforkable yielding
-type 'a t7 = Mk7 of 'a @@ unyielding
-type 'a t8 = Mk8 of 'a
+type 'a t7 = Mk7 of 'a @@ forkable unyielding
+type 'a t8 = Mk8 of 'a @@ forkable
 type 'a t9 = Mk9 of 'a @@ unyielding
 type 'a t10 = Mk10 of 'a
+type 'a t11 = Mk11 of 'a @@ forkable
+type 'a t12 = Mk12 of 'a
 val with_global_unforkable : ((string -> unit) @ unforkable -> 'a) -> 'a =
   <fun>
 |}]
@@ -122,139 +125,138 @@ let _ = with_global_unforkable (fun k -> let _ = Mk2 k in ())
 - : unit = ()
 |}]
 
-(* [unyielding] and [yielding] modalities: *)
-let _ = with_global_unforkable (fun k -> let _ = Mk3 k in ())
+(* [unforkable] and [forkable] modalities: *)
+let _ = with_global_unforkable (fun k -> let _ = Mk11 k in ())
 
 [%%expect{|
-Line 1, characters 53-54:
-1 | let _ = with_global_unforkable (fun k -> let _ = Mk3 k in ())
-                                                         ^
+Line 1, characters 54-55:
+1 | let _ = with_global_unforkable (fun k -> let _ = Mk11 k in ())
+                                                          ^
 Error: This value is "unforkable" but is expected to be "forkable".
 |}]
 
-let _ = with_global_unforkable (fun k -> let _ = Mk4 k in ())
+let _ = with_global_unforkable (fun k -> let _ = Mk12 k in ())
 
 [%%expect{|
-Line 1, characters 53-54:
-1 | let _ = with_global_unforkable (fun k -> let _ = Mk4 k in ())
-                                                         ^
-Error: This value is "unforkable" but is expected to be "forkable".
+- : unit = ()
 |}]
 
 (* Externals and [yielding]: *)
 
-external ok_yielding : 'a @ local -> unit = "%ignore"
+external ok_unforkable : 'a @ local -> unit = "%ignore"
 
-let _ = ok_yielding 4
+let _ = ok_unforkable 4
 
-let _ = ok_yielding (stack_ (Some "local string"))
+let _ = ok_unforkable (stack_ (Some "local string"))
 
-let _ = with_global_unforkable (fun k -> ok_yielding k)
+let _ = with_global_unforkable (fun k -> ok_unforkable k)
 
 [%%expect{|
-external ok_yielding : local_ 'a -> unit = "%ignore"
+external ok_unforkable : local_ 'a -> unit = "%ignore"
 - : unit = ()
 - : unit = ()
 - : unit = ()
 |}]
 
-external requires_unyielding : 'a @ local unyielding -> unit = "%ignore"
+external requires_forkable : 'a @ local forkable -> unit = "%ignore"
 
-let _ = requires_unyielding 4
+let _ = requires_forkable 4
 
-let _ = requires_unyielding (stack_ (Some "local string"))
+let _ = requires_forkable (stack_ (Some "local string"))
 
-let _ = with_global_unforkable (fun k -> requires_unyielding k)
+let _ = with_global_unforkable (fun k -> requires_forkable k)
 
 [%%expect{|
-external requires_unyielding : 'a @ local unyielding -> unit = "%ignore"
+external requires_forkable : 'a @ local forkable -> unit = "%ignore"
 - : unit = ()
 - : unit = ()
+Line 7, characters 59-60:
+7 | let _ = with_global_unforkable (fun k -> requires_forkable k)
+                                                               ^
+Error: This value is "unforkable" but is expected to be "forkable".
+|}]
+
+external returns_forkable : 'a -> 'a @ local forkable = "%identity"
+
+let _ = requires_forkable (returns_forkable "some string")
+
+[%%expect{|
+external returns_forkable : 'a -> 'a @ local forkable = "%identity"
 - : unit = ()
 |}]
 
-external returns_unyielding : 'a -> 'a @ local unyielding = "%identity"
-
-let _ = requires_unyielding (returns_unyielding "some string")
-
-[%%expect{|
-external returns_unyielding : 'a -> 'a @ local unyielding = "%identity"
-- : unit = ()
-|}]
-
-(* [@local_opt] and [yielding]: *)
+(* [@local_opt] and [forkable]: *)
 
 external id : ('a[@local_opt]) -> ('a[@local_opt]) = "%identity"
 
 let f1 x = id x
 let f2 (x @ local) = exclave_ id x
-let f3 (x @ yielding) = id x
-let f4 (x @ local unyielding) = exclave_ id x
+let f3 (x @ unforkable) = id x
+let f4 (x @ local forkable) = exclave_ id x
 
 [%%expect{|
 external id : ('a [@local_opt]) -> ('a [@local_opt]) = "%identity"
 val f1 : 'a -> 'a = <fun>
 val f2 : local_ 'a -> local_ 'a = <fun>
-val f3 : 'a @ yielding -> 'a @ yielding = <fun>
-val f4 : 'a @ local unyielding -> local_ 'a = <fun>
+val f3 : 'a @ unforkable -> 'a @ unforkable = <fun>
+val f4 : 'a @ local forkable -> local_ 'a = <fun>
 |}]
 
 (* Test [instance_prim] + mixed mode annots. *)
-external requires_unyielding : 'a @ local unyielding -> (unit [@local_opt]) = "%ignore"
+external requires_forkable : 'a @ local forkable -> (unit [@local_opt]) = "%ignore"
 
-let f1 x = requires_unyielding x
+let f1 x = requires_forkable x
 [%%expect{|
-external requires_unyielding : 'a @ local unyielding -> (unit [@local_opt])
+external requires_forkable : 'a @ local forkable -> (unit [@local_opt])
   = "%ignore"
 val f1 : 'a -> unit = <fun>
 |}]
 
-let f2 (x @ local) = exclave_ requires_unyielding x
+let f2 (x @ local) = exclave_ requires_forkable x
 
 [%%expect{|
-Line 1, characters 50-51:
-1 | let f2 (x @ local) = exclave_ requires_unyielding x
-                                                      ^
-Error: This value is "yielding" but is expected to be "unyielding".
+Line 1, characters 48-49:
+1 | let f2 (x @ local) = exclave_ requires_forkable x
+                                                    ^
+Error: This value is "unforkable" but is expected to be "forkable".
 |}]
 
-let f3 (x @ yielding) = requires_unyielding x
+let f3 (x @ unforkable) = requires_forkable x
 [%%expect{|
 Line 1, characters 44-45:
-1 | let f3 (x @ yielding) = requires_unyielding x
+1 | let f3 (x @ unforkable) = requires_forkable x
                                                 ^
-Error: This value is "yielding" but is expected to be "unyielding".
+Error: This value is "unforkable" but is expected to be "forkable".
 |}]
 
-let f4 (x @ local unyielding) = exclave_ requires_unyielding x
+let f4 (x @ local forkable) = exclave_ requires_forkable x
 [%%expect{|
-val f4 : 'a @ local unyielding -> local_ unit = <fun>
+val f4 : 'a @ local forkable -> local_ unit = <fun>
 |}]
 
 (* [@local_opt] overrides annotations. *)
-external overridden: ('a[@local_opt]) @ local unyielding -> unit = "%ignore"
+external overridden: ('a[@local_opt]) @ local forkable -> unit = "%ignore"
 
 let succeeds (x @ local) = overridden x
 [%%expect{|
-external overridden : ('a [@local_opt]) @ local unyielding -> unit
-  = "%ignore"
+external overridden : ('a [@local_opt]) @ local forkable -> unit = "%ignore"
 val succeeds : local_ 'a -> unit = <fun>
 |}]
 
-(* [mod global] implies [mod unyielding] by default. *)
+(* [mod global] implies [mod forkable] by default. *)
 
 type ('a : value mod global) u1
 
-type ('a : value mod global yielding) u2
+type ('a : value mod global unforkable) u2
 
-type w1 : value mod global yielding
+type w1 : value mod global unforkable
 
-type w2 : value mod global unyielding
+type w2 : value mod global forkable
 
 [%%expect{|
 type ('a : value mod global) u1
-type ('a : value mod global yielding) u2
-type w1 : value mod global yielding
+type ('a : value mod global unforkable) u2
+type w1 : value mod global unforkable
 type w2 : value mod global
 |}]
 
@@ -265,8 +267,8 @@ Line 1, characters 11-13:
 1 | type _z1 = w1 u1
                ^^
 Error: This type "w1" should be an instance of type "('a : value mod global)"
-       The kind of w1 is value mod global yielding
-         because of the definition of w1 at line 5, characters 0-35.
+       The kind of w1 is value mod global unforkable
+         because of the definition of w1 at line 5, characters 0-37.
        But the kind of w1 must be a subkind of value mod global
          because of the definition of u1 at line 1, characters 0-31.
 |}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1686,27 +1686,36 @@ let prim_mode' mvars = function
     Locality.allow_right Locality.local, None
   | Primitive.Prim_poly, _ ->
     match mvars with
-    | Some (mvar_l, mvar_y) -> mvar_l, Some mvar_y
+    | Some (mvar_l, (mvar_f, mvar_y)) -> mvar_l, Some (mvar_f, mvar_y)
     | None -> assert false
 
 (* Exported version. *)
 let prim_mode mvar prim =
-  let mvars = Option.map (fun mvar_l -> mvar_l, Yielding.newvar ()) mvar in
-  fst (prim_mode' mvars prim)
+  let mvar = Option.map
+    (fun mvar_l -> mvar_l, (Forkable.newvar (), Yielding.newvar ())) mvar
+  in
+  fst (prim_mode' mvar prim)
 
 (** Returns a new mode variable whose locality is the given locality and
     whose yieldingness is the given yieldingness, while all other axes are
     from the given [m]. This function is too specific to be put in [mode.ml] *)
-let with_locality_and_yielding (locality, yielding) m =
+let with_locality_and_forkable_yielding (locality, fy) m =
+  let forkable = Option.map fst fy in
+  let yielding = Option.map snd fy in
   let m' = Alloc.newvar () in
   Locality.equate_exn (Alloc.proj_comonadic Areality m') locality;
+  let forkable =
+    Option.value ~default:(Alloc.proj_comonadic Forkable m) forkable
+  in
   let yielding =
     Option.value ~default:(Alloc.proj_comonadic Yielding m) yielding
   in
+  Forkable.equate_exn (Alloc.proj_comonadic Forkable m') forkable;
   Yielding.equate_exn (Alloc.proj_comonadic Yielding m') yielding;
   let c =
     { Alloc.Comonadic.Const.max with
       areality = Locality.Const.min;
+      forkable = Forkable.Const.min;
       yielding = Yielding.Const.min}
   in
   Alloc.submode_exn (Alloc.meet_const c m') m;
@@ -1737,7 +1746,7 @@ let curry_mode alloc arg : Alloc.Const.t =
 let rec instance_prim_locals locals mvar_l mvar_y macc (loc, yld) ty =
   match locals, get_desc ty with
   | l :: locals, Tarrow ((lbl,marg,mret),arg,ret,commu) ->
-     let marg = with_locality_and_yielding
+     let marg = with_locality_and_forkable_yielding
       (prim_mode' (Some (mvar_l, mvar_y)) l) marg
      in
      let macc =
@@ -1749,7 +1758,7 @@ let rec instance_prim_locals locals mvar_l mvar_y macc (loc, yld) ty =
      in
      let mret =
        match locals with
-       | [] -> with_locality_and_yielding (loc, yld) mret
+       | [] -> with_locality_and_forkable_yielding (loc, yld) mret
        | _ :: _ ->
           let mret', _ = Alloc.newvar_above macc in (* curried arrow *)
           mret'
@@ -1830,11 +1839,11 @@ let instance_prim_mode (desc : Primitive.description) ty =
   if is_poly desc.prim_native_repr_res ||
        List.exists is_poly desc.prim_native_repr_args then
     let mode_l = Locality.newvar () in
-    let mode_y = Yielding.newvar () in
-    let finalret = prim_mode' (Some (mode_l, mode_y)) desc.prim_native_repr_res in
+    let mode_fy = Forkable.newvar (), Yielding.newvar () in
+    let finalret = prim_mode' (Some (mode_l, mode_fy)) desc.prim_native_repr_res in
     instance_prim_locals desc.prim_native_repr_args
-      mode_l mode_y (Alloc.disallow_right Alloc.legacy) finalret ty,
-    Some mode_l, Some mode_y
+      mode_l mode_fy (Alloc.disallow_right Alloc.legacy) finalret ty,
+    Some mode_l, Some mode_fy
   else
     ty, None, None
 
@@ -5110,6 +5119,7 @@ let mode_crossing_structure_memaddr =
     ~regionality:false
     ~linearity:true
     ~portability:true
+    ~forkable:true
     ~yielding:true
     ~statefulness:true
 
@@ -5122,6 +5132,7 @@ let mode_crossing_functor =
     ~regionality:false
     ~linearity:false
     ~portability:false
+    ~forkable:false
     ~yielding:false
     ~statefulness:false
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1840,7 +1840,9 @@ let instance_prim_mode (desc : Primitive.description) ty =
        List.exists is_poly desc.prim_native_repr_args then
     let mode_l = Locality.newvar () in
     let mode_fy = Forkable.newvar (), Yielding.newvar () in
-    let finalret = prim_mode' (Some (mode_l, mode_fy)) desc.prim_native_repr_res in
+    let finalret =
+      prim_mode' (Some (mode_l, mode_fy)) desc.prim_native_repr_res
+    in
     instance_prim_locals desc.prim_native_repr_args
       mode_l mode_fy (Alloc.disallow_right Alloc.legacy) finalret ty,
     Some mode_l, Some mode_fy

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -232,8 +232,9 @@ val prim_mode :
         -> (Mode.allowed * 'r) Mode.Locality.t
 val instance_prim:
         Primitive.description -> type_expr ->
-        type_expr * Mode.Locality.lr option
-        * Mode.Yielding.lr option * Jkind.Sort.t option
+        type_expr *
+        Mode.Locality.lr option * (Mode.Forkable.lr * Mode.Yielding.lr) option *
+        Jkind.Sort.t option
 
 (** Given (a @ m1 -> b -> c) @ m0, where [m0] and [m1] are modes expressed by
     user-syntax, [curry_mode m0 m1] gives the mode we implicitly interpret b->c

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -173,18 +173,24 @@ let value_descriptions ~loc env name
      match vd2.val_kind with
      | Val_prim p2 -> begin
          let locality = [ Mode.Locality.global; Mode.Locality.local ] in
+         let forkable = [ Mode.Forkable.forkable; Mode.Forkable.unforkable ] in
          let yielding = [ Mode.Yielding.unyielding; Mode.Yielding.yielding ] in
          List.iter (fun loc ->
+          List.iter (fun fork ->
            List.iter (fun yield ->
              let ty1, _, _, _ = Ctype.instance_prim p1 vd1.val_type in
-             let ty2, mode_l2, mode_y2, _ = Ctype.instance_prim p2 vd2.val_type in
+             let ty2, mode_l2, mode_fy2, _ = Ctype.instance_prim p2 vd2.val_type in
+             let mode_f2 = Option.map fst mode_fy2 in
+             let mode_y2 = Option.map snd mode_fy2 in
              Option.iter (Mode.Locality.equate_exn loc) mode_l2;
+             Option.iter (Mode.Forkable.equate_exn fork) (mode_f2);
              Option.iter (Mode.Yielding.equate_exn yield) mode_y2;
              try
                Ctype.moregeneral env true ty1 ty2
              with Ctype.Moregen err ->
                raise (Dont_match (Type err))
            ) yielding
+          ) forkable
          ) locality;
          match primitive_descriptions p1 p2 with
          | None -> Tcoerce_none

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -183,7 +183,7 @@ let value_descriptions ~loc env name
              let mode_f2 = Option.map fst mode_fy2 in
              let mode_y2 = Option.map snd mode_fy2 in
              Option.iter (Mode.Locality.equate_exn loc) mode_l2;
-             Option.iter (Mode.Forkable.equate_exn fork) (mode_f2);
+             Option.iter (Mode.Forkable.equate_exn fork) mode_f2;
              Option.iter (Mode.Yielding.equate_exn yield) mode_y2;
              try
                Ctype.moregeneral env true ty1 ty2

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -179,7 +179,9 @@ let value_descriptions ~loc env name
           List.iter (fun fork ->
            List.iter (fun yield ->
              let ty1, _, _, _ = Ctype.instance_prim p1 vd1.val_type in
-             let ty2, mode_l2, mode_fy2, _ = Ctype.instance_prim p2 vd2.val_type in
+             let ty2, mode_l2, mode_fy2, _ =
+               Ctype.instance_prim p2 vd2.val_type
+             in
              let mode_f2 = Option.map fst mode_fy2 in
              let mode_y2 = Option.map snd mode_fy2 in
              Option.iter (Mode.Locality.equate_exn loc) mode_l2;

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -259,6 +259,8 @@ let zap_axis_to_floor
       Mode.Linearity.zap_to_floor (Mode.Value.proj_comonadic Linearity m)
   | Comonadic Portability ->
       Mode.Portability.zap_to_floor (Mode.Value.proj_comonadic Portability  m)
+  | Comonadic Forkable ->
+      Mode.Forkable.zap_to_floor (Mode.Value.proj_comonadic Forkable m)
   | Comonadic Yielding ->
       Mode.Yielding.zap_to_floor (Mode.Value.proj_comonadic Yielding m)
   | Comonadic Statefulness ->
@@ -281,6 +283,8 @@ let zap_axis_to_ceil
       Mode.Linearity.zap_to_ceil (Mode.Value.proj_comonadic Linearity m)
   | Comonadic Portability ->
       Mode.Portability.zap_to_ceil (Mode.Value.proj_comonadic Portability m)
+  | Comonadic Forkable ->
+      Mode.Forkable.zap_to_ceil (Mode.Value.proj_comonadic Forkable m)
   | Comonadic Yielding ->
       Mode.Yielding.zap_to_ceil (Mode.Value.proj_comonadic Yielding m)
   | Comonadic Statefulness ->

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1802,8 +1802,11 @@ module Const = struct
             (* [global] implies [forkable unyielding], omit them. *)
             List.filter (fun m -> m <> "forkable" && m <> "unyielding") modes
           | true, true, false ->
-            (* [global] implies [forkable], omit it and print yielding. *)
+            (* [global] implies [forkable], omit it and print [yielding]. *)
             List.filter (fun m -> m <> "forkable") modes @ ["yielding"]
+          | false, true, true ->
+            (* [forkable] implies [unyielding], omit it. *)
+            List.filter (fun m -> m <> "unyielding") modes
           | true, false, true ->
             (* Print indicating [unforkable]. *)
             modes @ ["unforkable"]

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -482,6 +482,7 @@ module Mod_bounds = struct
     @@ Sub_result.combine (modal_less_or_equal (Comonadic Linearity))
     @@ Sub_result.combine (modal_less_or_equal (Monadic Contention))
     @@ Sub_result.combine (modal_less_or_equal (Comonadic Portability))
+    @@ Sub_result.combine (modal_less_or_equal (Comonadic Forkable))
     @@ Sub_result.combine (modal_less_or_equal (Comonadic Yielding))
     @@ Sub_result.combine (modal_less_or_equal (Comonadic Statefulness))
     @@ Sub_result.combine (modal_less_or_equal (Monadic Visibility))
@@ -1801,11 +1802,14 @@ module Const = struct
             (* [global] implies [forkable unyielding], omit them. *)
             List.filter (fun m -> m <> "forkable" && m <> "unyielding") modes
           | true, true, false ->
-            (* [global] implies [forkable], omit it but indicate [unyielding]. *)
-            List.filter (fun m -> m <> "forkable") modes @ ["unyielding"]
+            (* [global] implies [forkable], omit it and print yielding. *)
+            List.filter (fun m -> m <> "forkable") modes @ ["yielding"]
+          | true, false, true ->
+            (* Print indicating [unforkable]. *)
+            modes @ ["unforkable"]
           | true, false, false ->
-            (* Indicate both [forkable unyielding]. *)
-            modes @ ["forkable"; "unyielding"]
+            (* Print indicating [unforkable yielding]. *)
+            modes @ ["unforkable"; "yielding"]
           | _, _, _ -> modes
         in
         let modes =

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1793,27 +1793,21 @@ module Const = struct
       | Some modes ->
         (* Handle all the mode implications *)
         let modes =
-          match
-            ( List.mem "global" modes,
-              List.mem "forkable" modes,
-              List.mem "unyielding" modes )
-          with
-          | true, true, true ->
-            (* [global] implies [forkable unyielding], omit them. *)
-            List.filter (fun m -> m <> "forkable" && m <> "unyielding") modes
-          | true, true, false ->
-            (* [global] implies [forkable], omit it and print [yielding]. *)
-            List.filter (fun m -> m <> "forkable") modes @ ["yielding"]
-          | false, true, true ->
-            (* [forkable] implies [unyielding], omit it. *)
+          match List.mem "global" modes, List.mem "unyielding" modes with
+          | true, true ->
+            (* [global] implies [unyielding], omit it. *)
             List.filter (fun m -> m <> "unyielding") modes
-          | true, false, true ->
-            (* Print indicating [unforkable]. *)
-            modes @ ["unforkable"]
-          | true, false, false ->
-            (* Print indicating [unforkable yielding]. *)
-            modes @ ["unforkable"; "yielding"]
-          | _, _, _ -> modes
+          | true, false ->
+            (* Otherwise, print [mod global yielding] to indicate [yielding]. *)
+            modes @ ["yielding"]
+          | _, _ -> modes
+        in
+        let modes =
+          (* Likewise for [global] and [forkable]. *)
+          match List.mem "global" modes, List.mem "forkable" modes with
+          | true, true -> List.filter (fun m -> m <> "forkable") modes
+          | true, false -> modes @ ["unforkable"]
+          | _, _ -> modes
         in
         let modes =
           (* Likewise for [stateless] and [portable]. *)

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -311,12 +311,13 @@ module Axis_set = struct
     | Modal (Monadic Uniqueness) -> 2
     | Modal (Comonadic Portability) -> 3
     | Modal (Monadic Contention) -> 4
-    | Modal (Comonadic Yielding) -> 5
-    | Modal (Comonadic Statefulness) -> 6
-    | Modal (Monadic Visibility) -> 7
-    | Nonmodal Externality -> 8
-    | Nonmodal Nullability -> 9
-    | Nonmodal Separability -> 10
+    | Modal (Comonadic Forkable) -> 5
+    | Modal (Comonadic Yielding) -> 6
+    | Modal (Comonadic Statefulness) -> 7
+    | Modal (Monadic Visibility) -> 8
+    | Nonmodal Externality -> 9
+    | Nonmodal Nullability -> 10
+    | Nonmodal Separability -> 11
 
   let[@inline] axis_mask ax = 1 lsl axis_index ax
 
@@ -341,6 +342,7 @@ module Axis_set = struct
     |> set_axis (Modal (Monadic Uniqueness))
     |> set_axis (Modal (Comonadic Portability))
     |> set_axis (Modal (Monadic Contention))
+    |> set_axis (Modal (Comonadic Forkable))
     |> set_axis (Modal (Comonadic Yielding))
     |> set_axis (Modal (Comonadic Statefulness))
     |> set_axis (Modal (Monadic Visibility))

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -188,6 +188,7 @@ module Axis = struct
       Pack (Modal (Comonadic Linearity));
       Pack (Modal (Monadic Contention));
       Pack (Modal (Comonadic Portability));
+      Pack (Modal (Comonadic Forkable));
       Pack (Modal (Comonadic Yielding));
       Pack (Modal (Comonadic Statefulness));
       Pack (Modal (Monadic Visibility));

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2767,7 +2767,12 @@ module Comonadic_with (Areality : Areality) = struct
     let compare = Axis.compare
 
     let all =
-      [P Areality; P Linearity; P Portability; P Yielding; P Statefulness]
+      [ P Areality;
+        P Linearity;
+        P Portability;
+        P Forkable;
+        P Yielding;
+        P Statefulness ]
       |> List.sort (fun (P ax0) (P ax1) -> compare ax0 ax1)
   end
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2846,6 +2846,7 @@ module Comonadic_with (Areality : Areality) = struct
     let { areality = areality1;
           linearity = linearity1;
           portability = portability1;
+          forkable = forkable1;
           yielding = yielding1;
           statefulness = statefulness1
         } =
@@ -2854,6 +2855,7 @@ module Comonadic_with (Areality : Areality) = struct
     let { areality = areality2;
           linearity = linearity2;
           portability = portability2;
+          forkable = forkable2;
           yielding = yielding2;
           statefulness = statefulness2
         } =
@@ -2865,14 +2867,17 @@ module Comonadic_with (Areality : Areality) = struct
       then
         if Portability.Const.le portability1 portability2
         then
-          if Yielding.Const.le yielding1 yielding2
+          if Forkable.Const.le forkable1 forkable2
           then
-            if Statefulness.Const.le statefulness1 statefulness2
-            then assert false
-            else
-              Error
-                (Statefulness, { left = statefulness1; right = statefulness2 })
-          else Error (Yielding, { left = yielding1; right = yielding2 })
+            if Yielding.Const.le yielding1 yielding2
+            then
+              if Statefulness.Const.le statefulness1 statefulness2
+              then assert false
+              else
+                Error
+                  (Statefulness, { left = statefulness1; right = statefulness2 })
+            else Error (Yielding, { left = yielding1; right = yielding2 })
+          else Error (Forkable, { left = forkable1; right = forkable2 })
         else Error (Portability, { left = portability1; right = portability2 })
       else Error (Linearity, { left = linearity1; right = linearity2 })
     else Error (Areality, { left = areality1; right = areality2 })

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -497,6 +497,47 @@ module Lattices = struct
     end)
   end
 
+  module Forkable = struct
+    type t =
+      | Unforkable
+      | Forkable
+
+    include Total.Heyting (struct
+      type nonrec t = t
+
+      let min = Forkable
+
+      let max = Unforkable
+
+      let legacy = Forkable
+
+      let[@inline] le a b =
+        match a, b with
+        | Forkable, _ | _, Unforkable -> true
+        | Unforkable, Forkable -> false
+
+      let[@inline] equal a b =
+        match a, b with
+        | Unforkable, Unforkable -> true
+        | Forkable, Forkable -> true
+        | Unforkable, Forkable | Forkable, Unforkable -> false
+
+      let join a b =
+        match a, b with
+        | Unforkable, _ | _, Unforkable -> Unforkable
+        | Forkable, Forkable -> Forkable
+
+      let meet a b =
+        match a, b with
+        | Forkable, _ | _, Forkable -> Forkable
+        | Unforkable, Unforkable -> Unforkable
+
+      let print ppf = function
+        | Unforkable -> Format.fprintf ppf "unforkable"
+        | Forkable -> Format.fprintf ppf "forkable"
+    end)
+  end
+
   module Yielding = struct
     type t =
       | Yielding
@@ -726,6 +767,7 @@ module Lattices = struct
     { areality : 'areality;
       linearity : Linearity.t;
       portability : Portability.t;
+      forkable : Forkable.t;
       yielding : Yielding.t;
       statefulness : Statefulness.t
     }
@@ -737,30 +779,34 @@ module Lattices = struct
       let areality = Areality.min in
       let linearity = Linearity.min in
       let portability = Portability.min in
+      let forkable = Forkable.min in
       let yielding = Yielding.min in
       let statefulness = Statefulness.min in
-      { areality; linearity; portability; yielding; statefulness }
+      { areality; linearity; portability; forkable; yielding; statefulness }
 
     let max =
       let areality = Areality.max in
       let linearity = Linearity.max in
       let portability = Portability.max in
+      let forkable = Forkable.max in
       let yielding = Yielding.max in
       let statefulness = Statefulness.max in
-      { areality; linearity; portability; yielding; statefulness }
+      { areality; linearity; portability; forkable; yielding; statefulness }
 
     let legacy =
       let areality = Areality.legacy in
       let linearity = Linearity.legacy in
       let portability = Portability.legacy in
+      let forkable = Forkable.legacy in
       let yielding = Yielding.legacy in
       let statefulness = Statefulness.legacy in
-      { areality; linearity; portability; yielding; statefulness }
+      { areality; linearity; portability; forkable; yielding; statefulness }
 
     let le m1 m2 =
       let { areality = areality1;
             linearity = linearity1;
             portability = portability1;
+            forkable = forkable1;
             yielding = yielding1;
             statefulness = statefulness1
           } =
@@ -769,6 +815,7 @@ module Lattices = struct
       let { areality = areality2;
             linearity = linearity2;
             portability = portability2;
+            forkable = forkable2;
             yielding = yielding2;
             statefulness = statefulness2
           } =
@@ -777,6 +824,7 @@ module Lattices = struct
       Areality.le areality1 areality2
       && Linearity.le linearity1 linearity2
       && Portability.le portability1 portability2
+      && Forkable.le forkable1 forkable2
       && Yielding.le yielding1 yielding2
       && Statefulness.le statefulness1 statefulness2
 
@@ -784,6 +832,7 @@ module Lattices = struct
       let { areality = areality1;
             linearity = linearity1;
             portability = portability1;
+            forkable = forkable1;
             yielding = yielding1;
             statefulness = statefulness1
           } =
@@ -792,6 +841,7 @@ module Lattices = struct
       let { areality = areality2;
             linearity = linearity2;
             portability = portability2;
+            forkable = forkable2;
             yielding = yielding2;
             statefulness = statefulness2
           } =
@@ -800,6 +850,7 @@ module Lattices = struct
       Areality.equal areality1 areality2
       && Linearity.equal linearity1 linearity2
       && Portability.equal portability1 portability2
+      && Forkable.equal forkable1 forkable2
       && Yielding.equal yielding1 yielding2
       && Statefulness.equal statefulness1 statefulness2
 
@@ -807,25 +858,28 @@ module Lattices = struct
       let areality = Areality.join m1.areality m2.areality in
       let linearity = Linearity.join m1.linearity m2.linearity in
       let portability = Portability.join m1.portability m2.portability in
+      let forkable = Forkable.join m1.forkable m2.forkable in
       let yielding = Yielding.join m1.yielding m2.yielding in
       let statefulness = Statefulness.join m1.statefulness m2.statefulness in
-      { areality; linearity; portability; yielding; statefulness }
+      { areality; linearity; portability; forkable; yielding; statefulness }
 
     let meet m1 m2 =
       let areality = Areality.meet m1.areality m2.areality in
       let linearity = Linearity.meet m1.linearity m2.linearity in
       let portability = Portability.meet m1.portability m2.portability in
+      let forkable = Forkable.meet m1.forkable m2.forkable in
       let yielding = Yielding.meet m1.yielding m2.yielding in
       let statefulness = Statefulness.meet m1.statefulness m2.statefulness in
-      { areality; linearity; portability; yielding; statefulness }
+      { areality; linearity; portability; forkable; yielding; statefulness }
 
     let imply m1 m2 =
       let areality = Areality.imply m1.areality m2.areality in
       let linearity = Linearity.imply m1.linearity m2.linearity in
       let portability = Portability.imply m1.portability m2.portability in
+      let forkable = Forkable.imply m1.forkable m2.forkable in
       let yielding = Yielding.imply m1.yielding m2.yielding in
       let statefulness = Statefulness.imply m1.statefulness m2.statefulness in
-      { areality; linearity; portability; yielding; statefulness }
+      { areality; linearity; portability; forkable; yielding; statefulness }
 
     let print ppf m =
       Format.fprintf ppf "%a,%a,%a,%a,%a" Areality.print m.areality
@@ -887,6 +941,7 @@ module Lattices = struct
     | Uniqueness_op : Uniqueness_op.t obj
     | Linearity : Linearity.t obj
     | Portability : Portability.t obj
+    | Forkable : Forkable.t obj
     | Yielding : Yielding.t obj
     | Statefulness : Statefulness.t obj
     | Contention_op : Contention_op.t obj
@@ -901,6 +956,7 @@ module Lattices = struct
     | Uniqueness_op -> true
     | Linearity -> false
     | Portability -> false
+    | Forkable -> false
     | Yielding -> false
     | Statefulness -> false
     | Contention_op -> true
@@ -916,6 +972,7 @@ module Lattices = struct
     | Uniqueness_op -> Format.fprintf ppf "Uniqueness_op"
     | Linearity -> Format.fprintf ppf "Linearity"
     | Portability -> Format.fprintf ppf "Portability"
+    | Forkable -> Format.fprintf ppf "Forkable"
     | Yielding -> Format.fprintf ppf "Yielding"
     | Statefulness -> Format.fprintf ppf "Statefulness"
     | Contention_op -> Format.fprintf ppf "Contention_op"
@@ -931,6 +988,7 @@ module Lattices = struct
     | Uniqueness_op -> Uniqueness_op.min
     | Contention_op -> Contention_op.min
     | Visibility_op -> Visibility_op.min
+    | Forkable -> Forkable.min
     | Yielding -> Yielding.min
     | Statefulness -> Statefulness.min
     | Linearity -> Linearity.min
@@ -947,6 +1005,7 @@ module Lattices = struct
     | Visibility_op -> Visibility_op.max
     | Linearity -> Linearity.max
     | Portability -> Portability.max
+    | Forkable -> Forkable.max
     | Yielding -> Yielding.max
     | Statefulness -> Statefulness.max
     | Monadic_op -> Monadic_op.max
@@ -963,6 +1022,7 @@ module Lattices = struct
     | Visibility_op -> Visibility_op.le a b
     | Linearity -> Linearity.le a b
     | Portability -> Portability.le a b
+    | Forkable -> Forkable.le a b
     | Yielding -> Yielding.le a b
     | Statefulness -> Statefulness.le a b
     | Monadic_op -> Monadic_op.le a b
@@ -979,6 +1039,7 @@ module Lattices = struct
     | Visibility_op -> Visibility_op.join a b
     | Linearity -> Linearity.join a b
     | Portability -> Portability.join a b
+    | Forkable -> Forkable.join a b
     | Yielding -> Yielding.join a b
     | Statefulness -> Statefulness.join a b
     | Monadic_op -> Monadic_op.join a b
@@ -995,6 +1056,7 @@ module Lattices = struct
     | Visibility_op -> Visibility_op.meet a b
     | Linearity -> Linearity.meet a b
     | Portability -> Portability.meet a b
+    | Forkable -> Forkable.meet a b
     | Yielding -> Yielding.meet a b
     | Statefulness -> Statefulness.meet a b
     | Monadic_op -> Monadic_op.meet a b
@@ -1011,6 +1073,7 @@ module Lattices = struct
     | Visibility_op -> Visibility_op.imply a b
     | Linearity -> Linearity.imply a b
     | Portability -> Portability.imply a b
+    | Forkable -> Forkable.imply a b
     | Yielding -> Yielding.imply a b
     | Statefulness -> Statefulness.imply a b
     | Comonadic_with_locality -> Comonadic_with_locality.imply a b
@@ -1026,6 +1089,7 @@ module Lattices = struct
     | Visibility_op -> Visibility_op.print
     | Linearity -> Linearity.print
     | Portability -> Portability.print
+    | Forkable -> Forkable.print
     | Yielding -> Yielding.print
     | Statefulness -> Statefulness.print
     | Monadic_op -> Monadic_op.print
@@ -1046,13 +1110,15 @@ module Lattices = struct
       | Linearity, Linearity -> Some Refl
       | Portability, Portability -> Some Refl
       | Yielding, Yielding -> Some Refl
+      | Forkable, Forkable -> Some Refl
       | Statefulness, Statefulness -> Some Refl
       | Monadic_op, Monadic_op -> Some Refl
       | Comonadic_with_locality, Comonadic_with_locality -> Some Refl
       | Comonadic_with_regionality, Comonadic_with_regionality -> Some Refl
       | ( ( Locality | Regionality | Uniqueness_op | Contention_op
-          | Visibility_op | Linearity | Portability | Yielding | Statefulness
-          | Monadic_op | Comonadic_with_locality | Comonadic_with_regionality ),
+          | Visibility_op | Linearity | Portability | Forkable | Yielding
+          | Statefulness | Monadic_op | Comonadic_with_locality
+          | Comonadic_with_regionality ),
           _ ) ->
         None
   end)
@@ -1066,6 +1132,7 @@ module Lattices_mono = struct
   module Axis = struct
     type ('t, 'r) t =
       | Areality : ('a comonadic_with, 'a) t
+      | Forkable : ('areality comonadic_with, Forkable.t) t
       | Yielding : ('areality comonadic_with, Yielding.t) t
       | Linearity : ('areality comonadic_with, Linearity.t) t
       | Statefulness : ('areality comonadic_with, Statefulness.t) t
@@ -1076,13 +1143,14 @@ module Lattices_mono = struct
 
     let to_int : type a b. (a, b) t -> int = function
       | Areality -> 0
-      | Yielding -> 1
-      | Linearity -> 2
-      | Statefulness -> 3
-      | Portability -> 4
-      | Uniqueness -> 5
-      | Visibility -> 6
-      | Contention -> 7
+      | Forkable -> 1
+      | Yielding -> 2
+      | Linearity -> 3
+      | Statefulness -> 4
+      | Portability -> 5
+      | Uniqueness -> 6
+      | Visibility -> 7
+      | Contention -> 8
 
     let compare a b = to_int a - to_int b
 
@@ -1093,6 +1161,7 @@ module Lattices_mono = struct
       | Portability -> Format.fprintf ppf "portability"
       | Uniqueness -> Format.fprintf ppf "uniqueness"
       | Contention -> Format.fprintf ppf "contention"
+      | Forkable -> Format.fprintf ppf "forkable"
       | Yielding -> Format.fprintf ppf "yielding"
       | Statefulness -> Format.fprintf ppf "statefulness"
       | Visibility -> Format.fprintf ppf "visibility"
@@ -1105,11 +1174,12 @@ module Lattices_mono = struct
       | Portability, Portability -> Some Refl
       | Uniqueness, Uniqueness -> Some Refl
       | Contention, Contention -> Some Refl
+      | Forkable, Forkable -> Some Refl
       | Yielding, Yielding -> Some Refl
       | Statefulness, Statefulness -> Some Refl
       | Visibility, Visibility -> Some Refl
       | ( ( Areality | Linearity | Uniqueness | Portability | Contention
-          | Yielding | Statefulness | Visibility ),
+          | Forkable | Yielding | Statefulness | Visibility ),
           _ ) ->
         None
 
@@ -1119,6 +1189,7 @@ module Lattices_mono = struct
       | Areality -> t.areality
       | Linearity -> t.linearity
       | Portability -> t.portability
+      | Forkable -> t.forkable
       | Yielding -> t.yielding
       | Statefulness -> t.statefulness
       | Uniqueness -> t.uniqueness
@@ -1131,6 +1202,7 @@ module Lattices_mono = struct
       | Areality -> { t with areality = r }
       | Linearity -> { t with linearity = r }
       | Portability -> { t with portability = r }
+      | Forkable -> { t with forkable = r }
       | Yielding -> { t with yielding = r }
       | Statefulness -> { t with statefulness = r }
       | Uniqueness -> { t with uniqueness = r }
@@ -1291,6 +1363,8 @@ module Lattices_mono = struct
     | Linearity, Comonadic_with_regionality -> Linearity
     | Portability, Comonadic_with_locality -> Portability
     | Portability, Comonadic_with_regionality -> Portability
+    | Forkable, Comonadic_with_locality -> Forkable
+    | Forkable, Comonadic_with_regionality -> Forkable
     | Yielding, Comonadic_with_locality -> Yielding
     | Yielding, Comonadic_with_regionality -> Yielding
     | Statefulness, Comonadic_with_locality -> Statefulness
@@ -1306,7 +1380,7 @@ module Lattices_mono = struct
     | Regionality -> Comonadic_with_regionality
     | Uniqueness_op | Linearity | Monadic_op | Comonadic_with_regionality
     | Comonadic_with_locality | Contention_op | Visibility_op | Portability
-    | Yielding | Statefulness ->
+    | Forkable | Yielding | Statefulness ->
       assert false
 
   let rec src : type a b l r. b obj -> (a, b, l * r) morph -> a obj =
@@ -1480,9 +1554,10 @@ module Lattices_mono = struct
     in
     let linearity = unique_to_linear m.uniqueness in
     let portability = contended_to_portable m.contention in
+    let forkable = Forkable.min in
     let yielding = Yielding.min in
     let statefulness = visibility_to_statefulness m.visibility in
-    { areality; linearity; portability; yielding; statefulness }
+    { areality; linearity; portability; forkable; yielding; statefulness }
 
   let comonadic_to_monadic :
       type a. a comonadic_with obj -> a comonadic_with -> Monadic_op.t =
@@ -1502,9 +1577,10 @@ module Lattices_mono = struct
     in
     let linearity = unique_to_linear m.uniqueness in
     let portability = contended_to_portable m.contention in
+    let forkable = Forkable.max in
     let yielding = Yielding.max in
     let statefulness = visibility_to_statefulness m.visibility in
-    { areality; linearity; portability; yielding; statefulness }
+    { areality; linearity; portability; forkable; yielding; statefulness }
 
   let rec apply : type a b l r. b obj -> (a, b, l * r) morph -> a -> b =
    fun dst f a ->
@@ -1588,6 +1664,7 @@ module Lattices_mono = struct
         | Areality -> NoneResponsible
         | Linearity -> Axis Uniqueness
         | Portability -> Axis Contention
+        | Forkable -> NoneResponsible
         | Yielding -> NoneResponsible
         | Statefulness -> Axis Visibility
       in
@@ -1606,6 +1683,7 @@ module Lattices_mono = struct
            the result is put back into the areality axis. See [Lattices_mono.apply] *)
         match ax with
         | Areality -> Axis Areality
+        | Forkable -> Axis Forkable
         | Yielding -> Axis Yielding
         | Linearity -> Axis Linearity
         | Statefulness -> Axis Statefulness
@@ -1677,6 +1755,7 @@ module Lattices_mono = struct
       | Areality -> Some (compose dst f (Proj (src', Areality)))
       | Linearity -> Some (Proj (src', Linearity))
       | Portability -> Some (Proj (src', Portability))
+      | Forkable -> Some (Proj (src', Forkable))
       | Yielding -> Some (Proj (src', Yielding))
       | Statefulness -> Some (Proj (src', Statefulness)))
     | Proj _, Monadic_to_comonadic_min -> None
@@ -1824,6 +1903,7 @@ type 'a comonadic_with = 'a C.comonadic_with =
   { areality : 'a;
     linearity : C.Linearity.t;
     portability : C.Portability.t;
+    forkable : C.Forkable.t;
     yielding : C.Yielding.t;
     statefulness : C.Statefulness.t
   }
@@ -2598,6 +2678,29 @@ module Contention = struct
     | Visibility.Const.Immutable -> zap_to_ceil
 end
 
+module Forkable = struct
+  module Const = C.Forkable
+
+  module Obj = struct
+    type const = Const.t
+
+    let obj = C.Forkable
+  end
+
+  include Comonadic_gen (Obj)
+
+  let unforkable = of_const Unforkable
+
+  let forkable = of_const Forkable
+
+  let legacy = of_const Const.legacy
+
+  (* [forkable] is the default for [global]s and [unforkable] for [local]
+     or [regional] values, so we vary [zap_to_legacy] accordingly. *)
+  let zap_to_legacy ~global =
+    match global with true -> zap_to_floor | false -> zap_to_ceil
+end
+
 module Yielding = struct
   module Const = C.Yielding
 
@@ -2615,10 +2718,10 @@ module Yielding = struct
 
   let legacy = of_const Const.legacy
 
-  (* [unyielding] is the default for [global]s and [yielding] for [local]
-     or [regional] values, so we vary [zap_to_legacy] accordingly. *)
-  let zap_to_legacy ~global =
-    match global with true -> zap_to_floor | false -> zap_to_ceil
+  (* [unyielding] is the default for [forkable]s and [yielding] for [unforkable],
+     so we vary [zap_to_legacy] accordingly. *)
+  let zap_to_legacy ~forkable =
+    match forkable with true -> zap_to_floor | false -> zap_to_ceil
 end
 
 let regional_to_local m = S.apply Locality.Obj.obj C.Regional_to_local m
@@ -2727,8 +2830,12 @@ module Comonadic_with (Areality : Areality) = struct
       proj Portability m |> Portability.zap_to_legacy ~statefulness
     in
     let global = Areality.Const.(equal areality legacy) in
-    let yielding = proj Yielding m |> Yielding.zap_to_legacy ~global in
-    { areality; linearity; portability; yielding; statefulness }
+    let forkable = proj Forkable m |> Forkable.zap_to_legacy ~global in
+    let yielding =
+      proj Yielding m
+      |> Yielding.zap_to_legacy ~forkable:Forkable.Const.(equal forkable legacy)
+    in
+    { areality; linearity; portability; forkable; yielding; statefulness }
 
   let legacy = of_const Const.legacy
 
@@ -2956,21 +3063,23 @@ module Value_with (Areality : Areality) = struct
     | Monadic ax -> Monadic.proj_obj ax
     | Comonadic ax -> Comonadic.proj_obj ax
 
-  type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h) modes =
+  type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) modes =
     { areality : 'a;
       linearity : 'b;
       uniqueness : 'c;
       portability : 'd;
       contention : 'e;
-      yielding : 'f;
-      statefulness : 'g;
-      visibility : 'h
+      forkable : 'f;
+      yielding : 'g;
+      statefulness : 'h;
+      visibility : 'i
     }
 
   let split
       { areality;
         linearity;
         portability;
+        forkable;
         yielding;
         statefulness;
         uniqueness;
@@ -2979,12 +3088,12 @@ module Value_with (Areality : Areality) = struct
       } =
     let monadic : Monadic.Const.t = { uniqueness; contention; visibility } in
     let comonadic : Comonadic.Const.t =
-      { areality; linearity; portability; yielding; statefulness }
+      { areality; linearity; portability; forkable; yielding; statefulness }
     in
     { comonadic; monadic }
 
   let merge { comonadic; monadic } =
-    let ({ areality; linearity; portability; yielding; statefulness }
+    let ({ areality; linearity; portability; forkable; yielding; statefulness }
           : Comonadic.Const.t) =
       comonadic
     in
@@ -2992,6 +3101,7 @@ module Value_with (Areality : Areality) = struct
     { areality;
       linearity;
       portability;
+      forkable;
       yielding;
       statefulness;
       uniqueness;
@@ -3035,6 +3145,7 @@ module Value_with (Areality : Areality) = struct
         Uniqueness.Const.t,
         Portability.Const.t,
         Contention.Const.t,
+        Forkable.Const.t,
         Yielding.Const.t,
         Statefulness.Const.t,
         Visibility.Const.t )
@@ -3085,6 +3196,7 @@ module Value_with (Areality : Areality) = struct
           Uniqueness.Const.t option,
           Portability.Const.t option,
           Contention.Const.t option,
+          Forkable.Const.t option,
           Yielding.Const.t option,
           Statefulness.Const.t option,
           Visibility.Const.t option )
@@ -3096,6 +3208,7 @@ module Value_with (Areality : Areality) = struct
           linearity = None;
           portability = None;
           contention = None;
+          forkable = None;
           yielding = None;
           statefulness = None;
           visibility = None
@@ -3114,6 +3227,7 @@ module Value_with (Areality : Areality) = struct
           Option.value opt.contention ~default:default.contention
         in
         let yielding = Option.value opt.yielding ~default:default.yielding in
+        let forkable = Option.value opt.forkable ~default:default.forkable in
         let statefulness =
           Option.value opt.statefulness ~default:default.statefulness
         in
@@ -3125,6 +3239,7 @@ module Value_with (Areality : Areality) = struct
           linearity;
           portability;
           contention;
+          forkable;
           yielding;
           statefulness;
           visibility
@@ -3142,6 +3257,7 @@ module Value_with (Areality : Areality) = struct
           | Areality -> t.areality
           | Linearity -> t.linearity
           | Portability -> t.portability
+          | Forkable -> t.forkable
           | Yielding -> t.yielding
           | Statefulness -> t.statefulness)
 
@@ -3158,6 +3274,7 @@ module Value_with (Areality : Areality) = struct
           | Linearity -> { t with linearity = a }
           | Portability -> { t with portability = a }
           | Yielding -> { t with yielding = a }
+          | Forkable -> { t with forkable = a }
           | Statefulness -> { t with statefulness = a })
 
       let print ppf
@@ -3166,6 +3283,7 @@ module Value_with (Areality : Areality) = struct
             linearity;
             portability;
             contention;
+            forkable;
             yielding;
             statefulness;
             visibility
@@ -3174,7 +3292,7 @@ module Value_with (Areality : Areality) = struct
           | None -> Format.fprintf ppf "None"
           | Some a -> Format.fprintf ppf "Some %a" print a
         in
-        Format.fprintf ppf "%a,%a,%a,%a,%a,%a,%a,%a"
+        Format.fprintf ppf "%a,%a,%a,%a,%a,%a,%a,%a,%a"
           (option_print Areality.Const.print)
           areality
           (option_print Linearity.Const.print)
@@ -3185,6 +3303,8 @@ module Value_with (Areality : Areality) = struct
           portability
           (option_print Contention.Const.print)
           contention
+          (option_print Forkable.Const.print)
+          forkable
           (option_print Yielding.Const.print)
           yielding
           (option_print Statefulness.Const.print)
@@ -3202,6 +3322,7 @@ module Value_with (Areality : Areality) = struct
         diff Portability.Const.le m0.portability m1.portability
       in
       let contention = diff Contention.Const.le m0.contention m1.contention in
+      let forkable = diff Forkable.Const.le m0.forkable m1.forkable in
       let yielding = diff Yielding.Const.le m0.yielding m1.yielding in
       let statefulness =
         diff Statefulness.Const.le m0.statefulness m1.statefulness
@@ -3212,6 +3333,7 @@ module Value_with (Areality : Areality) = struct
         uniqueness;
         portability;
         contention;
+        forkable;
         yielding;
         statefulness;
         visibility
@@ -3484,6 +3606,7 @@ module Const = struct
          portability;
          uniqueness;
          contention;
+         forkable;
          yielding;
          statefulness;
          visibility
@@ -3495,6 +3618,7 @@ module Const = struct
       portability;
       uniqueness;
       contention;
+      forkable;
       yielding;
       statefulness;
       visibility
@@ -3507,6 +3631,7 @@ module Const = struct
       | Comonadic Areality -> Left Refl
       | Comonadic Linearity -> Right (Comonadic Linearity)
       | Comonadic Portability -> Right (Comonadic Portability)
+      | Comonadic Forkable -> Right (Comonadic Forkable)
       | Comonadic Yielding -> Right (Comonadic Yielding)
       | Comonadic Statefulness -> Right (Comonadic Statefulness)
       | Monadic Uniqueness -> Right (Monadic Uniqueness)
@@ -4242,10 +4367,18 @@ module Crossing = struct
     let create ~regionality:(Atom.Modality (Meet_with areality))
         ~linearity:(Atom.Modality (Meet_with linearity))
         ~portability:(Atom.Modality (Meet_with portability))
+        ~forkable:(Atom.Modality (Meet_with forkable))
         ~yielding:(Atom.Modality (Meet_with yielding))
         ~statefulness:(Atom.Modality (Meet_with statefulness)) =
       Modality
-        (Meet_const { areality; linearity; portability; statefulness; yielding })
+        (Meet_const
+           { areality;
+             linearity;
+             portability;
+             statefulness;
+             forkable;
+             yielding
+           })
 
     let proj (type a) (ax : a Mode.Axis.t) (Modality (Meet_const c)) : a Atom.t
         =
@@ -4438,7 +4571,7 @@ module Crossing = struct
     | Comonadic ax -> (Comonadic.proj [@inlined hint]) ax comonadic
 
   let create ~regionality ~linearity ~uniqueness ~portability ~contention
-      ~yielding ~statefulness ~visibility =
+      ~forkable ~yielding ~statefulness ~visibility =
     let regionality =
       if regionality
       then Per_axis.min (Comonadic Areality)
@@ -4464,6 +4597,11 @@ module Crossing = struct
       then Per_axis.min (Monadic Contention)
       else Per_axis.max (Monadic Contention)
     in
+    let forkable =
+      if forkable
+      then Per_axis.min (Comonadic Forkable)
+      else Per_axis.max (Comonadic Forkable)
+    in
     let yielding =
       if yielding
       then Per_axis.min (Comonadic Yielding)
@@ -4481,7 +4619,7 @@ module Crossing = struct
     in
     let monadic = Monadic.create ~uniqueness ~contention ~visibility in
     let comonadic =
-      Comonadic.create ~regionality ~linearity ~portability ~yielding
+      Comonadic.create ~regionality ~linearity ~portability ~yielding ~forkable
         ~statefulness
     in
     { monadic; comonadic }

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -364,6 +364,22 @@ module type S = sig
     include Common_axis_neg with module Const := Const
   end
 
+  module Forkable : sig
+    module Const : sig
+      type t =
+        | Unforkable
+        | Forkable
+
+      include Lattice with type t := t
+    end
+
+    include Common_axis_pos with module Const := Const
+
+    val unforkable : lr
+
+    val forkable : lr
+  end
+
   module Yielding : sig
     module Const : sig
       type t =
@@ -422,6 +438,7 @@ module type S = sig
     { areality : 'a;
       linearity : Linearity.Const.t;
       portability : Portability.Const.t;
+      forkable : Forkable.Const.t;
       yielding : Yielding.Const.t;
       statefulness : Statefulness.Const.t
     }
@@ -439,6 +456,7 @@ module type S = sig
     NB: must listed in the order of axis implication. See [typemode.ml]. *)
     type ('p, 'r) t =
       | Areality : ('a comonadic_with, 'a) t
+      | Forkable : ('areality comonadic_with, Forkable.Const.t) t
       | Yielding : ('areality comonadic_with, Yielding.Const.t) t
       | Linearity : ('areality comonadic_with, Linearity.Const.t) t
       | Statefulness : ('areality comonadic_with, Statefulness.Const.t) t
@@ -493,15 +511,16 @@ module type S = sig
       include Axis with type 'a t := 'a t
     end
 
-    type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h) modes =
+    type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) modes =
       { areality : 'a;
         linearity : 'b;
         uniqueness : 'c;
         portability : 'd;
         contention : 'e;
-        yielding : 'f;
-        statefulness : 'g;
-        visibility : 'h
+        forkable : 'f;
+        yielding : 'g;
+        statefulness : 'h;
+        visibility : 'i
       }
 
     module Const : sig
@@ -513,6 +532,7 @@ module type S = sig
               Uniqueness.Const.t,
               Portability.Const.t,
               Contention.Const.t,
+              Forkable.Const.t,
               Yielding.Const.t,
               Statefulness.Const.t,
               Visibility.Const.t )
@@ -527,6 +547,7 @@ module type S = sig
             Uniqueness.Const.t option,
             Portability.Const.t option,
             Contention.Const.t option,
+            Forkable.Const.t option,
             Yielding.Const.t option,
             Statefulness.Const.t option,
             Visibility.Const.t option )
@@ -921,6 +942,7 @@ module type S = sig
         regionality:Regionality.Const.t Atom.t ->
         linearity:Linearity.Const.t Atom.t ->
         portability:Portability.Const.t Atom.t ->
+        forkable:Forkable.Const.t Atom.t ->
         yielding:Yielding.Const.t Atom.t ->
         statefulness:Statefulness.Const.t Atom.t ->
         t
@@ -957,6 +979,7 @@ module type S = sig
       uniqueness:bool ->
       portability:bool ->
       contention:bool ->
+      forkable:bool ->
       yielding:bool ->
       statefulness:bool ->
       visibility:bool ->

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1440,7 +1440,7 @@ let tree_of_mode_old (t : Parsetree.mode loc) =
 let tree_of_mode_new (t: Parsetree.mode loc) =
   let Mode s = t.txt in Omd_new s
 
-let[@warning "-21-26"] tree_of_modes (modes : Mode.Alloc.Const.t) =
+let tree_of_modes (modes : Mode.Alloc.Const.t) =
   let diff = Mode.Alloc.Const.diff modes Mode.Alloc.Const.legacy in
 
   (* [forkable] has implied defaults depending on [areality]: *)

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1440,7 +1440,7 @@ let tree_of_mode_old (t : Parsetree.mode loc) =
 let tree_of_mode_new (t: Parsetree.mode loc) =
   let Mode s = t.txt in Omd_new s
 
-let tree_of_modes (modes : Mode.Alloc.Const.t) =
+let[@warning "-21-26"] tree_of_modes (modes : Mode.Alloc.Const.t) =
   let diff = Mode.Alloc.Const.diff modes Mode.Alloc.Const.legacy in
 
   (* [forkable] has implied defaults depending on [areality]: *)
@@ -1450,10 +1450,10 @@ let tree_of_modes (modes : Mode.Alloc.Const.t) =
     | _, _ -> Some modes.forkable
   in
 
-  (* [yielding] has implied defaults depending on [forkable]: *)
+  (* [yielding] has implied defaults depending on [areality]: *)
   let yielding =
-    match modes.forkable, modes.yielding with
-    | Unforkable, Yielding | Forkable, Unyielding -> None
+    match modes.areality, modes.yielding with
+    | Local, Yielding | Global, Unyielding -> None
     | _, _ -> Some modes.yielding
   in
 

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1443,10 +1443,17 @@ let tree_of_mode_new (t: Parsetree.mode loc) =
 let tree_of_modes (modes : Mode.Alloc.Const.t) =
   let diff = Mode.Alloc.Const.diff modes Mode.Alloc.Const.legacy in
 
-  (* [yielding] has implied defaults depending on [areality]: *)
+  (* [forkable] has implied defaults depending on [areality]: *)
+  let forkable =
+    match modes.areality, modes.forkable with
+    | Local, Unforkable | Global, Forkable -> None
+    | _, _ -> Some modes.forkable
+  in
+
+  (* [yielding] has implied defaults depending on [forkable]: *)
   let yielding =
-    match modes.areality, modes.yielding with
-    | Local, Yielding | Global, Unyielding -> None
+    match modes.forkable, modes.yielding with
+    | Unforkable, Yielding | Forkable, Unyielding -> None
     | _, _ -> Some modes.yielding
   in
 
@@ -1464,7 +1471,7 @@ let tree_of_modes (modes : Mode.Alloc.Const.t) =
     | _, _ -> Some modes.portability
   in
 
-  let diff = {diff with yielding; contention; portability} in
+  let diff = {diff with forkable; yielding; contention; portability} in
   (* The mapping passed to [tree_of_mode] must cover all non-legacy modes *)
   let l = Typemode.untransl_mode_annots diff in
   match all_or_none tree_of_mode_old l with

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -565,6 +565,7 @@ let mode_lazy expected_mode =
     Value.{
       Const.max with
       areality = Regionality.Const.Global;
+      forkable = Forkable.Const.Forkable;
       yielding = Yielding.Const.Unyielding }
   in
   let expected_mode =
@@ -574,7 +575,7 @@ let mode_lazy expected_mode =
   let mode_crossing =
     Crossing.create ~linearity:true ~portability:true
       ~regionality:false ~uniqueness:false ~contention:false ~statefulness:false
-      ~visibility:false ~yielding:false
+      ~visibility:false ~forkable:false ~yielding:false
   in
   let closure_mode =
     expected_mode |> as_single_mode |> Crossing.apply_right mode_crossing
@@ -660,6 +661,7 @@ let global_pat_mode {mode; _}=
   let mode =
     mode
     |> Value.meet_with Areality Regionality.Const.Global
+    |> Value.meet_with Forkable Forkable.Const.Forkable
     |> Value.meet_with Yielding Yielding.Const.Unyielding
   in
   simple_pat_mode mode
@@ -7324,6 +7326,7 @@ and type_expect_
         (* CR uniqueness: this shouldn't mention yielding *)
         { Value.Comonadic.Const.max with
           areality = Regionality.Const.Global
+        ; forkable = Forkable.Const.Forkable
         ; yielding = Yielding.Const.Unyielding }
       in
       let exp2 =
@@ -7666,6 +7669,7 @@ and type_ident env ?(recarg=Rejected) lid =
   - Portability: Closing over a nonportable module only to extract a portable
   value is fine.
   - Yielding: Modules are always unyielding (the strongest mode), so it's fine.
+  - Forkable: Modules are always forkable (the strongest mode), so it's fine.
   - All monadic axes: values are in a module via some join_with_m modality.
   Meanwhile, walking locks causes the mode to go through several join_with_m
   where [m] is the mode of a closure lock. Since join is commutative and

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -51,6 +51,8 @@ module Mode_axis_pair = struct
     | "contended" -> monadic Contention Contended
     | "shared" -> monadic Contention Shared
     | "uncontended" -> monadic Contention Uncontended
+    | "unforkable" -> comonadic Forkable Unforkable
+    | "forkable" -> comonadic Forkable Forkable
     | "yielding" -> comonadic Yielding Yielding
     | "unyielding" -> comonadic Yielding Unyielding
     | "stateless" -> comonadic Statefulness Stateless
@@ -107,6 +109,7 @@ module Transled_modifiers = struct
       portability :
         Mode.Portability.Const.t Comonadic.Atom.t Location.loc option;
       contention : Mode.Contention.Const.t Monadic.Atom.t Location.loc option;
+      forkable : Mode.Forkable.Const.t Comonadic.Atom.t Location.loc option;
       yielding : Mode.Yielding.Const.t Comonadic.Atom.t Location.loc option;
       statefulness :
         Mode.Statefulness.Const.t Comonadic.Atom.t Location.loc option;
@@ -122,6 +125,7 @@ module Transled_modifiers = struct
       uniqueness = None;
       portability = None;
       contention = None;
+      forkable = None;
       yielding = None;
       statefulness = None;
       visibility = None;
@@ -137,6 +141,7 @@ module Transled_modifiers = struct
     | Modal (Monadic Uniqueness) -> t.uniqueness
     | Modal (Comonadic Portability) -> t.portability
     | Modal (Monadic Contention) -> t.contention
+    | Modal (Comonadic Forkable) -> t.forkable
     | Modal (Comonadic Yielding) -> t.yielding
     | Modal (Comonadic Statefulness) -> t.statefulness
     | Modal (Monadic Visibility) -> t.visibility
@@ -152,6 +157,7 @@ module Transled_modifiers = struct
     | Modal (Monadic Uniqueness) -> { t with uniqueness = value }
     | Modal (Comonadic Portability) -> { t with portability = value }
     | Modal (Monadic Contention) -> { t with contention = value }
+    | Modal (Comonadic Forkable) -> { t with forkable = value }
     | Modal (Comonadic Yielding) -> { t with yielding = value }
     | Modal (Comonadic Statefulness) -> { t with statefulness = value }
     | Modal (Monadic Visibility) -> { t with visibility = value }
@@ -191,6 +197,8 @@ let transl_mod_bounds annots =
               Some { txt = Per_axis.min (Modal (Comonadic Portability)); loc };
             contention =
               Some { txt = Per_axis.min (Modal (Monadic Contention)); loc };
+            forkable =
+              Some { txt = Per_axis.min (Modal (Comonadic Forkable)); loc };
             yielding =
               Some { txt = Per_axis.min (Modal (Comonadic Yielding)); loc };
             externality = Some { txt = Externality.min; loc };
@@ -207,14 +215,26 @@ let transl_mod_bounds annots =
   in
   let empty_modifiers = Transled_modifiers.empty in
   let modifiers = List.fold_left step empty_modifiers annots in
-  (* Since [yielding] is the default mode in presence of [local],
-     the [global] modifier must also apply [unyielding] unless specified. *)
+  (* Since [unforkable] is the default mode in presence of [local],
+     the [global] modifier must also apply [forkable] unless specified. *)
   let modifiers =
     match
-      ( Transled_modifiers.get ~axis:(Modal (Comonadic Yielding)) modifiers,
+      ( Transled_modifiers.get ~axis:(Modal (Comonadic Forkable)) modifiers,
         Transled_modifiers.get ~axis:(Modal (Comonadic Areality)) modifiers )
     with
     | None, Some { txt = Modality (Meet_with Global); _ } ->
+      let set = Transled_modifiers.set ~axis:(Modal (Comonadic Forkable)) in
+      set modifiers
+        (Some { txt = Modality (Meet_with Forkable); loc = Location.none })
+    | _, _ -> modifiers
+  in
+  (* Likewise, [forkable] => [unyielding]. *)
+  let modifiers =
+    match
+      ( Transled_modifiers.get ~axis:(Modal (Comonadic Yielding)) modifiers,
+        Transled_modifiers.get ~axis:(Modal (Comonadic Forkable)) modifiers )
+    with
+    | None, Some { txt = Modality (Meet_with Forkable); _ } ->
       let set = Transled_modifiers.set ~axis:(Modal (Comonadic Yielding)) in
       set modifiers
         (Some { txt = Modality (Meet_with Unyielding); loc = Location.none })
@@ -260,6 +280,7 @@ let transl_mod_bounds annots =
   let uniqueness = modal (Monadic Uniqueness) modifiers.uniqueness in
   let portability = modal (Comonadic Portability) modifiers.portability in
   let contention = modal (Monadic Contention) modifiers.contention in
+  let forkable = modal (Comonadic Forkable) modifiers.forkable in
   let yielding = modal (Comonadic Yielding) modifiers.yielding in
   let statefulness = modal (Comonadic Statefulness) modifiers.statefulness in
   let visibility = modal (Monadic Visibility) modifiers.visibility in
@@ -280,19 +301,26 @@ let transl_mod_bounds annots =
   in
   let comonadic =
     Mode.Crossing.Comonadic.create ~regionality ~linearity ~portability
-      ~yielding ~statefulness
+      ~forkable ~yielding ~statefulness
   in
   let crossing : Crossing.t = { monadic; comonadic } in
   create crossing ~externality ~nullability ~separability
 
 let default_mode_annots (annots : Alloc.Const.Option.t) =
-  (* [yielding] has a different default depending on whether [areality]
+  (* [forkable] has a different default depending on whether [areality]
      is [global] or [local]. *)
-  let yielding =
-    match annots.yielding, annots.areality with
+  let forkable =
+    match annots.forkable, annots.areality with
     | (Some _ as y), _ | y, None -> y
-    | None, Some Locality.Const.Global -> Some Yielding.Const.Unyielding
-    | None, Some Locality.Const.Local -> Some Yielding.Const.Yielding
+    | None, Some Locality.Const.Global -> Some Forkable.Const.Forkable
+    | None, Some Locality.Const.Local -> Some Forkable.Const.Unforkable
+  in
+  (* Likewise for [yielding]. *)
+  let yielding =
+    match annots.yielding, annots.forkable with
+    | (Some _ as y), _ | y, None -> y
+    | None, Some Forkable.Const.Forkable -> Some Yielding.Const.Unyielding
+    | None, Some Forkable.Const.Unforkable -> Some Yielding.Const.Yielding
   in
   (* Likewise for [contention]. *)
   let contention =
@@ -311,7 +339,7 @@ let default_mode_annots (annots : Alloc.Const.Option.t) =
     | None, Some Statefulness.Const.(Observing | Stateful) ->
       Some Portability.Const.Nonportable
   in
-  { annots with yielding; contention; portability }
+  { annots with forkable; yielding; contention; portability }
 
 let transl_mode_annots annots : Alloc.Const.Option.t =
   let step modes_so_far { txt = Parsetree.Mode txt; loc } =
@@ -328,14 +356,22 @@ let transl_mode_annots annots : Alloc.Const.Option.t =
 
 let untransl_mode_annots (modes : Mode.Alloc.Const.Option.t) =
   let print_to_string_opt print a = Option.map (Format.asprintf "%a" print) a in
-  (* Untranslate [areality] and [yielding]. *)
+  (* Untranslate [areality] and [forkable]. *)
   let areality = print_to_string_opt Mode.Locality.Const.print modes.areality in
-  let yielding =
-    (* Since [yielding] has non-standard defaults, we special-case
+  let forkable =
+    (* Since [forkable] has non-standard defaults, we special-case
        whether we want to print it here. *)
-    match modes.yielding, modes.areality with
-    | Some Yielding.Const.Yielding, Some Locality.Const.Local
-    | Some Yielding.Const.Unyielding, Some Locality.Const.Global ->
+    match modes.forkable, modes.areality with
+    | Some Forkable.Const.Unforkable, Some Locality.Const.Local
+    | Some Forkable.Const.Forkable, Some Locality.Const.Global ->
+      None
+    | _, _ -> print_to_string_opt Mode.Forkable.Const.print modes.forkable
+  in
+  (* Untranslate [forkable] and [yielding]. *)
+  let yielding =
+    match modes.yielding, modes.forkable with
+    | Some Yielding.Const.Yielding, Some Forkable.Const.Unforkable
+    | Some Yielding.Const.Unyielding, Some Forkable.Const.Forkable ->
       None
     | _, _ -> print_to_string_opt Mode.Yielding.Const.print modes.yielding
   in
@@ -378,6 +414,7 @@ let untransl_mode_annots (modes : Mode.Alloc.Const.Option.t) =
       linearity;
       portability;
       contention;
+      forkable;
       yielding;
       statefulness;
       visibility ]
@@ -407,7 +444,7 @@ let untransl_modality (a : Modality.atom) : Parsetree.modality loc =
   { txt = Modality s; loc = Location.none }
 
 (* For now, mutable implies:
-   1. [global] and [unyielding]. This is for compatibility with existing code
+   1. [global forkable unyielding]. This is for compatibility with existing code
       and will be removed in the future.
    2. [many]. This is to remedy the coarse treatment of modalities in the
       uniqueness analysis.
@@ -420,6 +457,7 @@ let[@warning "-18"] mutable_implied_modalities ~for_mutable_variable mut =
   let comonadic : Modality.atom list =
     [ Atom (Comonadic Areality, Meet_with Regionality.Const.legacy);
       Atom (Comonadic Linearity, Meet_with Linearity.Const.legacy);
+      Atom (Comonadic Forkable, Meet_with Forkable.Const.legacy);
       Atom (Comonadic Yielding, Meet_with Yielding.Const.legacy) ]
   in
   let monadic : Modality.atom list =
@@ -442,7 +480,7 @@ let idx_expected_modalities ~(mut : bool) =
      creation to contain. Because these are coupled, this function checks that
      they are equal.
       1. The default modalities (id for non-mutable fields, global many aliased
-         unyielding for mutable fields) should work.
+         forkable unyielding for mutable fields) should work.
       2. It should also be safe wrt to type signatures given to block index
          primitives (see [idx_imm.mli] and [idx_mut.mli] in [Stdlib_beta]). *)
   let modality_of_list l =
@@ -459,6 +497,7 @@ let idx_expected_modalities ~(mut : bool) =
       modality_of_list
         [ Atom (Comonadic Areality, Meet_with Regionality.Const.legacy);
           Atom (Comonadic Linearity, Meet_with Linearity.Const.legacy);
+          Atom (Comonadic Forkable, Meet_with Forkable.Const.legacy);
           Atom (Comonadic Yielding, Meet_with Yielding.Const.legacy);
           Atom (Monadic Uniqueness, Join_with Uniqueness.Const.legacy) ]
       [@warning "-18"]
@@ -473,18 +512,24 @@ let idx_expected_modalities ~(mut : bool) =
       "Typemode.idx_expected_modalities: mismatch with mutable implied \
        modalities"
 
-(* Since [yielding] is the default mode in presence of [local],
-   the [global] modality must also apply [unyielding] unless specified.
+(* Since [unforkable] is the default mode in presence of [local],
+   the [global] modality must also apply [forkable] unless specified.
 
-   Similarly for [visibility]/[contention] and [statefulness]/[portability]. *)
+   Similarly for [forkable]/[yielding], [visibility]/[contention],
+   and [statefulness]/[portability]. *)
 let implied_modalities (Atom (ax, a) : Modality.atom) : Modality.atom list =
   match[@warning "-18"] ax, a with
   | Comonadic Areality, Meet_with a ->
-    let b : Yielding.Const.t =
+    let b : Forkable.Const.t =
       match a with
-      | Global -> Unyielding
-      | Local -> Yielding
+      | Global -> Forkable
+      | Local -> Unforkable
       | Regional -> assert false
+    in
+    [Atom (Comonadic Forkable, Meet_with b)]
+  | Comonadic Forkable, Meet_with a ->
+    let b : Yielding.Const.t =
+      match a with Forkable -> Unyielding | Unforkable -> Yielding
     in
     [Atom (Comonadic Yielding, Meet_with b)]
   | Monadic Visibility, Join_with a ->

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -68,6 +68,7 @@ module Jkind_mod_bounds = struct
   let uniqueness = Crossing.Axis.Monadic Uniqueness
   let portability = Crossing.Axis.Comonadic Portability
   let contention = Crossing.Axis.Monadic Contention
+  let forkable = Crossing.Axis.Comonadic Forkable
   let yielding = Crossing.Axis.Comonadic Yielding
   let statefulness = Crossing.Axis.Comonadic Statefulness
   let visibility = Crossing.Axis.Monadic Visibility
@@ -106,6 +107,7 @@ module Jkind_mod_bounds = struct
     let uniqueness = modal uniqueness in
     let portability = modal portability in
     let contention = modal contention in
+    let forkable = modal forkable in
     let yielding = modal yielding in
     let statefulness = modal statefulness in
     let visibility = modal visibility in
@@ -129,7 +131,7 @@ module Jkind_mod_bounds = struct
     in
     let comonadic =
       Crossing.Comonadic.create ~regionality ~linearity ~portability ~yielding
-        ~statefulness
+        ~forkable ~statefulness
     in
     let crossing : Mode.Crossing.t = { monadic; comonadic } in
     {
@@ -153,6 +155,7 @@ module Jkind_mod_bounds = struct
     let uniqueness = modal uniqueness in
     let portability = modal portability in
     let contention = modal contention in
+    let forkable = modal forkable in
     let yielding = modal yielding in
     let statefulness = modal statefulness in
     let visibility = modal visibility in
@@ -176,7 +179,7 @@ module Jkind_mod_bounds = struct
     in
     let comonadic =
       Crossing.Comonadic.create ~regionality ~linearity ~portability ~yielding
-        ~statefulness
+        ~forkable ~statefulness
     in
     let crossing : Mode.Crossing.t = { monadic; comonadic } in
     {
@@ -198,6 +201,7 @@ module Jkind_mod_bounds = struct
     modal uniqueness &&
     modal portability &&
     modal contention &&
+    modal forkable &&
     modal yielding &&
     modal statefulness &&
     modal visibility &&


### PR DESCRIPTION
Adds the `forkable` mode axis, which has identical behavior as `yielding`. This axis will be used to constrain the use of passwords, while yielding will only apply to effect handlers.

(See design doc for details)