### PR TITLE
Annotate, where possible, params as `local` and/or `read` in `Unix`

### DIFF
--- a/stdlib/bytes.ml
+++ b/stdlib/bytes.ml
@@ -26,22 +26,33 @@ open! Stdlib
    These functions have a "duplicated" comment above their definition.
 *)
 
-external length : bytes @ immutable -> int @@ portable = "%bytes_length"
-external string_length : string -> int @@ portable = "%string_length"
-external get : bytes -> int -> char @@ portable = "%bytes_safe_get"
-external set : bytes -> int -> char -> unit @@ portable = "%bytes_safe_set"
+external length :
+  (bytes[@local_opt]) @ immutable -> int @@ portable = "%bytes_length"
+external string_length :
+  (string[@local_opt]) -> int @@ portable = "%string_length"
+external get :
+  (bytes[@local_opt]) @ read -> int -> char @@ portable = "%bytes_safe_get"
+external set :
+  (bytes[@local_opt]) -> int -> char -> unit @@ portable = "%bytes_safe_set"
 external create : int -> bytes @@ portable = "caml_create_bytes"
-external unsafe_get : bytes -> int -> char @@ portable = "%bytes_unsafe_get"
-external unsafe_set : bytes -> int -> char -> unit @@ portable = "%bytes_unsafe_set"
-external unsafe_fill : bytes -> int -> int -> char -> unit @@ portable
-                     = "caml_fill_bytes" [@@noalloc]
-external unsafe_to_string : bytes -> string @@ portable = "%bytes_to_string"
-external unsafe_of_string : string -> bytes @@ portable = "%bytes_of_string"
+external unsafe_get :
+  (bytes[@local_opt]) @ read -> int -> char @@ portable = "%bytes_unsafe_get"
+external unsafe_set :
+  (bytes[@local_opt]) -> int -> char -> unit @@ portable = "%bytes_unsafe_set"
+external unsafe_fill :
+  (bytes[@local_opt]) -> int -> int -> char -> unit @@ portable
+  = "caml_fill_bytes" [@@noalloc]
+external unsafe_to_string :
+  (bytes[@local_opt]) -> (string[@local_opt]) @@ portable = "%bytes_to_string"
+external unsafe_of_string :
+  (string[@local_opt]) -> (bytes[@local_opt]) @@ portable = "%bytes_of_string"
 
-external unsafe_blit : bytes -> int -> bytes -> int -> int -> unit @@ portable
-                     = "caml_blit_bytes" [@@noalloc]
-external unsafe_blit_string : string -> int -> bytes -> int -> int -> unit @@ portable
-                     = "caml_blit_string" [@@noalloc]
+external unsafe_blit :
+  (bytes[@local_opt]) @ read -> int -> (bytes[@local_opt]) -> int -> int -> unit
+  @@ portable = "caml_blit_bytes" [@@noalloc]
+external unsafe_blit_string :
+  (string[@local_opt]) -> int -> (bytes[@local_opt]) -> int -> int -> unit
+  @@ portable = "caml_blit_string" [@@noalloc]
 
 let make n c =
   let s = create n in
@@ -64,7 +75,7 @@ let copy s =
   r
 
 let to_string b = unsafe_to_string (copy b)
-let of_string s = copy (unsafe_of_string s)
+let of_string s = copy (unsafe_of_string s) [@nontail]
 
 let sub s ofs len =
   if ofs < 0 || len < 0 || ofs > length s - len

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -59,7 +59,7 @@ open! Stdlib
 
    *)
 
-external length : bytes @ immutable -> int = "%bytes_length"
+external length : (bytes[@local_opt]) @ immutable -> int = "%bytes_length"
 (** Return the length (number of bytes) of the argument. *)
 
 external get : bytes -> int -> char = "%bytes_safe_get"
@@ -91,15 +91,15 @@ val init : int -> (int -> char) -> bytes
 val empty : bytes
 (** A byte sequence of size 0. *)
 
-val copy : bytes -> bytes
+val copy : bytes @ local -> bytes
 (** Return a new byte sequence that contains the same bytes as the
     argument. *)
 
-val of_string : string -> bytes
+val of_string : string @ local -> bytes
 (** Return a new byte sequence that contains the same bytes as the
     given string. *)
 
-val to_string : bytes -> string
+val to_string : bytes @ local -> string
 (** Return a new string that contains the same bytes as the given byte
     sequence. *)
 
@@ -344,7 +344,8 @@ val ends_with :
     always-correct {!to_string} and {!of_string} instead.
 *)
 
-val unsafe_to_string : bytes -> string
+external unsafe_to_string :
+  (bytes[@local_opt]) -> (string[@local_opt]) = "%bytes_to_string"
 (** Unsafely convert a byte sequence into a string.
 
     To reason about the use of [unsafe_to_string], it is convenient to
@@ -420,7 +421,8 @@ let bytes_length (s : bytes) =
    closure is fully applied and returns ownership.
 *)
 
-val unsafe_of_string : string -> bytes
+external unsafe_of_string :
+  (string[@local_opt]) -> (bytes[@local_opt]) = "%bytes_of_string"
 (** Unsafely convert a shared string to a byte sequence that should
     not be mutated.
 
@@ -817,15 +819,18 @@ let d1 = Domain.spawn (fun () -> Bytes.set_int32_ne b 0 100; b.[0] <- 'd' )
 
 (* The following is for system use only. Do not call directly. *)
 
-external unsafe_get : bytes -> int -> char = "%bytes_unsafe_get"
-external unsafe_set : bytes -> int -> char -> unit = "%bytes_unsafe_set"
+external unsafe_get :
+  (bytes[@local_opt]) @ read -> int -> char = "%bytes_unsafe_get"
+external unsafe_set :
+  (bytes[@local_opt]) -> int -> char -> unit = "%bytes_unsafe_set"
 external unsafe_blit :
-  bytes -> int -> bytes -> int -> int ->
-    unit = "caml_blit_bytes" [@@noalloc]
+  (bytes[@local_opt]) @ read -> int -> (bytes[@local_opt]) -> int -> int -> unit
+  = "caml_blit_bytes" [@@noalloc]
 external unsafe_blit_string :
-  string -> int -> bytes -> int -> int -> unit
+  (string[@local_opt]) -> int -> (bytes[@local_opt]) -> int -> int -> unit
   = "caml_blit_string" [@@noalloc]
 external unsafe_fill :
-  bytes -> int -> int -> char -> unit = "caml_fill_bytes" [@@noalloc]
+  (bytes[@local_opt]) -> int -> int -> char -> unit
+  = "caml_fill_bytes" [@@noalloc]
 
 val unsafe_escape : bytes -> bytes

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -61,7 +61,7 @@ open! Stdlib
 
 [@@@ocaml.nolabels]
 
-external length : bytes @ immutable -> int = "%bytes_length"
+external length : (bytes[@local_opt]) @ immutable -> int = "%bytes_length"
 (** Return the length (number of bytes) of the argument. *)
 
 external get : bytes -> int -> char = "%bytes_safe_get"
@@ -93,15 +93,15 @@ val init : int -> f:(int -> char) -> bytes
 val empty : bytes
 (** A byte sequence of size 0. *)
 
-val copy : bytes -> bytes
+val copy : bytes @ local -> bytes
 (** Return a new byte sequence that contains the same bytes as the
     argument. *)
 
-val of_string : string -> bytes
+val of_string : string @ local -> bytes
 (** Return a new byte sequence that contains the same bytes as the
     given string. *)
 
-val to_string : bytes -> string
+val to_string : bytes @ local -> string
 (** Return a new string that contains the same bytes as the given byte
     sequence. *)
 
@@ -346,7 +346,8 @@ val ends_with :
     always-correct {!to_string} and {!of_string} instead.
 *)
 
-val unsafe_to_string : bytes -> string
+external unsafe_to_string :
+  (bytes[@local_opt]) -> (string[@local_opt]) = "%bytes_to_string"
 (** Unsafely convert a byte sequence into a string.
 
     To reason about the use of [unsafe_to_string], it is convenient to
@@ -422,7 +423,8 @@ let bytes_length (s : bytes) =
    closure is fully applied and returns ownership.
 *)
 
-val unsafe_of_string : string -> bytes
+external unsafe_of_string :
+  (string[@local_opt]) -> (bytes[@local_opt]) = "%bytes_of_string"
 (** Unsafely convert a shared string to a byte sequence that should
     not be mutated.
 
@@ -819,15 +821,20 @@ let d1 = Domain.spawn (fun () -> Bytes.set_int32_ne b 0 100; b.[0] <- 'd' )
 
 (* The following is for system use only. Do not call directly. *)
 
-external unsafe_get : bytes -> int -> char = "%bytes_unsafe_get"
-external unsafe_set : bytes -> int -> char -> unit = "%bytes_unsafe_set"
+external unsafe_get :
+  (bytes[@local_opt]) @ read -> int -> char = "%bytes_unsafe_get"
+external unsafe_set :
+  (bytes[@local_opt]) -> int -> char -> unit = "%bytes_unsafe_set"
 external unsafe_blit :
-  src:bytes -> src_pos:int -> dst:bytes -> dst_pos:int -> len:int ->
-    unit = "caml_blit_bytes" [@@noalloc]
+  src:(bytes[@local_opt]) @ read -> src_pos:int ->
+  dst:(bytes[@local_opt]) -> dst_pos:int -> len:int -> unit
+  = "caml_blit_bytes" [@@noalloc]
 external unsafe_blit_string :
-  src:string -> src_pos:int -> dst:bytes -> dst_pos:int -> len:int -> unit
+  src:(string[@local_opt]) -> src_pos:int ->
+  dst:(bytes[@local_opt]) -> dst_pos:int -> len:int -> unit
   = "caml_blit_string" [@@noalloc]
 external unsafe_fill :
-  bytes -> pos:int -> len:int -> char -> unit = "caml_fill_bytes" [@@noalloc]
+  (bytes[@local_opt]) -> pos:int -> len:int -> char -> unit
+  = "caml_fill_bytes" [@@noalloc]
 
 val unsafe_escape : bytes -> bytes

--- a/stdlib/fun.mli
+++ b/stdlib/fun.mli
@@ -32,7 +32,7 @@ val const : ('a : value_or_null) ('b : value_or_null)
 (** [const c] is a function that always returns the value [c]. For any
     argument [x], [(const c) x] is [c]. *)
 
-val compose : ('a : value_or_null) ('b : value_or_null) 
+val compose : ('a : value_or_null) ('b : value_or_null)
   ('c : value_or_null).
   ('b -> 'c) -> ('a -> 'b) -> 'a -> 'c
 (** [compose f g] is a function composition of applying [g] then [f].
@@ -40,7 +40,7 @@ val compose : ('a : value_or_null) ('b : value_or_null)
 
     @since 5.2 *)
 
-val flip : ('a : value_or_null) ('b : value_or_null) 
+val flip : ('a : value_or_null) ('b : value_or_null)
   ('c : value_or_null).
   ('a -> 'b -> 'c) -> ('b -> 'a -> 'c)
 (** [flip f] reverses the argument order of the binary function
@@ -53,7 +53,7 @@ val negate : ('a : value_or_null) . ('a -> bool) -> ('a -> bool)
 (** {1:exception Exception handling} *)
 
 val protect : ('a : value_or_null).
-  finally:(unit -> unit) -> (unit -> 'a) -> 'a
+  finally:(unit -> unit) @ local once -> (unit -> 'a) @ local once -> 'a
 (** [protect ~finally work] invokes [work ()] and then [finally ()]
     before [work ()] returns with its value or an exception. In the
     latter case the exception is re-raised after [finally ()]. If

--- a/stdlib/list.mli
+++ b/stdlib/list.mli
@@ -134,7 +134,7 @@ val flatten : ('a : value_or_null). 'a list list -> 'a list
 
 (** {1 Comparison} *)
 
-val equal : ('a : value_or_null). 
+val equal : ('a : value_or_null).
   ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
 (** [equal eq [a1; ...; an] [b1; ..; bm]] holds when
     the two input lists have the same length, and for each
@@ -149,7 +149,7 @@ val equal : ('a : value_or_null).
     @since 4.12
 *)
 
-val compare : ('a : value_or_null). 
+val compare : ('a : value_or_null).
   ('a -> 'a -> int) -> 'a list -> 'a list -> int
 (** [compare cmp [a1; ...; an] [b1; ...; bm]] performs
     a lexicographic comparison of the two input lists,
@@ -314,12 +314,12 @@ val exists2 : ('a : value_or_null) ('b : value_or_null)
    to have different lengths.
  *)
 
-val mem : ('a : value_or_null). 'a -> 'a list -> bool
+val mem : ('a : value_or_null). 'a @ local -> 'a list @ local -> bool
 (** [mem a set] is true if and only if [a] is equal
    to an element of [set].
  *)
 
-val memq : ('a : value_or_null). 'a -> 'a list -> bool
+val memq : ('a : value_or_null). 'a @ local -> 'a list @ local -> bool
 (** Same as {!mem}, but uses physical equality instead of structural
    equality to compare list elements.
  *)
@@ -384,7 +384,7 @@ val filteri : ('a : value_or_null). (int -> 'a -> bool) -> 'a list -> 'a list
    @since 4.11
 *)
 
-val partition : ('a : value_or_null). 
+val partition : ('a : value_or_null).
   ('a -> bool) -> 'a list -> 'a list * 'a list
 (** [partition f l] returns a pair of lists [(l1, l2)], where
    [l1] is the list of all the elements of [l] that
@@ -393,7 +393,7 @@ val partition : ('a : value_or_null).
    The order of the elements in the input list is preserved.
  *)
 
-val partition_map : 
+val partition_map :
   ('a : value_or_null) ('b : value_or_null) ('c : value_or_null)
   . ('a -> ('b, 'c) Either.t) -> 'a list -> 'b list * 'c list
 (** [partition_map f l] returns a pair of lists [(l1, l2)] such that,
@@ -414,7 +414,7 @@ val partition_map :
 (** {1 Association lists} *)
 
 
-val assoc : ('a : value_or_null) ('b : value_or_null). 
+val assoc : ('a : value_or_null) ('b : value_or_null).
   'a -> ('a * 'b) list -> 'b
 (** [assoc a l] returns the value associated with key [a] in the list of
    pairs [l]. That is,
@@ -424,7 +424,7 @@ val assoc : ('a : value_or_null) ('b : value_or_null).
    list [l].
  *)
 
-val assoc_opt : ('a : value_or_null) ('b : value_or_null). 
+val assoc_opt : ('a : value_or_null) ('b : value_or_null).
   'a -> ('a * 'b) list -> 'b option
 (** [assoc_opt a l] returns the value associated with key [a] in the list of
     pairs [l]. That is,
@@ -440,33 +440,33 @@ val assq : ('a : value_or_null) ('b : value_or_null). 'a -> ('a * 'b) list -> 'b
    structural equality to compare keys.
  *)
 
-val assq_opt : ('a : value_or_null) ('b : value_or_null). 
+val assq_opt : ('a : value_or_null) ('b : value_or_null).
   'a -> ('a * 'b) list -> 'b option
 (** Same as {!assoc_opt}, but uses physical equality instead of
    structural equality to compare keys.
    @since 4.05
  *)
 
-val mem_assoc : ('a : value_or_null) ('b : value_or_null). 
+val mem_assoc : ('a : value_or_null) ('b : value_or_null).
   'a -> ('a * 'b) list -> bool
 (** Same as {!assoc}, but simply return [true] if a binding exists,
    and [false] if no bindings exist for the given key.
  *)
 
-val mem_assq : ('a : value_or_null) ('b : value_or_null). 
+val mem_assq : ('a : value_or_null) ('b : value_or_null).
   'a -> ('a * 'b) list -> bool
 (** Same as {!mem_assoc}, but uses physical equality instead of
    structural equality to compare keys.
  *)
 
-val remove_assoc : ('a : value_or_null) ('b : value_or_null). 
+val remove_assoc : ('a : value_or_null) ('b : value_or_null).
   'a -> ('a * 'b) list -> ('a * 'b) list
 (** [remove_assoc a l] returns the list of
    pairs [l] without the first pair with key [a], if any.
    Not tail-recursive.
  *)
 
-val remove_assq : ('a : value_or_null) ('b : value_or_null). 
+val remove_assq : ('a : value_or_null) ('b : value_or_null).
   'a -> ('a * 'b) list -> ('a * 'b) list
 (** Same as {!remove_assoc}, but uses physical equality instead
    of structural equality to compare keys. Not tail-recursive.
@@ -476,14 +476,14 @@ val remove_assq : ('a : value_or_null) ('b : value_or_null).
 (** {1 Lists of pairs} *)
 
 
-val split : ('a : value_or_null) ('b : value_or_null). 
+val split : ('a : value_or_null) ('b : value_or_null).
   ('a * 'b) list -> 'a list * 'b list
 (** Transform a list of pairs into a pair of lists:
    [split [(a1,b1); ...; (an,bn)]] is [([a1; ...; an], [b1; ...; bn])].
    Not tail-recursive.
  *)
 
-val combine : ('a : value_or_null) ('b : value_or_null). 
+val combine : ('a : value_or_null) ('b : value_or_null).
   'a list -> 'b list -> ('a * 'b) list
 (** Transform a pair of lists into a list of pairs:
    [combine [a1; ...; an] [b1; ...; bn]] is
@@ -531,7 +531,7 @@ val sort_uniq : ('a : value_or_null). ('a -> 'a -> int) -> 'a list -> 'a list
     @since 4.02 (4.03 in ListLabels)
  *)
 
-val merge : ('a : value_or_null). 
+val merge : ('a : value_or_null).
   ('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
 (** Merge two lists:
     Assuming that [l1] and [l2] are sorted according to the

--- a/stdlib/listLabels.mli
+++ b/stdlib/listLabels.mli
@@ -136,7 +136,7 @@ val flatten : ('a : value_or_null). 'a list list -> 'a list
 
 (** {1 Comparison} *)
 
-val equal : ('a : value_or_null). 
+val equal : ('a : value_or_null).
   eq:('a -> 'a -> bool) -> 'a list -> 'a list -> bool
 (** [equal eq [a1; ...; an] [b1; ..; bm]] holds when
     the two input lists have the same length, and for each
@@ -151,7 +151,7 @@ val equal : ('a : value_or_null).
     @since 4.12
 *)
 
-val compare : ('a : value_or_null). 
+val compare : ('a : value_or_null).
   cmp:('a -> 'a -> int) -> 'a list -> 'a list -> int
 (** [compare cmp [a1; ...; an] [b1; ...; bm]] performs
     a lexicographic comparison of the two input lists,
@@ -228,13 +228,13 @@ val fold_left_map :
     @since 4.11
 *)
 
-val fold_left : ('acc : value_or_null) ('a : value_or_null). 
+val fold_left : ('acc : value_or_null) ('a : value_or_null).
   f:('acc -> 'a -> 'acc) -> init:'acc -> 'a list -> 'acc
 (** [fold_left ~f ~init [b1; ...; bn]] is
    [f (... (f (f init b1) b2) ...) bn].
  *)
 
-val fold_right : ('a : value_or_null) ('acc : value_or_null). 
+val fold_right : ('a : value_or_null) ('acc : value_or_null).
   f:('a -> 'acc -> 'acc) -> 'a list -> init:'acc -> 'acc
 (** [fold_right ~f [a1; ...; an] ~init] is
    [f a1 (f a2 (... (f an init) ...))]. Not tail-recursive.
@@ -316,12 +316,12 @@ val exists2 : ('a : value_or_null) ('b : value_or_null)
    to have different lengths.
  *)
 
-val mem : ('a : value_or_null). 'a -> set:'a list -> bool
+val mem : ('a : value_or_null). 'a @ local -> set:'a list @ local -> bool
 (** [mem a ~set] is true if and only if [a] is equal
    to an element of [set].
  *)
 
-val memq : ('a : value_or_null). 'a -> set:'a list -> bool
+val memq : ('a : value_or_null). 'a @ local -> set:'a list @ local -> bool
 (** Same as {!mem}, but uses physical equality instead of structural
    equality to compare list elements.
  *)
@@ -386,7 +386,7 @@ val filteri : ('a : value_or_null). f:(int -> 'a -> bool) -> 'a list -> 'a list
    @since 4.11
 *)
 
-val partition : ('a : value_or_null). 
+val partition : ('a : value_or_null).
   f:('a -> bool) -> 'a list -> 'a list * 'a list
 (** [partition ~f l] returns a pair of lists [(l1, l2)], where
    [l1] is the list of all the elements of [l] that
@@ -395,7 +395,7 @@ val partition : ('a : value_or_null).
    The order of the elements in the input list is preserved.
  *)
 
-val partition_map : 
+val partition_map :
   ('a : value_or_null) ('b : value_or_null) ('c : value_or_null)
   . f:('a -> ('b, 'c) Either.t) -> 'a list -> 'b list * 'c list
 (** [partition_map f l] returns a pair of lists [(l1, l2)] such that,
@@ -442,33 +442,33 @@ val assq : ('a : value_or_null) ('b : value_or_null). 'a -> ('a * 'b) list -> 'b
    structural equality to compare keys.
  *)
 
-val assq_opt : ('a : value_or_null) ('b : value_or_null). 
+val assq_opt : ('a : value_or_null) ('b : value_or_null).
   'a -> ('a * 'b) list -> 'b option
 (** Same as {!assoc_opt}, but uses physical equality instead of
    structural equality to compare keys.
    @since 4.05
  *)
 
-val mem_assoc : ('a : value_or_null) ('b : value_or_null). 
+val mem_assoc : ('a : value_or_null) ('b : value_or_null).
   'a -> map:('a * 'b) list -> bool
 (** Same as {!assoc}, but simply return [true] if a binding exists,
    and [false] if no bindings exist for the given key.
  *)
 
-val mem_assq : ('a : value_or_null) ('b : value_or_null). 
+val mem_assq : ('a : value_or_null) ('b : value_or_null).
   'a -> map:('a * 'b) list -> bool
 (** Same as {!mem_assoc}, but uses physical equality instead of
    structural equality to compare keys.
  *)
 
-val remove_assoc : ('a : value_or_null) ('b : value_or_null). 
+val remove_assoc : ('a : value_or_null) ('b : value_or_null).
   'a -> ('a * 'b) list -> ('a * 'b) list
 (** [remove_assoc a l] returns the list of
    pairs [l] without the first pair with key [a], if any.
    Not tail-recursive.
  *)
 
-val remove_assq : ('a : value_or_null) ('b : value_or_null). 
+val remove_assq : ('a : value_or_null) ('b : value_or_null).
   'a -> ('a * 'b) list -> ('a * 'b) list
 (** Same as {!remove_assoc}, but uses physical equality instead
    of structural equality to compare keys. Not tail-recursive.
@@ -485,7 +485,7 @@ val split : ('a : value_or_null) ('b : value_or_null)
    Not tail-recursive.
  *)
 
-val combine : ('a : value_or_null) ('b : value_or_null). 
+val combine : ('a : value_or_null) ('b : value_or_null).
   'a list -> 'b list -> ('a * 'b) list
 (** Transform a pair of lists into a list of pairs:
    [combine [a1; ...; an] [b1; ...; bn]] is
@@ -514,7 +514,7 @@ val sort : ('a : value_or_null). cmp:('a -> 'a -> int) -> 'a list -> 'a list
    heap space and logarithmic stack space.
  *)
 
-val stable_sort : ('a : value_or_null). 
+val stable_sort : ('a : value_or_null).
   cmp:('a -> 'a -> int) -> 'a list -> 'a list
 (** Same as {!sort}, but the sorting algorithm is guaranteed to
    be stable (i.e. elements that compare equal are kept in their
@@ -524,19 +524,19 @@ val stable_sort : ('a : value_or_null).
    heap space and logarithmic stack space.
  *)
 
-val fast_sort : ('a : value_or_null). 
+val fast_sort : ('a : value_or_null).
   cmp:('a -> 'a -> int) -> 'a list -> 'a list
 (** Same as {!sort} or {!stable_sort}, whichever is
     faster on typical input.
  *)
 
-val sort_uniq : ('a : value_or_null). 
+val sort_uniq : ('a : value_or_null).
   cmp:('a -> 'a -> int) -> 'a list -> 'a list
 (** Same as {!sort}, but also remove duplicates.
     @since 4.02 (4.03 in ListLabels)
  *)
 
-val merge : ('a : value_or_null). 
+val merge : ('a : value_or_null).
   cmp:('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
 (** Merge two lists:
     Assuming that [l1] and [l2] are sorted according to the

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -279,7 +279,8 @@ let bool_of_string_opt = function
 let string_of_int n =
   format_int "%d" n
 
-external int_of_string : string -> int @@ portable = "caml_int_of_string"
+external int_of_string :
+  (string[@local_opt]) -> int @@ portable = "caml_int_of_string"
 
 let int_of_string_opt s =
   (* TODO: provide this directly as a non-raising primitive. *)

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -776,7 +776,7 @@ val int_of_string_opt: string -> int option
    @since 4.05
 *)
 
-external int_of_string : string -> int = "caml_int_of_string"
+external int_of_string : (string[@local_opt]) -> int = "caml_int_of_string"
 (** Same as {!Stdlib.int_of_string_opt}, but raise
    [Failure "int_of_string"] instead of returning [None]. *)
 

--- a/testsuite/tests/backtrace/pr2195-locs.byte.reference
+++ b/testsuite/tests/backtrace/pr2195-locs.byte.reference
@@ -1,4 +1,4 @@
 Fatal error: exception Stdlib.Exit
-Raised at Stdlib.open_in_gen in file "stdlib.ml", line 422, characters 28-54
+Raised at Stdlib.open_in_gen in file "stdlib.ml", line 423, characters 28-54
 Called from Pr2195 in file "pr2195.ml", line 24, characters 6-19
 Re-raised at Pr2195 in file "pr2195.ml", line 29, characters 4-41

--- a/testsuite/tests/backtrace/pr2195.opt.reference
+++ b/testsuite/tests/backtrace/pr2195.opt.reference
@@ -1,5 +1,5 @@
 Fatal error: exception Stdlib.Exit
-Raised at Stdlib.open_in_gen in file "stdlib.ml", line 422, characters 28-54
-Called from Stdlib.open_in in file "stdlib.ml", line 427, characters 2-45
+Raised at Stdlib.open_in_gen in file "stdlib.ml", line 423, characters 28-54
+Called from Stdlib.open_in in file "stdlib.ml", line 428, characters 2-45
 Called from Pr2195 in file "pr2195.ml", line 24, characters 6-19
 Re-raised at Pr2195 in file "pr2195.ml", line 29, characters 4-41

--- a/testsuite/tests/lib-fun/test.ml
+++ b/testsuite/tests/lib-fun/test.ml
@@ -31,7 +31,7 @@ let test_protect () =
   let double_raise () =
     let f () = raise Exit in
     try
-      Fun.protect ~finally:f f ()
+      Fun.protect ~finally:f f
     with
     | Exit -> ()
   in


### PR DESCRIPTION
This basically annotates parameters in `Unix` as `local` and/or `read` where possible with minimal changes to the implementation.

Additionally:
- `dir_handle` is annotated as `mutable_data`.
- `inet_addr` is annotated as `immutable_data`.

To make the local annotations possible in `Unix`:
- A bunch of arguments are annotated as local in `Bytes`.
  - A couple of strings need to be copied in the odd case of using an "emulated" implementation of a `Unix` function.
- `Fun.protect` is annotated as taking the closures as `@ local once`.
  -  Also, an extra argument passed to a raising `Fun.protect` is removed from a test case.
- `List.mem` and `List.memq` are annotated as taking their arguments as local.
- `int_of_string` is annotated as taking the string as local.

A few arguments, that could, in principle, be local, are left as global as they internally create arrays to pass to other functions and array elements are implicitly global.  The involved functions could, in principle, use immutable arrays, but that is a bigger change.  Also, operations that take channels are not localized.  There are also some uses of `Unix` functions through non-OxCaml signatures.

Review tip: The `xxxLabels.mli` files are checked to match the corresponding `xxx.mli` files.