### PR TITLE
Add option to print jkinds expanded for sake of Merlin

### DIFF
--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -759,6 +759,10 @@ val set_raw_type_expr : (Format.formatter -> Types.type_expr -> unit) -> unit
 
 val format : Format.formatter -> 'd Types.jkind -> unit
 
+(** Similar to [format], but the kind is expanded as much as possible rather
+    than written in terms of a kind abbreviation. This is used by Merlin. *)
+val format_expanded : Format.formatter -> 'd Types.jkind -> unit
+
 (** Format the history of this jkind: what interactions it has had and why
     it is the jkind that it is. Might be a no-op: see [display_histories]
     in the implementation of the [Jkind] module.


### PR DESCRIPTION
The jkind api doesn't currently offer a way to print out a fully-expanded jkind. This PR adds such a function, `format_expanded`, which will make it easy for Merlin to show the expanded jkind on hovers.

It's impossible to write an expect-test in the compiler's testsuite that covers `format_expanded` since it's never used in the codebase. But I don't think this change needs high scrutiny, and [this Merlin PR](https://github.com/oxcaml/merlin/pull/200) makes use of it.