### PR TITLE
Restore ability to share static constants

### DIFF
--- a/middle_end/flambda2/terms/static_const.ml
+++ b/middle_end/flambda2/terms/static_const.ml
@@ -306,8 +306,16 @@ include Container_types.Make (struct
           if c <> 0
           then c
           else
-            Misc.Stdlib.List.compare Simple.With_debuginfo.compare fields1
-              fields2
+            (* We explicitly drop the debuginfo part, as this comparison is used
+               to determine whether we can share static constants from different
+               program locations. See testsuite/tests/asmcomp/staticalloc.ml for
+               a check that sharing works properly. *)
+            Misc.Stdlib.List.compare
+              (fun s1 s2 ->
+                Simple.compare
+                  (Simple.With_debuginfo.simple s1)
+                  (Simple.With_debuginfo.simple s2))
+              fields1 fields2
     | Boxed_float32 or_var1, Boxed_float32 or_var2 ->
       Or_variable.compare Numeric_types.Float32_by_bit_pattern.compare or_var1
         or_var2


### PR DESCRIPTION
See added comment for details.

The test `asmcomp/staticalloc.ml` should now pass with Flambda2 `-O3` (it should be reactivated once both this PR and #4793 are merged).