### PR TITLE
Improve debug tracking for name mangling purposes

### DIFF
--- a/lambda/debuginfo.ml
+++ b/lambda/debuginfo.ml
@@ -78,10 +78,17 @@ module Scoped_location = struct
     | Empty -> s
     | Cons {str; _} -> str ^ sep ^ s
 
-  let enter_anonymous_function ~scopes ~assume_zero_alloc =
+  let enter_anonymous_function ~scopes ~assume_zero_alloc ~loc =
+    ignore loc; (* CR sspies: [loc] will be used in subsequent PRs. *)
     let str = str_fun scopes in
     Cons {item = Sc_anonymous_function; str; str_fun = str; name = ""; prev = scopes;
           assume_zero_alloc }
+
+  let enter_anonymous_module ~scopes ~loc =
+    ignore loc;
+    let str = str scopes in
+    Cons {item = Sc_module_definition; str; str_fun = str ^ ".(fun)"; name = "";
+          prev = scopes; assume_zero_alloc = ZA.Assume_info.none; }
 
   let enter_value_definition ~scopes ~assume_zero_alloc id =
     cons scopes Sc_value_definition (dot scopes (Ident.name id)) (Ident.name id)

--- a/lambda/debuginfo.mli
+++ b/lambda/debuginfo.mli
@@ -38,7 +38,14 @@ module Scoped_location : sig
 
   val empty_scopes : scopes
   val enter_anonymous_function :
-    scopes:scopes -> assume_zero_alloc:ZA.Assume_info.t -> scopes
+    scopes:scopes ->
+    assume_zero_alloc:ZA.Assume_info.t ->
+    loc:Location.t ->
+    scopes
+  val enter_anonymous_module :
+    scopes:scopes ->
+    loc:Location.t ->
+    scopes
   val enter_value_definition :
     scopes:scopes -> assume_zero_alloc:ZA.Assume_info.t -> Ident.t -> scopes
   val enter_compilation_unit : scopes:scopes -> Compilation_unit.t -> scopes

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1029,7 +1029,8 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
              modifs
              (Lvar cpy))
   | Texp_letmodule(None, loc, Mp_present, modl, body) ->
-      let lam = !transl_module ~scopes Tcoerce_none None modl in
+      let mod_scopes = enter_anonymous_module ~scopes ~loc:loc.loc in
+      let lam = !transl_module ~scopes:mod_scopes Tcoerce_none None modl in
       Lsequence(Lprim(Pignore, [lam], of_location ~scopes loc.loc),
                 transl_exp ~scopes sort body)
   | Texp_letmodule(Some id, _loc, Mp_present, modl, body) ->
@@ -1906,7 +1907,7 @@ and transl_function ~in_new_scope ~scopes e params body
   let scopes =
     if in_new_scope then
       update_assume_zero_alloc ~scopes ~assume_zero_alloc
-    else enter_anonymous_function ~scopes ~assume_zero_alloc
+    else enter_anonymous_function ~scopes ~assume_zero_alloc ~loc:e.exp_loc
   in
   let sreturn_mode = transl_alloc_mode_l sreturn_mode in
   let { params; body; return_sort; return_mode; region } =


### PR DESCRIPTION
This PR prepares for the structured name mangling scheme. It improves the debug information tracking in two regards. 
1. It adds tracking for entering anonymous modules.
2. It makes the source-level location of anonymous functions available (which can in subsequent PRs be integrated into the mangled name).

The changes should have no impact on the linkage names that are generated with the current (flat) name-mangling scheme.