### PR TITLE
Stop sign-extending small int simd casts

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -1608,17 +1608,9 @@ let emit_static_cast (cast : Cmm.static_cast) i =
   | V256_of_scalar Float16x16 ->
     Misc.fatal_error "float16 scalar type not supported"
   | Scalar_of_v128 Int16x8 | Scalar_of_v256 Int16x16 ->
-    (* CR-someday mslater: int16# shouldn't require sign extension *)
-    (* [movw] and [movzx] cannot operate on vector registers. We must sign
-       extend as the result is an untagged int8. *)
-    movd (argX i 0) (res32 i 0);
-    I.movsx (res16 i 0) (res i 0)
+    movd (argX i 0) (res32 i 0)
   | Scalar_of_v128 Int8x16 | Scalar_of_v256 Int8x32 ->
-    (* CR-someday mslater: int8# shouldn't require sign extension *)
-    (* [movb] and [movzx] cannot operate on vector registers. We must sign
-       extend as the result is an untagged int16. *)
-    movd (argX i 0) (res32 i 0);
-    I.movsx (res8 i 0) (res i 0)
+    movd (argX i 0) (res32 i 0)
   | V128_of_scalar Int16x8
   | V128_of_scalar Int8x16
   | V256_of_scalar Int16x16

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -227,15 +227,11 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
     ->
     may_use_stack_operand_for_only_argument map instr ~has_result:true
   | Op (Reinterpret_cast (Int64_of_float | Int32_of_float32))
-  | Op (Static_cast (Scalar_of_v128 (Int64x2 | Int32x4)))
-  | Op (Static_cast (Scalar_of_v256 (Int64x4 | Int32x8)))
-  | Op (Static_cast (Scalar_of_v512 (Int64x8 | Int32x16))) ->
+  | Op (Static_cast (Scalar_of_v128 (Int64x2 | Int32x4 | Int16x8 | Int8x16)))
+  | Op (Static_cast (Scalar_of_v256 (Int64x4 | Int32x8 | Int16x16 | Int8x32)))
+  | Op (Static_cast (Scalar_of_v512 (Int64x8 | Int32x16 | Int16x32 | Int8x64)))
+    ->
     may_use_stack_operand_for_result map instr ~num_args:1
-  | Op (Static_cast (Scalar_of_v128 (Int16x8 | Int8x16)))
-  | Op (Static_cast (Scalar_of_v256 (Int16x16 | Int8x32)))
-  | Op (Static_cast (Scalar_of_v512 (Int16x32 | Int8x64))) ->
-    (* CR-someday mslater: int8#/int16# shouldn't require sign extension *)
-    May_still_have_spilled_registers
   | Op
       (Static_cast
         ( Float_of_int (Float32 | Float64)


### PR DESCRIPTION
We now bind vector->int8/int16 casts with `int8#`/`int16#` return types, which causes the frontend to automatically insert code to sign-extend the result. Hence, we no longer need to sign-extend as a part of the `Static_cast` operation.