### PR TITLE
Add a GC tweak to disable the SIGSEGV handler

### DIFF
--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -59,6 +59,7 @@ extern uintnat caml_percent_sweep_per_mark; /* see major_gc.c */
 extern uintnat caml_gc_pacing_policy;       /* see major_gc.c */
 extern uintnat caml_gc_overhead_adjustment; /* see major_gc.c */
 extern uintnat caml_nohugepage_stacks;    /* see fiber.c */
+extern uintnat caml_enable_segv_handler;  /* see signals.c / signals_nat.c */
 
 CAMLprim value caml_gc_quick_stat(value v)
 {
@@ -445,6 +446,7 @@ static struct gc_tweak gc_tweaks[] = {
   { "gc_pacing_policy", &caml_gc_pacing_policy, 0 },
   { "gc_overhead_adjustment", &caml_gc_overhead_adjustment, 0 },
   { "nohugepage_stacks", &caml_nohugepage_stacks, 0 },
+  { "enable_segv_handler", &caml_enable_segv_handler, 0 },
 };
 
 enum {N_GC_TWEAKS = sizeof(gc_tweaks)/sizeof(gc_tweaks[0])};

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -52,6 +52,10 @@ CAMLexport atomic_uintnat caml_pending_signals[NSIG_WORDS];
 
 static caml_plat_mutex signal_install_mutex = CAML_PLAT_MUTEX_INITIALIZER;
 
+/* Only used in signals_nat.c, but defined here to avoid link errors
+   on bytecode builds */
+uintnat caml_enable_segv_handler = 1;
+
 /* Check whether there is an unblocked pending signal.
    This is relatively expensive, so only call it once we're sure there's
    at least one pending signal. */

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -150,6 +150,9 @@ DECLARE_SIGNAL_HANDLER(segv_handler)
 void caml_init_nat_signals(void)
 {
   struct sigaction act, oldact;
+  extern uintnat caml_enable_segv_handler;
+  if (!caml_enable_segv_handler)
+    return;
   SET_SIGACT(act, segv_handler);
   act.sa_flags |= SA_ONSTACK;
   sigemptyset(&act.sa_mask);


### PR DESCRIPTION
We install a handler for `SIGSEGV` so that, even with stack-checks disabled, stack overflow can in some cases be detected and converted to a `Stack_overflow` exception.

However, when attempting to debug a couple of truly nasty segfaults, the `SIGSEGV` handler gets in the way, leaving coredumps that are less informative than had the segfault killed the process directly. So, this patch adds a tweak `Xenable_segv_handler=0` to optionally disable this mechanism.