### PR TITLE
(LLVM backend) Improve debug printing 

### DIFF
--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -46,7 +46,8 @@ let class_of_operation (op : Operation.t)
     | Icldemote _
     | Iprefetch _ -> Class Op_other
     | Illvm_intrinsic intr ->
-      Misc.fatal_errorf "Unexpected llvm_intrinsic %s: not using LLVM backend"
+      Misc.fatal_errorf "CSE.class_of_operation: Unexpected llvm_intrinsic %s: \
+                         not using LLVM backend"
         intr
     end
   | Move | Spill | Reload

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -456,7 +456,8 @@ let operation_is_pure = function
   | Isimd op -> Simd.is_pure_operation op
   | Isimd_mem (op, _addr) -> Simd.Mem.is_pure_operation op
   | Illvm_intrinsic intr ->
-    Misc.fatal_errorf "Unexpected llvm_intrinsic %s: not using LLVM backend"
+      Misc.fatal_errorf "operation_is_pure: Unexpected llvm_intrinsic %s: \
+                         not using LLVM backend"
       intr
 
 (* Keep in sync with [Vectorize_specific] *)

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2247,8 +2247,8 @@ let emit_instr ~first ~fallthrough i =
       ~instr:i ~address Onetwentyeight_unaligned Store_modify;
     emit_simd_instr_with_memory_arg op i address
   | Lop (Specific (Illvm_intrinsic intr)) ->
-    Misc.fatal_errorf "Unexpected llvm_intrinsic %s: not using LLVM backend"
-      intr
+    Misc.fatal_errorf
+      "Emit: Unexpected llvm_intrinsic %s: not using LLVM backend" intr
   | Lop (Static_cast cast) -> emit_static_cast cast i
   | Lop (Reinterpret_cast cast) -> emit_reinterpret_cast cast i
   | Lop (Specific (Icldemote addr)) ->

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -597,7 +597,8 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
   | Op (Specific (Isimd_mem (op,_))) ->
     destroyed_by_simd_mem_op op
   | Op (Specific (Illvm_intrinsic intr)) ->
-      Misc.fatal_errorf "Unexpected llvm_intrinsic %s: not using LLVM backend"
+      Misc.fatal_errorf "destroyed_at_basic: Unexpected llvm_intrinsic %s: \
+                         not using LLVM backend"
         intr
   | Op (Move | Spill | Reload
        | Const_int _ | Const_float _ | Const_float32 _ | Const_symbol _

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -1496,7 +1496,8 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
     | Ipackf32 | Isimd _ | Iprefetch _ | Icldemote _ ->
       None
     | Illvm_intrinsic intr ->
-      Misc.fatal_errorf "Unexpected llvm_intrinsic %s: not using LLVM backend"
+      Misc.fatal_errorf
+        "Simd_selection: Unexpected llvm_intrinsic %s: not using LLVM backend"
         intr)
   | Alloc _ | Reinterpret_cast _ | Static_cast _ | Spill | Reload
   | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _

--- a/backend/amd64/vectorize_specific.ml
+++ b/backend/amd64/vectorize_specific.ml
@@ -60,7 +60,8 @@ let memory_access : Arch.specific_operation -> Memory_access.t option =
       "Unexpected simd instruction with memory operands before vectorization"
   | Ilea _ | Ibswap _ | Isextend32 | Izextend32 -> None
   | Illvm_intrinsic intr ->
-    Misc.fatal_errorf "Unexpected llvm_intrinsic %s: not using LLVM backend"
+    Misc.fatal_errorf
+      "Vectorize_specific: Unexpected llvm_intrinsic %s: not using LLVM backend"
       intr
 
 let is_seed_store :
@@ -73,5 +74,7 @@ let is_seed_store :
   | Ilea _ | Ibswap _ | Isextend32 | Izextend32 ->
     None
   | Illvm_intrinsic intr ->
-    Misc.fatal_errorf "Unexpected llvm_intrinsic %s: not using LLVM backend"
+    Misc.fatal_errorf
+      "Vectorize_specific.is_seed_store: Unexpected llvm_intrinsic %s: not \
+       using LLVM backend"
       intr

--- a/backend/arm64/CSE.ml
+++ b/backend/arm64/CSE.ml
@@ -45,7 +45,8 @@ let class_of_operation (op : Operation.t)
       | Isignext _ -> Op_pure
       | Isimd op -> of_simd_class (Simd.class_of_operation op)
       | Illvm_intrinsic intr ->
-        Misc.fatal_errorf "Unexpected llvm_intrinsic %s: not using LLVM backend"
+        Misc.fatal_errorf "CSE: Unexpected llvm_intrinsic %s: \
+                           not using LLVM backend"
           intr
     in
     Class op_class

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -374,7 +374,8 @@ let operation_is_pure : specific_operation -> bool = function
   | Isignext _ -> true
   | Isimd op -> Simd.operation_is_pure op
   | Illvm_intrinsic intr ->
-    Misc.fatal_errorf "Unexpected llvm_intrinsic %s: not using LLVM backend"
+      Misc.fatal_errorf "Arch.operation_is_pure: Unexpected llvm_intrinsic %s: \
+                                                  not using LLVM backend"
       intr
 
 (* Specific operations that can raise *)

--- a/backend/arm64/cfg_selection.ml
+++ b/backend/arm64/cfg_selection.ml
@@ -269,7 +269,9 @@ let pseudoregs_for_operation op arg res =
   | Name_for_debugger _ | Alloc _ ->
     raise Use_default_exn
   | Specific (Illvm_intrinsic intr) ->
-    Misc.fatal_errorf "Unexpected llvm_intrinsic %s: not using LLVM backend"
+    Misc.fatal_errorf
+      "Cfg_selection.pseudoregs_for_operation: Unexpected llvm_intrinsic %s: \
+       not using LLVM backend"
       intr
 
 let insert_op_debug env sub_cfg op dbg rs rd :

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1075,8 +1075,8 @@ let num_call_gc_points instr =
     | Lop (Const_vec256 _ | Const_vec512 _) ->
       Misc.fatal_error "arm64: got 256/512 bit vector"
     | Lop (Specific (Illvm_intrinsic intr)) ->
-      Misc.fatal_errorf "Unexpected llvm_intrinsic %s: not using LLVM backend"
-        intr
+      Misc.fatal_errorf
+        "Emit: Unexpected llvm_intrinsic %s: not using LLVM backend" intr
   in
   loop instr 0
 
@@ -1335,8 +1335,8 @@ module BR = Branch_relaxation.Make (struct
     | Lstackcheck _ -> 5
     | Lop (Specific (Isimd simd)) -> DSL.simd_instr_size simd
     | Lop (Specific (Illvm_intrinsic intr)) ->
-      Misc.fatal_errorf "Unexpected llvm_intrinsic %s: not using LLVM backend"
-        intr
+      Misc.fatal_errorf
+        "Emit.size:Unexpected llvm_intrinsic %s: not using LLVM backend" intr
 
   let relax_poll () = Lop (Specific Ifar_poll)
 
@@ -2348,8 +2348,8 @@ let emit_instr i =
              sc_max_frame_size_in_bytes = max_frame_size_bytes
            }
   | Lop (Specific (Illvm_intrinsic intr)) ->
-    Misc.fatal_errorf "Unexpected llvm_intrinsic %s: not using LLVM backend"
-      intr
+    Misc.fatal_errorf
+      "Emit:Unexpected llvm_intrinsic %s: not using LLVM backend" intr
 
 let emit_instr i =
   try emit_instr i

--- a/backend/arm64/vectorize_specific.ml
+++ b/backend/arm64/vectorize_specific.ml
@@ -25,7 +25,8 @@ let memory_access : Arch.specific_operation -> Memory_access.t option =
        operations at the moment. *)
     if Arch.operation_is_pure op then None else create Memory_access.Arbitrary
   | Illvm_intrinsic intr ->
-    Misc.fatal_errorf "Unexpected llvm_intrinsic %s: not using LLVM backend"
+    Misc.fatal_errorf
+      "Vectorize specific: Unexpected llvm_intrinsic %s: not using LLVM backend"
       intr
 
 let is_seed_store (op : Arch.specific_operation) =
@@ -35,5 +36,7 @@ let is_seed_store (op : Arch.specific_operation) =
   | Imove32 | Isignext _ | Isimd _ ->
     None
   | Illvm_intrinsic intr ->
-    Misc.fatal_errorf "Unexpected llvm_intrinsic %s: not using LLVM backend"
+    Misc.fatal_errorf
+      "Vectorize specific.is_seed_store: Unexpected llvm_intrinsic %s: not \
+       using LLVM backend"
       intr


### PR DESCRIPTION
Trivial change to content of fatal_error messages. This is useful for debugging when backtraces are broken.