### PR TITLE
Do not double link eval support files

### DIFF
--- a/optcomp/optlink.ml
+++ b/optcomp/optlink.ml
@@ -140,6 +140,9 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
         then objfiles
         else obj_file :: objfiles
       in
+      (* [file_name] is always returned irrespective of the [objfiles]
+         calculation above and the units calculation below: the aim is to know
+         the full set of files which were provided on the command line. *)
       ( file_name :: full_paths,
         objfiles,
         List.fold_right
@@ -233,6 +236,7 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
           else objfiles @ [stdexit]
         in
         let genfns = Generic_fns.Tbl.make () in
+        (* CR mshinwell/xclerc: This tuple should be a record *)
         let full_paths, ml_objfiles, units_tolink, cached_genfns_imports =
           (* This covers all files that the user has requested be linked *)
           List.fold_right


### PR DESCRIPTION
This aims to stop double linking errors (which are very confusing, since they name the same `.cmxa` file twice) for programs that explicitly link `Camlinternaleval` and/or other of its dependencies.  Programs such as `mdx` or many `compilerlibs` clients will fall into this category.  In #4894 this problem was solved via a command-line flag, but this approach should be better if it works - to be tested shortly.