### PR TITLE
New, reversible name mangling scheme

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4271,6 +4271,15 @@ let make_symbol ?compilation_unit name =
     | None -> Compilation_unit.get_current_exn ()
     | Some compilation_unit -> compilation_unit
   in
+  (* CR sspies: [make_symbol] always uses flat name mangling. Structured
+     mangling can currently only be enabled for functions with a code id. It
+     could, in principle, also be used for other symbols such as module entry
+     points, frame tables, etc. If desired, structured mangling for these can be
+     enabled here BUT this requires additional changes, since other parts of the
+     compiler currently hardcode the symbol names (e.g., frame tables).
+     [make_symbol] is called, for example, for [code_begin], [code_end],
+     [data_begin], [data_end], [entry], [frametable], [gc_roots], and
+     [jump_tables]. *)
   Symbol.for_name compilation_unit name
   |> Symbol.linkage_name |> Linkage_name.to_string
 

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4276,8 +4276,9 @@ let make_symbol ?compilation_unit name =
      could, in principle, also be used for other symbols such as module entry
      points, frame tables, etc. If desired, structured mangling for these can be
      enabled here BUT this requires additional changes, since other parts of the
-     compiler currently hardcode the symbol names (e.g., frame tables).
-     [make_symbol] is called, for example, for [code_begin], [code_end],
+     compiler currently hardcode the symbol names and some symbols should use C
+     linkage names to be referenced from the runtime (e.g., frame tables and GC
+     roots). [make_symbol] is called, for example, for [code_begin], [code_end],
      [data_begin], [data_end], [entry], [frametable], [gc_roots], and
      [jump_tables]. *)
   Symbol.for_name compilation_unit name

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
@@ -32,12 +32,22 @@ let for_fundecl ~get_file_id ~value_type_proto_die state (fundecl : L.fundecl)
       Debuginfo.Scoped_location.string_of_scopes ~include_zero_alloc:false
         item.dinfo_scopes
       |> Misc.remove_double_underscores
-    (* XXX Not sure what to do in the cases below *)
+    (* XXX Not sure what to do in the cases below; see comment in
+       [Debuginfo.to_structured_mangling_path] *)
     | [] | _ :: _ -> fun_name
   in
   let linkage_name =
     match Config.name_mangling_scheme with
     | Flat -> Some (linkage_name_from_debug ())
+    | Structured -> None
+    (* When structured mangling is used, there is no need for additional linkage
+       names on non-inlined functions, because the module path can be
+       reconstructed from the assembly symbol name. *)
+    (* CR sspies: This removes the linkage name for some symbols that still use
+       the old mangling scheme (see the comment in [make_symbol] in
+       cmm_helpers.ml). I observed this for the linkage name of the module entry
+       point, but for that one the linkage name is currently just the symbol
+       name (e.g., "camlTest__entry"). *)
   in
   let start_sym = Asm_symbol.create_global fun_name in
   let location_attributes =

--- a/configure.ac
+++ b/configure.ac
@@ -686,11 +686,12 @@ AC_ARG_ENABLE([cpp-mangling],
 
 AC_ARG_ENABLE([name-mangling],
   [AS_HELP_STRING([--enable-name-mangling=SCHEME],
-    [specify name mangling scheme [default=flat]])],
+    [specify name mangling scheme: flat or structured [default=flat]])],
   [AS_CASE([$enable_name_mangling],
     [flat], [name_mangling_scheme=flat],
+    [structured], [name_mangling_scheme=structured],
     [*], [AC_MSG_ERROR(m4_normalize([Invalid or missing name mangling scheme:
-      must be 'flat']))])],
+      must be 'flat' or 'structured']))])],
   [name_mangling_scheme=flat])
 
 AC_ARG_ENABLE([naked-pointers], [],
@@ -2897,7 +2898,8 @@ AS_IF([test x"$enable_cpp_mangling" = "xyes"],
 ## Name mangling scheme
 
 AS_CASE([$name_mangling_scheme],
-  [flat], [AC_DEFINE([NAME_MANGLING_FLAT])])
+  [flat], [AC_DEFINE([NAME_MANGLING_FLAT])],
+  [structured], [AC_DEFINE([NAME_MANGLING_STRUCTURED])])
 
 ## Check for mmap support for huge pages and contiguous heap
 OCAML_MMAP_SUPPORTS_HUGE_PAGES

--- a/dune
+++ b/dune
@@ -284,6 +284,7 @@
   printlambda
   runtimedef
   runtimetags
+  structured_mangling
   tmc
   simplif
   slambda_fracture

--- a/lambda/debuginfo.ml
+++ b/lambda/debuginfo.ml
@@ -45,7 +45,8 @@ module Scoped_location = struct
   type scopes =
     | Empty
     | Cons of {item: scope_item; str: string; str_fun: string; name : string; prev: scopes;
-               assume_zero_alloc: ZA.Assume_info.t}
+               assume_zero_alloc: ZA.Assume_info.t;
+               mangling_item: Structured_mangling.path_item option}
 
   let str = function
     | Empty -> ""
@@ -55,9 +56,9 @@ module Scoped_location = struct
     | Empty -> "(fun)"
     | Cons r -> r.str_fun
 
-  let cons scopes item str name ~assume_zero_alloc =
+  let cons scopes item str name mangling_item ~assume_zero_alloc =
     Cons {item; str; str_fun = str ^ ".(fun)"; name; prev = scopes;
-          assume_zero_alloc}
+          assume_zero_alloc; mangling_item}
 
   let empty_scopes = Empty
 
@@ -79,32 +80,45 @@ module Scoped_location = struct
     | Cons {str; _} -> str ^ sep ^ s
 
   let enter_anonymous_function ~scopes ~assume_zero_alloc ~loc =
-    ignore loc; (* CR sspies: [loc] will be used in subsequent PRs. *)
     let str = str_fun scopes in
+    let (file, line, col) = Location.get_pos_info loc.loc_start in
+    let file = Filename.basename file in
+    let mangling_item : Structured_mangling.path_item option =
+      Some (Anonymous_function (line, col, Some file))
+    in
     Cons {item = Sc_anonymous_function; str; str_fun = str; name = ""; prev = scopes;
-          assume_zero_alloc }
+          assume_zero_alloc; mangling_item }
 
   let enter_anonymous_module ~scopes ~loc =
-    ignore loc;
     let str = str scopes in
+    let (file, line, col) = Location.get_pos_info loc.loc_start in
+    let file = Filename.basename file in
+    let mangling_item : Structured_mangling.path_item option =
+      Some (Anonymous_module (line, col, Some file))
+    in
     Cons {item = Sc_module_definition; str; str_fun = str ^ ".(fun)"; name = "";
-          prev = scopes; assume_zero_alloc = ZA.Assume_info.none; }
+          prev = scopes; assume_zero_alloc = ZA.Assume_info.none;
+          mangling_item }
 
   let enter_value_definition ~scopes ~assume_zero_alloc id =
     cons scopes Sc_value_definition (dot scopes (Ident.name id)) (Ident.name id)
+      (Some (Function (Ident.name id)))
       ~assume_zero_alloc
 
   let enter_compilation_unit ~scopes cu =
     let name = Compilation_unit.name_as_string cu in
     cons scopes Sc_module_definition (dot scopes name) name
+      (Some (Compilation_unit cu))
       ~assume_zero_alloc:ZA.Assume_info.none
 
   let enter_module_definition ~scopes id =
-    cons scopes Sc_module_definition (dot scopes (Ident.name id)) (Ident.name id)
+    let name = Ident.name id in
+    cons scopes Sc_module_definition (dot scopes name) name (Some (Module name))
       ~assume_zero_alloc:ZA.Assume_info.none
 
   let enter_class_definition ~scopes id =
-    cons scopes Sc_class_definition (dot scopes (Ident.name id)) (Ident.name id)
+    let name = Ident.name id in
+    cons scopes Sc_class_definition (dot scopes name) name (Some (Class name))
       ~assume_zero_alloc:ZA.Assume_info.none
 
   let enter_method_definition ~scopes (s : Asttypes.label) =
@@ -114,15 +128,17 @@ module Scoped_location = struct
       | _ -> dot scopes s
     in
     cons scopes Sc_method_definition str s
-      ~assume_zero_alloc:ZA.Assume_info.none
+      ~assume_zero_alloc:ZA.Assume_info.none (Some (Function s))
 
   let enter_lazy ~scopes = cons scopes Sc_lazy (str scopes) ""
-                             ~assume_zero_alloc:ZA.Assume_info.none
+                             ~assume_zero_alloc:ZA.Assume_info.none None
 
   let enter_partial_or_eta_wrapper ~scopes ~loc =
-    ignore loc; (* CR sspies: [loc] will be used in subsequent PRs. *)
-    cons scopes Sc_partial_or_eta_wrapper (dot ~no_parens:() scopes "(partial)") ""
-      ~assume_zero_alloc:ZA.Assume_info.none
+    let (file, line, col) = Location.get_pos_info loc.loc_start in
+    let file = Filename.basename file in
+    cons scopes Sc_partial_or_eta_wrapper (dot ~no_parens:() scopes "(partial)")
+      "" ~assume_zero_alloc:ZA.Assume_info.none
+      (Some (Partial_function (line, col, Some file)))
 
   let update_assume_zero_alloc ~scopes ~assume_zero_alloc =
     match scopes with
@@ -435,3 +451,36 @@ let merge ~into:{ dbg = dbg1; assume_zero_alloc = a1; }
 let assume_zero_alloc t = t.assume_zero_alloc
 
 let get_dbg t = t.dbg
+
+let rec path_of_debug_info_scopes acc (scopes : Scoped_location.scopes) =
+  match scopes with
+  | Empty -> acc
+  | Cons { prev; mangling_item = None; _ } -> path_of_debug_info_scopes acc prev
+  | Cons { prev; mangling_item = Some mangling_item; _ } ->
+    path_of_debug_info_scopes (mangling_item :: acc) prev
+
+let to_structured_mangling_path ~name dbg : Structured_mangling.path =
+  (* We ensure the path ends with [name] to preserve all stamps that the name
+     includes. To do so, we drop the suffix of partial applications if there is
+     any and, additionally, the last function or anonymous function if there is
+     any. It should effectively be the same function as [name]. *)
+  let rec drop_partials_and_last_function (path : Structured_mangling.path) =
+    match path with
+    | Partial_function _ :: path -> drop_partials_and_last_function path
+    | Function _ :: path -> path
+    | Anonymous_function _ :: path -> path
+    | path -> path
+  in
+  let path_from_debug =
+    match to_items dbg with
+    | [] -> []
+    | item :: _ ->
+      (* CR sspies: The list of debuginfo items can contain more than one item
+         in case of inlining (see [merge]). For the moment, we use the first
+         item. In the future, it would be good to track the original source of
+         the function. See #5099. *)
+      path_of_debug_info_scopes [] item.dinfo_scopes
+  in
+  Structured_mangling.Function name
+  :: drop_partials_and_last_function (List.rev path_from_debug)
+  |> List.rev

--- a/lambda/debuginfo.mli
+++ b/lambda/debuginfo.mli
@@ -30,7 +30,8 @@ module Scoped_location : sig
   type scopes = private
     | Empty
     | Cons of {item: scope_item; str: string; str_fun: string; name : string; prev: scopes;
-               assume_zero_alloc: ZA.Assume_info.t}
+               assume_zero_alloc: ZA.Assume_info.t;
+               mangling_item: Structured_mangling.path_item option}
 
   val string_of_scopes : include_zero_alloc:bool -> scopes -> string
 
@@ -126,6 +127,11 @@ val merge : into:t -> t -> t
 
 val assume_zero_alloc : t -> ZA.Assume_info.t
 
+(** [to_structured_mangling_path] converts the debug info into a mangling path.
+    In all cases, the [name] is used to populate the last element of the path.
+*)
+val to_structured_mangling_path : name:string -> t -> Structured_mangling.path
+
 module Dbg : sig
   type t
 
@@ -146,4 +152,3 @@ module Dbg : sig
 end
 
 val get_dbg : t -> Dbg.t
-

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -46,8 +46,10 @@ let print_compact_location ppf (loc : Location.t) =
     if startchar >= 0 then Format.fprintf ppf ",%i--%i" startchar endchar
 
 let name_for_function (func : Lambda.lfunction) =
+  (* Name anonymous functions by their source location, if known, when using the
+     Flat name-mangling scheme. *)
   let mangling_scheme_locates_anonymous_functions =
-    match Config.name_mangling_scheme with Flat -> false
+    match Config.name_mangling_scheme with Flat -> false | Structured -> true
   in
   match func.loc with
   | Loc_unknown -> "fn"

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -842,6 +842,15 @@ module Code_id = struct
           else Printf.sprintf "%s_%d_code" name name_stamp
         in
         Symbol0.for_name compilation_unit name |> Symbol0.linkage_name
+      | Structured ->
+        let suffix =
+          if Flambda_features.Expert.shorten_symbol_names ()
+          then Printf.sprintf "_%d" name_stamp
+          else Printf.sprintf "_%d_code" name_stamp
+        in
+        let path = Debuginfo.to_structured_mangling_path ~name debug in
+        Symbol0.for_structured_mangling_path ~compilation_unit ~path ~suffix
+        |> Symbol0.linkage_name
     in
     let data : Code_id_data.t =
       { compilation_unit; name; debug_info = debug; linkage_name }

--- a/otherlibs/dynlink/dune
+++ b/otherlibs/dynlink/dune
@@ -162,6 +162,7 @@
   lambda
   runtimedef
   runtimetags
+  structured_mangling
   instruct
   opcodes
   bytesections
@@ -203,6 +204,8 @@
 ;; .ml:
 
 (copy_files ../../utils/runtimetags.ml)
+
+(copy_files ../../utils/structured_mangling.ml)
 
 (copy_files ../../utils/binutils.ml)
 
@@ -395,6 +398,8 @@
 ;; .mli:
 
 (copy_files ../../utils/runtimetags.mli)
+
+(copy_files ../../utils/structured_mangling.mli)
 
 (copy_files ../../utils/binutils.mli)
 
@@ -679,6 +684,7 @@
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Compilation_unit.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Import_info.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Linkage_name.cmo
+  .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Structured_mangling.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Symbol.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Docstrings.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Lexer.cmo
@@ -794,6 +800,7 @@
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Compilation_unit.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Import_info.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Linkage_name.cmx
+  .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Structured_mangling.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Symbol.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Docstrings.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Lexer.cmx

--- a/utils/.ocamlformat-enable
+++ b/utils/.ocamlformat-enable
@@ -16,4 +16,5 @@ arrayset.ml
 arrayset.mli
 priority_queue.ml
 priority_queue.mli
-
+structured_mangling.ml
+structured_mangling.mli

--- a/utils/config.common.ml.in
+++ b/utils/config.common.ml.in
@@ -72,6 +72,7 @@ let default_executable_name =
 
 type name_mangling_scheme =
   | Flat
+  | Structured
 
 exception Invalid_name_mangling_scheme of string
 
@@ -195,4 +196,5 @@ let merlin = false
 let name_mangling_scheme =
   match name_mangling_scheme_string with
   | "flat" -> Flat
+  | "structured" -> Structured
   | s -> raise (Invalid_name_mangling_scheme s)

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -211,6 +211,7 @@ val with_cpp_mangling : bool
 
 type name_mangling_scheme =
   | Flat
+  | Structured
 
 exception Invalid_name_mangling_scheme of string
 

--- a/utils/structured_mangling.ml
+++ b/utils/structured_mangling.ml
@@ -1,0 +1,243 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                  Samuel Hym and Tim McGilchrist, Tarides                   *
+ *                          Simon Spies, Jane Street                          *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025--2026 Jane Street Group LLC                             *
+ * opensource-contacts@janestreet.com                                         *
+ * Copyright (c) 2025--2026 Tarides                                           *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(** {1 Identifier encoding}
+
+    This section implements encoding of arbitrary strings into the output
+    character set (i.e., [[0-9A-Za-z_]], see {!is_out_char} for more details).
+
+    The encoded string is composed of:
+    - an optional [u], which is a flag indicating how the payload is encoded
+      ([u] stands for {i universal} or {i Unicode}, as it allows any string of
+      bytes to be encoded),
+    - a decimal integer, which is the length of the following component,
+    - the payload.
+
+    If the original string contains only output characters and does not start
+    with a digit, the payload is the original string as is and the optional [u]
+    is absent.
+
+    Otherwise, the encoded string will start by [u]. The payload is computed by
+    first decomposing the original string into the subsequence of its output
+    characters and its non-output characters, and then by concatenating:
+    {ul
+     {- for each chunk of consecutive non-output characters:
+        - encode its relative insertion position as a base-26 number (see
+          {!base26}),
+        - encode every character in that chunk by the hexadecimal code of each
+          byte, using lowercase letters (i.e., [[0-9a-f]], see {!hex}),
+     }
+     {- the separator character [_], }
+     {- the string of output characters. }
+    }
+
+    Note that the choices of using decimal integers for the length, base-26
+    numbers for the insertion positions and lowercase hexadecimal for bytes
+    means that no explicit separator is required, it's never ambiguous.
+
+    {2 Some examples}
+
+    - [Structured_mangling] is composed only of output characters and starts
+      with a letter (not a digit) so its payload is the original string and its
+      full encoding with a space to increase legibility is
+      [19 Structured_mangling].
+    - [>>=] contains only non-output characters, so it is decomposed into the
+      empty string (of output characters) and the sequence of consecutive
+      characters [>>=] (so, in hexadecimal [3e 3e 3d]) that should be inserted
+      at position 0 (so, in base-26 [A]); its full encoding is [u 8 A 3e3e3d _],
+      again with spaces to increase legibility.
+    - [let*] is decomposed into [let], and [*] (so [2a]) to insert at position 3
+      (so [D]) in [let]; its full encoding is [u 7 D 2a _ let].
+    - [func'sub'] is decomposed into [funcsub], ['] (so [27]) to insert at
+      position 4 (so [E]) and a second ['] to insert at relative position 3 (the
+      length of [sub], so [D]); its full encoding is then
+      [u 14 E 27 D 27 _ funcsub]. *)
+
+(** [is_out_char c] is true iff [c] is in the output character set, i.e., the
+    restricted set of characters that are allowed in our mangled symbols. That
+    set is constrained by portability across operating systems and architectures
+    and so is restricted to just ASCII alphanumeric and underscore characters.
+*)
+let is_out_char = function
+  | '0' .. '9' | 'A' .. 'Z' | 'a' .. 'z' | '_' -> true
+  | _ -> false
+
+(** [base26 buf n] encodes the integer [n] as a base-26 number using [[A-Z]]
+    into the buffer [buf], with [A] standing for 0, [B] for 1, ..., [Z] for 25,
+    [BA] for 26, [BB] for 27, ... *)
+let rec base26 buf n =
+  (* Technically, we are not constrained to just 26 characters here. Uniqueness
+     is still preserved if we include non-hex characters (i.e., [[g-z]]). *)
+  let upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" in
+  let r = n mod 26 and q = n / 26 in
+  if q > 0 then base26 buf q;
+  Buffer.add_char buf upper.[r]
+
+(** [hex buf c] encodes the [char] [c] in hexadecimal (using lowercase letters)
+    in the buffer [buf] *)
+let hex buf c =
+  let chars = "0123456789abcdef" in
+  let c = Char.code c in
+  let h = (c lsr 4) land 0xf and l = c land 0xf in
+  Buffer.add_char buf chars.[h];
+  Buffer.add_char buf chars.[l]
+
+(* State for the encoding state machine: [Raw] = processing output characters,
+   [Esc] = processing escaped (non-output) characters. *)
+type encode_state =
+  | Raw
+  | Esc
+
+(** [require_escaping str] is [true] iff (a) [str] contains a non-output
+    character or (b) it starts with a digit. The latter is important to ensure
+    that the encoded string can be non-ambiguously appended to the decimal
+    integer representing its length in the mangling scheme.
+
+    While not very common, identifiers that start with a digit can happen for
+    anonymous modules and functions from a file whose name starts with a digit.
+    For those, the compiler emits a warning but tolerates them. *)
+let require_escaping str =
+  String.length str > 0
+  &&
+  match str.[0] with
+  | '0' .. '9' -> true
+  | _ -> not (String.for_all is_out_char str)
+
+let rec encode buf str =
+  if not (require_escaping str)
+  then Printf.bprintf buf "%d%s" (String.length str) str
+  else
+    let raw = Buffer.create (String.length str)
+    and escaped = Buffer.create (2 * String.length str)
+    and ins_pos = ref 0 in
+    encode_split_parts str raw escaped ins_pos 0 Raw;
+    Printf.bprintf buf "u%d%a_%a"
+      (Buffer.length escaped + Buffer.length raw + 1)
+      Buffer.add_buffer escaped Buffer.add_buffer raw
+
+and encode_split_parts str raw escaped ins_pos i = function
+  | _ when i >= String.length str -> ()
+  | Raw ->
+    if is_out_char str.[i]
+    then (
+      Buffer.add_char raw str.[i];
+      incr ins_pos;
+      encode_split_parts str raw escaped ins_pos (i + 1) Raw)
+    else (
+      base26 escaped !ins_pos;
+      hex escaped str.[i];
+      encode_split_parts str raw escaped ins_pos (i + 1) Esc)
+  | Esc ->
+    if is_out_char str.[i]
+    then (
+      Buffer.add_char raw str.[i];
+      ins_pos := 1;
+      encode_split_parts str raw escaped ins_pos (i + 1) Raw)
+    else (
+      hex escaped str.[i];
+      encode_split_parts str raw escaped ins_pos (i + 1) Esc)
+
+(** {1 Path mangling} *)
+
+let ocaml_prefix = "_Caml"
+
+let tag_compilation_unit = "U"
+
+let tag_inline_marker = "I"
+
+let tag_module = "M"
+
+let tag_anonymous_module = "S" (* struct *)
+
+let tag_class = "O"
+
+let tag_function = "F"
+
+let tag_anonymous_function = "L" (* lambda *)
+
+let tag_partial_function = "P"
+
+type path_item =
+  | Compilation_unit of Compilation_unit.t
+  | Inline_marker
+  | Module of string
+  | Anonymous_module of int * int * string option
+  | Class of string
+  | Function of string
+  | Anonymous_function of int * int * string option
+  | Partial_function of int * int * string option
+
+type path = path_item list
+
+let mangle_path_item buf path_item =
+  let tag_prefixed ~tag sym = Printf.bprintf buf "%s%a" tag encode sym in
+  let tag_prefixed_loc ~line ~col ~file_opt ~tag =
+    let file_name = Option.value ~default:"" file_opt in
+    let ts = Printf.sprintf "%s_%d_%d" file_name line col in
+    tag_prefixed ~tag ts
+  in
+  match path_item with
+  | Compilation_unit cu ->
+    (* CR sspies: Use the Flat mangling scheme for parameterized libraries (and
+       [-for-pack] prefixes, with the [__] separator) for now. A Structured
+       version is postponed to a future PR. *)
+    let pack_separator () = "__" in
+    let sym = Compilation_unit.mangle_for_linkage_name ~pack_separator cu in
+    tag_prefixed ~tag:tag_compilation_unit sym
+  | Inline_marker -> Buffer.add_string buf tag_inline_marker
+  | Module sym -> tag_prefixed ~tag:tag_module sym
+  | Anonymous_module (line, col, file_opt) ->
+    tag_prefixed_loc ~line ~col ~file_opt ~tag:tag_anonymous_module
+  | Class sym -> tag_prefixed ~tag:tag_class sym
+  | Function sym -> tag_prefixed ~tag:tag_function sym
+  | Anonymous_function (line, col, file_opt) ->
+    tag_prefixed_loc ~line ~col ~file_opt ~tag:tag_anonymous_function
+  | Partial_function (line, col, file_opt) ->
+    tag_prefixed_loc ~line ~col ~file_opt ~tag:tag_partial_function
+
+let mangle_path buf path = List.iter (mangle_path_item buf) path
+
+let mangle_ident (cu : Compilation_unit.t) (path : path) =
+  (* Compare the current compilation unit with the one recorded in the [path] to
+     avoid repetition in the mangled name when they are identical, and to add an
+     explicit inline tag to separate the two compilation units (the one
+     currently created and the source of the code) when they differ. *)
+  let path =
+    Compilation_unit cu
+    ::
+    (match path with
+    | Compilation_unit cu' :: path' when Compilation_unit.equal cu cu' -> path'
+    | Compilation_unit _ :: _ -> Inline_marker :: path
+    | _ -> path)
+  in
+  let b = Buffer.create 10 in
+  Buffer.add_string b ocaml_prefix;
+  mangle_path b path;
+  Buffer.contents b

--- a/utils/structured_mangling.ml
+++ b/utils/structured_mangling.ml
@@ -130,19 +130,7 @@ let require_escaping str =
   | '0' .. '9' -> true
   | _ -> not (String.for_all is_out_char str)
 
-let rec encode buf str =
-  if not (require_escaping str)
-  then Printf.bprintf buf "%d%s" (String.length str) str
-  else
-    let raw = Buffer.create (String.length str)
-    and escaped = Buffer.create (2 * String.length str)
-    and ins_pos = ref 0 in
-    encode_split_parts str raw escaped ins_pos 0 Raw;
-    Printf.bprintf buf "u%d%a_%a"
-      (Buffer.length escaped + Buffer.length raw + 1)
-      Buffer.add_buffer escaped Buffer.add_buffer raw
-
-and encode_split_parts str raw escaped ins_pos i = function
+let rec encode_split_parts str raw escaped ins_pos i = function
   | _ when i >= String.length str -> ()
   | Raw ->
     if is_out_char str.[i]
@@ -163,6 +151,18 @@ and encode_split_parts str raw escaped ins_pos i = function
     else (
       hex escaped str.[i];
       encode_split_parts str raw escaped ins_pos (i + 1) Esc)
+
+let encode buf str =
+  if not (require_escaping str)
+  then Printf.bprintf buf "%d%s" (String.length str) str
+  else
+    let raw = Buffer.create (String.length str)
+    and escaped = Buffer.create (2 * String.length str)
+    and ins_pos = ref 0 in
+    encode_split_parts str raw escaped ins_pos 0 Raw;
+    Printf.bprintf buf "u%d%a_%a"
+      (Buffer.length escaped + Buffer.length raw + 1)
+      Buffer.add_buffer escaped Buffer.add_buffer raw
 
 (** {1 Path mangling} *)
 

--- a/utils/structured_mangling.mli
+++ b/utils/structured_mangling.mli
@@ -1,0 +1,76 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                  Samuel Hym and Tim McGilchrist, Tarides                   *
+ *                          Simon Spies, Jane Street                          *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025--2026 Jane Street Group LLC                             *
+ * opensource-contacts@janestreet.com                                         *
+ * Copyright (c) 2025--2026 Tarides                                           *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(** Structured name mangling for OxCaml symbols.
+
+    This module implements a mangling scheme that encodes OCaml identifiers into
+    a restricted character set (ASCII alphanumeric and underscore) suitable for
+    use in linker symbols. The scheme preserves the lexical structure of the
+    source program by encoding each scope (compilation unit, module, function,
+    etc.) as a tagged path item.
+
+    {2 Mangled symbol format}
+
+    A mangled symbol has the form [_Caml<path>] where [<path>] is a sequence of
+    tagged, length-prefixed identifiers:
+    - [U] - compilation Unit
+    - [I] - Inline marker
+    - [M] - Module
+    - [S] - anonymous Struct
+    - [O] - class (O for object)
+    - [F] - Function
+    - [L] - anonymous function (L for lambda)
+    - [P] - Partial application
+
+    For example, [Foo.Bar.baz] in compilation unit [Foo] mangles to
+    [_CamlU3FooM3BarF3baz]. *)
+
+(** A path item represents a single lexical scope in the mangling path. *)
+type path_item =
+  | Compilation_unit of Compilation_unit.t  (** A compilation unit (file) *)
+  | Inline_marker
+      (** A separator (between destination and source) to track inlining *)
+  | Module of string  (** A named module *)
+  | Anonymous_module of int * int * string option
+      (** [struct ... end] at (line, col, file) *)
+  | Class of string  (** A class definition *)
+  | Function of string  (** A named function *)
+  | Anonymous_function of int * int * string option
+      (** [fun ... -> ...] at (line, col, file) *)
+  | Partial_function of int * int * string option
+      (** A partial application at (line, col, file) *)
+
+(** A mangling path is a list of path items representing the full lexical
+    context of an identifier. *)
+type path = path_item list
+
+(** Transform a {!Compilation_unit.t} and a {!path} into a mangled name suitable
+    for creating a {!LinkageName.t} *)
+val mangle_ident : Compilation_unit.t -> path -> string

--- a/utils/structured_mangling.mli
+++ b/utils/structured_mangling.mli
@@ -30,7 +30,7 @@
 
 (** Structured name mangling for OxCaml symbols.
 
-    This module implements a mangling scheme that encodes OCaml identifiers into
+    This module implements a mangling scheme that encodes OxCaml identifiers into
     a restricted character set (ASCII alphanumeric and underscore) suitable for
     use in linker symbols. The scheme preserves the lexical structure of the
     source program by encoding each scope (compilation unit, module, function,

--- a/utils/structured_mangling.mli
+++ b/utils/structured_mangling.mli
@@ -67,6 +67,11 @@ type path_item =
   | Partial_function of int * int * string option
       (** A partial application at (line, col, file) *)
 
+(* CR sspies: Support for lazy expressions (they do not appear in the mangling
+   path at all) and object methods (they appear as regular functions) is still
+   missing; adding a construct for lazy expressions would allow us to make sure
+   there is always a mangling path item for every [Debuginfo] scope *)
+
 (** A mangling path is a list of path items representing the full lexical
     context of an identifier. *)
 type path = path_item list

--- a/utils/structured_mangling.mli
+++ b/utils/structured_mangling.mli
@@ -30,9 +30,9 @@
 
 (** Structured name mangling for OxCaml symbols.
 
-    This module implements a mangling scheme that encodes OxCaml identifiers into
-    a restricted character set (ASCII alphanumeric and underscore) suitable for
-    use in linker symbols. The scheme preserves the lexical structure of the
+    This module implements a mangling scheme that encodes OxCaml identifiers
+    into a restricted character set (ASCII alphanumeric and underscore) suitable
+    for use in linker symbols. The scheme preserves the lexical structure of the
     source program by encoding each scope (compilation unit, module, function,
     etc.) as a tagged path item.
 

--- a/utils/symbol.ml
+++ b/utils/symbol.ml
@@ -113,6 +113,13 @@ let for_name compilation_unit name =
     linkage_name;
     hash = Hashtbl.hash linkage_name; }
 
+let for_structured_mangling_path ~compilation_unit ~path ~suffix =
+  let name = Structured_mangling.mangle_ident compilation_unit path in
+  let linkage_name = name ^ suffix |> Linkage_name.of_string in
+  { compilation_unit;
+    linkage_name;
+    hash = Hashtbl.hash linkage_name; }
+
 let for_local_ident id =
   assert (not (Ident.is_global_or_predef id));
   let compilation_unit = CU.get_current_exn () in

--- a/utils/symbol.mli
+++ b/utils/symbol.mli
@@ -31,6 +31,13 @@ val for_local_ident : Ident.t -> t
 val unsafe_create : Compilation_unit.t -> Linkage_name.t -> t
 
 val for_name : Compilation_unit.t -> string -> t
+
+val for_structured_mangling_path :
+    compilation_unit:Compilation_unit.t ->
+    path:Structured_mangling.path ->
+    suffix:string ->
+    t
+
 val for_compilation_unit : Compilation_unit.t -> t
 val for_current_unit : unit -> t
 val for_new_const_in_current_unit : unit -> t


### PR DESCRIPTION
This PR adds support for a new name mangling scheme to OxCaml. The key advantage of this mangling scheme is that full module paths can be reconstructed by the de-mangler from the mangled name (i.e., including submodules and not just the compilation unit). An extended description of the implementation is provided in `structured_mangling.mli` and `structured_mangling.ml`.

**De-mangling Implementations.**
- [x] LLVM 16: https://github.com/ocaml-flambda/llvm-project/pull/27
- [x] LLVM 21: https://github.com/ocaml-flambda/llvm-project/pull/35
- [x] Linux Kernel: https://github.com/tmcgilchrist/linux/tree/name_mangling
- [x] addr2line binutils: https://github.com/tmcgilchrist/binutils-gdb/tree/name_mangling
- [ ] GDB: https://github.com/tmcgilchrist/binutils-gdb/pull/1
- [x] ocamlfilt (pure OCaml) : https://github.com/oxcaml/oxcaml/pull/5100