### PR TITLE
The resource argument passed to `Multicore.spawn` must be `contended`

### DIFF
--- a/otherlibs/systhreads/multicore.ml
+++ b/otherlibs/systhreads/multicore.ml
@@ -98,12 +98,12 @@ end
 
 type 'a spawn_result =
   | Spawned
-  | Failed of 'a * exn @@ aliased * Printexc.raw_backtrace @@ aliased
+  | Failed of 'a * exn @@ aliased many * Printexc.raw_backtrace @@ aliased many
 
 type 'a request_inner : value mod contended portable  =
-  { action : 'a @ unique portable -> unit @@ portable
-  ; argument : 'a @@ portable
-  ; mutable result : 'a spawn_result @@ portable
+  { action : 'a @ contended once portable unique -> unit @@ portable
+  ; argument : 'a @@ contended portable
+  ; mutable result : 'a spawn_result @@ contended portable
   ; mutable ready : bool
   ; mutex : Mutex.t
   ; condition : Condition.t
@@ -209,8 +209,8 @@ let () =
   done
 ;;
 
-external magic_unique__portable
-  : 'a @ portable -> 'a @ portable unique @@ portable
+external magic_unique__contended_portable
+  : 'a @ contended portable -> 'a @ contended portable unique @@ portable
   = "%identity"
 
 (** Run some function on a new thread. *)
@@ -225,7 +225,7 @@ let thread (Request { action; argument; _ })=
       wakeup_manager t
   in
   (* SAFETY: We know each value is only popped from the request stack once *)
-  match action (magic_unique__portable argument) with
+  match action (magic_unique__contended_portable argument) with
   | () -> decr ()
   | exception exn ->
     let bt = Printexc.get_raw_backtrace () in
@@ -292,20 +292,18 @@ let spawn_on ~domain:i f a =
   if i < 0 || max_domains () <= i
   then invalid_arg "Multicore.spawn_on: invalid domain index";
   create_initial_manager ();
-  let f =
-    let open struct
-      (* CR-someday vkarvonen: Perhaps at some point we might have a nice way
-         to pass a function through a data structure such that it is statically
-         known to be used only once without having to use a mutable box to do
-         so. *)
-      external magic_many
-        :  'a @ once portable
-        -> 'a @ many portable
-        @@ portable
-        = "%identity"
-    end in
-    magic_many f
-  in
+  let open struct
+    (* CR-someday vkarvonen: Perhaps at some point we might have a nice way to
+       pass a function through a data structure such that it is statically known
+       to be used only once without having to use a mutable box to do so. *)
+    external magic_many__contended_portable
+      :  'a @ contended once portable
+      -> 'a @ contended many portable
+      @@ portable
+      = "%identity"
+  end in
+  let f = magic_many__contended_portable f in
+  let a = magic_many__contended_portable a in
   let t = get i in
   let threads_before_incr = Atomic.fetch_and_add t.threads 1 in
   let mutex = Mutex.create () in
@@ -342,7 +340,7 @@ let spawn_on ~domain:i f a =
   Mutex.unlock mutex;
   (* SAFETY: We know that if we got an error here, the thread failed to spawn
      and hence no longer has a reference to [a] *)
-  magic_unique__portable request_inner.result
+  magic_unique__contended_portable request_inner.result
 ;;
 
 let spawn f =

--- a/otherlibs/systhreads/multicore.mli
+++ b/otherlibs/systhreads/multicore.mli
@@ -32,7 +32,7 @@ val current_domain : unit -> int
 
 type 'a spawn_result =
   | Spawned
-  | Failed of 'a * exn @@ aliased * Printexc.raw_backtrace @@ aliased
+  | Failed of 'a * exn @@ aliased many * Printexc.raw_backtrace @@ aliased many
 
 (** [spawn_on ~domain action] spawns [action] as a thread running on the
     specified [domain].
@@ -48,9 +48,9 @@ type 'a spawn_result =
     @raise Sys_error in case the system fails to create a new thread. *)
 val spawn_on
   :   domain:int
-  -> ('a @ unique portable -> unit) @ once portable unyielding
-  -> 'a @ unique portable
-  -> 'a spawn_result @ unique portable
+  -> ('a @ contended once portable unique -> unit) @ once portable unyielding
+  -> 'a @ contended once portable unique
+  -> 'a spawn_result @ contended once portable unique
 
 (** [spawn action] spawns [action] as a thread running on some domain.
 
@@ -63,6 +63,6 @@ val spawn_on
 
     @raise Sys_error in case the system fails to create a new thread. *)
 val spawn
-  :  ('a @ unique portable -> unit) @ once portable unyielding
-  -> 'a @ unique portable
-  -> 'a spawn_result @ unique portable
+  :  ('a @ contended once portable unique -> unit) @ once portable unyielding
+  -> 'a @ contended once portable unique
+  -> 'a spawn_result @ contended once portable unique

--- a/otherlibs/systhreads4/multicore.ml
+++ b/otherlibs/systhreads4/multicore.ml
@@ -98,12 +98,12 @@ end
 
 type 'a spawn_result =
   | Spawned
-  | Failed of 'a * exn @@ aliased * Printexc.raw_backtrace @@ aliased
+  | Failed of 'a * exn @@ aliased many * Printexc.raw_backtrace @@ aliased many
 
 type 'a request_inner : value mod contended portable  =
-  { action : 'a @ unique portable -> unit @@ portable
-  ; argument : 'a @@ portable
-  ; mutable result : 'a spawn_result @@ portable
+  { action : 'a @ contended once portable unique -> unit @@ portable
+  ; argument : 'a @@ contended portable
+  ; mutable result : 'a spawn_result @@ contended portable
   ; mutable ready : bool
   ; mutex : Mutex.t
   ; condition : Condition.t
@@ -208,8 +208,8 @@ let () =
   done
 ;;
 
-external magic_unique__portable
-  : 'a @ portable -> 'a @ portable unique @@ portable
+external magic_unique__contended_portable
+  : 'a @ contended portable -> 'a @ contended portable unique @@ portable
   = "%identity"
 
 (** Run some function on a new thread. *)
@@ -224,7 +224,7 @@ let thread (Request { action; argument; _ })=
       wakeup_manager t
   in
   (* SAFETY: We know each value is only popped from the request stack once *)
-  match action (magic_unique__portable argument) with
+  match action (magic_unique__contended_portable argument) with
   | () -> decr ()
   | exception exn ->
     let bt = Printexc.get_raw_backtrace () in
@@ -291,20 +291,18 @@ let spawn_on ~domain:i f a =
   if i < 0 || max_domains () <= i
   then invalid_arg "Multicore.spawn_on: invalid domain index";
   create_initial_manager ();
-  let f =
-    let open struct
-      (* CR-someday vkarvonen: Perhaps at some point we might have a nice way
-         to pass a function through a data structure such that it is statically
-         known to be used only once without having to use a mutable box to do
-         so. *)
-      external magic_many
-        :  'a @ once portable
-        -> 'a @ many portable
-        @@ portable
-        = "%identity"
-    end in
-    magic_many f
-  in
+  let open struct
+    (* CR-someday vkarvonen: Perhaps at some point we might have a nice way to
+       pass a function through a data structure such that it is statically known
+       to be used only once without having to use a mutable box to do so. *)
+    external magic_many__contended_portable
+      :  'a @ contended once portable
+      -> 'a @ contended many portable
+      @@ portable
+      = "%identity"
+  end in
+  let f = magic_many__contended_portable f in
+  let a = magic_many__contended_portable a in
   let t = get i in
   let threads_before_incr = Atomic.fetch_and_add t.threads 1 in
   let mutex = Mutex.create () in
@@ -341,7 +339,7 @@ let spawn_on ~domain:i f a =
   Mutex.unlock mutex;
   (* SAFETY: We know that if we got an error here, the thread failed to spawn
      and hence no longer has a reference to [a] *)
-  magic_unique__portable request_inner.result
+  magic_unique__contended_portable request_inner.result
 ;;
 
 let spawn f =

--- a/otherlibs/systhreads4/multicore.mli
+++ b/otherlibs/systhreads4/multicore.mli
@@ -32,7 +32,7 @@ val current_domain : unit -> int
 
 type 'a spawn_result =
   | Spawned
-  | Failed of 'a * exn @@ aliased * Printexc.raw_backtrace @@ aliased
+  | Failed of 'a * exn @@ aliased many * Printexc.raw_backtrace @@ aliased many
 
 (** [spawn_on ~domain action] spawns [action] as a thread running on the
     specified [domain].
@@ -48,9 +48,9 @@ type 'a spawn_result =
     @raise Sys_error in case the system fails to create a new thread. *)
 val spawn_on
   :   domain:int
-  -> ('a @ unique portable -> unit) @ once portable unyielding
-  -> 'a @ unique portable
-  -> 'a spawn_result @ unique portable
+  -> ('a @ contended once portable unique -> unit) @ once portable unyielding
+  -> 'a @ contended once portable unique
+  -> 'a spawn_result @ contended once portable unique
 
 (** [spawn action] spawns [action] as a thread running on some domain.
 
@@ -63,6 +63,6 @@ val spawn_on
 
     @raise Sys_error in case the system fails to create a new thread. *)
 val spawn
-  :  ('a @ unique portable -> unit) @ once portable unyielding
-  -> 'a @ unique portable
-  -> 'a spawn_result @ unique portable
+  :  ('a @ contended once portable unique -> unit) @ once portable unyielding
+  -> 'a @ contended once portable unique
+  -> 'a spawn_result @ contended once portable unique


### PR DESCRIPTION
This fixes a soundness issue in the API.

The resource argument is also annoted as `once` to give more flexibility for users.