### PR TITLE
(LLVM Backend) Exttypes should propagate val

### DIFF
--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -138,7 +138,10 @@ type exttype =
   | XVec512
 
 let machtype_of_exttype = function
-  | XInt -> typ_int
+  | XInt ->
+    (* [XInt] only gets created from values, and LLVM needs to keep track of
+       them properly. *)
+    if !Clflags.llvm_backend then typ_val else typ_int
   | XInt8 -> typ_int
   | XInt16 -> typ_int
   | XInt32 -> typ_int

--- a/oxcaml/tests/backend/llvmize/data_decl_ir.output
+++ b/oxcaml/tests/backend/llvmize/data_decl_ir.output
@@ -172,9 +172,9 @@ define  oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlData_decl__entry(i6
   %6 = alloca i64
   %7 = alloca ptr addrspace(1)
   %8 = alloca i64
-  %9 = alloca i64
-  %10 = alloca i64
-  %11 = alloca i64
+  %9 = alloca ptr addrspace(1)
+  %10 = alloca ptr addrspace(1)
+  %11 = alloca ptr addrspace(1)
   %12 = alloca ptr addrspace(1)
   %13 = alloca i64
   %14 = alloca i64
@@ -241,267 +241,270 @@ L123:
   %65 = load ptr addrspace(1), ptr addrspace(1) %64
   store ptr addrspace(1) %65, ptr %18
   %66 = load ptr addrspace(1), ptr %18
-  %67 = ptrtoint ptr addrspace(1) %66 to i64
-  store i64 %67, ptr %8
-  %68 = load i64, ptr %15
-  store i64 %68, ptr %9
+  store ptr addrspace(1) %66, ptr %7
+  %67 = load i64, ptr %15
+  %68 = inttoptr i64 %67 to ptr addrspace(1)
+  store ptr addrspace(1) %68, ptr %9
   %69 = load i64, ptr %14
-  store i64 %69, ptr %10
-  %70 = load i64, ptr %13
-  store i64 %70, ptr %11
-  %71 = load i64, ptr %8
-  %72 = load i64, ptr %9
-  %73 = load i64, ptr %10
-  %74 = load i64, ptr %11
-  %75 = load i64, ptr %ds
-  %76 = load i64, ptr %alloc
-  %77 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %75, i64 %76, ptr @caml_ml_output, i64 %71, i64 %72, i64 %73, i64 %74) "statepoint-id"="0"
-  %78 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %77, 0, 0
-  %79 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %77, 0, 1
-  store i64 %78, ptr %ds
-  store i64 %79, ptr %alloc
-  %80 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %77, 1, 0
-  store ptr addrspace(1) %80, ptr %3
+  %70 = inttoptr i64 %69 to ptr addrspace(1)
+  store ptr addrspace(1) %70, ptr %10
+  %71 = load i64, ptr %13
+  %72 = inttoptr i64 %71 to ptr addrspace(1)
+  store ptr addrspace(1) %72, ptr %11
+  %73 = load ptr addrspace(1), ptr %7
+  %74 = load ptr addrspace(1), ptr %9
+  %75 = load ptr addrspace(1), ptr %10
+  %76 = load ptr addrspace(1), ptr %11
+  %77 = load i64, ptr %ds
+  %78 = load i64, ptr %alloc
+  %79 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %77, i64 %78, ptr @caml_ml_output, ptr addrspace(1) %73, ptr addrspace(1) %74, ptr addrspace(1) %75, ptr addrspace(1) %76) "statepoint-id"="0"
+  %80 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %79, 0, 0
+  %81 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %79, 0, 1
+  store i64 %80, ptr %ds
+  store i64 %81, ptr %alloc
+  %82 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %79, 1, 0
+  store ptr addrspace(1) %82, ptr %3
   br label %L125
 L125:
-  %81 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %81, ptr %19
-  %82 = load ptr addrspace(1), ptr %19
-  store ptr addrspace(1) %82, ptr %20
+  %83 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %83, ptr %19
+  %84 = load ptr addrspace(1), ptr %19
+  store ptr addrspace(1) %84, ptr %20
   store i64 21, ptr %21
-  %83 = ptrtoint ptr @camlStdlib__print_endline_138 to i64
-  store i64 %83, ptr %22
-  %84 = load i64, ptr %22
-  %85 = inttoptr i64 %84 to ptr addrspace(1)
-  store ptr addrspace(1) %85, ptr %23
-  %86 = load ptr addrspace(1), ptr %23
-  %87 = getelementptr i8, ptr addrspace(1) %86, i64 16
+  %85 = ptrtoint ptr @camlStdlib__print_endline_138 to i64
+  store i64 %85, ptr %22
+  %86 = load i64, ptr %22
+  %87 = inttoptr i64 %86 to ptr addrspace(1)
   store ptr addrspace(1) %87, ptr %23
   %88 = load ptr addrspace(1), ptr %23
-  %89 = load ptr addrspace(1), ptr addrspace(1) %88
-  store ptr addrspace(1) %89, ptr %24
-  %90 = load ptr addrspace(1), ptr %24
-  %91 = ptrtoint ptr addrspace(1) %90 to i64
-  store i64 %91, ptr %8
-  %92 = load i64, ptr %21
-  store i64 %92, ptr %9
-  %93 = load i64, ptr %8
-  %94 = load i64, ptr %9
-  %95 = load i64, ptr %ds
-  %96 = load i64, ptr %alloc
-  %97 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %95, i64 %96, ptr @caml_ml_output_char, i64 %93, i64 %94) "statepoint-id"="0"
-  %98 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %97, 0, 0
-  %99 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %97, 0, 1
-  store i64 %98, ptr %ds
-  store i64 %99, ptr %alloc
-  %100 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %97, 1, 0
-  store ptr addrspace(1) %100, ptr %3
+  %89 = getelementptr i8, ptr addrspace(1) %88, i64 16
+  store ptr addrspace(1) %89, ptr %23
+  %90 = load ptr addrspace(1), ptr %23
+  %91 = load ptr addrspace(1), ptr addrspace(1) %90
+  store ptr addrspace(1) %91, ptr %24
+  %92 = load ptr addrspace(1), ptr %24
+  store ptr addrspace(1) %92, ptr %7
+  %93 = load i64, ptr %21
+  %94 = inttoptr i64 %93 to ptr addrspace(1)
+  store ptr addrspace(1) %94, ptr %9
+  %95 = load ptr addrspace(1), ptr %7
+  %96 = load ptr addrspace(1), ptr %9
+  %97 = load i64, ptr %ds
+  %98 = load i64, ptr %alloc
+  %99 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %97, i64 %98, ptr @caml_ml_output_char, ptr addrspace(1) %95, ptr addrspace(1) %96) "statepoint-id"="0"
+  %100 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %99, 0, 0
+  %101 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %99, 0, 1
+  store i64 %100, ptr %ds
+  store i64 %101, ptr %alloc
+  %102 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %99, 1, 0
+  store ptr addrspace(1) %102, ptr %3
   br label %L128
 L128:
-  %101 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %101, ptr %25
-  %102 = load ptr addrspace(1), ptr %25
-  store ptr addrspace(1) %102, ptr %26
-  %103 = ptrtoint ptr @camlStdlib__print_endline_138 to i64
-  store i64 %103, ptr %27
-  %104 = load i64, ptr %27
-  %105 = inttoptr i64 %104 to ptr addrspace(1)
-  store ptr addrspace(1) %105, ptr %28
-  %106 = load ptr addrspace(1), ptr %28
-  %107 = getelementptr i8, ptr addrspace(1) %106, i64 16
+  %103 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %103, ptr %25
+  %104 = load ptr addrspace(1), ptr %25
+  store ptr addrspace(1) %104, ptr %26
+  %105 = ptrtoint ptr @camlStdlib__print_endline_138 to i64
+  store i64 %105, ptr %27
+  %106 = load i64, ptr %27
+  %107 = inttoptr i64 %106 to ptr addrspace(1)
   store ptr addrspace(1) %107, ptr %28
   %108 = load ptr addrspace(1), ptr %28
-  %109 = load ptr addrspace(1), ptr addrspace(1) %108
-  store ptr addrspace(1) %109, ptr %29
-  %110 = load ptr addrspace(1), ptr %29
-  %111 = ptrtoint ptr addrspace(1) %110 to i64
-  store i64 %111, ptr %8
-  %112 = load i64, ptr %8
-  %113 = load i64, ptr %ds
-  %114 = load i64, ptr %alloc
-  %115 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %113, i64 %114, ptr @caml_ml_flush, i64 %112) "statepoint-id"="0"
-  %116 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %115, 0, 0
-  %117 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %115, 0, 1
-  store i64 %116, ptr %ds
-  store i64 %117, ptr %alloc
-  %118 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %115, 1, 0
-  store ptr addrspace(1) %118, ptr %3
+  %109 = getelementptr i8, ptr addrspace(1) %108, i64 16
+  store ptr addrspace(1) %109, ptr %28
+  %110 = load ptr addrspace(1), ptr %28
+  %111 = load ptr addrspace(1), ptr addrspace(1) %110
+  store ptr addrspace(1) %111, ptr %29
+  %112 = load ptr addrspace(1), ptr %29
+  store ptr addrspace(1) %112, ptr %7
+  %113 = load ptr addrspace(1), ptr %7
+  %114 = load i64, ptr %ds
+  %115 = load i64, ptr %alloc
+  %116 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %114, i64 %115, ptr @caml_ml_flush, ptr addrspace(1) %113) "statepoint-id"="0"
+  %117 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %116, 0, 0
+  %118 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %116, 0, 1
+  store i64 %117, ptr %ds
+  store i64 %118, ptr %alloc
+  %119 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %116, 1, 0
+  store ptr addrspace(1) %119, ptr %3
   br label %L131
 L131:
-  %119 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %119, ptr %30
-  %120 = load ptr addrspace(1), ptr %30
-  store ptr addrspace(1) %120, ptr %31
-  %121 = ptrtoint ptr @camlData_decl__float327 to i64
-  store i64 %121, ptr %32
-  %122 = ptrtoint ptr @camlData_decl__immstring38 to i64
-  store i64 %122, ptr %33
-  %123 = load i64, ptr %33
-  store i64 %123, ptr %8
-  %124 = load i64, ptr %32
-  store i64 %124, ptr %9
-  %125 = load i64, ptr %8
-  %126 = load i64, ptr %9
-  %127 = load i64, ptr %ds
-  %128 = load i64, ptr %alloc
-  %129 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %127, i64 %128, ptr @caml_format_float32, i64 %125, i64 %126) "statepoint-id"="0"
-  %130 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %129, 0, 0
-  %131 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %129, 0, 1
-  store i64 %130, ptr %ds
-  store i64 %131, ptr %alloc
-  %132 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %129, 1, 0
-  store ptr addrspace(1) %132, ptr %3
+  %120 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %120, ptr %30
+  %121 = load ptr addrspace(1), ptr %30
+  store ptr addrspace(1) %121, ptr %31
+  %122 = ptrtoint ptr @camlData_decl__float327 to i64
+  store i64 %122, ptr %32
+  %123 = ptrtoint ptr @camlData_decl__immstring38 to i64
+  store i64 %123, ptr %33
+  %124 = load i64, ptr %33
+  %125 = inttoptr i64 %124 to ptr addrspace(1)
+  store ptr addrspace(1) %125, ptr %7
+  %126 = load i64, ptr %32
+  %127 = inttoptr i64 %126 to ptr addrspace(1)
+  store ptr addrspace(1) %127, ptr %9
+  %128 = load ptr addrspace(1), ptr %7
+  %129 = load ptr addrspace(1), ptr %9
+  %130 = load i64, ptr %ds
+  %131 = load i64, ptr %alloc
+  %132 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %130, i64 %131, ptr @caml_format_float32, ptr addrspace(1) %128, ptr addrspace(1) %129) "statepoint-id"="0"
+  %133 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %132, 0, 0
+  %134 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %132, 0, 1
+  store i64 %133, ptr %ds
+  store i64 %134, ptr %alloc
+  %135 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %132, 1, 0
+  store ptr addrspace(1) %135, ptr %3
   br label %L134
 L134:
-  %133 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %133, ptr %34
-  %134 = load ptr addrspace(1), ptr %34
-  store ptr addrspace(1) %134, ptr %35
-  %135 = ptrtoint ptr @camlData_decl__const_block54 to i64
-  store i64 %135, ptr %36
+  %136 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %136, ptr %34
+  %137 = load ptr addrspace(1), ptr %34
+  store ptr addrspace(1) %137, ptr %35
+  %138 = ptrtoint ptr @camlData_decl__const_block54 to i64
+  store i64 %138, ptr %36
   store i64 1, ptr %37
-  %136 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
-  store i64 %136, ptr %38
-  %137 = load i64, ptr %38
-  store i64 %137, ptr %4
-  %138 = load i64, ptr %37
-  store i64 %138, ptr %6
-  %139 = load i64, ptr %36
-  store i64 %139, ptr %8
-  %140 = load i64, ptr %4
-  %141 = load i64, ptr %6
-  %142 = load i64, ptr %8
-  %143 = load i64, ptr %ds
-  %144 = load i64, ptr %alloc
-  %145 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %143, i64 %144, i64 %140, i64 %141, i64 %142) "statepoint-id"="0"
-  %146 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %145, 0, 0
-  %147 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %145, 0, 1
-  store i64 %146, ptr %ds
-  store i64 %147, ptr %alloc
-  %148 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %145, 1, 0
-  store ptr addrspace(1) %148, ptr %3
+  %139 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
+  store i64 %139, ptr %38
+  %140 = load i64, ptr %38
+  store i64 %140, ptr %4
+  %141 = load i64, ptr %37
+  store i64 %141, ptr %6
+  %142 = load i64, ptr %36
+  store i64 %142, ptr %8
+  %143 = load i64, ptr %4
+  %144 = load i64, ptr %6
+  %145 = load i64, ptr %8
+  %146 = load i64, ptr %ds
+  %147 = load i64, ptr %alloc
+  %148 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %146, i64 %147, i64 %143, i64 %144, i64 %145) "statepoint-id"="0"
+  %149 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %148, 0, 0
+  %150 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %148, 0, 1
+  store i64 %149, ptr %ds
+  store i64 %150, ptr %alloc
+  %151 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %148, 1, 0
+  store ptr addrspace(1) %151, ptr %3
   br label %L135
 L135:
-  %149 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %149, ptr %39
-  %150 = load ptr addrspace(1), ptr %39
-  store ptr addrspace(1) %150, ptr %40
-  %151 = ptrtoint ptr @camlData_decl__float4 to i64
-  store i64 %151, ptr %41
-  %152 = load i64, ptr %41
-  store i64 %152, ptr %4
-  %153 = load ptr addrspace(1), ptr %35
-  store ptr addrspace(1) %153, ptr %5
-  %154 = load ptr addrspace(1), ptr %40
-  store ptr addrspace(1) %154, ptr %7
-  %155 = load i64, ptr %4
-  %156 = load ptr addrspace(1), ptr %5
-  %157 = load ptr addrspace(1), ptr %7
-  %158 = load i64, ptr %ds
-  %159 = load i64, ptr %alloc
-  %160 = call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %158, i64 %159, i64 %155, ptr addrspace(1) %156, ptr addrspace(1) %157) "statepoint-id"="0"
-  %161 = extractvalue { { i64, i64 }, { i64 } } %160, 0, 0
-  %162 = extractvalue { { i64, i64 }, { i64 } } %160, 0, 1
-  store i64 %161, ptr %ds
-  store i64 %162, ptr %alloc
-  %163 = extractvalue { { i64, i64 }, { i64 } } %160, 1, 0
-  store i64 %163, ptr %4
+  %152 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %152, ptr %39
+  %153 = load ptr addrspace(1), ptr %39
+  store ptr addrspace(1) %153, ptr %40
+  %154 = ptrtoint ptr @camlData_decl__float4 to i64
+  store i64 %154, ptr %41
+  %155 = load i64, ptr %41
+  store i64 %155, ptr %4
+  %156 = load ptr addrspace(1), ptr %35
+  store ptr addrspace(1) %156, ptr %5
+  %157 = load ptr addrspace(1), ptr %40
+  store ptr addrspace(1) %157, ptr %7
+  %158 = load i64, ptr %4
+  %159 = load ptr addrspace(1), ptr %5
+  %160 = load ptr addrspace(1), ptr %7
+  %161 = load i64, ptr %ds
+  %162 = load i64, ptr %alloc
+  %163 = call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %161, i64 %162, i64 %158, ptr addrspace(1) %159, ptr addrspace(1) %160) "statepoint-id"="0"
+  %164 = extractvalue { { i64, i64 }, { i64 } } %163, 0, 0
+  %165 = extractvalue { { i64, i64 }, { i64 } } %163, 0, 1
+  store i64 %164, ptr %ds
+  store i64 %165, ptr %alloc
+  %166 = extractvalue { { i64, i64 }, { i64 } } %163, 1, 0
+  store i64 %166, ptr %4
   br label %L136
 L136:
-  %164 = load i64, ptr %4
-  store i64 %164, ptr %42
-  %165 = load i64, ptr %42
-  store i64 %165, ptr %43
-  store i64 11, ptr %44
-  %166 = load i64, ptr %44
-  store i64 %166, ptr %4
   %167 = load i64, ptr %4
-  %168 = load i64, ptr %ds
-  %169 = load i64, ptr %alloc
-  %170 = call oxcamlcc { { i64, i64 }, { i64 } } @camlData_decl__f_HIDE_STAMP(i64 %168, i64 %169, i64 %167) "statepoint-id"="0"
-  %171 = extractvalue { { i64, i64 }, { i64 } } %170, 0, 0
-  %172 = extractvalue { { i64, i64 }, { i64 } } %170, 0, 1
-  store i64 %171, ptr %ds
-  store i64 %172, ptr %alloc
-  %173 = extractvalue { { i64, i64 }, { i64 } } %170, 1, 0
-  store i64 %173, ptr %4
+  store i64 %167, ptr %42
+  %168 = load i64, ptr %42
+  store i64 %168, ptr %43
+  store i64 11, ptr %44
+  %169 = load i64, ptr %44
+  store i64 %169, ptr %4
+  %170 = load i64, ptr %4
+  %171 = load i64, ptr %ds
+  %172 = load i64, ptr %alloc
+  %173 = call oxcamlcc { { i64, i64 }, { i64 } } @camlData_decl__f_HIDE_STAMP(i64 %171, i64 %172, i64 %170) "statepoint-id"="0"
+  %174 = extractvalue { { i64, i64 }, { i64 } } %173, 0, 0
+  %175 = extractvalue { { i64, i64 }, { i64 } } %173, 0, 1
+  store i64 %174, ptr %ds
+  store i64 %175, ptr %alloc
+  %176 = extractvalue { { i64, i64 }, { i64 } } %173, 1, 0
+  store i64 %176, ptr %4
   br label %L137
 L137:
-  %174 = load i64, ptr %4
-  store i64 %174, ptr %45
-  %175 = load i64, ptr %45
-  store i64 %175, ptr %46
-  %176 = ptrtoint ptr @camlData_decl__const_block67 to i64
-  store i64 %176, ptr %47
+  %177 = load i64, ptr %4
+  store i64 %177, ptr %45
+  %178 = load i64, ptr %45
+  store i64 %178, ptr %46
+  %179 = ptrtoint ptr @camlData_decl__const_block67 to i64
+  store i64 %179, ptr %47
   store i64 1, ptr %48
-  %177 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
-  store i64 %177, ptr %49
-  %178 = load i64, ptr %49
-  store i64 %178, ptr %4
-  %179 = load i64, ptr %48
-  store i64 %179, ptr %6
-  %180 = load i64, ptr %47
-  store i64 %180, ptr %8
-  %181 = load i64, ptr %4
-  %182 = load i64, ptr %6
-  %183 = load i64, ptr %8
-  %184 = load i64, ptr %ds
-  %185 = load i64, ptr %alloc
-  %186 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %184, i64 %185, i64 %181, i64 %182, i64 %183) "statepoint-id"="0"
-  %187 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %186, 0, 0
-  %188 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %186, 0, 1
-  store i64 %187, ptr %ds
-  store i64 %188, ptr %alloc
-  %189 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %186, 1, 0
-  store ptr addrspace(1) %189, ptr %3
+  %180 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
+  store i64 %180, ptr %49
+  %181 = load i64, ptr %49
+  store i64 %181, ptr %4
+  %182 = load i64, ptr %48
+  store i64 %182, ptr %6
+  %183 = load i64, ptr %47
+  store i64 %183, ptr %8
+  %184 = load i64, ptr %4
+  %185 = load i64, ptr %6
+  %186 = load i64, ptr %8
+  %187 = load i64, ptr %ds
+  %188 = load i64, ptr %alloc
+  %189 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %187, i64 %188, i64 %184, i64 %185, i64 %186) "statepoint-id"="0"
+  %190 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %189, 0, 0
+  %191 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %189, 0, 1
+  store i64 %190, ptr %ds
+  store i64 %191, ptr %alloc
+  %192 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %189, 1, 0
+  store ptr addrspace(1) %192, ptr %3
   br label %L138
 L138:
-  %190 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %190, ptr %50
-  %191 = load ptr addrspace(1), ptr %50
-  store ptr addrspace(1) %191, ptr %51
-  %192 = load ptr addrspace(1), ptr %51
-  %193 = load i64, ptr addrspace(1) %192
-  store i64 %193, ptr %52
-  %194 = load i64, ptr %46
-  store i64 %194, ptr %4
+  %193 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %193, ptr %50
+  %194 = load ptr addrspace(1), ptr %50
+  store ptr addrspace(1) %194, ptr %51
   %195 = load ptr addrspace(1), ptr %51
-  store ptr addrspace(1) %195, ptr %5
-  %196 = load i64, ptr %4
-  %197 = load ptr addrspace(1), ptr %5
-  %198 = load i64, ptr %ds
-  %199 = load i64, ptr %alloc
-  %200 = load ptr, ptr %52
-  %201 = call oxcamlcc { { i64, i64 }, { i64 } } %200(i64 %198, i64 %199, i64 %196, ptr addrspace(1) %197) "statepoint-id"="0"
-  %202 = extractvalue { { i64, i64 }, { i64 } } %201, 0, 0
-  %203 = extractvalue { { i64, i64 }, { i64 } } %201, 0, 1
-  store i64 %202, ptr %ds
-  store i64 %203, ptr %alloc
-  %204 = extractvalue { { i64, i64 }, { i64 } } %201, 1, 0
-  store i64 %204, ptr %4
+  %196 = load i64, ptr addrspace(1) %195
+  store i64 %196, ptr %52
+  %197 = load i64, ptr %46
+  store i64 %197, ptr %4
+  %198 = load ptr addrspace(1), ptr %51
+  store ptr addrspace(1) %198, ptr %5
+  %199 = load i64, ptr %4
+  %200 = load ptr addrspace(1), ptr %5
+  %201 = load i64, ptr %ds
+  %202 = load i64, ptr %alloc
+  %203 = load ptr, ptr %52
+  %204 = call oxcamlcc { { i64, i64 }, { i64 } } %203(i64 %201, i64 %202, i64 %199, ptr addrspace(1) %200) "statepoint-id"="0"
+  %205 = extractvalue { { i64, i64 }, { i64 } } %204, 0, 0
+  %206 = extractvalue { { i64, i64 }, { i64 } } %204, 0, 1
+  store i64 %205, ptr %ds
+  store i64 %206, ptr %alloc
+  %207 = extractvalue { { i64, i64 }, { i64 } } %204, 1, 0
+  store i64 %207, ptr %4
   br label %L139
 L139:
-  %205 = load i64, ptr %4
-  store i64 %205, ptr %53
-  %206 = load i64, ptr %53
-  store i64 %206, ptr %54
-  %207 = ptrtoint ptr @camlData_decl to i64
-  store i64 %207, ptr %55
-  %208 = load i64, ptr %55
-  store i64 %208, ptr %56
-  %209 = load i64, ptr %56
-  %210 = inttoptr i64 %209 to ptr addrspace(1)
-  store ptr addrspace(1) %210, ptr %12
+  %208 = load i64, ptr %4
+  store i64 %208, ptr %53
+  %209 = load i64, ptr %53
+  store i64 %209, ptr %54
+  %210 = ptrtoint ptr @camlData_decl to i64
+  store i64 %210, ptr %55
+  %211 = load i64, ptr %55
+  store i64 %211, ptr %56
+  %212 = load i64, ptr %56
+  %213 = inttoptr i64 %212 to ptr addrspace(1)
+  store ptr addrspace(1) %213, ptr %12
   store i64 1, ptr %57
-  %211 = load i64, ptr %57
-  store i64 %211, ptr %4
-  %212 = load ptr addrspace(1), ptr %4
-  %213 = load i64, ptr %ds
-  %214 = load i64, ptr %alloc
-  %215 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } poison, i64 %213, 0, 0
-  %216 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } %215, i64 %214, 0, 1
-  %217 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } %216, ptr addrspace(1) %212, 1, 0
-  ret { { i64, i64 }, { ptr addrspace(1) } } %217
+  %214 = load i64, ptr %57
+  store i64 %214, ptr %4
+  %215 = load ptr addrspace(1), ptr %4
+  %216 = load i64, ptr %ds
+  %217 = load i64, ptr %alloc
+  %218 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } poison, i64 %216, 0, 0
+  %219 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } %218, i64 %217, 0, 1
+  %220 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } %219, ptr addrspace(1) %215, 1, 0
+  ret { { i64, i64 }, { ptr addrspace(1) } } %220
 }
 
 define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) returns_twice noinline {

--- a/oxcaml/tests/backend/llvmize/exn_part2_ir.output
+++ b/oxcaml/tests/backend/llvmize/exn_part2_ir.output
@@ -1771,10 +1771,10 @@ define  oxcamlcc { { i64, i64 }, { i64 } } @camlExn_part2__catch_wildcard_HIDE_S
   %4 = alloca i64
   store i64 %2, ptr %4
   %5 = alloca ptr addrspace(1)
-  %6 = alloca i64
-  %7 = alloca i64
-  %8 = alloca i64
-  %9 = alloca i64
+  %6 = alloca ptr addrspace(1)
+  %7 = alloca ptr addrspace(1)
+  %8 = alloca ptr addrspace(1)
+  %9 = alloca ptr addrspace(1)
   %10 = alloca i64
   %11 = alloca i64
   %12 = alloca i64
@@ -1904,104 +1904,105 @@ L403:
   %94 = load ptr addrspace(1), ptr addrspace(1) %93
   store ptr addrspace(1) %94, ptr %22
   %95 = load ptr addrspace(1), ptr %22
-  %96 = ptrtoint ptr addrspace(1) %95 to i64
-  store i64 %96, ptr %6
-  %97 = load i64, ptr %19
-  store i64 %97, ptr %7
+  store ptr addrspace(1) %95, ptr %6
+  %96 = load i64, ptr %19
+  %97 = inttoptr i64 %96 to ptr addrspace(1)
+  store ptr addrspace(1) %97, ptr %7
   %98 = load i64, ptr %18
-  store i64 %98, ptr %8
-  %99 = load i64, ptr %17
-  store i64 %99, ptr %9
-  %100 = load i64, ptr %6
-  %101 = load i64, ptr %7
-  %102 = load i64, ptr %8
-  %103 = load i64, ptr %9
-  %104 = load i64, ptr %ds
-  %105 = load i64, ptr %alloc
-  %106 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %104, i64 %105, ptr @caml_ml_output, i64 %100, i64 %101, i64 %102, i64 %103) "statepoint-id"="0"
-  %107 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %106, 0, 0
-  %108 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %106, 0, 1
-  store i64 %107, ptr %ds
-  store i64 %108, ptr %alloc
-  %109 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %106, 1, 0
-  store ptr addrspace(1) %109, ptr %5
+  %99 = inttoptr i64 %98 to ptr addrspace(1)
+  store ptr addrspace(1) %99, ptr %8
+  %100 = load i64, ptr %17
+  %101 = inttoptr i64 %100 to ptr addrspace(1)
+  store ptr addrspace(1) %101, ptr %9
+  %102 = load ptr addrspace(1), ptr %6
+  %103 = load ptr addrspace(1), ptr %7
+  %104 = load ptr addrspace(1), ptr %8
+  %105 = load ptr addrspace(1), ptr %9
+  %106 = load i64, ptr %ds
+  %107 = load i64, ptr %alloc
+  %108 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %106, i64 %107, ptr @caml_ml_output, ptr addrspace(1) %102, ptr addrspace(1) %103, ptr addrspace(1) %104, ptr addrspace(1) %105) "statepoint-id"="0"
+  %109 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %108, 0, 0
+  %110 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %108, 0, 1
+  store i64 %109, ptr %ds
+  store i64 %110, ptr %alloc
+  %111 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %108, 1, 0
+  store ptr addrspace(1) %111, ptr %5
   br label %L416
 L416:
-  %110 = load ptr addrspace(1), ptr %5
-  store ptr addrspace(1) %110, ptr %23
-  %111 = load ptr addrspace(1), ptr %23
-  store ptr addrspace(1) %111, ptr %24
+  %112 = load ptr addrspace(1), ptr %5
+  store ptr addrspace(1) %112, ptr %23
+  %113 = load ptr addrspace(1), ptr %23
+  store ptr addrspace(1) %113, ptr %24
   store i64 21, ptr %25
-  %112 = ptrtoint ptr @camlStdlib__print_endline_138 to i64
-  store i64 %112, ptr %26
-  %113 = load i64, ptr %26
-  %114 = inttoptr i64 %113 to ptr addrspace(1)
-  store ptr addrspace(1) %114, ptr %27
-  %115 = load ptr addrspace(1), ptr %27
-  %116 = getelementptr i8, ptr addrspace(1) %115, i64 16
+  %114 = ptrtoint ptr @camlStdlib__print_endline_138 to i64
+  store i64 %114, ptr %26
+  %115 = load i64, ptr %26
+  %116 = inttoptr i64 %115 to ptr addrspace(1)
   store ptr addrspace(1) %116, ptr %27
   %117 = load ptr addrspace(1), ptr %27
-  %118 = load ptr addrspace(1), ptr addrspace(1) %117
-  store ptr addrspace(1) %118, ptr %28
-  %119 = load ptr addrspace(1), ptr %28
-  %120 = ptrtoint ptr addrspace(1) %119 to i64
-  store i64 %120, ptr %6
-  %121 = load i64, ptr %25
-  store i64 %121, ptr %7
-  %122 = load i64, ptr %6
-  %123 = load i64, ptr %7
-  %124 = load i64, ptr %ds
-  %125 = load i64, ptr %alloc
-  %126 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %124, i64 %125, ptr @caml_ml_output_char, i64 %122, i64 %123) "statepoint-id"="0"
-  %127 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %126, 0, 0
-  %128 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %126, 0, 1
-  store i64 %127, ptr %ds
-  store i64 %128, ptr %alloc
-  %129 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %126, 1, 0
-  store ptr addrspace(1) %129, ptr %5
+  %118 = getelementptr i8, ptr addrspace(1) %117, i64 16
+  store ptr addrspace(1) %118, ptr %27
+  %119 = load ptr addrspace(1), ptr %27
+  %120 = load ptr addrspace(1), ptr addrspace(1) %119
+  store ptr addrspace(1) %120, ptr %28
+  %121 = load ptr addrspace(1), ptr %28
+  store ptr addrspace(1) %121, ptr %6
+  %122 = load i64, ptr %25
+  %123 = inttoptr i64 %122 to ptr addrspace(1)
+  store ptr addrspace(1) %123, ptr %7
+  %124 = load ptr addrspace(1), ptr %6
+  %125 = load ptr addrspace(1), ptr %7
+  %126 = load i64, ptr %ds
+  %127 = load i64, ptr %alloc
+  %128 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %126, i64 %127, ptr @caml_ml_output_char, ptr addrspace(1) %124, ptr addrspace(1) %125) "statepoint-id"="0"
+  %129 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %128, 0, 0
+  %130 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %128, 0, 1
+  store i64 %129, ptr %ds
+  store i64 %130, ptr %alloc
+  %131 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %128, 1, 0
+  store ptr addrspace(1) %131, ptr %5
   br label %L419
 L419:
-  %130 = load ptr addrspace(1), ptr %5
-  store ptr addrspace(1) %130, ptr %29
-  %131 = load ptr addrspace(1), ptr %29
-  store ptr addrspace(1) %131, ptr %30
-  %132 = ptrtoint ptr @camlStdlib__print_endline_138 to i64
-  store i64 %132, ptr %31
-  %133 = load i64, ptr %31
-  %134 = inttoptr i64 %133 to ptr addrspace(1)
-  store ptr addrspace(1) %134, ptr %32
-  %135 = load ptr addrspace(1), ptr %32
-  %136 = getelementptr i8, ptr addrspace(1) %135, i64 16
+  %132 = load ptr addrspace(1), ptr %5
+  store ptr addrspace(1) %132, ptr %29
+  %133 = load ptr addrspace(1), ptr %29
+  store ptr addrspace(1) %133, ptr %30
+  %134 = ptrtoint ptr @camlStdlib__print_endline_138 to i64
+  store i64 %134, ptr %31
+  %135 = load i64, ptr %31
+  %136 = inttoptr i64 %135 to ptr addrspace(1)
   store ptr addrspace(1) %136, ptr %32
   %137 = load ptr addrspace(1), ptr %32
-  %138 = load ptr addrspace(1), ptr addrspace(1) %137
-  store ptr addrspace(1) %138, ptr %33
-  %139 = load ptr addrspace(1), ptr %33
-  %140 = ptrtoint ptr addrspace(1) %139 to i64
-  store i64 %140, ptr %6
-  %141 = load i64, ptr %6
-  %142 = load i64, ptr %ds
-  %143 = load i64, ptr %alloc
-  %144 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %142, i64 %143, ptr @caml_ml_flush, i64 %141) "statepoint-id"="0"
-  %145 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %144, 0, 0
-  %146 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %144, 0, 1
-  store i64 %145, ptr %ds
-  store i64 %146, ptr %alloc
-  %147 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %144, 1, 0
-  store ptr addrspace(1) %147, ptr %5
+  %138 = getelementptr i8, ptr addrspace(1) %137, i64 16
+  store ptr addrspace(1) %138, ptr %32
+  %139 = load ptr addrspace(1), ptr %32
+  %140 = load ptr addrspace(1), ptr addrspace(1) %139
+  store ptr addrspace(1) %140, ptr %33
+  %141 = load ptr addrspace(1), ptr %33
+  store ptr addrspace(1) %141, ptr %6
+  %142 = load ptr addrspace(1), ptr %6
+  %143 = load i64, ptr %ds
+  %144 = load i64, ptr %alloc
+  %145 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %143, i64 %144, ptr @caml_ml_flush, ptr addrspace(1) %142) "statepoint-id"="0"
+  %146 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %145, 0, 0
+  %147 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %145, 0, 1
+  store i64 %146, ptr %ds
+  store i64 %147, ptr %alloc
+  %148 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %145, 1, 0
+  store ptr addrspace(1) %148, ptr %5
   br label %L422
 L422:
-  %148 = load ptr addrspace(1), ptr %5
-  store ptr addrspace(1) %148, ptr %34
-  %149 = load ptr addrspace(1), ptr %34
-  store ptr addrspace(1) %149, ptr %5
-  %150 = load i64, ptr %5
-  %151 = load i64, ptr %ds
-  %152 = load i64, ptr %alloc
-  %153 = insertvalue { { i64, i64 }, { i64 } } poison, i64 %151, 0, 0
-  %154 = insertvalue { { i64, i64 }, { i64 } } %153, i64 %152, 0, 1
-  %155 = insertvalue { { i64, i64 }, { i64 } } %154, i64 %150, 1, 0
-  ret { { i64, i64 }, { i64 } } %155
+  %149 = load ptr addrspace(1), ptr %5
+  store ptr addrspace(1) %149, ptr %34
+  %150 = load ptr addrspace(1), ptr %34
+  store ptr addrspace(1) %150, ptr %5
+  %151 = load i64, ptr %5
+  %152 = load i64, ptr %ds
+  %153 = load i64, ptr %alloc
+  %154 = insertvalue { { i64, i64 }, { i64 } } poison, i64 %152, 0, 0
+  %155 = insertvalue { { i64, i64 }, { i64 } } %154, i64 %153, 0, 1
+  %156 = insertvalue { { i64, i64 }, { i64 } } %155, i64 %151, 1, 0
+  ret { { i64, i64 }, { i64 } } %156
 }
 
 define  oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlExn_part2__entry(i64 %0, i64 %1) gc "oxcaml" {
@@ -2011,8 +2012,8 @@ define  oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlExn_part2__entry(i6
   store i64 %1, ptr %alloc
   %3 = alloca ptr addrspace(1)
   %4 = alloca i64
-  %5 = alloca i64
-  %6 = alloca i64
+  %5 = alloca ptr addrspace(1)
+  %6 = alloca ptr addrspace(1)
   %7 = alloca ptr addrspace(1)
   %8 = alloca i64
   %9 = alloca ptr addrspace(1)
@@ -2029,75 +2030,74 @@ L1:
 L432:
   store i64 1, ptr %8
   %17 = load i64, ptr %8
-  store i64 %17, ptr %5
-  %18 = load i64, ptr %5
-  %19 = load i64, ptr %ds
-  %20 = load i64, ptr %alloc
-  %21 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @c_call_wrapper.caml_fresh_oo_id(i64 %19, i64 %20, i64 %18) "gc-leaf-function"="true"
-  %22 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %21, 0, 0
-  %23 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %21, 0, 1
-  store i64 %22, ptr %ds
-  store i64 %23, ptr %alloc
-  %24 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %21, 1, 0
-  store ptr addrspace(1) %24, ptr %3
+  %18 = inttoptr i64 %17 to ptr addrspace(1)
+  store ptr addrspace(1) %18, ptr %5
+  %19 = load ptr addrspace(1), ptr %5
+  %20 = load i64, ptr %ds
+  %21 = load i64, ptr %alloc
+  %22 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @c_call_wrapper.caml_fresh_oo_id(i64 %20, i64 %21, ptr addrspace(1) %19) "gc-leaf-function"="true"
+  %23 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %22, 0, 0
+  %24 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %22, 0, 1
+  store i64 %23, ptr %ds
+  store i64 %24, ptr %alloc
+  %25 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %22, 1, 0
+  store ptr addrspace(1) %25, ptr %3
   br label %L434
 L434:
-  %25 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %25, ptr %9
-  %26 = load ptr addrspace(1), ptr %9
-  store ptr addrspace(1) %26, ptr %10
-  %27 = ptrtoint ptr @camlExn_part2__Exn3229 to i64
-  store i64 %27, ptr %11
-  %28 = load i64, ptr %11
-  %29 = inttoptr i64 %28 to ptr addrspace(1)
-  store ptr addrspace(1) %29, ptr %12
-  %30 = load ptr addrspace(1), ptr %12
-  %31 = getelementptr i8, ptr addrspace(1) %30, i64 8
-  store ptr addrspace(1) %31, ptr %12
-  %32 = load ptr addrspace(1), ptr %12
-  %33 = ptrtoint ptr addrspace(1) %32 to i64
-  store i64 %33, ptr %5
+  %26 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %26, ptr %9
+  %27 = load ptr addrspace(1), ptr %9
+  store ptr addrspace(1) %27, ptr %10
+  %28 = ptrtoint ptr @camlExn_part2__Exn3229 to i64
+  store i64 %28, ptr %11
+  %29 = load i64, ptr %11
+  %30 = inttoptr i64 %29 to ptr addrspace(1)
+  store ptr addrspace(1) %30, ptr %12
+  %31 = load ptr addrspace(1), ptr %12
+  %32 = getelementptr i8, ptr addrspace(1) %31, i64 8
+  store ptr addrspace(1) %32, ptr %12
+  %33 = load ptr addrspace(1), ptr %12
+  store ptr addrspace(1) %33, ptr %5
   %34 = load ptr addrspace(1), ptr %10
-  %35 = ptrtoint ptr addrspace(1) %34 to i64
-  store i64 %35, ptr %6
-  %36 = load i64, ptr %5
-  %37 = load i64, ptr %6
-  %38 = load i64, ptr %ds
-  %39 = load i64, ptr %alloc
-  %40 = call oxcamlcc { { i64, i64 }, {  } } @c_call_wrapper.caml_initialize(i64 %38, i64 %39, i64 %36, i64 %37) "gc-leaf-function"="true"
-  %41 = extractvalue { { i64, i64 }, {  } } %40, 0, 0
-  %42 = extractvalue { { i64, i64 }, {  } } %40, 0, 1
-  store i64 %41, ptr %ds
-  store i64 %42, ptr %alloc
+  store ptr addrspace(1) %34, ptr %6
+  %35 = load ptr addrspace(1), ptr %5
+  %36 = load ptr addrspace(1), ptr %6
+  %37 = load i64, ptr %ds
+  %38 = load i64, ptr %alloc
+  %39 = call oxcamlcc { { i64, i64 }, {  } } @c_call_wrapper.caml_initialize(i64 %37, i64 %38, ptr addrspace(1) %35, ptr addrspace(1) %36) "gc-leaf-function"="true"
+  %40 = extractvalue { { i64, i64 }, {  } } %39, 0, 0
+  %41 = extractvalue { { i64, i64 }, {  } } %39, 0, 1
+  store i64 %40, ptr %ds
+  store i64 %41, ptr %alloc
   br label %L435
 L435:
   store i64 1, ptr %13
-  %43 = ptrtoint ptr @camlExn_part2 to i64
-  store i64 %43, ptr %14
-  %44 = load i64, ptr %14
-  store i64 %44, ptr %15
-  %45 = load i64, ptr %15
-  %46 = inttoptr i64 %45 to ptr addrspace(1)
-  store ptr addrspace(1) %46, ptr %7
+  %42 = ptrtoint ptr @camlExn_part2 to i64
+  store i64 %42, ptr %14
+  %43 = load i64, ptr %14
+  store i64 %43, ptr %15
+  %44 = load i64, ptr %15
+  %45 = inttoptr i64 %44 to ptr addrspace(1)
+  store ptr addrspace(1) %45, ptr %7
   store i64 1, ptr %16
-  %47 = load i64, ptr %16
-  store i64 %47, ptr %4
-  %48 = load ptr addrspace(1), ptr %4
-  %49 = load i64, ptr %ds
-  %50 = load i64, ptr %alloc
-  %51 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } poison, i64 %49, 0, 0
-  %52 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } %51, i64 %50, 0, 1
-  %53 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } %52, ptr addrspace(1) %48, 1, 0
-  ret { { i64, i64 }, { ptr addrspace(1) } } %53
+  %46 = load i64, ptr %16
+  store i64 %46, ptr %4
+  %47 = load ptr addrspace(1), ptr %4
+  %48 = load i64, ptr %ds
+  %49 = load i64, ptr %alloc
+  %50 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } poison, i64 %48, 0, 0
+  %51 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } %50, i64 %49, 0, 1
+  %52 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } %51, ptr addrspace(1) %47, 1, 0
+  ret { { i64, i64 }, { ptr addrspace(1) } } %52
 }
 
-define private oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @c_call_wrapper.caml_fresh_oo_id(i64 %0, i64 %1, i64 %2) noinline {
+define private oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @c_call_wrapper.caml_fresh_oo_id(i64 %0, i64 %1, ptr addrspace(1) %2) noinline {
   %4 = add i64 %0, 104
   %5 = inttoptr i64 %4 to ptr
   %6 = load i64, ptr %5
   %7 = call  i64 @llvm.read_register.i64(metadata !{!"rsp\00"})
   call  void @llvm.write_register.i64(metadata !{!"rsp\00"}, i64 %6)
-  %8 = call  { ptr addrspace(1) } @caml_fresh_oo_id(i64 %2)
+  %8 = call  { ptr addrspace(1) } @caml_fresh_oo_id(ptr addrspace(1) %2)
   call  void @llvm.write_register.i64(metadata !{!"rsp\00"}, i64 %7)
   %9 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } poison, { ptr addrspace(1) } %8, 1
   %10 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } %9, i64 %0, 0, 0
@@ -2105,13 +2105,13 @@ define private oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @c_call_wrapper.c
   ret { { i64, i64 }, { ptr addrspace(1) } } %11
 }
 
-define private oxcamlcc { { i64, i64 }, {  } } @c_call_wrapper.caml_initialize(i64 %0, i64 %1, i64 %2, i64 %3) noinline {
+define private oxcamlcc { { i64, i64 }, {  } } @c_call_wrapper.caml_initialize(i64 %0, i64 %1, ptr addrspace(1) %2, ptr addrspace(1) %3) noinline {
   %5 = add i64 %0, 104
   %6 = inttoptr i64 %5 to ptr
   %7 = load i64, ptr %6
   %8 = call  i64 @llvm.read_register.i64(metadata !{!"rsp\00"})
   call  void @llvm.write_register.i64(metadata !{!"rsp\00"}, i64 %7)
-  %9 = call  {  } @caml_initialize(i64 %2, i64 %3)
+  %9 = call  {  } @caml_initialize(ptr addrspace(1) %2, ptr addrspace(1) %3)
   call  void @llvm.write_register.i64(metadata !{!"rsp\00"}, i64 %8)
   %10 = insertvalue { { i64, i64 }, {  } } poison, {  } %9, 1
   %11 = insertvalue { { i64, i64 }, {  } } %10, i64 %0, 0, 0

--- a/oxcaml/tests/backend/llvmize/extcalls_ir.output
+++ b/oxcaml/tests/backend/llvmize/extcalls_ir.output
@@ -8,12 +8,12 @@ define  oxcamlcc { { i64, i64 }, { i64 } } @camlExtcalls__call_too_many_HIDE_STA
   %4 = alloca i64
   store i64 %2, ptr %4
   %5 = alloca ptr addrspace(1)
-  %6 = alloca i64
-  %7 = alloca i64
-  %8 = alloca i64
-  %9 = alloca i64
-  %10 = alloca i64
-  %11 = alloca i64
+  %6 = alloca ptr addrspace(1)
+  %7 = alloca ptr addrspace(1)
+  %8 = alloca ptr addrspace(1)
+  %9 = alloca ptr addrspace(1)
+  %10 = alloca ptr addrspace(1)
+  %11 = alloca ptr addrspace(1)
   %12 = alloca i64
   %13 = alloca i64
   %14 = alloca i64
@@ -27,12 +27,12 @@ define  oxcamlcc { { i64, i64 }, { i64 } } @camlExtcalls__call_too_many_HIDE_STA
   %22 = alloca i64
   %23 = alloca i64
   %24 = alloca i64
-  %25 = alloca i64
-  %26 = alloca i64
-  %27 = alloca i64
-  %28 = alloca i64
-  %29 = alloca i64
-  %30 = alloca i64
+  %25 = alloca ptr addrspace(1)
+  %26 = alloca ptr addrspace(1)
+  %27 = alloca ptr addrspace(1)
+  %28 = alloca ptr addrspace(1)
+  %29 = alloca ptr addrspace(1)
+  %30 = alloca ptr addrspace(1)
   %31 = alloca ptr addrspace(1)
   br label %L1
 L1:
@@ -53,63 +53,75 @@ L101:
   store i64 5, ptr %23
   store i64 3, ptr %24
   %33 = load i64, ptr %24
-  store i64 %33, ptr %6
-  %34 = load i64, ptr %23
-  store i64 %34, ptr %7
-  %35 = load i64, ptr %22
-  store i64 %35, ptr %8
-  %36 = load i64, ptr %21
-  store i64 %36, ptr %9
-  %37 = load i64, ptr %20
-  store i64 %37, ptr %10
-  %38 = load i64, ptr %19
-  store i64 %38, ptr %11
-  %39 = load i64, ptr %18
-  store i64 %39, ptr %25
-  %40 = load i64, ptr %17
-  store i64 %40, ptr %26
-  %41 = load i64, ptr %16
-  store i64 %41, ptr %27
-  %42 = load i64, ptr %15
-  store i64 %42, ptr %28
-  %43 = load i64, ptr %14
-  store i64 %43, ptr %29
-  %44 = load i64, ptr %13
-  store i64 %44, ptr %30
-  %45 = load i64, ptr %6
-  %46 = load i64, ptr %7
-  %47 = load i64, ptr %8
-  %48 = load i64, ptr %9
-  %49 = load i64, ptr %10
-  %50 = load i64, ptr %11
-  %51 = load i64, ptr %25
-  %52 = load i64, ptr %26
-  %53 = load i64, ptr %27
-  %54 = load i64, ptr %28
-  %55 = load i64, ptr %29
-  %56 = load i64, ptr %30
-  %57 = load i64, ptr %ds
-  %58 = load i64, ptr %alloc
-  %59 = call oxcaml_c_stackcc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call_stack_args_llvm_backend(i64 %57, i64 %58, ptr @too_many, i64 48, i64 %45, i64 %46, i64 %47, i64 %48, i64 %49, i64 %50, i64 %51, i64 %52, i64 %53, i64 %54, i64 %55, i64 %56) "statepoint-id"="0"
-  %60 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %59, 0, 0
-  %61 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %59, 0, 1
-  store i64 %60, ptr %ds
-  store i64 %61, ptr %alloc
-  %62 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %59, 1, 0
-  store ptr addrspace(1) %62, ptr %5
+  %34 = inttoptr i64 %33 to ptr addrspace(1)
+  store ptr addrspace(1) %34, ptr %6
+  %35 = load i64, ptr %23
+  %36 = inttoptr i64 %35 to ptr addrspace(1)
+  store ptr addrspace(1) %36, ptr %7
+  %37 = load i64, ptr %22
+  %38 = inttoptr i64 %37 to ptr addrspace(1)
+  store ptr addrspace(1) %38, ptr %8
+  %39 = load i64, ptr %21
+  %40 = inttoptr i64 %39 to ptr addrspace(1)
+  store ptr addrspace(1) %40, ptr %9
+  %41 = load i64, ptr %20
+  %42 = inttoptr i64 %41 to ptr addrspace(1)
+  store ptr addrspace(1) %42, ptr %10
+  %43 = load i64, ptr %19
+  %44 = inttoptr i64 %43 to ptr addrspace(1)
+  store ptr addrspace(1) %44, ptr %11
+  %45 = load i64, ptr %18
+  %46 = inttoptr i64 %45 to ptr addrspace(1)
+  store ptr addrspace(1) %46, ptr %25
+  %47 = load i64, ptr %17
+  %48 = inttoptr i64 %47 to ptr addrspace(1)
+  store ptr addrspace(1) %48, ptr %26
+  %49 = load i64, ptr %16
+  %50 = inttoptr i64 %49 to ptr addrspace(1)
+  store ptr addrspace(1) %50, ptr %27
+  %51 = load i64, ptr %15
+  %52 = inttoptr i64 %51 to ptr addrspace(1)
+  store ptr addrspace(1) %52, ptr %28
+  %53 = load i64, ptr %14
+  %54 = inttoptr i64 %53 to ptr addrspace(1)
+  store ptr addrspace(1) %54, ptr %29
+  %55 = load i64, ptr %13
+  %56 = inttoptr i64 %55 to ptr addrspace(1)
+  store ptr addrspace(1) %56, ptr %30
+  %57 = load ptr addrspace(1), ptr %6
+  %58 = load ptr addrspace(1), ptr %7
+  %59 = load ptr addrspace(1), ptr %8
+  %60 = load ptr addrspace(1), ptr %9
+  %61 = load ptr addrspace(1), ptr %10
+  %62 = load ptr addrspace(1), ptr %11
+  %63 = load ptr addrspace(1), ptr %25
+  %64 = load ptr addrspace(1), ptr %26
+  %65 = load ptr addrspace(1), ptr %27
+  %66 = load ptr addrspace(1), ptr %28
+  %67 = load ptr addrspace(1), ptr %29
+  %68 = load ptr addrspace(1), ptr %30
+  %69 = load i64, ptr %ds
+  %70 = load i64, ptr %alloc
+  %71 = call oxcaml_c_stackcc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call_stack_args_llvm_backend(i64 %69, i64 %70, ptr @too_many, i64 48, ptr addrspace(1) %57, ptr addrspace(1) %58, ptr addrspace(1) %59, ptr addrspace(1) %60, ptr addrspace(1) %61, ptr addrspace(1) %62, ptr addrspace(1) %63, ptr addrspace(1) %64, ptr addrspace(1) %65, ptr addrspace(1) %66, ptr addrspace(1) %67, ptr addrspace(1) %68) "statepoint-id"="0"
+  %72 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %71, 0, 0
+  %73 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %71, 0, 1
+  store i64 %72, ptr %ds
+  store i64 %73, ptr %alloc
+  %74 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %71, 1, 0
+  store ptr addrspace(1) %74, ptr %5
   br label %L103
 L103:
-  %63 = load ptr addrspace(1), ptr %5
-  store ptr addrspace(1) %63, ptr %31
-  %64 = load ptr addrspace(1), ptr %31
-  store ptr addrspace(1) %64, ptr %5
-  %65 = load i64, ptr %5
-  %66 = load i64, ptr %ds
-  %67 = load i64, ptr %alloc
-  %68 = insertvalue { { i64, i64 }, { i64 } } poison, i64 %66, 0, 0
-  %69 = insertvalue { { i64, i64 }, { i64 } } %68, i64 %67, 0, 1
-  %70 = insertvalue { { i64, i64 }, { i64 } } %69, i64 %65, 1, 0
-  ret { { i64, i64 }, { i64 } } %70
+  %75 = load ptr addrspace(1), ptr %5
+  store ptr addrspace(1) %75, ptr %31
+  %76 = load ptr addrspace(1), ptr %31
+  store ptr addrspace(1) %76, ptr %5
+  %77 = load i64, ptr %5
+  %78 = load i64, ptr %ds
+  %79 = load i64, ptr %alloc
+  %80 = insertvalue { { i64, i64 }, { i64 } } poison, i64 %78, 0, 0
+  %81 = insertvalue { { i64, i64 }, { i64 } } %80, i64 %79, 0, 1
+  %82 = insertvalue { { i64, i64 }, { i64 } } %81, i64 %77, 1, 0
+  ret { { i64, i64 }, { i64 } } %82
 }
 
 define  oxcamlcc { { i64, i64 }, { i64 } } @camlExtcalls__call_print_and_add_HIDE_STAMP(i64 %0, i64 %1, i64 %2) gc "oxcaml" {
@@ -120,8 +132,8 @@ define  oxcamlcc { { i64, i64 }, { i64 } } @camlExtcalls__call_print_and_add_HID
   %4 = alloca i64
   store i64 %2, ptr %4
   %5 = alloca ptr addrspace(1)
-  %6 = alloca i64
-  %7 = alloca i64
+  %6 = alloca ptr addrspace(1)
+  %7 = alloca ptr addrspace(1)
   %8 = alloca i64
   %9 = alloca i64
   %10 = alloca i64
@@ -135,33 +147,35 @@ L105:
   store i64 21, ptr %9
   store i64 19, ptr %10
   %13 = load i64, ptr %10
-  store i64 %13, ptr %6
-  %14 = load i64, ptr %9
-  store i64 %14, ptr %7
-  %15 = load i64, ptr %6
-  %16 = load i64, ptr %7
-  %17 = load i64, ptr %ds
-  %18 = load i64, ptr %alloc
-  %19 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %17, i64 %18, ptr @print_and_add, i64 %15, i64 %16) "statepoint-id"="0"
-  %20 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %19, 0, 0
-  %21 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %19, 0, 1
-  store i64 %20, ptr %ds
-  store i64 %21, ptr %alloc
-  %22 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %19, 1, 0
-  store ptr addrspace(1) %22, ptr %5
+  %14 = inttoptr i64 %13 to ptr addrspace(1)
+  store ptr addrspace(1) %14, ptr %6
+  %15 = load i64, ptr %9
+  %16 = inttoptr i64 %15 to ptr addrspace(1)
+  store ptr addrspace(1) %16, ptr %7
+  %17 = load ptr addrspace(1), ptr %6
+  %18 = load ptr addrspace(1), ptr %7
+  %19 = load i64, ptr %ds
+  %20 = load i64, ptr %alloc
+  %21 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %19, i64 %20, ptr @print_and_add, ptr addrspace(1) %17, ptr addrspace(1) %18) "statepoint-id"="0"
+  %22 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %21, 0, 0
+  %23 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %21, 0, 1
+  store i64 %22, ptr %ds
+  store i64 %23, ptr %alloc
+  %24 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %21, 1, 0
+  store ptr addrspace(1) %24, ptr %5
   br label %L107
 L107:
-  %23 = load ptr addrspace(1), ptr %5
-  store ptr addrspace(1) %23, ptr %11
-  %24 = load ptr addrspace(1), ptr %11
-  store ptr addrspace(1) %24, ptr %5
-  %25 = load i64, ptr %5
-  %26 = load i64, ptr %ds
-  %27 = load i64, ptr %alloc
-  %28 = insertvalue { { i64, i64 }, { i64 } } poison, i64 %26, 0, 0
-  %29 = insertvalue { { i64, i64 }, { i64 } } %28, i64 %27, 0, 1
-  %30 = insertvalue { { i64, i64 }, { i64 } } %29, i64 %25, 1, 0
-  ret { { i64, i64 }, { i64 } } %30
+  %25 = load ptr addrspace(1), ptr %5
+  store ptr addrspace(1) %25, ptr %11
+  %26 = load ptr addrspace(1), ptr %11
+  store ptr addrspace(1) %26, ptr %5
+  %27 = load i64, ptr %5
+  %28 = load i64, ptr %ds
+  %29 = load i64, ptr %alloc
+  %30 = insertvalue { { i64, i64 }, { i64 } } poison, i64 %28, 0, 0
+  %31 = insertvalue { { i64, i64 }, { i64 } } %30, i64 %29, 0, 1
+  %32 = insertvalue { { i64, i64 }, { i64 } } %31, i64 %27, 1, 0
+  ret { { i64, i64 }, { i64 } } %32
 }
 
 define  oxcamlcc { { i64, i64 }, { i64 } } @camlExtcalls__call_int_and_float_HIDE_STAMP(i64 %0, i64 %1, i64 %2) gc "oxcaml" {
@@ -172,10 +186,10 @@ define  oxcamlcc { { i64, i64 }, { i64 } } @camlExtcalls__call_int_and_float_HID
   %4 = alloca i64
   store i64 %2, ptr %4
   %5 = alloca ptr addrspace(1)
-  %6 = alloca i64
-  %7 = alloca i64
-  %8 = alloca i64
-  %9 = alloca i64
+  %6 = alloca ptr addrspace(1)
+  %7 = alloca ptr addrspace(1)
+  %8 = alloca ptr addrspace(1)
+  %9 = alloca ptr addrspace(1)
   %10 = alloca i64
   %11 = alloca i64
   %12 = alloca i64
@@ -195,39 +209,43 @@ L109:
   store i64 %18, ptr %13
   store i64 3, ptr %14
   %19 = load i64, ptr %14
-  store i64 %19, ptr %6
-  %20 = load i64, ptr %13
-  store i64 %20, ptr %7
-  %21 = load i64, ptr %12
-  store i64 %21, ptr %8
-  %22 = load i64, ptr %11
-  store i64 %22, ptr %9
-  %23 = load i64, ptr %6
-  %24 = load i64, ptr %7
-  %25 = load i64, ptr %8
-  %26 = load i64, ptr %9
-  %27 = load i64, ptr %ds
-  %28 = load i64, ptr %alloc
-  %29 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %27, i64 %28, ptr @int_and_float, i64 %23, i64 %24, i64 %25, i64 %26) "statepoint-id"="0"
-  %30 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %29, 0, 0
-  %31 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %29, 0, 1
-  store i64 %30, ptr %ds
-  store i64 %31, ptr %alloc
-  %32 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %29, 1, 0
-  store ptr addrspace(1) %32, ptr %5
+  %20 = inttoptr i64 %19 to ptr addrspace(1)
+  store ptr addrspace(1) %20, ptr %6
+  %21 = load i64, ptr %13
+  %22 = inttoptr i64 %21 to ptr addrspace(1)
+  store ptr addrspace(1) %22, ptr %7
+  %23 = load i64, ptr %12
+  %24 = inttoptr i64 %23 to ptr addrspace(1)
+  store ptr addrspace(1) %24, ptr %8
+  %25 = load i64, ptr %11
+  %26 = inttoptr i64 %25 to ptr addrspace(1)
+  store ptr addrspace(1) %26, ptr %9
+  %27 = load ptr addrspace(1), ptr %6
+  %28 = load ptr addrspace(1), ptr %7
+  %29 = load ptr addrspace(1), ptr %8
+  %30 = load ptr addrspace(1), ptr %9
+  %31 = load i64, ptr %ds
+  %32 = load i64, ptr %alloc
+  %33 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %31, i64 %32, ptr @int_and_float, ptr addrspace(1) %27, ptr addrspace(1) %28, ptr addrspace(1) %29, ptr addrspace(1) %30) "statepoint-id"="0"
+  %34 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %33, 0, 0
+  %35 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %33, 0, 1
+  store i64 %34, ptr %ds
+  store i64 %35, ptr %alloc
+  %36 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %33, 1, 0
+  store ptr addrspace(1) %36, ptr %5
   br label %L111
 L111:
-  %33 = load ptr addrspace(1), ptr %5
-  store ptr addrspace(1) %33, ptr %15
-  %34 = load ptr addrspace(1), ptr %15
-  store ptr addrspace(1) %34, ptr %5
-  %35 = load i64, ptr %5
-  %36 = load i64, ptr %ds
-  %37 = load i64, ptr %alloc
-  %38 = insertvalue { { i64, i64 }, { i64 } } poison, i64 %36, 0, 0
-  %39 = insertvalue { { i64, i64 }, { i64 } } %38, i64 %37, 0, 1
-  %40 = insertvalue { { i64, i64 }, { i64 } } %39, i64 %35, 1, 0
-  ret { { i64, i64 }, { i64 } } %40
+  %37 = load ptr addrspace(1), ptr %5
+  store ptr addrspace(1) %37, ptr %15
+  %38 = load ptr addrspace(1), ptr %15
+  store ptr addrspace(1) %38, ptr %5
+  %39 = load i64, ptr %5
+  %40 = load i64, ptr %ds
+  %41 = load i64, ptr %alloc
+  %42 = insertvalue { { i64, i64 }, { i64 } } poison, i64 %40, 0, 0
+  %43 = insertvalue { { i64, i64 }, { i64 } } %42, i64 %41, 0, 1
+  %44 = insertvalue { { i64, i64 }, { i64 } } %43, i64 %39, 1, 0
+  ret { { i64, i64 }, { i64 } } %44
 }
 
 define  oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlExtcalls__entry(i64 %0, i64 %1) gc "oxcaml" {

--- a/oxcaml/tests/backend/llvmize/switch_ir.output
+++ b/oxcaml/tests/backend/llvmize/switch_ir.output
@@ -227,7 +227,7 @@ define  oxcamlcc { { i64, i64 }, { i64 } } @camlSwitch__test_next_HIDE_STAMP(i64
   %7 = alloca i64
   %8 = alloca ptr addrspace(1)
   %9 = alloca i64
-  %10 = alloca i64
+  %10 = alloca ptr addrspace(1)
   %11 = alloca i64
   %12 = alloca ptr addrspace(1)
   %13 = alloca i64
@@ -314,103 +314,105 @@ L146:
   %67 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
   store i64 %67, ptr %18
   %68 = load i64, ptr %18
-  store i64 %68, ptr %9
-  %69 = load i64, ptr %17
-  store i64 %69, ptr %10
-  %70 = load i64, ptr %9
-  %71 = load i64, ptr %10
-  %72 = load i64, ptr %ds
-  %73 = load i64, ptr %alloc
-  %74 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %72, i64 %73, ptr @caml_format_int, i64 %70, i64 %71) "statepoint-id"="32"
-  %75 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %74, 0, 0
-  %76 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %74, 0, 1
-  store i64 %75, ptr %ds
-  store i64 %76, ptr %alloc
-  %77 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %74, 1, 0
-  store ptr addrspace(1) %77, ptr %5
+  %69 = inttoptr i64 %68 to ptr addrspace(1)
+  store ptr addrspace(1) %69, ptr %8
+  %70 = load i64, ptr %17
+  %71 = inttoptr i64 %70 to ptr addrspace(1)
+  store ptr addrspace(1) %71, ptr %10
+  %72 = load ptr addrspace(1), ptr %8
+  %73 = load ptr addrspace(1), ptr %10
+  %74 = load i64, ptr %ds
+  %75 = load i64, ptr %alloc
+  %76 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %74, i64 %75, ptr @caml_format_int, ptr addrspace(1) %72, ptr addrspace(1) %73) "statepoint-id"="32"
+  %77 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %76, 0, 0
+  %78 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %76, 0, 1
+  store i64 %77, ptr %ds
+  store i64 %78, ptr %alloc
+  %79 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %76, 1, 0
+  store ptr addrspace(1) %79, ptr %5
   br label %L147
 L147:
-  %78 = load ptr addrspace(1), ptr %5
-  store ptr addrspace(1) %78, ptr %19
-  %79 = load ptr addrspace(1), ptr %19
-  store ptr addrspace(1) %79, ptr %20
-  %80 = load ptr addrspace(1), ptr %20
-  store ptr addrspace(1) %80, ptr %21
-  %81 = load ptr addrspace(1), ptr %21
-  store ptr addrspace(1) %81, ptr %12
-  %82 = load i64, ptr %ds
-  %83 = add i64 %82, 48
-  %84 = inttoptr i64 %83 to ptr
-  %85 = load i64, ptr %46
-  store i64 %85, ptr %84
+  %80 = load ptr addrspace(1), ptr %5
+  store ptr addrspace(1) %80, ptr %19
+  %81 = load ptr addrspace(1), ptr %19
+  store ptr addrspace(1) %81, ptr %20
+  %82 = load ptr addrspace(1), ptr %20
+  store ptr addrspace(1) %82, ptr %21
+  %83 = load ptr addrspace(1), ptr %21
+  store ptr addrspace(1) %83, ptr %12
+  %84 = load i64, ptr %ds
+  %85 = add i64 %84, 48
+  %86 = inttoptr i64 %85 to ptr
+  %87 = load i64, ptr %46
+  store i64 %87, ptr %86
   call  void @llvm.stackrestore(ptr %45)
   br label %L153
 L138:
-  %86 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
-  store i64 %86, ptr %alloc
+  %88 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
+  store i64 %88, ptr %alloc
   store i64 %43, ptr %4
-  %87 = load i64, ptr %4
-  %88 = inttoptr i64 %87 to ptr addrspace(1)
-  store ptr addrspace(1) %88, ptr %15
-  %89 = load i64, ptr %ds
-  %90 = add i64 %89, 64
-  %91 = inttoptr i64 %90 to ptr
-  %92 = load i64, ptr %14
-  store i64 %92, ptr %91
+  %89 = load i64, ptr %4
+  %90 = inttoptr i64 %89 to ptr addrspace(1)
+  store ptr addrspace(1) %90, ptr %15
+  %91 = load i64, ptr %ds
+  %92 = add i64 %91, 64
+  %93 = inttoptr i64 %92 to ptr
+  %94 = load i64, ptr %14
+  store i64 %94, ptr %93
   store i64 1, ptr %22
-  %93 = load i64, ptr %22
-  store i64 %93, ptr %23
-  %94 = ptrtoint ptr @camlSwitch__immstring38 to i64
-  store i64 %94, ptr %24
-  %95 = load i64, ptr %24
-  store i64 %95, ptr %25
-  %96 = load i64, ptr %25
-  %97 = inttoptr i64 %96 to ptr addrspace(1)
-  store ptr addrspace(1) %97, ptr %12
+  %95 = load i64, ptr %22
+  store i64 %95, ptr %23
+  %96 = ptrtoint ptr @camlSwitch__immstring38 to i64
+  store i64 %96, ptr %24
+  %97 = load i64, ptr %24
+  store i64 %97, ptr %25
+  %98 = load i64, ptr %25
+  %99 = inttoptr i64 %98 to ptr addrspace(1)
+  store ptr addrspace(1) %99, ptr %12
   br label %L153
 L153:
-  %98 = ptrtoint ptr @camlSwitch__const_block54 to i64
-  store i64 %98, ptr %26
+  %100 = ptrtoint ptr @camlSwitch__const_block54 to i64
+  store i64 %100, ptr %26
   store i64 1, ptr %27
-  %99 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
-  store i64 %99, ptr %28
-  %100 = load i64, ptr %28
-  store i64 %100, ptr %4
-  %101 = load i64, ptr %27
-  store i64 %101, ptr %7
-  %102 = load i64, ptr %26
-  store i64 %102, ptr %9
-  %103 = load i64, ptr %4
-  %104 = load i64, ptr %7
-  %105 = load i64, ptr %9
-  %106 = load i64, ptr %ds
-  %107 = load i64, ptr %alloc
-  %108 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %106, i64 %107, i64 %103, i64 %104, i64 %105) "statepoint-id"="0"
-  %109 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %108, 0, 0
-  %110 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %108, 0, 1
-  store i64 %109, ptr %ds
-  store i64 %110, ptr %alloc
-  %111 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %108, 1, 0
-  store ptr addrspace(1) %111, ptr %5
+  %101 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
+  store i64 %101, ptr %28
+  %102 = load i64, ptr %28
+  store i64 %102, ptr %4
+  %103 = load i64, ptr %27
+  store i64 %103, ptr %7
+  %104 = load i64, ptr %26
+  store i64 %104, ptr %9
+  %105 = load i64, ptr %4
+  %106 = load i64, ptr %7
+  %107 = load i64, ptr %9
+  %108 = load i64, ptr %ds
+  %109 = load i64, ptr %alloc
+  %110 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %108, i64 %109, i64 %105, i64 %106, i64 %107) "statepoint-id"="0"
+  %111 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %110, 0, 0
+  %112 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %110, 0, 1
+  store i64 %111, ptr %ds
+  store i64 %112, ptr %alloc
+  %113 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %110, 1, 0
+  store ptr addrspace(1) %113, ptr %5
   br label %L155
 L155:
-  %112 = load ptr addrspace(1), ptr %5
-  store ptr addrspace(1) %112, ptr %29
-  %113 = load ptr addrspace(1), ptr %29
-  store ptr addrspace(1) %113, ptr %30
-  %114 = load i64, ptr %11
-  store i64 %114, ptr %4
-  %115 = load ptr addrspace(1), ptr %12
-  store ptr addrspace(1) %115, ptr %6
-  %116 = load ptr addrspace(1), ptr %30
-  store ptr addrspace(1) %116, ptr %8
-  %117 = load i64, ptr %4
-  %118 = load ptr addrspace(1), ptr %6
-  %119 = load ptr addrspace(1), ptr %8
-  %120 = load i64, ptr %ds
-  %121 = load i64, ptr %alloc
-  %122 = musttail call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %120, i64 %121, i64 %117, ptr addrspace(1) %118, ptr addrspace(1) %119) "gc-leaf-function"="true" "statepoint-id"="0"
-  ret { { i64, i64 }, { i64 } } %122
+  %114 = load ptr addrspace(1), ptr %5
+  store ptr addrspace(1) %114, ptr %29
+  %115 = load ptr addrspace(1), ptr %29
+  store ptr addrspace(1) %115, ptr %30
+  %116 = load i64, ptr %11
+  store i64 %116, ptr %4
+  %117 = load ptr addrspace(1), ptr %12
+  store ptr addrspace(1) %117, ptr %6
+  %118 = load ptr addrspace(1), ptr %30
+  store ptr addrspace(1) %118, ptr %8
+  %119 = load i64, ptr %4
+  %120 = load ptr addrspace(1), ptr %6
+  %121 = load ptr addrspace(1), ptr %8
+  %122 = load i64, ptr %ds
+  %123 = load i64, ptr %alloc
+  %124 = musttail call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %122, i64 %123, i64 %119, ptr addrspace(1) %120, ptr addrspace(1) %121) "gc-leaf-function"="true" "statepoint-id"="0"
+  ret { { i64, i64 }, { i64 } } %124
 }
 
 define  oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlSwitch__entry(i64 %0, i64 %1) noinline gc "oxcaml" {
@@ -424,7 +426,7 @@ define  oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlSwitch__entry(i64 %
   %6 = alloca i64
   %7 = alloca ptr addrspace(1)
   %8 = alloca i64
-  %9 = alloca i64
+  %9 = alloca ptr addrspace(1)
   %10 = alloca ptr addrspace(1)
   %11 = alloca ptr addrspace(1)
   %12 = alloca i64
@@ -678,1322 +680,1338 @@ L178:
   %233 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
   store i64 %233, ptr %18
   %234 = load i64, ptr %18
-  store i64 %234, ptr %8
-  %235 = load i64, ptr %17
-  store i64 %235, ptr %9
-  %236 = load i64, ptr %8
-  %237 = load i64, ptr %9
-  %238 = load i64, ptr %ds
-  %239 = load i64, ptr %alloc
-  %240 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %238, i64 %239, ptr @caml_format_int, i64 %236, i64 %237) "statepoint-id"="32"
-  %241 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %240, 0, 0
-  %242 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %240, 0, 1
-  store i64 %241, ptr %ds
-  store i64 %242, ptr %alloc
-  %243 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %240, 1, 0
-  store ptr addrspace(1) %243, ptr %3
+  %235 = inttoptr i64 %234 to ptr addrspace(1)
+  store ptr addrspace(1) %235, ptr %7
+  %236 = load i64, ptr %17
+  %237 = inttoptr i64 %236 to ptr addrspace(1)
+  store ptr addrspace(1) %237, ptr %9
+  %238 = load ptr addrspace(1), ptr %7
+  %239 = load ptr addrspace(1), ptr %9
+  %240 = load i64, ptr %ds
+  %241 = load i64, ptr %alloc
+  %242 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %240, i64 %241, ptr @caml_format_int, ptr addrspace(1) %238, ptr addrspace(1) %239) "statepoint-id"="32"
+  %243 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %242, 0, 0
+  %244 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %242, 0, 1
+  store i64 %243, ptr %ds
+  store i64 %244, ptr %alloc
+  %245 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %242, 1, 0
+  store ptr addrspace(1) %245, ptr %3
   br label %L179
 L179:
-  %244 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %244, ptr %19
-  %245 = load ptr addrspace(1), ptr %19
-  store ptr addrspace(1) %245, ptr %20
-  %246 = load ptr addrspace(1), ptr %20
-  store ptr addrspace(1) %246, ptr %21
-  %247 = load ptr addrspace(1), ptr %21
-  store ptr addrspace(1) %247, ptr %11
-  %248 = load i64, ptr %ds
-  %249 = add i64 %248, 48
-  %250 = inttoptr i64 %249 to ptr
-  %251 = load i64, ptr %212
-  store i64 %251, ptr %250
+  %246 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %246, ptr %19
+  %247 = load ptr addrspace(1), ptr %19
+  store ptr addrspace(1) %247, ptr %20
+  %248 = load ptr addrspace(1), ptr %20
+  store ptr addrspace(1) %248, ptr %21
+  %249 = load ptr addrspace(1), ptr %21
+  store ptr addrspace(1) %249, ptr %11
+  %250 = load i64, ptr %ds
+  %251 = add i64 %250, 48
+  %252 = inttoptr i64 %251 to ptr
+  %253 = load i64, ptr %212
+  store i64 %253, ptr %252
   call  void @llvm.stackrestore(ptr %211)
   br label %L185
 L170:
-  %252 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
-  store i64 %252, ptr %alloc
+  %254 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
+  store i64 %254, ptr %alloc
   store i64 %209, ptr %4
-  %253 = load i64, ptr %4
-  %254 = inttoptr i64 %253 to ptr addrspace(1)
-  store ptr addrspace(1) %254, ptr %14
-  %255 = load i64, ptr %ds
-  %256 = add i64 %255, 64
-  %257 = inttoptr i64 %256 to ptr
-  %258 = load i64, ptr %13
-  store i64 %258, ptr %257
+  %255 = load i64, ptr %4
+  %256 = inttoptr i64 %255 to ptr addrspace(1)
+  store ptr addrspace(1) %256, ptr %14
+  %257 = load i64, ptr %ds
+  %258 = add i64 %257, 64
+  %259 = inttoptr i64 %258 to ptr
+  %260 = load i64, ptr %13
+  store i64 %260, ptr %259
   store i64 1, ptr %22
-  %259 = load i64, ptr %22
-  store i64 %259, ptr %23
-  %260 = ptrtoint ptr @camlSwitch__immstring38 to i64
-  store i64 %260, ptr %24
-  %261 = load i64, ptr %24
-  store i64 %261, ptr %25
-  %262 = load i64, ptr %25
-  %263 = inttoptr i64 %262 to ptr addrspace(1)
-  store ptr addrspace(1) %263, ptr %11
+  %261 = load i64, ptr %22
+  store i64 %261, ptr %23
+  %262 = ptrtoint ptr @camlSwitch__immstring38 to i64
+  store i64 %262, ptr %24
+  %263 = load i64, ptr %24
+  store i64 %263, ptr %25
+  %264 = load i64, ptr %25
+  %265 = inttoptr i64 %264 to ptr addrspace(1)
+  store ptr addrspace(1) %265, ptr %11
   br label %L185
 L185:
-  %264 = ptrtoint ptr @camlSwitch__const_block54 to i64
-  store i64 %264, ptr %26
+  %266 = ptrtoint ptr @camlSwitch__const_block54 to i64
+  store i64 %266, ptr %26
   store i64 1, ptr %27
-  %265 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
-  store i64 %265, ptr %28
-  %266 = load i64, ptr %28
-  store i64 %266, ptr %4
-  %267 = load i64, ptr %27
-  store i64 %267, ptr %6
-  %268 = load i64, ptr %26
-  store i64 %268, ptr %8
-  %269 = load i64, ptr %4
-  %270 = load i64, ptr %6
-  %271 = load i64, ptr %8
-  %272 = load i64, ptr %ds
-  %273 = load i64, ptr %alloc
-  %274 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %272, i64 %273, i64 %269, i64 %270, i64 %271) "statepoint-id"="0"
-  %275 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %274, 0, 0
-  %276 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %274, 0, 1
-  store i64 %275, ptr %ds
-  store i64 %276, ptr %alloc
-  %277 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %274, 1, 0
-  store ptr addrspace(1) %277, ptr %3
+  %267 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
+  store i64 %267, ptr %28
+  %268 = load i64, ptr %28
+  store i64 %268, ptr %4
+  %269 = load i64, ptr %27
+  store i64 %269, ptr %6
+  %270 = load i64, ptr %26
+  store i64 %270, ptr %8
+  %271 = load i64, ptr %4
+  %272 = load i64, ptr %6
+  %273 = load i64, ptr %8
+  %274 = load i64, ptr %ds
+  %275 = load i64, ptr %alloc
+  %276 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %274, i64 %275, i64 %271, i64 %272, i64 %273) "statepoint-id"="0"
+  %277 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %276, 0, 0
+  %278 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %276, 0, 1
+  store i64 %277, ptr %ds
+  store i64 %278, ptr %alloc
+  %279 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %276, 1, 0
+  store ptr addrspace(1) %279, ptr %3
   br label %L187
 L187:
-  %278 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %278, ptr %29
-  %279 = load ptr addrspace(1), ptr %29
-  store ptr addrspace(1) %279, ptr %30
+  %280 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %280, ptr %29
+  %281 = load ptr addrspace(1), ptr %29
+  store ptr addrspace(1) %281, ptr %30
   store i64 3, ptr %31
-  %280 = load i64, ptr %31
-  store i64 %280, ptr %4
-  %281 = load ptr addrspace(1), ptr %11
-  store ptr addrspace(1) %281, ptr %5
-  %282 = load ptr addrspace(1), ptr %30
-  store ptr addrspace(1) %282, ptr %7
-  %283 = load i64, ptr %4
-  %284 = load ptr addrspace(1), ptr %5
-  %285 = load ptr addrspace(1), ptr %7
-  %286 = load i64, ptr %ds
-  %287 = load i64, ptr %alloc
-  %288 = call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %286, i64 %287, i64 %283, ptr addrspace(1) %284, ptr addrspace(1) %285) "statepoint-id"="0"
-  %289 = extractvalue { { i64, i64 }, { i64 } } %288, 0, 0
-  %290 = extractvalue { { i64, i64 }, { i64 } } %288, 0, 1
-  store i64 %289, ptr %ds
-  store i64 %290, ptr %alloc
-  %291 = extractvalue { { i64, i64 }, { i64 } } %288, 1, 0
-  store i64 %291, ptr %4
+  %282 = load i64, ptr %31
+  store i64 %282, ptr %4
+  %283 = load ptr addrspace(1), ptr %11
+  store ptr addrspace(1) %283, ptr %5
+  %284 = load ptr addrspace(1), ptr %30
+  store ptr addrspace(1) %284, ptr %7
+  %285 = load i64, ptr %4
+  %286 = load ptr addrspace(1), ptr %5
+  %287 = load ptr addrspace(1), ptr %7
+  %288 = load i64, ptr %ds
+  %289 = load i64, ptr %alloc
+  %290 = call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %288, i64 %289, i64 %285, ptr addrspace(1) %286, ptr addrspace(1) %287) "statepoint-id"="0"
+  %291 = extractvalue { { i64, i64 }, { i64 } } %290, 0, 0
+  %292 = extractvalue { { i64, i64 }, { i64 } } %290, 0, 1
+  store i64 %291, ptr %ds
+  store i64 %292, ptr %alloc
+  %293 = extractvalue { { i64, i64 }, { i64 } } %290, 1, 0
+  store i64 %293, ptr %4
   br label %L188
 L188:
-  %292 = load i64, ptr %4
-  store i64 %292, ptr %32
-  %293 = load i64, ptr %32
-  store i64 %293, ptr %33
-  %294 = load i64, ptr %ds
-  %295 = add i64 %294, 64
-  %296 = inttoptr i64 %295 to ptr
-  %297 = load i64, ptr %296
-  store i64 %297, ptr %35
-  %298 = load i64, ptr %35
-  store i64 %298, ptr %36
-  %299 = load i64, ptr %ds
-  %300 = load i64, ptr %alloc
-  %301 = call oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %299, i64 %300) returns_twice "gc-leaf-function"="true"
-  %302 = extractvalue { { i64, i64 }, { i64 } } %301, 0, 0
-  %303 = extractvalue { { i64, i64 }, { i64 } } %301, 0, 1
-  store i64 %302, ptr %ds
-  store i64 %303, ptr %alloc
-  %304 = extractvalue { { i64, i64 }, { i64 } } %301, 1, 0
-  call void asm sideeffect "movq $0, %rax", "r"(i64 %304) "gc-leaf-function"="true"
+  %294 = load i64, ptr %4
+  store i64 %294, ptr %32
+  %295 = load i64, ptr %32
+  store i64 %295, ptr %33
+  %296 = load i64, ptr %ds
+  %297 = add i64 %296, 64
+  %298 = inttoptr i64 %297 to ptr
+  %299 = load i64, ptr %298
+  store i64 %299, ptr %35
+  %300 = load i64, ptr %35
+  store i64 %300, ptr %36
+  %301 = load i64, ptr %ds
+  %302 = load i64, ptr %alloc
+  %303 = call oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %301, i64 %302) returns_twice "gc-leaf-function"="true"
+  %304 = extractvalue { { i64, i64 }, { i64 } } %303, 0, 0
+  %305 = extractvalue { { i64, i64 }, { i64 } } %303, 0, 1
+  store i64 %304, ptr %ds
+  store i64 %305, ptr %alloc
+  %306 = extractvalue { { i64, i64 }, { i64 } } %303, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %306) "gc-leaf-function"="true"
   br label %L363
 L363:
-  %305 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
-  %306 = icmp eq i64 %305, 0
-  br i1 %306, label %L364, label %L193
+  %307 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
+  %308 = icmp eq i64 %307, 0
+  br i1 %308, label %L364, label %L193
 L364:
   store ptr blockaddress(@camlSwitch__entry, %L363), ptr @camlSwitch__entry.recover_rbp_var.L363
-  %307 = call  ptr @llvm.stacksave()
-  %308 = alloca { i64, i64, i64, i64 }
-  %309 = ptrtoint ptr %308 to i64
-  %310 = add i64 %309, 16
-  %311 = inttoptr i64 %310 to ptr
-  %312 = ptrtoint ptr %308 to i64
-  %313 = add i64 %312, 8
-  %314 = inttoptr i64 %313 to ptr
-  %315 = load i64, ptr %ds
-  %316 = add i64 %315, 48
-  %317 = inttoptr i64 %316 to ptr
-  %318 = load i64, ptr %317
-  store ptr %308, ptr %317
-  store ptr @camlSwitch__entry.recover_rbp_asm.L363, ptr %314
-  call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %311) "gc-leaf-function"="true"
-  store i64 %318, ptr %308
+  %309 = call  ptr @llvm.stacksave()
+  %310 = alloca { i64, i64, i64, i64 }
+  %311 = ptrtoint ptr %310 to i64
+  %312 = add i64 %311, 16
+  %313 = inttoptr i64 %312 to ptr
+  %314 = ptrtoint ptr %310 to i64
+  %315 = add i64 %314, 8
+  %316 = inttoptr i64 %315 to ptr
+  %317 = load i64, ptr %ds
+  %318 = add i64 %317, 48
+  %319 = inttoptr i64 %318 to ptr
+  %320 = load i64, ptr %319
+  store ptr %310, ptr %319
+  store ptr @camlSwitch__entry.recover_rbp_asm.L363, ptr %316
+  call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %313) "gc-leaf-function"="true"
+  store i64 %320, ptr %310
   store i64 7, ptr %38
-  %319 = load i64, ptr %38
-  store i64 %319, ptr %4
-  %320 = load i64, ptr %4
-  %321 = load i64, ptr %ds
-  %322 = load i64, ptr %alloc
-  %323 = call oxcamlcc { { i64, i64 }, { i64 } } @camlSwitch__next_HIDE_STAMP(i64 %321, i64 %322, i64 %320) "statepoint-id"="32"
-  %324 = extractvalue { { i64, i64 }, { i64 } } %323, 0, 0
-  %325 = extractvalue { { i64, i64 }, { i64 } } %323, 0, 1
-  store i64 %324, ptr %ds
-  store i64 %325, ptr %alloc
-  %326 = extractvalue { { i64, i64 }, { i64 } } %323, 1, 0
-  store i64 %326, ptr %4
+  %321 = load i64, ptr %38
+  store i64 %321, ptr %4
+  %322 = load i64, ptr %4
+  %323 = load i64, ptr %ds
+  %324 = load i64, ptr %alloc
+  %325 = call oxcamlcc { { i64, i64 }, { i64 } } @camlSwitch__next_HIDE_STAMP(i64 %323, i64 %324, i64 %322) "statepoint-id"="32"
+  %326 = extractvalue { { i64, i64 }, { i64 } } %325, 0, 0
+  %327 = extractvalue { { i64, i64 }, { i64 } } %325, 0, 1
+  store i64 %326, ptr %ds
+  store i64 %327, ptr %alloc
+  %328 = extractvalue { { i64, i64 }, { i64 } } %325, 1, 0
+  store i64 %328, ptr %4
   br label %L201
 L201:
-  %327 = load i64, ptr %4
-  store i64 %327, ptr %39
-  %328 = load i64, ptr %39
-  store i64 %328, ptr %40
-  %329 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
-  store i64 %329, ptr %41
-  %330 = load i64, ptr %41
-  store i64 %330, ptr %8
-  %331 = load i64, ptr %40
-  store i64 %331, ptr %9
-  %332 = load i64, ptr %8
-  %333 = load i64, ptr %9
-  %334 = load i64, ptr %ds
-  %335 = load i64, ptr %alloc
-  %336 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %334, i64 %335, ptr @caml_format_int, i64 %332, i64 %333) "statepoint-id"="32"
-  %337 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %336, 0, 0
-  %338 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %336, 0, 1
-  store i64 %337, ptr %ds
-  store i64 %338, ptr %alloc
-  %339 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %336, 1, 0
-  store ptr addrspace(1) %339, ptr %3
+  %329 = load i64, ptr %4
+  store i64 %329, ptr %39
+  %330 = load i64, ptr %39
+  store i64 %330, ptr %40
+  %331 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
+  store i64 %331, ptr %41
+  %332 = load i64, ptr %41
+  %333 = inttoptr i64 %332 to ptr addrspace(1)
+  store ptr addrspace(1) %333, ptr %7
+  %334 = load i64, ptr %40
+  %335 = inttoptr i64 %334 to ptr addrspace(1)
+  store ptr addrspace(1) %335, ptr %9
+  %336 = load ptr addrspace(1), ptr %7
+  %337 = load ptr addrspace(1), ptr %9
+  %338 = load i64, ptr %ds
+  %339 = load i64, ptr %alloc
+  %340 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %338, i64 %339, ptr @caml_format_int, ptr addrspace(1) %336, ptr addrspace(1) %337) "statepoint-id"="32"
+  %341 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %340, 0, 0
+  %342 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %340, 0, 1
+  store i64 %341, ptr %ds
+  store i64 %342, ptr %alloc
+  %343 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %340, 1, 0
+  store ptr addrspace(1) %343, ptr %3
   br label %L202
 L202:
-  %340 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %340, ptr %42
-  %341 = load ptr addrspace(1), ptr %42
-  store ptr addrspace(1) %341, ptr %43
-  %342 = load ptr addrspace(1), ptr %43
-  store ptr addrspace(1) %342, ptr %44
-  %343 = load ptr addrspace(1), ptr %44
-  store ptr addrspace(1) %343, ptr %34
-  %344 = load i64, ptr %ds
-  %345 = add i64 %344, 48
-  %346 = inttoptr i64 %345 to ptr
-  %347 = load i64, ptr %308
-  store i64 %347, ptr %346
-  call  void @llvm.stackrestore(ptr %307)
+  %344 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %344, ptr %42
+  %345 = load ptr addrspace(1), ptr %42
+  store ptr addrspace(1) %345, ptr %43
+  %346 = load ptr addrspace(1), ptr %43
+  store ptr addrspace(1) %346, ptr %44
+  %347 = load ptr addrspace(1), ptr %44
+  store ptr addrspace(1) %347, ptr %34
+  %348 = load i64, ptr %ds
+  %349 = add i64 %348, 48
+  %350 = inttoptr i64 %349 to ptr
+  %351 = load i64, ptr %310
+  store i64 %351, ptr %350
+  call  void @llvm.stackrestore(ptr %309)
   br label %L208
 L193:
-  %348 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
-  store i64 %348, ptr %alloc
-  store i64 %305, ptr %4
-  %349 = load i64, ptr %4
-  %350 = inttoptr i64 %349 to ptr addrspace(1)
-  store ptr addrspace(1) %350, ptr %37
-  %351 = load i64, ptr %ds
-  %352 = add i64 %351, 64
-  %353 = inttoptr i64 %352 to ptr
-  %354 = load i64, ptr %36
-  store i64 %354, ptr %353
+  %352 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
+  store i64 %352, ptr %alloc
+  store i64 %307, ptr %4
+  %353 = load i64, ptr %4
+  %354 = inttoptr i64 %353 to ptr addrspace(1)
+  store ptr addrspace(1) %354, ptr %37
+  %355 = load i64, ptr %ds
+  %356 = add i64 %355, 64
+  %357 = inttoptr i64 %356 to ptr
+  %358 = load i64, ptr %36
+  store i64 %358, ptr %357
   store i64 1, ptr %45
-  %355 = load i64, ptr %45
-  store i64 %355, ptr %46
-  %356 = ptrtoint ptr @camlSwitch__immstring38 to i64
-  store i64 %356, ptr %47
-  %357 = load i64, ptr %47
-  store i64 %357, ptr %48
-  %358 = load i64, ptr %48
-  %359 = inttoptr i64 %358 to ptr addrspace(1)
-  store ptr addrspace(1) %359, ptr %34
+  %359 = load i64, ptr %45
+  store i64 %359, ptr %46
+  %360 = ptrtoint ptr @camlSwitch__immstring38 to i64
+  store i64 %360, ptr %47
+  %361 = load i64, ptr %47
+  store i64 %361, ptr %48
+  %362 = load i64, ptr %48
+  %363 = inttoptr i64 %362 to ptr addrspace(1)
+  store ptr addrspace(1) %363, ptr %34
   br label %L208
 L208:
-  %360 = ptrtoint ptr @camlSwitch__const_block54 to i64
-  store i64 %360, ptr %49
+  %364 = ptrtoint ptr @camlSwitch__const_block54 to i64
+  store i64 %364, ptr %49
   store i64 1, ptr %50
-  %361 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
-  store i64 %361, ptr %51
-  %362 = load i64, ptr %51
-  store i64 %362, ptr %4
-  %363 = load i64, ptr %50
-  store i64 %363, ptr %6
-  %364 = load i64, ptr %49
-  store i64 %364, ptr %8
-  %365 = load i64, ptr %4
-  %366 = load i64, ptr %6
-  %367 = load i64, ptr %8
-  %368 = load i64, ptr %ds
-  %369 = load i64, ptr %alloc
-  %370 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %368, i64 %369, i64 %365, i64 %366, i64 %367) "statepoint-id"="0"
-  %371 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %370, 0, 0
-  %372 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %370, 0, 1
-  store i64 %371, ptr %ds
-  store i64 %372, ptr %alloc
-  %373 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %370, 1, 0
-  store ptr addrspace(1) %373, ptr %3
+  %365 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
+  store i64 %365, ptr %51
+  %366 = load i64, ptr %51
+  store i64 %366, ptr %4
+  %367 = load i64, ptr %50
+  store i64 %367, ptr %6
+  %368 = load i64, ptr %49
+  store i64 %368, ptr %8
+  %369 = load i64, ptr %4
+  %370 = load i64, ptr %6
+  %371 = load i64, ptr %8
+  %372 = load i64, ptr %ds
+  %373 = load i64, ptr %alloc
+  %374 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %372, i64 %373, i64 %369, i64 %370, i64 %371) "statepoint-id"="0"
+  %375 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %374, 0, 0
+  %376 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %374, 0, 1
+  store i64 %375, ptr %ds
+  store i64 %376, ptr %alloc
+  %377 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %374, 1, 0
+  store ptr addrspace(1) %377, ptr %3
   br label %L210
 L210:
-  %374 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %374, ptr %52
-  %375 = load ptr addrspace(1), ptr %52
-  store ptr addrspace(1) %375, ptr %53
+  %378 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %378, ptr %52
+  %379 = load ptr addrspace(1), ptr %52
+  store ptr addrspace(1) %379, ptr %53
   store i64 7, ptr %54
-  %376 = load i64, ptr %54
-  store i64 %376, ptr %4
-  %377 = load ptr addrspace(1), ptr %34
-  store ptr addrspace(1) %377, ptr %5
-  %378 = load ptr addrspace(1), ptr %53
-  store ptr addrspace(1) %378, ptr %7
-  %379 = load i64, ptr %4
-  %380 = load ptr addrspace(1), ptr %5
-  %381 = load ptr addrspace(1), ptr %7
-  %382 = load i64, ptr %ds
-  %383 = load i64, ptr %alloc
-  %384 = call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %382, i64 %383, i64 %379, ptr addrspace(1) %380, ptr addrspace(1) %381) "statepoint-id"="0"
-  %385 = extractvalue { { i64, i64 }, { i64 } } %384, 0, 0
-  %386 = extractvalue { { i64, i64 }, { i64 } } %384, 0, 1
-  store i64 %385, ptr %ds
-  store i64 %386, ptr %alloc
-  %387 = extractvalue { { i64, i64 }, { i64 } } %384, 1, 0
-  store i64 %387, ptr %4
+  %380 = load i64, ptr %54
+  store i64 %380, ptr %4
+  %381 = load ptr addrspace(1), ptr %34
+  store ptr addrspace(1) %381, ptr %5
+  %382 = load ptr addrspace(1), ptr %53
+  store ptr addrspace(1) %382, ptr %7
+  %383 = load i64, ptr %4
+  %384 = load ptr addrspace(1), ptr %5
+  %385 = load ptr addrspace(1), ptr %7
+  %386 = load i64, ptr %ds
+  %387 = load i64, ptr %alloc
+  %388 = call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %386, i64 %387, i64 %383, ptr addrspace(1) %384, ptr addrspace(1) %385) "statepoint-id"="0"
+  %389 = extractvalue { { i64, i64 }, { i64 } } %388, 0, 0
+  %390 = extractvalue { { i64, i64 }, { i64 } } %388, 0, 1
+  store i64 %389, ptr %ds
+  store i64 %390, ptr %alloc
+  %391 = extractvalue { { i64, i64 }, { i64 } } %388, 1, 0
+  store i64 %391, ptr %4
   br label %L211
 L211:
-  %388 = load i64, ptr %4
-  store i64 %388, ptr %55
-  %389 = load i64, ptr %55
-  store i64 %389, ptr %56
-  %390 = load i64, ptr %ds
-  %391 = add i64 %390, 64
-  %392 = inttoptr i64 %391 to ptr
-  %393 = load i64, ptr %392
-  store i64 %393, ptr %58
-  %394 = load i64, ptr %58
-  store i64 %394, ptr %59
-  %395 = load i64, ptr %ds
-  %396 = load i64, ptr %alloc
-  %397 = call oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %395, i64 %396) returns_twice "gc-leaf-function"="true"
-  %398 = extractvalue { { i64, i64 }, { i64 } } %397, 0, 0
-  %399 = extractvalue { { i64, i64 }, { i64 } } %397, 0, 1
-  store i64 %398, ptr %ds
-  store i64 %399, ptr %alloc
-  %400 = extractvalue { { i64, i64 }, { i64 } } %397, 1, 0
-  call void asm sideeffect "movq $0, %rax", "r"(i64 %400) "gc-leaf-function"="true"
+  %392 = load i64, ptr %4
+  store i64 %392, ptr %55
+  %393 = load i64, ptr %55
+  store i64 %393, ptr %56
+  %394 = load i64, ptr %ds
+  %395 = add i64 %394, 64
+  %396 = inttoptr i64 %395 to ptr
+  %397 = load i64, ptr %396
+  store i64 %397, ptr %58
+  %398 = load i64, ptr %58
+  store i64 %398, ptr %59
+  %399 = load i64, ptr %ds
+  %400 = load i64, ptr %alloc
+  %401 = call oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %399, i64 %400) returns_twice "gc-leaf-function"="true"
+  %402 = extractvalue { { i64, i64 }, { i64 } } %401, 0, 0
+  %403 = extractvalue { { i64, i64 }, { i64 } } %401, 0, 1
+  store i64 %402, ptr %ds
+  store i64 %403, ptr %alloc
+  %404 = extractvalue { { i64, i64 }, { i64 } } %401, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %404) "gc-leaf-function"="true"
   br label %L365
 L365:
-  %401 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
-  %402 = icmp eq i64 %401, 0
-  br i1 %402, label %L366, label %L216
+  %405 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
+  %406 = icmp eq i64 %405, 0
+  br i1 %406, label %L366, label %L216
 L366:
   store ptr blockaddress(@camlSwitch__entry, %L365), ptr @camlSwitch__entry.recover_rbp_var.L365
-  %403 = call  ptr @llvm.stacksave()
-  %404 = alloca { i64, i64, i64, i64 }
-  %405 = ptrtoint ptr %404 to i64
-  %406 = add i64 %405, 16
-  %407 = inttoptr i64 %406 to ptr
-  %408 = ptrtoint ptr %404 to i64
-  %409 = add i64 %408, 8
-  %410 = inttoptr i64 %409 to ptr
-  %411 = load i64, ptr %ds
-  %412 = add i64 %411, 48
-  %413 = inttoptr i64 %412 to ptr
-  %414 = load i64, ptr %413
-  store ptr %404, ptr %413
-  store ptr @camlSwitch__entry.recover_rbp_asm.L365, ptr %410
-  call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %407) "gc-leaf-function"="true"
-  store i64 %414, ptr %404
+  %407 = call  ptr @llvm.stacksave()
+  %408 = alloca { i64, i64, i64, i64 }
+  %409 = ptrtoint ptr %408 to i64
+  %410 = add i64 %409, 16
+  %411 = inttoptr i64 %410 to ptr
+  %412 = ptrtoint ptr %408 to i64
+  %413 = add i64 %412, 8
+  %414 = inttoptr i64 %413 to ptr
+  %415 = load i64, ptr %ds
+  %416 = add i64 %415, 48
+  %417 = inttoptr i64 %416 to ptr
+  %418 = load i64, ptr %417
+  store ptr %408, ptr %417
+  store ptr @camlSwitch__entry.recover_rbp_asm.L365, ptr %414
+  call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %411) "gc-leaf-function"="true"
+  store i64 %418, ptr %408
   store i64 11, ptr %61
-  %415 = load i64, ptr %61
-  store i64 %415, ptr %4
-  %416 = load i64, ptr %4
-  %417 = load i64, ptr %ds
-  %418 = load i64, ptr %alloc
-  %419 = call oxcamlcc { { i64, i64 }, { i64 } } @camlSwitch__next_HIDE_STAMP(i64 %417, i64 %418, i64 %416) "statepoint-id"="32"
-  %420 = extractvalue { { i64, i64 }, { i64 } } %419, 0, 0
-  %421 = extractvalue { { i64, i64 }, { i64 } } %419, 0, 1
-  store i64 %420, ptr %ds
-  store i64 %421, ptr %alloc
-  %422 = extractvalue { { i64, i64 }, { i64 } } %419, 1, 0
-  store i64 %422, ptr %4
+  %419 = load i64, ptr %61
+  store i64 %419, ptr %4
+  %420 = load i64, ptr %4
+  %421 = load i64, ptr %ds
+  %422 = load i64, ptr %alloc
+  %423 = call oxcamlcc { { i64, i64 }, { i64 } } @camlSwitch__next_HIDE_STAMP(i64 %421, i64 %422, i64 %420) "statepoint-id"="32"
+  %424 = extractvalue { { i64, i64 }, { i64 } } %423, 0, 0
+  %425 = extractvalue { { i64, i64 }, { i64 } } %423, 0, 1
+  store i64 %424, ptr %ds
+  store i64 %425, ptr %alloc
+  %426 = extractvalue { { i64, i64 }, { i64 } } %423, 1, 0
+  store i64 %426, ptr %4
   br label %L224
 L224:
-  %423 = load i64, ptr %4
-  store i64 %423, ptr %62
-  %424 = load i64, ptr %62
-  store i64 %424, ptr %63
-  %425 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
-  store i64 %425, ptr %64
-  %426 = load i64, ptr %64
-  store i64 %426, ptr %8
-  %427 = load i64, ptr %63
-  store i64 %427, ptr %9
-  %428 = load i64, ptr %8
-  %429 = load i64, ptr %9
-  %430 = load i64, ptr %ds
-  %431 = load i64, ptr %alloc
-  %432 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %430, i64 %431, ptr @caml_format_int, i64 %428, i64 %429) "statepoint-id"="32"
-  %433 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %432, 0, 0
-  %434 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %432, 0, 1
-  store i64 %433, ptr %ds
-  store i64 %434, ptr %alloc
-  %435 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %432, 1, 0
-  store ptr addrspace(1) %435, ptr %3
+  %427 = load i64, ptr %4
+  store i64 %427, ptr %62
+  %428 = load i64, ptr %62
+  store i64 %428, ptr %63
+  %429 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
+  store i64 %429, ptr %64
+  %430 = load i64, ptr %64
+  %431 = inttoptr i64 %430 to ptr addrspace(1)
+  store ptr addrspace(1) %431, ptr %7
+  %432 = load i64, ptr %63
+  %433 = inttoptr i64 %432 to ptr addrspace(1)
+  store ptr addrspace(1) %433, ptr %9
+  %434 = load ptr addrspace(1), ptr %7
+  %435 = load ptr addrspace(1), ptr %9
+  %436 = load i64, ptr %ds
+  %437 = load i64, ptr %alloc
+  %438 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %436, i64 %437, ptr @caml_format_int, ptr addrspace(1) %434, ptr addrspace(1) %435) "statepoint-id"="32"
+  %439 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %438, 0, 0
+  %440 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %438, 0, 1
+  store i64 %439, ptr %ds
+  store i64 %440, ptr %alloc
+  %441 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %438, 1, 0
+  store ptr addrspace(1) %441, ptr %3
   br label %L225
 L225:
-  %436 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %436, ptr %65
-  %437 = load ptr addrspace(1), ptr %65
-  store ptr addrspace(1) %437, ptr %66
-  %438 = load ptr addrspace(1), ptr %66
-  store ptr addrspace(1) %438, ptr %67
-  %439 = load ptr addrspace(1), ptr %67
-  store ptr addrspace(1) %439, ptr %57
-  %440 = load i64, ptr %ds
-  %441 = add i64 %440, 48
-  %442 = inttoptr i64 %441 to ptr
-  %443 = load i64, ptr %404
-  store i64 %443, ptr %442
-  call  void @llvm.stackrestore(ptr %403)
+  %442 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %442, ptr %65
+  %443 = load ptr addrspace(1), ptr %65
+  store ptr addrspace(1) %443, ptr %66
+  %444 = load ptr addrspace(1), ptr %66
+  store ptr addrspace(1) %444, ptr %67
+  %445 = load ptr addrspace(1), ptr %67
+  store ptr addrspace(1) %445, ptr %57
+  %446 = load i64, ptr %ds
+  %447 = add i64 %446, 48
+  %448 = inttoptr i64 %447 to ptr
+  %449 = load i64, ptr %408
+  store i64 %449, ptr %448
+  call  void @llvm.stackrestore(ptr %407)
   br label %L231
 L216:
-  %444 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
-  store i64 %444, ptr %alloc
-  store i64 %401, ptr %4
-  %445 = load i64, ptr %4
-  %446 = inttoptr i64 %445 to ptr addrspace(1)
-  store ptr addrspace(1) %446, ptr %60
-  %447 = load i64, ptr %ds
-  %448 = add i64 %447, 64
-  %449 = inttoptr i64 %448 to ptr
-  %450 = load i64, ptr %59
-  store i64 %450, ptr %449
+  %450 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
+  store i64 %450, ptr %alloc
+  store i64 %405, ptr %4
+  %451 = load i64, ptr %4
+  %452 = inttoptr i64 %451 to ptr addrspace(1)
+  store ptr addrspace(1) %452, ptr %60
+  %453 = load i64, ptr %ds
+  %454 = add i64 %453, 64
+  %455 = inttoptr i64 %454 to ptr
+  %456 = load i64, ptr %59
+  store i64 %456, ptr %455
   store i64 1, ptr %68
-  %451 = load i64, ptr %68
-  store i64 %451, ptr %69
-  %452 = ptrtoint ptr @camlSwitch__immstring38 to i64
-  store i64 %452, ptr %70
-  %453 = load i64, ptr %70
-  store i64 %453, ptr %71
-  %454 = load i64, ptr %71
-  %455 = inttoptr i64 %454 to ptr addrspace(1)
-  store ptr addrspace(1) %455, ptr %57
+  %457 = load i64, ptr %68
+  store i64 %457, ptr %69
+  %458 = ptrtoint ptr @camlSwitch__immstring38 to i64
+  store i64 %458, ptr %70
+  %459 = load i64, ptr %70
+  store i64 %459, ptr %71
+  %460 = load i64, ptr %71
+  %461 = inttoptr i64 %460 to ptr addrspace(1)
+  store ptr addrspace(1) %461, ptr %57
   br label %L231
 L231:
-  %456 = ptrtoint ptr @camlSwitch__const_block54 to i64
-  store i64 %456, ptr %72
+  %462 = ptrtoint ptr @camlSwitch__const_block54 to i64
+  store i64 %462, ptr %72
   store i64 1, ptr %73
-  %457 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
-  store i64 %457, ptr %74
-  %458 = load i64, ptr %74
-  store i64 %458, ptr %4
-  %459 = load i64, ptr %73
-  store i64 %459, ptr %6
-  %460 = load i64, ptr %72
-  store i64 %460, ptr %8
-  %461 = load i64, ptr %4
-  %462 = load i64, ptr %6
-  %463 = load i64, ptr %8
-  %464 = load i64, ptr %ds
-  %465 = load i64, ptr %alloc
-  %466 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %464, i64 %465, i64 %461, i64 %462, i64 %463) "statepoint-id"="0"
-  %467 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %466, 0, 0
-  %468 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %466, 0, 1
-  store i64 %467, ptr %ds
-  store i64 %468, ptr %alloc
-  %469 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %466, 1, 0
-  store ptr addrspace(1) %469, ptr %3
+  %463 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
+  store i64 %463, ptr %74
+  %464 = load i64, ptr %74
+  store i64 %464, ptr %4
+  %465 = load i64, ptr %73
+  store i64 %465, ptr %6
+  %466 = load i64, ptr %72
+  store i64 %466, ptr %8
+  %467 = load i64, ptr %4
+  %468 = load i64, ptr %6
+  %469 = load i64, ptr %8
+  %470 = load i64, ptr %ds
+  %471 = load i64, ptr %alloc
+  %472 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %470, i64 %471, i64 %467, i64 %468, i64 %469) "statepoint-id"="0"
+  %473 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %472, 0, 0
+  %474 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %472, 0, 1
+  store i64 %473, ptr %ds
+  store i64 %474, ptr %alloc
+  %475 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %472, 1, 0
+  store ptr addrspace(1) %475, ptr %3
   br label %L233
 L233:
-  %470 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %470, ptr %75
-  %471 = load ptr addrspace(1), ptr %75
-  store ptr addrspace(1) %471, ptr %76
+  %476 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %476, ptr %75
+  %477 = load ptr addrspace(1), ptr %75
+  store ptr addrspace(1) %477, ptr %76
   store i64 11, ptr %77
-  %472 = load i64, ptr %77
-  store i64 %472, ptr %4
-  %473 = load ptr addrspace(1), ptr %57
-  store ptr addrspace(1) %473, ptr %5
-  %474 = load ptr addrspace(1), ptr %76
-  store ptr addrspace(1) %474, ptr %7
-  %475 = load i64, ptr %4
-  %476 = load ptr addrspace(1), ptr %5
-  %477 = load ptr addrspace(1), ptr %7
-  %478 = load i64, ptr %ds
-  %479 = load i64, ptr %alloc
-  %480 = call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %478, i64 %479, i64 %475, ptr addrspace(1) %476, ptr addrspace(1) %477) "statepoint-id"="0"
-  %481 = extractvalue { { i64, i64 }, { i64 } } %480, 0, 0
-  %482 = extractvalue { { i64, i64 }, { i64 } } %480, 0, 1
-  store i64 %481, ptr %ds
-  store i64 %482, ptr %alloc
-  %483 = extractvalue { { i64, i64 }, { i64 } } %480, 1, 0
-  store i64 %483, ptr %4
+  %478 = load i64, ptr %77
+  store i64 %478, ptr %4
+  %479 = load ptr addrspace(1), ptr %57
+  store ptr addrspace(1) %479, ptr %5
+  %480 = load ptr addrspace(1), ptr %76
+  store ptr addrspace(1) %480, ptr %7
+  %481 = load i64, ptr %4
+  %482 = load ptr addrspace(1), ptr %5
+  %483 = load ptr addrspace(1), ptr %7
+  %484 = load i64, ptr %ds
+  %485 = load i64, ptr %alloc
+  %486 = call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %484, i64 %485, i64 %481, ptr addrspace(1) %482, ptr addrspace(1) %483) "statepoint-id"="0"
+  %487 = extractvalue { { i64, i64 }, { i64 } } %486, 0, 0
+  %488 = extractvalue { { i64, i64 }, { i64 } } %486, 0, 1
+  store i64 %487, ptr %ds
+  store i64 %488, ptr %alloc
+  %489 = extractvalue { { i64, i64 }, { i64 } } %486, 1, 0
+  store i64 %489, ptr %4
   br label %L234
 L234:
-  %484 = load i64, ptr %4
-  store i64 %484, ptr %78
-  %485 = load i64, ptr %78
-  store i64 %485, ptr %79
-  %486 = load i64, ptr %ds
-  %487 = add i64 %486, 64
-  %488 = inttoptr i64 %487 to ptr
-  %489 = load i64, ptr %488
-  store i64 %489, ptr %81
-  %490 = load i64, ptr %81
-  store i64 %490, ptr %82
-  %491 = load i64, ptr %ds
-  %492 = load i64, ptr %alloc
-  %493 = call oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %491, i64 %492) returns_twice "gc-leaf-function"="true"
-  %494 = extractvalue { { i64, i64 }, { i64 } } %493, 0, 0
-  %495 = extractvalue { { i64, i64 }, { i64 } } %493, 0, 1
-  store i64 %494, ptr %ds
-  store i64 %495, ptr %alloc
-  %496 = extractvalue { { i64, i64 }, { i64 } } %493, 1, 0
-  call void asm sideeffect "movq $0, %rax", "r"(i64 %496) "gc-leaf-function"="true"
+  %490 = load i64, ptr %4
+  store i64 %490, ptr %78
+  %491 = load i64, ptr %78
+  store i64 %491, ptr %79
+  %492 = load i64, ptr %ds
+  %493 = add i64 %492, 64
+  %494 = inttoptr i64 %493 to ptr
+  %495 = load i64, ptr %494
+  store i64 %495, ptr %81
+  %496 = load i64, ptr %81
+  store i64 %496, ptr %82
+  %497 = load i64, ptr %ds
+  %498 = load i64, ptr %alloc
+  %499 = call oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %497, i64 %498) returns_twice "gc-leaf-function"="true"
+  %500 = extractvalue { { i64, i64 }, { i64 } } %499, 0, 0
+  %501 = extractvalue { { i64, i64 }, { i64 } } %499, 0, 1
+  store i64 %500, ptr %ds
+  store i64 %501, ptr %alloc
+  %502 = extractvalue { { i64, i64 }, { i64 } } %499, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %502) "gc-leaf-function"="true"
   br label %L367
 L367:
-  %497 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
-  %498 = icmp eq i64 %497, 0
-  br i1 %498, label %L368, label %L239
+  %503 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
+  %504 = icmp eq i64 %503, 0
+  br i1 %504, label %L368, label %L239
 L368:
   store ptr blockaddress(@camlSwitch__entry, %L367), ptr @camlSwitch__entry.recover_rbp_var.L367
-  %499 = call  ptr @llvm.stacksave()
-  %500 = alloca { i64, i64, i64, i64 }
-  %501 = ptrtoint ptr %500 to i64
-  %502 = add i64 %501, 16
-  %503 = inttoptr i64 %502 to ptr
-  %504 = ptrtoint ptr %500 to i64
-  %505 = add i64 %504, 8
-  %506 = inttoptr i64 %505 to ptr
-  %507 = load i64, ptr %ds
-  %508 = add i64 %507, 48
+  %505 = call  ptr @llvm.stacksave()
+  %506 = alloca { i64, i64, i64, i64 }
+  %507 = ptrtoint ptr %506 to i64
+  %508 = add i64 %507, 16
   %509 = inttoptr i64 %508 to ptr
-  %510 = load i64, ptr %509
-  store ptr %500, ptr %509
-  store ptr @camlSwitch__entry.recover_rbp_asm.L367, ptr %506
-  call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %503) "gc-leaf-function"="true"
-  store i64 %510, ptr %500
-  store i64 15, ptr %84
-  %511 = load i64, ptr %84
-  store i64 %511, ptr %4
-  %512 = load i64, ptr %4
+  %510 = ptrtoint ptr %506 to i64
+  %511 = add i64 %510, 8
+  %512 = inttoptr i64 %511 to ptr
   %513 = load i64, ptr %ds
-  %514 = load i64, ptr %alloc
-  %515 = call oxcamlcc { { i64, i64 }, { i64 } } @camlSwitch__next_HIDE_STAMP(i64 %513, i64 %514, i64 %512) "statepoint-id"="32"
-  %516 = extractvalue { { i64, i64 }, { i64 } } %515, 0, 0
-  %517 = extractvalue { { i64, i64 }, { i64 } } %515, 0, 1
-  store i64 %516, ptr %ds
-  store i64 %517, ptr %alloc
-  %518 = extractvalue { { i64, i64 }, { i64 } } %515, 1, 0
-  store i64 %518, ptr %4
+  %514 = add i64 %513, 48
+  %515 = inttoptr i64 %514 to ptr
+  %516 = load i64, ptr %515
+  store ptr %506, ptr %515
+  store ptr @camlSwitch__entry.recover_rbp_asm.L367, ptr %512
+  call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %509) "gc-leaf-function"="true"
+  store i64 %516, ptr %506
+  store i64 15, ptr %84
+  %517 = load i64, ptr %84
+  store i64 %517, ptr %4
+  %518 = load i64, ptr %4
+  %519 = load i64, ptr %ds
+  %520 = load i64, ptr %alloc
+  %521 = call oxcamlcc { { i64, i64 }, { i64 } } @camlSwitch__next_HIDE_STAMP(i64 %519, i64 %520, i64 %518) "statepoint-id"="32"
+  %522 = extractvalue { { i64, i64 }, { i64 } } %521, 0, 0
+  %523 = extractvalue { { i64, i64 }, { i64 } } %521, 0, 1
+  store i64 %522, ptr %ds
+  store i64 %523, ptr %alloc
+  %524 = extractvalue { { i64, i64 }, { i64 } } %521, 1, 0
+  store i64 %524, ptr %4
   br label %L247
 L247:
-  %519 = load i64, ptr %4
-  store i64 %519, ptr %85
-  %520 = load i64, ptr %85
-  store i64 %520, ptr %86
-  %521 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
-  store i64 %521, ptr %87
-  %522 = load i64, ptr %87
-  store i64 %522, ptr %8
-  %523 = load i64, ptr %86
-  store i64 %523, ptr %9
-  %524 = load i64, ptr %8
-  %525 = load i64, ptr %9
-  %526 = load i64, ptr %ds
-  %527 = load i64, ptr %alloc
-  %528 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %526, i64 %527, ptr @caml_format_int, i64 %524, i64 %525) "statepoint-id"="32"
-  %529 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %528, 0, 0
-  %530 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %528, 0, 1
-  store i64 %529, ptr %ds
-  store i64 %530, ptr %alloc
-  %531 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %528, 1, 0
-  store ptr addrspace(1) %531, ptr %3
+  %525 = load i64, ptr %4
+  store i64 %525, ptr %85
+  %526 = load i64, ptr %85
+  store i64 %526, ptr %86
+  %527 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
+  store i64 %527, ptr %87
+  %528 = load i64, ptr %87
+  %529 = inttoptr i64 %528 to ptr addrspace(1)
+  store ptr addrspace(1) %529, ptr %7
+  %530 = load i64, ptr %86
+  %531 = inttoptr i64 %530 to ptr addrspace(1)
+  store ptr addrspace(1) %531, ptr %9
+  %532 = load ptr addrspace(1), ptr %7
+  %533 = load ptr addrspace(1), ptr %9
+  %534 = load i64, ptr %ds
+  %535 = load i64, ptr %alloc
+  %536 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %534, i64 %535, ptr @caml_format_int, ptr addrspace(1) %532, ptr addrspace(1) %533) "statepoint-id"="32"
+  %537 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %536, 0, 0
+  %538 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %536, 0, 1
+  store i64 %537, ptr %ds
+  store i64 %538, ptr %alloc
+  %539 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %536, 1, 0
+  store ptr addrspace(1) %539, ptr %3
   br label %L248
 L248:
-  %532 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %532, ptr %88
-  %533 = load ptr addrspace(1), ptr %88
-  store ptr addrspace(1) %533, ptr %89
-  %534 = load ptr addrspace(1), ptr %89
-  store ptr addrspace(1) %534, ptr %90
-  %535 = load ptr addrspace(1), ptr %90
-  store ptr addrspace(1) %535, ptr %80
-  %536 = load i64, ptr %ds
-  %537 = add i64 %536, 48
-  %538 = inttoptr i64 %537 to ptr
-  %539 = load i64, ptr %500
-  store i64 %539, ptr %538
-  call  void @llvm.stackrestore(ptr %499)
+  %540 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %540, ptr %88
+  %541 = load ptr addrspace(1), ptr %88
+  store ptr addrspace(1) %541, ptr %89
+  %542 = load ptr addrspace(1), ptr %89
+  store ptr addrspace(1) %542, ptr %90
+  %543 = load ptr addrspace(1), ptr %90
+  store ptr addrspace(1) %543, ptr %80
+  %544 = load i64, ptr %ds
+  %545 = add i64 %544, 48
+  %546 = inttoptr i64 %545 to ptr
+  %547 = load i64, ptr %506
+  store i64 %547, ptr %546
+  call  void @llvm.stackrestore(ptr %505)
   br label %L254
 L239:
-  %540 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
-  store i64 %540, ptr %alloc
-  store i64 %497, ptr %4
-  %541 = load i64, ptr %4
-  %542 = inttoptr i64 %541 to ptr addrspace(1)
-  store ptr addrspace(1) %542, ptr %83
-  %543 = load i64, ptr %ds
-  %544 = add i64 %543, 64
-  %545 = inttoptr i64 %544 to ptr
-  %546 = load i64, ptr %82
-  store i64 %546, ptr %545
+  %548 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
+  store i64 %548, ptr %alloc
+  store i64 %503, ptr %4
+  %549 = load i64, ptr %4
+  %550 = inttoptr i64 %549 to ptr addrspace(1)
+  store ptr addrspace(1) %550, ptr %83
+  %551 = load i64, ptr %ds
+  %552 = add i64 %551, 64
+  %553 = inttoptr i64 %552 to ptr
+  %554 = load i64, ptr %82
+  store i64 %554, ptr %553
   store i64 1, ptr %91
-  %547 = load i64, ptr %91
-  store i64 %547, ptr %92
-  %548 = ptrtoint ptr @camlSwitch__immstring38 to i64
-  store i64 %548, ptr %93
-  %549 = load i64, ptr %93
-  store i64 %549, ptr %94
-  %550 = load i64, ptr %94
-  %551 = inttoptr i64 %550 to ptr addrspace(1)
-  store ptr addrspace(1) %551, ptr %80
+  %555 = load i64, ptr %91
+  store i64 %555, ptr %92
+  %556 = ptrtoint ptr @camlSwitch__immstring38 to i64
+  store i64 %556, ptr %93
+  %557 = load i64, ptr %93
+  store i64 %557, ptr %94
+  %558 = load i64, ptr %94
+  %559 = inttoptr i64 %558 to ptr addrspace(1)
+  store ptr addrspace(1) %559, ptr %80
   br label %L254
 L254:
-  %552 = ptrtoint ptr @camlSwitch__const_block54 to i64
-  store i64 %552, ptr %95
+  %560 = ptrtoint ptr @camlSwitch__const_block54 to i64
+  store i64 %560, ptr %95
   store i64 1, ptr %96
-  %553 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
-  store i64 %553, ptr %97
-  %554 = load i64, ptr %97
-  store i64 %554, ptr %4
-  %555 = load i64, ptr %96
-  store i64 %555, ptr %6
-  %556 = load i64, ptr %95
-  store i64 %556, ptr %8
-  %557 = load i64, ptr %4
-  %558 = load i64, ptr %6
-  %559 = load i64, ptr %8
-  %560 = load i64, ptr %ds
-  %561 = load i64, ptr %alloc
-  %562 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %560, i64 %561, i64 %557, i64 %558, i64 %559) "statepoint-id"="0"
-  %563 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %562, 0, 0
-  %564 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %562, 0, 1
-  store i64 %563, ptr %ds
-  store i64 %564, ptr %alloc
-  %565 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %562, 1, 0
-  store ptr addrspace(1) %565, ptr %3
+  %561 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
+  store i64 %561, ptr %97
+  %562 = load i64, ptr %97
+  store i64 %562, ptr %4
+  %563 = load i64, ptr %96
+  store i64 %563, ptr %6
+  %564 = load i64, ptr %95
+  store i64 %564, ptr %8
+  %565 = load i64, ptr %4
+  %566 = load i64, ptr %6
+  %567 = load i64, ptr %8
+  %568 = load i64, ptr %ds
+  %569 = load i64, ptr %alloc
+  %570 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %568, i64 %569, i64 %565, i64 %566, i64 %567) "statepoint-id"="0"
+  %571 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %570, 0, 0
+  %572 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %570, 0, 1
+  store i64 %571, ptr %ds
+  store i64 %572, ptr %alloc
+  %573 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %570, 1, 0
+  store ptr addrspace(1) %573, ptr %3
   br label %L256
 L256:
-  %566 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %566, ptr %98
-  %567 = load ptr addrspace(1), ptr %98
-  store ptr addrspace(1) %567, ptr %99
+  %574 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %574, ptr %98
+  %575 = load ptr addrspace(1), ptr %98
+  store ptr addrspace(1) %575, ptr %99
   store i64 15, ptr %100
-  %568 = load i64, ptr %100
-  store i64 %568, ptr %4
-  %569 = load ptr addrspace(1), ptr %80
-  store ptr addrspace(1) %569, ptr %5
-  %570 = load ptr addrspace(1), ptr %99
-  store ptr addrspace(1) %570, ptr %7
-  %571 = load i64, ptr %4
-  %572 = load ptr addrspace(1), ptr %5
-  %573 = load ptr addrspace(1), ptr %7
-  %574 = load i64, ptr %ds
-  %575 = load i64, ptr %alloc
-  %576 = call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %574, i64 %575, i64 %571, ptr addrspace(1) %572, ptr addrspace(1) %573) "statepoint-id"="0"
-  %577 = extractvalue { { i64, i64 }, { i64 } } %576, 0, 0
-  %578 = extractvalue { { i64, i64 }, { i64 } } %576, 0, 1
-  store i64 %577, ptr %ds
-  store i64 %578, ptr %alloc
-  %579 = extractvalue { { i64, i64 }, { i64 } } %576, 1, 0
-  store i64 %579, ptr %4
+  %576 = load i64, ptr %100
+  store i64 %576, ptr %4
+  %577 = load ptr addrspace(1), ptr %80
+  store ptr addrspace(1) %577, ptr %5
+  %578 = load ptr addrspace(1), ptr %99
+  store ptr addrspace(1) %578, ptr %7
+  %579 = load i64, ptr %4
+  %580 = load ptr addrspace(1), ptr %5
+  %581 = load ptr addrspace(1), ptr %7
+  %582 = load i64, ptr %ds
+  %583 = load i64, ptr %alloc
+  %584 = call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %582, i64 %583, i64 %579, ptr addrspace(1) %580, ptr addrspace(1) %581) "statepoint-id"="0"
+  %585 = extractvalue { { i64, i64 }, { i64 } } %584, 0, 0
+  %586 = extractvalue { { i64, i64 }, { i64 } } %584, 0, 1
+  store i64 %585, ptr %ds
+  store i64 %586, ptr %alloc
+  %587 = extractvalue { { i64, i64 }, { i64 } } %584, 1, 0
+  store i64 %587, ptr %4
   br label %L257
 L257:
-  %580 = load i64, ptr %4
-  store i64 %580, ptr %101
-  %581 = load i64, ptr %101
-  store i64 %581, ptr %102
-  %582 = load i64, ptr %ds
-  %583 = add i64 %582, 64
-  %584 = inttoptr i64 %583 to ptr
-  %585 = load i64, ptr %584
-  store i64 %585, ptr %104
-  %586 = load i64, ptr %104
-  store i64 %586, ptr %105
-  %587 = load i64, ptr %ds
-  %588 = load i64, ptr %alloc
-  %589 = call oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %587, i64 %588) returns_twice "gc-leaf-function"="true"
-  %590 = extractvalue { { i64, i64 }, { i64 } } %589, 0, 0
-  %591 = extractvalue { { i64, i64 }, { i64 } } %589, 0, 1
-  store i64 %590, ptr %ds
-  store i64 %591, ptr %alloc
-  %592 = extractvalue { { i64, i64 }, { i64 } } %589, 1, 0
-  call void asm sideeffect "movq $0, %rax", "r"(i64 %592) "gc-leaf-function"="true"
+  %588 = load i64, ptr %4
+  store i64 %588, ptr %101
+  %589 = load i64, ptr %101
+  store i64 %589, ptr %102
+  %590 = load i64, ptr %ds
+  %591 = add i64 %590, 64
+  %592 = inttoptr i64 %591 to ptr
+  %593 = load i64, ptr %592
+  store i64 %593, ptr %104
+  %594 = load i64, ptr %104
+  store i64 %594, ptr %105
+  %595 = load i64, ptr %ds
+  %596 = load i64, ptr %alloc
+  %597 = call oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %595, i64 %596) returns_twice "gc-leaf-function"="true"
+  %598 = extractvalue { { i64, i64 }, { i64 } } %597, 0, 0
+  %599 = extractvalue { { i64, i64 }, { i64 } } %597, 0, 1
+  store i64 %598, ptr %ds
+  store i64 %599, ptr %alloc
+  %600 = extractvalue { { i64, i64 }, { i64 } } %597, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %600) "gc-leaf-function"="true"
   br label %L369
 L369:
-  %593 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
-  %594 = icmp eq i64 %593, 0
-  br i1 %594, label %L370, label %L262
+  %601 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
+  %602 = icmp eq i64 %601, 0
+  br i1 %602, label %L370, label %L262
 L370:
   store ptr blockaddress(@camlSwitch__entry, %L369), ptr @camlSwitch__entry.recover_rbp_var.L369
-  %595 = call  ptr @llvm.stacksave()
-  %596 = alloca { i64, i64, i64, i64 }
-  %597 = ptrtoint ptr %596 to i64
-  %598 = add i64 %597, 16
-  %599 = inttoptr i64 %598 to ptr
-  %600 = ptrtoint ptr %596 to i64
-  %601 = add i64 %600, 8
-  %602 = inttoptr i64 %601 to ptr
-  %603 = load i64, ptr %ds
-  %604 = add i64 %603, 48
-  %605 = inttoptr i64 %604 to ptr
-  %606 = load i64, ptr %605
-  store ptr %596, ptr %605
-  store ptr @camlSwitch__entry.recover_rbp_asm.L369, ptr %602
-  call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %599) "gc-leaf-function"="true"
-  store i64 %606, ptr %596
+  %603 = call  ptr @llvm.stacksave()
+  %604 = alloca { i64, i64, i64, i64 }
+  %605 = ptrtoint ptr %604 to i64
+  %606 = add i64 %605, 16
+  %607 = inttoptr i64 %606 to ptr
+  %608 = ptrtoint ptr %604 to i64
+  %609 = add i64 %608, 8
+  %610 = inttoptr i64 %609 to ptr
+  %611 = load i64, ptr %ds
+  %612 = add i64 %611, 48
+  %613 = inttoptr i64 %612 to ptr
+  %614 = load i64, ptr %613
+  store ptr %604, ptr %613
+  store ptr @camlSwitch__entry.recover_rbp_asm.L369, ptr %610
+  call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %607) "gc-leaf-function"="true"
+  store i64 %614, ptr %604
   store i64 19, ptr %107
-  %607 = load i64, ptr %107
-  store i64 %607, ptr %4
-  %608 = load i64, ptr %4
-  %609 = load i64, ptr %ds
-  %610 = load i64, ptr %alloc
-  %611 = call oxcamlcc { { i64, i64 }, { i64 } } @camlSwitch__next_HIDE_STAMP(i64 %609, i64 %610, i64 %608) "statepoint-id"="32"
-  %612 = extractvalue { { i64, i64 }, { i64 } } %611, 0, 0
-  %613 = extractvalue { { i64, i64 }, { i64 } } %611, 0, 1
-  store i64 %612, ptr %ds
-  store i64 %613, ptr %alloc
-  %614 = extractvalue { { i64, i64 }, { i64 } } %611, 1, 0
-  store i64 %614, ptr %4
+  %615 = load i64, ptr %107
+  store i64 %615, ptr %4
+  %616 = load i64, ptr %4
+  %617 = load i64, ptr %ds
+  %618 = load i64, ptr %alloc
+  %619 = call oxcamlcc { { i64, i64 }, { i64 } } @camlSwitch__next_HIDE_STAMP(i64 %617, i64 %618, i64 %616) "statepoint-id"="32"
+  %620 = extractvalue { { i64, i64 }, { i64 } } %619, 0, 0
+  %621 = extractvalue { { i64, i64 }, { i64 } } %619, 0, 1
+  store i64 %620, ptr %ds
+  store i64 %621, ptr %alloc
+  %622 = extractvalue { { i64, i64 }, { i64 } } %619, 1, 0
+  store i64 %622, ptr %4
   br label %L270
 L270:
-  %615 = load i64, ptr %4
-  store i64 %615, ptr %108
-  %616 = load i64, ptr %108
-  store i64 %616, ptr %109
-  %617 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
-  store i64 %617, ptr %110
-  %618 = load i64, ptr %110
-  store i64 %618, ptr %8
-  %619 = load i64, ptr %109
-  store i64 %619, ptr %9
-  %620 = load i64, ptr %8
-  %621 = load i64, ptr %9
-  %622 = load i64, ptr %ds
-  %623 = load i64, ptr %alloc
-  %624 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %622, i64 %623, ptr @caml_format_int, i64 %620, i64 %621) "statepoint-id"="32"
-  %625 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %624, 0, 0
-  %626 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %624, 0, 1
-  store i64 %625, ptr %ds
-  store i64 %626, ptr %alloc
-  %627 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %624, 1, 0
-  store ptr addrspace(1) %627, ptr %3
+  %623 = load i64, ptr %4
+  store i64 %623, ptr %108
+  %624 = load i64, ptr %108
+  store i64 %624, ptr %109
+  %625 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
+  store i64 %625, ptr %110
+  %626 = load i64, ptr %110
+  %627 = inttoptr i64 %626 to ptr addrspace(1)
+  store ptr addrspace(1) %627, ptr %7
+  %628 = load i64, ptr %109
+  %629 = inttoptr i64 %628 to ptr addrspace(1)
+  store ptr addrspace(1) %629, ptr %9
+  %630 = load ptr addrspace(1), ptr %7
+  %631 = load ptr addrspace(1), ptr %9
+  %632 = load i64, ptr %ds
+  %633 = load i64, ptr %alloc
+  %634 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %632, i64 %633, ptr @caml_format_int, ptr addrspace(1) %630, ptr addrspace(1) %631) "statepoint-id"="32"
+  %635 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %634, 0, 0
+  %636 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %634, 0, 1
+  store i64 %635, ptr %ds
+  store i64 %636, ptr %alloc
+  %637 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %634, 1, 0
+  store ptr addrspace(1) %637, ptr %3
   br label %L271
 L271:
-  %628 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %628, ptr %111
-  %629 = load ptr addrspace(1), ptr %111
-  store ptr addrspace(1) %629, ptr %112
-  %630 = load ptr addrspace(1), ptr %112
-  store ptr addrspace(1) %630, ptr %113
-  %631 = load ptr addrspace(1), ptr %113
-  store ptr addrspace(1) %631, ptr %103
-  %632 = load i64, ptr %ds
-  %633 = add i64 %632, 48
-  %634 = inttoptr i64 %633 to ptr
-  %635 = load i64, ptr %596
-  store i64 %635, ptr %634
-  call  void @llvm.stackrestore(ptr %595)
+  %638 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %638, ptr %111
+  %639 = load ptr addrspace(1), ptr %111
+  store ptr addrspace(1) %639, ptr %112
+  %640 = load ptr addrspace(1), ptr %112
+  store ptr addrspace(1) %640, ptr %113
+  %641 = load ptr addrspace(1), ptr %113
+  store ptr addrspace(1) %641, ptr %103
+  %642 = load i64, ptr %ds
+  %643 = add i64 %642, 48
+  %644 = inttoptr i64 %643 to ptr
+  %645 = load i64, ptr %604
+  store i64 %645, ptr %644
+  call  void @llvm.stackrestore(ptr %603)
   br label %L277
 L262:
-  %636 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
-  store i64 %636, ptr %alloc
-  store i64 %593, ptr %4
-  %637 = load i64, ptr %4
-  %638 = inttoptr i64 %637 to ptr addrspace(1)
-  store ptr addrspace(1) %638, ptr %106
-  %639 = load i64, ptr %ds
-  %640 = add i64 %639, 64
-  %641 = inttoptr i64 %640 to ptr
-  %642 = load i64, ptr %105
-  store i64 %642, ptr %641
+  %646 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
+  store i64 %646, ptr %alloc
+  store i64 %601, ptr %4
+  %647 = load i64, ptr %4
+  %648 = inttoptr i64 %647 to ptr addrspace(1)
+  store ptr addrspace(1) %648, ptr %106
+  %649 = load i64, ptr %ds
+  %650 = add i64 %649, 64
+  %651 = inttoptr i64 %650 to ptr
+  %652 = load i64, ptr %105
+  store i64 %652, ptr %651
   store i64 1, ptr %114
-  %643 = load i64, ptr %114
-  store i64 %643, ptr %115
-  %644 = ptrtoint ptr @camlSwitch__immstring38 to i64
-  store i64 %644, ptr %116
-  %645 = load i64, ptr %116
-  store i64 %645, ptr %117
-  %646 = load i64, ptr %117
-  %647 = inttoptr i64 %646 to ptr addrspace(1)
-  store ptr addrspace(1) %647, ptr %103
+  %653 = load i64, ptr %114
+  store i64 %653, ptr %115
+  %654 = ptrtoint ptr @camlSwitch__immstring38 to i64
+  store i64 %654, ptr %116
+  %655 = load i64, ptr %116
+  store i64 %655, ptr %117
+  %656 = load i64, ptr %117
+  %657 = inttoptr i64 %656 to ptr addrspace(1)
+  store ptr addrspace(1) %657, ptr %103
   br label %L277
 L277:
-  %648 = ptrtoint ptr @camlSwitch__const_block54 to i64
-  store i64 %648, ptr %118
+  %658 = ptrtoint ptr @camlSwitch__const_block54 to i64
+  store i64 %658, ptr %118
   store i64 1, ptr %119
-  %649 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
-  store i64 %649, ptr %120
-  %650 = load i64, ptr %120
-  store i64 %650, ptr %4
-  %651 = load i64, ptr %119
-  store i64 %651, ptr %6
-  %652 = load i64, ptr %118
-  store i64 %652, ptr %8
-  %653 = load i64, ptr %4
-  %654 = load i64, ptr %6
-  %655 = load i64, ptr %8
-  %656 = load i64, ptr %ds
-  %657 = load i64, ptr %alloc
-  %658 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %656, i64 %657, i64 %653, i64 %654, i64 %655) "statepoint-id"="0"
-  %659 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %658, 0, 0
-  %660 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %658, 0, 1
-  store i64 %659, ptr %ds
-  store i64 %660, ptr %alloc
-  %661 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %658, 1, 0
-  store ptr addrspace(1) %661, ptr %3
+  %659 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
+  store i64 %659, ptr %120
+  %660 = load i64, ptr %120
+  store i64 %660, ptr %4
+  %661 = load i64, ptr %119
+  store i64 %661, ptr %6
+  %662 = load i64, ptr %118
+  store i64 %662, ptr %8
+  %663 = load i64, ptr %4
+  %664 = load i64, ptr %6
+  %665 = load i64, ptr %8
+  %666 = load i64, ptr %ds
+  %667 = load i64, ptr %alloc
+  %668 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %666, i64 %667, i64 %663, i64 %664, i64 %665) "statepoint-id"="0"
+  %669 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %668, 0, 0
+  %670 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %668, 0, 1
+  store i64 %669, ptr %ds
+  store i64 %670, ptr %alloc
+  %671 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %668, 1, 0
+  store ptr addrspace(1) %671, ptr %3
   br label %L279
 L279:
-  %662 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %662, ptr %121
-  %663 = load ptr addrspace(1), ptr %121
-  store ptr addrspace(1) %663, ptr %122
+  %672 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %672, ptr %121
+  %673 = load ptr addrspace(1), ptr %121
+  store ptr addrspace(1) %673, ptr %122
   store i64 19, ptr %123
-  %664 = load i64, ptr %123
-  store i64 %664, ptr %4
-  %665 = load ptr addrspace(1), ptr %103
-  store ptr addrspace(1) %665, ptr %5
-  %666 = load ptr addrspace(1), ptr %122
-  store ptr addrspace(1) %666, ptr %7
-  %667 = load i64, ptr %4
-  %668 = load ptr addrspace(1), ptr %5
-  %669 = load ptr addrspace(1), ptr %7
-  %670 = load i64, ptr %ds
-  %671 = load i64, ptr %alloc
-  %672 = call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %670, i64 %671, i64 %667, ptr addrspace(1) %668, ptr addrspace(1) %669) "statepoint-id"="0"
-  %673 = extractvalue { { i64, i64 }, { i64 } } %672, 0, 0
-  %674 = extractvalue { { i64, i64 }, { i64 } } %672, 0, 1
-  store i64 %673, ptr %ds
-  store i64 %674, ptr %alloc
-  %675 = extractvalue { { i64, i64 }, { i64 } } %672, 1, 0
-  store i64 %675, ptr %4
+  %674 = load i64, ptr %123
+  store i64 %674, ptr %4
+  %675 = load ptr addrspace(1), ptr %103
+  store ptr addrspace(1) %675, ptr %5
+  %676 = load ptr addrspace(1), ptr %122
+  store ptr addrspace(1) %676, ptr %7
+  %677 = load i64, ptr %4
+  %678 = load ptr addrspace(1), ptr %5
+  %679 = load ptr addrspace(1), ptr %7
+  %680 = load i64, ptr %ds
+  %681 = load i64, ptr %alloc
+  %682 = call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %680, i64 %681, i64 %677, ptr addrspace(1) %678, ptr addrspace(1) %679) "statepoint-id"="0"
+  %683 = extractvalue { { i64, i64 }, { i64 } } %682, 0, 0
+  %684 = extractvalue { { i64, i64 }, { i64 } } %682, 0, 1
+  store i64 %683, ptr %ds
+  store i64 %684, ptr %alloc
+  %685 = extractvalue { { i64, i64 }, { i64 } } %682, 1, 0
+  store i64 %685, ptr %4
   br label %L280
 L280:
-  %676 = load i64, ptr %4
-  store i64 %676, ptr %124
-  %677 = load i64, ptr %124
-  store i64 %677, ptr %125
-  %678 = load i64, ptr %ds
-  %679 = add i64 %678, 64
-  %680 = inttoptr i64 %679 to ptr
-  %681 = load i64, ptr %680
-  store i64 %681, ptr %127
-  %682 = load i64, ptr %127
-  store i64 %682, ptr %128
-  %683 = load i64, ptr %ds
-  %684 = load i64, ptr %alloc
-  %685 = call oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %683, i64 %684) returns_twice "gc-leaf-function"="true"
-  %686 = extractvalue { { i64, i64 }, { i64 } } %685, 0, 0
-  %687 = extractvalue { { i64, i64 }, { i64 } } %685, 0, 1
-  store i64 %686, ptr %ds
-  store i64 %687, ptr %alloc
-  %688 = extractvalue { { i64, i64 }, { i64 } } %685, 1, 0
-  call void asm sideeffect "movq $0, %rax", "r"(i64 %688) "gc-leaf-function"="true"
+  %686 = load i64, ptr %4
+  store i64 %686, ptr %124
+  %687 = load i64, ptr %124
+  store i64 %687, ptr %125
+  %688 = load i64, ptr %ds
+  %689 = add i64 %688, 64
+  %690 = inttoptr i64 %689 to ptr
+  %691 = load i64, ptr %690
+  store i64 %691, ptr %127
+  %692 = load i64, ptr %127
+  store i64 %692, ptr %128
+  %693 = load i64, ptr %ds
+  %694 = load i64, ptr %alloc
+  %695 = call oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %693, i64 %694) returns_twice "gc-leaf-function"="true"
+  %696 = extractvalue { { i64, i64 }, { i64 } } %695, 0, 0
+  %697 = extractvalue { { i64, i64 }, { i64 } } %695, 0, 1
+  store i64 %696, ptr %ds
+  store i64 %697, ptr %alloc
+  %698 = extractvalue { { i64, i64 }, { i64 } } %695, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %698) "gc-leaf-function"="true"
   br label %L371
 L371:
-  %689 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
-  %690 = icmp eq i64 %689, 0
-  br i1 %690, label %L372, label %L285
+  %699 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
+  %700 = icmp eq i64 %699, 0
+  br i1 %700, label %L372, label %L285
 L372:
   store ptr blockaddress(@camlSwitch__entry, %L371), ptr @camlSwitch__entry.recover_rbp_var.L371
-  %691 = call  ptr @llvm.stacksave()
-  %692 = alloca { i64, i64, i64, i64 }
-  %693 = ptrtoint ptr %692 to i64
-  %694 = add i64 %693, 16
-  %695 = inttoptr i64 %694 to ptr
-  %696 = ptrtoint ptr %692 to i64
-  %697 = add i64 %696, 8
-  %698 = inttoptr i64 %697 to ptr
-  %699 = load i64, ptr %ds
-  %700 = add i64 %699, 48
-  %701 = inttoptr i64 %700 to ptr
-  %702 = load i64, ptr %701
-  store ptr %692, ptr %701
-  store ptr @camlSwitch__entry.recover_rbp_asm.L371, ptr %698
-  call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %695) "gc-leaf-function"="true"
-  store i64 %702, ptr %692
+  %701 = call  ptr @llvm.stacksave()
+  %702 = alloca { i64, i64, i64, i64 }
+  %703 = ptrtoint ptr %702 to i64
+  %704 = add i64 %703, 16
+  %705 = inttoptr i64 %704 to ptr
+  %706 = ptrtoint ptr %702 to i64
+  %707 = add i64 %706, 8
+  %708 = inttoptr i64 %707 to ptr
+  %709 = load i64, ptr %ds
+  %710 = add i64 %709, 48
+  %711 = inttoptr i64 %710 to ptr
+  %712 = load i64, ptr %711
+  store ptr %702, ptr %711
+  store ptr @camlSwitch__entry.recover_rbp_asm.L371, ptr %708
+  call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %705) "gc-leaf-function"="true"
+  store i64 %712, ptr %702
   store i64 5, ptr %130
-  %703 = load i64, ptr %130
-  store i64 %703, ptr %4
-  %704 = load i64, ptr %4
-  %705 = load i64, ptr %ds
-  %706 = load i64, ptr %alloc
-  %707 = call oxcamlcc { { i64, i64 }, { i64 } } @camlSwitch__next_HIDE_STAMP(i64 %705, i64 %706, i64 %704) "statepoint-id"="32"
-  %708 = extractvalue { { i64, i64 }, { i64 } } %707, 0, 0
-  %709 = extractvalue { { i64, i64 }, { i64 } } %707, 0, 1
-  store i64 %708, ptr %ds
-  store i64 %709, ptr %alloc
-  %710 = extractvalue { { i64, i64 }, { i64 } } %707, 1, 0
-  store i64 %710, ptr %4
+  %713 = load i64, ptr %130
+  store i64 %713, ptr %4
+  %714 = load i64, ptr %4
+  %715 = load i64, ptr %ds
+  %716 = load i64, ptr %alloc
+  %717 = call oxcamlcc { { i64, i64 }, { i64 } } @camlSwitch__next_HIDE_STAMP(i64 %715, i64 %716, i64 %714) "statepoint-id"="32"
+  %718 = extractvalue { { i64, i64 }, { i64 } } %717, 0, 0
+  %719 = extractvalue { { i64, i64 }, { i64 } } %717, 0, 1
+  store i64 %718, ptr %ds
+  store i64 %719, ptr %alloc
+  %720 = extractvalue { { i64, i64 }, { i64 } } %717, 1, 0
+  store i64 %720, ptr %4
   br label %L293
 L293:
-  %711 = load i64, ptr %4
-  store i64 %711, ptr %131
-  %712 = load i64, ptr %131
-  store i64 %712, ptr %132
-  %713 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
-  store i64 %713, ptr %133
-  %714 = load i64, ptr %133
-  store i64 %714, ptr %8
-  %715 = load i64, ptr %132
-  store i64 %715, ptr %9
-  %716 = load i64, ptr %8
-  %717 = load i64, ptr %9
-  %718 = load i64, ptr %ds
-  %719 = load i64, ptr %alloc
-  %720 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %718, i64 %719, ptr @caml_format_int, i64 %716, i64 %717) "statepoint-id"="32"
-  %721 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %720, 0, 0
-  %722 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %720, 0, 1
-  store i64 %721, ptr %ds
-  store i64 %722, ptr %alloc
-  %723 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %720, 1, 0
-  store ptr addrspace(1) %723, ptr %3
+  %721 = load i64, ptr %4
+  store i64 %721, ptr %131
+  %722 = load i64, ptr %131
+  store i64 %722, ptr %132
+  %723 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
+  store i64 %723, ptr %133
+  %724 = load i64, ptr %133
+  %725 = inttoptr i64 %724 to ptr addrspace(1)
+  store ptr addrspace(1) %725, ptr %7
+  %726 = load i64, ptr %132
+  %727 = inttoptr i64 %726 to ptr addrspace(1)
+  store ptr addrspace(1) %727, ptr %9
+  %728 = load ptr addrspace(1), ptr %7
+  %729 = load ptr addrspace(1), ptr %9
+  %730 = load i64, ptr %ds
+  %731 = load i64, ptr %alloc
+  %732 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %730, i64 %731, ptr @caml_format_int, ptr addrspace(1) %728, ptr addrspace(1) %729) "statepoint-id"="32"
+  %733 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %732, 0, 0
+  %734 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %732, 0, 1
+  store i64 %733, ptr %ds
+  store i64 %734, ptr %alloc
+  %735 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %732, 1, 0
+  store ptr addrspace(1) %735, ptr %3
   br label %L294
 L294:
-  %724 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %724, ptr %134
-  %725 = load ptr addrspace(1), ptr %134
-  store ptr addrspace(1) %725, ptr %135
-  %726 = load ptr addrspace(1), ptr %135
-  store ptr addrspace(1) %726, ptr %136
-  %727 = load ptr addrspace(1), ptr %136
-  store ptr addrspace(1) %727, ptr %126
-  %728 = load i64, ptr %ds
-  %729 = add i64 %728, 48
-  %730 = inttoptr i64 %729 to ptr
-  %731 = load i64, ptr %692
-  store i64 %731, ptr %730
-  call  void @llvm.stackrestore(ptr %691)
+  %736 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %736, ptr %134
+  %737 = load ptr addrspace(1), ptr %134
+  store ptr addrspace(1) %737, ptr %135
+  %738 = load ptr addrspace(1), ptr %135
+  store ptr addrspace(1) %738, ptr %136
+  %739 = load ptr addrspace(1), ptr %136
+  store ptr addrspace(1) %739, ptr %126
+  %740 = load i64, ptr %ds
+  %741 = add i64 %740, 48
+  %742 = inttoptr i64 %741 to ptr
+  %743 = load i64, ptr %702
+  store i64 %743, ptr %742
+  call  void @llvm.stackrestore(ptr %701)
   br label %L300
 L285:
-  %732 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
-  store i64 %732, ptr %alloc
-  store i64 %689, ptr %4
-  %733 = load i64, ptr %4
-  %734 = inttoptr i64 %733 to ptr addrspace(1)
-  store ptr addrspace(1) %734, ptr %129
-  %735 = load i64, ptr %ds
-  %736 = add i64 %735, 64
-  %737 = inttoptr i64 %736 to ptr
-  %738 = load i64, ptr %128
-  store i64 %738, ptr %737
+  %744 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
+  store i64 %744, ptr %alloc
+  store i64 %699, ptr %4
+  %745 = load i64, ptr %4
+  %746 = inttoptr i64 %745 to ptr addrspace(1)
+  store ptr addrspace(1) %746, ptr %129
+  %747 = load i64, ptr %ds
+  %748 = add i64 %747, 64
+  %749 = inttoptr i64 %748 to ptr
+  %750 = load i64, ptr %128
+  store i64 %750, ptr %749
   store i64 1, ptr %137
-  %739 = load i64, ptr %137
-  store i64 %739, ptr %138
-  %740 = ptrtoint ptr @camlSwitch__immstring38 to i64
-  store i64 %740, ptr %139
-  %741 = load i64, ptr %139
-  store i64 %741, ptr %140
-  %742 = load i64, ptr %140
-  %743 = inttoptr i64 %742 to ptr addrspace(1)
-  store ptr addrspace(1) %743, ptr %126
+  %751 = load i64, ptr %137
+  store i64 %751, ptr %138
+  %752 = ptrtoint ptr @camlSwitch__immstring38 to i64
+  store i64 %752, ptr %139
+  %753 = load i64, ptr %139
+  store i64 %753, ptr %140
+  %754 = load i64, ptr %140
+  %755 = inttoptr i64 %754 to ptr addrspace(1)
+  store ptr addrspace(1) %755, ptr %126
   br label %L300
 L300:
-  %744 = ptrtoint ptr @camlSwitch__const_block54 to i64
-  store i64 %744, ptr %141
+  %756 = ptrtoint ptr @camlSwitch__const_block54 to i64
+  store i64 %756, ptr %141
   store i64 1, ptr %142
-  %745 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
-  store i64 %745, ptr %143
-  %746 = load i64, ptr %143
-  store i64 %746, ptr %4
-  %747 = load i64, ptr %142
-  store i64 %747, ptr %6
-  %748 = load i64, ptr %141
-  store i64 %748, ptr %8
-  %749 = load i64, ptr %4
-  %750 = load i64, ptr %6
-  %751 = load i64, ptr %8
-  %752 = load i64, ptr %ds
-  %753 = load i64, ptr %alloc
-  %754 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %752, i64 %753, i64 %749, i64 %750, i64 %751) "statepoint-id"="0"
-  %755 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %754, 0, 0
-  %756 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %754, 0, 1
-  store i64 %755, ptr %ds
-  store i64 %756, ptr %alloc
-  %757 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %754, 1, 0
-  store ptr addrspace(1) %757, ptr %3
+  %757 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
+  store i64 %757, ptr %143
+  %758 = load i64, ptr %143
+  store i64 %758, ptr %4
+  %759 = load i64, ptr %142
+  store i64 %759, ptr %6
+  %760 = load i64, ptr %141
+  store i64 %760, ptr %8
+  %761 = load i64, ptr %4
+  %762 = load i64, ptr %6
+  %763 = load i64, ptr %8
+  %764 = load i64, ptr %ds
+  %765 = load i64, ptr %alloc
+  %766 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %764, i64 %765, i64 %761, i64 %762, i64 %763) "statepoint-id"="0"
+  %767 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %766, 0, 0
+  %768 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %766, 0, 1
+  store i64 %767, ptr %ds
+  store i64 %768, ptr %alloc
+  %769 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %766, 1, 0
+  store ptr addrspace(1) %769, ptr %3
   br label %L302
 L302:
-  %758 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %758, ptr %144
-  %759 = load ptr addrspace(1), ptr %144
-  store ptr addrspace(1) %759, ptr %145
+  %770 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %770, ptr %144
+  %771 = load ptr addrspace(1), ptr %144
+  store ptr addrspace(1) %771, ptr %145
   store i64 5, ptr %146
-  %760 = load i64, ptr %146
-  store i64 %760, ptr %4
-  %761 = load ptr addrspace(1), ptr %126
-  store ptr addrspace(1) %761, ptr %5
-  %762 = load ptr addrspace(1), ptr %145
-  store ptr addrspace(1) %762, ptr %7
-  %763 = load i64, ptr %4
-  %764 = load ptr addrspace(1), ptr %5
-  %765 = load ptr addrspace(1), ptr %7
-  %766 = load i64, ptr %ds
-  %767 = load i64, ptr %alloc
-  %768 = call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %766, i64 %767, i64 %763, ptr addrspace(1) %764, ptr addrspace(1) %765) "statepoint-id"="0"
-  %769 = extractvalue { { i64, i64 }, { i64 } } %768, 0, 0
-  %770 = extractvalue { { i64, i64 }, { i64 } } %768, 0, 1
-  store i64 %769, ptr %ds
-  store i64 %770, ptr %alloc
-  %771 = extractvalue { { i64, i64 }, { i64 } } %768, 1, 0
-  store i64 %771, ptr %4
+  %772 = load i64, ptr %146
+  store i64 %772, ptr %4
+  %773 = load ptr addrspace(1), ptr %126
+  store ptr addrspace(1) %773, ptr %5
+  %774 = load ptr addrspace(1), ptr %145
+  store ptr addrspace(1) %774, ptr %7
+  %775 = load i64, ptr %4
+  %776 = load ptr addrspace(1), ptr %5
+  %777 = load ptr addrspace(1), ptr %7
+  %778 = load i64, ptr %ds
+  %779 = load i64, ptr %alloc
+  %780 = call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %778, i64 %779, i64 %775, ptr addrspace(1) %776, ptr addrspace(1) %777) "statepoint-id"="0"
+  %781 = extractvalue { { i64, i64 }, { i64 } } %780, 0, 0
+  %782 = extractvalue { { i64, i64 }, { i64 } } %780, 0, 1
+  store i64 %781, ptr %ds
+  store i64 %782, ptr %alloc
+  %783 = extractvalue { { i64, i64 }, { i64 } } %780, 1, 0
+  store i64 %783, ptr %4
   br label %L303
 L303:
-  %772 = load i64, ptr %4
-  store i64 %772, ptr %147
-  %773 = load i64, ptr %147
-  store i64 %773, ptr %148
-  %774 = load i64, ptr %ds
-  %775 = add i64 %774, 64
-  %776 = inttoptr i64 %775 to ptr
-  %777 = load i64, ptr %776
-  store i64 %777, ptr %150
-  %778 = load i64, ptr %150
-  store i64 %778, ptr %151
-  %779 = load i64, ptr %ds
-  %780 = load i64, ptr %alloc
-  %781 = call oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %779, i64 %780) returns_twice "gc-leaf-function"="true"
-  %782 = extractvalue { { i64, i64 }, { i64 } } %781, 0, 0
-  %783 = extractvalue { { i64, i64 }, { i64 } } %781, 0, 1
-  store i64 %782, ptr %ds
-  store i64 %783, ptr %alloc
-  %784 = extractvalue { { i64, i64 }, { i64 } } %781, 1, 0
-  call void asm sideeffect "movq $0, %rax", "r"(i64 %784) "gc-leaf-function"="true"
+  %784 = load i64, ptr %4
+  store i64 %784, ptr %147
+  %785 = load i64, ptr %147
+  store i64 %785, ptr %148
+  %786 = load i64, ptr %ds
+  %787 = add i64 %786, 64
+  %788 = inttoptr i64 %787 to ptr
+  %789 = load i64, ptr %788
+  store i64 %789, ptr %150
+  %790 = load i64, ptr %150
+  store i64 %790, ptr %151
+  %791 = load i64, ptr %ds
+  %792 = load i64, ptr %alloc
+  %793 = call oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %791, i64 %792) returns_twice "gc-leaf-function"="true"
+  %794 = extractvalue { { i64, i64 }, { i64 } } %793, 0, 0
+  %795 = extractvalue { { i64, i64 }, { i64 } } %793, 0, 1
+  store i64 %794, ptr %ds
+  store i64 %795, ptr %alloc
+  %796 = extractvalue { { i64, i64 }, { i64 } } %793, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %796) "gc-leaf-function"="true"
   br label %L373
 L373:
-  %785 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
-  %786 = icmp eq i64 %785, 0
-  br i1 %786, label %L374, label %L308
+  %797 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
+  %798 = icmp eq i64 %797, 0
+  br i1 %798, label %L374, label %L308
 L374:
   store ptr blockaddress(@camlSwitch__entry, %L373), ptr @camlSwitch__entry.recover_rbp_var.L373
-  %787 = call  ptr @llvm.stacksave()
-  %788 = alloca { i64, i64, i64, i64 }
-  %789 = ptrtoint ptr %788 to i64
-  %790 = add i64 %789, 16
-  %791 = inttoptr i64 %790 to ptr
-  %792 = ptrtoint ptr %788 to i64
-  %793 = add i64 %792, 8
-  %794 = inttoptr i64 %793 to ptr
-  %795 = load i64, ptr %ds
-  %796 = add i64 %795, 48
-  %797 = inttoptr i64 %796 to ptr
-  %798 = load i64, ptr %797
-  store ptr %788, ptr %797
-  store ptr @camlSwitch__entry.recover_rbp_asm.L373, ptr %794
-  call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %791) "gc-leaf-function"="true"
-  store i64 %798, ptr %788
+  %799 = call  ptr @llvm.stacksave()
+  %800 = alloca { i64, i64, i64, i64 }
+  %801 = ptrtoint ptr %800 to i64
+  %802 = add i64 %801, 16
+  %803 = inttoptr i64 %802 to ptr
+  %804 = ptrtoint ptr %800 to i64
+  %805 = add i64 %804, 8
+  %806 = inttoptr i64 %805 to ptr
+  %807 = load i64, ptr %ds
+  %808 = add i64 %807, 48
+  %809 = inttoptr i64 %808 to ptr
+  %810 = load i64, ptr %809
+  store ptr %800, ptr %809
+  store ptr @camlSwitch__entry.recover_rbp_asm.L373, ptr %806
+  call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %803) "gc-leaf-function"="true"
+  store i64 %810, ptr %800
   store i64 1, ptr %153
-  %799 = load i64, ptr %153
-  store i64 %799, ptr %4
-  %800 = load i64, ptr %4
-  %801 = load i64, ptr %ds
-  %802 = load i64, ptr %alloc
-  %803 = call oxcamlcc { { i64, i64 }, { i64 } } @camlSwitch__next_HIDE_STAMP(i64 %801, i64 %802, i64 %800) "statepoint-id"="32"
-  %804 = extractvalue { { i64, i64 }, { i64 } } %803, 0, 0
-  %805 = extractvalue { { i64, i64 }, { i64 } } %803, 0, 1
-  store i64 %804, ptr %ds
-  store i64 %805, ptr %alloc
-  %806 = extractvalue { { i64, i64 }, { i64 } } %803, 1, 0
-  store i64 %806, ptr %4
+  %811 = load i64, ptr %153
+  store i64 %811, ptr %4
+  %812 = load i64, ptr %4
+  %813 = load i64, ptr %ds
+  %814 = load i64, ptr %alloc
+  %815 = call oxcamlcc { { i64, i64 }, { i64 } } @camlSwitch__next_HIDE_STAMP(i64 %813, i64 %814, i64 %812) "statepoint-id"="32"
+  %816 = extractvalue { { i64, i64 }, { i64 } } %815, 0, 0
+  %817 = extractvalue { { i64, i64 }, { i64 } } %815, 0, 1
+  store i64 %816, ptr %ds
+  store i64 %817, ptr %alloc
+  %818 = extractvalue { { i64, i64 }, { i64 } } %815, 1, 0
+  store i64 %818, ptr %4
   br label %L316
 L316:
-  %807 = load i64, ptr %4
-  store i64 %807, ptr %154
-  %808 = load i64, ptr %154
-  store i64 %808, ptr %155
-  %809 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
-  store i64 %809, ptr %156
-  %810 = load i64, ptr %156
-  store i64 %810, ptr %8
-  %811 = load i64, ptr %155
-  store i64 %811, ptr %9
-  %812 = load i64, ptr %8
-  %813 = load i64, ptr %9
-  %814 = load i64, ptr %ds
-  %815 = load i64, ptr %alloc
-  %816 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %814, i64 %815, ptr @caml_format_int, i64 %812, i64 %813) "statepoint-id"="32"
-  %817 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %816, 0, 0
-  %818 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %816, 0, 1
-  store i64 %817, ptr %ds
-  store i64 %818, ptr %alloc
-  %819 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %816, 1, 0
-  store ptr addrspace(1) %819, ptr %3
+  %819 = load i64, ptr %4
+  store i64 %819, ptr %154
+  %820 = load i64, ptr %154
+  store i64 %820, ptr %155
+  %821 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
+  store i64 %821, ptr %156
+  %822 = load i64, ptr %156
+  %823 = inttoptr i64 %822 to ptr addrspace(1)
+  store ptr addrspace(1) %823, ptr %7
+  %824 = load i64, ptr %155
+  %825 = inttoptr i64 %824 to ptr addrspace(1)
+  store ptr addrspace(1) %825, ptr %9
+  %826 = load ptr addrspace(1), ptr %7
+  %827 = load ptr addrspace(1), ptr %9
+  %828 = load i64, ptr %ds
+  %829 = load i64, ptr %alloc
+  %830 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %828, i64 %829, ptr @caml_format_int, ptr addrspace(1) %826, ptr addrspace(1) %827) "statepoint-id"="32"
+  %831 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %830, 0, 0
+  %832 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %830, 0, 1
+  store i64 %831, ptr %ds
+  store i64 %832, ptr %alloc
+  %833 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %830, 1, 0
+  store ptr addrspace(1) %833, ptr %3
   br label %L317
 L317:
-  %820 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %820, ptr %157
-  %821 = load ptr addrspace(1), ptr %157
-  store ptr addrspace(1) %821, ptr %158
-  %822 = load ptr addrspace(1), ptr %158
-  store ptr addrspace(1) %822, ptr %159
-  %823 = load ptr addrspace(1), ptr %159
-  store ptr addrspace(1) %823, ptr %149
-  %824 = load i64, ptr %ds
-  %825 = add i64 %824, 48
-  %826 = inttoptr i64 %825 to ptr
-  %827 = load i64, ptr %788
-  store i64 %827, ptr %826
-  call  void @llvm.stackrestore(ptr %787)
+  %834 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %834, ptr %157
+  %835 = load ptr addrspace(1), ptr %157
+  store ptr addrspace(1) %835, ptr %158
+  %836 = load ptr addrspace(1), ptr %158
+  store ptr addrspace(1) %836, ptr %159
+  %837 = load ptr addrspace(1), ptr %159
+  store ptr addrspace(1) %837, ptr %149
+  %838 = load i64, ptr %ds
+  %839 = add i64 %838, 48
+  %840 = inttoptr i64 %839 to ptr
+  %841 = load i64, ptr %800
+  store i64 %841, ptr %840
+  call  void @llvm.stackrestore(ptr %799)
   br label %L323
 L308:
-  %828 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
-  store i64 %828, ptr %alloc
-  store i64 %785, ptr %4
-  %829 = load i64, ptr %4
-  %830 = inttoptr i64 %829 to ptr addrspace(1)
-  store ptr addrspace(1) %830, ptr %152
-  %831 = load i64, ptr %ds
-  %832 = add i64 %831, 64
-  %833 = inttoptr i64 %832 to ptr
-  %834 = load i64, ptr %151
-  store i64 %834, ptr %833
+  %842 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
+  store i64 %842, ptr %alloc
+  store i64 %797, ptr %4
+  %843 = load i64, ptr %4
+  %844 = inttoptr i64 %843 to ptr addrspace(1)
+  store ptr addrspace(1) %844, ptr %152
+  %845 = load i64, ptr %ds
+  %846 = add i64 %845, 64
+  %847 = inttoptr i64 %846 to ptr
+  %848 = load i64, ptr %151
+  store i64 %848, ptr %847
   store i64 1, ptr %160
-  %835 = load i64, ptr %160
-  store i64 %835, ptr %161
-  %836 = ptrtoint ptr @camlSwitch__immstring38 to i64
-  store i64 %836, ptr %162
-  %837 = load i64, ptr %162
-  store i64 %837, ptr %163
-  %838 = load i64, ptr %163
-  %839 = inttoptr i64 %838 to ptr addrspace(1)
-  store ptr addrspace(1) %839, ptr %149
+  %849 = load i64, ptr %160
+  store i64 %849, ptr %161
+  %850 = ptrtoint ptr @camlSwitch__immstring38 to i64
+  store i64 %850, ptr %162
+  %851 = load i64, ptr %162
+  store i64 %851, ptr %163
+  %852 = load i64, ptr %163
+  %853 = inttoptr i64 %852 to ptr addrspace(1)
+  store ptr addrspace(1) %853, ptr %149
   br label %L323
 L323:
-  %840 = ptrtoint ptr @camlSwitch__const_block54 to i64
-  store i64 %840, ptr %164
+  %854 = ptrtoint ptr @camlSwitch__const_block54 to i64
+  store i64 %854, ptr %164
   store i64 1, ptr %165
-  %841 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
-  store i64 %841, ptr %166
-  %842 = load i64, ptr %166
-  store i64 %842, ptr %4
-  %843 = load i64, ptr %165
-  store i64 %843, ptr %6
-  %844 = load i64, ptr %164
-  store i64 %844, ptr %8
-  %845 = load i64, ptr %4
-  %846 = load i64, ptr %6
-  %847 = load i64, ptr %8
-  %848 = load i64, ptr %ds
-  %849 = load i64, ptr %alloc
-  %850 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %848, i64 %849, i64 %845, i64 %846, i64 %847) "statepoint-id"="0"
-  %851 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %850, 0, 0
-  %852 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %850, 0, 1
-  store i64 %851, ptr %ds
-  store i64 %852, ptr %alloc
-  %853 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %850, 1, 0
-  store ptr addrspace(1) %853, ptr %3
-  br label %L325
-L325:
-  %854 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %854, ptr %167
-  %855 = load ptr addrspace(1), ptr %167
-  store ptr addrspace(1) %855, ptr %168
-  store i64 1, ptr %169
-  %856 = load i64, ptr %169
+  %855 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
+  store i64 %855, ptr %166
+  %856 = load i64, ptr %166
   store i64 %856, ptr %4
-  %857 = load ptr addrspace(1), ptr %149
-  store ptr addrspace(1) %857, ptr %5
-  %858 = load ptr addrspace(1), ptr %168
-  store ptr addrspace(1) %858, ptr %7
+  %857 = load i64, ptr %165
+  store i64 %857, ptr %6
+  %858 = load i64, ptr %164
+  store i64 %858, ptr %8
   %859 = load i64, ptr %4
-  %860 = load ptr addrspace(1), ptr %5
-  %861 = load ptr addrspace(1), ptr %7
+  %860 = load i64, ptr %6
+  %861 = load i64, ptr %8
   %862 = load i64, ptr %ds
   %863 = load i64, ptr %alloc
-  %864 = call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %862, i64 %863, i64 %859, ptr addrspace(1) %860, ptr addrspace(1) %861) "statepoint-id"="0"
-  %865 = extractvalue { { i64, i64 }, { i64 } } %864, 0, 0
-  %866 = extractvalue { { i64, i64 }, { i64 } } %864, 0, 1
+  %864 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %862, i64 %863, i64 %859, i64 %860, i64 %861) "statepoint-id"="0"
+  %865 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %864, 0, 0
+  %866 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %864, 0, 1
   store i64 %865, ptr %ds
   store i64 %866, ptr %alloc
-  %867 = extractvalue { { i64, i64 }, { i64 } } %864, 1, 0
-  store i64 %867, ptr %4
+  %867 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %864, 1, 0
+  store ptr addrspace(1) %867, ptr %3
+  br label %L325
+L325:
+  %868 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %868, ptr %167
+  %869 = load ptr addrspace(1), ptr %167
+  store ptr addrspace(1) %869, ptr %168
+  store i64 1, ptr %169
+  %870 = load i64, ptr %169
+  store i64 %870, ptr %4
+  %871 = load ptr addrspace(1), ptr %149
+  store ptr addrspace(1) %871, ptr %5
+  %872 = load ptr addrspace(1), ptr %168
+  store ptr addrspace(1) %872, ptr %7
+  %873 = load i64, ptr %4
+  %874 = load ptr addrspace(1), ptr %5
+  %875 = load ptr addrspace(1), ptr %7
+  %876 = load i64, ptr %ds
+  %877 = load i64, ptr %alloc
+  %878 = call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %876, i64 %877, i64 %873, ptr addrspace(1) %874, ptr addrspace(1) %875) "statepoint-id"="0"
+  %879 = extractvalue { { i64, i64 }, { i64 } } %878, 0, 0
+  %880 = extractvalue { { i64, i64 }, { i64 } } %878, 0, 1
+  store i64 %879, ptr %ds
+  store i64 %880, ptr %alloc
+  %881 = extractvalue { { i64, i64 }, { i64 } } %878, 1, 0
+  store i64 %881, ptr %4
   br label %L326
 L326:
-  %868 = load i64, ptr %4
-  store i64 %868, ptr %170
-  %869 = load i64, ptr %170
-  store i64 %869, ptr %171
-  %870 = load i64, ptr %ds
-  %871 = add i64 %870, 64
-  %872 = inttoptr i64 %871 to ptr
-  %873 = load i64, ptr %872
-  store i64 %873, ptr %173
-  %874 = load i64, ptr %173
-  store i64 %874, ptr %174
-  %875 = load i64, ptr %ds
-  %876 = load i64, ptr %alloc
-  %877 = call oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %875, i64 %876) returns_twice "gc-leaf-function"="true"
-  %878 = extractvalue { { i64, i64 }, { i64 } } %877, 0, 0
-  %879 = extractvalue { { i64, i64 }, { i64 } } %877, 0, 1
-  store i64 %878, ptr %ds
-  store i64 %879, ptr %alloc
-  %880 = extractvalue { { i64, i64 }, { i64 } } %877, 1, 0
-  call void asm sideeffect "movq $0, %rax", "r"(i64 %880) "gc-leaf-function"="true"
+  %882 = load i64, ptr %4
+  store i64 %882, ptr %170
+  %883 = load i64, ptr %170
+  store i64 %883, ptr %171
+  %884 = load i64, ptr %ds
+  %885 = add i64 %884, 64
+  %886 = inttoptr i64 %885 to ptr
+  %887 = load i64, ptr %886
+  store i64 %887, ptr %173
+  %888 = load i64, ptr %173
+  store i64 %888, ptr %174
+  %889 = load i64, ptr %ds
+  %890 = load i64, ptr %alloc
+  %891 = call oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %889, i64 %890) returns_twice "gc-leaf-function"="true"
+  %892 = extractvalue { { i64, i64 }, { i64 } } %891, 0, 0
+  %893 = extractvalue { { i64, i64 }, { i64 } } %891, 0, 1
+  store i64 %892, ptr %ds
+  store i64 %893, ptr %alloc
+  %894 = extractvalue { { i64, i64 }, { i64 } } %891, 1, 0
+  call void asm sideeffect "movq $0, %rax", "r"(i64 %894) "gc-leaf-function"="true"
   br label %L375
 L375:
-  %881 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
-  %882 = icmp eq i64 %881, 0
-  br i1 %882, label %L376, label %L331
+  %895 = call i64 asm sideeffect "mov %rax, $0", "=r"() "gc-leaf-function"="true"
+  %896 = icmp eq i64 %895, 0
+  br i1 %896, label %L376, label %L331
 L376:
   store ptr blockaddress(@camlSwitch__entry, %L375), ptr @camlSwitch__entry.recover_rbp_var.L375
-  %883 = call  ptr @llvm.stacksave()
-  %884 = alloca { i64, i64, i64, i64 }
-  %885 = ptrtoint ptr %884 to i64
-  %886 = add i64 %885, 16
-  %887 = inttoptr i64 %886 to ptr
-  %888 = ptrtoint ptr %884 to i64
-  %889 = add i64 %888, 8
-  %890 = inttoptr i64 %889 to ptr
-  %891 = load i64, ptr %ds
-  %892 = add i64 %891, 48
-  %893 = inttoptr i64 %892 to ptr
-  %894 = load i64, ptr %893
-  store ptr %884, ptr %893
-  store ptr @camlSwitch__entry.recover_rbp_asm.L375, ptr %890
-  call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %887) "gc-leaf-function"="true"
-  store i64 %894, ptr %884
+  %897 = call  ptr @llvm.stacksave()
+  %898 = alloca { i64, i64, i64, i64 }
+  %899 = ptrtoint ptr %898 to i64
+  %900 = add i64 %899, 16
+  %901 = inttoptr i64 %900 to ptr
+  %902 = ptrtoint ptr %898 to i64
+  %903 = add i64 %902, 8
+  %904 = inttoptr i64 %903 to ptr
+  %905 = load i64, ptr %ds
+  %906 = add i64 %905, 48
+  %907 = inttoptr i64 %906 to ptr
+  %908 = load i64, ptr %907
+  store ptr %898, ptr %907
+  store ptr @camlSwitch__entry.recover_rbp_asm.L375, ptr %904
+  call void asm sideeffect "mov %rbp, ($0)", "r"(ptr %901) "gc-leaf-function"="true"
+  store i64 %908, ptr %898
   store i64 201, ptr %176
-  %895 = load i64, ptr %176
-  store i64 %895, ptr %4
-  %896 = load i64, ptr %4
-  %897 = load i64, ptr %ds
-  %898 = load i64, ptr %alloc
-  %899 = call oxcamlcc { { i64, i64 }, { i64 } } @camlSwitch__next_HIDE_STAMP(i64 %897, i64 %898, i64 %896) "statepoint-id"="32"
-  %900 = extractvalue { { i64, i64 }, { i64 } } %899, 0, 0
-  %901 = extractvalue { { i64, i64 }, { i64 } } %899, 0, 1
-  store i64 %900, ptr %ds
-  store i64 %901, ptr %alloc
-  %902 = extractvalue { { i64, i64 }, { i64 } } %899, 1, 0
-  store i64 %902, ptr %4
+  %909 = load i64, ptr %176
+  store i64 %909, ptr %4
+  %910 = load i64, ptr %4
+  %911 = load i64, ptr %ds
+  %912 = load i64, ptr %alloc
+  %913 = call oxcamlcc { { i64, i64 }, { i64 } } @camlSwitch__next_HIDE_STAMP(i64 %911, i64 %912, i64 %910) "statepoint-id"="32"
+  %914 = extractvalue { { i64, i64 }, { i64 } } %913, 0, 0
+  %915 = extractvalue { { i64, i64 }, { i64 } } %913, 0, 1
+  store i64 %914, ptr %ds
+  store i64 %915, ptr %alloc
+  %916 = extractvalue { { i64, i64 }, { i64 } } %913, 1, 0
+  store i64 %916, ptr %4
   br label %L339
 L339:
-  %903 = load i64, ptr %4
-  store i64 %903, ptr %177
-  %904 = load i64, ptr %177
-  store i64 %904, ptr %178
-  %905 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
-  store i64 %905, ptr %179
-  %906 = load i64, ptr %179
-  store i64 %906, ptr %8
-  %907 = load i64, ptr %178
-  store i64 %907, ptr %9
-  %908 = load i64, ptr %8
-  %909 = load i64, ptr %9
-  %910 = load i64, ptr %ds
-  %911 = load i64, ptr %alloc
-  %912 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %910, i64 %911, ptr @caml_format_int, i64 %908, i64 %909) "statepoint-id"="32"
-  %913 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %912, 0, 0
-  %914 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %912, 0, 1
-  store i64 %913, ptr %ds
-  store i64 %914, ptr %alloc
-  %915 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %912, 1, 0
-  store ptr addrspace(1) %915, ptr %3
+  %917 = load i64, ptr %4
+  store i64 %917, ptr %177
+  %918 = load i64, ptr %177
+  store i64 %918, ptr %178
+  %919 = ptrtoint ptr @camlStdlib__Int__immstring64 to i64
+  store i64 %919, ptr %179
+  %920 = load i64, ptr %179
+  %921 = inttoptr i64 %920 to ptr addrspace(1)
+  store ptr addrspace(1) %921, ptr %7
+  %922 = load i64, ptr %178
+  %923 = inttoptr i64 %922 to ptr addrspace(1)
+  store ptr addrspace(1) %923, ptr %9
+  %924 = load ptr addrspace(1), ptr %7
+  %925 = load ptr addrspace(1), ptr %9
+  %926 = load i64, ptr %ds
+  %927 = load i64, ptr %alloc
+  %928 = call oxcaml_ccc { { i64, i64 }, { ptr addrspace(1) } } @caml_c_call(i64 %926, i64 %927, ptr @caml_format_int, ptr addrspace(1) %924, ptr addrspace(1) %925) "statepoint-id"="32"
+  %929 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %928, 0, 0
+  %930 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %928, 0, 1
+  store i64 %929, ptr %ds
+  store i64 %930, ptr %alloc
+  %931 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %928, 1, 0
+  store ptr addrspace(1) %931, ptr %3
   br label %L340
 L340:
-  %916 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %916, ptr %180
-  %917 = load ptr addrspace(1), ptr %180
-  store ptr addrspace(1) %917, ptr %181
-  %918 = load ptr addrspace(1), ptr %181
-  store ptr addrspace(1) %918, ptr %182
-  %919 = load ptr addrspace(1), ptr %182
-  store ptr addrspace(1) %919, ptr %172
-  %920 = load i64, ptr %ds
-  %921 = add i64 %920, 48
-  %922 = inttoptr i64 %921 to ptr
-  %923 = load i64, ptr %884
-  store i64 %923, ptr %922
-  call  void @llvm.stackrestore(ptr %883)
+  %932 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %932, ptr %180
+  %933 = load ptr addrspace(1), ptr %180
+  store ptr addrspace(1) %933, ptr %181
+  %934 = load ptr addrspace(1), ptr %181
+  store ptr addrspace(1) %934, ptr %182
+  %935 = load ptr addrspace(1), ptr %182
+  store ptr addrspace(1) %935, ptr %172
+  %936 = load i64, ptr %ds
+  %937 = add i64 %936, 48
+  %938 = inttoptr i64 %937 to ptr
+  %939 = load i64, ptr %898
+  store i64 %939, ptr %938
+  call  void @llvm.stackrestore(ptr %897)
   br label %L346
 L331:
-  %924 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
-  store i64 %924, ptr %alloc
-  store i64 %881, ptr %4
-  %925 = load i64, ptr %4
-  %926 = inttoptr i64 %925 to ptr addrspace(1)
-  store ptr addrspace(1) %926, ptr %175
-  %927 = load i64, ptr %ds
-  %928 = add i64 %927, 64
-  %929 = inttoptr i64 %928 to ptr
-  %930 = load i64, ptr %174
-  store i64 %930, ptr %929
+  %940 = call i64 asm sideeffect "movq %r15, $0", "=r"() "gc-leaf-function"="true"
+  store i64 %940, ptr %alloc
+  store i64 %895, ptr %4
+  %941 = load i64, ptr %4
+  %942 = inttoptr i64 %941 to ptr addrspace(1)
+  store ptr addrspace(1) %942, ptr %175
+  %943 = load i64, ptr %ds
+  %944 = add i64 %943, 64
+  %945 = inttoptr i64 %944 to ptr
+  %946 = load i64, ptr %174
+  store i64 %946, ptr %945
   store i64 1, ptr %183
-  %931 = load i64, ptr %183
-  store i64 %931, ptr %184
-  %932 = ptrtoint ptr @camlSwitch__immstring38 to i64
-  store i64 %932, ptr %185
-  %933 = load i64, ptr %185
-  store i64 %933, ptr %186
-  %934 = load i64, ptr %186
-  %935 = inttoptr i64 %934 to ptr addrspace(1)
-  store ptr addrspace(1) %935, ptr %172
+  %947 = load i64, ptr %183
+  store i64 %947, ptr %184
+  %948 = ptrtoint ptr @camlSwitch__immstring38 to i64
+  store i64 %948, ptr %185
+  %949 = load i64, ptr %185
+  store i64 %949, ptr %186
+  %950 = load i64, ptr %186
+  %951 = inttoptr i64 %950 to ptr addrspace(1)
+  store ptr addrspace(1) %951, ptr %172
   br label %L346
 L346:
-  %936 = ptrtoint ptr @camlSwitch__const_block54 to i64
-  store i64 %936, ptr %187
+  %952 = ptrtoint ptr @camlSwitch__const_block54 to i64
+  store i64 %952, ptr %187
   store i64 1, ptr %188
-  %937 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
-  store i64 %937, ptr %189
-  %938 = load i64, ptr %189
-  store i64 %938, ptr %4
-  %939 = load i64, ptr %188
-  store i64 %939, ptr %6
-  %940 = load i64, ptr %187
-  store i64 %940, ptr %8
-  %941 = load i64, ptr %4
-  %942 = load i64, ptr %6
-  %943 = load i64, ptr %8
-  %944 = load i64, ptr %ds
-  %945 = load i64, ptr %alloc
-  %946 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %944, i64 %945, i64 %941, i64 %942, i64 %943) "statepoint-id"="0"
-  %947 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %946, 0, 0
-  %948 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %946, 0, 1
-  store i64 %947, ptr %ds
-  store i64 %948, ptr %alloc
-  %949 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %946, 1, 0
-  store ptr addrspace(1) %949, ptr %3
+  %953 = ptrtoint ptr @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 to i64
+  store i64 %953, ptr %189
+  %954 = load i64, ptr %189
+  store i64 %954, ptr %4
+  %955 = load i64, ptr %188
+  store i64 %955, ptr %6
+  %956 = load i64, ptr %187
+  store i64 %956, ptr %8
+  %957 = load i64, ptr %4
+  %958 = load i64, ptr %6
+  %959 = load i64, ptr %8
+  %960 = load i64, ptr %ds
+  %961 = load i64, ptr %alloc
+  %962 = call oxcamlcc { { i64, i64 }, { ptr addrspace(1) } } @camlCamlinternalFormat__make_printf_HIDE_STAMP(i64 %960, i64 %961, i64 %957, i64 %958, i64 %959) "statepoint-id"="0"
+  %963 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %962, 0, 0
+  %964 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %962, 0, 1
+  store i64 %963, ptr %ds
+  store i64 %964, ptr %alloc
+  %965 = extractvalue { { i64, i64 }, { ptr addrspace(1) } } %962, 1, 0
+  store ptr addrspace(1) %965, ptr %3
   br label %L348
 L348:
-  %950 = load ptr addrspace(1), ptr %3
-  store ptr addrspace(1) %950, ptr %190
-  %951 = load ptr addrspace(1), ptr %190
-  store ptr addrspace(1) %951, ptr %191
+  %966 = load ptr addrspace(1), ptr %3
+  store ptr addrspace(1) %966, ptr %190
+  %967 = load ptr addrspace(1), ptr %190
+  store ptr addrspace(1) %967, ptr %191
   store i64 201, ptr %192
-  %952 = load i64, ptr %192
-  store i64 %952, ptr %4
-  %953 = load ptr addrspace(1), ptr %172
-  store ptr addrspace(1) %953, ptr %5
-  %954 = load ptr addrspace(1), ptr %191
-  store ptr addrspace(1) %954, ptr %7
-  %955 = load i64, ptr %4
-  %956 = load ptr addrspace(1), ptr %5
-  %957 = load ptr addrspace(1), ptr %7
-  %958 = load i64, ptr %ds
-  %959 = load i64, ptr %alloc
-  %960 = call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %958, i64 %959, i64 %955, ptr addrspace(1) %956, ptr addrspace(1) %957) "statepoint-id"="0"
-  %961 = extractvalue { { i64, i64 }, { i64 } } %960, 0, 0
-  %962 = extractvalue { { i64, i64 }, { i64 } } %960, 0, 1
-  store i64 %961, ptr %ds
-  store i64 %962, ptr %alloc
-  %963 = extractvalue { { i64, i64 }, { i64 } } %960, 1, 0
-  store i64 %963, ptr %4
+  %968 = load i64, ptr %192
+  store i64 %968, ptr %4
+  %969 = load ptr addrspace(1), ptr %172
+  store ptr addrspace(1) %969, ptr %5
+  %970 = load ptr addrspace(1), ptr %191
+  store ptr addrspace(1) %970, ptr %7
+  %971 = load i64, ptr %4
+  %972 = load ptr addrspace(1), ptr %5
+  %973 = load ptr addrspace(1), ptr %7
+  %974 = load i64, ptr %ds
+  %975 = load i64, ptr %alloc
+  %976 = call oxcamlcc { { i64, i64 }, { i64 } } @caml_apply2(i64 %974, i64 %975, i64 %971, ptr addrspace(1) %972, ptr addrspace(1) %973) "statepoint-id"="0"
+  %977 = extractvalue { { i64, i64 }, { i64 } } %976, 0, 0
+  %978 = extractvalue { { i64, i64 }, { i64 } } %976, 0, 1
+  store i64 %977, ptr %ds
+  store i64 %978, ptr %alloc
+  %979 = extractvalue { { i64, i64 }, { i64 } } %976, 1, 0
+  store i64 %979, ptr %4
   br label %L349
 L349:
-  %964 = load i64, ptr %4
-  store i64 %964, ptr %193
-  %965 = load i64, ptr %193
-  store i64 %965, ptr %194
-  %966 = ptrtoint ptr @camlSwitch to i64
-  store i64 %966, ptr %195
-  %967 = load i64, ptr %195
-  store i64 %967, ptr %196
-  %968 = load i64, ptr %196
-  %969 = inttoptr i64 %968 to ptr addrspace(1)
-  store ptr addrspace(1) %969, ptr %10
+  %980 = load i64, ptr %4
+  store i64 %980, ptr %193
+  %981 = load i64, ptr %193
+  store i64 %981, ptr %194
+  %982 = ptrtoint ptr @camlSwitch to i64
+  store i64 %982, ptr %195
+  %983 = load i64, ptr %195
+  store i64 %983, ptr %196
+  %984 = load i64, ptr %196
+  %985 = inttoptr i64 %984 to ptr addrspace(1)
+  store ptr addrspace(1) %985, ptr %10
   store i64 1, ptr %197
-  %970 = load i64, ptr %197
-  store i64 %970, ptr %4
-  %971 = load ptr addrspace(1), ptr %4
-  %972 = load i64, ptr %ds
-  %973 = load i64, ptr %alloc
-  %974 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } poison, i64 %972, 0, 0
-  %975 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } %974, i64 %973, 0, 1
-  %976 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } %975, ptr addrspace(1) %971, 1, 0
-  ret { { i64, i64 }, { ptr addrspace(1) } } %976
+  %986 = load i64, ptr %197
+  store i64 %986, ptr %4
+  %987 = load ptr addrspace(1), ptr %4
+  %988 = load i64, ptr %ds
+  %989 = load i64, ptr %alloc
+  %990 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } poison, i64 %988, 0, 0
+  %991 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } %990, i64 %989, 0, 1
+  %992 = insertvalue { { i64, i64 }, { ptr addrspace(1) } } %991, ptr addrspace(1) %987, 1, 0
+  ret { { i64, i64 }, { ptr addrspace(1) } } %992
 }
 
 define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) returns_twice noinline {


### PR DESCRIPTION
LLVM needs to keep track of what is a value living on the OCaml heap and what is not. External C calls previously pretended everything was an integer, which caused problem. This fixes that if the LLVM backend is enabled.