### PR TITLE
Zero_alloc: fix the scope of warning 199

### DIFF
--- a/oxcaml/tests/backend/zero_alloc_checker/dune.inc
+++ b/oxcaml/tests/backend/zero_alloc_checker/dune.inc
@@ -543,6 +543,26 @@
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
+ (targets test_warning199_disabled.output.corrected)
+ (deps (:ml test_warning199_disabled.mli test_warning199_disabled.ml) filter.sh)
+ (action
+   (with-outputs-to test_warning199_disabled.output.corrected
+    (pipe-outputs
+    (with-accepted-exit-codes 0
+     (run %{bin:ocamlopt.opt} %{ml} -g -color never -error-style short -c
+          -zero-alloc-checker-details-extra
+          -zero-alloc-check default -zero-alloc-checker-details-cutoff 20 -O3))
+    (run "./filter.sh")
+   ))))
+
+(rule
+ (alias   runtest)
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
+ (deps test_warning199_disabled.output test_warning199_disabled.output.corrected)
+ (action (diff test_warning199_disabled.output test_warning199_disabled.output.corrected)))
+
+(rule
+ (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_never_returns_normally.output.corrected)
  (deps (:ml test_never_returns_normally.ml) filter.sh)
  (action

--- a/oxcaml/tests/backend/zero_alloc_checker/gen/gen_dune.ml
+++ b/oxcaml/tests/backend/zero_alloc_checker/gen/gen_dune.ml
@@ -143,6 +143,9 @@ let () =
   (* deleting dead functions works *)
   print_test_expected_output ~cutoff:default_cutoff
     ~extra_dep:(Some "test_warning199.mli") ~exit_code:0 "test_warning199";
+  print_test_expected_output ~cutoff:default_cutoff
+    ~extra_dep:(Some "test_warning199_disabled.mli") ~exit_code:0
+    "test_warning199_disabled";
   print_test_expected_output ~cutoff:default_cutoff ~extra_dep:None ~exit_code:0
     "test_never_returns_normally";
   print_test_expected_output ~extra_flags:"-zero-alloc-check opt"

--- a/oxcaml/tests/backend/zero_alloc_checker/test_warning199_disabled.ml
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_warning199_disabled.ml
@@ -1,0 +1,9 @@
+[@@@warning "-199"]
+
+module A = struct
+  type t = int
+
+  let r = raise (Failure "bar")
+
+  let[@zero_alloc] foo x = x + 1
+end

--- a/oxcaml/tests/backend/zero_alloc_checker/test_warning199_disabled.mli
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_warning199_disabled.mli
@@ -1,0 +1,7 @@
+module A : sig
+  type t
+
+  val r : exn
+
+  val foo : t -> t [@@zero_alloc]
+end

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -119,7 +119,6 @@ val mark_deprecated_mutable_used : Parsetree.attributes -> unit
     in late stages of compilation in the backend.
     Registering them helps detect code that is not checked,
     because it is optimized away by the middle-end.  *)
-val register_zero_alloc_attribute : string Location.loc -> unit
 val mark_zero_alloc_attribute_checked : string -> Location.t -> unit
 val warn_unchecked_zero_alloc_attribute : unit -> unit
 


### PR DESCRIPTION
The top-level attribute `[@@@warning "-199"]` doesn't work correctly. It is supposed to disable warnings about unchecked `zero_alloc` attributes, but these warnings are printed too late, after the warnings scope that contains the top-level attribute is closed: 
https://github.com/oxcaml/oxcaml/blob/bb4ad1e613bbb0f3b8d0cb36346afa1624d5a6e4/typing/typemod.ml#L3831

This PR fixes the bug by saving the scope in which each `zero_alloc` attribute is encountered. This approach is similar to the way other `delayed_checks` are handled during typing, but we can't reuse the same functions because zero_alloc checks are even more delayed. If this is deemed too expensive, we can optimize it by saving a single boolean value `is_active`.

Separately, maybe we should have a warning from flambda2 for cases when the top-level effect of a compilation unit is `raise`? (cc @mshinwell) 
