### PR TITLE
Fix typo in Tree pattern matching. 0xCaml documentation tutorial 1

### DIFF
--- a/jane/doc/extensions/_01-tutorials/01-intro-to-parallelism-part-1.md
+++ b/jane/doc/extensions/_01-tutorials/01-intro-to-parallelism-part-1.md
@@ -1354,7 +1354,7 @@ let average_par (par : Parallel.t) tree =
   let rec (total @ portable) par tree =
     match tree with
     | Tree.Leaf x -> ~total:(Thing.price x), ~count:1
-    | Tree.Node arr ->
+    | Tree.Nodes arr ->
       let seq = Parallel.Sequence.of_iarray arr in
       Parallel.Sequence.fold' par
         seq


### PR DESCRIPTION
Fix typographical error, in Tree pattern matching, used pattern was `Tree.Node` which was not consistent with the above `Tree` definition.