### PR TITLE
`Domain.self_index` is portable

### DIFF
--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -71,7 +71,7 @@ val recommended_domain_count : unit -> int @@ portable
 
     The value returned is at least [1]. *)
 
-val self_index : unit -> int
+val self_index : unit -> int @@ portable
 (** The index of the current domain. It is an integer unique among
     currently-running domains, in the interval [0; N-1] where N is the
     peak number of domains running simultaneously so far.


### PR DESCRIPTION
This annotates `Domain.self_index` as portable in the signature as it should have been.