### PR TITLE
Don't record backtrace on out-of-fibers test

### DIFF
--- a/testsuite/tests/effects/out_of_fibers.ml
+++ b/testsuite/tests/effects/out_of_fibers.ml
@@ -7,4 +7,6 @@
 
 external out_of_fibers : unit -> 'a = "test_out_of_fibers"
 
-let () = out_of_fibers ()
+let () =
+  Printexc.record_backtrace false;
+  out_of_fibers ()


### PR DESCRIPTION
The test produces a stack trace on various configs that mismatches the reference output.  Disabling stack traces should make the output the same in all configs.