### PR TITLE
Faster oldify

### DIFF
--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -164,11 +164,15 @@ CAMLdeprecated_typedef(addr, char *);
 /* Prefetching */
 
 #ifdef CAML_INTERNALS
-#if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
-#define caml_prefetch(p) __builtin_prefetch((p), 1, 3)
+#if (defined(__GNUC__) || defined(__clang__)) \
+     && __has_builtin(__builtin_prefetch)
+#define caml_prefetchr(p) __builtin_prefetch((p), 0, 3)
+/* 0 = intent to read; 3 = all cache levels */
+#define caml_prefetchw(p) __builtin_prefetch((p), 1, 3)
 /* 1 = intent to write; 3 = all cache levels */
 #else
-#define caml_prefetch(p)
+#define caml_prefetchr(p)
+#define caml_prefetchw(p)
 #endif
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/sizeclasses.h
+++ b/runtime/caml/sizeclasses.h
@@ -2,6 +2,9 @@
 #ifndef CAML_SIZECLASSES_H
 #define CAML_SIZECLASSES_H
 
+#include <assert.h>
+#include <limits.h>
+
 #define POOL_WSIZE 4096
 #define POOL_HEADER_WSIZE 7
 #define SIZECLASS_MAX 128
@@ -10,20 +13,21 @@
 typedef unsigned char sizeclass_t;
 static_assert(NUM_SIZECLASSES < (1 << (CHAR_BIT * sizeof(sizeclass_t))), "");
 
-/* The largest size for this size class.
+/* The slot sizes (and therefore the largest whsize) for each size class.
    (A gap is left after smaller objects) */
-static const unsigned int wsize_sizeclass[NUM_SIZECLASSES] =
+static const unsigned int whsize_sizeclass[NUM_SIZECLASSES] =
 { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16, 17, 19, 22, 25, 28, 32, 33, 37,
   42, 47, 53, 59, 65, 73, 81, 89, 99, 108, 118, 128 };
 
 /* The number of padding words to use, at the beginning of a pool
-   of this sizeclass, to reach exactly POOL_WSIZE words. */
-static const unsigned char wastage_sizeclass[NUM_SIZECLASSES] =
+   of each sizeclass, to reach exactly POOL_WSIZE words. */
+static const unsigned char padding_sizeclass[NUM_SIZECLASSES] =
 { 0, 1, 0, 1, 4, 3, 1, 1, 3, 9, 9, 1, 9, 9, 4, 19, 14, 1, 25, 30, 19, 15, 0,
   8, 18, 59, 1, 39, 84, 30, 93, 77, 121 };
 
-/* Map from (positive) object sizes to size classes. */
-static const sizeclass_t sizeclass_wsize[SIZECLASS_MAX + 1] =
+/* The size class (index into whsize_sizeclass) for each
+   whsize from 0 to SIZECLASS_MAX. Dummy value 255 at index 0. */
+static const sizeclass_t sizeclass_whsize[SIZECLASS_MAX + 1] =
 { 255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 11, 11, 12, 12, 13, 14, 14, 15,
   15, 15, 16, 16, 16, 17, 17, 17, 18, 18, 18, 18, 19, 20, 20, 20, 20, 21, 21,
   21, 21, 21, 22, 22, 22, 22, 22, 23, 23, 23, 23, 23, 23, 24, 24, 24, 24, 24,
@@ -31,4 +35,15 @@ static const sizeclass_t sizeclass_wsize[SIZECLASS_MAX + 1] =
   27, 27, 27, 27, 28, 28, 28, 28, 28, 28, 28, 28, 29, 29, 29, 29, 29, 29, 29,
   29, 29, 29, 30, 30, 30, 30, 30, 30, 30, 30, 30, 31, 31, 31, 31, 31, 31, 31,
   31, 31, 31, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32 };
+
+/* The number of free words left in the slot after a block of each whsize from
+   0 to SIZECLASS_MAX. Dummy value 255 at index 0. */
+static const mlsize_t wfrag_whsize[SIZECLASS_MAX + 1] =
+{ 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 2, 1, 0, 2,
+  1, 0, 2, 1, 0, 3, 2, 1, 0, 0, 3, 2, 1, 0, 4, 3, 2, 1, 0, 4, 3, 2, 1, 0, 5,
+  4, 3, 2, 1, 0, 5, 4, 3, 2, 1, 0, 5, 4, 3, 2, 1, 0, 7, 6, 5, 4, 3, 2, 1, 0,
+  7, 6, 5, 4, 3, 2, 1, 0, 7, 6, 5, 4, 3, 2, 1, 0, 9, 8, 7, 6, 5, 4, 3, 2, 1,
+  0, 8, 7, 6, 5, 4, 3, 2, 1, 0, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 9, 8, 7, 6, 5,
+  4, 3, 2, 1, 0 };
+
 #endif /* CAML_SIZECLASSES_H */

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -331,8 +331,8 @@ Caml_inline void prefetch_block(value v)
      somewhere between 1/8-1/2 of a prefetch operation (in expectation,
      depending on alignment, word size, and cache line size), which is
      cheap enough to make this worthwhile. */
-  caml_prefetch((const void *)Hp_val(v));
-  caml_prefetch((const void *)&Field(v, 3));
+  caml_prefetchw((const void *)Hp_val(v));
+  caml_prefetchw((const void *)&Field(v, 3));
 }
 
 static void ephe_next_cycle (void)
@@ -1278,7 +1278,7 @@ again:
       /* Didn't finish scanning this object, either because budget <= 0,
          or the prefetch buffer filled up. Leave the rest on the stack. */
       mark_stack_push_range(stk, me.start, me.end);
-      caml_prefetch((void*)(me.start + 1));
+      caml_prefetchw((void*)(me.start + 1));
 
       if (pb_size(&pb) > PREFETCH_BUFFER_MIN) {
         /* We may have just discovered more work when we were about to run out.

--- a/tools/gdb-macros
+++ b/tools/gdb-macros
@@ -149,7 +149,7 @@ define caml_search_pools
     if $caml_search_debug || $found_here
       printf " domain %d %s pool %lx-%lx sizeclass %d(%d)", \
              $domain_index, $arg0, $pool, ((char*)$pool)+$caml_pool_size, \
-             $pool->sz, wsize_sizeclass[$pool->sz]
+             $pool->sz, whsize_sizeclass[$pool->sz]
       if $caml_search_debug
         printf "\n"
       end

--- a/tools/gen_sizeclasses.ml
+++ b/tools/gen_sizeclasses.ml
@@ -12,70 +12,100 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let overhead block slot obj =
-  1. -. float_of_int((block / slot) * obj) /. float_of_int block
-
+let pool_words = 4096 (* Number of words in a pool *)
+let header_size = 7 (* Wsize_bsize(sizeof(struct pool)) *)
+let max_slot = 128 (* maximum whsize stored in pools (SIZECLASS_MAX) *)
 let max_overhead = 0.101
 
-(*
-  Prevention of false sharing requires certain sizeclasses to be present. This
-  ensures they are generated.
+(* `overhead pool slot whsize` is the fraction of `pool` which would be wasted
+   if slots of size `slot` were used to store blocks of size `whsize` *)
+
+let overhead pool slot whsize =
+  let slots = pool / slot in
+  (1. -. Float.of_int(slots * whsize) /. Float.of_int pool)
+
+(* Prevention of false sharing requires certain slot sizes to be present. This
+   ensures they are generated.
 
   Runtime has a constructor for atomics (`caml_atomic_make_contended`), which
-  aligns them with cache lines to avoid false sharing. The implementation
-  relies on the fact that pools are cache-aligned by design and slots of
-  appropriate size maintain this property. To be precise, slots whose size is a
-  multiple of cache line are laid out in such a way, that their boundaries
-  coincide with boundaries between cache lines.
+  aligns them with cache lines to avoid false sharing. The implementation relies
+  on the fact that pools are cache-aligned by design and slots of appropriate
+  size maintain this property (by padding after the pool header). To be precise,
+  slots whose size is a multiple of the cache line size are laid out in such a
+  way, that their boundaries coincide with boundaries between cache lines.
 *)
-let required_for_contended_atomic = function
+let size_required = function
   | 16 | 32 -> true
   | _ -> false
 
-let rec blocksizes block slot = function
-  | 0 -> []
-  | obj ->
-    if overhead block slot obj > max_overhead
-      || required_for_contended_atomic obj
-    then
-      if overhead block obj obj < max_overhead then
-        obj :: blocksizes block obj (obj - 1)
-      else
-        failwith (Format.sprintf
-          "%d-word objects cannot fit in %d-word arena below %.1f%% overhead"
-                                 obj block (100. *. max_overhead))
-    else blocksizes block slot (obj - 1)
+let avail_pool_words = pool_words - header_size
 
-let rec findi_acc i p = function
-  | [] -> raise Not_found
-  | x :: xs -> if p x then i else findi_acc (i + 1) p xs
-let findi = findi_acc 0
+(* `whsize_sizeclass` is the list of actual slot sizes, in ascending order *)
 
-let arena = 4096
-let header_size = 7
-let max_slot = 128
-let avail_arena = arena - header_size
-let sizes = List.rev (blocksizes avail_arena max_int max_slot)
+let whsize_sizeclass =
+  (* whsize_sizeclass' pool last whsize returns the minimal list of slot sizes
+     less than `last` into which `pool` words can be divided, such that:
+     - the required slot sizes are included in the list;
+     - the overhead does not exceed `max_overhead` *)
+  let rec whsize_sizeclass' pool last = function
+    | 0 -> []
+    | whsize ->
+      if overhead pool last whsize > max_overhead
+      || size_required whsize
+      then
+        if overhead pool whsize whsize < max_overhead then
+          whsize :: whsize_sizeclass' pool whsize (whsize - 1)
+        else
+          failwith
+            (Format.sprintf
+               "%d-word blocks won't fit in %d-word pool below %.1f%% overhead"
+               whsize pool (100. *. max_overhead))
+      else whsize_sizeclass' pool last (whsize - 1)
+  in
+  List.rev (whsize_sizeclass' avail_pool_words max_int max_slot)
 
-let rec size_slots n =
-  if n > max_slot then
-    []
-  else
-    findi (fun x -> n <= x) sizes :: size_slots (n + 1)
+(* sizeclass_whsize is the list of indexes into `whsize_sizeclass` for
+   allocating objects of all whsizes from 0 up to and including
+   `max_slot`. There's a dummy value 255 for whsize 0 *)
+let sizeclass_whsize =
+  let rec sizeclass_whsize' whsize =
+    if whsize > max_slot then
+      []
+    else
+      match List.find_index (fun slot -> whsize <= slot) whsize_sizeclass with
+      | Some i -> i :: sizeclass_whsize' (whsize + 1)
+      | None -> raise Not_found
+  in 255 :: (sizeclass_whsize' 1)
 
-let rec wastage =
-  sizes |> List.map (fun s -> avail_arena mod s)
+(* padding_sizeclass is a list giving the number of words of padding which
+   must be placed after the pool header when siots are the corresponding
+   size from `whsize_sizeclass` *)
+let padding_sizeclass =
+  whsize_sizeclass |> List.map (fun slot -> avail_pool_words mod slot)
+
+(* wfrag_whsize is a list giving the number of words left as a fragment when a
+   block of given whsize is allocated. There's a dummy value 255 for whsize
+   0 *)
+let wfrag_whsize =
+  255 :: ((List.tl sizeclass_whsize)
+          |> List.mapi (fun n s -> (List.nth whsize_sizeclass s - n - 1)))
 
 open Format
 
-let rec print_overheads n = function
-  | [] -> ()
-  | s :: ss when n > s -> print_overheads n ss
-  | (s :: _) as ss  ->
-     printf "%3d/%-3d: %.1f%%\n" n s (100. *. overhead avail_arena s n);
-     print_overheads (n+1) ss
+(*
 
-(* let () = print_overheads 1 sizes *)
+   (* Sanity-check code *)
+
+   let rec print_overheads n = function
+     | [] -> ()
+     | s :: ss when n > s -> print_overheads n ss
+     | (s :: _) as ss  ->
+        printf "%3d/%-3d: %.1f%%\n" n s (100. *. overhead avail_pool_words s n);
+        print_overheads (n+1) ss
+
+      let () = print_overheads 1 whsize_sizeclass
+
+*)
 
 let rec print_list ppf = function
   | [] -> ()
@@ -83,31 +113,47 @@ let rec print_list ppf = function
   | x :: xs -> fprintf ppf "%d,@ %a" x print_list xs
 
 let _ =
-  printf "/* This file is generated by tools/gen_sizeclasses.ml */\n";
-  printf "#ifndef CAML_SIZECLASSES_H\n";
-  printf "#define CAML_SIZECLASSES_H\n\n";
-  printf "#define POOL_WSIZE %d\n" arena;
-  printf "#define POOL_HEADER_WSIZE %d\n" header_size;
-  printf "#define SIZECLASS_MAX %d\n" max_slot;
-  printf "#define NUM_SIZECLASSES %d\n" (List.length sizes);
+  printf {|/* This file is generated by tools/gen_sizeclasses.ml */
+#ifndef CAML_SIZECLASSES_H
+#define CAML_SIZECLASSES_H
+
+#include <assert.h>
+#include <limits.h>
+|};
+  printf {|
+#define POOL_WSIZE %d
+#define POOL_HEADER_WSIZE %d
+#define SIZECLASS_MAX %d
+#define NUM_SIZECLASSES %d
+|}
+    pool_words header_size max_slot (List.length whsize_sizeclass);
   printf {|
 typedef unsigned char sizeclass_t;
 static_assert(NUM_SIZECLASSES < (1 << (CHAR_BIT * sizeof(sizeclass_t))), "");
 
-/* The largest size for this size class.
+/* The slot sizes (and therefore the largest whsize) for each size class.
    (A gap is left after smaller objects) */
-static const unsigned int wsize_sizeclass[NUM_SIZECLASSES] =@[<2>{ %a };@]
+static const unsigned int whsize_sizeclass[NUM_SIZECLASSES] =@[<2>{ %a };@]
 |}
-    print_list sizes;
+    print_list whsize_sizeclass;
   printf {|
 /* The number of padding words to use, at the beginning of a pool
-   of this sizeclass, to reach exactly POOL_WSIZE words. */
-static const unsigned char wastage_sizeclass[NUM_SIZECLASSES] =@[<2>{ %a };@]
+   of each sizeclass, to reach exactly POOL_WSIZE words. */
+static const unsigned char padding_sizeclass[NUM_SIZECLASSES] =@[<2>{ %a };@]
 |}
-    print_list wastage;
+    print_list padding_sizeclass;
   printf {|
-/* Map from (positive) object sizes to size classes. */
-static const sizeclass_t sizeclass_wsize[SIZECLASS_MAX + 1] =@[<2>{ %a };@]
+/* The size class (index into whsize_sizeclass) for each
+   whsize from 0 to SIZECLASS_MAX. Dummy value 255 at index 0. */
+static const sizeclass_t sizeclass_whsize[SIZECLASS_MAX + 1] =@[<2>{ %a };@]
 |}
-    print_list (255 :: size_slots 1);
-  printf "#endif /* CAML_SIZECLASSES_H */\n"
+    print_list sizeclass_whsize;
+  printf {|
+/* The number of free words left in the slot after a block of each whsize from
+   0 to SIZECLASS_MAX. Dummy value 255 at index 0. */
+static const mlsize_t wfrag_whsize[SIZECLASS_MAX + 1] =@[<2>{ %a };@]
+|}
+    print_list wfrag_whsize;
+  printf {|
+#endif /* CAML_SIZECLASSES_H */
+|}


### PR DESCRIPTION
This reworks the hot code of the minor collector, for performance gains measured at 2-4% of overall runtime in an important application.

- Exposing the "free lists" from the shared-heap allocator, so that the minor collector can inline the allocations when promoting small objects.
- Refactoring `alloc_shared`, `try_update_object_header` and `oldify_one` into `try_forward` and `oldify_one`, to reduce memory indirection.
- Adding various things into the `oldify_state` to reduce accesses to globals and make various accesses to the domain state all hit in the same one or two cache lines.
- Prefetch the tips of the shared-heap free lists.

I've also added a few comments which should help us (probably me!) the next time we want to rework this very performance-sensitive code.