### PR TITLE
`%tls_get` primitive

### DIFF
--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -59,7 +59,7 @@ let class_of_operation (op : Operation.t)
   | Stackoffset _ | Load _ | Store _ | Alloc _
   | Intop _ | Intop_imm _ | Intop_atomic _
   | Name_for_debugger _ | Probe_is_enabled _ | Opaque | Pause
-  | Begin_region | End_region | Poll | Dls_get
+  | Begin_region | End_region | Poll | Dls_get | Tls_get
     -> Use_default
 
 let is_cheap_operation _op

--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -221,7 +221,7 @@ let pseudoregs_for_operation op arg res =
   | Const_vec512 _ | Const_symbol _ | Stackoffset _ | Load _
   | Store (_, _, _)
   | Alloc _ | Name_for_debugger _ | Probe_is_enabled _ | Opaque | Pause
-  | Begin_region | End_region | Poll | Dls_get ->
+  | Begin_region | End_region | Poll | Dls_get | Tls_get ->
     raise Use_default_exn
   | Specific (Illvm_intrinsic intr) ->
     Misc.fatal_errorf "Unexpected llvm_intrinsic %s: not using LLVM backend"

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2325,6 +2325,7 @@ let emit_instr ~first ~fallthrough i =
     if Config.runtime5
     then I.mov (domain_field Domainstate.Domain_dls_state) (res i 0)
     else Misc.fatal_error "Dls is not supported in runtime4."
+  | Lop Tls_get -> I.mov (domain_field Domainstate.Domain_tls_state) (res i 0)
   | Lreloadretaddr -> ()
   | Lreturn -> I.ret ()
   | Llabel { label = lbl; section_name } ->

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -619,7 +619,7 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
        | Specific (Ilea _ | Ioffset_loc _ | Ibswap _
                   | Isextend32 | Izextend32
                   | Ilfence | Isfence | Imfence)
-       | Name_for_debugger _ | Dls_get | Pause)
+       | Name_for_debugger _ | Dls_get | Tls_get | Pause)
   | Poptrap _ | Prologue | Epilogue ->
     if fp then [| rbp |] else [||]
   | Stack_check _ ->
@@ -759,6 +759,7 @@ let operation_supported = function
   | Cprobe _ | Cprobe_is_enabled _ | Copaque | Cbeginregion | Cendregion
   | Ctuple_field _
   | Cdls_get
+  | Ctls_get
   | Cpoll
   | Cpause
   | Creinterpret_cast (Int_of_value | Value_of_int |

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -272,8 +272,8 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
       | Floatop (_, (Inegf | Iabsf | Icompf _))
       | Const_float _ | Const_float32 _ | Const_vec128 _ | Const_vec256 _
       | Const_vec512 _ | Stackoffset _ | Load _ | Store _ | Name_for_debugger _
-      | Probe_is_enabled _ | Opaque | Begin_region | End_region | Dls_get | Poll
-      | Pause | Alloc _ )
+      | Probe_is_enabled _ | Opaque | Begin_region | End_region | Dls_get
+      | Tls_get | Poll | Pause | Alloc _ )
   | Op (Reinterpret_cast (Int_of_value | Value_of_int))
   | Op
       (Specific

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -1159,7 +1159,7 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
       | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
       | Const_vec512 _ | Stackoffset _ | Intop_atomic _ | Floatop _ | Csel _
       | Probe_is_enabled _ | Opaque | Begin_region | End_region | Pause
-      | Name_for_debugger _ | Dls_get | Poll ->
+      | Name_for_debugger _ | Dls_get | Tls_get | Poll ->
         assert false
     in
     assert (arg_count = 0 && res_count = 1);
@@ -1214,7 +1214,7 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
       | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
       | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Intop_atomic _
       | Floatop _ | Csel _ | Probe_is_enabled _ | Opaque | Begin_region
-      | End_region | Name_for_debugger _ | Dls_get | Poll | Pause ->
+      | End_region | Name_for_debugger _ | Dls_get | Tls_get | Poll | Pause ->
         assert false
     in
     let consts = List.map extract_intop_imm_int cfg_ops in
@@ -1255,7 +1255,7 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
         | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
         | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Intop_atomic _
         | Floatop _ | Csel _ | Probe_is_enabled _ | Opaque | Begin_region
-        | End_region | Name_for_debugger _ | Dls_get | Poll | Pause ->
+        | End_region | Name_for_debugger _ | Dls_get | Tls_get | Poll | Pause ->
           assert false
       in
       let get_scale op =
@@ -1387,7 +1387,8 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
           | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
           | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Intop_atomic _
           | Floatop _ | Csel _ | Probe_is_enabled _ | Opaque | Begin_region
-          | End_region | Name_for_debugger _ | Dls_get | Poll | Pause ->
+          | End_region | Name_for_debugger _ | Dls_get | Tls_get | Poll | Pause
+            ->
             assert false
         in
         let consts = List.map extract_store_int_imm cfg_ops in
@@ -1503,5 +1504,5 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
   | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
   | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Intop_atomic _ | Floatop _
   | Csel _ | Probe_is_enabled _ | Opaque | Pause | Begin_region | End_region
-  | Name_for_debugger _ | Dls_get | Poll ->
+  | Name_for_debugger _ | Dls_get | Tls_get | Poll ->
     None

--- a/backend/arm64/CSE.ml
+++ b/backend/arm64/CSE.ml
@@ -59,7 +59,7 @@ let class_of_operation (op : Operation.t)
   | Stackoffset _ | Load _ | Store _ | Alloc _
   | Intop _ | Intop_imm _ | Intop_atomic _
   | Name_for_debugger _ | Probe_is_enabled _ | Opaque | Pause
-  | Begin_region | End_region | Poll | Dls_get
+  | Begin_region | End_region | Poll | Dls_get | Tls_get
     -> Use_default
 
 let is_cheap_operation (op : Operation.t)
@@ -77,5 +77,5 @@ let is_cheap_operation (op : Operation.t)
   | Stackoffset _ | Load _ | Store _ | Alloc _
   | Intop _ | Intop_imm _ | Intop_atomic _
   | Name_for_debugger _ | Probe_is_enabled _ | Opaque | Pause
-  | Begin_region | End_region | Poll | Dls_get
+  | Begin_region | End_region | Poll | Dls_get | Tls_get
     -> Cheap false

--- a/backend/arm64/cfg_selection.ml
+++ b/backend/arm64/cfg_selection.ml
@@ -258,8 +258,9 @@ let pseudoregs_for_operation op arg res =
       | Ishiftarith (_, _)
       | Ibswap _ | Isignext _ )
   | Move | Spill | Reload | Opaque | Pause | Begin_region | End_region | Dls_get
-  | Poll | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
-  | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Load _
+  | Tls_get | Poll | Const_int _ | Const_float32 _ | Const_float _
+  | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
+  | Stackoffset _ | Load _
   | Store (_, _, _)
   | Intop _
   | Intop_imm (_, _)

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -343,7 +343,7 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
         | Stackoffset _
         | Intop_imm _ | Intop_atomic _
         | Name_for_debugger _ | Probe_is_enabled _ | Opaque | Pause
-        | Begin_region | End_region | Dls_get)
+        | Begin_region | End_region | Dls_get | Tls_get)
   | Poptrap _ | Prologue | Epilogue
   | Op (Reinterpret_cast (Int_of_value | Value_of_int | Float_of_float32 |
                           Float32_of_float | Float_of_int64 | Int64_of_float |
@@ -491,6 +491,7 @@ let operation_supported : Cmm.operation -> bool = function
   | Cprobe _ | Cprobe_is_enabled _ | Copaque | Cpause
   | Cbeginregion | Cendregion | Ctuple_field _
   | Cdls_get
+  | Ctls_get
   | Cpoll
   | Creinterpret_cast (Int_of_value | Value_of_int |
                        Int64_of_float | Float_of_int64 |

--- a/backend/arm64/regalloc_stack_operands.ml
+++ b/backend/arm64/regalloc_stack_operands.ml
@@ -31,7 +31,7 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
         | Ibswap _ | Isignext _ | Isimd _ ))
   | Op
       ( Move | Spill | Reload | Opaque | Pause | Begin_region | End_region
-      | Dls_get | Poll | Const_int _ | Const_float32 _ | Const_float _
+      | Dls_get | Tls_get | Poll | Const_int _ | Const_float32 _ | Const_float _
       | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
       | Stackoffset _ | Load _
       | Store (_, _, _)

--- a/backend/branch_relaxation.ml
+++ b/backend/branch_relaxation.ml
@@ -74,7 +74,7 @@ module Make (T : Branch_relaxation_intf.S) = struct
         || opt_branch_overflows map pc lbl2 max_branch_offset
       | Lop
           ( Move | Spill | Reload | Opaque | Pause | Begin_region | End_region
-          | Dls_get | Const_int _ | Const_float32 _ | Const_float _
+          | Dls_get | Tls_get | Const_int _ | Const_float32 _ | Const_float _
           | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
           | Stackoffset _ | Load _
           | Store (_, _, _)
@@ -151,7 +151,7 @@ module Make (T : Branch_relaxation_intf.S) = struct
           | Lraise _ | Lstackcheck _
           | Lop
               ( Move | Spill | Reload | Opaque | Pause | Begin_region
-              | End_region | Dls_get | Const_int _ | Const_float32 _
+              | End_region | Dls_get | Tls_get | Const_int _ | Const_float32 _
               | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
               | Const_vec512 _ | Stackoffset _ | Load _
               | Store (_, _, _)

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -520,7 +520,7 @@ let is_noop_move instr =
       | Load _ | Store _ | Intop _ | Intop_imm _ | Intop_atomic _ | Floatop _
       | Opaque | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
       | Specific _ | Name_for_debugger _ | Begin_region | End_region | Dls_get
-      | Poll | Alloc _ | Pause )
+      | Tls_get | Poll | Alloc _ | Pause )
   | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue | Stack_check _
     ->
     false
@@ -606,9 +606,9 @@ let is_poll (instr : basic instruction) =
   | Reloadretaddr | Prologue | Epilogue | Pushtrap _ | Poptrap _ | Stack_check _
   | Op
       ( Alloc _ | Move | Spill | Reload | Opaque | Pause | Begin_region
-      | End_region | Dls_get | Const_int _ | Const_float32 _ | Const_float _
-      | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
-      | Stackoffset _ | Load _
+      | End_region | Dls_get | Tls_get | Const_int _ | Const_float32 _
+      | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
+      | Const_vec512 _ | Stackoffset _ | Load _
       | Store (_, _, _)
       | Intop _
       | Intop_imm (_, _)
@@ -624,9 +624,9 @@ let is_alloc (instr : basic instruction) =
   | Reloadretaddr | Prologue | Epilogue | Pushtrap _ | Poptrap _ | Stack_check _
   | Op
       ( Poll | Move | Spill | Reload | Opaque | Begin_region | End_region
-      | Dls_get | Pause | Const_int _ | Const_float32 _ | Const_float _
-      | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
-      | Stackoffset _ | Load _
+      | Dls_get | Tls_get | Pause | Const_int _ | Const_float32 _
+      | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
+      | Const_vec512 _ | Stackoffset _ | Load _
       | Store (_, _, _)
       | Intop _
       | Intop_imm (_, _)
@@ -642,9 +642,9 @@ let is_end_region (b : basic) =
   | Reloadretaddr | Prologue | Epilogue | Pushtrap _ | Poptrap _ | Stack_check _
   | Op
       ( Alloc _ | Poll | Move | Spill | Reload | Opaque | Begin_region | Dls_get
-      | Pause | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
-      | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
-      | Load _
+      | Tls_get | Pause | Const_int _ | Const_float32 _ | Const_float _
+      | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
+      | Stackoffset _ | Load _
       | Store (_, _, _)
       | Intop _
       | Intop_imm (_, _)
@@ -729,7 +729,7 @@ let remove_trap_instructions t removed_trap_handlers =
         | Load _ | Store _ | Intop _ | Intop_imm _ | Intop_atomic _ | Floatop _
         | Csel _ | Static_cast _ | Reinterpret_cast _ | Probe_is_enabled _
         | Opaque | Begin_region | End_region | Specific _ | Name_for_debugger _
-        | Dls_get | Poll | Alloc _ | Pause )
+        | Dls_get | Tls_get | Poll | Alloc _ | Pause )
     | Reloadretaddr | Prologue | Epilogue | Stack_check _ ->
       update_basic_next (DLL.Cursor.next cursor) ~stack_offset
   and update_body r ~stack_offset =

--- a/backend/cfg/cfg_available_regs.ml
+++ b/backend/cfg/cfg_available_regs.ml
@@ -358,7 +358,7 @@ module Transfer = struct
             | Load _ | Store _ | Intop _ | Intop_imm _ | Intop_atomic _
             | Floatop _ | Csel _ | Reinterpret_cast _ | Static_cast _
             | Probe_is_enabled _ | Opaque | Begin_region | End_region
-            | Specific _ | Dls_get | Poll | Alloc _ | Pause )
+            | Specific _ | Dls_get | Tls_get | Poll | Alloc _ | Pause )
         | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
         | Stack_check _ ->
           let is_op_end_region = Cfg.is_end_region in

--- a/backend/cfg/cfg_comballoc.ml
+++ b/backend/cfg/cfg_comballoc.ml
@@ -38,8 +38,8 @@ let rec find_next_allocation : cell option -> allocation option =
         | Stackoffset _ | Load _ | Store _ | Intop _ | Intop_imm _
         | Intop_atomic _ | Floatop _ | Csel _ | Reinterpret_cast _
         | Static_cast _ | Probe_is_enabled _ | Opaque | Begin_region
-        | End_region | Specific _ | Name_for_debugger _ | Dls_get | Poll | Pause
-          )
+        | End_region | Specific _ | Name_for_debugger _ | Dls_get | Tls_get
+        | Poll | Pause )
     | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
     | Stack_check _ ->
       find_next_allocation (DLL.next cell))
@@ -94,7 +94,7 @@ let find_compatible_allocations :
           | Stackoffset _ | Load _
           | Store (_, _, _)
           | Csel _ | Specific _ | Name_for_debugger _ | Probe_is_enabled _
-          | Static_cast _ | Dls_get
+          | Static_cast _ | Dls_get | Tls_get
           | Intop
               ( Iadd | Isub | Imul | Idiv | Imod | Iand | Ior | Ixor | Ilsl
               | Ilsr | Iasr | Ipopcnt | Imulh _ | Iclz _ | Ictz _ | Icomp _ )

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -326,7 +326,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
     | Name_for_debugger _ -> Op_other
     | Probe_is_enabled _ -> Op_other
     | Begin_region | End_region -> Op_other
-    | Dls_get -> Op_load Mutable
+    | Dls_get | Tls_get -> Op_load Mutable
 
   let class_of_operation op =
     match Target.class_of_operation op with
@@ -341,7 +341,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
     | Intop_imm (_, _)
     | Intop_atomic _ | Floatop _ | Csel _ | Static_cast _ | Reinterpret_cast _
     | Specific _ | Name_for_debugger _ | Probe_is_enabled _ | Begin_region
-    | End_region | Dls_get ->
+    | End_region | Dls_get | Tls_get ->
       false
 
   let kill_loads (n : numbering) : numbering = remove_mutable_load_numbering n
@@ -380,9 +380,9 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
       let n2 = set_unknown_regs n1 i.res in
       n2
     | Op
-        (( Const_int _ | Begin_region | End_region | Dls_get | Const_float32 _
-         | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
-         | Const_vec512 _ | Stackoffset _ | Load _
+        (( Const_int _ | Begin_region | End_region | Dls_get | Tls_get
+         | Const_float32 _ | Const_float _ | Const_symbol _ | Const_vec128 _
+         | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Load _
          | Store (_, _, _)
          | Intop _
          | Intop_imm (_, _)

--- a/backend/cfg/cfg_invariants.ml
+++ b/backend/cfg/cfg_invariants.ml
@@ -245,8 +245,8 @@ let check_stack_offset t label (block : Cfg.basic_block) =
             | Const_vec512 _ | Load _ | Store _ | Intop _ | Intop_imm _
             | Intop_atomic _ | Floatop _ | Csel _ | Static_cast _
             | Reinterpret_cast _ | Probe_is_enabled _ | Opaque | Begin_region
-            | End_region | Specific _ | Name_for_debugger _ | Dls_get | Poll
-            | Pause | Alloc _ )
+            | End_region | Specific _ | Name_for_debugger _ | Dls_get | Tls_get
+            | Poll | Pause | Alloc _ )
         | Reloadretaddr | Prologue | Epilogue | Stack_check _ ->
           cur_stack_offset)
   in

--- a/backend/cfg/cfg_polling.ml
+++ b/backend/cfg/cfg_polling.ml
@@ -188,9 +188,9 @@ module Polls_before_prtc_transfer = struct
     | Op (Alloc _) -> Ok Always_polls
     | Op
         ( Move | Spill | Reload | Opaque | Begin_region | End_region | Dls_get
-        | Pause | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
-        | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
-        | Load _
+        | Tls_get | Pause | Const_int _ | Const_float32 _ | Const_float _
+        | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
+        | Stackoffset _ | Load _
         | Store (_, _, _)
         | Intop _
         | Intop_imm (_, _)
@@ -357,7 +357,7 @@ let add_poll_or_alloc_basic :
     | Stackoffset _ | Load _ | Store _ | Intop _ | Intop_imm _ | Intop_atomic _
     | Floatop _ | Csel _ | Reinterpret_cast _ | Static_cast _
     | Probe_is_enabled _ | Opaque | Begin_region | End_region | Specific _
-    | Name_for_debugger _ | Dls_get | Pause ->
+    | Name_for_debugger _ | Dls_get | Tls_get | Pause ->
       points
     | Poll -> (Poll, instr.dbg) :: points
     | Alloc _ -> (Alloc, instr.dbg) :: points)

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -97,7 +97,8 @@ module Instruction_requirements = struct
           | Const_vec512 _ | Load _ | Store _ | Intop _ | Intop_imm _
           | Intop_atomic _ | Floatop _ | Csel _ | Reinterpret_cast _
           | Static_cast _ | Probe_is_enabled _ | Opaque | Begin_region
-          | End_region | Specific _ | Name_for_debugger _ | Dls_get | Pause )
+          | End_region | Specific _ | Name_for_debugger _ | Dls_get | Tls_get
+          | Pause )
       | Pushtrap _ | Poptrap _ | Reloadretaddr | Stack_check _ ->
         Requirements No_requirements
 end

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -138,7 +138,7 @@ let is_last_instruction_const_int (body : C.basic C.instruction Dll.t) :
           | Stack_check _
           | Op
               ( Const_int _ | Move | Spill | Reload | Opaque | Begin_region
-              | End_region | Dls_get | Poll | Pause | Const_float _
+              | End_region | Dls_get | Tls_get | Poll | Pause | Const_float _
               | Const_float32 _ | Const_symbol _ | Const_vec128 _
               | Const_vec256 _ | Const_vec512 _ | Stackoffset _ | Load _
               | Store (_, _, _)

--- a/backend/cfg/vectorize.ml
+++ b/backend/cfg/vectorize.ml
@@ -318,6 +318,7 @@ end = struct
     | Specific _, _
     | Name_for_debugger _, _
     | Dls_get, _
+    | Tls_get, _
     | Poll, _
     | Alloc _, _ ->
       false
@@ -801,8 +802,8 @@ end = struct
                         | Iasr | Ipopcnt | Imulh _ | Iclz _ | Ictz _ | Icomp _
                           ),
                         _ )
-                  | Opaque | Begin_region | End_region | Dls_get | Poll | Pause
-                  | Const_int _ | Const_float32 _ | Const_float _
+                  | Opaque | Begin_region | End_region | Dls_get | Tls_get
+                  | Poll | Pause | Const_int _ | Const_float32 _ | Const_float _
                   | Const_symbol _ | Const_vec128 _ | Const_vec256 _
                   | Const_vec512 _ | Stackoffset _ | Load _
                   | Store (_, _, _)
@@ -1037,7 +1038,7 @@ end = struct
           | Begin_region | End_region ->
             (* conservative, don't reorder around region begin/end. *)
             create Arbitrary
-          | Name_for_debugger _ | Dls_get | Poll | Opaque | Pause
+          | Name_for_debugger _ | Dls_get | Tls_get | Poll | Opaque | Pause
           | Probe_is_enabled _ ->
             (* conservative, don't reorder around this instruction. *)
             (* CR-someday gyorsh: Poll insertion pass is after the vectorizer.
@@ -2305,7 +2306,7 @@ end = struct
         | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
         | Stackoffset _ | Intop _ | Intop_imm _ | Intop_atomic _ | Floatop _
         | Csel _ | Probe_is_enabled _ | Opaque | Pause | Begin_region
-        | End_region | Name_for_debugger _ | Dls_get | Poll ->
+        | End_region | Name_for_debugger _ | Dls_get | Tls_get | Poll ->
           None)
 
     let from_block (block : Block.t) deps : t list =

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -74,7 +74,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       | Cxor | Clsl | Clsr | Casr | Ccmpi _ | Caddv | Cadda | Cnegf _ | Cclz _
       | Cctz _ | Cpopcnt | Cbswap _ | Ccsel _ | Cabsf _ | Caddf _ | Csubf _
       | Cmulf _ | Cdivf _ | Cpackf32 | Creinterpret_cast _ | Cstatic_cast _
-      | Ctuple_field _ | Ccmpf _ | Cdls_get ->
+      | Ctuple_field _ | Ccmpf _ | Cdls_get | Ctls_get ->
         List.for_all is_simple_expr args)
     | Cifthenelse _ | Cswitch _ | Ccatch _ | Cexit _ -> false
 
@@ -122,7 +122,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         | Catomic _ -> EC.arbitrary
         | Craise _ -> EC.effect_only Raise
         | Cload { mutability = Immutable } -> EC.none
-        | Cload { mutability = Mutable } | Cdls_get ->
+        | Cload { mutability = Mutable } | Cdls_get | Ctls_get ->
           EC.coeffect_only Read_mutable
         | Cprobe_is_enabled _ -> EC.coeffect_only Arbitrary
         | Ctuple_field _ | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi
@@ -327,6 +327,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       | _ -> SU.basic_op (Store (chunk, addr, is_assign)), [arg2; eloc]
       (* Inversion addr/datum in Istore *))
     | Cdls_get -> SU.basic_op Dls_get, args
+    | Ctls_get -> SU.basic_op Tls_get, args
     | Calloc (mode, alloc_block_kind) ->
       let placeholder_for_alloc_block_kind : Cmm.alloc_dbginfo_item =
         { alloc_words = 0; alloc_block_kind; alloc_dbg = Debuginfo.none }

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -471,6 +471,7 @@ type operation =
   | Cendregion
   | Ctuple_field of int * machtype array
   | Cdls_get
+  | Ctls_get
   | Cpoll
   | Cpause
 
@@ -645,7 +646,7 @@ let iter_shallow_tail f = function
   | Cop
       ( ( Calloc _ | Caddi | Csubi | Cmuli | Cdivi | Cmodi | Cand | Cor | Cxor
         | Clsl | Clsr | Casr | Cpopcnt | Caddv | Cadda | Cpackf32 | Copaque
-        | Cbeginregion | Cendregion | Cdls_get | Cpoll | Cpause
+        | Cbeginregion | Cendregion | Cdls_get | Ctls_get | Cpoll | Cpause
         | Capply (_, _)
         | Cextcall _ | Cload _
         | Cstore (_, _)
@@ -679,7 +680,7 @@ let map_shallow_tail f = function
     | Cop
         ( ( Calloc _ | Caddi | Csubi | Cmuli | Cdivi | Cmodi | Cand | Cor | Cxor
           | Clsl | Clsr | Casr | Cpopcnt | Caddv | Cadda | Cpackf32 | Copaque
-          | Cbeginregion | Cendregion | Cdls_get | Cpoll | Cpause
+          | Cbeginregion | Cendregion | Cdls_get | Ctls_get | Cpoll | Cpause
           | Capply (_, _)
           | Cextcall _ | Cload _
           | Cstore (_, _)

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -440,6 +440,7 @@ type operation =
   | Ctuple_field of int * machtype array
     (* the [machtype array] refers to the whole tuple *)
   | Cdls_get
+  | Ctls_get
   | Cpoll
   | Cpause
 

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4992,6 +4992,8 @@ let block_header x y = block_header x y
 
 let dls_get ~dbg = Cop (Cdls_get, [], dbg)
 
+let tls_get ~dbg = Cop (Ctls_get, [], dbg)
+
 let perform ~dbg eff =
   let cont =
     make_alloc dbg ~tag:Runtimetags.cont_tag

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1384,6 +1384,8 @@ val set_field_unboxed :
 
 val dls_get : dbg:Debuginfo.t -> expression
 
+val tls_get : dbg:Debuginfo.t -> expression
+
 val cpu_relax : dbg:Debuginfo.t -> expression
 
 val poll : dbg:Debuginfo.t -> expression

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -532,7 +532,7 @@ let preproc_stack_check ~fun_body ~frame_size ~trap_size =
     | Lprologue | Lepilogue_open | Lepilogue_close
     | Lop
         ( Move | Spill | Reload | Opaque | Begin_region | End_region | Dls_get
-        | Poll | Pause | Const_int _ | Const_float32 _ | Const_float _
+        | Tls_get | Poll | Pause | Const_int _ | Const_float32 _ | Const_float _
         | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
         | Load _
         | Store (_, _, _)

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -1280,6 +1280,10 @@ let basic_op t (i : Cfg.basic Cfg.instruction) (op : Operation.t) =
     let dls_state_ptr = load_domainstate_addr t Domain_dls_state in
     let dls_state = emit_ins t (I.load ~ptr:dls_state_ptr ~typ:T.i64) in
     store_into_reg t i.res.(0) dls_state
+  | Tls_get ->
+    let tls_state_ptr = load_domainstate_addr t Domain_tls_state in
+    let tls_state = emit_ins t (I.load ~ptr:tls_state_ptr ~typ:T.i64) in
+    store_into_reg t i.res.(0) tls_state
   | Poll -> () (* CR yusumez: insert poll call *)
   | Stackoffset _ -> () (* Handled separately via [statepoint_id_attr] *)
   | Spill | Reload -> not_implemented_basic ~msg:"spill / reload" i

--- a/backend/operation.ml
+++ b/backend/operation.ml
@@ -304,6 +304,7 @@ type t =
         regs : Reg.t array
       }
   | Dls_get
+  | Tls_get
   | Poll
   | Pause
   | Alloc of
@@ -347,6 +348,7 @@ let is_pure = function
   | Specific s -> Arch.operation_is_pure s
   | Name_for_debugger _ -> false
   | Dls_get -> true
+  | Tls_get -> true
   | Poll -> false
   | Pause -> false
   | Alloc _ -> false
@@ -430,6 +432,7 @@ let dump ppf op =
   | End_region -> Format.fprintf ppf "endregion"
   | Name_for_debugger _ -> Format.fprintf ppf "name_for_debugger"
   | Dls_get -> Format.fprintf ppf "dls_get"
+  | Tls_get -> Format.fprintf ppf "tls_get"
   | Poll -> Format.fprintf ppf "poll"
   | Pause -> Format.fprintf ppf "pause"
   | Alloc { bytes; dbginfo = _; mode = Heap } ->

--- a/backend/operation.mli
+++ b/backend/operation.mli
@@ -160,6 +160,7 @@ type t =
         regs : Reg.t array
       }
   | Dls_get
+  | Tls_get
   | Poll
   | Pause
   | Alloc of

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -322,6 +322,7 @@ let operation d = function
   | Cendregion -> "endregion"
   | Ctuple_field (field, _ty) -> to_string "tuple_field %i" field
   | Cdls_get -> "dls_get"
+  | Ctls_get -> "tls_get"
   | Cpoll -> "poll"
   | Cpause -> "pause"
 

--- a/backend/printoperation.ml
+++ b/backend/printoperation.ml
@@ -113,6 +113,7 @@ let operation ?(print_reg = Printreg.reg) (op : Operation.t) arg ppf res =
   | End_region -> fprintf ppf "endregion %a" reg arg.(0)
   | Specific op -> Arch.print_specific_operation reg op ppf arg
   | Dls_get -> fprintf ppf "dls_get"
+  | Tls_get -> fprintf ppf "tls_get"
   | Poll -> fprintf ppf "poll call"
   | Pause -> fprintf ppf "pause"
   | Probe_is_enabled { name } -> fprintf ppf "probe_is_enabled \"%s\"" name

--- a/backend/regalloc/regalloc_invariants.ml
+++ b/backend/regalloc/regalloc_invariants.ml
@@ -20,7 +20,7 @@ let precondition : Cfg_with_layout.t -> unit =
       | Load _ | Store _ | Intop _ | Intop_imm _ | Intop_atomic _ | Floatop _
       | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
       | Opaque | Begin_region | End_region | Specific _ | Name_for_debugger _
-      | Dls_get | Poll | Pause | Alloc _ ->
+      | Dls_get | Tls_get | Poll | Pause | Alloc _ ->
         ())
     | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
     | Stack_check _ ->
@@ -102,10 +102,10 @@ let postcondition_layout : Cfg_with_layout.t -> unit =
       | Reloadretaddr | Prologue | Epilogue | Pushtrap _ | Poptrap _
       | Stack_check _
       | Op
-          ( Move | Opaque | Begin_region | End_region | Dls_get | Poll | Pause
-          | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
-          | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
-          | Load _
+          ( Move | Opaque | Begin_region | End_region | Dls_get | Tls_get | Poll
+          | Pause | Const_int _ | Const_float32 _ | Const_float _
+          | Const_symbol _ | Const_vec128 _ | Const_vec256 _ | Const_vec512 _
+          | Stackoffset _ | Load _
           | Store (_, _, _)
           | Intop _
           | Intop_imm (_, _)

--- a/backend/regalloc/regalloc_irc_utils.ml
+++ b/backend/regalloc/regalloc_irc_utils.ml
@@ -170,6 +170,7 @@ let is_move_basic : Cfg.basic -> bool =
     | Specific _ -> false
     | Name_for_debugger _ -> false
     | Dls_get -> false
+    | Tls_get -> false
     | Poll -> false
     | Pause -> false
     | Alloc _ -> false)

--- a/backend/regalloc/regalloc_rewrite.ml
+++ b/backend/regalloc/regalloc_rewrite.ml
@@ -88,8 +88,8 @@ let coalesce_temp_spills_and_reloads (block : Cfg.basic_block)
     | Reloadretaddr | Prologue | Epilogue | Pushtrap _ | Poptrap _
     | Stack_check _
     | Op
-        ( Move | Opaque | Begin_region | End_region | Dls_get | Poll | Pause
-        | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
+        ( Move | Opaque | Begin_region | End_region | Dls_get | Tls_get | Poll
+        | Pause | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
         | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Stackoffset _
         | Load _
         | Store (_, _, _)

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -184,6 +184,7 @@ let oper_result_type = function
   | Calloc _ -> typ_val
   | Cstore (_c, _) -> typ_void
   | Cdls_get -> typ_val
+  | Ctls_get -> typ_val
   | Cprefetch _ -> typ_void
   | Catomic
       { op = Fetch_and_add | Compare_set | Exchange | Compare_exchange; _ } ->
@@ -542,7 +543,7 @@ module Stack_offset_and_exn = struct
         | Load _ | Store _ | Intop _ | Intop_imm _ | Intop_atomic _ | Floatop _
         | Csel _ | Static_cast _ | Reinterpret_cast _ | Probe_is_enabled _
         | Opaque | Begin_region | End_region | Specific _ | Name_for_debugger _
-        | Dls_get | Poll | Pause | Alloc _ )
+        | Dls_get | Tls_get | Poll | Pause | Alloc _ )
     | Reloadretaddr | Prologue | Epilogue ->
       stack_offset, traps
     | Stack_check _ ->

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -2619,7 +2619,7 @@ end = struct
           in
           transform t ~effect ~next ~exn:Value.bot "heap allocation" dbg
         | Specific s -> transform_specific t s ~next ~exn:Value.bot dbg
-        | Dls_get -> next
+        | Dls_get | Tls_get -> next
 
       let basic next (i : Cfg.basic Cfg.instruction) t : (domain, error) result
           =

--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -778,6 +778,7 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     | Patomic_lor_field -> ternary (Ccall "caml_atomic_lor_field")
     | Patomic_lxor_field -> ternary (Ccall "caml_atomic_lxor_field")
     | Pdls_get -> unary (Ccall "caml_domain_dls_get")
+    | Ptls_get -> unary (Ccall "caml_domain_tls_get")
     | Ppoll -> unary (Ccall "caml_process_pending_actions_with_root")
     | Pcpu_relax -> unary (Ccall "caml_ml_domain_cpu_relax")
     | Pisnull -> unary (Ccall "caml_is_null")

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -347,6 +347,7 @@ type primitive =
   | Ppoke of peek_or_poke
   (* Fetching domain-local state *)
   | Pdls_get
+  | Ptls_get
   (* Poll for runtime actions *)
   | Ppoll
   | Pcpu_relax
@@ -2055,6 +2056,7 @@ let primitive_may_allocate : primitive -> locality_mode option = function
   | Patomic_lor_field
   | Patomic_lxor_field
   | Pdls_get
+  | Ptls_get
   | Preinterpret_unboxed_int64_as_tagged_int63
   | Parray_element_size_in_bytes _
   | Pget_idx _ | Pset_idx _
@@ -2213,7 +2215,7 @@ let primitive_can_raise prim =
   | Patomic_sub_field  | Patomic_land_field | Patomic_lor_field
   | Patomic_lxor_field  | Patomic_load_field _ | Patomic_set_field _ -> false
   | Prunstack | Pperform | Presume | Preperform -> true (* XXX! *)
-  | Pdls_get | Ppoll | Pcpu_relax
+  | Pdls_get | Ptls_get | Ppoll | Pcpu_relax
   | Preinterpret_tagged_int63_as_unboxed_int64
   | Preinterpret_unboxed_int64_as_tagged_int63
   | Parray_element_size_in_bytes _
@@ -2584,7 +2586,7 @@ let primitive_result_layout (p : primitive) =
     layout_any_value
   | Patomic_compare_set_field _
   | Patomic_fetch_add_field -> layout_int
-  | Pdls_get -> layout_any_value
+  | Pdls_get | Ptls_get -> layout_any_value
   | Patomic_add_field
   | Patomic_sub_field
   | Patomic_land_field

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -363,6 +363,7 @@ type primitive =
      if the value is locally allocated *)
   (* Fetching domain-local state *)
   | Pdls_get
+  | Ptls_get
   (* Poll for runtime actions. May run pending actions such as signal
      handlers, finalizers, memprof callbacks, etc, as well as GCs and
      GC slices, so should not be moved or optimised away. *)

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -824,6 +824,7 @@ let primitive ppf = function
   | Patomic_lxor_field -> fprintf ppf "atomic_lxor_field"
   | Popaque _ -> fprintf ppf "opaque"
   | Pdls_get -> fprintf ppf "dls_get"
+  | Ptls_get -> fprintf ppf "tls_get"
   | Ppoll -> fprintf ppf "poll"
   | Pcpu_relax -> fprintf ppf "cpu_relax"
   | Pprobe_is_enabled {name} -> fprintf ppf "probe_is_enabled[%s]" name
@@ -1006,6 +1007,7 @@ let name_of_primitive = function
   | Pperform -> "Pperform"
   | Preperform -> "Preperform"
   | Pdls_get -> "Pdls_get"
+  | Ptls_get -> "Ptls_get"
   | Ppoll -> "Ppoll"
   | Pprobe_is_enabled _ -> "Pprobe_is_enabled"
   | Pobj_dup -> "Pobj_dup"

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -902,7 +902,7 @@ let rec choice ctx t =
     | Punbox_unit
 
     (* we don't handle effect or DLS primitives *)
-    | Prunstack | Pperform | Presume | Preperform | Pdls_get
+    | Prunstack | Pperform | Presume | Preperform | Pdls_get | Ptls_get
 
     (* we don't handle atomic primitives *)
     | Patomic_exchange_field _ | Patomic_compare_exchange_field _

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -1065,6 +1065,7 @@ let lookup_primitive loc ~poly_mode ~poly_sort pos p =
     | "%resume" ->
       if runtime5 then Primitive (Presume, 4) else Unsupported Presume
     | "%dls_get" -> Primitive (Pdls_get, 1)
+    | "%tls_get" -> Primitive (Ptls_get, 1)
     | "%poll" -> Primitive (Ppoll, 1)
     | "%unbox_nativeint" ->
       static_cast ~src:(i nativeint) ~dst:(naked (i nativeint))
@@ -2335,6 +2336,7 @@ let lambda_primitive_needs_event_after = function
   | Patomic_load_field _ | Patomic_set_field _
   | Pcpu_relax | Pctconst _ | Pint_as_pointer _ | Popaque _
   | Pdls_get
+  | Ptls_get
   | Pobj_magic _ | Punbox_vector _
   | Preinterpret_unboxed_int64_as_tagged_int63 | Ppeek _ | Ppoke _
   (* These don't allocate in bytecode; they're just identity functions: *)

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -326,6 +326,7 @@ let compute_static_size lam =
     | Patomic_fetch_add_field
     | Popaque _
     | Pdls_get
+    | Ptls_get
     | Ppeek _
     | Ppoke _
     | Pscalar _

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1242,7 +1242,7 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Pset_ptr _ | Patomic_exchange_field _ | Patomic_compare_exchange_field _
       | Patomic_compare_set_field _ | Patomic_fetch_add_field
       | Patomic_add_field | Patomic_sub_field | Patomic_land_field
-      | Patomic_lor_field | Patomic_lxor_field | Pdls_get | Ppoll
+      | Patomic_lor_field | Patomic_lxor_field | Pdls_get | Ptls_get | Ppoll
       | Patomic_load_field _ | Patomic_set_field _
       | Preinterpret_tagged_int63_as_unboxed_int64
       | Preinterpret_unboxed_int64_as_tagged_int63 | Ppeek _ | Ppoke _

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -2936,6 +2936,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     [Ternary (Atomic_field_int_arith Xor, atomic, field, i)]
   | Pcpu_relax, _ -> [Nullary Cpu_relax]
   | Pdls_get, _ -> [Nullary Dls_get]
+  | Ptls_get, _ -> [Nullary Tls_get]
   | Ppoll, _ -> [Nullary Poll]
   | Preinterpret_unboxed_int64_as_tagged_int63, [[i]] ->
     if not (Target_system.is_64_bit ())

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -548,7 +548,7 @@ let init_or_assign env (ia : Flambda_primitive.Init_or_assign.t) :
 let nullop _env (op : Flambda_primitive.nullary_primitive) : _ =
   match op with
   | Invalid _ | Optimised_out _ | Probe_is_enabled _ | Enter_inlined_apply _
-  | Dls_get | Poll | Cpu_relax ->
+  | Dls_get | Tls_get | Poll | Cpu_relax ->
     Misc.fatal_errorf "TODO: Nullary primitive: %a" Flambda_primitive.print
       (Flambda_primitive.Nullary op)
 

--- a/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_nullary_primitive.ml
@@ -52,6 +52,11 @@ let simplify_nullary_primitive dacc original_prim (prim : P.nullary_primitive)
     let ty = T.any_value in
     let dacc = DA.add_variable dacc result_var ty in
     Simplify_primitive_result.create named ~try_reify:false dacc
+  | Tls_get ->
+    let named = Named.create_prim original_prim dbg in
+    let ty = T.any_value in
+    let dacc = DA.add_variable dacc result_var ty in
+    Simplify_primitive_result.create named ~try_reify:false dacc
   | Poll ->
     let named = Named.create_prim original_prim dbg in
     let machine_width = DE.machine_width (DA.denv dacc) in

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -387,6 +387,7 @@ let nullary_prim_size prim =
   | Probe_is_enabled { name = _ } -> 4
   | Enter_inlined_apply _ -> 0
   | Dls_get -> 1
+  | Tls_get -> 1
   | Poll | Cpu_relax -> alloc_size
 
 let unary_prim_size ~machine_width prim =

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -338,6 +338,7 @@ type nullary_primitive =
       (** Used in classic mode to denote the start of an inlined function body.
           This is then used in to_cmm to correctly add inlined debuginfo. *)
   | Dls_get  (** Obtain the domain-local state block. *)
+  | Tls_get  (** Obtain the thread-local state block. *)
   | Poll
       (** Poll for runtime actions. May run pending actions such as signal
           handlers, finalizers, memprof callbacks, etc, as well as GCs and

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -976,6 +976,7 @@ let nullary_primitive _env res dbg prim =
        [to_cmm_primitive] but should instead be handled in [to_cmm_expr] to \
        correctly adjust the inlined debuginfo in the env."
   | Dls_get -> None, res, C.dls_get ~dbg
+  | Tls_get -> None, res, C.tls_get ~dbg
   | Poll -> None, res, C.poll ~dbg
   | Cpu_relax -> None, res, C.cpu_relax ~dbg
 

--- a/middle_end/flambda2/to_jsir/to_jsir_primitive.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_primitive.ml
@@ -104,6 +104,7 @@ let nullary_exn ~env ~res (f : Flambda_primitive.nullary_primitive) =
     (* CR selee: we should eventually use this debuginfo *)
     no_op ~env ~res
   | Dls_get -> use_prim' (Extern "caml_domain_dls_get")
+  | Tls_get -> use_prim' (Extern "caml_domain_tls_get")
   | Poll ->
     (* See [parse_bytecode.ml] in jsoo - treated as a noop *)
     no_op ~env ~res

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -488,7 +488,7 @@ module TLS0 = struct
   type tls_state = Obj_opt.t array
 
   external get_tls_state
-    : unit -> tls_state @@ portable = "caml_domain_tls_get"
+    : unit -> tls_state @@ portable = "%tls_get"
   [@@noalloc]
   external set_tls_state
     : tls_state -> unit @@ portable = "caml_domain_tls_set"


### PR DESCRIPTION
Adds a `%tls_get` primitive. It has exactly the same behavior as `%dls_get`, except it loads the TLS state and it's supported in runtime4. Updates `domain.ml` to use the primitive.