### PR TITLE
Remove excessive parentheses around locations in mode error hints

### DIFF
--- a/testsuite/tests/templates/basic/bad_instance_wrong_mode.reference
+++ b/testsuite/tests/templates/basic/bad_instance_wrong_mode.reference
@@ -3,5 +3,5 @@ File "bad_instance_wrong_mode.ml", line 6, characters 10-44:
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The value "Monoid_utils_of_list_monoid.concat" is "nonportable"
        but is expected to be "portable"
-       because it is used inside the function (at File "bad_instance_wrong_mode.ml", lines 1-7, characters 19-4)
+       because it is used inside the function at File "bad_instance_wrong_mode.ml", lines 1-7, characters 19-4
        which is expected to be "portable".

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
@@ -461,7 +461,7 @@ Line 2, characters 23-24:
 2 | fork (fun () -> Xm.set r 1);;
                            ^
 Error: The value "r" is "nonportable" but is expected to be "portable"
-       because it is used inside the function (at Line 2, characters 5-27)
+       because it is used inside the function at Line 2, characters 5-27
        which is expected to be "portable".
 |}]
 

--- a/testsuite/tests/typing-local/crossing.ml
+++ b/testsuite/tests/typing-local/crossing.ml
@@ -163,7 +163,7 @@ Line 2, characters 16-17:
 2 |   fun n -> lazy n
                     ^
 Error: The value "n" is "local" to the parent region but is expected to be "global"
-       because it is used inside the lazy expression (at Line 2, characters 11-17)
+       because it is used inside the lazy expression at Line 2, characters 11-17
        which is expected to be "global".
 |}]
 

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -443,7 +443,7 @@ Line 10, characters 24-26:
 10 |   let _force_heap = ref fn in
                              ^^
 Error: This value is "local"
-       because it closes over the value "foo" (at Line 5, characters 25-28)
+       because it closes over the value "foo" at Line 5, characters 25-28
        which is "local".
        However, the highlighted expression is expected to be "global".
 |}]
@@ -577,7 +577,7 @@ Line 3, characters 39-40:
 3 |   use_locally (fun x -> let _ = local_ r in r.contents <- Some x; x) 42
                                            ^
 Error: The value "r" is "local" but is expected to be "global"
-       because it is used inside the function (at Line 3, characters 14-68)
+       because it is used inside the function at Line 3, characters 14-68
        which is expected to be "global".
 |}]
 
@@ -697,7 +697,7 @@ Line 2, characters 30-31:
 2 |   let _ = lazy (print_string !x) in
                                   ^
 Error: The value "x" is "local" to the parent region but is expected to be "global"
-       because it is used inside the lazy expression (at Line 2, characters 10-32)
+       because it is used inside the lazy expression at Line 2, characters 10-32
        which is expected to be "global"
        because lazy expressions always need to be allocated on the heap.
 |}]
@@ -715,7 +715,7 @@ Line 3, characters 27-28:
 3 |     let () = print_string !x
                                ^
 Error: The value "x" is "local" to the parent region but is expected to be "global"
-       because it is used inside the functor (at Lines 2-4, characters 17-5)
+       because it is used inside the functor at Lines 2-4, characters 17-5
        which is expected to be "global"
        because modules always need to be allocated on the heap.
 |}]
@@ -733,7 +733,7 @@ Line 3, characters 27-28:
 3 |     let () = print_string !x
                                ^
 Error: The value "x" is "local" to the parent region but is expected to be "global"
-       because it is used inside the functor (at Lines 2-4, characters 17-5)
+       because it is used inside the functor at Lines 2-4, characters 17-5
        which is expected to be "global"
        because modules always need to be allocated on the heap.
 |}]
@@ -751,7 +751,7 @@ Line 3, characters 27-28:
 3 |     let () = print_string !x
                                ^
 Error: The value "x" is "local" to the parent region but is expected to be "global"
-       because it is used inside the functor (at Lines 2-4, characters 17-5)
+       because it is used inside the functor at Lines 2-4, characters 17-5
        which is expected to be "global"
        because modules always need to be allocated on the heap.
 |}]
@@ -769,7 +769,7 @@ Line 3, characters 27-28:
 3 |     let () = print_string !x
                                ^
 Error: The value "x" is "local" to the parent region but is expected to be "global"
-       because it is used inside the functor (at Lines 2-4, characters 17-5)
+       because it is used inside the functor at Lines 2-4, characters 17-5
        which is expected to be "global"
        because modules always need to be allocated on the heap.
 |}]
@@ -787,7 +787,7 @@ Line 3, characters 27-28:
 3 |     let () = print_string !x
                                ^
 Error: The value "x" is "local" to the parent region but is expected to be "global"
-       because it is used inside the functor (at Lines 2-4, characters 17-5)
+       because it is used inside the functor at Lines 2-4, characters 17-5
        which is expected to be "global"
        because modules always need to be allocated on the heap.
 |}]
@@ -1000,7 +1000,7 @@ Line 2, characters 41-42:
 2 | let foo (local_ x) = local_cb (fun () -> x := 17; 42)
                                              ^
 Error: The value "x" is "local" to the parent region but is expected to be "global"
-       because it is used inside the function (at Line 2, characters 30-53)
+       because it is used inside the function at Line 2, characters 30-53
        which is expected to be "global"
        because it is from the allocation at Line 2, characters 30-53
        which is expected to be "local" to the parent region or "global"

--- a/testsuite/tests/typing-modes/class.ml
+++ b/testsuite/tests/typing-modes/class.ml
@@ -173,7 +173,7 @@ Line 3, characters 17-20:
 3 |     portable_use foo
                      ^^^
 Error: This value is "nonportable"
-       because it closes over the class "cla" (at Line 2, characters 21-24)
+       because it closes over the class "cla" at Line 2, characters 21-24
        which is "nonportable"
        because classes are always at the legacy modes.
        However, the highlighted expression is expected to be "portable".

--- a/testsuite/tests/typing-modes/currying.ml
+++ b/testsuite/tests/typing-modes/currying.ml
@@ -295,7 +295,7 @@ Line 3, characters 63-64:
 3 |     fun ~a -> fun[@curry] ~b -> fun[@curry] ~c -> print_string a
                                                                    ^
 Error: The value "a" is "local" to the parent region but is expected to be "global"
-       because it is used inside the function (at Line 3, characters 14-64)
+       because it is used inside the function at Line 3, characters 14-64
        which is expected to be "global".
 |}]
 let overapp ~(local_ a) ~b = (); fun ~c ~d -> ()

--- a/testsuite/tests/typing-modes/exn.ml
+++ b/testsuite/tests/typing-modes/exn.ml
@@ -385,7 +385,7 @@ Line 8, characters 12-13:
 8 |     ignore (x : _ @ portable)
                 ^
 Error: The value "x" is "nonportable" but is expected to be "portable"
-       because it is used inside the function (at Lines 7-8, characters 21-29)
+       because it is used inside the function at Lines 7-8, characters 21-29
        which is expected to be "portable".
 |}]
 

--- a/testsuite/tests/typing-modes/forkable.ml
+++ b/testsuite/tests/typing-modes/forkable.ml
@@ -70,7 +70,7 @@ Line 2, characters 43-44:
 2 |   let closure @ local forkable = fun () -> k () in
                                                ^
 Error: The value "k" is "unforkable" but is expected to be "forkable"
-       because it is used inside the function (at Line 2, characters 33-47)
+       because it is used inside the function at Line 2, characters 33-47
        which is expected to be "forkable".
 |}]
 

--- a/testsuite/tests/typing-modes/hint.ml
+++ b/testsuite/tests/typing-modes/hint.ml
@@ -19,12 +19,12 @@ Line 10, characters 16-19:
 10 |         let _ = bar in ()
                      ^^^
 Error: The value "bar" is "nonportable"
-       because it closes over the value "foo" (at Line 7, characters 17-20)
+       because it closes over the value "foo" at Line 7, characters 17-20
        which is "nonportable"
        because it contains a usage (of the value "x" at Line 4, characters 8-9)
        which is expected to be "uncontended".
        However, the highlighted value "bar" is expected to be "portable"
-       because it is used inside the function (at Lines 9-10, characters 25-25)
+       because it is used inside the function at Lines 9-10, characters 25-25
        which is expected to be "portable".
 |}]
 
@@ -41,12 +41,12 @@ Line 6, characters 38-41:
 6 |     let (baz @ portable) () = let _ = bar in ()
                                           ^^^
 Error: The value "bar" is "nonportable"
-       because it closes over the value "foo" (at Line 5, characters 26-29)
+       because it closes over the value "foo" at Line 5, characters 26-29
        which is "nonportable"
        because it contains a usage (of the value "x" at Line 4, characters 17-18)
        which is expected to be "uncontended".
        However, the highlighted value "bar" is expected to be "portable"
-       because it is used inside the function (at Line 6, characters 25-47)
+       because it is used inside the function at Line 6, characters 25-47
        which is expected to be "portable".
 |}]
 
@@ -83,9 +83,9 @@ Error: Signature mismatch:
        is not included in
          val baz : unit -> unit @@ portable (* in a structure at nonportable *)
        The left-hand side is "nonportable"
-       because it closes over the value "bar" (at Line 8, characters 25-28)
+       because it closes over the value "bar" at Line 8, characters 25-28
        which is "nonportable"
-       because it closes over the value "foo" (at Line 7, characters 26-29)
+       because it closes over the value "foo" at Line 7, characters 26-29
        which is "nonportable"
        because it contains a usage (of the value "x" at Line 6, characters 17-18)
        which is expected to be "uncontended".

--- a/testsuite/tests/typing-modes/lazy.ml
+++ b/testsuite/tests/typing-modes/lazy.ml
@@ -26,7 +26,7 @@ Line 2, characters 18-19:
 2 |     lazy (let _ = x in ())
                       ^
 Error: The value "x" is "local" to the parent region but is expected to be "global"
-       because it is used inside the lazy expression (at Line 2, characters 4-26)
+       because it is used inside the lazy expression at Line 2, characters 4-26
        which is expected to be "global"
        because lazy expressions always need to be allocated on the heap.
 |}]
@@ -39,7 +39,7 @@ Line 2, characters 18-19:
 2 |     lazy (let _ = x in ())
                       ^
 Error: The value "x" is "yielding" but is expected to be "unyielding"
-       because it is used inside the lazy expression (at Line 2, characters 4-26)
+       because it is used inside the lazy expression at Line 2, characters 4-26
        which is expected to be "unyielding"
        because lazy expressions always need to be allocated on the heap.
 |}]

--- a/testsuite/tests/typing-modes/module.ml
+++ b/testsuite/tests/typing-modes/module.ml
@@ -43,9 +43,9 @@ Line 10, characters 17-20:
 10 |     portable_use foo
                       ^^^
 Error: This value is "nonportable"
-       because it closes over the module "F" (at Line 7, characters 23-24)
+       because it closes over the module "F" at Line 7, characters 23-24
        which is "nonportable"
-       because it closes over the value "foo" (at Line 15, characters 12-15)
+       because it closes over the value "foo" at Line 15, characters 12-15
        which is "nonportable".
        However, the highlighted expression is expected to be "portable".
 |}]
@@ -180,7 +180,7 @@ Line 3, characters 4-9:
 3 |     N.foo ()
         ^^^^^
 Error: The value "N.foo" is "nonportable" but is expected to be "portable"
-       because it is used inside the function (at Lines 1-3, characters 21-12)
+       because it is used inside the function at Lines 1-3, characters 21-12
        which is expected to be "portable".
 |}]
 
@@ -192,7 +192,7 @@ Line 3, characters 4-9:
 3 |     M.foo ()
         ^^^^^
 Error: The value "M.foo" is "nonportable" but is expected to be "portable"
-       because it is used inside the function (at Lines 1-3, characters 21-12)
+       because it is used inside the function at Lines 1-3, characters 21-12
        which is expected to be "portable".
 |}]
 
@@ -217,7 +217,7 @@ Line 4, characters 4-10:
 4 |     N'.foo ()
         ^^^^^^
 Error: The value "N'.foo" is "nonportable" but is expected to be "portable"
-       because it is used inside the function (at Lines 1-4, characters 21-13)
+       because it is used inside the function at Lines 1-4, characters 21-13
        which is expected to be "portable".
 |}]
 
@@ -232,7 +232,7 @@ Line 3, characters 19-20:
 3 |         module L = M
                        ^
 Error: The module "M" is "nonportable" but is expected to be "portable"
-       because it is used inside the function (at Lines 1-5, characters 21-14)
+       because it is used inside the function at Lines 1-5, characters 21-14
        which is expected to be "portable".
 |}]
 
@@ -388,7 +388,7 @@ Line 4, characters 14-17:
 4 |     let bar = foo
                   ^^^
 Error: The value "foo" is "nonportable" but is expected to be "portable"
-       because it is used inside the functor (at Lines 3-5, characters 22-3)
+       because it is used inside the functor at Lines 3-5, characters 22-3
        which is expected to be "portable".
 |}]
 

--- a/testsuite/tests/typing-modes/portable-contend.ml
+++ b/testsuite/tests/typing-modes/portable-contend.ml
@@ -125,7 +125,7 @@ Line 4, characters 23-26:
 4 |     let _ @ portable = bar in
                            ^^^
 Error: This value is "nonportable"
-       because it closes over the value "best_bytes" (at Line 3, characters 24-34)
+       because it closes over the value "best_bytes" at Line 3, characters 24-34
        which is "nonportable".
        However, the highlighted expression is expected to be "portable".
 |}]
@@ -298,7 +298,7 @@ Line 4, characters 23-26:
 4 |     let _ @ portable = bar in
                            ^^^
 Error: This value is "nonportable"
-       because it closes over the value "r" (at Line 3, characters 25-26)
+       because it closes over the value "r" at Line 3, characters 25-26
        which is "nonportable".
        However, the highlighted expression is expected to be "portable".
 |}]
@@ -350,7 +350,7 @@ Line 1, characters 105-115:
 1 | let foo : ('a @ contended portable -> (string -> string) @ portable) @ uncontended portable = fun a b -> best_bytes ()
                                                                                                              ^^^^^^^^^^
 Error: The value "best_bytes" is "nonportable" but is expected to be "portable"
-       because it is used inside the function (at Line 1, characters 94-118)
+       because it is used inside the function at Line 1, characters 94-118
        which is expected to be "portable".
 |}]
 

--- a/testsuite/tests/typing-modes/rec.ml
+++ b/testsuite/tests/typing-modes/rec.ml
@@ -36,7 +36,7 @@ Line 3, characters 12-13:
 3 |         bar x y
                 ^
 Error: The value "x" is "local" to the parent region but is expected to be "global"
-       because it is used inside the function (at Lines 2-3, characters 16-15)
+       because it is used inside the function at Lines 2-3, characters 16-15
        which is expected to be "global".
 |}]
 

--- a/testsuite/tests/typing-modes/statefulness-visibility.ml
+++ b/testsuite/tests/typing-modes/statefulness-visibility.ml
@@ -437,7 +437,7 @@ Line 1, characters 73-74:
 1 | let foo (f : (unit -> unit) @ stateful portable) @ stateless = fun () -> f ()
                                                                              ^
 Error: The value "f" is "stateful" but is expected to be "stateless"
-       because it is used inside the function (at Line 1, characters 63-77)
+       because it is used inside the function at Line 1, characters 63-77
        which is expected to be "stateless".
 |}]
 
@@ -449,7 +449,7 @@ Line 1, characters 64-65:
 1 | let foo (f : (unit -> unit) @ stateful) @ stateless = fun () -> f ()
                                                                     ^
 Error: The value "f" is "stateful" but is expected to be "stateless"
-       because it is used inside the function (at Line 1, characters 54-68)
+       because it is used inside the function at Line 1, characters 54-68
        which is expected to be "stateless".
 |}]
 
@@ -459,7 +459,7 @@ Line 1, characters 74-75:
 1 | let foo (f : (unit -> unit) @ observing portable) @ stateless = fun () -> f ()
                                                                               ^
 Error: The value "f" is "observing" but is expected to be "stateless"
-       because it is used inside the function (at Line 1, characters 64-78)
+       because it is used inside the function at Line 1, characters 64-78
        which is expected to be "stateless".
 |}]
 
@@ -507,7 +507,7 @@ Line 1, characters 64-65:
 1 | let foo (f : (unit -> unit) @ stateful) @ observing = fun () -> f ()
                                                                     ^
 Error: The value "f" is "stateful" but is expected to be "observing"
-       because it is used inside the function (at Line 1, characters 54-68)
+       because it is used inside the function at Line 1, characters 54-68
        which is expected to be "observing".
 |}]
 
@@ -690,7 +690,7 @@ Line 1, characters 42-43:
 1 | let foo (x : int ref) @ stateless = lazy (x.contents)
                                               ^
 Error: This value is "immutable"
-       because it is used inside the lazy expression (at Line 1, characters 36-53)
+       because it is used inside the lazy expression at Line 1, characters 36-53
        which is expected to be "stateless".
        However, the highlighted expression is expected to be "read" or "read_write"
        because its mutable field "contents" is being read.
@@ -702,7 +702,7 @@ Line 1, characters 42-43:
 1 | let zap (x : int ref) @ stateless = lazy (x.contents <- 3)
                                               ^
 Error: This value is "immutable"
-       because it is used inside the lazy expression (at Line 1, characters 36-58)
+       because it is used inside the lazy expression at Line 1, characters 36-58
        which is expected to be "stateless".
        However, the highlighted expression is expected to be "read_write"
        because its mutable field "contents" is being written.
@@ -716,7 +716,7 @@ Line 1, characters 42-43:
 1 | let bat (x : int ref) @ observing = lazy (x.contents <- 4)
                                               ^
 Error: This value is "read"
-       because it is used inside the lazy expression (at Line 1, characters 36-58)
+       because it is used inside the lazy expression at Line 1, characters 36-58
        which is expected to be "observing".
        However, the highlighted expression is expected to be "read_write"
        because its mutable field "contents" is being written.

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -463,7 +463,7 @@ Line 6, characters 12-15:
 6 |     let _ = M.x in
                 ^^^
 Error: The value "M.x" is "nonportable" but is expected to be "portable"
-       because it is used inside the function (at Lines 5-7, characters 23-6)
+       because it is used inside the function at Lines 5-7, characters 23-6
        which is expected to be "portable".
 |}]
 
@@ -1054,7 +1054,7 @@ Line 3, characters 12-13:
 3 |     let _ = f in
                 ^
 Error: The value "f" is "nonportable" but is expected to be "portable"
-       because it is used inside the function (at Lines 1-4, characters 21-6)
+       because it is used inside the function at Lines 1-4, characters 21-6
        which is expected to be "portable".
 |}]
 
@@ -1079,7 +1079,7 @@ Line 4, characters 12-13:
 4 |     let _ = f in
                 ^
 Error: The value "f" is "nonportable" but is expected to be "portable"
-       because it is used inside the function (at Lines 3-5, characters 23-6)
+       because it is used inside the function at Lines 3-5, characters 23-6
        which is expected to be "portable".
 |}]
 
@@ -1217,7 +1217,7 @@ Line 2, characters 18-19:
 2 |   let k = (module M : Func_nonportable) in
                       ^
 Error: The value "M.baz" is "nonportable" but is expected to be "portable"
-       because it is used inside the function (at Lines 1-3, characters 21-3)
+       because it is used inside the function at Lines 1-3, characters 21-3
        which is expected to be "portable".
 |}]
 
@@ -1234,7 +1234,7 @@ Line 4, characters 12-13:
 4 |     (module M : Empty)
                 ^
 Error: The module "M" is "local" but is expected to be "global"
-       because it is used inside the function (at Lines 3-4, characters 21-22)
+       because it is used inside the function at Lines 3-4, characters 21-22
        which is expected to be "global".
 |}]
 
@@ -1251,7 +1251,7 @@ Line 4, characters 12-13:
 4 |     (module M : Empty)
                 ^
 Error: The module "M" is "local" but is expected to be "global"
-       because it is used inside the function (at Lines 3-4, characters 21-22)
+       because it is used inside the function at Lines 3-4, characters 21-22
        which is expected to be "global".
 |}]
 
@@ -1311,7 +1311,7 @@ Line 3, characters 18-34:
                       ^^^^^^^^^^^^^^^^
 Error: The module "M_Func_portable'" is "nonportable"
        but is expected to be "portable"
-       because it is used inside the function (at Lines 2-4, characters 21-3)
+       because it is used inside the function at Lines 2-4, characters 21-3
        which is expected to be "portable".
 |}]
 
@@ -1328,7 +1328,7 @@ Line 4, characters 20-36:
 4 |     let k = (module M_Func_portable' : Func_portable) in
                         ^^^^^^^^^^^^^^^^
 Error: The module "M_Func_portable'" is "local" but is expected to be "global"
-       because it is used inside the function (at Lines 3-5, characters 21-5)
+       because it is used inside the function at Lines 3-5, characters 21-5
        which is expected to be "global".
 |}]
 
@@ -1341,7 +1341,7 @@ Line 2, characters 18-20:
 2 |   let k = (module M' : Module) in
                       ^^
 Error: The value "M'.M.baz" is "nonportable" but is expected to be "portable"
-       because it is used inside the function (at Lines 1-3, characters 21-3)
+       because it is used inside the function at Lines 1-3, characters 21-3
        which is expected to be "portable".
 |}]
 
@@ -1368,7 +1368,7 @@ Line 4, characters 18-19:
 4 |   let k = (module F : F) in
                       ^
 Error: The module "F" is "nonportable" but is expected to be "portable"
-       because it is used inside the function (at Lines 3-5, characters 21-3)
+       because it is used inside the function at Lines 3-5, characters 21-3
        which is expected to be "portable".
 |}]
 
@@ -1396,7 +1396,7 @@ Line 2, characters 18-19:
 2 |   let k = (module M : Class) in
                       ^
 Error: The class "M.cla" is "nonportable" but is expected to be "portable"
-       because it is used inside the function (at Lines 1-3, characters 21-3)
+       because it is used inside the function at Lines 1-3, characters 21-3
        which is expected to be "portable".
 |}]
 
@@ -1417,7 +1417,7 @@ Line 2, characters 25-26:
 2 |     let module M' = (val m : Func_portable) in
                              ^
 Error: The value "m" is "nonportable" but is expected to be "portable"
-       because it is used inside the function (at Lines 1-3, characters 21-6)
+       because it is used inside the function at Lines 1-3, characters 21-6
        which is expected to be "portable".
 |}]
 

--- a/testsuite/tests/typing-modes/yielding.ml
+++ b/testsuite/tests/typing-modes/yielding.ml
@@ -71,7 +71,7 @@ Line 2, characters 45-46:
 2 |   let closure @ local unyielding = fun () -> k () in
                                                  ^
 Error: The value "k" is "yielding" but is expected to be "unyielding"
-       because it is used inside the function (at Line 2, characters 35-49)
+       because it is used inside the function at Line 2, characters 35-49
        which is expected to be "unyielding".
 |}]
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2043,14 +2043,12 @@ module Report = struct
     | Expression -> Some (dprintf "expression")
     | Allocation -> Some (dprintf "allocation")
 
-  let print_pinpoint : ?parens:bool -> pinpoint -> (formatter -> unit) option =
-   fun ?(parens = true) (loc, desc) ->
+  let print_pinpoint : pinpoint -> (formatter -> unit) option =
+   fun (loc, desc) ->
     print_pinpoint_desc desc
     |> Option.map (fun print_desc ppf ->
            if Location.is_none loc
            then fprintf ppf "a %t" print_desc
-           else if parens
-           then fprintf ppf "the %t (at %a)" print_desc Location.print_loc loc
            else fprintf ppf "the %t at %a" print_desc Location.print_loc loc)
 
   let print_allocation_desc : allocation_desc -> formatter -> unit = function
@@ -2071,7 +2069,7 @@ module Report = struct
       print_pinpoint pp
       |> Option.map (fun print_pp -> dprintf "closes over %t" print_pp, pp)
     | Close_over { closed = pp; polarity = Monadic; _ } ->
-      print_pinpoint ~parens:false pp
+      print_pinpoint pp
       |> Option.map (fun print_pp ->
              dprintf "contains a usage (of %t)" print_pp, pp)
     | Is_closed_by { closure = pp; _ } ->


### PR DESCRIPTION
Instead of:
> the function (at File "bad_instance_wrong_mode.ml", lines 1-7, characters 19-4)

We now print:
> the function at File "bad_instance_wrong_mode.ml", lines 1-7, characters 19-4

The latter is more precise: the location is not just auxillary information, but necessary to pinpoint the function (so we can say "the function" instead of "a function").