### PR TITLE
stdlib printing local annotations

### DIFF
--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -212,8 +212,8 @@ external classify_float : (float [@unboxed]) -> fpclass @@ portable =
 
 (* String and byte sequence operations -- more in modules String and Bytes *)
 
-external string_length : string -> int @@ portable = "%string_length"
-external bytes_length : bytes -> int @@ portable = "%bytes_length"
+external string_length : string @ local -> int @@ portable = "%string_length"
+external bytes_length : bytes @ local -> int @@ portable = "%bytes_length"
 external bytes_create : int -> bytes @@ portable = "caml_create_bytes"
 external string_blit : string -> int -> bytes -> int -> int -> unit @@ portable
                      = "caml_blit_string" [@@noalloc]
@@ -369,9 +369,9 @@ let flush_all () =
         iter l
   in iter (out_channels_list ())
 
-external unsafe_output : out_channel -> bytes -> int -> int -> unit @@ portable
+external unsafe_output : out_channel -> bytes @ local -> int -> int -> unit @@ portable
                        = "caml_ml_output_bytes"
-external unsafe_output_string : out_channel -> string -> int -> int -> unit @@ portable
+external unsafe_output_string : out_channel -> string @ local -> int -> int -> unit @@ portable
                               = "caml_ml_output"
 
 external output_char : out_channel -> char -> unit @@ portable = "caml_ml_output_char"

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -859,10 +859,10 @@ val stderr : out_channel
 val print_char : char -> unit
 (** Print a character on standard output. *)
 
-val print_string : string -> unit
+val print_string : string @ local -> unit
 (** Print a string on standard output. *)
 
-val print_bytes : bytes -> unit
+val print_bytes : bytes @ local -> unit
 (** Print a byte sequence on standard output.
    @since 4.02 *)
 
@@ -875,7 +875,7 @@ val print_float : float -> unit
     The conversion of the number to a string uses {!string_of_float} and
     can involve a loss of precision. *)
 
-val print_endline : string -> unit
+val print_endline : string @ local -> unit
 (** Print a string, followed by a newline character, on
    standard output and flush standard output. *)
 
@@ -890,10 +890,10 @@ val print_newline : unit -> unit
 val prerr_char : char -> unit
 (** Print a character on standard error. *)
 
-val prerr_string : string -> unit
+val prerr_string : string @ local -> unit
 (** Print a string on standard error. *)
 
-val prerr_bytes : bytes -> unit
+val prerr_bytes : bytes @ local -> unit
 (** Print a byte sequence on standard error.
    @since 4.02 *)
 
@@ -906,7 +906,7 @@ val prerr_float : float -> unit
     The conversion of the number to a string uses {!string_of_float} and
     can involve a loss of precision. *)
 
-val prerr_endline : string -> unit
+val prerr_endline : string @ local -> unit
 (** Print a string, followed by a newline character on standard
    error and flush standard error. *)
 


### PR DESCRIPTION
add local annotations to a few printings functions in stdlib - in particular print_string, print_bytes, and print_endline (and their stderr analogs)