### PR TITLE
Use named binders for shapes

### DIFF
--- a/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
@@ -403,7 +403,7 @@ end = struct
     t
     |> S.Rec_var_env.map (fun (idx, ly) ->
         RS.DeBruijn_index.move_under_binder idx, ly)
-    |> S.Rec_var_env.add rv (RS.DeBruijn_index.create 0, layout)
+    |> S.Rec_var_env.add rv (RS.DeBruijn_index.zero, layout)
 
   module Lookup = struct
     type t =

--- a/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
@@ -357,24 +357,89 @@ and flatten_product_layout_exn (cs : t) =
 
 type complex_shape = t
 
+(** Tracks the recursive binders in scope during the conversion from the named
+    binders of [Shape.t] to the De Bruijn-indexed binders of
+    [Runtime_shape.t]. The environment maps each in-scope
+    [Shape.Rec_var_ident.t] to its De Bruijn index relative to the current
+    position (maintained by [add_binder]) and the layout at which its binder
+    was entered. *)
+module Rec_binder_env : sig
+  type t
+
+  val empty : t
+
+  (** [is_empty] means the shape being converted is closed (it can mention no
+      recursive variables), which makes it eligible for caching. *)
+  val is_empty : t -> bool
+
+  (** Enter a [Mu (rv, _)] binder whose layout is [layout]. *)
+  val add_binder : t -> Shape.Rec_var_ident.t -> layout:Layout.t option -> t
+
+  module Lookup : sig
+    type t =
+      | Bound of RS.DeBruijn_index.t * Layout.t option
+          (** The variable is in scope. The layout is the reconciled
+              binder/use-site layout ([None] if neither side knows it). *)
+      | Layout_mismatch of
+          { bound : Layout.t;
+            use : Layout.t
+          }
+          (** The variable is in scope, but the layout recorded at its binder
+              disagrees with the layout expected at the use site. *)
+      | Unbound
+  end
+
+  (** Look up a [Rec_var rv] use site, reconciling the layout recorded at the
+      binder with the layout [use_layout] expected at the use site. *)
+  val lookup :
+    t -> Shape.Rec_var_ident.t -> use_layout:Layout.t option -> Lookup.t
+end = struct
+  type t = (RS.DeBruijn_index.t * Layout.t option) S.Rec_var_env.t
+
+  let empty = S.Rec_var_env.empty
+
+  let is_empty = S.Rec_var_env.is_empty
+
+  let add_binder t rv ~layout =
+    t
+    |> S.Rec_var_env.map (fun (idx, ly) ->
+           RS.DeBruijn_index.move_under_binder idx, ly)
+    |> S.Rec_var_env.add rv (RS.DeBruijn_index.create 0, layout)
+
+  module Lookup = struct
+    type t =
+      | Bound of RS.DeBruijn_index.t * Layout.t option
+      | Layout_mismatch of
+          { bound : Layout.t;
+            use : Layout.t
+          }
+      | Unbound
+  end
+
+  let lookup t rv ~use_layout : Lookup.t =
+    match S.Rec_var_env.find_opt rv t with
+    | None -> Unbound
+    | Some (idx, bound_layout) -> (
+      match bound_layout, use_layout with
+      | Some bound, Some use when not (Layout.equal bound use) ->
+        Layout_mismatch { bound; use }
+      | (Some _ as layout), _ | None, layout -> Bound (idx, layout))
+end
+
 module Shape_cache : sig
   type t
 
   val create : int -> t
 
   val find_in_cache :
-    t ->
-    Shape.t ->
-    Layout.t ->
-    rec_env:'a S.Rec_var_env.t ->
-    complex_shape option
+    t -> Shape.t -> Layout.t -> rec_env:Rec_binder_env.t -> complex_shape option
 
   val add_to_cache :
     t ->
     Shape.t ->
     Layout.t ->
     complex_shape ->
-    rec_env:'a S.Rec_var_env.t ->
+    rec_env:Rec_binder_env.t ->
     unit
 end = struct
   type key =
@@ -401,13 +466,13 @@ end = struct
   let create initial_size = Cache.create initial_size
 
   let find_in_cache cache type_shape type_layout ~rec_env =
-    if S.Rec_var_env.is_empty rec_env
+    if Rec_binder_env.is_empty rec_env
     then Cache.find_opt cache { type_shape; type_layout }
     else None
 
   let add_to_cache cache type_shape type_layout value ~rec_env =
     (* [rec_env] being empty means that the shape is closed. *)
-    if S.Rec_var_env.is_empty rec_env
+    if Rec_binder_env.is_empty rec_env
     then Cache.add cache { type_shape; type_layout } value
 end
 
@@ -493,49 +558,31 @@ let rec type_shape_to_complex_shape_exn ~cache ~rec_env (type_shape : Shape.t)
        layout by forcing the runtime shape below. *)
     (* CR sspies: We should guess the layout from the recursive body [sh]
        instead of just using the current layout. *)
-    let rec_env =
-      rec_env
-      |> Shape.Rec_var_env.map (fun (idx, ly) ->
-          RS.DeBruijn_index.move_under_binder idx, ly)
-      |> Shape.Rec_var_env.add rv (RS.DeBruijn_index.create 0, type_layout)
-    in
+    let rec_env = Rec_binder_env.add_binder rec_env rv ~layout:type_layout in
     type_shape_to_complex_shape_exn ~cache ~rec_env sh type_layout
     |> force_runtime_shape_exn |> RS.mu |> runtime
-  | Rec_var rv, layout -> (
-    match Shape.Rec_var_env.find_opt rv rec_env, layout with
-    | Some (i, Some (Layout.Base base as ly1)), ly2_opt
-    (* We combine the [None] and [Some] layout cases with the guard: *)
-      when Option.value ~default:true (Option.map (Layout.equal ly1) ly2_opt)
-      -> (
+  | Rec_var rv, use_layout -> (
+    match Rec_binder_env.lookup rec_env rv ~use_layout with
+    | Bound (i, Some (Layout.Base base)) -> (
       match RS.Runtime_layout.of_base_layout base with
       | Void -> void
       | Other runtime_layout -> runtime (RS.rec_var i runtime_layout))
-    | Some (_, Some ly1), Some ly2 when not (Layout.equal ly1 ly2) ->
+    | Bound (_, Some (Layout.Product _ as ly)) ->
+      (* We currently do not support unboxed recursive types; fall back to an
+         unknown shape for the layout. *)
+      layout_to_unknown_shape ly
+    | Bound (_, Some (Univar _)) ->
+      Misc.fatal_error "type_shape_to_complex_shape_exn: Univar"
+    | Bound (_, Some (Genvar _)) ->
+      Misc.fatal_error "type_shape_to_complex_shape_exn: Genvar"
+    | Bound (_, None) -> raise Layout_missing
+    | Layout_mismatch { bound; use } ->
       err_or_unknown_exn (fun f ->
           f "Recursive variable has wrong layout. Expected %a, got %a" pp_layout
-            ly2 pp_layout ly1)
-      (* In all cases below, if there are two layouts, they are the same. *)
-    | Some (_, Some ly1), (None | Some _) ->
-      (*= In this case, either:
-          - [ly1] is a product and the second layout is None
-          - [ly1] is a product and the second layout is equal to Some [ly1].
-
-          If [ly1] is a base layout, we would have taken the first branch (if
-          equal to the second layout) or the second branch (if not equal to the
-          second layout). *)
-      layout_to_unknown_shape ly1
-    | Some (i, None), Some (Layout.Base base) -> (
-      match RS.Runtime_layout.of_base_layout base with
-      | Void -> void
-      | Other runtime_layout -> runtime (RS.rec_var i runtime_layout))
-    | Some (_, None), Some (Layout.Product _ as ly) ->
-      layout_to_unknown_shape ly
-    | (Some (_, None) | None), Some (Univar _) ->
-      Misc.fatal_error "type_shape_to_complex_shape_exn: Univar"
-    | (Some (_, None) | None), Some (Genvar _) ->
-      Misc.fatal_error "type_shape_to_complex_shape_exn: Genvar"
-    | Some (_, None), None -> raise Layout_missing
-    | None, _ -> raise Layout_missing)
+            use pp_layout bound)
+    | Unbound ->
+      err_or_unknown_exn (fun f ->
+          f "unbound recursive variable %a" S.Rec_var_ident.print rv))
   | Alias sh, type_layout ->
     type_shape_to_complex_shape_exn ~cache ~rec_env sh type_layout
   | Arrow, (None | Some (Base Scannable)) -> runtime RS.func
@@ -868,5 +915,5 @@ and type_shape_to_complex_shape ~cache ~rec_env type_shape type_layout : t =
 
 let type_shape_to_complex_shape ~cache evaluated_shape type_layout =
   let type_shape = Type_shape.Evaluated_shape.shape evaluated_shape in
-  type_shape_to_complex_shape ~cache ~rec_env:Shape.Rec_var_env.empty type_shape
+  type_shape_to_complex_shape ~cache ~rec_env:Rec_binder_env.empty type_shape
     type_layout

--- a/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
@@ -355,15 +355,14 @@ and flatten_product_layout_exn (cs : t) =
   | Unboxed_product { components; kind = Unboxed_tuple } ->
     List.map (fun arg -> None, arg) components
 
-type complex_shape = t
-
 (** Tracks the recursive binders in scope during the conversion from the named
-    binders of [Shape.t] to the De Bruijn-indexed binders of
-    [Runtime_shape.t]. The environment maps each in-scope
-    [Shape.Rec_var_ident.t] to its De Bruijn index relative to the current
-    position (maintained by [add_binder]) and the layout at which its binder
-    was entered. *)
+    binders of [Shape.t] to the De Bruijn-indexed binders of [Runtime_shape.t].
+    The environment maps each in-scope [Shape.Rec_var_ident.t] to its De Bruijn
+    index relative to the current position (maintained by [add_binder]) and the
+    layout at which its binder was entered. *)
 module Rec_binder_env : sig
+  type complex_shape := t
+
   type t
 
   val empty : t
@@ -403,7 +402,7 @@ end = struct
   let add_binder t rv ~layout =
     t
     |> S.Rec_var_env.map (fun (idx, ly) ->
-           RS.DeBruijn_index.move_under_binder idx, ly)
+        RS.DeBruijn_index.move_under_binder idx, ly)
     |> S.Rec_var_env.add rv (RS.DeBruijn_index.create 0, layout)
 
   module Lookup = struct
@@ -427,6 +426,8 @@ end = struct
 end
 
 module Shape_cache : sig
+  type complex_shape := t
+
   type t
 
   val create : int -> t
@@ -461,7 +462,7 @@ end = struct
     (* CR sspies: Add a hash function to Layout.t *)
   end)
 
-  type t = complex_shape Cache.t
+  type nonrec t = t Cache.t
 
   let create initial_size = Cache.create initial_size
 

--- a/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
@@ -355,7 +355,28 @@ and flatten_product_layout_exn (cs : t) =
   | Unboxed_product { components; kind = Unboxed_tuple } ->
     List.map (fun arg -> None, arg) components
 
-module Shape_cache = struct
+type complex_shape = t
+
+module Shape_cache : sig
+  type t
+
+  val create : int -> t
+
+  val find_in_cache :
+    t ->
+    Shape.t ->
+    Layout.t ->
+    rec_env:'a S.Rec_var_env.t ->
+    complex_shape option
+
+  val add_to_cache :
+    t ->
+    Shape.t ->
+    Layout.t ->
+    complex_shape ->
+    rec_env:'a S.Rec_var_env.t ->
+    unit
+end = struct
   type key =
     { type_shape : Shape.t;
       type_layout : Layout.t
@@ -375,18 +396,18 @@ module Shape_cache = struct
     (* CR sspies: Add a hash function to Layout.t *)
   end)
 
-  type nonrec t = t Cache.t
+  type t = complex_shape Cache.t
 
   let create initial_size = Cache.create initial_size
 
   let find_in_cache cache type_shape type_layout ~rec_env =
-    if S.DeBruijn_env.is_empty rec_env
+    if S.Rec_var_env.is_empty rec_env
     then Cache.find_opt cache { type_shape; type_layout }
     else None
 
   let add_to_cache cache type_shape type_layout value ~rec_env =
     (* [rec_env] being empty means that the shape is closed. *)
-    if S.DeBruijn_env.is_empty rec_env
+    if S.Rec_var_env.is_empty rec_env
     then Cache.add cache { type_shape; type_layout } value
 end
 
@@ -466,49 +487,55 @@ let rec type_shape_to_complex_shape_exn ~cache ~rec_env (type_shape : Shape.t)
       match runtime_layout with
       | Void -> void
       | Other runtime_layout -> runtime (RS.unknown runtime_layout)))
-  | Mu sh, type_layout ->
+  | Mu (rv, sh), type_layout ->
     (* We currently do not support unboxed recursive types (e.g., recursively
        defined mixed records). Those will fall back to default for printing the
        layout by forcing the runtime shape below. *)
     (* CR sspies: We should guess the layout from the recursive body [sh]
        instead of just using the current layout. *)
-    let rec_env = Shape.DeBruijn_env.push rec_env type_layout in
+    let rec_env =
+      rec_env
+      |> Shape.Rec_var_env.map (fun (idx, ly) ->
+          RS.DeBruijn_index.move_under_binder idx, ly)
+      |> Shape.Rec_var_env.add rv (RS.DeBruijn_index.create 0, type_layout)
+    in
     type_shape_to_complex_shape_exn ~cache ~rec_env sh type_layout
     |> force_runtime_shape_exn |> RS.mu |> runtime
-  | Rec_var i, layout -> (
-    match Shape.DeBruijn_env.get_opt rec_env ~de_bruijn_index:i, layout with
-    | Some (Some (Layout.Base base as ly1)), ly2_opt
+  | Rec_var rv, layout -> (
+    match Shape.Rec_var_env.find_opt rv rec_env, layout with
+    | Some (i, Some (Layout.Base base as ly1)), ly2_opt
     (* We combine the [None] and [Some] layout cases with the guard: *)
       when Option.value ~default:true (Option.map (Layout.equal ly1) ly2_opt)
       -> (
       match RS.Runtime_layout.of_base_layout base with
       | Void -> void
       | Other runtime_layout -> runtime (RS.rec_var i runtime_layout))
-    | Some (Some ly1), Some ly2 when not (Layout.equal ly1 ly2) ->
+    | Some (_, Some ly1), Some ly2 when not (Layout.equal ly1 ly2) ->
       err_or_unknown_exn (fun f ->
           f "Recursive variable has wrong layout. Expected %a, got %a" pp_layout
             ly2 pp_layout ly1)
       (* In all cases below, if there are two layouts, they are the same. *)
-    | (Some (Some ly1), (None | Some _)) as _ly2_opt ->
+    | Some (_, Some ly1), (None | Some _) ->
       (*= In this case, either:
-          - [ly1] is a product and [_ly2_opt] is None
-          - [ly1] is a product and [_ly2_opt] is equal to Some [ly1].
+          - [ly1] is a product and the second layout is None
+          - [ly1] is a product and the second layout is equal to Some [ly1].
 
           If [ly1] is a base layout, we would have taken the first branch (if
           equal to the second layout) or the second branch (if not equal to the
           second layout). *)
       layout_to_unknown_shape ly1
-    | (Some None | None), Some (Layout.Base base) -> (
+    | Some (i, None), Some (Layout.Base base) -> (
       match RS.Runtime_layout.of_base_layout base with
       | Void -> void
       | Other runtime_layout -> runtime (RS.rec_var i runtime_layout))
-    | (Some None | None), Some (Layout.Product _ as ly) ->
+    | Some (_, None), Some (Layout.Product _ as ly) ->
       layout_to_unknown_shape ly
-    | (Some None | None), Some (Univar _) ->
+    | (Some (_, None) | None), Some (Univar _) ->
       Misc.fatal_error "type_shape_to_complex_shape_exn: Univar"
-    | (Some None | None), Some (Genvar _) ->
+    | (Some (_, None) | None), Some (Genvar _) ->
       Misc.fatal_error "type_shape_to_complex_shape_exn: Genvar"
-    | (Some None | None), None -> raise Layout_missing)
+    | Some (_, None), None -> raise Layout_missing
+    | None, _ -> raise Layout_missing)
   | Alias sh, type_layout ->
     type_shape_to_complex_shape_exn ~cache ~rec_env sh type_layout
   | Arrow, (None | Some (Base Scannable)) -> runtime RS.func
@@ -841,5 +868,5 @@ and type_shape_to_complex_shape ~cache ~rec_env type_shape type_layout : t =
 
 let type_shape_to_complex_shape ~cache evaluated_shape type_layout =
   let type_shape = Type_shape.Evaluated_shape.shape evaluated_shape in
-  type_shape_to_complex_shape ~cache ~rec_env:Shape.DeBruijn_env.empty
-    type_shape type_layout
+  type_shape_to_complex_shape ~cache ~rec_env:Shape.Rec_var_env.empty type_shape
+    type_layout

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
@@ -1238,21 +1238,21 @@ end
 
 module Dwarf_die_cache : sig
   val find_in_cache :
-    RS.t -> rec_env:'a S.DeBruijn_env.t -> Proto_die.reference option
+    RS.t -> rec_env:'a RS.DeBruijn_env.t -> Proto_die.reference option
 
   val add_to_cache :
-    RS.t -> Proto_die.reference -> rec_env:'a S.DeBruijn_env.t -> unit
+    RS.t -> Proto_die.reference -> rec_env:'a RS.DeBruijn_env.t -> unit
 end = struct
   let cache = RS.Cache.create 100
 
   let find_in_cache (runtime_shape : RS.t) ~rec_env =
-    if S.DeBruijn_env.is_empty rec_env
+    if RS.DeBruijn_env.is_empty rec_env
     then RS.Cache.find_opt cache runtime_shape
     else None
 
   let add_to_cache (runtime_shape : RS.t) reference ~rec_env =
     (* [rec_env] being empty means that the shape is closed. *)
-    if S.DeBruijn_env.is_empty rec_env
+    if RS.DeBruijn_env.is_empty rec_env
     then RS.Cache.add cache runtime_shape reference
 end
 
@@ -1305,7 +1305,7 @@ and runtime_shape_to_dwarf_die_memo ~reference ?name (t : RS.t)
   in
   let die_with_extended_env sh new_ref =
     runtime_shape_to_dwarf_die ~parent_proto_die ~fallback_value_die
-      ~rec_env:(S.DeBruijn_env.push rec_env new_ref)
+      ~rec_env:(RS.DeBruijn_env.push rec_env new_ref)
       sh
   in
   match t.desc with
@@ -1406,7 +1406,7 @@ and runtime_shape_to_dwarf_die_memo ~reference ?name (t : RS.t)
              Format.pp_print_string)
           constructor_names)
   | Rec_var (de_bruijn_index, layout) -> (
-    match S.DeBruijn_env.get_opt rec_env ~de_bruijn_index with
+    match RS.DeBruijn_env.get_opt rec_env ~de_bruijn_index with
     | Some reference' ->
       create_typedef_die ~reference ~parent_proto_die ?name reference'
     | None ->
@@ -1414,7 +1414,7 @@ and runtime_shape_to_dwarf_die_memo ~reference ?name (t : RS.t)
           f
             "Recursive variable environment lookup failed: rec_env returned \
              None for de Bruijn index %a"
-            S.DeBruijn_index.print de_bruijn_index))
+            RS.DeBruijn_index.print de_bruijn_index))
   | Mu sh ->
     (* CR sspies: We are creating two typedefs for recursive types. One should
        be enough. *)
@@ -1579,7 +1579,7 @@ let runtime_shape_to_dwarf_die_with_aliased_name (type_name : string)
     let unnamed_die =
       runtime_shape_to_dwarf_die runtime_shape ~parent_proto_die
         ~fallback_value_die (* note that we do not pass the type name here *)
-        ~rec_env:S.DeBruijn_env.empty
+        ~rec_env:RS.DeBruijn_env.empty
     in
     let reference = Proto_die.create_reference () in
     let runtime_layout = RS.runtime_layout runtime_shape in

--- a/backend/debug/dwarf/dwarf_ocaml/runtime_shape.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/runtime_shape.ml
@@ -35,10 +35,7 @@ module Layout = Sort.Const
 module DeBruijn_index = struct
   type t = int
 
-  let create n =
-    if n < 0
-    then Misc.fatal_errorf "DeBruijn_index.create: negative index %d" n
-    else n
+  let zero = 0
 
   let move_under_binder n = n + 1
 

--- a/backend/debug/dwarf/dwarf_ocaml/runtime_shape.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/runtime_shape.ml
@@ -32,6 +32,33 @@ module S = Shape
 module Sort = Jkind_types.Sort
 module Layout = Sort.Const
 
+module DeBruijn_index = struct
+  type t = int
+
+  let create n =
+    if n < 0
+    then Misc.fatal_errorf "DeBruijn_index.create: negative index %d" n
+    else n
+
+  let move_under_binder n = n + 1
+
+  let equal n1 n2 = Int.equal n1 n2
+
+  let print fmt n = Format.fprintf fmt "%d" n
+end
+
+module DeBruijn_env = struct
+  type 'a t = 'a list
+
+  let empty = []
+
+  let get_opt t ~de_bruijn_index = List.nth_opt t de_bruijn_index
+
+  let push t x = x :: t
+
+  let is_empty = function [] -> true | _ -> false
+end
+
 module Or_void = struct
   type 'a t =
     | Other of 'a
@@ -192,7 +219,7 @@ and desc =
       }
   | Func
   | Mu of t
-  | Rec_var of Shape.DeBruijn_index.t * Runtime_layout.t
+  | Rec_var of DeBruijn_index.t * Runtime_layout.t
 (* The layout is part of [Unknown] and [Rec_var] to ensure that equality can be
    tested by simply comparing the descriptions. That is, the runtime_layout and
    hash fields are just precomputed from the desc field and carry no additional
@@ -692,7 +719,7 @@ let rec print fmt { desc } =
   | Func -> Format.fprintf fmt "Func"
   | Mu shape -> Format.fprintf fmt "Mu(%a)" print shape
   | Rec_var (idx, ly) ->
-    Format.fprintf fmt "Rec_var(%a, %a)" Shape.DeBruijn_index.print idx
+    Format.fprintf fmt "Rec_var(%a, %a)" DeBruijn_index.print idx
       Runtime_layout.print ly
 
 and print_predef fmt p =
@@ -812,7 +839,7 @@ let rec equal { desc = desc1 } { desc = desc2 } =
   | Func, Func -> true
   | Mu shape1, Mu shape2 -> equal shape1 shape2
   | Rec_var (idx1, ly1), Rec_var (idx2, ly2) ->
-    Shape.DeBruijn_index.equal idx1 idx2 && Runtime_layout.equal ly1 ly2
+    DeBruijn_index.equal idx1 idx2 && Runtime_layout.equal ly1 ly2
   | ( ( Unknown _ | Predef _ | Tuple _ | Variant _ | Record _ | Func | Mu _
       | Rec_var _ ),
       _ ) ->

--- a/backend/debug/dwarf/dwarf_ocaml/runtime_shape.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/runtime_shape.mli
@@ -28,6 +28,33 @@
 
 module Sort = Jkind_types.Sort
 
+(** De Bruijn indices for recursive binders in runtime shapes. *)
+module DeBruijn_index : sig
+  type t
+
+  (** Initial index, pick [0] for the top-level index. Cannot be negative. *)
+  val create : int -> t
+
+  val move_under_binder : t -> t
+
+  val equal : t -> t -> bool
+
+  val print : Format.formatter -> t -> unit
+end
+
+(** De Bruijn environment for working with recursive binders. *)
+module DeBruijn_env : sig
+  type 'a t
+
+  val empty : 'a t
+
+  val is_empty : 'a t -> bool
+
+  val push : 'a t -> 'a -> 'a t
+
+  val get_opt : 'a t -> de_bruijn_index:DeBruijn_index.t -> 'a option
+end
+
 module Or_void : sig
   type 'a t =
     | Other of 'a
@@ -122,9 +149,7 @@ and desc = private
       }
   | Func
   | Mu of t
-  | Rec_var of Shape.DeBruijn_index.t * Runtime_layout.t
-(* CR sspies: Use regular identifiers beforehand and only switch to DeBruijn at
-   this level. *)
+  | Rec_var of DeBruijn_index.t * Runtime_layout.t
 
 and tuple_kind = private
   | Tuple_boxed
@@ -293,8 +318,8 @@ val func : t
 *)
 val mu : t -> t
 
-(** Create a reference to a recursive binding using de Bruijn indexing. *)
-val rec_var : Shape.DeBruijn_index.t -> Runtime_layout.t -> t
+(** Create a reference to a recursive binding. *)
+val rec_var : DeBruijn_index.t -> Runtime_layout.t -> t
 
 (** Project the runtime layout of a shape. *)
 val runtime_layout : t -> Runtime_layout.t

--- a/backend/debug/dwarf/dwarf_ocaml/runtime_shape.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/runtime_shape.mli
@@ -32,8 +32,8 @@ module Sort = Jkind_types.Sort
 module DeBruijn_index : sig
   type t
 
-  (** Initial index, pick [0] for the top-level index. Cannot be negative. *)
-  val create : int -> t
+  (** The top-level index. *)
+  val zero : t
 
   val move_under_binder : t -> t
 

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -88,6 +88,7 @@ let init_parameters () =
 let initial_env () =
   Ident.reinit();
   Types.Uid.reinit();
+  Shape.Rec_var_ident.reinit();
   let initially_opened_module =
     if !Clflags.nopervasives then
       None

--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -108,33 +108,46 @@ module Uid = struct
     | _ -> false
 end
 
-module DeBruijn_index = struct
-  type t = int
+module Rec_var_ident = struct
+  (* Identifiers are qualified by the current compilation unit, because
+     shapes are marshalled into .cms files and mixed with locally created
+     shapes when imported. The compilation unit avoids identifier collisions. *)
+  type t =
+    { comp_unit : Compilation_unit.t option;
+      id : int
+    }
 
-  let create n =
-    if n < 0
-    then Misc.fatal_errorf "De_bruijn_index.create: negative index %d" n
-    else n
+  let counter = ref 0
 
-  let move_under_binder n = n + 1
+  let reinit () = counter := 0
 
-  let equal n1 n2 = Int.equal n1 n2
+  let mk_fresh () =
+    let comp_unit = Compilation_unit.get_current () in
+    let n = !counter in
+    incr counter;
+    { comp_unit; id = n }
 
-  let print fmt n = Format.fprintf fmt "%d" n
+  let equal t1 t2 =
+    Int.equal t1.id t2.id
+    && Option.equal Compilation_unit.equal t1.comp_unit t2.comp_unit
+
+  let compare t1 t2 =
+    let c = Int.compare t1.id t2.id in
+    if c <> 0 then c
+    else Option.compare Compilation_unit.compare t1.comp_unit t2.comp_unit
+
+  let hash { comp_unit; id } =
+    Hashtbl.hash (Option.map Compilation_unit.hash comp_unit, id)
+
+  let print fmt { comp_unit; id } =
+    match comp_unit with
+    | None -> Format.fprintf fmt "rv%d" id
+    | Some cu ->
+      Format.fprintf fmt "rv%s.%d"
+        (Compilation_unit.full_path_as_string cu) id
 end
 
-
-module DeBruijn_env = struct
-  type 'a t = 'a list
-
-  let empty = []
-
-  let get_opt t ~de_bruijn_index = List.nth_opt t de_bruijn_index
-
-  let push t x = x :: t
-
-  let is_empty = function [] -> true | _ -> false
-end
+module Rec_var_env = Map.Make (Rec_var_ident)
 
 module Sig_component_kind = struct
   type t =
@@ -530,8 +543,8 @@ and desc =
   | Predef of Predef.t * t list
   | Arrow
   | Poly_variant of t poly_variant_constructors
-  | Mu of t
-  | Rec_var of int
+  | Mu of Rec_var_ident.t * t
+  | Rec_var of Rec_var_ident.t
 
   (* constructors for type declarations *)
   | Variant of (t * Layout.t option) complex_constructors
@@ -626,9 +639,9 @@ let rec equal_desc0 d1 d2 =
     if not (equal t1 t2) then false
     else equal v1 v2
   | Leaf, Leaf -> true
-  | Mu (t1_body), Mu (t2_body) ->
-    equal t1_body t2_body
-  | Rec_var i1, Rec_var i2 -> Int.equal i1 i2
+  | Mu (rv1, t1_body), Mu (rv2, t2_body) ->
+    Rec_var_ident.equal rv1 rv2 && equal t1_body t2_body
+  | Rec_var rv1, Rec_var rv2 -> Rec_var_ident.equal rv1 rv2
   | Struct t1, Struct t2 ->
     Item.Map.equal equal t1 t2
   | Proj (t1, i1), Proj (t2, i2) ->
@@ -742,14 +755,15 @@ let rec print fmt t =
         Format.fprintf fmt "@[%a(@,%a)%a@]" aux t1 aux t2 print_uid_opt uid
     | Leaf ->
         Format.fprintf fmt "<%a>" (Format.pp_print_option Uid.print) uid
-    | Mu (t_body) ->
-      Format.fprintf fmt "Rec@[%a %a@]"
+    | Mu (rv, t_body) ->
+      Format.fprintf fmt "Mu@[%a %a.%a@]"
         print_uid_opt uid
+        Rec_var_ident.print rv
         print_nested t_body
-    | Rec_var id ->
-      Format.fprintf fmt "#%d%a"
-      id
-      print_uid_opt uid
+    | Rec_var rv ->
+      Format.fprintf fmt "#%a%a"
+        Rec_var_ident.print rv
+        print_uid_opt uid
     | Proj (t, item) ->
         begin match uid with
         | None ->
@@ -1011,14 +1025,14 @@ let comp_unit ?uid s =
     hash = Hashtbl.hash (hash_comp_unit, uid, s);
     approximated = false }
 
-let mu ?uid t_body =
-  { uid; desc = Mu (t_body);
-    hash = Hashtbl.hash (hash_mu, uid, t_body.hash);
+let mu ?uid rv t_body =
+  { uid; desc = Mu (rv, t_body);
+    hash = Hashtbl.hash (hash_mu, uid, Rec_var_ident.hash rv, t_body.hash);
     approximated = false }
 
-let rec_var ?uid n =
-  { uid; desc = Rec_var n;
-    hash = Hashtbl.hash (hash_rec_var, uid, n);
+let rec_var ?uid rv =
+  { uid; desc = Rec_var rv;
+    hash = Hashtbl.hash (hash_rec_var, uid, Rec_var_ident.hash rv);
     approximated = false }
 
 let app_list (base_shape : t) (args : t list) : t =
@@ -1164,8 +1178,8 @@ let set_uid_if_none t uid =
   | Proj (t, i) -> proj ~uid t i
   | Comp_unit c -> comp_unit ~uid c
   | Error s -> error ~uid s
-  | Mu t -> mu ~uid t
-  | Rec_var i -> rec_var ~uid i
+  | Mu (rv, t) -> mu ~uid rv t
+  | Rec_var rv -> rec_var ~uid rv
   | Constr (c, ts) -> constr ~uid c ts
   | Tuple ts -> tuple ~uid ts
   | Unboxed_tuple ts -> unboxed_tuple ~uid ts

--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -123,7 +123,7 @@ module Rec_var_ident = struct
 
   let mk_fresh () =
     let comp_unit =
-      match Compilation_unit.get_current () with
+      match Current_unit.get_cu () with
       | None -> ""
       | Some cu -> Compilation_unit.full_path_as_string cu
     in

--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -113,7 +113,7 @@ module Rec_var_ident = struct
      shapes are marshalled into .cms files and mixed with locally created
      shapes when imported. The compilation unit avoids identifier collisions. *)
   type t =
-    { comp_unit : Compilation_unit.t option;
+    { comp_unit : string;
       id : int
     }
 
@@ -122,29 +122,28 @@ module Rec_var_ident = struct
   let reinit () = counter := 0
 
   let mk_fresh () =
-    let comp_unit = Compilation_unit.get_current () in
+    let comp_unit =
+      match Compilation_unit.get_current () with
+      | None -> ""
+      | Some cu -> Compilation_unit.full_path_as_string cu
+    in
     let n = !counter in
     incr counter;
     { comp_unit; id = n }
 
   let equal t1 t2 =
-    Int.equal t1.id t2.id
-    && Option.equal Compilation_unit.equal t1.comp_unit t2.comp_unit
+    Int.equal t1.id t2.id && String.equal t1.comp_unit t2.comp_unit
 
   let compare t1 t2 =
     let c = Int.compare t1.id t2.id in
-    if c <> 0 then c
-    else Option.compare Compilation_unit.compare t1.comp_unit t2.comp_unit
+    if c <> 0 then c else String.compare t1.comp_unit t2.comp_unit
 
-  let hash { comp_unit; id } =
-    Hashtbl.hash (Option.map Compilation_unit.hash comp_unit, id)
+  let hash { comp_unit; id } = Hashtbl.hash (comp_unit, id)
 
   let print fmt { comp_unit; id } =
     match comp_unit with
-    | None -> Format.fprintf fmt "rv%d" id
-    | Some cu ->
-      Format.fprintf fmt "rv%s.%d"
-        (Compilation_unit.full_path_as_string cu) id
+    | "" -> Format.fprintf fmt "rv%d" id
+    | comp_unit -> Format.fprintf fmt "rv%s.%d" comp_unit id
 end
 
 module Rec_var_env = Map.Make (Rec_var_ident)

--- a/typing/shape.mli
+++ b/typing/shape.mli
@@ -79,23 +79,38 @@ module Uid : sig
   include Identifiable.S with type t := t
 end
 
-(** We use de Bruijn indices for some binders in [Shape.t] below to increase
-    sharing. That is, de Bruijn indices ensure that alpha-equivalent terms are
-    actually equal. This reduces redundancy when we emit shape information into
-    the debug information in later stages of the compiler (see [dwarf_type.ml]),
-    since equal shapes produce the same debug information. *)
-module DeBruijn_index : sig
+module Rec_var_ident : sig
   type t
 
-  (* Initial index, pick [0] for the top-level index. Cannot be negative. *)
-  val create : int -> t
+  val mk_fresh : unit -> t
 
-  val move_under_binder : t -> t
+  (** Reset the internal identifier counter. *)
+  val reinit : unit -> unit
 
-  val equal: t -> t -> bool
+  val equal : t -> t -> bool
 
-  val print: Format.formatter -> t -> unit
+  val compare : t -> t -> int
 
+  val hash : t -> int
+
+  val print : Format.formatter -> t -> unit
+end
+
+(** Environment for mapping [Rec_var_ident.t] to values. Used to track
+    bindings when converting from named recursive variables to De Bruijn
+    indices. *)
+module Rec_var_env : sig
+  type 'a t
+
+  val empty : 'a t
+
+  val is_empty : 'a t -> bool
+
+  val add : Rec_var_ident.t -> 'a -> 'a t -> 'a t
+
+  val find_opt : Rec_var_ident.t -> 'a t -> 'a option
+
+  val map : ('a -> 'b) -> 'a t -> 'b t
 end
 
 module Sig_component_kind : sig
@@ -248,11 +263,10 @@ and desc =
   | Predef of Predef.t * t list (* predef type with arguments *)
   | Arrow
   | Poly_variant of t poly_variant_constructors
-  | Mu of t
-  (** [Mu t] represents a binder for a recursive type with body [t]. Its
-      variables are [Rec_var n] below, where [n] is a DeBruijn-index to maximize
-      sharing between alpha-equivalent shapes.  *)
-  | Rec_var of DeBruijn_index.t
+  | Mu of Rec_var_ident.t * t
+  (** [Mu (rv, t)] represents a binder for a recursive type with body [t],
+      binding the recursive variable [rv]. *)
+  | Rec_var of Rec_var_ident.t
 
   (* constructors for type declarations *)
   | Variant of (t * Layout.t option) complex_constructors
@@ -374,8 +388,8 @@ val unboxed_tuple : ?uid:Uid.t -> t list -> t
 val predef : ?uid:Uid.t -> Predef.t -> t list -> t
 val arrow : ?uid:Uid.t -> unit -> t
 val poly_variant : ?uid:Uid.t -> t poly_variant_constructors -> t
-val mu : ?uid:Uid.t -> t -> t
-val rec_var : ?uid:Uid.t -> DeBruijn_index.t -> t
+val mu : ?uid:Uid.t -> Rec_var_ident.t -> t -> t
+val rec_var : ?uid:Uid.t -> Rec_var_ident.t -> t
 
 (* constructors for type declarations *)
 val variant :
@@ -466,16 +480,3 @@ val of_path :
 val set_uid_if_none : t -> Uid.t -> t
 
 module Cache : Hashtbl.S with type key = t
-
-(** DeBruijn Environment for working with the recursive binders. *)
-module DeBruijn_env : sig
-  type 'a t
-
-  val empty : 'a t
-
-  val is_empty : 'a t -> bool
-
-  val push : 'a t -> 'a -> 'a t
-
-  val get_opt : 'a t -> de_bruijn_index:DeBruijn_index.t -> 'a option
-end

--- a/typing/shape_reduce.ml
+++ b/typing/shape_reduce.ml
@@ -141,8 +141,8 @@ end) = struct
     | NLeaf
     | NComp_unit of string
     | NError of string
-    | NMu of nf
-    | NRec_var of Shape.DeBruijn_index.t
+    | NMu of Shape.Rec_var_ident.t * nf
+    | NRec_var of Shape.Rec_var_ident.t
     | NMutrec of nf Ident.Map.t
     | NProj_decl of nf * Ident.t
     | NConstr of Ident.t * nf list
@@ -234,8 +234,9 @@ end) = struct
     | NComp_unit c1, NComp_unit c2 -> String.equal c1 c2
     | NAlias a1, NAlias a2 -> equal_delayed_nf a1 a2
     | NError e1, NError e2 -> String.equal e1 e2
-    | NMu (nf1), NMu (nf2) -> equal_nf nf1 nf2
-    | NRec_var i1, NRec_var i2 -> DeBruijn_index.equal i1 i2
+    | NMu (rv1, nf1), NMu (rv2, nf2) ->
+      Shape.Rec_var_ident.equal rv1 rv2 && equal_nf nf1 nf2
+    | NRec_var rv1, NRec_var rv2 -> Shape.Rec_var_ident.equal rv1 rv2
     | NMutrec defs1, NMutrec defs2 ->
       Ident.Map.equal equal_nf defs1 defs2
     | NProj_decl (nf1, id1), NProj_decl (nf2, id2) ->
@@ -568,8 +569,8 @@ end) = struct
               reduce env res
           end
       | Leaf -> return NLeaf
-      | Mu t_body -> return (NMu (reduce env t_body))
-      | Rec_var n -> return (NRec_var n)
+      | Mu (rv, t_body) -> return (NMu (rv, reduce env t_body))
+      | Rec_var rv -> return (NRec_var rv)
       | Struct m ->
           let mnf = Item.Map.map (delay_reduce env) m in
           return (NStruct mnf)
@@ -657,10 +658,10 @@ end) = struct
     | NComp_unit s -> comp_unit ?uid s
     | NAlias nf -> alias ?uid (read_back_force nf)
     | NError t -> error ?uid t
-    | NMu (t_body) ->
-      mu ?uid (read_back t_body)
-    | NRec_var n ->
-      rec_var ?uid n
+    | NMu (rv, t_body) ->
+      mu ?uid rv (read_back t_body)
+    | NRec_var rv ->
+      rec_var ?uid rv
     | NMutrec defs ->
       let t_defs = Ident.Map.map read_back defs in
       mutrec ?uid t_defs

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -47,90 +47,21 @@ module Recursive_binder : sig
 
   val mark_as_used : t -> Shape.t
 
-  val close_term_if_binder_is_used :
-    ?preserve_uid:bool -> t -> Shape.t -> Shape.t
+  val close_term_if_binder_is_used : t -> Shape.t -> Shape.t
 end = struct
-  (* CR sspies: To improve performance, consider replacing this pass with
-     a single pass over the resulting definition that simultaneously turns
-     all binders into DeBruijn indices. *)
-  let rec shape_subst_uid_with_rec_var ~preserve_uid uid rv outer =
-    let open Shape in
-    let subst = shape_subst_uid_with_rec_var ~preserve_uid uid rv in
-    let subst_list = List.map subst in
-    match outer.desc with
-    | Leaf when Option.equal Uid.equal outer.uid (Some uid) ->
-      let uid = if preserve_uid then Some uid else None in
-      Shape.rec_var ?uid rv
-    | Leaf | Error _ | Rec_var _ | Comp_unit _ | Var _ -> outer (* base cases *)
-    | Alias sh -> Shape.alias ?uid:outer.uid (subst sh)
-    | App (sh, arg) -> Shape.app ?uid:outer.uid (subst sh) ~arg:(subst arg)
-    | Proj (sh, item) -> Shape.proj ?uid:outer.uid (subst sh) item
-    | Struct map -> Shape.str ?uid:outer.uid (Item.Map.map subst map)
-    | Abs (var, sh) -> Shape.abs ?uid:outer.uid var (subst sh)
-    | Mu sh ->
-      Shape.mu ?uid:outer.uid
-        (shape_subst_uid_with_rec_var ~preserve_uid uid
-           (Shape.DeBruijn_index.move_under_binder rv)
-           sh)
-    | Mutrec map -> Shape.mutrec ?uid:outer.uid (Ident.Map.map subst map)
-    | Proj_decl (sh, id) -> Shape.proj_decl ?uid:outer.uid (subst sh) id
-    | Constr (id, args) -> Shape.constr ?uid:outer.uid id (subst_list args)
-    | Tuple shapes -> Shape.tuple ?uid:outer.uid (subst_list shapes)
-    | Unboxed_tuple shapes ->
-      Shape.unboxed_tuple ?uid:outer.uid (subst_list shapes)
-    | Predef (predef, args) ->
-      Shape.predef predef ?uid:outer.uid (subst_list args)
-    | Arrow -> Shape.arrow ?uid:outer.uid ()
-    | Poly_variant fields ->
-      Shape.poly_variant ?uid:outer.uid
-        (poly_variant_constructors_map subst fields)
-    | Record { fields; kind } ->
-      Shape.record ?uid:outer.uid kind
-        (List.map
-           (fun (name, uid_opt, sh, layout) -> name, uid_opt, subst sh, layout)
-           fields)
-    | Variant constructors ->
-      Shape.variant ?uid:outer.uid
-        (Shape.complex_constructors_map
-           (fun (sh, layout) -> subst sh, layout)
-           constructors)
-    | Variant_unboxed
-        { name; variant_uid; arg_name; arg_uid; arg_shape; arg_layout } ->
-      Shape.variant_unboxed ?uid:outer.uid ~variant_uid ~arg_uid name arg_name
-        (subst arg_shape) arg_layout
-    | Unknown_type -> Shape.unknown_type ?uid:outer.uid ()
-    | At_layout (shape, layout) -> Shape.at_layout ?uid:outer.uid shape layout
-
   type t =
-    { uid : Uid.t;
+    { rv : Shape.Rec_var_ident.t;
       mutable used : bool
     }
 
-  let create () = { uid = Uid.mk ~current_unit:None; used = false }
+  let create () = { rv = Shape.Rec_var_ident.mk_fresh (); used = false }
 
-  (* CR sspies: Looking at this again after some evaluation of the shape
-     mechanism, I think there is a question here of whether we want to use de
-     Bruijn indices or just new identifiers for our recursive variables. The
-     latter would allow us to avoid [shape_subst_uid_with_rec_var] in
-     [close_term_if_binder_is_used], which saves us a (potentially costly) shape
-     traversal. The benefit of the de Bruijn indices is that they increase
-     sharing between types that have the exact same recursive structure. I'm not
-     sure how much this happens in practice.
-  *)
   let mark_as_used db =
     db.used <- true;
-    Shape.leaf db.uid
+    Shape.rec_var db.rv
 
-  let close_term_if_binder_is_used ?(preserve_uid = true) db sh =
-    if not db.used
-    then sh
-    else
-      let sh =
-        shape_subst_uid_with_rec_var ~preserve_uid db.uid
-          (Shape.DeBruijn_index.create 0)
-          sh
-      in
-      Shape.mu ?uid:(if preserve_uid then Some db.uid else None) sh
+  let close_term_if_binder_is_used db sh =
+    if not db.used then sh else Shape.mu db.rv sh
 end
 
 module Type_shape = struct
@@ -375,8 +306,7 @@ module Type_shape = struct
           | Tpackage _ -> unknown_shape_value
           (* CR sspies: Support first-class modules. *)
         in
-        Recursive_binder.close_term_if_binder_is_used ~preserve_uid:false
-          rec_binder type_shape
+        Recursive_binder.close_term_if_binder_is_used rec_binder type_shape
 
   let of_type_expr (expr : Types.type_expr) shape_for_constr =
     of_type_expr_go ~visited:Numbers.Int.Map.empty ~depth:0 expr []
@@ -978,8 +908,7 @@ and unfold_and_evaluate0 ~diagnostics ~depth ~steps_remaining subst_type
         let ts = Ident.Map.find id ts in
         unfold_and_evaluate ~diagnostics ~depth ~steps_remaining subst_type
           subst_constr (Shape.app_list ts args)
-        |> Recursive_binder.close_term_if_binder_is_used ~preserve_uid:false
-             rec_binder
+        |> Recursive_binder.close_term_if_binder_is_used rec_binder
         |> Option.some
       | Unknown_type | At_layout _ | Error _ -> None
       | Var _
@@ -1093,8 +1022,8 @@ and unfold_and_evaluate0 ~diagnostics ~depth ~steps_remaining subst_type
       | Tuple args -> Shape.tuple (unfold_and_eval_list args)
       | Unboxed_tuple args -> Shape.unboxed_tuple (unfold_and_eval_list args)
       | Predef (p, args) -> Shape.predef p (unfold_and_eval_list args)
-      | Mu body ->
-        Shape.mu
+      | Mu (rv, body) ->
+        Shape.mu rv
           (unfold_and_evaluate ~diagnostics ~depth ~steps_remaining subst_type
              subst_constr body)
       | Alias t ->


### PR DESCRIPTION
**TL;DR** Building on top of #4916, this PR moves the use of De Bruijn indices from the shape level to the level of runtime shapes. This has the key benefit that we save ourselves a costly, recursive traversal when computing the type shapes.

**De  Bruijn vs. named binder representation.** In the implementation before this PR, the representation of recursive types as shapes uses De Bruijn indexing for variables. This PR replaces it with a new type, `Rec_var_ident.t`.  `Rec_var_ident.t` is a named representation for binders but---to avoid freshness issues---internally implemented using a counter. (We could have used `Ident.t` for the variables, but that would lead to lots of renaming of the identifiers that are being generated elsewhere in the compiler.) The key benefit of the named representation is that when we add a binder, we do not have to update any indices in `close_term_if_binder_is_used`, which saves us a recursive traversal over the shapes.

To still retain the benefits of the De Bruijn representation (increased sharing at the DWARF level), we do eventually translate the recursive binders to a De Bruijn representation, but only in the next step, the translation `type_shape_to_complex_shape` from fully evaluated shapes to complex shapes.