### PR TITLE
Fix loading paths from paths file

### DIFF
--- a/utils/load_path.ml
+++ b/utils/load_path.ml
@@ -80,8 +80,8 @@ end = struct
       |> List.map (fun basename -> { basename; path = Filename.concat path basename }) in
     { path; files; hidden }
 
-  let read_path_list_file' path =
-    let ic = open_in path in
+  let read_path_list_file' path_list_file_path =
+    let ic = open_in path_list_file_path in
     Misc.try_finally
       (fun () ->
         let rec loop acc =
@@ -94,12 +94,12 @@ end = struct
         loop [])
       ~always:(fun () -> close_in ic)
 
-  let read_path_list_file path =
-    let files = read_path_list_file' path in
+  let read_path_list_file path_list_file_path =
+    let files = read_path_list_file' path_list_file_path in
     List.map (fun { basename; path } ->
       let path = if Filename.is_relative path then
         (* Paths are relative to parent directory of path list file *)
-        Filename.concat (Filename.dirname path) path
+        Filename.concat (Filename.dirname path_list_file_path) path
       else
         path
       in


### PR DESCRIPTION
Fix `read_path_list_file` in `load_path.ml` to take `Filename.dirname` from the correct path. There was a bug caused by variable `path` hiding another variable with the same name. This feature renames outer variable so that it's not shadowed anymore.

This code path is not executed anywhere in production (and this is why this bug was not noticed). We tried to start using it, but sadly found this bug.

Tested manually that compiler is now able to figure out paths correctly. Before this change if you had file manifest.txt containing:
```
foo.cmi lib/foo/foo.cmi
```
And you pass `-I-paths ../../manifest.txt`, compiler will interpret it (due to the bug) as `foo.cmi` is accessible at `lib/foo/lib/foo/foo.cmi`. After this change it correctly interprets it as accessible at `../../lib/foo/foo.cmi`.