### PR TITLE
Tentative fix for ocamlformat CI

### DIFF
--- a/.github/workflows/ocamlformat.yml
+++ b/.github/workflows/ocamlformat.yml
@@ -33,6 +33,9 @@ jobs:
     - name: Install a recent version of re
       run: opam install 're>=1.10.0'
 
+    - name: Install cmdliner 1.3.0
+      run: opam pin -y cmdliner 1.3.0
+
     - name: Install ocamlformat 0.24.1
       run: opam pin -y ocamlformat 0.24.1
 


### PR DESCRIPTION
The error on the ocamlformat job on recent PRs looks like the error we get when we use a library not ported to cmdliner 2.0.
This PR proposes to pin cmdliner to 1.3.0 to work around this issue.