### PR TITLE
Non-reaper changes for rewriting of types in the reaper

### DIFF
--- a/middle_end/flambda2/datalog/flambda2_datalog.ml
+++ b/middle_end/flambda2/datalog/flambda2_datalog.ml
@@ -70,10 +70,12 @@ module Datalog = struct
 
   include Datalog
 
-  type ('t, 'k, 'v) table = ('t, 'k, 'v) Table.Id.t
+  type (!'t, !'k, !'v) table = ('t, 'k, 'v) Table.Id.t
 
   let create_table ?(provenance = true) ~name ~default_value columns =
     Table.Id.create ~provenance ~name ~columns ~default_value
+
+  let columns table = Table.Id.columns table
 
   type ('t, 'k) relation = ('t, 'k, unit) table
 

--- a/middle_end/flambda2/datalog/flambda2_datalog.mli
+++ b/middle_end/flambda2/datalog/flambda2_datalog.mli
@@ -70,7 +70,7 @@ module Datalog : sig
     end) : S with type t = int
   end
 
-  type ('t, 'k, 'v) table
+  type (!'t, !'k, !'v) table
 
   (** The [provenance] argument is [true] by default. If set to [false],
       provenance tracking will be disabled for this table. This is useful for
@@ -82,6 +82,8 @@ module Datalog : sig
     default_value:'v ->
     ('t, 'k, 'v) Column.hlist ->
     ('t, 'k, 'v) table
+
+  val columns : ('t, 'k, 'v) table -> ('t, 'k, 'v) Column.hlist
 
   type ('t, 'k) relation = ('t, 'k, unit) table
 

--- a/middle_end/flambda2/datalog/table.ml
+++ b/middle_end/flambda2/datalog/table.ml
@@ -56,7 +56,7 @@ let concat is_trie ~earlier:t1 ~later:t2 =
   Trie.union is_trie (fun _ v -> Some v) t1 t2
 
 module Id = struct
-  type ('t, 'k, 'v) t =
+  type (!'t, !'k, !'v) t =
     { id : ('t * 'k) Type.Id.t;
       name : string;
       is_trie : ('t, 'k, 'v) Trie.is_trie;

--- a/middle_end/flambda2/datalog/table.mli
+++ b/middle_end/flambda2/datalog/table.mli
@@ -20,7 +20,7 @@ module Type : sig
 end
 
 module Id : sig
-  type ('t, 'k, 'v) t
+  type (!'t, !'k, !'v) t
 
   val print : Format.formatter -> ('t, 'k, 'v) t -> unit
 

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -245,6 +245,8 @@ let with_param_modes param_modes t = { t with param_modes }
 
 let with_is_tupled is_tupled t = { t with is_tupled }
 
+let with_result_types result_types t = { t with result_types }
+
 module Option = struct
   include Option
 

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -142,6 +142,8 @@ val with_param_modes : Alloc_mode.For_types.t list -> t -> t
 
 val with_is_tupled : bool -> t -> t
 
+val with_result_types : Result_types.t Or_unknown_or_bottom.t -> t -> t
+
 val print : Format.formatter -> t -> unit
 
 (** [free_names] does not return occurrences of value slots inside the


### PR DESCRIPTION
Extracted from #5043. After that, the only changes not in the `reaper/` subfolder are the types changes, which will come with a separate PR, and the change in `flambda2.ml` that make the reaper able to modify the typing_env.