### PR TITLE
Implement Dynamic in stdlib

### DIFF
--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -1300,142 +1300,12 @@ typedef struct {
 
 #define Is_bound(b) Is_block((b)->dyn)
 
-/* Hash tables of bindings. Linear probing, add-only, growing when half full.
- *
- * At present we only use these for per-thread base values (those set
- * with set_root), but I'm keeping this code generic as we may want
- * other binding hash tables in future. */
-
-#define DYNAMIC_INIT_CAPACITY 8
-
-typedef struct {
-  size_t mask; /* capacity - 1 */
-  size_t count;
-  binding_t bindings;
-} binding_table_s, *binding_table_t;
-
-static void dynamic_table_fresh(binding_table_t table)
-{
-  table->mask = (size_t)-1;
-  table->count = 0;
-  table->bindings = NULL;
-}
-
-static void dynamic_table_add(binding_table_t table, value dyn, value val)
-{
-  size_t mask = table->mask;
-  value hash = Hash_dyn(dyn);
-  size_t i = hash & mask;
-  size_t j = i;
-  while(Is_block(table->bindings[j].dyn)) { /* collision */
-    j = (j + 1) & mask; /* linear probing */
-    CAMLassert (j != i); /* Caller guarantees table has space */
-  }
-  table->bindings[j].dyn = dyn;
-  table->bindings[j].val = val;
-}
-
-static bool dynamic_table_grow(binding_table_t table)
-{
-  size_t old_capacity = table->mask + 1;
-  size_t new_capacity = old_capacity ? old_capacity * 2 : DYNAMIC_INIT_CAPACITY;
-  size_t new_mask = new_capacity - 1;
-  CAMLassert(Is_power_of_2(new_capacity));
-
-  binding_t new_bindings = caml_stat_alloc_noexc(sizeof(binding_s) * new_capacity);
-  if (!new_bindings) {
-    return false;
-  }
-  for (size_t j = 0; j < new_capacity; ++ j) { /* ensure new table is empty */
-    new_bindings[j].dyn = Val_null;
-  }
-  binding_t old_bindings = table->bindings;
-  table->mask = new_mask;
-  table->bindings = new_bindings;
-
-  /* Copy existing bindings */
-  for (size_t i = 0; i < old_capacity; ++ i) {
-    if (Is_bound(&old_bindings[i])) {
-      dynamic_table_add(table, old_bindings[i].dyn, old_bindings[i].val);
-    }
-  }
-  if (old_bindings) {
-    caml_stat_free(old_bindings);
-  }
-  return true;
-}
-
-/* Find the binding of `dyn` in `table`, or an empty binding if not
- * present. Returns the binding in `*binding_out`, and a bool
- * indicating whether the binding was found. If the table is empty,
- * sets `binding_out` to NULL and returns `false`. Does not
- * allocate. */
-
-static bool dynamic_table_find(binding_table_t table, value dyn, binding_t *binding_out)
-{
-  if (table->bindings == NULL) {
-    *binding_out = NULL;
-    return false;
-  }
-  uintnat hash = Hash_dyn(dyn);
-  size_t i = hash & table->mask;
-  while (true) {
-    binding_t binding = table->bindings + i;
-    if (binding->dyn == dyn) { /* Found */
-      *binding_out = binding;
-      return true;
-    } else if (!Is_bound(binding)) { /* Not found */
-      *binding_out = binding;
-      return false;
-    }
-    /* Linear probe */
-    i = (i + 1) & table->mask;
-  }
-}
-
-/* Set `dyn` to `val` in `table`. Update if already present; otherwise
- * add (growing the table if half-full). May allocate on the C heap. */
-
-static bool dynamic_table_bind(binding_table_t table, value dyn, value val)
-{
-  binding_t binding = NULL;
-  bool found = dynamic_table_find(table, dyn, &binding);
-  if (!binding) { /* Table was empty */
-    bool res = dynamic_table_grow(table);
-    if (!res) {
-      return res;
-    }
-    found = dynamic_table_find(table, dyn, &binding);
-    CAMLassert(!found);
-  }
-  CAMLassert(binding);
-  if (found) { /* Update binding */
-    binding->val = val;
-  } else { /* Not found */
-    if (table->count * 2 == table->mask+1) {
-      /* grow when half-full (includes the special case of being empty) */
-      bool res = dynamic_table_grow(table);
-      if (!res) {
-        return res;
-      }
-      dynamic_table_add(table, dyn, val);
-    } else {
-      CAMLassert(!Is_bound(binding));
-      binding->dyn = dyn;
-      binding->val = val;
-    }
-    ++ table->count;
-  }
-  return true;
-}
-
 /* Per-thread dynamic binding data structure */
 
 /* Must match Dynamic_ definitions in amd64.S */
 
 typedef struct dynamic_thread_s {
   binding_s cache[DYNAMIC_CACHE_SIZE];
-  binding_table_s base;
 } dynamic_thread_s, *dynamic_thread_t;
 
 static void dynamic_flush_cache(dynamic_thread_t thread)
@@ -1452,35 +1322,16 @@ CAMLexport dynamic_thread_t caml_dynamic_new_thread(dynamic_thread_t parent)
 {
   dynamic_thread_t res = caml_stat_alloc_noexc(sizeof(dynamic_thread_s));
   if (!res) {
-    goto fail_alloc;
+    return NULL;
   }
   /* Not even going to think about the semantics of copying cache entries */
   dynamic_flush_cache(res);
-  dynamic_table_fresh(&res->base);
 
-  if (parent && parent->base.count) { /* Existing base bindings to copy */
-    size_t capacity = parent->base.mask + 1;
-    binding_t new_bindings = caml_stat_alloc_noexc(sizeof(binding_s) * capacity);
-    if (!new_bindings) {
-      goto fail_alloc_bindings;
-    }
-    memcpy(new_bindings, parent->base.bindings, sizeof(binding_s) * capacity);
-    res->base.mask = parent->base.mask;
-    res->base.count = parent->base.count;
-    res->base.bindings = new_bindings;
-  }
   return res;
-fail_alloc_bindings:
-  caml_stat_free(res);
-fail_alloc:
-  return NULL;
 }
 
 CAMLexport void caml_dynamic_delete_thread(dynamic_thread_t thread)
 {
-  if (thread->base.bindings) {
-    caml_stat_free(thread->base.bindings);
-  }
   caml_stat_free(thread);
 }
 
@@ -1505,34 +1356,6 @@ CAMLexport void caml_dynamic_scan_thread_roots(dynamic_thread_t thread,
       f(fdata, thread->cache[i].val, &thread->cache[i].val);
     }
   }
-  for (size_t i = 0; i < (size_t)thread->base.mask + 1; ++i) {
-    if (Is_bound(&thread->base.bindings[i])) {
-      f(fdata, thread->base.bindings[i].dyn, &thread->base.bindings[i].dyn);
-      f(fdata, thread->base.bindings[i].val, &thread->base.bindings[i].val);
-    }
-  }
-
-}
-
-CAMLprim value caml_dynamic_set_root(value dyn, value val)
-{
-  CAMLparam2(dyn, val); /* TODO: remove unless we can GC */
-  dynamic_thread_t thread = Caml_state->dynamic_bindings;
-  CAMLassert(thread);
-  bool res = dynamic_table_bind(&thread->base, dyn, val);
-  if (!res) {
-    caml_raise_out_of_memory();
-  }
-
-  /* invalidate cache */
-  uintnat hash = Hash_dyn(dyn);
-  uintnat index = hash & (DYNAMIC_CACHE_SIZE - 1);
-  binding_t entry = thread->cache + index;
-  if (entry->dyn == dyn) {
-    entry->dyn = Val_null;
-  }
-
-  CAMLreturn(Val_unit);
 }
 
 /* Get the current value of a dynamic variable. Does not allocate.
@@ -1562,15 +1385,7 @@ CAMLprim value caml_dynamic_get(value dyn)
     stack = Stack_parent(stack);
   }
 
-  /* Not bound on a fiber; check the thread base bindings */
-  binding_t binding = NULL;
-  bool found = dynamic_table_find(&thread->base, dyn, &binding);
-  if (found) {
-    val = binding->val;
-    goto found;
-  }
-
-  /* Back to the initial binding */
+  /* Not bound on a fiber; back to the initial binding */
   val = Val_dyn(dyn);
 
 found:

--- a/runtime4/misc.c
+++ b/runtime4/misc.c
@@ -391,7 +391,7 @@ CAMLprim value caml_atomic_lxor(value ref, value incr) {
   return caml_atomic_lxor_field(ref, Val_long(0), incr);
 }
 
-// Dummy implementations so effect.ml can compile
+// Dummy implementations so effect.ml + dynamic.ml can compile
 
 CAMLprim value caml_continuation_use_noexc(void)
 {
@@ -421,4 +421,14 @@ CAMLprim value caml_domain_dls_compare_and_set(void)
 CAMLprim value caml_no_bytecode_impl(void)
 {
   caml_failwith("No bytecode implementation provided for this external");
+}
+
+CAMLprim value caml_dynamic_make(void)
+{
+  caml_fatal_error("Effects not implemented in runtime4");
+}
+
+CAMLprim value caml_dynamic_get(void)
+{
+  caml_fatal_error("Effects not implemented in runtime4");
 }

--- a/stdlib/dune
+++ b/stdlib/dune
@@ -76,6 +76,8 @@
   atomic.mli
   backoff.ml
   backoff.mli
+  dynamic.ml
+  dynamic.mli
   effect.ml
   effect.mli
   bigarray.ml
@@ -228,6 +230,9 @@
   .stdlib.objs/byte/stdlib__Backoff.cmi
   .stdlib.objs/byte/stdlib__Backoff.cmt
   .stdlib.objs/byte/stdlib__Backoff.cmti
+  .stdlib.objs/byte/stdlib__Dynamic.cmi
+  .stdlib.objs/byte/stdlib__Dynamic.cmt
+  .stdlib.objs/byte/stdlib__Dynamic.cmti
   .stdlib.objs/byte/stdlib__Effect.cmi
   .stdlib.objs/byte/stdlib__Effect.cmt
   .stdlib.objs/byte/stdlib__Effect.cmti
@@ -503,6 +508,7 @@
   .stdlib.objs/native/stdlib__Dynarray.cmx
   .stdlib.objs/native/stdlib__Atomic.cmx
   .stdlib.objs/native/stdlib__Backoff.cmx
+  .stdlib.objs/native/stdlib__Dynamic.cmx
   .stdlib.objs/native/stdlib__Effect.cmx
   .stdlib.objs/native/stdlib__Either.cmx
   .stdlib.objs/native/stdlib__In_channel.cmx

--- a/stdlib/dynamic.ml
+++ b/stdlib/dynamic.ml
@@ -1,0 +1,60 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Aspen Smith, Jane Street                         *)
+(*                                                                        *)
+(*   Copyright 2025 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type ('a : value_or_null) t : value mod contended portable
+
+(* This is the same type as [Effect.t], but redefined here to avoid circular
+   dependencies. *)
+type 'a effect
+type (-'a, +'b) cont
+type last_fiber [@@immediate]
+
+external make
+  : ('a : value_or_null mod contended).
+  'a @ portable -> 'a t
+  @@ portable
+  = "caml_dynamic_make"
+
+external get
+  : ('a : value_or_null mod contended). 'a t -> 'a @ portable
+  @@ portable
+  = "caml_dynamic_get"
+
+external reperform :
+  'a effect @ unique ->
+  ('a, 'b) cont @ unique ->
+  last_fiber ->
+  'b @ unique once
+  @@ portable
+  = "%reperform"
+
+external with_stack_bind :
+  'a 'b 'c ('d : value_or_null mod contended) 'e.
+  ('a @ unique once -> 'b @ unique once) ->
+  (exn -> 'b) ->
+  ('c effect @ unique ->
+   ('c, 'b) cont @ unique ->
+   last_fiber ->
+   'b @ unique once) ->
+  'd t ->
+  'd @ portable ->
+  ('e @ once unique -> 'a @ unique once) @ once ->
+  'e ->
+  'b @ once unique
+  @@ portable
+  = "%with_stack_bind" "%with_stack_bind"
+
+let with_temporarily d v ~f =
+  let effc eff k last_fiber = reperform eff k last_fiber in
+  with_stack_bind (fun x -> x) (fun e -> raise e) effc d v (fun () -> f ()) ()

--- a/stdlib/dynamic.mli
+++ b/stdlib/dynamic.mli
@@ -1,0 +1,56 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Aspen Smith, Jane Street                         *)
+(*                                                                        *)
+(*   Copyright 2025 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+@@ portable
+
+(** A value of type ['a Dynamic.t] is a dynamically scoped variable of type
+    ['a].
+
+    [Dynamic] works like [Ref], except that changes to its value are only
+    visible to the current fiber and its children.
+
+    Every dynamic variable has a single "root" value, which is visible by
+    default to all running fibers. A fiber can temporarily change the locally
+    visible value of a dynamic variable within the scope of a function by
+    calling [with_temporarily]. During the execution of [with_temporarily],
+    any changes to the root value of the dynamic variable (eg via calls to
+    [set_root] by the current or other fibers) are unobservable until after
+    the outermost call to [with_temporarily] returns. *)
+type ('a : value_or_null) t : value mod contended portable
+
+(** [make v] creates a new dynamic variable with initial root value [v].
+
+    Since any domain can access the [Dynamic.t], the value must be portable.
+    Since any domain can access and modify the [Dynamic.t] without
+    synchronization, the type of values in the [Dynamic.t] must cross the
+    contention axis. *)
+val make : ('a : value_or_null mod contended). 'a @ portable -> 'a t
+
+(** [get dynamic] retrieves the current value of the dynamic variable [dynamic]
+    in the current fiber.
+
+    Within a call to [with_temporarily], this returns the {i local} value
+    of the dynamic variable (the value that was passed to [with_temporarily].
+    Outside of a call to [with_temporarily], this returns the {i root} value *)
+val get : ('a : value_or_null mod contended). 'a t -> 'a @ portable
+
+(** [with_temporarily dynamic v ~f] invokes [f] in a context where [dynamic] is
+    set to [v], then restores [dynamic] to the parent value (either the root
+    value, or the value set by a surrounding call to [with_temporarily]). *)
+val with_temporarily :
+  ('a : value mod contended) 'b.
+  'a t ->
+  'a @ portable ->
+  f:(unit -> 'b @ unique once) @ once ->
+  'b @ unique once

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -632,6 +632,7 @@ module Complex        = Complex
 module Condition      = Condition
 module Digest         = Digest
 module Domain         = Domain
+module Dynamic        = Dynamic
 module Dynarray       = Dynarray
 module Effect         = Effect
 module Either         = Either

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1433,6 +1433,7 @@ module Domain         = Domain
 [@@alert unstable
     "The Domain interface may change in incompatible ways in the future."
 ]
+module Dynamic        = Dynamic
 module Dynarray       = Dynarray
 module Effect         = Effect
 [@@alert "-unstable"]

--- a/testsuite/tests/effects/dynamic.ml
+++ b/testsuite/tests/effects/dynamic.ml
@@ -5,43 +5,7 @@
    { native; }
 *)
 
-(* Tests the runtime support for dynamic bindings. Dynamic.t isn't yet implemented in the
-   OxCaml stdlib, only the runtime support for it, so testing that requires faking a bit
-   more infrastructure here in the test case. *)
-
-module Dynamic : sig
-  type 'a t
-
-  val make : 'a -> 'a t
-  val get : 'a t -> 'a
-
-  val with_temporarily : 'a t -> 'a -> f: (unit -> 'b) -> 'b
-
-end = struct
-  type last_fiber : immediate
-  type (-'a, +'b) cont
-  type 'a t
-
-  external reperform :
-    'a Effect.t -> ('a, 'b) cont -> last_fiber -> 'b = "%reperform"
-
-  external with_stack_bind :
-    ('a -> 'b) ->
-    (exn -> 'b) ->
-    ('c Effect.t -> ('c, 'b) cont -> last_fiber -> 'b) ->
-    'd t ->
-    'd ->
-    ('e -> 'a) ->
-    'e ->
-    'b = "%with_stack_bind"
-
-  external make : 'a -> 'a t = "caml_dynamic_make"
-  external get : 'a t -> 'a = "caml_dynamic_get"
-
-  let with_temporarily d v ~f =
-    let effc eff k last_fiber = reperform eff k last_fiber in
-    with_stack_bind (fun x -> x) (fun e -> raise e) effc d v f ()
-end
+(* Tests the runtime support for dynamic bindings. *)
 
 type _ Effect.t += E : unit -> unit Effect.t
 

--- a/testsuite/tests/effects/dynamic.ml
+++ b/testsuite/tests/effects/dynamic.ml
@@ -14,7 +14,6 @@ module Dynamic : sig
 
   val make : 'a -> 'a t
   val get : 'a t -> 'a
-  val set_root : 'a t -> 'a -> unit
 
   val with_temporarily : 'a t -> 'a -> f: (unit -> 'b) -> 'b
 
@@ -38,7 +37,6 @@ end = struct
 
   external make : 'a -> 'a t = "caml_dynamic_make"
   external get : 'a t -> 'a = "caml_dynamic_get"
-  external set_root : 'a t -> 'a -> unit = "caml_dynamic_set_root"
 
   let with_temporarily d v ~f =
     let effc eff k last_fiber = reperform eff k last_fiber in
@@ -88,6 +86,7 @@ let sync_thread f =
 *)
 
 let _ =
+  print_endline "\n# Test 1";
   let r = ref (Dynamic.make 57) in
   let go = on_my_mark (fun () -> (Printf.printf "get on earlier thread [expect 1]: %d\n" (Dynamic.get (!r)))) in
   let d = Dynamic.make 1 in
@@ -96,122 +95,75 @@ let _ =
    r := d;
    go ())
 
-(* `set_root` should change the value seen:
-   - on this thread;
-   - on a child thread created after `set_root`;
-   - but not on a child thread created previously.
-*)
-
-let _ =
-  let r = ref (Dynamic.make 57) in
-  let go = on_my_mark (fun () -> (Printf.printf "get on pre-existing thread after set_root [expect 3]: %d\n" (Dynamic.get (!r)))) in
-  let d = Dynamic.make 3 in
-  (Dynamic.set_root d 2;
-   Printf.printf "get after set_root [expect 2]: %d\n" (Dynamic.get d);
-   Thread.join (Thread.create (fun () -> Printf.printf "get on child thread created after set_root [expect 2]: %d\n" (Dynamic.get d)) ());
-   r := d;
-   go ();
-   Thread.join (Thread.create (fun () -> Dynamic.set_root d 4) ());
-   Printf.printf "get after set_root on child thread [expect 2]: %d\n" (Dynamic.get d))
-
 (* `with_temporarily` should change the value seen:
    - within its dynamic extent;
    - but not on some other thread while it is running;
    - or after it returns;
 *)
 
-let test_with_temp d n =
+let test_with_temp d outside n =
   let (wait, go) = trigger () in
-  let outside = Dynamic.get d in
-  let t = Thread.create (fun () -> (wait (); Printf.printf "In other thread during with_temporarily [expect %d]: %d\n" outside (Dynamic.get d))) () in
+  let t = Thread.create (fun () ->
+    (wait ();
+     Printf.printf "In other thread during with_temporarily [expect %d]: %d\n"
+       outside
+       (Dynamic.get d))) () in
   (Dynamic.with_temporarily d n
      ~f:(fun () -> (Printf.printf "with_temporarily [expect %d]: %d\n" n (Dynamic.get d);
                     go (); Thread.join t;
-                    Printf.printf "with_temporarily still [expect %d]: %d\n" n (Dynamic.get d)));
-   Printf.printf "after with_temporarily [expect %d]: %d\n" outside (Dynamic.get d))
-
-let _ = let d = Dynamic.make 42 in
-  (Dynamic.set_root d 7; test_with_temp d 6)
-
-(* In the presence of effects, check that set_root values are visible in other fibers,
-   without contaminating the value on a pre-existing thread. *)
+                    Printf.printf "with_temporarily still [expect %d]: %d\n" n (Dynamic.get d))))
 
 let _ =
-
-  let n = 10 in
-  let outside = n+10 in
-  let d = Dynamic.make outside in
-  let check_other_thread, finish =
-    sync_thread (fun () -> Printf.printf "In pre-existing thread [expect %d]: %d\n" outside (Dynamic.get d)) in
-
-  let f () =
-    (Printf.printf "In fiber [expect %d]: %d\n" n (Dynamic.get d);
-     check_other_thread();
-     Dynamic.set_root d (n+1);
-     Effect.perform (E ());
-     Printf.printf "In continuation [expect %d]: %d\n" (n+2) (Dynamic.get d);
-     Dynamic.set_root d (n+3)) in
-
-  let h : type a. a Effect.t -> ((a, 'b) Effect.Deep.continuation -> 'b) option = function
-    | E () -> Some (fun k ->
-      Printf.printf "in handler [expect %d]: %d\n" (n+1) (Dynamic.get d);
-      check_other_thread();
-      Dynamic.set_root d (n+2);
-      Effect.Deep.continue k ();
-      Printf.printf "after continuation [expect %d]: %d\n" (n+4) (Dynamic.get d))
-    | e -> None in
-
-  Dynamic.set_root d n;
-  Effect.Deep.match_with f ()
-    { retc = (fun () -> (Printf.printf "after fiber [expect %d]: %d\n" (n+3) (Dynamic.get d);
-                         check_other_thread();
-                         Dynamic.set_root d (n+4)));
-      exnc = (fun e -> raise e);
-      effc = h };
-  finish()
+  print_endline "\n# Test 2";
+  let d = Dynamic.make 7 in
+  (test_with_temp d 7 7);
+  Printf.printf "after with_temporarily [expect %d]: %d\n" 7 (Dynamic.get d)
 
 (* Does with_temporarily work correctly in effect handlers? *)
 
 let _ =
-
+  print_endline "\n# Test 3";
   let n = 20 in
   let outside = n+10 in
   let d = Dynamic.make outside in
   let check_other_thread, finish =
-    sync_thread (fun () -> Printf.printf "In pre-existing thread [expect %d]: %d\n" outside (Dynamic.get d)) in
+    sync_thread (fun () ->
+      Printf.printf "In pre-existing thread [expect %d]: %d\n"
+        outside
+        (Dynamic.get d)) in
 
   let f () =
     (Printf.printf "In fiber [expect %d]: %d\n" n (Dynamic.get d);
      check_other_thread();
-     Dynamic.set_root d (n+1);
-     Effect.perform (E ());
-     Printf.printf "In continuation [expect %d]: %d\n" (n+3) (Dynamic.get d);
-     Dynamic.set_root d (n+4)) in
+     Dynamic.with_temporarily d (n+1) ~f:(fun () ->
+       Effect.perform (E ());
+       Printf.printf "In continuation [expect %d]: %d\n" (n+1) (Dynamic.get d))) in
 
   let h : type a. a Effect.t -> ((a, 'b) Effect.Deep.continuation -> 'b) option = function
     | E () -> Some (fun k ->
-      Printf.printf "in handler [expect %d]: %d\n" (n+1) (Dynamic.get d);
-      test_with_temp d (n+2);
+      Printf.printf "in handler [expect %d]: %d\n" n (Dynamic.get d);
+      test_with_temp d outside (n+2);
       check_other_thread();
-      Dynamic.set_root d (n+3);
-      Effect.Deep.continue k ();
-      Printf.printf "after continuation [expect %d]: %d\n" (n+5) (Dynamic.get d))
+      Dynamic.with_temporarily d (n+3) ~f:(fun () ->
+        Effect.Deep.continue k ();
+        Printf.printf "after continuation [expect %d]: %d\n" (n+3) (Dynamic.get d)))
     | e -> None in
 
-  (Dynamic.set_root d n;
+  (Dynamic.with_temporarily d n ~f:(fun () ->
    Effect.Deep.match_with f ()
-     { retc = (fun () -> (Printf.printf "after fiber [expect %d]: %d\n" (n+4) (Dynamic.get d);
-                          check_other_thread();
-                          Dynamic.set_root d (n+5)));
+     { retc = (fun () ->
+         (Printf.printf "after fiber [expect %d]: %d\n" (n+3) (Dynamic.get d);
+          check_other_thread()));
        exnc = (fun e -> raise e);
        effc = h };
-   finish())
+   finish()))
 
 (* Does with_temporarily work inside effect contexts? This usefully tests that effects are
    passed up through the with_temporarily context to the outer effect context (testing the
    `reperform` in the implementation of `with_temporarily`. *)
 
 let _ =
+  print_endline "\n# Test 4";
   let n = 40 in
   let outside = n+10 in
   let d = Dynamic.make outside in
@@ -222,28 +174,24 @@ let _ =
     (Printf.printf "In fiber [expect %d]: %d\n" n (Dynamic.get d);
      Dynamic.with_temporarily d (n+1)
      ~f:(fun () -> (check_other_thread();
-                    Dynamic.set_root d (n+2);
-                    (* set_root shouldn't affect the value because we're in a with_temp *)
                     Printf.printf "with_temporarily in fiber [expect %d]: %d\n" (n+1) (Dynamic.get d);
                     Effect.perform (E ());
                     Printf.printf "continuing in with_temporarily [expect %d]: %d\n" (n+1) (Dynamic.get d)));
-     Printf.printf "still in continuation, after with_temporarily [expect %d]: %d\n" (n+3) (Dynamic.get d);
-     Dynamic.set_root d (n+4)) in
+     Printf.printf "still in continuation, after with_temporarily [expect %d]: %d\n" (n+3) (Dynamic.get d)) in
 
   let h : type a. a Effect.t -> ((a, 'b) Effect.Deep.continuation -> 'b) option = function
     | E () -> Some (fun k ->
-      Printf.printf "in handler [expect %d): %d\n" (n+2) (Dynamic.get d);
-      Dynamic.set_root d (n+3);
-      Effect.Deep.continue k ();
-      Printf.printf "after continuation returns [expect %d]: %d\n" (n+6) (Dynamic.get d))
+      Printf.printf "in handler [expect %d): %d\n" n (Dynamic.get d);
+      Dynamic.with_temporarily d (n+3) ~f:(fun () ->
+        Effect.Deep.continue k ();
+        Printf.printf "after continuation returns [expect %d]: %d\n" (n+6) (Dynamic.get d)))
     | e -> None in
 
-  (Dynamic.set_root d n;
+  (Dynamic.with_temporarily d n ~f:(fun () ->
    Effect.Deep.match_with f ()
-     { retc = (fun () -> (Printf.printf "after fiber [expect %d]: %d\n" (n+4) (Dynamic.get d);
+     { retc = (fun () -> (Printf.printf "after fiber [expect %d]: %d\n" (n+3) (Dynamic.get d);
                           check_other_thread();
-                          test_with_temp d (n+5);
-                          Dynamic.set_root d (n+6)));
+                          test_with_temp d outside (n+5)));
        exnc = (fun e -> raise e);
        effc = h };
-   finish())
+   finish()))

--- a/testsuite/tests/effects/dynamic.reference
+++ b/testsuite/tests/effects/dynamic.reference
@@ -1,47 +1,40 @@
+
+# Test 1
 get [expect 1]: 1
 get on other thread [expect 1]: 1
 get on earlier thread [expect 1]: 1
-get after set_root [expect 2]: 2
-get on child thread created after set_root [expect 2]: 2
-get on pre-existing thread after set_root [expect 3]: 3
-get after set_root on child thread [expect 2]: 2
-with_temporarily [expect 6]: 6
+
+# Test 2
+with_temporarily [expect 7]: 7
 In other thread during with_temporarily [expect 7]: 7
-with_temporarily still [expect 6]: 6
+with_temporarily still [expect 7]: 7
 after with_temporarily [expect 7]: 7
-In fiber [expect 10]: 10
-In pre-existing thread [expect 20]: 20
-in handler [expect 11]: 11
-In pre-existing thread [expect 20]: 20
-In continuation [expect 12]: 12
-after fiber [expect 13]: 13
-In pre-existing thread [expect 20]: 20
-after continuation [expect 14]: 14
-In pre-existing thread [expect 20]: 20
+
+# Test 3
 In fiber [expect 20]: 20
 In pre-existing thread [expect 30]: 30
-in handler [expect 21]: 21
+in handler [expect 20]: 20
 with_temporarily [expect 22]: 22
-In other thread during with_temporarily [expect 21]: 21
+In other thread during with_temporarily [expect 30]: 30
 with_temporarily still [expect 22]: 22
-after with_temporarily [expect 21]: 21
 In pre-existing thread [expect 30]: 30
-In continuation [expect 23]: 23
-after fiber [expect 24]: 24
+In continuation [expect 21]: 21
+after fiber [expect 23]: 23
 In pre-existing thread [expect 30]: 30
-after continuation [expect 25]: 25
+after continuation [expect 23]: 23
 In pre-existing thread [expect 30]: 30
+
+# Test 4
 In fiber [expect 40]: 40
 In pre-existing thread [expect 50]: 50
 with_temporarily in fiber [expect 41]: 41
-in handler [expect 42): 42
+in handler [expect 40): 40
 continuing in with_temporarily [expect 41]: 41
 still in continuation, after with_temporarily [expect 43]: 43
-after fiber [expect 44]: 44
+after fiber [expect 43]: 43
 In pre-existing thread [expect 50]: 50
 with_temporarily [expect 45]: 45
-In other thread during with_temporarily [expect 44]: 44
+In other thread during with_temporarily [expect 50]: 50
 with_temporarily still [expect 45]: 45
-after with_temporarily [expect 44]: 44
-after continuation returns [expect 46]: 46
+after continuation returns [expect 46]: 43
 In pre-existing thread [expect 50]: 50

--- a/testsuite/tests/effects/dynamic.reference
+++ b/testsuite/tests/effects/dynamic.reference
@@ -5,9 +5,9 @@ get on other thread [expect 1]: 1
 get on earlier thread [expect 1]: 1
 
 # Test 2
-with_temporarily [expect 7]: 7
+with_temporarily [expect 8]: 8
 In other thread during with_temporarily [expect 7]: 7
-with_temporarily still [expect 7]: 7
+with_temporarily still [expect 8]: 8
 after with_temporarily [expect 7]: 7
 
 # Test 3
@@ -17,6 +17,7 @@ in handler [expect 20]: 20
 with_temporarily [expect 22]: 22
 In other thread during with_temporarily [expect 30]: 30
 with_temporarily still [expect 22]: 22
+after with_temporarily [expect 20]: 20
 In pre-existing thread [expect 30]: 30
 In continuation [expect 21]: 21
 after fiber [expect 23]: 23
@@ -28,7 +29,7 @@ In pre-existing thread [expect 30]: 30
 In fiber [expect 40]: 40
 In pre-existing thread [expect 50]: 50
 with_temporarily in fiber [expect 41]: 41
-in handler [expect 40): 40
+in handler [expect 40]: 40
 continuing in with_temporarily [expect 41]: 41
 still in continuation, after with_temporarily [expect 43]: 43
 after fiber [expect 43]: 43
@@ -36,5 +37,6 @@ In pre-existing thread [expect 50]: 50
 with_temporarily [expect 45]: 45
 In other thread during with_temporarily [expect 50]: 50
 with_temporarily still [expect 45]: 45
-after continuation returns [expect 46]: 43
+after with_temporarily [expect 43]: 43
+after continuation returns [expect 43]: 43
 In pre-existing thread [expect 50]: 50


### PR DESCRIPTION
Define a "canonical" definition of the OCaml interface to runtime dynamic
bindings in the stdlib. This is basically the same interface as the one defined
in Basement, albeit without `set_root`. We don't really have any need for the
full interface in stdlib, but preemption has a need for a canonical definition
of the `Dynamic.t` type, and it's relatively cheap to just define the full
interface here, as that also lets us avoid redefining it in tests.
