### PR TITLE
Expose domain index

### DIFF
--- a/runtime4/domain.c
+++ b/runtime4/domain.c
@@ -132,6 +132,11 @@ CAMLprim value caml_ml_domain_id(void)
   caml_failwith("Domains not supported on runtime4");
 }
 
+CAMLprim value caml_ml_domain_index(void)
+{
+  caml_failwith("Domains not supported on runtime4");
+}
+
 CAMLprim value caml_domain_dls_set(void)
 {
   caml_failwith("Domains not supported on runtime4");

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -191,6 +191,7 @@ module Runtime_4 = struct
   let self () = 0
   let is_main_domain () = true
   let recommended_domain_count () = 1
+  let self_index () = 0
 end
 
 module Runtime_5 = struct
@@ -353,6 +354,9 @@ module Runtime_5 = struct
 
   let is_main_domain () = (self () :> int) = 0
 
+  external self_index : unit -> int @@ portable
+    = "caml_ml_domain_index" [@@noalloc]
+
   (******** Callbacks **********)
 
   (* first spawn, domain startup and at exit functionality *)
@@ -470,6 +474,7 @@ module type S = sig
   val self : unit -> id @@ portable
   val is_main_domain : unit -> bool @@ portable
   val recommended_domain_count : unit -> int @@ portable
+  val self_index : unit -> int @@ portable
   val before_first_spawn : (unit -> unit) -> unit @@ nonportable
   val at_exit : (unit -> unit) @ portable -> unit @@ portable
   val do_at_exit : unit -> unit @@ nonportable

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -71,6 +71,18 @@ val recommended_domain_count : unit -> int @@ portable
 
     The value returned is at least [1]. *)
 
+val self_index : unit -> int
+(** The index of the current domain. It is an integer unique among
+    currently-running domains, in the interval [0; N-1] where N is the
+    peak number of domains running simultaneously so far.
+
+    The index of a terminated domain may be reused for a new
+    domain. Use [(Domain.self () :> int)] instead for an identifier
+    unique among all domains ever created by the program.
+
+    @since 5.3
+*)
+
 val before_first_spawn : (unit -> unit) -> unit @@ nonportable
 (** [before_first_spawn f] registers [f] to be called before the first domain
     is spawned by the program. The functions registered with


### PR DESCRIPTION
This exposes `caml_ml_domain_index` as `Domain.self_index` for use cases such as avoiding contention based on using arrays with per domain elements.

See https://github.com/ocaml/ocaml/pull/13171 for the upstream version.