### PR TITLE
Fix removed operations count of switches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
             os: warp-ubuntu-latest-x64-8x
             build_ocamlparam: ''
             ocamlparam: '_,Oclassic=1'
-            disable_testcases: 'testsuite/tests/typing-local/regression_cmm_unboxing.ml testsuite/tests/int64-unboxing/test.ml testsuite/tests/flambda2/inlining_cost_of_primitive_on_parameters.ml testsuite/tests/flambda2/code_size_of_single_arg_switch.ml testsuite/tests/flambda2/code_size_of_boolean_not_switch.ml'
+            disable_testcases: 'testsuite/tests/typing-local/regression_cmm_unboxing.ml testsuite/tests/int64-unboxing/test.ml testsuite/tests/flambda2/inlining_cost_of_primitive_on_parameters.ml testsuite/tests/flambda2/code_size_of_single_arg_switch.ml testsuite/tests/flambda2/code_size_of_boolean_not_switch.ml testsuite/tests/flambda2/removed_operations_of_switch.ml'
 
           - name: runtime4 (aarch64-darwin)
             config: --disable-runtime5 --disable-warn-error

--- a/middle_end/flambda2/simplify/simplify_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_expr.ml
@@ -119,10 +119,7 @@ let rec simplify_expr dacc expr ~down_to_up =
   | Apply_cont apply_cont ->
     Simplify_apply_cont_expr.simplify_apply_cont dacc apply_cont ~down_to_up
   | Switch switch ->
-    Simplify_switch_expr.simplify_switch
-      ~simplify_let_with_bound_pattern:
-        Simplify_let_expr.simplify_let_with_bound_pattern
-      ~simplify_function_body dacc switch ~down_to_up
+    Simplify_switch_expr.simplify_switch dacc switch ~down_to_up
   | Invalid { message } ->
     (* CR mshinwell: Make sure that a program can be simplified to just
        [Invalid]. *)

--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -524,13 +524,3 @@ let simplify_let ~simplify_expr ~simplify_function_body dacc let_expr
     ~f:
       (simplify_let0 ~simplify_expr ~simplify_function_body dacc let_expr
          ~down_to_up)
-
-let simplify_let_with_bound_pattern ~simplify_expr_with_bound_pattern
-    ~simplify_function_body dacc let_expr ~down_to_up =
-  let module L = Flambda.Let in
-  L.pattern_match let_expr ~f:(fun bound_pattern ->
-      simplify_let0
-        ~simplify_expr:(fun dacc body ~down_to_up ->
-          simplify_expr_with_bound_pattern dacc (bound_pattern, body)
-            ~down_to_up)
-        ~simplify_function_body dacc let_expr ~down_to_up bound_pattern)

--- a/middle_end/flambda2/simplify/simplify_let_expr.mli
+++ b/middle_end/flambda2/simplify/simplify_let_expr.mli
@@ -20,9 +20,3 @@ val simplify_let :
   simplify_expr:Expr.t Simplify_common.expr_simplifier ->
   simplify_function_body:Simplify_common.simplify_function_body ->
   Let.t Simplify_common.expr_simplifier
-
-val simplify_let_with_bound_pattern :
-  simplify_expr_with_bound_pattern:
-    (Bound_pattern.t * Expr.t) Simplify_common.expr_simplifier ->
-  simplify_function_body:Simplify_common.simplify_function_body ->
-  Let.t Simplify_common.expr_simplifier

--- a/middle_end/flambda2/simplify/simplify_switch_expr.mli
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.mli
@@ -14,11 +14,4 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val simplify_switch :
-  simplify_let_with_bound_pattern:
-    (simplify_expr_with_bound_pattern:
-       (Bound_pattern.t * Flambda.Expr.t) Simplify_common.expr_simplifier ->
-    simplify_function_body:Simplify_common.simplify_function_body ->
-    Flambda.Let.t Simplify_common.expr_simplifier) ->
-  simplify_function_body:Simplify_common.simplify_function_body ->
-  Flambda.Switch.t Simplify_common.expr_simplifier
+val simplify_switch : Flambda.Switch.t Simplify_common.expr_simplifier

--- a/testsuite/tests/flambda2/code_size_of_single_arg_switch.compilers.reference
+++ b/testsuite/tests/flambda2/code_size_of_single_arg_switch.compilers.reference
@@ -4,7 +4,7 @@ let code switch_converted_to_lookup_table_0 deleted in
 let code switch_converted_to_lookup_table'_1 deleted in
 let code switch_converted_to_affine_2 deleted in
 let code switch_converted_to_affine'_3 deleted in
-let $camlCode_size_of_single_arg_switch__switch_block42 =
+let $camlCode_size_of_single_arg_switch__switch_block40 =
   Value_array [|1;
   2;
   4|]
@@ -15,7 +15,7 @@ let code loopify(never) size(2) newer_version_of(switch_converted_to_lookup_tabl
         -> k * k1
         : imm tagged =
   let arg =
-    %array_load $camlCode_size_of_single_arg_switch__switch_block42.(x)
+    %array_load $camlCode_size_of_single_arg_switch__switch_block40.(x)
   in
   cont k (arg)
 in

--- a/testsuite/tests/flambda2/removed_operations_of_switch.compilers.reference
+++ b/testsuite/tests/flambda2/removed_operations_of_switch.compilers.reference
@@ -1,0 +1,38 @@
+
+After simplify:
+let code f_0 deleted in
+let code g_1 deleted in
+let code loopify(never) size(27) newer_version_of(f_0)
+      f_0_1 (b : imm tagged, x, y)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : [ 0 of val * val ] =
+  (let untagged = %untag_imm b in
+   switch untagged
+     | 0 -> k2
+     | 1 -> k3)
+    where k3 =
+      let Pmakeblock = %Block 0 (x, y) in
+      cont k (Pmakeblock)
+    where k2 =
+      let Pmakeblock = %Block 0 (y, x) in
+      cont k (Pmakeblock)
+in
+let $camlRemoved_operations_of_switch__f_2 = closure f_0_1 @f in
+let code loopify(never) size(4) newer_version_of(g_1)
+      g_1_1 (b : imm tagged, x, y)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : [ 0 of val * val ] =
+  apply direct(f_0_1)
+    ($camlRemoved_operations_of_switch__f_2 : _ -> [ 0 of val * val ])
+      (b, x, y)
+      -> k * k1
+in
+let $camlRemoved_operations_of_switch__g_3 = closure g_1_1 @g in
+let $camlRemoved_operations_of_switch =
+  Block 0 ($camlRemoved_operations_of_switch__f_2,
+           $camlRemoved_operations_of_switch__g_3)
+in
+cont done ($camlRemoved_operations_of_switch)
+

--- a/testsuite/tests/flambda2/removed_operations_of_switch.ml
+++ b/testsuite/tests/flambda2/removed_operations_of_switch.ml
@@ -1,0 +1,35 @@
+(* TEST
+ compile_only = "true";
+ ocamlopt_flags = "-flambda2-inline-small-function-size 26 -flambda2-inline-threshold 26.99 -flambda2-inline-large-function-size 100 -dfexpr";
+ flambda2;
+ setup-ocamlopt.byte-build-env;
+ ocamlopt.byte;
+ check-ocamlopt.byte-output;
+*)
+
+
+let f b x y =
+  (* Code size of f is 27:
+   *
+   * let untagged = %untag_imm b in [%untag_imm: 1]
+   * switch untagged with           [switch: 0]
+   * | 0 -> k0                      [switch arm: 5]
+   * | 1 -> k1                      [switch arm: 5]
+   * where k0 =
+   *   let Pmakeblock = %Block 0 (x, y) in
+   *                                [block(n): 5 + n = 7]
+   *   ret Pmakeblock               [apply_cont: 1]
+   * where k1 =
+   *   let Pmakeblock = %Block 0 (y, x) in
+   *                                [block(n): 5 + n = 7]
+   *   ret Pmakeblock               [apply_cont: 1]
+   *)
+  if b
+  then (x, y)
+  else (y, x)
+
+let g b x y =
+  (* Inlining does not actually improve the code, so we should
+     choose *not* to inline with a threshold just below the size
+     of [f]. *)
+  f b x y


### PR DESCRIPTION
Switches in flambda2 are always performed on a naked immediate scrutinee, and sometime encode a `%tag_immediate` primitive (confusingly recorded as an "identity switch").

We currently implement this by unconditionally introducing a tagged version of the scrutinee before simplifying the switch, so that if the switch is actually an identity switch, we can find that primitive in the CSE environment. This primitive is also used for "boolean not" switches, affine switches, and switches that can be converted to a lookup table.

In other words, a switch:

```fexpr
switch x with
| 0 -> k e0
| 1 -> k e1
| 2 -> k e2
```

is always simplified as:

```fexpr
let tagged_scrutinee = %tag_immediate x in
switch x with
| 0 -> k e0
| 1 -> k e1
| 2 -> k e2
```

This means that whenever we simplify a switch that is not eliminated (into a `%tag_immediate` or `%boolean_not`, or an array load or an affine expression) we count the removal of the `%tag_immediate` primitive as a removed operations, potentially causing speculative inlining to trigger even though no optimisations were made.

This patch changes the logic for introducing the `%tag_immediate` primitive to follow the same pattern as we use for `%boolean_not` and affine expressions: instead of optimistically introducing it in the downwards pass, we simply look it up in the CSE environment in the upwards pass and introduce it if it does not exist.

Note that this means that in situations where we have a switch that can be simplified into a `%tag_immediate` primitive, followed by an actual `%tag_immediate` primitive (or another such switch) in the same function, we will fail to CSE the `%tag_immediate` primitive. This situation should be relatively rare, though.