### PR TITLE
Move get_sort to jkind_types

### DIFF
--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -84,14 +84,6 @@ module Layout = struct
   module Const = struct
     include Jkind_types.Layout.Const
 
-    let rec get_sort : t -> Sort.Const.t option = function
-      | Any -> None
-      | Base b -> Some (Base b)
-      | Product ts ->
-        Option.map
-          (fun x -> Sort.Const.Product x)
-          (Misc.Stdlib.List.map_option get_sort ts)
-
     let rec of_sort_const : Sort.Const.t -> t = function
       | Base b -> Base b
       | Product consts -> Product (List.map of_sort_const consts)

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -666,6 +666,14 @@ module Layout = struct
       | Product cs1, Product cs2 -> List.equal equal cs1 cs2
       | (Base _ | Any | Product _), _ -> false
 
+    let rec get_sort : t -> Sort.Const.t option = function
+      | Any -> None
+      | Base b -> Some (Sort.Const.Base b)
+      | Product ts ->
+        Option.map
+          (fun x -> Sort.Const.Product x)
+          (Misc.Stdlib.List.map_option get_sort ts)
+
     module Static = struct
       let value = Base Sort.Value
 

--- a/typing/jkind_types.mli
+++ b/typing/jkind_types.mli
@@ -118,6 +118,8 @@ module Layout : sig
     val equal : t -> t -> bool
 
     val max : t
+
+    val get_sort : t -> Sort.Const.t option
   end
 
   val of_const : Const.t -> Sort.t t


### PR DESCRIPTION
As a follow-up to #5070, this PR moves `get_sort` to `jkind_types.ml`. Without it, the changes in #4928 create a dependency cycle between `Env` and `Type_shape`. 