### PR TITLE
Allow for coalesced moves when computing availability

### DIFF
--- a/backend/cfg/cfg_available_regs.ml
+++ b/backend/cfg/cfg_available_regs.ml
@@ -282,12 +282,14 @@ module Transfer = struct
           let results =
             Array.map2
               (fun arg_reg result_reg ->
-                match RD.Set.find_reg_exn avail_before arg_reg with
+                (* We have to use [find_reg_with_same_location_exn] and not just
+                   [find_reg_exn] because the register allocator can elide moves,
+                   meaning that [arg_reg] might have one register stamp at [instr]
+                   but a different register stamp on the previous occurrence (from which
+                   we would have computed [avail_before]).  All that we need here, though,
+                   is the debug info from any register with the same location. *)
+                match RD.Set.find_reg_with_same_location_exn avail_before arg_reg with
                 | exception Not_found ->
-                  (* Note that [arg_reg] might not be in
-                     [all_regs_that_might_be_named], meaning it wouldn't be
-                     found in [avail_before]. In that case we shouldn't
-                     propagate anything. *)
                   None
                 | arg_reg ->
                   if Option.is_some (RD.debug_info arg_reg)

--- a/backend/debug/reg_with_debug_info.ml
+++ b/backend/debug/reg_with_debug_info.ml
@@ -173,6 +173,11 @@ module Set = struct
     | [] -> raise Not_found
     | [reg] -> reg
     | _ -> assert false
+
+  let find_reg_with_same_location_exn t (reg : Reg.t) =
+    match elements (filter (fun t -> Reg.same_loc t.reg reg) t) with
+    | [] -> raise Not_found
+    | reg::_ -> reg
 end
 
 let print ~print_reg ppf t =

--- a/backend/debug/reg_with_debug_info.mli
+++ b/backend/debug/reg_with_debug_info.mli
@@ -89,6 +89,8 @@ module Set : sig
 
   val find_reg_exn : t -> Reg.t -> reg_with_debug_info
 
+  val find_reg_with_same_location_exn : t -> Reg.t -> reg_with_debug_info
+
   val filter_reg : t -> Reg.t -> t
 
   val forget_debug_info : t -> Reg.Set.t


### PR DESCRIPTION
There is a bug in `Cfg_available_regs` which causes variable availability information to be lost.  The problem is that the register allocator can elide no-op moves, which means that after register allocation, the Nth and (N+1)th occurrences of `Reg.t` values referring to the same physical register or stack slot may have different stamps.  This means that an existing lookup during the availability calculation can fail; see the comment in the diff.  In due course we will reassess whether we need to alter some of the data structures here to make things more robust.