### PR TITLE
Restrict substitution of Alias bindings for DWARF

### DIFF
--- a/bytecomp/bytepackager.ml
+++ b/bytecomp/bytepackager.ml
@@ -222,7 +222,7 @@ let build_global_target ~ppf_dump oc ~packed_compilation_unit state members
   in
   if !Clflags.dump_rawlambda then
     Format.fprintf ppf_dump "%a@." Printlambda.lambda lam;
-  let lam = Simplif.simplify_lambda lam in
+  let lam = Simplif.simplify_lambda_for_bytecode lam in
   if !Clflags.dump_lambda then
     Format.fprintf ppf_dump "%a@." Printlambda.lambda lam;
   let blam =

--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -49,7 +49,7 @@ let raw_lambda_to_bytecode i raw_lambda ~as_arg_for =
        |> print_if i.ppf_dump Clflags.dump_debug_uid_tables
           (fun ppf _ -> Type_shape.print_debug_uid_tables ppf)
        |> print_if i.ppf_dump Clflags.dump_rawlambda Printlambda.lambda
-       |> Simplif.simplify_lambda
+       |> Simplif.simplify_lambda_for_bytecode
        |> print_if i.ppf_dump Clflags.dump_lambda Printlambda.lambda
        |> Blambda_of_lambda.blambda_of_lambda
             ~compilation_unit:(Some i.module_name)

--- a/driver/jscompile.ml
+++ b/driver/jscompile.ml
@@ -44,7 +44,8 @@ let raw_lambda_to_jsir i raw_lambda ~as_arg_for =
          Builtin_attributes.warn_unused ();
          program.code
          |> print_if i.ppf_dump Clflags.dump_rawlambda Printlambda.lambda
-         |> Simplif.simplify_lambda
+         |> Simplif.simplify_lambda ~restrict_to_upstream_dwarf:true
+              ~gdwarf_may_alter_codegen:false
          |> print_if i.ppf_dump Clflags.dump_lambda Printlambda.lambda
          |> fun lambda ->
          let arg_descr =

--- a/lambda/simplif.mli
+++ b/lambda/simplif.mli
@@ -27,7 +27,13 @@
 
 open Lambda
 
-val simplify_lambda: lambda -> lambda
+val simplify_lambda
+   : lambda
+  -> restrict_to_upstream_dwarf:bool
+  -> gdwarf_may_alter_codegen:bool
+  -> lambda
+
+val simplify_lambda_for_bytecode : lambda -> lambda
 
 val split_default_wrapper
    : id:Ident.t

--- a/optcomp/optcompile.ml
+++ b/optcomp/optcompile.ml
@@ -92,7 +92,12 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
     |> Compiler_hooks.execute_and_pipe Compiler_hooks.Raw_lambda
     |> Profile.(record generate) (fun (program : Lambda.program) ->
            Builtin_attributes.warn_unused ();
-           let code = Simplif.simplify_lambda program.Lambda.code in
+           let code =
+             Simplif.simplify_lambda program.Lambda.code
+               ~restrict_to_upstream_dwarf:
+                 !Dwarf_flags.restrict_to_upstream_dwarf
+               ~gdwarf_may_alter_codegen:!Dwarf_flags.gdwarf_may_alter_codegen
+           in
            { program with Lambda.code }
            |> print_if i.ppf_dump Clflags.dump_lambda Printlambda.program
            |> Compiler_hooks.execute_and_pipe Compiler_hooks.Lambda

--- a/optcomp/optpackager.ml
+++ b/optcomp/optpackager.ml
@@ -124,7 +124,11 @@ end) : S = struct
         let main_module_block_size, code =
           Translmod.transl_package components coercion
         in
-        let code = Simplif.simplify_lambda code in
+        let code =
+          Simplif.simplify_lambda code
+            ~restrict_to_upstream_dwarf:!Dwarf_flags.restrict_to_upstream_dwarf
+            ~gdwarf_may_alter_codegen:!Dwarf_flags.gdwarf_may_alter_codegen
+        in
         let main_module_block_format : Lambda.main_module_block_format =
           Mb_struct { mb_size = main_module_block_size }
         in

--- a/toplevel/byte/topeval.ml
+++ b/toplevel/byte/topeval.ml
@@ -69,7 +69,7 @@ let may_trace = ref false (* Global lock on tracing *)
 let load_lambda ppf lam =
   if !Clflags.dump_debug_uid_tables then Type_shape.print_debug_uid_tables ppf;
   if !Clflags.dump_rawlambda then fprintf ppf "%a@." Printlambda.lambda lam;
-  let slam = Simplif.simplify_lambda lam in
+  let slam = Simplif.simplify_lambda_for_bytecode lam in
   if !Clflags.dump_lambda then fprintf ppf "%a@." Printlambda.lambda slam;
   let blam = Blambda_of_lambda.blambda_of_lambda ~compilation_unit:None slam in
   if !Clflags.dump_blambda then fprintf ppf "%a@." Printblambda.blambda blam;

--- a/toplevel/native/opttoploop.ml
+++ b/toplevel/native/opttoploop.ml
@@ -287,7 +287,12 @@ let default_load ppf (program : Lambda.program) =
 let load_lambda ppf ~compilation_unit ~required_globals lam size =
   if !Clflags.dump_debug_uid_tables then Type_shape.print_debug_uid_tables ppf;
   if !Clflags.dump_rawlambda then fprintf ppf "%a@." Printlambda.lambda lam;
-  let slam = Simplif.simplify_lambda lam in
+  let slam =
+    Simplif.simplify_lambda lam
+      ~restrict_to_upstream_dwarf:
+        !Dwarf_flags.restrict_to_upstream_dwarf
+      ~gdwarf_may_alter_codegen:!Dwarf_flags.gdwarf_may_alter_codegen
+  in
   if !Clflags.dump_lambda then fprintf ppf "%a@." Printlambda.lambda slam;
   let program =
     { Lambda.

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -96,7 +96,12 @@ let may_trace = ref false (* Global lock on tracing *)
 let load_lambda ppf ~compilation_unit ~required_globals phrase_name lam size =
   if !Clflags.dump_debug_uid_tables then Type_shape.print_debug_uid_tables ppf;
   if !Clflags.dump_rawlambda then fprintf ppf "%a@." Printlambda.lambda lam;
-  let slam = Simplif.simplify_lambda lam in
+  let slam =
+    Simplif.simplify_lambda lam
+      ~restrict_to_upstream_dwarf:
+        !Dwarf_flags.restrict_to_upstream_dwarf
+      ~gdwarf_may_alter_codegen:!Dwarf_flags.gdwarf_may_alter_codegen
+  in
   if !Clflags.dump_lambda then fprintf ppf "%a@." Printlambda.lambda slam;
 
   let program =


### PR DESCRIPTION
We should do an experiment to see if it's worth having `Alias` in `Lambda` any more.  Its utility seems dubious given that complex expressions originally bound in this way and substituted by `Simplif` (because they were only used once) will be let-bound again on the way into Flambda 2 anyway (except losing the user's variable names if there were any).  The question is really whether the resulting placement of such expressions would be in any way problematic, if we just leave it to Flambda 2 and remove `Alias`.

`Alias` is also inherently risky as it doesn't do any checks as to whether substitutions done by `Simplif` on such bindings are correct.  It also conceals compiler bugs: this PR is careful not to allow variable-to-variable `Alias` bindings to be substituted, until such time as we find and fix a bug (presumably in `Matching`) that is giving the wrong layouts on such bindings (and will cause Flambda 2 to issue a fatal error).

In the meantime, when generating full DWARF and allowing codegen to change, we'd like to turn this substitution off.  This will allow more variables to become visible in the debugger.  (I think in general this is a better approach than complicating Lambda with phantom lets.)