### PR TITLE
Add `const` qualifiers to `argv` in `caml_startup` functions

### DIFF
--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -678,14 +678,14 @@ int main_os(int argc, char_os **argv)
                     caml_data, sizeof(caml_data),
                     caml_sections, sizeof(caml_sections),
                     /* pooling */ 0,
-                    argv);
+                    (char_os const * const *) argv);
   caml_do_exit(0);
   return 0; /* not reached */
 }
 |}
        end else begin
          output_string outchan {|
-void caml_startup(char_os ** argv)
+void caml_startup(char_os const * const * argv)
 {
   caml_startup_code(caml_code, sizeof(caml_code),
                     caml_data, sizeof(caml_data),
@@ -694,7 +694,7 @@ void caml_startup(char_os ** argv)
                     argv);
 }
 
-value caml_startup_exn(char_os ** argv)
+value caml_startup_exn(char_os const * const * argv)
 {
   return caml_startup_code_exn(caml_code, sizeof(caml_code),
                                caml_data, sizeof(caml_data),
@@ -703,7 +703,7 @@ value caml_startup_exn(char_os ** argv)
                                argv);
 }
 
-void caml_startup_pooled(char_os ** argv)
+void caml_startup_pooled(char_os const * const * argv)
 {
   caml_startup_code(caml_code, sizeof(caml_code),
                     caml_data, sizeof(caml_data),
@@ -712,7 +712,7 @@ void caml_startup_pooled(char_os ** argv)
                     argv);
 }
 
-value caml_startup_pooled_exn(char_os ** argv)
+value caml_startup_pooled_exn(char_os const * const * argv)
 {
   return caml_startup_code_exn(caml_code, sizeof(caml_code),
                                caml_data, sizeof(caml_data),

--- a/runtime/caml/callback.h
+++ b/runtime/caml/callback.h
@@ -61,11 +61,11 @@ CAMLextern const value * caml_named_value (char const * name);
 typedef void (*caml_named_action) (const value*, char *);
 CAMLextern void caml_iterate_named_values(caml_named_action f);
 
-CAMLextern void caml_main (char_os ** argv);
-CAMLextern void caml_startup (char_os ** argv);
-CAMLextern value caml_startup_exn (char_os ** argv);
-CAMLextern void caml_startup_pooled (char_os ** argv);
-CAMLextern value caml_startup_pooled_exn (char_os ** argv);
+CAMLextern void caml_main (char_os const * const * argv);
+CAMLextern void caml_startup (char_os const * const * argv);
+CAMLextern value caml_startup_exn (char_os const * const * argv);
+CAMLextern void caml_startup_pooled (char_os const * const * argv);
+CAMLextern value caml_startup_pooled_exn (char_os const * const * argv);
 CAMLextern void caml_shutdown (void);
 
 #ifdef __cplusplus

--- a/runtime/caml/startup.h
+++ b/runtime/caml/startup.h
@@ -27,14 +27,14 @@ CAMLextern void caml_startup_code(
            char *data, asize_t data_size,
            char *section_table, asize_t section_table_size,
            int pooling,
-           char_os **argv);
+           char_os const * const * argv);
 
 CAMLextern value caml_startup_code_exn(
   code_t code, asize_t code_size,
   char *data, asize_t data_size,
   char *section_table, asize_t section_table_size,
   int pooling,
-  char_os **argv);
+  char_os const * const * argv);
 
 /* These enum members should all be negative */
 enum { FILE_NOT_FOUND = -1, BAD_BYTECODE = -2, WRONG_MAGIC = -3, NO_FDS = -4 };

--- a/runtime/caml/sys.h
+++ b/runtime/caml/sys.h
@@ -29,7 +29,8 @@ CAMLnoret CAMLextern void caml_sys_error (value);
 CAMLnoret CAMLextern void caml_sys_io_error (value);
 
 CAMLextern double caml_sys_time_unboxed(value);
-CAMLextern void caml_sys_init (const char_os * exe_name, char_os ** argv);
+CAMLextern void caml_sys_init (const char_os * exe_name,
+                               char_os const * const * argv);
 
 CAMLnoret CAMLextern void caml_do_exit (int);
 

--- a/runtime/main.c
+++ b/runtime/main.c
@@ -34,7 +34,7 @@ int main_os(int argc, char_os **argv)
   caml_expand_command_line(&argc, &argv);
 #endif
 
-  caml_main(argv);
+  caml_main((char_os const * const *) argv);
   caml_do_exit(0);
   return 0; /* not reached */
 }

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -300,7 +300,7 @@ static void do_print_help(void)
 
 /* Parse options on the command line */
 
-static int parse_command_line(char_os **argv)
+static int parse_command_line(char_os const * const * argv)
 {
   int i, len, parsed;
   /* cast to make caml_params mutable; this assumes we are only called
@@ -332,7 +332,7 @@ static int parse_command_line(char_os **argv)
         break;
       case 'I':
         if (argv[i + 1] != NULL) {
-          caml_ext_table_add(&caml_shared_libs_path, argv[i + 1]);
+          caml_ext_table_add(&caml_shared_libs_path, (void *) argv[i + 1]);
           i++;
         } else {
           error("option '-I' needs an argument.");
@@ -451,7 +451,7 @@ extern void caml_install_invalid_parameter_handler(void);
 
 /* Main entry point when loading code from a file */
 
-CAMLexport void caml_main(char_os **argv)
+CAMLexport void caml_main(char_os const * const * argv)
 {
   int fd, pos;
   struct exec_trailer trail;
@@ -482,7 +482,7 @@ CAMLexport void caml_main(char_os **argv)
   pos = 0;
 
   /* First, try argv[0] (when ocamlrun is called by a bytecode program) */
-  exe_name = argv[0];
+  exe_name = (char_os *) argv[0];
   fd = caml_attempt_open(&exe_name, &trail, 0);
 
   /* Little grasshopper wonders why we do that at all, since
@@ -505,7 +505,7 @@ CAMLexport void caml_main(char_os **argv)
     if (argv[pos] == 0) {
       error("no bytecode file specified");
     }
-    exe_name = argv[pos];
+    exe_name = (char_os *) argv[pos];
     fd = caml_attempt_open(&exe_name, &trail, 1);
     switch(fd) {
     case FILE_NOT_FOUND:
@@ -595,7 +595,7 @@ CAMLexport value caml_startup_code_exn(
            char *data, asize_t data_size,
            char *section_table, asize_t section_table_size,
            int pooling,
-           char_os **argv)
+           char_os const * const * argv)
 {
   char_os * exe_name;
   value res;
@@ -667,7 +667,7 @@ CAMLexport void caml_startup_code(
            char *data, asize_t data_size,
            char *section_table, asize_t section_table_size,
            int pooling,
-           char_os **argv)
+           char_os const * const * argv)
 {
   value res;
 

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -105,7 +105,7 @@ extern void caml_install_invalid_parameter_handler(void);
 
 #endif
 
-value caml_startup_common(char_os **argv, int pooling)
+value caml_startup_common(char_os const * const * argv, int pooling)
 {
   const char_os * exe_name, * proc_self_exe;
   value res;
@@ -157,29 +157,29 @@ value caml_startup_common(char_os **argv, int pooling)
   return res;
 }
 
-value caml_startup_exn(char_os **argv)
+value caml_startup_exn(char_os const * const * argv)
 {
   return caml_startup_common(argv, /* pooling */ 0);
 }
 
-void caml_startup(char_os **argv)
+void caml_startup(char_os const * const * argv)
 {
   value res = caml_startup_exn(argv);
   if (Is_exception_result(res))
     caml_fatal_uncaught_exception(Extract_exception(res));
 }
 
-void caml_main(char_os **argv)
+void caml_main(char_os const * const * argv)
 {
   caml_startup(argv);
 }
 
-value caml_startup_pooled_exn(char_os **argv)
+value caml_startup_pooled_exn(char_os const * const * argv)
 {
   return caml_startup_common(argv, /* pooling */ 1);
 }
 
-void caml_startup_pooled(char_os **argv)
+void caml_startup_pooled(char_os const * const * argv)
 {
   value res = caml_startup_pooled_exn(argv);
   if (Is_exception_result(res))

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -462,7 +462,7 @@ CAMLprim value caml_sys_executable_name(value unit)
   return caml_copy_string_of_os(caml_params->exe_name);
 }
 
-void caml_sys_init(const char_os * exe_name, char_os **argv)
+void caml_sys_init(const char_os * exe_name, char_os const * const * argv)
 {
 #ifdef _WIN32
   /* Initialises the caml_win32_* globals on Windows with the version of
@@ -474,7 +474,7 @@ void caml_sys_init(const char_os * exe_name, char_os **argv)
 #endif
   caml_init_exe_name(exe_name);
   main_argv = caml_alloc_array((void *)caml_copy_string_of_os,
-                               (char const **) argv);
+                               (char const * const *) argv);
   caml_register_generational_global_root(&main_argv);
 }
 

--- a/testsuite/tests/embedded/cmmain.c
+++ b/testsuite/tests/embedded/cmmain.c
@@ -29,11 +29,11 @@ int main_os(int argc, char_os ** argv)
   /* Initializing the runtime twice, to check that it's possible to
      make nested calls to caml_startup/caml_shutdown. */
 #ifdef NO_BYTECODE_FILE
-  caml_startup(argv);
-  caml_startup(argv);
+  caml_startup((char_os const * const *) argv);
+  caml_startup((char_os const * const *) argv);
 #else
-  caml_main(argv);
-  caml_main(argv);
+  caml_main((char_os const * const *) argv);
+  caml_main((char_os const * const *) argv);
 #endif
 
   printf("Back in C code...\n");

--- a/testsuite/tests/lib-dynlink-csharp/entry.c
+++ b/testsuite/tests/lib-dynlink-csharp/entry.c
@@ -40,5 +40,5 @@ _DLLAPI void _CALLPROC start_caml_engine() {
   wchar_t * argv[2];
   argv[0] = L"--";
   argv[1] = NULL;
-  caml_startup(argv);
+  caml_startup((char_os const * const *) argv);
 }

--- a/testsuite/tests/manual-module-init-cycle/driver.c
+++ b/testsuite/tests/manual-module-init-cycle/driver.c
@@ -13,7 +13,7 @@ int main(int argc, char **argv)
 
   printf("Step 1: caml_startup (no modules should initialize)\n");
   fflush(stdout);
-  caml_startup(argv);
+  caml_startup((char_os const * const *) argv);
   printf("Step 1: done\n\n");
   fflush(stdout);
 

--- a/testsuite/tests/manual-module-init-sticky-failure/driver.c
+++ b/testsuite/tests/manual-module-init-sticky-failure/driver.c
@@ -6,7 +6,7 @@
 
 int main(int argc, char **argv)
 {
-  caml_startup(argv);
+  caml_startup((char_os const * const *) argv);
   caml_init_module("Sticky_failure_test");
   return 0;
 }

--- a/testsuite/tests/manual-module-init/driver.c
+++ b/testsuite/tests/manual-module-init/driver.c
@@ -17,7 +17,7 @@ int main(int argc, char **argv)
 
   printf("Step 1: caml_startup (no modules should initialize)\n");
   fflush(stdout);
-  caml_startup(argv);
+  caml_startup((char_os const * const *) argv);
   printf("Step 1: done\n\n");
   fflush(stdout);
 

--- a/testsuite/tests/output-complete-obj/test.ml_stub.c
+++ b/testsuite/tests/output-complete-obj/test.ml_stub.c
@@ -7,6 +7,6 @@
 
 int main_os(int argc, char_os **argv)
 {
-  caml_startup(argv);
+  caml_startup((char_os const * const *) argv);
   return 0;
 }


### PR DESCRIPTION
The OxCaml runtime never modifies the pointers `argv` points to, or any of the strings those pointers point to. It would be nice to express that constraint in the relevant function prototypes.

Two notes:
- `main()` doesn't have `const` qualifiers: both the C standard and POSIX are clear that it's legitimate for `main` to modify the pointed-to pointers or the underlying strings, and we have to follow those standards for that function, so this change is for the `caml_startup` functions only.

 - `const` qualifiers are no guarantee: it is trivial to remove them with a cast (and we do that in a couple of places here, so that the pointers can be passed to other functions which are not `const`-qualified). But if a function doesn't modify pointed-to data, it's polite to express that in the prototype with const qualifiers.