### PR TITLE
Use level in a sort var when decomposing products

### DIFF
--- a/typing/env.ml
+++ b/typing/env.ml
@@ -4775,7 +4775,7 @@ let print_unsupported_quotation ppf =
   | Open_qt -> fprintf ppf "Opening modules"
 
 
-let report_lookup_error ~level _loc env ppf = function
+let report_lookup_error _loc env ppf = function
   | Unbound_value(lid, hint) -> begin
       fprintf ppf "Unbound value %a"
         (Style.as_inline_code !print_longident) lid;
@@ -4991,8 +4991,7 @@ let report_lookup_error ~level _loc env ppf = function
                    captured by an object.@ %a@]"
         (Style.as_inline_code !print_longident) lid
         (fun v -> Jkind.Violation.report_with_offender
-           ~offender:(fun ppf -> !print_type_expr ppf typ)
-           ~level v)
+           ~offender:(fun ppf -> !print_type_expr ppf typ) v)
         err
   | No_unboxed_version (lid, decl) ->
       fprintf ppf "@[The type %a has no unboxed version.@]"
@@ -5041,7 +5040,7 @@ let report_lookup_error ~level _loc env ppf = function
         (Style.as_inline_code !print_longident) lid
         print_stage usage_stage
 
-let report_error ~level ppf = function
+let report_error ppf = function
   | Missing_module(_, path1, path2) ->
       fprintf ppf "@[@[<hov>";
       if Path.same path1 path2 then
@@ -5058,7 +5057,7 @@ let report_error ~level ppf = function
   | Illegal_value_name(_loc, name) ->
       fprintf ppf "%a is not a valid value identifier."
        Style.inline_code name
-  | Lookup_error(loc, t, err) -> report_lookup_error ~level loc t ppf err
+  | Lookup_error(loc, t, err) -> report_lookup_error loc t ppf err
   | Incomplete_instantiation { unset_param } ->
       fprintf ppf "@[<hov>Not enough instance arguments: the parameter@ %a@ is \
                    required.@]"
@@ -5094,7 +5093,7 @@ let () =
             then Location.error_of_printer_file
             else Location.error_of_printer ~loc ?sub:None
           in
-          Some (error_of_printer (report_error ~level:Btype.generic_level) err)
+          Some (error_of_printer report_error err)
       | _ ->
           None
     )

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -645,10 +645,9 @@ exception Error of error
 
 open Format
 
-val report_error: level:int -> formatter -> error -> unit
+val report_error: formatter -> error -> unit
 
-val report_lookup_error:
-    level:int -> Location.t -> t -> formatter -> lookup_error -> unit
+val report_lookup_error: Location.t -> t -> formatter -> lookup_error -> unit
 
 val in_signature: bool -> t -> t
 

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -678,8 +678,7 @@ let report_type_mismatch first second decl env ppf err =
   | Parameter_jkind (ty, v) ->
       pr "The problem is in the kinds of a parameter:@,";
       Jkind.Violation.report_with_offender
-        ~offender:(fun pp -> Printtyp.type_expr pp ty)
-        ~level:(Ctype.get_current_level ()) ppf v
+        ~offender:(fun pp -> Printtyp.type_expr pp ty) ppf v
   | Private_variant (_ty1, _ty2, mismatch) ->
       report_private_variant_mismatch first second decl env ppf mismatch
   | Private_object (_ty1, _ty2, mismatch) ->
@@ -706,9 +705,7 @@ let report_type_mismatch first second decl env ppf err =
          (choose ord first second) decl
          "has a constructor represented as a null pointer";
       pr "@ Hint: add [%@%@or_null_reexport]."
-  | Jkind v ->
-      Jkind.Violation.report_with_name ~name:first
-        ~level:(Ctype.get_current_level ()) ppf v
+  | Jkind v -> Jkind.Violation.report_with_name ~name:first ppf v
   | Unsafe_mode_crossing mismatch ->
     pr "They have different unsafe mode crossing behavior:@,@[<v 2>%a@]"
       (fun ppf (first, second, mismatch) ->

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -289,7 +289,7 @@ module Layout = struct
     | Any, Any -> true
     | (Any | Sort _ | Product _), _ -> false
 
-  let sub ~level t1 t2 =
+  let sub t1 t2 =
     let rec sub t1 t2 : Misc.Le_result.t =
       match t1, t2 with
       | Any, Any -> Equal
@@ -305,13 +305,13 @@ module Layout = struct
            to end up less than a sort (so, no [any]), but it seems easier to keep
            this case lined up with the inverse case, which definitely cannot use
            [to_product_sort]. *)
-        match Sort.decompose_into_product ~level s2 (List.length ts1) with
+        match Sort.decompose_into_product s2 (List.length ts1) with
         | None -> Not_le
         | Some ss2 ->
           Misc.Le_result.combine_list
             (List.map2 (fun t1 s2 -> sub t1 (Sort s2)) ts1 ss2))
       | Sort s1, Product ts2 -> (
-        match Sort.decompose_into_product ~level s1 (List.length ts2) with
+        match Sort.decompose_into_product s1 (List.length ts2) with
         | None -> Not_le
         | Some ss1 ->
           Misc.Le_result.combine_list
@@ -320,10 +320,10 @@ module Layout = struct
     Sub_result.of_le_result (sub t1 t2) ~failure_reason:(fun () ->
         [Layout_disagreement])
 
-  let rec intersection ~level t1 t2 =
+  let rec intersection t1 t2 =
     (* pre-condition to [products]: [ts1] and [ts2] have the same length *)
     let products ts1 ts2 =
-      let components = List.map2 (intersection ~level) ts1 ts2 in
+      let components = List.map2 intersection ts1 ts2 in
       Option.map
         (fun x -> Product x)
         (Misc.Stdlib.List.some_if_all_elements_are_some components)
@@ -335,7 +335,7 @@ module Layout = struct
     | Product ts1, Product ts2 ->
       if List.compare_lengths ts1 ts2 = 0 then products ts1 ts2 else None
     | Product ts, Sort sort | Sort sort, Product ts -> (
-      match Sort.decompose_into_product ~level sort (List.length ts) with
+      match Sort.decompose_into_product sort (List.length ts) with
       | None -> None
       | Some sorts -> products ts (List.map (fun x -> Sort x) sorts))
 
@@ -2259,8 +2259,7 @@ module Jkind_desc = struct
   let equate_or_equal ~allow_mutation t1 t2 =
     Layout_and_axes.equal (Layout.equate_or_equal ~allow_mutation) t1 t2
 
-  let sub (type l r) ~type_equal:_ ~context ~level
-      (sub : (allowed * r) jkind_desc)
+  let sub (type l r) ~type_equal:_ ~context (sub : (allowed * r) jkind_desc)
       ({ layout = lay2; mod_bounds = bounds2; with_bounds = No_with_bounds } :
         (l * allowed) jkind_desc) =
     let axes_max_on_right =
@@ -2274,14 +2273,14 @@ module Jkind_desc = struct
       Layout_and_axes.normalize ~skip_axes:axes_max_on_right ~mode:Ignore_best
         ~context sub
     in
-    let layout = Layout.sub ~level lay1 lay2 in
+    let layout = Layout.sub lay1 lay2 in
     let bounds = Mod_bounds.less_or_equal bounds1 bounds2 in
     Sub_result.combine layout bounds
 
-  let intersection ~level
+  let intersection
       { layout = lay1; mod_bounds = mod_bounds1; with_bounds = with_bounds1 }
       { layout = lay2; mod_bounds = mod_bounds2; with_bounds = with_bounds2 } =
-    match Layout.intersection ~level lay1 lay2 with
+    match Layout.intersection lay1 lay2 with
     | None -> None
     | Some layout ->
       Some
@@ -3584,11 +3583,11 @@ module Violation = struct
     if first_ran_out then report_fuel_for_type "first";
     if second_ran_out then report_fuel_for_type "second"
 
-  let report_general ~level preamble pp_former former ppf t =
+  let report_general preamble pp_former former ppf t =
     let mismatch_type =
       match t.violation with
       | Not_a_subjkind (k1, k2, _) ->
-        if Sub_result.is_le (Layout.sub ~level k1.jkind.layout k2.jkind.layout)
+        if Sub_result.is_le (Layout.sub k1.jkind.layout k2.jkind.layout)
         then Mode
         else Layout
       | No_intersection _ -> Layout
@@ -3680,15 +3679,12 @@ module Violation = struct
 
   let pp_t ppf x = fprintf ppf "%t" x
 
-  let report_with_offender ~offender ~level =
-    report_general ~level "" pp_t offender
+  let report_with_offender ~offender = report_general "" pp_t offender
 
-  let report_with_offender_sort ~offender ~level =
-    report_general ~level "A representable layout was expected, but " pp_t
-      offender
+  let report_with_offender_sort ~offender =
+    report_general "A representable layout was expected, but " pp_t offender
 
-  let report_with_name ~name ~level =
-    report_general ~level "" pp_print_string name
+  let report_with_name ~name = report_general "" pp_print_string name
 end
 
 (******************************)
@@ -3728,7 +3724,7 @@ let score_reason = function
   | Creation (Concrete_creation _ | Concrete_legacy_creation _) -> -1
   | _ -> 0
 
-let combine_histories ~type_equal ~context ~level reason (Pack_jkind k1)
+let combine_histories ~type_equal ~context reason (Pack_jkind k1)
     (Pack_jkind k2) =
   if flattened_histories
   then
@@ -3738,7 +3734,7 @@ let combine_histories ~type_equal ~context ~level reason (Pack_jkind k1)
       else history_b
     in
     let choose_subjkind_history k_a history_a k_b history_b =
-      match Jkind_desc.sub ~level ~type_equal ~context k_a k_b with
+      match Jkind_desc.sub ~type_equal ~context k_a k_b with
       | Less -> history_a
       | Not_le _ ->
         (* CR layouts: this will be wrong if we ever have a non-trivial meet in
@@ -3763,19 +3759,19 @@ let combine_histories ~type_equal ~context ~level reason (Pack_jkind k1)
         history2 = k2.history
       }
 
-let has_intersection ~level t1 t2 =
+let has_intersection t1 t2 =
   (* Need to check only the layouts: all the axes have bottom elements. *)
-  Option.is_some (Layout.intersection ~level t1.jkind.layout t2.jkind.layout)
+  Option.is_some (Layout.intersection t1.jkind.layout t2.jkind.layout)
 
-let intersection_or_error ~type_equal ~context ~reason ~level t1 t2 =
-  match Jkind_desc.intersection ~level t1.jkind t2.jkind with
+let intersection_or_error ~type_equal ~context ~reason t1 t2 =
+  match Jkind_desc.intersection t1.jkind t2.jkind with
   | None -> Error (Violation.of_ ~context (No_intersection (t1, t2)))
   | Some jkind ->
     Ok
       { jkind;
         annotation = None;
         history =
-          combine_histories ~type_equal ~context ~level reason (Pack_jkind t1)
+          combine_histories ~type_equal ~context reason (Pack_jkind t1)
             (Pack_jkind t2);
         has_warned = t1.has_warned || t2.has_warned;
         ran_out_of_fuel_during_normalize =
@@ -3801,35 +3797,32 @@ let map_type_expr f t =
 (* this is hammered on; it must be fast! *)
 let check_sub ~context sub super = Jkind_desc.sub ~context sub.jkind super.jkind
 
-let sub_with_reason ~type_equal ~context ~level sub super =
-  Sub_result.require_le (check_sub ~type_equal ~context ~level sub super)
+let sub_with_reason ~type_equal ~context sub super =
+  Sub_result.require_le (check_sub ~type_equal ~context sub super)
 
-let sub ~type_equal ~context ~level sub super =
-  Result.is_ok (sub_with_reason ~type_equal ~context ~level sub super)
+let sub ~type_equal ~context sub super =
+  Result.is_ok (sub_with_reason ~type_equal ~context sub super)
 
 type sub_or_intersect =
   | Sub
   | Disjoint of Violation.Sub_failure_reason.t Nonempty_list.t
   | Has_intersection of Violation.Sub_failure_reason.t Nonempty_list.t
 
-let sub_or_intersect ~type_equal ~context ~level t1 t2 =
-  match sub_with_reason ~type_equal ~context ~level t1 t2 with
+let sub_or_intersect ~type_equal ~context t1 t2 =
+  match sub_with_reason ~type_equal ~context t1 t2 with
   | Ok () -> Sub
   | Error reason ->
-    if has_intersection ~level t1 t2
-    then Has_intersection reason
-    else Disjoint reason
+    if has_intersection t1 t2 then Has_intersection reason else Disjoint reason
 
-let sub_or_error ~type_equal ~context ~level t1 t2 =
-  match sub_or_intersect ~type_equal ~context ~level t1 t2 with
+let sub_or_error ~type_equal ~context t1 t2 =
+  match sub_or_intersect ~type_equal ~context t1 t2 with
   | Sub -> Ok ()
   | Disjoint reason | Has_intersection reason ->
     Error
       (Violation.of_ ~context
          (Not_a_subjkind (t1, t2, Nonempty_list.to_list reason)))
 
-let sub_jkind_l ~type_equal ~context ~level ?(allow_any_crossing = false) sub
-    super =
+let sub_jkind_l ~type_equal ~context ?(allow_any_crossing = false) sub super =
   (* This function implements the "SUB" judgement from kind-inference.md. *)
   let open Misc.Stdlib.Monad.Result.Syntax in
   let require_le sub_result =
@@ -3850,7 +3843,7 @@ let sub_jkind_l ~type_equal ~context ~level ?(allow_any_crossing = false) sub
   in
   let* () =
     (* Validate layouts *)
-    require_le (Layout.sub ~level sub.jkind.layout super.jkind.layout)
+    require_le (Layout.sub sub.jkind.layout super.jkind.layout)
   in
   match allow_any_crossing with
   | true -> Ok ()

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -103,7 +103,7 @@ module Layout : sig
 
   val of_const : Const.t -> Sort.t t
 
-  val sub : level:int -> Sort.t t -> Sort.t t -> Sub_result.t
+  val sub : Sort.t t -> Sort.t t -> Sub_result.t
 
   module Debug_printers : sig
     val t :
@@ -220,25 +220,16 @@ module Violation : sig
   (** Prints a violation and the thing that had an unexpected jkind
       ([offender], which you supply an arbitrary printer for). *)
   val report_with_offender :
-    offender:(Format.formatter -> unit) ->
-    level:int ->
-    Format.formatter ->
-    t ->
-    unit
+    offender:(Format.formatter -> unit) -> Format.formatter -> t -> unit
 
   (** Like [report_with_offender], but additionally prints that the issue is
       that a representable jkind was expected. *)
   val report_with_offender_sort :
-    offender:(Format.formatter -> unit) ->
-    level:int ->
-    Format.formatter ->
-    t ->
-    unit
+    offender:(Format.formatter -> unit) -> Format.formatter -> t -> unit
 
   (** Simpler version of [report_with_offender] for when the thing that had an
       unexpected jkind is available as a string. *)
-  val report_with_name :
-    name:string -> level:int -> Format.formatter -> t -> unit
+  val report_with_name : name:string -> Format.formatter -> t -> unit
 end
 
 (******************************)
@@ -787,7 +778,7 @@ val equal : Types.jkind_lr -> Types.jkind_lr -> bool
     sort variables. Works over any mix of l- and r-jkinds, because the only
     way not to have an intersection is by looking at the layout: all axes
     have a bottom element. *)
-val has_intersection : level:int -> 'd1 Types.jkind -> 'd2 Types.jkind -> bool
+val has_intersection : 'd1 Types.jkind -> 'd2 Types.jkind -> bool
 
 (** Finds the intersection of two jkinds, constraining sort variables to
     create one if needed, or returns a [Violation.t] if an intersection does
@@ -800,7 +791,6 @@ val intersection_or_error :
   type_equal:(Types.type_expr -> Types.type_expr -> bool) ->
   context:jkind_context ->
   reason:History.interact_reason ->
-  level:int ->
   ('l1 * allowed) Types.jkind ->
   ('l2 * allowed) Types.jkind ->
   (('l1 * allowed) Types.jkind, Violation.t) Result.t
@@ -810,7 +800,6 @@ val intersection_or_error :
 val sub :
   type_equal:(Types.type_expr -> Types.type_expr -> bool) ->
   context:jkind_context ->
-  level:int ->
   Types.jkind_l ->
   Types.jkind_r ->
   bool
@@ -828,7 +817,6 @@ type sub_or_intersect =
 val sub_or_intersect :
   type_equal:(Types.type_expr -> Types.type_expr -> bool) ->
   context:jkind_context ->
-  level:int ->
   (allowed * 'r) Types.jkind ->
   ('l * allowed) Types.jkind ->
   sub_or_intersect
@@ -838,7 +826,6 @@ val sub_or_intersect :
 val sub_or_error :
   type_equal:(Types.type_expr -> Types.type_expr -> bool) ->
   context:jkind_context ->
-  level:int ->
   (allowed * 'r) Types.jkind ->
   ('l * allowed) Types.jkind ->
   (unit, Violation.t) result
@@ -850,7 +837,6 @@ val sub_or_error :
 val sub_jkind_l :
   type_equal:(Types.type_expr -> Types.type_expr -> bool) ->
   context:jkind_context ->
-  level:int ->
   ?allow_any_crossing:bool ->
   Types.jkind_l ->
   Types.jkind_l ->

--- a/typing/jkind_types.mli
+++ b/typing/jkind_types.mli
@@ -91,7 +91,7 @@ module Sort : sig
 
   (** Decompose a sort into a list (of the given length) of fresh sort variables,
       equating the input sort with the product of the output sorts. *)
-  val decompose_into_product : level:int -> t -> int -> t list option
+  val decompose_into_product : t -> int -> t list option
 end
 
 module Layout : sig

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -3253,13 +3253,13 @@ let explanation (type variety) intro prev env
   | Errortrace.Bad_jkind (t,e) ->
       Some (dprintf "@ @[<hov>%a@]"
               (Jkind.Violation.report_with_offender
-                 ~offender:(fun ppf -> type_expr ppf t)
-                 ~level:(get_current_level ())) e)
+                 ~offender:(fun ppf -> type_expr ppf t))
+              e)
   | Errortrace.Bad_jkind_sort (t,e) ->
       Some (dprintf "@ @[<hov>%a@]"
               (Jkind.Violation.report_with_offender_sort
-                 ~offender:(fun ppf -> type_expr ppf t)
-                 ~level:(get_current_level ())) e)
+                 ~offender:(fun ppf -> type_expr ppf t))
+              e)
   | Errortrace.Unequal_var_jkinds (t1,k1,t2,k2) ->
       let fmt_history t k ppf =
         Jkind.(format_history ~intro:(

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -2384,9 +2384,7 @@ let report_error env ppf =
   | Non_value_binding (nm, err) ->
     fprintf ppf
       "@[Variables bound in a class must have layout value.@ %a@]"
-      (Jkind.Violation.report_with_name
-         ~name:nm
-         ~level:(Ctype.get_current_level ()))
+      (Jkind.Violation.report_with_name ~name:nm)
       err
   | Non_value_let_binding (nm, sort) ->
     fprintf ppf

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -11282,8 +11282,7 @@ let report_error ~loc env =
   | Non_value_object (err, explanation) ->
     Location.error_of_printer ~loc (fun ppf () ->
       fprintf ppf "Object types must have layout value.@ %a"
-        (Jkind.Violation.report_with_name ~name:"the type of this expression"
-           ~level:(Ctype.get_current_level ()))
+        (Jkind.Violation.report_with_name ~name:"the type of this expression")
         err;
       report_type_expected_explanation_opt explanation ppf)
       ()
@@ -11291,8 +11290,7 @@ let report_error ~loc env =
     Location.error_of_printer ~loc (fun ppf () ->
       fprintf ppf "Variables bound in a \"let rec\" must have layout value.@ %a"
         (fun v -> Jkind.Violation.report_with_offender
-           ~offender:(fun ppf -> Printtyp.type_expr ppf ty)
-           ~level:(Ctype.get_current_level ()) v)
+           ~offender:(fun ppf -> Printtyp.type_expr ppf ty) v)
         err)
       ()
   | Undefined_method (ty, me, valid_methods) ->
@@ -11850,26 +11848,26 @@ let report_error ~loc env =
       Location.errorf ~loc
         "@[Function arguments and returns must be representable.@]@ %a"
         (Jkind.Violation.report_with_offender
-           ~offender:(fun ppf -> Printtyp.type_expr ppf ty)
-           ~level:(get_current_level ())) violation
+           ~offender:(fun ppf -> Printtyp.type_expr ppf ty))
+        violation
   | Record_projection_not_rep (ty,violation) ->
       Location.errorf ~loc
         "@[Records being projected from must be representable.@]@ %a"
         (Jkind.Violation.report_with_offender
-           ~offender:(fun ppf -> Printtyp.type_expr ppf ty)
-           ~level:(get_current_level ())) violation
+           ~offender:(fun ppf -> Printtyp.type_expr ppf ty))
+        violation
   | Record_not_rep (ty,violation) ->
       Location.errorf ~loc
         "@[Record expressions must be representable.@]@ %a"
         (Jkind.Violation.report_with_offender
-           ~offender:(fun ppf -> Printtyp.type_expr ppf ty)
-           ~level:(get_current_level ())) violation
+           ~offender:(fun ppf -> Printtyp.type_expr ppf ty))
+        violation
   | Mutable_var_not_rep (ty, violation) ->
       Location.errorf ~loc
         "@[Mutable variables must be representable.@]@ %a"
         (Jkind.Violation.report_with_offender
-           ~offender:(fun ppf -> Printtyp.type_expr ppf ty)
-           ~level:(get_current_level ())) violation
+           ~offender:(fun ppf -> Printtyp.type_expr ppf ty))
+        violation
   | Invalid_label_for_src_pos arg_label ->
       Location.errorf ~loc
         "A position argument must not be %s."

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1513,8 +1513,7 @@ let narrow_to_manifest_jkind env loc decl =
         let type_equal = Ctype.type_equal env in
         let context = Ctype.mk_jkind_context_always_principal env in
         match
-          Jkind.sub_jkind_l ~type_equal ~context
-            ~level:(Ctype.get_current_level ()) manifest_jkind decl.type_jkind
+          Jkind.sub_jkind_l ~type_equal ~context manifest_jkind decl.type_jkind
         with
         | Ok () -> ()
         | Error v -> raise (Error (loc, Jkind_mismatch_of_type (ty,v)))
@@ -2172,7 +2171,7 @@ let rec update_decl_jkind env dpath decl =
      other types in a (maybe mutually recursive) type declaration. See Note [Default
      jkinds in transl_declaration]) *)
   match
-    Jkind.Layout.sub ~level:(Ctype.get_current_level ())
+    Jkind.Layout.sub
       new_decl.type_jkind.jkind.layout decl.type_jkind.jkind.layout
   with
   | Not_le reason ->
@@ -2825,7 +2824,6 @@ let normalize_decl_jkinds env decls =
           ~type_equal
           ~context
           ~allow_any_crossing
-          ~level:(Ctype.get_current_level ())
           decl.type_jkind
           original_decl.type_jkind
       with
@@ -4407,8 +4405,8 @@ let report_jkind_mismatch_due_to_bad_inference ppf ty violation loc =
      the declaration where this error is reported.@]"
     loc
     (Jkind.Violation.report_with_offender
-       ~offender:(fun ppf -> Printtyp.type_expr ppf ty)
-       ~level:(Ctype.get_current_level ())) violation
+       ~offender:(fun ppf -> Printtyp.type_expr ppf ty))
+    violation
 
 let report_error ppf = function
   | Repeated_parameter ->
@@ -4698,13 +4696,11 @@ let report_error ppf = function
       in
       fprintf ppf "type %a" Style.inline_code path_end
     in
-    Jkind.Violation.report_with_offender ~offender
-      ~level:(Ctype.get_current_level ()) ppf v
+    Jkind.Violation.report_with_offender ~offender ppf v
   | Jkind_mismatch_of_type (ty,v) ->
     let offender ppf = fprintf ppf "type %a"
         (Style.as_inline_code Printtyp.type_expr) ty in
-    Jkind.Violation.report_with_offender ~offender
-      ~level:(Ctype.get_current_level ()) ppf v
+    Jkind.Violation.report_with_offender ~offender ppf v
   | Jkind_sort {kloc; typ; err} ->
     let s =
       match kloc with
@@ -4730,16 +4726,15 @@ let report_error ppf = function
     fprintf ppf "@[%s must have a representable layout%t.@ %a@]" s
       extra
       (Jkind.Violation.report_with_offender
-         ~offender:(fun ppf -> Printtyp.type_expr ppf typ)
-         ~level:(Ctype.get_current_level ())) err
+         ~offender:(fun ppf -> Printtyp.type_expr ppf typ))
+      err
   | Jkind_empty_record ->
     fprintf ppf "@[Records must contain at least one runtime value.@]"
   | Non_value_in_sig (err, val_name, ty) ->
     let offender ppf = fprintf ppf "type %a" Printtyp.type_expr ty in
     fprintf ppf "@[This type signature for %a is not a value type.@ %a@]"
       Style.inline_code val_name
-      (Jkind.Violation.report_with_offender ~offender
-         ~level:(Ctype.get_current_level ()))
+      (Jkind.Violation.report_with_offender ~offender)
       err
   | Invalid_jkind_in_block (typ, sort_const, lloc) ->
     let struct_desc =

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -1211,8 +1211,8 @@ let report_error ppf = function
       | Some err ->
         fprintf ppf "@ %a"
         (Jkind.Violation.report_with_offender
-           ~offender:(fun ppf -> Printtyp.type_expr ppf ty)
-           ~level:(Ctype.get_current_level ())) err
+           ~offender:(fun ppf -> Printtyp.type_expr ppf ty))
+        err
       end
   | Sort_without_extension (sort, maturity, ty) ->
       fprintf ppf "Non-value layout %a detected" Jkind.Sort.format sort;
@@ -1269,8 +1269,8 @@ let report_error ppf = function
   | Not_a_sort (ty, err) ->
       fprintf ppf "A representable layout is required here.@ %a"
         (Jkind.Violation.report_with_offender
-           ~offender:(fun ppf -> Printtyp.type_expr ppf ty)
-           ~level:(Ctype.get_current_level ()) ) err
+           ~offender:(fun ppf -> Printtyp.type_expr ppf ty))
+        err
   | Unsupported_product_in_lazy const ->
       fprintf ppf
         "Product layout %a detected in [lazy] in [Typeopt.Layout]@ \
@@ -1308,8 +1308,8 @@ let report_error ppf = function
           Printtyp.type_expr array_type
           Printtyp.type_expr ty
           (Jkind.Violation.report_with_offender
-             ~offender:(fun ppf -> Printtyp.type_expr ppf ty)
-             ~level:(Ctype.get_current_level ())) err
+             ~offender:(fun ppf -> Printtyp.type_expr ppf ty))
+          err
       | None ->
         fprintf ppf
           "This array operation expects an array type, but %a does not appear@ \

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1640,8 +1640,8 @@ let report_error env ppf =
     fprintf ppf "@[%s types must have layout value.@ %a@]"
       s (Jkind.Violation.report_with_offender
            ~offender:(fun ppf ->
-               Style.as_inline_code Printtyp.type_expr ppf typ)
-           ~level:(get_current_level ())) err
+               Style.as_inline_code Printtyp.type_expr ppf typ))
+      err
   | Non_sort {vloc; typ; err} ->
     let s =
       match vloc with
@@ -1651,14 +1651,14 @@ let report_error env ppf =
     fprintf ppf "@[%s types must have a representable layout.@ %a@]"
       s (Jkind.Violation.report_with_offender
            ~offender:(fun ppf ->
-               Style.as_inline_code Printtyp.type_expr ppf typ)
-           ~level:(get_current_level ())) err
+               Style.as_inline_code Printtyp.type_expr ppf typ))
+      err
   | Bad_jkind_annot(ty, violation) ->
     fprintf ppf "@[<b 2>Bad layout annotation:@ %a@]"
       (Jkind.Violation.report_with_offender
          ~offender:(fun ppf ->
-             Style.as_inline_code Printtyp.type_expr ppf ty)
-         ~level:(get_current_level ())) violation
+             Style.as_inline_code Printtyp.type_expr ppf ty))
+      violation
   | Did_you_mean_unboxed lid ->
     fprintf ppf "@[%a isn't a class type.@ \
                  Did you mean the unboxed type %a?@]"


### PR DESCRIPTION
I spotted #4785 go past, took a quick look, and spotted a simplification: we don't actually need to pass the level into `decompose_product`. Instead, if the sort being decomposed is a variable, we can just re-use its level. This removes lots of level passing!

Proof that this new treatment is correct:

- The current level is less than, equal to, or greater than the level in the existing sort variable.

  - If it is less than: something has gone horribly wrong: the level in a variable should never be greater than the current level (unless it is generic_level).

    - If it is generic_level: something has gone horribly wrong: we should not be unifying things that are generic level. Instead we should instantiate first.

  - If it is equal to: then the new treatment is the same as the old.

  - If it is greater than: then proper treatment of levels says that we must correct the level of any new variables created in the old decompose_product to match that of the existing sort variable, leading to the same behavior as implemented here.

Review: @Dreian, but I'm sure @ccasin will be interested too.