### PR TITLE
Make SIMD constants/casts use int8#/int16#

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -1600,25 +1600,24 @@ let emit_static_cast (cast : Cmm.static_cast) i =
   | V128_of_scalar Float32x4 | V256_of_scalar Float32x8 ->
     if distinct then movss (arg i 0) (resX i 0)
   | Scalar_of_v128 Int16x8 | Scalar_of_v256 Int16x16 ->
-    (* [movw] and [movzx] cannot operate on vector registers. We must zero
-       extend as the result is an untagged positive int. CR mslater: (SIMD)
-       remove zx once we have unboxed int16 *)
+    (* CR-someday mslater: int16# shouldn't require sign extension *)
+    (* [movw] and [movzx] cannot operate on vector registers. We must sign
+       extend as the result is an untagged int8. *)
     movd (argX i 0) (res32 i 0);
-    I.movzx (res16 i 0) (res i 0)
+    I.movsx (res16 i 0) (res i 0)
   | Scalar_of_v128 Int8x16 | Scalar_of_v256 Int8x32 ->
-    (* [movb] and [movzx] cannot operate on vector registers. We must zero
-       extend as the result is an untagged positive int. CR mslater: (SIMD)
-       remove zx once we have unboxed int8 *)
+    (* CR-someday mslater: int8# shouldn't require sign extension *)
+    (* [movb] and [movzx] cannot operate on vector registers. We must sign
+       extend as the result is an untagged int16. *)
     movd (argX i 0) (res32 i 0);
-    I.movzx (res8 i 0) (res i 0)
+    I.movsx (res8 i 0) (res i 0)
   | V128_of_scalar Int16x8
   | V128_of_scalar Int8x16
   | V256_of_scalar Int16x16
   | V256_of_scalar Int8x32 ->
     (* [movw] and [movb] cannot operate on vector registers. Moving 32 bits is
-       OK because the argument is an untagged positive int and these operations
-       leave the top bits of the vector unspecified. CR mslater: (SIMD) don't
-       load 32 bits once we have unboxed int16/int8 *)
+       OK because the argument is an untagged int and these operations leave the
+       top bits of the vector unspecified. *)
     movd (arg32 i 0) (resX i 0)
   | V512_of_scalar _ | Scalar_of_v512 _ ->
     (* CR-soon mslater: avx512 *)

--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -276,20 +276,18 @@ let const_int64_args =
     ~type_name:"int64"
 
 let int64_of_int8 i =
-  (* CR mslater: (SIMD) replace once we have unboxed int8 *)
-  if i < 0 || i > 0xff
-  then bad_immediate "Int8 constant not in range [0x0,0xff]: 0x%016x" i;
-  Int64.of_int i
+  if i < -0x80 || i > 0x7f
+  then bad_immediate "Int8 constant not in range [0x0,0xff]: 0x%x" i;
+  Int64.of_int i |> Int64.logand 0xffL
 
 let int64_of_int16 i =
-  (* CR mslater: (SIMD) replace once we have unboxed int16 *)
-  if i < 0 || i > 0xffff
-  then bad_immediate "Int16 constant not in range [0x0,0xffff]: 0x%016x" i;
-  Int64.of_int i
+  if i < -0x8000 || i > 0x7fff
+  then bad_immediate "Int16 constant not in range [0x0,0xffff]: 0x%x" i;
+  Int64.of_int i |> Int64.logand 0xffffL
 
 let int64_of_int32 i =
   if i < Int32.to_int Int32.min_int || i > Int32.to_int Int32.max_int
-  then bad_immediate "Int32 constant not in range [0x0,0xffffffff]: 0x%016x" i;
+  then bad_immediate "Int32 constant not in range [0x0,0xffffffff]: 0x%x" i;
   Int64.of_int i |> Int64.logand 0xffffffffL
 
 let int64_of_float32 f =

--- a/oxcaml/tests/.ocamlformat-ignore
+++ b/oxcaml/tests/.ocamlformat-ignore
@@ -6,6 +6,10 @@ backend/vectorizer/test_float32_unboxed.ml
 simd/*_u.ml
 simd/let_mutable.ml
 simd/unbox_types.ml
+simd/consts.ml
+simd/consts256.ml
+simd/consts_u.ml
+simd/consts256_u.ml
 simd/arrays.ml
 simd/arrays256.ml
 simd/amd64/load_store.ml

--- a/oxcaml/tests/simd/consts.ml
+++ b/oxcaml/tests/simd/consts.ml
@@ -1,4 +1,5 @@
 open Stdlib
+open Stdlib_stable
 open Utils
 
 [@@@ocaml.warning "-unused-module"]
@@ -181,22 +182,22 @@ end
 module Int16x8 = struct
   type t = int16x8
 
-  external low_to : (t[@unboxed]) -> (int[@untagged])
+  external low_to : (t[@unboxed]) -> int16#
     = "" "caml_int16x8_low_to_int"
     [@@noalloc] [@@builtin]
 
-  external const1 : (int[@untagged]) -> (t[@unboxed]) = "" "caml_int16x8_const1"
+  external const1 : int16# -> (t[@unboxed]) = "" "caml_int16x8_const1"
     [@@noalloc] [@@builtin]
 
   external const8 :
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
     (t[@unboxed]) = "" "caml_int16x8_const8"
     [@@noalloc] [@@builtin]
 
@@ -206,11 +207,11 @@ module Int16x8 = struct
     let i64 = i16 i in
     let i64 = Int64.(logor (shift_left i64 16) i64) in
     let i64 = Int64.(logor (shift_left i64 32) i64) in
-    let v = const1 i in
+    let v = const1 (Int16_u.of_int i) in
     let l = int16x8_low_int64 v in
     let h = int16x8_high_int64 v in
     eq l h i64 i64;
-    let _i = low_to v in
+    let _i = low_to v |> Int16_u.to_int |> (land) 0xffff in
     eqi _i 0 i 0
 
   let () =
@@ -232,11 +233,12 @@ module Int16x8 = struct
           (logor (shift_left (i16 h) 48) (shift_left (i16 g) 32))
           (logor (shift_left (i16 f) 16) (i16 e)))
     in
-    let v = const8 a b c d e f g h in
+    let v = const8 (Int16_u.of_int a) (Int16_u.of_int b) (Int16_u.of_int c) (Int16_u.of_int d)
+                   (Int16_u.of_int e) (Int16_u.of_int f) (Int16_u.of_int g) (Int16_u.of_int h) in
     let l = int16x8_low_int64 v in
     let h = int16x8_high_int64 v in
     eq l h l64 h64;
-    let _a = low_to v in
+    let _a = low_to v |> Int16_u.to_int |> (land) 0xffff in
     eqi _a 0 a 0
 
   let () =
@@ -250,30 +252,30 @@ end
 module Int8x16 = struct
   type t = int8x16
 
-  external low_to : (t[@unboxed]) -> (int[@untagged])
+  external low_to : (t[@unboxed]) -> int8#
     = "" "caml_int8x16_low_to_int"
     [@@noalloc] [@@builtin]
 
-  external const1 : (int[@untagged]) -> (t[@unboxed]) = "" "caml_int8x16_const1"
+  external const1 : int8# -> (t[@unboxed]) = "" "caml_int8x16_const1"
     [@@noalloc] [@@builtin]
 
   external const16 :
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
     (t[@unboxed]) = "" "caml_int8x16_const16"
     [@@noalloc] [@@builtin]
 
@@ -284,11 +286,11 @@ module Int8x16 = struct
     let i64 = Int64.(logor (shift_left i64 8) i64) in
     let i64 = Int64.(logor (shift_left i64 16) i64) in
     let i64 = Int64.(logor (shift_left i64 32) i64) in
-    let v = const1 i in
+    let v = const1 (Int8_u.of_int i) in
     let l = int8x16_low_int64 v in
     let h = int8x16_high_int64 v in
     eq l h i64 i64;
-    let _i = low_to v in
+    let _i = low_to v |> Int8_u.to_int |> (land) 0xff in
     eqi _i 0 i 0
 
   let () =
@@ -324,11 +326,14 @@ module Int8x16 = struct
           (logor (shift_left (i8 n) 8) (i8 m)))
     in
     let h64 = Int64.(logor (shift_left h32 32) l32) in
-    let v = const16 a b c d e f g h i j k l m n o p in
+    let v = const16 (Int8_u.of_int a) (Int8_u.of_int b) (Int8_u.of_int c) (Int8_u.of_int d)
+                    (Int8_u.of_int e) (Int8_u.of_int f) (Int8_u.of_int g) (Int8_u.of_int h)
+                    (Int8_u.of_int i) (Int8_u.of_int j) (Int8_u.of_int k) (Int8_u.of_int l)
+                    (Int8_u.of_int m) (Int8_u.of_int n) (Int8_u.of_int o) (Int8_u.of_int p) in
     let l = int8x16_low_int64 v in
     let h = int8x16_high_int64 v in
     eq l h l64 h64;
-    let _a = low_to v in
+    let _a = low_to v |> Int8_u.to_int |> (land) 0xff in
     eqi _a 0 a 0
 
   let () =

--- a/oxcaml/tests/simd/consts256.ml
+++ b/oxcaml/tests/simd/consts256.ml
@@ -1,4 +1,5 @@
 open Stdlib
+open Stdlib_stable
 open Utils256
 
 [@@@ocaml.warning "-unused-module"]
@@ -228,31 +229,31 @@ end
 module Int16x16 = struct
   type t = int16x16
 
-  external low_to : (t[@unboxed]) -> (int[@untagged])
+  external low_to : (t[@unboxed]) -> int16#
     = "" "caml_int16x16_low_to_int"
     [@@noalloc] [@@builtin]
 
-  external const1 : (int[@untagged]) -> (t[@unboxed])
+  external const1 : int16# -> (t[@unboxed])
     = "" "caml_int16x16_const1"
     [@@noalloc] [@@builtin]
 
   external const16 :
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
     (t[@unboxed]) = "" "caml_int16x16_const16"
     [@@noalloc] [@@builtin]
 
@@ -262,13 +263,13 @@ module Int16x16 = struct
     let i64 = i16 i in
     let i64 = Int64.(logor (shift_left i64 16) i64) in
     let i64 = Int64.(logor (shift_left i64 32) i64) in
-    let v = const1 i in
+    let v = const1 (Int16_u.of_int i) in
     let w0 = int16x16_first_int64 v in
     let w1 = int16x16_second_int64 v in
     let w2 = int16x16_third_int64 v in
     let w3 = int16x16_fourth_int64 v in
     eq4 w0 w1 w2 w3 i64 i64 i64 i64;
-    let _i = low_to v in
+    let _i = low_to v |> Int16_u.to_int |> (land) 0xffff in
     eqi _i 0 i 0
 
   let () =
@@ -302,13 +303,16 @@ module Int16x16 = struct
           (logor (shift_left (i16 p) 48) (shift_left (i16 o) 32))
           (logor (shift_left (i16 n) 16) (i16 m)))
     in
-    let v = const16 a b c d e f g h i j k l m n o p in
+    let v = const16 (Int16_u.of_int a) (Int16_u.of_int b) (Int16_u.of_int c) (Int16_u.of_int d)
+                    (Int16_u.of_int e) (Int16_u.of_int f) (Int16_u.of_int g) (Int16_u.of_int h)
+                    (Int16_u.of_int i) (Int16_u.of_int j) (Int16_u.of_int k) (Int16_u.of_int l)
+                    (Int16_u.of_int m) (Int16_u.of_int n) (Int16_u.of_int o) (Int16_u.of_int p) in
     let _w0 = int16x16_first_int64 v in
     let _w1 = int16x16_second_int64 v in
     let _w2 = int16x16_third_int64 v in
     let _w3 = int16x16_fourth_int64 v in
     eq4 _w0 _w1 _w2 _w3 w0 w1 w2 w3;
-    let _a = low_to v in
+    let _a = low_to v |> Int16_u.to_int |> (land) 0xffff in
     eqi _a 0 a 0
 
   let () =
@@ -325,46 +329,46 @@ end
 module Int8x32 = struct
   type t = int8x32
 
-  external low_to : (t[@unboxed]) -> (int[@untagged])
+  external low_to : (t[@unboxed]) -> int8#
     = "" "caml_int8x32_low_to_int"
     [@@noalloc] [@@builtin]
 
-  external const1 : (int[@untagged]) -> (t[@unboxed]) = "" "caml_int8x32_const1"
+  external const1 : int8# -> (t[@unboxed]) = "" "caml_int8x32_const1"
     [@@noalloc] [@@builtin]
 
   external const32 :
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
     (t[@unboxed]) = "" "caml_int8x32_const32"
     [@@noalloc] [@@builtin]
 
@@ -375,13 +379,13 @@ module Int8x32 = struct
     let i64 = Int64.(logor (shift_left i64 8) i64) in
     let i64 = Int64.(logor (shift_left i64 16) i64) in
     let i64 = Int64.(logor (shift_left i64 32) i64) in
-    let v = const1 i in
+    let v = const1 (Int8_u.of_int i) in
     let w0 = int8x32_first_int64 v in
     let w1 = int8x32_second_int64 v in
     let w2 = int8x32_third_int64 v in
     let w3 = int8x32_fourth_int64 v in
     eq4 w0 w1 w2 w3 i64 i64 i64 i64;
-    let _i = low_to v in
+    let _i = low_to v |> Int8_u.to_int |> (land) 0xff in
     eqi _i 0 i 0
 
   let () =
@@ -445,15 +449,21 @@ module Int8x32 = struct
     in
     let w3 = Int64.(logor (shift_left h32 32) l32) in
     let v =
-      const32 a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee
-        ff
+      const32 (Int8_u.of_int a) (Int8_u.of_int b) (Int8_u.of_int c) (Int8_u.of_int d)
+              (Int8_u.of_int e) (Int8_u.of_int f) (Int8_u.of_int g) (Int8_u.of_int h)
+              (Int8_u.of_int i) (Int8_u.of_int j) (Int8_u.of_int k) (Int8_u.of_int l)
+              (Int8_u.of_int m) (Int8_u.of_int n) (Int8_u.of_int o) (Int8_u.of_int p)
+              (Int8_u.of_int q) (Int8_u.of_int r) (Int8_u.of_int s) (Int8_u.of_int t)
+              (Int8_u.of_int u) (Int8_u.of_int v) (Int8_u.of_int w) (Int8_u.of_int x)
+              (Int8_u.of_int y) (Int8_u.of_int z) (Int8_u.of_int aa) (Int8_u.of_int bb)
+              (Int8_u.of_int cc) (Int8_u.of_int dd) (Int8_u.of_int ee) (Int8_u.of_int ff)
     in
     let _w0 = int8x32_first_int64 v in
     let _w1 = int8x32_second_int64 v in
     let _w2 = int8x32_third_int64 v in
     let _w3 = int8x32_fourth_int64 v in
     eq4 _w0 _w1 _w2 _w3 w0 w1 w2 w3;
-    let _a = low_to v in
+    let _a = low_to v |> Int8_u.to_int |> (land) 0xff in
     eqi _a 0 a 0
 
   let () =

--- a/oxcaml/tests/simd/consts256_u.ml
+++ b/oxcaml/tests/simd/consts256_u.ml
@@ -1,4 +1,5 @@
 open Stdlib
+open Stdlib_stable
 open Utils256_u
 
 [@@@ocaml.warning "-unused-module"]
@@ -207,30 +208,30 @@ end
 module Int16x16 = struct
   type t = int16x16
 
-  external low_to : (t[@unboxed]) -> (int[@untagged])
+  external low_to : (t[@unboxed]) -> int16#
     = "" "caml_int16x16_low_to_int"
     [@@noalloc] [@@builtin]
 
-  external const1 : (int[@untagged]) -> (t[@unboxed]) = "" "caml_int16x16_const1"
+  external const1 : int16# -> (t[@unboxed]) = "" "caml_int16x16_const1"
     [@@noalloc] [@@builtin]
 
   external const16 :
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
+    int16# ->
     (t[@unboxed]) = "" "caml_int16x16_const16"
     [@@noalloc] [@@builtin]
 
@@ -240,13 +241,13 @@ module Int16x16 = struct
     let i64 = i16 i in
     let i64 = Int64.(logor (shift_left i64 16) i64) in
     let i64 = Int64.(logor (shift_left i64 32) i64) in
-    let v = const1 i in
+    let v = const1 (Int16_u.of_int i) in
     let w0 = int16x16_first_int64 v in
     let w1 = int16x16_second_int64 v in
     let w2 = int16x16_third_int64 v in
     let w3 = int16x16_fourth_int64 v in
     eq4 w0 w1 w2 w3 i64 i64 i64 i64;
-    let _i = low_to v in
+    let _i = low_to v |> Int16_u.to_int |> (land) 0xffff in
     eqi _i 0 i 0
 
   let () =
@@ -280,13 +281,16 @@ module Int16x16 = struct
           (logor (shift_left (i16 p) 48) (shift_left (i16 o) 32))
           (logor (shift_left (i16 n) 16) (i16 m)))
     in
-    let v = const16 a b c d e f g h i j k l m n o p in
+    let v = const16 (Int16_u.of_int a) (Int16_u.of_int b) (Int16_u.of_int c) (Int16_u.of_int d)
+                    (Int16_u.of_int e) (Int16_u.of_int f) (Int16_u.of_int g) (Int16_u.of_int h)
+                    (Int16_u.of_int i) (Int16_u.of_int j) (Int16_u.of_int k) (Int16_u.of_int l)
+                    (Int16_u.of_int m) (Int16_u.of_int n) (Int16_u.of_int o) (Int16_u.of_int p) in
     let _w0 = int16x16_first_int64 v in
     let _w1 = int16x16_second_int64 v in
     let _w2 = int16x16_third_int64 v in
     let _w3 = int16x16_fourth_int64 v in
     eq4 _w0 _w1 _w2 _w3 w0 w1 w2 w3;
-    let _a = low_to v in
+    let _a = low_to v |> Int16_u.to_int |> (land) 0xffff in
     eqi _a 0 a 0
 
   let () =
@@ -300,46 +304,46 @@ end
 module Int8x32 = struct
   type t = int8x32
 
-  external low_to : (t[@unboxed]) -> (int[@untagged])
+  external low_to : (t[@unboxed]) -> int8#
     = "" "caml_int8x32_low_to_int"
     [@@noalloc] [@@builtin]
 
-  external const1 : (int[@untagged]) -> (t[@unboxed]) = "" "caml_int8x32_const1"
+  external const1 : int8# -> (t[@unboxed]) = "" "caml_int8x32_const1"
     [@@noalloc] [@@builtin]
 
   external const32 :
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
-    (int[@untagged]) ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
+    int8# ->
     (t[@unboxed]) = "" "caml_int8x32_const32"
     [@@noalloc] [@@builtin]
 
@@ -350,13 +354,13 @@ module Int8x32 = struct
     let i64 = Int64.(logor (shift_left i64 8) i64) in
     let i64 = Int64.(logor (shift_left i64 16) i64) in
     let i64 = Int64.(logor (shift_left i64 32) i64) in
-    let v = const1 i in
+    let v = const1 (Int8_u.of_int i) in
     let w0 = int8x32_first_int64 v in
     let w1 = int8x32_second_int64 v in
     let w2 = int8x32_third_int64 v in
     let w3 = int8x32_fourth_int64 v in
     eq4 w0 w1 w2 w3 i64 i64 i64 i64;
-    let _i = low_to v in
+    let _i = low_to v |> Int8_u.to_int |> (land) 0xff in
     eqi _i 0 i 0
 
   let () =
@@ -418,13 +422,22 @@ module Int8x32 = struct
           (logor (shift_left (i8 dd) 8) (i8 cc)))
     in
     let w3 = Int64.(logor (shift_left h32 32) l32) in
-    let v = const32 a b c d e f g h i j k l m n o p q r s t u v w x y z aa bb cc dd ee ff in
+    let v =
+      const32 (Int8_u.of_int a) (Int8_u.of_int b) (Int8_u.of_int c) (Int8_u.of_int d)
+              (Int8_u.of_int e) (Int8_u.of_int f) (Int8_u.of_int g) (Int8_u.of_int h)
+              (Int8_u.of_int i) (Int8_u.of_int j) (Int8_u.of_int k) (Int8_u.of_int l)
+              (Int8_u.of_int m) (Int8_u.of_int n) (Int8_u.of_int o) (Int8_u.of_int p)
+              (Int8_u.of_int q) (Int8_u.of_int r) (Int8_u.of_int s) (Int8_u.of_int t)
+              (Int8_u.of_int u) (Int8_u.of_int v) (Int8_u.of_int w) (Int8_u.of_int x)
+              (Int8_u.of_int y) (Int8_u.of_int z) (Int8_u.of_int aa) (Int8_u.of_int bb)
+              (Int8_u.of_int cc) (Int8_u.of_int dd) (Int8_u.of_int ee) (Int8_u.of_int ff)
+    in
     let _w0 = int8x32_first_int64 v in
     let _w1 = int8x32_second_int64 v in
     let _w2 = int8x32_third_int64 v in
     let _w3 = int8x32_fourth_int64 v in
     eq4 _w0 _w1 _w2 _w3 w0 w1 w2 w3;
-    let _a = low_to v in
+    let _a = low_to v |> Int8_u.to_int |> (land) 0xff in
     eqi _a 0 a 0
 
   let () =

--- a/oxcaml/tests/simd/consts_u.ml
+++ b/oxcaml/tests/simd/consts_u.ml
@@ -1,4 +1,5 @@
 open Stdlib
+open Stdlib_stable
 open Utils
 
 (* !!!
@@ -212,12 +213,12 @@ module Int16x8 = struct
 
     type t = int16x8
 
-    external low_to : (t [@unboxed]) -> (int [@untagged]) = "" "caml_int16x8_low_to_int"
+    external low_to : (t [@unboxed]) -> int16# = "" "caml_int16x8_low_to_int"
         [@@noalloc] [@@builtin]
 
-    external const1 : (int [@untagged]) -> (t [@unboxed]) = "" "caml_int16x8_const1"
+    external const1 : int16# -> (t [@unboxed]) = "" "caml_int16x8_const1"
         [@@noalloc] [@@builtin]
-    external const8 : (int [@untagged]) -> (int [@untagged]) -> (int [@untagged]) -> (int [@untagged]) -> (int [@untagged]) -> (int [@untagged]) -> (int [@untagged]) -> (int [@untagged]) -> (t [@unboxed]) = "" "caml_int16x8_const8"
+    external const8 : int16# -> int16# -> int16# -> int16# -> int16# -> int16# -> int16# -> int16# -> (t [@unboxed]) = "" "caml_int16x8_const8"
         [@@noalloc] [@@builtin]
 
     let i16 i = Int64.(of_int i |> logand 0xffffL)
@@ -225,11 +226,11 @@ module Int16x8 = struct
         let i64 = i16 i in
         let i64 = Int64.(logor (shift_left i64 16) i64) in
         let i64 = Int64.(logor (shift_left i64 32) i64) in
-        let v = const1 i in
+        let v = const1 (Int16_u.of_int i) in
         let l = int16x8_low_int64 v in
         let h = int16x8_high_int64 v in
         eq l h i64 i64;
-        let _i = low_to v in
+        let _i = low_to v |> Int16_u.to_int |> (land) 0xffff in
         eqi _i 0 i 0
     ;;
     let () =
@@ -243,11 +244,12 @@ module Int16x8 = struct
                                (logor (shift_left (i16 b) 16) (i16 a))) in
         let h64 = Int64.(logor (logor (shift_left (i16 h) 48) (shift_left (i16 g) 32))
                                (logor (shift_left (i16 f) 16) (i16 e))) in
-        let v = const8 a b c d e f g h in
+        let v = const8 (Int16_u.of_int a) (Int16_u.of_int b) (Int16_u.of_int c) (Int16_u.of_int d)
+                       (Int16_u.of_int e) (Int16_u.of_int f) (Int16_u.of_int g) (Int16_u.of_int h) in
         let l = int16x8_low_int64 v in
         let h = int16x8_high_int64 v in
         eq l h l64 h64;
-        let _a = low_to v in
+        let _a = low_to v |> Int16_u.to_int |> (land) 0xffff in
         eqi _a 0 a 0
     ;;
     let () =
@@ -263,15 +265,15 @@ module Int8x16 = struct
 
     type t = int8x16
 
-    external low_to : (t [@unboxed]) -> (int [@untagged]) = "" "caml_int8x16_low_to_int"
+    external low_to : (t [@unboxed]) -> int8# = "" "caml_int8x16_low_to_int"
         [@@noalloc] [@@builtin]
 
-    external const1 : (int [@untagged]) -> (t [@unboxed]) = "" "caml_int8x16_const1"
+    external const1 : int8# -> (t [@unboxed]) = "" "caml_int8x16_const1"
         [@@noalloc] [@@builtin]
-    external const16 : (int [@untagged]) -> (int [@untagged]) -> (int [@untagged]) -> (int [@untagged]) ->
-                       (int [@untagged]) -> (int [@untagged]) -> (int [@untagged]) -> (int [@untagged]) ->
-                       (int [@untagged]) -> (int [@untagged]) -> (int [@untagged]) -> (int [@untagged]) ->
-                       (int [@untagged]) -> (int [@untagged]) -> (int [@untagged]) -> (int [@untagged]) ->
+    external const16 : int8# -> int8# -> int8# -> int8# ->
+                       int8# -> int8# -> int8# -> int8# ->
+                       int8# -> int8# -> int8# -> int8# ->
+                       int8# -> int8# -> int8# -> int8# ->
                        (t [@unboxed]) = "" "caml_int8x16_const16"
         [@@noalloc] [@@builtin]
 
@@ -281,11 +283,11 @@ module Int8x16 = struct
         let i64 = Int64.(logor (shift_left i64 8) i64) in
         let i64 = Int64.(logor (shift_left i64 16) i64) in
         let i64 = Int64.(logor (shift_left i64 32) i64) in
-        let v = const1 i in
+        let v = const1 (Int8_u.of_int i) in
         let l = int8x16_low_int64 v in
         let h = int8x16_high_int64 v in
         eq l h i64 i64;
-        let _i = low_to v in
+        let _i = low_to v |> Int8_u.to_int |> (land) 0xff in
         eqi _i 0 i 0
     ;;
     let () =
@@ -305,11 +307,14 @@ module Int8x16 = struct
         let h32 = Int64.(logor (logor (shift_left (i8 p) 24) (shift_left (i8 o) 16))
                                (logor (shift_left (i8 n) 8) (i8 m))) in
         let h64 = Int64.(logor (shift_left h32 32) l32) in
-        let v = const16 a b c d e f g h i j k l m n o p in
+        let v = const16 (Int8_u.of_int a) (Int8_u.of_int b) (Int8_u.of_int c) (Int8_u.of_int d)
+                        (Int8_u.of_int e) (Int8_u.of_int f) (Int8_u.of_int g) (Int8_u.of_int h)
+                        (Int8_u.of_int i) (Int8_u.of_int j) (Int8_u.of_int k) (Int8_u.of_int l)
+                        (Int8_u.of_int m) (Int8_u.of_int n) (Int8_u.of_int o) (Int8_u.of_int p) in
         let l = int8x16_low_int64 v in
         let h = int8x16_high_int64 v in
         eq l h l64 h64;
-        let _a = low_to v in
+        let _a = low_to v |> Int8_u.to_int |> (land) 0xff in
         eqi _a 0 a 0
     ;;
     let () =

--- a/oxcaml/tests/simd/errors/dune
+++ b/oxcaml/tests/simd/errors/dune
@@ -13,13 +13,10 @@
    (diff f64c2.expected f64c2.corrected)
    (diff i8c1.expected i8c1.corrected)
    (diff i8c16.expected i8c16.corrected)
-   (diff i8_range.expected i8_range.corrected)
    (diff i16c1.expected i16c1.corrected)
    (diff i16c8.expected i16c8.corrected)
-   (diff i16_range.expected i16_range.corrected)
    (diff i32c1.expected i32c1.corrected)
    (diff i32c4.expected i32c4.corrected)
-   (diff i32_range.expected i32_range.corrected)
    (diff i64c1.expected i64c1.corrected)
    (diff i64c2.expected i64c2.corrected))))
 
@@ -95,27 +92,6 @@
  (action
   (with-outputs-to
    i32c4.corrected
-   (with-accepted-exit-codes
-    2
-    (run
-     %{bin:ocamlopt.opt}
-     %{ml}
-     -extension
-     simd
-     -color
-     never
-     -error-style
-     short)))))
-
-(rule
- (enabled_if
-  (= %{context_name} "main"))
- (targets i32_range.corrected)
- (deps
-  (:ml i32_range.ml))
- (action
-  (with-outputs-to
-   i32_range.corrected
    (with-accepted-exit-codes
     2
     (run
@@ -215,27 +191,6 @@
 (rule
  (enabled_if
   (= %{context_name} "main"))
- (targets i16_range.corrected)
- (deps
-  (:ml i16_range.ml))
- (action
-  (with-outputs-to
-   i16_range.corrected
-   (with-accepted-exit-codes
-    2
-    (run
-     %{bin:ocamlopt.opt}
-     %{ml}
-     -extension
-     simd
-     -color
-     never
-     -error-style
-     short)))))
-
-(rule
- (enabled_if
-  (= %{context_name} "main"))
  (targets i8c1.corrected)
  (deps
   (:ml i8c1.ml))
@@ -263,27 +218,6 @@
  (action
   (with-outputs-to
    i8c16.corrected
-   (with-accepted-exit-codes
-    2
-    (run
-     %{bin:ocamlopt.opt}
-     %{ml}
-     -extension
-     simd
-     -color
-     never
-     -error-style
-     short)))))
-
-(rule
- (enabled_if
-  (= %{context_name} "main"))
- (targets i8_range.corrected)
- (deps
-  (:ml i8_range.ml))
- (action
-  (with-outputs-to
-   i8_range.corrected
    (with-accepted-exit-codes
     2
     (run

--- a/oxcaml/tests/simd/errors/i16_range.expected
+++ b/oxcaml/tests/simd/errors/i16_range.expected
@@ -1,2 +1,0 @@
-File "i16_range.ml", line 1:
-Error: Int16 constant not in range [0x0,0xffff]: 0x0000000000010000

--- a/oxcaml/tests/simd/errors/i16_range.ml
+++ b/oxcaml/tests/simd/errors/i16_range.ml
@@ -1,8 +1,0 @@
-open Stdlib
-
-type t = int16x8
-
-external const1 : (int[@untagged]) -> (t[@unboxed]) = "" "caml_int16x8_const1"
-  [@@noalloc] [@@builtin]
-
-let _ = const1 0x10000

--- a/oxcaml/tests/simd/errors/i32_range.expected
+++ b/oxcaml/tests/simd/errors/i32_range.expected
@@ -1,2 +1,0 @@
-File "i32_range.ml", line 1:
-Error: Int32 constant not in range [0x0,0xffffffff]: 0x0000000100000000

--- a/oxcaml/tests/simd/errors/i32_range.ml
+++ b/oxcaml/tests/simd/errors/i32_range.ml
@@ -1,8 +1,0 @@
-open Stdlib
-
-type t = int32x4
-
-external const1 : (int[@untagged]) -> (t[@unboxed]) = "" "caml_int32x4_const1"
-  [@@noalloc] [@@builtin]
-
-let _ = const1 0x100000000

--- a/oxcaml/tests/simd/errors/i8_range.expected
+++ b/oxcaml/tests/simd/errors/i8_range.expected
@@ -1,2 +1,0 @@
-File "i8_range.ml", line 1:
-Error: Int8 constant not in range [0x0,0xff]: 0x0000000000000100

--- a/oxcaml/tests/simd/errors/i8_range.ml
+++ b/oxcaml/tests/simd/errors/i8_range.ml
@@ -1,8 +1,0 @@
-open Stdlib
-
-type t = int8x16
-
-external const1 : (int[@untagged]) -> (t[@unboxed]) = "" "caml_int8x16_const1"
-  [@@noalloc] [@@builtin]
-
-let _ = const1 0x100


### PR DESCRIPTION
Previously, the `int8xN`/`int16xN` cmm intrinsics expected and produced zero-extended `int8`/`int16` scalars in 64-bit registers. This switches them to sign-extension, allowing their interfaces to use the new `int8#` and `int16#` types.

Note this does not apply to intrinsics in `simd_selection.ml` (particularly the extract functions). These will need to sign-extend in user code.

The range-error tests have been deleted, as exposing the intrinsics with `int8#`/`int16#` means out of range values cannot be represented. The constants tests have been updated.