### PR TITLE
Exception declaration loc should cover attribute loc

### DIFF
--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -4216,7 +4216,7 @@ sig_exception_declaration:
   attrs2 = attributes
   attrs = post_item_attributes
     { let vars, args, res = vars_args_res in
-      let loc = make_loc ($startpos, $endpos(attrs2)) in
+      let loc = make_loc $sloc in
       let docs = symbol_docs $sloc in
       Te.mk_exception ~attrs ~loc
         (Te.decl id ~vars ~args ?res ~attrs:(attrs1 @ attrs2) ~loc ~docs)

--- a/testsuite/tests/parsetree/locations_test.compilers.reference
+++ b/testsuite/tests/parsetree/locations_test.compilers.reference
@@ -93,7 +93,7 @@ Ptop_def
                 Pexp_ident "payload" (//toplevel//[2,1+22]..[2,1+29])
           ]
         ptyext_constructor =
-          extension_constructor (//toplevel//[2,1+0]..[2,1+13])
+          extension_constructor (//toplevel//[2,1+0]..[2,1+30])
             pext_name = "Exn"
             pext_kind =
               Pext_decl

--- a/testsuite/tests/parsing/attributes.compilers.reference
+++ b/testsuite/tests/parsing/attributes.compilers.reference
@@ -5,7 +5,7 @@
       attribute "foo"
         []
       ptyext_constructor =
-        extension_constructor (attributes.ml[8,120+0]..[8,120+20])
+        extension_constructor (attributes.ml[8,120+0]..[8,120+28])
           attribute "foo"
             []
           pext_name = "Foo"
@@ -20,7 +20,7 @@
       attribute "foo"
         []
       ptyext_constructor =
-        extension_constructor (attributes.ml[10,150+0]..[10,150+36])
+        extension_constructor (attributes.ml[10,150+0]..[10,150+44])
           attribute "foo"
             []
           pext_name = "Bar"
@@ -156,7 +156,7 @@
               attribute "foo"
                 []
               ptyext_constructor =
-                extension_constructor (attributes.ml[37,450+2]..[37,450+38])
+                extension_constructor (attributes.ml[37,450+2]..[37,450+46])
                   attribute "foo"
                     []
                   pext_name = "Bar"

--- a/testsuite/tests/parsing/exception_location.ml
+++ b/testsuite/tests/parsing/exception_location.ml
@@ -43,7 +43,7 @@ let () = test_impl "exception E of int [@@deriving sexp]"
 
 [%%expect {|
 Structure item loc: File "file.ml", line 1, characters 0-36
-Exception declaration loc: File "file.ml", line 1, characters 0-18
-Exception constructor loc: File "file.ml", line 1, characters 0-18
+Exception declaration loc: File "file.ml", line 1, characters 0-36
+Exception constructor loc: File "file.ml", line 1, characters 0-36
 Exception constructor name loc: File "file.ml", line 1, characters 10-11
 |}]


### PR DESCRIPTION
What the title says - this is causing errors in internal build.
(The upstream has the same problem)