### PR TITLE
Add missing `Skip` hints for monadic modes in comonadic conversions

### DIFF
--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
@@ -475,5 +475,8 @@ val r' : int ref = {contents = 0}
 Line 2, characters 16-18:
 2 | fork (fun () -> r' := 1);;
                     ^^
-Error: This value is "contended" but is expected to be "uncontended".
+Error: This value is "contended"
+       because it is used inside the function (at Line 2, characters 5-24)
+       which is expected to be "portable".
+       However, the highlighted expression is expected to be "uncontended".
 |}]

--- a/testsuite/tests/typing-modes/exn.ml
+++ b/testsuite/tests/typing-modes/exn.ml
@@ -290,7 +290,10 @@ let (foo @ stateless) () =
 Line 3, characters 34-35:
 3 |     raise (StatefulFun (fun () -> x.contents <- 1))
                                       ^
-Error: This value is "immutable" but is expected to be "read_write"
+Error: This value is "immutable"
+       because it is used inside the function (at Line 3, characters 23-50)
+       which is expected to be "stateless".
+       However, the highlighted expression is expected to be "read_write"
        because its mutable field "contents" is being written.
 |}]
 
@@ -304,7 +307,8 @@ Line 4, characters 23-24:
                            ^
 Error: This value is "stateful"
        because it contains a usage (of the value "x" at Line 3, characters 15-16)
-       which is expected to be "read_write".
+       which is expected to be "read_write"
+       because its mutable field "contents" is being written.
        However, the highlighted expression is expected to be "stateless".
 |}]
 

--- a/testsuite/tests/typing-modes/portable-contend.ml
+++ b/testsuite/tests/typing-modes/portable-contend.ml
@@ -142,7 +142,8 @@ Line 4, characters 23-26:
                            ^^^
 Error: This value is "nonportable"
        because it contains a usage (of the value "r" at Line 3, characters 25-26)
-       which is expected to be "shared" or "uncontended".
+       which is expected to be "shared" or "uncontended"
+       because its mutable field "a" is being read.
        However, the highlighted expression is expected to be "portable".
 |}]
 
@@ -157,7 +158,8 @@ Line 3, characters 23-26:
                            ^^^
 Error: This value is "nonportable"
        because it contains a usage (of the value "r" at Line 2, characters 25-26)
-       which is expected to be "shared" or "uncontended".
+       which is expected to be "shared" or "uncontended"
+       because its mutable field "a" is being read.
        However, the highlighted expression is expected to be "portable".
 |}]
 

--- a/testsuite/tests/typing-modes/statefulness-visibility.ml
+++ b/testsuite/tests/typing-modes/statefulness-visibility.ml
@@ -421,7 +421,10 @@ let foo @ stateless =
 Line 2, characters 25-26:
 2 |     fun () -> Atomic.set a 0
                              ^
-Error: This value is "immutable" but is expected to be "read_write".
+Error: This value is "immutable"
+       because it is used inside the function (at Line 2, characters 4-28)
+       which is expected to be "stateless".
+       However, the highlighted expression is expected to be "read_write".
 |}]
 
 (* Closing over a stateful value also gives stateful. *)

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -447,7 +447,10 @@ end
 Line 7, characters 20-23:
 7 |     uncontended_use M.r
                         ^^^
-Error: This value is "contended" but is expected to be "uncontended".
+Error: This value is "contended"
+       because it is used inside the function (at Lines 5-7, characters 23-23)
+       which is expected to be "portable".
+       However, the highlighted expression is expected to be "uncontended".
 |}]
 
 module Close_over_value_comonadic = struct

--- a/testsuite/tests/typing-unique/unique_mod_class.ml
+++ b/testsuite/tests/typing-unique/unique_mod_class.ml
@@ -148,7 +148,10 @@ module M : sig val foo : string end
 Line 7, characters 12-17:
 7 |   unique_id M.foo
                 ^^^^^
-Error: This value is "aliased" but is expected to be "unique".
+Error: This value is "aliased"
+       because it is used inside the function (at Lines 6-7, characters 22-17)
+       which is expected to be "many".
+       However, the highlighted expression is expected to be "unique".
 |}]
 
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3773,7 +3773,8 @@ let alloc_as_value_unhint m =
   let comonadic = comonadic_locality_as_regionality comonadic in
   { comonadic; monadic }
 
-let alloc_as_value m = m |> Alloc.unhint |> alloc_as_value_unhint |> Value.hint
+let alloc_as_value m =
+  m |> Alloc.unhint |> alloc_as_value_unhint |> Value.hint ~monadic:Skip
 
 let alloc_to_value_l2r_unhint m =
   let { comonadic; monadic } = m in
@@ -3785,7 +3786,7 @@ let alloc_to_value_l2r_unhint m =
 
 let alloc_to_value_l2r m =
   m |> Alloc.disallow_right |> Alloc.unhint |> alloc_to_value_l2r_unhint
-  |> Value.hint
+  |> Value.hint ~monadic:Skip
 
 let value_to_alloc_r2g_unhint m =
   let { comonadic; monadic } = m in
@@ -3796,7 +3797,7 @@ let value_to_alloc_r2g_unhint m =
   { comonadic; monadic }
 
 let value_to_alloc_r2g m =
-  m |> Value.unhint |> value_to_alloc_r2g_unhint |> Alloc.hint
+  m |> Value.unhint |> value_to_alloc_r2g_unhint |> Alloc.hint ~monadic:Skip
 
 let value_r2g ?hint m =
   Value.wrap ~monadic:Skip ?comonadic:hint
@@ -3809,7 +3810,7 @@ let value_to_alloc_r2l_unhint m =
   { comonadic; monadic }
 
 let value_to_alloc_r2l m =
-  m |> Value.unhint |> value_to_alloc_r2l_unhint |> Alloc.hint
+  m |> Value.unhint |> value_to_alloc_r2l_unhint |> Alloc.hint ~monadic:Skip
 
 module Modality = struct
   (* Inferred modalities


### PR DESCRIPTION
Several functions that convert between locality/regionality don't change the monadic axes, which should be reflected by the hints. Currently it defaults to `Unknown`, this PR changes it to `Skip` which means "the morphism shouldn't change the mode".

This help connect hint chains that were cut-off before. As a result, we see richer hints.