### PR TITLE
Disallow block indices to [@atomic] fields

### DIFF
--- a/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
+++ b/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
@@ -490,6 +490,18 @@ val idx_imm : ('a, 'b) idx_imm -> ('a, 'b) idx_imm = <fun>
 val idx_mut : ('a, 'b) idx_mut -> ('a, 'b) idx_mut = <fun>
 |}]
 
+(*****************************************)
+(* Block indices to atomic record fields *)
+type atomic = { mutable i : int [@atomic] }
+let bad () = (.i)
+[%%expect{|
+type atomic = { mutable i : int [@atomic]; }
+Line 2, characters 13-17:
+2 | let bad () = (.i)
+                 ^^^^
+Error: Block indices do not yet support [@atomic] record fields.
+|}]
+
 (**************)
 (* Modalities *)
 

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -315,6 +315,7 @@ type error =
   | Block_access_private_record
   | Block_index_modality_mismatch of
       { mut : bool; err : Mode.Modality.equate_error }
+  | Block_index_atomic_unsupported
   | Submode_failed of Mode.Value.error * submode_reason *
       Env.shared_context option
   | Curried_application_complete of


### PR DESCRIPTION
Atomic fields should only be accessed via atomic loads/stores, so it's unsafe to create `idx_mut`s to this, as this would allow that to be bypassed. In the future, we can add `idx_atomic`.