### PR TITLE
Add -dfexpr-after flag to control when to print fexpr

### DIFF
--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -905,6 +905,13 @@ let mk_dfexpr f =
     Arg.Unit f,
     " Like -dflambda but outputs fexpr language\n     (Flambda 2 only)" )
 
+let mk_dfexpr_after f =
+  let passes = [ "simplify"; "reaper" ] in
+  ( "-dfexpr-after",
+    Arg.Symbol (passes, f),
+    " <pass> Like -dfexpr, but dumps after the provided pass (Flambda 2 only)"
+  )
+
 let mk_dfexpr_to f =
   ( "-dfexpr-to",
     Arg.String f,
@@ -1196,6 +1203,7 @@ module type Oxcaml_options = sig
   val drawfexpr_to : string -> unit
   val dfexpr : unit -> unit
   val dfexpr_to : string -> unit
+  val dfexpr_after : string -> unit
   val dflexpect_to : string -> unit
   val dslot_offsets : unit -> unit
   val dfreshen : unit -> unit
@@ -1372,6 +1380,7 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_drawfexpr_to F.drawfexpr_to;
       mk_dfexpr F.dfexpr;
       mk_dfexpr_to F.dfexpr_to;
+      mk_dfexpr_after F.dfexpr_after;
       mk_dflexpect_to F.dflexpect_to;
       mk_dslot_offsets F.dslot_offsets;
       mk_dfreshen F.dfreshen;
@@ -1731,6 +1740,11 @@ module Oxcaml_options_impl = struct
   let drawfexpr () = Flambda2.Dump.rawfexpr := Flambda2.Dump.Main_dump_stream
   let drawfexpr_to file = Flambda2.Dump.rawfexpr := Flambda2.Dump.File file
   let dfexpr () = Flambda2.Dump.fexpr := Flambda2.Dump.Main_dump_stream
+
+  let dfexpr_after pass =
+    dfexpr ();
+    Flambda2.Dump.fexpr_after := Flambda2.Dump.This_pass pass
+
   let dfexpr_to file = Flambda2.Dump.fexpr := Flambda2.Dump.File file
   let dflexpect_to file = Flambda2.Dump.flexpect := Flambda2.Dump.File file
   let dslot_offsets = set' Flambda2.Dump.slot_offsets

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -156,6 +156,7 @@ module type Oxcaml_options = sig
   val drawfexpr_to : string -> unit
   val dfexpr : unit -> unit
   val dfexpr_to : string -> unit
+  val dfexpr_after : string -> unit
   val dflexpect_to : string -> unit
   val dslot_offsets : unit -> unit
   val dfreshen : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -243,9 +243,11 @@ module Flambda2 = struct
 
   module Dump = struct
     type target = Nowhere | Main_dump_stream | File of Misc.filepath
+    type pass = Last_pass | This_pass of string
 
     let rawfexpr = ref Nowhere
     let fexpr = ref Nowhere
+    let fexpr_after = ref Last_pass
     let flexpect = ref Nowhere
     let slot_offsets = ref false
     let freshen = ref false

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -183,9 +183,11 @@ module Flambda2 : sig
 
   module Dump : sig
     type target = Nowhere | Main_dump_stream | File of Misc.filepath
+    type pass = Last_pass | This_pass of string
 
     val rawfexpr : target ref
     val fexpr : target ref
+    val fexpr_after : pass ref
     val flexpect : target ref
     val slot_offsets : bool ref
     val freshen : bool ref

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -215,6 +215,9 @@ let lambda_to_flambda ~ppf_dump:ppf ~prefixname ~machine_width
       print_flambda last_pass_name
         (Flambda_features.dump_simplify ())
         ppf flambda;
+      print_fexpr "simplify"
+        (Flambda_features.dump_fexpr (This_pass "simplify"))
+        ppf flambda;
       print_flexpect "simplify" ppf ~raw_flambda flambda;
       let ( flambda,
             free_names,
@@ -229,6 +232,9 @@ let lambda_to_flambda ~ppf_dump:ppf ~prefixname ~machine_width
                 Flambda2_reaper.Reaper.run ~machine_width ~cmx_loader ~all_code
                   ~final_typing_env flambda)
           in
+          print_fexpr "reaper"
+            (Flambda_features.dump_fexpr (This_pass "reaper"))
+            ppf flambda;
           print_flexpect "reaper" ppf ~raw_flambda flambda;
           ( flambda,
             free_names,
@@ -247,7 +253,9 @@ let lambda_to_flambda ~ppf_dump:ppf ~prefixname ~machine_width
       print_flambda last_pass_name
         (Flambda_features.dump_flambda ())
         ppf flambda;
-      print_fexpr last_pass_name (Flambda_features.dump_fexpr ()) ppf flambda;
+      print_fexpr last_pass_name
+        (Flambda_features.dump_fexpr Last_pass)
+        ppf flambda;
       let { unit = flambda; exported_offsets; cmx; all_code; reachable_names } =
         build_run_result flambda ~free_names ~final_typing_env ~all_code
           slot_offsets

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -149,7 +149,16 @@ let dump_flambda () = !Clflags.dump_flambda
 
 let dump_rawfexpr () = !Oxcaml_flags.Flambda2.Dump.rawfexpr
 
-let dump_fexpr () = !Oxcaml_flags.Flambda2.Dump.fexpr
+type pass = Oxcaml_flags.Flambda2.Dump.pass =
+  | Last_pass
+  | This_pass of string
+
+let dump_fexpr pass =
+  match pass, !Oxcaml_flags.Flambda2.Dump.fexpr_after with
+  | Last_pass, Last_pass -> !Oxcaml_flags.Flambda2.Dump.fexpr
+  | This_pass pass1, This_pass pass2 when String.equal pass1 pass2 ->
+    !Oxcaml_flags.Flambda2.Dump.fexpr
+  | (Last_pass | This_pass _), _ -> Nowhere
 
 let dump_flexpect () = !Oxcaml_flags.Flambda2.Dump.flexpect
 

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -101,7 +101,11 @@ val dump_flambda : unit -> bool
 
 val dump_rawfexpr : unit -> dump_target
 
-val dump_fexpr : unit -> dump_target
+type pass = Oxcaml_flags.Flambda2.Dump.pass =
+  | Last_pass
+  | This_pass of string
+
+val dump_fexpr : pass -> dump_target
 
 val dump_flexpect : unit -> dump_target
 

--- a/testsuite/tests/flambda2/code_size_of_boolean_not_switch.ml
+++ b/testsuite/tests/flambda2/code_size_of_boolean_not_switch.ml
@@ -1,7 +1,7 @@
 (* TEST
  compile_only = "true";
  flambda2;
- ocamlopt_flags = "-flambda2-inline-small-function-size 1 -flambda2-inline-large-function-size 1 -dfexpr";
+ ocamlopt_flags = "-flambda2-inline-small-function-size 1 -flambda2-inline-large-function-size 1 -dfexpr-after simplify";
  setup-ocamlopt.byte-build-env;
  ocamlopt.byte;
  check-ocamlopt.byte-output;

--- a/testsuite/tests/flambda2/code_size_of_single_arg_switch.ml
+++ b/testsuite/tests/flambda2/code_size_of_single_arg_switch.ml
@@ -1,7 +1,7 @@
 (* TEST
  compile_only = "true";
  flambda2;
- ocamlopt_flags = "-flambda2-inline-small-function-size 0 -flambda2-inline-large-function-size 0 -dfexpr";
+ ocamlopt_flags = "-flambda2-inline-small-function-size 0 -flambda2-inline-large-function-size 0 -dfexpr-after simplify";
  setup-ocamlopt.byte-build-env;
  ocamlopt.byte;
  check-ocamlopt.byte-output;

--- a/testsuite/tests/flambda2/inlining_cost_of_primitive_on_parameters.ml
+++ b/testsuite/tests/flambda2/inlining_cost_of_primitive_on_parameters.ml
@@ -1,6 +1,6 @@
 (* TEST
  compile_only = "true";
- ocamlopt_flags = "-flambda2-inline-small-function-size 0 -flambda2-inline-threshold 7.99 -dfexpr";
+ ocamlopt_flags = "-flambda2-inline-small-function-size 0 -flambda2-inline-threshold 7.99 -dfexpr-after simplify";
  flambda2;
  setup-ocamlopt.byte-build-env;
  ocamlopt.byte;

--- a/testsuite/tests/flambda2/removed_operations_of_switch.ml
+++ b/testsuite/tests/flambda2/removed_operations_of_switch.ml
@@ -1,6 +1,6 @@
 (* TEST
  compile_only = "true";
- ocamlopt_flags = "-flambda2-inline-small-function-size 26 -flambda2-inline-threshold 26.99 -flambda2-inline-large-function-size 100 -dfexpr";
+ ocamlopt_flags = "-flambda2-inline-small-function-size 26 -flambda2-inline-threshold 26.99 -flambda2-inline-large-function-size 100 -dfexpr-after simplify";
  flambda2;
  setup-ocamlopt.byte-build-env;
  ocamlopt.byte;


### PR DESCRIPTION
Current valid values are `-dfexpr-after simplify` to dump fexpr after simplify, and `-dfexpr-after reaper` to dump fexpr after the reaper. With `-dfexpr`, dump fexpr after the last pass.

Note that to avoid conflicting behavior with `-dfexpr-to`, there is currently no way to dump fexpr after different passes in the same execution.