### PR TITLE
Add quotation-related nodes to parse tree

### DIFF
--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -552,6 +552,8 @@ module E = struct
     | Pexp_stack e -> sub.expr sub e
     | Pexp_comprehension e -> iter_comp_exp sub e
     | Pexp_overwrite (e1, e2) -> sub.expr sub e1; sub.expr sub e2
+    | Pexp_quotation e -> sub.expr sub e
+    | Pexp_splice e -> sub.expr sub e
     | Pexp_hole -> ()
 
   let iter_binding_op sub {pbop_op; pbop_pat; pbop_exp; pbop_loc} =

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -629,6 +629,8 @@ module E = struct
     | Pexp_stack e -> stack ~loc ~attrs (sub.expr sub e)
     | Pexp_comprehension c -> comprehension ~loc ~attrs (map_cexp sub c)
     | Pexp_overwrite (e1, e2) -> overwrite ~loc ~attrs (sub.expr sub e1) (sub.expr sub e2)
+    | Pexp_quotation _ -> failwith "Convert to Texp_quote"
+    | Pexp_splice _ -> failwith "Convert to Texp_splice"
     | Pexp_hole -> hole ~loc ~attrs ()
 
   let map_binding_op sub {pbop_op; pbop_pat; pbop_exp; pbop_loc} =

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -323,6 +323,8 @@ let rec add_expr bv exp =
   | Pexp_overwrite (e1, e2) -> add_expr bv e1; add_expr bv e2
   | Pexp_hole -> ()
   | Pexp_unreachable -> ()
+  | Pexp_quotation e -> add_expr bv e
+  | Pexp_splice e -> add_expr bv e
   | Pexp_comprehension x -> add_comprehension_expr bv x
 
 and add_comprehension_expr bv = function

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -527,6 +527,8 @@ and expression_desc =
           - [CLAUSES] is a series of [comprehension_clause].
     *)
   | Pexp_overwrite of expression * expression (** overwrite_ exp with exp *)
+  | Pexp_quotation of expression (** runtime metaprogramming quotations <[E]> *)
+  | Pexp_splice of expression (** runtime metaprogramming: quotations $(E) *)
   | Pexp_hole (** _ *)
 
 and case =

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -472,6 +472,12 @@ and expression i ppf x =
       line i ppf "Pexp_overwrite\n";
       expression i ppf e1;
       expression i ppf e2;
+  | Pexp_quotation e ->
+      line i ppf "Pexp_quotation\n";
+      expression i ppf e
+  | Pexp_splice e ->
+      line i ppf "Pexp_splice\n";
+      expression i ppf e
   | Pexp_hole ->
     line i ppf "Pexp_hole"
 

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -497,6 +497,12 @@ and expression i ppf x =
       line i ppf "Pexp_overwrite\n";
       expression i ppf e1;
       expression i ppf e2
+  | Pexp_quotation e ->
+      line i ppf "Pexp_quotation\n";
+      expression i ppf e
+  | Pexp_splice e ->
+      line i ppf "Pexp_splice\n";
+      expression i ppf e
   | Pexp_hole ->
       line i ppf "Pexp_hole"
   )

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -294,6 +294,7 @@ type error =
   | Impossible_function_jkind of
       { some_args_ok : bool; ty_fun : type_expr; jkind : jkind_lr }
   | Overwrite_of_invalid_term
+  | Unsupported_construct_metaprogramming
   | Unexpected_hole
 
 exception Error of Location.t * Env.t * error
@@ -7356,6 +7357,10 @@ and type_expect_
             exp_type = exp2.exp_type;
             exp_attributes = sexp.pexp_attributes;
             exp_env = env }
+  | Pexp_quotation _ ->
+      raise (Error (loc, env, Unsupported_construct_metaprogramming))
+  | Pexp_splice _ ->
+      raise (Error (loc, env, Unsupported_construct_metaprogramming))
   | Pexp_hole ->
       begin match overwrite with
       | Assigning(typ, fields_mode) ->
@@ -11727,6 +11732,9 @@ let report_error ~loc env =
   | Overwrite_of_invalid_term ->
       Location.errorf ~loc
         "Overwriting is only supported on tuples, constructors and boxed records."
+  | Unsupported_construct_metaprogramming ->
+      Location.errorf ~loc
+        "Runtime metaprogramming is not fully supported."
   | Unexpected_hole ->
       Location.errorf ~loc
         "wildcard \"_\" not expected."

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -340,6 +340,7 @@ type error =
   | Impossible_function_jkind of
       { some_args_ok : bool; ty_fun : type_expr; jkind : jkind_lr }
   | Overwrite_of_invalid_term
+  | Unsupported_construct_metaprogramming
   | Unexpected_hole
 
 exception Error of Location.t * Env.t * error


### PR DESCRIPTION
The parse tree is updated with `Pexp_quotation` and `Pexp_splice` constructors.

These cannot be presently created and they do not get converted to their corresponding typed tree representations.