### PR TITLE
Fix spill placement with respect to Name_for_debugger

### DIFF
--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -220,11 +220,12 @@ let rewrite_gen :
           | Load_before_cell cell -> DLL.insert_before cell new_instr
           | Store_after_cell cell ->
             (* See comment before Insert_skipping_name_for_debugger *)
-            Insert_skipping_name_for_debugger.insert_after cell new_instr from
+            Insert_skipping_name_for_debugger.insert_after cell new_instr
+              ~reg:from
           | Load_after_list list -> DLL.add_end list new_instr
           | Store_before_list list ->
             (* See comment before Insert_skipping_name_for_debugger *)
-            Insert_skipping_name_for_debugger.add_begin list new_instr from);
+            Insert_skipping_name_for_debugger.add_begin list new_instr ~reg:from);
         temp)
       else reg
     in

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -252,14 +252,14 @@ let insert_spills_in_block :
       || occurs_array (Proc.destroyed_at_basic instr.desc) reg)
     ~insert:(fun cell instr reg ->
       (* See comment before Insert_skipping_name_for_debugger *)
-      Insert_skipping_name_for_debugger.insert_after cell instr reg)
+      Insert_skipping_name_for_debugger.insert_after cell instr ~reg)
     ~copy_default:
       (match DLL.hd block.body with
       | None -> dummy_instr_of_terminator block.terminator
       | Some hd -> hd)
     ~add_default:(fun list instr reg ->
       (* See comment before Insert_skipping_name_for_debugger *)
-      Insert_skipping_name_for_debugger.add_begin list instr reg)
+      Insert_skipping_name_for_debugger.add_begin list instr ~reg)
     ~move_cell:DLL.prev ~block_subst ~stack_subst block cell
     live_at_destruction_point
 
@@ -329,7 +329,7 @@ let insert_reloads_in_block :
       (* We don't need special handling here, because we wouldn't expect a new
          Name_for_debugger operation anyway (that should have occurred when the
          variable was first introduced, i.e. before the first spill); and
-         furthermore, we prefer the spilled registers (c.f.
+         furthermore, we prefer the spilled registers (cf.
          Reg_availability_set.canonicalise), so it's probably not necessary to
          add a Name_for_debugger on the reloaded one. *)
       DLL.insert_before cell instr)

--- a/backend/regalloc/regalloc_utils.mli
+++ b/backend/regalloc/regalloc_utils.mli
@@ -99,14 +99,14 @@ module Move : sig
   val to_string : t -> string
 end
 
+module DLL = Oxcaml_utils.Doubly_linked_list
+
 module Insert_skipping_name_for_debugger : sig
   val insert_after :
-    Instruction.t Oxcaml_utils.Doubly_linked_list.cell ->
-    Instruction.t ->
-    Reg.t ->
-    unit
+    Instruction.t DLL.cell -> Instruction.t -> reg:Reg.t -> unit
 
-  val add_begin : Cfg.basic_instruction_list -> Instruction.t -> Reg.t -> unit
+  val add_begin :
+    Cfg.basic_instruction_list -> Instruction.t -> reg:Reg.t -> unit
 end
 
 val same_reg_class : Reg.t -> Reg.t -> bool


### PR DESCRIPTION
## Summary

This PR fixes the placement of spill instructions with respect to `Name_for_debugger` pseudo-instructions to ensure that spilled registers correctly inherit debug names.

## Problem

When the register allocator inserts a spill instruction like `spill-t/4567[s:0] <- t/1234`, if there are `Name_for_debugger` instructions immediately following that name register `t/1234`, the spill instruction must be inserted **after** those `Name_for_debugger` instructions. Otherwise, the spilled register `spill-t/4567` will not receive the debug name, resulting in missing or incorrect debug information.

## Solution

Added a new `Insert_skipping_name_for_debugger` module in `regalloc_utils.ml` that provides helper functions to insert spill instructions while skipping over relevant `Name_for_debugger` instructions:

1. **`insert_after`**: Inserts a spill after a cell, skipping over any `Name_for_debugger` instructions that name the register being spilled
2. **`add_begin`**: Adds a spill at the beginning of a block, skipping over relevant `Name_for_debugger` instructions

**Key design decisions:**
- Register matching uses `Reg.same_loc` rather than stamp comparison, since the register allocator can change stamps while preserving physical locations
- Only `Name_for_debugger` instructions that name the **same location** as the register being spilled are skipped
- Reloads do not need special handling because:
  - `Name_for_debugger` operations should have occurred when the variable was first introduced (before the first spill)
  - We prefer spilled registers in the availability analysis (see `Reg_availability_set.canonicalise`)

## Changes

- **`regalloc_utils.ml/mli`**: Added `Insert_skipping_name_for_debugger` module with comprehensive documentation
- **`regalloc_rewrite.ml`**: Updated `Store_after_cell` and `Store_before_list` cases to use the new helpers
- **`regalloc_split.ml`**: 
  - Modified `insert_spills_or_reloads_in_block` signature to pass the register to insertion callbacks
  - Updated `insert_spills_in_block` to use the new helpers for spill insertion
  - Updated `insert_reloads_in_block` with explanation of why reloads don't need special handling
  - Removed stale CR comment about needing special handling for `Iname_for_debugger`

**Files changed:** 4 files (regalloc_rewrite.ml, regalloc_split.ml, regalloc_utils.ml, regalloc_utils.mli)