### PR TITLE
Move size of nested sets of closures from code_size to cost_metrics

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -133,7 +133,7 @@ module Inlining = struct
 
   let definition_inlining_decision inline cost_metrics =
     let inline_threshold = threshold () in
-    let code_size = Cost_metrics.size cost_metrics in
+    let code_size = Cost_metrics.total_size cost_metrics in
     match (inline : Inline_attribute.t) with
     | Never_inline ->
       Function_decl_inlining_decision_type.Never_inline_attribute

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -469,6 +469,7 @@ and static_let_expr env bound_static defining_expr body : Fexpr.expr =
             })
       in
       let code_size =
+        (* CR ncourant: what to do here? *)
         Code.cost_metrics code |> Cost_metrics.size |> Code_size.to_int
       in
       let result_mode : Fexpr.alloc_mode_for_assignments =

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -147,9 +147,9 @@ let inlining_does_decrease_code_size ~code_or_metadata cost_metrics =
     code_or_metadata
     |> Code_or_metadata.code_metadata
     |> Code_metadata.cost_metrics
-    |> Cost_metrics.size
+    |> Cost_metrics.total_size
   in
-  let inlined_code_size = Cost_metrics.size cost_metrics in
+  let inlined_code_size = Cost_metrics.total_size cost_metrics in
   not (Code_size.( <= ) original_code_size inlined_code_size)
 
 let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr

--- a/middle_end/flambda2/simplify/inlining/function_decl_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/function_decl_inlining_decision.ml
@@ -32,7 +32,7 @@ let make_decision0 ~inlining_arguments:args ~inline ~stub ~cost_metrics:metrics
       let small_function_size =
         Inlining_arguments.small_function_size args |> Code_size.of_int
       in
-      let size = Cost_metrics.size metrics in
+      let size = Cost_metrics.total_size metrics in
       let is_small = Code_size.( <= ) size small_function_size in
       let is_large = Code_size.( <= ) large_function_size size in
       let is_recursive =
@@ -52,10 +52,11 @@ let make_decision0 ~inlining_arguments:args ~inline ~stub ~cost_metrics:metrics
       then Function_body_too_large large_function_size
       else if is_small
       then
-        Small_function { size = Cost_metrics.size metrics; small_function_size }
+        Small_function
+          { size = Cost_metrics.total_size metrics; small_function_size }
       else
         Speculatively_inlinable
-          { size = Cost_metrics.size metrics;
+          { size = Cost_metrics.total_size metrics;
             small_function_size;
             large_function_size
           }

--- a/middle_end/flambda2/simplify_shared/inlining_report.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_report.ml
@@ -220,31 +220,44 @@ module Context = struct
               } =
           Cost_metrics.removed c
         in
+        let nested = Cost_metrics.nested_removed c in
         let table =
-          [ [ `String "Call";
+          [ [ `String "";
+              `String "Call";
               `String "Alloc";
               `String "Prim";
               `String "Branch";
               `String "Direct call of indirect";
               `String "Specialized poly compare";
               `String "Requested inline" ];
-            [ `Int call;
+            [ `String "Inside function";
+              `Int call;
               `Int alloc;
               `Int prim;
               `Int branch;
               `Int direct_call_of_indirect;
               `Int specialized_poly_compare;
-              `Int requested_inline ] ]
+              `Int requested_inline ];
+            [ `String "In nested closures";
+              `Int nested.call;
+              `Int nested.alloc;
+              `Int nested.prim;
+              `Int nested.branch;
+              `Int nested.direct_call_of_indirect;
+              `Int nested.specialized_poly_compare;
+              `Int nested.requested_inline ] ]
           |> Table.create
         in
         Format.fprintf ppf
-          "@[<v>@[<h>Code@ size@ was@ estimated@ to@ be@ %a@]@,\
+          "@[<v>@[<h>Code@ size@ was@ estimated@ to@ be@ %a (%a nested)@]@,\
            @,\
            @[<h>Benefits@ of@ inlining@ this@ call:@;\
            @]@,\
            @[<h>%a@]@]@,\
            @,"
-          Code_size.print (Cost_metrics.size c) Table.print table
+          Code_size.print (Cost_metrics.size c) Code_size.print
+          (Cost_metrics.nested_size c)
+          Table.print table
     in
     let print_depth ppf = function
       | None -> ()

--- a/middle_end/flambda2/terms/cost_metrics.mli
+++ b/middle_end/flambda2/terms/cost_metrics.mli
@@ -22,7 +22,15 @@ val from_size : Code_size.t -> t
 
 val size : t -> Code_size.t
 
+val nested_size : t -> Code_size.t
+
+val total_size : t -> Code_size.t
+
 val removed : t -> Removed_operations.t
+
+val nested_removed : t -> Removed_operations.t
+
+val total_removed : t -> Removed_operations.t
 
 val print : Format.formatter -> t -> unit
 


### PR DESCRIPTION
This should be a no-op for inlining decisions, but allows tracking size and removed_operations in nested sets of closures, as part of a fix for #5141.