### PR TITLE
Move recursion check down the decision pipeline

### DIFF
--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -142,12 +142,15 @@ let argument_types_useful dacc apply =
       (Apply.args apply)
 
 let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr
-    ~return_arity : Call_site_inlining_decision_type.t =
+    ~return_arity ~rec_info : Call_site_inlining_decision_type.t =
   let denv = DA.denv dacc in
   let disable_inlining = DE.disable_inlining denv in
   let decision =
     Code_or_metadata.code_metadata code_or_metadata
     |> Code_metadata.inlining_decision
+  in
+  let max_rec_depth =
+    Flambda_features.Inlining.max_rec_depth (Round (DE.round (DA.denv dacc)))
   in
   let in_a_stub, doing_speculative_inlining =
     match disable_inlining with
@@ -157,6 +160,10 @@ let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr
   in
   if in_a_stub
   then In_a_stub
+  else if Function_decl_inlining_decision_type.is_stub decision
+  then Definition_says_inline { was_inline_always = false }
+  else if Simplify_rec_info_expr.depth_may_exceed dacc rec_info max_rec_depth
+  then Recursion_depth_exceeded
   else if Function_decl_inlining_decision_type.must_be_inlined decision
   then
     Definition_says_inline
@@ -280,20 +287,11 @@ let make_decision0 dacc ~simplify_expr ~function_type ~apply ~return_arity :
           in
           match policy with
           | `Heuristic ->
-            let max_rec_depth =
-              Flambda_features.Inlining.max_rec_depth
-                (Round (DE.round (DA.denv dacc)))
-            in
-            if Simplify_rec_info_expr.depth_may_exceed dacc rec_info
-                 max_rec_depth
-            then (
-              fail_if_must_inline ();
-              Recursion_depth_exceeded)
-            else if must_inline
+            if must_inline
             then Replay_history_says_must_inline
             else
               might_inline dacc ~apply ~code_or_metadata ~function_type
-                ~simplify_expr ~return_arity
+                ~simplify_expr ~return_arity ~rec_info
           | `Unroll unroll_to ->
             if Simplify_rec_info_expr.can_unroll dacc rec_info
             then

--- a/middle_end/flambda2/terms/function_decl_inlining_decision_type.ml
+++ b/middle_end/flambda2/terms/function_decl_inlining_decision_type.ml
@@ -190,3 +190,11 @@ let equal t1 t2 =
       | Functor _ | Recursive | Jsir_inlining_disabled ),
       _ ) ->
     false
+
+let is_stub t =
+  match t with
+  | Stub -> true
+  | Not_yet_decided | Never_inline_attribute | Function_body_too_large _
+  | Attribute_inline | Small_function _ | Speculatively_inlinable _ | Functor _
+  | Recursive | Jsir_inlining_disabled ->
+    false

--- a/middle_end/flambda2/terms/function_decl_inlining_decision_type.mli
+++ b/middle_end/flambda2/terms/function_decl_inlining_decision_type.mli
@@ -44,3 +44,5 @@ val has_attribute_inline : t -> bool
 val cannot_be_inlined : t -> bool
 
 val equal : t -> t -> bool
+
+val is_stub : t -> bool


### PR DESCRIPTION
This allows optional wrappers to be inlined in the main worker if the function is recursive.

In particular, the test `asmcomp/optargs.ml` now passes.