### PR TITLE
Fix the simplify terminator pass: guard code paths that can render the graph irreducible

### DIFF
--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -266,9 +266,10 @@ let evaluate_terminator (known_values : known_value Reg.UsingLocEquality.Tbl.t)
   | Call_no_return _ | Call _ | Prim _ ->
     None
 
-let block_known_values (block : C.basic_block) ~(is_after_regalloc : bool) :
-    bool =
-  if !Oxcaml_flags.cfg_value_propagation && is_after_regalloc
+let block_known_values (block : C.basic_block) ~(is_after_regalloc : bool)
+    ~(allowed_to_be_irreducible : bool) : bool =
+  if !Oxcaml_flags.cfg_value_propagation
+     && is_after_regalloc && allowed_to_be_irreducible
   then (
     let known_values = collect_known_values block.body in
     match evaluate_terminator known_values block.terminator with
@@ -355,9 +356,14 @@ let block (cfg : C.t) (block : C.basic_block) : bool =
       let l = Label.Set.min_elt labels in
       block.terminator <- { block.terminator with desc = Always l };
       false)
-    else block_known_values block ~is_after_regalloc
+    else
+      block_known_values block ~is_after_regalloc
+        ~allowed_to_be_irreducible:cfg.allowed_to_be_irreducible
   | Switch labels ->
-    let shortcircuit = block_known_values block ~is_after_regalloc in
+    let shortcircuit =
+      block_known_values block ~is_after_regalloc
+        ~allowed_to_be_irreducible:cfg.allowed_to_be_irreducible
+    in
     if shortcircuit
     then true
     else (


### PR DESCRIPTION
This pull request ensures that transformations that
may render the graph irreducible are guarded with
the `cfg.allowed_to_be_irreducible` condition.
This condition becomes true when loop information
is no longer used. At this point, it is possible to
enable graph rewrite that produce non-natural loops.

The terminator changes in `simplify_switch` do not
need to be guarded because they cannot shortcircuit
the header of a loop. [This change](https://github.com/oxcaml/oxcaml/blob/179d283988a767cf33385b08235f46d1ed100a1c/backend/cfg/simplify_terminator.ml#L356) does not need to
be guarded because it cannot shortcircuit a block.
All the other changes are guarded.

(I have manually checked on simple examples that
there are no regressions in the compilation of
loops - _i.e._ that the jump on conditional jump
is not back.)