### PR TITLE
Exceptions cross statefulness and visibility

### DIFF
--- a/jane/doc/extensions/_05-modes/reference.md
+++ b/jane/doc/extensions/_05-modes/reference.md
@@ -123,3 +123,5 @@ let (bar @ portable) f =
 
 let () = bar foo (* prints "foo" *)
 ```
+
+Exceptions also cross statefulness and visibility with identical restrictions.

--- a/testsuite/tests/typing-layouts-or-null/immediate.ml
+++ b/testsuite/tests/typing-layouts-or-null/immediate.ml
@@ -230,7 +230,7 @@ Line 1, characters 19-30:
                        ^^^^^^^^^^^
 Error: This type "exn or_null" should be an instance of type
          "('a : immediate64_or_null)"
-       The kind of exn or_null is value_or_null mod contended portable
+       The kind of exn or_null is value_or_null mod stateless immutable
          because it is the primitive type or_null.
        But the kind of exn or_null must be a subkind of immediate64_or_null
          because of the definition of accept_immediate64_or_null at line 1, characters 0-58.

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1468,8 +1468,8 @@ module Const = struct
               (let crossing =
                  Crossing.create ~regionality:false ~linearity:false
                    ~portability:true ~forkable:false ~yielding:false
-                   ~uniqueness:false ~contention:true ~statefulness:false
-                   ~visibility:false ~staticity:false
+                   ~uniqueness:false ~contention:true ~statefulness:true
+                   ~visibility:true ~staticity:false
                in
                Mod_bounds.create crossing ~externality:Externality.max
                  ~nullability:Nullability.Non_null

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -282,7 +282,7 @@ module Const : sig
     (** Immutable non-float values that don't contain functions. *)
     val immutable_data : t
 
-    (** Exceptions; only crossing portability *)
+    (** Exceptions; crossing portability, contention, statelessness and visibility. *)
     val exn : t
 
     (** Atomically mutable non-float values that don't contain functions. *)


### PR DESCRIPTION
Make exceptions cross statefulness and visibility just like they already do portability and contention. This is sufficient to allow throwing exceptions from `stateless` functions, and is hopefully sound enough since we use the same criteria as for portability and contention.