### PR TITLE
Add automated metrics collection to CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -408,6 +408,7 @@ jobs:
         cd metrics-repo
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
+        git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/oxcaml/oxcaml-metrics.git
         git add data/
         git commit -m "Add metrics for commit ${{ github.sha }}"
         git push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -425,7 +425,7 @@ jobs:
         git config --global credential.https://github.com.helper "!gh auth git-credential"
 
         git add data/
-        git commit -m "Add metrics for commit ${{ github.sha }}"
+        git commit -m "Add metrics for commit ${COMMIT_HASH}"
         git push
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -378,7 +378,12 @@ jobs:
 
         # Generate timestamp and short commit hash
         TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-        COMMIT_HASH="${{ github.sha }}"
+        # Use the actual commit being tested (not the merge commit for PRs)
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          COMMIT_HASH="${{ github.event.pull_request.head.sha }}"
+        else
+          COMMIT_HASH="${{ github.sha }}"
+        fi
         SHORT_HASH="${COMMIT_HASH:0:8}"
         DATE=$(date -u +"%Y-%m-%d")
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -359,6 +359,57 @@ jobs:
             -validate -param SPLIT_AROUND_LOOPS:on -regalloc $allocator || exit 1; \
         done
 
+    - name: Collect and push metrics
+      if: matrix.name == 'flambda2_o3' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      run: |
+        # Checkout metrics repository
+        git clone https://x-access-token:${{ secrets.METRICS_REPO_TOKEN }}@github.com/oxcaml/oxcaml-metrics.git metrics-repo
+
+        # Create data directory if it doesn't exist
+        mkdir -p metrics-repo/data
+
+        # Generate timestamp and short commit hash
+        TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        COMMIT_HASH="${{ github.sha }}"
+        SHORT_HASH="${COMMIT_HASH:0:8}"
+        DATE=$(date -u +"%Y-%m-%d")
+
+        # CSV filename
+        CSV_FILE="metrics-repo/data/metrics-${DATE}-${SHORT_HASH}.csv"
+
+        # Extensions to track
+        EXTENSIONS="exe opt a cmxa cma cmi cmx cmo cms cmsi cmt cmti o"
+
+        # Write CSV header
+        echo "timestamp,commit_hash,extension,total_size_bytes" > "$CSV_FILE"
+
+        # Collect metrics for each extension
+        for ext in $EXTENSIONS; do
+          total_size=0
+          if find ${{ github.workspace }}/_install -name "*.${ext}" -type f > /tmp/files_${ext} 2>/dev/null; then
+            # Calculate total size of all files with this extension
+            while IFS= read -r file; do
+              if [ -f "$file" ]; then
+                size=$(stat -c%s "$file" 2>/dev/null || echo 0)
+                total_size=$((total_size + size))
+              fi
+            done < /tmp/files_${ext}
+          fi
+          # Write to CSV
+          echo "${TIMESTAMP},${COMMIT_HASH},${ext},${total_size}" >> "$CSV_FILE"
+        done
+
+        echo "Generated metrics file: $CSV_FILE"
+        cat "$CSV_FILE"
+
+        # Commit and push metrics
+        cd metrics-repo
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add data/
+        git commit -m "Add metrics for commit ${{ github.sha }}"
+        git push
+
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
@@ -388,6 +439,7 @@ jobs:
 #       with:
 #         name: _runtest-${{ github.sha }}-${{ github.run_id }}-${{ matrix.name }}
 #         path: ${{ github.workspace }}/oxcaml/_runtest
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -361,9 +361,11 @@ jobs:
 
     - name: Collect and push metrics
       if: matrix.name == 'flambda2_o3' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      env:
+        GH_TOKEN: ${{ secrets.METRICS_REPO_TOKEN }}
       run: |
         # Checkout metrics repository
-        git clone https://x-access-token:${{ secrets.METRICS_REPO_TOKEN }}@github.com/oxcaml/oxcaml-metrics.git metrics-repo
+        gh repo clone oxcaml/oxcaml-metrics metrics-repo
 
         # Create data directory if it doesn't exist
         mkdir -p metrics-repo/data

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -421,8 +421,8 @@ jobs:
         git config user.email "github-actions[bot]@users.noreply.github.com"
 
         # Configure git to use gh for authentication
-        git config --global credential.helper ""
-        git config --global credential.https://github.com.helper "!gh auth git-credential"
+        git config --local credential.helper ""
+        git config --local credential.https://github.com.helper "!gh auth git-credential"
 
         git add data/
         git commit -m "Add metrics for commit ${COMMIT_HASH}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -408,7 +408,11 @@ jobs:
         cd metrics-repo
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/oxcaml/oxcaml-metrics.git
+
+        # Configure git to use gh for authentication
+        git config --global credential.helper ""
+        git config --global credential.https://github.com.helper "!gh auth git-credential"
+
         git add data/
         git commit -m "Add metrics for commit ${{ github.sha }}"
         git push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -440,7 +440,6 @@ jobs:
 #         name: _runtest-${{ github.sha }}-${{ github.run_id }}-${{ matrix.name }}
 #         path: ${{ github.workspace }}/oxcaml/_runtest
 
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -360,7 +360,7 @@ jobs:
         done
 
     - name: Collect and push metrics
-      if: matrix.name == 'flambda2_o3' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: matrix.name == 'flambda2_o3'
       env:
         GH_TOKEN: ${{ secrets.METRICS_REPO_TOKEN }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -291,6 +291,12 @@ jobs:
         ulimit -c unlimited
         make $target \
           || (if [ "$expected_fail" = true ]; then exit 0; else exit 1; fi);
+
+        # Install the compiler for flambda2_o3 configuration to populate _install directory
+        # This is needed for the metrics collection step to analyze installed artifacts
+        if [ "${{ matrix.name }}" = "flambda2_o3" ]; then
+          make install
+        fi
       env:
         BUILD_OCAMLPARAM: ${{ matrix.build_ocamlparam }}
         OCAMLPARAM: ${{ matrix.ocamlparam }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -366,7 +366,7 @@ jobs:
         done
 
     - name: Collect and push metrics
-      if: matrix.name == 'flambda2_o3'
+      if: matrix.name == 'flambda2_o3' && github.ref == 'refs/heads/main' && github.event_name == 'push'
       env:
         GH_TOKEN: ${{ secrets.METRICS_REPO_TOKEN }}
       run: |


### PR DESCRIPTION
  ## Summary
  Adds automated file size metrics collection to the GitHub Actions build workflow for tracking
  compiler output sizes over time.

  ## Changes
  - Modified `.github/workflows/build.yml` to collect and push metrics after successful
  `flambda2_o3` builds
  - Metrics are collected only on pushes to `main` branch
  - Tracks total file sizes for extensions: `.exe`, `.opt`, `.a`, `.cmxa`, `.cma`, `.cmi`, `.cmx`,
   `.cmo`, `.cms`, `.cmsi`, `.cmt`, `.cmti`, `.o`
  - Generates CSV files in format: `metrics-YYYY-MM-DD-{commit-hash}.csv`
  - Automatically pushes metrics to `oxcaml/oxcaml-metrics` repository under `data/` directory

  ## Implementation Details
  - Uses existing `METRICS_REPO_TOKEN` secret for authentication
  - Scans `_install` directory directly from the build job (no artifacts needed)
  - Each CSV contains timestamp, commit hash, file extension, and total size in bytes
  - One row per extension for easy regression analysis

  ## Test Plan
  - [ ] Verify workflow runs successfully on main branch pushes
  - [x] Confirm metrics files are generated and pushed to metrics repository
  - [x] Check that metrics collection doesn't interfere with existing build process