### PR TITLE
datalog: Get rid of weird `with_parameters` API

### DIFF
--- a/middle_end/flambda2/datalog/datalog.ml
+++ b/middle_end/flambda2/datalog/datalog.ml
@@ -81,17 +81,20 @@ let rec add_parameters : type a. a String.hlist -> a Parameter.hlist = function
   | [] -> []
   | name :: names -> Parameter.create name :: add_parameters names
 
-let with_parameters params f info =
-  let [] = info.parameters in
-  let parameters = add_parameters params in
-  f (Term.parameters parameters) { info with parameters }
+let compile_with_parameters0 parameters f =
+  let parameters = add_parameters parameters in
+  let info = { context = Cursor.create_context (); parameters } in
+  f (Term.parameters parameters) info
 
 let foreach vars f info =
   let variables = add_variables info.context vars in
   f variables info
 
-let compile xs f =
-  foreach xs f { context = Cursor.create_context (); parameters = [] }
+let compile_with_parameters parameters vars f =
+  compile_with_parameters0 parameters (fun ps ->
+      foreach vars (fun vs -> f ps vs))
+
+let compile xs f = compile_with_parameters [] xs (fun [] xs -> f xs)
 
 let bind_iterator actions var iterator =
   Cursor.add_action actions (Cursor.bind_iterator var iterator)

--- a/middle_end/flambda2/datalog/datalog.mli
+++ b/middle_end/flambda2/datalog/datalog.mli
@@ -45,8 +45,11 @@ val map_program : ('p, 'a) program -> ('a -> 'b) -> ('p, 'b) program
 
 val compile : 'v String.hlist -> ('v Term.hlist -> (nil, 'a) program) -> 'a
 
-val with_parameters :
-  'p String.hlist -> ('p Term.hlist -> ('p, 'a) program) -> (nil, 'a) program
+val compile_with_parameters :
+  'p String.hlist ->
+  'v String.hlist ->
+  ('p Term.hlist -> 'v Term.hlist -> ('p, 'a) program) ->
+  'a
 
 val foreach :
   'a String.hlist -> ('a Term.hlist -> ('p, 'b) program) -> ('p, 'b) program

--- a/middle_end/flambda2/datalog/flambda2_datalog.ml
+++ b/middle_end/flambda2/datalog/flambda2_datalog.ml
@@ -290,9 +290,8 @@ module Datalog = struct
       where (f variables) @@ yield variables
 
     let create_with_parameters ~parameters variables f =
-      compile variables (fun variables ->
-          with_parameters parameters (fun parameters ->
-              where (f parameters variables) @@ yield variables))
+      compile_with_parameters parameters variables (fun parameters variables ->
+          where (f parameters variables) (yield variables))
 
     let fold_with_parameters cursor parameters database ~init ~f =
       Cursor.With_parameters.naive_fold cursor parameters database f init

--- a/middle_end/flambda2/datalog/flambda2_datalog.mli
+++ b/middle_end/flambda2/datalog/flambda2_datalog.mli
@@ -488,8 +488,11 @@ module Datalog : sig
     *)
   val compile : 'v String.hlist -> ('v Term.hlist -> (nil, 'a) program) -> 'a
 
-  val with_parameters :
-    'p String.hlist -> ('p Term.hlist -> ('p, 'a) program) -> (nil, 'a) program
+  val compile_with_parameters :
+    'p String.hlist ->
+    'v String.hlist ->
+    ('p Term.hlist -> 'v Term.hlist -> ('p, 'a) program) ->
+    'a
 
   (** [foreach vars prog] binds the variables [vars] in [prog].
 


### PR DESCRIPTION
The `with_parameters` API with allows to set parameters at an arbitrary depth in a query is weird and imposes unnecessary constraints on the implementation of the datalog frontend. Drop it in favour of a more intuitive `compile_with_parameters` variant of `compile`.