### PR TITLE
Fix rewriting of result_types

### DIFF
--- a/middle_end/flambda2/reaper/dep_solver.ml
+++ b/middle_end/flambda2/reaper/dep_solver.ml
@@ -254,6 +254,15 @@ let rec pp_unboxed_elt pp_unboxed ppf = function
 
 let print_unboxed_fields = pp_unboxed_elt
 
+let rec fold_unboxed_with_kind (f : Flambda_kind.t -> 'a -> 'b -> 'b)
+    (fields : 'a unboxed_fields Field.Map.t) acc =
+  Field.Map.fold
+    (fun field elt acc ->
+      match elt with
+      | Not_unboxed elt -> f (Field.kind field) elt acc
+      | Unboxed fields -> fold_unboxed_with_kind f fields acc)
+    fields acc
+
 (* CR-someday ncourant: track fields that are known to be constant, here and in
    changed_representation, to avoid having them be represented. This is a bit
    complex for two main reasons:
@@ -2377,21 +2386,8 @@ module Rewriter = struct
           ))
 
   let rec patterns_for_unboxed_fields ~machine_width ~bind_function_slots db
-      ~var fields unboxed_fields unboxed_block acc =
+      ~var fields unboxed_fields unboxed_block =
     let open Flambda2_types.Rewriter in
-    if Lazy.force debug_types
-    then
-      Format.eprintf
-        "[patterns_for_unboxed_fields] unboxed_block = \
-         %a@.[patterns_for_unboxed_fields] fields_usage = \
-         %a@.[patterns_for_unboxed_fields] unboxed_fields = %a@."
-        Code_id_or_name.print unboxed_block
-        (Field.Map.print (fun ff -> function
-           | Used_as_top -> Format.fprintf ff "Top"
-           | Used_as_vars vs -> Code_id_or_name.Map.print Unit.print ff vs))
-        fields
-        (Field.Map.print (pp_unboxed_elt (fun ff _ -> Format.fprintf ff "_")))
-        unboxed_fields;
     let combined =
       Field.Map.merge
         (fun field field_use unboxed_field ->
@@ -2414,20 +2410,15 @@ module Rewriter = struct
             Some (field_use, unboxed_fields))
         fields unboxed_fields
     in
-    let rec forget unboxed_fields acc =
-      match unboxed_fields with
-      | Not_unboxed x -> (None, x) :: acc
-      | Unboxed unboxed_fields ->
-        Field.Map.fold
-          (fun _ unboxed_fields acc -> forget unboxed_fields acc)
-          unboxed_fields acc
+    let forget unboxed_fields =
+      map_unboxed_fields (fun x -> None, x) unboxed_fields
     in
-    let for_one_use field (field_use, unboxed_fields) acc =
+    let for_one_use field (field_use, unboxed_fields) =
       let field_source = get_single_field_source db unboxed_block field in
       match unboxed_fields with
       | Not_unboxed x ->
         let v = Var.create () in
-        (Some v, x) :: acc, Pattern.var v (var x field_source field_use)
+        Not_unboxed (Some v, x), Pattern.var v (var x field_source field_use)
       | Unboxed unboxed_fields -> (
         match field_use with
         | Used_as_top ->
@@ -2449,30 +2440,33 @@ module Rewriter = struct
               get_fields db
                 (get_all_usages ~follow_known_arity_calls:true db flow_to)
             in
-            patterns_for_unboxed_fields ~machine_width ~bind_function_slots:None
-              db ~var fields unboxed_fields field_source acc))
+            let vars, patterns =
+              patterns_for_unboxed_fields ~machine_width
+                ~bind_function_slots:None db ~var fields unboxed_fields
+                field_source
+            in
+            Unboxed vars, patterns))
     in
     let[@local] closure value_slots =
       let value_slots = Value_slot.Map.bindings value_slots in
-      let acc, pats =
+      let vars, pats =
         List.fold_left_map
           (fun acc (value_slot, use) ->
-            let acc, pat = for_one_use (Field.value_slot value_slot) use acc in
-            acc, Pattern.value_slot value_slot pat)
-          acc value_slots
+            let field = Field.value_slot value_slot in
+            let vars, pat = for_one_use field use in
+            Field.Map.add field vars acc, Pattern.value_slot value_slot pat)
+          Field.Map.empty value_slots
       in
       let pats =
         match bind_function_slots with None -> pats | Some p -> p @ pats
       in
-      acc, Pattern.closure pats
+      vars, Pattern.closure pats
     in
     match classify_field_map combined with
     | Empty when Option.is_some bind_function_slots ->
       closure Value_slot.Map.empty
     | Empty | Could_not_classify ->
-      ( Field.Map.fold
-          (fun _ (_, unboxed_fields) acc -> forget unboxed_fields acc)
-          combined acc,
+      ( Field.Map.map (fun (_, unboxed_fields) -> forget unboxed_fields) combined,
         Pattern.any )
     | Block_fields { is_int; get_tag; fields } ->
       if Option.is_some bind_function_slots
@@ -2480,15 +2474,18 @@ module Rewriter = struct
         Misc.fatal_errorf
           "[patterns_for_unboxed_fields] sees a block but needs to bind \
            function slots";
+      let acc = Field.Map.empty in
       let acc =
         match is_int with
         | None -> acc
-        | Some (_, unboxed_fields) -> forget unboxed_fields acc
+        | Some (_, unboxed_fields) ->
+          Field.Map.add Field.is_int (forget unboxed_fields) acc
       in
       let acc =
         match get_tag with
         | None -> acc
-        | Some (_, unboxed_fields) -> forget unboxed_fields acc
+        | Some (_, unboxed_fields) ->
+          Field.Map.add Field.get_tag (forget unboxed_fields) acc
       in
       let acc = ref acc in
       let pats = ref [] in
@@ -2497,8 +2494,9 @@ module Rewriter = struct
           match use with
           | None -> ()
           | Some (kind, use) ->
-            let nacc, pat = for_one_use (Field.block i kind) use !acc in
-            acc := nacc;
+            let field = Field.block i kind in
+            let vars, pat = for_one_use field use in
+            acc := Field.Map.add field vars !acc;
             pats
               := Pattern.block_field
                    (Target_ocaml_int.of_int machine_width i)
@@ -2596,8 +2594,6 @@ module Rewriter = struct
           flambda_type print_t0 usages;
       Rule.rewrite Pattern.any (Expr.unknown (Flambda2_types.kind flambda_type))
     in
-    if Lazy.force debug_types
-    then Format.eprintf "REWRITE usages = %a@." print_t0 usages;
     match usages with
     | _ when forget_all_types -> forget_type ()
     | No_usages -> forget_type ()
@@ -2643,19 +2639,9 @@ module Rewriter = struct
         let[@local] change_representation_of_closures fields closure_source
             value_slots_reprs function_slots_reprs =
           let patterns = ref [] in
-          if Lazy.force debug_types
-          then (
-            Format.eprintf "OLD type: %a@." Flambda2_types.print flambda_type;
-            Format.eprintf "OLD->NEW function slots: %a@."
-              (Function_slot.Map.print Function_slot.print)
-              function_slots_reprs);
           let all_function_slots_in_set =
             Function_slot.Map.fold
               (fun function_slot (_, uses) m ->
-                if Lazy.force debug_types
-                then
-                  Format.eprintf "OLD function slot: %a@." Function_slot.print
-                    function_slot;
                 let new_function_slot =
                   Function_slot.Map.find function_slot function_slots_reprs
                 in
@@ -2710,18 +2696,18 @@ module Rewriter = struct
                     Many_sources_usages usages
                 in
                 result, metadata)
-              fields value_slots_reprs closure_source []
+              fields value_slots_reprs closure_source
           in
           let all_value_slots_in_set =
-            List.fold_left
-              (fun m (var, value_slot) ->
+            fold_unboxed_with_kind
+              (fun _kind (var, value_slot) m ->
                 let e =
                   match var with
                   | None -> Expr.unknown (Value_slot.kind value_slot)
                   | Some var -> Expr.var var
                 in
                 Value_slot.Map.add value_slot e m)
-              Value_slot.Map.empty bound
+              bound Value_slot.Map.empty
           in
           let new_function_slot =
             Function_slot.Map.find current_function_slot function_slots_reprs
@@ -2859,15 +2845,6 @@ module Rewriter = struct
                    (fun _ c acc -> Code_id_or_name.Map.add c () acc)
                    set_of_closures Code_id_or_name.Map.empty)
             in
-            if Lazy.force debug_types
-            then
-              Format.eprintf "ZZZ: %a@."
-                (Field.Map.print (fun ff t ->
-                     match t with
-                     | Used_as_top -> Format.fprintf ff "Top"
-                     | Used_as_vars m ->
-                       Code_id_or_name.Map.print Unit.print ff m))
-                fields;
             change_representation_of_closures fields
               (Function_slot.Map.find current_function_slot set_of_closures)
               value_slots_reprs function_slots_reprs)
@@ -2890,11 +2867,6 @@ module Rewriter = struct
                 (fun clos () ->
                   Code_id_or_name.Map.mem clos result.changed_representation)
                 usages_for_value_slots);
-            if Lazy.force debug_types
-            then
-              Format.eprintf "USAGES_FOR_VALUE_SLOTS is: %a@."
-                (Code_id_or_name.Map.print Unit.print)
-                usages_for_value_slots;
             let changed_representation =
               Code_id_or_name.Map.bindings
                 (Code_id_or_name.Map.mapi
@@ -3032,15 +3004,6 @@ module Rewriter = struct
                        (fun _ c acc -> Code_id_or_name.Map.add c () acc)
                        set_of_closures Code_id_or_name.Map.empty)
                 in
-                if Lazy.force debug_types
-                then
-                  Format.eprintf "ZZZ: %a@."
-                    (Field.Map.print (fun ff t ->
-                         match t with
-                         | Used_as_top -> Format.fprintf ff "Top"
-                         | Used_as_vars m ->
-                           Code_id_or_name.Map.print Unit.print ff m))
-                    fields;
                 change_representation_of_closures fields
                   (Function_slot.Map.find current_function_slot set_of_closures)
                   value_slots_reprs function_slots_reprs)
@@ -3068,12 +3031,6 @@ module Rewriter = struct
       let field = Field.block (Target_ocaml_int.to_int index) field_kind in
       follow_field result t field
     in
-    if Lazy.force debug_types
-    then (
-      Format.eprintf "%a -[%d]-> %a@." print_t0 t
-        (Target_ocaml_int.to_int index)
-        print_t0 r;
-      Format.eprintf "%a@." Flambda2_types.print flambda_type);
     result, r
 
   let array_slot (result, _t) _index _typing_env _flambda_type =
@@ -3135,15 +3092,19 @@ let rewrite_typing_env result ~unit_symbol:_ typing_env =
   then Format.eprintf "NEW typing env: %a@." Typing_env.print r;
   r
 
-let rewrite_result_types result ~old_typing_env func_params func_results
-    result_types =
+type keep_or_delete =
+  | Keep
+  | Delete
+
+let rewrite_result_types result ~old_typing_env ~my_closure:func_my_closure
+    ~params:func_params ~results:func_results result_types =
   if Lazy.force debug_types
   then Format.eprintf "OLD result types: %a@." Result_types.print result_types;
   let params, results, env_extension =
     Result_types.pattern_match result_types ~f:(fun ~params ~results tee ->
         params, results, tee)
   in
-  let variable_pattern var =
+  let variable_pattern var to_keep =
     let kind = Variable.kind var in
     let name = Variable.name var in
     let var = Code_id_or_name.var var in
@@ -3177,48 +3138,50 @@ let rewrite_result_types result ~old_typing_env func_params func_results
             Variable.name v, (result, metadata))
           fields unboxed_fields
           (Option.get (get_allocation_point db var))
-          []
       in
       let all_vars =
-        List.rev_map
-          (fun (pattern_var, v) ->
+        fold_unboxed_with_kind
+          (fun _kind (pattern_var, v) acc ->
             if Option.is_none pattern_var
             then
               Format.eprintf
                 "In [rewrite_result_types], could not get a pattern variable \
                  for unboxed var %a@."
                 Variable.print v;
-            Option.get pattern_var)
-          bound
+            Option.get pattern_var :: acc)
+          bound []
       in
       (pat, kind), all_vars)
     else
-      let metadata =
-        if not (has_source db var)
-        then result, Rewriter.No_source
-        else if not (has_use db var)
-        then result, Rewriter.No_usages
-        else
-          match get_allocation_point db var with
-          | Some alloc_point -> result, Rewriter.Single_source alloc_point
-          | None ->
-            if is_top db var
-            then result, Rewriter.Many_sources_any_usage
-            else
-              ( result,
-                Rewriter.Many_sources_usages
-                  (get_direct_usages db (Code_id_or_name.Map.singleton var ()))
-              )
-      in
-      let v = Flambda2_types.Rewriter.Var.create () in
-      let pat = Flambda2_types.Rewriter.Pattern.var v (name, metadata) in
-      (pat, kind), [v]
+      match to_keep with
+      | Delete -> (Flambda2_types.Rewriter.Pattern.any, kind), []
+      | Keep ->
+        let metadata =
+          if not (has_source db var)
+          then result, Rewriter.No_source
+          else if not (has_use db var)
+          then result, Rewriter.No_usages
+          else
+            match get_allocation_point db var with
+            | Some alloc_point -> result, Rewriter.Single_source alloc_point
+            | None ->
+              if is_top db var
+              then result, Rewriter.Many_sources_any_usage
+              else
+                ( result,
+                  Rewriter.Many_sources_usages
+                    (get_direct_usages db
+                       (Code_id_or_name.Map.singleton var ())) )
+        in
+        let v = Flambda2_types.Rewriter.Var.create () in
+        let pat = Flambda2_types.Rewriter.Pattern.var v (name, metadata) in
+        (pat, kind), [v]
   in
   let patterns_list func_vars type_vars =
     let patterns, vars =
       List.fold_left2
-        (fun (patterns, vars) funcv typev ->
-          let pat, vs = variable_pattern funcv in
+        (fun (patterns, vars) (funcv, to_keep) typev ->
+          let pat, vs = variable_pattern funcv to_keep in
           ( Variable.Map.add (Bound_parameter.var typev) pat patterns,
             List.rev_append vs vars ))
         (Variable.Map.empty, []) func_vars
@@ -3228,6 +3191,16 @@ let rewrite_result_types result ~old_typing_env func_params func_results
   in
   let params_patterns, params_vars = patterns_list func_params params in
   let results_patterns, results_vars = patterns_list func_results results in
+  let unbox_my_closure_vars =
+    match
+      Code_id_or_name.Map.find_opt
+        (Code_id_or_name.var func_my_closure)
+        result.unboxed_fields
+    with
+    | None -> []
+    | Some fields ->
+      fold_unboxed_with_kind (fun kind v acc -> (v, kind) :: acc) fields []
+  in
   let new_vars, new_env_extension =
     TypesRewrite.rewrite_env_extension_with_extra_variables old_typing_env
       (Variable.Map.disjoint_union params_patterns results_patterns)
@@ -3235,18 +3208,27 @@ let rewrite_result_types result ~old_typing_env func_params func_results
       (params_vars @ results_vars)
   in
   let make_bp vars =
-    Bound_parameters.create
-      (List.map
-         (fun v ->
-           let var = Flambda2_types.Rewriter.Var.Map.find v new_vars in
-           Bound_parameter.create var
-             (Flambda_kind.With_subkind.anything (Variable.kind var))
-             Flambda_debug_uid.none)
-         vars)
+    List.map
+      (fun v ->
+        let var = Flambda2_types.Rewriter.Var.Map.find v new_vars in
+        Bound_parameter.create var
+          (Flambda_kind.With_subkind.anything (Variable.kind var))
+          Flambda_debug_uid.none)
+      vars
   in
   let new_result_types =
-    Result_types.create ~params:(make_bp params_vars)
-      ~results:(make_bp results_vars) new_env_extension
+    Result_types.create
+      ~params:
+        (Bound_parameters.create
+           (List.map
+              (fun (v, k) ->
+                Bound_parameter.create v
+                  (Flambda_kind.With_subkind.anything k)
+                  Flambda_debug_uid.none)
+              unbox_my_closure_vars
+           @ make_bp params_vars))
+      ~results:(Bound_parameters.create (make_bp results_vars))
+      new_env_extension
   in
   if Lazy.force debug_types
   then

--- a/middle_end/flambda2/reaper/dep_solver.mli
+++ b/middle_end/flambda2/reaper/dep_solver.mli
@@ -29,6 +29,12 @@ val print_unboxed_fields :
   'a unboxed_fields ->
   unit
 
+val fold_unboxed_with_kind :
+  (Flambda_kind.t -> 'a -> 'b -> 'b) ->
+  'a unboxed_fields Field.Map.t ->
+  'b ->
+  'b
+
 type unboxed = Variable.t unboxed_fields Field.Map.t
 
 type changed_representation =
@@ -76,10 +82,15 @@ val code_id_actually_directly_called :
 val rewrite_typing_env :
   result -> unit_symbol:Symbol.t -> typing_env -> typing_env
 
+type keep_or_delete =
+  | Keep
+  | Delete
+
 val rewrite_result_types :
   result ->
   old_typing_env:typing_env ->
-  Variable.t list ->
-  Variable.t list ->
+  my_closure:Variable.t ->
+  params:(Variable.t * keep_or_delete) list ->
+  results:(Variable.t * keep_or_delete) list ->
   Result_types.t ->
   Result_types.t

--- a/middle_end/flambda2/tests/reaper/rewrite_types1.ml
+++ b/middle_end/flambda2/tests/reaper/rewrite_types1.ml
@@ -1,0 +1,9 @@
+external __dummy2__ : unit -> 'a = "%opaque"
+let merge_fold cmp =
+  let loop () () = (__dummy2__ ()) cmp
+  [@@inline never ][@@local never ] in
+  loop () ()
+  [@@inline ][@@local never ]
+
+let merge_iter () =
+  merge_fold (__dummy2__ ()) [@@inline ][@@local never ]

--- a/middle_end/flambda2/tests/reaper/rewrite_types1.mli
+++ b/middle_end/flambda2/tests/reaper/rewrite_types1.mli
@@ -1,0 +1,1 @@
+val merge_iter : unit -> unit

--- a/middle_end/flambda2/tests/reaper/rewrite_types2.ml
+++ b/middle_end/flambda2/tests/reaper/rewrite_types2.ml
@@ -1,0 +1,5 @@
+(* ocamlopt -flambda2-reaper -reaper-local-fields -flambda2-result-types-all-functions -c rewrite_types1.mli rewrite_types1.ml rewrite_types2.ml *)
+
+external __ignore__ : 'a -> unit = "%ignore"
+let check_uniqueness_of_merged () =
+  __ignore__ (Rewrite_types1.merge_iter ())


### PR DESCRIPTION
- Removed parameters were not removed from the result_types
- Parameters from unboxed closures were not added to the result_types
- Parameters could sometimes be in an incorrect order in the result_types

Note : the fix currently creates a result_types where some parameters are not defined. This does not seem to cause problems, but it is not very clean; an upcoming pull request by @bclement-ocp should change the types rewriting API to make it possible to fix that.