### PR TITLE
Fix parameterised modules with native Dynlink

### DIFF
--- a/otherlibs/dynlink/native/dynlink.ml
+++ b/otherlibs/dynlink/native/dynlink.ml
@@ -58,11 +58,11 @@ module Native = struct
   module Unit_header = struct
     type t = Cmxs_format.dynunit
 
-    let name (t : t) = t.dynu_name |> Compilation_unit.name_as_string
+    let name (t : t) = t.dynu_name |> Compilation_unit.full_path_as_string
     let crc (t : t) = Some t.dynu_crc
 
     let convert_cmx_import import =
-      let cu = Import_info.cu import |> Compilation_unit.name_as_string in
+      let cu = Import_info.cu import |> Compilation_unit.full_path_as_string in
       let crc = Import_info.crc import in
       cu, crc
 


### PR DESCRIPTION
Dynlink does checks of imports and of multiply-loaded modules based on the name of the module. Unfortunately, the native Dynlink has been using `Compilation_unit.name_as_string` to find the name. This projects out the head of an instance name, removing the arguments, such that Dynlink can't tell the difference betwen compilation units that differ only by arguments. This is guaranteed to produce failures because an instance will have the same "name" as the base module.

This patch fixes this by using `Compilation_unit.full_path_as_string` instead. (The bytecode Dynlink backend was already using the right thing.)