### PR TITLE
Reword allocation hints

### DIFF
--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -857,8 +857,7 @@ Error: This value is "local"
        because it is "stack_"-allocated.
        However, the highlighted expression is expected to be "global"
        because it is an element of the tuple at Line 1, characters 23-39
-       which is expected to be "global"
-       because it is from the allocation at Line 1, characters 23-39
+       which is expected to be "global" because it is an allocation
        which is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.

--- a/testsuite/tests/typing-layouts-products/basics_implicit_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/basics_implicit_unboxed_records.ml
@@ -138,7 +138,7 @@ Line 4, characters 2-7:
 Error: This value is "local"
        because it is the field "left" of the record at Line 3, characters 6-25
        which is "local"
-       because it is from the allocation (at Line 2, characters 10-25) containing a value
+       because it is allocated at Line 2, characters 10-25 with content
        which is "local" to the parent region.
        However, the highlighted expression is expected to be "local" to the parent region or "global"
        because it is a function return value.

--- a/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
@@ -163,7 +163,7 @@ Line 4, characters 2-7:
 Error: This value is "local"
        because it is the field "left" of the record at Line 3, characters 6-25
        which is "local"
-       because it is from the allocation (at Line 2, characters 10-25) containing a value
+       because it is allocated at Line 2, characters 10-25 with content
        which is "local" to the parent region.
        However, the highlighted expression is expected to be "local" to the parent region or "global"
        because it is a function return value.

--- a/testsuite/tests/typing-local/atomic_loc.ml
+++ b/testsuite/tests/typing-local/atomic_loc.ml
@@ -31,7 +31,7 @@ Line 1, characters 38-62:
 1 | let contents_loc_escape (t @ local) = [%atomic.loc t.contents]
                                           ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This value is "local" to the parent region but is expected to be "global"
-       because it is from the allocation at Line 1, characters 38-62
+       because it is an allocation
        which is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -379,7 +379,7 @@ Line 1, characters 47-48:
 1 | let eta (local_ f : ?a:bool -> unit -> int) = (f : unit -> int)
                                                    ^
 Error: This value is "local" to the parent region but is expected to be "global"
-       because it is from the allocation for coercing the function at Line 1, characters 47-48
+       because it is to omit some parameters by partial application (and thus an allocation)
        which is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.
@@ -1009,8 +1009,7 @@ Line 2, characters 41-42:
                                              ^
 Error: The value "x" is "local" to the parent region but is expected to be "global"
        because it is used inside the function (at Line 2, characters 30-53)
-       which is expected to be "global"
-       because it is from the allocation at Line 2, characters 30-53
+       which is expected to be "global" because it is an allocation
        which is expected to be "local" to the parent region or "global"
        because it is an argument in a tail call.
 |}]
@@ -1663,7 +1662,7 @@ Error: This value is "local"
        which is "local"
        because it is an element of the tuple at Line 3, characters 8-10
        which is "local"
-       because it is from the allocation (at Line 2, characters 11-15) containing a value
+       because it is allocated at Line 2, characters 11-15 with content
        which is "local" to the parent region
        because it is a tuple that contains the expression (at Line 2, characters 11-12)
        which is "local" to the parent region.
@@ -1683,7 +1682,7 @@ Line 5, characters 11-12:
 Error: This value is "local"
        because it is an element of the tuple at Line 4, characters 15-17
        which is "local"
-       because it is from the allocation (at Line 2, characters 8-12) containing a value
+       because it is allocated at Line 2, characters 8-12 with content
        which is "local" to the parent region
        because it is a tuple that contains the expression (at Line 2, characters 8-9)
        which is "local" to the parent region.
@@ -1740,7 +1739,7 @@ Line 6, characters 9-10:
 Error: This value is "local"
        because it is an element of the tuple at Line 5, characters 13-15
        which is "local"
-       because it is from the allocation (at Line 3, characters 14-18) containing a value
+       because it is allocated at Line 3, characters 14-18 with content
        which is "local" to the parent region
        because it is a tuple that contains the expression (at Line 3, characters 14-15)
        which is "local" to the parent region.
@@ -2513,8 +2512,7 @@ Line 2, characters 8-9:
             ^
 Error: This value is "local" to the parent region but is expected to be "global"
        because it is contained (via constructor "GFoo") in the value at Line 2, characters 2-17
-       which is expected to be "global"
-       because it is from the allocation at Line 2, characters 2-17
+       which is expected to be "global" because it is an allocation
        which is expected to be "local" to the parent region or "global"
        because it is a function return value.
        Hint: Use exclave_ to return a local value.

--- a/testsuite/tests/typing-modal-kinds/principal.ml
+++ b/testsuite/tests/typing-modal-kinds/principal.ml
@@ -17,7 +17,7 @@ Line 1, characters 72-73:
 Error: This value is "local"
        because it is contained (via constructor "Pair") in the value at Line 1, characters 37-48
        which is "local"
-       because it is from the allocation (at Line 1, characters 51-68) containing a value
+       because it is allocated at Line 1, characters 51-68 with content
        which is "local" to the parent region.
        However, the highlighted expression is expected to be "local" to the parent region or "global"
        because it is a function return value.
@@ -33,7 +33,7 @@ Line 1, characters 72-73:
 Error: This value is "local"
        because it is contained (via constructor "Pair") in the value at Line 1, characters 37-48
        which is "local"
-       because it is from the allocation (at Line 1, characters 51-68) containing a value
+       because it is allocated at Line 1, characters 51-68 with content
        which is "local" to the parent region.
        However, the highlighted expression is expected to be "local" to the parent region or "global"
        because it is a function return value.
@@ -51,7 +51,7 @@ Line 1, characters 63-64:
 Error: This value is "local"
        because it is contained (via constructor "Pair") in the value at Line 1, characters 34-45
        which is "local"
-       because it is from the allocation (at Line 1, characters 48-59) containing a value
+       because it is allocated at Line 1, characters 48-59 with content
        which is "local" to the parent region.
        However, the highlighted expression is expected to be "local" to the parent region or "global"
        because it is a function return value.
@@ -69,7 +69,7 @@ Line 1, characters 63-64:
 Error: This value is "local"
        because it is contained (via constructor "Pair") in the value at Line 1, characters 34-45
        which is "local"
-       because it is from the allocation (at Line 1, characters 48-59) containing a value
+       because it is allocated at Line 1, characters 48-59 with content
        which is "local" to the parent region.
        However, the highlighted expression is expected to be "local" to the parent region or "global"
        because it is a function return value.

--- a/testsuite/tests/typing-modes/tuple_modes.ml
+++ b/testsuite/tests/typing-modes/tuple_modes.ml
@@ -98,7 +98,7 @@ Line 4, characters 22-23:
 4 |     | x -> use_global x; ()
                           ^
 Error: This value is "local"
-       because it is from the allocation (at Line 2, characters 10-16) containing a value
+       because it is allocated at Line 2, characters 10-16 with content
        which is "local" to the parent region
        because it is a tuple that contains the expression (at Line 2, characters 14-16)
        which is "local" to the parent region.
@@ -150,7 +150,7 @@ Line 4, characters 44-46:
 Error: This value is "local"
        because it is an element of the tuple at Line 4, characters 39-40
        which is "local"
-       because it is from the allocation (at Line 2, characters 10-16) containing a value
+       because it is allocated at Line 2, characters 10-16 with content
        which is "local" to the parent region
        because it is a tuple that contains the expression (at Line 2, characters 14-16)
        which is "local" to the parent region.
@@ -249,7 +249,7 @@ Line 4, characters 2-4:
 Error: This value is "local"
        because it is an element of the tuple at Line 3, characters 16-17
        which is "local"
-       because it is from the allocation (at Line 2, characters 10-16) containing a value
+       because it is allocated at Line 2, characters 10-16 with content
        which is "local" to the parent region
        because it is a tuple that contains the expression (at Line 2, characters 11-12)
        which is "local" to the parent region.

--- a/typing/mode_hint.mli
+++ b/typing/mode_hint.mli
@@ -110,8 +110,6 @@ type 'd morph =
   | Captured_by_partial_application : (disallowed * 'r) morph
   | Adj_captured_by_partial_application : ('l * disallowed) morph
   | Crossing : ('l * 'r) morph
-  (* CR-soon zqian: the location on [Allocation_*] should probably be removed
-     once we introduce "containing" hints, since the locations would be duplicative. *)
   | Allocation_r : allocation -> (disallowed * 'r) morph
   | Allocation_l : allocation -> ('l * disallowed) morph
   | Contains_l : ('l * disallowed, 'd) polarity * contains -> 'd morph


### PR DESCRIPTION
Based on #4919 

- After #4919, the containing relations are explicitly expressed,  the vague wording ("from the allocation" "containing a value") in the allocation hint can be dropped.
- A bit polish of wording in general.