### PR TITLE
(LLVM Backend) Emit float data as bits

### DIFF
--- a/oxcaml/tests/backend/llvmize/data_decl_ir.output
+++ b/oxcaml/tests/backend/llvmize/data_decl_ir.output
@@ -505,9 +505,9 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @header.camlData_decl__f_2 = global i64 4345, section ".data", align 8
 @camlData_decl__f_2 = global { ptr, i64 } { ptr @camlData_decl__f_HIDE_STAMP, i64 108086391056891909 }, section ".data", align 8
 @header.camlData_decl__float4 = global i64 2045, section ".data", align 8
-@camlData_decl__float4 = global { double } { double 3.14159265358979311600 }, section ".data", align 8
+@camlData_decl__float4 = global { double } { double 0x400921fb54442d18 }, section ".data", align 8
 @header.camlData_decl__float327 = global i64 3071, section ".data", align 8
-@camlData_decl__float327 = global { ptr, float } { ptr @caml_float32_ops, float 2.71828174591064453125 }, section ".data", align 8
+@camlData_decl__float327 = global { ptr, float } { ptr @caml_float32_ops, float 0x4005bf0a80000000 }, section ".data", align 8
 @header.camlData_decl__immstring35 = global i64 5116, section ".data", align 8
 @camlData_decl__immstring35 = global { [ 30 x i8 ], [ 1 x i8 ], i8 } { [ 30 x i8 ] c"\6f\6e\65\20\6f\66\20\74\68\65\20\73\74\72\69\6e\67\73\0a\6f\66\20\61\6c\6c\20\74\69\6d\65", [ 1 x i8 ] zeroinitializer, i8 1 }, section ".data", align 8
 @header.camlData_decl__immstring38 = global i64 2044, section ".data", align 8

--- a/oxcaml/tests/backend/llvmize/extcalls_ir.output
+++ b/oxcaml/tests/backend/llvmize/extcalls_ir.output
@@ -539,9 +539,9 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @header.camlExtcalls__call_too_many_4 = global i64 3063, section ".data", align 8
 @camlExtcalls__call_too_many_4 = global { ptr, i64 } { ptr @camlExtcalls__call_too_many_HIDE_STAMP, i64 108086391056891909 }, section ".data", align 8
 @header.camlExtcalls__float38 = global i64 2045, section ".data", align 8
-@camlExtcalls__float38 = global { double } { double 4.00000000000000000000 }, section ".data", align 8
+@camlExtcalls__float38 = global { double } { double 0x4010000000000000 }, section ".data", align 8
 @header.camlExtcalls__float36 = global i64 2045, section ".data", align 8
-@camlExtcalls__float36 = global { double } { double 2.00000000000000000000 }, section ".data", align 8
+@camlExtcalls__float36 = global { double } { double 0x4000000000000000 }, section ".data", align 8
 @temp.Extcalls.0 = global { ptr, ptr, ptr } { ptr @int_and_float, ptr @too_many, ptr @print_and_add }, section ".data", align 8
 @camlExtcalls__call_too_many_with_try_HIDE_STAMP.recover_rbp_asm.L122 = external global ptr
 @camlExtcalls__call_too_many_with_try_HIDE_STAMP.recover_rbp_var.L122 = global ptr zeroinitializer, section ".data", align 8

--- a/oxcaml/tests/backend/llvmize/tailcall_ir.output
+++ b/oxcaml/tests/backend/llvmize/tailcall_ir.output
@@ -954,7 +954,7 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 @header.camlTailcall__const_block85 = global i64 2828, section ".data", align 8
 @camlTailcall__const_block85 = global { i64, i64 } { i64 21, i64 1 }, section ".data", align 8
 @header.camlTailcall__float108 = global i64 2045, section ".data", align 8
-@camlTailcall__float108 = global { double } { double 41.29999999999999715783 }, section ".data", align 8
+@camlTailcall__float108 = global { double } { double 0x4044a66666666666 }, section ".data", align 8
 @camlCamlinternalFormat__make_printf_HIDE_STAMP = external global ptr
 @camlStdlib__Format__fn$5b$2fworkspace_root$2fformat.ml$3a1450$2c4$2d$2d59$5d_521 = external global ptr
 @camlTailcall2 = external global ptr


### PR DESCRIPTION
Emitting floats textually sometimes causes issues with `nan`s, so we emit their bitwise representations directly in the IR