### PR TITLE
Switch to cachix install nix action to avoid timeouts

### DIFF
--- a/.github/workflows/nix-github-actions.yml
+++ b/.github/workflows/nix-github-actions.yml
@@ -19,8 +19,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v20
-      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: cachix/install-nix-action@v31
       - id: set-matrix
         name: Generate Nix Matrix
         run: |
@@ -42,8 +41,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v20
-      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: cachix/install-nix-action@v31
       - run: nix build -L '.#${{ matrix.attr }}'
 
 concurrency:


### PR DESCRIPTION
My theory as to why we're experiencing timeouts is that the previous install nix action was hitting a service that would ban the IP if too many requests came in at the same time. IE DOS protection.  The way this action works is we create 10 requests rapidly, which may be enough to trigger this protection.

Switch to the cachix install nix action, which just uses the official nixos install scripts to install nix from nixos.org. I believe nixos.org has much higher usage limits, and should avoid the download timeouts we were seeing with the other one.