### PR TITLE
Add PR number column to metrics CSV

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -391,6 +391,10 @@ jobs:
         SHORT_HASH="${COMMIT_HASH:0:8}"
         DATE=$(date -u +"%Y-%m-%d")
 
+        # Extract PR number from commit message
+        COMMIT_MESSAGE="${{ github.event.head_commit.message }}"
+        PR_NUMBER=$(echo "$COMMIT_MESSAGE" | grep -oP '\(#\K[0-9]+(?=\))' || echo "N/A")
+
         # CSV filename
         CSV_FILE="metrics-repo/data/metrics-${DATE}-${SHORT_HASH}.csv"
 
@@ -398,7 +402,8 @@ jobs:
         ${{ github.workspace }}/oxcaml/scripts/collect-size-metrics.sh \
           "${{ github.workspace }}/_install" \
           "$CSV_FILE" \
-          "$COMMIT_HASH"
+          "$COMMIT_HASH" \
+          "$PR_NUMBER"
 
         echo "Contents of generated metrics file:"
         cat "$CSV_FILE"

--- a/scripts/collect-size-metrics.sh
+++ b/scripts/collect-size-metrics.sh
@@ -2,16 +2,17 @@
 set -euo pipefail
 
 # Script to collect file size metrics from _install directory
-# Usage: collect-metrics.sh <install_directory> <output_csv_file> <commit_hash>
+# Usage: collect-metrics.sh <install_directory> <output_csv_file> <commit_hash> <pr_number>
 
-if [ $# -ne 3 ]; then
-    echo "Usage: $0 <install_directory> <output_csv_file> <commit_hash>" >&2
+if [ $# -lt 3 ] || [ $# -gt 4 ]; then
+    echo "Usage: $0 <install_directory> <output_csv_file> <commit_hash> [pr_number]" >&2
     exit 1
 fi
 
 INSTALL_DIR="$1"
 CSV_FILE="$2"
 COMMIT_HASH="$3"
+PR_NUMBER="${4:-N/A}"
 
 # Validate input directory exists
 if [ ! -d "$INSTALL_DIR" ]; then
@@ -26,7 +27,7 @@ TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 EXTENSIONS="exe opt a cmxa cma cmi cmx cmo cms cmsi cmt cmti o"
 
 # Write CSV header
-echo "timestamp,commit_hash,extension,total_size_bytes" > "$CSV_FILE"
+echo "timestamp,commit_hash,pr_number,extension,total_size_bytes" > "$CSV_FILE"
 
 # Collect metrics for each extension
 for ext in $EXTENSIONS; do
@@ -45,7 +46,7 @@ for ext in $EXTENSIONS; do
         rm -f "$temp_file"
     fi
     # Write to CSV
-    echo "${TIMESTAMP},${COMMIT_HASH},${ext},${total_size}" >> "$CSV_FILE"
+    echo "${TIMESTAMP},${COMMIT_HASH},${PR_NUMBER},${ext},${total_size}" >> "$CSV_FILE"
 done
 
 echo "Generated metrics file: $CSV_FILE"

--- a/scripts/collect-size-metrics.sh
+++ b/scripts/collect-size-metrics.sh
@@ -4,15 +4,15 @@ set -euo pipefail
 # Script to collect file size metrics from _install directory
 # Usage: collect-metrics.sh <install_directory> <output_csv_file> <commit_hash> <pr_number>
 
-if [ $# -lt 3 ] || [ $# -gt 4 ]; then
-    echo "Usage: $0 <install_directory> <output_csv_file> <commit_hash> [pr_number]" >&2
+if [ $# -ne 4 ]; then
+    echo "Usage: $0 <install_directory> <output_csv_file> <commit_hash> <pr_number>" >&2
     exit 1
 fi
 
 INSTALL_DIR="$1"
 CSV_FILE="$2"
 COMMIT_HASH="$3"
-PR_NUMBER="${4:-N/A}"
+PR_NUMBER="$4"
 
 # Validate input directory exists
 if [ ! -d "$INSTALL_DIR" ]; then


### PR DESCRIPTION
Updates the metrics collection workflow and script to include the pull request number in the generated CSV files. The PR number is extracted from the commit message and stored in a new column between commit_hash and extension. When no PR number is found, "N/A" is recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)