### PR TITLE
amd64: make jumps to `caml_call_gc*` deref GOT

### DIFF
--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -463,10 +463,10 @@ let destroyed_at_c_call =
   if win64 then destroyed_at_c_call_win64 else destroyed_at_c_call_unix
 
 let destroyed_at_alloc_or_poll =
-  if X86_proc.use_plt then
-    destroyed_by_plt_stub
-  else
-    [| r11 |]
+  (* Calls to [caml_call_gc] are marked to dereference GOT entries
+     directly (if at all), so there's no PLT stub involved. Hence,
+     r10 is safe, even with dynlinkable code. *)
+  [| r11 |]
 
 let destroyed_at_pushtrap =
   [| r11 |]


### PR DESCRIPTION
If invocations of `caml_call_gc` and similar functions might go through a PLT stub, we have to consider `r10` as potentially clobbered at poll and alloc points.

We can instead emit code as-if these functions were marked with `__attribute__((__noplt__))` (in some C code), which then leads to the compiler emitting code like `call *sym@GOTPCREL(%rip)` instead of `call sym@PLT`, which leads to direct dereference of an address from the GOT, which doesn't lead to a (potential) dynamic loader invocation.

As a result, we don't need to treat `r10` as potentially clobbered any longer.

This is an alternative approach to what's implemented in #5160.

Closes: https://github.com/oxcaml/oxcaml/pull/5160
See: https://github.com/oxcaml/oxcaml/pull/5160#issuecomment-3675486883