### PR TITLE
(LLVM Backend) Recover RBP earlier for exception handling

### DIFF
--- a/backend/llvm/llvm_ir.ml
+++ b/backend/llvm/llvm_ir.ml
@@ -292,6 +292,10 @@ module Ident = struct
 
   let to_string_hum t = match t with Local s -> "%" ^ s | Global s -> "@" ^ s
 
+  let to_string_raw = function
+    | Local s | Global s ->
+      Asm_targets.(Asm_symbol.create s |> Asm_symbol.encode)
+
   module Gen = struct
     type ident = t
 

--- a/backend/llvm/llvm_ir.ml
+++ b/backend/llvm/llvm_ir.ml
@@ -290,11 +290,11 @@ module Ident = struct
     | Local s -> s ^ ":"
     | Global _ -> fail "Type.to_label_string_exn"
 
-  let to_string_hum t = match t with Local s -> "%" ^ s | Global s -> "@" ^ s
+  let to_string_hum t = match t with Local s -> s | Global s -> s
 
-  let to_string_raw = function
-    | Local s | Global s ->
-      Asm_targets.(Asm_symbol.create s |> Asm_symbol.encode)
+  let to_string_encoded = function
+    | Local s -> s
+    | Global s -> Asm_targets.(Asm_symbol.create s |> Asm_symbol.encode)
 
   module Gen = struct
     type ident = t

--- a/backend/llvm/llvm_ir.mli
+++ b/backend/llvm/llvm_ir.mli
@@ -129,7 +129,7 @@ module Ident : sig
 
   val to_string_hum : t -> string
 
-  val to_string_raw : t -> string
+  val to_string_encoded : t -> string
 
   module Gen : sig
     type ident = t

--- a/backend/llvm/llvm_ir.mli
+++ b/backend/llvm/llvm_ir.mli
@@ -129,6 +129,8 @@ module Ident : sig
 
   val to_string_hum : t -> string
 
+  val to_string_raw : t -> string
+
   module Gen : sig
     type ident = t
 

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -77,7 +77,9 @@ type c_call_wrapper =
 type trap_block_info =
   { trap_block : LL.Value.t;
     stacksave_ptr : LL.Value.t;
-    exn_bucket : LL.Value.t
+    exn_bucket : LL.Value.t;
+    recover_rbp_asm_ident : LL.Ident.t;
+    recover_rbp_var_ident : LL.Ident.t
   }
 
 (* CR yusumez: Refactor into its own sub-module *)
@@ -115,9 +117,11 @@ type t =
     mutable c_call_wrappers : c_call_wrapper String.Map.t;
         (* Wrappers for noalloc C calls. This is currently needed since
            manipulating the stack inline is broken. *)
-    mutable stack_offset : int
+    mutable stack_offset : int;
         (* Accumulate [Stackoffset]s to be able to calculate the # of trap
            blocks at a given instruction via [i.stack_offset] *)
+    mutable all_trap_blocks : trap_block_info list;
+    mutable module_asm : string list
   }
 
 (* current_fun_info interface *)
@@ -168,7 +172,9 @@ let create ~llvmir_filename ~ppf_dump =
     referenced_symbols = String.Set.empty;
     called_intrinsics = String.Map.empty;
     c_call_wrappers = String.Map.empty;
-    stack_offset = 0
+    stack_offset = 0;
+    all_trap_blocks = [];
+    module_asm = []
   }
 
 let add_called_intrinsic t name ~args ~res =
@@ -209,8 +215,13 @@ let add_function_def t fundef = t.function_defs <- fundef :: t.function_defs
 
 let add_data_def t data_def = t.data_defs <- data_def :: t.data_defs
 
+let add_module_asm t asm_lines = t.module_asm <- asm_lines @ t.module_asm
+
 let complete_func_def t =
   add_function_def t (E.get_fun (get_fun_info t).emitter);
+  t.all_trap_blocks
+    <- (Label.Tbl.to_list (get_fun_info t).trap_blocks |> List.map snd)
+       @ t.all_trap_blocks;
   t.current_fun_info <- None
 
 let gc_name = "oxcaml" (* The name of the [GCStrategy] we use in LLVM *)
@@ -1195,7 +1206,7 @@ let emit_basic t (i : Cfg.basic Cfg.instruction) =
   | Poptrap { lbl_handler } -> (
     match Label.Tbl.find_opt (get_fun_info t).trap_blocks lbl_handler with
     | None -> fail_msg "unbalanced trap pop"
-    | Some { trap_block; stacksave_ptr; exn_bucket = _ } ->
+    | Some { trap_block; stacksave_ptr; _ } ->
       (* Restore previous exn handler sp (top word on trap block) *)
       let exn_sp_ptr = load_domainstate_addr t Domain_exn_handler in
       let prev_exn_sp = emit_ins t (I.load ~ptr:trap_block ~typ:T.i64) in
@@ -1239,6 +1250,18 @@ let emit_basic t (i : Cfg.basic Cfg.instruction) =
     |> ignore (* Note that we don't need the returned identifier here. *);
     (* Record label here - we will jump here for the handler *)
     let try_and_exn_entry = V.of_label (Cmm.new_label ()) in
+    let fun_name =
+      E.get_fun_ident (get_fun_info t).emitter |> LL.Ident.to_string_raw
+    in
+    let label_name =
+      LL.Ident.to_string_raw (V.get_ident_exn try_and_exn_entry)
+    in
+    let recover_rbp_asm_ident =
+      LL.Ident.global ("recover_rbp_asm." ^ fun_name ^ "." ^ label_name)
+    in
+    let recover_rbp_var_ident =
+      LL.Ident.global ("recover_rbp_var." ^ fun_name ^ "." ^ label_name)
+    in
     emit_ins_no_res t (I.br try_and_exn_entry);
     emit_label t try_and_exn_entry;
     (* Extract the result of the call, or the exception bucket. *)
@@ -1257,6 +1280,14 @@ let emit_basic t (i : Cfg.basic Cfg.instruction) =
       (I.br_cond ~cond:exn_bucket_is_zero ~ifso:try_label ~ifnot:exn_label);
     (* Enter try block from this point onwards. *)
     emit_label t try_label;
+    (* Take the address of common entry and put it somewhere accessible *)
+    emit_ins_no_res t
+      (I.store
+         ~ptr:(V.of_ident ~typ:T.ptr recover_rbp_var_ident)
+         ~to_store:
+           (V.blockaddress
+              ~func:(E.get_fun_ident (get_fun_info t).emitter)
+              ~block:(V.get_ident_exn try_and_exn_entry)));
     (* Save state of stack *)
     let stacksave_ptr = call_llvm_intrinsic t "stacksave" [] T.ptr in
     (* Allocate trap block on stack. It will get allocated at the top of the
@@ -1273,10 +1304,7 @@ let emit_basic t (i : Cfg.basic Cfg.instruction) =
     (* Fill up the slots *)
     emit_ins_no_res t
       (I.store ~ptr:handler_slot
-         ~to_store:
-           (V.blockaddress
-              ~func:(E.get_fun_ident (get_fun_info t).emitter)
-              ~block:(V.get_ident_exn try_and_exn_entry)));
+         ~to_store:(V.of_ident ~typ:T.ptr recover_rbp_asm_ident));
     emit_ins_no_res t
       (I.inline_asm ~asm:"mov %rbp, ($0)" ~constraints:"r" ~args:[rbp_slot]
          ~res_type:T.Or_void.void ~sideeffect:true);
@@ -1286,7 +1314,12 @@ let emit_basic t (i : Cfg.basic Cfg.instruction) =
     | Some _ -> fail_msg "multiple pushtraps for the same handler"
     | None ->
       Label.Tbl.add (get_fun_info t).trap_blocks lbl_handler
-        { trap_block; stacksave_ptr; exn_bucket })
+        { trap_block;
+          stacksave_ptr;
+          exn_bucket;
+          recover_rbp_asm_ident;
+          recover_rbp_var_ident
+        })
 
 (* Cfg translation entry *)
 
@@ -1451,9 +1484,8 @@ let trap_handler_entry t (block : Cfg.basic_block) label =
     match Label.Tbl.find_opt (get_fun_info t).trap_blocks label with
     | Some { exn_bucket; _ } ->
       (* Restore RBP (+ remove padding) *)
-      emit_ins_no_res t
-        (I.inline_asm ~asm:"pop %rbp; addq $$8, %rsp" ~constraints:"" ~args:[]
-           ~res_type:T.Or_void.void ~sideeffect:true);
+      (* emit_ins_no_res t (I.inline_asm ~asm:"pop %rbp; addq $$8, %rsp"
+         ~constraints:"" ~args:[] ~res_type:T.Or_void.void ~sideeffect:true); *)
       (* Restore allocation pointer *)
       let new_alloc_ptr =
         emit_ins t
@@ -1701,6 +1733,23 @@ let define_wrap_try t =
   emit_ins_no_res t (I.ret res);
   complete_func_def t
 
+let define_restore_rbp t =
+  List.iter
+    (fun ({ recover_rbp_asm_ident; recover_rbp_var_ident; _ } : trap_block_info) ->
+      let recover_rbp_asm = LL.Ident.to_string_raw recover_rbp_asm_ident in
+      let recover_rbp_var = LL.Ident.to_string_raw recover_rbp_var_ident in
+      add_module_asm t
+        [ "  .text";
+          recover_rbp_asm ^ ":";
+          "  pop %rbp";
+          "  addq $8, %rsp";
+          "  movq " ^ recover_rbp_var ^ "(%rip), %rbx";
+          "  jmpq *%rbx" ];
+      add_data_def t (LL.Data.external_ recover_rbp_asm);
+      add_data_def t
+        (LL.Data.constant recover_rbp_var (V.zeroinitializer T.ptr)))
+    t.all_trap_blocks
+
 (* Declare menitoned but not declared data items as extern *)
 let declare_data t =
   String.Set.diff t.referenced_symbols t.defined_symbols
@@ -1708,7 +1757,8 @@ let declare_data t =
 
 let define_auxiliary_functions t =
   define_c_call_wrappers t;
-  define_wrap_try t
+  define_wrap_try t;
+  define_restore_rbp t
 
 (* Interface with the rest of the compiler *)
 
@@ -1823,6 +1873,10 @@ let write_llvmir_to_file t =
   String.Map.iter
     (fun _ fundecl -> LL.Fundecl.pp_t t.ppf fundecl)
     t.called_intrinsics;
+  F.pp_line t.ppf "";
+  List.iter
+    (fun asm_line -> F.pp_line t.ppf {|module asm "%s"|} asm_line)
+    t.module_asm;
   write_module_metadata t
 
 let end_assembly () =

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -1251,10 +1251,10 @@ let emit_basic t (i : Cfg.basic Cfg.instruction) =
     (* Record label here - we will jump here for the handler *)
     let try_and_exn_entry = V.of_label (Cmm.new_label ()) in
     let fun_name =
-      E.get_fun_ident (get_fun_info t).emitter |> LL.Ident.to_string_raw
+      E.get_fun_ident (get_fun_info t).emitter |> LL.Ident.to_string_hum
     in
     let label_name =
-      LL.Ident.to_string_raw (V.get_ident_exn try_and_exn_entry)
+      LL.Ident.to_string_hum (V.get_ident_exn try_and_exn_entry)
     in
     let recover_rbp_asm_ident =
       LL.Ident.global ("recover_rbp_asm." ^ fun_name ^ "." ^ label_name)
@@ -1736,8 +1736,8 @@ let define_wrap_try t =
 let define_restore_rbp t =
   List.iter
     (fun ({ recover_rbp_asm_ident; recover_rbp_var_ident; _ } : trap_block_info) ->
-      let recover_rbp_asm = LL.Ident.to_string_raw recover_rbp_asm_ident in
-      let recover_rbp_var = LL.Ident.to_string_raw recover_rbp_var_ident in
+      let recover_rbp_asm = LL.Ident.to_string_encoded recover_rbp_asm_ident in
+      let recover_rbp_var = LL.Ident.to_string_encoded recover_rbp_var_ident in
       add_module_asm t
         [ "  .text";
           recover_rbp_asm ^ ":";
@@ -1745,9 +1745,12 @@ let define_restore_rbp t =
           "  addq $8, %rsp";
           "  movq " ^ recover_rbp_var ^ "(%rip), %rbx";
           "  jmpq *%rbx" ];
-      add_data_def t (LL.Data.external_ recover_rbp_asm);
       add_data_def t
-        (LL.Data.constant recover_rbp_var (V.zeroinitializer T.ptr)))
+        (LL.Data.external_ (LL.Ident.to_string_hum recover_rbp_asm_ident));
+      add_data_def t
+        (LL.Data.constant
+           (LL.Ident.to_string_hum recover_rbp_var_ident)
+           (V.zeroinitializer T.ptr)))
     t.all_trap_blocks
 
 (* Declare menitoned but not declared data items as extern *)

--- a/oxcaml/tests/backend/llvmize/alloc_ir.output
+++ b/oxcaml/tests/backend/llvmize/alloc_ir.output
@@ -1211,5 +1211,6 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 declare i1 @llvm.expect.i1(i1, i1)
 
+
 !0 = !{ i32 1, !"oxcaml_module", !"Alloc" }
 !llvm.module.flags = !{ !0 }

--- a/oxcaml/tests/backend/llvmize/array_rev_ir.output
+++ b/oxcaml/tests/backend/llvmize/array_rev_ir.output
@@ -320,5 +320,6 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @camlArray_rev_data = external global ptr
 
 
+
 !0 = !{ i32 1, !"oxcaml_module", !"Array_rev" }
 !llvm.module.flags = !{ !0 }

--- a/oxcaml/tests/backend/llvmize/const_val_ir.output
+++ b/oxcaml/tests/backend/llvmize/const_val_ir.output
@@ -45,5 +45,6 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @camlConst_val = global { i64 } { i64 75 }, section ".data", align 8
 
 
+
 !0 = !{ i32 1, !"oxcaml_module", !"Const_val" }
 !llvm.module.flags = !{ !0 }

--- a/oxcaml/tests/backend/llvmize/csel_ir.output
+++ b/oxcaml/tests/backend/llvmize/csel_ir.output
@@ -626,5 +626,6 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @caml_curry3 = external global ptr
 
 
+
 !0 = !{ i32 1, !"oxcaml_module", !"Csel" }
 !llvm.module.flags = !{ !0 }

--- a/oxcaml/tests/backend/llvmize/data_decl_ir.output
+++ b/oxcaml/tests/backend/llvmize/data_decl_ir.output
@@ -558,5 +558,6 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @caml_ml_output_char = external global ptr
 
 
+
 !0 = !{ i32 1, !"oxcaml_module", !"Data_decl" }
 !llvm.module.flags = !{ !0 }

--- a/oxcaml/tests/backend/llvmize/exn_part2_ir.output
+++ b/oxcaml/tests/backend/llvmize/exn_part2_ir.output
@@ -89,6 +89,7 @@ L142:
   %68 = icmp eq i64 %67, 0
   br i1 %68, label %L143, label %L106
 L143:
+  store ptr blockaddress(@camlExn_part2__catch_exn1_from_llvm_0_9_code, %L142), ptr @recover_rbp_var.camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP.L142
   %69 = call  ptr @llvm.stacksave()
   %70 = alloca { i64, i64, i64, i64 }
   %71 = ptrtoint ptr %70 to i64
@@ -102,7 +103,7 @@ L143:
   %79 = inttoptr i64 %78 to ptr
   %80 = load i64, ptr %79
   store ptr %70, ptr %79
-  store ptr blockaddress(@camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP, %L142), ptr %76
+  store ptr @recover_rbp_asm.camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP.L142, ptr %76
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %73) "gc-leaf-function"="true"
   store i64 %80, ptr %70
   store i64 5, ptr %15
@@ -167,7 +168,6 @@ L117:
   %117 = insertvalue { { i64, i64 }, { i64 } } %116, i64 %112, 1, 0
   ret { { i64, i64 }, { i64 } } %117
 L106:
-  call void asm sideeffect "pop %rbp; addq $$8, %rsp", ""() "gc-leaf-function"="true"
   %118 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
   store i64 %118, ptr %alloc
   store i64 %67, ptr %4
@@ -387,6 +387,7 @@ L176:
   %53 = icmp eq i64 %52, 0
   br i1 %53, label %L177, label %L152
 L177:
+  store ptr blockaddress(@camlExn_part2__raise_exn1_catch_exn2_from_llvm_1_10_code, %L176), ptr @recover_rbp_var.camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP.L176
   %54 = call  ptr @llvm.stacksave()
   %55 = alloca { i64, i64, i64, i64 }
   %56 = ptrtoint ptr %55 to i64
@@ -400,7 +401,7 @@ L177:
   %64 = inttoptr i64 %63 to ptr
   %65 = load i64, ptr %64
   store ptr %55, ptr %64
-  store ptr blockaddress(@camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP, %L176), ptr %61
+  store ptr @recover_rbp_asm.camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP.L176, ptr %61
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %58) "gc-leaf-function"="true"
   store i64 %65, ptr %55
   %66 = ptrtoint ptr @camlExn_part1 to i64
@@ -458,7 +459,6 @@ L162:
   %99 = insertvalue { { i64, i64 }, { i64 } } %98, i64 %94, 1, 0
   ret { { i64, i64 }, { i64 } } %99
 L152:
-  call void asm sideeffect "pop %rbp; addq $$8, %rsp", ""() "gc-leaf-function"="true"
   %100 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
   store i64 %100, ptr %alloc
   store i64 %52, ptr %4
@@ -603,6 +603,7 @@ L218:
   %63 = icmp eq i64 %62, 0
   br i1 %63, label %L219, label %L185
 L219:
+  store ptr blockaddress(@camlExn_part2__catch_exn1_nested_from_llvm_2_11_code, %L218), ptr @recover_rbp_var.camlExn_part2__catch_exn1_nested_from_llvm_HIDE_STAMP.L218
   %64 = call  ptr @llvm.stacksave()
   %65 = alloca { i64, i64, i64, i64 }
   %66 = ptrtoint ptr %65 to i64
@@ -616,7 +617,7 @@ L219:
   %74 = inttoptr i64 %73 to ptr
   %75 = load i64, ptr %74
   store ptr %65, ptr %74
-  store ptr blockaddress(@camlExn_part2__catch_exn1_nested_from_llvm_HIDE_STAMP, %L218), ptr %71
+  store ptr @recover_rbp_asm.camlExn_part2__catch_exn1_nested_from_llvm_HIDE_STAMP.L218, ptr %71
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %68) "gc-leaf-function"="true"
   store i64 %75, ptr %65
   store i64 9, ptr %15
@@ -661,7 +662,6 @@ L194:
   %99 = insertvalue { { i64, i64 }, { i64 } } %98, i64 %94, 1, 0
   ret { { i64, i64 }, { i64 } } %99
 L185:
-  call void asm sideeffect "pop %rbp; addq $$8, %rsp", ""() "gc-leaf-function"="true"
   %100 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
   store i64 %100, ptr %alloc
   store i64 %62, ptr %4
@@ -1088,6 +1088,7 @@ L332:
   %107 = icmp eq i64 %106, 0
   br i1 %107, label %L333, label %L244
 L333:
+  store ptr blockaddress(@camlExn_part2__complicated_6_15_code, %L332), ptr @recover_rbp_var.camlExn_part2__complicated_HIDE_STAMP.L332
   %108 = call  ptr @llvm.stacksave()
   %109 = alloca { i64, i64, i64, i64 }
   %110 = ptrtoint ptr %109 to i64
@@ -1101,7 +1102,7 @@ L333:
   %118 = inttoptr i64 %117 to ptr
   %119 = load i64, ptr %118
   store ptr %109, ptr %118
-  store ptr blockaddress(@camlExn_part2__complicated_HIDE_STAMP, %L332), ptr %115
+  store ptr @recover_rbp_asm.camlExn_part2__complicated_HIDE_STAMP.L332, ptr %115
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %112) "gc-leaf-function"="true"
   store i64 %119, ptr %109
   %120 = ptrtoint ptr @camlExn_part1 to i64
@@ -1164,6 +1165,7 @@ L334:
   %155 = icmp eq i64 %154, 0
   br i1 %155, label %L335, label %L260
 L335:
+  store ptr blockaddress(@camlExn_part2__complicated_6_15_code, %L334), ptr @recover_rbp_var.camlExn_part2__complicated_HIDE_STAMP.L334
   %156 = call  ptr @llvm.stacksave()
   %157 = alloca { i64, i64, i64, i64 }
   %158 = ptrtoint ptr %157 to i64
@@ -1177,7 +1179,7 @@ L335:
   %166 = inttoptr i64 %165 to ptr
   %167 = load i64, ptr %166
   store ptr %157, ptr %166
-  store ptr blockaddress(@camlExn_part2__complicated_HIDE_STAMP, %L334), ptr %163
+  store ptr @recover_rbp_asm.camlExn_part2__complicated_HIDE_STAMP.L334, ptr %163
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %160) "gc-leaf-function"="true"
   store i64 %167, ptr %157
   %168 = ptrtoint ptr @camlExn_part1 to i64
@@ -1240,6 +1242,7 @@ L336:
   %203 = icmp eq i64 %202, 0
   br i1 %203, label %L337, label %L276
 L337:
+  store ptr blockaddress(@camlExn_part2__complicated_6_15_code, %L336), ptr @recover_rbp_var.camlExn_part2__complicated_HIDE_STAMP.L336
   %204 = call  ptr @llvm.stacksave()
   %205 = alloca { i64, i64, i64, i64 }
   %206 = ptrtoint ptr %205 to i64
@@ -1253,7 +1256,7 @@ L337:
   %214 = inttoptr i64 %213 to ptr
   %215 = load i64, ptr %214
   store ptr %205, ptr %214
-  store ptr blockaddress(@camlExn_part2__complicated_HIDE_STAMP, %L336), ptr %211
+  store ptr @recover_rbp_asm.camlExn_part2__complicated_HIDE_STAMP.L336, ptr %211
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %208) "gc-leaf-function"="true"
   store i64 %215, ptr %205
   store i64 1, ptr %43
@@ -1295,7 +1298,6 @@ L284:
   call  void @llvm.stackrestore(ptr %204)
   br label %L301
 L276:
-  call void asm sideeffect "pop %rbp; addq $$8, %rsp", ""() "gc-leaf-function"="true"
   %237 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
   store i64 %237, ptr %alloc
   store i64 %202, ptr %5
@@ -1373,7 +1375,6 @@ L301:
   call  void @llvm.stackrestore(ptr %156)
   br label %L320
 L260:
-  call void asm sideeffect "pop %rbp; addq $$8, %rsp", ""() "gc-leaf-function"="true"
   %281 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
   store i64 %281, ptr %alloc
   store i64 %154, ptr %5
@@ -1462,7 +1463,6 @@ L320:
   %334 = insertvalue { { i64, i64 }, { i64 } } %333, i64 %329, 1, 0
   ret { { i64, i64 }, { i64 } } %334
 L244:
-  call void asm sideeffect "pop %rbp; addq $$8, %rsp", ""() "gc-leaf-function"="true"
   %335 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
   store i64 %335, ptr %alloc
   store i64 %106, ptr %5
@@ -1580,6 +1580,7 @@ L394:
   %46 = icmp eq i64 %45, 0
   br i1 %46, label %L395, label %L353
 L395:
+  store ptr blockaddress(@camlExn_part2__raise_in_loop_7_16_code, %L394), ptr @recover_rbp_var.camlExn_part2__raise_in_loop_HIDE_STAMP.L394
   %47 = call  ptr @llvm.stacksave()
   %48 = alloca { i64, i64, i64, i64 }
   %49 = ptrtoint ptr %48 to i64
@@ -1593,7 +1594,7 @@ L395:
   %57 = inttoptr i64 %56 to ptr
   %58 = load i64, ptr %57
   store ptr %48, ptr %57
-  store ptr blockaddress(@camlExn_part2__raise_in_loop_HIDE_STAMP, %L394), ptr %54
+  store ptr @recover_rbp_asm.camlExn_part2__raise_in_loop_HIDE_STAMP.L394, ptr %54
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %51) "gc-leaf-function"="true"
   store i64 %58, ptr %48
   %59 = ptrtoint ptr @camlExn_part1 to i64
@@ -1642,7 +1643,6 @@ L363:
   call  void @llvm.stackrestore(ptr %47)
   br label %L384
 L353:
-  call void asm sideeffect "pop %rbp; addq $$8, %rsp", ""() "gc-leaf-function"="true"
   %86 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
   store i64 %86, ptr %alloc
   store i64 %45, ptr %4
@@ -1820,6 +1820,7 @@ L426:
   %48 = icmp eq i64 %47, 0
   br i1 %48, label %L427, label %L403
 L427:
+  store ptr blockaddress(@camlExn_part2__catch_wildcard_8_17_code, %L426), ptr @recover_rbp_var.camlExn_part2__catch_wildcard_HIDE_STAMP.L426
   %49 = call  ptr @llvm.stacksave()
   %50 = alloca { i64, i64, i64, i64 }
   %51 = ptrtoint ptr %50 to i64
@@ -1833,7 +1834,7 @@ L427:
   %59 = inttoptr i64 %58 to ptr
   %60 = load i64, ptr %59
   store ptr %50, ptr %59
-  store ptr blockaddress(@camlExn_part2__catch_wildcard_HIDE_STAMP, %L426), ptr %56
+  store ptr @recover_rbp_asm.camlExn_part2__catch_wildcard_HIDE_STAMP.L426, ptr %56
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %53) "gc-leaf-function"="true"
   store i64 %60, ptr %50
   store i64 1, ptr %14
@@ -1865,7 +1866,6 @@ L411:
   %78 = insertvalue { { i64, i64 }, { i64 } } %77, i64 %73, 1, 0
   ret { { i64, i64 }, { i64 } } %78
 L403:
-  call void asm sideeffect "pop %rbp; addq $$8, %rsp", ""() "gc-leaf-function"="true"
   %79 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
   store i64 %79, ptr %alloc
   store i64 %47, ptr %4
@@ -2151,6 +2151,22 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @camlExn_part2__const_block192 = global { ptr, i64, i64 } { ptr @camlExn_part2__immstring190, i64 101, i64 95 }, section ".data", align 8
 @header.camlExn_part2__immstring190 = global i64 3068, section ".data", align 8
 @camlExn_part2__immstring190 = global { [ 12 x i8 ], [ 3 x i8 ], i8 } { [ 12 x i8 ] c"\65\78\6e\5f\70\61\72\74\32\2e\6d\6c", [ 3 x i8 ] zeroinitializer, i8 3 }, section ".data", align 8
+@recover_rbp_asm.camlExn_part2__catch_wildcard_HIDE_STAMP.L426 = external global ptr
+@recover_rbp_var.camlExn_part2__catch_wildcard_HIDE_STAMP.L426 = global ptr zeroinitializer, section ".data", align 8
+@recover_rbp_asm.camlExn_part2__raise_in_loop_HIDE_STAMP.L394 = external global ptr
+@recover_rbp_var.camlExn_part2__raise_in_loop_HIDE_STAMP.L394 = global ptr zeroinitializer, section ".data", align 8
+@recover_rbp_asm.camlExn_part2__complicated_HIDE_STAMP.L332 = external global ptr
+@recover_rbp_var.camlExn_part2__complicated_HIDE_STAMP.L332 = global ptr zeroinitializer, section ".data", align 8
+@recover_rbp_asm.camlExn_part2__complicated_HIDE_STAMP.L334 = external global ptr
+@recover_rbp_var.camlExn_part2__complicated_HIDE_STAMP.L334 = global ptr zeroinitializer, section ".data", align 8
+@recover_rbp_asm.camlExn_part2__complicated_HIDE_STAMP.L336 = external global ptr
+@recover_rbp_var.camlExn_part2__complicated_HIDE_STAMP.L336 = global ptr zeroinitializer, section ".data", align 8
+@recover_rbp_asm.camlExn_part2__catch_exn1_nested_from_llvm_HIDE_STAMP.L218 = external global ptr
+@recover_rbp_var.camlExn_part2__catch_exn1_nested_from_llvm_HIDE_STAMP.L218 = global ptr zeroinitializer, section ".data", align 8
+@recover_rbp_asm.camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP.L176 = external global ptr
+@recover_rbp_var.camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP.L176 = global ptr zeroinitializer, section ".data", align 8
+@recover_rbp_asm.camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP.L142 = external global ptr
+@recover_rbp_var.camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP.L142 = global ptr zeroinitializer, section ".data", align 8
 @camlExn_part1 = external global ptr
 @camlStdlib__print_endline_138 = external global ptr
 @caml_c_call = external global ptr
@@ -2168,6 +2184,55 @@ declare i64 @llvm.read_register.i64(metadata)
 declare void @llvm.stackrestore(ptr)
 declare ptr @llvm.stacksave()
 declare void @llvm.write_register.i64(metadata, i64)
+
+module asm "  .text"
+module asm "recover_rbp_asm.camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP.L142:"
+module asm "  pop %rbp"
+module asm "  addq $8, %rsp"
+module asm "  movq recover_rbp_var.camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP.L142(%rip), %rbx"
+module asm "  jmpq *%rbx"
+module asm "  .text"
+module asm "recover_rbp_asm.camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP.L176:"
+module asm "  pop %rbp"
+module asm "  addq $8, %rsp"
+module asm "  movq recover_rbp_var.camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP.L176(%rip), %rbx"
+module asm "  jmpq *%rbx"
+module asm "  .text"
+module asm "recover_rbp_asm.camlExn_part2__catch_exn1_nested_from_llvm_HIDE_STAMP.L218:"
+module asm "  pop %rbp"
+module asm "  addq $8, %rsp"
+module asm "  movq recover_rbp_var.camlExn_part2__catch_exn1_nested_from_llvm_HIDE_STAMP.L218(%rip), %rbx"
+module asm "  jmpq *%rbx"
+module asm "  .text"
+module asm "recover_rbp_asm.camlExn_part2__complicated_HIDE_STAMP.L336:"
+module asm "  pop %rbp"
+module asm "  addq $8, %rsp"
+module asm "  movq recover_rbp_var.camlExn_part2__complicated_HIDE_STAMP.L336(%rip), %rbx"
+module asm "  jmpq *%rbx"
+module asm "  .text"
+module asm "recover_rbp_asm.camlExn_part2__complicated_HIDE_STAMP.L334:"
+module asm "  pop %rbp"
+module asm "  addq $8, %rsp"
+module asm "  movq recover_rbp_var.camlExn_part2__complicated_HIDE_STAMP.L334(%rip), %rbx"
+module asm "  jmpq *%rbx"
+module asm "  .text"
+module asm "recover_rbp_asm.camlExn_part2__complicated_HIDE_STAMP.L332:"
+module asm "  pop %rbp"
+module asm "  addq $8, %rsp"
+module asm "  movq recover_rbp_var.camlExn_part2__complicated_HIDE_STAMP.L332(%rip), %rbx"
+module asm "  jmpq *%rbx"
+module asm "  .text"
+module asm "recover_rbp_asm.camlExn_part2__raise_in_loop_HIDE_STAMP.L394:"
+module asm "  pop %rbp"
+module asm "  addq $8, %rsp"
+module asm "  movq recover_rbp_var.camlExn_part2__raise_in_loop_HIDE_STAMP.L394(%rip), %rbx"
+module asm "  jmpq *%rbx"
+module asm "  .text"
+module asm "recover_rbp_asm.camlExn_part2__catch_wildcard_HIDE_STAMP.L426:"
+module asm "  pop %rbp"
+module asm "  addq $8, %rsp"
+module asm "  movq recover_rbp_var.camlExn_part2__catch_wildcard_HIDE_STAMP.L426(%rip), %rbx"
+module asm "  jmpq *%rbx"
 
 !0 = !{ i32 1, !"oxcaml_module", !"Exn_part2" }
 !llvm.module.flags = !{ !0 }

--- a/oxcaml/tests/backend/llvmize/exn_part2_ir.output
+++ b/oxcaml/tests/backend/llvmize/exn_part2_ir.output
@@ -89,7 +89,7 @@ L142:
   %68 = icmp eq i64 %67, 0
   br i1 %68, label %L143, label %L106
 L143:
-  store ptr blockaddress(@camlExn_part2__catch_exn1_from_llvm_0_9_code, %L142), ptr @recover_rbp_var.camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP.L142
+  store ptr blockaddress(@camlExn_part2__catch_exn1_from_llvm_0_9_code, %L142), ptr @camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP.recover_rbp_var.L142
   %69 = call  ptr @llvm.stacksave()
   %70 = alloca { i64, i64, i64, i64 }
   %71 = ptrtoint ptr %70 to i64
@@ -103,7 +103,7 @@ L143:
   %79 = inttoptr i64 %78 to ptr
   %80 = load i64, ptr %79
   store ptr %70, ptr %79
-  store ptr @recover_rbp_asm.camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP.L142, ptr %76
+  store ptr @camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP.recover_rbp_asm.L142, ptr %76
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %73) "gc-leaf-function"="true"
   store i64 %80, ptr %70
   store i64 5, ptr %15
@@ -387,7 +387,7 @@ L176:
   %53 = icmp eq i64 %52, 0
   br i1 %53, label %L177, label %L152
 L177:
-  store ptr blockaddress(@camlExn_part2__raise_exn1_catch_exn2_from_llvm_1_10_code, %L176), ptr @recover_rbp_var.camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP.L176
+  store ptr blockaddress(@camlExn_part2__raise_exn1_catch_exn2_from_llvm_1_10_code, %L176), ptr @camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP.recover_rbp_var.L176
   %54 = call  ptr @llvm.stacksave()
   %55 = alloca { i64, i64, i64, i64 }
   %56 = ptrtoint ptr %55 to i64
@@ -401,7 +401,7 @@ L177:
   %64 = inttoptr i64 %63 to ptr
   %65 = load i64, ptr %64
   store ptr %55, ptr %64
-  store ptr @recover_rbp_asm.camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP.L176, ptr %61
+  store ptr @camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP.recover_rbp_asm.L176, ptr %61
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %58) "gc-leaf-function"="true"
   store i64 %65, ptr %55
   %66 = ptrtoint ptr @camlExn_part1 to i64
@@ -603,7 +603,7 @@ L218:
   %63 = icmp eq i64 %62, 0
   br i1 %63, label %L219, label %L185
 L219:
-  store ptr blockaddress(@camlExn_part2__catch_exn1_nested_from_llvm_2_11_code, %L218), ptr @recover_rbp_var.camlExn_part2__catch_exn1_nested_from_llvm_HIDE_STAMP.L218
+  store ptr blockaddress(@camlExn_part2__catch_exn1_nested_from_llvm_2_11_code, %L218), ptr @camlExn_part2__catch_exn1_nested_from_llvm_HIDE_STAMP.recover_rbp_var.L218
   %64 = call  ptr @llvm.stacksave()
   %65 = alloca { i64, i64, i64, i64 }
   %66 = ptrtoint ptr %65 to i64
@@ -617,7 +617,7 @@ L219:
   %74 = inttoptr i64 %73 to ptr
   %75 = load i64, ptr %74
   store ptr %65, ptr %74
-  store ptr @recover_rbp_asm.camlExn_part2__catch_exn1_nested_from_llvm_HIDE_STAMP.L218, ptr %71
+  store ptr @camlExn_part2__catch_exn1_nested_from_llvm_HIDE_STAMP.recover_rbp_asm.L218, ptr %71
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %68) "gc-leaf-function"="true"
   store i64 %75, ptr %65
   store i64 9, ptr %15
@@ -1088,7 +1088,7 @@ L332:
   %107 = icmp eq i64 %106, 0
   br i1 %107, label %L333, label %L244
 L333:
-  store ptr blockaddress(@camlExn_part2__complicated_6_15_code, %L332), ptr @recover_rbp_var.camlExn_part2__complicated_HIDE_STAMP.L332
+  store ptr blockaddress(@camlExn_part2__complicated_6_15_code, %L332), ptr @camlExn_part2__complicated_HIDE_STAMP.recover_rbp_var.L332
   %108 = call  ptr @llvm.stacksave()
   %109 = alloca { i64, i64, i64, i64 }
   %110 = ptrtoint ptr %109 to i64
@@ -1102,7 +1102,7 @@ L333:
   %118 = inttoptr i64 %117 to ptr
   %119 = load i64, ptr %118
   store ptr %109, ptr %118
-  store ptr @recover_rbp_asm.camlExn_part2__complicated_HIDE_STAMP.L332, ptr %115
+  store ptr @camlExn_part2__complicated_HIDE_STAMP.recover_rbp_asm.L332, ptr %115
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %112) "gc-leaf-function"="true"
   store i64 %119, ptr %109
   %120 = ptrtoint ptr @camlExn_part1 to i64
@@ -1165,7 +1165,7 @@ L334:
   %155 = icmp eq i64 %154, 0
   br i1 %155, label %L335, label %L260
 L335:
-  store ptr blockaddress(@camlExn_part2__complicated_6_15_code, %L334), ptr @recover_rbp_var.camlExn_part2__complicated_HIDE_STAMP.L334
+  store ptr blockaddress(@camlExn_part2__complicated_6_15_code, %L334), ptr @camlExn_part2__complicated_HIDE_STAMP.recover_rbp_var.L334
   %156 = call  ptr @llvm.stacksave()
   %157 = alloca { i64, i64, i64, i64 }
   %158 = ptrtoint ptr %157 to i64
@@ -1179,7 +1179,7 @@ L335:
   %166 = inttoptr i64 %165 to ptr
   %167 = load i64, ptr %166
   store ptr %157, ptr %166
-  store ptr @recover_rbp_asm.camlExn_part2__complicated_HIDE_STAMP.L334, ptr %163
+  store ptr @camlExn_part2__complicated_HIDE_STAMP.recover_rbp_asm.L334, ptr %163
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %160) "gc-leaf-function"="true"
   store i64 %167, ptr %157
   %168 = ptrtoint ptr @camlExn_part1 to i64
@@ -1242,7 +1242,7 @@ L336:
   %203 = icmp eq i64 %202, 0
   br i1 %203, label %L337, label %L276
 L337:
-  store ptr blockaddress(@camlExn_part2__complicated_6_15_code, %L336), ptr @recover_rbp_var.camlExn_part2__complicated_HIDE_STAMP.L336
+  store ptr blockaddress(@camlExn_part2__complicated_6_15_code, %L336), ptr @camlExn_part2__complicated_HIDE_STAMP.recover_rbp_var.L336
   %204 = call  ptr @llvm.stacksave()
   %205 = alloca { i64, i64, i64, i64 }
   %206 = ptrtoint ptr %205 to i64
@@ -1256,7 +1256,7 @@ L337:
   %214 = inttoptr i64 %213 to ptr
   %215 = load i64, ptr %214
   store ptr %205, ptr %214
-  store ptr @recover_rbp_asm.camlExn_part2__complicated_HIDE_STAMP.L336, ptr %211
+  store ptr @camlExn_part2__complicated_HIDE_STAMP.recover_rbp_asm.L336, ptr %211
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %208) "gc-leaf-function"="true"
   store i64 %215, ptr %205
   store i64 1, ptr %43
@@ -1580,7 +1580,7 @@ L394:
   %46 = icmp eq i64 %45, 0
   br i1 %46, label %L395, label %L353
 L395:
-  store ptr blockaddress(@camlExn_part2__raise_in_loop_7_16_code, %L394), ptr @recover_rbp_var.camlExn_part2__raise_in_loop_HIDE_STAMP.L394
+  store ptr blockaddress(@camlExn_part2__raise_in_loop_7_16_code, %L394), ptr @camlExn_part2__raise_in_loop_HIDE_STAMP.recover_rbp_var.L394
   %47 = call  ptr @llvm.stacksave()
   %48 = alloca { i64, i64, i64, i64 }
   %49 = ptrtoint ptr %48 to i64
@@ -1594,7 +1594,7 @@ L395:
   %57 = inttoptr i64 %56 to ptr
   %58 = load i64, ptr %57
   store ptr %48, ptr %57
-  store ptr @recover_rbp_asm.camlExn_part2__raise_in_loop_HIDE_STAMP.L394, ptr %54
+  store ptr @camlExn_part2__raise_in_loop_HIDE_STAMP.recover_rbp_asm.L394, ptr %54
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %51) "gc-leaf-function"="true"
   store i64 %58, ptr %48
   %59 = ptrtoint ptr @camlExn_part1 to i64
@@ -1820,7 +1820,7 @@ L426:
   %48 = icmp eq i64 %47, 0
   br i1 %48, label %L427, label %L403
 L427:
-  store ptr blockaddress(@camlExn_part2__catch_wildcard_8_17_code, %L426), ptr @recover_rbp_var.camlExn_part2__catch_wildcard_HIDE_STAMP.L426
+  store ptr blockaddress(@camlExn_part2__catch_wildcard_8_17_code, %L426), ptr @camlExn_part2__catch_wildcard_HIDE_STAMP.recover_rbp_var.L426
   %49 = call  ptr @llvm.stacksave()
   %50 = alloca { i64, i64, i64, i64 }
   %51 = ptrtoint ptr %50 to i64
@@ -1834,7 +1834,7 @@ L427:
   %59 = inttoptr i64 %58 to ptr
   %60 = load i64, ptr %59
   store ptr %50, ptr %59
-  store ptr @recover_rbp_asm.camlExn_part2__catch_wildcard_HIDE_STAMP.L426, ptr %56
+  store ptr @camlExn_part2__catch_wildcard_HIDE_STAMP.recover_rbp_asm.L426, ptr %56
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %53) "gc-leaf-function"="true"
   store i64 %60, ptr %50
   store i64 1, ptr %14
@@ -2151,22 +2151,22 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @camlExn_part2__const_block192 = global { ptr, i64, i64 } { ptr @camlExn_part2__immstring190, i64 101, i64 95 }, section ".data", align 8
 @header.camlExn_part2__immstring190 = global i64 3068, section ".data", align 8
 @camlExn_part2__immstring190 = global { [ 12 x i8 ], [ 3 x i8 ], i8 } { [ 12 x i8 ] c"\65\78\6e\5f\70\61\72\74\32\2e\6d\6c", [ 3 x i8 ] zeroinitializer, i8 3 }, section ".data", align 8
-@recover_rbp_asm.camlExn_part2__catch_wildcard_HIDE_STAMP.L426 = external global ptr
-@recover_rbp_var.camlExn_part2__catch_wildcard_HIDE_STAMP.L426 = global ptr zeroinitializer, section ".data", align 8
-@recover_rbp_asm.camlExn_part2__raise_in_loop_HIDE_STAMP.L394 = external global ptr
-@recover_rbp_var.camlExn_part2__raise_in_loop_HIDE_STAMP.L394 = global ptr zeroinitializer, section ".data", align 8
-@recover_rbp_asm.camlExn_part2__complicated_HIDE_STAMP.L332 = external global ptr
-@recover_rbp_var.camlExn_part2__complicated_HIDE_STAMP.L332 = global ptr zeroinitializer, section ".data", align 8
-@recover_rbp_asm.camlExn_part2__complicated_HIDE_STAMP.L334 = external global ptr
-@recover_rbp_var.camlExn_part2__complicated_HIDE_STAMP.L334 = global ptr zeroinitializer, section ".data", align 8
-@recover_rbp_asm.camlExn_part2__complicated_HIDE_STAMP.L336 = external global ptr
-@recover_rbp_var.camlExn_part2__complicated_HIDE_STAMP.L336 = global ptr zeroinitializer, section ".data", align 8
-@recover_rbp_asm.camlExn_part2__catch_exn1_nested_from_llvm_HIDE_STAMP.L218 = external global ptr
-@recover_rbp_var.camlExn_part2__catch_exn1_nested_from_llvm_HIDE_STAMP.L218 = global ptr zeroinitializer, section ".data", align 8
-@recover_rbp_asm.camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP.L176 = external global ptr
-@recover_rbp_var.camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP.L176 = global ptr zeroinitializer, section ".data", align 8
-@recover_rbp_asm.camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP.L142 = external global ptr
-@recover_rbp_var.camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP.L142 = global ptr zeroinitializer, section ".data", align 8
+@camlExn_part2__catch_wildcard_HIDE_STAMP.recover_rbp_asm.L426 = external global ptr
+@camlExn_part2__catch_wildcard_HIDE_STAMP.recover_rbp_var.L426 = global ptr zeroinitializer, section ".data", align 8
+@camlExn_part2__raise_in_loop_HIDE_STAMP.recover_rbp_asm.L394 = external global ptr
+@camlExn_part2__raise_in_loop_HIDE_STAMP.recover_rbp_var.L394 = global ptr zeroinitializer, section ".data", align 8
+@camlExn_part2__complicated_HIDE_STAMP.recover_rbp_asm.L332 = external global ptr
+@camlExn_part2__complicated_HIDE_STAMP.recover_rbp_var.L332 = global ptr zeroinitializer, section ".data", align 8
+@camlExn_part2__complicated_HIDE_STAMP.recover_rbp_asm.L334 = external global ptr
+@camlExn_part2__complicated_HIDE_STAMP.recover_rbp_var.L334 = global ptr zeroinitializer, section ".data", align 8
+@camlExn_part2__complicated_HIDE_STAMP.recover_rbp_asm.L336 = external global ptr
+@camlExn_part2__complicated_HIDE_STAMP.recover_rbp_var.L336 = global ptr zeroinitializer, section ".data", align 8
+@camlExn_part2__catch_exn1_nested_from_llvm_HIDE_STAMP.recover_rbp_asm.L218 = external global ptr
+@camlExn_part2__catch_exn1_nested_from_llvm_HIDE_STAMP.recover_rbp_var.L218 = global ptr zeroinitializer, section ".data", align 8
+@camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP.recover_rbp_asm.L176 = external global ptr
+@camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP.recover_rbp_var.L176 = global ptr zeroinitializer, section ".data", align 8
+@camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP.recover_rbp_asm.L142 = external global ptr
+@camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP.recover_rbp_var.L142 = global ptr zeroinitializer, section ".data", align 8
 @camlExn_part1 = external global ptr
 @camlStdlib__print_endline_138 = external global ptr
 @caml_c_call = external global ptr
@@ -2186,52 +2186,52 @@ declare ptr @llvm.stacksave()
 declare void @llvm.write_register.i64(metadata, i64)
 
 module asm "  .text"
-module asm "recover_rbp_asm.camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP.L142:"
+module asm "camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP.recover_rbp_asm.L142:"
 module asm "  pop %rbp"
 module asm "  addq $8, %rsp"
-module asm "  movq recover_rbp_var.camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP.L142(%rip), %rbx"
+module asm "  movq camlExn_part2__catch_exn1_from_llvm_HIDE_STAMP.recover_rbp_var.L142(%rip), %rbx"
 module asm "  jmpq *%rbx"
 module asm "  .text"
-module asm "recover_rbp_asm.camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP.L176:"
+module asm "camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP.recover_rbp_asm.L176:"
 module asm "  pop %rbp"
 module asm "  addq $8, %rsp"
-module asm "  movq recover_rbp_var.camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP.L176(%rip), %rbx"
+module asm "  movq camlExn_part2__raise_exn1_catch_exn2_from_llvm_HIDE_STAMP.recover_rbp_var.L176(%rip), %rbx"
 module asm "  jmpq *%rbx"
 module asm "  .text"
-module asm "recover_rbp_asm.camlExn_part2__catch_exn1_nested_from_llvm_HIDE_STAMP.L218:"
+module asm "camlExn_part2__catch_exn1_nested_from_llvm_HIDE_STAMP.recover_rbp_asm.L218:"
 module asm "  pop %rbp"
 module asm "  addq $8, %rsp"
-module asm "  movq recover_rbp_var.camlExn_part2__catch_exn1_nested_from_llvm_HIDE_STAMP.L218(%rip), %rbx"
+module asm "  movq camlExn_part2__catch_exn1_nested_from_llvm_HIDE_STAMP.recover_rbp_var.L218(%rip), %rbx"
 module asm "  jmpq *%rbx"
 module asm "  .text"
-module asm "recover_rbp_asm.camlExn_part2__complicated_HIDE_STAMP.L336:"
+module asm "camlExn_part2__complicated_HIDE_STAMP.recover_rbp_asm.L336:"
 module asm "  pop %rbp"
 module asm "  addq $8, %rsp"
-module asm "  movq recover_rbp_var.camlExn_part2__complicated_HIDE_STAMP.L336(%rip), %rbx"
+module asm "  movq camlExn_part2__complicated_HIDE_STAMP.recover_rbp_var.L336(%rip), %rbx"
 module asm "  jmpq *%rbx"
 module asm "  .text"
-module asm "recover_rbp_asm.camlExn_part2__complicated_HIDE_STAMP.L334:"
+module asm "camlExn_part2__complicated_HIDE_STAMP.recover_rbp_asm.L334:"
 module asm "  pop %rbp"
 module asm "  addq $8, %rsp"
-module asm "  movq recover_rbp_var.camlExn_part2__complicated_HIDE_STAMP.L334(%rip), %rbx"
+module asm "  movq camlExn_part2__complicated_HIDE_STAMP.recover_rbp_var.L334(%rip), %rbx"
 module asm "  jmpq *%rbx"
 module asm "  .text"
-module asm "recover_rbp_asm.camlExn_part2__complicated_HIDE_STAMP.L332:"
+module asm "camlExn_part2__complicated_HIDE_STAMP.recover_rbp_asm.L332:"
 module asm "  pop %rbp"
 module asm "  addq $8, %rsp"
-module asm "  movq recover_rbp_var.camlExn_part2__complicated_HIDE_STAMP.L332(%rip), %rbx"
+module asm "  movq camlExn_part2__complicated_HIDE_STAMP.recover_rbp_var.L332(%rip), %rbx"
 module asm "  jmpq *%rbx"
 module asm "  .text"
-module asm "recover_rbp_asm.camlExn_part2__raise_in_loop_HIDE_STAMP.L394:"
+module asm "camlExn_part2__raise_in_loop_HIDE_STAMP.recover_rbp_asm.L394:"
 module asm "  pop %rbp"
 module asm "  addq $8, %rsp"
-module asm "  movq recover_rbp_var.camlExn_part2__raise_in_loop_HIDE_STAMP.L394(%rip), %rbx"
+module asm "  movq camlExn_part2__raise_in_loop_HIDE_STAMP.recover_rbp_var.L394(%rip), %rbx"
 module asm "  jmpq *%rbx"
 module asm "  .text"
-module asm "recover_rbp_asm.camlExn_part2__catch_wildcard_HIDE_STAMP.L426:"
+module asm "camlExn_part2__catch_wildcard_HIDE_STAMP.recover_rbp_asm.L426:"
 module asm "  pop %rbp"
 module asm "  addq $8, %rsp"
-module asm "  movq recover_rbp_var.camlExn_part2__catch_wildcard_HIDE_STAMP.L426(%rip), %rbx"
+module asm "  movq camlExn_part2__catch_wildcard_HIDE_STAMP.recover_rbp_var.L426(%rip), %rbx"
 module asm "  jmpq *%rbx"
 
 !0 = !{ i32 1, !"oxcaml_module", !"Exn_part2" }

--- a/oxcaml/tests/backend/llvmize/extcalls_ir.output
+++ b/oxcaml/tests/backend/llvmize/extcalls_ir.output
@@ -291,5 +291,6 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @too_many = external global ptr
 
 
+
 !0 = !{ i32 1, !"oxcaml_module", !"Extcalls" }
 !llvm.module.flags = !{ !0 }

--- a/oxcaml/tests/backend/llvmize/float_ops_ir.output
+++ b/oxcaml/tests/backend/llvmize/float_ops_ir.output
@@ -358,5 +358,6 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 declare double @llvm.fabs.double(double)
 
+
 !0 = !{ i32 1, !"oxcaml_module", !"Float_ops" }
 !llvm.module.flags = !{ !0 }

--- a/oxcaml/tests/backend/llvmize/gcd_ir.output
+++ b/oxcaml/tests/backend/llvmize/gcd_ir.output
@@ -258,5 +258,6 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @caml_raise_exn = external global ptr
 
 
+
 !0 = !{ i32 1, !"oxcaml_module", !"Gcd" }
 !llvm.module.flags = !{ !0 }

--- a/oxcaml/tests/backend/llvmize/id_fn.output
+++ b/oxcaml/tests/backend/llvmize/id_fn.output
@@ -72,5 +72,6 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @camlId_fn__f_1 = global { ptr, i64 } { ptr @camlId_fn__f_HIDE_STAMP, i64 108086391056891909 }, section ".data", align 8
 
 
+
 !0 = !{ i32 1, !"oxcaml_module", !"Id_fn" }
 !llvm.module.flags = !{ !0 }

--- a/oxcaml/tests/backend/llvmize/indirect_call_ir.output
+++ b/oxcaml/tests/backend/llvmize/indirect_call_ir.output
@@ -103,5 +103,6 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @caml_curry2 = external global ptr
 
 
+
 !0 = !{ i32 1, !"oxcaml_module", !"Indirect_call" }
 !llvm.module.flags = !{ !0 }

--- a/oxcaml/tests/backend/llvmize/int_ops_ir.output
+++ b/oxcaml/tests/backend/llvmize/int_ops_ir.output
@@ -1784,5 +1784,6 @@ declare i64 @llvm.ctlz.i64(i64, i1)
 declare i64 @llvm.ctpop.i64(i64)
 declare i64 @llvm.cttz.i64(i64, i1)
 
+
 !0 = !{ i32 1, !"oxcaml_module", !"Int_ops" }
 !llvm.module.flags = !{ !0 }

--- a/oxcaml/tests/backend/llvmize/many_args_ir.output
+++ b/oxcaml/tests/backend/llvmize/many_args_ir.output
@@ -172,5 +172,6 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @caml_apply13 = external global ptr
 
 
+
 !0 = !{ i32 1, !"oxcaml_module", !"Many_args" }
 !llvm.module.flags = !{ !0 }

--- a/oxcaml/tests/backend/llvmize/multi_ret_ir.output
+++ b/oxcaml/tests/backend/llvmize/multi_ret_ir.output
@@ -102,5 +102,6 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @caml_curryF_F_F_F_RFFFF = external global ptr
 
 
+
 !0 = !{ i32 1, !"oxcaml_module", !"Multi_ret" }
 !llvm.module.flags = !{ !0 }

--- a/oxcaml/tests/backend/llvmize/switch_ir.output
+++ b/oxcaml/tests/backend/llvmize/switch_ir.output
@@ -275,6 +275,7 @@ L158:
   %44 = icmp eq i64 %43, 0
   br i1 %44, label %L159, label %L138
 L159:
+  store ptr blockaddress(@camlSwitch__test_next_1_3_code, %L158), ptr @recover_rbp_var.camlSwitch__test_next_HIDE_STAMP.L158
   %45 = call  ptr @llvm.stacksave()
   %46 = alloca { i64, i64, i64, i64 }
   %47 = ptrtoint ptr %46 to i64
@@ -288,7 +289,7 @@ L159:
   %55 = inttoptr i64 %54 to ptr
   %56 = load i64, ptr %55
   store ptr %46, ptr %55
-  store ptr blockaddress(@camlSwitch__test_next_HIDE_STAMP, %L158), ptr %52
+  store ptr @recover_rbp_asm.camlSwitch__test_next_HIDE_STAMP.L158, ptr %52
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %49) "gc-leaf-function"="true"
   store i64 %56, ptr %46
   %57 = load i64, ptr %11
@@ -344,7 +345,6 @@ L147:
   call  void @llvm.stackrestore(ptr %45)
   br label %L153
 L138:
-  call void asm sideeffect "pop %rbp; addq $$8, %rsp", ""() "gc-leaf-function"="true"
   %86 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
   store i64 %86, ptr %alloc
   store i64 %43, ptr %4
@@ -637,6 +637,7 @@ L361:
   %210 = icmp eq i64 %209, 0
   br i1 %210, label %L362, label %L170
 L362:
+  store ptr blockaddress(@camlSwitch__entry, %L361), ptr @recover_rbp_var.camlSwitch__entry.L361
   %211 = call  ptr @llvm.stacksave()
   %212 = alloca { i64, i64, i64, i64 }
   %213 = ptrtoint ptr %212 to i64
@@ -650,7 +651,7 @@ L362:
   %221 = inttoptr i64 %220 to ptr
   %222 = load i64, ptr %221
   store ptr %212, ptr %221
-  store ptr blockaddress(@camlSwitch__entry, %L361), ptr %218
+  store ptr @recover_rbp_asm.camlSwitch__entry.L361, ptr %218
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %215) "gc-leaf-function"="true"
   store i64 %222, ptr %212
   store i64 3, ptr %15
@@ -707,7 +708,6 @@ L179:
   call  void @llvm.stackrestore(ptr %211)
   br label %L185
 L170:
-  call void asm sideeffect "pop %rbp; addq $$8, %rsp", ""() "gc-leaf-function"="true"
   %252 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
   store i64 %252, ptr %alloc
   store i64 %209, ptr %4
@@ -806,6 +806,7 @@ L363:
   %306 = icmp eq i64 %305, 0
   br i1 %306, label %L364, label %L193
 L364:
+  store ptr blockaddress(@camlSwitch__entry, %L363), ptr @recover_rbp_var.camlSwitch__entry.L363
   %307 = call  ptr @llvm.stacksave()
   %308 = alloca { i64, i64, i64, i64 }
   %309 = ptrtoint ptr %308 to i64
@@ -819,7 +820,7 @@ L364:
   %317 = inttoptr i64 %316 to ptr
   %318 = load i64, ptr %317
   store ptr %308, ptr %317
-  store ptr blockaddress(@camlSwitch__entry, %L363), ptr %314
+  store ptr @recover_rbp_asm.camlSwitch__entry.L363, ptr %314
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %311) "gc-leaf-function"="true"
   store i64 %318, ptr %308
   store i64 7, ptr %38
@@ -876,7 +877,6 @@ L202:
   call  void @llvm.stackrestore(ptr %307)
   br label %L208
 L193:
-  call void asm sideeffect "pop %rbp; addq $$8, %rsp", ""() "gc-leaf-function"="true"
   %348 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
   store i64 %348, ptr %alloc
   store i64 %305, ptr %4
@@ -975,6 +975,7 @@ L365:
   %402 = icmp eq i64 %401, 0
   br i1 %402, label %L366, label %L216
 L366:
+  store ptr blockaddress(@camlSwitch__entry, %L365), ptr @recover_rbp_var.camlSwitch__entry.L365
   %403 = call  ptr @llvm.stacksave()
   %404 = alloca { i64, i64, i64, i64 }
   %405 = ptrtoint ptr %404 to i64
@@ -988,7 +989,7 @@ L366:
   %413 = inttoptr i64 %412 to ptr
   %414 = load i64, ptr %413
   store ptr %404, ptr %413
-  store ptr blockaddress(@camlSwitch__entry, %L365), ptr %410
+  store ptr @recover_rbp_asm.camlSwitch__entry.L365, ptr %410
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %407) "gc-leaf-function"="true"
   store i64 %414, ptr %404
   store i64 11, ptr %61
@@ -1045,7 +1046,6 @@ L225:
   call  void @llvm.stackrestore(ptr %403)
   br label %L231
 L216:
-  call void asm sideeffect "pop %rbp; addq $$8, %rsp", ""() "gc-leaf-function"="true"
   %444 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
   store i64 %444, ptr %alloc
   store i64 %401, ptr %4
@@ -1144,6 +1144,7 @@ L367:
   %498 = icmp eq i64 %497, 0
   br i1 %498, label %L368, label %L239
 L368:
+  store ptr blockaddress(@camlSwitch__entry, %L367), ptr @recover_rbp_var.camlSwitch__entry.L367
   %499 = call  ptr @llvm.stacksave()
   %500 = alloca { i64, i64, i64, i64 }
   %501 = ptrtoint ptr %500 to i64
@@ -1157,7 +1158,7 @@ L368:
   %509 = inttoptr i64 %508 to ptr
   %510 = load i64, ptr %509
   store ptr %500, ptr %509
-  store ptr blockaddress(@camlSwitch__entry, %L367), ptr %506
+  store ptr @recover_rbp_asm.camlSwitch__entry.L367, ptr %506
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %503) "gc-leaf-function"="true"
   store i64 %510, ptr %500
   store i64 15, ptr %84
@@ -1214,7 +1215,6 @@ L248:
   call  void @llvm.stackrestore(ptr %499)
   br label %L254
 L239:
-  call void asm sideeffect "pop %rbp; addq $$8, %rsp", ""() "gc-leaf-function"="true"
   %540 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
   store i64 %540, ptr %alloc
   store i64 %497, ptr %4
@@ -1313,6 +1313,7 @@ L369:
   %594 = icmp eq i64 %593, 0
   br i1 %594, label %L370, label %L262
 L370:
+  store ptr blockaddress(@camlSwitch__entry, %L369), ptr @recover_rbp_var.camlSwitch__entry.L369
   %595 = call  ptr @llvm.stacksave()
   %596 = alloca { i64, i64, i64, i64 }
   %597 = ptrtoint ptr %596 to i64
@@ -1326,7 +1327,7 @@ L370:
   %605 = inttoptr i64 %604 to ptr
   %606 = load i64, ptr %605
   store ptr %596, ptr %605
-  store ptr blockaddress(@camlSwitch__entry, %L369), ptr %602
+  store ptr @recover_rbp_asm.camlSwitch__entry.L369, ptr %602
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %599) "gc-leaf-function"="true"
   store i64 %606, ptr %596
   store i64 19, ptr %107
@@ -1383,7 +1384,6 @@ L271:
   call  void @llvm.stackrestore(ptr %595)
   br label %L277
 L262:
-  call void asm sideeffect "pop %rbp; addq $$8, %rsp", ""() "gc-leaf-function"="true"
   %636 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
   store i64 %636, ptr %alloc
   store i64 %593, ptr %4
@@ -1482,6 +1482,7 @@ L371:
   %690 = icmp eq i64 %689, 0
   br i1 %690, label %L372, label %L285
 L372:
+  store ptr blockaddress(@camlSwitch__entry, %L371), ptr @recover_rbp_var.camlSwitch__entry.L371
   %691 = call  ptr @llvm.stacksave()
   %692 = alloca { i64, i64, i64, i64 }
   %693 = ptrtoint ptr %692 to i64
@@ -1495,7 +1496,7 @@ L372:
   %701 = inttoptr i64 %700 to ptr
   %702 = load i64, ptr %701
   store ptr %692, ptr %701
-  store ptr blockaddress(@camlSwitch__entry, %L371), ptr %698
+  store ptr @recover_rbp_asm.camlSwitch__entry.L371, ptr %698
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %695) "gc-leaf-function"="true"
   store i64 %702, ptr %692
   store i64 5, ptr %130
@@ -1552,7 +1553,6 @@ L294:
   call  void @llvm.stackrestore(ptr %691)
   br label %L300
 L285:
-  call void asm sideeffect "pop %rbp; addq $$8, %rsp", ""() "gc-leaf-function"="true"
   %732 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
   store i64 %732, ptr %alloc
   store i64 %689, ptr %4
@@ -1651,6 +1651,7 @@ L373:
   %786 = icmp eq i64 %785, 0
   br i1 %786, label %L374, label %L308
 L374:
+  store ptr blockaddress(@camlSwitch__entry, %L373), ptr @recover_rbp_var.camlSwitch__entry.L373
   %787 = call  ptr @llvm.stacksave()
   %788 = alloca { i64, i64, i64, i64 }
   %789 = ptrtoint ptr %788 to i64
@@ -1664,7 +1665,7 @@ L374:
   %797 = inttoptr i64 %796 to ptr
   %798 = load i64, ptr %797
   store ptr %788, ptr %797
-  store ptr blockaddress(@camlSwitch__entry, %L373), ptr %794
+  store ptr @recover_rbp_asm.camlSwitch__entry.L373, ptr %794
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %791) "gc-leaf-function"="true"
   store i64 %798, ptr %788
   store i64 1, ptr %153
@@ -1721,7 +1722,6 @@ L317:
   call  void @llvm.stackrestore(ptr %787)
   br label %L323
 L308:
-  call void asm sideeffect "pop %rbp; addq $$8, %rsp", ""() "gc-leaf-function"="true"
   %828 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
   store i64 %828, ptr %alloc
   store i64 %785, ptr %4
@@ -1820,6 +1820,7 @@ L375:
   %882 = icmp eq i64 %881, 0
   br i1 %882, label %L376, label %L331
 L376:
+  store ptr blockaddress(@camlSwitch__entry, %L375), ptr @recover_rbp_var.camlSwitch__entry.L375
   %883 = call  ptr @llvm.stacksave()
   %884 = alloca { i64, i64, i64, i64 }
   %885 = ptrtoint ptr %884 to i64
@@ -1833,7 +1834,7 @@ L376:
   %893 = inttoptr i64 %892 to ptr
   %894 = load i64, ptr %893
   store ptr %884, ptr %893
-  store ptr blockaddress(@camlSwitch__entry, %L375), ptr %890
+  store ptr @recover_rbp_asm.camlSwitch__entry.L375, ptr %890
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %887) "gc-leaf-function"="true"
   store i64 %894, ptr %884
   store i64 201, ptr %176
@@ -1890,7 +1891,6 @@ L340:
   call  void @llvm.stackrestore(ptr %883)
   br label %L346
 L331:
-  call void asm sideeffect "pop %rbp; addq $$8, %rsp", ""() "gc-leaf-function"="true"
   %924 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
   store i64 %924, ptr %alloc
   store i64 %881, ptr %4
@@ -2023,6 +2023,24 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @camlSwitch__const_block17 = global { ptr, i64, i64 } { ptr @camlSwitch__immstring15, i64 5, i64 5 }, section ".data", align 8
 @header.camlSwitch__immstring15 = global i64 3068, section ".data", align 8
 @camlSwitch__immstring15 = global { [ 9 x i8 ], [ 6 x i8 ], i8 } { [ 9 x i8 ] c"\73\77\69\74\63\68\2e\6d\6c", [ 6 x i8 ] zeroinitializer, i8 6 }, section ".data", align 8
+@recover_rbp_asm.camlSwitch__entry.L367 = external global ptr
+@recover_rbp_var.camlSwitch__entry.L367 = global ptr zeroinitializer, section ".data", align 8
+@recover_rbp_asm.camlSwitch__entry.L371 = external global ptr
+@recover_rbp_var.camlSwitch__entry.L371 = global ptr zeroinitializer, section ".data", align 8
+@recover_rbp_asm.camlSwitch__entry.L375 = external global ptr
+@recover_rbp_var.camlSwitch__entry.L375 = global ptr zeroinitializer, section ".data", align 8
+@recover_rbp_asm.camlSwitch__entry.L361 = external global ptr
+@recover_rbp_var.camlSwitch__entry.L361 = global ptr zeroinitializer, section ".data", align 8
+@recover_rbp_asm.camlSwitch__entry.L365 = external global ptr
+@recover_rbp_var.camlSwitch__entry.L365 = global ptr zeroinitializer, section ".data", align 8
+@recover_rbp_asm.camlSwitch__entry.L369 = external global ptr
+@recover_rbp_var.camlSwitch__entry.L369 = global ptr zeroinitializer, section ".data", align 8
+@recover_rbp_asm.camlSwitch__entry.L373 = external global ptr
+@recover_rbp_var.camlSwitch__entry.L373 = global ptr zeroinitializer, section ".data", align 8
+@recover_rbp_asm.camlSwitch__entry.L363 = external global ptr
+@recover_rbp_var.camlSwitch__entry.L363 = global ptr zeroinitializer, section ".data", align 8
+@recover_rbp_asm.camlSwitch__test_next_HIDE_STAMP.L158 = external global ptr
+@recover_rbp_var.camlSwitch__test_next_HIDE_STAMP.L158 = global ptr zeroinitializer, section ".data", align 8
 @camlCamlinternalFormat__make_printf_HIDE_STAMP = external global ptr
 @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1451$2c4$2d$2d59$5d_521 = external global ptr
 @camlStdlib__Int__immstring64 = external global ptr
@@ -2034,6 +2052,61 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 declare void @llvm.stackrestore(ptr)
 declare ptr @llvm.stacksave()
+
+module asm "  .text"
+module asm "recover_rbp_asm.camlSwitch__test_next_HIDE_STAMP.L158:"
+module asm "  pop %rbp"
+module asm "  addq $8, %rsp"
+module asm "  movq recover_rbp_var.camlSwitch__test_next_HIDE_STAMP.L158(%rip), %rbx"
+module asm "  jmpq *%rbx"
+module asm "  .text"
+module asm "recover_rbp_asm.camlSwitch__entry.L363:"
+module asm "  pop %rbp"
+module asm "  addq $8, %rsp"
+module asm "  movq recover_rbp_var.camlSwitch__entry.L363(%rip), %rbx"
+module asm "  jmpq *%rbx"
+module asm "  .text"
+module asm "recover_rbp_asm.camlSwitch__entry.L373:"
+module asm "  pop %rbp"
+module asm "  addq $8, %rsp"
+module asm "  movq recover_rbp_var.camlSwitch__entry.L373(%rip), %rbx"
+module asm "  jmpq *%rbx"
+module asm "  .text"
+module asm "recover_rbp_asm.camlSwitch__entry.L369:"
+module asm "  pop %rbp"
+module asm "  addq $8, %rsp"
+module asm "  movq recover_rbp_var.camlSwitch__entry.L369(%rip), %rbx"
+module asm "  jmpq *%rbx"
+module asm "  .text"
+module asm "recover_rbp_asm.camlSwitch__entry.L365:"
+module asm "  pop %rbp"
+module asm "  addq $8, %rsp"
+module asm "  movq recover_rbp_var.camlSwitch__entry.L365(%rip), %rbx"
+module asm "  jmpq *%rbx"
+module asm "  .text"
+module asm "recover_rbp_asm.camlSwitch__entry.L361:"
+module asm "  pop %rbp"
+module asm "  addq $8, %rsp"
+module asm "  movq recover_rbp_var.camlSwitch__entry.L361(%rip), %rbx"
+module asm "  jmpq *%rbx"
+module asm "  .text"
+module asm "recover_rbp_asm.camlSwitch__entry.L375:"
+module asm "  pop %rbp"
+module asm "  addq $8, %rsp"
+module asm "  movq recover_rbp_var.camlSwitch__entry.L375(%rip), %rbx"
+module asm "  jmpq *%rbx"
+module asm "  .text"
+module asm "recover_rbp_asm.camlSwitch__entry.L371:"
+module asm "  pop %rbp"
+module asm "  addq $8, %rsp"
+module asm "  movq recover_rbp_var.camlSwitch__entry.L371(%rip), %rbx"
+module asm "  jmpq *%rbx"
+module asm "  .text"
+module asm "recover_rbp_asm.camlSwitch__entry.L367:"
+module asm "  pop %rbp"
+module asm "  addq $8, %rsp"
+module asm "  movq recover_rbp_var.camlSwitch__entry.L367(%rip), %rbx"
+module asm "  jmpq *%rbx"
 
 !0 = !{ i32 1, !"oxcaml_module", !"Switch" }
 !llvm.module.flags = !{ !0 }

--- a/oxcaml/tests/backend/llvmize/switch_ir.output
+++ b/oxcaml/tests/backend/llvmize/switch_ir.output
@@ -275,7 +275,7 @@ L158:
   %44 = icmp eq i64 %43, 0
   br i1 %44, label %L159, label %L138
 L159:
-  store ptr blockaddress(@camlSwitch__test_next_1_3_code, %L158), ptr @recover_rbp_var.camlSwitch__test_next_HIDE_STAMP.L158
+  store ptr blockaddress(@camlSwitch__test_next_1_3_code, %L158), ptr @camlSwitch__test_next_HIDE_STAMP.recover_rbp_var.L158
   %45 = call  ptr @llvm.stacksave()
   %46 = alloca { i64, i64, i64, i64 }
   %47 = ptrtoint ptr %46 to i64
@@ -289,7 +289,7 @@ L159:
   %55 = inttoptr i64 %54 to ptr
   %56 = load i64, ptr %55
   store ptr %46, ptr %55
-  store ptr @recover_rbp_asm.camlSwitch__test_next_HIDE_STAMP.L158, ptr %52
+  store ptr @camlSwitch__test_next_HIDE_STAMP.recover_rbp_asm.L158, ptr %52
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %49) "gc-leaf-function"="true"
   store i64 %56, ptr %46
   %57 = load i64, ptr %11
@@ -637,7 +637,7 @@ L361:
   %210 = icmp eq i64 %209, 0
   br i1 %210, label %L362, label %L170
 L362:
-  store ptr blockaddress(@camlSwitch__entry, %L361), ptr @recover_rbp_var.camlSwitch__entry.L361
+  store ptr blockaddress(@camlSwitch__entry, %L361), ptr @camlSwitch__entry.recover_rbp_var.L361
   %211 = call  ptr @llvm.stacksave()
   %212 = alloca { i64, i64, i64, i64 }
   %213 = ptrtoint ptr %212 to i64
@@ -651,7 +651,7 @@ L362:
   %221 = inttoptr i64 %220 to ptr
   %222 = load i64, ptr %221
   store ptr %212, ptr %221
-  store ptr @recover_rbp_asm.camlSwitch__entry.L361, ptr %218
+  store ptr @camlSwitch__entry.recover_rbp_asm.L361, ptr %218
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %215) "gc-leaf-function"="true"
   store i64 %222, ptr %212
   store i64 3, ptr %15
@@ -806,7 +806,7 @@ L363:
   %306 = icmp eq i64 %305, 0
   br i1 %306, label %L364, label %L193
 L364:
-  store ptr blockaddress(@camlSwitch__entry, %L363), ptr @recover_rbp_var.camlSwitch__entry.L363
+  store ptr blockaddress(@camlSwitch__entry, %L363), ptr @camlSwitch__entry.recover_rbp_var.L363
   %307 = call  ptr @llvm.stacksave()
   %308 = alloca { i64, i64, i64, i64 }
   %309 = ptrtoint ptr %308 to i64
@@ -820,7 +820,7 @@ L364:
   %317 = inttoptr i64 %316 to ptr
   %318 = load i64, ptr %317
   store ptr %308, ptr %317
-  store ptr @recover_rbp_asm.camlSwitch__entry.L363, ptr %314
+  store ptr @camlSwitch__entry.recover_rbp_asm.L363, ptr %314
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %311) "gc-leaf-function"="true"
   store i64 %318, ptr %308
   store i64 7, ptr %38
@@ -975,7 +975,7 @@ L365:
   %402 = icmp eq i64 %401, 0
   br i1 %402, label %L366, label %L216
 L366:
-  store ptr blockaddress(@camlSwitch__entry, %L365), ptr @recover_rbp_var.camlSwitch__entry.L365
+  store ptr blockaddress(@camlSwitch__entry, %L365), ptr @camlSwitch__entry.recover_rbp_var.L365
   %403 = call  ptr @llvm.stacksave()
   %404 = alloca { i64, i64, i64, i64 }
   %405 = ptrtoint ptr %404 to i64
@@ -989,7 +989,7 @@ L366:
   %413 = inttoptr i64 %412 to ptr
   %414 = load i64, ptr %413
   store ptr %404, ptr %413
-  store ptr @recover_rbp_asm.camlSwitch__entry.L365, ptr %410
+  store ptr @camlSwitch__entry.recover_rbp_asm.L365, ptr %410
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %407) "gc-leaf-function"="true"
   store i64 %414, ptr %404
   store i64 11, ptr %61
@@ -1144,7 +1144,7 @@ L367:
   %498 = icmp eq i64 %497, 0
   br i1 %498, label %L368, label %L239
 L368:
-  store ptr blockaddress(@camlSwitch__entry, %L367), ptr @recover_rbp_var.camlSwitch__entry.L367
+  store ptr blockaddress(@camlSwitch__entry, %L367), ptr @camlSwitch__entry.recover_rbp_var.L367
   %499 = call  ptr @llvm.stacksave()
   %500 = alloca { i64, i64, i64, i64 }
   %501 = ptrtoint ptr %500 to i64
@@ -1158,7 +1158,7 @@ L368:
   %509 = inttoptr i64 %508 to ptr
   %510 = load i64, ptr %509
   store ptr %500, ptr %509
-  store ptr @recover_rbp_asm.camlSwitch__entry.L367, ptr %506
+  store ptr @camlSwitch__entry.recover_rbp_asm.L367, ptr %506
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %503) "gc-leaf-function"="true"
   store i64 %510, ptr %500
   store i64 15, ptr %84
@@ -1313,7 +1313,7 @@ L369:
   %594 = icmp eq i64 %593, 0
   br i1 %594, label %L370, label %L262
 L370:
-  store ptr blockaddress(@camlSwitch__entry, %L369), ptr @recover_rbp_var.camlSwitch__entry.L369
+  store ptr blockaddress(@camlSwitch__entry, %L369), ptr @camlSwitch__entry.recover_rbp_var.L369
   %595 = call  ptr @llvm.stacksave()
   %596 = alloca { i64, i64, i64, i64 }
   %597 = ptrtoint ptr %596 to i64
@@ -1327,7 +1327,7 @@ L370:
   %605 = inttoptr i64 %604 to ptr
   %606 = load i64, ptr %605
   store ptr %596, ptr %605
-  store ptr @recover_rbp_asm.camlSwitch__entry.L369, ptr %602
+  store ptr @camlSwitch__entry.recover_rbp_asm.L369, ptr %602
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %599) "gc-leaf-function"="true"
   store i64 %606, ptr %596
   store i64 19, ptr %107
@@ -1482,7 +1482,7 @@ L371:
   %690 = icmp eq i64 %689, 0
   br i1 %690, label %L372, label %L285
 L372:
-  store ptr blockaddress(@camlSwitch__entry, %L371), ptr @recover_rbp_var.camlSwitch__entry.L371
+  store ptr blockaddress(@camlSwitch__entry, %L371), ptr @camlSwitch__entry.recover_rbp_var.L371
   %691 = call  ptr @llvm.stacksave()
   %692 = alloca { i64, i64, i64, i64 }
   %693 = ptrtoint ptr %692 to i64
@@ -1496,7 +1496,7 @@ L372:
   %701 = inttoptr i64 %700 to ptr
   %702 = load i64, ptr %701
   store ptr %692, ptr %701
-  store ptr @recover_rbp_asm.camlSwitch__entry.L371, ptr %698
+  store ptr @camlSwitch__entry.recover_rbp_asm.L371, ptr %698
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %695) "gc-leaf-function"="true"
   store i64 %702, ptr %692
   store i64 5, ptr %130
@@ -1651,7 +1651,7 @@ L373:
   %786 = icmp eq i64 %785, 0
   br i1 %786, label %L374, label %L308
 L374:
-  store ptr blockaddress(@camlSwitch__entry, %L373), ptr @recover_rbp_var.camlSwitch__entry.L373
+  store ptr blockaddress(@camlSwitch__entry, %L373), ptr @camlSwitch__entry.recover_rbp_var.L373
   %787 = call  ptr @llvm.stacksave()
   %788 = alloca { i64, i64, i64, i64 }
   %789 = ptrtoint ptr %788 to i64
@@ -1665,7 +1665,7 @@ L374:
   %797 = inttoptr i64 %796 to ptr
   %798 = load i64, ptr %797
   store ptr %788, ptr %797
-  store ptr @recover_rbp_asm.camlSwitch__entry.L373, ptr %794
+  store ptr @camlSwitch__entry.recover_rbp_asm.L373, ptr %794
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %791) "gc-leaf-function"="true"
   store i64 %798, ptr %788
   store i64 1, ptr %153
@@ -1820,7 +1820,7 @@ L375:
   %882 = icmp eq i64 %881, 0
   br i1 %882, label %L376, label %L331
 L376:
-  store ptr blockaddress(@camlSwitch__entry, %L375), ptr @recover_rbp_var.camlSwitch__entry.L375
+  store ptr blockaddress(@camlSwitch__entry, %L375), ptr @camlSwitch__entry.recover_rbp_var.L375
   %883 = call  ptr @llvm.stacksave()
   %884 = alloca { i64, i64, i64, i64 }
   %885 = ptrtoint ptr %884 to i64
@@ -1834,7 +1834,7 @@ L376:
   %893 = inttoptr i64 %892 to ptr
   %894 = load i64, ptr %893
   store ptr %884, ptr %893
-  store ptr @recover_rbp_asm.camlSwitch__entry.L375, ptr %890
+  store ptr @camlSwitch__entry.recover_rbp_asm.L375, ptr %890
   call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %887) "gc-leaf-function"="true"
   store i64 %894, ptr %884
   store i64 201, ptr %176
@@ -2023,24 +2023,24 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @camlSwitch__const_block17 = global { ptr, i64, i64 } { ptr @camlSwitch__immstring15, i64 5, i64 5 }, section ".data", align 8
 @header.camlSwitch__immstring15 = global i64 3068, section ".data", align 8
 @camlSwitch__immstring15 = global { [ 9 x i8 ], [ 6 x i8 ], i8 } { [ 9 x i8 ] c"\73\77\69\74\63\68\2e\6d\6c", [ 6 x i8 ] zeroinitializer, i8 6 }, section ".data", align 8
-@recover_rbp_asm.camlSwitch__entry.L367 = external global ptr
-@recover_rbp_var.camlSwitch__entry.L367 = global ptr zeroinitializer, section ".data", align 8
-@recover_rbp_asm.camlSwitch__entry.L371 = external global ptr
-@recover_rbp_var.camlSwitch__entry.L371 = global ptr zeroinitializer, section ".data", align 8
-@recover_rbp_asm.camlSwitch__entry.L375 = external global ptr
-@recover_rbp_var.camlSwitch__entry.L375 = global ptr zeroinitializer, section ".data", align 8
-@recover_rbp_asm.camlSwitch__entry.L361 = external global ptr
-@recover_rbp_var.camlSwitch__entry.L361 = global ptr zeroinitializer, section ".data", align 8
-@recover_rbp_asm.camlSwitch__entry.L365 = external global ptr
-@recover_rbp_var.camlSwitch__entry.L365 = global ptr zeroinitializer, section ".data", align 8
-@recover_rbp_asm.camlSwitch__entry.L369 = external global ptr
-@recover_rbp_var.camlSwitch__entry.L369 = global ptr zeroinitializer, section ".data", align 8
-@recover_rbp_asm.camlSwitch__entry.L373 = external global ptr
-@recover_rbp_var.camlSwitch__entry.L373 = global ptr zeroinitializer, section ".data", align 8
-@recover_rbp_asm.camlSwitch__entry.L363 = external global ptr
-@recover_rbp_var.camlSwitch__entry.L363 = global ptr zeroinitializer, section ".data", align 8
-@recover_rbp_asm.camlSwitch__test_next_HIDE_STAMP.L158 = external global ptr
-@recover_rbp_var.camlSwitch__test_next_HIDE_STAMP.L158 = global ptr zeroinitializer, section ".data", align 8
+@camlSwitch__entry.recover_rbp_asm.L367 = external global ptr
+@camlSwitch__entry.recover_rbp_var.L367 = global ptr zeroinitializer, section ".data", align 8
+@camlSwitch__entry.recover_rbp_asm.L371 = external global ptr
+@camlSwitch__entry.recover_rbp_var.L371 = global ptr zeroinitializer, section ".data", align 8
+@camlSwitch__entry.recover_rbp_asm.L375 = external global ptr
+@camlSwitch__entry.recover_rbp_var.L375 = global ptr zeroinitializer, section ".data", align 8
+@camlSwitch__entry.recover_rbp_asm.L361 = external global ptr
+@camlSwitch__entry.recover_rbp_var.L361 = global ptr zeroinitializer, section ".data", align 8
+@camlSwitch__entry.recover_rbp_asm.L365 = external global ptr
+@camlSwitch__entry.recover_rbp_var.L365 = global ptr zeroinitializer, section ".data", align 8
+@camlSwitch__entry.recover_rbp_asm.L369 = external global ptr
+@camlSwitch__entry.recover_rbp_var.L369 = global ptr zeroinitializer, section ".data", align 8
+@camlSwitch__entry.recover_rbp_asm.L373 = external global ptr
+@camlSwitch__entry.recover_rbp_var.L373 = global ptr zeroinitializer, section ".data", align 8
+@camlSwitch__entry.recover_rbp_asm.L363 = external global ptr
+@camlSwitch__entry.recover_rbp_var.L363 = global ptr zeroinitializer, section ".data", align 8
+@camlSwitch__test_next_HIDE_STAMP.recover_rbp_asm.L158 = external global ptr
+@camlSwitch__test_next_HIDE_STAMP.recover_rbp_var.L158 = global ptr zeroinitializer, section ".data", align 8
 @camlCamlinternalFormat__make_printf_HIDE_STAMP = external global ptr
 @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1451$2c4$2d$2d59$5d_521 = external global ptr
 @camlStdlib__Int__immstring64 = external global ptr
@@ -2054,58 +2054,58 @@ declare void @llvm.stackrestore(ptr)
 declare ptr @llvm.stacksave()
 
 module asm "  .text"
-module asm "recover_rbp_asm.camlSwitch__test_next_HIDE_STAMP.L158:"
+module asm "camlSwitch__test_next_HIDE_STAMP.recover_rbp_asm.L158:"
 module asm "  pop %rbp"
 module asm "  addq $8, %rsp"
-module asm "  movq recover_rbp_var.camlSwitch__test_next_HIDE_STAMP.L158(%rip), %rbx"
+module asm "  movq camlSwitch__test_next_HIDE_STAMP.recover_rbp_var.L158(%rip), %rbx"
 module asm "  jmpq *%rbx"
 module asm "  .text"
-module asm "recover_rbp_asm.camlSwitch__entry.L363:"
+module asm "camlSwitch__entry.recover_rbp_asm.L363:"
 module asm "  pop %rbp"
 module asm "  addq $8, %rsp"
-module asm "  movq recover_rbp_var.camlSwitch__entry.L363(%rip), %rbx"
+module asm "  movq camlSwitch__entry.recover_rbp_var.L363(%rip), %rbx"
 module asm "  jmpq *%rbx"
 module asm "  .text"
-module asm "recover_rbp_asm.camlSwitch__entry.L373:"
+module asm "camlSwitch__entry.recover_rbp_asm.L373:"
 module asm "  pop %rbp"
 module asm "  addq $8, %rsp"
-module asm "  movq recover_rbp_var.camlSwitch__entry.L373(%rip), %rbx"
+module asm "  movq camlSwitch__entry.recover_rbp_var.L373(%rip), %rbx"
 module asm "  jmpq *%rbx"
 module asm "  .text"
-module asm "recover_rbp_asm.camlSwitch__entry.L369:"
+module asm "camlSwitch__entry.recover_rbp_asm.L369:"
 module asm "  pop %rbp"
 module asm "  addq $8, %rsp"
-module asm "  movq recover_rbp_var.camlSwitch__entry.L369(%rip), %rbx"
+module asm "  movq camlSwitch__entry.recover_rbp_var.L369(%rip), %rbx"
 module asm "  jmpq *%rbx"
 module asm "  .text"
-module asm "recover_rbp_asm.camlSwitch__entry.L365:"
+module asm "camlSwitch__entry.recover_rbp_asm.L365:"
 module asm "  pop %rbp"
 module asm "  addq $8, %rsp"
-module asm "  movq recover_rbp_var.camlSwitch__entry.L365(%rip), %rbx"
+module asm "  movq camlSwitch__entry.recover_rbp_var.L365(%rip), %rbx"
 module asm "  jmpq *%rbx"
 module asm "  .text"
-module asm "recover_rbp_asm.camlSwitch__entry.L361:"
+module asm "camlSwitch__entry.recover_rbp_asm.L361:"
 module asm "  pop %rbp"
 module asm "  addq $8, %rsp"
-module asm "  movq recover_rbp_var.camlSwitch__entry.L361(%rip), %rbx"
+module asm "  movq camlSwitch__entry.recover_rbp_var.L361(%rip), %rbx"
 module asm "  jmpq *%rbx"
 module asm "  .text"
-module asm "recover_rbp_asm.camlSwitch__entry.L375:"
+module asm "camlSwitch__entry.recover_rbp_asm.L375:"
 module asm "  pop %rbp"
 module asm "  addq $8, %rsp"
-module asm "  movq recover_rbp_var.camlSwitch__entry.L375(%rip), %rbx"
+module asm "  movq camlSwitch__entry.recover_rbp_var.L375(%rip), %rbx"
 module asm "  jmpq *%rbx"
 module asm "  .text"
-module asm "recover_rbp_asm.camlSwitch__entry.L371:"
+module asm "camlSwitch__entry.recover_rbp_asm.L371:"
 module asm "  pop %rbp"
 module asm "  addq $8, %rsp"
-module asm "  movq recover_rbp_var.camlSwitch__entry.L371(%rip), %rbx"
+module asm "  movq camlSwitch__entry.recover_rbp_var.L371(%rip), %rbx"
 module asm "  jmpq *%rbx"
 module asm "  .text"
-module asm "recover_rbp_asm.camlSwitch__entry.L367:"
+module asm "camlSwitch__entry.recover_rbp_asm.L367:"
 module asm "  pop %rbp"
 module asm "  addq $8, %rsp"
-module asm "  movq recover_rbp_var.camlSwitch__entry.L367(%rip), %rbx"
+module asm "  movq camlSwitch__entry.recover_rbp_var.L367(%rip), %rbx"
 module asm "  jmpq *%rbx"
 
 !0 = !{ i32 1, !"oxcaml_module", !"Switch" }

--- a/oxcaml/tests/backend/llvmize/tailcall_ir.output
+++ b/oxcaml/tests/backend/llvmize/tailcall_ir.output
@@ -1039,5 +1039,6 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @caml_curry3 = external global ptr
 
 
+
 !0 = !{ i32 1, !"oxcaml_module", !"Tailcall" }
 !llvm.module.flags = !{ !0 }


### PR DESCRIPTION
This adds module-level asm to handle RBP recovery first thing before trap handler entry. This is needed since in the previous version, it was possible for LLVM to restore values from the stack using RBP before it was recovered.

Since there is no clear way to access a label in a function from module-level asm, we store the label address in a dedicated global variable and load from it in asm.