### PR TITLE
Set send_interrupt to NULL in swapgil test stubs

### DIFF
--- a/testsuite/tests/lib-systhreads/swapgil_stubs.c
+++ b/testsuite/tests/lib-systhreads/swapgil_stubs.c
@@ -146,7 +146,9 @@ value swap_gil(value unused)
   s->reinitialize_after_fork = runtime_reinitialize;
   s->can_skip_yield = NULL;
   s->yield = runtime_yield;
+#ifdef CAML_RUNTIME_5
   s->send_interrupt = NULL;
+#endif
   caml_switch_runtime_locking_scheme(s);
   return Val_unit;
 }


### PR DESCRIPTION
This should fix the random failure seen in #4626 