### PR TITLE
Clearer output of beat.ml test

### DIFF
--- a/testsuite/tests/lib-threads/beat.reference
+++ b/testsuite/tests/lib-threads/beat.reference
@@ -1,1 +1,8 @@
-passed
+resonant, with slack:
+  passed.
+resonant, with no slack:
+  passed.
+not resonant, with slack:
+  passed.
+not resonant, with no slack:
+  passed.


### PR DESCRIPTION
This makes the `lib-threads/beat.ml` test clearer, possibly more robust, and easier to modify. It also turns it back on on MacOS.

We have seen sporadic off-by-one failures of `lib-threads/beat.ml` in CI, such as [this one](https://github.com/oxcaml/oxcaml/actions/runs/20228697494/job/58066175112#step:13:6927). It's also [turned off on MacOS](https://github.com/oxcaml/oxcaml/pull/1496), because of "off-by-one" failures.

Note that the test already has an off-by-one allowance, so these failures are actually off-by-two.

We don't know why these failures happen, but the test has some curious features. Specifically: it both (a) has two thread counters with resonant periods (1/2 and 1/3 seconds), and (b) counts those periods over a duration which is an exact multiple of _both_ periods (3 seconds). It's unclear from the history whether one or both of these features is the motivation for the test: either could contribute to an off-by-one failure (but I think not off-by-two). So I've rewritten the test so that it runs 4 times, with each of these conditions true or false.  If we see off-by-two failures again in future then the test is now easy to modify to be more lenient under specific conditions.

Also if we want the test to go faster that's now a one-line change.