### PR TITLE
Add -g to the default flags

### DIFF
--- a/dune
+++ b/dune
@@ -17,13 +17,25 @@
 (env
  (release
   (flags
-   (:standard -principal -w +a-4-9-40-41-42-44-45-48-66-67-70)))
+   (:standard -g -principal -w +a-4-9-40-41-42-44-45-48-66-67-70)))
  (main
   (flags
-   (:standard -principal -warn-error +A -w +a-4-9-40-41-42-44-45-48-66-67-70)))
+   (:standard
+    -g
+    -principal
+    -warn-error
+    +A
+    -w
+    +a-4-9-40-41-42-44-45-48-66-67-70)))
  (dev
   (flags
-   (:standard -principal -w +a-4-9-40-41-42-44-45-48-66-67-70 -warn-error +A))))
+   (:standard
+    -g
+    -principal
+    -w
+    +a-4-9-40-41-42-44-45-48-66-67-70
+    -warn-error
+    +A))))
 
 (include dune.runtime_selection)
 


### PR DESCRIPTION
Previously -g was only passed to ocamlc invocations (I'm admittedly not sure why), adding this to the flags means we also get debug info for anything compiled with ocamlopt. Importantly for me this includes compiler-libs.