### PR TITLE
Bytecode compilation: differentiate Bytes.get from String.get

### DIFF
--- a/bytecomp/blambda.ml
+++ b/bytecomp/blambda.ml
@@ -99,6 +99,7 @@ type primitive =
   | Lsrint
   | Asrint
   | Intcomp of comparison
+  | Getstringchar
   | Getbyteschar
   | Getvectitem
   | Setfield of int

--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -615,7 +615,8 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     | Pstringrefs -> binary (Ccall "caml_string_get")
     | Pbytesrefs -> binary (Ccall "caml_bytes_get")
     | Pbytessets -> ternary (Ccall "caml_bytes_set")
-    | Pstringrefu | Pbytesrefu -> binary Getbyteschar
+    | Pstringrefu -> binary Getstringchar
+    | Pbytesrefu -> binary Getbyteschar
     | Pbytessetu -> ternary Setbyteschar
     | Pstring_load_16 { index_kind; _ } ->
       binary (indexing_primitive index_kind "caml_string_get16")

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -301,6 +301,7 @@ let comp_primitive stack_info p sz args =
   | Asrint -> Kasrint
   | Offsetint n -> Koffsetint n
   | Offsetref n -> Koffsetref n
+  | Getstringchar -> Kgetstringchar
   | Getbyteschar -> Kgetbyteschar
   | Setbyteschar -> Ksetbyteschar
   | Vectlength -> Kvectlength

--- a/bytecomp/printblambda.ml
+++ b/bytecomp/printblambda.ml
@@ -54,6 +54,7 @@ let primitive ppf = function
   | Lsrint -> pp_print_string ppf "lsrint"
   | Asrint -> pp_print_string ppf "asrint"
   | Intcomp cmp -> comparison ppf cmp
+  | Getstringchar -> pp_print_string ppf "getstringchar"
   | Getbyteschar -> pp_print_string ppf "getbyteschar"
   | Getvectitem -> pp_print_string ppf "getvectitem"
   | Setfield i -> fprintf ppf "setfield %d" i


### PR DESCRIPTION
Js_of_ocaml uses by default a different representation for strings than for bytes, so it needs this information.

In the OxCaml opam repository, Js_of_ocaml is patched to change this default. It would be better if this patch was not needed.
https://github.com/oxcaml/opam-repository/blob/b192fe2e6d0a272fd441160d4c88cd984c7dde87/packages/js_of_ocaml/js_of_ocaml.6.0.1%2Box/files/js_of_ocaml-important-config-changes.patch#L7-L8