### PR TITLE
datalog: Add provenance information for debugging

### DIFF
--- a/middle_end/flambda2/datalog/column.ml
+++ b/middle_end/flambda2/datalog/column.ml
@@ -70,6 +70,18 @@ let rec is_trie : type t k v. (t, k, v) hlist -> (t, k, v) Trie.is_trie =
   | { repr = Patricia_tree_repr; _ } :: (_ :: _ as columns) ->
     Trie.patricia_tree_of_trie (is_trie columns)
 
+let compare_key : type m k v. (m, k, v) id -> k -> k -> int =
+ fun column x y -> Value.compare_repr (value_repr column) x y
+
+let rec compare_keys :
+    type t k v. (t, k, v) hlist -> k Constant.hlist -> k Constant.hlist -> int =
+ fun columns xs ys ->
+  match columns, xs, ys with
+  | [], [], [] -> 0
+  | column :: columns, x :: xs, y :: ys ->
+    let c = compare_key column x y in
+    if c <> 0 then c else compare_keys columns xs ys
+
 module Make (X : sig
   val name : string
 

--- a/middle_end/flambda2/datalog/column.mli
+++ b/middle_end/flambda2/datalog/column.mli
@@ -44,6 +44,11 @@ val print_key : ('t, 'k, 'v) id -> Format.formatter -> 'k -> unit
 val print_keys :
   ('t, 'k, 'v) hlist -> Format.formatter -> 'k Constant.hlist -> unit
 
+val compare_key : ('t, 'k, 'v) id -> 'k -> 'k -> int
+
+val compare_keys :
+  ('t, 'k, 'v) hlist -> 'k Constant.hlist -> 'k Constant.hlist -> int
+
 val is_trie : ('t, 'k, 'v) hlist -> ('t, 'k, 'v) Trie.is_trie
 
 module Make (_ : sig

--- a/middle_end/flambda2/datalog/datalog.mli
+++ b/middle_end/flambda2/datalog/datalog.mli
@@ -33,6 +33,10 @@ module String : sig
   include Heterogenous_list.S with type 'a t := string
 end
 
+type bindings
+
+val print_bindings : Format.formatter -> bindings -> unit
+
 (** The type [('p, 'v) program] is the type of programs returning
       values of type ['v] with parameters ['p].
 
@@ -83,6 +87,12 @@ type callback
 
 val create_callback :
   ('a Constant.hlist -> unit) -> name:string -> 'a Term.hlist -> callback
+
+val create_callback_with_bindings :
+  (bindings -> 'a Constant.hlist -> unit) ->
+  name:string ->
+  'a Term.hlist ->
+  callback
 
 val yield : 'v Term.hlist -> ('p, ('p, 'v) Cursor.With_parameters.t) program
 

--- a/middle_end/flambda2/datalog/dune
+++ b/middle_end/flambda2/datalog/dune
@@ -9,5 +9,7 @@
  (flags
   (:standard
    -open
-   Flambda2_algorithms))
- (libraries ocamlcommon flambda2_algorithms))
+   Flambda2_algorithms
+   -open
+   Flambda2_ui))
+ (libraries ocamlcommon flambda2_algorithms flambda2_ui))

--- a/middle_end/flambda2/datalog/flambda2_datalog.ml
+++ b/middle_end/flambda2/datalog/flambda2_datalog.ml
@@ -72,13 +72,13 @@ module Datalog = struct
 
   type ('t, 'k, 'v) table = ('t, 'k, 'v) Table.Id.t
 
-  let create_table ~name ~default_value columns =
-    Table.Id.create ~name ~columns ~default_value
+  let create_table ?(provenance = true) ~name ~default_value columns =
+    Table.Id.create ~provenance ~name ~columns ~default_value
 
   type ('t, 'k) relation = ('t, 'k, unit) table
 
-  let create_relation ~name columns =
-    create_table ~name ~default_value:() columns
+  let create_relation ?provenance ~name columns =
+    create_table ?provenance ~name ~default_value:() columns
 
   module Schema = struct
     module type S0 = sig

--- a/middle_end/flambda2/datalog/flambda2_datalog.mli
+++ b/middle_end/flambda2/datalog/flambda2_datalog.mli
@@ -72,7 +72,12 @@ module Datalog : sig
 
   type ('t, 'k, 'v) table
 
+  (** The [provenance] argument is [true] by default. If set to [false],
+      provenance tracking will be disabled for this table. This is useful for
+      derived tables that are defined by a single rule, such as indices defined
+      by a permutation of another table. *)
   val create_table :
+    ?provenance:bool ->
     name:string ->
     default_value:'v ->
     ('t, 'k, 'v) Column.hlist ->
@@ -89,6 +94,8 @@ module Datalog : sig
         a map from [ty1] whose values are maps from [ty2] to [ty2]. The order of
         arguments provided to a relation thus have profound implication for the
         performance of iterations on the relation, and needs to be chosen carefully.
+
+        See documentation of [create_table] for the [provenance] argument.
 
         @raise Misc.Fatal_error if [schema] is empty.
 
@@ -107,7 +114,10 @@ module Datalog : sig
         ]}
           *)
   val create_relation :
-    name:string -> ('t, 'k, unit) Column.hlist -> ('t, 'k) relation
+    ?provenance:bool ->
+    name:string ->
+    ('t, 'k, unit) Column.hlist ->
+    ('t, 'k) relation
 
   module Constant : sig
     (** The [Constant] module only provides a heterogenous list to represent
@@ -437,6 +447,15 @@ module Datalog : sig
   type rule
 
   module Schedule : sig
+    (** Enable provenance tracking in rules.
+
+      This makes the computation of rules slower and should only be enabled for
+      debugging.
+
+      {b Warning}: This flag is used during the compilation of rules. Enabling it
+      will {b not} allow provenance tracking for rules that already exist. *)
+    val enable_provenance_for_debug : unit -> unit
+
     type t
 
     (** [saturate rules] is a schedule that repeatedly applies the rules in
@@ -457,7 +476,7 @@ module Datalog : sig
 
     type stats
 
-    val create_stats : unit -> stats
+    val create_stats : database -> stats
 
     val print_stats : Format.formatter -> stats -> unit
 
@@ -468,6 +487,10 @@ module Datalog : sig
       *)
     val run : ?stats:stats -> t -> database -> database
   end
+
+  type bindings
+
+  val print_bindings : Format.formatter -> bindings -> unit
 
   (** The type [('p, 'v) program] is the type of programs returning values
       of type ['v] with parameters ['p].

--- a/middle_end/flambda2/datalog/schedule.ml
+++ b/middle_end/flambda2/datalog/schedule.ml
@@ -13,6 +13,16 @@
 (*                                                                        *)
 (**************************************************************************)
 
+open Heterogenous_list
+
+(* CR bclement: It's a shame that we can't easily have provenance information as
+   a runtime flag due to the way we evaluate rules before parsing arguments.
+   There might be a better way, but we need to be cautious not to degrade
+   performance when not using provenance. *)
+let use_provenance = ref false
+
+let enable_provenance_for_debug () = use_provenance := true
+
 (** An ['a incremental] represents a value (database or table), paired with
     another copy representing the latest changes to the value. *)
 type 'a incremental =
@@ -40,6 +50,66 @@ type binder =
 
 let print_binder ppf (Binder { table_id; _ }) = Table.Id.print ppf table_id
 
+type rule_id = Rule_id of int [@@unboxed]
+
+let fresh_rule_id =
+  let cnt = ref 0 in
+  fun () ->
+    incr cnt;
+    Rule_id !cnt
+
+(* This is used to generate a unique name for rules, it just needs to be
+   somewhat random, not necessarily secure in any way*)
+let fasthash h =
+  let h = h lxor (h lsr 23) in
+  let h = h * 2388976653695081527 in
+  let h = h lxor (h lsr 47) in
+  h
+
+let print_rule_id ppf (Rule_id id) =
+  let n = ref (fasthash id) in
+  for _ = 0 to 12 do
+    let c = (36 + (!n mod 36)) mod 36 in
+    let c =
+      if c < 10
+      then char_of_int (int_of_char '0' + c)
+      else char_of_int (int_of_char 'a' + c - 10)
+    in
+    Format.pp_print_char ppf c;
+    n := !n / 36
+  done;
+  assert (!n = 0)
+
+let rule_id_to_string rule_id = Format.asprintf "%a" print_rule_id rule_id
+
+type fact_id =
+  | Fact_id : ('t, 'k, 'v) Table.Id.t * 'k Constant.hlist -> fact_id
+
+let compare_fact_id (Fact_id (tid1, args1)) (Fact_id (tid2, args2)) =
+  let c = Table.Id.compare tid1 tid2 in
+  if c <> 0
+  then c
+  else
+    let Equal = Table.Id.provably_equal_keys_exn tid1 tid2 in
+    let columns1 = Table.Id.columns tid1 in
+    Column.compare_keys columns1 args1 args2
+
+module FactMap = Map.Make (struct
+  type t = fact_id
+
+  let compare = compare_fact_id
+end)
+
+type provenance =
+  | Input
+  | Rule of rule_id * Datalog.bindings
+
+let add_if_not_exists sources tid args provenance =
+  let fact = Fact_id (tid, args) in
+  match FactMap.find_opt fact sources with
+  | None -> FactMap.add fact provenance sources
+  | Some _ -> sources
+
 (** A rule consists of:
 
       - A [Cursor.t] to iterates on the entries produced by the right-hand
@@ -56,19 +126,14 @@ type rule =
   | Rule :
       { cursor : 'a Cursor.t;
         binders : binder list;
-        rule_id : int
+        provenance_table_ref : provenance FactMap.t ref;
+        rule_id : rule_id
       }
       -> rule
 
 type deduction =
   [ `Atom of Datalog.atom
   | `And of deduction list ]
-
-let fresh_rule_id =
-  let cnt = ref 0 in
-  fun () ->
-    incr cnt;
-    !cnt
 
 let find_or_create_ref (type t k v) binders (table_id : (t, k, v) Table.Id.t) :
     t incremental ref =
@@ -90,29 +155,48 @@ let deduce (atoms : deduction) =
     | `Atom atom -> f atom acc
     | `And atoms -> List.fold_left (fun acc atoms -> fold f atoms acc) acc atoms
   in
+  let rule_id = fresh_rule_id () in
   let binders : (int, binder) Hashtbl.t = Hashtbl.create 17 in
+  let provenance_table_ref = ref FactMap.empty in
   let callbacks =
     fold
       (fun (Datalog.Atom (tid, args)) callbacks ->
         let is_trie = Table.Id.is_trie tid in
         let table_ref = find_or_create_ref binders tid in
-        Datalog.create_callback
-          ~name:(Table.Id.name tid ^ ".insert")
-          (fun keys ->
-            let incremental_table = !table_ref in
-            match Trie.find_opt is_trie keys incremental_table.current with
-            | Some _ -> ()
-            | None ->
-              table_ref
-                := incremental
-                     ~current:
-                       (Trie.add_or_replace is_trie keys ()
-                          incremental_table.current)
-                     ~difference:
-                       (Trie.add_or_replace is_trie keys ()
-                          incremental_table.difference))
-          args
-        :: callbacks)
+        let[@inline] callback_fn ~accept keys =
+          let incremental_table = !table_ref in
+          match Trie.find_opt is_trie keys incremental_table.current with
+          | Some _ -> ()
+          | None ->
+            (accept [@inlined hint]) ();
+            table_ref
+              := incremental
+                   ~current:
+                     (Trie.add_or_replace is_trie keys ()
+                        incremental_table.current)
+                   ~difference:
+                     (Trie.add_or_replace is_trie keys ()
+                        incremental_table.difference)
+        in
+        let name = Table.Id.name tid ^ ".insert" in
+        let callback =
+          if !use_provenance
+          then
+            Datalog.create_callback_with_bindings ~name
+              (fun bindings keys ->
+                callback_fn
+                  ~accept:(fun [@inline] () ->
+                    provenance_table_ref
+                      := add_if_not_exists !provenance_table_ref tid keys
+                           (Rule (rule_id, bindings) : provenance))
+                  keys)
+              args
+          else
+            Datalog.create_callback ~name
+              (fun keys -> callback_fn ~accept:(fun [@inline] () -> ()) keys)
+              args
+        in
+        callback :: callbacks)
       atoms []
   in
   let binders =
@@ -120,26 +204,199 @@ let deduce (atoms : deduction) =
   in
   Datalog.map_program (Datalog.execute callbacks) (fun cursor ->
       let cursor = Cursor.With_parameters.without_parameters cursor in
-      Rule { cursor; binders; rule_id = fresh_rule_id () })
+      Rule { cursor; binders; provenance_table_ref; rule_id })
 
-type stats = (int, rule * float) Hashtbl.t
+type stats =
+  { timings : (rule_id, rule * float) Hashtbl.t;
+    mutable provenance : provenance FactMap.t
+  }
 
-let create_stats () = Hashtbl.create 17
+let rec vars : type a b c. (a, b, c) Column.hlist -> b Datalog.String.hlist =
+  function
+  | [] -> []
+  | _column :: columns -> "_" :: vars columns
+
+let provenance_from_db db =
+  Table.Map.fold db ~init:FactMap.empty ~f:(fun (Binding (tid, _)) provenance ->
+      let cursor =
+        Datalog.compile
+          (vars (Table.Id.columns tid))
+          (fun args -> Datalog.where_atom tid args (Datalog.yield args))
+      in
+      let cursor = Cursor.With_parameters.without_parameters cursor in
+      Cursor.naive_fold cursor db
+        (fun args provenance -> add_if_not_exists provenance tid args Input)
+        provenance)
+
+let create_stats db =
+  let provenance =
+    if !use_provenance then provenance_from_db db else FactMap.empty
+  in
+  { timings = Hashtbl.create 17; provenance }
 
 let add_timing ~stats (Rule { rule_id; _ } as rule) time =
-  Hashtbl.replace stats rule_id
-    (rule, time +. try snd (Hashtbl.find stats rule_id) with Not_found -> -0.)
+  Hashtbl.replace stats.timings rule_id
+    ( rule,
+      time
+      +. try snd (Hashtbl.find stats.timings rule_id) with Not_found -> -0. )
+
+module CharMap = Map.Make (Char)
+
+type char_trie =
+  { count : int;
+    trie : char_trie CharMap.t
+  }
+
+let rec add_to_trie char_trie word ~pos =
+  if pos >= String.length word
+  then { char_trie with count = char_trie.count + 1 }
+  else
+    let trie =
+      CharMap.update word.[pos]
+        (fun sub_trie ->
+          let sub_trie =
+            Option.value sub_trie ~default:{ count = 0; trie = CharMap.empty }
+          in
+          Some (add_to_trie sub_trie word ~pos:(pos + 1)))
+        char_trie.trie
+    in
+    { count = char_trie.count + 1; trie }
+
+let rec unique_prefix_len char_trie word ~pos =
+  if pos >= String.length word
+  then String.length word
+  else if char_trie.count = 1
+  then pos
+  else
+    match CharMap.find_opt word.[pos] char_trie.trie with
+    | None -> String.length word
+    | Some sub_trie -> unique_prefix_len sub_trie word ~pos:(pos + 1)
+
+let print_string_with_unique_prefix len ppf s =
+  Format.fprintf ppf "%t%s%t%s" Flambda_colours.expr_keyword
+    (String.sub s 0 len) Flambda_colours.pop
+    (String.sub s len (String.length s - len))
+
+let print_rule char_trie ppf (Rule { cursor; binders; rule_id; _ }) =
+  let rule_id = rule_id_to_string rule_id in
+  let len = unique_prefix_len char_trie rule_id ~pos:0 in
+  Format.fprintf ppf "%a:@ @[@[%a@]@ :- %a@]"
+    (print_string_with_unique_prefix len)
+    rule_id
+    (Format.pp_print_list
+       ~pp_sep:(fun ppf () -> Format.fprintf ppf ",@ ")
+       print_binder)
+    binders Cursor.print cursor
+
+let print_fact ppf (tid, args) =
+  Format.fprintf ppf "@[%a(@;<1 2>@[<hv>%a@]@,)@]" Table.Id.print tid
+    (Column.print_keys (Table.Id.columns tid))
+    args
+
+let print_provenance_group char_trie rule_id ppf provenance =
+  let first = ref false in
+  FactMap.iter
+    (fun (Fact_id (tid, args)) bindings ->
+      if not !first then Format.fprintf ppf "@ ";
+      first := false;
+      let rule_id = rule_id_to_string rule_id in
+      let len = unique_prefix_len char_trie rule_id ~pos:0 in
+      Format.fprintf ppf "@[<hv 2>%a :-@ @[<2>%a@ @[%a@]@]@]" print_fact
+        (tid, args)
+        (print_string_with_unique_prefix len)
+        rule_id Datalog.print_bindings bindings)
+    provenance
+
+type table_provenance =
+  | Table_provenance : ('t, 'k, 'v) Table.Id.t -> table_provenance
+
+let print_provenance char_trie rule_defs ppf provenance =
+  let group_by_table_id = Hashtbl.create 17 in
+  FactMap.iter
+    (fun (Fact_id (tid, args)) provenance ->
+      if Table.Id.has_provenance tid
+      then
+        let input_provenance, group_by_rule_id =
+          match Hashtbl.find_opt group_by_table_id (Table.Id.uid tid) with
+          | None ->
+            let input_provenance = ref FactMap.empty in
+            let group_by_rule_id = Hashtbl.create 17 in
+            Hashtbl.replace group_by_table_id (Table.Id.uid tid)
+              (Table_provenance tid, input_provenance, group_by_rule_id);
+            input_provenance, group_by_rule_id
+          | Some (_, input_provenance, group_by_rule_id) ->
+            input_provenance, group_by_rule_id
+        in
+        match (provenance : provenance) with
+        | Input ->
+          input_provenance := add_if_not_exists !input_provenance tid args ()
+        | Rule (rule_id, bindings) ->
+          let group =
+            match Hashtbl.find_opt group_by_rule_id rule_id with
+            | None -> FactMap.empty
+            | Some group -> group
+          in
+          let group = add_if_not_exists group tid args bindings in
+          Hashtbl.replace group_by_rule_id rule_id group)
+    provenance;
+  Hashtbl.iter
+    (fun _ (Table_provenance tid, input_provenance, group_by_rule_id) ->
+      if Hashtbl.length group_by_rule_id > 0
+      then (
+        let header = Format.asprintf "Provenance for %a" Table.Id.print tid in
+        let header_len = String.length header in
+        let header_marker = String.make header_len '=' in
+        Format.fprintf ppf "@ @ @[<v 1>@[<v>%s@ %s@]@ " header header_marker;
+        if not (FactMap.is_empty !input_provenance)
+        then (
+          Format.fprintf ppf "Input facts@ -----------@ ";
+          FactMap.iter
+            (fun (Fact_id (tid, args)) () ->
+              Format.fprintf ppf "@ %a" print_fact (tid, args))
+            !input_provenance);
+        Hashtbl.iter
+          (fun rule_id group ->
+            let rule_id_s = rule_id_to_string rule_id in
+            let len = unique_prefix_len char_trie rule_id_s ~pos:0 in
+            let header =
+              Format.asprintf "%a from %s" Table.Id.print tid rule_id_s
+            in
+            let header_len = String.length header in
+            let header_marker = String.make header_len '-' in
+            Format.fprintf ppf "@ @ @[<v 1>@[<v>%a from %a@ %s@]@ "
+              Table.Id.print tid
+              (print_string_with_unique_prefix len)
+              rule_id_s header_marker;
+            Format.fprintf ppf "%a@ " (print_rule char_trie)
+              (Hashtbl.find rule_defs rule_id);
+            print_provenance_group char_trie rule_id ppf group;
+            Format.fprintf ppf "@]")
+          group_by_rule_id;
+        Format.fprintf ppf "@]"))
+    group_by_table_id
 
 let print_stats ppf stats =
+  let char_trie = { count = 0; trie = CharMap.empty } in
+  let char_trie =
+    if !use_provenance
+    then
+      Hashtbl.fold
+        (fun _ (Rule { rule_id; _ }, _time) char_trie ->
+          add_to_trie char_trie (rule_id_to_string rule_id) ~pos:0)
+        stats.timings char_trie
+    else char_trie
+  in
   Format.fprintf ppf "@[<v>";
+  let rule_defs = Hashtbl.create 17 in
   Hashtbl.iter
-    (fun _ (Rule { cursor; binders; _ }, time) ->
-      Format.fprintf ppf "@[@[@[%a@]@ :- %a@]@,: %f@]@ "
-        (Format.pp_print_list
-           ~pp_sep:(fun ppf () -> Format.fprintf ppf ",@ ")
-           print_binder)
-        binders Cursor.print cursor time)
-    stats;
+    (fun _ ((Rule { rule_id; _ } as rule), time) ->
+      Hashtbl.replace rule_defs rule_id rule;
+      Format.fprintf ppf "@[<v 2>%a@,: %f@]@ " (print_rule char_trie) rule time)
+    stats.timings;
+  if !use_provenance
+  then (
+    Format.fprintf ppf "Provenance@ ==========@ ";
+    print_provenance char_trie rule_defs ppf stats.provenance);
   Format.fprintf ppf "@]"
 
 (** Evaluate a single rule using semi-naive evaluation.
@@ -156,7 +413,10 @@ let print_stats ppf stats =
     database [incremental_db].
 *)
 let run_rule_incremental ?stats ~previous ~diff ~current incremental_db
-    (Rule { binders; cursor; _ } as rule) =
+    (Rule { binders; cursor; provenance_table_ref; _ } as rule) =
+  (match stats with
+  | None -> ()
+  | Some stats -> provenance_table_ref := stats.provenance);
   List.iter
     (fun (Binder { table_id; previous; current }) ->
       let incremental_table =
@@ -170,15 +430,22 @@ let run_rule_incremental ?stats ~previous ~diff ~current incremental_db
   let time1 = Sys.time () in
   let seminaive_time = time1 -. time0 in
   Option.iter (fun stats -> add_timing ~stats rule seminaive_time) stats;
-  List.fold_left
-    (fun incremental_db (Binder { table_id; previous; current }) ->
-      let previous = !previous and { current; difference } = !current in
-      if previous == current
-      then incremental_db
-      else
-        incremental_set (Table.Map.set table_id) { current; difference }
-          incremental_db)
-    incremental_db binders
+  (match stats with
+  | None -> ()
+  | Some stats -> stats.provenance <- !provenance_table_ref);
+  provenance_table_ref := FactMap.empty;
+  let incremental_db =
+    List.fold_left
+      (fun incremental_db (Binder { table_id; previous; current }) ->
+        let previous = !previous and { current; difference } = !current in
+        if previous == current
+        then incremental_db
+        else
+          incremental_set (Table.Map.set table_id) { current; difference }
+            incremental_db)
+      incremental_db binders
+  in
+  incremental_db
 
 type t =
   | Saturate of rule list
@@ -190,7 +457,8 @@ let saturate rules = Saturate rules
 
 let run_rules_incremental ?stats rules ~previous ~diff ~current incremental_db =
   List.fold_left
-    (run_rule_incremental ?stats ~previous ~diff ~current)
+    (fun incremental_db rule ->
+      run_rule_incremental ?stats ~previous ~diff ~current incremental_db rule)
     incremental_db rules
 
 (** Repeatedly apply the rules in [rules] to the database [current] until

--- a/middle_end/flambda2/datalog/schedule.mli
+++ b/middle_end/flambda2/datalog/schedule.mli
@@ -13,9 +13,18 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** Enable provenance tracking in rules.
+
+  This makes the computation of rules slower and should only be enabled for
+  debugging.
+
+  {b Warning}: This flag is used during the compilation of rules. Enabling it
+  will {b not} allow provenance tracking for rules that already exist. *)
+val enable_provenance_for_debug : unit -> unit
+
 type stats
 
-val create_stats : unit -> stats
+val create_stats : Table.Map.t -> stats
 
 val print_stats : Format.formatter -> stats -> unit
 

--- a/middle_end/flambda2/datalog/table.ml
+++ b/middle_end/flambda2/datalog/table.ml
@@ -61,7 +61,8 @@ module Id = struct
       name : string;
       is_trie : ('t, 'k, 'v) Trie.is_trie;
       columns : ('t, 'k, 'v) Column.hlist;
-      default_value : 'v
+      default_value : 'v;
+      provenance : bool
     }
 
   let is_trie { is_trie; _ } = is_trie
@@ -91,14 +92,16 @@ module Id = struct
   let compare { id = id1; _ } { id = id2; _ } =
     compare (Type.Id.uid id1) (Type.Id.uid id2)
 
-  let create ~name ~columns ~default_value =
+  let create ~provenance ~name ~columns ~default_value =
     (* Store the [is_trie] value in order to avoid a double loop to create it
        when it is used. *)
     (* CR bclement: most iterations on [is_trie] could probably be replaced with
        iterations on [columns] instead, at which point we could get rid of
        [is_trie] entirely. *)
     let is_trie = Column.is_trie columns in
-    { id = Type.Id.make (); name; is_trie; columns; default_value }
+    { id = Type.Id.make (); name; is_trie; columns; default_value; provenance }
+
+  let has_provenance { provenance; _ } = provenance
 
   let[@inline] columns { columns; _ } = columns
 
@@ -189,4 +192,6 @@ module Map = struct
         in
         Some (Binding (id1, table)))
       tables1 tables2
+
+  let fold ~f m ~init = Int.Map.fold (fun _ binding acc -> f binding acc) m init
 end

--- a/middle_end/flambda2/datalog/table.mli
+++ b/middle_end/flambda2/datalog/table.mli
@@ -50,9 +50,12 @@ module Id : sig
 
   val is_trie : ('t, 'k, 'v) t -> ('t, 'k, 'v) Trie.is_trie
 
+  val has_provenance : ('t, 'k, 'v) t -> bool
+
   type ('k, 'v) poly = Id : ('t, 'k, 'v) t -> ('k, 'v) poly
 
   val create :
+    provenance:bool ->
     name:string ->
     columns:('t, 'k, 'v) Column.hlist ->
     default_value:'v ->
@@ -77,4 +80,8 @@ module Map : sig
   val set : ('t, 'k, 'v) Id.t -> 't -> t -> t
 
   val concat : earlier:t -> later:t -> t
+
+  type binding = Binding : ('t, 'k, 'v) Id.t * 't -> binding
+
+  val fold : f:(binding -> 'a -> 'a) -> t -> init:'a -> 'a
 end

--- a/middle_end/flambda2/datalog/value.ml
+++ b/middle_end/flambda2/datalog/value.ml
@@ -35,5 +35,8 @@ let int_repr ~print = Int_repr { print }
 let equal_repr : type a. a repr -> a -> a -> bool =
  fun (Int_repr _) x1 x2 -> Int.equal x1 x2
 
+let compare_repr : type a. a repr -> a -> a -> int =
+ fun (Int_repr _) x1 x2 -> Int.compare x1 x2
+
 let print_repr : type a. a repr -> Format.formatter -> a -> unit =
  fun (Int_repr { print }) ppf x -> print ppf x

--- a/middle_end/flambda2/datalog/value.mli
+++ b/middle_end/flambda2/datalog/value.mli
@@ -33,4 +33,6 @@ val int_repr : print:(Format.formatter -> int -> unit) -> int repr
 
 val equal_repr : 'a repr -> 'a -> 'a -> bool
 
+val compare_repr : 'a repr -> 'a -> 'a -> int
+
 val print_repr : 'a repr -> Format.formatter -> 'a -> unit


### PR DESCRIPTION
This adds support for displaying the reason a particular fact was derived by the datalog engine. This information is only enable if the variable `use_provenance` is set in `datalog/schedule.ml`: since most datalog rules are compiled when loading the reaper module, it is complicated to use a runtime flag without degrading the performance when not computing provenance information.

Note: this depends on, and includes, #4815, #4816 and #4817. Only the last commit (with the same title as the PR) is new.