### PR TITLE
Enable two incorrectly skipped parallel tests

### DIFF
--- a/testsuite/tests/parallel/deadcont.ml
+++ b/testsuite/tests/parallel/deadcont.ml
@@ -1,6 +1,7 @@
 (* TEST
- skip;
+ flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  { bytecode; }
  { native; }
 *)

--- a/testsuite/tests/parallel/mctest.ml
+++ b/testsuite/tests/parallel/mctest.ml
@@ -1,6 +1,7 @@
 (* TEST
- skip;
+ flags += "-alert -do_not_spawn_domains -alert -unsafe_multidomain";
  runtime5;
+ multidomain;
  include unix;
  hasunix;
  {


### PR DESCRIPTION
I think these TEST stanzas were typo'd when the parallel tests were re-enabled.