### PR TITLE
Remove the "regional" special printing

### DIFF
--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -823,7 +823,7 @@ Line 1, characters 10-24:
 1 | let f x = stack_ (ref x)
               ^^^^^^^^^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/composite.ml
+++ b/testsuite/tests/typing-jkind-bounds/composite.ml
@@ -65,7 +65,7 @@ let foo (t : t @ local) = use_global t [@nontail]
 Line 1, characters 37-38:
 1 | let foo (t : t @ local) = use_global t [@nontail]
                                          ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (***********************************************************************)
@@ -124,7 +124,7 @@ let foo (t : t @ local) = use_global t [@nontail]
 Line 1, characters 37-38:
 1 | let foo (t : t @ local) = use_global t [@nontail]
                                          ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (***********************************************************************)
@@ -145,7 +145,7 @@ let foo (t : t @ local) = use_global t [@nontail]
 Line 1, characters 37-38:
 1 | let foo (t : t @ local) = use_global t [@nontail]
                                          ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (***********************************************************************)
@@ -206,7 +206,7 @@ let foo (t : int t @ local) = use_global t [@nontail]
 Line 1, characters 41-42:
 1 | let foo (t : int t @ local) = use_global t [@nontail]
                                              ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (***********************************************************************)
@@ -287,7 +287,7 @@ let foo (t : int t @ local) = use_global t [@nontail]
 Line 1, characters 41-42:
 1 | let foo (t : int t @ local) = use_global t [@nontail]
                                              ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (***********************************************************************)
@@ -314,7 +314,7 @@ let foo (t : int t @ local) = use_global t [@nontail]
 Line 1, characters 41-42:
 1 | let foo (t : int t @ local) = use_global t [@nontail]
                                              ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (***********************************************************************)

--- a/testsuite/tests/typing-jkind-bounds/gadt.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt.ml
@@ -74,7 +74,7 @@ let foo (t : t @ local) = use_global t [@nontail]
 Line 1, characters 37-38:
 1 | let foo (t : t @ local) = use_global t [@nontail]
                                          ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (***********************************************************************)

--- a/testsuite/tests/typing-jkind-bounds/predef.ml
+++ b/testsuite/tests/typing-jkind-bounds/predef.ml
@@ -148,7 +148,7 @@ let foo (t : int option @ local) = use_global t [@nontail]
 Line 1, characters 46-47:
 1 | let foo (t : int option @ local) = use_global t [@nontail]
                                                   ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* ref *)
@@ -369,7 +369,7 @@ let foo (t : int list @ local) = use_global t [@nontail]
 Line 1, characters 44-45:
 1 | let foo (t : int list @ local) = use_global t [@nontail]
                                                 ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* array *)
@@ -580,5 +580,5 @@ let foo (t : int iarray @ local) = use_global t [@nontail]
 Line 1, characters 46-47:
 1 | let foo (t : int iarray @ local) = use_global t [@nontail]
                                                   ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]

--- a/testsuite/tests/typing-jkind-bounds/records.ml
+++ b/testsuite/tests/typing-jkind-bounds/records.ml
@@ -395,7 +395,7 @@ let foo (t : t @ local) = use_global t [@nontail]
 Line 1, characters 37-38:
 1 | let foo (t : t @ local) = use_global t [@nontail]
                                          ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : t @ aliased) = use_unique t
@@ -420,7 +420,7 @@ let foo (t : t @ local) = use_global t [@nontail]
 Line 1, characters 37-38:
 1 | let foo (t : t @ local) = use_global t [@nontail]
                                          ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : t @ aliased) = use_unique t
@@ -454,7 +454,7 @@ let foo (t : int t @ local) = use_global t [@nontail]
 Line 1, characters 41-42:
 1 | let foo (t : int t @ local) = use_global t [@nontail]
                                              ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : int t @ aliased) = use_unique t
@@ -497,7 +497,7 @@ let foo (t : _ t @ local) = use_global t [@nontail]
 Line 1, characters 39-40:
 1 | let foo (t : _ t @ local) = use_global t [@nontail]
                                            ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : _ t @ aliased) = use_unique t
@@ -530,7 +530,7 @@ let foo (t : ('a : immutable_data) t @ local) = use_global t [@nontail]
 Line 1, characters 59-60:
 1 | let foo (t : ('a : immutable_data) t @ local) = use_global t [@nontail]
                                                                ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : ('a : immutable_data) t @ aliased) = use_unique t
@@ -563,7 +563,7 @@ let foo (t : _ t @ local) = use_global t [@nontail]
 Line 1, characters 39-40:
 1 | let foo (t : _ t @ local) = use_global t [@nontail]
                                            ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : _ t @ aliased) = use_unique t

--- a/testsuite/tests/typing-jkind-bounds/row.ml
+++ b/testsuite/tests/typing-jkind-bounds/row.ml
@@ -59,7 +59,7 @@ let don't_cross_locality (x : int t @ local) = use_global x [@nontail]
 Line 1, characters 58-59:
 1 | let don't_cross_locality (x : int t @ local) = use_global x [@nontail]
                                                               ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 

--- a/testsuite/tests/typing-jkind-bounds/variants.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants.ml
@@ -397,7 +397,7 @@ let foo (t : t @ local) = use_global t [@nontail]
 Line 1, characters 37-38:
 1 | let foo (t : t @ local) = use_global t [@nontail]
                                          ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : t @ aliased) = use_unique t
@@ -422,7 +422,7 @@ let foo (t : t @ local) = use_global t [@nontail]
 Line 1, characters 37-38:
 1 | let foo (t : t @ local) = use_global t [@nontail]
                                          ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : t @ aliased) = use_unique t
@@ -456,7 +456,7 @@ let foo (t : int t @ local) = use_global t [@nontail]
 Line 1, characters 41-42:
 1 | let foo (t : int t @ local) = use_global t [@nontail]
                                              ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : int t @ aliased) = use_unique t
@@ -499,7 +499,7 @@ let foo (t : _ t @ local) = use_global t [@nontail]
 Line 1, characters 39-40:
 1 | let foo (t : _ t @ local) = use_global t [@nontail]
                                            ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : _ t @ aliased) = use_unique t
@@ -532,7 +532,7 @@ let foo (t : ('a : immutable_data) t @ local) = use_global t [@nontail]
 Line 1, characters 59-60:
 1 | let foo (t : ('a : immutable_data) t @ local) = use_global t [@nontail]
                                                                ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : ('a : immutable_data) t @ aliased) = use_unique t
@@ -565,7 +565,7 @@ let foo (t : _ t @ local) = use_global t [@nontail]
 Line 1, characters 39-40:
 1 | let foo (t : _ t @ local) = use_global t [@nontail]
                                            ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : _ t @ aliased) = use_unique t

--- a/testsuite/tests/typing-jkind-bounds/with_basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics.ml
@@ -37,7 +37,7 @@ let foo (t : int option @ local) =
 Line 2, characters 13-14:
 2 |   use_global t [@nontail]
                  ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : int option @ aliased) =
@@ -83,7 +83,7 @@ let foo (t : ('a -> 'a) option @ local) =
 Line 2, characters 13-14:
 2 |   use_global t [@nontail]
                  ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : ('a -> 'a) option @ aliased) =
@@ -120,7 +120,7 @@ let foo (t : int ref option @ local) =
 Line 2, characters 13-14:
 2 |   use_global t [@nontail]
                  ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : int ref option @ aliased) =
@@ -171,7 +171,7 @@ let foo (t : ('a -> 'a) ref option @ local) =
 Line 2, characters 13-14:
 2 |   use_global t [@nontail]
                  ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : ('a -> 'a) ref option @ aliased) =
@@ -220,7 +220,7 @@ let foo (t : 'a option @ local) =
 Line 2, characters 13-14:
 2 |   use_global t [@nontail]
                  ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : 'a option @ aliased) =
@@ -276,7 +276,7 @@ let foo (t : ('a : value mod contended portable) option @ local) =
 Line 2, characters 13-14:
 2 |   use_global t [@nontail]
                  ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (type a : value mod aliased) (t : a option @ aliased) =
@@ -307,7 +307,7 @@ let foo (t : int list @ local) =
 Line 2, characters 13-14:
 2 |   use_global t [@nontail]
                  ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : int list @ aliased) =
@@ -353,7 +353,7 @@ let foo (t : ('a -> 'a) list @ local) =
 Line 2, characters 13-14:
 2 |   use_global t [@nontail]
                  ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : ('a -> 'a) list @ aliased) =
@@ -390,7 +390,7 @@ let foo (t : int ref list @ local) =
 Line 2, characters 13-14:
 2 |   use_global t [@nontail]
                  ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : int ref list @ aliased) =
@@ -441,7 +441,7 @@ let foo (t : ('a -> 'a) ref list @ local) =
 Line 2, characters 13-14:
 2 |   use_global t [@nontail]
                  ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : ('a -> 'a) ref list @ aliased) =
@@ -490,7 +490,7 @@ let foo (t : 'a list @ local) =
 Line 2, characters 13-14:
 2 |   use_global t [@nontail]
                  ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : 'a list @ aliased) =
@@ -531,7 +531,7 @@ let foo (type a : value mod contended portable) (t : a list @ local) =
 Line 2, characters 13-14:
 2 |   use_global t [@nontail]
                  ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (type a : value mod contended portable) (t : a list @ aliased) =
@@ -1130,7 +1130,7 @@ let foo (t : int t @ local) = use_global t [@nontail]
 Line 1, characters 41-42:
 1 | let foo (t : int t @ local) = use_global t [@nontail]
                                              ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (t : int t @ aliased) = use_unique t

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -966,7 +966,7 @@ let f_internal_utuple_does_not_mode_cross_local_1
 Line 2, characters 57-58:
 2 |   : local_ #(int * string) -> #(int * string) = fun x -> x
                                                              ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let f_external_utuple_mode_crosses_local_2
@@ -982,7 +982,7 @@ let f_internal_utuple_does_not_mode_cross_local_2
 Line 2, characters 77-78:
 2 |   : local_ #(int * #(bool * string)) -> #(int * #(bool * string)) = fun x -> x
                                                                                  ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 type t = #(int * int)
@@ -1002,7 +1002,7 @@ type t = #(string * int)
 Line 3, characters 67-68:
 3 |   : local_ #(int * #(t * bool)) -> #(int * #(t * bool)) = fun x -> x
                                                                        ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* Unboxed records version of the same test *)
@@ -1024,7 +1024,7 @@ type local_nocross1 = #{ i : int; s : string; }
 Line 3, characters 55-56:
 3 |   : local_ local_nocross1 -> local_nocross1 = fun x -> x
                                                            ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 type local_cross2_inner = #{ b : bool; i : int }
@@ -1048,7 +1048,7 @@ type local_nocross2 = #{ i : int; inner : local_nocross2_inner; }
 Line 4, characters 55-56:
 4 |   : local_ local_nocross2 -> local_nocross2 = fun x -> x
                                                            ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 type t = #{ i1 : int; i2 : int }
@@ -1076,7 +1076,7 @@ type local_nocross3 = #{ i : int; inner : local_nocross3_inner; }
 Line 5, characters 55-56:
 5 |   : local_ local_nocross3 -> local_nocross3 = fun x -> x
                                                            ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (****************************************************)
@@ -1098,7 +1098,7 @@ type t : float64 & value
 Line 3, characters 29-30:
 3 |   : local_ t -> t = fun x -> x
                                  ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 type t : immediate & ((float64 mod global) & immediate)
@@ -1119,7 +1119,7 @@ type t : value & (value & float64)
 Line 3, characters 29-30:
 3 |   : local_ t -> t = fun x -> x
                                  ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (*********************)

--- a/testsuite/tests/typing-layouts-products/basics_implicit_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/basics_implicit_unboxed_records.ml
@@ -136,7 +136,7 @@ Line 4, characters 2-7:
 4 |   left'
       ^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]

--- a/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
@@ -161,7 +161,7 @@ Line 4, characters 2-7:
 4 |   left'
       ^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]

--- a/testsuite/tests/typing-local/atomic_loc.ml
+++ b/testsuite/tests/typing-local/atomic_loc.ml
@@ -30,7 +30,7 @@ let contents_loc_escape (t @ local) = [%atomic.loc t.contents]
 Line 1, characters 38-62:
 1 | let contents_loc_escape (t @ local) = [%atomic.loc t.contents]
                                           ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 
@@ -41,5 +41,5 @@ let contents_can't_escape_by_mode_crossing
 Line 3, characters 11-35:
 3 | = fun t -> [%atomic.loc t.contents]
                ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]

--- a/testsuite/tests/typing-local/crossing.ml
+++ b/testsuite/tests/typing-local/crossing.ml
@@ -54,7 +54,7 @@ let f : local_ _ -> _ =
 Line 2, characters 14-15:
 2 |   fun x -> f' x
                   ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* 2. constructor argument crosses mode at construction *)
@@ -70,7 +70,7 @@ let f : local_ _ -> bar =
 Line 2, characters 21-22:
 2 |   fun n -> Bar0 (42, n)
                          ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* 3. record field crosses mode at construction *)
@@ -86,7 +86,7 @@ let f : local_ _ -> foo =
 Line 2, characters 24-25:
 2 |   fun n -> {x = 42; y = n}
                             ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* 4. expression crosses mode when being constrained *)
@@ -102,7 +102,7 @@ let f : local_ _ -> _ =
 Line 2, characters 12-13:
 2 |   fun n -> (n : string)
                 ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* 5. polymorphic variant arguments crosses mode on construction*)
@@ -118,7 +118,7 @@ let f : local_ _ -> [> `Text of string] =
 Line 2, characters 17-18:
 2 |   fun n -> `Text n
                      ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* tuple elements crosses mode at construction *)
@@ -134,7 +134,7 @@ let f : local_ _ -> string * string =
 Line 2, characters 12-13:
 2 |   fun n -> (n, n)
                 ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* array elements crosses mode at construction *)
@@ -150,7 +150,7 @@ let f: local_ _ -> string array =
 Line 2, characters 13-14:
 2 |   fun n -> [|n; n|]
                  ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* after discussion with sdolan, we agree that
@@ -162,7 +162,7 @@ let f: local_ _ -> int lazy_t =
 Line 2, characters 16-17:
 2 |   fun n -> lazy n
                     ^
-Error: The value "n" is in the parent region but is expected to be "global"
+Error: The value "n" is "local" to the parent region but is expected to be "global"
        because it is used inside a lazy expression
        which is expected to be "global".
 |}]
@@ -180,7 +180,7 @@ let f : local_ foo -> _ =
 Line 2, characters 11-14:
 2 |   fun r -> r.y
                ^^^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* the expected type is not considered when mode crossing the result of
@@ -276,7 +276,7 @@ let f : local_ bar -> _ =
 Line 4, characters 21-22:
 4 |     | Bar0 (_, y) -> y
                          ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* record fields crosses modes upon pattern matching *)
@@ -306,7 +306,7 @@ let f : local_ foo -> _ =
 Line 4, characters 16-17:
 4 |     | {y; _} -> y
                     ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* constraint crosses modes upon pattern matching  *)
@@ -322,7 +322,7 @@ let f : local_ _ -> _ =
 Line 2, characters 22-23:
 2 |   fun (x : string) -> x
                           ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 

--- a/testsuite/tests/typing-local/let_mutable.ml
+++ b/testsuite/tests/typing-local/let_mutable.ml
@@ -152,7 +152,7 @@ Line 4, characters 9-24:
 4 |     x <- local_ (i :: x)
              ^^^^^^^^^^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global".
+       but is expected to be "local" to the parent region or "global".
 |}]
 
 
@@ -189,7 +189,7 @@ Line 5, characters 9-26:
 5 |     x <- (local_ (x + !i));
              ^^^^^^^^^^^^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global".
+       but is expected to be "local" to the parent region or "global".
 |}]
 
 let foo4_4 y = (* Can't sneak local out of non-local while cond region *)
@@ -203,7 +203,7 @@ Line 3, characters 13-29:
 3 |   while x <- (local_ (x + 1)); x <= 100 do
                  ^^^^^^^^^^^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global".
+       but is expected to be "local" to the parent region or "global".
 |}]
 
 (* exclave_ closes one region, not two *)
@@ -237,7 +237,7 @@ Line 5, characters 11-30:
 5 |       x <- local_ ((i*j) :: x)
                ^^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global".
+       but is expected to be "local" to the parent region or "global".
 |}]
 
 (* This is valid since both regions are closed *)
@@ -266,7 +266,7 @@ Line 4, characters 2-3:
       ^
 Error: This value is "local"
        because it is "stack_"-allocated.
-       However, the highlighted expression is expected to be in the parent region or "global"
+       However, the highlighted expression is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -283,7 +283,7 @@ Line 4, characters 2-3:
       ^
 Error: This value is "local"
        because it is "stack_"-allocated.
-       However, the highlighted expression is expected to be in the parent region or "global"
+       However, the highlighted expression is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -362,7 +362,7 @@ let disallowed_6_2 =
 Line 6, characters 11-12:
 6 |       x <- z
                ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* 6.3: The mode system doesn't distinguish higher levels of regionality from
@@ -379,7 +379,7 @@ let disallowed_6_3 =
 Line 6, characters 11-12:
 6 |       x <- y
                ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* Test 11: binding a mutable variable shouldn't be simplified away *)
@@ -642,7 +642,7 @@ Line 4, characters 2-3:
       ^
 Error: This value is "local"
        because it is "stack_"-allocated.
-       However, the highlighted expression is expected to be in the parent region or "global"
+       However, the highlighted expression is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -10,7 +10,7 @@ Line 3, characters 2-3:
 3 |   r
       ^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -43,7 +43,7 @@ Line 3, characters 2-3:
 3 |   r
       ^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -56,7 +56,7 @@ Line 3, characters 2-3:
 3 |   r
       ^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -69,7 +69,7 @@ Line 3, characters 2-3:
 3 |   f
       ^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -82,7 +82,7 @@ Line 3, characters 2-3:
 3 |   f
       ^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -279,7 +279,7 @@ Line 1, characters 15-21:
 1 | let apply2 x = f4 x x
                    ^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
   Hint: This is a partial application
@@ -291,7 +291,7 @@ Line 1, characters 15-23:
 1 | let apply3 x = f4 x x x
                    ^^^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
   Hint: This is a partial application
@@ -334,7 +334,7 @@ Line 3, characters 2-5:
 3 |   res
       ^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -349,7 +349,7 @@ Line 3, characters 2-5:
 3 |   res
       ^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -360,7 +360,7 @@ Line 1, characters 61-65:
 1 | let optret1 (f : ?x:int -> local_ (y:unit -> unit -> int)) = f ()
                                                                  ^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
   Hint: This is a partial application
@@ -378,7 +378,7 @@ let eta (local_ f : ?a:bool -> unit -> int) = (f : unit -> int)
 Line 1, characters 47-48:
 1 | let eta (local_ f : ?a:bool -> unit -> int) = (f : unit -> int)
                                                    ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let etajoin p (f : ?b:bool -> unit -> int) (local_ g : unit -> int) =
@@ -551,7 +551,7 @@ let leak_id =
 Line 2, characters 24-25:
 2 |   use_locally (fun x -> x) 42
                             ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let leak_ref =
@@ -562,7 +562,7 @@ let leak_ref =
 Line 3, characters 43-44:
 3 |   use_locally (fun x -> r.contents <- Some x; x) 42
                                                ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let leak_ref_2 =
@@ -583,7 +583,7 @@ let leak_ref_3 =
 Line 3, characters 64-65:
 3 |   use_locally' (fun x -> let _ = local_ r in r.contents <- Some x; x) 42
                                                                     ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 
@@ -600,7 +600,7 @@ let do_leak_exn =
 Line 2, characters 66-67:
 2 |   use_locally (fun x -> let _exn = local_ raise (Invalid_argument x) in "bluh") "blah"
                                                                       ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* handled exceptions are known to be global *)
@@ -677,7 +677,7 @@ Line 3, characters 10-11:
 3 |   (module M : S)
               ^
 Error: Signature mismatch:
-       Got in the parent region
+       Got "local" to the parent region
        but expected "global"
        because it is a module and thus needs to be allocated on the heap.
 |}]
@@ -691,7 +691,7 @@ let foo (local_ x) =
 Line 2, characters 30-31:
 2 |   let _ = lazy (print_string !x) in
                                   ^
-Error: The value "x" is in the parent region but is expected to be "global"
+Error: The value "x" is "local" to the parent region but is expected to be "global"
        because it is used inside a lazy expression
        which is expected to be "global"
        because lazy expressions always need to be allocated on the heap.
@@ -709,7 +709,7 @@ let foo (local_ x) =
 Line 3, characters 27-28:
 3 |     let () = print_string !x
                                ^
-Error: The value "x" is in the parent region but is expected to be "global"
+Error: The value "x" is "local" to the parent region but is expected to be "global"
        because it is used inside a functor which is expected to be "global"
        because modules always need to be allocated on the heap.
 |}]
@@ -726,7 +726,7 @@ let foo (local_ x) =
 Line 3, characters 27-28:
 3 |     let () = print_string !x
                                ^
-Error: The value "x" is in the parent region but is expected to be "global"
+Error: The value "x" is "local" to the parent region but is expected to be "global"
        because it is used inside a functor which is expected to be "global"
        because modules always need to be allocated on the heap.
 |}]
@@ -743,7 +743,7 @@ let foo (local_ x) =
 Line 3, characters 27-28:
 3 |     let () = print_string !x
                                ^
-Error: The value "x" is in the parent region but is expected to be "global"
+Error: The value "x" is "local" to the parent region but is expected to be "global"
        because it is used inside a functor which is expected to be "global"
        because modules always need to be allocated on the heap.
 |}]
@@ -760,7 +760,7 @@ let foo (local_ x) =
 Line 3, characters 27-28:
 3 |     let () = print_string !x
                                ^
-Error: The value "x" is in the parent region but is expected to be "global"
+Error: The value "x" is "local" to the parent region but is expected to be "global"
        because it is used inside a functor which is expected to be "global"
        because modules always need to be allocated on the heap.
 |}]
@@ -777,7 +777,7 @@ let foo (local_ x) =
 Line 3, characters 27-28:
 3 |     let () = print_string !x
                                ^
-Error: The value "x" is in the parent region but is expected to be "global"
+Error: The value "x" is "local" to the parent region but is expected to be "global"
        because it is used inside a functor which is expected to be "global"
        because modules always need to be allocated on the heap.
 |}]
@@ -852,7 +852,7 @@ let foo (local_ x) =
 Line 4, characters 10-11:
 4 |       let y = x in
               ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (local_ x) =
@@ -962,7 +962,7 @@ let foo (local_ x) =
 Line 3, characters 14-15:
 3 |   let rec g = x :: g in
                   ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* Cannot pass local values to tail calls *)
@@ -978,7 +978,7 @@ Line 5, characters 8-9:
 5 |   print r
             ^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is an argument in a tail call.
 |}]
 
@@ -989,7 +989,7 @@ val local_cb : local_ (unit -> 'a) -> 'a = <fun>
 Line 2, characters 41-42:
 2 | let foo (local_ x) = local_cb (fun () -> x := 17; 42)
                                              ^
-Error: The value "x" is in the parent region but is expected to be "global"
+Error: The value "x" is "local" to the parent region but is expected to be "global"
        because it is used inside a function which is expected to be "global".
 |}]
 
@@ -1034,7 +1034,7 @@ Line 4, characters 2-5:
 4 |   foo ()
       ^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is the function in a tail call.
 |}]
 
@@ -1065,7 +1065,7 @@ Line 3, characters 2-3:
 3 |   r
       ^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -1202,7 +1202,7 @@ Line 3, characters 2-7:
 3 |   x.imm
       ^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -1239,7 +1239,7 @@ Line 3, characters 2-5:
 3 |   imm
       ^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -1284,7 +1284,7 @@ let foo (local_ mut) =
 Line 2, characters 12-15:
 2 |   let _ = { mut } in
                 ^^^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 let foo () =
   let mut = local_ ref 5 in
@@ -1303,7 +1303,7 @@ let foo (local_ gbl) =
 Line 2, characters 12-15:
 2 |   let _ = { gbl } in
                 ^^^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 let foo () =
   let gbl = local_ ref 5 in
@@ -1330,7 +1330,7 @@ Line 3, characters 2-8:
 3 |   x.#imm
       ^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -1367,7 +1367,7 @@ Line 3, characters 2-5:
 3 |   imm
       ^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -1416,7 +1416,7 @@ let foo (local_ mut) =
 Line 2, characters 13-16:
 2 |   let _ = #{ mut } in
                  ^^^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 let foo () =
   let mut = local_ ref 5 in
@@ -1435,7 +1435,7 @@ let foo (local_ gbl) =
 Line 2, characters 13-16:
 2 |   let _ = #{ gbl } in
                  ^^^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 let foo () =
   let gbl = local_ ref 5 in
@@ -1485,7 +1485,7 @@ let foo (local_ gbl) =
 Line 2, characters 13-16:
 2 |   let _ = #{ gbl } in
                  ^^^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 let foo () =
   let gbl = local_ ref 5 in
@@ -1663,7 +1663,7 @@ let foo p (local_ x) y (local_ z) =
 Line 5, characters 9-10:
 5 |   escape b;;
              ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo p (local_ x) y z =
@@ -1675,7 +1675,7 @@ let foo p (local_ x) y z =
 Line 5, characters 9-10:
 5 |   escape a;;
              ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo p (local_ x) y z =
@@ -1709,7 +1709,7 @@ let foo (local_ x) =
 Line 4, characters 26-27:
 4 |   | Some _ as y -> escape y
                               ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (local_ x) =
@@ -1722,7 +1722,7 @@ val foo : local_ int -> unit = <fun>
 Line 3, characters 21-22:
 3 |   | 0 as y -> escape y
                          ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (local_ x) =
@@ -1735,7 +1735,7 @@ val foo : local_ char -> unit = <fun>
 Line 3, characters 28-29:
 3 |   | 'a'..'e' as y -> escape y
                                 ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (local_ x) =
@@ -1746,7 +1746,7 @@ let foo (local_ x) =
 Line 3, characters 23-24:
 3 |   | 1.1 as y -> escape y
                            ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (local_ x) =
@@ -1765,7 +1765,7 @@ let foo (local_ x) =
 Line 3, characters 28-29:
 3 |   | (`Foo _) as y -> escape y
                                 ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (local_ x) =
@@ -1775,7 +1775,7 @@ let foo (local_ x) =
 Line 3, characters 35-36:
 3 |   | (None | Some _) as y -> escape y
                                        ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (local_ x) =
@@ -1785,7 +1785,7 @@ let foo (local_ x) =
 Line 3, characters 33-34:
 3 |   | (Some _|None) as y -> escape y
                                      ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 type foo = [`Foo | `Bar]
@@ -1808,7 +1808,7 @@ type foo = [ `Bar of int | `Foo ]
 Line 5, characters 24-25:
 5 |   | #foo as y -> escape y
                             ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* Primitives *)
@@ -1970,7 +1970,7 @@ Line 3, characters 63-64:
 3 | let testbool2 f = let local_ r = ref 42 in true && (false || f r)
                                                                    ^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is an argument in a tail call.
 |}]
 
@@ -2455,7 +2455,7 @@ let f (local_ s : string) =
 Line 2, characters 8-9:
 2 |   GFoo (s, "bar")
             ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let f =
@@ -2499,7 +2499,7 @@ Line 4, characters 20-22:
 4 |   | GFoo (_, s') -> s'
                         ^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -2513,7 +2513,7 @@ let f (local_ x : gfoo) =
 Line 3, characters 24-26:
 3 |   | GFoo (_, s') -> ref s'
                             ^^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* Test of array.*)
@@ -2528,7 +2528,7 @@ let f (local_ x : string) = ref [: x; "foo" :]
 Line 1, characters 35-36:
 1 | let f (local_ x : string) = ref [: x; "foo" :]
                                        ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* constructing local iarray from local elements is fine *)
@@ -2552,7 +2552,7 @@ let f (local_ a : string iarray) =
 Line 3, characters 22-23:
 3 |   | [: x; _ :] -> ref x
                           ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* a test that was passing type check *)
@@ -2565,7 +2565,7 @@ Line 3, characters 14-16:
 3 |   | [:s':] -> s'
                   ^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -2634,7 +2634,7 @@ Line 11, characters 13-59:
 11 |   let f () = fold_until [] ~init:0 ~f:(fun _ _ -> Right ())
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
   Hint: This is a partial application

--- a/testsuite/tests/typing-modal-kinds/expected_mode.ml
+++ b/testsuite/tests/typing-modal-kinds/expected_mode.ml
@@ -75,7 +75,7 @@ let string_escape : local_ _ -> string * string = fun x -> x, x
 Line 1, characters 59-60:
 1 | let string_escape : local_ _ -> string * string = fun x -> x, x
                                                                ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let int_escape : local_ _ -> int * int = fun x -> x, x
@@ -90,7 +90,7 @@ let string_list_escape : local_ _ -> string list * string list = fun x -> x, x
 Line 1, characters 74-75:
 1 | let string_list_escape : local_ _ -> string list * string list = fun x -> x, x
                                                                               ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let int_list_escape : local_ _ -> int list * int list = fun x -> x, x
@@ -99,7 +99,7 @@ let int_list_escape : local_ _ -> int list * int list = fun x -> x, x
 Line 1, characters 65-66:
 1 | let int_list_escape : local_ _ -> int list * int list = fun x -> x, x
                                                                      ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let hidden_string_escape : local_ _ -> Hidden_string.t * Hidden_string.t =
@@ -109,7 +109,7 @@ let hidden_string_escape : local_ _ -> Hidden_string.t * Hidden_string.t =
 Line 2, characters 11-12:
 2 |   fun x -> x, x
                ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let hidden_int_escape : local_ _ -> Hidden_int.t * Hidden_int.t =
@@ -126,7 +126,7 @@ let float_escape : local_ _ -> float * float = fun x -> x, x
 Line 1, characters 56-57:
 1 | let float_escape : local_ _ -> float * float = fun x -> x, x
                                                             ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* CR layouts v2.8: The following should pass, even in principal mode. Internal ticket 5111 *)
@@ -139,7 +139,7 @@ val float_u_escape : local_ float# -> (float#, float#) Float_u.pair = <fun>
 Line 2, characters 27-28:
 2 |   fun x -> Float_u.mk_pair x x [@nontail]
                                ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let hidden_float_u_escape :
@@ -154,7 +154,7 @@ val hidden_float_u_escape :
 Line 3, characters 27-28:
 3 |   fun x -> Float_u.mk_pair x x [@nontail]
                                ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let float_u_record_escape : local_ _ -> float_u_record * float_u_record =
@@ -164,7 +164,7 @@ let float_u_record_escape : local_ _ -> float_u_record * float_u_record =
 Line 2, characters 11-12:
 2 |   fun x -> x, x
                ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let float_u_record_list_escape :
@@ -175,7 +175,7 @@ let float_u_record_list_escape :
 Line 3, characters 11-12:
 3 |   fun x -> x, x
                ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let function_escape : local_ _ -> (int -> int) * (int -> int) = fun x -> x, x
@@ -184,7 +184,7 @@ let function_escape : local_ _ -> (int -> int) * (int -> int) = fun x -> x, x
 Line 1, characters 73-74:
 1 | let function_escape : local_ _ -> (int -> int) * (int -> int) = fun x -> x, x
                                                                              ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let function_list_escape : local_ _ -> (int -> int) list * (int -> int) list =
@@ -194,7 +194,7 @@ let function_list_escape : local_ _ -> (int -> int) list * (int -> int) list =
 Line 2, characters 11-12:
 2 |   fun x -> x, x
                ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 type t_value

--- a/testsuite/tests/typing-modal-kinds/principal.ml
+++ b/testsuite/tests/typing-modal-kinds/principal.ml
@@ -15,7 +15,7 @@ Line 1, characters 72-73:
 1 | let string_escape_l (local_ y) = let Pair (x, _) = Pair (y, "hello") in x
                                                                             ^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -27,7 +27,7 @@ Line 1, characters 72-73:
 1 | let string_escape_r (local_ y) = let Pair (x, _) = Pair ("hello", y) in x
                                                                             ^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -41,7 +41,7 @@ Line 1, characters 63-64:
 1 | let int_escape_l (local_ y) = let Pair (x, _) = Pair (y, 5) in x
                                                                    ^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -55,7 +55,7 @@ Line 1, characters 63-64:
 1 | let int_escape_r (local_ y) = let Pair (x, _) = Pair (5, y) in x
                                                                    ^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -66,7 +66,7 @@ let string_escape_expected_l : local_ _ -> _ pair = fun x -> Pair (x, "hello")
 Line 1, characters 67-68:
 1 | let string_escape_expected_l : local_ _ -> _ pair = fun x -> Pair (x, "hello")
                                                                        ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let string_escape_expected_r : local_ _ -> _ pair = fun x -> Pair ("hello", x)
@@ -75,7 +75,7 @@ let string_escape_expected_r : local_ _ -> _ pair = fun x -> Pair ("hello", x)
 Line 1, characters 76-77:
 1 | let string_escape_expected_r : local_ _ -> _ pair = fun x -> Pair ("hello", x)
                                                                                 ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 
@@ -86,7 +86,7 @@ let int_escape_expected_l : local_ _ -> _ pair = fun x -> Pair (x, 5)
 Line 1, characters 64-65:
 1 | let int_escape_expected_l : local_ _ -> _ pair = fun x -> Pair (x, 5)
                                                                     ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let int_escape_expected_r : local_ _ -> _ pair = fun x -> Pair (5, x)
@@ -97,7 +97,7 @@ val int_escape_expected_r : local_ int -> int pair = <fun>
 Line 1, characters 67-68:
 1 | let int_escape_expected_r : local_ _ -> _ pair = fun x -> Pair (5, x)
                                                                        ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let escape : 'a -> unit = fun _ -> ()
@@ -117,7 +117,7 @@ val pattern_l : local_ int pair -> unit = <fun>
 Line 3, characters 26-27:
 3 |   | Pair (y, 0) -> escape y
                               ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let pattern_r (local_ x) =
@@ -131,5 +131,5 @@ val pattern_r : local_ int pair -> unit = <fun>
 Line 3, characters 26-27:
 3 |   | Pair (0, y) -> escape y
                               ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]

--- a/testsuite/tests/typing-modes/crossing.ml
+++ b/testsuite/tests/typing-modes/crossing.ml
@@ -129,7 +129,7 @@ let cross_local (x : cross_local @ local) : _ @ global = x
 Line 1, characters 57-58:
 1 | let cross_local (x : cross_local @ local) : _ @ global = x
                                                              ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let cross_many (x : cross_many @ once) : _ @ many = x

--- a/testsuite/tests/typing-modes/currying.ml
+++ b/testsuite/tests/typing-modes/currying.ml
@@ -17,7 +17,7 @@ Line 1, characters 15-18:
 1 | let apply1 x = g x
                    ^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
   Hint: This is a partial application
@@ -42,7 +42,7 @@ Line 1, characters 23-32:
 1 | let apply3_wrapped x = (g x x) x
                            ^^^^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
   Hint: This is a partial application
@@ -94,7 +94,7 @@ Line 1, characters 64-79:
                                                                     ^^^^^^^^^^^^^^^
 Error: This value is "local" but is expected to be "global"
        because it is captured by a partial application
-       which is expected to be in the parent region or "global"
+       which is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -105,7 +105,7 @@ Line 1, characters 64-79:
                                                                     ^^^^^^^^^^^^^^^
 Error: This value is "local" but is expected to be "global"
        because it is captured by a partial application
-       which is expected to be in the parent region or "global"
+       which is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -116,7 +116,7 @@ Line 1, characters 56-71:
                                                             ^^^^^^^^^^^^^^^
 Error: This value is "local" but is expected to be "global"
        because it is captured by a partial application
-       which is expected to be in the parent region or "global"
+       which is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -126,7 +126,7 @@ Line 1, characters 56-71:
 1 | let app4 (f : b:local_ int ref -> a:int -> unit) = f ~b:(local_ ref 42)
                                                             ^^^^^^^^^^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is an argument in a tail call.
 |}]
 let app42 (f : a:local_ int ref -> (int -> b:local_ int ref -> c:int -> unit)) =
@@ -153,7 +153,7 @@ Line 2, characters 7-21:
 2 |   f ~a:(local_ ref 1) 2
            ^^^^^^^^^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is an argument in a tail call.
 |}]
 let app5 (f : b:local_ int ref -> a:int -> unit) = f ~a:42
@@ -189,7 +189,7 @@ Line 1, characters 52-65:
 1 | let app4' (f : b:local_ int ref -> a:int -> unit) = f ~b:(ref 42)
                                                         ^^^^^^^^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
   Hint: This is a partial application
@@ -246,7 +246,7 @@ Line 1, characters 50-59:
 1 | let rapp3 (f : a:int -> unit -> local_ int ref) = f ~a:1 ()
                                                       ^^^^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -263,7 +263,7 @@ Line 7, characters 2-5:
 7 |   res
       ^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -294,7 +294,7 @@ let bug3 () =
 Line 3, characters 63-64:
 3 |     fun ~a -> fun[@curry] ~b -> fun[@curry] ~c -> print_string a
                                                                    ^
-Error: The value "a" is in the parent region but is expected to be "global"
+Error: The value "a" is "local" to the parent region but is expected to be "global"
        because it is used inside a function which is expected to be "global".
 |}]
 let overapp ~(local_ a) ~b = (); fun ~c ~d -> ()
@@ -375,7 +375,7 @@ Line 3, characters 25-31:
 3 |   let local_ perm ~foo = f ~foo in
                              ^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
   Hint: This is a partial application

--- a/testsuite/tests/typing-modes/lazy.ml
+++ b/testsuite/tests/typing-modes/lazy.ml
@@ -25,7 +25,7 @@ let foo (local_ x) =
 Line 2, characters 18-19:
 2 |     lazy (let _ = x in ())
                       ^
-Error: The value "x" is in the parent region but is expected to be "global"
+Error: The value "x" is "local" to the parent region but is expected to be "global"
        because it is used inside a lazy expression
        which is expected to be "global"
        because lazy expressions always need to be allocated on the heap.

--- a/testsuite/tests/typing-modes/modes.ml
+++ b/testsuite/tests/typing-modes/modes.ml
@@ -72,7 +72,7 @@ Line 1, characters 22-36:
 1 | let foo a b @ local = local_ "hello"
                           ^^^^^^^^^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -83,7 +83,7 @@ Line 1, characters 29-43:
 1 | let foo = fun a b @ local -> local_ "hello"
                                  ^^^^^^^^^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -105,7 +105,7 @@ Line 1, characters 22-31:
 1 | let foo a b @ local = local_ 42
                           ^^^^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -116,7 +116,7 @@ Line 1, characters 29-38:
 1 | let foo = fun a b @ local -> local_ 42
                                  ^^^^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -137,7 +137,7 @@ Line 1, characters 22-31:
 1 | let foo a b @ local = local_ 42
                           ^^^^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -148,7 +148,7 @@ Line 1, characters 29-38:
 1 | let foo = fun a b @ local -> local_ 42
                                  ^^^^^^^^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]

--- a/testsuite/tests/typing-modes/mutable.ml
+++ b/testsuite/tests/typing-modes/mutable.ml
@@ -90,7 +90,7 @@ let foo (local_ r) = ref r.s
 Line 1, characters 25-28:
 1 | let foo (local_ r) = ref r.s
                              ^^^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let foo (local_ r) =

--- a/testsuite/tests/typing-modes/rec.ml
+++ b/testsuite/tests/typing-modes/rec.ml
@@ -35,7 +35,7 @@ let te (local_ x) =
 Line 3, characters 12-13:
 3 |         bar x y
                 ^
-Error: The value "x" is in the parent region but is expected to be "global"
+Error: The value "x" is "local" to the parent region but is expected to be "global"
        because it is used inside a function which is expected to be "global".
 |}]
 

--- a/testsuite/tests/typing-modes/stack.ml
+++ b/testsuite/tests/typing-modes/stack.ml
@@ -222,7 +222,7 @@ Line 1, characters 11-24:
                ^^^^^^^^^^^^^
 Error: This value is "local"
        because it is "stack_"-allocated.
-       However, the highlighted expression is expected to be in the parent region or "global"
+       However, the highlighted expression is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -241,7 +241,7 @@ Line 3, characters 4-5:
         ^
 Error: This value is "local"
        because it is "stack_"-allocated.
-       However, the highlighted expression is expected to be in the parent region or "global"
+       However, the highlighted expression is expected to be "local" to the parent region or "global"
        because it is the function in a tail call.
 |}]
 
@@ -253,7 +253,7 @@ Line 2, characters 4-23:
         ^^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
        because it is "stack_"-allocated.
-       However, the highlighted expression is expected to be in the parent region or "global"
+       However, the highlighted expression is expected to be "local" to the parent region or "global"
        because it is the function in a tail call.
 |}]
 
@@ -289,7 +289,7 @@ Line 3, characters 6-24:
           ^^^^^^^^^^^^^^^^^^
 Error: This value is "local"
        because it is "stack_"-allocated.
-       However, the highlighted expression is expected to be in the parent region or "global"
+       However, the highlighted expression is expected to be "local" to the parent region or "global"
        because it is an argument in a tail call.
 |}]
 
@@ -299,7 +299,7 @@ let f4 (local_ x) =
 Line 2, characters 16-17:
 2 |     List.length x
                     ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* Allocations that are not supported for stack *)
@@ -403,7 +403,7 @@ Line 3, characters 2-5:
       ^^^
 Error: This value is "local"
        because it is "stack_"-allocated.
-       However, the highlighted expression is expected to be in the parent region or "global"
+       However, the highlighted expression is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]

--- a/testsuite/tests/typing-modes/tuple_modes.ml
+++ b/testsuite/tests/typing-modes/tuple_modes.ml
@@ -26,7 +26,7 @@ Line 5, characters 4-5:
 5 |     x
         ^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -42,7 +42,7 @@ Line 5, characters 4-5:
 5 |     x
         ^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -68,7 +68,7 @@ let f e0 (e1 @ local) =
 Line 3, characters 42-44:
 3 |     | x0, x1 -> use_global x0; use_global x1; ()
                                               ^^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let f e0 (e1 @ local) =
@@ -78,7 +78,7 @@ let f e0 (e1 @ local) =
 Line 3, characters 45-47:
 3 |     | #(x0, x1) -> use_global x0; use_global x1; ()
                                                  ^^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let f e0 (e1 @ local) =
@@ -100,7 +100,7 @@ let f e0 (e1 @ local) =
 Line 4, characters 30-31:
 4 |     | x -> use_global_product x; ()
                                   ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 
@@ -132,7 +132,7 @@ Line 4, characters 44-46:
 4 |     | x -> use_local x; let (x0, x1) = x in x0
                                                 ^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]
@@ -154,7 +154,7 @@ let f b e0 (e1 @ local) (e @ local)=
 Line 3, characters 27-29:
 3 |     | x0, x1 -> use_global x0; use_local x1; ()
                                ^^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let f b e0 (e1 @ local) (e @ local)=
@@ -164,7 +164,7 @@ let f b e0 (e1 @ local) (e @ local)=
 Line 3, characters 30-32:
 3 |     | #(x0, x1) -> use_global x0; use_local x1; ()
                                   ^^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let f b e0 (e1 @ local) e2 e3 =
@@ -188,7 +188,7 @@ let f b e0 (e1 @ local) e2 e3 =
 Line 3, characters 42-44:
 3 |     | x0, x1 -> use_global x0; use_global x1; ()
                                               ^^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let f b e0 (e1 @ local) e2 e3 =
@@ -198,7 +198,7 @@ let f b e0 (e1 @ local) e2 e3 =
 Line 3, characters 45-47:
 3 |     | #(x0, x1) -> use_global x0; use_global x1; ()
                                                  ^^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 (* An unboxed tuple is not an allocation, but a regular tuple is *)
@@ -219,7 +219,7 @@ Line 4, characters 2-4:
 4 |   a'
       ^^
 Error: This value is "local"
-       but is expected to be in the parent region or "global"
+       but is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
 |}]

--- a/testsuite/tests/typing-unique/overwriting.ml
+++ b/testsuite/tests/typing-unique/overwriting.ml
@@ -89,7 +89,7 @@ let disallowed_by_locality (local_ unique_ r) (local_ x) =
 Line 2, characters 22-23:
 2 |   overwrite_ r with { x }
                           ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let gc_soundness_bug (unique_ r) (local_ x) =
@@ -107,7 +107,7 @@ let disallowed_by_locality (unique_ r) (local_ x) =
 Line 2, characters 22-23:
 2 |   overwrite_ r with { x }
                           ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let gc_soundness_no_bug (local_ unique_ r) x =
@@ -144,7 +144,7 @@ Line 3, characters 13-14:
                  ^
 Error: This value is "local"
        because it is "stack_"-allocated.
-       However, the highlighted expression is expected to be in the parent region or "global".
+       However, the highlighted expression is expected to be "local" to the parent region or "global".
 |}]
 
 let returning_regional () x =
@@ -178,7 +178,7 @@ let disallowed_by_regionality (local_ unique_ r) x =
 Line 3, characters 16-17:
 3 |   let ref = ref r in
                     ^
-Error: This value is in the parent region but is expected to be "global".
+Error: This value is "local" to the parent region but is expected to be "global".
 |}]
 
 let gc_soundness_no_bug (unique_ r) x =

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2080,7 +2080,7 @@ module Report = struct
     let mode_printer = Misc.Style.as_inline_code (C.print obj) in
     match side, obj, x with
     | `Actual, Regionality, Regional ->
-      fprintf ppf "in the parent region"
+      fprintf ppf "%a to the parent region" mode_printer C.Regionality.Local
       (* CR-someday zqian: treat the following cases generally. *)
     | `Expected, Contention_op, Shared ->
       (* When "shared" is expected, we tell the user that either shared or
@@ -2091,7 +2091,8 @@ module Report = struct
       fprintf ppf "%a or %a" mode_printer C.Visibility.Read mode_printer
         C.Visibility.Read_write
     | `Expected, Regionality, Regional ->
-      fprintf ppf "in the parent region or %a" mode_printer C.Regionality.Global
+      fprintf ppf "%a to the parent region or %a" mode_printer
+        C.Regionality.Local mode_printer C.Regionality.Global
     | _ -> mode_printer ppf x
    [@@ocaml.warning "-4"]
 


### PR DESCRIPTION
What the title says - the current different printing of `regional` on the LHS vs. RHS could cause confusion.