### PR TITLE
Test shrink-wrapping in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -386,6 +386,10 @@ jobs:
         done
         for allocator in irc ls gi; do \
           ./_build/main/tools/regalloc/regalloc.exe _build \
+            -validate -insert-prologue -regalloc $allocator || exit 1; \
+        done
+        for allocator in irc ls gi; do \
+          ./_build/main/tools/regalloc/regalloc.exe _build \
             -validate -param SPLIT_AROUND_LOOPS:on -regalloc $allocator || exit 1; \
         done
 


### PR DESCRIPTION
This pull request add an option to the
`regalloc.exe` tool so that it can be
instructed to insert prologues (using
shrink-wrapping), and uses that option
in the CI job testing register allocation.