### PR TITLE
Don't install `VERSION`

### DIFF
--- a/dune
+++ b/dune
@@ -498,8 +498,7 @@
  (files
   Makefile.build_config
   Makefile.config_if_required
-  Makefile.config
-  VERSION)
+  Makefile.config)
  (section lib)
  (package ocaml))
 


### PR DESCRIPTION
Internal rules stopped depending on `VERSION`, so we can finally stop installing it and match upstream.