### PR TITLE
Ignore No_such_module in Cm_bundle

### DIFF
--- a/asmcomp/cm_bundle.ml
+++ b/asmcomp/cm_bundle.ml
@@ -42,8 +42,7 @@ let cmi_bundle ~quoted_globals =
     match missing_globals with
     | [] -> cmis
     | global :: missing_globals ->
-      if CU.Name.Map.mem global cmis
-        || CU.Name.equal global no_such_module
+      if CU.Name.Map.mem global cmis || CU.Name.equal global no_such_module
       then loop cmis missing_globals
       else
         let path =
@@ -69,8 +68,7 @@ let cmx_bundle ~quoted_globals =
     match missing_globals with
     | [] -> cmxs
     | global :: missing_globals ->
-      if CU.Name.Map.mem global cmxs
-        || CU.Name.equal global no_such_module
+      if CU.Name.Map.mem global cmxs || CU.Name.equal global no_such_module
       then loop cmxs missing_globals
       else
         let path =


### PR DESCRIPTION
Not sure what the proper fix is for this module name which is generated by the JS-internal build rules, but this can be used for now.