### PR TITLE
Disallow legacy mode syntax in comprehension

### DIFF
--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -3008,20 +3008,6 @@ comprehension_iterator:
 comprehension_clause_binding:
   | attributes pattern comprehension_iterator
       { { pcomp_cb_pattern = $2 ; pcomp_cb_iterator = $3 ; pcomp_cb_attributes = $1 } }
-  (* We can't write [[e for local_ x = 1 to 10]], because the [local_] has to
-     move to the RHS and there's nowhere for it to move to; besides, you never
-     want that [int] to be [local_].  But we can parse [[e for local_ x in xs]].
-     We have to have that as a separate rule here because it moves the [local_]
-     over to the RHS of the binding, so we need everything to be visible. *)
-  | attributes mode_legacy pattern IN expr
-      { let expr =
-          mkexp_constraint ~loc:$sloc ~exp:$5 ~cty:None ~modes:[$2]
-        in
-        { pcomp_cb_pattern    = $3
-        ; pcomp_cb_iterator   = Pcomp_in expr
-        ; pcomp_cb_attributes = $1
-        }
-      }
 ;
 
 comprehension_clause:

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -316,18 +316,6 @@ val nums : (int * int * int) array =
     (9, 3, 4); (9, 3, 2); (9, 0, 1); (9, 0, 3); (10, 5, 3); (10, 2, 2)|]
 |}]
 
-(* local_ is allowed in the parser in this one place, but the type-checker
-   rejects *)
-let broken_local =
-  [ 5 for local_ n in [ 1; 2 ] ];;
-
-[%%expect{|
-Line 2, characters 10-30:
-2 |   [ 5 for local_ n in [ 1; 2 ] ];;
-              ^^^^^^^^^^^^^^^^^^^^
-Error: This value is "local" but is expected to be "global".
-|}]
-
 (* User-written attributes *)
 let nums =
   ([(x[@test.attr1]) for (x[@test.attr2]) in ([][@test.attr3])] [@test.attr4]);;


### PR DESCRIPTION
Currently we allow `for local_ n in [1;2;3]`, which is parsed as `for n in ([1;2;3] : _ @ local)`. This causes some roundtrip issues. Also, it's rather strange that the mode is on the RHS instead of the LHS.

This PR disallows such syntax.

Internal codebase doesn't use this syntax (except for handling parsetree).