### PR TITLE
chamelon: Allow building with boot compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,11 @@ ci-coverage: boot-runtest coverage
 # 	cp chamelon/dune.upstream chamelon/dune
 # 	RUNTIME_DIR=$(RUNTIME_DIR) $(dune) build $(ws_main) @chamelon/all
 
+.PHONY: boot-minimizer
+boot-minimizer:
+	cp chamelon/dune.ox chamelon/dune
+	RUNTIME_DIR=$(RUNTIME_DIR) $(dune) build $(ws_boot) @chamelon/all
+
 .PHONY: minimizer
 minimizer: runtime-stdlib
 	cp chamelon/dune.ox chamelon/dune

--- a/chamelon/dune.ox
+++ b/chamelon/dune.ox
@@ -2,7 +2,7 @@
  (name chamelon)
  (public_name chamelon)
  (modes native)
- (libraries ocamlcommon unix str
+ (libraries ocamlcommon
    (select compat.ml from ( -> compat.ox.ml))
  )
  (package ocaml)


### PR DESCRIPTION
Chamelon does not build in the `boot.ws` dune workspace due to dependencies on the `unix` and `str` libraries, which are resolved by dune to the local version of those libraries that now contain annotations (portability etc.) that cannot be parsed by the system compiler.

This is unfortunate, as being able to build the minimizer in the `boot.ws` workspace is useful, especially when debugging crashes that occur while building the compiler itself.

This patch side-steps the issue by replacing the only use of those libraries within Chamelon with a custom search-and-replace function, allowing it to build in the `boot.ws` dune workspace.