### PR TITLE
rewrite-in-types: Support `Is_int` and `Get_tag` patterns

### DIFF
--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -952,6 +952,10 @@ module Rewriter : sig
     val block_field :
       Target_ocaml_int.t -> Flambda_kind.t -> 'a t -> 'a block_field
 
+    val is_int : 'a t -> 'a block_field
+
+    val get_tag : 'a t -> 'a block_field
+
     val block : ?tag:Tag.t -> 'a block_field list -> 'a t
 
     type 'a array_field

--- a/middle_end/flambda2/types/traversals.mli
+++ b/middle_end/flambda2/types/traversals.mli
@@ -22,6 +22,10 @@ module Pattern : sig
   val block_field :
     Target_ocaml_int.t -> Flambda_kind.t -> 'a t -> 'a block_field
 
+  val is_int : 'a t -> 'a block_field
+
+  val get_tag : 'a t -> 'a block_field
+
   val block : ?tag:Tag.t -> 'a block_field list -> 'a t
 
   type 'a array_field


### PR DESCRIPTION
They are currently treated just like any other block field for simplicity.