### PR TITLE
Add locking scheme version

### DIFF
--- a/otherlibs/systhreads/caml/threads.h
+++ b/otherlibs/systhreads/caml/threads.h
@@ -69,6 +69,11 @@ CAMLextern_libthreads int caml_c_thread_unregister(void);
 */
 
 enum caml_thread_type { Thread_type_caml, Thread_type_c_registered };
+
+/* locking scheme version 0 has no send_interrupt field. */
+
+#define CAML_LOCKING_SCHEME_VERSION 1 /* Adds send_interrupt field */
+
 struct caml_locking_scheme {
   void* context;
   void (*lock)(void*);
@@ -95,6 +100,8 @@ struct caml_locking_scheme {
   /* If non-NULL, called without the lock held when the runtime urgently
      needs to take the lock to service an interrupt, such as for GC */
   void (*send_interrupt)(void*);
+
+  /* TODO: add magic number including version number, to improve checking */
 };
 
 /* Switch to a new runtime locking scheme.


### PR DESCRIPTION
As the locking scheme evolves, it needs to do so in lock-step with client code. This PR introduces a scheme version number, so client code can be conditionalized, relaxing the lock-step. For example, if `CAML_LOCKING_SCHEME_VERSION` is not defined, `send_interrupt` should not be set.

It might be nice to add a magic number to the struct in future, which would include the version number, so we can validate (and potentially reject) a struct passed to us by a client.