### PR TITLE
Fix [Ast_mapper] for quotes and splices

### DIFF
--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -633,8 +633,8 @@ module E = struct
     | Pexp_stack e -> stack ~loc ~attrs (sub.expr sub e)
     | Pexp_comprehension c -> comprehension ~loc ~attrs (map_cexp sub c)
     | Pexp_overwrite (e1, e2) -> overwrite ~loc ~attrs (sub.expr sub e1) (sub.expr sub e2)
-    | Pexp_quote e -> quote ~loc ~attrs e
-    | Pexp_splice e -> splice ~loc ~attrs e
+    | Pexp_quote e -> quote ~loc ~attrs (sub.expr sub e)
+    | Pexp_splice e -> splice ~loc ~attrs (sub.expr sub e)
     | Pexp_hole -> hole ~loc ~attrs ()
 
   let map_binding_op sub {pbop_op; pbop_pat; pbop_exp; pbop_loc} =

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -290,9 +290,9 @@ val x0 : <[[> `C of int ] as '_weak3]> expr = <[`C 543]>
 
 <[ let Some x = Some "foo" in x ]>;;
 [%%expect {|
-Line 291, characters 3-31:
-291 | <[ let Some x = Some "foo" in x ]>;;
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 3-31:
+1 | <[ let Some x = Some "foo" in x ]>;;
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 None
@@ -302,9 +302,9 @@ None
 
 <[ let x::xs = [1; 2; 3] in x ]>;;
 [%%expect {|
-Line 303, characters 3-29:
-303 | <[ let x::xs = [1; 2; 3] in x ]>;;
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 3-29:
+1 | <[ let x::xs = [1; 2; 3] in x ]>;;
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 []
@@ -314,9 +314,9 @@ Here is an example of a case that is not matched:
 
 <[ let x::xs = [1; 2; 3] in xs ]>;;
 [%%expect {|
-Line 315, characters 3-30:
-315 | <[ let x::xs = [1; 2; 3] in xs ]>;;
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 3-30:
+1 | <[ let x::xs = [1; 2; 3] in xs ]>;;
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Here is an example of a case that is not matched:
 []
@@ -644,40 +644,40 @@ module Mod : sig type t = int val mk : 'a -> 'a end
 
 <[ fun (module _ : S) x -> 42 ]>;;
 [%%expect {|
-Line 645, characters 19-20:
-645 | <[ fun (module _ : S) x -> 42 ]>;;
-                         ^
-Error: Identifier "S" is used at Line 645, characters 19-20,
+Line 1, characters 19-20:
+1 | <[ fun (module _ : S) x -> 42 ]>;;
+                       ^
+Error: Identifier "S" is used at Line 1, characters 19-20,
        inside a quotation (<[ ... ]>);
        it is introduced at Lines 1-7, characters 0-3, outside any quotations.
 |}];;
 
 <[ let module M = struct type t = int let x = 42 end in M.x ]>;;
 [%%expect {|
-Line 655, characters 18-52:
-655 | <[ let module M = struct type t = int let x = 42 end in M.x ]>;;
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 18-52:
+1 | <[ let module M = struct type t = int let x = 42 end in M.x ]>;;
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Module definition using "struct..end"
        is not supported inside quoted expressions,
-       as seen at Line 655, characters 18-52.
+       as seen at Line 1, characters 18-52.
 |}];;
 
 <[ Mod.mk 42 ]>;;
 [%%expect {|
-Line 665, characters 3-9:
-665 | <[ Mod.mk 42 ]>;;
-         ^^^^^^
-Error: Identifier "Mod" is used at Line 665, characters 3-9,
+Line 1, characters 3-9:
+1 | <[ Mod.mk 42 ]>;;
+       ^^^^^^
+Error: Identifier "Mod" is used at Line 1, characters 3-9,
        inside a quotation (<[ ... ]>);
        it is introduced at File "_none_", line 1, outside any quotations.
 |}];;
 
 let x = 42 in <[ x ]>;;
 [%%expect {|
-Line 675, characters 17-18:
-675 | let x = 42 in <[ x ]>;;
-                       ^
-Error: Identifier "x" is used at Line 675, characters 17-18,
+Line 1, characters 17-18:
+1 | let x = 42 in <[ x ]>;;
+                     ^
+Error: Identifier "x" is used at Line 1, characters 17-18,
        inside a quotation (<[ ... ]>);
        it is introduced at Line 1, characters 4-5, outside any quotations.
 |}];;
@@ -689,21 +689,21 @@ let x = <[ 123 ]> in <[ $x ]>;;
 
 <[ let o = object method f = 1 end in o#f ]>;;
 [%%expect {|
-Line 690, characters 11-34:
-690 | <[ let o = object method f = 1 end in o#f ]>;;
-                 ^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 11-34:
+1 | <[ let o = object method f = 1 end in o#f ]>;;
+               ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Object definition using "object..end"
        is not supported inside quoted expressions,
-       as seen at Line 690, characters 11-34.
+       as seen at Line 1, characters 11-34.
 |}];;
 
 <[ let open List in map ]>;;
 [%%expect {|
-Line 700, characters 3-23:
-700 | <[ let open List in map ]>;;
-         ^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 3-23:
+1 | <[ let open List in map ]>;;
+       ^^^^^^^^^^^^^^^^^^^^
 Error: Opening modules is not supported inside quoted expressions,
-       as seen at Line 700, characters 3-23.
+       as seen at Line 1, characters 3-23.
 |}];;
 
 <[ fun x -> $ (<[ x ]>) ]>;;

--- a/testsuite/tests/quotation/quotation_typing.ml
+++ b/testsuite/tests/quotation/quotation_typing.ml
@@ -92,10 +92,10 @@ Error: Splices ($) are not allowed in the initial stage,
 
 let p x = <[x]>;;
 [%%expect {|
-Line 93, characters 12-13:
-93 | let p x = <[x]>;;
-                 ^
-Error: Identifier "x" is used at Line 93, characters 12-13,
+Line 1, characters 12-13:
+1 | let p x = <[x]>;;
+                ^
+Error: Identifier "x" is used at Line 1, characters 12-13,
        inside a quotation (<[ ... ]>);
        it is introduced at Line 1, characters 6-7, outside any quotations.
 |}];;
@@ -117,9 +117,9 @@ val foo1 : 'a -> <[$('a) -> int]> expr = <fun>
 
 let foo2 (x: 'a) = <[fun (y : 'a) -> 1]>;;
 [%%expect {|
-Line 118, characters 30-32:
-118 | let foo2 (x: 'a) = <[fun (y : 'a) -> 1]>;;
-                                    ^^
+Line 1, characters 30-32:
+1 | let foo2 (x: 'a) = <[fun (y : 'a) -> 1]>;;
+                                  ^^
 Error: Type variable "'a" is used inside a quotation (<[ ... ]>),
        it already occurs outside any quotations.
        Hint: Consider using "$'a".
@@ -127,9 +127,9 @@ Error: Type variable "'a" is used inside a quotation (<[ ... ]>),
 
 let foo3 (x: 'a) = <[fun (y : <['a]>) -> 1]>;;
 [%%expect {|
-Line 128, characters 32-34:
-128 | let foo3 (x: 'a) = <[fun (y : <['a]>) -> 1]>;;
-                                      ^^
+Line 1, characters 32-34:
+1 | let foo3 (x: 'a) = <[fun (y : <['a]>) -> 1]>;;
+                                    ^^
 Error: Type variable "'a" is used inside 2 layers of quotation (<[ ... ]>),
        it already occurs outside any quotations.
        Hint: Consider using "$($'a)".
@@ -147,10 +147,10 @@ val foo5 : 'a expr -> <[$('a) -> $('a) * $('a)]> expr = <fun>
 
 let foo6 (type a) (type b) x = <[fun (y : a) -> y]>;;
 [%%expect {|
-Line 148, characters 42-43:
-148 | let foo6 (type a) (type b) x = <[fun (y : a) -> y]>;;
-                                                ^
-Error: Identifier "a" is used at Line 148, characters 42-43,
+Line 1, characters 42-43:
+1 | let foo6 (type a) (type b) x = <[fun (y : a) -> y]>;;
+                                              ^
+Error: Identifier "a" is used at Line 1, characters 42-43,
        inside a quotation (<[ ... ]>);
        it is introduced at Line 1, characters 15-16, outside any quotations.
 |}];;
@@ -195,10 +195,10 @@ type t4 = A | B;;
 <[A]>;;
 [%%expect {|
 type t4 = A | B
-Line 195, characters 2-3:
-195 | <[A]>;;
-        ^
-Error: Constructor "A" used at Line 195, characters 2-3
+Line 3, characters 2-3:
+3 | <[A]>;;
+      ^
+Error: Constructor "A" used at Line 3, characters 2-3
        cannot be used in this context;
        "A" is not defined inside a quotation (<[ ... ]>).
 |}];;


### PR DESCRIPTION
AST mapping over quotes and splices was actually just AST iteration.
Coincidentally, this fixes the problem with boundlessly growing line numbers in `quotation` tests.