### PR TITLE
Properly escape `COMMIT_MESSAGE` in `metrics_collection`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -397,6 +397,7 @@ jobs:
       if: matrix.name == 'metrics_collection' && github.ref == 'refs/heads/main' && github.event_name == 'push'
       env:
         GH_TOKEN: ${{ secrets.METRICS_REPO_TOKEN }}
+        COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
       run: |
         # Checkout metrics repository
         gh repo clone oxcaml/oxcaml-metrics metrics-repo
@@ -414,7 +415,6 @@ jobs:
         DATE=$(date -u +"%Y-%m-%d")
 
         # Extract PR number from commit message
-        COMMIT_MESSAGE="${{ github.event.head_commit.message }}"
         PR_NUMBER=$(echo "$COMMIT_MESSAGE" | grep -oP '\(#\K[0-9]+(?=\))' || echo "N/A")
 
         # CSV filename


### PR DESCRIPTION
Previously, backticks in commit messages would spawn subshells in this CI job. See <https://github.com/oxcaml/oxcaml/actions/runs/18670949530/job/53231475750> for one example.