### PR TITLE
Switch Classic mode's fallback inlining heuristic to off by default

### DIFF
--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -278,7 +278,6 @@ module Flambda2 = struct
 
     let oclassic = {
       default with
-      fallback_inlining_heuristic = true;
       shorten_symbol_names = true;
     }
 


### PR DESCRIPTION
As title. The "fallback inlining heuristic", meant to let classic mode emulate Closure more closely, appears to cause unexpected results in practice.

No performance monitoring has been done: without attributes it shouldn't matter much, as classic mode doesn't perform that much inlining anyway, but in presence of `[@inline always]` attributes classic mode will be able to respect them in more cases, which could result in more generated code and longer compilation times.