### PR TITLE
(LLVM Backend) Fix wrap try result

### DIFF
--- a/oxcaml/tests/backend/llvmize/exn_part2_ir.output
+++ b/oxcaml/tests/backend/llvmize/exn_part2_ir.output
@@ -83,6 +83,7 @@ L101:
   store i64 %64, ptr %ds
   store i64 %65, ptr %alloc
   %66 = extractvalue { { i64, i64 }, { i64 } } %63, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %66) "gc-leaf-function"="true"
   br label %L142
 L142:
   %67 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
@@ -381,6 +382,7 @@ L146:
   store i64 %49, ptr %ds
   store i64 %50, ptr %alloc
   %51 = extractvalue { { i64, i64 }, { i64 } } %48, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %51) "gc-leaf-function"="true"
   br label %L176
 L176:
   %52 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
@@ -597,6 +599,7 @@ L180:
   store i64 %59, ptr %ds
   store i64 %60, ptr %alloc
   %61 = extractvalue { { i64, i64 }, { i64 } } %58, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %61) "gc-leaf-function"="true"
   br label %L218
 L218:
   %62 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
@@ -1082,6 +1085,7 @@ L241:
   store i64 %103, ptr %ds
   store i64 %104, ptr %alloc
   %105 = extractvalue { { i64, i64 }, { i64 } } %102, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %105) "gc-leaf-function"="true"
   br label %L332
 L332:
   %106 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
@@ -1159,6 +1163,7 @@ L257:
   store i64 %151, ptr %ds
   store i64 %152, ptr %alloc
   %153 = extractvalue { { i64, i64 }, { i64 } } %150, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %153) "gc-leaf-function"="true"
   br label %L334
 L334:
   %154 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
@@ -1236,6 +1241,7 @@ L273:
   store i64 %199, ptr %ds
   store i64 %200, ptr %alloc
   %201 = extractvalue { { i64, i64 }, { i64 } } %198, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %201) "gc-leaf-function"="true"
   br label %L336
 L336:
   %202 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
@@ -1574,6 +1580,7 @@ L347:
   store i64 %42, ptr %ds
   store i64 %43, ptr %alloc
   %44 = extractvalue { { i64, i64 }, { i64 } } %41, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %44) "gc-leaf-function"="true"
   br label %L394
 L394:
   %45 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
@@ -1814,6 +1821,7 @@ L400:
   store i64 %44, ptr %ds
   store i64 %45, ptr %alloc
   %46 = extractvalue { { i64, i64 }, { i64 } } %43, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %46) "gc-leaf-function"="true"
   br label %L426
 L426:
   %47 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"

--- a/oxcaml/tests/backend/llvmize/switch_ir.output
+++ b/oxcaml/tests/backend/llvmize/switch_ir.output
@@ -269,6 +269,7 @@ L132:
   store i64 %40, ptr %ds
   store i64 %41, ptr %alloc
   %42 = extractvalue { { i64, i64 }, { i64 } } %39, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %42) "gc-leaf-function"="true"
   br label %L158
 L158:
   %43 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
@@ -631,6 +632,7 @@ L167:
   store i64 %206, ptr %ds
   store i64 %207, ptr %alloc
   %208 = extractvalue { { i64, i64 }, { i64 } } %205, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %208) "gc-leaf-function"="true"
   br label %L361
 L361:
   %209 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
@@ -800,6 +802,7 @@ L188:
   store i64 %302, ptr %ds
   store i64 %303, ptr %alloc
   %304 = extractvalue { { i64, i64 }, { i64 } } %301, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %304) "gc-leaf-function"="true"
   br label %L363
 L363:
   %305 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
@@ -969,6 +972,7 @@ L211:
   store i64 %398, ptr %ds
   store i64 %399, ptr %alloc
   %400 = extractvalue { { i64, i64 }, { i64 } } %397, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %400) "gc-leaf-function"="true"
   br label %L365
 L365:
   %401 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
@@ -1138,6 +1142,7 @@ L234:
   store i64 %494, ptr %ds
   store i64 %495, ptr %alloc
   %496 = extractvalue { { i64, i64 }, { i64 } } %493, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %496) "gc-leaf-function"="true"
   br label %L367
 L367:
   %497 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
@@ -1307,6 +1312,7 @@ L257:
   store i64 %590, ptr %ds
   store i64 %591, ptr %alloc
   %592 = extractvalue { { i64, i64 }, { i64 } } %589, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %592) "gc-leaf-function"="true"
   br label %L369
 L369:
   %593 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
@@ -1476,6 +1482,7 @@ L280:
   store i64 %686, ptr %ds
   store i64 %687, ptr %alloc
   %688 = extractvalue { { i64, i64 }, { i64 } } %685, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %688) "gc-leaf-function"="true"
   br label %L371
 L371:
   %689 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
@@ -1645,6 +1652,7 @@ L303:
   store i64 %782, ptr %ds
   store i64 %783, ptr %alloc
   %784 = extractvalue { { i64, i64 }, { i64 } } %781, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %784) "gc-leaf-function"="true"
   br label %L373
 L373:
   %785 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
@@ -1814,6 +1822,7 @@ L326:
   store i64 %878, ptr %ds
   store i64 %879, ptr %alloc
   %880 = extractvalue { { i64, i64 }, { i64 } } %877, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %880) "gc-leaf-function"="true"
   br label %L375
 L375:
   %881 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"


### PR DESCRIPTION
(based on #4757 for test consistency)

Because of the (admittedly messed up) way we use `wrap_try`, we wouldn't use its result. This apparently made LLVM optimise away the body of `wrap_try` despite getting inlined. This PR now explicitly uses that result by putting it into RAX via inline asm (which also makes us slightly more confident that the result indeed ends up in RAX).