### PR TITLE
Reaper: fix for zero-alloc functions

### DIFF
--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -645,7 +645,7 @@ let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
                           stack_ofs; stack_align = _; effects = _; }; _} ->
     assert (stack_ofs >= 0);
     if alloc || stack_ofs > 0 then all_phys_regs else destroyed_at_c_call
-  | Call {op = Indirect | Direct _; _} -> all_phys_regs
+  | Call {op = Indirect _ | Direct _; _} -> all_phys_regs
 
 (* CR-soon xclerc for xclerc: consider having more destruction points.
    We current return `true` when `destroyed_at_terminator` returns
@@ -668,7 +668,7 @@ let is_destruction_point ~(more_destruction_points : bool) (terminator : Cfg_int
       true
     else
       if alloc then true else false
-  | Call {op = Indirect | Direct _; _} ->
+  | Call {op = Indirect _ | Direct _; _} ->
     true
 
 (* Layout of the stack frame *)

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -309,7 +309,7 @@ let terminator (map : spilled_map) (term : Cfg.terminator Cfg.instruction) =
   | Always _ | Return | Raise _ | Switch _ | Tailcall_self _ | Tailcall_func _
   | Call_no_return _
   | Prim { op = External _; _ }
-  | Call { op = Indirect | Direct _; _ } ->
+  | Call { op = Indirect _ | Direct _; _ } ->
     (* no rewrite *)
     May_still_have_spilled_registers
   | Prim { op = Probe _; _ } -> may_use_stack_operands_everywhere map term

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -372,7 +372,7 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
 let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
   match terminator with
   | Never -> assert false
-  | Call {op = Indirect | Direct _; _} ->
+  | Call {op = Indirect _ | Direct _; _} ->
     all_phys_regs
   | Always _ | Parity_test _ | Truth_test _ | Float_test _
   | Int_test _ | Switch _ | Return | Raise _ | Tailcall_self _
@@ -390,7 +390,7 @@ let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
 let is_destruction_point ~(more_destruction_points : bool) (terminator : Cfg_intf.S.terminator) =
   match terminator with
   | Never -> assert false
-  | Call {op = Indirect | Direct _; _} ->
+  | Call {op = Indirect _ | Direct _; _} ->
     true
   | Always _ | Parity_test _ | Truth_test _ | Float_test _
   | Int_test _ | Switch _ | Return | Raise _ | Tailcall_self _

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -182,7 +182,7 @@ let replace_successor_labels t ~normal ~exn block ~f =
       | Switch labels -> Switch (Array.map f labels)
       | Tailcall_self { destination } ->
         Tailcall_self { destination = f destination }
-      | Tailcall_func Indirect
+      | Tailcall_func (Indirect _)
       | Tailcall_func (Direct _)
       | Return | Raise _ | Call_no_return _ ->
         block.terminator.desc

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -361,14 +361,16 @@ let dump_terminator' ?(print_reg = Printreg.reg) ?(res = [||]) ?(args = [||])
              }
          })
   | Tailcall_func call ->
+    (* CR ncourant: here and below, maybe the callees should be printed when
+       they are known *)
     dump_linear_call_op ppf
       (match call with
-      | Indirect -> Linear.Ltailcall_ind
+      | Indirect _callees -> Linear.Ltailcall_ind
       | Direct func -> Linear.Ltailcall_imm { func })
   | Call { op = call; label_after } ->
     Format.fprintf ppf "%t%a" print_res dump_linear_call_op
       (match call with
-      | Indirect -> Linear.Lcall_ind
+      | Indirect _callees -> Linear.Lcall_ind
       | Direct func -> Linear.Lcall_imm { func });
     Format.fprintf ppf "%sgoto %a" sep Label.format label_after
   | Prim { op = prim; label_after } ->

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -33,7 +33,7 @@ open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
 
 module S = struct
   type func_call_operation =
-    | Indirect
+    | Indirect of Cmm.symbol list option
     | Direct of Cmm.symbol
 
   type external_call_operation =

--- a/backend/cfg/cfg_polling.ml
+++ b/backend/cfg/cfg_polling.ml
@@ -215,7 +215,7 @@ module Polls_before_prtc_transfer = struct
     | Switch _ ->
       Ok dom
     | Raise _ -> Ok exn
-    | Tailcall_self _ | Tailcall_func Indirect -> Ok Might_not_poll
+    | Tailcall_self _ | Tailcall_func (Indirect _) -> Ok Might_not_poll
     | Tailcall_func (Direct func) ->
       if String.Set.mem func.sym_name future_funcnames
          || function_is_assumed_to_never_poll func.sym_name

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -60,7 +60,7 @@ module Instruction_requirements = struct
       match instr.desc with
       (* These will cause the function to return, and therefore the stack should
          be unwound. *)
-      | Cfg.Return | Tailcall_func Indirect -> Requires_no_prologue
+      | Cfg.Return | Tailcall_func (Indirect _) -> Requires_no_prologue
       | Tailcall_func (Direct func)
         when not (String.equal func.sym_name fun_name) ->
         Requires_no_prologue

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -143,7 +143,7 @@ let linearize_terminator cfg_with_layout (func : string) start
     match terminator.desc with
     | Return -> [L.Lreturn], None
     | Raise kind -> [L.Lraise kind], None
-    | Tailcall_func Indirect -> [L.Lcall_op Ltailcall_ind], None
+    | Tailcall_func (Indirect _) -> [L.Lcall_op Ltailcall_ind], None
     | Tailcall_func (Direct func_symbol) ->
       [L.Lcall_op (Ltailcall_imm { func = func_symbol })], None
     | Tailcall_self { destination } ->
@@ -174,7 +174,7 @@ let linearize_terminator cfg_with_layout (func : string) start
     | Call { op; label_after } ->
       let op : Linear.call_operation =
         match op with
-        | Indirect -> Lcall_ind
+        | Indirect _ -> Lcall_ind
         | Direct func_symbol -> Lcall_imm { func = func_symbol }
       in
       branch_or_fallthrough [L.Lcall_op op] label_after, None

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -807,7 +807,8 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       | Never_returns -> ()
       | Ok r1 -> emit_tail (bind_let env sub_cfg v r1) sub_cfg e2)
     | Cphantom_let (_var, _defining_expr, body) -> emit_tail env sub_cfg body
-    | Cop ((Capply (ty, Rc_normal) as op), args, dbg) ->
+    | Cop ((Capply { result_type = ty; region = Rc_normal; _ } as op), args, dbg)
+      ->
       emit_tail_apply env sub_cfg ty op args dbg
     | Csequence (e1, e2) -> (
       match emit_expr env sub_cfg e1 ~bound_name:None with
@@ -1231,7 +1232,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       let label_after = Cmm.new_label () in
       let new_op, new_args = select_operation op simple_args dbg ~label_after in
       match new_op with
-      | Terminator (Call { op = Indirect; label_after } as term) ->
+      | Terminator (Call { op = Indirect callees; label_after } as term) ->
         let** r1 = emit_tuple env sub_cfg new_args in
         let rd = Reg.createv ty in
         let rarg = Array.sub r1 1 (Array.length r1 - 1) in
@@ -1240,7 +1241,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         let stack_ofs = Stdlib.Int.max stack_ofs_args stack_ofs_res in
         if stack_ofs = 0 && SU.trap_stack_is_empty env
         then (
-          let call = Cfg.Tailcall_func Indirect in
+          let call = Cfg.Tailcall_func (Indirect callees) in
           SU.insert_moves env sub_cfg rarg loc_arg;
           SU.insert_debug' env sub_cfg call dbg
             (Array.append [| r1.(0) |] loc_arg)

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -402,8 +402,21 @@ type alloc_dbginfo_item =
 
 type alloc_dbginfo = alloc_dbginfo_item list
 
+type is_global =
+  | Global
+  | Local
+
+type symbol =
+  { sym_name : string;
+    sym_global : is_global
+  }
+
 type operation =
-  | Capply of machtype * Lambda.region_close
+  | Capply of
+      { result_type : machtype;
+        region : Lambda.region_close;
+        callees : symbol list option
+      }
   | Cextcall of
       { func : string;
         ty : machtype;
@@ -474,19 +487,10 @@ type operation =
   | Cpoll
   | Cpause
 
-type is_global =
-  | Global
-  | Local
-
 let equal_is_global g g' =
   match g, g' with
   | Local, Local | Global, Global -> true
   | Local, Global | Global, Local -> false
-
-type symbol =
-  { sym_name : string;
-    sym_global : is_global
-  }
 
 type vec128_bits =
   { word0 : int64; (* Least significant *)
@@ -645,8 +649,7 @@ let iter_shallow_tail f = function
   | Cop
       ( ( Calloc _ | Caddi | Csubi | Cmuli | Cdivi | Cmodi | Cand | Cor | Cxor
         | Clsl | Clsr | Casr | Cpopcnt | Caddv | Cadda | Cpackf32 | Copaque
-        | Cbeginregion | Cendregion | Cdls_get | Cpoll | Cpause
-        | Capply (_, _)
+        | Cbeginregion | Cendregion | Cdls_get | Cpoll | Cpause | Capply _
         | Cextcall _ | Cload _
         | Cstore (_, _)
         | Cmulhi _ | Cbswap _ | Ccsel _ | Cclz _ | Cctz _ | Cprefetch _
@@ -679,8 +682,7 @@ let map_shallow_tail f = function
     | Cop
         ( ( Calloc _ | Caddi | Csubi | Cmuli | Cdivi | Cmodi | Cand | Cor | Cxor
           | Clsl | Clsr | Casr | Cpopcnt | Caddv | Cadda | Cpackf32 | Copaque
-          | Cbeginregion | Cendregion | Cdls_get | Cpoll | Cpause
-          | Capply (_, _)
+          | Cbeginregion | Cendregion | Cdls_get | Cpoll | Cpause | Capply _
           | Cextcall _ | Cload _
           | Cstore (_, _)
           | Cmulhi _ | Cbswap _ | Ccsel _ | Cclz _ | Cctz _ | Cprefetch _

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -366,8 +366,36 @@ type alloc_dbginfo_item =
 
 type alloc_dbginfo = alloc_dbginfo_item list
 
+type is_global =
+  | Global
+  | Local
+
+val equal_is_global : is_global -> is_global -> bool
+
+(* Symbols are marked with whether they are local or global, at both definition
+   and use sites.
+
+   Symbols defined as [Local] may only be referenced within the same file, and
+   all such references must also be [Local].
+
+   Symbols defined as [Global] may be referenced from other files. References
+   from other files must be [Global], but references from the same file may be
+   [Local].
+
+   (Marking symbols in this way speeds up linking, as many references can then
+   be resolved early) *)
+type symbol =
+  { sym_name : string;
+    sym_global : is_global
+  }
+
 type operation =
-  | Capply of machtype * Lambda.region_close
+  | Capply of
+      { result_type : machtype;
+        region : Lambda.region_close;
+        callees : symbol list option
+            (* List of possible callees, or [None] if not known *)
+      }
   | Cextcall of
       { func : string;
         ty : machtype;
@@ -442,29 +470,6 @@ type operation =
   | Cdls_get
   | Cpoll
   | Cpause
-
-type is_global =
-  | Global
-  | Local
-
-val equal_is_global : is_global -> is_global -> bool
-
-(* Symbols are marked with whether they are local or global, at both definition
-   and use sites.
-
-   Symbols defined as [Local] may only be referenced within the same file, and
-   all such references must also be [Local].
-
-   Symbols defined as [Global] may be referenced from other files. References
-   from other files must be [Global], but references from the same file may be
-   [Local].
-
-   (Marking symbols in this way speeds up linking, as many references can then
-   be resolved early) *)
-type symbol =
-  { sym_name : string;
-    sym_global : is_global
-  }
 
 (* SIMD vectors are untyped in the backend. This record holds the bitwise
    representation of a 128-bit value. [word0] is the least significant word. *)

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2130,16 +2130,20 @@ let call_cached_method obj tag cache pos args args_type result (apos, mode) dbg
     (List.map Extended_machtype.change_tagged_int_to_val args_type)
     (Extended_machtype.change_tagged_int_to_val result)
     mode;
+  let sym =
+    send_function_name
+      (List.map Extended_machtype.change_tagged_int_to_val args_type)
+      (Extended_machtype.change_tagged_int_to_val result)
+      mode
+  in
   Cop
-    ( Capply (Extended_machtype.to_machtype result, apos),
+    ( Capply
+        { result_type = Extended_machtype.to_machtype result;
+          region = apos;
+          callees = Some [sym]
+        },
       (* See the cases for caml_apply regarding [change_tagged_int_to_val]. *)
-      Cconst_symbol
-        ( send_function_name
-            (List.map Extended_machtype.change_tagged_int_to_val args_type)
-            (Extended_machtype.change_tagged_int_to_val result)
-            mode,
-          dbg )
-      :: obj :: tag :: cache :: pos :: args,
+      Cconst_symbol (sym, dbg) :: obj :: tag :: cache :: pos :: args,
       dbg )
 
 (* Allocation *)
@@ -3096,12 +3100,12 @@ let call_caml_apply extended_ty extended_args_type mut clos args pos mode dbg =
      excessive numbers of caml_apply functions. *)
   let ty = Extended_machtype.to_machtype extended_ty in
   let really_call_caml_apply clos args =
-    let cargs =
-      Cconst_symbol (apply_function_sym extended_args_type extended_ty mode, dbg)
-      :: args
-      @ [clos]
-    in
-    Cop (Capply (ty, pos), cargs, dbg)
+    let sym = apply_function_sym extended_args_type extended_ty mode in
+    let cargs = (Cconst_symbol (sym, dbg) :: args) @ [clos] in
+    Cop
+      ( Capply { result_type = ty; region = pos; callees = Some [sym] },
+        cargs,
+        dbg )
   in
   if !Oxcaml_flags.caml_apply_inline_fast_path
   then
@@ -3126,7 +3130,7 @@ let call_caml_apply extended_ty extended_args_type mut clos args pos mode dbg =
                     dbg ),
                 dbg,
                 Cop
-                  ( Capply (ty, pos),
+                  ( Capply { result_type = ty; region = pos; callees = None },
                     (get_field_codepointer mut clos 2 dbg :: args) @ [clos],
                     dbg ),
                 dbg,
@@ -3155,7 +3159,11 @@ let apply_or_call_caml_apply result arity mut clos args pos mode dbg =
   | [_] ->
     bind "fun" clos (fun clos ->
         Cop
-          ( Capply (Extended_machtype.to_machtype result, pos),
+          ( Capply
+              { result_type = Extended_machtype.to_machtype result;
+                region = pos;
+                callees = None
+              },
             (get_field_codepointer mut clos 0 dbg :: args) @ [clos],
             dbg ))
   | _ -> call_caml_apply result arity mut clos args pos mode dbg
@@ -3370,7 +3378,7 @@ let apply_function_body arity result (mode : Cmx_format.alloc_mode) =
     | [arg] -> (
       let app =
         Cop
-          ( Capply (result, Rc_normal),
+          ( Capply { result_type = result; region = Rc_normal; callees = None },
             [ get_field_codepointer Asttypes.Mutable (Cvar clos) 0 (dbg ());
               Cvar arg;
               Cvar clos ],
@@ -3389,7 +3397,8 @@ let apply_function_body arity result (mode : Cmx_format.alloc_mode) =
       Clet
         ( VP.create newclos,
           Cop
-            ( Capply (typ_val, Rc_normal),
+            ( Capply
+                { result_type = typ_val; region = Rc_normal; callees = None },
               [ get_field_codepointer Asttypes.Mutable (Cvar clos) 0 (dbg ());
                 Cvar arg;
                 Cvar clos ],
@@ -3420,7 +3429,7 @@ let apply_function_body arity result (mode : Cmx_format.alloc_mode) =
               dbg () ),
           dbg (),
           Cop
-            ( Capply (result, Rc_normal),
+            ( Capply { result_type = result; region = Rc_normal; callees = None },
               get_field_codepointer Asttypes.Mutable (Cvar clos) 2 (dbg ())
               :: List.map (fun s -> Cvar s) all_args,
               dbg () ),
@@ -3549,7 +3558,7 @@ let tuplify_function arity return =
       fun_args = [VP.create arg, typ_val; VP.create clos, typ_val];
       fun_body =
         Cop
-          ( Capply (return, Rc_normal),
+          ( Capply { result_type = return; region = Rc_normal; callees = None },
             get_field_codepointer Asttypes.Mutable (Cvar clos) 2 (dbg ())
             :: access_components 0
             @ [Cvar clos],
@@ -3692,7 +3701,7 @@ let rec make_curry_apply result narity args_type args clos n =
   match args_type with
   | [] ->
     Cop
-      ( Capply (result, Rc_normal),
+      ( Capply { result_type = result; region = Rc_normal; callees = None },
         (get_field_codepointer Asttypes.Mutable (Cvar clos) 2 (dbg ()) :: args)
         @ [Cvar clos],
         dbg () )
@@ -4162,7 +4171,7 @@ let entry_point namelist =
     in
     Csequence
       ( Cop
-          ( Capply (typ_void, Rc_normal),
+          ( Capply { result_type = typ_void; region = Rc_normal; callees = None },
             [Cop (mk_load_immut Word_int, [f], dbg ())],
             dbg () ),
         incr_global_inited () )
@@ -4549,31 +4558,40 @@ let store ~dbg kind init ~addr ~new_value =
   Cop (Cstore (kind, init), [addr; new_value], dbg)
 
 let direct_call ~dbg ty pos f_code_sym args =
-  Cop (Capply (ty, pos), f_code_sym :: args, dbg)
+  Cop
+    ( Capply { result_type = ty; region = pos; callees = Some [f_code_sym] },
+      Cconst_symbol (f_code_sym, dbg) :: args,
+      dbg )
 
 let indirect_call ~dbg ty pos alloc_mode f args_type args =
   might_split_call_caml_apply ty args_type Asttypes.Mutable f args pos
     alloc_mode dbg
 
-let indirect_full_call ~dbg ty pos alloc_mode f args_type args =
-  match args_type with
-  (* the single-argument case is already optimized by indirect_call *)
-  | [_] -> indirect_call ~dbg ty pos alloc_mode f args_type args
-  | [] -> Misc.fatal_error "indirect_full_call: args_type was empty"
-  | _ :: _ :: _ ->
-    (* Use a variable to avoid duplicating the cmm code of the closure [f]. *)
-    let v = Backend_var.create_local "*closure*" in
-    let v' = Backend_var.With_provenance.create v in
-    (* get the function's code pointer *)
-    let fun_ptr =
-      load ~dbg Word_int Asttypes.Mutable ~addr:(field_address (Cvar v) 2 dbg)
+let indirect_full_call ~dbg ty pos f ~callees args_type args =
+  (* Use a variable to avoid duplicating the cmm code of the closure [f]. *)
+  let v = Backend_var.create_local "*closure*" in
+  let v' = Backend_var.With_provenance.create v in
+  (* get the function's code pointer *)
+  let fun_ptr =
+    let offset =
+      match args_type with
+      | [_] -> 0
+      | [] -> Misc.fatal_error "indirect_full_call: args_type was empty"
+      | _ :: _ :: _ -> 2
     in
-    letin v' ~defining_expr:f
-      ~body:
-        (Cop
-           ( Capply (Extended_machtype.to_machtype ty, pos),
-             (fun_ptr :: args) @ [Cvar v],
-             dbg ))
+    load ~dbg Word_int Asttypes.Mutable
+      ~addr:(field_address (Cvar v) offset dbg)
+  in
+  letin v' ~defining_expr:f
+    ~body:
+      (Cop
+         ( Capply
+             { result_type = Extended_machtype.to_machtype ty;
+               region = pos;
+               callees
+             },
+           (fun_ptr :: args) @ [Cvar v],
+           dbg ))
 
 let bigarray_load ~dbg ~elt_kind ~elt_size ~elt_chunk ~bigarray ~index =
   let ba_data_f = field_address bigarray 1 dbg in
@@ -5000,42 +5018,39 @@ let perform ~dbg eff =
   in
   (* Rc_normal means "allow tailcalls". Preventing them here by using Rc_nontail
      improves backtraces of paused fibers. *)
+  let sym = Cmm.global_symbol "caml_perform" in
   Cop
-    ( Capply (typ_val, Rc_nontail),
-      [Cconst_symbol (Cmm.global_symbol "caml_perform", dbg); eff; cont],
+    ( Capply { result_type = typ_val; region = Rc_nontail; callees = Some [sym] },
+      [Cconst_symbol (sym, dbg); eff; cont],
       dbg )
 
 let run_stack ~dbg ~stack ~f ~arg =
   (* Rc_normal would be fine here, but this is unlikely to ever be a tail call
      (usages of this primitive shouldn't be generated in tail position), so we
      use Rc_nontail for clarity. *)
+  let sym = Cmm.global_symbol "caml_runstack" in
   Cop
-    ( Capply (typ_val, Rc_nontail),
-      [Cconst_symbol (Cmm.global_symbol "caml_runstack", dbg); stack; f; arg],
+    ( Capply { result_type = typ_val; region = Rc_nontail; callees = Some [sym] },
+      [Cconst_symbol (sym, dbg); stack; f; arg],
       dbg )
 
 let resume ~dbg ~stack ~f ~arg ~last_fiber =
   (* Rc_normal is required here, because there are some uses of effects with
      repeated resumes, and these should consume O(1) stack space by tail-calling
      caml_resume. *)
+  let sym = Cmm.global_symbol "caml_resume" in
   Cop
-    ( Capply (typ_val, Rc_normal),
-      [ Cconst_symbol (Cmm.global_symbol "caml_resume", dbg);
-        stack;
-        f;
-        arg;
-        last_fiber ],
+    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
+      [Cconst_symbol (sym, dbg); stack; f; arg; last_fiber],
       dbg )
 
 let reperform ~dbg ~eff ~cont ~last_fiber =
   (* Rc_normal is required here, this is used in tail position and should tail
      call. *)
+  let sym = Cmm.global_symbol "caml_reperform" in
   Cop
-    ( Capply (typ_val, Rc_normal),
-      [ Cconst_symbol (Cmm.global_symbol "caml_reperform", dbg);
-        eff;
-        cont;
-        last_fiber ],
+    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
+      [Cconst_symbol (sym, dbg); eff; cont; last_fiber],
       dbg )
 
 let poll ~dbg = return_unit dbg (Cop (Cpoll, [], dbg))

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -982,7 +982,7 @@ val direct_call :
   dbg:Debuginfo.t ->
   machtype ->
   Lambda.region_close ->
-  expression ->
+  symbol ->
   expression list ->
   expression
 
@@ -1003,8 +1003,8 @@ val indirect_full_call :
   dbg:Debuginfo.t ->
   Extended_machtype.t ->
   Lambda.region_close ->
-  Cmx_format.alloc_mode ->
   expression ->
+  callees:symbol list option ->
   Extended_machtype.t list ->
   expression list ->
   expression

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -524,7 +524,7 @@ let call ?(tail = false) t (i : Cfg.terminator Cfg.instruction)
     (* [Indirect] has the function in i.arg.(0) *)
     match op with
     | Direct _ -> 0, Array.length i.arg
-    | Indirect -> 1, Array.length i.arg - 1
+    | Indirect _ -> 1, Array.length i.arg - 1
   in
   let arg_regs = Array.sub i.arg args_begin args_end |> reg_list_for_call in
   let args = prepare_call_args_from_regs t arg_regs in
@@ -540,7 +540,7 @@ let call ?(tail = false) t (i : Cfg.terminator Cfg.instruction)
     | Direct { sym_name; sym_global = _ } ->
       add_referenced_symbol t sym_name;
       LL.Ident.global sym_name
-    | Indirect -> load_reg_to_temp ~typ:T.ptr t i.arg.(0) |> V.get_ident_exn
+    | Indirect _ -> load_reg_to_temp ~typ:T.ptr t i.arg.(0) |> V.get_ident_exn
   in
   let attrs = gc_attr ~can_call_gc:true t i in
   let res =

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -251,7 +251,7 @@ let static_cast : Cmm.static_cast -> string = function
   | V512_of_scalar ty -> Printf.sprintf "scalar->%s" (vec512_name ty)
 
 let operation d = function
-  | Capply (_ty, _) -> "app" ^ location d
+  | Capply { result_type = _ty; region = _; callees = _ } -> "app" ^ location d
   | Cextcall { func = lbl; _ } ->
     Printf.sprintf "extcall \"%s\"%s" lbl (location d)
   | Cload { memory_chunk; mutability; is_atomic } -> (
@@ -388,7 +388,7 @@ let rec expr ppf = function
         fprintf ppf "@[<2>(%s" (operation dbg op);
         List.iter (fun e -> fprintf ppf "@ %a" expr e) el;
         (match[@warning "-4"] op with
-        | Capply (mty, _) -> fprintf ppf "@ %a" machtype mty
+        | Capply { result_type = mty; _ } -> fprintf ppf "@ %a" machtype mty
         | Cextcall
             { ty;
               ty_args;

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -170,7 +170,7 @@ let select_mutable_flag : Asttypes.mutable_flag -> Operation.mutable_flag =
 (* Infer the type of the result of an operation *)
 
 let oper_result_type = function
-  | Capply (ty, _) -> ty
+  | Capply { result_type = ty; _ } -> ty
   | Cextcall { ty; ty_args = _; alloc = _; func = _; _ } -> ty
   | Cload { memory_chunk; _ } -> (
     match memory_chunk with

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -2653,7 +2653,9 @@ end = struct
           transform_tailcall_imm t t.current_fun_name dbg
         | Tailcall_func (Direct { sym_name; _ }) ->
           transform_tailcall_imm t sym_name dbg
-        | Tailcall_func Indirect ->
+        | Tailcall_func (Indirect (Some _callees)) -> failwith "TODO"
+        (* XXX what to do here? *)
+        | Tailcall_func (Indirect None) ->
           (* Sound to ignore [next] and [exn] because the call never returns. *)
           let w = create_witnesses t Indirect_tailcall dbg in
           transform_top t ~next:Value.normal_return ~exn:Value.exn_escape w
@@ -2683,9 +2685,12 @@ end = struct
           in
           let k = Witness.Probe { name; handler_code_sym } in
           transform_call t ~next ~exn handler_code_sym k ~desc dbg
-        | Call { op = Indirect; _ } ->
+        | Call { op = Indirect None; _ } ->
           let w = create_witnesses t Indirect_call dbg in
           transform_top t ~next ~exn w "indirect call" dbg
+        | Call { op = Indirect (Some _callees); _ } ->
+          (* XXX what to do here? *)
+          failwith "todo"
         | Call { op = Direct { sym_name = func; _ }; _ } ->
           let k = Witness.Direct_call { callee = func } in
           transform_call t ~next ~exn func k ~desc:("direct call to " ^ func)

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -502,6 +502,20 @@ let mk_no_flambda2_reaper f =
     Printf.sprintf " Disable reaper pass%s (Flambda2 only)"
       (format_not_default Flambda2.Default.enable_reaper) )
 
+let mk_reaper_preserve_direct_calls f =
+  ( "-reaper-preserve-direct-calls",
+    Arg.Symbol ([ "never"; "always"; "zero-alloc"; "auto" ], f),
+    Printf.sprintf
+      " Choose the direct call preservation strategy of the reaper (Flambda2 \
+       only)\n\
+      \      Valid values are: \n\
+      \       \"never\": do not try to preserve direct calls to old functions;\n\
+      \       \"always\": always preserve existing direct calls;\n\
+      \       \"zero-alloc\": preserve direct calls only in zero-alloc checked \
+       functions;\n\
+      \       \"auto\": preserve direct calls for which a set of possibly \
+       called functions cannot be determined." )
+
 let mk_flambda2_expert_fallback_inlining_heuristic f =
   ( "-flambda2-expert-fallback-inlining-heuristic",
     Arg.Unit f,
@@ -1026,6 +1040,7 @@ module type Oxcaml_options = sig
   val flambda2_join_depth : int -> unit
   val flambda2_reaper : unit -> unit
   val no_flambda2_reaper : unit -> unit
+  val reaper_preserve_direct_calls : string -> unit
   val flambda2_expert_fallback_inlining_heuristic : unit -> unit
   val no_flambda2_expert_fallback_inlining_heuristic : unit -> unit
   val flambda2_expert_inline_effects_in_cmm : unit -> unit
@@ -1166,6 +1181,7 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_flambda2_join_depth F.flambda2_join_depth;
       mk_flambda2_reaper F.flambda2_reaper;
       mk_no_flambda2_reaper F.no_flambda2_reaper;
+      mk_reaper_preserve_direct_calls F.reaper_preserve_direct_calls;
       mk_flambda2_expert_fallback_inlining_heuristic
         F.flambda2_expert_fallback_inlining_heuristic;
       mk_no_flambda2_expert_fallback_inlining_heuristic
@@ -1375,7 +1391,8 @@ module Oxcaml_options_impl = struct
       Oxcaml_flags.Set Oxcaml_flags.All_functions
 
   let no_flambda2_result_types () =
-    Flambda2.function_result_types := Oxcaml_flags.Set Oxcaml_flags.Never
+    Flambda2.function_result_types :=
+      Oxcaml_flags.Set (Oxcaml_flags.Never : Oxcaml_flags.function_result_types)
 
   let flambda2_basic_meet () = ()
   let flambda2_advanced_meet () = ()
@@ -1404,6 +1421,23 @@ module Oxcaml_options_impl = struct
   let flambda2_join_depth n = Flambda2.join_depth := Oxcaml_flags.Set n
   let flambda2_reaper = set Flambda2.enable_reaper
   let no_flambda2_reaper = clear Flambda2.enable_reaper
+
+  let reaper_preserve_direct_calls s =
+    match s with
+    | "never" ->
+        Flambda2.reaper_preserve_direct_calls :=
+          Oxcaml_flags.Set
+            (Oxcaml_flags.Never : Oxcaml_flags.reaper_preserve_direct_calls)
+    | "always" ->
+        Flambda2.reaper_preserve_direct_calls :=
+          Oxcaml_flags.Set Oxcaml_flags.Always
+    | "zero-alloc" ->
+        Flambda2.reaper_preserve_direct_calls :=
+          Oxcaml_flags.Set Oxcaml_flags.Zero_alloc
+    | "auto" ->
+        Flambda2.reaper_preserve_direct_calls :=
+          Oxcaml_flags.Set Oxcaml_flags.Auto
+    | _ -> () (* This should not occur as we use Arg.Symbol *)
 
   let flambda2_expert_fallback_inlining_heuristic =
     set Flambda2.Expert.fallback_inlining_heuristic
@@ -1800,7 +1834,9 @@ module Extra_params = struct
     | "flambda2-join-points" -> set Flambda2.join_points
     | "flambda2-result-types" ->
         (match String.lowercase_ascii v with
-        | "never" -> Flambda2.function_result_types := Oxcaml_flags.(Set Never)
+        | "never" ->
+            Flambda2.function_result_types :=
+              Oxcaml_flags.(Set (Never : function_result_types))
         | "functors-only" ->
             Flambda2.function_result_types := Oxcaml_flags.(Set Functors_only)
         | "all-functions" ->
@@ -1919,6 +1955,23 @@ module Extra_params = struct
         Oxcaml_flags.cached_generic_functions_path := v;
         true
     | "reaper" -> set Flambda2.enable_reaper
+    | "reaper-perserve-direct-calls" ->
+        (match String.lowercase_ascii v with
+        | "never" ->
+            Flambda2.reaper_preserve_direct_calls :=
+              Oxcaml_flags.(Set (Never : reaper_preserve_direct_calls))
+        | "always" ->
+            Flambda2.reaper_preserve_direct_calls := Oxcaml_flags.(Set Always)
+        | "zero-alloc" ->
+            Flambda2.reaper_preserve_direct_calls :=
+              Oxcaml_flags.(Set Zero_alloc)
+        | "auto" ->
+            Flambda2.reaper_preserve_direct_calls := Oxcaml_flags.(Set Auto)
+        | _ ->
+            Misc.fatal_error
+              "Syntax: reaper-preserve-direct-calls: \
+               always|never|zero-alloc|auto");
+        true
     | _ -> false
 end
 

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -101,6 +101,7 @@ module type Oxcaml_options = sig
   val flambda2_join_depth : int -> unit
   val flambda2_reaper : unit -> unit
   val no_flambda2_reaper : unit -> unit
+  val reaper_preserve_direct_calls : string -> unit
   val flambda2_expert_fallback_inlining_heuristic : unit -> unit
   val no_flambda2_expert_fallback_inlining_heuristic : unit -> unit
   val flambda2_expert_inline_effects_in_cmm : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -107,8 +107,10 @@ let caml_apply_inline_fast_path = ref false  (* -caml-apply-inline-fast-path *)
 
 type function_result_types = Never | Functors_only | All_functions
 type join_algorithm = Binary | N_way | Checked
+type reaper_preserve_direct_calls = Never | Always | Zero_alloc | Auto
 type opt_level = Oclassic | O2 | O3
 type 'a or_default = Set of 'a | Default
+
 
 let dump_inlining_paths = ref false
 let davail = ref false
@@ -150,8 +152,9 @@ module Flambda2 = struct
     let cse_depth = 2
     let join_depth = 5
     let join_algorithm = Binary
-    let function_result_types = Never
+    let function_result_types : function_result_types = Never
     let enable_reaper = false
+    let reaper_preserve_direct_calls : reaper_preserve_direct_calls = Zero_alloc
     let unicode = true
     let kind_checks = false
   end
@@ -166,6 +169,7 @@ module Flambda2 = struct
     join_algorithm : join_algorithm;
     function_result_types : function_result_types;
     enable_reaper : bool;
+    reaper_preserve_direct_calls : reaper_preserve_direct_calls;
     unicode : bool;
     kind_checks : bool;
   }
@@ -180,6 +184,7 @@ module Flambda2 = struct
     join_algorithm = Default.join_algorithm;
     function_result_types = Default.function_result_types;
     enable_reaper = Default.enable_reaper;
+    reaper_preserve_direct_calls = Default.reaper_preserve_direct_calls;
     unicode = Default.unicode;
     kind_checks = Default.kind_checks;
   }
@@ -216,6 +221,7 @@ module Flambda2 = struct
   let kind_checks = ref Default
   let function_result_types = ref Default
   let enable_reaper = ref Default
+  let reaper_preserve_direct_calls = ref Default
 
   module Dump = struct
     type target = Nowhere | Main_dump_stream | File of Misc.filepath

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -93,6 +93,7 @@ val long_frames_threshold : int ref
 val caml_apply_inline_fast_path : bool ref
 
 type function_result_types = Never | Functors_only | All_functions
+type reaper_preserve_direct_calls = Never | Always | Zero_alloc | Auto
 type join_algorithm = Binary | N_way | Checked
 type opt_level = Oclassic | O2 | O3
 type 'a or_default = Set of 'a | Default
@@ -128,6 +129,7 @@ module Flambda2 : sig
     val join_algorithm : join_algorithm
     val function_result_types : function_result_types
     val enable_reaper : bool
+    val reaper_preserve_direct_calls : reaper_preserve_direct_calls
     val unicode : bool
     val kind_checks : bool
   end
@@ -145,6 +147,7 @@ module Flambda2 : sig
     join_algorithm : join_algorithm;
     function_result_types : function_result_types;
     enable_reaper : bool;
+    reaper_preserve_direct_calls : reaper_preserve_direct_calls;
     unicode : bool;
     kind_checks : bool;
   }
@@ -161,6 +164,7 @@ module Flambda2 : sig
   val join_depth : int or_default ref
   val join_algorithm : join_algorithm or_default ref
   val enable_reaper : bool or_default ref
+  val reaper_preserve_direct_calls : reaper_preserve_direct_calls or_default ref
   val unicode : bool or_default ref
   val kind_checks : bool or_default ref
 

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -994,8 +994,9 @@ module Expr_with_acc = struct
         match Apply.call_kind apply with
         | Function { function_call = Direct _; _ } -> true
         | Function
-            { function_call = Indirect_unknown_arity | Indirect_known_arity; _ }
-          ->
+            { function_call = Indirect_unknown_arity | Indirect_known_arity _;
+              _
+            } ->
           false
         | Method _ | C_call _ | Effect _ -> false)
     in

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -1075,7 +1075,7 @@ let rec expr env (e : Fexpr.expr) : Flambda.Expr.t =
         | Some { params_arity = Some params_arity; ret_arity } ->
           let params_arity = arity params_arity in
           let return_arity = arity ret_arity in
-          ( Call_kind.indirect_function_call_known_arity alloc,
+          ( Call_kind.indirect_function_call_known_arity ~code_ids:Unknown alloc,
             params_arity,
             return_arity )
         | None | Some { params_arity = None; ret_arity = _ } ->

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -1123,7 +1123,7 @@ and apply_expr env (app : Apply_expr.t) : Fexpr.expr =
       let alloc = alloc_mode_for_applications env alloc_mode in
       Function (Direct { code_id; function_slot; alloc })
     | Function
-        { function_call = Indirect_unknown_arity | Indirect_known_arity;
+        { function_call = Indirect_unknown_arity | Indirect_known_arity _;
           alloc_mode
         } ->
       let alloc = alloc_mode_for_applications env alloc_mode in
@@ -1136,7 +1136,7 @@ and apply_expr env (app : Apply_expr.t) : Fexpr.expr =
   let return_arity = Apply_expr.return_arity app in
   let arities : Fexpr.function_arities option =
     match Apply_expr.call_kind app with
-    | Function { function_call = Indirect_known_arity; alloc_mode = _ } ->
+    | Function { function_call = Indirect_known_arity _; alloc_mode = _ } ->
       let params_arity = Some (complex_arity param_arity) in
       let ret_arity = arity return_arity in
       Some { params_arity; ret_arity }

--- a/middle_end/flambda2/reaper/dep_solver.ml
+++ b/middle_end/flambda2/reaper/dep_solver.ml
@@ -1137,6 +1137,9 @@ let datalog_rules =
     (let$ [allocation_id] = ["allocation_id"] in
      [any_source_pred allocation_id]
      ==> cannot_change_representation0 allocation_id);
+    (let$ [call_witness; code_id] = ["call_witness"; "code_id"] in
+     [constructor_rel call_witness (fld Code_id_of_call_witness) code_id]
+     ==> cannot_change_representation0 call_witness);
     (* Note this rule is here to still allow changing the calling convention of
        symbols /!\ when adding back the local value slots, there should be a few
        more rules here *)
@@ -1777,7 +1780,6 @@ let code_id_actually_directly_called_query =
                        (Field.encode (Code_of_closure Known_arity_code_pointer)))
                     call_witness;
                   sources_rel call_witness indirect;
-                  any_usage_pred call_witness;
                   constructor_rel indirect
                     (Term.constant (Field.encode Code_id_of_call_witness))
                     codeid ]

--- a/middle_end/flambda2/reaper/dep_solver.ml
+++ b/middle_end/flambda2/reaper/dep_solver.ml
@@ -1233,7 +1233,7 @@ let datalog_rules =
        filter_field
          (fun (f : Field.t) ->
            match[@ocaml.warning "-4"] f with
-           | Apply (Indirect_code_pointer, _) -> true
+           | Apply (Unknown_arity_code_pointer, _) -> true
            | _ -> false)
          relation;
        constructor_rel set_of_closures coderel call_witness;
@@ -1262,7 +1262,7 @@ let datalog_rules =
        filter
          (fun [f] ->
            match[@ocaml.warning "-4"] CoField.decode f with
-           | Param (Indirect_code_pointer, _) -> true
+           | Param (Unknown_arity_code_pointer, _) -> true
            | _ -> false)
          [relation];
        constructor_rel set_of_closures coderel call_witness;

--- a/middle_end/flambda2/reaper/dep_solver.ml
+++ b/middle_end/flambda2/reaper/dep_solver.ml
@@ -833,12 +833,14 @@ let get_all_usages :
        in
        [ out x;
          rev_accessor_rel x
-           (Term.constant (Field.encode Code_of_closure))
+           (Term.constant
+              (Field.encode (Code_of_closure Known_arity_code_pointer)))
            indirect_call_witness;
          sources_rel indirect_call_witness indirect;
          constructor_rel indirect code_id_of_witness code_id;
-         (* CR ncourant: this only works because this can only correspond to a
-            full application, otherwise we wouldn't have unboxed! *)
+         (* Note ncourant: this only works because this can only correspond to a
+            full application, otherwise we wouldn't have unboxed! We should
+            probably check that [Unknown_arity_code_pointer] never occurs. *)
          code_id_my_closure_rel code_id my_closure_of_code_id;
          usages_rel my_closure_of_code_id y ]
        ==> out y),
@@ -1043,20 +1045,13 @@ let to_change_representation = rel1 "to_change_representation" Cols.[n]
 let datalog_rules =
   let open! Syntax in
   let open! Global_flow_graph in
-  (* let field_cannot_be_destructured (i : Field.t) = match[@ocaml.warning "-4"]
-     i with | Code_of_closure | Apply _ | Code_id_of_call_witness _ -> true | _
-     -> false in *)
   let real_field (i : Field.t) =
     match[@ocaml.warning "-4"] i with
-    | Code_of_closure | Apply _ | Code_id_of_call_witness _ -> false
+    | Code_of_closure _ | Apply _ | Code_id_of_call_witness _ -> false
     | _ -> true
   in
-  (* let relation_prevents_unboxing : Field.t -> _ = function | Block _ |
-     Value_slot _ -> false | Function_slot _ -> false (* todo *) |
-     Code_of_closure | Is_int | Get_tag -> true | Apply _ -> true (* todo? *)
-     in *)
   let is_code_field : Field.t -> _ = function[@ocaml.warning "-4"]
-    | Code_of_closure -> true
+    | Code_of_closure _ -> true
     | _ -> false
   in
   let is_apply_field : Field.t -> _ = function[@ocaml.warning "-4"]
@@ -1080,6 +1075,9 @@ let datalog_rules =
        usages_rel base usage;
        field_usages_rel usage relation _v ]
      ==> field_of_constructor_is_used base relation);
+    (* CR ncourant: this marks any [Apply] field as
+       [field_of_constructor_is_used], as long as the function is called.
+       Shouldn't that be gated behind a [cannot_change_calling_convetion]? *)
     (let$ [base; relation; from; coderel; indirect_call_witness] =
        ["base"; "relation"; "from"; "coderel"; "indirect_call_witness"]
      in
@@ -1089,8 +1087,16 @@ let datalog_rules =
        any_usage_pred indirect_call_witness;
        filter_field is_code_field coderel ]
      ==> field_of_constructor_is_used base relation);
+    (* If any usage is possible, do not change the representation. Note that
+       this rule will change in the future, when local value slots are properly
+       tracked: a closure will only local value slots that has any_use will
+       still be able to have its representation changed. *)
     (let$ [x] = ["x"] in
      [any_usage_pred x] ==> cannot_change_representation0 x);
+    (* If there exists an alias which has another source, and which uses any
+       real field of our allocation, we cannot change the representation. This
+       currently requires 4 rules due to the absence of disjunction in the
+       datalog engine. *)
     (let$ [allocation_id; alias; alias_source; field; _v] =
        ["allocation_id"; "alias"; "alias_source"; "field"; "_v"]
      in
@@ -1123,11 +1129,15 @@ let datalog_rules =
        filter_field real_field field;
        field_usages_top_rel alias field ]
      ==> cannot_change_representation0 allocation_id);
+    (* If the allocation has a source distinct from itself, its representation
+       cannot be changed (in fact, in that case, it shouldn't even be an
+       allocation). *)
     (let$ [allocation_id; source] = ["allocation_id"; "source"] in
      [sources_rel allocation_id source; distinct Cols.n source allocation_id]
      ==> cannot_change_representation0 allocation_id);
     (* Used but not its own source: either from any source, or it has no source
-       at all and it is dead code. In either case, do not unbox *)
+       at all and it is dead code. In either case, do not unbox or change the
+       representation. *)
     (let$ [allocation_id; usage] = ["allocation_id"; "usage"] in
      [ usages_rel allocation_id usage;
        not (sources_rel allocation_id allocation_id) ]
@@ -1186,6 +1196,9 @@ let datalog_rules =
     (let$ [allocation_id] = ["allocation_id"] in
      [any_source_pred allocation_id]
      ==> cannot_change_closure_calling_convention allocation_id);
+    (* If the calling convention of a closure cannot be changed, the calling
+       convention of its code_id cannot be either. From now on,
+       [cannot_change_closure_calling_convention] should no longer be used. *)
     (let$ [ set_of_closures;
             coderel;
             indirect_call_witness;
@@ -1204,13 +1217,12 @@ let datalog_rules =
        cannot_change_closure_calling_convention set_of_closures ]
      ==> cannot_change_calling_convention code_id);
     (* CR ncourant: we're preventing changing the calling convention of
-       functions called with indirect_unknown_arity. This could be improved
-       later, but will require wrappers for over- and partial applications, as
-       well as untupling. *)
-    (* CR ncourant: this is currently wrong for functions which take no
-       arguments and return no values! Fixing this would require making the
-       distinction Direct/Indirect for code_of_closure, which wouldn't be a bad
-       thing to do but is not done yet. *)
+       functions called with Indirect_unknown_arity. The two commented rules
+       below could allow to transform some Indirect_unknown_arity calls to
+       direct calls and not taking them into account here, but this would
+       require wrappers for over- and partial applications, as well as
+       untupling. As these wrappers are complex to write correctly, this is not
+       done yet. *)
     (let$ [ set_of_closures;
             usage;
             relation;
@@ -1233,38 +1245,9 @@ let datalog_rules =
        filter_field
          (fun (f : Field.t) ->
            match[@ocaml.warning "-4"] f with
-           | Apply (Unknown_arity_code_pointer, _) -> true
+           | Code_of_closure Unknown_arity_code_pointer -> true
            | _ -> false)
          relation;
-       constructor_rel set_of_closures coderel call_witness;
-       filter_field is_code_field coderel;
-       constructor_rel call_witness code_id_of_witness codeid ]
-     ==> cannot_change_calling_convention codeid);
-    (let$ [ set_of_closures;
-            usage;
-            relation;
-            _v;
-            coderel;
-            call_witness;
-            code_id_of_witness;
-            codeid ] =
-       [ "set_of_closures";
-         "usage";
-         "relation";
-         "_v";
-         "coderel";
-         "call_witness";
-         "code_id_of_witness";
-         "codeid" ]
-     in
-     [ usages_rel set_of_closures usage;
-       rev_coaccessor_rel usage relation _v;
-       filter
-         (fun [f] ->
-           match[@ocaml.warning "-4"] CoField.decode f with
-           | Param (Unknown_arity_code_pointer, _) -> true
-           | _ -> false)
-         [relation];
        constructor_rel set_of_closures coderel call_witness;
        filter_field is_code_field coderel;
        constructor_rel call_witness code_id_of_witness codeid ]
@@ -1299,6 +1282,9 @@ let datalog_rules =
              ~code_id:(fun _ -> false))
          [x] ]
      ==> cannot_change_representation0 x);
+    (* If the representation of any closure in a set of closures cannot be
+       changed, the representation of all the closures in the set cannot be
+       changed. *)
     (let$ [x] = ["x"] in
      [cannot_change_representation0 x] ==> cannot_change_representation1 x);
     (let$ [x; field; y] = ["x"; "field"; "y"] in
@@ -1308,27 +1294,37 @@ let datalog_rules =
      ==> cannot_change_representation1 y);
     (let$ [x] = ["x"] in
      [cannot_change_representation1 x] ==> cannot_change_representation x);
-    (* Due to value_kinds not taking representation changes into account for
-       now, blocks cannot have their representation changed, so we prevent it
-       here. *)
+    (* Due to value_kinds rewriting not taking representation changes into
+       account for now, blocks cannot have their representation changed, so we
+       prevent it here. *)
     (let$ [x; field; y] = ["x"; "field"; "y"] in
      [ constructor_rel x field y;
        filter_field
          (fun (f : Field.t) ->
            match f with
            | Block _ | Is_int | Get_tag -> true
-           | Value_slot _ | Function_slot _ | Code_of_closure | Apply _
+           | Value_slot _ | Function_slot _ | Code_of_closure _ | Apply _
            | Code_id_of_call_witness _ ->
              false)
          field ]
      ==> cannot_change_representation x);
+    (* The use of [cannot_change_representation1] is here to still allow
+       unboxing of blocks, even if we cannot change their representation due to
+       the value_kind limitation. *)
     (let$ [x] = ["x"] in
      [cannot_change_representation1 x] ==> cannot_unbox0 x);
+    (* This is repeated from the earlier occurrence in
+       [cannot_change_representation0]. It is here because in the future, when
+       we want to allow the changing of the representation of local value slots,
+       it will remain necessary. *)
     (let$ [x] = ["x"] in
      [any_usage_pred x] ==> cannot_unbox0 x);
     (* (let$ [x; field] = ["x"; "field"] in [ field_of_constructor_is_used x
        field; filter_field field_cannot_be_destructured field ] ==>
        cannot_unbox0 x); *)
+    (* Unboxing a closure requires changing its calling convention, as we must
+       pass the value slots as extra arguments. Thus, we prevent unboxing of
+       closures if their calling convention cannot be changed. *)
     (let$ [x; coderel; call_witness; code_id_of_witness; codeid] =
        ["x"; "coderel"; "call_witness"; "code_id_of_witness"; "codeid"]
      in
@@ -1337,6 +1333,8 @@ let datalog_rules =
        constructor_rel call_witness code_id_of_witness codeid;
        cannot_change_calling_convention codeid ]
      ==> cannot_unbox0 x);
+    (* An allocation that is one of the results of a function can only be
+       unboxed if the function's calling conventation can be changed. *)
     (let$ [ alias;
             allocation_id;
             relation;
@@ -1365,11 +1363,13 @@ let datalog_rules =
        constructor_rel call_witness code_id_of_witness codeid;
        cannot_change_calling_convention codeid ]
      ==> cannot_unbox0 allocation_id);
+    (* Likewise, an allocation passed as a parameter of a function can only be
+       unboxed if the function's calling convention can be changed. *)
     (* CR ncourant: note that this can fail to trigger if the alias is
        any_source but has no use! This is not a problem but makes it necessary
-       to delete unused params in calls. In the future, we could modify this
-       check to ensure it only triggers if the variable is indeed used, allowing
-       slightly more unboxing. *)
+       to replace unused params in calls with poison values. In the future, we
+       could modify this check to ensure it only triggers if the variable is
+       indeed used, allowing slightly more unboxing. *)
     (let$ [ alias;
             allocation_id;
             relation;
@@ -1408,14 +1408,22 @@ let datalog_rules =
            | Param (Direct_code_pointer, _) -> false)
          [relation] ]
      ==> cannot_unbox0 allocation_id);
+    (* An allocation that is stored in another can only be unboxed if either the
+       representation of the other allocation can be changed, of it the field it
+       is stored in is never read, as in that case a poison value will be stored
+       instead. *)
     (let$ [alias; allocation_id; relation; to_] =
        ["alias"; "allocation_id"; "relation"; "to_"]
      in
      [ sources_rel alias allocation_id;
        rev_constructor_rel alias relation to_;
        field_of_constructor_is_used to_ relation;
+       filter_field real_field relation;
+       (* ^ XXX check *)
        cannot_change_representation to_ ]
      ==> cannot_unbox0 allocation_id);
+    (* As previously: if any closure of a set of closures cannot be unboxed,
+       then every closure in the set cannot be unboxed. *)
     (let$ [x] = ["x"] in
      [cannot_unbox0 x] ==> cannot_unbox x);
     (let$ [x; field; y] = ["x"; "field"; "y"] in
@@ -1423,6 +1431,8 @@ let datalog_rules =
        constructor_rel x field y;
        filter_field is_function_slot field ]
      ==> cannot_unbox y);
+    (* Compute allocations to unbox or to change representation. This requires
+       the rules to be executed in order. *)
     (let$ [x] = ["x"] in
      [any_usage_pred x; not (cannot_unbox x)] ==> to_unbox x);
     (let$ [x; _y] = ["x"; "_y"] in
@@ -1558,7 +1568,7 @@ let rec mk_unboxed_fields ~has_to_be_unboxed ~mk db usages name_prefix =
     (fun field field_use ->
       match field with
       | Function_slot _ | Code_id_of_call_witness _ -> assert false
-      | Apply _ | Code_of_closure -> None
+      | Apply _ | Code_of_closure _ -> None
       | Block _ | Value_slot _ | Is_int | Get_tag -> (
         let new_name =
           Flambda_colours.without_colours ~f:(fun () ->
@@ -1827,16 +1837,28 @@ let cannot_change_calling_convention uses v =
 
 let code_id_actually_called_query =
   let open Syntax in
-  let open Global_flow_graph in
+  let open! Global_flow_graph in
   compile [] (fun [] ->
-      with_parameters ["set_of_closures"; "coderel"]
-        (fun [set_of_closres; coderel] ->
+      with_parameters ["set_of_closures"] (fun [set_of_closures] ->
           foreach
-            ["indirect_call_witness"; "indirect"; "code_id_of_witness"; "codeid"]
-            (fun [indirect_call_witness; indirect; code_id_of_witness; codeid]
+            [ "coderel";
+              "indirect_call_witness";
+              "indirect";
+              "code_id_of_witness";
+              "codeid" ]
+            (fun
+              [ coderel;
+                indirect_call_witness;
+                indirect;
+                code_id_of_witness;
+                codeid ]
             ->
               where
-                [ rev_accessor_rel set_of_closres coderel indirect_call_witness;
+                [ filter_field
+                    (function[@warning "-4"]
+                      | (Code_of_closure _ : Field.t) -> true | _ -> false)
+                    coderel;
+                  rev_accessor_rel set_of_closures coderel indirect_call_witness;
                   sources_rel indirect_call_witness indirect;
                   any_usage_pred indirect_call_witness;
                   constructor_rel indirect code_id_of_witness codeid ]
@@ -1849,16 +1871,28 @@ let code_id_actually_called uses v =
   then None
   else if exists_with_parameters
             cannot_change_calling_convention_of_called_closure_query1
-            [Code_id_or_name.name v; Field.encode Code_of_closure]
+            [ Code_id_or_name.name v;
+              Field.encode (Code_of_closure Known_arity_code_pointer) ]
             uses.db
           || exists_with_parameters
                cannot_change_calling_convention_of_called_closure_query2
-               [Code_id_or_name.name v; Field.encode Code_of_closure]
+               [ Code_id_or_name.name v;
+                 Field.encode (Code_of_closure Known_arity_code_pointer) ]
+               uses.db
+          || exists_with_parameters
+               cannot_change_calling_convention_of_called_closure_query1
+               [ Code_id_or_name.name v;
+                 Field.encode (Code_of_closure Unknown_arity_code_pointer) ]
+               uses.db
+          || exists_with_parameters
+               cannot_change_calling_convention_of_called_closure_query2
+               [ Code_id_or_name.name v;
+                 Field.encode (Code_of_closure Unknown_arity_code_pointer) ]
                uses.db
   then None
   else
     Datalog.Cursor.fold_with_parameters code_id_actually_called_query
-      [Code_id_or_name.name v; Field.encode Code_of_closure]
+      [Code_id_or_name.name v]
       uses.db ~init:None
       ~f:(fun [code_id_of_witness; codeid] acc ->
         let num_already_applied_params =

--- a/middle_end/flambda2/reaper/dep_solver.ml
+++ b/middle_end/flambda2/reaper/dep_solver.ml
@@ -79,9 +79,9 @@ end
 module Cols = struct
   let n = Code_id_or_name.datalog_column_id
 
-  let f = Global_flow_graph.FieldC.datalog_column_id
+  let f = Global_flow_graph.Field.Encoded.datalog_column_id
 
-  let cf = Global_flow_graph.CoFieldC.datalog_column_id
+  let cf = Global_flow_graph.CoField.Encoded.datalog_column_id
 end
 
 let rel1_r name schema =
@@ -862,7 +862,7 @@ let get_all_usages :
     Usages (Datalog.get_table out_tbl db)
 
 let fieldc_map_to_field_map m =
-  Global_flow_graph.FieldC.Map.fold
+  Global_flow_graph.Field.Encoded.Map.fold
     (fun k r acc -> Field.Map.add (Field.decode k) r acc)
     m Field.Map.empty
 
@@ -903,7 +903,7 @@ let get_fields : Datalog.database -> usages -> field_usage Field.Map.t =
         db rs
     in
     fieldc_map_to_field_map
-      (FieldC.Map.merge
+      (Field.Encoded.Map.merge
          (fun k x y ->
            match x, y with
            | None, None -> assert false

--- a/middle_end/flambda2/reaper/dep_solver.ml
+++ b/middle_end/flambda2/reaper/dep_solver.ml
@@ -1420,7 +1420,8 @@ let datalog_rules =
        field_of_constructor_is_used to_ relation;
        filter_field real_field relation;
        (* ^ XXX check *)
-       cannot_change_representation to_ ]
+       cannot_change_representation to_;
+       cannot_unbox0 to_ ]
      ==> cannot_unbox0 allocation_id);
     (* As previously: if any closure of a set of closures cannot be unboxed,
        then every closure in the set cannot be unboxed. *)

--- a/middle_end/flambda2/reaper/dep_solver.ml
+++ b/middle_end/flambda2/reaper/dep_solver.ml
@@ -1846,13 +1846,9 @@ let code_id_actually_directly_called_query =
                 (yield [code_id_of_witness; codeid]))))
 
 let code_id_actually_directly_called uses v =
-  if exists_with_parameters any_usage_pred_query
+  if exists_with_parameters unknown_code_id_actually_directly_called_query
        [Code_id_or_name.name v]
        uses.db
-  then Or_unknown.Unknown
-  else if exists_with_parameters unknown_code_id_actually_directly_called_query
-            [Code_id_or_name.name v]
-            uses.db
   then Or_unknown.Unknown
   else
     Or_unknown.Known

--- a/middle_end/flambda2/reaper/dep_solver.ml
+++ b/middle_end/flambda2/reaper/dep_solver.ml
@@ -1404,8 +1404,8 @@ let datalog_rules =
        filter
          (fun [f] ->
            match CoField.decode f with
-           | Param (Indirect_code_pointer, _) -> true
-           | Param (Direct_code_pointer, _) -> false)
+           | Param (Unknown_arity_code_pointer, _) -> true
+           | Param (Known_arity_code_pointer, _) -> false)
          [relation] ]
      ==> cannot_unbox0 allocation_id);
     (* An allocation that is stored in another can only be unboxed if either the

--- a/middle_end/flambda2/reaper/dep_solver.mli
+++ b/middle_end/flambda2/reaper/dep_solver.mli
@@ -74,4 +74,5 @@ val rewrite_kind_with_subkind :
 
 val cannot_change_calling_convention : result -> Code_id.t -> bool
 
-val code_id_actually_called : result -> Name.t -> (Code_id.t * int) option
+val code_id_actually_directly_called :
+  result -> Name.t -> Code_id.Set.t Or_unknown.t

--- a/middle_end/flambda2/reaper/global_flow_graph.ml
+++ b/middle_end/flambda2/reaper/global_flow_graph.ml
@@ -226,6 +226,8 @@ module CoConstructor_rel =
   Datalog.Schema.Relation3 (Code_id_or_name) (CoFieldC) (Code_id_or_name)
 module Any_usage_pred = Datalog.Schema.Relation1 (Code_id_or_name)
 module Any_source_pred = Datalog.Schema.Relation1 (Code_id_or_name)
+module Code_id_my_closure_rel =
+  Datalog.Schema.Relation2 (Code_id_or_name) (Code_id_or_name)
 
 type graph =
   { mutable alias_rel : Alias_rel.t;
@@ -236,7 +238,8 @@ type graph =
     mutable coconstructor_rel : CoConstructor_rel.t;
     mutable propagate_rel : Propagate_rel.t;
     mutable any_usage_pred : Any_usage_pred.t;
-    mutable any_source_pred : Any_source_pred.t
+    mutable any_source_pred : Any_source_pred.t;
+    mutable code_id_my_closure_rel : Code_id_my_closure_rel.t
   }
 
 let print_iter_edges ~print_edge graph =
@@ -285,6 +288,9 @@ let any_usage_pred = Any_usage_pred.create ~name:"any_usage"
 
 let any_source_pred = Any_source_pred.create ~name:"any_source"
 
+let code_id_my_closure_rel =
+  Code_id_my_closure_rel.create ~name:"code_id_my_closure"
+
 let to_datalog graph =
   Datalog.set_table alias_rel graph.alias_rel
   @@ Datalog.set_table use_rel graph.use_rel
@@ -295,6 +301,7 @@ let to_datalog graph =
   @@ Datalog.set_table propagate_rel graph.propagate_rel
   @@ Datalog.set_table any_usage_pred graph.any_usage_pred
   @@ Datalog.set_table any_source_pred graph.any_source_pred
+  @@ Datalog.set_table code_id_my_closure_rel graph.code_id_my_closure_rel
   @@ Datalog.empty
 
 type 'a rel0 = [> `Atom of Datalog.atom] as 'a
@@ -335,6 +342,9 @@ let any_usage_pred var = Datalog.atom any_usage_pred [var]
 
 let any_source_pred var = Datalog.atom any_source_pred [var]
 
+let code_id_my_closure_rel code_id var =
+  Datalog.atom code_id_my_closure_rel [code_id; var]
+
 let create () =
   { alias_rel = Alias_rel.empty;
     use_rel = Use_rel.empty;
@@ -344,7 +354,8 @@ let create () =
     coconstructor_rel = CoConstructor_rel.empty;
     propagate_rel = Propagate_rel.empty;
     any_usage_pred = Any_usage_pred.empty;
-    any_source_pred = Any_source_pred.empty
+    any_source_pred = Any_source_pred.empty;
+    code_id_my_closure_rel = Code_id_my_closure_rel.empty
   }
 
 let add_alias t ~to_ ~from =
@@ -400,3 +411,9 @@ let add_use t (var : Code_id_or_name.t) =
 
 let add_any_source t (var : Code_id_or_name.t) =
   t.any_source_pred <- Any_source_pred.add_or_replace [var] () t.any_source_pred
+
+let add_code_id_my_closure t code_id my_closure =
+  t.code_id_my_closure_rel
+    <- Code_id_my_closure_rel.add_or_replace
+         [Code_id_or_name.code_id code_id; Code_id_or_name.var my_closure]
+         () t.code_id_my_closure_rel

--- a/middle_end/flambda2/reaper/global_flow_graph.ml
+++ b/middle_end/flambda2/reaper/global_flow_graph.ml
@@ -13,16 +13,16 @@
 (*                                                                        *)
 (**************************************************************************)
 type closure_entry_point =
-  | Indirect_code_pointer
-  | Direct_code_pointer
+  | Unknown_arity_code_pointer
+  | Known_arity_code_pointer
 
 let closure_entry_point_to_int = function
-  | Indirect_code_pointer -> 0
-  | Direct_code_pointer -> 1
+  | Unknown_arity_code_pointer -> 0
+  | Known_arity_code_pointer -> 1
 
 let closure_entry_point_to_string = function
-  | Indirect_code_pointer -> "Indirect_code_pointer"
-  | Direct_code_pointer -> "Direct_code_pointer"
+  | Unknown_arity_code_pointer -> "Unknown_arity_code_pointer"
+  | Known_arity_code_pointer -> "Known_arity_code_pointer"
 
 module Field = struct
   module M = struct

--- a/middle_end/flambda2/reaper/global_flow_graph.ml
+++ b/middle_end/flambda2/reaper/global_flow_graph.ml
@@ -38,7 +38,7 @@ module Field = struct
       | Is_int
       | Get_tag
       | Apply of return_kind
-      | Code_id_of_call_witness of int
+      | Code_id_of_call_witness
 
     let compare_return_kind r1 r2 =
       match r1, r2 with
@@ -61,44 +61,43 @@ module Field = struct
       | Is_int, Is_int -> 0
       | Get_tag, Get_tag -> 0
       | Apply r1, Apply r2 -> compare_return_kind r1 r2
-      | Code_id_of_call_witness c1, Code_id_of_call_witness c2 ->
-        Int.compare c1 c2
+      | Code_id_of_call_witness, Code_id_of_call_witness -> 0
       | ( Block _,
           ( Value_slot _ | Function_slot _ | Code_of_closure _ | Is_int
-          | Get_tag | Apply _ | Code_id_of_call_witness _ ) ) ->
+          | Get_tag | Apply _ | Code_id_of_call_witness ) ) ->
         -1
       | ( ( Value_slot _ | Function_slot _ | Code_of_closure _ | Is_int
-          | Get_tag | Apply _ | Code_id_of_call_witness _ ),
+          | Get_tag | Apply _ | Code_id_of_call_witness ),
           Block _ ) ->
         1
       | ( Value_slot _,
           ( Function_slot _ | Code_of_closure _ | Is_int | Get_tag | Apply _
-          | Code_id_of_call_witness _ ) ) ->
+          | Code_id_of_call_witness ) ) ->
         -1
       | ( ( Function_slot _ | Code_of_closure _ | Is_int | Get_tag | Apply _
-          | Code_id_of_call_witness _ ),
+          | Code_id_of_call_witness ),
           Value_slot _ ) ->
         1
       | ( Function_slot _,
           ( Code_of_closure _ | Is_int | Get_tag | Apply _
-          | Code_id_of_call_witness _ ) ) ->
+          | Code_id_of_call_witness ) ) ->
         -1
       | ( ( Code_of_closure _ | Is_int | Get_tag | Apply _
-          | Code_id_of_call_witness _ ),
+          | Code_id_of_call_witness ),
           Function_slot _ ) ->
         1
-      | ( Code_of_closure _,
-          (Is_int | Get_tag | Apply _ | Code_id_of_call_witness _) ) ->
+      | Code_of_closure _, (Is_int | Get_tag | Apply _ | Code_id_of_call_witness)
+        ->
         -1
-      | ( (Is_int | Get_tag | Apply _ | Code_id_of_call_witness _),
+      | ( (Is_int | Get_tag | Apply _ | Code_id_of_call_witness),
           Code_of_closure _ ) ->
         1
-      | Is_int, (Get_tag | Apply _ | Code_id_of_call_witness _) -> -1
-      | (Get_tag | Apply _ | Code_id_of_call_witness _), Is_int -> 1
-      | Get_tag, (Apply _ | Code_id_of_call_witness _) -> -1
-      | (Apply _ | Code_id_of_call_witness _), Get_tag -> 1
-      | Apply _, Code_id_of_call_witness _ -> -1
-      | Code_id_of_call_witness _, Apply _ -> 1
+      | Is_int, (Get_tag | Apply _ | Code_id_of_call_witness) -> -1
+      | (Get_tag | Apply _ | Code_id_of_call_witness), Is_int -> 1
+      | Get_tag, (Apply _ | Code_id_of_call_witness) -> -1
+      | (Apply _ | Code_id_of_call_witness), Get_tag -> 1
+      | Apply _, Code_id_of_call_witness -> -1
+      | Code_id_of_call_witness, Apply _ -> 1
 
     let equal a b = compare a b = 0
 
@@ -114,8 +113,7 @@ module Field = struct
       | Get_tag -> Format.fprintf ppf "Get_tag"
       | Apply (Normal i) -> Format.fprintf ppf "Apply (Normal %i)" i
       | Apply Exn -> Format.fprintf ppf "Apply Exn"
-      | Code_id_of_call_witness i ->
-        Format.fprintf ppf "Code_id_of_call_witness %d" i
+      | Code_id_of_call_witness -> Format.fprintf ppf "Code_id_of_call_witness"
   end
 
   include M
@@ -125,7 +123,7 @@ module Field = struct
     | Value_slot vs -> Value_slot.kind vs
     | Function_slot _ -> Flambda_kind.value
     | Is_int | Get_tag -> Flambda_kind.naked_immediate
-    | (Code_of_closure _ | Apply _ | Code_id_of_call_witness _) as field ->
+    | (Code_of_closure _ | Apply _ | Code_id_of_call_witness) as field ->
       Misc.fatal_errorf "[field_kind] for virtual field %a" print field
 
   module Container = Container_types.Make (M)

--- a/middle_end/flambda2/reaper/global_flow_graph.mli
+++ b/middle_end/flambda2/reaper/global_flow_graph.mli
@@ -30,7 +30,7 @@ module Field : sig
     | Is_int (* value checked for [Is_int] *)
     | Get_tag (* tag of the value is read *)
     | Apply of return_kind
-    | Code_id_of_call_witness of int
+    | Code_id_of_call_witness
   (* Returns of functions: either exn path or nth value for normal returns *)
 
   val equal : t -> t -> bool

--- a/middle_end/flambda2/reaper/global_flow_graph.mli
+++ b/middle_end/flambda2/reaper/global_flow_graph.mli
@@ -14,8 +14,8 @@
 (**************************************************************************)
 
 type closure_entry_point =
-  | Indirect_code_pointer
-  | Direct_code_pointer
+  | Unknown_arity_code_pointer
+  | Known_arity_code_pointer
 
 module Field : sig
   type return_kind =

--- a/middle_end/flambda2/reaper/global_flow_graph.mli
+++ b/middle_end/flambda2/reaper/global_flow_graph.mli
@@ -29,7 +29,7 @@ module Field : sig
     | Code_of_closure of closure_entry_point (* code_id in a set of closurse *)
     | Is_int (* value checked for [Is_int] *)
     | Get_tag (* tag of the value is read *)
-    | Apply of closure_entry_point * return_kind
+    | Apply of return_kind
     | Code_id_of_call_witness of int
   (* Returns of functions: either exn path or nth value for normal returns *)
 
@@ -41,15 +41,15 @@ module Field : sig
 
   module Map : Container_types.Map with type key = t
 
-  val encode : t -> int
+  module Encoded : Datalog.Column.S
 
-  val decode : int -> t
+  val encode : t -> Encoded.t
+
+  val decode : Encoded.t -> t
 end
 
-module FieldC : Datalog.Column.S with type t = int
-
 module CoField : sig
-  type t = Param of closure_entry_point * int
+  type t = Param of int
 
   val equal : t -> t -> bool
 
@@ -57,12 +57,12 @@ module CoField : sig
 
   module Map : Container_types.Map with type key = t
 
-  val encode : t -> int
+  module Encoded : Datalog.Column.S
 
-  val decode : int -> t
+  val encode : t -> Encoded.t
+
+  val decode : Encoded.t -> t
 end
-
-module CoFieldC : Datalog.Column.S with type t = int
 
 type graph
 
@@ -80,13 +80,17 @@ val alias_rel : (Code_id_or_name.t, Code_id_or_name.t, _) rel2
 
 val use_rel : (Code_id_or_name.t, Code_id_or_name.t, _) rel2
 
-val accessor_rel : (Code_id_or_name.t, int, Code_id_or_name.t, _) rel3
+val accessor_rel :
+  (Code_id_or_name.t, Field.Encoded.t, Code_id_or_name.t, _) rel3
 
-val constructor_rel : (Code_id_or_name.t, int, Code_id_or_name.t, _) rel3
+val constructor_rel :
+  (Code_id_or_name.t, Field.Encoded.t, Code_id_or_name.t, _) rel3
 
-val coaccessor_rel : (Code_id_or_name.t, int, Code_id_or_name.t, _) rel3
+val coaccessor_rel :
+  (Code_id_or_name.t, CoField.Encoded.t, Code_id_or_name.t, _) rel3
 
-val coconstructor_rel : (Code_id_or_name.t, int, Code_id_or_name.t, _) rel3
+val coconstructor_rel :
+  (Code_id_or_name.t, CoField.Encoded.t, Code_id_or_name.t, _) rel3
 
 val propagate_rel :
   (Code_id_or_name.t, Code_id_or_name.t, Code_id_or_name.t, _) rel3

--- a/middle_end/flambda2/reaper/global_flow_graph.mli
+++ b/middle_end/flambda2/reaper/global_flow_graph.mli
@@ -26,7 +26,7 @@ module Field : sig
     | Block of int * Flambda_kind.t (* nth field of a block *)
     | Value_slot of Value_slot.t
     | Function_slot of Function_slot.t
-    | Code_of_closure (* code_id in a set of closurse *)
+    | Code_of_closure of closure_entry_point (* code_id in a set of closurse *)
     | Is_int (* value checked for [Is_int] *)
     | Get_tag (* tag of the value is read *)
     | Apply of closure_entry_point * return_kind

--- a/middle_end/flambda2/reaper/global_flow_graph.mli
+++ b/middle_end/flambda2/reaper/global_flow_graph.mli
@@ -95,6 +95,8 @@ val any_usage_pred : (Code_id_or_name.t, _) rel1
 
 val any_source_pred : (Code_id_or_name.t, _) rel1
 
+val code_id_my_closure_rel : (Code_id_or_name.t, Code_id_or_name.t, _) rel2
+
 val create : unit -> graph
 
 val add_opaque_let_dependency :
@@ -127,6 +129,8 @@ val add_coaccessor_dep :
 
 val add_coconstructor_dep :
   graph -> base:Code_id_or_name.t -> CoField.t -> from:Code_id_or_name.t -> unit
+
+val add_code_id_my_closure : graph -> Code_id.t -> Variable.t -> unit
 
 val print_iter_edges :
   print_edge:(Code_id_or_name.t * Code_id_or_name.t * string -> unit) ->

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -24,7 +24,6 @@ let unit_with_body (unit : Flambda_unit.t) (body : Flambda.Expr.t) =
     ~used_value_slots:(Flambda_unit.used_value_slots unit)
 
 let run ~machine_width ~cmx_loader ~all_code (unit : Flambda_unit.t) =
-  if true then failwith "aaa";
   let debug_print = Flambda_features.dump_reaper () in
   let load_code = Flambda_cmx.get_imported_code cmx_loader in
   let get_code_metadata code_id =

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -24,6 +24,7 @@ let unit_with_body (unit : Flambda_unit.t) (body : Flambda.Expr.t) =
     ~used_value_slots:(Flambda_unit.used_value_slots unit)
 
 let run ~machine_width ~cmx_loader ~all_code (unit : Flambda_unit.t) =
+  if true then failwith "aaa";
   let debug_print = Flambda_features.dump_reaper () in
   let load_code = Flambda_cmx.get_imported_code cmx_loader in
   let get_code_metadata code_id =

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -709,10 +709,10 @@ let make_apply_wrapper env
                 match Apply.call_kind apply with
                 | Function { function_call = Direct _; _ } -> error ()
                 | Function { function_call = Indirect_known_arity; _ } ->
-                  GFG.Direct_code_pointer
+                  GFG.Known_arity_code_pointer
                 | Function { function_call = Indirect_unknown_arity; _ }
                 | C_call _ | Method _ | Effect _ ->
-                  GFG.Indirect_code_pointer
+                  GFG.Unknown_arity_code_pointer
               in
               let field =
                 GFG.Field.Apply (direct_or_indirect, GFG.Field.Normal i)
@@ -984,7 +984,7 @@ let rebuild_apply env apply =
           match callee_with_known_arity with
           | Some callee ->
             if DS.cofield_has_use env.uses callee
-                 (Param (Direct_code_pointer, i))
+                 (Param (Known_arity_code_pointer, i))
             then arg
             else
               Simple.pattern_match arg

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -402,7 +402,12 @@ let rewrite_set_of_closures env res ~(bound : Name.t list)
       bound
   in
   let code_is_used bound_name =
-    DS.field_used env.uses (Code_id_or_name.name bound_name) Code_of_closure
+    DS.field_used env.uses
+      (Code_id_or_name.name bound_name)
+      (Code_of_closure Known_arity_code_pointer)
+    || DS.field_used env.uses
+         (Code_id_or_name.name bound_name)
+         (Code_of_closure Unknown_arity_code_pointer)
   in
   let new_repr =
     match bound with
@@ -435,7 +440,7 @@ let rewrite_set_of_closures env res ~(bound : Name.t list)
           (fun field (uf : _ DS.unboxed_fields) value_slots ->
             match (field : Field.t) with
             | Is_int | Get_tag | Block _ -> assert false
-            | Code_of_closure | Apply _ | Code_id_of_call_witness _ ->
+            | Code_of_closure _ | Apply _ | Code_id_of_call_witness _ ->
               assert false
             | Function_slot _ -> assert false
             | Value_slot value_slot -> (
@@ -1174,7 +1179,7 @@ let rebuild_singleton_binding_which_is_being_unboxed env bv
               Left
                 (Simple.untagged_const_int
                    (Tag.to_targetint_31_63 env.machine_width tag))
-            | Value_slot _ | Function_slot _ | Code_of_closure | Apply _
+            | Value_slot _ | Function_slot _ | Code_of_closure _ | Apply _
             | Code_id_of_call_witness _ ->
               assert false
           in
@@ -1269,7 +1274,7 @@ let rebuild_set_of_closures_binding_which_is_being_unboxed env bvs
                   (* CR sspies: Missing debug uid. *)
                 in
                 RE.create_let bp (Named.create_simple arg) ~body:hole
-            | Block _ | Is_int | Get_tag | Function_slot _ | Code_of_closure
+            | Block _ | Is_int | Get_tag | Function_slot _ | Code_of_closure _
             | Apply _ | Code_id_of_call_witness _ ->
               assert false)
           to_bind hole)
@@ -1353,7 +1358,7 @@ let rebuild_singleton_binding_whose_representation_is_being_changed env bp bv
                 (rewrite_simple env (Simple.const_one env.machine_width))
                 mp
             | Unboxed _ -> Misc.fatal_errorf "trying to unbox simple")
-          | Value_slot _ | Function_slot _ | Code_of_closure | Apply _
+          | Value_slot _ | Function_slot _ | Code_of_closure _ | Apply _
           | Code_id_of_call_witness _ ->
             assert false)
         fields Int.Map.empty

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -913,16 +913,10 @@ let decide_whether_apply_needs_calling_convention_change env apply =
                     those calls to [Indirect_known_arity]. *)
                  Compilation_unit.is_current (Symbol.compilation_unit s))
                c ->
-        let code_ids = Code_id.Set.singleton code_id in
         let call_kind =
-          if Code_id.Set.exists
-               (fun code_id ->
-                 Compilation_unit.is_current
-                   (Code_id.get_compilation_unit code_id))
-               code_ids
+          if Compilation_unit.is_current (Code_id.get_compilation_unit code_id)
           then
-            Call_kind.indirect_function_call_known_arity
-              ~code_ids:(Known (Code_id.Set.singleton code_id))
+            Call_kind.indirect_function_call_known_arity ~code_ids:Unknown
               alloc_mode
           else call_kind
         in
@@ -932,7 +926,12 @@ let decide_whether_apply_needs_calling_convention_change env apply =
       (* called (Option.get (Apply.callee apply)) alloc_mode call_kind true *)
       None, call_kind, false
     | Function { function_call = Indirect_known_arity _; alloc_mode } ->
-      called (Option.get (Apply.callee apply)) alloc_mode call_kind false
+      called
+        (Option.get (Apply.callee apply))
+        alloc_mode
+        (Call_kind.indirect_function_call_known_arity ~code_ids:Unknown
+           alloc_mode)
+        false
     | C_call _ | Method _ | Effect _ -> None, call_kind, false
   in
   match code_id_actually_called with

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -576,7 +576,7 @@ and traverse_apply denv acc apply : rev_expr =
 
 and traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
   match Apply.call_kind apply with
-  | Function { function_call = Direct code_id; _ } ->
+  | Function { function_call = Direct code_id; _ } -> (
     (* CR ncourant: think about cross-module propagation *)
     (* if Compilation_unit.is_current (Code_id.get_compilation_unit code_id)
        then ( let apply_dep = { Traverse_acc.function_containing_apply_expr =
@@ -590,28 +590,30 @@ and traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
       Acc.make_known_arity_apply_widget acc ~denv ~params:(Apply.args apply)
         ~returns:return_args ~exn:exn_arg
     in
-    (if Option.is_some (Apply.callee apply)
-    then
-      let closure =
-        Acc.simple_to_name acc ~denv (Option.get (Apply.callee apply))
-      in
-      Graph.add_accessor_dep (Acc.graph acc) ~to_:call_widget
-        (Code_of_closure Known_arity_code_pointer)
-        ~base:(Code_id_or_name.name closure));
-    if Compilation_unit.is_current (Code_id.get_compilation_unit code_id)
-       && (Option.is_none (Apply.callee apply)
-          || denv.should_preserve_direct_calls)
-    then
-      let apply_dep =
-        { Traverse_acc.function_containing_apply_expr = denv.current_code_id;
-          apply_code_id = code_id;
-          apply_closure = Apply.callee apply;
-          apply_call_witness = call_widget
-        }
-      in
-      Acc.add_apply apply_dep acc
-    else if Option.is_none (Apply.callee apply)
-    then default_acc acc
+    let[@local] add_apply acc =
+      if Compilation_unit.is_current (Code_id.get_compilation_unit code_id)
+      then
+        let apply_dep =
+          { Traverse_acc.function_containing_apply_expr = denv.current_code_id;
+            apply_code_id = code_id;
+            apply_closure = Apply.callee apply;
+            apply_call_witness = call_widget
+          }
+        in
+        Acc.add_apply apply_dep acc
+      else default_acc acc
+    in
+    match Apply.callee apply with
+    | None -> add_apply acc
+    | Some callee -> (
+      (let closure = Acc.simple_to_name acc ~denv callee in
+       Graph.add_accessor_dep (Acc.graph acc) ~to_:call_widget
+         (Code_of_closure Known_arity_code_pointer)
+         ~base:(Code_id_or_name.name closure));
+      match denv.should_preserve_direct_calls with
+      | Yes -> add_apply acc
+      | No -> ()
+      | Auto -> failwith "todo"))
   | Function { function_call = Indirect_known_arity _; _ } ->
     let call_widget =
       Acc.make_known_arity_apply_widget acc ~denv ~params:(Apply.args apply)
@@ -683,6 +685,16 @@ and traverse_function_params_and_body acc code_id code ~return_continuation
      it is highly unclear what should be done for zero_alloc code, so we simply
      mark the code as escaping. *)
   let is_opaque = Code_metadata.is_opaque code_metadata in
+  let check_zero_alloc =
+    match Code.zero_alloc_attribute code with
+    | Default_zero_alloc ->
+      (* The effect of [Clflags.zero_alloc_assert] has been compiled into
+         [Check] earlier. *)
+      false
+    | Assume _ -> false
+    | Check _ -> true
+  in
+  let is_opaque = is_opaque || check_zero_alloc in
   let code_dep = Acc.find_code acc code_id in
   Graph.add_code_id_my_closure (Acc.graph acc) code_id my_closure;
   let maybe_opaque var = if is_opaque then Variable.rename var else var in
@@ -706,19 +718,17 @@ and traverse_function_params_and_body acc code_id code ~return_continuation
     };
   Acc.fixed_arity_continuation acc return_continuation;
   Acc.fixed_arity_continuation acc exn_continuation;
-  let check_zero_alloc =
-    match Code.zero_alloc_attribute code with
-    | Default_zero_alloc ->
-      (* The effect of [Clflags.zero_alloc_assert] has been compiled into
-         [Check] earlier. *)
-      false
-    | Assume _ -> false
-    | Check _ -> true
+  let should_preserve_direct_calls =
+    match Flambda_features.reaper_preserve_direct_calls () with
+    | Never -> No
+    | Always -> Yes
+    | Zero_alloc -> if check_zero_alloc then Yes else No
+    | Auto -> Auto
   in
   let denv =
     { parent = Hole;
       conts;
-      should_preserve_direct_calls = check_zero_alloc;
+      should_preserve_direct_calls;
       current_code_id = Some code_id;
       le_monde_exterieur;
       all_constants
@@ -832,10 +842,16 @@ let run ~get_code_metadata (unit : Flambda_unit.t) =
       };
     Acc.fixed_arity_continuation acc return_continuation;
     Acc.fixed_arity_continuation acc exn_continuation;
+    let should_preserve_direct_calls =
+      match Flambda_features.reaper_preserve_direct_calls () with
+      | Never | Zero_alloc -> No
+      | Always -> Yes
+      | Auto -> Auto
+    in
     traverse
       { parent = Hole;
         conts;
-        should_preserve_direct_calls = false;
+        should_preserve_direct_calls;
         current_code_id = None;
         le_monde_exterieur = Name.symbol le_monde_exterieur;
         all_constants = Name.symbol all_constants

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -694,7 +694,6 @@ and traverse_function_params_and_body acc code_id code ~return_continuation
     | Assume _ -> false
     | Check _ -> true
   in
-  let is_opaque = is_opaque || check_zero_alloc in
   let code_dep = Acc.find_code acc code_id in
   Graph.add_code_id_my_closure (Acc.graph acc) code_id my_closure;
   let maybe_opaque var = if is_opaque then Variable.rename var else var in

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -230,6 +230,7 @@ and traverse_let denv acc let_expr : rev_expr =
     { parent = let_acc;
       conts = denv.conts;
       current_code_id = denv.current_code_id;
+      should_preserve_direct_calls = denv.should_preserve_direct_calls;
       le_monde_exterieur = denv.le_monde_exterieur;
       all_constants = denv.all_constants
     }
@@ -423,6 +424,7 @@ and traverse_let_cont_non_recursive denv acc cont ~body handler =
     let denv =
       { parent = Let_cont { cont; handler; parent = denv.parent };
         conts;
+        should_preserve_direct_calls = denv.should_preserve_direct_calls;
         current_code_id = denv.current_code_id;
         le_monde_exterieur = denv.le_monde_exterieur;
         all_constants = denv.all_constants
@@ -433,6 +435,7 @@ and traverse_let_cont_non_recursive denv acc cont ~body handler =
   traverse_cont_handler
     { parent = Hole;
       conts = denv.conts;
+      should_preserve_direct_calls = denv.should_preserve_direct_calls;
       current_code_id = denv.current_code_id;
       le_monde_exterieur = denv.le_monde_exterieur;
       all_constants = denv.all_constants
@@ -481,6 +484,7 @@ and traverse_let_cont_recursive denv acc ~invariant_params ~body handlers =
           traverse
             { parent = Hole;
               conts;
+              should_preserve_direct_calls = denv.should_preserve_direct_calls;
               current_code_id = denv.current_code_id;
               le_monde_exterieur = denv.le_monde_exterieur;
               all_constants = denv.all_constants
@@ -494,6 +498,7 @@ and traverse_let_cont_recursive denv acc ~invariant_params ~body handlers =
   let denv =
     { parent = Let_cont_rec { invariant_params; handlers; parent = denv.parent };
       conts;
+      should_preserve_direct_calls = denv.should_preserve_direct_calls;
       current_code_id = denv.current_code_id;
       le_monde_exterieur = denv.le_monde_exterieur;
       all_constants = denv.all_constants
@@ -643,9 +648,10 @@ and traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
        calls_are_not_pure } in Acc.add_apply apply_dep acc; if Option.is_some
        (Apply.callee apply) then add_call_widget function_call) else default_acc
        acc *)
-    if Option.is_some (Apply.callee apply)
-    then add_call_widget function_call
-    else if Compilation_unit.is_current (Code_id.get_compilation_unit code_id)
+    if Option.is_some (Apply.callee apply) then add_call_widget function_call;
+    if Compilation_unit.is_current (Code_id.get_compilation_unit code_id)
+       && (Option.is_none (Apply.callee apply)
+          || denv.should_preserve_direct_calls)
     then
       let apply_dep =
         { Traverse_acc.function_containing_apply_expr = denv.current_code_id;
@@ -658,7 +664,8 @@ and traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
         }
       in
       Acc.add_apply apply_dep acc
-    else default_acc acc
+    else if Option.is_none (Apply.callee apply)
+    then default_acc acc
   | Function
       { function_call =
           (Indirect_unknown_arity | Indirect_known_arity _) as function_call;
@@ -738,9 +745,19 @@ and traverse_function_params_and_body acc code_id code ~return_continuation
     };
   Acc.fixed_arity_continuation acc return_continuation;
   Acc.fixed_arity_continuation acc exn_continuation;
+  let check_zero_alloc =
+    match Code.zero_alloc_attribute code with
+    | Default_zero_alloc ->
+      (* The effect of [Clflags.zero_alloc_assert] has been compiled into
+         [Check] earlier. *)
+      false
+    | Assume _ -> false
+    | Check _ -> true
+  in
   let denv =
     { parent = Hole;
       conts;
+      should_preserve_direct_calls = check_zero_alloc;
       current_code_id = Some code_id;
       le_monde_exterieur;
       all_constants
@@ -857,6 +874,7 @@ let run ~get_code_metadata (unit : Flambda_unit.t) =
     traverse
       { parent = Hole;
         conts;
+        should_preserve_direct_calls = false;
         current_code_id = None;
         le_monde_exterieur = Name.symbol le_monde_exterieur;
         all_constants = Name.symbol all_constants

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -742,6 +742,7 @@ and traverse_function_params_and_body acc code_id code ~return_continuation
      mark the code as escaping. *)
   let is_opaque = Code_metadata.is_opaque code_metadata in
   let code_dep = Acc.find_code acc code_id in
+  Graph.add_code_id_my_closure (Acc.graph acc) code_id my_closure;
   let maybe_opaque var = if is_opaque then Variable.rename var else var in
   let return = List.map maybe_opaque code_dep.return in
   let exn = maybe_opaque code_dep.exn in

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -628,7 +628,7 @@ and traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
           first;
         Graph.add_accessor_dep (Acc.graph acc)
           ~to_:(Code_id_or_name.var calls_are_not_pure)
-          Code_of_closure ~base:callee;
+          (Code_of_closure closure_entry_point) ~base:callee;
         Graph.add_accessor_dep (Acc.graph acc)
           ~to_:(Code_id_or_name.var exn_arg)
           (Apply (closure_entry_point, Exn))

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -604,9 +604,9 @@ and traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
       | Indirect_unknown_arity ->
         ( Flambda_arity.group_by_parameter (Apply.args_arity apply)
             (Apply.args apply),
-          Global_flow_graph.Indirect_code_pointer )
+          Global_flow_graph.Unknown_arity_code_pointer )
       | Indirect_known_arity | Direct _ ->
-        [Apply.args apply], Global_flow_graph.Direct_code_pointer
+        [Apply.args apply], Global_flow_graph.Known_arity_code_pointer
     in
     (* List.iter (fun arg -> Acc.used ~denv arg acc) (Apply.args apply); *)
     let callee =

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -38,7 +38,7 @@ let prepare_code ~denv acc (code_id : Code_id.t) (code : Code.t) =
     List.mapi
       (fun i kind ->
         Variable.create
-          (Format.asprintf "function_return_%i_%a" i Code_id.print code_id)
+          (Format.asprintf "function_return_%i_%s" i (Code_id.name code_id))
           (Flambda_kind.With_subkind.kind kind))
       (Flambda_arity.unarized_components (Code.result_arity code))
   in
@@ -68,17 +68,13 @@ let prepare_code ~denv acc (code_id : Code_id.t) (code : Code.t) =
     | Assume _ -> false
     | Check _ -> true
   in
-  let call_witnesses =
-    List.init
-      (if Code.is_tupled code then 1 else Flambda_arity.num_params arity)
-      (fun i ->
-        Code_id_or_name.var
-          (* These witnesses are not going to end up as actual program
-             variables; giving them kind Value is a bit misleading but should
-             not cause any issue. *)
-          (Variable.create
-             (Printf.sprintf "witness_%d_for_%s" i (Code_id.name code_id))
-             Flambda_kind.value))
+  let is_tupled = Code.is_tupled code in
+  let known_arity_call_witness =
+    Acc.create_known_arity_call_witness acc code_id ~params ~returns:return ~exn
+  in
+  let unknown_arity_call_witnesses =
+    Acc.create_unknown_arity_call_witnesses acc code_id ~is_tupled ~arity
+      ~params ~returns:return ~exn
   in
   let code_dep =
     { Traverse_acc.arity;
@@ -86,35 +82,21 @@ let prepare_code ~denv acc (code_id : Code_id.t) (code : Code.t) =
       my_closure;
       exn;
       params;
-      is_tupled = Code.is_tupled code;
-      call_witnesses
+      is_tupled;
+      known_arity_call_witness;
+      unknown_arity_call_witnesses
     }
   in
-  List.iteri
-    (fun i witness ->
-      Graph.add_constructor_dep (Acc.graph acc) ~base:witness
-        (Code_id_of_call_witness i)
-        ~from:(Code_id_or_name.code_id code_id))
-    call_witnesses;
-  Graph.add_alias (Acc.graph acc)
-    ~to_:(Code_id_or_name.code_id code_id)
-    ~from:(Code_id_or_name.name denv.le_monde_exterieur);
-  (* Graph.add_use_dep (Acc.graph acc) ~to_:indirect_call_witness
-     ~from:(Code_id_or_name.code_id code_id); *)
-  (* let le_monde_exterieur = denv.le_monde_exterieur in List.iter (fun param ->
-     let param = Code_id_or_name.var param in Graph.add_propagate_dep (Acc.graph
-     acc) ~if_used:indirect_call_witness ~from:le_monde_exterieur ~to_:param)
-     params; *)
+  Graph.add_any_source (Acc.graph acc) (Code_id_or_name.code_id code_id);
   if has_unsafe_result_type || never_delete
   then (
     List.iter
       (fun var -> Acc.used ~denv (Simple.var var) acc)
       ((my_closure :: params) @ (exn :: return));
-    let le_monde_exterieur = Code_id_or_name.name denv.le_monde_exterieur in
     List.iter
       (fun param ->
         let param = Code_id_or_name.var param in
-        Graph.add_alias (Acc.graph acc) ~to_:param ~from:le_monde_exterieur)
+        Graph.add_any_source (Acc.graph acc) param)
       (my_closure :: params));
   if never_delete then Acc.used_code_id code_id acc;
   Acc.add_code code_id code_dep acc
@@ -537,10 +519,9 @@ and traverse_cont_handler :
 and traverse_apply denv acc apply : rev_expr =
   let return_args =
     match Apply.continuation apply with
-    | Never_returns -> None
+    | Never_returns -> []
     | Return cont -> (
-      match Continuation.Map.find cont denv.conts with
-      | Normal params -> Some params)
+      match Continuation.Map.find cont denv.conts with Normal params -> params)
   in
   let exn_arg =
     let exn = Apply.exn_continuation apply in
@@ -562,11 +543,9 @@ and traverse_apply denv acc apply : rev_expr =
     (match Apply.callee apply with
     | None -> ()
     | Some callee -> Acc.used ~denv callee acc);
+    Acc.any_source ~denv exn_arg acc;
     Acc.alias_dep ~denv exn_arg (Simple.name denv.le_monde_exterieur) acc;
-    List.iter
-      (fun param ->
-        Acc.alias_dep ~denv param (Simple.name denv.le_monde_exterieur) acc)
-      (match return_args with None -> [] | Some l -> l);
+    List.iter (fun param -> Acc.any_source ~denv param acc) return_args;
     match Apply.call_kind apply with
     | Function _ -> ()
     | Method { obj; kind = _; alloc_mode = _ } -> Acc.used ~denv obj acc

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -575,70 +575,8 @@ and traverse_apply denv acc apply : rev_expr =
   { expr; holed_expr = denv.parent }
 
 and traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
-  let calls_are_not_pure = Variable.create "not_pure" Flambda_kind.value in
-  Acc.used ~denv (Simple.var calls_are_not_pure) acc;
-  let add_call_widget (function_call : Call_kind.Function_call.t) =
-    let args, closure_entry_point =
-      match function_call with
-      | Indirect_unknown_arity ->
-        ( Flambda_arity.group_by_parameter (Apply.args_arity apply)
-            (Apply.args apply),
-          Global_flow_graph.Unknown_arity_code_pointer )
-      | Indirect_known_arity _ | Direct _ ->
-        [Apply.args apply], Global_flow_graph.Known_arity_code_pointer
-    in
-    (* List.iter (fun arg -> Acc.used ~denv arg acc) (Apply.args apply); *)
-    let callee =
-      match Apply.callee apply with
-      | None -> assert false
-      | Some callee ->
-        Code_id_or_name.name (Acc.simple_to_name acc ~denv callee)
-    in
-    let rec add_deps callee args calls_are_not_pure =
-      match args with
-      | [] -> Misc.fatal_error "add_deps: no args"
-      | first :: rest -> (
-        List.iteri
-          (fun i arg ->
-            Graph.add_coaccessor_dep (Acc.graph acc)
-              ~to_:(Code_id_or_name.name (Acc.simple_to_name acc ~denv arg))
-              (Param (closure_entry_point, i))
-              ~base:callee)
-          first;
-        Graph.add_accessor_dep (Acc.graph acc)
-          ~to_:(Code_id_or_name.var calls_are_not_pure)
-          (Code_of_closure closure_entry_point) ~base:callee;
-        Graph.add_accessor_dep (Acc.graph acc)
-          ~to_:(Code_id_or_name.var exn_arg)
-          (Apply (closure_entry_point, Exn))
-          ~base:callee;
-        match rest with
-        | [] -> (
-          match return_args with
-          | None -> ()
-          | Some return_args ->
-            List.iteri
-              (fun i return_arg ->
-                Graph.add_accessor_dep (Acc.graph acc)
-                  ~to_:(Code_id_or_name.var return_arg)
-                  (Apply (closure_entry_point, Normal i))
-                  ~base:callee)
-              return_args)
-        | _ :: _ ->
-          let v = Variable.create "partial_apply" Flambda_kind.value in
-          Graph.add_accessor_dep (Acc.graph acc) ~to_:(Code_id_or_name.var v)
-            (Apply (closure_entry_point, Normal 0))
-            ~base:callee;
-          let calls_are_not_pure =
-            Variable.create "not_pure" Flambda_kind.value
-          in
-          Acc.used ~denv (Simple.var calls_are_not_pure) acc;
-          add_deps (Code_id_or_name.var v) rest calls_are_not_pure)
-    in
-    add_deps callee args calls_are_not_pure
-  in
   match Apply.call_kind apply with
-  | Function { function_call = Direct code_id as function_call; _ } ->
+  | Function { function_call = Direct code_id; _ } ->
     (* CR ncourant: think about cross-module propagation *)
     (* if Compilation_unit.is_current (Code_id.get_compilation_unit code_id)
        then ( let apply_dep = { Traverse_acc.function_containing_apply_expr =
@@ -648,7 +586,18 @@ and traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
        calls_are_not_pure } in Acc.add_apply apply_dep acc; if Option.is_some
        (Apply.callee apply) then add_call_widget function_call) else default_acc
        acc *)
-    if Option.is_some (Apply.callee apply) then add_call_widget function_call;
+    let call_widget =
+      Acc.make_known_arity_apply_widget acc ~denv ~params:(Apply.args apply)
+        ~returns:return_args ~exn:exn_arg
+    in
+    (if Option.is_some (Apply.callee apply)
+    then
+      let closure =
+        Acc.simple_to_name acc ~denv (Option.get (Apply.callee apply))
+      in
+      Graph.add_accessor_dep (Acc.graph acc) ~to_:call_widget
+        (Code_of_closure Known_arity_code_pointer)
+        ~base:(Code_id_or_name.name closure));
     if Compilation_unit.is_current (Code_id.get_compilation_unit code_id)
        && (Option.is_none (Apply.callee apply)
           || denv.should_preserve_direct_calls)
@@ -656,24 +605,36 @@ and traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
       let apply_dep =
         { Traverse_acc.function_containing_apply_expr = denv.current_code_id;
           apply_code_id = code_id;
-          apply_args = Apply.args apply;
           apply_closure = Apply.callee apply;
-          params_of_apply_return_cont = return_args;
-          param_of_apply_exn_cont = exn_arg;
-          not_pure_call_witness = calls_are_not_pure
+          apply_call_witness = call_widget
         }
       in
       Acc.add_apply apply_dep acc
     else if Option.is_none (Apply.callee apply)
     then default_acc acc
-  | Function
-      { function_call =
-          (Indirect_unknown_arity | Indirect_known_arity _) as function_call;
-        _
-      } ->
-    (* CR bclement/ncourant: think about indirect calls where we know a set of
-       code ids (this should very rarely happen) *)
-    add_call_widget function_call
+  | Function { function_call = Indirect_known_arity _; _ } ->
+    let call_widget =
+      Acc.make_known_arity_apply_widget acc ~denv ~params:(Apply.args apply)
+        ~returns:return_args ~exn:exn_arg
+    in
+    let closure =
+      Acc.simple_to_name acc ~denv (Option.get (Apply.callee apply))
+    in
+    Graph.add_accessor_dep (Acc.graph acc) ~to_:call_widget
+      (Code_of_closure Known_arity_code_pointer)
+      ~base:(Code_id_or_name.name closure)
+  | Function { function_call = Indirect_unknown_arity; _ } ->
+    let call_widget =
+      Acc.make_unknown_arity_apply_widget acc ~denv
+        ~arity:(Apply.args_arity apply) ~params:(Apply.args apply)
+        ~returns:return_args ~exn:exn_arg
+    in
+    let closure =
+      Acc.simple_to_name acc ~denv (Option.get (Apply.callee apply))
+    in
+    Graph.add_accessor_dep (Acc.graph acc) ~to_:call_widget
+      (Code_of_closure Unknown_arity_code_pointer)
+      ~base:(Code_id_or_name.name closure)
   | Method _ | C_call _ | Effect _ -> default_acc acc
 
 and traverse_apply_cont denv acc apply_cont : rev_expr =

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -600,7 +600,7 @@ and traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
         ( Flambda_arity.group_by_parameter (Apply.args_arity apply)
             (Apply.args apply),
           Global_flow_graph.Unknown_arity_code_pointer )
-      | Indirect_known_arity | Direct _ ->
+      | Indirect_known_arity _ | Direct _ ->
         [Apply.args apply], Global_flow_graph.Known_arity_code_pointer
     in
     (* List.iter (fun arg -> Acc.used ~denv arg acc) (Apply.args apply); *)
@@ -682,9 +682,11 @@ and traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
     else default_acc acc
   | Function
       { function_call =
-          (Indirect_unknown_arity | Indirect_known_arity) as function_call;
+          (Indirect_unknown_arity | Indirect_known_arity _) as function_call;
         _
       } ->
+    (* CR bclement/ncourant: think about indirect calls where we know a set of
+       code ids (this should very rarely happen) *)
     add_call_widget function_call
   | Method _ | C_call _ | Effect _ -> default_acc acc
 

--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -28,7 +28,6 @@ module Env = struct
     { parent : Rev_expr.rev_expr_holed;
       conts : cont_kind Continuation.Map.t;
       current_code_id : Code_id.t option;
-      should_preserve_direct_calls : bool;
       le_monde_exterieur : Name.t;
       all_constants : Name.t
     }

--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -28,6 +28,7 @@ module Env = struct
     { parent : Rev_expr.rev_expr_holed;
       conts : cont_kind Continuation.Map.t;
       current_code_id : Code_id.t option;
+      should_preserve_direct_calls : bool;
       le_monde_exterieur : Name.t;
       all_constants : Name.t
     }

--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -24,11 +24,16 @@ type continuation_info =
 module Env = struct
   type cont_kind = Normal of Variable.t list
 
+  type should_preserve_direct_calls =
+    | Yes
+    | No
+    | Auto
+
   type t =
     { parent : Rev_expr.rev_expr_holed;
       conts : cont_kind Continuation.Map.t;
       current_code_id : Code_id.t option;
-      should_preserve_direct_calls : bool;
+      should_preserve_direct_calls : should_preserve_direct_calls;
       le_monde_exterieur : Name.t;
       all_constants : Name.t
     }

--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -40,18 +40,16 @@ type code_dep =
     return : Variable.t list; (* Dummy variable representing return value *)
     exn : Variable.t; (* Dummy variable representing exn return value *)
     is_tupled : bool;
-    call_witnesses :
+    known_arity_call_witness : Code_id_or_name.t;
+    unknown_arity_call_witnesses :
       Code_id_or_name.t list (* One element for each (complex) parameter *)
   }
 
 type apply_dep =
   { function_containing_apply_expr : Code_id.t option;
     apply_code_id : Code_id.t;
-    apply_args : Simple.t list;
     apply_closure : Simple.t option;
-    params_of_apply_return_cont : Variable.t list option;
-    param_of_apply_exn_cont : Variable.t;
-    not_pure_call_witness : Variable.t
+    apply_call_witness : Code_id_or_name.t
   }
 
 type closure_dep =
@@ -149,6 +147,23 @@ let used ~(denv : Env.t) dep t =
       ~to_:(Code_id_or_name.code_id code_id)
       ~from:(Code_id_or_name.name name)
 
+let any_source ~(denv : Env.t) v t =
+  match denv.current_code_id with
+  | None -> Graph.add_any_source t.deps (Code_id_or_name.var v)
+  | Some code_id ->
+    Graph.add_propagate_dep t.deps
+      ~if_used:(Code_id_or_name.code_id code_id)
+      ~from:(Code_id_or_name.name denv.le_monde_exterieur)
+      ~to_:(Code_id_or_name.var v)
+
+let cond_alias t ~(denv : Env.t) ~from ~to_ =
+  match denv.current_code_id with
+  | None -> Graph.add_alias t.deps ~from ~to_
+  | Some code_id ->
+    Graph.add_propagate_dep t.deps
+      ~if_used:(Code_id_or_name.code_id code_id)
+      ~from ~to_
+
 let used_code_id code_id t =
   Graph.add_use t.deps (Code_id_or_name.code_id code_id)
 
@@ -181,7 +196,228 @@ let add_set_of_closures_dep let_bound_name_of_the_closure closure_code_id
        }
        :: t.set_of_closures_dep
 
-let record_set_of_closure_deps ~get_code_metadata ~le_monde_exterieur t =
+(* Encoding of sets of closures and apply
+ *
+ * Let us consider, for now, a set of closures that is only directly called.
+ * Assume that it has a value slot x, two function slots f and g, with
+ * associated code_ids p (param a, return s) and q (param b, return t).
+ * We will name the respective witnesses n and m, and ignore exception returns
+ * to make the diagram simpler.
+ 
+ * We will create a widget looking like this:
+ *  ┌──╔═══╗─────[g]────>╔═══╗──┐
+ * [f] ║ f ║             ║ g ║ [g]
+ *  └─>╚═══╝<────[f]─────╚═══╝<─┘
+ *      │ │     ╔═══╗     │ │
+ *      │ └[x]─>║ x ║<─[x]┘ │
+ *    [wit]     ╚═══╝     [wit]
+ *      │                   │
+ *      v                   v
+ *    ╔═══╗               ╔═══╗
+ *    ║ n ║               ║ m ║
+ *    ╚═══╝               ╚═══╝
+ *     ││║          ╔═══╗  ││║          ╔═══╗
+ *     ││╚[param0]═>║ a ║  ││╚[param0]═>║ b ║
+ *     ││           ╚═══╝  ││           ╚═══╝
+ *     ││           ╔═══╗  ││           ╔═══╗
+ *     │└[return0]─>║ s ║  │└[return0]─>║ t ║
+ *     │            ╚═══╝  │            ╚═══╝
+ *     │            ╔═══╗  │            ╔═══╗
+ *     └─[code_id]─>║ p ║  └─[code_id]─>║ q ║
+ *                  ╚═══╝               ╚═══╝
+ *
+ * For indirect calls, we have a series of call witnesses for each
+ * complex parameter, each with coconstructors for each part of the
+ * complex parameter, the code_id, and returning a value with the next call
+ * witness.
+ *)
+
+let create_known_arity_call_witness t code_id ~params ~returns ~exn =
+  let witness =
+    Variable.create
+      (Format.asprintf "known_arity_witness_%s" (Code_id.name code_id))
+      Flambda_kind.rec_info
+    (* dummy kind to make sure the rest of the code breaks if this is ever
+       used *)
+  in
+  let witness = Code_id_or_name.var witness in
+  List.iteri
+    (fun i v ->
+      Graph.add_coconstructor_dep t.deps ~base:witness (Param i)
+        ~from:(Code_id_or_name.var v))
+    params;
+  List.iteri
+    (fun i v ->
+      Graph.add_constructor_dep t.deps ~base:witness (Apply (Normal i))
+        ~from:(Code_id_or_name.var v))
+    returns;
+  Graph.add_constructor_dep t.deps ~base:witness (Apply Exn)
+    ~from:(Code_id_or_name.var exn);
+  Graph.add_constructor_dep t.deps ~base:witness Code_id_of_call_witness
+    ~from:(Code_id_or_name.code_id code_id);
+  witness
+
+let make_known_arity_apply_widget t ~denv ~params ~returns ~exn =
+  let witness =
+    Code_id_or_name.var
+      (Variable.create "known_arity_apply" Flambda_kind.rec_info)
+  in
+  List.iteri
+    (fun i v ->
+      Graph.add_coaccessor_dep t.deps ~base:witness (Param i)
+        ~to_:(Code_id_or_name.var v))
+    params;
+  List.iteri
+    (fun i v ->
+      Graph.add_accessor_dep t.deps ~base:witness (Apply (Normal i))
+        ~to_:(Code_id_or_name.var v))
+    returns;
+  Graph.add_accessor_dep t.deps ~base:witness (Apply Exn)
+    ~to_:(Code_id_or_name.var exn);
+  let called =
+    Code_id_or_name.var (Variable.create "called" Flambda_kind.rec_info)
+  in
+  Graph.add_accessor_dep t.deps ~base:witness Code_id_of_call_witness
+    ~to_:called;
+  Graph.add_use t.deps called;
+  let apply =
+    Code_id_or_name.var (Variable.create "apply" Flambda_kind.rec_info)
+  in
+  cond_alias t ~denv ~from:apply ~to_:witness;
+  apply
+
+let create_unknown_arity_call_witnesses t code_id ~is_tupled ~arity ~params
+    ~returns ~exn =
+  if is_tupled
+  then (
+    let witness =
+      Variable.create
+        (Format.asprintf "unknown_arity_witness_tupled_%s"
+           (Code_id.name code_id))
+        Flambda_kind.rec_info
+    in
+    let witness = Code_id_or_name.var witness in
+    List.iteri
+      (fun i v ->
+        Graph.add_constructor_dep t.deps ~base:witness (Apply (Normal i))
+          ~from:(Code_id_or_name.var v))
+      returns;
+    Graph.add_constructor_dep t.deps ~base:witness (Apply Exn)
+      ~from:(Code_id_or_name.var exn);
+    Graph.add_constructor_dep t.deps ~base:witness Code_id_of_call_witness
+      ~from:(Code_id_or_name.code_id code_id);
+    let untuple_var =
+      Code_id_or_name.var (Variable.create "untuple_var" Flambda_kind.value)
+    in
+    Graph.add_coconstructor_dep t.deps ~base:witness (Param 0) ~from:untuple_var;
+    (* CR ncourant: this should be changed if we ever allow non-value tuples *)
+    List.iteri
+      (fun i v ->
+        Graph.add_accessor_dep t.deps ~to_:(Code_id_or_name.var v)
+          (Block (i, Flambda_kind.value))
+          ~base:untuple_var)
+      params;
+    [witness])
+  else
+    let rec add_deps params_and_witnesses =
+      match params_and_witnesses with
+      | [] -> Misc.fatal_error "add_deps: no params"
+      | (first, witness) :: rest -> (
+        List.iteri
+          (fun i arg ->
+            Graph.add_coconstructor_dep t.deps ~from:(Code_id_or_name.var arg)
+              (Param i) ~base:witness)
+          first;
+        Graph.add_constructor_dep t.deps ~base:witness Code_id_of_call_witness
+          ~from:(Code_id_or_name.code_id code_id);
+        match rest with
+        | [] ->
+          Graph.add_constructor_dep t.deps ~base:witness (Apply Exn)
+            ~from:(Code_id_or_name.var exn);
+          List.iteri
+            (fun i return_arg ->
+              Graph.add_constructor_dep t.deps
+                ~from:(Code_id_or_name.var return_arg)
+                (Apply (Normal i)) ~base:witness)
+            returns
+        | (_, next_witness) :: _ ->
+          let v =
+            Code_id_or_name.var
+              (Variable.create "partial_apply" Flambda_kind.value)
+          in
+          Graph.add_constructor_dep t.deps ~from:v (Apply (Normal 0))
+            ~base:witness;
+          Graph.add_constructor_dep t.deps ~from:next_witness
+            (Code_of_closure Unknown_arity_code_pointer) ~base:v;
+          add_deps rest)
+    in
+    let params = Flambda_arity.group_by_parameter arity params in
+    let witnesses =
+      List.mapi
+        (fun i _ ->
+          Code_id_or_name.var
+            (Variable.create
+               (Format.asprintf "unknown_arity_witness_%d_%s" i
+                  (Code_id.name code_id))
+               Flambda_kind.rec_info))
+        params
+    in
+    add_deps (List.combine params witnesses);
+    witnesses
+
+let make_unknown_arity_apply_widget t ~denv ~arity ~params ~returns ~exn =
+  let called =
+    Code_id_or_name.var (Variable.create "called" Flambda_kind.rec_info)
+  in
+  Graph.add_use t.deps called;
+  let rec add_deps params_and_witnesses =
+    match params_and_witnesses with
+    | [] -> Misc.fatal_error "add_deps: no params"
+    | (first, witness) :: rest -> (
+      List.iteri
+        (fun i v ->
+          Graph.add_coaccessor_dep t.deps ~base:witness (Param i)
+            ~to_:(Code_id_or_name.var v))
+        first;
+      Graph.add_accessor_dep t.deps ~base:witness (Apply Exn)
+        ~to_:(Code_id_or_name.var exn);
+      Graph.add_accessor_dep t.deps ~base:witness Code_id_of_call_witness
+        ~to_:called;
+      match rest with
+      | [] ->
+        List.iteri
+          (fun i v ->
+            Graph.add_accessor_dep t.deps ~base:witness (Apply (Normal i))
+              ~to_:(Code_id_or_name.var v))
+          returns
+      | (_, next_witness) :: _ ->
+        let v =
+          Code_id_or_name.var
+            (Variable.create "partial_apply" Flambda_kind.value)
+        in
+        Graph.add_accessor_dep t.deps ~base:witness (Apply (Normal 0)) ~to_:v;
+        Graph.add_accessor_dep t.deps ~base:v
+          (Code_of_closure Unknown_arity_code_pointer) ~to_:next_witness;
+        add_deps rest)
+  in
+  let params = Flambda_arity.group_by_parameter arity params in
+  let witnesses =
+    List.mapi
+      (fun i _ ->
+        Code_id_or_name.var
+          (Variable.create
+             (Format.asprintf "unknown_arity_apply_%d" i)
+             Flambda_kind.rec_info))
+      params
+  in
+  add_deps (List.combine params witnesses);
+  let apply =
+    Code_id_or_name.var (Variable.create "apply" Flambda_kind.rec_info)
+  in
+  cond_alias t ~denv ~from:apply ~to_:(List.hd witnesses);
+  apply
+
+let record_set_of_closure_deps t =
   List.iter
     (fun { let_bound_name_of_the_closure = name;
            closure_code_id = code_id;
@@ -196,209 +432,67 @@ let record_set_of_closure_deps ~get_code_metadata ~le_monde_exterieur t =
           not
             (Compilation_unit.is_current (Code_id.get_compilation_unit code_id)));
         (* The code comes from another compilation unit; so we don't know what
-           happens once it is applied. As such, it must escape the whole block.
-           Besides, return values can be anything. *)
-        Graph.add_constructor_dep t.deps
-          ~base:(Code_id_or_name.name name)
-          (Code_of_closure Unknown_arity_code_pointer)
-          ~from:(Code_id_or_name.name name);
-        Graph.add_constructor_dep t.deps
-          ~base:(Code_id_or_name.name name)
-          (Code_of_closure Known_arity_code_pointer)
-          ~from:(Code_id_or_name.name name);
-        let code_metadata = get_code_metadata code_id in
-        let num_returns =
-          Flambda_arity.cardinal_unarized
-            (Code_metadata.result_arity code_metadata)
+           happens once it is applied. As such, it must escape the whole
+           block. *)
+        let witness =
+          Code_id_or_name.var
+            (Variable.create
+               (Format.asprintf "external_code_id_witness_%s"
+                  (Code_id.name code_id))
+               Flambda_kind.value)
         in
-        for i = 0 to num_returns - 1 do
-          Graph.add_constructor_dep t.deps
-            ~base:(Code_id_or_name.name name)
-            (Apply (Known_arity_code_pointer, Normal i))
-            ~from:(Code_id_or_name.name le_monde_exterieur);
-          Graph.add_constructor_dep t.deps
-            ~base:(Code_id_or_name.name name)
-            (Apply (Unknown_arity_code_pointer, Normal i))
-            ~from:(Code_id_or_name.name le_monde_exterieur)
-        done;
-        Graph.add_constructor_dep t.deps
-          ~base:(Code_id_or_name.name name)
-          (Apply (Known_arity_code_pointer, Exn))
-          ~from:(Code_id_or_name.name le_monde_exterieur);
-        Graph.add_constructor_dep t.deps
-          ~base:(Code_id_or_name.name name)
-          (Apply (Unknown_arity_code_pointer, Exn))
-          ~from:(Code_id_or_name.name le_monde_exterieur);
-        let params_unarized =
-          Flambda_arity.unarize_per_parameter
-            (Code_metadata.params_arity code_metadata)
-        in
-        let is_tupled = Code_metadata.is_tupled code_metadata in
-        let num_indirect_params =
-          if is_tupled then 1 else List.length (List.hd params_unarized)
-        in
-        let num_direct_params =
-          List.length
-            (Flambda_arity.unarize (Code_metadata.params_arity code_metadata))
-        in
-        let always_used = Variable.create "always_used" Flambda_kind.value in
-        Graph.add_use t.deps (Code_id_or_name.var always_used);
-        for i = 0 to num_direct_params - 1 do
-          Graph.add_coconstructor_dep t.deps
-            ~base:(Code_id_or_name.name name)
-            (Param (Known_arity_code_pointer, i))
-            ~from:(Code_id_or_name.var always_used)
-        done;
-        for i = 0 to num_indirect_params - 1 do
-          Graph.add_coconstructor_dep t.deps
-            ~base:(Code_id_or_name.name name)
-            (Param (Unknown_arity_code_pointer, i))
-            ~from:(Code_id_or_name.var always_used)
-        done
-      | code_dep ->
-        Graph.add_alias t.deps
-          ~to_:(Code_id_or_name.var code_dep.my_closure)
-          ~from:(Code_id_or_name.name name);
-        let call_witnesses = code_dep.call_witnesses in
-        Graph.add_constructor_dep t.deps ~from:(List.hd call_witnesses)
+        Graph.add_any_source t.deps witness;
+        Graph.add_constructor_dep t.deps ~from:witness
           (Code_of_closure Known_arity_code_pointer)
           ~base:(Code_id_or_name.name name);
-        List.iteri
-          (fun i v ->
-            Graph.add_constructor_dep t.deps
-              ~base:(Code_id_or_name.name name)
-              (Apply (Known_arity_code_pointer, Normal i))
-              ~from:(Code_id_or_name.var v))
-          code_dep.return;
-        List.iteri
-          (fun i v ->
-            Graph.add_coconstructor_dep t.deps
-              ~base:(Code_id_or_name.name name)
-              (Param (Known_arity_code_pointer, i))
-              ~from:(Code_id_or_name.var v))
-          code_dep.params;
+        Graph.add_constructor_dep t.deps ~from:witness
+          (Code_of_closure Unknown_arity_code_pointer)
+          ~base:(Code_id_or_name.name name);
+        Graph.add_constructor_dep t.deps ~base:witness Code_id_of_call_witness
+          ~from:(Code_id_or_name.name name)
+      | code_dep ->
+        Graph.add_propagate_dep t.deps
+          ~to_:(Code_id_or_name.var code_dep.my_closure)
+          ~from:(Code_id_or_name.name name)
+          ~if_used:(Code_id_or_name.code_id code_id);
+        Graph.add_constructor_dep t.deps ~from:code_dep.known_arity_call_witness
+          (Code_of_closure Known_arity_code_pointer)
+          ~base:(Code_id_or_name.name name);
         Graph.add_constructor_dep t.deps
-          ~base:(Code_id_or_name.name name)
-          (Apply (Known_arity_code_pointer, Exn))
-          ~from:(Code_id_or_name.var code_dep.exn);
-        if code_dep.is_tupled
-        then (
-          assert (List.compare_length_with call_witnesses 1 = 0);
-          let call_witness = List.hd call_witnesses in
-          Graph.add_constructor_dep t.deps
-            ~base:(Code_id_or_name.name name)
-            (Apply (Unknown_arity_code_pointer, Exn))
-            ~from:(Code_id_or_name.var code_dep.exn);
-          List.iteri
-            (fun i return_arg ->
-              Graph.add_constructor_dep t.deps
-                ~from:(Code_id_or_name.var return_arg)
-                (Apply (Unknown_arity_code_pointer, Normal i))
-                ~base:(Code_id_or_name.name name))
-            code_dep.return;
-          Graph.add_constructor_dep t.deps ~from:call_witness
-            (Code_of_closure Unknown_arity_code_pointer)
-            ~base:(Code_id_or_name.name name);
-          let untuple_var = Variable.create "untuple_var" Flambda_kind.value in
-          Graph.add_coconstructor_dep t.deps
-            ~from:(Code_id_or_name.var untuple_var)
-            (Param (Unknown_arity_code_pointer, 0))
-            ~base:(Code_id_or_name.name name);
-          List.iteri
-            (fun i v ->
-              Graph.add_accessor_dep t.deps ~to_:(Code_id_or_name.var v)
-                (Block (i, Flambda_kind.value))
-                ~base:(Code_id_or_name.var untuple_var))
-            code_dep.params)
-        else
-          let rec add_deps func params_and_witnesses =
-            match params_and_witnesses with
-            | [] -> Misc.fatal_error "add_deps: no params"
-            | (first, witness) :: rest -> (
-              List.iteri
-                (fun i arg ->
-                  Graph.add_coconstructor_dep t.deps
-                    ~from:(Code_id_or_name.var arg)
-                    (Param (Unknown_arity_code_pointer, i))
-                    ~base:func)
-                first;
-              Graph.add_constructor_dep t.deps ~from:witness
-                (Code_of_closure Unknown_arity_code_pointer) ~base:func;
-              match rest with
-              | [] ->
-                Graph.add_constructor_dep t.deps ~base:func
-                  (Apply (Unknown_arity_code_pointer, Exn))
-                  ~from:(Code_id_or_name.var code_dep.exn);
-                List.iteri
-                  (fun i return_arg ->
-                    Graph.add_constructor_dep t.deps
-                      ~from:(Code_id_or_name.var return_arg)
-                      (Apply (Unknown_arity_code_pointer, Normal i))
-                      ~base:func)
-                  code_dep.return
-              | _ :: _ ->
-                let v = Variable.create "partial_apply" Flambda_kind.value in
-                Graph.add_constructor_dep t.deps ~from:(Code_id_or_name.var v)
-                  (Apply (Unknown_arity_code_pointer, Normal 0))
-                  ~base:func;
-                add_deps (Code_id_or_name.var v) rest)
-          in
-          let params =
-            Flambda_arity.group_by_parameter code_dep.arity code_dep.params
-          in
-          assert (List.compare_lengths call_witnesses params = 0);
-          add_deps
-            (Code_id_or_name.name name)
-            (List.combine params call_witnesses))
+          ~from:(List.hd code_dep.unknown_arity_call_witnesses)
+          (Code_of_closure Unknown_arity_code_pointer)
+          ~base:(Code_id_or_name.name name))
     t.set_of_closures_dep
 
 let graph t = t.deps
 
-let deps t ~get_code_metadata ~le_monde_exterieur ~all_constants =
+let deps t ~get_code_metadata:_ ~le_monde_exterieur:_ ~all_constants =
   List.iter
     (fun { function_containing_apply_expr;
            apply_code_id;
-           apply_args;
            apply_closure;
-           params_of_apply_return_cont;
-           param_of_apply_exn_cont;
-           not_pure_call_witness
+           apply_call_witness
          } ->
       let code_dep = find_code t apply_code_id in
-      Graph.add_alias t.deps
-        ~from:(List.hd code_dep.call_witnesses)
-        ~to_:(Code_id_or_name.var not_pure_call_witness);
-      let add_cond_dep param name =
-        let param = Name.var param in
+      Graph.add_alias t.deps ~from:code_dep.known_arity_call_witness
+        ~to_:apply_call_witness;
+      match apply_closure with
+      | None -> ()
+      | Some closure -> (
         match function_containing_apply_expr with
         | None ->
           Graph.add_alias t.deps
-            ~to_:(Code_id_or_name.name param)
-            ~from:(Code_id_or_name.name name)
+            ~to_:(Code_id_or_name.var code_dep.my_closure)
+            ~from:
+              (Code_id_or_name.name (simple_to_name t ~all_constants closure))
         | Some code_id ->
           Graph.add_propagate_dep t.deps
-            ~if_used:(Code_id_or_name.code_id code_id)
-            ~from:(Code_id_or_name.name name)
-            ~to_:(Code_id_or_name.name param)
-      in
-      List.iter2
-        (fun param arg ->
-          add_cond_dep param (simple_to_name t ~all_constants arg))
-        code_dep.params apply_args;
-      (match apply_closure with
-      | None -> add_cond_dep code_dep.my_closure le_monde_exterieur
-      | Some apply_closure ->
-        add_cond_dep code_dep.my_closure
-          (simple_to_name t ~all_constants apply_closure));
-      (match params_of_apply_return_cont with
-      | None -> ()
-      | Some apply_return ->
-        List.iter2
-          (fun arg param -> add_cond_dep param (Name.var arg))
-          code_dep.return apply_return);
-      add_cond_dep param_of_apply_exn_cont (Name.var code_dep.exn))
+            ~to_:(Code_id_or_name.var code_dep.my_closure)
+            ~from:
+              (Code_id_or_name.name (simple_to_name t ~all_constants closure))
+            ~if_used:(Code_id_or_name.code_id code_id)))
     t.apply_deps;
-  record_set_of_closure_deps ~get_code_metadata ~le_monde_exterieur t;
+  record_set_of_closure_deps t;
   t.deps
 
 let simple_to_name t ~denv s =

--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -258,7 +258,7 @@ let create_known_arity_call_witness t code_id ~params ~returns ~exn =
     ~from:(Code_id_or_name.code_id code_id);
   witness
 
-let make_known_arity_apply_widget t ~denv ~params ~returns ~exn =
+let make_known_arity_apply_widget t ~(denv : Env.t) ~params ~returns ~exn =
   let witness =
     Code_id_or_name.var
       (Variable.create "known_arity_apply" Flambda_kind.rec_info)
@@ -266,7 +266,9 @@ let make_known_arity_apply_widget t ~denv ~params ~returns ~exn =
   List.iteri
     (fun i v ->
       Graph.add_coaccessor_dep t.deps ~base:witness (Param i)
-        ~to_:(Code_id_or_name.var v))
+        ~to_:
+          (Code_id_or_name.name
+             (simple_to_name t ~all_constants:denv.all_constants v)))
     params;
   List.iteri
     (fun i v ->
@@ -366,7 +368,8 @@ let create_unknown_arity_call_witnesses t code_id ~is_tupled ~arity ~params
     add_deps (List.combine params witnesses);
     witnesses
 
-let make_unknown_arity_apply_widget t ~denv ~arity ~params ~returns ~exn =
+let make_unknown_arity_apply_widget t ~(denv : Env.t) ~arity ~params ~returns
+    ~exn =
   let called =
     Code_id_or_name.var (Variable.create "called" Flambda_kind.rec_info)
   in
@@ -378,7 +381,9 @@ let make_unknown_arity_apply_widget t ~denv ~arity ~params ~returns ~exn =
       List.iteri
         (fun i v ->
           Graph.add_coaccessor_dep t.deps ~base:witness (Param i)
-            ~to_:(Code_id_or_name.var v))
+            ~to_:
+              (Code_id_or_name.name
+                 (simple_to_name t ~all_constants:denv.all_constants v)))
         first;
       Graph.add_accessor_dep t.deps ~base:witness (Apply Exn)
         ~to_:(Code_id_or_name.var exn);

--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -211,20 +211,20 @@ let record_set_of_closure_deps ~get_code_metadata ~le_monde_exterieur t =
         for i = 0 to num_returns - 1 do
           Graph.add_constructor_dep t.deps
             ~base:(Code_id_or_name.name name)
-            (Apply (Direct_code_pointer, Normal i))
+            (Apply (Known_arity_code_pointer, Normal i))
             ~from:(Code_id_or_name.name le_monde_exterieur);
           Graph.add_constructor_dep t.deps
             ~base:(Code_id_or_name.name name)
-            (Apply (Indirect_code_pointer, Normal i))
+            (Apply (Unknown_arity_code_pointer, Normal i))
             ~from:(Code_id_or_name.name le_monde_exterieur)
         done;
         Graph.add_constructor_dep t.deps
           ~base:(Code_id_or_name.name name)
-          (Apply (Direct_code_pointer, Exn))
+          (Apply (Known_arity_code_pointer, Exn))
           ~from:(Code_id_or_name.name le_monde_exterieur);
         Graph.add_constructor_dep t.deps
           ~base:(Code_id_or_name.name name)
-          (Apply (Indirect_code_pointer, Exn))
+          (Apply (Unknown_arity_code_pointer, Exn))
           ~from:(Code_id_or_name.name le_monde_exterieur);
         let params_unarized =
           Flambda_arity.unarize_per_parameter
@@ -243,13 +243,13 @@ let record_set_of_closure_deps ~get_code_metadata ~le_monde_exterieur t =
         for i = 0 to num_direct_params - 1 do
           Graph.add_coconstructor_dep t.deps
             ~base:(Code_id_or_name.name name)
-            (Param (Direct_code_pointer, i))
+            (Param (Known_arity_code_pointer, i))
             ~from:(Code_id_or_name.var always_used)
         done;
         for i = 0 to num_indirect_params - 1 do
           Graph.add_coconstructor_dep t.deps
             ~base:(Code_id_or_name.name name)
-            (Param (Indirect_code_pointer, i))
+            (Param (Unknown_arity_code_pointer, i))
             ~from:(Code_id_or_name.var always_used)
         done
       | code_dep ->
@@ -260,19 +260,19 @@ let record_set_of_closure_deps ~get_code_metadata ~le_monde_exterieur t =
           (fun i v ->
             Graph.add_constructor_dep t.deps
               ~base:(Code_id_or_name.name name)
-              (Apply (Direct_code_pointer, Normal i))
+              (Apply (Known_arity_code_pointer, Normal i))
               ~from:(Code_id_or_name.var v))
           code_dep.return;
         List.iteri
           (fun i v ->
             Graph.add_coconstructor_dep t.deps
               ~base:(Code_id_or_name.name name)
-              (Param (Direct_code_pointer, i))
+              (Param (Known_arity_code_pointer, i))
               ~from:(Code_id_or_name.var v))
           code_dep.params;
         Graph.add_constructor_dep t.deps
           ~base:(Code_id_or_name.name name)
-          (Apply (Direct_code_pointer, Exn))
+          (Apply (Known_arity_code_pointer, Exn))
           ~from:(Code_id_or_name.var code_dep.exn);
         let call_witnesses = code_dep.call_witnesses in
         if code_dep.is_tupled
@@ -281,13 +281,13 @@ let record_set_of_closure_deps ~get_code_metadata ~le_monde_exterieur t =
           let call_witness = List.hd call_witnesses in
           Graph.add_constructor_dep t.deps
             ~base:(Code_id_or_name.name name)
-            (Apply (Indirect_code_pointer, Exn))
+            (Apply (Unknown_arity_code_pointer, Exn))
             ~from:(Code_id_or_name.var code_dep.exn);
           List.iteri
             (fun i return_arg ->
               Graph.add_constructor_dep t.deps
                 ~from:(Code_id_or_name.var return_arg)
-                (Apply (Indirect_code_pointer, Normal i))
+                (Apply (Unknown_arity_code_pointer, Normal i))
                 ~base:(Code_id_or_name.name name))
             code_dep.return;
           Graph.add_constructor_dep t.deps ~from:call_witness Code_of_closure
@@ -295,7 +295,7 @@ let record_set_of_closure_deps ~get_code_metadata ~le_monde_exterieur t =
           let untuple_var = Variable.create "untuple_var" Flambda_kind.value in
           Graph.add_coconstructor_dep t.deps
             ~from:(Code_id_or_name.var untuple_var)
-            (Param (Indirect_code_pointer, 0))
+            (Param (Unknown_arity_code_pointer, 0))
             ~base:(Code_id_or_name.name name);
           List.iteri
             (fun i v ->
@@ -312,7 +312,7 @@ let record_set_of_closure_deps ~get_code_metadata ~le_monde_exterieur t =
                 (fun i arg ->
                   Graph.add_coconstructor_dep t.deps
                     ~from:(Code_id_or_name.var arg)
-                    (Param (Indirect_code_pointer, i))
+                    (Param (Unknown_arity_code_pointer, i))
                     ~base:func)
                 first;
               Graph.add_constructor_dep t.deps ~from:witness Code_of_closure
@@ -320,19 +320,19 @@ let record_set_of_closure_deps ~get_code_metadata ~le_monde_exterieur t =
               match rest with
               | [] ->
                 Graph.add_constructor_dep t.deps ~base:func
-                  (Apply (Indirect_code_pointer, Exn))
+                  (Apply (Unknown_arity_code_pointer, Exn))
                   ~from:(Code_id_or_name.var code_dep.exn);
                 List.iteri
                   (fun i return_arg ->
                     Graph.add_constructor_dep t.deps
                       ~from:(Code_id_or_name.var return_arg)
-                      (Apply (Indirect_code_pointer, Normal i))
+                      (Apply (Unknown_arity_code_pointer, Normal i))
                       ~base:func)
                   code_dep.return
               | _ :: _ ->
                 let v = Variable.create "partial_apply" Flambda_kind.value in
                 Graph.add_constructor_dep t.deps ~from:(Code_id_or_name.var v)
-                  (Apply (Indirect_code_pointer, Normal 0))
+                  (Apply (Unknown_arity_code_pointer, Normal 0))
                   ~base:func;
                 add_deps (Code_id_or_name.var v) rest)
           in

--- a/middle_end/flambda2/reaper/traverse_acc.mli
+++ b/middle_end/flambda2/reaper/traverse_acc.mli
@@ -40,17 +40,15 @@ type code_dep =
     return : Variable.t list; (* Dummy variable representing return value *)
     exn : Variable.t; (* Dummy variable representing exn return value *)
     is_tupled : bool;
-    call_witnesses : Code_id_or_name.t list
+    known_arity_call_witness : Code_id_or_name.t;
+    unknown_arity_call_witnesses : Code_id_or_name.t list
   }
 
 type apply_dep =
   { function_containing_apply_expr : Code_id.t option;
     apply_code_id : Code_id.t;
-    apply_args : Simple.t list;
     apply_closure : Simple.t option;
-    params_of_apply_return_cont : Variable.t list option;
-    param_of_apply_exn_cont : Variable.t;
-    not_pure_call_witness : Variable.t
+    apply_call_witness : Code_id_or_name.t
   }
 
 type t
@@ -73,6 +71,8 @@ val root : Variable.t -> t -> unit
 
 val used : denv:Env.t -> Simple.t -> t -> unit
 
+val any_source : denv:Env.t -> Variable.t -> t -> unit
+
 val used_code_id : Code_id.t -> t -> unit
 
 val called : denv:Env.t -> Code_id.t -> t -> unit
@@ -86,6 +86,41 @@ val continuation_info : t -> Continuation.t -> continuation_info -> unit
 val get_continuation_info : t -> continuation_info Continuation.Map.t
 
 val add_apply : apply_dep -> t -> unit
+
+val create_known_arity_call_witness :
+  t ->
+  Code_id.t ->
+  params:Variable.t list ->
+  returns:Variable.t list ->
+  exn:Variable.t ->
+  Code_id_or_name.t
+
+val make_known_arity_apply_widget :
+  t ->
+  denv:Env.t ->
+  params:Variable.t list ->
+  returns:Variable.t list ->
+  exn:Variable.t ->
+  Code_id_or_name.t
+
+val create_unknown_arity_call_witnesses :
+  t ->
+  Code_id.t ->
+  is_tupled:bool ->
+  arity:[`Complex] Flambda_arity.t ->
+  params:Variable.t list ->
+  returns:Variable.t list ->
+  exn:Variable.t ->
+  Code_id_or_name.t list
+
+val make_unknown_arity_apply_widget :
+  t ->
+  denv:Env.t ->
+  arity:[`Complex] Flambda_arity.t ->
+  params:Variable.t list ->
+  returns:Variable.t list ->
+  exn:Variable.t ->
+  Code_id_or_name.t
 
 val add_set_of_closures_dep :
   Name.t -> Code_id.t -> only_full_applications:bool -> t -> unit

--- a/middle_end/flambda2/reaper/traverse_acc.mli
+++ b/middle_end/flambda2/reaper/traverse_acc.mli
@@ -99,7 +99,7 @@ val create_known_arity_call_witness :
 val make_known_arity_apply_widget :
   t ->
   denv:Env.t ->
-  params:Variable.t list ->
+  params:Simple.t list ->
   returns:Variable.t list ->
   exn:Variable.t ->
   Code_id_or_name.t
@@ -118,7 +118,7 @@ val make_unknown_arity_apply_widget :
   t ->
   denv:Env.t ->
   arity:[`Complex] Flambda_arity.t ->
-  params:Variable.t list ->
+  params:Simple.t list ->
   returns:Variable.t list ->
   exn:Variable.t ->
   Code_id_or_name.t

--- a/middle_end/flambda2/reaper/traverse_acc.mli
+++ b/middle_end/flambda2/reaper/traverse_acc.mli
@@ -24,11 +24,16 @@ type continuation_info =
 module Env : sig
   type cont_kind = Normal of Variable.t list
 
+  type should_preserve_direct_calls =
+    | Yes
+    | No
+    | Auto
+
   type t =
     { parent : Rev_expr.rev_expr_holed;
       conts : cont_kind Continuation.Map.t;
       current_code_id : Code_id.t option;
-      should_preserve_direct_calls : bool;
+      should_preserve_direct_calls : should_preserve_direct_calls;
       le_monde_exterieur : Name.t;
       all_constants : Name.t
     }

--- a/middle_end/flambda2/reaper/traverse_acc.mli
+++ b/middle_end/flambda2/reaper/traverse_acc.mli
@@ -28,7 +28,6 @@ module Env : sig
     { parent : Rev_expr.rev_expr_holed;
       conts : cont_kind Continuation.Map.t;
       current_code_id : Code_id.t option;
-      should_preserve_direct_calls : bool;
       le_monde_exterieur : Name.t;
       all_constants : Name.t
     }

--- a/middle_end/flambda2/reaper/traverse_acc.mli
+++ b/middle_end/flambda2/reaper/traverse_acc.mli
@@ -28,6 +28,7 @@ module Env : sig
     { parent : Rev_expr.rev_expr_holed;
       conts : cont_kind Continuation.Map.t;
       current_code_id : Code_id.t option;
+      should_preserve_direct_calls : bool;
       le_monde_exterieur : Name.t;
       all_constants : Name.t
     }

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -832,9 +832,9 @@ let arity_mismatch ~(params_arity : [`Complex] Flambda_arity.t)
   has_mismatch params args
 
 let simplify_direct_function_call ~simplify_expr dacc apply
-    ~callee's_code_id_from_type ~callee's_code_id_from_call_kind
-    ~callee's_function_slot ~result_arity ~result_types ~recursive
-    ~must_be_detupled ~closure_alloc_mode_from_type ~apply_alloc_mode
+    ~callee's_code_id_from_type ~callee's_code_ids_from_call_kind
+    ~callee's_function_slot ~coming_from_indirect ~result_arity ~result_types
+    ~recursive ~must_be_detupled ~closure_alloc_mode_from_type ~apply_alloc_mode
     function_decl ~down_to_up =
   (match Apply.probe apply, Apply.inlined apply with
   | None, _ | Some _, Never_inlined -> ()
@@ -843,21 +843,28 @@ let simplify_direct_function_call ~simplify_expr dacc apply
       "[Apply] terms with a [probe] (i.e. that call a tracing probe) must \
        always be marked as [Never_inline]:@ %a"
       Apply.print apply);
-  let coming_from_indirect = Option.is_none callee's_code_id_from_call_kind in
-  let callee's_code_id : _ Or_bottom.t =
-    match callee's_code_id_from_call_kind with
-    | None -> Ok callee's_code_id_from_type
-    | Some callee's_code_id_from_call_kind ->
+  let callee's_code_ids : _ Or_bottom.t =
+    match (callee's_code_ids_from_call_kind : _ Or_unknown.t) with
+    | Unknown -> Ok (Code_id.Set.singleton callee's_code_id_from_type)
+    | Known callee's_code_ids_from_call_kind ->
       let typing_env = DA.typing_env dacc in
-      Code_age_relation.meet
+      Code_age_relation.meet_set
         (TE.code_age_relation typing_env)
         ~resolver:(TE.code_age_relation_resolver typing_env)
-        callee's_code_id_from_call_kind callee's_code_id_from_type
+        callee's_code_ids_from_call_kind
+        (Code_id.Set.singleton callee's_code_id_from_type)
   in
-  match callee's_code_id with
+  match callee's_code_ids with
   | Bottom ->
     replace_apply_by_invalid dacc ~down_to_up (Closure_type_was_invalid apply)
-  | Ok callee's_code_id ->
+  | Ok callee's_code_ids ->
+    let callee's_code_id =
+      (* XXX: go to indirect_known_arity if there are multiple code ids even
+         with the types. *)
+      match Code_id.Set.get_singleton callee's_code_ids with
+      | Some callee's_code_id -> callee's_code_id
+      | None -> callee's_code_id_from_type
+    in
     let call_kind =
       Call_kind.direct_function_call callee's_code_id apply_alloc_mode
     in
@@ -1023,14 +1030,29 @@ let simplify_function_call_where_callee's_type_unavailable dacc apply
     match call with
     | Indirect_unknown_arity ->
       Call_kind.indirect_function_call_unknown_arity apply_alloc_mode
-    | Indirect_known_arity ->
-      Call_kind.indirect_function_call_known_arity apply_alloc_mode
+    | Indirect_known_arity Unknown ->
+      Call_kind.indirect_function_call_known_arity ~code_ids:Unknown
+        apply_alloc_mode
+    | Indirect_known_arity (Known code_ids) ->
+      (* If this records a non-simplified code id, we can't continue keeping
+         track of the possible code ids without maintaining this non-simplified
+         code id alive, so we just forget everything. *)
+      if Code_id.Set.is_empty
+           (Code_id.Set.inter code_ids (DA.code_ids_never_simplified dacc))
+      then
+        Call_kind.indirect_function_call_known_arity ~code_ids:(Known code_ids)
+          apply_alloc_mode
+      else
+        Call_kind.indirect_function_call_known_arity ~code_ids:Unknown
+          apply_alloc_mode
     | Direct code_id ->
       (* Keep the code ID if it corresponds to a simplified function, otherwise
          demote it to avoid keeping non-simplified code alive. Keep the
          function's arity as it is never allowed to change. *)
       if Code_id.Set.mem code_id (DA.code_ids_never_simplified dacc)
-      then Call_kind.indirect_function_call_known_arity apply_alloc_mode
+      then
+        Call_kind.indirect_function_call_known_arity ~code_ids:Unknown
+          apply_alloc_mode
       else Call_kind.direct_function_call code_id apply_alloc_mode
   in
   let apply = Apply_expr.with_call_kind apply call_kind in
@@ -1053,20 +1075,21 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
      When simplifying a function call, it can happen that we need to change the
      calling convention. Currently this only happens when we have a generic call
      (Indirect_unknown_arity), which uses the generic/function_declaration
-     calling convention, but se simplify it into a direct call, which uses the
+     calling convention, but we simplify it into a direct call, which uses the
      callee's code calling convention. In this case, we need to "detuple" the
      call in order to correctly adapt to the change in calling convention. *)
   let call_must_be_detupled is_function_decl_tupled =
     match call with
-    | Direct _ | Indirect_known_arity ->
+    | Direct _ | Indirect_known_arity _ ->
       (* In these cases, the calling convention already used in the application
          being simplified is that of the code actually called. Thus we must not
          detuple the function. *)
       false
+    | Indirect_unknown_arity ->
       (* In the indirect case, the calling convention used currently is the
          generic one. Thus we need to detuple the call iff the function
          declaration is tupled. *)
-    | Indirect_unknown_arity -> is_function_decl_tupled
+      is_function_decl_tupled
   in
   let type_unavailable () =
     simplify_function_call_where_callee's_type_unavailable dacc apply call
@@ -1088,7 +1111,7 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
         ~result_arity:(Code_metadata.result_arity callee's_code_metadata)
         ~result_types:(Code_metadata.result_types callee's_code_metadata)
         ~down_to_up ~coming_from_indirect:false ~callee's_code_metadata
-    | Indirect_known_arity | Indirect_unknown_arity ->
+    | Indirect_known_arity _ | Indirect_unknown_arity ->
       Misc.fatal_errorf
         "No callee provided for non-direct OCaml function call:@ %a" Apply.print
         apply)
@@ -1099,10 +1122,16 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
           closure_alloc_mode_from_type,
           _closures_entry,
           func_decl_type ) ->
-      let callee's_code_id_from_call_kind =
+      let callee's_code_ids_from_call_kind : _ Or_unknown.t =
         match call with
-        | Direct code_id -> Some code_id
-        | Indirect_unknown_arity | Indirect_known_arity -> None
+        | Direct code_id -> Known (Code_id.Set.singleton code_id)
+        | Indirect_known_arity code_ids -> code_ids
+        | Indirect_unknown_arity -> Unknown
+      in
+      let coming_from_indirect =
+        match call with
+        | Direct _ -> true
+        | Indirect_known_arity _ | Indirect_unknown_arity -> false
       in
       let callee's_code_id_from_type = T.Function_type.code_id func_decl_type in
       let callee's_code_or_metadata =
@@ -1115,8 +1144,8 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
         call_must_be_detupled (Code_metadata.is_tupled callee's_code_metadata)
       in
       simplify_direct_function_call ~simplify_expr dacc apply
-        ~callee's_code_id_from_type ~callee's_code_id_from_call_kind
-        ~callee's_function_slot
+        ~callee's_code_id_from_type ~callee's_code_ids_from_call_kind
+        ~callee's_function_slot ~coming_from_indirect
         ~result_arity:(Code_metadata.result_arity callee's_code_metadata)
         ~result_types:(Code_metadata.result_types callee's_code_metadata)
         ~recursive:(Code_metadata.recursive callee's_code_metadata)

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -832,9 +832,9 @@ let arity_mismatch ~(params_arity : [`Complex] Flambda_arity.t)
   has_mismatch params args
 
 let simplify_direct_function_call ~simplify_expr dacc apply
-    ~callee's_code_id_from_type ~callee's_code_id_from_call_kind
-    ~callee's_function_slot ~result_arity ~result_types ~recursive
-    ~must_be_detupled ~closure_alloc_mode_from_type ~apply_alloc_mode
+    ~callee's_code_id_from_type ~callee's_code_ids_from_call_kind
+    ~callee's_function_slot ~coming_from_indirect ~result_arity ~result_types
+    ~recursive ~must_be_detupled ~closure_alloc_mode_from_type ~apply_alloc_mode
     function_decl ~down_to_up =
   (match Apply.probe apply, Apply.inlined apply with
   | None, _ | Some _, Never_inlined -> ()
@@ -843,21 +843,28 @@ let simplify_direct_function_call ~simplify_expr dacc apply
       "[Apply] terms with a [probe] (i.e. that call a tracing probe) must \
        always be marked as [Never_inline]:@ %a"
       Apply.print apply);
-    let coming_from_indirect = Option.is_none callee's_code_id_from_call_kind in
-    let callee's_code_id : _ Or_bottom.t =
-    match callee's_code_id_from_call_kind with
-    | None -> Ok callee's_code_id_from_type
-    | Some callee's_code_id_from_call_kind ->
+  let callee's_code_ids : _ Or_bottom.t =
+    match (callee's_code_ids_from_call_kind : _ Or_unknown.t) with
+    | Unknown -> Ok (Code_id.Set.singleton callee's_code_id_from_type)
+    | Known callee's_code_ids_from_call_kind ->
       let typing_env = DA.typing_env dacc in
-      Code_age_relation.meet
+      Code_age_relation.meet_set
         (TE.code_age_relation typing_env)
         ~resolver:(TE.code_age_relation_resolver typing_env)
-        callee's_code_id_from_call_kind callee's_code_id_from_type
+        callee's_code_ids_from_call_kind
+        (Code_id.Set.singleton callee's_code_id_from_type)
   in
-  match callee's_code_id with
+  match callee's_code_ids with
   | Bottom ->
     replace_apply_by_invalid dacc ~down_to_up (Closure_type_was_invalid apply)
-  | Ok callee's_code_id ->
+  | Ok callee's_code_ids ->
+    let callee's_code_id =
+      (* XXX: go to indirect_known_arity if there are multiple code ids even
+         with the types. *)
+      match Code_id.Set.get_singleton callee's_code_ids with
+      | Some callee's_code_id -> callee's_code_id
+      | None -> callee's_code_id_from_type
+    in
     let call_kind =
       Call_kind.direct_function_call callee's_code_id apply_alloc_mode
     in
@@ -1115,10 +1122,16 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
           closure_alloc_mode_from_type,
           _closures_entry,
           func_decl_type ) ->
-      let callee's_code_id_from_call_kind =
+      let callee's_code_ids_from_call_kind : _ Or_unknown.t =
         match call with
-        | Direct code_id -> Some code_id
-        | Indirect_known_arity _ | Indirect_unknown_arity -> None
+        | Direct code_id -> Known (Code_id.Set.singleton code_id)
+        | Indirect_known_arity code_ids -> code_ids
+        | Indirect_unknown_arity -> Unknown
+      in
+      let coming_from_indirect =
+        match call with
+        | Direct _ -> true
+        | Indirect_known_arity _ | Indirect_unknown_arity -> false
       in
       let callee's_code_id_from_type = T.Function_type.code_id func_decl_type in
       let callee's_code_or_metadata =
@@ -1131,8 +1144,8 @@ let simplify_function_call ~simplify_expr dacc apply ~callee_ty
         call_must_be_detupled (Code_metadata.is_tupled callee's_code_metadata)
       in
       simplify_direct_function_call ~simplify_expr dacc apply
-        ~callee's_code_id_from_type ~callee's_code_id_from_call_kind
-        ~callee's_function_slot
+        ~callee's_code_id_from_type ~callee's_code_ids_from_call_kind
+        ~callee's_function_slot ~coming_from_indirect
         ~result_arity:(Code_metadata.result_arity callee's_code_metadata)
         ~result_types:(Code_metadata.result_types callee's_code_metadata)
         ~recursive:(Code_metadata.recursive callee's_code_metadata)

--- a/middle_end/flambda2/terms/call_kind.ml
+++ b/middle_end/flambda2/terms/call_kind.ml
@@ -26,7 +26,7 @@ module Function_call = struct
     match call with
     | Direct code_id ->
       fprintf ppf "@[<hov 1>(Direct %a)@]" Code_id.print code_id
-    | Indirect_unknown_arity -> fprintf ppf "Indirect_unkknown_arity"
+    | Indirect_unknown_arity -> fprintf ppf "Indirect_unknown_arity"
     | Indirect_known_arity code_ids ->
       fprintf ppf "@[<hov 1>(Indirect_known_arity@ %a)@]"
         (Or_unknown.print Code_id.Set.print)

--- a/middle_end/flambda2/terms/call_kind.ml
+++ b/middle_end/flambda2/terms/call_kind.ml
@@ -20,14 +20,17 @@ module Function_call = struct
   type t =
     | Direct of Code_id.t
     | Indirect_unknown_arity
-    | Indirect_known_arity
+    | Indirect_known_arity of Code_id.Set.t Or_unknown.t
 
   let print ppf call =
     match call with
     | Direct code_id ->
       fprintf ppf "@[<hov 1>(Direct %a)@]" Code_id.print code_id
-    | Indirect_unknown_arity -> fprintf ppf "Indirect_unknown_arity"
-    | Indirect_known_arity -> fprintf ppf "Indirect_known_arity"
+    | Indirect_unknown_arity -> fprintf ppf "Indirect_unkknown_arity"
+    | Indirect_known_arity code_ids ->
+      fprintf ppf "@[<hov 1>(Indirect_known_arity@ %a)@]"
+        (Or_unknown.print Code_id.Set.print)
+        code_ids
 end
 
 module Method_kind = struct
@@ -226,8 +229,8 @@ let direct_function_call code_id alloc_mode =
 let indirect_function_call_unknown_arity alloc_mode =
   Function { function_call = Indirect_unknown_arity; alloc_mode }
 
-let indirect_function_call_known_arity alloc_mode =
-  Function { function_call = Indirect_known_arity; alloc_mode }
+let indirect_function_call_known_arity ~code_ids alloc_mode =
+  Function { function_call = Indirect_known_arity code_ids; alloc_mode }
 
 let method_call kind ~obj alloc_mode = Method { kind; obj; alloc_mode }
 
@@ -242,8 +245,15 @@ let free_names t =
     Name_occurrences.add_code_id
       (Alloc_mode.For_applications.free_names alloc_mode)
       code_id Name_mode.normal
+  | Function
+      { function_call = Indirect_known_arity (Known code_ids); alloc_mode } ->
+    let free_names = Alloc_mode.For_applications.free_names alloc_mode in
+    Code_id.Set.fold
+      (fun code_id free_names ->
+        Name_occurrences.add_code_id free_names code_id Name_mode.normal)
+      code_ids free_names
   | Function { function_call = Indirect_unknown_arity; alloc_mode }
-  | Function { function_call = Indirect_known_arity; alloc_mode } ->
+  | Function { function_call = Indirect_known_arity Unknown; alloc_mode } ->
     Alloc_mode.For_applications.free_names alloc_mode
   | C_call
       { needs_caml_c_call = _;
@@ -269,8 +279,24 @@ let apply_renaming t renaming =
     then t
     else Function { function_call = Direct code_id'; alloc_mode = alloc_mode' }
   | Function
+      { function_call = Indirect_known_arity (Known code_ids); alloc_mode } ->
+    let code_ids' =
+      Code_id.Set.map (Renaming.apply_code_id renaming) code_ids
+    in
+    let alloc_mode' =
+      Alloc_mode.For_applications.apply_renaming alloc_mode renaming
+    in
+    if Code_id.Set.equal code_ids code_ids' && alloc_mode == alloc_mode'
+    then t
+    else
+      Function
+        { function_call = Indirect_known_arity (Known code_ids');
+          alloc_mode = alloc_mode'
+        }
+  | Function
       { function_call =
-          (Indirect_unknown_arity | Indirect_known_arity) as function_call;
+          (Indirect_unknown_arity | Indirect_known_arity Unknown) as
+          function_call;
         alloc_mode
       } ->
     let alloc_mode' =
@@ -312,8 +338,15 @@ let ids_for_export t =
     Ids_for_export.add_code_id
       (Alloc_mode.For_applications.ids_for_export alloc_mode)
       code_id
+  | Function
+      { function_call = Indirect_known_arity (Known code_ids); alloc_mode } ->
+    Code_id.Set.fold
+      (fun code_id ids_for_export ->
+        Ids_for_export.add_code_id ids_for_export code_id)
+      code_ids
+      (Alloc_mode.For_applications.ids_for_export alloc_mode)
   | Function { function_call = Indirect_unknown_arity; alloc_mode }
-  | Function { function_call = Indirect_known_arity; alloc_mode } ->
+  | Function { function_call = Indirect_known_arity Unknown; alloc_mode } ->
     Alloc_mode.For_applications.ids_for_export alloc_mode
   | C_call
       { needs_caml_c_call = _;

--- a/middle_end/flambda2/terms/call_kind.mli
+++ b/middle_end/flambda2/terms/call_kind.mli
@@ -22,7 +22,8 @@ module Function_call : sig
         (** The [code_id] uniquely determines the function symbol that
             must be called. *)
     | Indirect_unknown_arity
-    | Indirect_known_arity
+    | Indirect_known_arity of Code_id.Set.t Or_unknown.t
+        (** If a [Code_id.Set.t] is provided, only *)
 end
 
 module Method_kind : sig
@@ -111,7 +112,8 @@ val direct_function_call : Code_id.t -> Alloc_mode.For_applications.t -> t
 
 val indirect_function_call_unknown_arity : Alloc_mode.For_applications.t -> t
 
-val indirect_function_call_known_arity : Alloc_mode.For_applications.t -> t
+val indirect_function_call_known_arity :
+  code_ids:Code_id.Set.t Or_unknown.t -> Alloc_mode.For_applications.t -> t
 
 val method_call :
   Method_kind.t -> obj:Simple.t -> Alloc_mode.For_applications.t -> t

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -520,7 +520,7 @@ let apply apply =
   (* CR mshinwell: Check / fix these numbers *)
   | Function { function_call = Indirect_unknown_arity; alloc_mode = _ } ->
     indirect_call_size
-  | Function { function_call = Indirect_known_arity; alloc_mode = _ } ->
+  | Function { function_call = Indirect_known_arity _; alloc_mode = _ } ->
     indirect_call_size
   | C_call { needs_caml_c_call = true; _ } -> needs_caml_c_call_extcall_size
   | C_call { needs_caml_c_call = false; _ } ->

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -328,7 +328,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
       env,
       res,
       Ece.all )
-  | Function { function_call = Indirect_known_arity; alloc_mode } ->
+  | Function { function_call = Indirect_known_arity _; alloc_mode } ->
     fail_if_probe apply;
     let callee =
       match callee with

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -298,7 +298,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
     | None ->
       ( C.direct_call ~dbg
           (C.Extended_machtype.to_machtype return_ty)
-          pos (C.symbol ~dbg code_sym) args,
+          pos code_sym args,
         free_vars,
         env,
         res,
@@ -328,7 +328,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
       env,
       res,
       Ece.all )
-  | Function { function_call = Indirect_known_arity _; alloc_mode } ->
+  | Function { function_call = Indirect_known_arity callees; alloc_mode = _ } ->
     fail_if_probe apply;
     let callee =
       match callee with
@@ -338,15 +338,24 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
           "Application expression did not provide callee for indirect call:@ %a"
           Apply.print apply
     in
+    let callees =
+      match callees with
+      | Unknown -> None
+      | Known code_id_set ->
+        Some
+          (List.map
+             (fun code_id ->
+               To_cmm_result.symbol_of_code_id res code_id
+                 ~currently_in_inlined_body:(Env.currently_in_inlined_body env))
+             (Code_id.Set.elements code_id_set))
+    in
     if not (C.check_arity (Apply.args_arity apply) args)
     then
       Misc.fatal_errorf
         "To_cmm expects indirect_known_arity calls to be full applications in \
          order to translate them"
     else
-      ( C.indirect_full_call ~dbg return_ty pos
-          (C.alloc_mode_for_applications_to_cmx alloc_mode)
-          callee args_ty args,
+      ( C.indirect_full_call ~dbg return_ty pos callee ~callees args_ty args,
         free_vars,
         env,
         res,

--- a/middle_end/flambda2/to_jsir/to_jsir.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir.ml
@@ -341,7 +341,7 @@ and apply_expr ~env ~res e =
       Misc.fatal_error "Received a nonempty callee for effects"
     | ( None,
         ( Function
-            { function_call = Indirect_unknown_arity | Indirect_known_arity;
+            { function_call = Indirect_unknown_arity | Indirect_known_arity _;
               alloc_mode = _
             }
         | Method _ | C_call _ ) ) ->

--- a/middle_end/flambda2/types/env/code_age_relation.ml
+++ b/middle_end/flambda2/types/env/code_age_relation.ml
@@ -63,7 +63,11 @@ let meet_set t ~resolver ids1 ids2 : _ Or_bottom.t =
       let ids_to_root = all_ids_up_to_root t ~resolver id in
       not (Code_id.Set.is_empty (Code_id.Set.inter ids_to_root other_ids))
     in
-    let ids = Code_id.Set.union (Code_id.Set.filter (should_keep_id ids1) ids2) (Code_id.Set.filter (should_keep_id ids2) ids1) in
+    let ids =
+      Code_id.Set.union
+        (Code_id.Set.filter (should_keep_id ids1) ids2)
+        (Code_id.Set.filter (should_keep_id ids2) ids1)
+    in
     if Code_id.Set.is_empty ids then Bottom else Ok ids
 
 let _num_ids_up_to_root t ~resolver id =

--- a/middle_end/flambda2/types/env/code_age_relation.ml
+++ b/middle_end/flambda2/types/env/code_age_relation.ml
@@ -48,7 +48,7 @@ let rec all_ids_up_to_root0 t ~resolver id all_ids_so_far =
           (* Inlining the base case, so that we do not recursively loop in case
              of a code_id that is not bound in the map *)
           match Code_id.Map.find id t with
-          | exception Not_found -> Code_id.Set.singleton id
+          | exception Not_found -> all_ids_so_far
           | older -> all_ids_up_to_root0 t ~resolver older all_ids_so_far))
     | older -> all_ids_up_to_root0 t ~resolver older all_ids_so_far
 

--- a/middle_end/flambda2/types/env/code_age_relation.mli
+++ b/middle_end/flambda2/types/env/code_age_relation.mli
@@ -38,6 +38,13 @@ val meet :
   Code_id.t ->
   Code_id.t Or_bottom.t
 
+val meet_set :
+  t ->
+  resolver:(Compilation_unit.t -> t option) ->
+  Code_id.Set.t ->
+  Code_id.Set.t ->
+  Code_id.Set.t Or_bottom.t
+
 (** [join] calculates the newest common ancestor of the given pieces of code, or
     identifies that the pieces of code are unrelated. *)
 val join :

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -60,6 +60,13 @@ module Code_age_relation : sig
     Code_id.t ->
     Code_id.t ->
     Code_id.t Or_bottom.t
+
+  val meet_set :
+    t ->
+    resolver:(Compilation_unit.t -> t option) ->
+    Code_id.Set.t ->
+    Code_id.Set.t ->
+    Code_id.Set.t Or_bottom.t
 end
 
 module Typing_env_extension : sig

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -72,6 +72,16 @@ let enable_reaper () =
   !Oxcaml_flags.Flambda2.enable_reaper
   |> with_default ~f:(fun d -> d.enable_reaper)
 
+type reaper_preserve_direct_calls = Oxcaml_flags.reaper_preserve_direct_calls =
+  | Never
+  | Always
+  | Zero_alloc
+  | Auto
+
+let reaper_preserve_direct_calls () =
+  !Oxcaml_flags.Flambda2.reaper_preserve_direct_calls
+  |> with_default ~f:(fun d -> d.reaper_preserve_direct_calls)
+
 let flat_float_array () = Config.flat_float_array
 
 let function_result_types ~is_a_functor =

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -47,6 +47,14 @@ val join_algorithm : unit -> join_algorithm
 
 val enable_reaper : unit -> bool
 
+type reaper_preserve_direct_calls = Oxcaml_flags.reaper_preserve_direct_calls =
+  | Never
+  | Always
+  | Zero_alloc
+  | Auto
+
+val reaper_preserve_direct_calls : unit -> reaper_preserve_direct_calls
+
 val kind_checks : unit -> bool
 
 val flat_float_array : unit -> bool

--- a/oxcaml/tests/backend/validators/check_prologue_validation.ml
+++ b/oxcaml/tests/backend/validators/check_prologue_validation.ml
@@ -267,7 +267,8 @@ let () =
                 exn = None;
                 terminator =
                   { id = make_id ();
-                    desc = Call { op = Indirect None; label_after = new_label 1 };
+                    desc =
+                      Call { op = Indirect None; label_after = new_label 1 };
                     arg = [||];
                     res = [||]
                   }

--- a/oxcaml/tests/backend/validators/check_prologue_validation.ml
+++ b/oxcaml/tests/backend/validators/check_prologue_validation.ml
@@ -267,7 +267,7 @@ let () =
                 exn = None;
                 terminator =
                   { id = make_id ();
-                    desc = Call { op = Indirect; label_after = new_label 1 };
+                    desc = Call { op = Indirect None; label_after = new_label 1 };
                     arg = [||];
                     res = [||]
                   }

--- a/oxcaml/tests/backend/validators/check_regalloc_validation.ml
+++ b/oxcaml/tests/backend/validators/check_regalloc_validation.ml
@@ -139,7 +139,7 @@ let base_templ () : Cfg_desc.t * (unit -> InstructionId.t) =
             exn = None;
             terminator =
               { id = make_id ();
-                desc = Call { op = Indirect; label_after = move_tmp_res_label };
+                desc = Call { op = Indirect None; label_after = move_tmp_res_label };
                 arg = arg_locs;
                 res = tmp_result_locs
               }

--- a/oxcaml/tests/backend/validators/check_regalloc_validation.ml
+++ b/oxcaml/tests/backend/validators/check_regalloc_validation.ml
@@ -139,7 +139,8 @@ let base_templ () : Cfg_desc.t * (unit -> InstructionId.t) =
             exn = None;
             terminator =
               { id = make_id ();
-                desc = Call { op = Indirect None; label_after = move_tmp_res_label };
+                desc =
+                  Call { op = Indirect None; label_after = move_tmp_res_label };
                 arg = arg_locs;
                 res = tmp_result_locs
               }

--- a/oxcaml/testsuite/tools/parsecmm.mly
+++ b/oxcaml/testsuite/tools/parsecmm.mly
@@ -221,7 +221,11 @@ expr:
   | LBRACKET RBRACKET { Ctuple [] }
   | LPAREN LET letdef sequence RPAREN { make_letdef $3 $4 }
   | LPAREN APPLY location expr exprlist machtype RPAREN
-                { Cop(Capply {result_type = $6; region = Lambda.Rc_normal; callees = None},
+                { Cop(Capply {
+                        result_type = $6;
+                        region = Lambda.Rc_normal;
+                        callees = None
+                      },
                       $4 :: List.rev $5, debuginfo ?loc:$3 ()) }
   | LPAREN EXTCALL STRING exprlist machtype RPAREN
                {Cop(Cextcall {func=$3; ty=$5; alloc=false;

--- a/oxcaml/testsuite/tools/parsecmm.mly
+++ b/oxcaml/testsuite/tools/parsecmm.mly
@@ -221,7 +221,7 @@ expr:
   | LBRACKET RBRACKET { Ctuple [] }
   | LPAREN LET letdef sequence RPAREN { make_letdef $3 $4 }
   | LPAREN APPLY location expr exprlist machtype RPAREN
-                { Cop(Capply ($6, Lambda.Rc_normal),
+                { Cop(Capply {result_type = $6; region = Lambda.Rc_normal; callees = None},
                       $4 :: List.rev $5, debuginfo ?loc:$3 ()) }
   | LPAREN EXTCALL STRING exprlist machtype RPAREN
                {Cop(Cextcall {func=$3; ty=$5; alloc=false;


### PR DESCRIPTION
Direct calls should now be preserved in all zero-alloc functions. The choice to preserve direct calls is gated behind a flag with 4 possible values: never, always, in zero-alloc functions, and "auto" (currently unimplemented, in the future, will preserve direct calls only if they would otherwise be demoted to `Indirect_known_arity` with an unknown set of callees).