### PR TITLE
reaper: More flexible API for rewriting types

### DIFF
--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -1067,13 +1067,16 @@ module Rewriter : sig
     val function_slot :
       set_of_closures -> Function_slot.t -> typing_env -> flambda_type -> t
   end) : sig
-    val rewrite : typing_env -> (Symbol.t -> X.t) -> typing_env
+    type context
 
-    val rewrite_env_extension_with_extra_variables :
+    val create_context : (Symbol.t -> X.t) -> context
+
+    val rewrite_symbols : context -> Typing_env.t -> Typing_env.t
+
+    val rewrite_variables :
+      context ->
       Typing_env.t ->
       ((string * X.t) pattern * Flambda_kind.t) Variable.Map.t ->
-      Typing_env_extension.With_extra_variables.t ->
-      Var.t list ->
-      Variable.t Var.Map.t * Typing_env_extension.With_extra_variables.t
+      (Var.t -> Variable.t * flambda_type) * Typing_env.t
   end
 end

--- a/middle_end/flambda2/types/traversals.mli
+++ b/middle_end/flambda2/types/traversals.mli
@@ -138,12 +138,15 @@ module Make (X : sig
   val function_slot :
     set_of_closures -> Function_slot.t -> Typing_env.t -> Type_grammar.t -> t
 end) : sig
-  val rewrite : Typing_env.t -> (Symbol.t -> X.t) -> Typing_env.t
+  type context
 
-  val rewrite_env_extension_with_extra_variables :
+  val create_context : (Symbol.t -> X.t) -> context
+
+  val rewrite_symbols : context -> Typing_env.t -> Typing_env.t
+
+  val rewrite_variables :
+    context ->
     Typing_env.t ->
     ((string * X.t) pattern * Flambda_kind.t) Variable.Map.t ->
-    Typing_env_extension.With_extra_variables.t ->
-    Var.t list ->
-    Variable.t Var.Map.t * Typing_env_extension.With_extra_variables.t
+    (Var.t -> Variable.t * Type_grammar.t) * Typing_env.t
 end


### PR DESCRIPTION
This changes the interface between the typing env and the reaper for rewriting in types to only rewrite symbols or variables in a _typing env_, letting the reaper deal with env extensions directly instead of having specialized versions of rewriting for env extensions.