### PR TITLE
typedcore marks a coerced application as nontail

### DIFF
--- a/testsuite/tests/regression/tailcall-optional-args/tailcall_optional_args.ml
+++ b/testsuite/tests/regression/tailcall-optional-args/tailcall_optional_args.ml
@@ -1,0 +1,4 @@
+(* TEST *)
+
+let with_optional y ?z:_ x = y + x
+let with_coercion y : int -> int = with_optional y

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -8830,6 +8830,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
               |> mode_morph (fun _mode -> exp_mode)
               |> expect_mode_cross env ty_expected'
             in
+            let expected_mode = {expected_mode with position = RNontail} in
             type_exp ~overwrite env expected_mode sarg)
       in
       let rec make_args args ty_fun =


### PR DESCRIPTION
This fixes a bug where typedtree could generate a function application claiming it was in tail position when it wasn't. It now unconditionally marks the expression that it's coercing in type_argument as nontail.