### PR TITLE
Refactor probes code generation

### DIFF
--- a/backend/.ocamlformat-enable
+++ b/backend/.ocamlformat-enable
@@ -71,6 +71,8 @@ printoperation.ml
 printoperation.mli
 printreg.ml
 printreg.mli
+probe_emission.ml
+probe_emission.mli
 reg_class.mli
 reg_class_utils.ml
 reg_class_utils.mli

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -1092,59 +1092,9 @@ let tailrec_entry_point = ref None
 
 (* Emit tracing probes *)
 
-type probe =
-  { stack_offset : int;
-    num_stack_slots : int Stack_class.Tbl.t;
-    probe_name : string;
-    probe_enabled_at_init : bool;
-    probe_handler_code_sym : string;
-    (* Record frame info held in the corresponding mutable variables. *)
-    probe_label : label;
-    (* Probe site, recorded in .note.stapsdt section for enabling and disabling
-       the probes *)
-    probe_insn : Linear.instruction
-        (* Iprobe instruction, recorded at probe site and used for emitting the
-           notes and the wrapper code at the end of the compilation unit. *)
-  }
-
 let probe_handler_wrapper_name probe_label =
   let w = Printf.sprintf "probe_wrapper_%s" (Label.to_string probe_label) in
   Cmm_helpers.make_symbol w |> S.create
-
-let probes = ref []
-
-let probe_semaphores = ref String.Map.empty
-
-let stapsdt_base_emitted = ref false
-
-let reset_probes () =
-  probes := [];
-  probe_semaphores := String.Map.empty
-
-let find_or_add_semaphore name enabled_at_init dbg =
-  match String.Map.find_opt name !probe_semaphores with
-  | Some (label, symbol, e) ->
-    (match e, enabled_at_init with
-    | None, None -> ()
-    | None, Some _ ->
-      let d = label, symbol, enabled_at_init in
-      probe_semaphores
-        := String.Map.remove name !probe_semaphores |> String.Map.add name d
-    | Some _, None ->
-      (* [find_or_add_semaphore] is called with None for Iprobe_is_enabled
-         during code emission only. [find_or_add_semaphore] us called with Some
-         to emit probe notes only after all code is emitted. *)
-      assert false
-    | Some b, Some b' ->
-      if not (Bool.equal b b')
-      then raise (Emitaux.Error (Inconsistent_probe_init (name, dbg))));
-    label
-  | None ->
-    let sym = "caml_probes_semaphore_" ^ name in
-    let symbol = S.Predef.caml_probes_semaphore ~name in
-    let d = sym, symbol, enabled_at_init in
-    probe_semaphores := String.Map.add name d !probe_semaphores;
-    sym
 
 let emit_call_probe_handler_wrapper i ~enabled_at_init ~probe_label =
   assert !frame_required;
@@ -2356,17 +2306,10 @@ let emit_instr ~first ~fallthrough i =
   | Lop (Name_for_debugger _) -> ()
   | Lcall_op (Lprobe { enabled_at_init; name; handler_code_sym }) ->
     let probe_label = Cmm.new_label () in
-    let probe =
-      { probe_label;
-        probe_insn = i;
-        probe_name = name;
-        probe_enabled_at_init = enabled_at_init;
-        probe_handler_code_sym = handler_code_sym;
-        stack_offset = !stack_offset;
-        num_stack_slots = Stack_class.Tbl.copy num_stack_slots
-      }
-    in
-    probes := probe :: !probes;
+    Probe_emission.add_probe ~probe_label ~probe_insn:i ~probe_name:name
+      ~probe_enabled_at_init:enabled_at_init
+      ~probe_handler_code_sym:handler_code_sym ~stack_offset:!stack_offset
+      ~num_stack_slots:(Stack_class.Tbl.copy num_stack_slots);
     D.define_label (label_to_asm_label ~section:Text probe_label);
     I.nop ();
     (* for uprobes and usdt probes as well *)
@@ -2376,7 +2319,7 @@ let emit_instr ~first ~fallthrough i =
        See [emit_probe_handler_wrapper] below. *)
     emit_call_probe_handler_wrapper i ~enabled_at_init ~probe_label
   | Lop (Probe_is_enabled { name }) ->
-    let semaphore_sym = find_or_add_semaphore name None i.dbg in
+    let semaphore_sym = Probe_emission.find_or_add_semaphore name None i.dbg in
     (* Load unsigned 2-byte integer value of the semaphore. According to the
        documentation [1], semaphores are of type unsigned short. [1]
        https://sourceware.org/systemtap/wiki/UserSpaceProbeImplementation *)
@@ -2654,8 +2597,7 @@ let reset_all () =
   reset_debug_info ();
   (* PR#5603 *)
   reset_imp_table ();
-  reset_probes ();
-  stapsdt_base_emitted := false;
+  Probe_emission.reset ();
   reset_traps ();
   float_constants := [];
   all_functions := []
@@ -2834,7 +2776,7 @@ let stack_locations ~offset regs =
   in
   locs |> Array.of_list
 
-let emit_probe_handler_wrapper p =
+let emit_probe_handler_wrapper (p : Probe_emission.probe) =
   let wrap_label = probe_handler_wrapper_name p.probe_label in
   let probe_name = p.probe_name in
   let handler_code_sym = p.probe_handler_code_sym in
@@ -2937,144 +2879,6 @@ let emit_probe_handler_wrapper p =
   D.cfi_endproc ();
   emit_function_type_and_size wrap_label
 
-let emit_stapsdt_base_section () =
-  if not !stapsdt_base_emitted
-  then (
-    stapsdt_base_emitted := true;
-    D.switch_to_section Stapsdt_base;
-    (* Note that the Stapsdt symbols do not follow the usual symbol encoding
-       convention. Hence, in this rare case, we create the symbol as a raw
-       symbol for which no subsequent encoding will be done.*)
-    let stapsdt_sym = S.Predef.stapsdt_base in
-    D.weak stapsdt_sym;
-    D.hidden stapsdt_sym;
-    D.define_symbol_label ~section:Stapsdt_base stapsdt_sym;
-    D.space ~bytes:1;
-    D.size_const stapsdt_sym
-      1L (* 1 byte; alternative would be . - _.stapsdt.base *))
-
-let emit_elf_note ~section ~owner ~typ ~emit_desc =
-  D.align ~fill_x86_bin_emitter:Zero ~bytes:4;
-  let a = L.create section in
-  let b = L.create section in
-  let c = L.create section in
-  let d = L.create section in
-  D.between_labels_32_bit ~upper:b ~lower:a ();
-  D.between_labels_32_bit ~upper:d ~lower:c ();
-  D.int32 typ;
-  D.define_label a;
-  D.string (owner ^ "\000");
-  D.define_label b;
-  D.align ~fill_x86_bin_emitter:Zero ~bytes:4;
-  D.define_label c;
-  emit_desc ();
-  D.define_label d;
-  D.align ~fill_x86_bin_emitter:Zero ~bytes:4
-
-let emit_probe_note_desc ~probe_name ~probe_label ~semaphore_label ~probe_args =
-  (match probe_label with
-  | Some probe_label ->
-    let lbl = label_to_asm_label ~section:Stapsdt_note probe_label in
-    D.label lbl
-  | None -> D.int64 0L);
-  (match Target_system.is_macos () with
-  | false -> D.symbol S.Predef.stapsdt_base
-  | true -> D.int64 0L);
-  D.symbol semaphore_label;
-  D.string "ocaml_2\000";
-  D.string (probe_name ^ "\000");
-  D.string (probe_args ^ "\000")
-
-let emit_probe_notes0 () =
-  D.switch_to_section Stapsdt_note;
-  let stap_arg arg =
-    let arg_name =
-      match arg.loc with
-      | Stack s ->
-        Printf.sprintf "%d(%%rsp)"
-          (slot_offset s (Stack_class.of_machtype arg.Reg.typ))
-      | Reg reg -> Reg_class.register_name arg.Reg.typ reg
-      | Unknown ->
-        Misc.fatal_errorf "Cannot create probe: illegal argument: %a"
-          Printreg.reg arg
-    in
-    Printf.sprintf "%d@%s" (Select_utils.size_component arg.Reg.typ) arg_name
-  in
-  let describe_one_probe p =
-    let probe_name = p.probe_name in
-    let enabled_at_init = p.probe_enabled_at_init in
-    let args =
-      Array.fold_right (fun arg acc -> stap_arg arg :: acc) p.probe_insn.arg []
-      |> String.concat " "
-    in
-    let semsym =
-      find_or_add_semaphore probe_name (Some enabled_at_init) p.probe_insn.dbg
-    in
-    let semaphore_label = S.create semsym in
-    let emit_desc () =
-      emit_probe_note_desc ~probe_label:(Some p.probe_label) ~semaphore_label
-        ~probe_name ~probe_args:args
-    in
-    emit_elf_note ~section:Stapsdt_note ~owner:"stapsdt" ~typ:3l ~emit_desc
-  in
-  List.iter describe_one_probe !probes;
-  ()
-
-let emit_dummy_probe_notes () =
-  (* A semaphore may be used via [%probe_is_enabled] without a corresponding
-     probe site in the same compilation unit or even the entire program due to
-     inlining or optimizations or user defined special cases. Emit dummy probe
-     notes to correctly toggle such semaphores. A dummy note has no associated
-     probe site or probe handler. *)
-  let describe_dummy_probe ~probe_name sym =
-    let semaphore_label = S.create sym in
-    let emit_desc () =
-      emit_probe_note_desc ~probe_name ~probe_label:None ~semaphore_label
-        ~probe_args:""
-    in
-    emit_elf_note ~section:Stapsdt_note ~owner:"stapsdt" ~typ:3l ~emit_desc
-  in
-  let semaphores_without_probes =
-    List.fold_left
-      (fun acc probe -> String.Map.remove probe.probe_name acc)
-      !probe_semaphores !probes
-  in
-  if not (String.Map.is_empty semaphores_without_probes)
-  then (
-    D.switch_to_section Stapsdt_note;
-    String.Map.iter
-      (fun probe_name (sym, _, _) -> describe_dummy_probe ~probe_name sym)
-      semaphores_without_probes)
-
-let emit_probe_semaphores () =
-  (match Target_system.is_macos () with
-  | false ->
-    emit_stapsdt_base_section ();
-    D.switch_to_section Probes
-  | true -> D.switch_to_section Probes);
-  D.align ~fill_x86_bin_emitter:Zero ~bytes:2;
-  String.Map.iter
-    (fun _ (label, label_sym, enabled_at_init) ->
-      (* Unresolved weak symbols have a zero value regardless of the following
-         initialization. *)
-      let enabled_at_init = Option.value enabled_at_init ~default:false in
-      D.weak label_sym;
-      D.hidden label_sym;
-      D.define_symbol_label ~section:Probes label_sym;
-      D.int16 (Numbers.Int16.of_int_exn 0);
-      (* for systemtap probes *)
-      D.int16 (Numbers.Int16.of_int_exn (Bool.to_int enabled_at_init));
-      (* for ocaml probes *)
-      add_def_symbol label)
-    !probe_semaphores
-
-let emit_probe_notes () =
-  (match !probes with [] -> () | _ -> emit_probe_notes0 ());
-  if not (String.Map.is_empty !probe_semaphores)
-  then (
-    emit_dummy_probe_notes ();
-    emit_probe_semaphores ())
-
 let emit_trap_notes () =
   (* Don't emit trap notes on windows and macos systems *)
   let is_system_supported =
@@ -3100,9 +2904,10 @@ let emit_trap_notes () =
      && not (L.Set.is_empty traps.enter_traps)
   then (
     D.switch_to_section Note_ocaml_eh;
-    emit_elf_note ~section:Note_ocaml_eh ~owner:"OCaml" ~typ:1l ~emit_desc;
-    (* Reuse stapsdt base section for calcluating addresses after pre-link *)
-    emit_stapsdt_base_section ();
+    Emitaux.emit_elf_note ~section:Note_ocaml_eh ~owner:"OCaml" ~typ:1l
+      ~emit_desc;
+    (* Reuse stapsdt base section for calculating addresses after prelinking *)
+    Emitaux.emit_stapsdt_base_section ();
     (* Switch back to Data section *)
     D.data ())
 
@@ -3128,7 +2933,7 @@ let end_assembly () =
     D.align ~fill_x86_bin_emitter:Zero ~bytes:64;
     List.iter (fun (cst, lbl) -> emit_vec512_constant cst lbl) !vec512_constants);
   (* Emit probe handler wrappers *)
-  List.iter emit_probe_handler_wrapper !probes;
+  List.iter emit_probe_handler_wrapper (Probe_emission.get_probes ());
   emit_named_text_section (Cmm_helpers.make_symbol "jump_tables");
   emit_jump_tables ();
   let code_end = Cmm_helpers.make_symbol "code_end" in
@@ -3189,7 +2994,7 @@ let end_assembly () =
   let frametable_sym = S.create (Cmm_helpers.make_symbol "frametable") in
   D.size frametable_sym;
   D.data ();
-  emit_probe_notes ();
+  Probe_emission.emit_probe_notes ~slot_offset ~add_def_symbol;
   emit_trap_notes ();
   D.mark_stack_non_executable ();
   (* Note that [mark_stack_non_executable] switches the section on Linux. *)

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -136,3 +136,12 @@ val add_stack_checks_if_needed :
   stack_threshold_size:int ->
   trap_size:int ->
   Linear.fundecl
+
+val emit_stapsdt_base_section : unit -> unit
+
+val emit_elf_note :
+  section:Asm_targets.Asm_section.t ->
+  owner:string ->
+  typ:int32 ->
+  emit_desc:(unit -> unit) ->
+  unit

--- a/backend/probe_emission.ml
+++ b/backend/probe_emission.ml
@@ -1,0 +1,205 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+module D = Asm_targets.Asm_directives
+module S = Asm_targets.Asm_symbol
+module L = Asm_targets.Asm_label
+module String = Misc.Stdlib.String
+
+type probe =
+  { stack_offset : int;
+    num_stack_slots : int Stack_class.Tbl.t;
+    probe_name : string;
+    probe_enabled_at_init : bool;
+    probe_handler_code_sym : string;
+    (* Record frame info held in the corresponding mutable variables. *)
+    probe_label : Label.t;
+    (* Probe site, recorded in .note.stapsdt section for enabling and disabling
+       the probes *)
+    probe_insn : Linear.instruction
+        (* Iprobe instruction, recorded at probe site and used for emitting the
+           notes and the wrapper code at the end of the compilation unit. *)
+  }
+
+let probes = ref []
+
+let get_probes () = !probes
+
+let add_probe ~stack_offset ~num_stack_slots ~probe_name ~probe_enabled_at_init
+    ~probe_handler_code_sym ~probe_label ~probe_insn =
+  let probe =
+    { stack_offset;
+      num_stack_slots;
+      probe_name;
+      probe_enabled_at_init;
+      probe_handler_code_sym;
+      probe_label;
+      probe_insn
+    }
+  in
+  probes := probe :: !probes
+
+type semaphore_data = string * Asm_targets.Asm_symbol.t * bool option
+
+let probe_semaphores = ref String.Map.empty
+
+let find_or_add_semaphore name enabled_at_init dbg =
+  match String.Map.find_opt name !probe_semaphores with
+  | Some (label, symbol, e) ->
+    (match e, enabled_at_init with
+    | None, None -> ()
+    | None, Some _ ->
+      let d = label, symbol, enabled_at_init in
+      probe_semaphores
+        := String.Map.remove name !probe_semaphores |> String.Map.add name d
+    | Some _, None ->
+      (* [find_or_add_semaphore] is called with None for Iprobe_is_enabled
+         during code emission only. [find_or_add_semaphore] is called with Some
+         to emit probe notes only after all code is emitted. *)
+      assert false
+    | Some b, Some b' ->
+      if not (Bool.equal b b')
+      then raise (Emitaux.Error (Inconsistent_probe_init (name, dbg))));
+    label
+  | None ->
+    let symbol = S.Predef.caml_probes_semaphore ~name in
+    let sym = S.to_raw_string symbol in
+    let d = sym, symbol, enabled_at_init in
+    probe_semaphores := String.Map.add name d !probe_semaphores;
+    sym
+
+let emit_probe_note_desc ~probe_name ~probe_label ~semaphore_label ~probe_args =
+  (match probe_label with
+  | Some probe_label ->
+    let lbl = L.create_int Stapsdt_note (Label.to_int probe_label) in
+    D.label lbl
+  | None -> D.int64 0L);
+  (match Target_system.is_macos () with
+  | false -> D.symbol S.Predef.stapsdt_base
+  | true -> D.int64 0L);
+  D.symbol semaphore_label;
+  D.string "ocaml_2\000";
+  D.string (probe_name ^ "\000");
+  D.string (probe_args ^ "\000")
+
+let emit_probe_notes0 ~slot_offset =
+  D.switch_to_section Stapsdt_note;
+  let stap_arg (arg : Reg.t) =
+    let arg_name =
+      match arg.loc with
+      | Stack s ->
+        Printf.sprintf "%d(%%rsp)"
+          (slot_offset s (Stack_class.of_machtype arg.Reg.typ))
+      | Reg reg -> Reg_class.register_name arg.Reg.typ reg
+      | Unknown ->
+        Misc.fatal_errorf "Cannot create probe: illegal argument: %a"
+          Printreg.reg arg
+    in
+    Printf.sprintf "%d@%s" (Select_utils.size_component arg.Reg.typ) arg_name
+  in
+  let describe_one_probe p =
+    let probe_name = p.probe_name in
+    let enabled_at_init = p.probe_enabled_at_init in
+    let args =
+      Array.fold_right (fun arg acc -> stap_arg arg :: acc) p.probe_insn.arg []
+      |> String.concat " "
+    in
+    let semsym =
+      find_or_add_semaphore probe_name (Some enabled_at_init) p.probe_insn.dbg
+    in
+    let semaphore_label = S.create semsym in
+    let emit_desc () =
+      emit_probe_note_desc ~probe_label:(Some p.probe_label) ~semaphore_label
+        ~probe_name ~probe_args:args
+    in
+    Emitaux.emit_elf_note ~section:Stapsdt_note ~owner:"stapsdt" ~typ:3l
+      ~emit_desc
+  in
+  List.iter describe_one_probe !probes
+
+let emit_dummy_probe_notes () =
+  (* A semaphore may be used via [%probe_is_enabled] without a corresponding
+     probe site in the same compilation unit or even the entire program due to
+     inlining or optimizations or user defined special cases. Emit dummy probe
+     notes to correctly toggle such semaphores. A dummy note has no associated
+     probe site or probe handler. *)
+  let describe_dummy_probe ~probe_name sym =
+    let semaphore_label = S.create sym in
+    let emit_desc () =
+      emit_probe_note_desc ~probe_name ~probe_label:None ~semaphore_label
+        ~probe_args:""
+    in
+    Emitaux.emit_elf_note ~section:Stapsdt_note ~owner:"stapsdt" ~typ:3l
+      ~emit_desc
+  in
+  let semaphores_without_probes =
+    List.fold_left
+      (fun acc probe -> String.Map.remove probe.probe_name acc)
+      !probe_semaphores !probes
+  in
+  if not (String.Map.is_empty semaphores_without_probes)
+  then (
+    D.switch_to_section Stapsdt_note;
+    String.Map.iter
+      (fun probe_name (sym, _, _) -> describe_dummy_probe ~probe_name sym)
+      semaphores_without_probes)
+
+let emit_probe_semaphores ~add_def_symbol =
+  (match Target_system.is_macos () with
+  | false ->
+    Emitaux.emit_stapsdt_base_section ();
+    D.switch_to_section Probes
+  | true -> D.switch_to_section Probes);
+  D.align ~fill_x86_bin_emitter:Zero
+    ~bytes:(if Target_system.is_macos () then 8 else 2);
+  String.Map.iter
+    (fun _ (label, label_sym, enabled_at_init) ->
+      (* Unresolved weak symbols have a zero value regardless of the following
+         initialization. *)
+      let enabled_at_init = Option.value enabled_at_init ~default:false in
+      if not (Target_system.is_macos ())
+      then (
+        D.weak label_sym;
+        D.hidden label_sym);
+      D.define_symbol_label ~section:Probes label_sym;
+      D.int16 (Numbers.Int16.of_int_exn 0);
+      (* for systemtap probes *)
+      D.int16 (Numbers.Int16.of_int_exn (Bool.to_int enabled_at_init));
+      (* for ocaml probes *)
+      add_def_symbol label)
+    !probe_semaphores
+
+let emit_probe_notes ~slot_offset ~add_def_symbol =
+  (match !probes with [] -> () | _ -> emit_probe_notes0 ~slot_offset);
+  if not (String.Map.is_empty !probe_semaphores)
+  then (
+    emit_dummy_probe_notes ();
+    emit_probe_semaphores ~add_def_symbol)
+
+let reset () =
+  probes := [];
+  probe_semaphores := String.Map.empty

--- a/backend/probe_emission.mli
+++ b/backend/probe_emission.mli
@@ -1,0 +1,76 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(** Probe management for code emission *)
+
+type probe = private
+  { stack_offset : int;
+    num_stack_slots : int Stack_class.Tbl.t;
+    probe_name : string;
+    probe_enabled_at_init : bool;
+    probe_handler_code_sym : string;
+        (** Record frame info held in the corresponding mutable variables. *)
+    probe_label : Label.t;
+        (** Probe site, recorded in .note.stapsdt section for enabling and
+            disabling the probes *)
+    probe_insn : Linear.instruction
+        (** For optimized probes, the Iprobe instruction, recorded at the
+            probe site and used for emitting the notes and the wrapper code
+            at the end of the compilation unit.  For non-optimized probes,
+            this will be a direct call instruction. *)
+  }
+
+val get_probes : unit -> probe list
+
+(** Add a probe site. *)
+val add_probe :
+  stack_offset:int ->
+  num_stack_slots:int Stack_class.Tbl.t ->
+  probe_name:string ->
+  probe_enabled_at_init:bool ->
+  probe_handler_code_sym:string ->
+  probe_label:Label.t ->
+  probe_insn:Linear.instruction ->
+  unit
+
+(** Reset the probe semaphore registry *)
+val reset : unit -> unit
+
+(** Find or add a semaphore for a probe name.
+    Returns the label string for the semaphore symbol.
+    - [name]: probe name
+    - [enabled_at_init]: whether the probe is enabled at initialization
+    - [dbg]: debug info for error reporting
+    Raises Emitaux.Error (Inconsistent_probe_init ...) if the same probe
+    is used with different enabled_at_init values. *)
+val find_or_add_semaphore : string -> bool option -> Debuginfo.t -> string
+
+(** Emit probe notes and semaphores to the assembly output *)
+val emit_probe_notes :
+  slot_offset:(Reg.stack_location -> Stack_class.t -> int) ->
+  add_def_symbol:(string -> unit) ->
+  unit

--- a/dune
+++ b/dune
@@ -570,6 +570,7 @@
   printoperation
   printreg
   proc
+  probe_emission
   simd
   simd_selection
   simd_proc


### PR DESCRIPTION
Separate PR for the refactoring part of https://github.com/oxcaml/oxcaml/pull/4991. 
Moves non-target specific code for emitting probes out of `backend/amd64/emit.ml` into `Emitaux` and some into a separate new file `probes_emission.ml`.