### PR TITLE
Name_for_debugger: improved register handling

### DIFF
--- a/backend/cfg/cfg_available_regs.ml
+++ b/backend/cfg/cfg_available_regs.ml
@@ -252,7 +252,17 @@ module Transfer = struct
              advance.) *)
           for part_of_value = 0 to num_parts_of_value - 1 do
             let reg = regs.(part_of_value) in
-            if RD_quotient_set.mem_reg_by_loc avail_before reg
+            (* Registers that still have unknown locations should not be used in
+               the Cfg at this point (they would cause fatal errors in the
+               emitter). As such we ignore them explicitly here
+               ([mem_reg_by_loc] would cause a fatal error otherwise).
+
+               Registers in [Name_for_debugger] operations that are still in
+               use, but which have been substituted since the original
+               construction of such operations, should have been renamed by
+               [Regalloc_substitution.apply_basic_instruction_in_place]. *)
+            if (not (Reg.is_unknown reg))
+               && RD_quotient_set.mem_reg_by_loc avail_before reg
             then
               let regd =
                 RD.create ~reg ~holds_value_of:ident ~part_of_value

--- a/backend/regalloc/regalloc_substitution.ml
+++ b/backend/regalloc/regalloc_substitution.ml
@@ -29,16 +29,27 @@ let apply_array : t -> Reg.t array -> Reg.t array =
 let apply_set : t -> Reg.Set.t -> Reg.Set.t =
  fun subst set -> Reg.Set.map (fun reg -> apply_reg subst reg) set
 
-(* CR mshinwell: Apply substitution to [Iname_for_debugger] registers. *)
-let apply_instruction_in_place : t -> _ Cfg.instruction -> unit =
+let apply_instruction_in_place0 : t -> _ Cfg.instruction -> unit =
  fun subst instr ->
   apply_array_in_place subst instr.arg;
   apply_array_in_place subst instr.res
 
+let apply_basic_instruction_in_place : t -> Cfg.basic Cfg.instruction -> unit =
+ fun subst instr ->
+  apply_instruction_in_place0 subst instr;
+  match[@ocaml.warning "-fragile-match"] instr.desc with
+  | Op (Name_for_debugger { regs; _ }) -> apply_array_in_place subst regs
+  | _ -> ()
+
+let apply_terminator_instruction_in_place :
+    t -> Cfg.terminator Cfg.instruction -> unit =
+ fun subst instr -> apply_instruction_in_place0 subst instr
+
 let apply_block_in_place : t -> Cfg.basic_block -> unit =
  fun subst block ->
-  DLL.iter block.body ~f:(fun instr -> apply_instruction_in_place subst instr);
-  apply_instruction_in_place subst block.terminator
+  DLL.iter block.body ~f:(fun instr ->
+      apply_basic_instruction_in_place subst instr);
+  apply_terminator_instruction_in_place subst block.terminator
 
 type map = t Label.Tbl.t
 

--- a/backend/regalloc/regalloc_substitution.mli
+++ b/backend/regalloc/regalloc_substitution.mli
@@ -10,8 +10,6 @@ val apply_array : t -> Reg.t array -> Reg.t array
 
 val apply_set : t -> Reg.Set.t -> Reg.Set.t
 
-val apply_instruction_in_place : t -> _ Cfg.instruction -> unit
-
 val apply_block_in_place : t -> Cfg.basic_block -> unit
 
 type map = t Label.Tbl.t


### PR DESCRIPTION
`Name_for_debugger` operations are unusual because they carry their register arguments directly on the operation, to avoid the risk of disturbing backend analyses and transformations.  This means that during substitution of registers, they need to be updated, which this patch now does.  In addition this patch makes `Cfg_available_regs` ignore registers with unknown locations in these argument sets, which can happen if the register in question is no longer used.  This avoids fatal errors that can occur at the existing `5.2.0minus-22` tag.