### PR TITLE
Add -gdwarf-may-alter-codegen-experimental

### DIFF
--- a/backend/cfg/cfg_available_regs.ml
+++ b/backend/cfg/cfg_available_regs.ml
@@ -13,10 +13,9 @@ module V = Backend_var
    to be seen in the debugger, for example when the last use of some variable is
    just before a call, and the debugger is standing in the callee. It may
    however affect the semantics of e.g. finalizers. *)
-let extend_live () = false
-(* CR sspies: This used to be set by [-gdwarf-may-alter-codegen]. But the
-   computation is currently broken, so we've disabled the flag. Fix the
-   compuation and re-enable the flag. *)
+(* CR mshinwell: We've seen a bug when enabling this, so it should be assumed
+   codegen is broken when enabled. *)
+let extend_live () = !Dwarf_flags.gdwarf_may_alter_codegen_experimental
 
 (* CR xclerc for xclerc: consider passing this value through the context. *)
 let all_regs_that_might_be_named = ref Reg.Set.empty

--- a/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
+++ b/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
@@ -175,6 +175,8 @@ let gdwarf_self_tail_calls = ref default_gdwarf_self_tail_calls
 
 let gdwarf_may_alter_codegen = ref false
 
+let gdwarf_may_alter_codegen_experimental = ref false
+
 let dwarf_inlined_frames = ref false
 
 let default_gdwarf_compression = "zlib"

--- a/backend/debug/dwarf/dwarf_flags/dwarf_flags.mli
+++ b/backend/debug/dwarf/dwarf_flags/dwarf_flags.mli
@@ -73,6 +73,8 @@ val ddwarf_types : bool ref
 
 val gdwarf_may_alter_codegen : bool ref
 
+val gdwarf_may_alter_codegen_experimental : bool ref
+
 (** Setting this to [true] will emit sufficient DWARF to get inlined frame
     information, but won't emit information e.g. about local variables (unless
     [restrict_to_upstream_dwarf] is set to [false], although that implies

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -894,7 +894,20 @@ let mk_gdwarf_may_alter_codegen f =
 let mk_no_gdwarf_may_alter_codegen f =
   ( "-gno-dwarf-may-alter-codegen",
     Arg.Unit f,
-    " Do not alter code\n     generation when emitting debugging information" )
+    " Do not alter code generation when emitting debugging information" )
+
+let mk_gdwarf_may_alter_codegen_experimental f =
+  ( "-gdwarf-may-alter-codegen-experimental",
+    Arg.Unit f,
+    " Like -gdwarf-may-alter-codegen but with more experimental features.\n\
+    \     Implies -gdwarf-may-alter-codegen.\n\
+    \     THIS MAY GENERATE BROKEN CODE." )
+
+let mk_no_gdwarf_may_alter_codegen_experimental f =
+  ( "-gno-dwarf-may-alter-codegen-experimental",
+    Arg.Unit f,
+    " Disable experimental changes to code generation when emitting\n\
+    \     debugging information." )
 
 let mk_gdwarf_max_function_complexity f =
   ( "-gdwarf-max-function-complexity",
@@ -1590,6 +1603,8 @@ module type Debugging_options = sig
   val no_dwarf_for_startup_file : unit -> unit
   val gdwarf_may_alter_codegen : unit -> unit
   val no_gdwarf_may_alter_codegen : unit -> unit
+  val gdwarf_may_alter_codegen_experimental : unit -> unit
+  val no_gdwarf_may_alter_codegen_experimental : unit -> unit
   val gdwarf_max_function_complexity : int -> unit
   val gdwarf_compression : string -> unit
   val gdwarf_fission : string -> unit
@@ -1607,6 +1622,10 @@ module Make_debugging_options (F : Debugging_options) = struct
       mk_no_dwarf_for_startup_file F.no_dwarf_for_startup_file;
       mk_gdwarf_may_alter_codegen F.gdwarf_may_alter_codegen;
       mk_no_gdwarf_may_alter_codegen F.no_gdwarf_may_alter_codegen;
+      mk_gdwarf_may_alter_codegen_experimental
+        F.gdwarf_may_alter_codegen_experimental;
+      mk_no_gdwarf_may_alter_codegen_experimental
+        F.no_gdwarf_may_alter_codegen_experimental;
       mk_gdwarf_max_function_complexity F.gdwarf_max_function_complexity;
       mk_gdwarf_compression F.gdwarf_compression;
       mk_gdwarf_fission F.gdwarf_fission;
@@ -1634,7 +1653,15 @@ module Debugging_options_impl = struct
   let gdwarf_may_alter_codegen () = Debugging.gdwarf_may_alter_codegen := true
 
   let no_gdwarf_may_alter_codegen () =
-    Debugging.gdwarf_may_alter_codegen := false
+    Debugging.gdwarf_may_alter_codegen := false;
+    Debugging.gdwarf_may_alter_codegen_experimental := false
+
+  let gdwarf_may_alter_codegen_experimental () =
+    Debugging.gdwarf_may_alter_codegen := true;
+    Debugging.gdwarf_may_alter_codegen_experimental := true
+
+  let no_gdwarf_may_alter_codegen_experimental () =
+    Debugging.gdwarf_may_alter_codegen_experimental := false
 
   let gdwarf_max_function_complexity c =
     Debugging.dwarf_max_function_complexity := c
@@ -1813,6 +1840,8 @@ module Extra_params = struct
     | "dasm-comments" -> set' Oxcaml_flags.dasm_comments
     | "gupstream-dwarf" -> set' Debugging.restrict_to_upstream_dwarf
     | "gdwarf-may-alter-codegen" -> set' Debugging.gdwarf_may_alter_codegen
+    | "gdwarf-may-alter-codegen-experimental" ->
+        set' Debugging.gdwarf_may_alter_codegen_experimental
     | "gstartup" -> set' Debugging.dwarf_for_startup_file
     | "gdwarf-pedantic" -> set' Clflags.dwarf_pedantic
     | "gdwarf-max-function-complexity" ->

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -161,6 +161,8 @@ module type Debugging_options = sig
   val no_dwarf_for_startup_file : unit -> unit
   val gdwarf_may_alter_codegen : unit -> unit
   val no_gdwarf_may_alter_codegen : unit -> unit
+  val gdwarf_may_alter_codegen_experimental : unit -> unit
+  val no_gdwarf_may_alter_codegen_experimental : unit -> unit
   val gdwarf_max_function_complexity : int -> unit
   val gdwarf_compression : string -> unit
   val gdwarf_fission : string -> unit


### PR DESCRIPTION
This adds an option like `-gdwarf-may-alter-codegen`, but for experimental changes which might break code generation.  The live range extension during `Cfg_available_regs` is now enabled when this flag is passed, so we can start debugging it.