### PR TITLE
Revert "Restore ability to share static constants (#4800)"

### DIFF
--- a/middle_end/flambda2/terms/static_const.ml
+++ b/middle_end/flambda2/terms/static_const.ml
@@ -306,16 +306,8 @@ include Container_types.Make (struct
           if c <> 0
           then c
           else
-            (* We explicitly drop the debuginfo part, as this comparison is used
-               to determine whether we can share static constants from different
-               program locations. See testsuite/tests/asmcomp/staticalloc.ml for
-               a check that sharing works properly. *)
-            Misc.Stdlib.List.compare
-              (fun s1 s2 ->
-                Simple.compare
-                  (Simple.With_debuginfo.simple s1)
-                  (Simple.With_debuginfo.simple s2))
-              fields1 fields2
+            Misc.Stdlib.List.compare Simple.With_debuginfo.compare fields1
+              fields2
     | Boxed_float32 or_var1, Boxed_float32 or_var2 ->
       Or_variable.compare Numeric_types.Float32_by_bit_pattern.compare or_var1
         or_var2

--- a/testsuite/tests/typing-layouts-void/void_extended_tests.ml
+++ b/testsuite/tests/typing-layouts-void/void_extended_tests.ml
@@ -20,7 +20,6 @@
 
 type void : void mod everything
 external void : unit -> void = "%unbox_unit"
-external op : 'a -> 'a = "%opaque"
 
 let test_num = ref 0
 let start_test name =
@@ -68,8 +67,8 @@ let test1 () =
   Printf.printf "  Hash vh2: %d\n" (Hashtbl.hash vh2);
 
   (* Test polymorphic variants with void *)
-  let pv1 = Mixed (op 42, void (), "hello") in
-  let pv2 = Mixed (op 42, void (), "hello") in
+  let pv1 = Mixed (42, void (), "hello") in
+  let pv2 = Mixed (42, void (), "hello") in
   (try
     Printf.printf "  Equality pv1 = pv2: %b\n" (pv1 = pv2)
   with Invalid_argument msg ->
@@ -80,8 +79,8 @@ let test1 () =
     Printf.printf "  Compare pv1 pv2: failed (%s)\n" msg);
 
   (* Test records with void *)
-  let r1 = { rv = void (); rx = op 100 } in
-  let r2 = { rv = void (); rx = op 100 } in
+  let r1 = { rv = void (); rx = 100 } in
+  let r2 = { rv = void (); rx = 100 } in
   (try
     Printf.printf "  Equality r1 = r2: %b\n" (r1 = r2)
   with Invalid_argument msg ->


### PR DESCRIPTION
This reverts commit bc557897204aa7a2e86886c65ae5d0f8022102de.

#4800 causes surprising tests failures and confusing backtraces in some examples. This indicates that the change is risky in code that relies on physical equality. Revert to allow time for extra testing.
