### PR TITLE
Remove probes support for old Closure middle end

### DIFF
--- a/lambda/translcore.mli
+++ b/lambda/translcore.mli
@@ -71,7 +71,3 @@ val transl_module :
 val transl_object :
       (scopes:scopes -> Ident.t -> string list ->
        class_expr -> lambda) ref
-
-(* Declarations to be wrapped around the entire body *)
-val clear_probe_handlers : unit -> unit
-val declare_probe_handlers : lambda -> lambda

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -1004,7 +1004,6 @@ let transl_implementation compilation_unit impl =
   reset_labels ();
   primitive_declarations := [];
   Translprim.clear_used_primitives ();
-  Translcore.clear_probe_handlers ();
   let scopes = enter_compilation_unit ~scopes:empty_scopes compilation_unit in
   let body, (size, arg_block_idx) =
     Translobj.transl_label_init (fun () ->
@@ -1012,7 +1011,7 @@ let transl_implementation compilation_unit impl =
         transl_implementation_module ~scopes compilation_unit
           impl
       in
-      Translcore.declare_probe_handlers body, (size, arg_block_idx))
+      body, (size, arg_block_idx))
   in
   let body, main_module_block_format =
     match has_parameters () with
@@ -1239,11 +1238,10 @@ let transl_toplevel_item_and_close ~scopes itm =
     (transl_label_init
        (fun () ->
           let expr = transl_toplevel_item ~scopes itm
-          in Translcore.declare_probe_handlers expr, ()))
+          in expr, ()))
 
 let transl_toplevel_definition str =
   reset_labels ();
-  Translcore.clear_probe_handlers ();
   Translprim.clear_used_primitives ();
   make_sequence
     (transl_toplevel_item_and_close ~scopes:empty_scopes)


### PR DESCRIPTION
This removes a hack that was only necessary for Closure, which isn't in the tree any more.