### PR TITLE
Race condition when using `-dump-dir` with a nonexistent path

### DIFF
--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -109,14 +109,17 @@ let read_clflags_from_env () =
   set_from_env Clflags.error_style Clflags.error_style_reader;
   ()
 
+let directory_exists dir =
+  Sys.file_exists dir && Sys.is_directory dir
+
 let rec make_directory dir =
-  if Sys.file_exists dir then () else
+  if directory_exists dir then () else
     begin
       make_directory (Filename.dirname dir);
       (try
         Sys.mkdir dir 0o777
       with (Sys_error _) as se ->
-        if not (Sys.file_exists dir) then raise se)
+        if not (directory_exists dir) then raise se)
     end
 
 let with_ppf_file ~file_prefix ~file_extension f =


### PR DESCRIPTION
I have seen the issue a couple of times on the CI
while working on something else. My understanding
is that the race happens because of the parallelism
created by the build system. There might be a better
fix, I did not put much thought into that pull request.