### PR TITLE
Add support for parsing crossings

### DIFF
--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -55,6 +55,32 @@ module Const : sig
   val float : ?suffix:char -> string -> constant
 end
 
+(** {1 Modes and Modalities} *)
+
+module Modes : sig
+  val mk : ?loc:loc -> core_modes -> crossings -> modes
+
+  (* NOTE: This function will merge the locations of the provided modes.
+     This could lead to poor error reporting if the modes come from vastly
+     different places in the source code. This is mostly used to combine
+     legacy mode annotations with new mode annotations. *)
+  val merge : modes -> modes -> modes
+
+  (* If [loc = None], merges the locations of provided [core_modes]. *)
+  val of_core_modes : ?loc:loc -> core_modes -> modes
+end
+
+module Modalities : sig
+  val mk : ?loc:loc -> core_modalities -> crossings -> modalities
+
+  (* NOTE: Like [Modes.merge], this function will merge the locations
+     of the provided modalities and should be used with caution. *)
+  val merge : modalities -> modalities -> modalities
+
+  (* If [loc = None], merges the locations of provided [core_modes]. *)
+  val of_core_modalities : ?loc:loc -> core_modalities -> modalities
+end
+
 (** {1 Attributes} *)
 module Attr : sig
   val mk: ?loc:loc -> str -> payload -> attribute
@@ -72,7 +98,7 @@ module Typ :
     val var: ?loc:loc -> ?attrs:attrs -> string -> jkind_annotation option
       -> core_type
     val arrow: ?loc:loc -> ?attrs:attrs -> arg_label -> core_type -> core_type ->
-      mode with_loc list -> mode with_loc list -> core_type
+      modes -> modes -> core_type
     val tuple: ?loc:loc -> ?attrs:attrs -> (string option * core_type) list -> core_type
     val unboxed_tuple: ?loc:loc -> ?attrs:attrs
                        -> (string option * core_type) list -> core_type
@@ -135,7 +161,7 @@ module Pat:
       pattern
     val or_: ?loc:loc -> ?attrs:attrs -> pattern -> pattern -> pattern
     val constraint_: ?loc:loc -> ?attrs:attrs -> pattern -> core_type option
-                     -> mode with_loc list -> pattern
+                     -> modes -> pattern
     val type_: ?loc:loc -> ?attrs:attrs -> lid -> pattern
     val lazy_: ?loc:loc -> ?attrs:attrs -> pattern -> pattern
     val unpack: ?loc:loc -> ?attrs:attrs -> str_opt -> pattern
@@ -192,7 +218,7 @@ module Exp:
     val coerce: ?loc:loc -> ?attrs:attrs -> expression -> core_type option
                 -> core_type -> expression
     val constraint_: ?loc:loc -> ?attrs:attrs -> expression -> core_type option
-                     -> mode with_loc list -> expression
+                     -> modes -> expression
     val send: ?loc:loc -> ?attrs:attrs -> expression -> str -> expression
     val new_: ?loc:loc -> ?attrs:attrs -> lid -> expression
     val setinstvar: ?loc:loc -> ?attrs:attrs -> str -> expression -> expression
@@ -233,7 +259,7 @@ module Exp:
 module Val:
   sig
     val mk: ?loc:loc -> ?attrs:attrs -> ?docs:docs -> ?prim:string list ->
-      ?modalities:modality with_loc list -> str -> core_type -> value_description
+      ?modalities:modalities -> str -> core_type -> value_description
   end
 
 (** Type declarations *)
@@ -253,11 +279,11 @@ module Type:
       str ->
       constructor_declaration
 
-    val constructor_arg: ?loc:loc -> ?modalities:modality with_loc list -> core_type ->
+    val constructor_arg: ?loc:loc -> ?modalities:modalities -> core_type ->
       constructor_argument
 
     val field: ?loc:loc -> ?attrs:attrs -> ?info:info ->
-      ?mut:mutable_flag -> ?modalities:modality with_loc list -> str -> core_type ->
+      ?mut:mutable_flag -> ?modalities:modalities -> str -> core_type ->
       label_declaration
   end
 
@@ -353,7 +379,7 @@ module Sig:
 
 module Sg:
   sig
-    val mk : ?loc:loc -> ?modalities:modality with_loc list ->
+    val mk : ?loc:loc -> ?modalities:modalities ->
       signature_item list -> signature
   end
 
@@ -428,10 +454,9 @@ module Incl:
 module Vb:
   sig
     val mk: ?loc: loc -> ?attrs:attrs -> ?docs:docs -> ?text:text ->
-      ?value_constraint:value_constraint -> ?modes:mode with_loc list -> pattern ->
+      ?value_constraint:value_constraint -> ?modes:modes -> pattern ->
       expression -> value_binding
   end
-
 
 (** {1 Class language} *)
 

--- a/parsing/ast_invariants.ml
+++ b/parsing/ast_invariants.ml
@@ -51,9 +51,9 @@ let simple_longident id =
   in
   if not (is_simple id.txt) then complex_id id.loc
 
-let check_empty_constraint ~loc ty mode =
-  match ty, mode with
-  | None, [] -> empty_constraint loc
+let check_empty_constraint ~loc ty modes =
+  match ty, modes with
+  | None, No_modes -> empty_constraint loc
   | _ -> ()
 
 (* Is this pattern a single variable, possibly with a type annotation? *)

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -838,12 +838,22 @@ let default_iterator =
     attributes = (fun this l -> List.iter (this.attribute this) l);
 
     (* Location inside a mode expression needs to be traversed. *)
-    modes = (fun this m ->
-      List.iter (iter_loc this) m
+    modes = (fun this modes ->
+      match modes with
+      | No_modes -> ()
+      | Modes {modes; crossings; loc} ->
+          List.iter (iter_loc this) modes;
+          List.iter (iter_loc this) crossings;
+          this.location this loc
     );
 
-    modalities = (fun this m ->
-      List.iter (iter_loc this) m
+    modalities = (fun this modalities ->
+      match modalities with
+      | No_modalities -> ()
+      | Modalities {modalities; crossings; loc} ->
+          List.iter (iter_loc this) modalities;
+          List.iter (iter_loc this) crossings;
+          this.location this loc
     );
 
     payload =
@@ -860,9 +870,9 @@ let default_iterator =
          match pjkind_desc with
          | Pjk_default -> ()
          | Pjk_abbreviation (_ : string) -> ()
-         | Pjk_mod (t, mode_list) ->
+         | Pjk_mod (t, crossings) ->
              this.jkind_annotation this t;
-             this.modes this mode_list
+             List.iter (iter_loc this) crossings
          | Pjk_with (t, ty, modalities) ->
              this.jkind_annotation this t;
              this.typ this ty;

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -969,8 +969,11 @@ let default_mapper =
         match pjkind_desc with
         | Pjk_default -> Pjk_default
         | Pjk_abbreviation (s : string) -> Pjk_abbreviation s
-        | Pjk_mod (t, mode_list) ->
-          Pjk_mod (this.jkind_annotation this t, this.modes this mode_list)
+        | Pjk_mod (t, crossings) ->
+          Pjk_mod (
+            this.jkind_annotation this t,
+            List.map (map_loc this) crossings
+          )
         | Pjk_with (t, ty, modalities) ->
           Pjk_with (
             this.jkind_annotation this t,
@@ -983,11 +986,21 @@ let default_mapper =
       in
       { pjkind_loc; pjkind_desc });
 
-    modes = (fun this m ->
-      List.map (map_loc this) m);
+    modes = (fun this modes ->
+      match modes with
+      | No_modes -> No_modes
+      | Modes { modes; crossings; loc } ->
+        Modes { modes = List.map (map_loc this) modes
+              ; crossings = List.map (map_loc this) crossings
+              ; loc = this.location this loc } );
 
-    modalities = (fun this m ->
-      List.map (map_loc this) m);
+    modalities = (fun this modalities ->
+      match modalities with
+      | No_modalities -> No_modalities
+      | Modalities { modalities; crossings; loc } ->
+        Modalities { modalities = List.map (map_loc this) modalities
+                   ; crossings = List.map (map_loc this) crossings
+                   ; loc = this.location this loc } );
 
     directive_argument =
       (fun this a ->
@@ -1263,7 +1276,7 @@ let apply_lazy ~source ~target mapper =
       with exn ->
         { psg_items = [{psig_desc = Psig_extension (extension_of_exn exn, []);
           psig_loc = Location.none}];
-          psg_modalities = []; psg_loc = Location.none }
+          psg_modalities = No_modalities; psg_loc = Location.none }
     in
     let fields = PpxContext.update_cookies fields in
     let psg_items = Sig.attribute (PpxContext.mk fields) :: psg_items in

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -141,7 +141,7 @@ and add_jkind bv (jkind : jkind_annotation) =
   match jkind.pjkind_desc with
   | Pjk_default -> ()
   | Pjk_abbreviation _ -> ()
-  | Pjk_mod (jkind, (_ : modes)) -> add_jkind bv jkind
+  | Pjk_mod (jkind, (_ : crossings)) -> add_jkind bv jkind
   | Pjk_with (jkind, typ, (_ : modalities)) ->
       add_jkind bv jkind;
       add_type bv typ;

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -59,11 +59,44 @@ type constant =
 
 type location_stack = Location.t list
 
+type crossing = | Crossing of string [@@unboxed]
+type crossings = crossing loc list
+
 type modality = | Modality of string [@@unboxed]
-type modalities = modality loc list
+type core_modalities = modality loc list
+type modalities =
+  | No_modalities
+  | Modalities of {
+      modalities : core_modalities;
+      crossings : crossings;
+      loc : Location.t
+    }
+(** [Modalities { modalities = M; crossings = C; loc = L }] represents
+    - [@@ M mod C]  when [M = _ :: _] and [C = _ :: _]
+    - [@@ M]        when [M = _ :: _] and [C = []]
+    - [mod C]       when [M = []] and [C = _ :: _]
+
+    Invariant: [M] and [C] will never both be empty in a [Modalities].
+    If both are empty, then [No_modalities] is to be used.
+  *)
 
 type mode = | Mode of string [@@unboxed]
-type modes = mode loc list
+type core_modes = mode loc list
+type modes =
+  | No_modes
+  | Modes of {
+      modes : core_modes;
+      crossings : crossings;
+      loc : Location.t
+  }
+(** [Modes { modes = M; crossings = C; loc = L }] represents
+    - [@ M mod C]  when [M = _ :: _] and [C = _ :: _]
+    - [@ M]        when [M = _ :: _] and [C = []]
+    - [mod C]      when [M = []] and [C = _ :: _]
+
+    Invariant: [M] and [C] will never both be empty in a [Modes].
+    If both are empty, then [No_modes] is to be used.
+  *)
 
 type include_kind = Structure | Functor
 
@@ -119,6 +152,8 @@ and core_type_desc =
             - [?l:(T1 @ M1) -> (T2 @ M2)] when [lbl] is
                                      {{!arg_label.Optional}[Optional]}.
          *)
+        (* CR modes: crossings should be supported on arrow types, and this
+           documentation should be updated once that is the case *)
   | Ptyp_tuple of (string option * core_type) list
       (** [Ptyp_tuple(tl)] represents a product type:
           - [T1 * ... * Tn]       when [tl] is [(None,T1);...;(None,Tn)]
@@ -337,9 +372,9 @@ and pattern_desc =
       (** Pattern [[| P1; ...; Pn |]] or [[: P1; ...; Pn :]] *)
   | Ppat_or of pattern * pattern  (** Pattern [P1 | P2] *)
   | Ppat_constraint of pattern * core_type option * modes
-      (** [Ppat_constraint(tyopt, modes)] represents:
-          - [(P : ty @@ modes)] when [tyopt] is [Some ty]
-          - [(P @ modes)] when [tyopt] is [None]
+      (** [Ppat_constraint(tyopt, {modes; crossings; _})] represents:
+          - [(P : ty @ modes mod crossings)] when [tyopt] is [Some ty]
+          - [(P @ modes mod crossings)] when [tyopt] is [None]
          *)
   | Ppat_type of Longident.t loc  (** Pattern [#tconst] *)
   | Ppat_lazy of pattern  (** Pattern [lazy P] *)
@@ -476,7 +511,8 @@ and expression_desc =
             - [for i = E1 downto E2 do E3 done]
                  when [direction] is {{!Asttypes.direction_flag.Downto}[Downto]}
          *)
-  | Pexp_constraint of expression * core_type option * modes  (** [(E : T @@ modes)] *)
+  | Pexp_constraint of expression * core_type option * modes
+      (** [(E : T @ modes mod crossings)] *)
   | Pexp_coerce of expression * core_type option * core_type
       (** [Pexp_coerce(E, from, T)] represents
             - [(E :> T)]      when [from] is [None],
@@ -633,9 +669,11 @@ and function_constraint =
     *)
     ret_mode_annotations : modes;
     (** The mode annotation placed on a function's body, e.g.
-       [let f x : int -> int @@ local = ...].
+       [let f x : (int -> int) @ local = ...].
        This field constrains the mode of function's body.
     *)
+    (* CR modes: this documentation should be updated once crossings on arrow
+       types are supported *)
     ret_type_constraint : type_constraint option;
     (** The type constraint placed on a function's body. *)
   }
@@ -1082,7 +1120,7 @@ and module_type_desc =
   | Pmty_ident of Longident.t loc  (** [Pmty_ident(S)] represents [S] *)
   | Pmty_signature of signature  (** [sig ... end] *)
   | Pmty_functor of functor_parameter * module_type * modes
-      (** [functor(X : MT1 @@ modes) -> MT2 @ modes] *)
+      (** [functor(X : MT1 @ modes) -> MT2 @ modes] *)
   | Pmty_with of module_type * with_constraint list  (** [MT with ...] *)
   | Pmty_typeof of module_expr  (** [module type of ME] *)
   | Pmty_extension of extension  (** [[%id]] *)
@@ -1094,8 +1132,8 @@ and functor_parameter =
   | Unit  (** [()] *)
   | Named of string option loc * module_type * modes
       (** [Named(name, MT)] represents:
-            - [(X : MT @@ modes)] when [name] is [Some X],
-            - [(_ : MT @@ modes)] when [name] is [None] *)
+            - [(X : MT @ modes)] when [name] is [Some X],
+            - [(_ : MT @ modes)] when [name] is [None] *)
 
 and signature =
   {
@@ -1246,9 +1284,10 @@ and module_expr_desc =
   | Pmod_apply of module_expr * module_expr  (** [ME1(ME2)] *)
   | Pmod_apply_unit of module_expr (** [ME1()] *)
   | Pmod_constraint of module_expr * module_type option * modes
-      (** - [(ME : MT @@ modes)]
+      (** - [(ME : MT @ modes)]
           - [(ME @ modes)]
           - [(ME : MT)]
+          as well as other cases where only one of modes and crossings appears
       *)
   | Pmod_unpack of expression  (** [(val E)] *)
   | Pmod_extension of extension  (** [[%id]] *)
@@ -1346,7 +1385,7 @@ and jkind_annotation_desc =
   (* CR layouts v2.8: [mod] can have only layouts on the left, not
      full kind annotations. We may want to narrow this type some.
      Internal ticket 5085. *)
-  | Pjk_mod of jkind_annotation * modes
+  | Pjk_mod of jkind_annotation * crossings
   | Pjk_with of jkind_annotation * core_type * modalities
   | Pjk_kind_of of core_type
   | Pjk_product of jkind_annotation list

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -143,19 +143,38 @@ let arg_label i ppf = function
   | Optional s -> line i ppf "Optional \"%s\"\n" s
   | Labelled s -> line i ppf "Labelled \"%s\"\n" s
 
+let crossing i ppf crossing =
+  line i ppf "mod %a\n" fmt_string_loc
+    (Location.map (fun (Crossing x) -> x) crossing)
+
+let crossings i ppf mods =
+  List.iter (fun m -> crossing i ppf m) mods
+
 let modality i ppf modality =
   line i ppf "modality %a\n" fmt_string_loc
     (Location.map (fun (Modality x) -> x) modality)
 
-let modalities i ppf modalities =
-  List.iter (fun m -> modality i ppf m) modalities
+let modalities i ppf m =
+  match m with
+  | No_modalities -> ()
+  | Modalities { modalities = m; crossings = c; loc } ->
+    line i ppf "modalities %a\n" fmt_location loc;
+    let i = i+1 in
+    List.iter (fun m -> modality i ppf m) m;
+    crossings i ppf c
 
 let mode i ppf mode =
   line i ppf "mode %a\n" fmt_string_loc
     (Location.map (fun (Mode x) -> x) mode)
 
-let modes i ppf modes =
-  List.iter (fun m -> mode i ppf m) modes
+let modes i ppf m =
+  match m with
+  | No_modes -> ()
+  | Modes { modes = m; crossings = c; loc } ->
+    line i ppf "modes %a\n" fmt_location loc;
+    let i = i+1 in
+    List.iter (fun m -> mode i ppf m) m;
+    crossings i ppf c
 
 let include_kind i ppf = function
   | Structure -> line i ppf "Structure\n"
@@ -553,7 +572,7 @@ and jkind_annotation i ppf (jkind : jkind_annotation) =
   | Pjk_mod (jkind, m) ->
       line i ppf "Pjk_mod\n";
       jkind_annotation (i+1) ppf jkind;
-      modes (i+1) ppf m
+      crossings (i+1) ppf m
   | Pjk_with (jkind, type_, modalities_) ->
       line i ppf "Pjk_with\n";
       jkind_annotation (i+1) ppf jkind;

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -163,19 +163,38 @@ let arg_label i ppf = function
   | Labelled s -> line i ppf "Labelled \"%s\"\n" s
 ;;
 
+let crossing i ppf crossing =
+  line i ppf "mod %a\n" fmt_string_loc
+    (Location.map (fun (Crossing x) -> x) crossing)
+
+let crossings i ppf mods =
+  List.iter (fun m -> crossing i ppf m) mods
+
 let modality i ppf modality =
   line i ppf "modality %a\n" fmt_string_loc
     (Location.map (fun (Modality x) -> x) modality)
 
-let modalities i ppf modalities =
-  List.iter (fun m -> modality i ppf m) modalities
+let modalities i ppf m =
+  match m with
+  | No_modalities -> ()
+  | Modalities { modalities = m; crossings = c; loc } ->
+    line i ppf "modalities %a\n" fmt_location loc;
+    let i = i+1 in
+    List.iter (fun m -> modality i ppf m) m;
+    crossings i ppf c
 
 let mode i ppf mode =
   line i ppf "mode %a\n" fmt_string_loc
     (Location.map (fun (Mode x) -> x) mode)
 
-let modes i ppf modes =
-  List.iter (fun m -> mode i ppf m) modes
+let modes i ppf m =
+  match m with
+  | No_modes -> ()
+  | Modes { modes = m; crossings = c; loc } ->
+    line i ppf "modes %a\n" fmt_location loc;
+    let i = i+1 in
+    List.iter (fun m -> mode i ppf m) m;
+    crossings i ppf c
 
 let include_kind i ppf = function
   | Structure -> line i ppf "Structure\n"
@@ -580,12 +599,12 @@ and jkind_annotation i ppf (jkind : jkind_annotation) =
   | Pjk_mod (jkind, m) ->
       line i ppf "Pjk_mod\n";
       jkind_annotation (i+1) ppf jkind;
-      modes (i+1) ppf m
-  | Pjk_with (jkind, type_, modalities) ->
+      crossings (i+1) ppf m
+  | Pjk_with (jkind, type_, modalities_) ->
       line i ppf "Pjk_with\n";
       jkind_annotation (i+1) ppf jkind;
       core_type (i+1) ppf type_;
-      list i modality ppf modalities
+      modalities (i+1) ppf modalities_
   | Pjk_kind_of type_ ->
       line i ppf "Pjk_kind_of\n";
       core_type (i+1) ppf type_

--- a/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -35,7 +35,7 @@ module Example = struct
   let modality         = { txt = Modality "uncontended"
                          ; loc
                          }
-  let modalities       = [ modality ]
+  let modalities       = Ast_helper.Modalities.of_core_modalities [ modality ]
   let class_field      = { pcf_desc = Pcf_initializer expression
                          ; pcf_loc = loc
                          ; pcf_attributes = []
@@ -63,7 +63,7 @@ module Example = struct
                                { pmd_name = located (Some "M")
                                ; pmd_type = module_type
                                ; pmd_attributes = []
-                               ; pmd_modalities = []
+                               ; pmd_modalities = No_modalities
                                ; pmd_loc = loc
                                }
                          ; psig_loc = loc
@@ -74,7 +74,7 @@ module Example = struct
                          ; pvb_attributes = []
                          ; pvb_loc = loc
                          ; pvb_constraint = None
-                         ; pvb_modes = []
+                         ; pvb_modes = No_modes
                          }
   let payload          = PStr structure
   let class_signature  = { pcsig_self = core_type

--- a/testsuite/tests/parsetree/modes_ast_mapper.ml
+++ b/testsuite/tests/parsetree/modes_ast_mapper.ml
@@ -2,32 +2,36 @@
  include ocamlcommon;
 *)
 
-let locs_to_string (locs : 'a Location.loc list) (f : 'a -> string) : string =
+let locs_to_string ?(sep = " ") locs f : string =
   List.map
     (fun (m : _ Location.loc) ->
        Format.asprintf "%s [%a]" (f m.txt) Location.print_loc m.loc
     )
     locs
-  |> String.concat " "
+  |> String.concat sep
 
 let mapper: Ast_mapper.mapper =
   let open Ast_mapper in
   { default_mapper with
     modes = (fun sub m ->
       (match m with
-      | [] -> ();
-      | _ ->
-        Format.printf "modes: %s\n"
-          (locs_to_string m (fun (Mode s) -> s))
+      | No_modes -> ();
+      | Modes { modes; crossings; _ } ->
+        Format.printf "modes: %s%s\n"
+          (locs_to_string modes (fun (Mode s) -> s))
+          (locs_to_string ~sep:"" crossings
+            (fun (Crossing s) -> Format.sprintf " mod %s" s));
       );
       default_mapper.modes sub m
     );
     modalities = (fun sub m ->
       (match m with
-        | [] -> ();
-        | _ ->
-          Format.printf "modalities: %s\n"
-            (locs_to_string m (fun (Modality s) -> s))
+        | No_modalities -> ();
+        | Modalities { modalities; crossings; _ } ->
+          Format.printf "modalities: %s%s\n"
+            (locs_to_string modalities (fun (Modality s) -> s))
+            (locs_to_string ~sep:"" crossings
+              (fun (Crossing s) -> Format.sprintf " mod %s" s));
       );
       default_mapper.modalities sub m
     );

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -336,6 +336,21 @@ let f ?(local_ x = 42)
       ?(local_ x : ('a : any) 'b . 'a -> 'b @ once portable = assert false)
       ?(local_ x : ('a : any) 'b . ('a -> 'b) @ once portable = assert false)
 
+      (* currently, the combination of legacy mode syntax [local_] and
+         [mod crossings] syntax WILL parse, but it will not round trip,
+         as the legacy mode gets printed as [@ local]. *)
+      (* ?(local_ x @ once portable mod contended aliased = 42) *)
+      ?(x mod contended aliased = 42)
+      ?(x @ once portable mod contended aliased = 42)
+      ?(x : int mod contended aliased = 42)
+      ?(x : int @ once portable mod contended aliased = 42)
+      ?(x : ('a -> 'a) @ once portable mod contended aliased = fun x -> x)
+      ?(x : ('a : any) 'b . 'a @ once portable mod contended aliased = assert false)
+      (* CR modes: this currently does not parse:
+           ?(x : ('a : any) 'b . 'a -> 'b @ once portable mod contended aliased = assert false)
+         see [parsing/mod_contended.ml] for more examples *)
+      ?(x : ('a : any) 'b . ('a -> 'b) @ once portable mod contended aliased = assert false)
+
       ?x:(local_ (y, z) = 42)
       ?x:(local_ (y, z) @ once portable = 42)
       ?x:(local_ (y, z) : int @ once portable = 42)
@@ -343,6 +358,14 @@ let f ?(local_ x = 42)
       ?x:(local_ (y, z) : ('a : any) 'b . 'a @ once portable = 42)
       ?x:(local_ (y, z) : ('a : any) 'b . 'a -> 'b @ once portable = 42)
       ?x:(local_ (y, z) : ('a : any) 'b . ('a -> 'b) @ once portable = 42)
+
+      ?x:((y, z) mod contended aliased = 42)
+      ?x:((y, z) @ once portable mod contended aliased = 42)
+      ?x:((y, z) : int mod contended aliased = 42)
+      ?x:((y, z) : int @ once portable mod contended aliased = 42)
+      ?x:((y, z) : ('a -> 'a) @ once portable mod contended aliased = fun x -> x)
+      ?x:((y, z) : ('a : any) 'b . 'a @ once portable mod contended aliased = assert false)
+      ?x:((y, z) : ('a : any) 'b . ('a -> 'b) @ once portable mod contended aliased = assert false)
 
       ~(local_ x)
       ~(local_ x @ once portable)
@@ -352,6 +375,14 @@ let f ?(local_ x = 42)
       ~(local_ x : ('a : any) 'b . 'a -> 'b @ once portable)
       ~(local_ x : ('a : any) 'b . ('a -> 'b) @ once portable)
 
+      ~(x mod contended aliased)
+      ~(x @ once portable mod contended aliased)
+      ~(x : int mod contended aliased)
+      ~(x : int @ once portable mod contended aliased)
+      ~(x : ('a -> 'a) @ once portable mod contended aliased)
+      ~(x : ('a : any) 'b . 'a @ once portable mod contended aliased)
+      ~(x : ('a : any) 'b . ('a -> 'b) @ once portable mod contended aliased)
+
       ~x:(local_ (y, z))
       ~x:(local_ (y, z) @ once portable)
       ~x:(local_ (y, z) : int @ once portable)
@@ -360,6 +391,14 @@ let f ?(local_ x = 42)
       ~x:(local_ (y, z) : ('a : any) 'b . ('a -> 'b) @ once portable)
       ~x:(local_ (y, z) : ('a : any) 'b . 'a -> 'b @ once portable)
 
+      ~x:((y, z) mod contended aliased)
+      ~x:((y, z) @ once portable mod contended aliased)
+      ~x:((y, z) : int mod contended aliased)
+      ~x:((y, z) : int @ once portable mod contended aliased)
+      ~x:((y, z) : ('a -> 'a) @ once portable mod contended aliased)
+      ~x:((y, z) : ('a : any) 'b . 'a @ once portable mod contended aliased)
+      ~x:((y, z) : ('a : any) 'b . ('a -> 'b) @ once portable mod contended aliased)
+
       (local_ (y, z))
       (local_ (y, z) @ once portable)
       (local_ (y, z) : int @ once portable)
@@ -367,6 +406,14 @@ let f ?(local_ x = 42)
       (local_ (y, z) : ('a : any) 'b . 'a @ once portable)
       (local_ (y, z) : ('a : any) 'b . ('a -> 'b) @ once portable)
       (local_ (y, z) : ('a : any) 'b . 'a -> 'b @ once portable)
+
+      ((y, z) mod contended aliased)
+      ((y, z) @ once portable mod contended aliased)
+      ((y, z) : int mod contended aliased)
+      ((y, z) : int @ once portable mod contended aliased)
+      ((y, z) : ('a -> 'a) @ once portable mod contended aliased)
+      ((y, z) : ('a : any) 'b . 'a @ once portable mod contended aliased)
+      ((y, z) : ('a : any) 'b . ('a -> 'b) @ once portable mod contended aliased)
 
       = ();;
 
@@ -386,25 +433,56 @@ let g () =
   let local_ f a b : (int -> int) @ once portable = 42 in
 
   let (f @ local unique) = 42 in
-  let (f @ local unique) a b @ once portable = 42 in
-  let (f @ local unique) a b : int @ once portable = 42 in
-  let (f @ local unique) a b : (int -> int) @ once portable = 42 in
+  let (f mod contended aliased) = 42 in
+  let (f @ local unique mod contended aliased) = 42 in
+  let (f @ local unique mod contended aliased) a b @ once portable = 42 in
+  let (f @ local unique mod contended aliased) a b mod contended aliased = 42 in
+  let (f @ local unique mod contended aliased) a b @ once portable mod contended aliased = 42 in
+  let (f @ local unique mod contended aliased) a b : int @ once portable = 42 in
+  let (f @ local unique mod contended aliased) a b : int mod contended aliased = 42 in
+  let (f @ local unique mod contended aliased) a b : int @ once portable mod contended aliased = 42 in
+  let (f @ local unique mod contended aliased) a b : (int -> int) @ once portable = 42 in
+  let (f @ local unique mod contended aliased) a b : (int -> int) mod contended aliased = 42 in
+  let (f @ local unique mod contended aliased) a b : (int -> int) @ once portable mod contended aliased = 42 in
 
   let local_ a @ once portable = 42 in
   let local_ a : int @ once portable = 42 in
   let local_ a : (int -> int) @ once portable = 42 in
 
+  let a mod contended aliased = 42 in
+  let (a mod contended) mod aliased = 42 in
+  let a @ once portable mod contended aliased = 42 in
+  let a : int mod contended aliased = 42 in
+  let a : int @ once portable mod contended aliased = 42 in
+  let a : (int -> int) mod contended aliased = 42 in
+  let a : (int -> int) @ once portable mod contended aliased = 42 in
+
   let local_ a : ('a : any) 'b. 'a @ once portable = 42 in
   let local_ a : ('a : any) 'b. 'a -> 'a @ once portable = 42 in
   let local_ a : ('a : any) 'b. ('a -> 'a) @ once portable = 42 in
 
+  let a : ('a : any) 'b. 'a mod contended aliased = 42 in
+  let a : ('a : any) 'b. 'a @ once portable mod contended aliased = 42 in
+  let a : ('a : any) 'b. ('a -> 'a) mod contended aliased = 42 in
+  let a : ('a : any) 'b. ('a -> 'a) @ once portable mod contended aliased = 42 in
+
   let a : type (a : any) b. int @ once portable = 42 in
+  let a : type (a : any) b. int mod contended aliased = 42 in
+  let a : type (a : any) b. int @ once portable mod contended aliased = 42 in
   let a : type (a : any) b. a -> b @ once portable = 42 in
   let a : type (a : any) b. (a -> b) @ once portable = 42 in
+  let a : type (a : any) b. (a -> b) mod contended aliased  = 42 in
+  let a : type (a : any) b. (a -> b) @ once portable mod contended aliased  = 42 in
 
   let (a, b) @ once portable = 42 in
+  let (a, b) mod contended aliased = 42 in
+  let (a, b) @ once portable mod contended aliased = 42 in
   let (a, b) : int @ once portable = 42 in
+  let (a, b) : int mod contended aliased = 42 in
+  let (a, b) : int @ once portable mod contended aliased = 42 in
   let (a, b) : (int -> int) @ once portable = 42 in
+  let (a, b) : (int -> int) mod contended aliased = 42 in
+  let (a, b) : (int -> int) @ once portable mod contended aliased = 42 in
 
   () ;;
 
@@ -419,46 +497,59 @@ Error: This expression has type "int" but an expression was expected of type
 (* expressions *)
 let g () = exclave_ local_
   let f = (() : _ @ unique once) in
+  let f = (() : _ mod contended aliased) in
+  let f = (() : _ @ unique once mod contended aliased) in
   let f x y @ local unique = exclave_ local_ (x + y : _ @ once unique) in
+  let f x y mod contended aliased = exclave_ local_ (x + y : _ @ once unique) in
+  let f x y @ local unique mod contended aliased = exclave_ local_ (x + y : _ @ once unique) in
+  let f = (42 : int mod contended aliased) + (42 : int @ once portable mod contended) in
+  let f = (42 : _ mod contended aliased) + (42 : _ @ once portable mod contended) in
   local_ (() : _ @ unique once);;
 
+(* CR modes: currently, this fatal errors after parsing.
+   once mod crossings are implemented, these should changed back to be type errors *)
 [%%expect{|
-Line 2, characters 6-7:
-2 |   let f = (() : _ @ unique once) in
-          ^
-Warning 26 [unused-var]: unused variable f.
+>> Fatal error: crossings as mode annotations are not yet implemented
+Uncaught exception: Misc.Fatal_error
 
-Line 3, characters 6-7:
-3 |   let f x y @ local unique = exclave_ local_ (x + y : _ @ once unique) in
-          ^
-Warning 26 [unused-var]: unused variable f.
-
-val g : unit -> unit @ local once = <fun>
 |}]
 
 (* type declarations *)
 type record =
   { global_ field0 : int
   ; field1 : int @@ global portable contended
-  ; global_ field2 : int @@ portable contended
-  ; normal_field : int
+  ; field2 : int mod contended aliased
+  ; field3 : int @@ global portable contended mod contended aliased
+  ; global_ field4 : int @@ portable contended
+  ; normal_field5 : int
+  ; normal_field6 : int mod contended aliased
+  ; normal_field7 : (int -> int) mod contended aliased
+  ; normal_field8 : (int -> int) @@ portable contended mod contended aliased
   };;
 
 [%%expect{|
-type record = {
-  field0 : int @@ global;
-  field1 : int @@ global portable contended;
-  field2 : int @@ global portable contended;
-  normal_field : int;
-}
+>> Fatal error: crossings as modalities are not yet implemented
+Uncaught exception: Misc.Fatal_error
+
 |}]
 
 type 'a parameterized_record =
   { global_ field0 : 'a
   ; field1 : 'a @@ global portable contended
-  ; global_ field2 : 'a @@ portable contended
-  ; normal_field : 'a
+  ; field2 : 'a mod contended aliased
+  ; field3 : 'a @@ global portable contended mod contended aliased
+  ; global_ field4 : 'a @@ portable contended
+  ; normal_field5 : 'a
+  ; normal_field6 : 'a mod contended aliased
+  ; normal_field7 : ('a -> 'a) mod contended aliased
+  ; normal_field8 : ('a -> 'a) @@ portable contended mod contended aliased
   };;
+
+[%%expect{|
+>> Fatal error: crossings as modalities are not yet implemented
+Uncaught exception: Misc.Fatal_error
+
+|}]
 
 type t =
   | Foo of global_ int * int
@@ -468,18 +559,27 @@ type t =
   | Foo4 of global_ (int * int) @@ portable contended
 
 [%%expect{|
-type 'a parameterized_record = {
-  field0 : 'a @@ global;
-  field1 : 'a @@ global portable contended;
-  field2 : 'a @@ global portable contended;
-  normal_field : 'a;
-}
 type t =
     Foo of int @@ global * int
   | Foo1 of int @@ global portable contended * int
   | Foo2 of int @@ global * int @@ global portable contended
   | Foo3 of int @@ global * int @@ portable contended
   | Foo4 of (int * int) @@ global portable contended
+|}]
+
+type t =
+  | T1 of int mod contended aliased
+  | T2 of int @@ once portable mod contended aliased
+  | T3 of (int -> int) mod contended aliased
+  | T4 of (int -> int) @@ once portable mod contended aliased
+  | T5 of int @@ once portable mod contended aliased * int mod contended aliased
+  | T6 : int @@ once portable mod contended aliased * int mod contended -> t
+  | T7 : { x : int @@ once portable mod contended aliased } -> t
+
+[%%expect{|
+>> Fatal error: crossings as modalities are not yet implemented
+Uncaught exception: Misc.Fatal_error
+
 |}]
 
 (* arrow types *)
@@ -581,10 +681,28 @@ module type S =
   end
 |}]
 
-external x4 : string -> string @@ portable many = "%identity"
+module type S = sig
+  val x1 : int mod contended aliased
+  val x2 : int @@ once portable mod contended aliased
+  val x3 : (int -> int) mod contended aliased
+  val x4 : (int -> int) @@ once portable mod contended aliased
+end
 
 [%%expect{|
-external x4 : string -> string @@ portable = "%identity"
+>> Fatal error: crossings as modalities are not yet implemented
+Uncaught exception: Misc.Fatal_error
+
+|}]
+
+external x1 : (string -> string) @@ portable many = "%identity"
+external x2 : int mod contended aliased = "%identity"
+external x3 : int @@ portable many mod contended aliased = "%identity"
+
+[%%expect{|
+external x1 : string -> string @@ portable = "%identity"
+>> Fatal error: crossings as mode annotations are not yet implemented
+Uncaught exception: Misc.Fatal_error
+
 |}]
 
 type t =
@@ -615,6 +733,15 @@ type t2 = {
   mutable x : float @@ local once;
   mutable f : float -> float @@ local once;
 }
+|}]
+
+type t3 = { mutable x : float @@ local once mod contended aliased
+          ; mutable f : (float -> float) @@ local once mod contended aliased }
+
+[%%expect{|
+>> Fatal error: crossings as modalities are not yet implemented
+Uncaught exception: Misc.Fatal_error
+
 |}]
 
 let f1 (x @ local) (f @ once) : t1 = exclave_ { x; f }
@@ -666,18 +793,18 @@ module M : sig end @@ stateless
 module F (X : S @ portable) = struct
 end
 [%%expect{|
-Line 1, characters 18-26:
+Line 1, characters 16-26:
 1 | module F (X : S @ portable) = struct
-                      ^^^^^^^^
+                    ^^^^^^^^^^
 Error: Mode annotations on functor parameters are not supported yet.
 |}]
 
 module F (_ : S @ portable) = struct
 end
 [%%expect{|
-Line 1, characters 18-26:
+Line 1, characters 16-26:
 1 | module F (_ : S @ portable) = struct
-                      ^^^^^^^^
+                    ^^^^^^^^^^
 Error: Mode annotations on functor parameters are not supported yet.
 |}]
 
@@ -689,18 +816,18 @@ module M' : S @@ stateless
 module F (M : S @ portable) : S @ portable = struct
 end
 [%%expect{|
-Line 1, characters 18-26:
+Line 1, characters 16-26:
 1 | module F (M : S @ portable) : S @ portable = struct
-                      ^^^^^^^^
+                    ^^^^^^^^^^
 Error: Mode annotations on functor parameters are not supported yet.
 |}]
 
 module F (M : S @ portable) @ portable = struct
 end
 [%%expect{|
-Line 1, characters 18-26:
+Line 1, characters 16-26:
 1 | module F (M : S @ portable) @ portable = struct
-                      ^^^^^^^^
+                    ^^^^^^^^^^
 Error: Mode annotations on functor parameters are not supported yet.
 |}]
 
@@ -730,18 +857,18 @@ module M : S @@ stateless
 
 module type S' = functor () (M : S @ portable) (_ : S @ portable) -> S @ portable
 [%%expect{|
-Line 1, characters 37-45:
+Line 1, characters 35-45:
 1 | module type S' = functor () (M : S @ portable) (_ : S @ portable) -> S @ portable
-                                         ^^^^^^^^
+                                       ^^^^^^^^^^
 Error: Mode annotations on functor parameters are not supported yet.
 |}]
 
 
 module type S' = () -> S @ portable -> S @ portable -> S @ portable
 [%%expect{|
-Line 1, characters 27-35:
+Line 1, characters 25-35:
 1 | module type S' = () -> S @ portable -> S @ portable -> S @ portable
-                               ^^^^^^^^
+                             ^^^^^^^^^^
 Error: Mode annotations on functor parameters are not supported yet.
 |}]
 

--- a/testsuite/tests/parsing/illegal_ppx.ml
+++ b/testsuite/tests/parsing/illegal_ppx.ml
@@ -50,10 +50,10 @@ let nested_pat_constraint loc =
     (H.Pat.constraint_
        (H.Pat.mk Ppat_any)
        None
-       [mode "bar"]
+       (H.Modes.of_core_modes [mode "bar"])
     )
     (Some (H.Typ.mk (Ptyp_any None)))
-    [mode "foo"]
+    (H.Modes.of_core_modes [mode "foo"])
 
 (* Malformed labeled tuples *)
 

--- a/testsuite/tests/ppx-error-message/ppx_error_message.ml
+++ b/testsuite/tests/ppx-error-message/ppx_error_message.ml
@@ -37,7 +37,7 @@ let () =
                       [ Ast_helper.Rf.tag { txt = str; loc } true [] ]
                       Closed
                       None ))
-                    [])
+                    No_modes)
                   (Ast_helper.Attr.mk
                      { txt = "ocaml.error_message"; loc }
                      (PStr

--- a/testsuite/tests/typing-crossings/syntax-error.compilers.reference
+++ b/testsuite/tests/typing-crossings/syntax-error.compilers.reference
@@ -1,0 +1,83 @@
+Line 10, characters 32-33:
+10 | let foo : type a. (a -> a) mod  = fun x -> x;;
+                                     ^
+Error: Syntax error: "crossing expression" expected.
+Line 2, characters 15-16:
+2 | let (x, y) mod = "hello", "world";;
+                   ^
+Error: Syntax error: "crossing expression" expected.
+Line 2, characters 19-20:
+2 | let (x, y) : _ mod = "hello", "world";;
+                       ^
+Error: Syntax error: "crossing expression" expected.
+Line 2, characters 12-13:
+2 | let foo mod = "hello";;
+                ^
+Error: Syntax error: "crossing expression" expected.
+Line 2, characters 27-28:
+2 | let foo = ("hello" : _ mod );;
+                               ^
+Error: Syntax error: "crossing expression" expected.
+Line 2, characters 23-24:
+2 | let foo = ("hello" mod );;
+                           ^
+Error: Syntax error
+val foo : bar:string -> string = <fun>
+Line 5, characters 16-19:
+5 |   foo ~(bar : _ mod )
+                    ^^^
+Error: Syntax error
+Line 4, characters 12-15:
+4 |   foo ~(bar mod )
+                ^^^
+Error: Syntax error
+type r = { a : string; b : string; }
+Line 3, characters 15-18:
+3 | let r = {a : _ mod = "hello";
+                   ^^^
+Error: Syntax error: "}" expected
+Line 3, characters 8-9:
+3 | let r = {a : _ mod = "hello";
+            ^
+  This "{" might be unmatched
+Line 3, characters 5-8:
+3 |   {a mod  = "hello";
+         ^^^
+Error: Syntax error: "}" expected
+Line 3, characters 2-3:
+3 |   {a mod  = "hello";
+      ^
+  This "{" might be unmatched
+Line 5, characters 8-11:
+5 |   ~(bar mod ), ~(biz mod )
+            ^^^
+Error: Syntax error
+Line 4, characters 0-1:
+4 | }
+    ^
+Error: Syntax error: "crossing expression" expected.
+Line 2, characters 12-15:
+2 | let foo ((x mod ), (y@)) = x + y ;;
+                ^^^
+Error: Syntax error: ")" expected
+Line 2, characters 9-10:
+2 | let foo ((x mod ), (y@)) = x + y ;;
+             ^
+  This "(" might be unmatched
+Line 2, characters 16-19:
+2 | let foo ((x : _ mod ), (y : _ mod )) = x + y;;
+                    ^^^
+Error: Syntax error: ")" expected
+Line 2, characters 9-10:
+2 | let foo ((x : _ mod ), (y : _ mod )) = x + y;;
+             ^
+  This "(" might be unmatched
+Line 3, characters 15-16:
+3 |   let (bar mod ) a b = () in
+                   ^
+Error: Syntax error: "crossing expression" expected.
+Line 2, characters 10-38:
+2 | let foo = ("bar" :> int mod contended);;
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Syntax error: "mode annotations" not expected.
+

--- a/testsuite/tests/typing-crossings/syntax-error.ml
+++ b/testsuite/tests/typing-crossings/syntax-error.ml
@@ -1,0 +1,167 @@
+(* TEST
+ toplevel;
+*)
+
+(* This file contains some syntax errors for mod crossings, as well as
+   documentation for behavior which is not currently supported. *)
+
+(* mostly from [typing-modes/syntax-error.ml] *)
+
+let foo : type a. (a -> a) mod  = fun x -> x;;
+
+let (x, y) mod = "hello", "world";;
+
+let (x, y) : _ mod = "hello", "world";;
+
+let foo mod = "hello";;
+
+let foo = ("hello" : _ mod );;
+
+let foo = ("hello" mod );;
+
+let foo ~bar = bar ^ "hello";;
+
+let x =
+  let bar = "world" in
+  (* this error message doesn't say that a crossing expression is expected *)
+  foo ~(bar : _ mod )
+;;
+
+let x =
+  let bar = "world" in
+  foo ~(bar mod )
+;;
+
+type r = {a : string; b : string};;
+
+(* this error is slightly different than in [typing-modes/syntax-error.ml] version *)
+let r = {a : _ mod = "hello";
+         b : _ mod = "world"}
+;;
+
+let r =
+  {a mod  = "hello";
+   b mod  = "world"}
+;;
+
+let foo () =
+  let bar = "hello" in
+  let biz = "world" in
+  ~(bar mod ), ~(biz mod )
+;;
+
+type r = {
+  x : string mod
+}
+;;
+
+let foo ((x mod ), (y@)) = x + y ;;
+
+let foo ((x : _ mod ), (y : _ mod )) = x + y;;
+
+let foo () =
+  let (bar mod ) a b = () in
+  bar 42 24;
+  ()
+;;
+
+let foo = ("bar" :> int mod contended);;
+
+(* currently, mod crossings can appear by some arrows, but will _not_ parse properly.
+   specifically,
+      [val v : int -> int mod contended aliased @@ once portable]
+   currently parses as
+       [val v : (int -> int) mod contended aliased @@ once portable]
+   instead of
+       [val v : int -> (int mod contended aliased @@ once portable)]
+
+   it should parse in the second way, since parentheses are not allowed to appear in
+   that position, whereas they are allowed to appear for the first case.
+*)
+
+(* more examples with arrow types:
+
+module type S = sig
+  val v : int -> int mod contended aliased
+  val v : int -> int @@ once portable mod contended aliased
+
+  external ex : int -> int mod contended aliased = "foo3"
+  external ex : int -> int @@ once portable mod contended aliased = "foo4"
+
+  type t = int mod contended aliased -> int
+  type 'a t = 'a -> 'a mod contended aliased @@ once portable
+  type fn = int @ portable contended mod contended aliased -> local_ int @ portable contended;;
+end
+
+module M = struct
+  let v : int -> int mod contended aliased = fun _ -> 42
+  let v : int -> int @ once portable mod contended aliased = fun _ -> 42
+  let v : int mod contended aliased -> int = fun _ -> 42
+
+  let f ?(x : ('a : any) 'b . 'a -> 'b @ once portable mod contended aliased = assert false)
+      ?x:(local_ (y, z) : ('a : any) 'b . 'a -> 'b @ once portable mod contended aliased = 42)
+      ~(x : ('a : any) 'b . 'a -> 'b @ once portable mod contended aliased)
+      ~x:((y, z) : ('a : any) 'b . 'a -> 'b @ once portable mod contended aliased)
+      ((y, z) : ('a : any) 'b . 'a -> 'b @ once portable mod contended aliased)
+
+  let g () =
+    let a : ('a : any) 'b. 'a -> 'a @ once portable mod contended aliased = 42 in
+    let a : type (a : any) b. a -> b @ once portable mod contended aliased = 42 in
+    let (a, b) : int -> int @ once portable mod contended aliased = 42 in
+  ()
+end
+*)
+
+(* mod crossings are not supported with modules / functors / etc, both
+   in mode positions and in modality positions. these do not parse and
+   are not currently intended to be supported *)
+
+(* in addition to the mod modes on arrow types, there are some more odd consequences
+   of this choice of syntax, which are noted here for examination:
+
+  mod modalities interaction with with-bounds: parses as mod jkind_annotation
+
+  type 'a t : immutable_data with 'a mod contended
+  type 'a t : immutable_data with 'a -> 'a mod contended
+
+  kind_of_ similarly has weird precedence-related cases.
+
+  type 'a t : kind_of_ 'a mod global
+  (* these two cases parse identically *)
+  type 'a t : kind_of_ 'a -> 'a mod global
+  type 'a t : kind_of_ ('a -> 'a) mod global
+*)
+
+(* it is worthwhile to also test...
+    - that comments work; specifically, that doc comments are attached to the
+      right thing after parsing
+    - that attributes work too
+*)
+
+(* currently, mod crossings can coexist with legacy modes, but this is not
+   explicitly intended to be supported. I believe that these will parse but not
+   pretty-print in the expected way. Examples are included below:
+
+let f ?(local_ x @ once portable mod contended aliased = 42) = ()
+
+type record =
+  { global_ field1 : int mod contended aliased
+  ; global_ field5 : int @@ portable contended mod contended aliased
+  };;
+
+type 'a parameterized_record =
+  { global_ field1 : 'a mod contended aliased
+  ; global_ field5 : 'a @@ portable contended mod contended aliased
+  };;
+
+(* there are more interesting combinations here too *)
+type t =
+  | Foo of global_ int mod contended * int
+  | Foo1 of global_ int @@ portable contended mod contended * int
+
+let g () =
+  let local_ f a b @ once portable mod contended aliased = 42 in
+  let local_ a : (int -> int) @ once portable mod contended aliased = 42 in
+  let local_ a : ('a : any) 'b. ('a -> 'a) @ once portable mod contended aliased = 42 in
+  ()
+*)

--- a/testsuite/tests/typing-layouts-products/parsing_ambiguous_product.compilers.reference
+++ b/testsuite/tests/typing-layouts-products/parsing_ambiguous_product.compilers.reference
@@ -21,12 +21,12 @@
               Pjk_mod
                 jkind (parsing_ambiguous_product.ml[12,327+11]..[12,327+16])
                 Pjk_abbreviation "value"
-                mode "global" (parsing_ambiguous_product.ml[12,327+21]..[12,327+27])
+                mod "global" (parsing_ambiguous_product.ml[12,327+21]..[12,327+27])
               jkind (parsing_ambiguous_product.ml[12,327+31]..[12,327+49])
               Pjk_mod
                 jkind (parsing_ambiguous_product.ml[12,327+32]..[12,327+37])
                 Pjk_abbreviation "value"
-                mode "global" (parsing_ambiguous_product.ml[12,327+42]..[12,327+48])
+                mod "global" (parsing_ambiguous_product.ml[12,327+42]..[12,327+48])
             ]
     ]
   structure_item (parsing_ambiguous_product.ml[14,380+0]..[14,380+45])
@@ -53,11 +53,11 @@
                 Pjk_mod
                   jkind (parsing_ambiguous_product.ml[14,380+10]..[14,380+15])
                   Pjk_abbreviation "value"
-                  mode "global" (parsing_ambiguous_product.ml[14,380+20]..[14,380+26])
+                  mod "global" (parsing_ambiguous_product.ml[14,380+20]..[14,380+26])
                 jkind (parsing_ambiguous_product.ml[14,380+29]..[14,380+34])
                 Pjk_abbreviation "value"
               ]
-              mode "global" (parsing_ambiguous_product.ml[14,380+39]..[14,380+45])
+              mod "global" (parsing_ambiguous_product.ml[14,380+39]..[14,380+45])
     ]
   structure_item (parsing_ambiguous_product.ml[16,429+0]..[16,429+47])
     Pstr_type Rec
@@ -83,11 +83,11 @@
                 Pjk_mod
                   jkind (parsing_ambiguous_product.ml[16,429+11]..[16,429+16])
                   Pjk_abbreviation "value"
-                  mode "global" (parsing_ambiguous_product.ml[16,429+21]..[16,429+27])
+                  mod "global" (parsing_ambiguous_product.ml[16,429+21]..[16,429+27])
                 jkind (parsing_ambiguous_product.ml[16,429+30]..[16,429+35])
                 Pjk_abbreviation "value"
               ]
-              mode "global" (parsing_ambiguous_product.ml[16,429+41]..[16,429+47])
+              mod "global" (parsing_ambiguous_product.ml[16,429+41]..[16,429+47])
     ]
 ]
 

--- a/testsuite/tests/typing-modes/global_and_aliased.ml
+++ b/testsuite/tests/typing-modes/global_and_aliased.ml
@@ -18,9 +18,9 @@ type 'a t3 = { x3 : 'a @@ global; } [@@unboxed]
 type 'a t4 : value mod global = { x4 : 'a @@ global unique } [@@unboxed]
 
 [%%expect{|
-Line 1, characters 45-58:
+Line 1, characters 42-58:
 1 | type 'a t4 : value mod global = { x4 : 'a @@ global unique } [@@unboxed]
-                                                 ^^^^^^^^^^^^^
+                                              ^^^^^^^^^^^^^^^^
 Error: The modality "global" can't be used together with "unique"
 |}]
 
@@ -123,9 +123,9 @@ type 'a mut5 = { mutable x5 : 'a @@ local unique; }
 type 'a mut6 = { mutable x6 : 'a @@ unique }
 
 [%%expect{|
-Line 1, characters 36-42:
+Line 1, characters 33-42:
 1 | type 'a mut6 = { mutable x6 : 'a @@ unique }
-                                        ^^^^^^
+                                     ^^^^^^^^^
 Error: The modality "global" can't be used together with "unique"
 |}]
 

--- a/testsuite/tests/typing-modes/module.ml
+++ b/testsuite/tests/typing-modes/module.ml
@@ -239,25 +239,25 @@ Error: The module "M" is "nonportable" but is expected to be "portable"
 module F (X : S @ portable) = struct
 end
 [%%expect{|
-Line 1, characters 18-26:
+Line 1, characters 16-26:
 1 | module F (X : S @ portable) = struct
-                      ^^^^^^^^
+                    ^^^^^^^^^^
 Error: Mode annotations on functor parameters are not supported yet.
 |}]
 
 module type S = functor () (M : S @ portable) (_ : S @ portable) -> S
 [%%expect{|
-Line 1, characters 36-44:
+Line 1, characters 34-44:
 1 | module type S = functor () (M : S @ portable) (_ : S @ portable) -> S
-                                        ^^^^^^^^
+                                      ^^^^^^^^^^
 Error: Mode annotations on functor parameters are not supported yet.
 |}]
 
 module type S = functor () (M : S) (_ : S) -> S @ portable
 [%%expect{|
-Line 1, characters 50-58:
+Line 1, characters 48-58:
 1 | module type S = functor () (M : S) (_ : S) -> S @ portable
-                                                      ^^^^^^^^
+                                                    ^^^^^^^^^^
 Error: Mode annotations on functor return are not supported yet.
 |}]
 

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2000,11 +2000,11 @@ module Const = struct
       match diff base actual with
       | None -> None
       | Some diff ->
-        let modes =
+        let crossings =
           Typemode.untransl_mod_bounds diff
-          |> List.map (fun { Location.txt = Parsetree.Mode s; _ } -> s)
+          |> List.map (fun { Location.txt = Parsetree.Crossing s; _ } -> s)
         in
-        Some modes
+        Some crossings
 
     let modality_to_ignore_axes axes_to_ignore =
       (* The modality is constant along axes to ignore and id along others *)

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -284,7 +284,11 @@ let make_method loc cl_num expr =
         pparam_loc = pat.ppat_loc;
       }
     ]
-    {ret_type_constraint=None; ret_mode_annotations=[]; mode_annotations=[]} (Pfunction_body expr)
+    { ret_type_constraint=None;
+      ret_mode_annotations=No_modes;
+      mode_annotations=No_modes
+    }
+    (Pfunction_body expr)
 
 (*******************************)
 

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -3849,8 +3849,16 @@ let transl_value_decl env loc ~modal ~why valdecl =
   let mode, val_modalities =
     match modal with
     | Str_primitive ->
-        let modality_to_mode {txt = Modality m; loc} = {txt = Mode m; loc} in
-        let modes = List.map modality_to_mode valdecl.pval_modalities in
+        let modes =
+          match valdecl.pval_modalities with
+          | No_modalities -> No_modes
+          | Modalities { loc; modalities; crossings } ->
+            let modality_to_mode {txt = Modality m; loc} = {txt = Mode m; loc} in
+            let modes =
+              List.map modality_to_mode modalities
+            in
+            Modes { loc; modes; crossings }
+        in
         let mode =
           modes
           |> Typemode.transl_mode_annots
@@ -3863,8 +3871,8 @@ let transl_value_decl env loc ~modal ~why valdecl =
     | Sig_value (md_mode, sig_modalities) ->
         let modalities =
           match valdecl.pval_modalities with
-          | [] -> sig_modalities
-          | l -> Typemode.transl_modalities ~maturity:Stable Immutable l
+          | No_modalities -> sig_modalities
+          | modas -> Typemode.transl_modalities ~maturity:Stable Immutable modas
         in
         let modalities = Mode.Modality.of_const modalities in
         md_mode, modalities

--- a/typing/typemode.mli
+++ b/typing/typemode.mli
@@ -1,7 +1,7 @@
 (** Interpret mode syntax as mode annotation, where axes can be left unspecified *)
 val transl_mode_annots : Parsetree.modes -> Mode.Alloc.Const.Option.t
 
-val untransl_mode_annots : Mode.Alloc.Const.Option.t -> Parsetree.modes
+val untransl_mode_annots : Mode.Alloc.Const.Option.t -> Parsetree.core_modes
 
 (** Interpret mode syntax as alloc mode (on arrow types), where axes are set to
     legacy if unspecified *)
@@ -28,11 +28,11 @@ val untransl_modality : Mode.Modality.atom -> Parsetree.modality Location.loc
     attributes on the field and remove mutable-implied modalities accordingly.
     *)
 val untransl_modalities :
-  Types.mutability -> Mode.Modality.Const.t -> Parsetree.modalities
+  Types.mutability -> Mode.Modality.Const.t -> Parsetree.core_modalities
 
 (** Interpret a mod-bounds. *)
-val transl_mod_bounds : Parsetree.modes -> Types.Jkind_mod_bounds.t
+val transl_mod_bounds : Parsetree.crossings -> Types.Jkind_mod_bounds.t
 
-val untransl_mod_bounds : Types.Jkind_mod_bounds.t -> Parsetree.modes
+val untransl_mod_bounds : Types.Jkind_mod_bounds.t -> Parsetree.crossings
 
 val idx_expected_modalities : mut:bool -> Mode.Modality.Const.t

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -698,7 +698,7 @@ let transl_label_from_pat (label : Parsetree.arg_label)
   (* We should only strip off the constraint node if the label translates
      to Position, as this means the type annotation is [%call_pos] and
      nothing more. *)
-  | {ppat_desc = Ppat_constraint (inner_pat, ty, []); _} ->
+  | {ppat_desc = Ppat_constraint (inner_pat, ty, No_modes); _} ->
       let label = transl_label label ty in
       let pat = if Btype.is_position label then inner_pat else pat in
       label, pat
@@ -708,7 +708,7 @@ let transl_label_from_pat (label : Parsetree.arg_label)
 let transl_label_from_expr (label : Parsetree.arg_label)
     (expr : Parsetree.expression) =
   match expr with
-  | {pexp_desc = Pexp_constraint (inner_expr, ty, []); _} ->
+  | {pexp_desc = Pexp_constraint (inner_expr, ty, No_modes); _} ->
       let label = transl_label label ty in
       let expr = if Btype.is_position label then inner_expr else expr in
       label, expr

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -1631,7 +1631,9 @@ end = struct
   let variant_field s t = child (Projection.Variant_field s) t
 
   let array_index mut i t =
-    let modality = Typemode.transl_modalities ~maturity:Stable mut [] in
+    let modality =
+      Typemode.transl_modalities ~maturity:Stable mut No_modalities
+    in
     modal_child modality (Projection.Array_index i) t
 
   let memory_address t = child Projection.Memory_address t


### PR DESCRIPTION
Adds parsing support for tracking crossings (i.e. `mod contended`, formerly `cocontended`) on a per-value basis, not just in the modal bounds of a kinds (aka on a per-type basis). This PR adds parsing logic and refactors the parsetree accordingly.

Generally, `mod <crossings>` may now appear in positions where `@ <modes>` or `@@ <modalities>` can, with three current exceptions:
- Will not parse in places related to modules (i.e. module declarations, signatures, include, etc)
- Does not parse on arrow types (in positions where `@ <modes>` does), though this should be supported in the future
- Does not parse in with-bounds (despite modalities being allowed there)

The test file `testing-crossings/syntax-error.ml` has examples of some of these curious cases.

Using any of these `mod <crossings>` will result in a fatal error, as type checking behavior is not implemented in this PR.

The new `modes` and `modalities` data definitions include a location, as well as a `No_modes/modalities` constructor to avoid carrying around dummy `Location.none`s in the AST when no mode/modality annotations are present.