### PR TITLE
Fix environment scoping in jkind errors

### DIFF
--- a/testsuite/tests/typing-jkind-bounds/error_env.ml
+++ b/testsuite/tests/typing-jkind-bounds/error_env.ml
@@ -14,7 +14,7 @@ Line 1, characters 29-35:
                                  ^^^^^^
 Error: This expression has type "'a * 'b"
        but an expression was expected of type "('c : value mod portable)"
-       The kind of 'a * 'b is immutable_data with 'a with 'a
+       The kind of 'a * 'b is immutable_data with 'a with 'b
          because it's a tuple type.
        But the kind of 'a * 'b must be a subkind of value mod portable
          because of the definition of require_portable at line 1, characters 21-56.
@@ -28,7 +28,7 @@ Line 1, characters 29-44:
 Error: This expression has type "'a * 'b * 'c * 'd * 'e"
        but an expression was expected of type "('f : value mod portable)"
        The kind of 'a * 'b * 'c * 'd * 'e is
-           immutable_data with 'a with 'a with 'a with 'a with 'a
+           immutable_data with 'a with 'b with 'c with 'd with 'e
          because it's a tuple type.
        But the kind of 'a * 'b * 'c * 'd * 'e must be a subkind of
            value mod portable
@@ -42,7 +42,7 @@ Line 1, characters 29-45:
                                  ^^^^^^^^^^^^^^^^
 Error: This expression has type "'a * 'b"
        but an expression was expected of type "('c : value mod portable)"
-       The kind of 'a * 'b is immutable_data with 'a with 'a
+       The kind of 'a * 'b is immutable_data with 'a with 'b
          because it's a tuple type.
        But the kind of 'a * 'b must be a subkind of value mod portable
          because of the definition of require_portable at line 1, characters 21-56.
@@ -57,7 +57,7 @@ Line 2, characters 29-35:
                                  ^^^^^^
 Error: This expression has type "'a * 'b"
        but an expression was expected of type "('c : value mod portable)"
-       The kind of 'a * 'b is immutable_data with 'a with 'a
+       The kind of 'a * 'b is immutable_data with 'a with 'b
          because it's a tuple type.
        But the kind of 'a * 'b must be a subkind of value mod portable
          because of the definition of require_portable at line 1, characters 21-56.
@@ -72,7 +72,7 @@ Line 2, characters 29-35:
                                  ^^^^^^
 Error: This expression has type "'a * 'b"
        but an expression was expected of type "('c : value mod portable)"
-       The kind of 'a * 'b is immutable_data with 'a with 'a
+       The kind of 'a * 'b is immutable_data with 'a with 'b
          because it's a tuple type.
        But the kind of 'a * 'b must be a subkind of value mod portable
          because of the definition of require_portable at line 1, characters 21-56.
@@ -85,7 +85,7 @@ Line 1, characters 53-59:
                                                          ^^^^^^
 Error: This expression has type "'a * 'b"
        but an expression was expected of type "('c : value mod portable)"
-       The kind of 'a * 'b is immutable_data with 'a with 'a
+       The kind of 'a * 'b is immutable_data with 'a with 'b
          because it's a tuple type.
        But the kind of 'a * 'b must be a subkind of value mod portable
          because of the definition of require_portable at line 1, characters 21-56.

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1056,9 +1056,9 @@ end
 (* CR layouts v2.8: This should sometimes be for type schemes, not types
    (which print weak variables like ['_a] correctly), but this works better
    for the common case. When we re-do printing, fix. Internal ticket 4435. *)
-let outcometree_of_type = ref (fun _ -> assert false)
+let outcometrees_of_types = ref (fun _ -> assert false)
 
-let set_outcometree_of_type p = outcometree_of_type := p
+let set_outcometrees_of_types p = outcometrees_of_types := p
 
 let outcometree_of_modalities = ref (fun _ _ -> assert false)
 
@@ -1169,16 +1169,27 @@ module Const = struct
         get_modal_bounds ~base:base.jkind.mod_bounds actual.mod_bounds
       in
       let printable_with_bounds =
-        List.map
-          (fun (type_expr, type_info) ->
-            let axes_ignored_by_modalities =
-              With_bounds.Type_info.axes_ignored_by_modalities
-                ~mod_bounds:actual.mod_bounds ~type_info
-            in
-            ( !outcometree_of_type type_expr,
-              !outcometree_of_modalities Types.Immutable
-                (modality_to_ignore_axes axes_ignored_by_modalities) ))
-          (With_bounds.to_list actual.with_bounds)
+        (* This match statement is a bit of a hack. When printing type
+           variables, this function is called if we need to print a jkind
+           annotation. But outcometrees_of_types resets the printing env, which
+           shouldn't be done in the middle of printing a type / signature.
+           Fortunately, only r-kinds can appear in a jkind annotation, so if we
+           don't call outcometrees_of_types on an empty list here, we avoid the
+           issue. *)
+        match With_bounds.to_list actual.with_bounds with
+        | [] -> []
+        | with_bounds ->
+          let otys = !outcometrees_of_types (List.map fst with_bounds) in
+          List.map2
+            (fun (_, type_info) out_type ->
+              let axes_ignored_by_modalities =
+                With_bounds.Type_info.axes_ignored_by_modalities
+                  ~mod_bounds:actual.mod_bounds ~type_info
+              in
+              ( out_type,
+                !outcometree_of_modalities Types.Immutable
+                  (modality_to_ignore_axes axes_ignored_by_modalities) ))
+            with_bounds otys
       in
       match matching_layouts, modal_bounds with
       | true, Some modal_bounds ->
@@ -2404,8 +2415,9 @@ module Violation = struct
                             (ty, ({ relevant_axes } : With_bounds_type_info.t))
                           ->
                             match Axis_set.mem relevant_axes axis with
-                            | true -> Some (!outcometree_of_type ty)
+                            | true -> Some (!outcometrees_of_types [ty])
                             | false -> None)
+                     |> List.flatten
                  in
                  let ojkind =
                    List.fold_left

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -590,7 +590,8 @@ val normalize :
 (* pretty printing *)
 
 (** Call these before trying to print. *)
-val set_outcometree_of_type : (Types.type_expr -> Outcometree.out_type) -> unit
+val set_outcometrees_of_types :
+  (Types.type_expr list -> Outcometree.out_type list) -> unit
 
 val set_outcometree_of_modalities :
   (Types.mutability -> Mode.Modality.Const.t -> Outcometree.out_mode list) ->

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1807,9 +1807,9 @@ let tree_of_type_scheme ty =
 
 let () =
   Env.print_type_expr := type_expr;
-  Jkind.set_outcometree_of_type (fun ty ->
-    prepare_for_printing [ty];
-    tree_of_typexp Type ty);
+  Jkind.set_outcometrees_of_types (fun tys ->
+    prepare_for_printing tys;
+    List.map (tree_of_typexp Type) tys);
   Jkind.set_outcometree_of_modalities tree_of_modalities;
   Jkind.set_print_type_expr type_expr;
   Jkind.set_raw_type_expr raw_type_expr


### PR DESCRIPTION
This PR fixes a jkind error printing bug. The first commit add tests reproing the bug, and the second resolves the issue.