### PR TITLE
Improve performance of debug info generation

### DIFF
--- a/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
@@ -359,20 +359,23 @@ and flatten_product_layout_exn (cs : t) =
     binders of [Shape.t] to the De Bruijn-indexed binders of [Runtime_shape.t].
     The environment maps each in-scope [Shape.Rec_var_ident.t] to its De Bruijn
     index relative to the current position (maintained by [add_binder]) and the
-    layout at which its binder was entered. *)
-module Rec_binder_env : sig
-  type complex_shape := t
+    layout at which its binder was entered.
 
+    Environments are hash-consed (deduplicated in a [table]) so that they can
+    be used as part of [Shape_cache] keys with O(1) equality and hashing. *)
+module Rec_binder_env : sig
   type t
 
-  val empty : t
+  (** A hash-consing table interning the environments. *)
+  type table
 
-  (** [is_empty] means the shape being converted is closed (it can mention no
-      recursive variables), which makes it eligible for caching. *)
-  val is_empty : t -> bool
+  val create_table : initial_size:int -> table
+
+  val empty : table -> t
 
   (** Enter a [Mu (rv, _)] binder whose layout is [layout]. *)
-  val add_binder : t -> Shape.Rec_var_ident.t -> layout:Layout.t option -> t
+  val add_binder :
+    table -> t -> Shape.Rec_var_ident.t -> layout:Layout.t option -> t
 
   module Lookup : sig
     type t =
@@ -392,18 +395,38 @@ module Rec_binder_env : sig
       binder with the layout [use_layout] expected at the use site. *)
   val lookup :
     t -> Shape.Rec_var_ident.t -> use_layout:Layout.t option -> Lookup.t
+
+  (** O(1) equality and hashing on the hash-consed representation, for use in
+      cache keys. *)
+  val equal : t -> t -> bool
+
+  val hash : t -> int
 end = struct
-  type t = (RS.DeBruijn_index.t * Layout.t option) S.Rec_var_env.t
+  include
+    Hash_consed.Dedup
+      (struct
+        type t = (RS.DeBruijn_index.t * Layout.t option) S.Rec_var_env.t
 
-  let empty = S.Rec_var_env.empty
+        let hash_value (idx, ly_opt) =
+          Hashtbl.hash (RS.DeBruijn_index.hash idx, ly_opt)
 
-  let is_empty = S.Rec_var_env.is_empty
+        let equal_value (i1, l1) (i2, l2) =
+          RS.DeBruijn_index.equal i1 i2 && Option.equal Layout.equal l1 l2
 
-  let add_binder t rv ~layout =
-    t
-    |> S.Rec_var_env.map (fun (idx, ly) ->
-        RS.DeBruijn_index.move_under_binder idx, ly)
-    |> S.Rec_var_env.add rv (RS.DeBruijn_index.zero, layout)
+        let hash = S.Rec_var_env.hash hash_value
+
+        let equal = S.Rec_var_env.equal equal_value
+      end)
+      ()
+
+  let empty table = create table S.Rec_var_env.empty
+
+  let add_binder table t rv ~layout =
+    modify table t (fun map ->
+        S.Rec_var_env.map
+          (fun (idx, ly) -> RS.DeBruijn_index.move_under_binder idx, ly)
+          map
+        |> S.Rec_var_env.add rv (RS.DeBruijn_index.zero, layout))
 
   module Lookup = struct
     type t =
@@ -416,7 +439,7 @@ end = struct
   end
 
   let lookup t rv ~use_layout : Lookup.t =
-    match S.Rec_var_env.find_opt rv t with
+    match S.Rec_var_env.find_opt rv (value t) with
     | None -> Unbound
     | Some (idx, bound_layout) -> (
       match bound_layout, use_layout with
@@ -425,56 +448,82 @@ end = struct
       | (Some _ as layout), _ | None, layout -> Bound (idx, layout))
 end
 
+type complex_shape = t
+
 module Shape_cache : sig
   type complex_shape := t
 
   type t
 
-  val create : int -> t
+  val create : initial_size:int -> t
+
+  (** The empty recursive-binder environment, interned in this cache's table so
+      that it can be used as part of a cache key. *)
+  val empty_rec_env : t -> Rec_binder_env.t
+
+  (** [add_rec_binder t rec_env rv type_layout] extends [rec_env] with a binding
+      for the recursive variable [rv] at [type_layout]. The result is interned
+      in this cache's table for use as part of a cache key. *)
+  val add_rec_binder :
+    t ->
+    Rec_binder_env.t ->
+    S.Rec_var_ident.t ->
+    Layout.t option ->
+    Rec_binder_env.t
 
   val find_in_cache :
-    t -> Shape.t -> Layout.t -> rec_env:Rec_binder_env.t -> complex_shape option
+    t ->
+    type_shape:Shape.t ->
+    type_layout:Layout.t ->
+    rec_env:Rec_binder_env.t ->
+    complex_shape option
 
   val add_to_cache :
     t ->
-    Shape.t ->
-    Layout.t ->
-    complex_shape ->
+    type_shape:Shape.t ->
+    type_layout:Layout.t ->
     rec_env:Rec_binder_env.t ->
+    outp:complex_shape ->
     unit
 end = struct
   type key =
     { type_shape : Shape.t;
-      type_layout : Layout.t
+      type_layout : Layout.t;
+      rec_env : Rec_binder_env.t
     }
 
-  (* CR sspies: This caching will need performance improvements along with the
-     other caches in the future. *)
   module Cache = Hashtbl.Make (struct
     type t = key
 
-    let equal ({ type_shape = x1; type_layout = y1 } : t)
-        ({ type_shape = x2; type_layout = y2 } : t) =
-      Shape.equal x1 x2 && Layout.equal y1 y2
+    let equal ({ type_shape = x1; type_layout = y1; rec_env = r1 } : t)
+        ({ type_shape = x2; type_layout = y2; rec_env = r2 } : t) =
+      Shape.equal x1 x2 && Layout.equal y1 y2 && Rec_binder_env.equal r1 r2
 
-    let hash { type_shape; type_layout } =
-      Hashtbl.hash (type_shape.hash, type_layout)
+    let hash { type_shape; type_layout; rec_env } =
+      Hashtbl.hash (type_shape.hash, type_layout, Rec_binder_env.hash rec_env)
     (* CR sspies: Add a hash function to Layout.t *)
   end)
 
-  type nonrec t = t Cache.t
+  type t =
+    { cache : complex_shape Cache.t;
+      rec_env_table : Rec_binder_env.table
+    }
 
-  let create initial_size = Cache.create initial_size
+  let create ~initial_size =
+    { cache = Cache.create initial_size;
+      rec_env_table = Rec_binder_env.create_table ~initial_size
+    }
 
-  let find_in_cache cache type_shape type_layout ~rec_env =
-    if Rec_binder_env.is_empty rec_env
-    then Cache.find_opt cache { type_shape; type_layout }
-    else None
+  let empty_rec_env t = Rec_binder_env.empty t.rec_env_table
 
-  let add_to_cache cache type_shape type_layout value ~rec_env =
-    (* [rec_env] being empty means that the shape is closed. *)
-    if Rec_binder_env.is_empty rec_env
-    then Cache.add cache { type_shape; type_layout } value
+  let add_rec_binder t rec_env rv type_layout =
+    Rec_binder_env.add_binder t.rec_env_table rec_env rv ~layout:type_layout
+
+  let find_in_cache t ~type_shape ~type_layout ~rec_env =
+    Cache.find_opt t.cache { type_shape; type_layout; rec_env }
+
+  let add_to_cache t ~type_shape ~type_layout ~rec_env ~outp =
+    Cache.add t.cache { type_shape; type_layout; rec_env } outp
 end
 
 (** Lays out the elements in the shape sequentially while erasing all voids.
@@ -559,7 +608,7 @@ let rec type_shape_to_complex_shape_exn ~cache ~rec_env (type_shape : Shape.t)
        layout by forcing the runtime shape below. *)
     (* CR sspies: We should guess the layout from the recursive body [sh]
        instead of just using the current layout. *)
-    let rec_env = Rec_binder_env.add_binder rec_env rv ~layout:type_layout in
+    let rec_env = Shape_cache.add_rec_binder cache rec_env rv type_layout in
     type_shape_to_complex_shape_exn ~cache ~rec_env sh type_layout
     |> force_runtime_shape_exn |> RS.mu |> runtime
   | Rec_var rv, use_layout -> (
@@ -902,7 +951,7 @@ and predef_to_complex_shape_exn ~cache ~rec_env (predef : S.Predef.t) ~args :
           args)
 
 and type_shape_to_complex_shape ~cache ~rec_env type_shape type_layout : t =
-  match Shape_cache.find_in_cache cache type_shape type_layout ~rec_env with
+  match Shape_cache.find_in_cache cache ~type_layout ~type_shape ~rec_env with
   | Some shape -> shape
   | None ->
     let shape =
@@ -911,10 +960,10 @@ and type_shape_to_complex_shape ~cache ~rec_env type_shape type_layout : t =
           (Some type_layout)
       with Layout_missing -> layout_to_unknown_shape type_layout
     in
-    Shape_cache.add_to_cache cache type_shape type_layout shape ~rec_env;
+    Shape_cache.add_to_cache cache ~type_shape ~type_layout ~outp:shape ~rec_env;
     shape
 
 let type_shape_to_complex_shape ~cache evaluated_shape type_layout =
   let type_shape = Type_shape.Evaluated_shape.shape evaluated_shape in
-  type_shape_to_complex_shape ~cache ~rec_env:Rec_binder_env.empty type_shape
-    type_layout
+  let rec_env = Shape_cache.empty_rec_env cache in
+  type_shape_to_complex_shape ~cache ~rec_env type_shape type_layout

--- a/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
@@ -361,8 +361,8 @@ and flatten_product_layout_exn (cs : t) =
     index relative to the current position (maintained by [add_binder]) and the
     layout at which its binder was entered.
 
-    Environments are hash-consed (deduplicated in a [table]) so that they can
-    be used as part of [Shape_cache] keys with O(1) equality and hashing. *)
+    Environments are hash-consed (deduplicated in a [table]) so that they can be
+    used as part of [Shape_cache] keys with O(1) equality and hashing. *)
 module Rec_binder_env : sig
   type t
 

--- a/backend/debug/dwarf/dwarf_ocaml/complex_shape.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/complex_shape.mli
@@ -94,7 +94,7 @@ val flatten_complex_shape : t -> RS.t RS.Or_void.t list
 module Shape_cache : sig
   type t
 
-  val create : int -> t
+  val create : initial_size:int -> t
 end
 
 (** Convert an evaluated type shape and layout to a complex shape for DWARF type

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_state.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_state.ml
@@ -16,6 +16,8 @@ open! Int_replace_polymorphic_compare
 open Asm_targets
 open Dwarf_low
 open Dwarf_high
+module RS = Runtime_shape
+module String = Misc.Stdlib.String
 
 type function_range =
   { start_label : Asm_label.t;
@@ -50,6 +52,109 @@ module Diagnostics = struct
   type t = { mutable variables : variable_reduction list }
 end
 
+(* Context threaded through the translation of runtime shapes to DWARF DIEs: a
+   cache of the DIEs generated so far and the recursive-variable environment. *)
+module Die_gen_ctx = struct
+  (* Recursive-variable environments, deduplicated for use as [Cache] keys. *)
+  module Rec_var_env = struct
+    include
+      Hash_consed.Dedup
+        (struct
+          type t = Proto_die.reference RS.DeBruijn_env.t
+
+          let hash = RS.DeBruijn_env.hash Asm_targets.Asm_label.hash
+
+          let equal = RS.DeBruijn_env.equal Asm_targets.Asm_label.equal
+        end)
+        ()
+
+    let empty table = create table RS.DeBruijn_env.empty
+
+    let push table rec_env ref =
+      modify table rec_env (fun env -> RS.DeBruijn_env.push env ref)
+
+    let get_opt rec_env ~de_bruijn_index =
+      RS.DeBruijn_env.get_opt (value rec_env) ~de_bruijn_index
+  end
+
+  module Cache = struct
+    type key =
+      { runtime_shape : RS.t;
+        rec_env : Rec_var_env.t
+      }
+
+    module Tbl = Hashtbl.Make (struct
+      type t = key
+
+      let equal ({ runtime_shape = s1; rec_env = r1 } : t)
+          ({ runtime_shape = s2; rec_env = r2 } : t) =
+        RS.equal s1 s2 && Rec_var_env.equal r1 r2
+
+      let hash { runtime_shape; rec_env } =
+        Hashtbl.hash (RS.hash runtime_shape, Rec_var_env.hash rec_env)
+    end)
+
+    type t = Proto_die.reference Tbl.t
+
+    let create ~initial_size = Tbl.create initial_size
+
+    let find cache ~inp ~rec_env =
+      Tbl.find_opt cache { runtime_shape = inp; rec_env }
+
+    let add cache ~inp ~rec_env ~outp =
+      Tbl.add cache { runtime_shape = inp; rec_env } outp
+  end
+
+  (* DWARF DIE cache for named type shapes. *)
+  module Name_cache = struct
+    type t = (RS.t * Proto_die.reference) String.Tbl.t
+
+    let create ~initial_size = String.Tbl.create initial_size
+
+    (* Search for the first unused suffix-numbered version of [name]. If we come
+       across a type of the same name and runtime shape, then we simply reuse
+       that reference. For name conflicts, we search for the next available
+       suffix-numbered version of the name, [name/n]. *)
+    let find_unused_name_or_cached t name runtime_shape :
+        (Proto_die.reference, string) Either.t =
+      let rec aux inc : _ Either.t =
+        let name_suffix = if inc = 0 then "" else "/" ^ string_of_int inc in
+        let name = name ^ name_suffix in
+        match String.Tbl.find_opt t name with
+        | Some (runtime_shape', reference) ->
+          if RS.equal runtime_shape runtime_shape'
+          then Left reference
+          else aux (inc + 1)
+        | None -> Right name
+      in
+      aux 0
+
+    let add t name runtime_shape reference =
+      String.Tbl.add t name (runtime_shape, reference)
+  end
+
+  type t =
+    { cache : Cache.t;
+      name_cache : Name_cache.t;
+      rec_env_table : Rec_var_env.table
+    }
+
+  let create ~initial_size =
+    { cache = Cache.create ~initial_size;
+      name_cache = Name_cache.create ~initial_size;
+      rec_env_table = Rec_var_env.create_table ~initial_size
+    }
+
+  let cache t = t.cache
+
+  let name_cache t = t.name_cache
+
+  let empty_rec_env t = Rec_var_env.empty t.rec_env_table
+
+  let push_rec_binder t rec_env ref =
+    Rec_var_env.push t.rec_env_table rec_env ref
+end
+
 type t =
   { compilation_unit_header_label : Asm_label.t;
     compilation_unit_proto_die : Proto_die.t;
@@ -63,7 +168,9 @@ type t =
     get_file_num : string -> int;
     sourcefile : string;
     diagnostics : Diagnostics.t;
-    complex_shape_cache : Complex_shape.Shape_cache.t
+    complex_shape_cache : Complex_shape.Shape_cache.t;
+    eval_context : Type_shape.Evaluated_shape.Eval_context.t;
+    die_gen_ctx : Die_gen_ctx.t
   }
 
 let create ~compilation_unit_header_label ~compilation_unit_proto_die
@@ -81,7 +188,10 @@ let create ~compilation_unit_header_label ~compilation_unit_proto_die
     get_file_num;
     sourcefile;
     diagnostics = { variables = [] };
-    complex_shape_cache = Complex_shape.Shape_cache.create 100
+    complex_shape_cache = Complex_shape.Shape_cache.create ~initial_size:100;
+    eval_context =
+      Type_shape.Evaluated_shape.Eval_context.create ~initial_size:256;
+    die_gen_ctx = Die_gen_ctx.create ~initial_size:256
   }
 
 let compilation_unit_header_label t = t.compilation_unit_header_label
@@ -107,6 +217,10 @@ let sourcefile t = t.sourcefile
 let diagnostics t = t.diagnostics
 
 let complex_shape_cache t = t.complex_shape_cache
+
+let eval_context t = t.eval_context
+
+let die_gen_ctx t = t.die_gen_ctx
 
 let add_variable_reduction_diagnostic t diagnostic =
   t.diagnostics.variables <- diagnostic :: t.diagnostics.variables

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_state.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_state.ml
@@ -102,7 +102,7 @@ module Die_gen_ctx = struct
       Tbl.find_opt cache { runtime_shape = inp; rec_env }
 
     let add cache ~inp ~rec_env ~outp =
-      Tbl.add cache { runtime_shape = inp; rec_env } outp
+      Tbl.replace cache { runtime_shape = inp; rec_env } outp
   end
 
   (* DWARF DIE cache for named type shapes. *)

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_state.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_state.mli
@@ -17,6 +17,7 @@
 open Asm_targets
 open Dwarf_low
 open Dwarf_high
+module RS = Runtime_shape
 
 type function_range =
   { start_label : Asm_label.t;
@@ -49,6 +50,67 @@ module Diagnostics : sig
     }
 
   type t = { mutable variables : variable_reduction list }
+end
+
+(** Context threaded through the translation of runtime shapes to DWARF DIEs. *)
+module Die_gen_ctx : sig
+  (** The recursive-variable environment used when translating runtime shapes to
+      DWARF DIEs. *)
+  module Rec_var_env : sig
+    type t
+
+    include Hashtbl.HashedType with type t := t
+
+    val get_opt :
+      t -> de_bruijn_index:RS.DeBruijn_index.t -> Proto_die.reference option
+  end
+
+  (** Cache memoizing [runtime_shape_to_dwarf_die] results. *)
+  module Cache : sig
+    type t
+
+    val create : initial_size:int -> t
+
+    val find :
+      t -> inp:RS.t -> rec_env:Rec_var_env.t -> Proto_die.reference option
+
+    val add :
+      t -> inp:RS.t -> rec_env:Rec_var_env.t -> outp:Proto_die.reference -> unit
+  end
+
+  (** DWARF DIE cache for named type shapes. *)
+  module Name_cache : sig
+    type t
+
+    val create : initial_size:int -> t
+
+    (** [find_unused_name_or_cached t name runtime_shape] returns
+        [Left reference] if a (possibly suffix-numbered) version of [name] is
+        already associated with [runtime_shape], or [Right name'] with the first
+        unused suffix-numbered version of [name] otherwise. *)
+    val find_unused_name_or_cached :
+      t -> string -> RS.t -> (Proto_die.reference, string) Either.t
+
+    val add : t -> string -> RS.t -> Proto_die.reference -> unit
+  end
+
+  type t
+
+  val create : initial_size:int -> t
+
+  val cache : t -> Cache.t
+
+  val name_cache : t -> Name_cache.t
+
+  (** The empty recursive-variable environment, interned in this context's table
+      so that it can be used as part of a cache key. *)
+  val empty_rec_env : t -> Rec_var_env.t
+
+  (** [push_rec_binder t rec_env ref] extends [rec_env] with a binding for
+      [ref]. The result is interned in this context's table for use as part of a
+      cache key. *)
+  val push_rec_binder :
+    t -> Rec_var_env.t -> Proto_die.reference -> Rec_var_env.t
 end
 
 type t
@@ -89,6 +151,10 @@ val sourcefile : t -> string
 val diagnostics : t -> Diagnostics.t
 
 val complex_shape_cache : t -> Complex_shape.Shape_cache.t
+
+val eval_context : t -> Type_shape.Evaluated_shape.Eval_context.t
+
+val die_gen_ctx : t -> Die_gen_ctx.t
 
 val add_variable_reduction_diagnostic :
   t -> Diagnostics.variable_reduction -> unit

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_state.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_state.mli
@@ -17,7 +17,6 @@
 open Asm_targets
 open Dwarf_low
 open Dwarf_high
-module RS = Runtime_shape
 
 type function_range =
   { start_label : Asm_label.t;
@@ -62,7 +61,9 @@ module Die_gen_ctx : sig
     include Hashtbl.HashedType with type t := t
 
     val get_opt :
-      t -> de_bruijn_index:RS.DeBruijn_index.t -> Proto_die.reference option
+      t ->
+      de_bruijn_index:Runtime_shape.DeBruijn_index.t ->
+      Proto_die.reference option
   end
 
   (** Cache memoizing [runtime_shape_to_dwarf_die] results. *)
@@ -72,10 +73,17 @@ module Die_gen_ctx : sig
     val create : initial_size:int -> t
 
     val find :
-      t -> inp:RS.t -> rec_env:Rec_var_env.t -> Proto_die.reference option
+      t ->
+      inp:Runtime_shape.t ->
+      rec_env:Rec_var_env.t ->
+      Proto_die.reference option
 
     val add :
-      t -> inp:RS.t -> rec_env:Rec_var_env.t -> outp:Proto_die.reference -> unit
+      t ->
+      inp:Runtime_shape.t ->
+      rec_env:Rec_var_env.t ->
+      outp:Proto_die.reference ->
+      unit
   end
 
   (** DWARF DIE cache for named type shapes. *)
@@ -89,9 +97,9 @@ module Die_gen_ctx : sig
         already associated with [runtime_shape], or [Right name'] with the first
         unused suffix-numbered version of [name] otherwise. *)
     val find_unused_name_or_cached :
-      t -> string -> RS.t -> (Proto_die.reference, string) Either.t
+      t -> string -> Runtime_shape.t -> (Proto_die.reference, string) Either.t
 
-    val add : t -> string -> RS.t -> Proto_die.reference -> unit
+    val add : t -> string -> Runtime_shape.t -> Proto_die.reference -> unit
   end
 
   type t

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
@@ -1207,54 +1207,10 @@ let create_boxed_simd_type ?name ~reference ~parent_proto_die split =
            DAH.create_type_from_reference ~proto_die_reference:base_ref ])
     ()
 
-module Shape_with_layout = struct
-  type t =
-    { type_shape : Shape.t;
-      type_layout : Layout.t
-    }
-
-  include Identifiable.Make (struct
-    type nonrec t = t
-
-    let compare = Stdlib.compare
-    (* CR sspies: Fix compare and equals on this type. Move the module to type
-       shape once it is more cleaned up. *)
-
-    let print fmt { type_shape; type_layout } =
-      Format.fprintf fmt "%a @ %a" Shape.print type_shape
-        (Format_doc.compat Layout.format)
-        type_layout
-
-    let hash { type_shape; type_layout } =
-      Hashtbl.hash (type_shape.hash, type_layout)
-
-    let equal ({ type_shape = x1; type_layout = y1 } : t)
-        ({ type_shape = x2; type_layout = y2 } : t) =
-      Shape.equal x1 x2 && Layout.equal y1 y2
-
-    let output _oc _t = Misc.fatal_error "unimplemented"
-  end)
-end
-
-module Dwarf_die_cache : sig
-  val find_in_cache :
-    RS.t -> rec_env:'a RS.DeBruijn_env.t -> Proto_die.reference option
-
-  val add_to_cache :
-    RS.t -> Proto_die.reference -> rec_env:'a RS.DeBruijn_env.t -> unit
-end = struct
-  let cache = RS.Cache.create 100
-
-  let find_in_cache (runtime_shape : RS.t) ~rec_env =
-    if RS.DeBruijn_env.is_empty rec_env
-    then RS.Cache.find_opt cache runtime_shape
-    else None
-
-  let add_to_cache (runtime_shape : RS.t) reference ~rec_env =
-    (* [rec_env] being empty means that the shape is closed. *)
-    if RS.DeBruijn_env.is_empty rec_env
-    then RS.Cache.add cache runtime_shape reference
-end
+module Die_gen_ctx = DS.Die_gen_ctx
+module Rec_var_env = Die_gen_ctx.Rec_var_env
+module Cache = Die_gen_ctx.Cache
+module Name_cache = Die_gen_ctx.Name_cache
 
 let partition_constructors constructors ~f =
   List.partition_map
@@ -1276,22 +1232,22 @@ let partition_constructors constructors ~f =
    [runtime_shape_to_dwarf_die] only works for types without names, and types
    with names are handled in [runtime_shape_to_dwarf_die_with_aliased_name]
    below. *)
-let rec runtime_shape_to_dwarf_die (t : RS.t) ~parent_proto_die
+let rec runtime_shape_to_dwarf_die ~ctx (t : RS.t) ~parent_proto_die
     ~fallback_value_die ~rec_env =
-  match Dwarf_die_cache.find_in_cache t ~rec_env with
+  match Cache.find (Die_gen_ctx.cache ctx) ~inp:t ~rec_env with
   | Some reference -> reference
   | None ->
     let reference = Proto_die.create_reference () in
-    Dwarf_die_cache.add_to_cache t reference ~rec_env;
+    Cache.add (Die_gen_ctx.cache ctx) ~inp:t ~rec_env ~outp:reference;
     let name = None in
     (* Instead of omitting the name argument below, we fix it to be [None] here
        such that it is easier to change this code if in the future we want to
        change how the names of types are handled. *)
-    runtime_shape_to_dwarf_die_memo t ?name ~reference ~parent_proto_die
+    runtime_shape_to_dwarf_die_memo ~ctx t ?name ~reference ~parent_proto_die
       ~fallback_value_die ~rec_env;
     reference
 
-and runtime_shape_to_dwarf_die_memo ~reference ?name (t : RS.t)
+and runtime_shape_to_dwarf_die_memo ~ctx ~reference ?name (t : RS.t)
     ~parent_proto_die ~fallback_value_die ~rec_env : unit =
   let err ~fallback f =
     if !Clflags.dwarf_pedantic
@@ -1301,11 +1257,12 @@ and runtime_shape_to_dwarf_die_memo ~reference ?name (t : RS.t)
         ~fallback_value_die ()
   in
   let die sh =
-    runtime_shape_to_dwarf_die ~parent_proto_die ~fallback_value_die ~rec_env sh
+    runtime_shape_to_dwarf_die ~ctx ~parent_proto_die ~fallback_value_die
+      ~rec_env sh
   in
   let die_with_extended_env sh new_ref =
-    runtime_shape_to_dwarf_die ~parent_proto_die ~fallback_value_die
-      ~rec_env:(RS.DeBruijn_env.push rec_env new_ref)
+    runtime_shape_to_dwarf_die ~ctx ~parent_proto_die ~fallback_value_die
+      ~rec_env:(Die_gen_ctx.push_rec_binder ctx rec_env new_ref)
       sh
   in
   match t.desc with
@@ -1313,8 +1270,8 @@ and runtime_shape_to_dwarf_die_memo ~reference ?name (t : RS.t)
     create_runtime_layout_type ~reference type_layout ?name ~parent_proto_die
       ~fallback_value_die ()
   | Predef p ->
-    predef_to_dwarf_die ~reference ?name p ~parent_proto_die ~fallback_value_die
-      ~rec_env
+    predef_to_dwarf_die ~ctx ~reference ?name p ~parent_proto_die
+      ~fallback_value_die ~rec_env
   | Tuple { args; kind = Tuple_boxed } ->
     (* CR sspies: In the future, tuples have to be handled like mixed
        records. *)
@@ -1406,7 +1363,7 @@ and runtime_shape_to_dwarf_die_memo ~reference ?name (t : RS.t)
              Format.pp_print_string)
           constructor_names)
   | Rec_var (de_bruijn_index, layout) -> (
-    match RS.DeBruijn_env.get_opt rec_env ~de_bruijn_index with
+    match Rec_var_env.get_opt rec_env ~de_bruijn_index with
     | Some reference' ->
       create_typedef_die ~reference ~parent_proto_die ?name reference'
     | None ->
@@ -1421,10 +1378,11 @@ and runtime_shape_to_dwarf_die_memo ~reference ?name (t : RS.t)
     let reference' = die_with_extended_env sh reference in
     create_typedef_die ~reference ~parent_proto_die ?name reference'
 
-and predef_to_dwarf_die ~reference ?name (t : RS.predef) ~parent_proto_die
+and predef_to_dwarf_die ~ctx ~reference ?name (t : RS.predef) ~parent_proto_die
     ~fallback_value_die ~rec_env =
   let die sh =
-    runtime_shape_to_dwarf_die ~parent_proto_die ~fallback_value_die ~rec_env sh
+    runtime_shape_to_dwarf_die ~ctx ~parent_proto_die ~fallback_value_die
+      ~rec_env sh
   in
   match t with
   | Array (Regular s) ->
@@ -1456,11 +1414,6 @@ and predef_to_dwarf_die ~reference ?name (t : RS.predef) ~parent_proto_die
       ~fallback_value_die ()
 (* CR sspies: Create a separate block for lazy values. We now have type
    information for them. *)
-
-(** This second cache is for named type shapes. Every type name should be
-    associated with at most one DWARF die, so this cache maps type names to type
-    shapes and DWARF dies. *)
-let name_cache = String.Tbl.create 16
 
 module With_cms_reduce = Shape_reduce.Make (struct
   let fuel () = MB.of_option !Clflags.gdwarf_config_shape_reduce_fuel
@@ -1549,43 +1502,29 @@ end)
 
 module D = Shape_reduction_diagnostics
 
-(* Search for the first unused suffix-numbered version of [name] in the
-   [name_cache] cache. If we come along a type of the same name and runtime
-   shape, then we simply use that reference. *)
-let find_unused_type_name_or_cached (name : string) (runtime_shape : RS.t) :
-    (Proto_die.reference, string) Either.t =
-  let rec aux inc : _ Either.t =
-    let name_suffix = if inc = 0 then "" else "/" ^ string_of_int inc in
-    let name = name ^ name_suffix in
-    match String.Tbl.find_opt name_cache name with
-    | Some (runtime_shape', reference) ->
-      if RS.equal runtime_shape runtime_shape'
-      then Left reference
-      else aux (inc + 1)
-    | None -> Right name
-  in
-  aux 0
-
 (* We represent all types as DIE entries of the form [typedef ... type_name;]
    and use caching for types that have the same name and shape. For name
    conflicts, we search for the next available suffix-numbered version of the
    name, [type_name/n]. *)
-let runtime_shape_to_dwarf_die_with_aliased_name (type_name : string)
+let runtime_shape_to_dwarf_die_with_aliased_name ~ctx (type_name : string)
     (runtime_shape : RS.t) ~parent_proto_die ~fallback_value_die :
     Proto_die.reference =
-  match find_unused_type_name_or_cached type_name runtime_shape with
+  let name_cache = Die_gen_ctx.name_cache ctx in
+  match
+    Name_cache.find_unused_name_or_cached name_cache type_name runtime_shape
+  with
   | Left reference -> reference
   | Right name ->
     let unnamed_die =
-      runtime_shape_to_dwarf_die runtime_shape ~parent_proto_die
+      runtime_shape_to_dwarf_die ~ctx runtime_shape ~parent_proto_die
         ~fallback_value_die (* note that we do not pass the type name here *)
-        ~rec_env:RS.DeBruijn_env.empty
+        ~rec_env:(Die_gen_ctx.empty_rec_env ctx)
     in
     let reference = Proto_die.create_reference () in
     let runtime_layout = RS.runtime_layout runtime_shape in
     let layout_name = RL.to_string runtime_layout in
     let full_name = name ^ " @ " ^ layout_name in
-    String.Tbl.add name_cache name (runtime_shape, reference);
+    Name_cache.add name_cache name runtime_shape reference;
     create_typedef_die ~reference ~name:full_name ~parent_proto_die unnamed_die;
     reference
 
@@ -1633,6 +1572,7 @@ let variable_to_die state ~value_type_proto_die (var_uid : Uid.t)
       Profile.record "unfold_and_evaluate"
         (fun () ->
           Type_shape.Evaluated_shape.unfold_and_evaluate
+            ~ctx:(DS.eval_context state)
             ~diagnostics:(D.shape_evaluation_diagnostics reduction_diagnostics)
             type_shape)
         ~accumulate:true ()
@@ -1699,8 +1639,9 @@ let variable_to_die state ~value_type_proto_die (var_uid : Uid.t)
         let reference =
           Profile.record "dwarf_produce_dies"
             (fun () ->
-              runtime_shape_to_dwarf_die_with_aliased_name type_name
-                runtime_shape ~parent_proto_die ~fallback_value_die)
+              runtime_shape_to_dwarf_die_with_aliased_name
+                ~ctx:(DS.die_gen_ctx state) type_name runtime_shape
+                ~parent_proto_die ~fallback_value_die)
             ~accumulate:true ()
         in
         if Debugging_the_compiler.enabled ()

--- a/backend/debug/dwarf/dwarf_ocaml/runtime_shape.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/runtime_shape.ml
@@ -41,6 +41,8 @@ module DeBruijn_index = struct
 
   let equal n1 n2 = Int.equal n1 n2
 
+  let hash n = n
+
   let print fmt n = Format.fprintf fmt "%d" n
 end
 
@@ -53,7 +55,10 @@ module DeBruijn_env = struct
 
   let push t x = x :: t
 
-  let is_empty = function [] -> true | _ -> false
+  let equal equal_elem = List.equal equal_elem
+
+  let hash hash_elem l =
+    List.fold_left (fun acc v -> Hashtbl.hash (hash_elem v, acc)) 0 l
 end
 
 module Or_void = struct
@@ -908,11 +913,3 @@ let constructor_args = function
     List.map
       (fun { field_type; label } -> { field_type; label = Some label })
       args
-
-module Cache = Hashtbl.Make (struct
-  type nonrec t = t
-
-  let equal = equal
-
-  let hash = hash
-end)

--- a/backend/debug/dwarf/dwarf_ocaml/runtime_shape.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/runtime_shape.mli
@@ -39,6 +39,8 @@ module DeBruijn_index : sig
 
   val equal : t -> t -> bool
 
+  val hash : t -> int
+
   val print : Format.formatter -> t -> unit
 end
 
@@ -48,11 +50,13 @@ module DeBruijn_env : sig
 
   val empty : 'a t
 
-  val is_empty : 'a t -> bool
-
   val push : 'a t -> 'a -> 'a t
 
   val get_opt : 'a t -> de_bruijn_index:DeBruijn_index.t -> 'a option
+
+  val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+  val hash : ('a -> int) -> 'a t -> int
 end
 
 module Or_void : sig
@@ -329,5 +333,3 @@ val print : Format.formatter -> t -> unit
 val equal : t -> t -> bool
 
 val hash : t -> int
-
-module Cache : Hashtbl.S with type key = t

--- a/dune
+++ b/dune
@@ -150,6 +150,7 @@
   config
   build_path_prefix_map
   misc
+  hash_consed
   identifiable
   numbers
   arg_helper

--- a/otherlibs/dynlink/dune
+++ b/otherlibs/dynlink/dune
@@ -138,6 +138,7 @@
   value_rec_types
   btype
   lazy_backtrack
+  hash_consed
   type_shape
   zero_alloc_utils
   diffing
@@ -268,6 +269,8 @@
 (copy_files ../../utils/linkage_name.ml)
 
 (copy_files ../../utils/lazy_backtrack.ml)
+
+(copy_files ../../utils/hash_consed.ml)
 
 (copy_files ../../utils/zero_alloc_utils.ml)
 
@@ -473,6 +476,8 @@
 (copy_files ../../utils/linkage_name.mli)
 
 (copy_files ../../utils/lazy_backtrack.mli)
+
+(copy_files ../../utils/hash_consed.mli)
 
 (copy_files ../../utils/zero_alloc_utils.mli)
 
@@ -725,6 +730,7 @@
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Printast.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Syntaxerr.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Lazy_backtrack.cmo
+  .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Hash_consed.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Zero_alloc_utils.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Diffing.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Diffing_with_keys.cmo
@@ -857,6 +863,7 @@
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Lexer.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Path.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Lazy_backtrack.cmx
+  .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Hash_consed.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Zero_alloc_utils.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Diffing.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Diffing_with_keys.cmx

--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -146,7 +146,16 @@ module Rec_var_ident = struct
     | comp_unit -> Format.fprintf fmt "rv%s.%d" comp_unit id
 end
 
-module Rec_var_env = Map.Make (Rec_var_ident)
+module Rec_var_env = struct
+  include Map.Make (Rec_var_ident)
+
+  let hash hash_value m =
+    fold
+      (fun k v acc -> Hashtbl.hash (Rec_var_ident.hash k, hash_value v, acc))
+      m 0
+
+  let equal eq_value m1 m2 = m1 == m2 || equal eq_value m1 m2
+end
 
 module Sig_component_kind = struct
   type t =
@@ -642,7 +651,7 @@ let rec equal_desc0 d1 d2 =
     Rec_var_ident.equal rv1 rv2 && equal t1_body t2_body
   | Rec_var rv1, Rec_var rv2 -> Rec_var_ident.equal rv1 rv2
   | Struct t1, Struct t2 ->
-    Item.Map.equal equal t1 t2
+    t1 == t2 || Item.Map.equal equal t1 t2
   | Proj (t1, i1), Proj (t2, i2) ->
     if Item.compare i1 i2 <> 0 then false
     else equal t1 t2
@@ -651,7 +660,7 @@ let rec equal_desc0 d1 d2 =
     Ident.equal c1 c2
     && List.equal equal ts1 ts2
   | Mutrec t1, Mutrec t2 ->
-    Ident.Map.equal equal t1 t2
+    t1 == t2 || Ident.Map.equal equal t1 t2
   | Proj_decl (t1, i1), Proj_decl (t2, i2) ->
     if Ident.equal i1 i2 then
       equal t1 t2
@@ -719,6 +728,8 @@ and equal_poly_variant_constructor
   { pv_constr_name = name2; pv_constr_args = args2 } =
   String.equal name1 name2 &&
   List.equal equal args1 args2
+
+let hash t = t.hash
 
 let rec print fmt t =
   let print_uid_opt =
@@ -1262,11 +1273,3 @@ module Map = struct
     let item = Item.jkind id in
     Item.Map.add item (proj shape item) t
 end
-
-module Cache = Hashtbl.Make (struct
-  type nonrec t = t
-
-  let hash t = t.hash
-
-  let equal = equal
-end)

--- a/typing/shape.mli
+++ b/typing/shape.mli
@@ -111,6 +111,10 @@ module Rec_var_env : sig
   val find_opt : Rec_var_ident.t -> 'a t -> 'a option
 
   val map : ('a -> 'b) -> 'a t -> 'b t
+
+  val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+  val hash : ('a -> int) -> 'a t -> int
 end
 
 module Sig_component_kind : sig
@@ -364,6 +368,8 @@ val equal_record_kind : record_kind -> record_kind -> bool
 val equal_complex_constructor :
   ('a -> 'a -> bool) -> 'a complex_constructor -> 'a complex_constructor -> bool
 
+val hash : t -> int
+
 (* Smart constructors *)
 
 val for_unnamed_functor_param : var
@@ -478,5 +484,3 @@ val of_path :
   namespace:Sig_component_kind.t -> Path.t -> t
 
 val set_uid_if_none : t -> Uid.t -> t
-
-module Cache : Hashtbl.S with type key = t

--- a/typing/shape_reduce.ml
+++ b/typing/shape_reduce.ml
@@ -227,7 +227,7 @@ end) = struct
       else false
     | NLeaf, NLeaf -> true
     | NStruct t1, NStruct t2 ->
-      Item.Map.equal equal_delayed_nf t1 t2
+      t1 == t2 || Item.Map.equal equal_delayed_nf t1 t2
     | NProj (t1, i1), NProj (t2, i2) ->
       if Item.compare i1 i2 <> 0 then false
       else equal_nf t1 t2
@@ -238,7 +238,7 @@ end) = struct
       Shape.Rec_var_ident.equal rv1 rv2 && equal_nf nf1 nf2
     | NRec_var rv1, NRec_var rv2 -> Shape.Rec_var_ident.equal rv1 rv2
     | NMutrec defs1, NMutrec defs2 ->
-      Ident.Map.equal equal_nf defs1 defs2
+      defs1 == defs2 || Ident.Map.equal equal_nf defs1 defs2
     | NProj_decl (nf1, id1), NProj_decl (nf2, id2) ->
       Ident.equal id1 id2 && equal_nf nf1 nf2
     | NConstr (id1, args1), NConstr (id2, args2) ->

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -948,7 +948,7 @@ end = struct
 
   let create ~initial_size = Cache.create initial_size
 
-  let add eval_cache ~inp ~env ~outp = Cache.add eval_cache (inp, env) outp
+  let add eval_cache ~inp ~env ~outp = Cache.replace eval_cache (inp, env) outp
 
   let find eval_cache ~inp ~env = Cache.find_opt eval_cache (inp, env)
 end

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -832,6 +832,14 @@ module Eval_env = struct
   (* The substitution maps are deduplicated individually (rather than as one
    bundle) to avoid combinatorial blowup when one map changes and the others
    stay the same. *)
+  (* CR-someday sspies: Each extension of an environment re-hashes the whole
+     map when interning it, making a chain of [n] extensions O(n^2). If this
+     shows up in profiles, cache a commutative (multiset) hash alongside each
+     map, i.e. the sum of the per-binding hashes, and update it incrementally
+     on extension. The same applies to [Rec_binder_env.add_binder] in
+     [Complex_shape], where fixing it additionally requires switching the
+     environment to absolute binder depths to avoid the De Bruijn shift
+     rewriting the entire map. *)
   type t =
     { type_var_env : Type_var_env.t;
       mutrec_env : Mutrec_env.t;

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -48,6 +48,10 @@ module Recursive_binder : sig
   val mark_as_used : t -> Shape.t
 
   val close_term_if_binder_is_used : t -> Shape.t -> Shape.t
+
+  val equal : t -> t -> bool
+
+  val hash : t -> int
 end = struct
   type t =
     { rv : Shape.Rec_var_ident.t;
@@ -62,6 +66,10 @@ end = struct
 
   let close_term_if_binder_is_used db sh =
     if not db.used then sh else Shape.mu db.rv sh
+
+  let equal t1 t2 = t1 == t2
+
+  let hash t = Shape.Rec_var_ident.hash t.rv
 end
 
 module Type_shape = struct
@@ -775,32 +783,117 @@ let rec decompose_application (t : Shape.t) =
   | Unknown_type | At_layout _ ->
     t, []
 
-let find_constr_id_with_args (subst_constr, _) id args =
-  match Ident.Map.find_opt id subst_constr with
-  | Some t ->
-    List.find_opt (fun (args', _) -> List.equal Shape.equal args args') t
-    |> Option.map snd
-  | None -> None
+module Shape_map = struct
+  type t = Shape.t Ident.Map.t
 
-let find_mut_rec_shape (_, subst_constr_mut) id =
-  Ident.Map.find_opt id subst_constr_mut
-
-let update_subst_with_id_arg_binder (subst_constr, subst_constr_mut) id args
-    rec_binder =
-  let new_list =
-    (args, rec_binder)
-    ::
-    (match Ident.Map.find_opt id subst_constr with
-    | Some t -> t
-    | None -> [])
-  in
-  Ident.Map.add id new_list subst_constr, subst_constr_mut
-
-let update_subst_with_mutrec_decl (subst_constr, subst_constr_mut) t map =
-  ( subst_constr,
+  let hash m =
     Ident.Map.fold
-      (fun id _ map -> Ident.Map.add id (Shape.proj_decl t id) map)
-      map subst_constr_mut )
+      (fun id shape acc -> Hashtbl.hash (Ident.hash id, shape.Shape.hash, acc))
+      m 0
+
+  let equal m1 m2 = m1 == m2 || Ident.Map.equal Shape.equal m1 m2
+end
+
+(* Maps type variables to their shape substitutions, for beta reduction of type
+   applications. *)
+module Type_var_env = Hash_consed.Dedup (Shape_map) ()
+
+(* Maps constructor ids to the mutually recursive declaration shapes they belong
+   to. *)
+module Mutrec_env = Hash_consed.Dedup (Shape_map) ()
+
+(* Maps constructor ids to (args, recursive binder) pairs, for cycle detection
+   during evaluation. *)
+module Rec_constr_env =
+  Hash_consed.Dedup
+    (struct
+      type t = (Shape.t list * Recursive_binder.t) list Ident.Map.t
+
+      let hash =
+        let hash_entry (args, rb) =
+          Hashtbl.hash
+            (List.map (fun s -> s.Shape.hash) args, Recursive_binder.hash rb)
+        in
+        fun m ->
+          Ident.Map.fold
+            (fun id entries acc ->
+              Hashtbl.hash (Ident.hash id, List.map hash_entry entries, acc))
+            m 0
+
+      let equal =
+        let equal_entry (args1, rb1) (args2, rb2) =
+          Recursive_binder.equal rb1 rb2 && List.equal Shape.equal args1 args2
+        in
+        fun m1 m2 -> m1 == m2 || Ident.Map.equal (List.equal equal_entry) m1 m2
+    end)
+    ()
+
+module Eval_env = struct
+  (* The substitution maps are deduplicated individually (rather than as one
+   bundle) to avoid combinatorial blowup when one map changes and the others
+   stay the same. *)
+  type t =
+    { type_var_env : Type_var_env.t;
+      mutrec_env : Mutrec_env.t;
+      rec_constr_env : Rec_constr_env.t
+    }
+
+  let equal t1 t2 =
+    Type_var_env.equal t1.type_var_env t2.type_var_env
+    && Mutrec_env.equal t1.mutrec_env t2.mutrec_env
+    && Rec_constr_env.equal t1.rec_constr_env t2.rec_constr_env
+
+  let hash { type_var_env; mutrec_env; rec_constr_env } =
+    Hashtbl.hash
+      ( Type_var_env.hash type_var_env,
+        Mutrec_env.hash mutrec_env,
+        Rec_constr_env.hash rec_constr_env )
+
+  let empty ~type_var_table ~mutrec_table ~rec_constr_table =
+    { type_var_env = Type_var_env.create type_var_table Ident.Map.empty;
+      mutrec_env = Mutrec_env.create mutrec_table Ident.Map.empty;
+      rec_constr_env = Rec_constr_env.create rec_constr_table Ident.Map.empty
+    }
+
+  let lookup_rec_constr t id args =
+    let rec_constr_env = Rec_constr_env.value t.rec_constr_env in
+    match Ident.Map.find_opt id rec_constr_env with
+    | Some entries ->
+      List.find_opt
+        (fun (args', _) -> List.equal Shape.equal args args')
+        entries
+      |> Option.map snd
+    | None -> None
+
+  let lookup_mutrec_decl t id =
+    Ident.Map.find_opt id (Mutrec_env.value t.mutrec_env)
+
+  let lookup_type_var t id =
+    Ident.Map.find_opt id (Type_var_env.value t.type_var_env)
+
+  let extend_rec_constr_env ~rec_constr_table t id args rec_binder =
+    let map = Rec_constr_env.value t.rec_constr_env in
+    let old_list = Option.value ~default:[] (Ident.Map.find_opt id map) in
+    let map = Ident.Map.add id ((args, rec_binder) :: old_list) map in
+    { t with rec_constr_env = Rec_constr_env.create rec_constr_table map }
+
+  let extend_mutrec_env ~mutrec_table t ~self ~defs =
+    let map =
+      Ident.Map.fold
+        (fun id _ acc -> Ident.Map.add id (Shape.proj_decl self id) acc)
+        defs
+        (Mutrec_env.value t.mutrec_env)
+    in
+    { t with mutrec_env = Mutrec_env.create mutrec_table map }
+
+  let extend_type_var_env ~type_var_table t id shape =
+    let map = Ident.Map.add id shape (Type_var_env.value t.type_var_env) in
+    { t with type_var_env = Type_var_env.create type_var_table map }
+end
+
+(* Deduplicates evaluated shapes so that structurally-equal results are
+   shared. *)
+module Shape_dedup = Hash_consed.Dedup (Shape) ()
 
 module Evaluation_diagnostics = struct
   type evaluate_diagnostics = { mutable reduction_steps : int }
@@ -823,42 +916,54 @@ end
 module D = Evaluation_diagnostics
 
 (* The cache can be used across invocations of [unfold_and_evaluate] and can
-   improve the performance if we deal with the same type (or components of it)
+   improve performance if we deal with the same type (or components of it)
    repeatedly. *)
-let eval_cache = Shape.Cache.create 256
+module Eval_cache : sig
+  type t
 
-let add_to_cache t res subst_type (subst_constr_mut, subst_constr) =
-  (* Due to internal sharing in memory, type shapes can become too large to
-     traverse recursively. As such, we cannot check here whether the shape [t]
-     is actually closed. We approximate this by checking whether it is being
-     evaluated in an empty environment, since an empty environment will always
-     lead to the same result (regardless of whether the shape is actually
-     closed). In an empty environment:
+  val create : initial_size:int -> t
 
-     - [subst_type] is empty, meaning there are no free type variables to
-       substitute,
+  val add : t -> inp:Shape.t -> env:Eval_env.t -> outp:Shape.t -> unit
 
-     - [subst_constr_mut] is empty, meaning there are no mutually-recursive
-       declarations that we could insert for [Constr]-entries, and
+  val find : t -> inp:Shape.t -> env:Eval_env.t -> Shape.t option
+end = struct
+  module Cache = Hashtbl.Make (struct
+    type t = Shape.t * Eval_env.t
 
-     - [subst_constr] is empty, meaning there are no recursive occurrences
-       of a particular [Constr (id, args)] to be substituted with a recursive
-       variable. *)
-  if
-    Ident.Map.is_empty subst_type
-    && Ident.Map.is_empty subst_constr_mut
-    && Ident.Map.is_empty subst_constr
-  then Shape.Cache.add eval_cache t res
+    let equal (s1, env1) (s2, env2) =
+      Shape.equal s1 s2 && Eval_env.equal env1 env2
 
-let find_in_cache t subst_type (subst_constr_mut, subst_constr) =
-  (* We perform the same emptiness check as in [add_to_cache] when looking up a
-     value. *)
-  if
-    Ident.Map.is_empty subst_type
-    && Ident.Map.is_empty subst_constr_mut
-    && Ident.Map.is_empty subst_constr
-  then Shape.Cache.find_opt eval_cache t
-  else None
+    let hash (s, env) = Hashtbl.hash (s.Shape.hash, Eval_env.hash env)
+  end)
+
+  type t = Shape.t Cache.t
+
+  let create ~initial_size = Cache.create initial_size
+
+  let add eval_cache ~inp ~env ~outp = Cache.add eval_cache (inp, env) outp
+
+  let find eval_cache ~inp ~env = Cache.find_opt eval_cache (inp, env)
+end
+
+(* Bundles the hash-consing tables and the evaluation cache used by
+   [unfold_and_evaluate]. *)
+module Eval_context = struct
+  type t =
+    { type_var_table : Type_var_env.table;
+      mutrec_table : Mutrec_env.table;
+      rec_constr_table : Rec_constr_env.table;
+      shape_dedup_table : Shape_dedup.table;
+      eval_cache : Eval_cache.t
+    }
+
+  let create ~initial_size =
+    { type_var_table = Type_var_env.create_table ~initial_size;
+      mutrec_table = Mutrec_env.create_table ~initial_size;
+      rec_constr_table = Rec_constr_env.create_table ~initial_size;
+      shape_dedup_table = Shape_dedup.create_table ~initial_size;
+      eval_cache = Eval_cache.create ~initial_size
+    }
+end
 
 let is_above_unfold_and_evaluate_max_depth depth =
   match !Clflags.gdwarf_config_shape_eval_depth with
@@ -867,27 +972,31 @@ let is_above_unfold_and_evaluate_max_depth depth =
 
 (* To unroll the mutually recursive declarations, we perform a simple call by
    value evaluation and catch cycles for ident binders. *)
-let rec unfold_and_evaluate ~diagnostics ~depth ~steps_remaining subst_type
-    subst_constr (t : Shape.t) =
+let rec unfold_and_evaluate ~ctx ~diagnostics ~depth ~steps_remaining ~env
+    (t : Shape.t) =
   D.count_evaluation_step diagnostics;
   if Misc.Maybe_bounded.is_depleted steps_remaining
   then Shape.unknown_type ()
   else if is_above_unfold_and_evaluate_max_depth depth
-  then Shape.unknown_type ()
+  then
+    (* CR sspies: There is a caching bug here, which can lead to worse results:
+       The fallback value returned here goes into the cache and is reused by
+       subsequent calls even if they have a larger depth limit (or more
+       evaluation steps) available such that they could in principle still
+       compute the fully evaluated result. *)
+    Shape.unknown_type ()
   else (
     Misc.Maybe_bounded.decr steps_remaining;
-    match find_in_cache t subst_type subst_constr with
+    match Eval_cache.find ctx.Eval_context.eval_cache ~inp:t ~env with
     | Some res -> res
     | None ->
-      unfold_and_evaluate0 ~diagnostics ~depth ~steps_remaining subst_type
-        subst_constr t)
+      unfold_and_evaluate0 ~ctx ~diagnostics ~depth ~steps_remaining ~env t)
 
-and unfold_and_evaluate0 ~diagnostics ~depth ~steps_remaining subst_type
-    subst_constr (t : Shape.t) =
+and unfold_and_evaluate0 ~ctx ~diagnostics ~depth ~steps_remaining ~env
+    (t : Shape.t) =
   let head, args = decompose_application t in
   let unfold_and_eval =
-    unfold_and_evaluate ~diagnostics ~depth ~steps_remaining subst_type
-      subst_constr
+    unfold_and_evaluate ~ctx ~diagnostics ~depth ~steps_remaining ~env
   in
   let unfold_and_eval_list = List.map unfold_and_eval in
   let maybe_evaluated_shape =
@@ -901,13 +1010,18 @@ and unfold_and_evaluate0 ~diagnostics ~depth ~steps_remaining subst_type
       | Mutrec ts ->
         let depth = depth + 1 in
         let rec_binder = Recursive_binder.create () in
-        let subst_constr = update_subst_with_mutrec_decl subst_constr str ts in
-        let subst_constr =
-          update_subst_with_id_arg_binder subst_constr id args rec_binder
+        let env =
+          Eval_env.extend_mutrec_env ~mutrec_table:ctx.Eval_context.mutrec_table
+            env ~self:str ~defs:ts
+        in
+        let env =
+          Eval_env.extend_rec_constr_env
+            ~rec_constr_table:ctx.Eval_context.rec_constr_table env id args
+            rec_binder
         in
         let ts = Ident.Map.find id ts in
-        unfold_and_evaluate ~diagnostics ~depth ~steps_remaining subst_type
-          subst_constr (Shape.app_list ts args)
+        unfold_and_evaluate ~ctx ~diagnostics ~depth ~steps_remaining ~env
+          (Shape.app_list ts args)
         |> Recursive_binder.close_term_if_binder_is_used rec_binder
         |> Option.some
       | Unknown_type | At_layout _ | Error _ -> None
@@ -954,15 +1068,15 @@ and unfold_and_evaluate0 ~diagnostics ~depth ~steps_remaining subst_type
     | None -> (
       match t.desc with
       | Var id -> (
-        match Ident.Map.find_opt id subst_type with
+        match Eval_env.lookup_type_var env id with
         | Some t -> t
         | None -> t (* we encountered a free variable *))
       | Constr (id, constr_args) -> (
         let constr_args = unfold_and_eval_list constr_args in
-        match find_constr_id_with_args subst_constr id constr_args with
+        match Eval_env.lookup_rec_constr env id constr_args with
         | Some t -> Recursive_binder.mark_as_used t
         | None -> (
-          match find_mut_rec_shape subst_constr id with
+          match Eval_env.lookup_mutrec_decl env id with
           | Some t -> unfold_and_eval (Shape.app_list t constr_args)
           | None -> Shape.unknown_type ()))
       | App (f, arg) -> (
@@ -970,9 +1084,11 @@ and unfold_and_evaluate0 ~diagnostics ~depth ~steps_remaining subst_type
         let arg = unfold_and_eval arg in
         match f.Shape.desc with
         | Abs (x, s') ->
-          unfold_and_evaluate ~diagnostics ~depth ~steps_remaining
-            (Ident.Map.add x arg subst_type)
-            subst_constr s'
+          let env =
+            Eval_env.extend_type_var_env
+              ~type_var_table:ctx.Eval_context.type_var_table env x arg
+          in
+          unfold_and_evaluate ~ctx ~diagnostics ~depth ~steps_remaining ~env s'
         | Var _
         | App (_, _)
         | Struct _ | Alias _ | Leaf
@@ -1016,20 +1132,18 @@ and unfold_and_evaluate0 ~diagnostics ~depth ~steps_remaining subst_type
           arg_layout
       | Proj (t, i) ->
         Shape.proj
-          (unfold_and_evaluate ~diagnostics ~depth ~steps_remaining subst_type
-             subst_constr t)
+          (unfold_and_evaluate ~ctx ~diagnostics ~depth ~steps_remaining ~env t)
           i
       | Tuple args -> Shape.tuple (unfold_and_eval_list args)
       | Unboxed_tuple args -> Shape.unboxed_tuple (unfold_and_eval_list args)
       | Predef (p, args) -> Shape.predef p (unfold_and_eval_list args)
       | Mu (rv, body) ->
         Shape.mu rv
-          (unfold_and_evaluate ~diagnostics ~depth ~steps_remaining subst_type
-             subst_constr body)
+          (unfold_and_evaluate ~ctx ~diagnostics ~depth ~steps_remaining ~env
+             body)
       | Alias t ->
         Shape.alias
-          (unfold_and_evaluate ~diagnostics ~depth ~steps_remaining subst_type
-             subst_constr t)
+          (unfold_and_evaluate ~ctx ~diagnostics ~depth ~steps_remaining ~env t)
       | At_layout (t, layout) -> Shape.at_layout (unfold_and_eval t) layout
       | Struct items -> Shape.str (Shape.Item.Map.map unfold_and_eval items)
       (* normal forms for CBV evaluation *)
@@ -1037,18 +1151,24 @@ and unfold_and_evaluate0 ~diagnostics ~depth ~steps_remaining subst_type
       | Unknown_type ->
         t)
   in
-  add_to_cache t result subst_type subst_constr;
+  let result =
+    Shape_dedup.canonical ctx.Eval_context.shape_dedup_table result
+  in
+  Eval_cache.add ctx.Eval_context.eval_cache ~inp:t ~env ~outp:result;
   result
 
-let unfold_and_evaluate ?(diagnostics = Evaluation_diagnostics.no_diagnostics) t
-    =
+let unfold_and_evaluate ~ctx
+    ?(diagnostics = Evaluation_diagnostics.no_diagnostics) t =
   let steps_remaining =
     Misc.Maybe_bounded.of_option
       !Clflags.gdwarf_config_max_evaluation_steps_per_variable
   in
-  unfold_and_evaluate ~diagnostics ~depth:0 ~steps_remaining Ident.Map.empty
-    (Ident.Map.empty, Ident.Map.empty)
-    t
+  let env =
+    Eval_env.empty ~type_var_table:ctx.Eval_context.type_var_table
+      ~mutrec_table:ctx.Eval_context.mutrec_table
+      ~rec_constr_table:ctx.Eval_context.rec_constr_table
+  in
+  unfold_and_evaluate ~ctx ~diagnostics ~depth:0 ~steps_remaining ~env t
 
 (** Instead of exposing [unfold_and_evaluate] directly, we expose the module
     [Evaluated_shape] such that subsequent translations can, using types,
@@ -1056,6 +1176,8 @@ let unfold_and_evaluate ?(diagnostics = Evaluation_diagnostics.no_diagnostics) t
     [Complex_shape.type_shape_to_complex_shape]. *)
 module Evaluated_shape = struct
   type t = Shape.t
+
+  module Eval_context = Eval_context
 
   let unfold_and_evaluate = unfold_and_evaluate
 

--- a/typing/type_shape.mli
+++ b/typing/type_shape.mli
@@ -97,10 +97,18 @@ end
 module Evaluated_shape : sig
   type t
 
+  (** Holds the hash-consing tables and evaluation cache used by
+      [unfold_and_evaluate]. *)
+  module Eval_context : sig
+    type t
+
+    val create : initial_size:int -> t
+  end
+
   (** Evaluate a shape that has already been reduced via [shape_reduce]. This
       unfolds recursive declarations into recursive types using [Mu]. *)
   val unfold_and_evaluate :
-    ?diagnostics:Evaluation_diagnostics.t -> Shape.t -> t
+    ctx:Eval_context.t -> ?diagnostics:Evaluation_diagnostics.t -> Shape.t -> t
 
   (** Access the underlying shape. *)
   val shape : t -> Shape.t

--- a/utils/.ocamlformat-enable
+++ b/utils/.ocamlformat-enable
@@ -2,6 +2,8 @@ compilation_unit.ml
 compilation_unit.mli
 doubly_linked_list.ml
 doubly_linked_list.mli
+hash_consed.ml
+hash_consed.mli
 import_info.ml
 import_info.mli
 language_extension_kernel.ml

--- a/utils/hash_consed.ml
+++ b/utils/hash_consed.ml
@@ -1,0 +1,96 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Simon Spies, Jane Street Europe                       *)
+(*                                                                        *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   Permission is hereby granted, free of charge, to any person          *)
+(*   obtaining a copy of this software and associated documentation       *)
+(*   files (the "Software"), to deal in the Software without              *)
+(*   restriction, including without limitation the rights to use, copy,   *)
+(*   modify, merge, publish, distribute, sublicense, and/or sell copies   *)
+(*   of the Software, and to permit persons to whom the Software is       *)
+(*   furnished to do so, subject to the following conditions:             *)
+(*                                                                        *)
+(*   The above copyright notice and this permission notice shall be       *)
+(*   included in all copies or substantial portions of the Software.      *)
+(*                                                                        *)
+(*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,      *)
+(*   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF   *)
+(*   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND                *)
+(*   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS  *)
+(*   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN   *)
+(*   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN    *)
+(*   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE     *)
+(*   SOFTWARE.                                                            *)
+(*                                                                        *)
+(**************************************************************************)
+
+module type S = sig
+  type elt
+
+  type t
+
+  type table
+
+  val create_table : initial_size:int -> table
+
+  val create : table -> elt -> t
+
+  val value : t -> elt
+
+  val hash : t -> int
+
+  val equal : t -> t -> bool
+
+  val canonical : table -> elt -> elt
+
+  val modify : table -> t -> (elt -> elt) -> t
+end
+
+module Dedup (H : Hashtbl.HashedType) () = struct
+  type elt = H.t
+
+  type t =
+    { hash : int;
+      value : H.t
+    }
+
+  module Tbl = Hashtbl.Make (struct
+    type nonrec t = t
+
+    let equal t1 t2 =
+      (* It is crucial that we use [H.equal] here such that the hash table
+         lookup below is up to structural equality. *)
+      Int.equal t1.hash t2.hash && H.equal t1.value t2.value
+
+    (* We hash at creation time, so there is no need to recompute the hash using
+       [H.hash]. *)
+    let hash t = t.hash
+  end)
+
+  type table = t Tbl.t
+
+  let create_table ~initial_size = Tbl.create initial_size
+
+  let create table value =
+    let hash = H.hash value in
+    let elem = { hash; value } in
+    match Tbl.find_opt table elem with
+    | Some existing -> existing
+    | None ->
+      Tbl.add table elem elem;
+      elem
+
+  let value e = e.value
+
+  let hash e = e.hash
+
+  let equal e1 e2 = Int.equal e1.hash e2.hash && e1.value == e2.value
+
+  let canonical table value = (create table value).value
+
+  let modify table e f = create table (f e.value)
+end

--- a/utils/hash_consed.ml
+++ b/utils/hash_consed.ml
@@ -88,7 +88,9 @@ module Dedup (H : Hashtbl.HashedType) () = struct
 
   let hash e = e.hash
 
-  let equal e1 e2 = Int.equal e1.hash e2.hash && e1.value == e2.value
+  (* Interning returns one canonical element per equivalence class, so physical
+     equality suffices for elements interned in the same table. *)
+  let equal e1 e2 = e1 == e2
 
   let canonical table value = (create table value).value
 

--- a/utils/hash_consed.mli
+++ b/utils/hash_consed.mli
@@ -1,0 +1,75 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Simon Spies, Jane Street Europe                       *)
+(*                                                                        *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   Permission is hereby granted, free of charge, to any person          *)
+(*   obtaining a copy of this software and associated documentation       *)
+(*   files (the "Software"), to deal in the Software without              *)
+(*   restriction, including without limitation the rights to use, copy,   *)
+(*   modify, merge, publish, distribute, sublicense, and/or sell copies   *)
+(*   of the Software, and to permit persons to whom the Software is       *)
+(*   furnished to do so, subject to the following conditions:             *)
+(*                                                                        *)
+(*   The above copyright notice and this permission notice shall be       *)
+(*   included in all copies or substantial portions of the Software.      *)
+(*                                                                        *)
+(*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,      *)
+(*   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF   *)
+(*   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND                *)
+(*   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS  *)
+(*   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN   *)
+(*   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN    *)
+(*   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE     *)
+(*   SOFTWARE.                                                            *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Hash-consing utilities.
+
+    This module enables hash-consing via the [Dedup] functor. An application of
+    [Dedup] yields an abstract element type [t] and an abstract type [table].
+    These help to avoid mixing values that are memoized in different tables,
+    which would break the invariant that structural equality of two values
+    implies physical equality of the deduplicated version. *)
+
+module type S = sig
+  (** The underlying element type. *)
+  type elt
+
+  (** A deduplicated element. *)
+  type t
+
+  (** A hash-consing table. *)
+  type table
+
+  (** [create_table ~initial_size] creates a fresh, empty hash-consing table. *)
+  val create_table : initial_size:int -> table
+
+  (** [create table v] returns the canonical element for [v] in [table]. If a
+      structurally equal value already exists in [table], that element is
+      returned. Otherwise, a new element is created and added to [table]. *)
+  val create : table -> elt -> t
+
+  (** [value e] returns the underlying value of [e]. *)
+  val value : t -> elt
+
+  (** [hash e] returns the precomputed hash of [e]. O(1). *)
+  val hash : t -> int
+
+  (** [equal e1 e2] returns [true] iff [e1] and [e2] are the same hash-consed
+      element. This is O(1) because it uses physical equality on the values. *)
+  val equal : t -> t -> bool
+
+  (** [canonical table v] is the canonical, shared representative of [v]. *)
+  val canonical : table -> elt -> elt
+
+  (** [modify table e f] applies [f] to the underlying value and re-interns the
+      result. *)
+  val modify : table -> t -> (elt -> elt) -> t
+end
+
+module Dedup (H : Hashtbl.HashedType) () : S with type elt = H.t

--- a/utils/hash_consed.mli
+++ b/utils/hash_consed.mli
@@ -32,9 +32,16 @@
 
     This module enables hash-consing via the [Dedup] functor. An application of
     [Dedup] yields an abstract element type [t] and an abstract type [table].
-    These help to avoid mixing values that are memoized in different tables,
-    which would break the invariant that structural equality of two values
-    implies physical equality of the deduplicated version. *)
+    Since the functor is generative, elements of distinct applications cannot be
+    mixed up.
+
+    Note, however, that a single application can be used to create several
+    tables, and the types do not prevent mixing elements interned in different
+    tables of the same application. Doing so breaks the invariant that
+    structural equality of the underlying values implies physical equality of
+    the interned elements: [equal] can spuriously return [false] for such
+    elements. All elements that are compared with each other (e.g. as parts of
+    keys in the same cache) must therefore be interned in the same table. *)
 
 module type S = sig
   (** The underlying element type. *)
@@ -60,8 +67,10 @@ module type S = sig
   (** [hash e] returns the precomputed hash of [e]. O(1). *)
   val hash : t -> int
 
-  (** [equal e1 e2] returns [true] iff [e1] and [e2] are the same hash-consed
-      element. This is O(1) because it uses physical equality on the values. *)
+  (** [equal e1 e2] is physical equality of the hash-consed elements. This is
+      O(1) and coincides with structural equality of the underlying values,
+      provided [e1] and [e2] were interned in the same table (see the module
+      comment above). *)
   val equal : t -> t -> bool
 
   (** [canonical table v] is the canonical, shared representative of [v]. *)


### PR DESCRIPTION
Building on #5111, this PR improves the performance of the debug info generation by introducing additional caching. In particular, it generalizes caching to apply also to non-empty environments, avoiding performance cliffs for files that use shapes in non-empty environments. 