### PR TITLE
Refactor metrics to also push profiles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,12 +31,8 @@ jobs:
             config: --enable-runtime5 --enable-poll-insertion
             os: warp-ubuntu-latest-x64-8x
 
-          - name: runtime5 multidomain stack-checks (x86_64-linux)
-            config: --enable-runtime5 --enable-stack-checks --enable-poll-insertion --enable-multidomain
-            os: warp-ubuntu-latest-x64-8x
-
           - name: runtime5 multidomain (x86_64-linux)
-            config: --enable-runtime5 --enable-poll-insertion --enable-multidomain
+            config: --enable-runtime5 --enable-stack-checks --enable-poll-insertion --enable-multidomain
             os: warp-ubuntu-latest-x64-8x
 
           - name: runtime4 dev (x86_64-linux)
@@ -70,7 +66,7 @@ jobs:
           - name: runtime4 O3 metrics (x86_64-linux)
             config: --disable-runtime5
             os: warp-ubuntu-latest-x64-8x
-            build_ocamlparam: ''
+            build_ocamlparam: '_'
             ocamlparam: '_,O3=1'
             collect_metrics: true
 
@@ -237,6 +233,13 @@ jobs:
       - name: Build, install and test OxCaml
         if: matrix.dwarf_tests_only != true && matrix.llvmize_tests_only != true
         run: |
+          if [ "${{ matrix.collect_metrics }}" = "true" ]; then
+            mkdir $GITHUB_WORKSPACE/_profile_csv
+            ORIG_BUILD_OCAMLPARAM="$BUILD_OCAMLPARAM"
+            ORIG_OCAMLPARAM="$OCAMLPARAM"
+            BUILD_OCAMLPARAM="$BUILD_OCAMLPARAM,dump-dir=$GITHUB_WORKSPACE/_profile_csv,dump-into-csv=1,profile=1"
+            OCAMLPARAM="$OCAMLPARAM,dump-dir=$GITHUB_WORKSPACE/_profile_csv,dump-into-csv=1,profile=1"
+          fi
           if [ "$run_testsuite" = true ]; then target=ci; else target=compiler; fi
           ulimit -c unlimited
           make $target \
@@ -245,6 +248,8 @@ jobs:
           # Install the compiler for metrics_collection configuration to populate _install directory
           # This is needed for the metrics collection step to analyze installed artifacts
           if [ "${{ matrix.collect_metrics }}" = "true" ]; then
+            BUILD_OCAMLPARAM="$ORIG_BUILD_OCAMLPARAM"
+            OCAMLPARAM="$ORIG_OCAMLPARAM"
             make install
           fi
         env:
@@ -414,11 +419,12 @@ jobs:
           fi
 
           # Use the metrics collection script (CSV filename and PR number computed internally)
-          python3 ${{ github.workspace }}/scripts/collect-size-metrics.py \
+          python3 ${{ github.workspace }}/scripts/collect-metrics.py \
             --install-dir "${{ github.workspace }}/_install" \
             --output-dir "metrics-repo/raw-data" \
             --commit-hash "$COMMIT_HASH" \
             --commit-message "$COMMIT_MESSAGE" \
+            --profile-dir "${{ github.workspace }}/_profile_csv" \
             --verbose
 
           # Commit and push metrics

--- a/oxcaml/tests/backend/vectorizer/dune.inc
+++ b/oxcaml/tests/backend/vectorizer/dune.inc
@@ -4,7 +4,11 @@
  (enabled_if (= %{context_name} "main"))
  (targets test1_runner.exe test1.cmx.dump)
  (deps test1.mli test1.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test1_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test1_runner.exe))))
 
 (rule
  (alias   runtest)
@@ -37,7 +41,11 @@
  (enabled_if (= %{context_name} "main"))
  (targets test1_vectorized_runner.exe test1_vectorized.cmx.dump)
  (deps test1_vectorized.mli test1_vectorized.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test1_vectorized_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test1_vectorized_runner.exe))))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
@@ -80,7 +88,11 @@
  (enabled_if (= %{context_name} "main"))
  (targets test_arrays_runner.exe test_arrays.cmx.dump)
  (deps test_arrays.mli test_arrays.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test_arrays_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test_arrays_runner.exe))))
 
 (rule
  (alias   runtest)
@@ -113,7 +125,11 @@
  (enabled_if (= %{context_name} "main"))
  (targets test_arrays_vectorized_runner.exe test_arrays_vectorized.cmx.dump)
  (deps test_arrays_vectorized.mli test_arrays_vectorized.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test_arrays_vectorized_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test_arrays_vectorized_runner.exe))))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
@@ -156,7 +172,11 @@
  (enabled_if (= %{context_name} "main"))
  (targets test_int64_unboxed_runner.exe test_int64_unboxed.cmx.dump)
  (deps test_int64_unboxed.mli test_int64_unboxed.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test_int64_unboxed_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test_int64_unboxed_runner.exe))))
 
 (rule
  (alias   runtest)
@@ -189,7 +209,11 @@
  (enabled_if (= %{context_name} "main"))
  (targets test_int64_unboxed_vectorized_runner.exe test_int64_unboxed_vectorized.cmx.dump)
  (deps test_int64_unboxed_vectorized.mli test_int64_unboxed_vectorized.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test_int64_unboxed_vectorized_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test_int64_unboxed_vectorized_runner.exe))))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
@@ -232,7 +256,11 @@
  (enabled_if (= %{context_name} "main"))
  (targets test_float_unboxed_runner.exe test_float_unboxed.cmx.dump)
  (deps test_float_unboxed.mli test_float_unboxed.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test_float_unboxed_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test_float_unboxed_runner.exe))))
 
 (rule
  (alias   runtest)
@@ -265,7 +293,11 @@
  (enabled_if (= %{context_name} "main"))
  (targets test_float_unboxed_vectorized_runner.exe test_float_unboxed_vectorized.cmx.dump)
  (deps test_float_unboxed_vectorized.mli test_float_unboxed_vectorized.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test_float_unboxed_vectorized_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test_float_unboxed_vectorized_runner.exe))))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
@@ -308,7 +340,11 @@
  (enabled_if (= %{context_name} "main"))
  (targets test_int64_runner.exe test_int64.cmx.dump)
  (deps test_int64.mli test_int64.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test_int64_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test_int64_runner.exe))))
 
 (rule
  (alias   runtest)
@@ -341,7 +377,11 @@
  (enabled_if (= %{context_name} "main"))
  (targets test_int64_vectorized_runner.exe test_int64_vectorized.cmx.dump)
  (deps test_int64_vectorized.mli test_int64_vectorized.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test_int64_vectorized_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test_int64_vectorized_runner.exe))))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
@@ -384,7 +424,11 @@
  (enabled_if (= %{context_name} "main"))
  (targets test_float_runner.exe test_float.cmx.dump)
  (deps test_float.mli test_float.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test_float_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test_float_runner.exe))))
 
 (rule
  (alias   runtest)
@@ -417,7 +461,11 @@
  (enabled_if (= %{context_name} "main"))
  (targets test_float_vectorized_runner.exe test_float_vectorized.cmx.dump)
  (deps test_float_vectorized.mli test_float_vectorized.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test_float_vectorized_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test_float_vectorized_runner.exe))))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
@@ -460,7 +508,11 @@
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_float32_unboxed_runner.exe test_float32_unboxed.cmx.dump)
  (deps test_float32_unboxed.mli test_float32_unboxed.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test_float32_unboxed_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test_float32_unboxed_runner.exe))))
 
 (rule
  (alias   runtest)
@@ -493,7 +545,11 @@
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
  (targets test_float32_unboxed_vectorized_runner.exe test_float32_unboxed_vectorized.cmx.dump)
  (deps test_float32_unboxed_vectorized.mli test_float32_unboxed_vectorized.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test_float32_unboxed_vectorized_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test_float32_unboxed_vectorized_runner.exe))))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
@@ -536,7 +592,11 @@
  (enabled_if (= %{context_name} "main"))
  (targets test_int32_unboxed_runner.exe test_int32_unboxed.cmx.dump)
  (deps test_int32_unboxed.mli test_int32_unboxed.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test_int32_unboxed_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test_int32_unboxed_runner.exe))))
 
 (rule
  (alias   runtest)
@@ -569,7 +629,11 @@
  (enabled_if (= %{context_name} "main"))
  (targets test_int32_unboxed_vectorized_runner.exe test_int32_unboxed_vectorized.cmx.dump)
  (deps test_int32_unboxed_vectorized.mli test_int32_unboxed_vectorized.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test_int32_unboxed_vectorized_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test_int32_unboxed_vectorized_runner.exe))))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
@@ -612,7 +676,11 @@
  (enabled_if (= %{context_name} "main"))
  (targets test_spill_valx2_runner.exe test_spill_valx2.cmx.dump)
  (deps test_spill_valx2.mli test_spill_valx2.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test_spill_valx2_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test_spill_valx2_runner.exe))))
 
 (rule
  (alias   runtest)
@@ -645,7 +713,11 @@
  (enabled_if (= %{context_name} "main"))
  (targets test_spill_valx2_vectorized_runner.exe test_spill_valx2_vectorized.cmx.dump)
  (deps test_spill_valx2_vectorized.mli test_spill_valx2_vectorized.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test_spill_valx2_vectorized_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test_spill_valx2_vectorized_runner.exe))))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
@@ -688,7 +760,11 @@
  (enabled_if (= %{context_name} "main"))
  (targets test_register_compatible_runner.exe test_register_compatible.cmx.dump)
  (deps test_register_compatible.mli test_register_compatible.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test_register_compatible_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -no-vectorize -o test_register_compatible_runner.exe))))
 
 (rule
  (alias   runtest)
@@ -721,7 +797,11 @@
  (enabled_if (= %{context_name} "main"))
  (targets test_register_compatible_vectorized_runner.exe test_register_compatible_vectorized.cmx.dump)
  (deps test_register_compatible_vectorized.mli test_register_compatible_vectorized.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test_register_compatible_vectorized_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -vectorize -o test_register_compatible_vectorized_runner.exe))))
 
 (rule
  (enabled_if (and (= %{context_name} "main") (= %{architecture} "amd64")) )
@@ -776,7 +856,11 @@
  (enabled_if (= %{context_name} "main"))
  (targets test1_classic_runner.exe test1_classic.cmx.dump)
  (deps test1_classic.mli test1_classic.ml)
- (action (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -Oclassic -vectorize -o test1_classic_runner.exe)))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -O3 -g -dump-into-file -dcfg -dvectorize -dlinear -regalloc cfg -extension simd -vectorize-max-block-size 1000 -Oclassic -vectorize -o test1_classic_runner.exe))))
 
 (rule
  (enabled_if (= %{context_name} "main"))

--- a/oxcaml/tests/backend/vectorizer/gen/gen_dune.ml
+++ b/oxcaml/tests/backend/vectorizer/gen/gen_dune.ml
@@ -38,6 +38,9 @@ let compile ~enabled_if ~extra_flags name =
     | "cmx_dump" -> cmx_dump name
     | _ -> assert false
   in
+  (* We override the OCAMLPARAM environment variable below, because
+   * the vectorizer tests uses the "dump-to-file" feature of the
+   * compiler which is also used by the CI job for metrics collection. *)
   rule ~subst
     {|
 (rule
@@ -45,7 +48,11 @@ let compile ~enabled_if ~extra_flags name =
  ${enabled_if}
  (targets ${runner} ${cmx_dump})
  (deps ${deps})
- (action (run %{bin:ocamlopt.opt} %{deps} ${flags} ${extra_flags} -o ${runner})))
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} ${flags} ${extra_flags} -o ${runner}))))
 |}
 
 let run ~enabled_if name =

--- a/testsuite/tests/profile/counters/language_extensions/test.ml
+++ b/testsuite/tests/profile/counters/language_extensions/test.ml
@@ -3,6 +3,7 @@
 subdirectories = "include_functor immutable_array_comprehensions comprehensions \
                   immutable_arrays module_strengthening labeled_tuples nested";
 setup-ocamlc.byte-build-env;
+set OCAMLPARAM = "";
 ocamlc_byte_exit_status = "0";
 flags = "-dcounters -extension include_functor -extension comprehensions \
         -extension immutable_arrays -extension immutable_arrays \


### PR DESCRIPTION
  ## Summary

  Extends the metrics collection workflow to capture compiler profiling data alongside artifact
  sizes.

  ## Changes

  - **Profiling enabled**: Added `profile=1,dump-dir=_profile_csv,dump-into-csv=1` to compilation
  parameters for the metrics workflow
  - **Profile archiving**: Script now collects all profile CSV files from the build directory and
  creates a `profiles-{date}-{hash}.tar.gz` archive
  - **Improved error handling**: Extracted `warn()` and `fatal()` helper functions for consistent
  error reporting
  - **Directory validation**: All input directories (install, output, build) are now validated
  before use
  - **Script renamed**: `collect-size-metrics.py` → `collect-metrics.py` to reflect its broader
  purpose

  ## Impact

  The workflow now generates two files per run:
  - `artifact-sizes-{date}-{hash}.csv` - Individual artifact sizes (unchanged)
  - `profiles-{date}-{hash}.tar.gz` - Compiler profiling data (new)

  Both files are committed to the metrics repository for analysis.