### PR TITLE
Better testing of unsigned compare

### DIFF
--- a/testsuite/tests/lib-smallint/test_int16.ml
+++ b/testsuite/tests/lib-smallint/test_int16.ml
@@ -6,6 +6,7 @@
 (* External declarations for unsigned comparison primitives *)
 external unsigned_lt : int16 -> int16 -> bool = "%int16_unsigned_lessthan"
 external unsigned_gt : int16 -> int16 -> bool = "%int16_unsigned_greaterthan"
+external [@layout_poly] id : ('a : any). 'a -> 'a = "%opaque"
 
 let () =
   Test_smallint.run
@@ -50,16 +51,62 @@ let () =
 
   (* Test the unsigned_lt primitive directly *)
   assert (unsigned_lt I.zero I.minus_one = true); (* 0 < 65535 *)
+  assert (unsigned_lt I.zero (id I.minus_one) = true);
+  assert (unsigned_lt (id I.zero) I.minus_one = true);
+  assert (unsigned_lt (id I.zero) (id I.minus_one) = true);
+
   assert (unsigned_lt I.minus_one I.zero = false); (* 65535 not < 0 *)
+  assert (unsigned_lt I.minus_one (id I.zero) = false);
+  assert (unsigned_lt (id I.minus_one) I.zero = false);
+  assert (unsigned_lt (id I.minus_one) (id I.zero) = false);
+
   assert (unsigned_lt I.max_int I.min_int = true); (* 32767 < 32768 *)
+  assert (unsigned_lt I.max_int (id I.min_int) = true);
+  assert (unsigned_lt (id I.max_int) I.min_int = true);
+  assert (unsigned_lt (id I.max_int) (id I.min_int) = true);
+
   assert (unsigned_lt I.min_int I.max_int = false); (* 32768 not < 32767 *)
+  assert (unsigned_lt I.min_int (id I.max_int) = false);
+  assert (unsigned_lt (id I.min_int) I.max_int = false);
+  assert (unsigned_lt (id I.min_int) (id I.max_int) = false);
+
   assert (unsigned_lt pos_100 neg_100 = true); (* 100 < 65436 *)
+  assert (unsigned_lt pos_100 (id neg_100) = true);
+  assert (unsigned_lt (id pos_100) neg_100 = true);
+  assert (unsigned_lt (id pos_100) (id neg_100) = true);
+
   assert (unsigned_lt neg_100 pos_100 = false); (* 65436 not < 100 *)
+  assert (unsigned_lt neg_100 (id pos_100) = false);
+  assert (unsigned_lt (id neg_100) pos_100 = false);
+  assert (unsigned_lt (id neg_100) (id pos_100) = false);
 
   (* Test unsigned greater than using primitive comparisons *)
   assert (unsigned_gt I.minus_one I.zero = true); (* 65535 > 0 *)
+  assert (unsigned_gt I.minus_one (id I.zero) = true);
+  assert (unsigned_gt (id I.minus_one) I.zero = true);
+  assert (unsigned_gt (id I.minus_one) (id I.zero) = true);
+
   assert (unsigned_gt I.zero I.minus_one = false); (* 0 not > 65535 *)
+  assert (unsigned_gt I.zero (id I.minus_one) = false);
+  assert (unsigned_gt (id I.zero) I.minus_one = false);
+  assert (unsigned_gt (id I.zero) (id I.minus_one) = false);
+
   assert (unsigned_gt I.min_int I.max_int = true); (* 32768 > 32767 *)
+  assert (unsigned_gt I.min_int (id I.max_int) = true);
+  assert (unsigned_gt (id I.min_int) I.max_int = true);
+  assert (unsigned_gt (id I.min_int) (id I.max_int) = true);
+
   assert (unsigned_gt I.max_int I.min_int = false); (* 32767 not > 32768 *)
+  assert (unsigned_gt I.max_int (id I.min_int) = false);
+  assert (unsigned_gt (id I.max_int) I.min_int = false);
+  assert (unsigned_gt (id I.max_int) (id I.min_int) = false);
+
   assert (unsigned_gt neg_100 pos_100 = true); (* 65436 > 100 *)
+  assert (unsigned_gt neg_100 (id pos_100) = true);
+  assert (unsigned_gt (id neg_100) pos_100 = true);
+  assert (unsigned_gt (id neg_100) (id pos_100) = true);
+
   assert (unsigned_gt pos_100 neg_100 = false); (* 100 not > 65436 *)
+  assert (unsigned_gt pos_100 (id neg_100) = false);
+  assert (unsigned_gt (id pos_100) neg_100 = false);
+  assert (unsigned_gt (id pos_100) (id neg_100) = false);

--- a/testsuite/tests/lib-smallint/test_int8.ml
+++ b/testsuite/tests/lib-smallint/test_int8.ml
@@ -6,6 +6,7 @@
 (* External declarations for unsigned comparison primitives *)
 external unsigned_lt : int8 -> int8 -> bool = "%int8_unsigned_lessthan"
 external unsigned_gt : int8 -> int8 -> bool = "%int8_unsigned_greaterthan"
+external [@layout_poly] id : ('a : any). 'a -> 'a = "%opaque"
 
 let () =
   Test_smallint.run
@@ -51,14 +52,52 @@ let () =
 
   (* Test the unsigned_lt primitive directly *)
   assert (unsigned_lt I.zero I.minus_one = true); (* 0 < 255 *)
+  assert (unsigned_lt I.zero (id I.minus_one) = true);
+  assert (unsigned_lt (id I.zero) I.minus_one = true);
+  assert (unsigned_lt (id I.zero) (id I.minus_one) = true);
+
   assert (unsigned_lt I.minus_one I.zero = false); (* 255 not < 0 *)
+  assert (unsigned_lt I.minus_one (id I.zero) = false);
+  assert (unsigned_lt (id I.minus_one) I.zero = false);
+  assert (unsigned_lt (id I.minus_one) (id I.zero) = false);
+
   assert (unsigned_lt I.max_int I.min_int = true); (* 127 < 128 *)
+  assert (unsigned_lt I.max_int (id I.min_int) = true);
+  assert (unsigned_lt (id I.max_int) I.min_int = true);
+  assert (unsigned_lt (id I.max_int) (id I.min_int) = true);
+
   assert (unsigned_lt I.min_int I.max_int = false); (* 128 not < 127 *)
+  assert (unsigned_lt I.min_int (id I.max_int) = false);
+  assert (unsigned_lt (id I.min_int) I.max_int = false);
+  assert (unsigned_lt (id I.min_int) (id I.max_int) = false);
+
   assert (unsigned_lt neg_2 two = false); (* 254 not < 2 *)
+  assert (unsigned_lt neg_2 (id two) = false);
+  assert (unsigned_lt (id neg_2) two = false);
+  assert (unsigned_lt (id neg_2) (id two) = false);
+
   assert (unsigned_lt two neg_2 = true); (* 2 < 254 *)
+  assert (unsigned_lt two (id neg_2) = true);
+  assert (unsigned_lt (id two) neg_2 = true);
+  assert (unsigned_lt (id two) (id neg_2) = true);
 
   (* Test unsigned greater than using primitive comparisons *)
   assert (unsigned_gt I.minus_one I.zero = true); (* 255 > 0 *)
+  assert (unsigned_gt I.minus_one (id I.zero) = true);
+  assert (unsigned_gt (id I.minus_one) I.zero = true);
+  assert (unsigned_gt (id I.minus_one) (id I.zero) = true);
+
   assert (unsigned_gt I.zero I.minus_one = false); (* 0 not > 255 *)
+  assert (unsigned_gt I.zero (id I.minus_one) = false);
+  assert (unsigned_gt (id I.zero) I.minus_one = false);
+  assert (unsigned_gt (id I.zero) (id I.minus_one) = false);
+
   assert (unsigned_gt I.min_int I.max_int = true); (* 128 > 127 *)
+  assert (unsigned_gt I.min_int (id I.max_int) = true);
+  assert (unsigned_gt (id I.min_int) I.max_int = true);
+  assert (unsigned_gt (id I.min_int) (id I.max_int) = true);
+
   assert (unsigned_gt I.max_int I.min_int = false); (* 127 not > 128 *)
+  assert (unsigned_gt I.max_int (id I.min_int) = false);
+  assert (unsigned_gt (id I.max_int) I.min_int = false);
+  assert (unsigned_gt (id I.max_int) (id I.min_int) = false);

--- a/testsuite/tests/typing-layouts-bits16/test_int16_u.ml
+++ b/testsuite/tests/typing-layouts-bits16/test_int16_u.ml
@@ -6,6 +6,7 @@
 (* External declarations for unsigned comparison primitives *)
 external unsigned_lt : int16# -> int16# -> bool = "%int16#_unsigned_lessthan"
 external unsigned_gt : int16# -> int16# -> bool = "%int16#_unsigned_greaterthan"
+external [@layout_poly] id : ('a : any). 'a -> 'a = "%opaque"
 
 module Int16 = Stdlib_stable.Int16
 module Int16_u = Stdlib_stable.Int16_u
@@ -345,16 +346,46 @@ let () =
 
   (* Test the unsigned_lt primitive directly *)
   assert (unsigned_lt (I.zero ()) (I.minus_one ()) = true); (* 0 < 65535 *)
+  assert (unsigned_lt (I.zero ()) (id (I.minus_one ())) = true);
+  assert (unsigned_lt (id (I.zero ())) (I.minus_one ()) = true);
+  assert (unsigned_lt (id (I.zero ())) (id (I.minus_one ())) = true);
+
   assert (unsigned_lt (I.minus_one ()) (I.zero ()) = false); (* 65535 not < 0 *)
+  assert (unsigned_lt (I.minus_one ()) (id (I.zero ())) = false);
+  assert (unsigned_lt (id (I.minus_one ())) (I.zero ()) = false);
+  assert (unsigned_lt (id (I.minus_one ())) (id (I.zero ())) = false);
+
   assert (unsigned_lt (I.max_int ()) (I.min_int ()) = true); (* 32767 < 32768 *)
+  assert (unsigned_lt (I.max_int ()) (id (I.min_int ())) = true);
+  assert (unsigned_lt (id (I.max_int ())) (I.min_int ()) = true);
+  assert (unsigned_lt (id (I.max_int ())) (id (I.min_int ())) = true);
+
   assert (unsigned_lt (I.min_int ()) (I.max_int ())
     = false); (* 32768 not < 32767 *)
+  assert (unsigned_lt (I.min_int ()) (id (I.max_int ())) = false);
+  assert (unsigned_lt (id (I.min_int ())) (I.max_int ()) = false);
+  assert (unsigned_lt (id (I.min_int ())) (id (I.max_int ())) = false);
 
   (* Test unsigned greater than using primitive comparisons *)
   assert (unsigned_gt (I.minus_one ()) (I.zero ()) = true); (* 65535 > 0 *)
+  assert (unsigned_gt (I.minus_one ()) (id (I.zero ())) = true);
+  assert (unsigned_gt (id (I.minus_one ())) (I.zero ()) = true);
+  assert (unsigned_gt (id (I.minus_one ())) (id (I.zero ())) = true);
+
   assert (unsigned_gt (I.zero ()) (I.minus_one ()) = false); (* 0 not > 65535 *)
+  assert (unsigned_gt (I.zero ()) (id (I.minus_one ())) = false);
+  assert (unsigned_gt (id (I.zero ())) (I.minus_one ()) = false);
+  assert (unsigned_gt (id (I.zero ())) (id (I.minus_one ())) = false);
+
   assert (unsigned_gt (I.min_int ()) (I.max_int ()) = true); (* 32768 > 32767 *)
+  assert (unsigned_gt (I.min_int ()) (id (I.max_int ())) = true);
+  assert (unsigned_gt (id (I.min_int ())) (I.max_int ()) = true);
+  assert (unsigned_gt (id (I.min_int ())) (id (I.max_int ())) = true);
+
   assert (unsigned_gt (I.max_int ()) (I.min_int ())
     = false); (* 32767 not > 32768 *)
+  assert (unsigned_gt (I.max_int ()) (id (I.min_int ())) = false);
+  assert (unsigned_gt (id (I.max_int ())) (I.min_int ()) = false);
+  assert (unsigned_gt (id (I.max_int ())) (id (I.min_int ())) = false);
 
   ()

--- a/testsuite/tests/typing-layouts-bits32/test_int32_u.ml
+++ b/testsuite/tests/typing-layouts-bits32/test_int32_u.ml
@@ -5,6 +5,7 @@
 (* External declarations for unsigned comparison primitives *)
 external unsigned_lt : int32# -> int32# -> bool = "%int32#_unsigned_lessthan"
 external unsigned_gt : int32# -> int32# -> bool = "%int32#_unsigned_greaterthan"
+external [@layout_poly] id : ('a : any). 'a -> 'a = "%opaque"
 
 module Int32_u = Stdlib_upstream_compatible.Int32_u
 
@@ -356,18 +357,65 @@ let () =
 
   (* Test the unsigned_lt primitive directly *)
   assert (unsigned_lt zero minus_one = true); (* 0 < 0xFFFFFFFF *)
+  assert (unsigned_lt zero (id minus_one) = true);
+  assert (unsigned_lt (id zero) minus_one = true);
+  assert (unsigned_lt (id zero) (id minus_one) = true);
+
   assert (unsigned_lt minus_one zero = false);
+  assert (unsigned_lt minus_one (id zero) = false);
+  assert (unsigned_lt (id minus_one) zero = false);
+  assert (unsigned_lt (id minus_one) (id zero) = false);
+
   assert (unsigned_lt max_int min_int = true); (* 0x7FFFFFFF < 0x80000000 *)
+  assert (unsigned_lt max_int (id min_int) = true);
+  assert (unsigned_lt (id max_int) min_int = true);
+  assert (unsigned_lt (id max_int) (id min_int) = true);
+
   assert (unsigned_lt min_int max_int = false);
+  assert (unsigned_lt min_int (id max_int) = false);
+  assert (unsigned_lt (id min_int) max_int = false);
+  assert (unsigned_lt (id min_int) (id max_int) = false);
+
   assert (unsigned_lt pos_1000 neg_1000 = true);
+  assert (unsigned_lt pos_1000 (id neg_1000) = true);
+  assert (unsigned_lt (id pos_1000) neg_1000 = true);
+  assert (unsigned_lt (id pos_1000) (id neg_1000) = true);
+
   assert (unsigned_lt neg_1000 pos_1000 = false);
+  assert (unsigned_lt neg_1000 (id pos_1000) = false);
+  assert (unsigned_lt (id neg_1000) pos_1000 = false);
+  assert (unsigned_lt (id neg_1000) (id pos_1000) = false);
+
 
   (* Test unsigned greater than using primitive comparisons *)
   assert (unsigned_gt minus_one zero = true); (* 0xFFFFFFFF > 0 *)
+  assert (unsigned_gt minus_one (id zero) = true);
+  assert (unsigned_gt (id minus_one) zero = true);
+  assert (unsigned_gt (id minus_one) (id zero) = true);
+
   assert (unsigned_gt zero minus_one = false);
+  assert (unsigned_gt zero (id minus_one) = false);
+  assert (unsigned_gt (id zero) minus_one = false);
+  assert (unsigned_gt (id zero) (id minus_one) = false);
+
   assert (unsigned_gt min_int max_int = true); (* 0x80000000 > 0x7FFFFFFF *)
+  assert (unsigned_gt min_int (id max_int) = true);
+  assert (unsigned_gt (id min_int) max_int = true);
+  assert (unsigned_gt (id min_int) (id max_int) = true);
+
   assert (unsigned_gt max_int min_int = false);
+  assert (unsigned_gt max_int (id min_int) = false);
+  assert (unsigned_gt (id max_int) min_int = false);
+  assert (unsigned_gt (id max_int) (id min_int) = false);
+
   assert (unsigned_gt neg_1000 pos_1000 = true);
+  assert (unsigned_gt neg_1000 (id pos_1000) = true);
+  assert (unsigned_gt (id neg_1000) pos_1000 = true);
+  assert (unsigned_gt (id neg_1000) (id pos_1000) = true);
+
   assert (unsigned_gt pos_1000 neg_1000 = false);
+  assert (unsigned_gt pos_1000 (id neg_1000) = false);
+  assert (unsigned_gt (id pos_1000) neg_1000 = false);
+  assert (unsigned_gt (id pos_1000) (id neg_1000) = false);
 
   ()

--- a/testsuite/tests/typing-layouts-bits64/test_int64_u.ml
+++ b/testsuite/tests/typing-layouts-bits64/test_int64_u.ml
@@ -5,6 +5,7 @@
 (* External declarations for unsigned comparison primitives *)
 external unsigned_lt : int64# -> int64# -> bool = "%int64#_unsigned_lessthan"
 external unsigned_gt : int64# -> int64# -> bool = "%int64#_unsigned_greaterthan"
+external [@layout_poly] id : ('a : any). 'a -> 'a = "%opaque"
 
 module Int64_u = Stdlib_upstream_compatible.Int64_u
 module Int32_u = Stdlib_upstream_compatible.Int32_u
@@ -377,20 +378,66 @@ let () =
 
   (* Test the unsigned_lt primitive directly *)
   assert (unsigned_lt zero minus_one = true); (* 0 < 0xFFFFFFFFFFFFFFFF *)
+  assert (unsigned_lt zero (id minus_one) = true);
+  assert (unsigned_lt (id zero) minus_one = true);
+  assert (unsigned_lt (id zero) (id minus_one) = true);
+
   assert (unsigned_lt minus_one zero = false);
+  assert (unsigned_lt minus_one (id zero) = false);
+  assert (unsigned_lt (id minus_one) zero = false);
+  assert (unsigned_lt (id minus_one) (id zero) = false);
+
   assert (unsigned_lt max_int min_int
     = true); (* 0x7FFFFFFFFFFFFFFF < 0x8000000000000000 *)
+  assert (unsigned_lt max_int (id min_int) = true);
+  assert (unsigned_lt (id max_int) min_int = true);
+  assert (unsigned_lt (id max_int) (id min_int) = true);
+
   assert (unsigned_lt min_int max_int = false);
+  assert (unsigned_lt min_int (id max_int) = false);
+  assert (unsigned_lt (id min_int) max_int = false);
+  assert (unsigned_lt (id min_int) (id max_int) = false);
+
   assert (unsigned_lt pos_billion neg_billion = true);
+  assert (unsigned_lt pos_billion (id neg_billion) = true);
+  assert (unsigned_lt (id pos_billion) neg_billion = true);
+  assert (unsigned_lt (id pos_billion) (id neg_billion) = true);
+
   assert (unsigned_lt neg_billion pos_billion = false);
+  assert (unsigned_lt neg_billion (id pos_billion) = false);
+  assert (unsigned_lt (id neg_billion) pos_billion = false);
+  assert (unsigned_lt (id neg_billion) (id pos_billion) = false);
 
   (* Test unsigned greater than using primitive comparisons *)
   assert (unsigned_gt minus_one zero = true); (* 0xFFFFFFFFFFFFFFFF > 0 *)
+  assert (unsigned_gt minus_one (id zero) = true);
+  assert (unsigned_gt (id minus_one) zero = true);
+  assert (unsigned_gt (id minus_one) (id zero) = true);
+
   assert (unsigned_gt zero minus_one = false);
+  assert (unsigned_gt zero (id minus_one) = false);
+  assert (unsigned_gt (id zero) minus_one = false);
+  assert (unsigned_gt (id zero) (id minus_one) = false);
+
   assert (unsigned_gt min_int max_int
     = true); (* 0x8000000000000000 > 0x7FFFFFFFFFFFFFFF *)
+  assert (unsigned_gt min_int (id max_int) = true);
+  assert (unsigned_gt (id min_int) max_int = true);
+  assert (unsigned_gt (id min_int) (id max_int) = true);
+
   assert (unsigned_gt max_int min_int = false);
+  assert (unsigned_gt max_int (id min_int) = false);
+  assert (unsigned_gt (id max_int) min_int = false);
+  assert (unsigned_gt (id max_int) (id min_int) = false);
+
   assert (unsigned_gt neg_billion pos_billion = true);
+  assert (unsigned_gt neg_billion (id pos_billion) = true);
+  assert (unsigned_gt (id neg_billion) pos_billion = true);
+  assert (unsigned_gt (id neg_billion) (id pos_billion) = true);
+
   assert (unsigned_gt pos_billion neg_billion = false);
+  assert (unsigned_gt pos_billion (id neg_billion) = false);
+  assert (unsigned_gt (id pos_billion) neg_billion = false);
+  assert (unsigned_gt (id pos_billion) (id neg_billion) = false);
 
   ()

--- a/testsuite/tests/typing-layouts-bits8/test_int8_u.ml
+++ b/testsuite/tests/typing-layouts-bits8/test_int8_u.ml
@@ -6,6 +6,7 @@
 (* External declarations for unsigned comparison primitives *)
 external unsigned_lt : int8# -> int8# -> bool = "%int8#_unsigned_lessthan"
 external unsigned_gt : int8# -> int8# -> bool = "%int8#_unsigned_greaterthan"
+external [@layout_poly] id : ('a : any). 'a -> 'a = "%opaque"
 
 module Int8 = Stdlib_stable.Int8
 module Int8_u = Stdlib_stable.Int8_u
@@ -330,16 +331,46 @@ let () =
 
   (* Test the unsigned_lt primitive directly *)
   assert (unsigned_lt (I.zero ()) (I.minus_one ()) = true); (* 0 < 255 *)
+  assert (unsigned_lt (I.zero ()) (id (I.minus_one ())) = true);
+  assert (unsigned_lt (id (I.zero ())) (I.minus_one ()) = true);
+  assert (unsigned_lt (id (I.zero ())) (id (I.minus_one ())) = true);
+
   assert (unsigned_lt (I.minus_one ()) (I.zero ()) = false); (* 255 not < 0 *)
+  assert (unsigned_lt (I.minus_one ()) (id (I.zero ())) = false);
+  assert (unsigned_lt (id (I.minus_one ())) (I.zero ()) = false);
+  assert (unsigned_lt (id (I.minus_one ())) (id (I.zero ())) = false);
+
   assert (unsigned_lt (I.max_int ()) (I.min_int ()) = true); (* 127 < 128 *)
+  assert (unsigned_lt (I.max_int ()) (id (I.min_int ())) = true);
+  assert (unsigned_lt (id (I.max_int ())) (I.min_int ()) = true);
+  assert (unsigned_lt (id (I.max_int ())) (id (I.min_int ())) = true);
+
   assert (unsigned_lt (I.min_int ()) (I.max_int ())
     = false); (* 128 not < 127 *)
+  assert (unsigned_lt (I.min_int ()) (id (I.max_int ())) = false);
+  assert (unsigned_lt (id (I.min_int ())) (I.max_int ()) = false);
+  assert (unsigned_lt (id (I.min_int ())) (id (I.max_int ())) = false);
 
   (* Test unsigned greater than using primitive comparisons *)
   assert (unsigned_gt (I.minus_one ()) (I.zero ()) = true); (* 255 > 0 *)
+  assert (unsigned_gt (I.minus_one ()) (id (I.zero ())) = true);
+  assert (unsigned_gt (id (I.minus_one ())) (I.zero ()) = true);
+  assert (unsigned_gt (id (I.minus_one ())) (id (I.zero ())) = true);
+
   assert (unsigned_gt (I.zero ()) (I.minus_one ()) = false); (* 0 not > 255 *)
+  assert (unsigned_gt (I.zero ()) (id (I.minus_one ())) = false);
+  assert (unsigned_gt (id (I.zero ())) (I.minus_one ()) = false);
+  assert (unsigned_gt (id (I.zero ())) (id (I.minus_one ())) = false);
+
   assert (unsigned_gt (I.min_int ()) (I.max_int ()) = true); (* 128 > 127 *)
+  assert (unsigned_gt (I.min_int ()) (id (I.max_int ())) = true);
+  assert (unsigned_gt (id (I.min_int ())) (I.max_int ()) = true);
+  assert (unsigned_gt (id (I.min_int ())) (id (I.max_int ())) = true);
+
   assert (unsigned_gt (I.max_int ()) (I.min_int ())
     = false); (* 127 not > 128 *)
+  assert (unsigned_gt (I.max_int ()) (id (I.min_int ())) = false);
+  assert (unsigned_gt (id (I.max_int ())) (I.min_int ()) = false);
+  assert (unsigned_gt (id (I.max_int ())) (id (I.min_int ())) = false);
 
   ()

--- a/testsuite/tests/typing-layouts-untagged-immediate/test_int_u.ml
+++ b/testsuite/tests/typing-layouts-untagged-immediate/test_int_u.ml
@@ -7,6 +7,7 @@
 (* External declarations for unsigned comparison primitives *)
 external unsigned_lt : int# -> int# -> bool = "%int#_unsigned_lessthan"
 external unsigned_gt : int# -> int# -> bool = "%int#_unsigned_greaterthan"
+external [@layout_poly] id : ('a : any). 'a -> 'a = "%opaque"
 
 module Int = Stdlib_stable.Int
 module Int_u = Stdlib_stable.Int_u
@@ -350,18 +351,64 @@ let () =
 
   (* Test the unsigned_lt primitive directly *)
   assert (unsigned_lt (I.zero ()) (I.minus_one ()) = true);
+  assert (unsigned_lt (I.zero ()) (id (I.minus_one ())) = true);
+  assert (unsigned_lt (id (I.zero ())) (I.minus_one ()) = true);
+  assert (unsigned_lt (id (I.zero ())) (id (I.minus_one ())) = true);
+
   assert (unsigned_lt (I.minus_one ()) (I.zero ()) = false);
+  assert (unsigned_lt (I.minus_one ()) (id (I.zero ())) = false);
+  assert (unsigned_lt (id (I.minus_one ())) (I.zero ()) = false);
+  assert (unsigned_lt (id (I.minus_one ())) (id (I.zero ())) = false);
+
   assert (unsigned_lt (I.max_int ()) (I.min_int ()) = true);
+  assert (unsigned_lt (I.max_int ()) (id (I.min_int ())) = true);
+  assert (unsigned_lt (id (I.max_int ())) (I.min_int ()) = true);
+  assert (unsigned_lt (id (I.max_int ())) (id (I.min_int ())) = true);
+
   assert (unsigned_lt (I.min_int ()) (I.max_int ()) = false);
+  assert (unsigned_lt (I.min_int ()) (id (I.max_int ())) = false);
+  assert (unsigned_lt (id (I.min_int ())) (I.max_int ()) = false);
+  assert (unsigned_lt (id (I.min_int ())) (id (I.max_int ())) = false);
+
   assert (unsigned_lt pos_100 neg_100 = true);
+  assert (unsigned_lt pos_100 (id neg_100) = true);
+  assert (unsigned_lt (id pos_100) neg_100 = true);
+  assert (unsigned_lt (id pos_100) (id neg_100) = true);
+
   assert (unsigned_lt neg_100 pos_100 = false);
+  assert (unsigned_lt neg_100 (id pos_100) = false);
+  assert (unsigned_lt (id neg_100) pos_100 = false);
+  assert (unsigned_lt (id neg_100) (id pos_100) = false);
 
   (* Test unsigned greater than using primitive comparisons *)
   assert (unsigned_gt (I.minus_one ()) (I.zero ()) = true);
+  assert (unsigned_gt (I.minus_one ()) (id (I.zero ())) = true);
+  assert (unsigned_gt (id (I.minus_one ())) (I.zero ()) = true);
+  assert (unsigned_gt (id (I.minus_one ())) (id (I.zero ())) = true);
+
   assert (unsigned_gt (I.zero ()) (I.minus_one ()) = false);
+  assert (unsigned_gt (I.zero ()) (id (I.minus_one ())) = false);
+  assert (unsigned_gt (id (I.zero ())) (I.minus_one ()) = false);
+  assert (unsigned_gt (id (I.zero ())) (id (I.minus_one ())) = false);
+
   assert (unsigned_gt (I.min_int ()) (I.max_int ()) = true);
+  assert (unsigned_gt (I.min_int ()) (id (I.max_int ())) = true);
+  assert (unsigned_gt (id (I.min_int ())) (I.max_int ()) = true);
+  assert (unsigned_gt (id (I.min_int ())) (id (I.max_int ())) = true);
+
   assert (unsigned_gt (I.max_int ()) (I.min_int ()) = false);
+  assert (unsigned_gt (I.max_int ()) (id (I.min_int ())) = false);
+  assert (unsigned_gt (id (I.max_int ())) (I.min_int ()) = false);
+  assert (unsigned_gt (id (I.max_int ())) (id (I.min_int ())) = false);
+
   assert (unsigned_gt neg_100 pos_100 = true);
+  assert (unsigned_gt neg_100 (id pos_100) = true);
+  assert (unsigned_gt (id neg_100) pos_100 = true);
+  assert (unsigned_gt (id neg_100) (id pos_100) = true);
+
   assert (unsigned_gt pos_100 neg_100 = false);
+  assert (unsigned_gt pos_100 (id neg_100) = false);
+  assert (unsigned_gt (id pos_100) neg_100 = false);
+  assert (unsigned_gt (id pos_100) (id neg_100) = false);
 
   ()

--- a/testsuite/tests/typing-layouts-word/test_nativeint_u.ml
+++ b/testsuite/tests/typing-layouts-word/test_nativeint_u.ml
@@ -5,6 +5,7 @@
 (* External declarations for unsigned comparison primitives *)
 external unsigned_lt : nativeint# -> nativeint# -> bool = "%nativeint#_unsigned_lessthan"
 external unsigned_gt : nativeint# -> nativeint# -> bool = "%nativeint#_unsigned_greaterthan"
+external [@layout_poly] id : ('a : any). 'a -> 'a = "%opaque"
 
 module Nativeint_u = Stdlib_upstream_compatible.Nativeint_u
 module Int32_u = Stdlib_upstream_compatible.Int32_u
@@ -372,18 +373,64 @@ let () =
 
   (* Test the unsigned_lt primitive directly *)
   assert (unsigned_lt zero minus_one = true);
+  assert (unsigned_lt zero (id minus_one) = true);
+  assert (unsigned_lt (id zero) minus_one = true);
+  assert (unsigned_lt (id zero) (id minus_one) = true);
+
   assert (unsigned_lt minus_one zero = false);
+  assert (unsigned_lt minus_one (id zero) = false);
+  assert (unsigned_lt (id minus_one) zero = false);
+  assert (unsigned_lt (id minus_one) (id zero) = false);
+
   assert (unsigned_lt max_int min_int = true);
+  assert (unsigned_lt max_int (id min_int) = true);
+  assert (unsigned_lt (id max_int) min_int = true);
+  assert (unsigned_lt (id max_int) (id min_int) = true);
+
   assert (unsigned_lt min_int max_int = false);
+  assert (unsigned_lt min_int (id max_int) = false);
+  assert (unsigned_lt (id min_int) max_int = false);
+  assert (unsigned_lt (id min_int) (id max_int) = false);
+
   assert (unsigned_lt pos_million neg_million = true);
+  assert (unsigned_lt pos_million (id neg_million) = true);
+  assert (unsigned_lt (id pos_million) neg_million = true);
+  assert (unsigned_lt (id pos_million) (id neg_million) = true);
+
   assert (unsigned_lt neg_million pos_million = false);
+  assert (unsigned_lt neg_million (id pos_million) = false);
+  assert (unsigned_lt (id neg_million) pos_million = false);
+  assert (unsigned_lt (id neg_million) (id pos_million) = false);
 
   (* Test unsigned greater than using primitive comparisons *)
   assert (unsigned_gt minus_one zero = true);
+  assert (unsigned_gt minus_one (id zero) = true);
+  assert (unsigned_gt (id minus_one) zero = true);
+  assert (unsigned_gt (id minus_one) (id zero) = true);
+
   assert (unsigned_gt zero minus_one = false);
+  assert (unsigned_gt zero (id minus_one) = false);
+  assert (unsigned_gt (id zero) minus_one = false);
+  assert (unsigned_gt (id zero) (id minus_one) = false);
+
   assert (unsigned_gt min_int max_int = true);
+  assert (unsigned_gt min_int (id max_int) = true);
+  assert (unsigned_gt (id min_int) max_int = true);
+  assert (unsigned_gt (id min_int) (id max_int) = true);
+
   assert (unsigned_gt max_int min_int = false);
+  assert (unsigned_gt max_int (id min_int) = false);
+  assert (unsigned_gt (id max_int) min_int = false);
+  assert (unsigned_gt (id max_int) (id min_int) = false);
+
   assert (unsigned_gt neg_million pos_million = true);
+  assert (unsigned_gt neg_million (id pos_million) = true);
+  assert (unsigned_gt (id neg_million) pos_million = true);
+  assert (unsigned_gt (id neg_million) (id pos_million) = true);
+
   assert (unsigned_gt pos_million neg_million = false);
+  assert (unsigned_gt pos_million (id neg_million) = false);
+  assert (unsigned_gt (id pos_million) neg_million = false);
+  assert (unsigned_gt (id pos_million) (id neg_million) = false);
 
   ()


### PR DESCRIPTION
I don't know which ways unsigned compare can be optimized, so the tests with exactly one argument opaque may be unnecessary.