### PR TITLE
Add missing `Skip` mode hints

### DIFF
--- a/testsuite/tests/typing-modes/exn.ml
+++ b/testsuite/tests/typing-modes/exn.ml
@@ -185,7 +185,10 @@ let (foo @ portable) () =
 Line 3, characters 21-22:
 3 |     | Contended r -> r := 4
                          ^
-Error: This value is "contended" but is expected to be "uncontended".
+Error: This value is "contended"
+       because it is used inside the function at Lines 1-4, characters 21-13
+       which is expected to be "portable".
+       However, the highlighted expression is expected to be "uncontended".
 |}]
 
 let (foo @ portable) () =
@@ -206,7 +209,10 @@ let (foo @ portable) () =
 Line 2, characters 11-20:
 2 |     raise (Contended (ref 42))
                ^^^^^^^^^
-Error: This value is "contended" but is expected to be "uncontended".
+Error: This value is "contended"
+       because it is used inside the function at Lines 1-2, characters 21-30
+       which is expected to be "portable".
+       However, the highlighted expression is expected to be "uncontended".
   Hint: All arguments of the constructor "Contended"
   must cross this axis to use it in this position.
 |}]
@@ -343,7 +349,10 @@ let (foo @ stateless) f =
 Line 3, characters 24-25:
 3 |     | ReadWriteRef r -> r.contents <- 1
                             ^
-Error: This value is "immutable" but is expected to be "read_write"
+Error: This value is "immutable"
+       because it is used inside the function at Lines 1-4, characters 22-13
+       which is expected to be "stateless".
+       However, the highlighted expression is expected to be "read_write"
        because its mutable field "contents" is being written.
 |}]
 
@@ -365,7 +374,10 @@ let (foo @ stateless) () =
 Line 2, characters 11-23:
 2 |     raise (ReadWriteRef {contents = 0})
                ^^^^^^^^^^^^
-Error: This value is "immutable" but is expected to be "read_write".
+Error: This value is "immutable"
+       because it is used inside the function at Lines 1-2, characters 22-39
+       which is expected to be "stateless".
+       However, the highlighted expression is expected to be "read_write".
   Hint: All arguments of the constructor "ReadWriteRef"
   must cross this axis to use it in this position.
 |}]

--- a/testsuite/tests/typing-unique/overwriting.ml
+++ b/testsuite/tests/typing-unique/overwriting.ml
@@ -152,7 +152,9 @@ Line 3, characters 13-14:
                  ^
 Error: This value is "local"
        because it is "stack_"-allocated.
-       However, the highlighted expression is expected to be "local" to the parent region or "global".
+       However, the highlighted expression is expected to be "local" to the parent region or "global"
+       because it is a function return value.
+       Hint: Use exclave_ to return a local value.
 |}]
 
 let returning_regional () x =

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3072,10 +3072,10 @@ module Comonadic_with (Areality : Areality) = struct
   end
 
   let min_with ax m =
-    Solver.apply Obj.obj (Min_with ax) (Solver.disallow_right m)
+    Solver.apply ~hint:Skip Obj.obj (Min_with ax) (Solver.disallow_right m)
 
   let max_with ax m =
-    Solver.apply Obj.obj (Max_with ax) (Solver.disallow_left m)
+    Solver.apply ~hint:Skip Obj.obj (Max_with ax) (Solver.disallow_left m)
 
   let meet_with ax c m = meet_const (Const.max_with ax c) m
 
@@ -3212,7 +3212,7 @@ module Monadic = struct
   let join_with ax c m = join_const (Const.min_with ax c) m
 
   let min_with ax m =
-    Solver.apply Obj.obj (Max_with ax) (Solver.disallow_left m)
+    Solver.apply ~hint:Skip Obj.obj (Max_with ax) (Solver.disallow_left m)
 
   let zap_to_legacy m : Const.t =
     let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy in


### PR DESCRIPTION
This PR adds several `Skip` that were missing. The helps to recover some mode error hints that were cut off.