### PR TITLE
Add dedicated metrics_collection matrix entry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -408,6 +408,7 @@ jobs:
         cd metrics-repo
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
+        git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/oxcaml/oxcaml-metrics.git
         git add data/
         git commit -m "Add metrics for commit ${{ github.sha }}"
         git push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -425,7 +425,7 @@ jobs:
         git config --global credential.https://github.com.helper "!gh auth git-credential"
 
         git add data/
-        git commit -m "Add metrics for commit ${{ github.sha }}"
+        git commit -m "Add metrics for commit ${COMMIT_HASH}"
         git push
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -378,7 +378,12 @@ jobs:
 
         # Generate timestamp and short commit hash
         TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-        COMMIT_HASH="${{ github.sha }}"
+        # Use the actual commit being tested (not the merge commit for PRs)
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          COMMIT_HASH="${{ github.event.pull_request.head.sha }}"
+        else
+          COMMIT_HASH="${{ github.sha }}"
+        fi
         SHORT_HASH="${COMMIT_HASH:0:8}"
         DATE=$(date -u +"%Y-%m-%d")
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -359,6 +359,57 @@ jobs:
             -validate -param SPLIT_AROUND_LOOPS:on -regalloc $allocator || exit 1; \
         done
 
+    - name: Collect and push metrics
+      if: matrix.name == 'flambda2_o3' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      run: |
+        # Checkout metrics repository
+        git clone https://x-access-token:${{ secrets.METRICS_REPO_TOKEN }}@github.com/oxcaml/oxcaml-metrics.git metrics-repo
+
+        # Create data directory if it doesn't exist
+        mkdir -p metrics-repo/data
+
+        # Generate timestamp and short commit hash
+        TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        COMMIT_HASH="${{ github.sha }}"
+        SHORT_HASH="${COMMIT_HASH:0:8}"
+        DATE=$(date -u +"%Y-%m-%d")
+
+        # CSV filename
+        CSV_FILE="metrics-repo/data/metrics-${DATE}-${SHORT_HASH}.csv"
+
+        # Extensions to track
+        EXTENSIONS="exe opt a cmxa cma cmi cmx cmo cms cmsi cmt cmti o"
+
+        # Write CSV header
+        echo "timestamp,commit_hash,extension,total_size_bytes" > "$CSV_FILE"
+
+        # Collect metrics for each extension
+        for ext in $EXTENSIONS; do
+          total_size=0
+          if find ${{ github.workspace }}/_install -name "*.${ext}" -type f > /tmp/files_${ext} 2>/dev/null; then
+            # Calculate total size of all files with this extension
+            while IFS= read -r file; do
+              if [ -f "$file" ]; then
+                size=$(stat -c%s "$file" 2>/dev/null || echo 0)
+                total_size=$((total_size + size))
+              fi
+            done < /tmp/files_${ext}
+          fi
+          # Write to CSV
+          echo "${TIMESTAMP},${COMMIT_HASH},${ext},${total_size}" >> "$CSV_FILE"
+        done
+
+        echo "Generated metrics file: $CSV_FILE"
+        cat "$CSV_FILE"
+
+        # Commit and push metrics
+        cd metrics-repo
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add data/
+        git commit -m "Add metrics for commit ${{ github.sha }}"
+        git push
+
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
@@ -388,6 +439,7 @@ jobs:
 #       with:
 #         name: _runtest-${{ github.sha }}-${{ github.run_id }}-${{ matrix.name }}
 #         path: ${{ github.workspace }}/oxcaml/_runtest
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -361,9 +361,11 @@ jobs:
 
     - name: Collect and push metrics
       if: matrix.name == 'flambda2_o3' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      env:
+        GH_TOKEN: ${{ secrets.METRICS_REPO_TOKEN }}
       run: |
         # Checkout metrics repository
-        git clone https://x-access-token:${{ secrets.METRICS_REPO_TOKEN }}@github.com/oxcaml/oxcaml-metrics.git metrics-repo
+        gh repo clone oxcaml/oxcaml-metrics metrics-repo
 
         # Create data directory if it doesn't exist
         mkdir -p metrics-repo/data

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -408,7 +408,11 @@ jobs:
         cd metrics-repo
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/oxcaml/oxcaml-metrics.git
+
+        # Configure git to use gh for authentication
+        git config --global credential.helper ""
+        git config --global credential.https://github.com.helper "!gh auth git-credential"
+
         git add data/
         git commit -m "Add metrics for commit ${{ github.sha }}"
         git push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -440,7 +440,6 @@ jobs:
 #         name: _runtest-${{ github.sha }}-${{ github.run_id }}-${{ matrix.name }}
 #         path: ${{ github.workspace }}/oxcaml/_runtest
 
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -376,9 +376,7 @@ jobs:
         # Create data directory if it doesn't exist
         mkdir -p metrics-repo/data
 
-        # Generate timestamp and short commit hash
-        TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-        # Use the actual commit being tested (not the merge commit for PRs)
+        # Determine the actual commit being tested (not the merge commit for PRs)
         if [ "${{ github.event_name }}" = "pull_request" ]; then
           COMMIT_HASH="${{ github.event.pull_request.head.sha }}"
         else
@@ -390,29 +388,13 @@ jobs:
         # CSV filename
         CSV_FILE="metrics-repo/data/metrics-${DATE}-${SHORT_HASH}.csv"
 
-        # Extensions to track
-        EXTENSIONS="exe opt a cmxa cma cmi cmx cmo cms cmsi cmt cmti o"
+        # Use the metrics collection script
+        ${{ github.workspace }}/oxcaml/scripts/collect-size-metrics.sh \
+          "${{ github.workspace }}/_install" \
+          "$CSV_FILE" \
+          "$COMMIT_HASH"
 
-        # Write CSV header
-        echo "timestamp,commit_hash,extension,total_size_bytes" > "$CSV_FILE"
-
-        # Collect metrics for each extension
-        for ext in $EXTENSIONS; do
-          total_size=0
-          if find ${{ github.workspace }}/_install -name "*.${ext}" -type f > /tmp/files_${ext} 2>/dev/null; then
-            # Calculate total size of all files with this extension
-            while IFS= read -r file; do
-              if [ -f "$file" ]; then
-                size=$(stat -c%s "$file" 2>/dev/null || echo 0)
-                total_size=$((total_size + size))
-              fi
-            done < /tmp/files_${ext}
-          fi
-          # Write to CSV
-          echo "${TIMESTAMP},${COMMIT_HASH},${ext},${total_size}" >> "$CSV_FILE"
-        done
-
-        echo "Generated metrics file: $CSV_FILE"
+        echo "Contents of generated metrics file:"
         cat "$CSV_FILE"
 
         # Commit and push metrics

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,12 @@ jobs:
             build_ocamlparam: ''
             ocamlparam: '_,O3=1'
 
+          - name: metrics_collection
+            config: --enable-middle-end=flambda2
+            os: ubuntu-latest
+            build_ocamlparam: ''
+            ocamlparam: '_,O3=1'
+
           - name: flambda2_frame_pointers_oclassic_polling
             config: --enable-middle-end=flambda2 --enable-frame-pointers --enable-poll-insertion --enable-flambda-invariants
             os: ubuntu-latest
@@ -292,9 +298,9 @@ jobs:
         make $target \
           || (if [ "$expected_fail" = true ]; then exit 0; else exit 1; fi);
 
-        # Install the compiler for flambda2_o3 configuration to populate _install directory
+        # Install the compiler for metrics_collection configuration to populate _install directory
         # This is needed for the metrics collection step to analyze installed artifacts
-        if [ "${{ matrix.name }}" = "flambda2_o3" ]; then
+        if [ "${{ matrix.name }}" = "metrics_collection" ]; then
           make install
         fi
       env:
@@ -366,7 +372,7 @@ jobs:
         done
 
     - name: Collect and push metrics
-      if: matrix.name == 'flambda2_o3' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: matrix.name == 'metrics_collection' && github.ref == 'refs/heads/main' && github.event_name == 'push'
       env:
         GH_TOKEN: ${{ secrets.METRICS_REPO_TOKEN }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -360,7 +360,7 @@ jobs:
         done
 
     - name: Collect and push metrics
-      if: matrix.name == 'flambda2_o3' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: matrix.name == 'flambda2_o3'
       env:
         GH_TOKEN: ${{ secrets.METRICS_REPO_TOKEN }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -291,6 +291,12 @@ jobs:
         ulimit -c unlimited
         make $target \
           || (if [ "$expected_fail" = true ]; then exit 0; else exit 1; fi);
+
+        # Install the compiler for flambda2_o3 configuration to populate _install directory
+        # This is needed for the metrics collection step to analyze installed artifacts
+        if [ "${{ matrix.name }}" = "flambda2_o3" ]; then
+          make install
+        fi
       env:
         BUILD_OCAMLPARAM: ${{ matrix.build_ocamlparam }}
         OCAMLPARAM: ${{ matrix.ocamlparam }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -366,7 +366,7 @@ jobs:
         done
 
     - name: Collect and push metrics
-      if: matrix.name == 'flambda2_o3'
+      if: matrix.name == 'flambda2_o3' && github.ref == 'refs/heads/main' && github.event_name == 'push'
       env:
         GH_TOKEN: ${{ secrets.METRICS_REPO_TOKEN }}
       run: |

--- a/scripts/collect-size-metrics.sh
+++ b/scripts/collect-size-metrics.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+# Script to collect file size metrics from _install directory
+# Usage: collect-metrics.sh <install_directory> <output_csv_file> <commit_hash>
+
+if [ $# -ne 3 ]; then
+    echo "Usage: $0 <install_directory> <output_csv_file> <commit_hash>" >&2
+    exit 1
+fi
+
+INSTALL_DIR="$1"
+CSV_FILE="$2"
+COMMIT_HASH="$3"
+
+# Validate input directory exists
+if [ ! -d "$INSTALL_DIR" ]; then
+    echo "Error: Install directory '$INSTALL_DIR' does not exist" >&2
+    exit 1
+fi
+
+# Generate timestamp
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Extensions to track
+EXTENSIONS="exe opt a cmxa cma cmi cmx cmo cms cmsi cmt cmti o"
+
+# Write CSV header
+echo "timestamp,commit_hash,extension,total_size_bytes" > "$CSV_FILE"
+
+# Collect metrics for each extension
+for ext in $EXTENSIONS; do
+    total_size=0
+    if find "$INSTALL_DIR" -name "*.${ext}" -type f > "/tmp/files_${ext}" 2>/dev/null; then
+        # Calculate total size of all files with this extension
+        while IFS= read -r file; do
+            if [ -f "$file" ]; then
+                size=$(stat -c%s "$file" 2>/dev/null || echo 0)
+                total_size=$((total_size + size))
+            fi
+        done < "/tmp/files_${ext}"
+        # Clean up temporary file
+        rm -f "/tmp/files_${ext}"
+    fi
+    # Write to CSV
+    echo "${TIMESTAMP},${COMMIT_HASH},${ext},${total_size}" >> "$CSV_FILE"
+done
+
+echo "Generated metrics file: $CSV_FILE"
+echo "Metrics collected for commit: $COMMIT_HASH"

--- a/scripts/collect-size-metrics.sh
+++ b/scripts/collect-size-metrics.sh
@@ -31,17 +31,16 @@ echo "timestamp,commit_hash,extension,total_size_bytes" > "$CSV_FILE"
 # Collect metrics for each extension
 for ext in $EXTENSIONS; do
     total_size=0
-    if find "$INSTALL_DIR" -name "*.${ext}" -type f > "/tmp/files_${ext}" 2>/dev/null; then
-        # Calculate total size of all files with this extension
-        while IFS= read -r file; do
-            if [ -f "$file" ]; then
-                size=$(stat -c%s "$file" 2>/dev/null || echo 0)
-                total_size=$((total_size + size))
-            fi
-        done < "/tmp/files_${ext}"
-        # Clean up temporary file
-        rm -f "/tmp/files_${ext}"
+    temp_file=$(mktemp)
+    if find "$INSTALL_DIR" -name "*.${ext}" -type f > "$temp_file" 2>/dev/null; then
+        # Calculate total size of all files with this extension using du
+        if [ -s "$temp_file" ]; then
+            # Use du to get size in bytes, summing all files
+            total_size=$(du -bc $(cat "$temp_file") 2>/dev/null | tail -n1 | cut -f1 || echo 0)
+        fi
     fi
+    # Clean up temporary file
+    rm -f "$temp_file"
     # Write to CSV
     echo "${TIMESTAMP},${COMMIT_HASH},${ext},${total_size}" >> "$CSV_FILE"
 done


### PR DESCRIPTION
 ## Summary

  - Add dedicated metrics_collection matrix entry instead of reusing flambda2_o3 for metrics
  collection
  - Provides better separation of concerns and allows independent configuration tweaking
  - Update workflow conditions to target the new dedicated entry

##  Changes

  - New matrix entry: metrics_collection with same configuration as flambda2_o3 (Flambda2, O3
  optimization)
  - Updated install step: Only installs compiler for metrics_collection entry
  - Updated metrics step: Condition changed from flambda2_o3 to metrics_collection

##  Benefits

  - Modularity: Metrics collection configuration can be modified independently from flambda2_o3
  testing
  - Clarity: Makes it explicit which CI job is responsible for metrics collection
  - Flexibility: Allows future customization of metrics collection settings without affecting
  other test configurations

  🤖 Generated with https://claude.ai/code