### PR TITLE
Don't access globals in the tight marking loop

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1198,14 +1198,14 @@ Caml_noinline static intnat do_some_marking(struct mark_stack* stk,
 again:
       if (Tag_hd(hd) == Lazy_tag || Tag_hd(hd) == Forcing_tag) {
         if (!atomic_compare_exchange_strong(Hp_atomic_val(block), &hd,
-              With_status_hd(hd, caml_global_heap_state.MARKED))) {
+              With_status_hd(hd, heap_state.MARKED))) {
           hd = Hd_val(block);
           goto again;
         }
       } else {
         atomic_store_relaxed(
             Hp_atomic_val(block),
-            With_status_hd(hd, caml_global_heap_state.MARKED));
+            With_status_hd(hd, heap_state.MARKED));
       }
 
       budget--; /* header word */


### PR DESCRIPTION
This is the first of a short series of PRs driven by inspection and careful performance measurement of the inner loops and hotspots of the GC. First, `do_some_marking` in the major GC. This function is already pretty optimised, but has two references to global state rather than to the (already existing) local copies of it, which actually live in registers.

I have carefully contemplated the disassembly of do_some_marking (see [this gist](https://gist.github.com/NickBarnes/b4e4bb1d3f3bb8f9d3d8509733880631)), with reference to `perf report` (and in particular `perf mem report`) of a pretty good test, and I think there's not much more local optimisation we can do on it. We could keep some more values in variables (`stk->stack`, `stk->count`, `caml_minor_heaps_start` or `caml_minor_heaps_end`), in the hope that the compiler would register-allocate them, but register pressure is fairly high and `perf mem` doesn't identify any of those as hotspots. The top few things that aren't L1 or LFB/MAB hits are:

- `child = *me.start` ([line 1266](https://github.com/oxcaml/oxcaml/blob/a377580282ddd0f5ee5f5905fe02b7c896dc2df7/runtime/major_gc.c#L1266)) : 0.42% RAM hit, 0.01% L3 hit.
- `hd = Hd_val(block)` ([line 1178](https://github.com/oxcaml/oxcaml/blob/a377580282ddd0f5ee5f5905fe02b7c896dc2df7/runtime/major_gc.c#L1178)): 0.16% L2 hit.
- `pb_push(&pn, child)` ([line 1273](https://github.com/oxcaml/oxcaml/blob/a377580282ddd0f5ee5f5905fe02b7c896dc2df7/runtime/major_gc.c#L1273)): 0.01% L1 miss.
