### PR TITLE
Reaper: fix that some indirect_unknown_arity arguments were incorrectly deleted

### DIFF
--- a/middle_end/flambda2/reaper/dep_solver.ml
+++ b/middle_end/flambda2/reaper/dep_solver.ml
@@ -3560,8 +3560,16 @@ let get_field_sources :
           [ ~~(One.flag any);
             in_ % [x];
             in_field % [field];
-            field_sources x field y ]
-          ==> out % [y]) ]
+            field_sources x field y;
+            any_source y ]
+          ==> One.flag any);
+         (let$ [x; field; y; z] = ["x"; "field"; "y"; "z"] in
+          [ ~~(One.flag any);
+            in_ % [x];
+            in_field % [field];
+            field_sources x field y;
+            sources y z ]
+          ==> out % [z]) ]
      in
      if One.to_bool any then Any_source else Sources out)
 

--- a/middle_end/flambda2/tests/reaper/indirect_params.ml
+++ b/middle_end/flambda2/tests/reaper/indirect_params.ml
@@ -1,0 +1,8 @@
+(* ocamlopt.opt -flambda2-reaper -reaper-local-fields -o indirect_params.ml && ./indirect_params *)
+
+let f x = let () = () in fun y -> x + y
+let[@inline never][@local never] h x y =
+  let[@inline never][@local never] g f = f x y in
+  g f
+
+let () = assert (h 1 2 = 3)


### PR DESCRIPTION
The sources were not correctly followed by `get_field_sources`.