### PR TITLE
Fix exception declaration location

### DIFF
--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -4203,7 +4203,7 @@ str_exception_declaration:
   attrs = post_item_attributes
   { let loc = make_loc $sloc in
     let docs = symbol_docs $sloc in
-    Te.mk_exception ~attrs
+    Te.mk_exception ~attrs ~loc
       (Te.rebind id lid ~attrs:(attrs1 @ attrs2) ~loc ~docs)
     , ext }
 ;
@@ -4218,7 +4218,7 @@ sig_exception_declaration:
     { let vars, args, res = vars_args_res in
       let loc = make_loc ($startpos, $endpos(attrs2)) in
       let docs = symbol_docs $sloc in
-      Te.mk_exception ~attrs
+      Te.mk_exception ~attrs ~loc
         (Te.decl id ~vars ~args ?res ~attrs:(attrs1 @ attrs2) ~loc ~docs)
       , ext }
 ;

--- a/testsuite/tests/parsing/exception_location.ml
+++ b/testsuite/tests/parsing/exception_location.ml
@@ -25,7 +25,7 @@ let () = test_impl "exception E of int"
 
 [%%expect {|
 Structure item loc: File "file.ml", line 1, characters 0-18
-Exception declaration loc: File "_none_", line 1
+Exception declaration loc: File "file.ml", line 1, characters 0-18
 Exception constructor loc: File "file.ml", line 1, characters 0-18
 Exception constructor name loc: File "file.ml", line 1, characters 10-11
 |}]
@@ -34,7 +34,7 @@ let () = test_impl "exception E = F"
 
 [%%expect {|
 Structure item loc: File "file.ml", line 1, characters 0-15
-Exception declaration loc: File "_none_", line 1
+Exception declaration loc: File "file.ml", line 1, characters 0-15
 Exception constructor loc: File "file.ml", line 1, characters 0-15
 Exception constructor name loc: File "file.ml", line 1, characters 10-11
 |}]
@@ -43,7 +43,7 @@ let () = test_impl "exception E of int [@@deriving sexp]"
 
 [%%expect {|
 Structure item loc: File "file.ml", line 1, characters 0-36
-Exception declaration loc: File "_none_", line 1
+Exception declaration loc: File "file.ml", line 1, characters 0-18
 Exception constructor loc: File "file.ml", line 1, characters 0-18
 Exception constructor name loc: File "file.ml", line 1, characters 10-11
 |}]


### PR DESCRIPTION
These were previously none, causing bad error messages in some cases. Particularly:
```
type t = unit

let sexp_of_t = `bad_type

exception T of t [@@deriving sexp]
```
produces
```
File "my_library/_none_", lines 1-2, characters 0-0:
This expression has type [> `bad_type ]
This is not a function; it cannot be applied.
```
with a dummy error location.

Review by commit.