### PR TITLE
chamelon: allow stopping minimization with `Ctrl-C`

### DIFF
--- a/chamelon/dune.ox
+++ b/chamelon/dune.ox
@@ -2,10 +2,26 @@
  (name chamelon)
  (public_name chamelon)
  (modes native)
+ ; We don't use [unix] in [libraries] as that causes ocaml/otherlibs/unix/
+ ; to be built against the system compiler, which won't work.
+ (ocamlc_flags (:standard -I +unix unix.cma))
+ (ocamlopt_flags (:standard -I +unix unix.cmxa))
  (libraries ocamlcommon
    (select compat.ml from ( -> compat.ox.ml))
  )
  (package ocaml)
+ (enabled_if (= %{context_name} "default"))
+)
+
+(executable
+ (name chamelon)
+ (public_name chamelon)
+ (modes native)
+ (libraries ocamlcommon unix
+   (select compat.ml from ( -> compat.ox.ml))
+ )
+ (package ocaml)
+ (enabled_if (= %{context_name} "main"))
 )
 
 (env

--- a/chamelon/iterator.ml
+++ b/chamelon/iterator.ml
@@ -77,7 +77,8 @@ let minimize_at minimize cur_file map ~pos ~len =
   (nmap, pos <= !r)
 
 let step_minimizer c minimize cur_file map ~pos ~len =
-  Format.eprintf "Trying %s: pos=%d, len=%d... " minimize.minimizer_name pos len;
+  Format.eprintf "Trying %s: pos=%d, len=%d... @?" minimize.minimizer_name pos
+    len;
   let map, changed = minimize_at minimize cur_file map ~pos ~len in
   let r =
     if changed then (


### PR DESCRIPTION
We currently use `Sys.command`, which internally calls the `system` C function, which in turn blocks (ignores) the SIGINT signals from hitting `Ctrl-C` during the evaluation of the underlying compilation command.

This makes it hard to stop minimization; the underlying compilation command does receive a SIGINT signal when the user hits `Ctrl-C`, but we cannot robustly detect it from the result of `Sys.command`.

This patch replaces the use of `Sys.command` with calls to the `Unix` module. The `Unix` module provides better information on the exit status of the underlying command, but we don't even need to make use of it since `Unix.create_process` (unlike `Sys.command`) does not use `system` and hence does not mask SIGINT.

I did not find a way to be able to use the `Unix` module when chamelon is built using the boot compiler without resorting to some dark `dune` invocations (which we already use elsewhere for this purpose -- credit to Mark Shinwell for both the trick of passing `unix.cmxa` to `ocamlopt_flags` instead of adding `unix` to the `libraries`, and for pointing me to the `context_name` variable).