### PR TITLE
Refactor metrics to store size for each artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -411,10 +411,10 @@ jobs:
 
           # Use the metrics collection script (CSV filename and PR number computed internally)
           python3 ${{ github.workspace }}/scripts/collect-size-metrics.py \
-            "${{ github.workspace }}/_install" \
-            "metrics-repo/raw-data" \
-            "$COMMIT_HASH" \
-            "$COMMIT_MESSAGE" \
+            --install-dir "${{ github.workspace }}/_install" \
+            --output-dir "metrics-repo/raw-data" \
+            --commit-hash "$COMMIT_HASH" \
+            --commit-message "$COMMIT_MESSAGE" \
             --verbose
 
           # Commit and push metrics

--- a/scripts/collect-size-metrics.py
+++ b/scripts/collect-size-metrics.py
@@ -69,18 +69,22 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Collect file size metrics from install directory"
     )
-    parser.add_argument("install_directory", help="Path to install directory")
-    parser.add_argument("output_directory", help="Output directory for CSV file")
-    parser.add_argument("commit_hash", help="Git commit hash")
-    parser.add_argument("commit_message", help="Git commit message")
+    parser.add_argument("--install-dir", required=True,
+                        help="Path to install directory")
+    parser.add_argument("--output-dir", required=True,
+                        help="Output directory for CSV file")
+    parser.add_argument("--commit-hash", required=True,
+                        help="Git commit hash")
+    parser.add_argument("--commit-message", required=True,
+                        help="Git commit message")
     parser.add_argument("--verbose", action="store_true",
                         help="Print contents of generated CSV file")
 
     args = parser.parse_args()
 
     collect_metrics(
-        args.install_directory,
-        args.output_directory,
+        args.install_dir,
+        args.output_dir,
         args.commit_hash,
         args.commit_message,
         args.verbose


### PR DESCRIPTION
  ## Summary

  Refactors the metrics collection workflow to provide more granular artifact tracking and
  improved usability.

  ## Changes

  - **Per-artifact reporting**: Metrics are now reported for each individual artifact with its
  relative path, rather than aggregating by file extension
  - **Updated storage location**: Metrics files are now stored in `raw-data/` directory instead of
   `data/`
  - **Clearer file naming**: CSV files now use `artifact-sizes-` prefix instead of `metrics-`
  prefix
  - **Named arguments**: Script now uses explicit named arguments (`--install-dir`,
  `--output-dir`, `--commit-hash`, `--commit-message`) for better clarity

  ## Impact

  The generated CSV files will now contain significantly more detailed information, with one row
  per artifact showing its full path and individual size. This enables more precise tracking of
  size changes across builds.
