### PR TITLE
Add instruction, block, and move counters to CFG profiling

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -263,7 +263,11 @@ let count_duplicate_spills_reloads_in_block (block : Cfg.basic_block) =
   in
   dup_spills, dup_reloads
 
-type spills_reloads_moves = { spills : int; reloads : int; moves : int }
+type spills_reloads_moves =
+  { spills : int;
+    reloads : int;
+    moves : int
+  }
 
 let count_spills_reloads_moves (block : Cfg.basic_block) =
   let f (acc : spills_reloads_moves) (instr : Cfg.basic Cfg.instruction) =


### PR DESCRIPTION
Extends cfg_block_counters to track three additional metrics:
- Total instruction count per block (body length + terminator)
- Block count (returns 1 per block for aggregation)
- Move instruction count

Refactors count_spills_reloads to count_spills_reloads_moves, introducing a record type for cleaner return values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)