### PR TITLE
Add 'Pjk_' prefix to jkind_annot_desc variants.

### DIFF
--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -142,12 +142,12 @@ module Typ = struct
     and loop_jkind jkind =
       let pjkind_desc =
         match jkind.pjkind_desc with
-        | Default as x -> x
-        | Abbreviation _ as x -> x
-        | Mod (jkind, modes) -> Mod (loop_jkind jkind, modes)
-        | With (jkind, typ, modalities) -> With (loop_jkind jkind, loop typ, modalities)
-        | Kind_of typ -> Kind_of (loop typ)
-        | Product jkinds -> Product (List.map loop_jkind jkinds)
+        | Pjk_default as x -> x
+        | Pjk_abbreviation _ as x -> x
+        | Pjk_mod (jkind, modes) -> Pjk_mod (loop_jkind jkind, modes)
+        | Pjk_with (jkind, typ, modalities) -> Pjk_with (loop_jkind jkind, loop typ, modalities)
+        | Pjk_kind_of typ -> Pjk_kind_of (loop typ)
+        | Pjk_product jkinds -> Pjk_product (List.map loop_jkind jkinds)
       in
       { jkind with pjkind_desc }
     and loop_row_field field =

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -854,17 +854,17 @@ let default_iterator =
       (fun this { pjkind_loc; pjkind_desc } ->
          this.location this pjkind_loc;
          match pjkind_desc with
-         | Default -> ()
-         | Abbreviation (_ : string) -> ()
-         | Mod (t, mode_list) ->
+         | Pjk_default -> ()
+         | Pjk_abbreviation (_ : string) -> ()
+         | Pjk_mod (t, mode_list) ->
              this.jkind_annotation this t;
              this.modes this mode_list
-         | With (t, ty, modalities) ->
+         | Pjk_with (t, ty, modalities) ->
              this.jkind_annotation this t;
              this.typ this ty;
              this.modalities this modalities
-         | Kind_of ty -> this.typ this ty
-         | Product ts -> List.iter (this.jkind_annotation this) ts);
+         | Pjk_kind_of ty -> this.typ this ty
+         | Pjk_product ts -> List.iter (this.jkind_annotation this) ts);
 
     directive_argument =
       (fun this a ->

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -961,14 +961,14 @@ let default_mapper =
       let pjkind_loc = this.location this pjkind_loc in
       let pjkind_desc =
         match pjkind_desc with
-        | Default -> Default
-        | Abbreviation (s : string) -> Abbreviation s
-        | Mod (t, mode_list) ->
-          Mod (this.jkind_annotation this t, this.modes this mode_list)
-        | With (t, ty, modalities) ->
-          With (this.jkind_annotation this t, this.typ this ty, this.modalities this modalities)
-        | Kind_of ty -> Kind_of (this.typ this ty)
-        | Product ts -> Product (List.map (this.jkind_annotation this) ts)
+        | Pjk_default -> Pjk_default
+        | Pjk_abbreviation (s : string) -> Pjk_abbreviation s
+        | Pjk_mod (t, mode_list) ->
+          Pjk_mod (this.jkind_annotation this t, this.modes this mode_list)
+        | Pjk_with (t, ty, modalities) ->
+          Pjk_with (this.jkind_annotation this t, this.typ this ty, this.modalities this modalities)
+        | Pjk_kind_of ty -> Pjk_kind_of (this.typ this ty)
+        | Pjk_product ts -> Pjk_product (List.map (this.jkind_annotation this) ts)
       in
       { pjkind_loc; pjkind_desc });
 

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -137,15 +137,15 @@ and add_package_type bv (lid, l) =
    prefixes. *)
 and add_jkind bv (jkind : jkind_annotation) =
   match jkind.pjkind_desc with
-  | Default -> ()
-  | Abbreviation _ -> ()
-  | Mod (jkind, (_ : modes)) -> add_jkind bv jkind
-  | With (jkind, typ, (_ : modalities)) ->
+  | Pjk_default -> ()
+  | Pjk_abbreviation _ -> ()
+  | Pjk_mod (jkind, (_ : modes)) -> add_jkind bv jkind
+  | Pjk_with (jkind, typ, (_ : modalities)) ->
       add_jkind bv jkind;
       add_type bv typ;
-  | Kind_of typ ->
+  | Pjk_kind_of typ ->
       add_type bv typ
-  | Product jkinds ->
+  | Pjk_product jkinds ->
       List.iter (fun jkind -> add_jkind bv jkind) jkinds
 
 and add_vars_jkinds bv vars_jkinds =

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -4051,22 +4051,22 @@ jkind_desc:
           (fun {txt; loc} -> {txt = Mode txt; loc})
           $3
       in
-      Mod ($1, modes)
+      Pjk_mod ($1, modes)
     }
   | jkind_annotation WITH core_type optional_atat_modalities_expr {
-      With ($1, $3, $4)
+      Pjk_with ($1, $3, $4)
     }
   | ident {
-      Abbreviation $1
+      Pjk_abbreviation $1
     }
   | KIND_OF ty=core_type {
-      Kind_of ty
+      Pjk_kind_of ty
     }
   | UNDERSCORE {
-      Default
+      Pjk_default
     }
   | reverse_product_jkind %prec below_AMPERSAND {
-      Product (List.rev $1)
+      Pjk_product (List.rev $1)
     }
   | LPAREN jkind_desc RPAREN {
       $2

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -1334,15 +1334,15 @@ and module_binding =
 (** Values of type [module_binding] represents [module X = ME] *)
 
 and jkind_annotation_desc =
-  | Default
-  | Abbreviation of string
+  | Pjk_default
+  | Pjk_abbreviation of string
   (* CR layouts v2.8: [mod] can have only layouts on the left, not
      full kind annotations. We may want to narrow this type some.
      Internal ticket 5085. *)
-  | Mod of jkind_annotation * modes
-  | With of jkind_annotation * core_type * modalities
-  | Kind_of of core_type
-  | Product of jkind_annotation list
+  | Pjk_mod of jkind_annotation * modes
+  | Pjk_with of jkind_annotation * core_type * modalities
+  | Pjk_kind_of of core_type
+  | Pjk_product of jkind_annotation list
 
 and jkind_annotation =
   { pjkind_loc : Location.t

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -452,9 +452,9 @@ and type_with_label ctxt f (label, c, mode) =
       (core_type_with_optional_legacy_modes core_type1 ctxt) (c, mode)
 
 and jkind_annotation ?(nested = false) ctxt f k = match k.pjkind_desc with
-  | Default -> pp f "_"
-  | Abbreviation s -> pp f "%s" s
-  | Mod (t, modes) ->
+  | Pjk_default -> pp f "_"
+  | Pjk_abbreviation s -> pp f "%s" s
+  | Pjk_mod (t, modes) ->
     begin match modes with
     | [] -> Misc.fatal_error "malformed jkind annotation"
     | _ :: _ ->
@@ -464,15 +464,15 @@ and jkind_annotation ?(nested = false) ctxt f k = match k.pjkind_desc with
           (pp_print_list ~pp_sep:pp_print_space mode) modes
       ) f (t, modes)
     end
-  | With (t, ty, modalities) ->
+  | Pjk_with (t, ty, modalities) ->
     Misc.pp_parens_if nested (fun f (t, ty, modalities) ->
       pp f "%a with %a%a"
         (jkind_annotation ~nested:true ctxt) t
         (core_type ctxt) ty
         optional_space_atat_modalities modalities;
     ) f (t, ty, modalities)
-  | Kind_of ty -> pp f "kind_of_ %a" (core_type ctxt) ty
-  | Product ts ->
+  | Pjk_kind_of ty -> pp f "kind_of_ %a" (core_type ctxt) ty
+  | Pjk_product ts ->
     Misc.pp_parens_if nested (fun f ts ->
       pp f "@[%a@]" (list (jkind_annotation ~nested:true ctxt) ~sep:"@ & ") ts
     ) f ts

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -535,23 +535,23 @@ and jkind_annotation_opt i ppf jkind =
 and jkind_annotation i ppf (jkind : jkind_annotation) =
   line i ppf "jkind %a\n" fmt_location jkind.pjkind_loc;
   match jkind.pjkind_desc with
-  | Default -> line i ppf "Default\n"
-  | Abbreviation jkind ->
-      line i ppf "Abbreviation \"%s\"\n" jkind
-  | Mod (jkind, m) ->
-      line i ppf "Mod\n";
+  | Pjk_default -> line i ppf "Pjk_default\n"
+  | Pjk_abbreviation jkind ->
+      line i ppf "Pjk_abbreviation \"%s\"\n" jkind
+  | Pjk_mod (jkind, m) ->
+      line i ppf "Pjk_mod\n";
       jkind_annotation (i+1) ppf jkind;
       modes (i+1) ppf m
-  | With (jkind, type_, modalities_) ->
-      line i ppf "With\n";
+  | Pjk_with (jkind, type_, modalities_) ->
+      line i ppf "Pjk_with\n";
       jkind_annotation (i+1) ppf jkind;
       core_type (i+1) ppf type_;
       modalities (i+1) ppf modalities_
-  | Kind_of type_ ->
-      line i ppf "Kind_of\n";
+  | Pjk_kind_of type_ ->
+      line i ppf "Pjk_kind_of\n";
       core_type (i+1) ppf type_
-  | Product jkinds ->
-      line i ppf "Product\n";
+  | Pjk_product jkinds ->
+      line i ppf "Pjk_product\n";
       list i jkind_annotation ppf jkinds
 
 and function_param i ppf { pparam_desc = desc; pparam_loc = loc } =

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -562,23 +562,23 @@ and jkind_annotation_opt i ppf jkind =
 and jkind_annotation i ppf (jkind : jkind_annotation) =
   line i ppf "jkind %a\n" fmt_location jkind.pjkind_loc;
   match jkind.pjkind_desc with
-  | Default -> line i ppf "Default\n"
-  | Abbreviation jkind ->
-      line i ppf "Abbreviation \"%s\"\n" jkind
-  | Mod (jkind, m) ->
-      line i ppf "Mod\n";
+  | Pjk_default -> line i ppf "Pjk_default\n"
+  | Pjk_abbreviation jkind ->
+      line i ppf "Pjk_abbreviation \"%s\"\n" jkind
+  | Pjk_mod (jkind, m) ->
+      line i ppf "Pjk_mod\n";
       jkind_annotation (i+1) ppf jkind;
       modes (i+1) ppf m
-  | With (jkind, type_, modalities) ->
-      line i ppf "With\n";
+  | Pjk_with (jkind, type_, modalities) ->
+      line i ppf "Pjk_with\n";
       jkind_annotation (i+1) ppf jkind;
       core_type (i+1) ppf type_;
       list i modality ppf modalities
-  | Kind_of type_ ->
-      line i ppf "Kind_of\n";
+  | Pjk_kind_of type_ ->
+      line i ppf "Pjk_kind_of\n";
       core_type (i+1) ppf type_
-  | Product jkinds ->
-      line i ppf "Product\n";
+  | Pjk_product jkinds ->
+      line i ppf "Pjk_product\n";
       list i jkind_annotation ppf jkinds
 
 and function_param i ppf { pparam_desc = desc; pparam_loc = loc } =

--- a/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -91,7 +91,7 @@ module Example = struct
                          ; ptype_jkind_annotation =
                              Some
                                { pjkind_loc = loc;
-                                 pjkind_desc =  Default;
+                                 pjkind_desc =  Pjk_default;
                                }
                          }
   let tyvar            = "no_tyvars_require_extensions"
@@ -99,9 +99,9 @@ module Example = struct
   let jkind_annotation : jkind_annotation =
     { pjkind_loc = loc;
       pjkind_desc =
-        With
+        Pjk_with
           ( { pjkind_loc = loc;
-              pjkind_desc = Abbreviation "value";
+              pjkind_desc = Pjk_abbreviation "value";
             }
           , core_type
           , modalities

--- a/testsuite/tests/typing-layouts-products/parsing_ambiguous_product.compilers.reference
+++ b/testsuite/tests/typing-layouts-products/parsing_ambiguous_product.compilers.reference
@@ -15,17 +15,17 @@
         ptype_jkind_annotation =
           Some
             jkind (parsing_ambiguous_product.ml[12,327+10]..[12,327+49])
-            Product
+            Pjk_product
             [
               jkind (parsing_ambiguous_product.ml[12,327+10]..[12,327+28])
-              Mod
+              Pjk_mod
                 jkind (parsing_ambiguous_product.ml[12,327+11]..[12,327+16])
-                Abbreviation "value"
+                Pjk_abbreviation "value"
                 mode "global" (parsing_ambiguous_product.ml[12,327+21]..[12,327+27])
               jkind (parsing_ambiguous_product.ml[12,327+31]..[12,327+49])
-              Mod
+              Pjk_mod
                 jkind (parsing_ambiguous_product.ml[12,327+32]..[12,327+37])
-                Abbreviation "value"
+                Pjk_abbreviation "value"
                 mode "global" (parsing_ambiguous_product.ml[12,327+42]..[12,327+48])
             ]
     ]
@@ -45,17 +45,17 @@
         ptype_jkind_annotation =
           Some
             jkind (parsing_ambiguous_product.ml[14,380+10]..[14,380+45])
-            Mod
+            Pjk_mod
               jkind (parsing_ambiguous_product.ml[14,380+10]..[14,380+34])
-              Product
+              Pjk_product
               [
                 jkind (parsing_ambiguous_product.ml[14,380+10]..[14,380+26])
-                Mod
+                Pjk_mod
                   jkind (parsing_ambiguous_product.ml[14,380+10]..[14,380+15])
-                  Abbreviation "value"
+                  Pjk_abbreviation "value"
                   mode "global" (parsing_ambiguous_product.ml[14,380+20]..[14,380+26])
                 jkind (parsing_ambiguous_product.ml[14,380+29]..[14,380+34])
-                Abbreviation "value"
+                Pjk_abbreviation "value"
               ]
               mode "global" (parsing_ambiguous_product.ml[14,380+39]..[14,380+45])
     ]
@@ -75,17 +75,17 @@
         ptype_jkind_annotation =
           Some
             jkind (parsing_ambiguous_product.ml[16,429+10]..[16,429+47])
-            Mod
+            Pjk_mod
               jkind (parsing_ambiguous_product.ml[16,429+10]..[16,429+36])
-              Product
+              Pjk_product
               [
                 jkind (parsing_ambiguous_product.ml[16,429+11]..[16,429+27])
-                Mod
+                Pjk_mod
                   jkind (parsing_ambiguous_product.ml[16,429+11]..[16,429+16])
-                  Abbreviation "value"
+                  Pjk_abbreviation "value"
                   mode "global" (parsing_ambiguous_product.ml[16,429+21]..[16,429+27])
                 jkind (parsing_ambiguous_product.ml[16,429+30]..[16,429+35])
-                Abbreviation "value"
+                Pjk_abbreviation "value"
               ]
               mode "global" (parsing_ambiguous_product.ml[16,429+41]..[16,429+47])
     ]

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -130,7 +130,7 @@ end = struct
         const_jkind
         ~quality
         ~annotation:(Some { pjkind_loc = Location.none;
-                            pjkind_desc = Abbreviation builtin.name })
+                            pjkind_desc = Pjk_abbreviation builtin.name })
         ~why:Jkind.History.Imported)
 
   let best_builtins : (allowed * disallowed) builtins = make_builtins Best


### PR DESCRIPTION
This make it more in line with the rest of the parsetree, and opens up the namespace to use those constructors for more specific purposes.