### PR TITLE
Add an abstract `unit#` type of kind `void mod everything`

### DIFF
--- a/testsuite/tests/typing-layouts-void/basics_void.ml
+++ b/testsuite/tests/typing-layouts-void/basics_void.ml
@@ -2,6 +2,19 @@
  expect;
 *)
 
+(* unit# can be ignored with [;] *)
+
+external unbox_unit : unit -> unit# = "%unbox_unit"
+[%%expect{|
+external unbox_unit : unit -> unit# = "%unbox_unit"
+|}]
+
+let () =
+  unbox_unit ();
+  ()
+[%%expect{|
+|}]
+
 type unit_u : void mod everything
 [%%expect{|
 type unit_u : void mod everything

--- a/testsuite/tests/typing-layouts/hash_types.ml
+++ b/testsuite/tests/typing-layouts/hash_types.ml
@@ -18,14 +18,26 @@ type float_u : float64 = float#
 type float_u = float#
 |}]
 
+type unit_u : void mod everything = unit#
+
 (* Unboxed versions are accessible through aliases... *)
 module Float = struct
   type t = float
 end
 type t = Float.t#
 [%%expect{|
+type unit_u = unit#
 module Float : sig type t = float end
 type t = Float.t#
+|}]
+
+module Unit = struct
+  type t = unit
+end
+type t = Unit.t#
+[%%expect{|
+module Unit : sig type t = unit end
+type t = Unit.t#
 |}]
 
 (* ...but not if the alias is abstract. *)
@@ -45,12 +57,28 @@ Line 1, characters 11-19:
 Error: The type "Float.t" has no unboxed version.
 |}]
 
+module Unit : sig
+  type t
+end = struct
+  type t = unit
+end
+[%%expect{|
+module Unit : sig type t end
+|}]
+
 (* The alias can also have type parameters. *)
 type f : float64 = unit ff#
 and 'a ff = float
 [%%expect{|
 type f = unit ff#
 and 'a ff = float
+|}]
+
+type u : void = string uu#
+and 'a uu = unit
+[%%expect{|
+type u = string uu#
+and 'a uu = unit
 |}]
 
 (* If a type with an unboxed version is shadowed by another, [#]

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -1391,6 +1391,8 @@ module Jkind0 = struct
           name = "void mod everything"
         }
 
+      let kind_of_unboxed_unit = void_mod_everything
+
       let immediate =
         { jkind =
             mk_jkind (Base Value) ~crossing:cross_all_except_staticity

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -495,6 +495,9 @@ module Jkind0 : sig
       (** The jkind of unboxed 64-bit floats with mode crossing. *)
       val kind_of_unboxed_float : t
 
+      (** The jkind of unboxed units with mode crossing. *)
+      val kind_of_unboxed_unit : t
+
       (** The jkind of unboxed 32-bit floats with no mode crossing. *)
       val float32 : t
 

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -138,6 +138,7 @@ and path_float32x16 = Pident ident_float32x16
 and path_float64x8 = Pident ident_float64x8
 
 let path_unboxed_float = Path.unboxed_version path_float
+and path_unboxed_unit = Path.unboxed_version path_unit
 and path_unboxed_float32 = Path.unboxed_version path_float32
 and path_unboxed_nativeint = Path.unboxed_version path_nativeint
 and path_unboxed_char = Path.unboxed_version path_char
@@ -195,6 +196,7 @@ and type_lexing_position = newgenty (Tconstr(path_lexing_position, [], ref Mnil)
 and type_atomic_loc t = newgenty (Tconstr(path_atomic_loc, [t], ref Mnil))
 and type_code t = newgenty (Tconstr(path_code, [t], ref Mnil))
 
+and type_unboxed_unit = newgenty (Tconstr(path_unboxed_unit, [], ref Mnil))
 and type_unboxed_float = newgenty (Tconstr(path_unboxed_float, [], ref Mnil))
 and type_unboxed_float32 = newgenty (Tconstr(path_unboxed_float32, [], ref Mnil))
 and type_unboxed_nativeint =
@@ -359,12 +361,10 @@ let mk_add_type add_type =
         let type_jkind =
           Jkind.of_builtin ~why:(Unboxed_primitive type_ident) unboxed_jkind
         in
-        let type_kind =
-          match kind with
-            | Type_abstract Definition -> Type_abstract Definition
-            | _ ->
-              Misc.fatal_error "Predef.mk_add_type: non-abstract unboxed kind"
-        in
+        (* All unboxed versions of types explicitly added in the predef are
+           abstract, as they are special cased. Other unboxed versions are
+           automatically derived. *)
+        let type_kind = Type_abstract Definition in
         let type_manifest =
           match manifest with
           | None -> None
@@ -701,6 +701,7 @@ let build_initial_env add_type add_extension empty_env =
   |> add_type ident_unit
        ~kind:(variant [cstr ident_void []])
        ~jkind:Jkind.Const.Builtin.immediate
+       ~unboxed_jkind:Jkind.Const.Builtin.kind_of_unboxed_unit
   (* Predefined exceptions - alphabetical order *)
   |> add_extension ident_assert_failure
        [newgenty (Ttuple[None, type_string; None, type_int; None, type_int]),

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -41,6 +41,7 @@ val type_floatarray:type_expr
 val type_lexing_position:type_expr
 val type_atomic_loc:type_expr -> type_expr
 val type_code: type_expr -> type_expr
+val type_unboxed_unit: type_expr
 val type_unboxed_float:type_expr
 val type_unboxed_float32:type_expr
 val type_unboxed_nativeint:type_expr
@@ -123,6 +124,7 @@ val path_floatarray: Path.t
 val path_lexing_position: Path.t
 val path_code: Path.t
 
+val path_unboxed_unit : Path.t
 val path_unboxed_float: Path.t
 val path_unboxed_float32: Path.t
 val path_unboxed_nativeint: Path.t

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4980,7 +4980,9 @@ let generalize_and_check_univars env kind exp ty_expected vars =
 let check_statement exp =
   let ty = get_desc (expand_head exp.exp_env exp.exp_type) in
   match ty with
-  | Tconstr (p, _, _)  when Path.same p Predef.path_unit -> ()
+  | Tconstr (p, _, _) when Path.same p Predef.path_unit
+                        || Path.same p Predef.path_unboxed_unit ->
+    ()
   (* CR layouts v5: when we have unboxed unit, add a case here for it *)
   | Tvar _ -> ()
   | _ ->


### PR DESCRIPTION
Add an unboxed version to `unit`. The type `unit#` is abstract and has kind `void mod everything`.
```ocaml
type u : void mod everything = unit#
```

When you ignore a `unit#` with `;`, it does not give the `non-unit-statement` warning.

In the future, we plan to add unboxed variants, after which `unit#` will be constructed/destructed with `()` (overloading the same constructor as `unit`, so it would be type-disambiguated). For now, we create a `unit#` with the existing `%unbox_unit`.

```ocaml
external unbox_unit : unit -> unit# = "%unbox_unit"
```