### PR TITLE
Fix [Arch.operation_allocates] for Illvm_intrinsic

### DIFF
--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -468,9 +468,10 @@ let operation_allocates = function
   | Ilfence | Isfence | Imfence
   | Istore_int (_, _, _) | Ioffset_loc (_, _)
   | Icldemote _ | Iprefetch _ -> false
-  | Illvm_intrinsic intr ->
-    Misc.fatal_errorf "Unexpected llvm_intrinsic %s: not using LLVM backend"
-      intr
+  | Illvm_intrinsic _intr ->
+      (* Used by the zero_alloc checker that runs before the Llvmize. *)
+      false
+
 
 open X86_ast
 

--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -460,6 +460,8 @@ let select_operation
       let bitwidth = select_bitwidth bitwidth in
       Rewritten (specific (Ibswap { bitwidth }), args)
     | Cextcall { func; builtin = true; _ } ->
+      (* Illvm_intrinsic must not allocate on the OCaml heap. See
+         [Arch.operation_allocates]. *)
       Rewritten (specific (Illvm_intrinsic func), args)
     | _ -> Use_default
     (* LLVM backend doesn't need target-specific instructons/operands since they

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -395,9 +395,9 @@ let operation_allocates = function
   | Isignext _
   | Ibswap _
   | Isimd _ -> false
-  | Illvm_intrinsic intr ->
-    Misc.fatal_errorf "Unexpected llvm_intrinsic %s: not using LLVM backend"
-      intr
+  | Illvm_intrinsic _intr ->
+      (* Used by the zero_alloc checker that runs before the Llvmize. *)
+      false
 
 (* See `amd64/arch.ml`. *)
 let equal_addressing_mode_without_displ (addressing_mode_1: addressing_mode)

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -899,6 +899,8 @@ let intrinsic t (i : Cfg.basic Cfg.instruction) intrinsic_name =
     let conved_res = do_conv res (T.of_reg i.res.(0)) in
     store_into_reg t i.res.(0) conved_res
   in
+  (* Intrinsics must not allocate on the OCaml heap. See
+     [Arch.operation_allocates]. *)
   match intrinsic_name with
   | "caml_sse2_float64_min" ->
     do_intrinsic_call "x86.sse2.min.sd" [T.doublex2; T.doublex2] T.doublex2


### PR DESCRIPTION
This intrinsic is used by the `zero_alloc` checker, which runs before `llvmize`. 