### PR TITLE
flambda2: Remove code age relation join

### DIFF
--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -22,6 +22,8 @@ let keep_lifted_constant_only_if_used uacc acc lifted_constant =
     match UA.reachable_code_ids uacc with
     | Unknown -> Bound_static.binds_code bound
     | Known { live_code_ids = _; ancestors_of_live_code_ids } ->
+      (* CR bclement for gbury: This is likely no longer needed now that the
+         code age relation join has been removed. *)
       not
         (Code_id.Set.disjoint
            (Bound_static.code_being_defined bound)

--- a/middle_end/flambda2/types/env/code_age_relation.ml
+++ b/middle_end/flambda2/types/env/code_age_relation.ml
@@ -65,20 +65,6 @@ let meet t ~resolver id1 id2 : _ Or_bottom.t =
     then Ok id1
     else Bottom
 
-let join ~target_t:_ ~resolver:_ _t1 _t2 id1 id2 : _ Or_unknown.t =
-  (* Lowest ("newest") common ancestor, if such exists. *)
-  if Code_id.equal id1 id2 then Known id1 else Unknown
-(* let id1_to_root = all_ids_up_to_root ~resolver t1 id1 in let id2_to_root =
-   all_ids_up_to_root ~resolver t2 id2 in let shared_ids = Code_id.Set.inter
-   id1_to_root id2_to_root in let shared_ids_in_scope = Code_id.Set.filter (fun
-   id -> let is_imported = not (Compilation_unit.is_current
-   (Code_id.get_compilation_unit id)) in is_imported || Code_id.Map.mem id
-   target_t) shared_ids in if Code_id.Set.is_empty shared_ids_in_scope then
-   Unknown else let newest_shared_id, _ = shared_ids_in_scope |>
-   Code_id.Set.elements |> List.map (fun id -> id, num_ids_up_to_root target_t
-   ~resolver id) |> List.sort (fun (_, len1) (_, len2) -> -Int.compare len1
-   len2) |> List.hd in Known newest_shared_id *)
-
 let union t1 t2 = Code_id.Map.disjoint_union ~eq:Code_id.equal t1 t2
 
 let all_code_ids_for_export t =

--- a/middle_end/flambda2/types/env/code_age_relation.mli
+++ b/middle_end/flambda2/types/env/code_age_relation.mli
@@ -38,17 +38,6 @@ val meet :
   Code_id.t ->
   Code_id.t Or_bottom.t
 
-(** [join] calculates the newest common ancestor of the given pieces of code, or
-    identifies that the pieces of code are unrelated. *)
-val join :
-  target_t:t ->
-  resolver:(Compilation_unit.t -> t option) ->
-  t ->
-  t ->
-  Code_id.t ->
-  Code_id.t ->
-  Code_id.t Or_unknown.t
-
 val union : t -> t -> t
 
 val all_code_ids_for_export : t -> Code_id.Set.t

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -620,11 +620,6 @@ module Source_env : sig
 
   val create : TE.t -> t
 
-  val code_age_relation : t -> Code_age_relation.t
-
-  val code_age_relation_resolver :
-    t -> Compilation_unit.t -> Code_age_relation.t option
-
   val machine_width : t -> Target_system.Machine_width.t
 
   val exists_in_source_env : t -> Variable.t -> Variable_in_source_env.t option
@@ -654,11 +649,6 @@ end = struct
   type t = { source_env : TE.t } [@@unboxed]
 
   let create source_env = { source_env }
-
-  let code_age_relation { source_env } = TE.code_age_relation source_env
-
-  let code_age_relation_resolver { source_env } =
-    TE.code_age_relation_resolver source_env
 
   let machine_width { source_env; _ } = TE.machine_width source_env
 
@@ -1319,13 +1309,6 @@ type t =
 type n_way_join_type = t -> TG.t join_arg list -> TG.t Or_unknown.t * t
 
 let joined_env t index = Joined_envs.get_nth_joined_env t.joined_envs index
-
-let code_age_relation t =
-  Source_env.code_age_relation (Bindings_in_target_env.source_env t.bindings)
-
-let code_age_relation_resolver t =
-  Source_env.code_age_relation_resolver
-    (Bindings_in_target_env.source_env t.bindings)
 
 let machine_width t =
   Source_env.machine_width (Bindings_in_target_env.source_env t.bindings)

--- a/middle_end/flambda2/types/env/join_env.mli
+++ b/middle_end/flambda2/types/env/join_env.mli
@@ -24,11 +24,6 @@ type n_way_join_type =
 
 val joined_env : t -> env_id -> Typing_env.t
 
-val code_age_relation : t -> Code_age_relation.t
-
-val code_age_relation_resolver :
-  t -> Compilation_unit.t -> Code_age_relation.t option
-
 val machine_width : t -> Target_system.Machine_width.t
 
 val n_way_join_simples :

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -2450,27 +2450,13 @@ and join_function_type (env : Join_env.t)
   match func_type1, func_type2 with
   | Unknown, _ | _, Unknown -> Unknown
   | ( Known { code_id = code_id1; rec_info = rec_info1 },
-      Known { code_id = code_id2; rec_info = rec_info2 } ) -> (
-    let target_typing_env = Join_env.target_join_env env in
-    (* As a note, sometimes it might be preferable not to do the code age
-       relation join, and take the hit of an indirect call in exchange for
-       calling specialised versions of the code. Maybe an annotation would be
-       needed. Dolan thinks there isn't a single good answer here and we should
-       maybe just not do the join. (The code age relation meet would remain
-       though as it's useful elsewhere.) *)
-    match
-      Code_age_relation.join
-        ~target_t:(TE.code_age_relation target_typing_env)
-        ~resolver:(TE.code_age_relation_resolver target_typing_env)
-        (TE.code_age_relation (Join_env.left_join_env env))
-        (TE.code_age_relation (Join_env.right_join_env env))
-        code_id1 code_id2
-    with
-    | Unknown -> Unknown
-    | Known code_id -> (
+      Known { code_id = code_id2; rec_info = rec_info2 } ) ->
+    if Code_id.equal code_id1 code_id2
+    then
       match join env rec_info1 rec_info2 with
-      | Known rec_info -> Known (TG.Function_type.create code_id ~rec_info)
-      | Unknown -> Unknown))
+      | Known rec_info -> Known (TG.Function_type.create code_id1 ~rec_info)
+      | Unknown -> Unknown
+    else Unknown
 
 and join_env_extension env (ext1 : TEE.t) (ext2 : TEE.t) : TEE.t =
   let equations =


### PR DESCRIPTION
This is disabled since #818 (over 3 years ago) and has not been re-enabled since. It has been the source of confusion over the years, and it is probably safe to remove it for real.

This leaves the logic in dataflow to preserve ancestors of live code IDs. It will be removed in a separate patch.