### PR TITLE
datalog: Store representation of high-level variables

### DIFF
--- a/middle_end/flambda2/datalog/column.ml
+++ b/middle_end/flambda2/datalog/column.ml
@@ -1,0 +1,91 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                       Basile Clément, OCamlPro                             *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 OCamlPro                                                *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+open Heterogenous_list
+
+type (_, _, _) repr =
+  | Patricia_tree_repr : ('a Patricia_tree.map, int, 'a) repr
+
+type ('t, 'k, 'v) id =
+  { name : string;
+    value_repr : 'k Value.repr;
+    repr : ('t, 'k, 'v) repr
+  }
+
+let equal_key { value_repr; _ } = Value.equal_repr value_repr
+
+let print_key { value_repr; _ } = Value.print_repr value_repr
+
+let value_repr { value_repr; _ } = value_repr
+
+type (_, _, _) hlist =
+  | [] : ('v, nil, 'v) hlist
+  | ( :: ) : ('t, 'k, 's) id * ('s, 'ks, 'v) hlist -> ('t, 'k -> 'ks, 'v) hlist
+
+let rec print_keys :
+    type t k v. (t, k, v) hlist -> Format.formatter -> k Constant.hlist -> unit
+    =
+ fun columns ppf keys ->
+  match columns, keys with
+  | [], [] -> ()
+  | [column], [key] -> print_key column ppf key
+  | column :: (_ :: _ as columns), key :: keys ->
+    Format.fprintf ppf "%a,@ %a" (print_key column) key (print_keys columns)
+      keys
+
+(* We could expose the fact that we do not support relations without arguments
+   in the types, but a runtime error here allows us to give a better error
+   message. Plus, we might support constant relations (represented as an option)
+   in the future. *)
+let rec is_trie : type t k v. (t, k, v) hlist -> (t, k, v) Trie.is_trie =
+  function
+  | [] -> Misc.fatal_error "Cannot create relation with no arguments"
+  | [{ repr = Patricia_tree_repr; _ }] -> Trie.patricia_tree_is_trie
+  | { repr = Patricia_tree_repr; _ } :: (_ :: _ as columns) ->
+    Trie.patricia_tree_of_trie (is_trie columns)
+
+module Make (X : sig
+  val name : string
+
+  val print : Format.formatter -> int -> unit
+end) =
+struct
+  type t = int
+
+  let print = X.print
+
+  module Tree = Patricia_tree.Make (X)
+  module Set = Tree.Set
+  module Map = Tree.Map
+
+  let value_repr = Value.int_repr ~print
+
+  let datalog_column_id =
+    { name = X.name; value_repr; repr = Patricia_tree_repr }
+end

--- a/middle_end/flambda2/datalog/column.mli
+++ b/middle_end/flambda2/datalog/column.mli
@@ -1,0 +1,64 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                       Basile Clément, OCamlPro                             *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 OCamlPro                                                *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+open Heterogenous_list
+
+type ('t, 'k, 'v) id
+
+type (_, _, _) hlist =
+  | [] : ('v, nil, 'v) hlist
+  | ( :: ) : ('t, 'k, 's) id * ('s, 'ks, 'v) hlist -> ('t, 'k -> 'ks, 'v) hlist
+
+val value_repr : ('t, 'k, 'v) id -> 'k Value.repr
+
+val equal_key : ('t, 'k, 'v) id -> 'k -> 'k -> bool
+
+val print_key : ('t, 'k, 'v) id -> Format.formatter -> 'k -> unit
+
+val print_keys :
+  ('t, 'k, 'v) hlist -> Format.formatter -> 'k Constant.hlist -> unit
+
+val is_trie : ('t, 'k, 'v) hlist -> ('t, 'k, 'v) Trie.is_trie
+
+module Make (_ : sig
+  val name : string
+
+  val print : Format.formatter -> int -> unit
+end) : sig
+  type t = int
+
+  val print : Format.formatter -> t -> unit
+
+  module Set : Container_types.Set with type elt = t
+
+  module Map :
+    Container_types.Map_plus_iterator with type key = t with module Set = Set
+
+  val datalog_column_id : ('a Map.t, t, 'a) id
+end

--- a/middle_end/flambda2/datalog/cursor.ml
+++ b/middle_end/flambda2/datalog/cursor.ml
@@ -15,10 +15,6 @@
 
 open Datalog_imports
 
-type _ value_repr = Int_repr : int value_repr
-
-let int_repr = Int_repr
-
 (* Note: we don't use [with_name] here to avoid the extra indirection during
    execution. *)
 type vm_action =
@@ -34,7 +30,7 @@ type vm_action =
       * 'k option Channel.receiver
       * string
       * string
-      * 'k value_repr
+      * 'k Value.repr
       -> vm_action
   | Filter :
       ('k Constant.hlist -> bool) * 'k Option_receiver.hlist * string list
@@ -362,8 +358,8 @@ let evaluate = function
          (Trie.find_opt is_trie (Option_receiver.recv args) (Channel.recv cell))
     then Virtual_machine.Skip
     else Virtual_machine.Accept
-  | Unless_eq (cell1, cell2, _cell1_name, _cell2_name, Int_repr) ->
-    if Int.equal
+  | Unless_eq (cell1, cell2, _cell1_name, _cell2_name, repr) ->
+    if Value.equal_repr repr
          (Option.get (Channel.recv cell1))
          (Option.get (Channel.recv cell2))
     then Virtual_machine.Skip

--- a/middle_end/flambda2/datalog/cursor.mli
+++ b/middle_end/flambda2/datalog/cursor.mli
@@ -15,10 +15,6 @@
 
 open Datalog_imports
 
-type 'a value_repr
-
-val int_repr : int value_repr
-
 type action
 
 val bind_iterator :
@@ -31,7 +27,7 @@ val unless :
   action
 
 val unless_eq :
-  'k value_repr ->
+  'k Value.repr ->
   'k option Channel.receiver with_name ->
   'k option Channel.receiver with_name ->
   action

--- a/middle_end/flambda2/datalog/datalog.mli
+++ b/middle_end/flambda2/datalog/datalog.mli
@@ -67,7 +67,7 @@ val unless_atom :
   ('p, 'a) program
 
 val unless_eq :
-  'k Cursor.value_repr ->
+  'k Value.repr ->
   'k Term.t ->
   'k Term.t ->
   ('p, 'a) program ->

--- a/middle_end/flambda2/datalog/table.mli
+++ b/middle_end/flambda2/datalog/table.mli
@@ -46,14 +46,15 @@ module Id : sig
 
   val compare : (_, _, _) t -> (_, _, _) t -> int
 
+  val columns : ('t, 'k, 'v) t -> ('t, 'k, 'v) Column.hlist
+
   val is_trie : ('t, 'k, 'v) t -> ('t, 'k, 'v) Trie.is_trie
 
   type ('k, 'v) poly = Id : ('t, 'k, 'v) t -> ('k, 'v) poly
 
   val create :
     name:string ->
-    is_trie:('t, 'k, 'v) Trie.is_trie ->
-    print_keys:(Format.formatter -> 'k Constant.hlist -> unit) ->
+    columns:('t, 'k, 'v) Column.hlist ->
     default_value:'v ->
     ('t, 'k, 'v) t
 

--- a/middle_end/flambda2/datalog/value.ml
+++ b/middle_end/flambda2/datalog/value.ml
@@ -1,0 +1,39 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                       Basile Clément, OCamlPro                             *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 OCamlPro                                                *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+type _ repr =
+  | Int_repr : { print : Format.formatter -> int -> unit } -> int repr
+
+let int_repr ~print = Int_repr { print }
+
+let equal_repr : type a. a repr -> a -> a -> bool =
+ fun (Int_repr _) x1 x2 -> Int.equal x1 x2
+
+let print_repr : type a. a repr -> Format.formatter -> a -> unit =
+ fun (Int_repr { print }) ppf x -> print ppf x

--- a/middle_end/flambda2/datalog/value.mli
+++ b/middle_end/flambda2/datalog/value.mli
@@ -1,0 +1,36 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                       Basile Clément, OCamlPro                             *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 OCamlPro                                                *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+type _ repr
+
+val int_repr : print:(Format.formatter -> int -> unit) -> int repr
+
+val equal_repr : 'a repr -> 'a -> 'a -> bool
+
+val print_repr : 'a repr -> Format.formatter -> 'a -> unit


### PR DESCRIPTION
This allows to print the value associated with variables, which is required to be able to display provenance information.

This is mostly moving things around so that the dependencies (between OCaml modules) are in the right place.

Note: this depends on, and includes, #4816 and #4815. Only the last commit (with the same title as the PR) is new.