### PR TITLE
Binary (machine code) emitter for arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,8 +89,8 @@ jobs:
           - name: runtime5 regalloc (aarch64-darwin)
             config: --enable-runtime5 --disable-warn-error
             os: warp-macos-15-arm64-6x
-            build_ocamlparam: '_,w=-46,save-ir-before=register_allocation'
-            ocamlparam: '_,w=-46,save-ir-before=register_allocation'
+            build_ocamlparam: '_,w=-46,save-ir-before=register_allocation,verify-binary-emitter=1'
+            ocamlparam: '_,w=-46,save-ir-before=register_allocation,verify-binary-emitter=1'
             run_regalloc_tool: true
 
           - name: runtime5 debug regalloc (aarch64-darwin)
@@ -105,8 +105,8 @@ jobs:
           - name: runtime5 regalloc (aarch64-linux)
             config: --enable-runtime5 --disable-warn-error
             os: warp-ubuntu-latest-arm64-8x
-            build_ocamlparam: '_,w=-46,save-ir-before=register_allocation'
-            ocamlparam: '_,w=-46,save-ir-before=register_allocation'
+            build_ocamlparam: '_,w=-46,save-ir-before=register_allocation,verify-binary-emitter=1'
+            ocamlparam: '_,w=-46,save-ir-before=register_allocation,verify-binary-emitter=1'
             run_regalloc_tool: true
 
           - name: runtime5 regalloc multidomain (aarch64-linux)

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -559,6 +559,7 @@ let compile_genfuns ~ppf_dump f =
 let compile_unit unix ~output_prefix ~asm_filename ~keep_asm ~obj_filename
     ~may_reduce_heap ~ppf_dump gen =
   reset ();
+  Emitaux.output_prefix := output_prefix;
   let create_asm =
     should_emit () && (keep_asm || not !Emitaux.binary_backend_available)
   in
@@ -641,6 +642,7 @@ let compile_unit unix ~output_prefix ~asm_filename ~keep_asm ~obj_filename
           "Binary emitter verification skipped (no binary sections)@."
     | (Mismatch _ | Object_file_error _) as result ->
       Binary_emitter_verify.print_result Format.err_formatter result;
+      Format.eprintf "Binary sections saved to: %s@." binary_sections_dir;
       raise (Error (Binary_emitter_mismatch obj_filename))
 
 let end_gen_implementation unix ?toplevel ~ppf_dump ~sourcefile make_cmm =

--- a/backend/.ocamlformat-enable
+++ b/backend/.ocamlformat-enable
@@ -10,6 +10,8 @@ amd64/stack_check.ml
 amd64/stack_class.ml
 amd64/vectorize_specific.ml
 amd64/regalloc_stack_operands.ml
+amd64/binary_emitter_helpers.ml
+amd64/binary_emitter_helpers.mli
 arm64/cfg_selection.ml
 arm64/dsl_helpers.ml
 arm64/dsl_helpers.mli
@@ -25,6 +27,13 @@ arm64/vectorize_specific.ml
 arm64/regalloc_stack_operands.ml
 arm64/ast/*.ml
 arm64/ast/*.mli
+arm64/binary_emitter/**/*.ml
+arm64/binary_emitter/**/*.mli
+arm64/binary_emitter_helpers.ml
+arm64/binary_emitter_helpers.mli
+binary_emitter_intf/**/*.ml*
+arm64_logical_immediates.mli
+jit_backend.ml*
 asm_targets/**/*.ml
 asm_targets/**/*.mli
 branch_relaxation.ml

--- a/backend/amd64/binary_emitter_helpers.ml
+++ b/backend/amd64/binary_emitter_helpers.ml
@@ -1,0 +1,35 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(** CR mshinwell: Implement binary sections saving for x86 to match ARM64.
+    Currently this module provides stub implementations. *)
+
+let should_use_binary_emitter () = false
+
+let begin_emission () = fun _ -> ()
+
+let end_emission () = ()

--- a/backend/amd64/binary_emitter_helpers.mli
+++ b/backend/amd64/binary_emitter_helpers.mli
@@ -1,0 +1,41 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(** Hooks for connecting the x86 binary emitter to the emit process.
+
+    CR mshinwell: Implement binary sections saving for x86 to match ARM64.
+    Currently this module provides stub implementations. *)
+
+(** Returns true if the binary emitter should be enabled for this compilation.
+    Currently always returns false on x86. *)
+val should_use_binary_emitter : unit -> bool
+
+(** Initialize the binary emitter if needed. Returns a no-op callback on x86. *)
+val begin_emission : unit -> Asm_targets.Asm_directives.Directive.t -> unit
+
+(** Finalize the binary emitter if it was enabled. No-op on x86. *)
+val end_emission : unit -> unit

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2997,15 +2997,13 @@ let end_assembly () =
   D.int64 0L;
   D.text ();
   (* We align to 8 bytes before the frame table. Perhaps somewhat
-     counterintuitively, we use [~fill:Zero] even though we are
-     now in the text section. The reason is that the additional padding will
-     never be executed, so there is no need to pad it with nops in the X86
-     binary emitter. *)
+     counterintuitively, we use [~fill:Zero] even though we are now in the text
+     section. The reason is that the additional padding will never be executed,
+     so there is no need to pad it with nops in the X86 binary emitter. *)
   (* CR sspies: We should just determine the filling based on the current
-     section for the binary emitter and then remove the argument
-     [fill]. This is the only place, where it does not seem to
-     match the current section, and it seems it does not matter whether we pad
-     with zeros or nops here. *)
+     section for the binary emitter and then remove the argument [fill]. This is
+     the only place, where it does not seem to match the current section, and it
+     seems it does not matter whether we pad with zeros or nops here. *)
   D.align ~fill:Zero ~bytes:8;
   (* PR#7591 *)
   emit_global_label ~section:Text "frametable";

--- a/backend/arm64/binary_emitter/add_sub_helpers.ml
+++ b/backend/arm64/binary_emitter/add_sub_helpers.ml
@@ -1,0 +1,145 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+(* Decode shift type and amount for add/sub shifted register instructions.
+   Returns (shift_type, amount) where shift_type is 00=LSL, 01=LSR, 10=ASR. *)
+let decode_shift_kind_int : type a. a Operand.Shift.Kind.t -> int =
+ fun kind ->
+  match kind with Operand.Shift.Kind.LSL -> 0b00 | LSR -> 0b01 | ASR -> 0b10
+
+let decode_shift_amount_six : type a. a Immediate.t -> int =
+ fun amount ->
+  match amount with
+  | Six n -> n
+  | Twelve _ | Sixteen_unsigned _ | Sym _ | Float _ | Nativeint _ ->
+    Misc.fatal_error "decode_shift_amount_six: expected Six immediate"
+
+(* Check if a register is SP (stack pointer) by examining its name *)
+let is_sp_reg : type a. a Reg.t -> bool =
+ fun r ->
+  match r.reg_name with
+  | GP GP_reg_name.SP -> true
+  | GP GP_reg_name.WSP -> true
+  | GP (W | X | WZR | XZR | LR | FP) -> false
+  | Neon _ -> false
+
+let encode_add_sub_shifted_register ~sf ~op ~s ~shift ~rm ~imm6 ~rn ~rd =
+  let open Int32 in
+  let max_shift = if sf = 1 then 63 else 31 in
+  if imm6 < 0 || imm6 > max_shift
+  then Misc.fatal_errorf "ADD/SUB shift amount out of range: %d" imm6 ();
+  let result = zero in
+  let result = logor result (shift_left (of_int sf) 31) in
+  let result = logor result (shift_left (of_int op) 30) in
+  let result = logor result (shift_left (of_int s) 29) in
+  let result = logor result (shift_left (of_int 0b01011) 24) in
+  let result = logor result (shift_left (of_int shift) 22) in
+  let result = logor result (shift_left (of_int rm) 16) in
+  let result = logor result (shift_left (of_int imm6) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rd) in
+  result
+
+(* Add/subtract (extended register) encoding - C4.1.92.2 Encoding: sf op S 01011
+   00 1 Rm option imm3 Rn Rd Used when Rn is SP or when an extend operation is
+   needed *)
+let encode_add_sub_extended_register ~sf ~op ~s ~rm ~option ~imm3 ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int sf) 31) in
+  let result = logor result (shift_left (of_int op) 30) in
+  let result = logor result (shift_left (of_int s) 29) in
+  let result = logor result (shift_left (of_int 0b01011) 24) in
+  let result = logor result (shift_left (of_int 0b00) 22) in
+  let result = logor result (shift_left (of_int 1) 21) in
+  (* bit 21 = 1 for extended *)
+  let result = logor result (shift_left (of_int rm) 16) in
+  let result = logor result (shift_left (of_int option) 13) in
+  let result = logor result (shift_left (of_int imm3) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rd) in
+  result
+
+(* Add/subtract (immediate) - C4.1.92.3 *)
+let encode_add_sub_immediate ~sf ~op ~s ~sh ~imm12 ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int sf) 31) in
+  let result = logor result (shift_left (of_int op) 30) in
+  let result = logor result (shift_left (of_int s) 29) in
+  let result = logor result (shift_left (of_int 0b100010) 23) in
+  let result = logor result (shift_left (of_int sh) 22) in
+  let result = logor result (shift_left (of_int imm12) 10) in
+  let result = logor result (shift_left (of_int (Reg.gp_encoding rn)) 5) in
+  let result = logor result (of_int (Reg.gp_encoding rd)) in
+  result
+
+(* Helper to encode add/sub immediate with automatic shift detection. When imm12
+   > 0xFFF but is a multiple of 4096 and the quotient fits in 12 bits, use sh=1
+   and encode imm12 / 4096. This matches the assembler's behavior when given
+   large immediate values like #0x6000 which become #0x6, lsl #12. *)
+let encode_add_sub_imm_auto_shift ~op ~s ~imm12 ~shift_opt ~rn ~rd =
+  let sf = Reg.gp_sf rd in
+  let sh_from_opt = match shift_opt with Some _ -> 1 | None -> 0 in
+  let sh, actual_imm12 =
+    if imm12 <= 0xFFF
+    then sh_from_opt, imm12
+    else if sh_from_opt = 1
+    then
+      Misc.fatal_errorf
+        "Cannot encode add/sub immediate with explicit shift and value > 0xFFF"
+    else if imm12 land 0xFFF = 0 && imm12 lsr 12 <= 0xFFF
+    then 1, imm12 lsr 12
+    else
+      Misc.fatal_errorf "Cannot encode add/sub immediate %d (0x%x)" imm12 imm12
+  in
+  encode_add_sub_immediate ~sf ~op ~s ~sh ~imm12:actual_imm12 ~rn ~rd
+
+(* Helper to encode add/sub shifted register instructions.
+
+   - op: 0=ADD, 1=SUB - s: 0=no flags, 1=set flags
+
+   When Rn is SP, we must use extended register encoding because the shifted
+   register form interprets register 31 as XZR, not SP. *)
+let encode_add_sub_shifted_reg ~op ~s ~shift ~imm6 ~rd ~rn ~rm =
+  let sf = Reg.gp_sf rd in
+  let rd_enc = Reg.gp_encoding rd in
+  let rn_enc = Reg.gp_encoding rn in
+  let rm_enc = Reg.gp_encoding rm in
+  (* Check if Rn is SP - if so, use extended register encoding *)
+  if is_sp_reg rn && shift = 0 && imm6 = 0
+  then
+    (* Use extended register form with option=011 (UXTX/LSL for 64-bit) *)
+    encode_add_sub_extended_register ~sf ~op ~s ~rm:rm_enc ~option:0b011 ~imm3:0
+      ~rn:rn_enc ~rd:rd_enc
+  else
+    encode_add_sub_shifted_register ~sf ~op ~s ~shift ~rm:rm_enc ~imm6
+      ~rn:rn_enc ~rd:rd_enc

--- a/backend/arm64/binary_emitter/add_sub_helpers.mli
+++ b/backend/arm64/binary_emitter/add_sub_helpers.mli
@@ -1,0 +1,90 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+val decode_shift_kind_int : 'a Operand.Shift.Kind.t -> int
+
+(** Extract shift amount from an Imm.t. Used for shifted register operations
+    where the instruction types guarantee a Six immediate, but OCaml can't prove
+    this statically due to [<] constraints. *)
+val decode_shift_amount_six : 'a Immediate.t -> int
+
+val is_sp_reg : 'a Reg.t -> bool
+
+val encode_add_sub_shifted_register :
+  sf:int ->
+  op:int ->
+  s:int ->
+  shift:int ->
+  rm:int ->
+  imm6:int ->
+  rn:int ->
+  rd:int ->
+  int32
+
+val encode_add_sub_extended_register :
+  sf:int ->
+  op:int ->
+  s:int ->
+  rm:int ->
+  option:int ->
+  imm3:int ->
+  rn:int ->
+  rd:int ->
+  int32
+
+val encode_add_sub_immediate :
+  sf:int ->
+  op:int ->
+  s:int ->
+  sh:int ->
+  imm12:int ->
+  rn:[`GP of 'a] Reg.t ->
+  rd:[`GP of 'b] Reg.t ->
+  int32
+
+val encode_add_sub_imm_auto_shift :
+  op:int ->
+  s:int ->
+  imm12:int ->
+  shift_opt:'a option ->
+  rn:[`GP of 'b] Reg.t ->
+  rd:[`GP of 'c] Reg.t ->
+  int32
+
+val encode_add_sub_shifted_reg :
+  op:int ->
+  s:int ->
+  shift:int ->
+  imm6:int ->
+  rd:[`GP of 'a] Reg.t ->
+  rn:[`GP of 'b] Reg.t ->
+  rm:[`GP of 'c] Reg.t ->
+  int32

--- a/backend/arm64/binary_emitter/adr_helpers.ml
+++ b/backend/arm64/binary_emitter/adr_helpers.ml
@@ -1,0 +1,52 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+let split_21bit_immediate (imm21 : int) : int * int =
+  if imm21 < -0x100000 || imm21 > 0xfffff
+  then
+    Misc.fatal_errorf
+      "Immediate value %d (0x%x) out of range for 21-bit signed immediate (max \
+       ±0x100000)"
+      imm21 imm21;
+  let immlo = imm21 land 0b11 in
+  let immhi = (imm21 lsr 2) land 0x7ffff in
+  immlo, immhi
+
+(* PC-relative addressing - C4.1.92.2 *)
+let encode_adr ~op ~immlo ~immhi ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int op) 31) in
+  let result = logor result (shift_left (of_int immlo) 29) in
+  let result = logor result (shift_left (of_int 0b10000) 24) in
+  let result = logor result (shift_left (of_int immhi) 5) in
+  let result = logor result (of_int (Reg.gp_encoding rd)) in
+  result

--- a/backend/arm64/binary_emitter/adr_helpers.mli
+++ b/backend/arm64/binary_emitter/adr_helpers.mli
@@ -1,0 +1,35 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+val split_21bit_immediate : int -> int * int
+
+val encode_adr :
+  op:int -> immlo:int -> immhi:int -> rd:[`GP of 'a] Reg.t -> int32

--- a/backend/arm64/binary_emitter/all_section_states.ml
+++ b/backend/arm64/binary_emitter/all_section_states.ml
@@ -1,0 +1,176 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+(* Collection of section states for all sections in an assembly unit. *)
+
+module Asm_label = Asm_targets.Asm_label
+module Asm_section = Asm_targets.Asm_section
+module Asm_symbol = Asm_targets.Asm_symbol
+module D = Asm_targets.Asm_directives
+module Symbol = Arm64_ast.Ast.Symbol
+
+type t =
+  { sections : Section_state.t Asm_section.Tbl.t;
+    (* Individual sections track sections by their exact name string rather than
+       the Asm_section.t enum. This is needed for function sections where each
+       function gets its own .text.caml.<funcname> section. These sections are
+       tracked separately so we can compare them individually against the
+       assembler output during verification. *)
+    individual_sections : (string, Section_state.t) Hashtbl.t;
+    for_jit : bool;
+    direct_assignments : (string, D.Directive.Constant.t) Hashtbl.t
+  }
+
+let create ~for_jit =
+  { sections = Asm_section.Tbl.create 10;
+    individual_sections = Hashtbl.create 16;
+    for_jit;
+    direct_assignments = Hashtbl.create 16
+  }
+
+let for_jit t = t.for_jit
+
+let get_or_create t section =
+  match Asm_section.Tbl.find_opt t.sections section with
+  | Some state -> state
+  | None ->
+    let state = Section_state.create () in
+    Asm_section.Tbl.add t.sections section state;
+    state
+
+let find t section = Asm_section.Tbl.find_opt t.sections section
+
+let find_exn t section = Asm_section.Tbl.find t.sections section
+
+let iter t ~f = Asm_section.Tbl.iter f t.sections
+
+let fold t ~init ~f = Asm_section.Tbl.fold f t.sections init
+
+(* Individual sections: for sections tracked by their exact name string, such as
+   function sections (.text.caml.<funcname>). *)
+
+let get_or_create_individual t name =
+  match Hashtbl.find_opt t.individual_sections name with
+  | Some state -> state
+  | None ->
+    let state = Section_state.create () in
+    Hashtbl.add t.individual_sections name state;
+    state
+
+let find_individual t name = Hashtbl.find_opt t.individual_sections name
+
+let iter_individual t ~f = Hashtbl.iter f t.individual_sections
+
+let fold_individual t ~init ~f = Hashtbl.fold f t.individual_sections init
+
+(* Search individual sections for a label or symbol. Returns (offset, section)
+   if found. *)
+let find_in_any_individual_section t target =
+  let result = ref None in
+  Hashtbl.iter
+    (fun section_name state ->
+      if Option.is_none !result
+      then
+        let section = Asm_section.Function_text section_name in
+        match Section_state.find_target_offset_in_bytes state target with
+        | Some offset -> result := Some (offset, section)
+        | None -> ())
+    t.individual_sections;
+  !result
+
+(* Search individual sections for a label or symbol. Returns (offset, section,
+   state) if found. *)
+let find_in_any_individual_section_with_state t target =
+  let result = ref None in
+  Hashtbl.iter
+    (fun section_name state ->
+      if Option.is_none !result
+      then
+        let section = Asm_section.Function_text section_name in
+        match Section_state.find_target_offset_in_bytes state target with
+        | Some offset -> result := Some (offset, section, state)
+        | None -> ())
+    t.individual_sections;
+  !result
+
+(* Search all sections for a label or symbol. Returns (offset, section,
+   section_state) if found. This is needed when the caller needs to access the
+   actual state where the label was found. *)
+let find_in_any_section_with_state t target =
+  let result = ref None in
+  Asm_section.Tbl.iter
+    (fun section state ->
+      if Option.is_none !result
+      then
+        match Section_state.find_target_offset_in_bytes state target with
+        | Some offset -> result := Some (offset, section, state)
+        | None -> ())
+    t.sections;
+  (* If not found in standard sections, search individual sections. *)
+  (if Option.is_none !result
+   then
+     match find_in_any_individual_section_with_state t target with
+     | Some (offset, section, state) -> result := Some (offset, section, state)
+     | None -> ());
+  !result
+
+(* Search all sections for a label or symbol. Returns (offset, section) if
+   found. Cross-section references are handled via relocations. *)
+let find_in_any_section t target =
+  let result = ref None in
+  Asm_section.Tbl.iter
+    (fun section state ->
+      if Option.is_none !result
+      then
+        match Section_state.find_target_offset_in_bytes state target with
+        | Some offset -> result := Some (offset, section)
+        | None -> ())
+    t.sections;
+  (* If not found in standard sections, search individual sections. *)
+  (if Option.is_none !result
+   then
+     match find_in_any_individual_section t target with
+     | Some (offset, section) -> result := Some (offset, section)
+     | None -> ());
+  !result
+
+(* Reset all section offsets to 0 (for second pass). *)
+let reset_offsets t =
+  Asm_section.Tbl.iter
+    (fun _section state -> Section_state.set_offset_in_bytes state 0)
+    t.sections;
+  Hashtbl.iter
+    (fun _name state -> Section_state.set_offset_in_bytes state 0)
+    t.individual_sections
+
+(* Direct assignments (e.g., .set temp0, L100 - L101) *)
+let add_direct_assignment t name expr =
+  Hashtbl.replace t.direct_assignments name expr
+
+let find_direct_assignment t name = Hashtbl.find_opt t.direct_assignments name

--- a/backend/arm64/binary_emitter/all_section_states.mli
+++ b/backend/arm64/binary_emitter/all_section_states.mli
@@ -1,0 +1,91 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+(** Collection of section states for all sections in an assembly unit. *)
+
+module Asm_label = Asm_targets.Asm_label
+module Asm_section = Asm_targets.Asm_section
+module Asm_symbol = Asm_targets.Asm_symbol
+module Symbol = Arm64_ast.Ast.Symbol
+
+type t
+
+val create : for_jit:bool -> t
+
+val for_jit : t -> bool
+
+val get_or_create : t -> Asm_section.t -> Section_state.t
+
+val find : t -> Asm_section.t -> Section_state.t option
+
+val find_exn : t -> Asm_section.t -> Section_state.t
+
+val iter : t -> f:(Asm_section.t -> Section_state.t -> unit) -> unit
+
+val fold :
+  t -> init:'a -> f:(Asm_section.t -> Section_state.t -> 'a -> 'a) -> 'a
+
+(** Individual sections: for sections tracked by their exact name string rather
+    than the [Asm_section.t] enum. This is needed for function sections where
+    each function gets its own [.text.caml.<funcname>] section. These sections
+    are tracked separately so we can compare them individually against the
+    assembler output during verification. *)
+
+val get_or_create_individual : t -> string -> Section_state.t
+
+val find_individual : t -> string -> Section_state.t option
+
+val iter_individual : t -> f:(string -> Section_state.t -> unit) -> unit
+
+val fold_individual :
+  t -> init:'a -> f:(string -> Section_state.t -> 'a -> 'a) -> 'a
+
+val find_in_any_individual_section :
+  t -> Symbol.target -> (int * Asm_section.t) option
+
+(** Search individual sections for a label or symbol. Returns (offset, section,
+    state) if found. *)
+val find_in_any_individual_section_with_state :
+  t -> Symbol.target -> (int * Asm_section.t * Section_state.t) option
+
+(** Search all sections for a label or symbol. Returns (offset, section,
+    section_state) if found. This is needed when the caller needs to access the
+    actual state where the label was found. *)
+val find_in_any_section_with_state :
+  t -> Symbol.target -> (int * Asm_section.t * Section_state.t) option
+
+val find_in_any_section : t -> Symbol.target -> (int * Asm_section.t) option
+
+val reset_offsets : t -> unit
+
+module D = Asm_targets.Asm_directives
+
+val add_direct_assignment : t -> string -> D.Directive.Constant.t -> unit
+
+val find_direct_assignment : t -> string -> D.Directive.Constant.t option

--- a/backend/arm64/binary_emitter/binary_emitter.ml
+++ b/backend/arm64/binary_emitter/binary_emitter.ml
@@ -1,0 +1,155 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+module Asm_section = Asm_targets.Asm_section
+module D = Asm_targets.Asm_directives
+
+(* Re-export modules for the library interface *)
+module All_section_states = All_section_states
+module Section_state = Section_state
+
+type instruction_or_directive =
+  | Instruction of Instruction.t
+  | Directive of D.Directive.t
+
+type t = { mutable enqueued_rev : instruction_or_directive list }
+
+let create () = { enqueued_rev = [] }
+
+let enqueue t insn_or_directive =
+  t.enqueued_rev <- insn_or_directive :: t.enqueued_rev
+
+let enqueued t = List.rev t.enqueued_rev
+
+let dump_instructions t =
+  Format.printf "=== ARM64 Binary Emitter Instructions ===@.";
+  let offset = ref 0 in
+  List.iter
+    (fun insn_or_directive ->
+      match insn_or_directive with
+      | Instruction i ->
+        Format.printf "%04x: %a@." !offset Instruction.print i;
+        offset := !offset + 4
+      | Directive d ->
+        let buf = Buffer.create 256 in
+        D.Directive.print buf d;
+        Format.printf "      [directive: %s]@." (Buffer.contents buf))
+    (enqueued t);
+  Format.printf "=== End Instructions ===@."
+
+let add_instruction t i = enqueue t (Instruction i)
+
+let add_directive t d = enqueue t (Directive d)
+
+let iter emitter ~all_sections ~on_insn ~on_directive =
+  let current_state =
+    ref (All_section_states.get_or_create all_sections Asm_section.Text)
+  in
+  List.iter
+    (fun insn_or_directive ->
+      match insn_or_directive with
+      | Instruction i ->
+        on_insn !current_state i;
+        let offset = Section_state.offset_in_bytes !current_state in
+        Section_state.set_offset_in_bytes !current_state (offset + 4)
+      | Directive d ->
+        (match[@warning "-4"] d with
+        | Section (section, _) ->
+          current_state := All_section_states.get_or_create all_sections section
+        | _ -> ());
+        on_directive !current_state d;
+        let offset_in_bytes = Section_state.offset_in_bytes !current_state in
+        let new_offset =
+          D.Directive.increment_offset_in_bytes d ~offset_in_bytes
+        in
+        Section_state.set_offset_in_bytes !current_state new_offset)
+    (enqueued emitter)
+
+(* First pass: compute offsets of local symbol and label definitions *)
+let compute_label_offsets emitter ~all_sections =
+  iter emitter ~all_sections
+    ~on_insn:(fun _state _insn -> ())
+    ~on_directive:(fun state directive ->
+      match directive with
+      | New_label (Label lbl, _) -> Section_state.define_label state lbl
+      | New_label (Symbol sym, _) -> Section_state.define_symbol state sym
+      | Global sym ->
+        Section_state.define_symbol state sym;
+        Section_state.mark_global state sym
+      (* Weak symbols also have symbol table entries on ELF, so track them
+         too *)
+      | Weak sym ->
+        Section_state.define_symbol state sym;
+        Section_state.mark_global state sym
+      | Direct_assignment (name, expr) ->
+        All_section_states.add_direct_assignment all_sections name expr
+      (* Directives that don't define labels or symbols *)
+      | Align _ | Bytes _ | Cfi_adjust_cfa_offset _ | Cfi_def_cfa_offset _
+      | Cfi_endproc | Cfi_offset _ | Cfi_startproc | Cfi_remember_state
+      | Cfi_restore_state | Cfi_def_cfa_register _ | Comment _ | Const _
+      | File _ | Indirect_symbol _ | Loc _ | New_line | Private_extern _
+      | Section _ | Size _ | Sleb128 _ | Space _ | Type _ | Uleb128 _
+      | Protected _ | Hidden _ | External _ | Reloc _ ->
+        ())
+
+(* Second pass: emit machine code and data *)
+let emit_code_and_data emitter ~all_sections =
+  let current_section = ref Asm_section.Text in
+  iter emitter ~all_sections
+    ~on_insn:(fun state (Instruction.I { name; operands }) ->
+      let encoded =
+        Encode_instruction.encode_instruction ~all_sections state name operands
+      in
+      let buf = Section_state.buffer state in
+      (* Emit as little-endian 32-bit *)
+      let emit shift =
+        Int32.to_int (Int32.shift_right_logical encoded shift) land 0xff
+        |> Char.chr |> Buffer.add_char buf
+      in
+      emit 0;
+      emit 8;
+      emit 16;
+      emit 24)
+    ~on_directive:
+      (Encode_directive.emit_directive ~current_section ~all_sections)
+
+let emit ?(for_jit = false) emitter =
+  let all_sections = All_section_states.create ~for_jit in
+  compute_label_offsets emitter ~all_sections;
+  All_section_states.reset_offsets all_sections;
+  emit_code_and_data emitter ~all_sections;
+  all_sections
+
+module For_jit = For_jit
+module Encode_directive = Encode_directive
+
+(* Re-export ref to control relocation emission behavior for verification *)
+let emit_relocs_for_all_symbol_refs =
+  Encode_directive.emit_relocs_for_all_symbol_refs

--- a/backend/arm64/binary_emitter/binary_emitter.mli
+++ b/backend/arm64/binary_emitter/binary_emitter.mli
@@ -1,0 +1,69 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+module Section_state = Section_state
+
+type t
+
+val create : unit -> t
+
+val add_instruction : t -> Instruction.t -> unit
+
+val add_directive : t -> Asm_targets.Asm_directives.Directive.t -> unit
+
+val emit : ?for_jit:bool -> t -> All_section_states.t
+
+val dump_instructions : t -> unit
+
+(** Module implementing Binary_emitter_intf.S for use by ocaml-jit *)
+module For_jit :
+  Binary_emitter_intf.S
+    with type Assembled_section.t = Section_state.t
+     and type Relocation.t = Relocation.t
+
+module Encode_directive : sig
+  (** On Linux ELF, local labels (starting with .L) don't have symbol table
+      entries. The assembler converts them to section symbol + offset. This
+      function performs that conversion. Returns (symbol_name, addend) where
+      symbol_name is either the original label or the section name, and addend
+      includes the offset within the section plus any original offset. On macOS,
+      returns the original label name and offset unchanged. *)
+  val resolve_local_label_for_elf :
+    all_sections:All_section_states.t ->
+    target:Symbol.target ->
+    sym_offset:int ->
+    string * int
+end
+
+(** When true, emit relocations for ALL 8-byte symbol references (matching
+    assembler behavior). When false, only emit relocations for cross-section
+    references and resolve same-section refs at emit time. Set to true for
+    verification against the assembler. *)
+val emit_relocs_for_all_symbol_refs : bool ref

--- a/backend/arm64/binary_emitter/bitfield_helpers.ml
+++ b/backend/arm64/binary_emitter/bitfield_helpers.ml
@@ -1,0 +1,44 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+(* Bitfield encoding - C4.1.92.8 Used for SBFM, BFM, UBFM *)
+let encode_bitfield ~sf ~opc ~n ~immr ~imms ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int sf) 31) in
+  let result = logor result (shift_left (of_int opc) 29) in
+  let result = logor result (shift_left (of_int 0b100110) 23) in
+  let result = logor result (shift_left (of_int n) 22) in
+  let result = logor result (shift_left (of_int immr) 16) in
+  let result = logor result (shift_left (of_int imms) 10) in
+  let result = logor result (shift_left (of_int (Reg.gp_encoding rn)) 5) in
+  let result = logor result (of_int (Reg.gp_encoding rd)) in
+  result

--- a/backend/arm64/binary_emitter/bitfield_helpers.mli
+++ b/backend/arm64/binary_emitter/bitfield_helpers.mli
@@ -1,0 +1,40 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+val encode_bitfield :
+  sf:int ->
+  opc:int ->
+  n:int ->
+  immr:int ->
+  imms:int ->
+  rn:[`GP of 'a] Reg.t ->
+  rd:[`GP of 'b] Reg.t ->
+  int32

--- a/backend/arm64/binary_emitter/branch_helpers.ml
+++ b/backend/arm64/binary_emitter/branch_helpers.ml
@@ -1,0 +1,194 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+module Symbol = Arm64_ast.Ast.Symbol
+
+(* Helper to compute a 26-bit PC-relative offset for B/BL instructions. If the
+   symbol is undefined, creates a relocation and returns 0.
+
+   On Linux ELF (not macOS), we also emit relocations for global symbols even
+   when they're defined in the same file. This matches the system assembler's
+   behavior which uses RELA relocations with zero in the instruction for all
+   global symbol references, allowing for symbol interposition at link time. *)
+let compute_branch_imm26 state ~instr_name ~reloc_kind (sym : _ Symbol.t) =
+  let is_global_symbol =
+    match sym.target with
+    | Symbol s ->
+      Option.is_some (Section_state.find_symbol_offset_in_bytes state s)
+    | Label _ -> false
+  in
+  (* Create relocation with addend 0 (branching to symbol itself) *)
+  let make_reloc () =
+    let r = { Relocation.Kind.target = sym.target; addend = 0 } in
+    Section_state.add_relocation_at_current_offset state
+      ~reloc_kind:(reloc_kind r)
+  in
+  (* On Linux ELF, emit relocations for global symbols to match assembler *)
+  let macosx = String.equal Config.system "macosx" in
+  if (not macosx) && is_global_symbol
+  then (
+    make_reloc ();
+    0)
+  else
+    match Section_state.find_target_offset_in_bytes state sym.target with
+    | None ->
+      (* Symbol is undefined - create a relocation and use 0 as placeholder *)
+      make_reloc ();
+      0
+    | Some target_offset ->
+      let pc_relative_offset =
+        target_offset - Section_state.offset_in_bytes state
+      in
+      let target_key () = Relocation.target_to_string sym.target in
+      if pc_relative_offset mod 4 <> 0
+      then
+        Misc.fatal_errorf "%s offset %d to symbol '%s' must be 4-byte aligned"
+          instr_name pc_relative_offset (target_key ());
+      let imm26 = pc_relative_offset / 4 in
+      if imm26 < -0x2000000 || imm26 > 0x1FFFFFF
+      then
+        Misc.fatal_errorf
+          "%s offset %d to symbol '%s' out of range (max ±128MB)" instr_name
+          pc_relative_offset (target_key ());
+      imm26
+
+(* Helper to compute a 19-bit PC-relative offset for CBZ/CBNZ instructions *)
+let compute_branch_imm19 state ~instr_name (sym : _ Symbol.t) =
+  match Section_state.find_target_offset_in_bytes state sym.target with
+  | None ->
+    let target_key = Relocation.target_to_string sym.target in
+    Misc.fatal_errorf "%s references undefined symbol '%s'" instr_name
+      target_key
+  | Some target_offset ->
+    let pc_relative_offset =
+      target_offset - Section_state.offset_in_bytes state
+    in
+    let target_key () = Relocation.target_to_string sym.target in
+    if pc_relative_offset mod 4 <> 0
+    then
+      Misc.fatal_errorf "%s offset %d to symbol '%s' must be 4-byte aligned"
+        instr_name pc_relative_offset (target_key ());
+    let imm19 = pc_relative_offset / 4 in
+    if imm19 < -0x40000 || imm19 > 0x3FFFF
+    then
+      Misc.fatal_errorf "%s offset %d to symbol '%s' out of range (max ±1MB)"
+        instr_name pc_relative_offset (target_key ());
+    imm19
+
+(* Helper to compute a 14-bit PC-relative offset for TBZ/TBNZ instructions *)
+let compute_branch_imm14 state ~instr_name (sym : _ Symbol.t) =
+  match Section_state.find_target_offset_in_bytes state sym.target with
+  | None ->
+    let target_key = Relocation.target_to_string sym.target in
+    Misc.fatal_errorf "%s references undefined symbol '%s'" instr_name
+      target_key
+  | Some target_offset ->
+    let pc_relative_offset =
+      target_offset - Section_state.offset_in_bytes state
+    in
+    let target_key () = Relocation.target_to_string sym.target in
+    if pc_relative_offset mod 4 <> 0
+    then
+      Misc.fatal_errorf "%s offset %d to symbol '%s' must be 4-byte aligned"
+        instr_name pc_relative_offset (target_key ());
+    let imm14 = pc_relative_offset / 4 in
+    if imm14 < -0x2000 || imm14 > 0x1FFF
+    then
+      Misc.fatal_errorf "%s offset %d to symbol '%s' out of range (max ±32KB)"
+        instr_name pc_relative_offset (target_key ());
+    imm14
+
+(* Conditional branch (immediate) - C4.1.93.1
+
+   Encoding: 0101010 | 0 | imm19 | o0 | cond
+
+   o0=0 for B.cond *)
+let encode_conditional_branch ~imm19 ~cond =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int 0b01010100) 24) in
+  let result = logor result (shift_left (of_int (imm19 land 0x7FFFF)) 5) in
+  let result = logor result (shift_left (of_int 0) 4) in
+  (* o0 = 0 for B.cond *)
+  let result = logor result (of_int cond) in
+  result
+
+(* Unconditional branch (register) - C4.1.93.13
+
+   Encoding: 1101011 | opc[3:0] | op2[4:0] | op3[5:0] | Rn | op4[4:0] *)
+let encode_branch_register ~opc ~rn =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int 0b1101011) 25) in
+  let result = logor result (shift_left (of_int opc) 21) in
+  let result = logor result (shift_left (of_int 0b11111) 16) in
+  (* op2 = 11111 *)
+  let result = logor result (shift_left (of_int 0b000000) 10) in
+  (* op3 = 000000 *)
+  let result = logor result (shift_left (of_int (Reg.gp_encoding rn)) 5) in
+  let result = logor result (of_int 0b00000) in
+  (* op4 = 00000 *)
+  result
+
+(* Unconditional branch (immediate) - C4.1.93.14 Encoding: op | 00101 | imm26 *)
+let encode_branch_immediate ~op ~imm26 =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int op) 31) in
+  let result = logor result (shift_left (of_int 0b00101) 26) in
+  let result = logor result (of_int (imm26 land 0x3FFFFFF)) in
+  result
+
+(* Compare and branch (immediate) - C4.1.93.15
+
+   Encoding: sf | 011010 | op | imm19 | Rt *)
+let encode_compare_branch ~sf ~op ~imm19 ~rt =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int sf) 31) in
+  let result = logor result (shift_left (of_int 0b011010) 25) in
+  let result = logor result (shift_left (of_int op) 24) in
+  let result = logor result (shift_left (of_int (imm19 land 0x7FFFF)) 5) in
+  let result = logor result (of_int rt) in
+  result
+
+(* Test and branch (immediate) - C4.1.93.16
+
+   Encoding: b5 | 011011 | op | b40 | imm14 | Rt *)
+let encode_test_branch ~b5 ~op ~b40 ~imm14 ~rt =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int b5) 31) in
+  let result = logor result (shift_left (of_int 0b011011) 25) in
+  let result = logor result (shift_left (of_int op) 24) in
+  let result = logor result (shift_left (of_int b40) 19) in
+  let result = logor result (shift_left (of_int (imm14 land 0x3FFF)) 5) in
+  let result = logor result (of_int rt) in
+  result

--- a/backend/arm64/binary_emitter/branch_helpers.mli
+++ b/backend/arm64/binary_emitter/branch_helpers.mli
@@ -1,0 +1,54 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+val compute_branch_imm26 :
+  Section_state.t ->
+  instr_name:string ->
+  reloc_kind:(Relocation.Kind.target_with_addend -> Relocation.Kind.t) ->
+  'a Symbol.t ->
+  int
+
+val compute_branch_imm19 :
+  Section_state.t -> instr_name:string -> 'a Symbol.t -> int
+
+val compute_branch_imm14 :
+  Section_state.t -> instr_name:string -> 'a Symbol.t -> int
+
+val encode_conditional_branch : imm19:int -> cond:int -> int32
+
+val encode_branch_register : opc:int -> rn:[`GP of 'a] Reg.t -> int32
+
+val encode_branch_immediate : op:int -> imm26:int -> int32
+
+val encode_compare_branch : sf:int -> op:int -> imm19:int -> rt:int -> int32
+
+val encode_test_branch :
+  b5:int -> op:int -> b40:int -> imm14:int -> rt:int -> int32

--- a/backend/arm64/binary_emitter/condition_helpers.ml
+++ b/backend/arm64/binary_emitter/condition_helpers.ml
@@ -1,0 +1,67 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+let encode_condition (cond : Cond.t) : int =
+  match cond with
+  | EQ -> 0b0000
+  | NE -> 0b0001
+  | CS -> 0b0010
+  | CC -> 0b0011
+  | MI -> 0b0100
+  | PL -> 0b0101
+  | VS -> 0b0110
+  | VC -> 0b0111
+  | HI -> 0b1000
+  | LS -> 0b1001
+  | GE -> 0b1010
+  | LT -> 0b1011
+  | GT -> 0b1100
+  | LE -> 0b1101
+
+(* Floating-point condition codes use the same encoding as integer conditions.
+   The difference is semantic: after FCMP, the flags have different meanings. *)
+let encode_float_condition (cond : Float_cond.t) : int =
+  match cond with
+  | EQ -> 0b0000
+  | NE -> 0b0001
+  | CS -> 0b0010
+  | CC -> 0b0011
+  | HI -> 0b1000
+  | LS -> 0b1001
+  | GE -> 0b1010
+  | LT -> 0b1011
+  | GT -> 0b1100
+  | LE -> 0b1101
+
+let encode_branch_condition (cond : Branch_cond.t) : int =
+  match cond with
+  | Int c -> encode_condition c
+  | Float c -> encode_float_condition c

--- a/backend/arm64/binary_emitter/condition_helpers.mli
+++ b/backend/arm64/binary_emitter/condition_helpers.mli
@@ -1,0 +1,36 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+val encode_condition : Cond.t -> int
+
+val encode_float_condition : Float_cond.t -> int
+
+val encode_branch_condition : Branch_cond.t -> int

--- a/backend/arm64/binary_emitter/csel_helpers.ml
+++ b/backend/arm64/binary_emitter/csel_helpers.ml
@@ -1,0 +1,48 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+(* Conditional select - C4.1.94.12
+
+   Encoding: sf | op | S | 11010100 | Rm | cond | op2 | Rn | Rd *)
+let encode_conditional_select ~sf ~op ~op2 ~rm ~cond ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int sf) 31) in
+  let result = logor result (shift_left (of_int op) 30) in
+  let result = logor result (shift_left (of_int 0b0) 29) in
+  (* S = 0 *)
+  let result = logor result (shift_left (of_int 0b11010100) 21) in
+  let result = logor result (shift_left (of_int (Reg.gp_encoding rm)) 16) in
+  let result = logor result (shift_left (of_int cond) 12) in
+  let result = logor result (shift_left (of_int op2) 10) in
+  let result = logor result (shift_left (of_int (Reg.gp_encoding rn)) 5) in
+  let result = logor result (of_int (Reg.gp_encoding rd)) in
+  result

--- a/backend/arm64/binary_emitter/csel_helpers.mli
+++ b/backend/arm64/binary_emitter/csel_helpers.mli
@@ -1,0 +1,40 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+val encode_conditional_select :
+  sf:int ->
+  op:int ->
+  op2:int ->
+  rm:[`GP of 'a] Reg.t ->
+  cond:int ->
+  rn:[`GP of 'b] Reg.t ->
+  rd:[`GP of 'c] Reg.t ->
+  int32

--- a/backend/arm64/binary_emitter/data_proc_helpers.ml
+++ b/backend/arm64/binary_emitter/data_proc_helpers.ml
@@ -1,0 +1,72 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+(* Data-processing (2 source) - C4.1.94.1 *)
+let encode_data_proc_2_source ~sf ~s ~opcode ~rm ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int sf) 31) in
+  let result = logor result (shift_left (of_int s) 29) in
+  let result = logor result (shift_left (of_int 0b11010110) 21) in
+  let result = logor result (shift_left (of_int (Reg.gp_encoding rm)) 16) in
+  let result = logor result (shift_left (of_int opcode) 10) in
+  let result = logor result (shift_left (of_int (Reg.gp_encoding rn)) 5) in
+  let result = logor result (of_int (Reg.gp_encoding rd)) in
+  result
+
+(* Data-processing (1 source) - C4.1.94.2 *)
+let encode_data_proc_1_source ~sf ~s ~opcode2 ~opcode ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int sf) 31) in
+  let result = logor result (shift_left (of_int 0b1) 30) in
+  let result = logor result (shift_left (of_int s) 29) in
+  let result = logor result (shift_left (of_int 0b11010110) 21) in
+  let result = logor result (shift_left (of_int opcode2) 16) in
+  let result = logor result (shift_left (of_int opcode) 10) in
+  let result = logor result (shift_left (of_int (Reg.gp_encoding rn)) 5) in
+  let result = logor result (of_int (Reg.gp_encoding rd)) in
+  result
+
+(* Data-processing (3 source) - C4.1.94.13 *)
+let encode_data_proc_3_source ~sf ~op54 ~op31 ~o0 ~rm ~ra ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int sf) 31) in
+  let result = logor result (shift_left (of_int op54) 29) in
+  let result = logor result (shift_left (of_int 0b11011) 24) in
+  let result = logor result (shift_left (of_int op31) 21) in
+  let result = logor result (shift_left (of_int (Reg.gp_encoding rm)) 16) in
+  let result = logor result (shift_left (of_int o0) 15) in
+  let result = logor result (shift_left (of_int (Reg.gp_encoding ra)) 10) in
+  let result = logor result (shift_left (of_int (Reg.gp_encoding rn)) 5) in
+  let result = logor result (of_int (Reg.gp_encoding rd)) in
+  result

--- a/backend/arm64/binary_emitter/data_proc_helpers.mli
+++ b/backend/arm64/binary_emitter/data_proc_helpers.mli
@@ -1,0 +1,59 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+val encode_data_proc_2_source :
+  sf:int ->
+  s:int ->
+  opcode:int ->
+  rm:[`GP of 'a] Reg.t ->
+  rn:[`GP of 'b] Reg.t ->
+  rd:[`GP of 'c] Reg.t ->
+  int32
+
+val encode_data_proc_1_source :
+  sf:int ->
+  s:int ->
+  opcode2:int ->
+  opcode:int ->
+  rn:[`GP of 'a] Reg.t ->
+  rd:[`GP of 'b] Reg.t ->
+  int32
+
+val encode_data_proc_3_source :
+  sf:int ->
+  op54:int ->
+  op31:int ->
+  o0:int ->
+  rm:[`GP of 'a] Reg.t ->
+  ra:[`GP of 'b] Reg.t ->
+  rn:[`GP of 'c] Reg.t ->
+  rd:[`GP of 'd] Reg.t ->
+  int32

--- a/backend/arm64/binary_emitter/dune
+++ b/backend/arm64/binary_emitter/dune
@@ -1,0 +1,9 @@
+(include_subdirs unqualified)
+
+(library
+ (name arm64_binary_emitter)
+ (wrapped true)
+ (ocamlopt_flags
+  (:standard -w +4
+   (:include %{project_root}/ocamlopt_flags.sexp)))
+ (libraries ocamlcommon asm_targets arm64_ast binary_emitter_intf))

--- a/backend/arm64/binary_emitter/encode_directive.ml
+++ b/backend/arm64/binary_emitter/encode_directive.ml
@@ -1,0 +1,594 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+module Asm_section = Asm_targets.Asm_section
+module Asm_label = Asm_targets.Asm_label
+module Asm_symbol = Asm_targets.Asm_symbol
+module D = Asm_targets.Asm_directives
+module C = D.Directive.Constant
+module SS = Section_state
+module Symbol = Arm64_ast.Ast.Symbol
+
+let rec extract_symbol_name (cst : C.t) =
+  match cst with
+  | Label lbl -> Some (Asm_label.encode lbl)
+  | Symbol sym -> Some (Asm_symbol.encode sym)
+  | Variable name -> Some name
+  | Add (a, _) | Sub (a, _) -> extract_symbol_name a
+  | Signed_int _ | Unsigned_int _ | This -> None
+
+(* Extract (target, offset) from expressions like (Label - This) + offset *)
+let extract_target_this_offset (cst : C.t) : (Symbol.target * int64) option =
+  match[@warning "-4"] cst with
+  | Add (Sub (Label lbl, This), Signed_int offset) ->
+    Some (Symbol.Label lbl, offset)
+  | Add (Sub (Symbol sym, This), Signed_int offset) ->
+    Some (Symbol.Symbol sym, offset)
+  | Sub (Label lbl, This) -> Some (Symbol.Label lbl, 0L)
+  | Sub (Symbol sym, This) -> Some (Symbol.Symbol sym, 0L)
+  | _ -> None
+
+let rec eval_constant state ~all_sections const =
+  (* For same-section relative expressions like (Label - This), the offset
+     within the section is all that matters. Cross-section references are
+     detected and handled via relocations before this function is called. *)
+  let this () = Int64.of_int (SS.offset_in_bytes state) in
+  let lookup_label lbl =
+    (* First try current section, then fall back to global lookup. *)
+    match SS.find_label_offset_in_bytes state lbl with
+    | Some offset -> Some (Int64.of_int offset)
+    | None -> (
+      match
+        All_section_states.find_in_any_section all_sections (Symbol.Label lbl)
+      with
+      | Some (offset, _section) -> Some (Int64.of_int offset)
+      | None -> None)
+  in
+  let lookup_symbol sym =
+    (* Note: We do NOT suppress global symbols here even in PIC mode (dlcode).
+       This lookup is used for evaluating constant expressions like "symbol -
+       label" which compute relative offsets at assembly time. The dlcode check
+       for absolute symbol references is handled separately in
+       is_absolute_symbol_reference. *)
+    match SS.find_symbol_offset_in_bytes state sym with
+    | Some offset -> Some (Int64.of_int offset)
+    | None -> (
+      match
+        All_section_states.find_in_any_section all_sections (Symbol.Symbol sym)
+      with
+      | Some (offset, _section) -> Some (Int64.of_int offset)
+      | None -> None)
+  in
+  let lookup_variable name =
+    (* Check if this is a direct assignment (e.g., temp0 from .set) *)
+    match All_section_states.find_direct_assignment all_sections name with
+    | Some expr ->
+      (* Recursively evaluate the assigned expression *)
+      eval_constant state ~all_sections expr
+    | None -> None
+  in
+  C.eval ~this ~lookup_label ~lookup_symbol ~lookup_variable const
+
+(* Handle cross-section (Label - This) + offset pattern. This occurs in
+   frametable entries where a DATA section location references a TEXT section
+   label (return address), or when DATA references read-only data sections like
+   .rodata.cst8. On ELF with function sections, we emit R_AARCH64_PREL32 with
+   section name and addend. On macOS, we emit PREL32_PAIR using symbol pairs. *)
+let is_cross_section_relative_reference state ~all_sections ~current_section c =
+  match extract_target_this_offset c with
+  | None -> None
+  | Some (target, offset_upper) -> (
+    (* First check if target is in current section *)
+    match SS.find_target_offset_in_bytes state target with
+    | Some _ -> None (* Same section, use normal eval *)
+    | None -> (
+      let macosx = String.equal Config.system "macosx" in
+      let for_jit = All_section_states.for_jit all_sections in
+      (* On ELF (not JIT) with function sections, check individual sections
+         first. The assembler emits R_AARCH64_PREL32 with section symbol and
+         addend. For JIT mode, we aggregate sections so can't use section
+         symbols. *)
+      if
+        (not macosx) && (not for_jit)
+        &&
+        match
+          All_section_states.find_in_any_individual_section_with_state
+            all_sections target
+        with
+        | Some (target_offset, section, _target_state) ->
+          if not (Asm_section.equal current_section Asm_section.Data)
+          then
+            Misc.fatal_errorf
+              "Cross-section (Label - This) from non-DATA section %s to %s not \
+               supported"
+              (Asm_section.to_string current_section)
+              (Asm_section.to_string section)
+          else
+            (* ELF with function sections: use R_AARCH64_PREL32 with section
+               symbol and addend. The addend is the offset of the label within
+               the section plus any user-specified offset. *)
+            let addend = target_offset + Int64.to_int offset_upper in
+            SS.add_relocation_at_current_offset state
+              ~reloc_kind:(R_AARCH64_PREL32 { section; addend });
+            true
+        | None -> false
+      then Some 0L (* ELF RELA: addend in relocation, emit 0 in data *)
+      else
+        (* Try cross-section lookup for standard sections. Use
+           find_in_any_section_with_state to get the actual state where the
+           target was found. *)
+        match
+          All_section_states.find_in_any_section_with_state all_sections target
+        with
+        | None -> None (* Not found at all *)
+        | Some (target_offset, label_section, _target_state) -> (
+          if Asm_section.equal label_section current_section
+          then None (* Same section after all *)
+          else if not (Asm_section.equal current_section Asm_section.Data)
+          then
+            Misc.fatal_errorf
+              "Cross-section (Label - This) from non-DATA section %s to %s not \
+               supported"
+              (Asm_section.to_string current_section)
+              (Asm_section.to_string label_section)
+          else if (not macosx) && not for_jit
+          then (
+            (* ELF without function sections: use R_AARCH64_PREL32 with standard
+               section symbol. The assembler uses section symbols for
+               cross-section references. *)
+            let addend = target_offset + Int64.to_int offset_upper in
+            SS.add_relocation_at_current_offset state
+              ~reloc_kind:(R_AARCH64_PREL32 { section = label_section; addend });
+            Some 0L (* ELF RELA: addend in relocation, emit 0 in data *))
+          else
+            (* macOS or JIT: use symbol pairs (SUBTRACTOR + UNSIGNED). The
+               linker computes: plus_sym - minus_sym + addend So: addend =
+               (target - plus_sym) - (current - minus_sym) *)
+            let current_pos = SS.offset_in_bytes state in
+            (* Find nearest symbol in DATA for SUBTRACTOR *)
+            match SS.find_nearest_symbol_before state current_pos with
+            | None ->
+              Misc.fatal_error
+                "No symbol in DATA section for cross-section relocation"
+            | Some (minus_symbol, minus_sym_offset) -> (
+              (* Find nearest symbol in target section for UNSIGNED. Note: when
+                 using find_in_any_section_with_state, we get the target offset
+                 within the actual section state. *)
+              let target_state_for_lookup =
+                All_section_states.find_exn all_sections label_section
+              in
+              match
+                SS.find_nearest_symbol_before target_state_for_lookup
+                  target_offset
+              with
+              | None ->
+                Misc.fatal_errorf
+                  "No symbol in %s section for cross-section relocation"
+                  (Asm_section.to_string label_section)
+              | Some (plus_sym, plus_sym_offset) ->
+                let addend =
+                  Int64.add offset_upper
+                    (Int64.sub
+                       (Int64.of_int (target_offset - plus_sym_offset))
+                       (Int64.of_int (current_pos - minus_sym_offset)))
+                in
+                (* find_nearest_symbol_before returns Asm_symbol.t directly *)
+                let plus_target : Symbol.target = Symbol plus_sym in
+                let minus_target : Symbol.target = Symbol minus_symbol in
+                SS.add_relocation_at_current_offset state
+                  ~reloc_kind:
+                    (R_AARCH64_PREL32_PAIR { plus_target; minus_target });
+                (* On macOS (Mach-O), the addend must be in the data. *)
+                Some addend))))
+
+(* Returns true if we're on a RELA platform (Linux ELF) where addends are stored
+   in the relocation entry rather than in the instruction/data. On REL platforms
+   (macOS Mach-O), addends are encoded in the instruction. *)
+let is_rela_platform () =
+  match Config.system with
+  | "linux" | "linux_eabi" | "linux_eabihf" | "freebsd" | "netbsd" | "openbsd"
+    ->
+    true
+  | "macosx" | "darwin" -> false
+  | _ -> false (* Default to REL behavior for unknown systems *)
+
+(* Encode a Symbol.target to its string representation *)
+let encode_target (target : Symbol.target) : string =
+  match target with
+  | Label lbl -> Asm_label.encode lbl
+  | Symbol sym -> Asm_symbol.encode sym
+
+(* Check if a target is a global symbol in the given state. Only symbols
+   explicitly marked as global (via Global or Weak directives) return true.
+   File-scope symbols defined only via New_label return false. *)
+let is_global_in_state state (target : Symbol.target) : bool =
+  match target with Symbol sym -> SS.is_global state sym | Label _ -> false
+
+(* For verification against the assembler, local symbols need to be converted:
+
+   - On Linux ELF: local symbols (.L prefix) don't have symbol table entries,
+   assembler converts them to section symbol + offset
+
+   - On macOS: local symbols (L prefix) don't have symbol table entries,
+   assembler converts them to nearest global symbol + offset
+
+   Returns (symbol_name, addend) where symbol_name is the converted symbol name
+   and addend includes any necessary offset adjustments. *)
+let resolve_local_label_for_elf ~all_sections ~target ~sym_offset =
+  let sym_name = encode_target target in
+  if is_rela_platform ()
+  then
+    (* Linux ELF: check if this is a local/file-scope symbol that needs
+       conversion to section + offset *)
+    let is_local_label =
+      String.length sym_name >= 2
+      && Char.equal sym_name.[0] '.'
+      && Char.equal sym_name.[1] 'L'
+    in
+    (* Try to find the symbol in individual sections first (function
+       sections) *)
+    let try_individual_sections () =
+      match
+        All_section_states.find_in_any_individual_section_with_state
+          all_sections target
+      with
+      | Some (label_offset, section, target_state) ->
+        (* Check if this is a global symbol in the target section *)
+        let is_global_in_target = is_global_in_state target_state target in
+        if is_local_label || not is_global_in_target
+        then
+          let section_name = Asm_section.to_string section in
+          Some (section_name, label_offset + sym_offset)
+        else None
+      | None -> None
+    in
+    (* Try to find in standard sections *)
+    let try_standard_sections () =
+      match
+        All_section_states.find_in_any_section_with_state all_sections target
+      with
+      | Some (label_offset, section, target_state) ->
+        let section_name = Asm_section.to_string section in
+        let is_global_in_target = is_global_in_state target_state target in
+        if is_local_label || not is_global_in_target
+        then Some (section_name, label_offset + sym_offset)
+        else None
+      | None -> None
+    in
+    match try_individual_sections () with
+    | Some result -> result
+    | None -> (
+      match try_standard_sections () with
+      | Some result -> result
+      | None ->
+        (* Symbol not found or is global - use original name *)
+        sym_name, sym_offset)
+  else
+    (* macOS: check if this is a local label (L prefix) that needs conversion to
+       nearest global symbol + offset *)
+    let is_local_label =
+      String.length sym_name >= 1 && Char.equal sym_name.[0] 'L'
+    in
+    if not is_local_label
+    then (* Global symbol or external - use directly *)
+      sym_name, sym_offset
+    else
+      (* Find the target's offset and section *)
+      match
+        All_section_states.find_in_any_section_with_state all_sections target
+      with
+      | None ->
+        (* Target not found - use original name (will be external reference) *)
+        sym_name, sym_offset
+      | Some (label_offset, _section, target_state) -> (
+        if
+          (* Check if target is actually a global symbol *)
+          is_global_in_state target_state target
+        then sym_name, sym_offset
+        else
+          (* Find global symbol at the target offset (if co-located) or nearest
+             before. This handles function entry labels which are co-located
+             with global function symbols. *)
+          let target_abs_offset = label_offset in
+          match
+            SS.find_global_symbol_at_or_before target_state target_abs_offset
+          with
+          | None ->
+            (* No global symbol before target - shouldn't happen in well-formed
+               output, fall back to original *)
+            sym_name, sym_offset
+          | Some (nearest_sym, nearest_sym_offset) ->
+            let addend = target_abs_offset - nearest_sym_offset + sym_offset in
+            Asm_symbol.encode nearest_sym, addend)
+
+(* When true, emit relocations for ALL 8-byte symbol references (matching
+   assembler behavior). When false, only emit relocations for cross-section
+   references and resolve same-section refs at emit time. Set to true for
+   verification against the assembler. *)
+let emit_relocs_for_all_symbol_refs = ref false
+
+(* Extract (target, addend) from absolute symbol expressions like: - Symbol sym
+   -> (Symbol sym, 0) - Label lbl -> (Label lbl, 0) - Add (Symbol sym,
+   Signed_int offset) -> (Symbol sym, offset) - Add (Signed_int offset, Symbol
+   sym) -> (Symbol sym, offset) - Add (Label lbl, Signed_int offset) -> (Label
+   lbl, offset) *)
+let rec target_and_addend_of_constant (cst : C.t) :
+    (Symbol.target * int64) option =
+  match cst with
+  | Label lbl -> Some (Label lbl, 0L)
+  | Symbol sym -> Some (Symbol sym, 0L)
+  (* Symbol/Label + offset (either order) *)
+  | Add (Symbol sym, Signed_int offset) | Add (Signed_int offset, Symbol sym) ->
+    Some (Symbol sym, offset)
+  | Add (Label lbl, Signed_int offset) | Add (Signed_int offset, Label lbl) ->
+    Some (Label lbl, offset)
+  | Add (Symbol sym, Unsigned_int offset) | Add (Unsigned_int offset, Symbol sym)
+    ->
+    Some (Symbol sym, Numbers.Uint64.to_int64 offset)
+  | Add (Label lbl, Unsigned_int offset) | Add (Unsigned_int offset, Label lbl)
+    ->
+    Some (Label lbl, Numbers.Uint64.to_int64 offset)
+  (* Nested expressions with offset on right *)
+  | Add (inner, Signed_int offset) -> (
+    match target_and_addend_of_constant inner with
+    | Some (target, inner_offset) -> Some (target, Int64.add inner_offset offset)
+    | None -> None)
+  | Add (inner, Unsigned_int offset) -> (
+    match target_and_addend_of_constant inner with
+    | Some (target, inner_offset) ->
+      Some (target, Int64.add inner_offset (Numbers.Uint64.to_int64 offset))
+    | None -> None)
+  (* Nested expressions with offset on left *)
+  | Add (Signed_int offset, inner) -> (
+    match target_and_addend_of_constant inner with
+    | Some (target, inner_offset) -> Some (target, Int64.add offset inner_offset)
+    | None -> None)
+  | Add (Unsigned_int offset, inner) -> (
+    match target_and_addend_of_constant inner with
+    | Some (target, inner_offset) ->
+      Some (target, Int64.add (Numbers.Uint64.to_int64 offset) inner_offset)
+    | None -> None)
+  | Add (_, _) -> None (* Other Add patterns not supported *)
+  | Signed_int _ | Unsigned_int _ | This | Variable _ | Sub _ -> None
+
+(* Handle absolute symbol reference. For .8byte symbol references in object
+   files, the assembler always emits relocations. We can either match that
+   behavior (for verification) or resolve same-section refs at emit time (more
+   efficient for JIT). For 4-byte references, we also handle them in
+   verification mode. *)
+let is_absolute_symbol_reference state ~all_sections ~current_section
+    ~width_bytes (cst : C.t) =
+  (* Only handle 4-byte and 8-byte symbol references *)
+  if width_bytes <> 8 && width_bytes <> 4
+  then None
+  else
+    match target_and_addend_of_constant cst with
+    | None -> None
+    | Some (target, addend) -> (
+      let for_jit = All_section_states.for_jit all_sections in
+      (* Check if symbol is in the same section *)
+      let same_section_offset = SS.find_target_offset_in_bytes state target in
+      let is_same_section = Option.is_some same_section_offset in
+      (* Check if this is a global symbol (explicit Global/Weak directive) *)
+      let is_global = is_global_in_state state target in
+      (* On macOS (REL), the data value depends on target type and scope:
+
+         - For global symbols: emit just the addend (relocation points to
+         symbol)
+
+         - For local labels/file-scope symbols: the assembler finds the nearest
+         global symbol before the target and creates a relocation to that
+         symbol. The data contains (target_offset - symbol_offset + addend).
+
+         - On Linux RELA: addend in relocation, emit 0 in data *)
+      if is_same_section
+      then
+        if for_jit || !emit_relocs_for_all_symbol_refs
+        then (
+          let target_offset = Option.get same_section_offset in
+          if is_rela_platform ()
+          then (
+            (* Linux RELA: emit 0, put original target in relocation *)
+            SS.add_relocation_at_current_offset state
+              ~reloc_kind:(R_AARCH64_ABS64 { target; addend = 0 });
+            Some 0L)
+          else if is_global
+          then (
+            (* Global symbol on macOS: emit addend, relocation to symbol *)
+            SS.add_relocation_at_current_offset state
+              ~reloc_kind:(R_AARCH64_ABS64 { target; addend = 0 });
+            Some addend)
+          else
+            (* Local label or file-scope symbol on macOS: find global symbol at
+               or before target and emit offset relative to it *)
+            match SS.find_global_symbol_at_or_before state target_offset with
+            | Some (nearest_sym, nearest_sym_offset) ->
+              let data_value =
+                Int64.add addend
+                  (Int64.of_int (target_offset - nearest_sym_offset))
+              in
+              SS.add_relocation_at_current_offset state
+                ~reloc_kind:
+                  (R_AARCH64_ABS64 { target = Symbol nearest_sym; addend = 0 });
+              Some data_value
+            | None ->
+              (* No global symbol before target - fall back to absolute offset.
+                 This shouldn't happen in well-formed OCaml output. *)
+              SS.add_relocation_at_current_offset state
+                ~reloc_kind:(R_AARCH64_ABS64 { target; addend = 0 });
+              Some (Int64.add addend (Int64.of_int target_offset)))
+        else None (* Resolve same-section refs at emit time via eval_constant *)
+      else
+        (* Cross-section reference - always needs relocation *)
+        match
+          All_section_states.find_in_any_section_with_state all_sections target
+        with
+        | None -> None (* Not found, will fall through to emit_unresolved *)
+        | Some (target_offset, sym_section, target_state) ->
+          if
+            Asm_section.equal sym_section current_section
+            && (not for_jit)
+            && not !emit_relocs_for_all_symbol_refs
+          then None (* Same section after all, resolve at emit time *)
+          else
+            (* Check if global in the target section's state *)
+            let is_global_in_target = is_global_in_state target_state target in
+            (* Check if target is a Label in a TEXT section. On macOS, labels in
+               TEXT sections get symbol table entries and direct relocations.
+               Labels in DATA/rodata sections get converted to
+               section+offset. *)
+            let is_label_in_text =
+              match target with
+              | Symbol.Label _ -> Asm_section.section_is_text sym_section
+              | Symbol _ -> false
+            in
+            let data_value =
+              if is_rela_platform ()
+              then 0L
+              else if is_global_in_target || is_label_in_text
+              then addend
+              else Int64.add addend (Int64.of_int target_offset)
+            in
+            (* Keep original target in relocation for JIT use. The conversion to
+               section+offset for verification is done in emit.ml *)
+            SS.add_relocation_at_current_offset state
+              ~reloc_kind:(R_AARCH64_ABS64 { target; addend = 0 });
+            Some data_value)
+
+(* Handle unresolved symbol reference by emitting the addend (on macOS) or zeros
+   (on Linux) and recording a relocation for the linker to patch. *)
+let emit_unresolved_symbol_relocation state ~width_bytes c =
+  let buf = SS.buffer state in
+  let addend =
+    match target_and_addend_of_constant c with
+    | Some (target, addend) when width_bytes = 8 ->
+      SS.add_relocation_at_current_offset state
+        ~reloc_kind:(R_AARCH64_ABS64 { target; addend = 0 });
+      addend
+    | Some _ ->
+      let symbol_name = Option.get (extract_symbol_name c) in
+      Misc.fatal_errorf
+        "Unresolved %d-byte reference to symbol %s (only 8-byte relocations \
+         supported)"
+        width_bytes symbol_name
+    | None ->
+      Misc.fatal_errorf
+        "Unresolved %d-byte constant expression (only 8-byte relocations \
+         supported)"
+        width_bytes
+  in
+  (* On macOS (REL), emit addend in the data. On Linux (RELA), emit zeros. *)
+  if is_rela_platform ()
+  then
+    for _ = 1 to width_bytes do
+      Buffer.add_char buf '\x00'
+    done
+  else D.Directive.emit_int_le buf ~width_bytes addend
+
+(* Emit a constant value, handling cross-section references and relocations. *)
+let emit_constant state ~all_sections ~current_section constant =
+  let buf = SS.buffer state in
+  let module C = D.Directive.Constant_with_width in
+  let c = C.constant constant in
+  let width = C.width_in_bytes constant in
+  let width_bytes = C.Width_in_bytes.to_int width in
+  let abs_result =
+    is_absolute_symbol_reference state ~all_sections ~current_section
+      ~width_bytes c
+  in
+  let value_opt =
+    match
+      is_cross_section_relative_reference state ~all_sections ~current_section c
+    with
+    | Some addend -> Some addend
+    | None -> (
+      match abs_result with
+      | Some v -> Some v
+      | None -> eval_constant state ~all_sections c)
+  in
+  match value_opt with
+  | Some value -> D.Directive.emit_int_le buf ~width_bytes value
+  | None -> emit_unresolved_symbol_relocation state ~width_bytes c
+
+let emit_alignment state ~bytes ~(fill : D.align_padding) =
+  let buf = SS.buffer state in
+  let offset = SS.offset_in_bytes state in
+  let remainder = offset mod bytes in
+  if remainder <> 0
+  then
+    let padding = bytes - remainder in
+    match fill with
+    | Nop ->
+      (* Emit NOP instructions (4 bytes each) for code alignment *)
+      let nop_count = padding / 4 in
+      let zero_count = padding mod 4 in
+      let nop = Int64.of_int32 (Nop_helpers.encode_nop ()) in
+      for _ = 1 to nop_count do
+        D.Directive.emit_int_le buf ~width_bytes:4 nop
+      done;
+      for _ = 1 to zero_count do
+        Buffer.add_char buf '\x00'
+      done
+    | Zero ->
+      for _ = 1 to padding do
+        Buffer.add_char buf '\x00'
+      done
+
+let emit_directive state ~current_section ~all_sections
+    (directive : D.Directive.t) =
+  let buf = SS.buffer state in
+  (* Update current section when we see a Section directive *)
+  (match[@warning "-4"] directive with
+  | Section (section, _) -> current_section := section
+  | _ -> ());
+  match directive with
+  | Bytes { str; _ } -> Buffer.add_string buf str
+  | Space { bytes } ->
+    for _ = 1 to bytes do
+      Buffer.add_char buf '\x00'
+    done
+  | Align { bytes; fill } -> emit_alignment state ~bytes ~fill
+  | Const { constant; _ } ->
+    emit_constant state ~all_sections ~current_section:!current_section constant
+  | Sleb128 { constant; _ } -> (
+    match eval_constant state ~all_sections constant with
+    | Some value -> D.Directive.emit_sleb128 buf value
+    | None -> Misc.fatal_error "Cannot emit SLEB128 for external symbol")
+  | Uleb128 { constant; _ } -> (
+    match eval_constant state ~all_sections constant with
+    | Some value -> D.Directive.emit_uleb128 buf value
+    | None -> Misc.fatal_error "Cannot emit ULEB128 for external symbol")
+  (* Directives that don't emit data *)
+  | Cfi_adjust_cfa_offset _ | Cfi_def_cfa_offset _ | Cfi_endproc | Cfi_offset _
+  | Cfi_startproc | Cfi_remember_state | Cfi_restore_state
+  | Cfi_def_cfa_register _ | Comment _ | Direct_assignment _ | File _ | Global _
+  | Indirect_symbol _ | Loc _ | New_label _ | New_line | Private_extern _
+  | Section _ | Size _ | Type _ | Protected _ | Hidden _ | Weak _ | External _
+  | Reloc _ ->
+    ()

--- a/backend/arm64/binary_emitter/encode_directive.mli
+++ b/backend/arm64/binary_emitter/encode_directive.mli
@@ -1,0 +1,68 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+module Asm_section = Asm_targets.Asm_section
+module D = Asm_targets.Asm_directives
+module Symbol = Arm64_ast.Ast.Symbol
+
+val eval_constant :
+  Section_state.t ->
+  all_sections:All_section_states.t ->
+  D.Directive.Constant.t ->
+  int64 option
+
+val emit_directive :
+  Section_state.t ->
+  current_section:Asm_section.t ref ->
+  all_sections:All_section_states.t ->
+  D.Directive.t ->
+  unit
+
+(** Returns true if we're on a RELA platform (Linux ELF) where addends are
+    stored in the relocation entry rather than in the instruction/data. On REL
+    platforms (macOS Mach-O), addends are encoded in the instruction. *)
+val is_rela_platform : unit -> bool
+
+(** On Linux ELF, local labels (starting with .L) don't have symbol table
+    entries. The assembler converts them to section symbol + offset. This
+    function performs that conversion. Returns (symbol_name, addend) where
+    symbol_name is either the original label or the section name, and addend
+    includes the offset within the section plus any original offset. On macOS,
+    returns the original label name and offset unchanged. *)
+val resolve_local_label_for_elf :
+  all_sections:All_section_states.t ->
+  target:Symbol.target ->
+  sym_offset:int ->
+  string * int
+
+(** When true, emit relocations for ALL 8-byte symbol references (matching
+    assembler behavior). When false, only emit relocations for cross-section
+    references and resolve same-section refs at emit time. Set to true for
+    verification against the assembler. *)
+val emit_relocs_for_all_symbol_refs : bool ref

--- a/backend/arm64/binary_emitter/encode_instruction.ml
+++ b/backend/arm64/binary_emitter/encode_instruction.ml
@@ -1,0 +1,1406 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+module Asm_label = Asm_targets.Asm_label
+
+let encode_instruction : type num operands.
+    all_sections:All_section_states.t ->
+    Section_state.t ->
+    (num, operands) Instruction_name.t ->
+    (num, operands) many ->
+    int32 =
+ fun ~all_sections state instr operands ->
+  match operands, instr with
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      ABS_vector ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* ABS: U=0, opcode=01011 *)
+    Simd_helpers.encode_simd_two_reg_misc ~q ~u:0 ~size ~opcode:0b01011 ~rn ~rd
+  | Quad (Reg rd, Reg rn, Imm (Twelve imm12), Optional shift), ADD_immediate ->
+    Add_sub_helpers.encode_add_sub_imm_auto_shift ~op:0 ~s:0 ~imm12
+      ~shift_opt:shift ~rn ~rd
+  | Quad (Reg rd, Reg rn, Imm (Sym sym), Optional shift), ADD_immediate -> (
+    let sh = match shift with Some _ -> 1 | None -> 0 in
+    match sym.reloc with
+    | Needs_reloc reloc ->
+      (* Keep original target in relocation for JIT use. The conversion to
+         section+offset for verification is done in emit.ml *)
+      let reloc_kind : Relocation.Kind.t =
+        let r = { Relocation.Kind.target = sym.target; addend = sym.offset } in
+        match reloc with
+        | LOWER_TWELVE | PAGE_OFF -> R_AARCH64_ADD_ABS_LO12_NC r
+        | GOT_LOWER_TWELVE | GOT_PAGE_OFF -> R_AARCH64_LD64_GOT_LO12_NC r
+      in
+      Section_state.add_relocation_at_current_offset state ~reloc_kind;
+      (* On RELA platforms (Linux), encode 0 in instruction - addend is in
+         relocation. On REL platforms (macOS), encode addend in instruction. *)
+      let imm12 =
+        if Encode_directive.is_rela_platform () then 0 else sym.offset
+      in
+      Add_sub_helpers.encode_add_sub_immediate ~sf:1 ~op:0 ~s:0 ~sh ~imm12 ~rn
+        ~rd)
+  | ( Quad
+        ( Reg ({ reg_name = GP _; _ } as rd),
+          Reg ({ reg_name = GP _; _ } as rn),
+          Reg ({ reg_name = GP _; _ } as rm),
+          Optional shift_opt ),
+      ADD_shifted_register ) ->
+    let shift, imm6 =
+      match shift_opt with
+      | None -> 0, 0
+      | Some (Shift { kind; amount }) ->
+        ( Add_sub_helpers.decode_shift_kind_int kind,
+          Add_sub_helpers.decode_shift_amount_six amount )
+    in
+    Add_sub_helpers.encode_add_sub_shifted_reg ~op:0 ~s:0 ~shift ~imm6 ~rd ~rn
+      ~rm
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      ADDP_vector ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* ADDP: U=0, opcode=10111 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:0 ~size ~rm ~opcode:0b10111 ~rn
+      ~rd
+  | Quad (Reg rd, Reg rn, Imm (Twelve imm12), Optional shift), ADDS ->
+    Add_sub_helpers.encode_add_sub_imm_auto_shift ~op:0 ~s:1 ~imm12
+      ~shift_opt:shift ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      ADD_vector ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    Simd_helpers.encode_simd_three_same ~q ~u:0 ~size ~rm ~opcode:0b10000 ~rn
+      ~rd
+  | ( Pair
+        ( Reg { reg_name = Neon (Scalar _); index = rd },
+          Reg { reg_name = Neon (Vector vec); index = rn } ),
+      ADDV ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* ADDV: U=0, opcode=11011 *)
+    Simd_helpers.encode_simd_across_lanes ~q ~u:0 ~size ~opcode:0b11011 ~rn ~rd
+  | Pair (Reg rd, Imm (Sym sym)), ADR ->
+    (* ADR only accepts Same_section_and_unit symbols (local labels) *)
+    let Same_section_and_unit = sym.reloc in
+    let lbl =
+      match sym.target with
+      | Label lbl -> lbl
+      | Symbol _ -> Misc.fatal_error "ADR: expected label, got symbol"
+    in
+    (* Compute PC-relative offset at assembly time *)
+    let target_offset =
+      match Section_state.find_label_offset_in_bytes state lbl with
+      | Some off -> off
+      | None ->
+        Misc.fatal_errorf "ADR: label %a not found in current section"
+          Asm_label.print lbl
+    in
+    let current_offset = Section_state.offset_in_bytes state in
+    let pc_rel = target_offset - current_offset + sym.offset in
+    let immlo, immhi = Adr_helpers.split_21bit_immediate pc_rel in
+    Adr_helpers.encode_adr ~op:0 ~immlo ~immhi ~rd
+  | Pair (Reg rd, Imm (Sym sym)), ADRP ->
+    (* Keep original target in relocation for JIT use. The conversion to
+       section+offset for verification is done in emit.ml *)
+    let reloc_kind : Relocation.Kind.t =
+      let r = { Relocation.Kind.target = sym.target; addend = sym.offset } in
+      match sym.reloc with
+      | Needs_reloc GOT_PAGE -> R_AARCH64_ADR_GOT_PAGE r
+      | Needs_reloc PAGE -> R_AARCH64_ADR_PREL_PG_HI21 r
+    in
+    Section_state.add_relocation_at_current_offset state ~reloc_kind;
+    (* On RELA platforms (Linux), encode 0 in instruction - addend is in
+       relocation. On REL platforms (macOS), encode addend in instruction. *)
+    let offset =
+      if Encode_directive.is_rela_platform () then 0 else sym.offset
+    in
+    let immlo, immhi = Adr_helpers.split_21bit_immediate offset in
+    Adr_helpers.encode_adr ~op:1 ~immlo ~immhi ~rd
+  | Triple (Reg rd, Reg rn, Bitmask bitmask), AND_immediate ->
+    let n, immr, imms = Operand.Bitmask.decode_n_immr_imms bitmask in
+    Logical_helpers.encode_logical_immediate ~sf:1 ~opc:0b00 ~n ~immr ~imms ~rn
+      ~rd
+  | ( Quad
+        ( Reg ({ reg_name = GP _; _ } as rd),
+          Reg ({ reg_name = GP _; _ } as rn),
+          Reg ({ reg_name = GP _; _ } as rm),
+          Optional shift_opt ),
+      AND_shifted_register ) ->
+    let shift, imm6 =
+      match shift_opt with
+      | None -> 0, 0
+      | Some (Shift { kind; amount }) ->
+        ( Add_sub_helpers.decode_shift_kind_int kind,
+          Add_sub_helpers.decode_shift_amount_six amount )
+    in
+    Logical_helpers.encode_logical_shifted_reg ~opc:0b00 ~shift ~imm6 ~rd ~rn
+      ~rm
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      AND_vector ) ->
+    let q, _ = Simd_helpers.vector_q_size vec in
+    (* AND: U=0, size=00, opcode=00011 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:0 ~size:0b00 ~rm ~opcode:0b00011
+      ~rn ~rd
+  | Triple (Reg rd, Reg rn, Reg rm), ASRV ->
+    let sf = Reg.gp_sf rd in
+    Data_proc_helpers.encode_data_proc_2_source ~sf ~s:0 ~opcode:0b001010 ~rm
+      ~rn ~rd
+  | Singleton (Imm (Sym sym)), B ->
+    let imm26 =
+      Branch_helpers.compute_branch_imm26 state ~instr_name:"B"
+        ~reloc_kind:(fun r -> R_AARCH64_JUMP26 r)
+        sym
+    in
+    Branch_helpers.encode_branch_immediate ~op:0 ~imm26
+  | Singleton (Imm (Sym sym)), B_cond cond ->
+    let imm19 =
+      Branch_helpers.compute_branch_imm19 state ~instr_name:"B.cond" sym
+    in
+    let cond = Condition_helpers.encode_branch_condition cond in
+    Branch_helpers.encode_conditional_branch ~imm19 ~cond
+  | Singleton (Imm (Sym sym)), BL ->
+    let imm26 =
+      Branch_helpers.compute_branch_imm26 state ~instr_name:"BL"
+        ~reloc_kind:(fun r -> R_AARCH64_CALL26 r)
+        sym
+    in
+    Branch_helpers.encode_branch_immediate ~op:1 ~imm26
+  | Singleton (Reg rn), BLR ->
+    Branch_helpers.encode_branch_register ~opc:0b0001 ~rn
+  | Singleton (Reg rn), BR ->
+    Branch_helpers.encode_branch_register ~opc:0b0000 ~rn
+  | Pair (Reg rt, Imm (Sym sym)), CBNZ ->
+    let imm19 =
+      Branch_helpers.compute_branch_imm19 state ~instr_name:"CBNZ" sym
+    in
+    let sf = Reg.gp_sf rt in
+    let rt = Reg.gp_encoding rt in
+    Branch_helpers.encode_compare_branch ~sf ~op:1 ~imm19 ~rt
+  | Pair (Reg rt, Imm (Sym sym)), CBZ ->
+    let imm19 =
+      Branch_helpers.compute_branch_imm19 state ~instr_name:"CBZ" sym
+    in
+    let sf = Reg.gp_sf rt in
+    let rt = Reg.gp_encoding rt in
+    Branch_helpers.encode_compare_branch ~sf ~op:0 ~imm19 ~rt
+  | Pair (Reg rd, Reg rn), CLZ ->
+    let sf = Reg.gp_sf rd in
+    Data_proc_helpers.encode_data_proc_1_source ~sf ~s:0 ~opcode2:0b00000
+      ~opcode:0b000100 ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      CM_register cond ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* Integer vector compares (register):
+
+       - CMGT: U=0, opcode=00110
+
+       - CMGE: U=0, opcode=00111
+
+       - CMEQ: U=1, opcode=10001
+
+       - CMHI: U=1, opcode=00110
+
+       - CMHS: U=1, opcode=00111 *)
+    let u, opcode =
+      match cond with
+      | Simd_int_cmp.GT -> 0, 0b00110
+      | Simd_int_cmp.GE -> 0, 0b00111
+      | Simd_int_cmp.EQ -> 1, 0b10001
+      | Simd_int_cmp.HI -> 1, 0b00110
+      | Simd_int_cmp.HS -> 1, 0b00111
+      | Simd_int_cmp.LT | Simd_int_cmp.LE ->
+        Misc.fatal_error "Unsupported CM_register condition"
+    in
+    Simd_helpers.encode_simd_three_same ~q ~u ~size ~rm ~opcode ~rn ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      CM_zero cond ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* Integer vector compares (zero):
+
+       - CMGT (zero): U=0, opcode=01000
+
+       - CMEQ (zero): U=0, opcode=01001
+
+       - CMLT (zero): U=0, opcode=01010
+
+       - CMGE (zero): U=1, opcode=01000
+
+       - CMLE (zero): U=1, opcode=01001 *)
+    let u, opcode =
+      match cond with
+      | Simd_int_cmp.GT -> 0, 0b01000
+      | Simd_int_cmp.EQ -> 0, 0b01001
+      | Simd_int_cmp.LT -> 0, 0b01010
+      | Simd_int_cmp.GE -> 1, 0b01000
+      | Simd_int_cmp.LE -> 1, 0b01001
+      | Simd_int_cmp.HI | Simd_int_cmp.HS ->
+        Misc.fatal_error "Unsupported CM_zero condition"
+    in
+    Simd_helpers.encode_simd_two_reg_misc ~q ~u ~size ~opcode ~rn ~rd
+  | Pair (Reg rd, Reg rn), CNT ->
+    (* FEAT_CSSC required *)
+    let sf = Reg.gp_sf rd in
+    Data_proc_helpers.encode_data_proc_1_source ~sf ~s:0 ~opcode2:0b00000
+      ~opcode:0b000111 ~rn ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      CNT_vector ) ->
+    let q, _ = Simd_helpers.vector_q_size vec in
+    (* CNT: U=0, size=00, opcode=00101 *)
+    Simd_helpers.encode_simd_two_reg_misc ~q ~u:0 ~size:0b00 ~opcode:0b00101 ~rn
+      ~rd
+  | Quad (Reg rd, Reg rn, Reg rm, Cond cond), CSEL ->
+    let sf = Reg.gp_sf rd in
+    let cond = Condition_helpers.encode_condition cond in
+    Csel_helpers.encode_conditional_select ~sf ~op:0 ~op2:0b00 ~rm ~cond ~rn ~rd
+  | Quad (Reg rd, Reg rn, Reg rm, Cond cond), CSINC ->
+    let sf = Reg.gp_sf rd in
+    let cond = Condition_helpers.encode_condition cond in
+    Csel_helpers.encode_conditional_select ~sf ~op:0 ~op2:0b01 ~rm ~cond ~rn ~rd
+  | Pair (Reg rd, Reg rn), CTZ ->
+    (* FEAT_CSSC required *)
+    let sf = Reg.gp_sf rd in
+    Data_proc_helpers.encode_data_proc_1_source ~sf ~s:0 ~opcode2:0b00000
+      ~opcode:0b000110 ~rn ~rd
+  | _, DMB barrier ->
+    Load_store_helpers.encode_memory_barrier ~op2:0b101 barrier
+  | _, DSB barrier ->
+    Load_store_helpers.encode_memory_barrier ~op2:0b100 barrier
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      DUP lane_idx ) ->
+    let q, _ = Simd_helpers.vector_q_size vec in
+    let imm5 =
+      Simd_helpers.simd_copy_imm5 vec (Neon_reg_name.Lane_index.to_int lane_idx)
+    in
+    (* DUP (element): op=0, imm4=0000 *)
+    Simd_helpers.encode_simd_copy ~q ~op:0 ~imm5 ~imm4:0b0000 ~rn ~rd
+  | Triple (Reg rd, Reg rn, Bitmask bitmask), EOR_immediate ->
+    let n, immr, imms = Operand.Bitmask.decode_n_immr_imms bitmask in
+    Logical_helpers.encode_logical_immediate ~sf:1 ~opc:0b10 ~n ~immr ~imms ~rn
+      ~rd
+  | ( Quad
+        ( Reg ({ reg_name = GP _; _ } as rd),
+          Reg ({ reg_name = GP _; _ } as rn),
+          Reg ({ reg_name = GP _; _ } as rm),
+          Optional shift_opt ),
+      EOR_shifted_register ) ->
+    let shift, imm6 =
+      match shift_opt with
+      | None -> 0, 0
+      | Some (Shift { kind; amount }) ->
+        ( Add_sub_helpers.decode_shift_kind_int kind,
+          Add_sub_helpers.decode_shift_amount_six amount )
+    in
+    Logical_helpers.encode_logical_shifted_reg ~opc:0b10 ~shift ~imm6 ~rd ~rn
+      ~rm
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      EOR_vector ) ->
+    let q, _ = Simd_helpers.vector_q_size vec in
+    (* EOR: U=1, size=00, opcode=00011 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:1 ~size:0b00 ~rm ~opcode:0b00011
+      ~rn ~rd
+  | Quad (Reg rd, Reg rn, Reg rm, Imm (Six imm4)), EXT ->
+    (* EXT is 128-bit only (V16B), so Q=1 *)
+    Simd_helpers.encode_simd_extract ~q:1 ~rm:rm.index ~imm4 ~rn:rn.index
+      ~rd:rd.index
+  | ( Pair
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Reg { index = rn; _ } ),
+      FABS ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    Fp_helpers.encode_fp_1_source ~ftype ~opcode:0b000001 ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      FADD ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    Fp_helpers.encode_fp_2_source ~ftype ~rm ~opcode:0b0010 ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      FADDP_vector ) ->
+    let q, sz = Simd_helpers.vector_q_fp_sz vec in
+    (* FADDP: U=1, size=0x, opcode=11010 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:1 ~size:sz ~rm ~opcode:0b11010 ~rn
+      ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      FADD_vector ) ->
+    let q, sz = Simd_helpers.vector_q_fp_sz vec in
+    (* FADD: U=0, size=0x, opcode=11010 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:0 ~size:sz ~rm ~opcode:0b11010 ~rn
+      ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      FCM_register cond ) ->
+    let q, sz = Simd_helpers.vector_q_fp_sz vec in
+    (* FP vector compares (register):
+
+       - FCMEQ: U=0, size=0x, opcode=11100
+
+       - FCMGE: U=1, size=0x, opcode=11100
+
+       - FCMGT: U=1, size=1x, opcode=11100 *)
+    let u, size_hi =
+      match cond with
+      | Float_cond.EQ -> 0, 0
+      | Float_cond.GE -> 1, 0
+      | Float_cond.GT -> 1, 1
+      | Float_cond.LE | Float_cond.LT | Float_cond.NE | Float_cond.CC
+      | Float_cond.CS | Float_cond.LS | Float_cond.HI ->
+        Misc.fatal_error "Unsupported FCM_register condition"
+    in
+    let size = (size_hi lsl 1) lor sz in
+    Simd_helpers.encode_simd_three_same ~q ~u ~size ~rm ~opcode:0b11100 ~rn ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      FCM_zero cond ) ->
+    let q, sz = Simd_helpers.vector_q_fp_sz vec in
+    (* FP vector compares (zero):
+
+       - FCMGT (zero): U=0, size=1x, opcode=01100
+
+       - FCMEQ (zero): U=0, size=1x, opcode=01101
+
+       - FCMLT (zero): U=0, size=1x, opcode=01110
+
+       - FCMGE (zero): U=1, size=1x, opcode=01100
+
+       - FCMLE (zero): U=1, size=1x, opcode=01101 *)
+    let u, opcode =
+      match cond with
+      | Float_cond.GT -> 0, 0b01100
+      | Float_cond.EQ -> 0, 0b01101
+      | Float_cond.LT -> 0, 0b01110
+      | Float_cond.GE -> 1, 0b01100
+      | Float_cond.LE -> 1, 0b01101
+      | Float_cond.NE | Float_cond.CC | Float_cond.CS | Float_cond.LS
+      | Float_cond.HI ->
+        Misc.fatal_error "Unsupported FCM_zero condition"
+    in
+    let size = (1 lsl 1) lor sz in
+    (* size=1x *)
+    Simd_helpers.encode_simd_two_reg_misc ~q ~u ~size ~opcode ~rn ~rd
+  | ( Pair
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rn },
+          Reg { index = rm; _ } ),
+      FCMP ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    Fp_helpers.encode_fp_compare ~ftype ~rm ~opc2:0b00000 ~rn
+  | ( Quad
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ },
+          Cond cond ),
+      FCSEL ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    let cond = Condition_helpers.encode_condition cond in
+    Fp_helpers.encode_fp_cond_select ~ftype ~rm ~cond ~rn ~rd
+  (* FCVT: convert between single and double precision *)
+  | ( Pair
+        ( Reg { reg_name = Neon (Scalar D); index = rd },
+          Reg { reg_name = Neon (Scalar S); index = rn } ),
+      FCVT ) ->
+    (* FCVT Dd, Sn: ftype=00 (source=single), opcode=000101 (to double) *)
+    Fp_helpers.encode_fp_1_source ~ftype:0 ~opcode:0b000101 ~rn ~rd
+  | ( Pair
+        ( Reg { reg_name = Neon (Scalar S); index = rd },
+          Reg { reg_name = Neon (Scalar D); index = rn } ),
+      FCVT ) ->
+    (* FCVT Sd, Dn: ftype=01 (source=double), opcode=000100 (to single) *)
+    Fp_helpers.encode_fp_1_source ~ftype:1 ~opcode:0b000100 ~rn ~rd
+  (* FCVT same-precision conversions: use FMOV instead *)
+  | ( Pair
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Reg { index = rn; _ } ),
+      FCVT ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    Fp_helpers.encode_fp_1_source ~ftype ~opcode:0b000000 ~rn ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      FCVTL_vector ) ->
+    (* FCVTL converts from narrower to wider FP (e.g., V2S->V2D) U=0,
+       opcode=10111, sz bit encodes SOURCE element size: sz=0: half -> single,
+       sz=1: single -> double *)
+    let size =
+      match vec with
+      | V2D -> 1 (* sz=1: 32-bit source (single) -> 64-bit dest (double) *)
+    in
+    (* Q=0 for lower half (FCVTL), Q=1 for upper half (FCVTL2) *)
+    Simd_helpers.encode_simd_two_reg_misc ~q:0 ~u:0 ~size ~opcode:0b10111 ~rn
+      ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      FCVTN_vector ) ->
+    (* FCVTN converts from wider to narrower FP (e.g., V2D->V2S) U=0,
+       opcode=10110, sz bit encodes SOURCE element size: sz=0: single -> half,
+       sz=1: double -> single *)
+    (* Q=0 for lower half (FCVTN with V2S), Q=1 for upper half (FCVTN2 with V4S) *)
+    let q = match vec with V2S -> 0 | V4S -> 1 in
+    Simd_helpers.encode_simd_two_reg_misc ~q ~u:0 ~size:1 ~opcode:0b10110 ~rn
+      ~rd
+  (* FCVTNS: FP to signed int, round to nearest with ties to even *)
+  | ( Pair
+        ( Reg { reg_name = GP X; index = rd },
+          Reg { reg_name = Neon (Scalar _ as scalar); index = rn } ),
+      FCVTNS ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    Fp_helpers.encode_fp_int_conv ~sf:1 ~ftype ~rmode:0b00 ~opcode:0b000 ~rn ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      FCVTNS_vector ) ->
+    let q, sz = Simd_helpers.vector_q_fp_sz vec in
+    (* FCVTNS (vector): U=0, size=0x, opcode=11010 *)
+    Simd_helpers.encode_simd_two_reg_misc ~q ~u:0 ~size:sz ~opcode:0b11010 ~rn
+      ~rd
+  (* FCVTZS: FP to signed int, round toward zero *)
+  | ( Pair
+        ( Reg { reg_name = GP X; index = rd },
+          Reg { reg_name = Neon (Scalar _ as scalar); index = rn } ),
+      FCVTZS ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    Fp_helpers.encode_fp_int_conv ~sf:1 ~ftype ~rmode:0b11 ~opcode:0b000 ~rn ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      FCVTZS_vector ) ->
+    let q, sz = Simd_helpers.vector_q_fp_sz vec in
+    (* FCVTZS (vector, integer): U=0, size=1x, opcode=11011 *)
+    Simd_helpers.encode_simd_two_reg_misc ~q ~u:0 ~size:(0b10 lor sz)
+      ~opcode:0b11011 ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      FDIV ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    Fp_helpers.encode_fp_2_source ~ftype ~rm ~opcode:0b0001 ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      FDIV_vector ) ->
+    let q, sz = Simd_helpers.vector_q_fp_sz vec in
+    (* FDIV: U=1, size=0x, opcode=11111 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:1 ~size:sz ~rm ~opcode:0b11111 ~rn
+      ~rd
+  | ( Quad
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ },
+          Reg { index = ra; _ } ),
+      FMADD ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    Fp_helpers.encode_fp_3_source ~ftype ~o1:0 ~rm ~o0:0 ~ra ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      FMAX ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    Fp_helpers.encode_fp_2_source ~ftype ~rm ~opcode:0b0100 ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      FMAX_vector ) ->
+    let q, sz = Simd_helpers.vector_q_fp_sz vec in
+    (* FMAX: U=0, size=0x, opcode=11110 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:0 ~size:sz ~rm ~opcode:0b11110 ~rn
+      ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      FMIN ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    Fp_helpers.encode_fp_2_source ~ftype ~rm ~opcode:0b0101 ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      FMIN_vector ) ->
+    let q, sz = Simd_helpers.vector_q_fp_sz vec in
+    (* FMIN: U=0, size=1x, opcode=11110 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:0 ~size:(0b10 lor sz) ~rm
+      ~opcode:0b11110 ~rn ~rd
+  | ( Quad
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ },
+          Reg { index = ra; _ } ),
+      FMSUB ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    Fp_helpers.encode_fp_3_source ~ftype ~o1:0 ~rm ~o0:1 ~ra ~rn ~rd
+  | ( Pair
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Reg { index = rn; _ } ),
+      FMOV_fp ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    Fp_helpers.encode_fp_1_source ~ftype ~opcode:0b000000 ~rn ~rd
+  (* FMOV_gp_to_fp_32: GP-to-FP (W to S) *)
+  | ( Pair
+        ( Reg { reg_name = Neon (Scalar S); index = rd },
+          Reg { reg_name = GP W; index = rn } ),
+      FMOV_gp_to_fp_32 ) ->
+    (* sf=0, ftype=00, rmode=00, opcode=111 for GP->FP single *)
+    Fp_helpers.encode_fp_int_conv ~sf:0 ~ftype:0 ~rmode:0b00 ~opcode:0b111 ~rn
+      ~rd
+  (* FMOV_gp_to_fp_32: GP-to-FP (WZR to S) *)
+  | ( Pair
+        ( Reg { reg_name = Neon (Scalar S); index = rd },
+          Reg { reg_name = GP WZR; index = rn } ),
+      FMOV_gp_to_fp_32 ) ->
+    Fp_helpers.encode_fp_int_conv ~sf:0 ~ftype:0 ~rmode:0b00 ~opcode:0b111 ~rn
+      ~rd
+  (* FMOV_gp_to_fp_64: GP-to-FP (X to D) *)
+  | ( Pair
+        ( Reg { reg_name = Neon (Scalar D); index = rd },
+          Reg { reg_name = GP X; index = rn } ),
+      FMOV_gp_to_fp_64 ) ->
+    (* sf=1, ftype=01, rmode=00, opcode=111 for GP->FP double *)
+    Fp_helpers.encode_fp_int_conv ~sf:1 ~ftype:1 ~rmode:0b00 ~opcode:0b111 ~rn
+      ~rd
+  (* FMOV_gp_to_fp_64: GP-to-FP (XZR to D) *)
+  | ( Pair
+        ( Reg { reg_name = Neon (Scalar D); index = rd },
+          Reg { reg_name = GP XZR; index = rn } ),
+      FMOV_gp_to_fp_64 ) ->
+    Fp_helpers.encode_fp_int_conv ~sf:1 ~ftype:1 ~rmode:0b00 ~opcode:0b111 ~rn
+      ~rd
+  (* FMOV_fp_to_gp_32: FP-to-GP (S to W) *)
+  | ( Pair
+        ( Reg { reg_name = GP W; index = rd },
+          Reg { reg_name = Neon (Scalar S); index = rn } ),
+      FMOV_fp_to_gp_32 ) ->
+    (* sf=0, ftype=00, rmode=00, opcode=110 for FP->GP single *)
+    Fp_helpers.encode_fp_int_conv ~sf:0 ~ftype:0 ~rmode:0b00 ~opcode:0b110 ~rn
+      ~rd
+  (* FMOV_fp_to_gp_64: FP-to-GP (D to X) *)
+  | ( Pair
+        ( Reg { reg_name = GP X; index = rd },
+          Reg { reg_name = Neon (Scalar D); index = rn } ),
+      FMOV_fp_to_gp_64 ) ->
+    (* sf=1, ftype=01, rmode=00, opcode=110 for FP->GP double *)
+    Fp_helpers.encode_fp_int_conv ~sf:1 ~ftype:1 ~rmode:0b00 ~opcode:0b110 ~rn
+      ~rd
+  (* FMOV scalar immediate - Float case *)
+  | ( Pair
+        (Reg { reg_name = Neon (Scalar _ as scalar); index = rd }, Imm (Float f)),
+      FMOV_scalar_immediate ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    let bits = Int64.bits_of_float f in
+    (* Extract imm8 from double-precision IEEE bits using VFPExpandImm inverse:
+       VFPExpandImm expands imm8 to:
+       sign:NOT(imm8[6]):Replicate(imm8[6],8):imm8[5:0]:Zeros(48) So to encode,
+       we extract: imm8[7] = sign (bit 63) imm8[6] = NOT(bit 62) - inverted MSB
+       of exponent imm8[5:4] = bits 53:52 - lower exponent bits after the
+       replicated part imm8[3:0] = bits 51:48 - top 4 mantissa bits For single,
+       we convert from double representation. *)
+    let sign = Int64.(to_int (logand (shift_right_logical bits 63) 1L)) in
+    let exp10 = Int64.(to_int (logand (shift_right_logical bits 62) 1L)) in
+    let imm8_5_4 = Int64.(to_int (logand (shift_right_logical bits 52) 3L)) in
+    let frac = Int64.(to_int (logand (shift_right_logical bits 48) 0xFL)) in
+    let imm8 =
+      (sign lsl 7) lor ((1 - exp10) lsl 6) lor (imm8_5_4 lsl 4) lor frac
+    in
+    Fp_helpers.encode_fp_immediate ~ftype ~imm8 ~rd
+  (* FMOV scalar immediate - Nativeint case (raw bits) *)
+  | ( Pair
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Imm (Nativeint n) ),
+      FMOV_scalar_immediate ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    let imm8 = Nativeint.to_int n land 0xFF in
+    Fp_helpers.encode_fp_immediate ~ftype ~imm8 ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      FMUL ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    Fp_helpers.encode_fp_2_source ~ftype ~rm ~opcode:0b0000 ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      FMUL_vector ) ->
+    let q, sz = Simd_helpers.vector_q_fp_sz vec in
+    (* FMUL: U=1, size=0x, opcode=11011 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:1 ~size:sz ~rm ~opcode:0b11011 ~rn
+      ~rd
+  | ( Pair
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Reg { index = rn; _ } ),
+      FNEG ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    Fp_helpers.encode_fp_1_source ~ftype ~opcode:0b000010 ~rn ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      FNEG_vector ) ->
+    let q, sz = Simd_helpers.vector_q_fp_sz vec in
+    (* FNEG: U=1, size=1x, opcode=01111 *)
+    Simd_helpers.encode_simd_two_reg_misc ~q ~u:1 ~size:(0b10 lor sz)
+      ~opcode:0b01111 ~rn ~rd
+  | ( Quad
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ },
+          Reg { index = ra; _ } ),
+      FNMADD ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    Fp_helpers.encode_fp_3_source ~ftype ~o1:1 ~rm ~o0:0 ~ra ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      FNMUL ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    Fp_helpers.encode_fp_2_source ~ftype ~rm ~opcode:0b1000 ~rn ~rd
+  | ( Quad
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ },
+          Reg { index = ra; _ } ),
+      FNMSUB ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    Fp_helpers.encode_fp_3_source ~ftype ~o1:1 ~rm ~o0:1 ~ra ~rn ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      FRECPE_vector ) ->
+    let q, sz = Simd_helpers.vector_q_fp_sz vec in
+    (* FRECPE: U=0, size=1x, opcode=11101 *)
+    Simd_helpers.encode_simd_two_reg_misc ~q ~u:0 ~size:(0b10 lor sz)
+      ~opcode:0b11101 ~rn ~rd
+  (* FRINT: round FP to integer in FP format.
+
+     Opcodes: N=001000, P=001001, M=001010, Z=001011, A=001100, X=001110 *)
+  | ( Pair
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Reg { index = rn; _ } ),
+      FRINT rmode ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    let opcode =
+      match rmode with
+      | Rounding_mode.N -> 0b001000
+      | Rounding_mode.P -> 0b001001
+      | Rounding_mode.M -> 0b001010
+      | Rounding_mode.Z -> 0b001011
+      | Rounding_mode.A -> 0b001100
+      | Rounding_mode.X -> 0b001110
+      | Rounding_mode.I -> 0b001111
+    in
+    Fp_helpers.encode_fp_1_source ~ftype ~opcode ~rn ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      FRINT_vector rm ) ->
+    let q, sz = Simd_helpers.vector_q_fp_sz vec in
+    (* FRINT(mode) vector - encoding depends on rounding mode:
+
+       - N: U=0, size=0x, opcode=11000
+
+       - M: U=0, size=0x, opcode=11001
+
+       - P: U=0, size=1x, opcode=11000
+
+       - Z: U=0, size=1x, opcode=11001
+
+       - X: U=1, size=0x, opcode=11001 *)
+    let u, size_hi, opcode =
+      match rm with
+      | Rounding_mode.N -> 0, 0, 0b11000
+      | Rounding_mode.M -> 0, 0, 0b11001
+      | Rounding_mode.P -> 0, 1, 0b11000
+      | Rounding_mode.Z -> 0, 1, 0b11001
+      | Rounding_mode.X -> 1, 0, 0b11001
+      | Rounding_mode.A | Rounding_mode.I ->
+        Misc.fatal_error "FRINT_vector: unsupported rounding mode"
+    in
+    let size = (size_hi lsl 1) lor sz in
+    Simd_helpers.encode_simd_two_reg_misc ~q ~u ~size ~opcode ~rn ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      FRSQRTE_vector ) ->
+    let q, sz = Simd_helpers.vector_q_fp_sz vec in
+    (* FRSQRTE: U=1, size=1x, opcode=11101 *)
+    Simd_helpers.encode_simd_two_reg_misc ~q ~u:1 ~size:(0b10 lor sz)
+      ~opcode:0b11101 ~rn ~rd
+  | ( Pair
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Reg { index = rn; _ } ),
+      FSQRT ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    Fp_helpers.encode_fp_1_source ~ftype ~opcode:0b000011 ~rn ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      FSQRT_vector ) ->
+    let q, sz = Simd_helpers.vector_q_fp_sz vec in
+    (* FSQRT: U=1, size=1x, opcode=11111 *)
+    Simd_helpers.encode_simd_two_reg_misc ~q ~u:1 ~size:(0b10 lor sz)
+      ~opcode:0b11111 ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      FSUB ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    Fp_helpers.encode_fp_2_source ~ftype ~rm ~opcode:0b0011 ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      FSUB_vector ) ->
+    let q, sz = Simd_helpers.vector_q_fp_sz vec in
+    (* FSUB: U=0, size=1x, opcode=11010 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:0 ~size:(0b10 lor sz) ~rm
+      ~opcode:0b11010 ~rn ~rd
+  | ( Pair
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { reg_name = GP _; index = rn } ),
+      INS (_elem_constraint, lane_idx) ) ->
+    let imm5 =
+      Simd_helpers.simd_copy_imm5 vec (Neon_reg_name.Lane_index.to_int lane_idx)
+    in
+    (* INS (general): Q=1, op=0, imm4=0011 *)
+    Simd_helpers.encode_simd_copy ~q:1 ~op:0 ~imm5 ~imm4:0b0011 ~rn ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      INS_V lanes ) ->
+    let dest_idx =
+      Neon_reg_name.Lane_index.to_int
+        (Neon_reg_name.Lane_index.Src_and_dest.dest_index lanes)
+    in
+    let src_idx =
+      Neon_reg_name.Lane_index.to_int
+        (Neon_reg_name.Lane_index.Src_and_dest.src_index lanes)
+    in
+    let imm5 = Simd_helpers.simd_copy_imm5 vec dest_idx in
+    (* INS (element): Q=1, op=1, imm4 encodes source index in size-dependent
+       way *)
+    let imm4 = Simd_helpers.simd_ins_element_imm4 vec src_idx in
+    Simd_helpers.encode_simd_copy ~q:1 ~op:1 ~imm5 ~imm4 ~rn ~rd
+  | Pair (Reg ({ reg_name = GP _; _ } as rd), Mem (Reg rn)), LDAR ->
+    Load_store_helpers.encode_load_acquire ~rd ~rn
+  | Triple (Reg rt1, Reg rt2, Mem addressing), LDP _ ->
+    Load_store_helpers.encode_load_store_pair_gp ~instr_name:"LDP" ~l:1 ~rt1
+      ~rt2 addressing
+  | Pair (Reg rd, Mem addressing), LDR ->
+    Load_store_helpers.encode_load_store_gp ~all_sections state
+      ~instr_name:"LDR" ~opc:0b01 ~rd addressing
+  | ( Pair (Reg ({ reg_name = Neon (Scalar _); _ } as rd), Mem addressing),
+      LDR_simd_and_fp ) ->
+    Load_store_helpers.encode_load_store_simd_fp ~all_sections state
+      ~instr_name:"LDR" ~is_load:true ~rd addressing
+  | Pair (Reg rd, Mem addressing), LDRB ->
+    (* LDRB: size=00, opc=01 *)
+    Load_store_helpers.encode_load_store_byte ~all_sections state
+      ~instr_name:"LDRB" ~opc:0b01 ~rd addressing
+  | Pair (Reg rd, Mem addressing), LDRH ->
+    (* LDRH: size=01, opc=01 *)
+    Load_store_helpers.encode_load_store_halfword ~all_sections state
+      ~instr_name:"LDRH" ~opc:0b01 ~rd addressing
+  | Pair (Reg rd, Mem addressing), LDRSB ->
+    (* LDRSB (sign-extend byte to 64-bit): size=00, opc=10 *)
+    Load_store_helpers.encode_load_store_byte ~all_sections state
+      ~instr_name:"LDRSB" ~opc:0b10 ~rd addressing
+  | Pair (Reg rd, Mem addressing), LDRSH ->
+    (* LDRSH (sign-extend halfword to 64-bit): size=01, opc=10 *)
+    Load_store_helpers.encode_load_store_halfword ~all_sections state
+      ~instr_name:"LDRSH" ~opc:0b10 ~rd addressing
+  | Pair (Reg rd, Mem addressing), LDRSW ->
+    (* LDRSW (sign-extend word to 64-bit): size=10, opc=10 *)
+    Load_store_helpers.encode_load_store_gp_sized ~all_sections state
+      ~instr_name:"LDRSW" ~size:0b10 ~opc:0b10 ~rd addressing
+  | Triple (Reg rd, Reg rn, Reg rm), LSLV ->
+    let sf = Reg.gp_sf rd in
+    Data_proc_helpers.encode_data_proc_2_source ~sf ~s:0 ~opcode:0b001000 ~rm
+      ~rn ~rd
+  | Triple (Reg rd, Reg rn, Reg rm), LSRV ->
+    let sf = Reg.gp_sf rd in
+    Data_proc_helpers.encode_data_proc_2_source ~sf ~s:0 ~opcode:0b001001 ~rm
+      ~rn ~rd
+  | Quad (Reg rd, Reg rn, Reg rm, Reg ra), MADD ->
+    let sf = Reg.gp_sf rd in
+    Data_proc_helpers.encode_data_proc_3_source ~sf ~op54:0b00 ~op31:0b000 ~o0:0
+      ~rm ~ra ~rn ~rd
+  | ( Pair (Reg { reg_name = Neon (Vector vec); index = rd }, Imm (Twelve imm)),
+      MOVI ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* MOVI encoding depends on element size: - For byte elements (size=00):
+       op=0, cmode=1110, byte replication - For 64-bit elements (size=11): op=1,
+       cmode=1110, 64-bit immediate For zeroing, imm=0, abc=000, defgh=00000 *)
+    let imm8 = imm land 0xFF in
+    let abc = (imm8 lsr 5) land 0b111 in
+    let defgh = imm8 land 0b11111 in
+    let op = if size = 0b11 then 1 else 0 in
+    Simd_helpers.encode_simd_modified_imm ~q ~op ~abc ~cmode:0b1110 ~defgh ~rd
+  | ( Pair (Reg { reg_name = Neon (Scalar _); index = rd }, Imm (Twelve imm)),
+      MOVI ) ->
+    (* MOVI to scalar (D register): Q=0, op=1, cmode=1110 for 64-bit
+       immediate *)
+    let imm8 = imm land 0xFF in
+    let abc = (imm8 lsr 5) land 0b111 in
+    let defgh = imm8 land 0b11111 in
+    Simd_helpers.encode_simd_modified_imm ~q:0 ~op:1 ~abc ~cmode:0b1110 ~defgh
+      ~rd
+  | Triple (Reg rd, Imm imm, Lsl_by_multiple_of_16_bits shift), MOVK ->
+    let imm16 = match imm with Sixteen_unsigned n -> n in
+    let hw = Operand.Lsl_by_multiple_of_16_bits.to_int shift / 16 in
+    Mov_helpers.encode_move_wide ~sf:1 ~opc:0b11 ~hw ~imm16 ~rd
+  | Triple (Reg rd, Imm imm, Optional shift_opt), MOVN ->
+    let imm16 = match imm with Sixteen_unsigned n -> n in
+    let hw =
+      match shift_opt with
+      | None -> 0
+      | Some (Lsl_by_multiple_of_16_bits shift) ->
+        Operand.Lsl_by_multiple_of_16_bits.to_int shift / 16
+    in
+    Mov_helpers.encode_move_wide ~sf:1 ~opc:0b00 ~hw ~imm16 ~rd
+  | Triple (Reg rd, Imm imm, Optional shift_opt), MOVZ ->
+    let imm16 = match imm with Sixteen_unsigned n -> n in
+    let hw =
+      match shift_opt with
+      | None -> 0
+      | Some (Lsl_by_multiple_of_16_bits shift) ->
+        Operand.Lsl_by_multiple_of_16_bits.to_int shift / 16
+    in
+    Mov_helpers.encode_move_wide ~sf:1 ~opc:0b10 ~hw ~imm16 ~rd
+  | Quad (Reg rd, Reg rn, Reg rm, Reg ra), MSUB ->
+    let sf = Reg.gp_sf rd in
+    Data_proc_helpers.encode_data_proc_3_source ~sf ~op54:0b00 ~op31:0b000 ~o0:1
+      ~rm ~ra ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      MUL_vector ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* MUL: U=0, opcode=10011 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:0 ~size ~rm ~opcode:0b10011 ~rn
+      ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      MVN_vector ) ->
+    let q, _ = Simd_helpers.vector_q_size vec in
+    (* NOT/MVN: U=1, size=00, opcode=00101 *)
+    Simd_helpers.encode_simd_two_reg_misc ~q ~u:1 ~size:0b00 ~opcode:0b00101 ~rn
+      ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      NEG_vector ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* NEG: U=1, opcode=01011 *)
+    Simd_helpers.encode_simd_two_reg_misc ~q ~u:1 ~size ~opcode:0b01011 ~rn ~rd
+  | _, NOP -> Nop_helpers.encode_nop ()
+  | Triple (Reg rd, Reg rn, Bitmask bitmask), ORR_immediate ->
+    let n, immr, imms = Operand.Bitmask.decode_n_immr_imms bitmask in
+    Logical_helpers.encode_logical_immediate ~sf:1 ~opc:0b01 ~n ~immr ~imms ~rn
+      ~rd
+  | ( Quad
+        ( Reg ({ reg_name = GP _; _ } as rd),
+          Reg ({ reg_name = GP _; _ } as rn),
+          Reg ({ reg_name = GP _; _ } as rm),
+          Optional shift_opt ),
+      ORR_shifted_register ) ->
+    let shift, imm6 =
+      match shift_opt with
+      | None -> 0, 0
+      | Some (Shift { kind; amount }) ->
+        ( Add_sub_helpers.decode_shift_kind_int kind,
+          Add_sub_helpers.decode_shift_amount_six amount )
+    in
+    Logical_helpers.encode_logical_shifted_reg ~opc:0b01 ~shift ~imm6 ~rd ~rn
+      ~rm
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      ORR_vector ) ->
+    let q, _ = Simd_helpers.vector_q_size vec in
+    (* ORR: U=0, size=10, opcode=00011 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:0 ~size:0b10 ~rm ~opcode:0b00011
+      ~rn ~rd
+  | Pair (Reg rd, Reg rn), RBIT ->
+    let sf = Reg.gp_sf rd in
+    Data_proc_helpers.encode_data_proc_1_source ~sf ~s:0 ~opcode2:0b00000
+      ~opcode:0b000000 ~rn ~rd
+  | _, RET ->
+    (* RET defaults to X30 (LR). Encoding is same as BR/BLR but with opc=0010
+       and Rn=11111 (X30) encoded in bits 9:5 *)
+    let open Int32 in
+    let result = zero in
+    let result = logor result (shift_left (of_int 0b1101011) 25) in
+    let result = logor result (shift_left (of_int 0b0010) 21) in
+    (* opc = 0010 *)
+    let result = logor result (shift_left (of_int 0b11111) 16) in
+    (* op2 = 11111 *)
+    let result = logor result (shift_left (of_int 0b000000) 10) in
+    (* op3 = 000000 *)
+    let result = logor result (shift_left (of_int 30) 5) in
+    (* Rn = X30 = 11110 *)
+    let result = logor result (of_int 0b00000) in
+    (* op4 = 00000 *)
+    result
+  | Pair (Reg rd, Reg rn), REV ->
+    let sf = Reg.gp_sf rd in
+    let opcode = if sf = 1 then 0b000011 else 0b000010 in
+    Data_proc_helpers.encode_data_proc_1_source ~sf ~s:0 ~opcode2:0b00000
+      ~opcode ~rn ~rd
+  | Pair (Reg rd, Reg rn), REV16 ->
+    let sf = Reg.gp_sf rd in
+    Data_proc_helpers.encode_data_proc_1_source ~sf ~s:0 ~opcode2:0b00000
+      ~opcode:0b000001 ~rn ~rd
+  | Quad (Reg rd, Reg rn, Imm (Six immr), Imm (Six imms)), SBFM ->
+    let sf = Reg.gp_sf rd in
+    let n = sf in
+    Bitfield_helpers.encode_bitfield ~sf ~opc:0b00 ~n ~immr ~imms ~rn ~rd
+  (* SCVTF: signed integer to FP conversion *)
+  | ( Pair
+        ( Reg { reg_name = Neon (Scalar _ as scalar); index = rd },
+          Reg { reg_name = GP X; index = rn } ),
+      SCVTF ) ->
+    let ftype = Fp_helpers.scalar_ftype scalar in
+    (* sf=1 (64-bit int), rmode=00, opcode=010 *)
+    Fp_helpers.encode_fp_int_conv ~sf:1 ~ftype ~rmode:0b00 ~opcode:0b010 ~rn ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      SCVTF_vector ) ->
+    let q, sz = Simd_helpers.vector_q_fp_sz vec in
+    (* SCVTF (vector, integer): U=0, size=0x, opcode=11101 *)
+    Simd_helpers.encode_simd_two_reg_misc ~q ~u:0 ~size:sz ~opcode:0b11101 ~rn
+      ~rd
+  | Triple (Reg rd, Reg rn, Reg rm), SDIV ->
+    let sf = Reg.gp_sf rd in
+    Data_proc_helpers.encode_data_proc_2_source ~sf ~s:0 ~opcode:0b000011 ~rm
+      ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Shift_by_element_width shift ),
+      SHL ) ->
+    let q, _ = Simd_helpers.vector_q_size vec in
+    let shift_amount = Operand.Shift_by_element_width.to_int shift in
+    let immh, immb = Shift_immh_immb_helpers.shl_immh_immb vec shift_amount in
+    (* SHL: U=0, opcode=01010 *)
+    Simd_helpers.encode_simd_shift_imm ~q ~u:0 ~immh ~immb ~opcode:0b01010 ~rn
+      ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      SMAX_vector ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* SMAX: U=0, opcode=01100 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:0 ~size ~rm ~opcode:0b01100 ~rn
+      ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      SMIN_vector ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* SMIN: U=0, opcode=01101 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:0 ~size ~rm ~opcode:0b01101 ~rn
+      ~rd
+  | ( Pair
+        ( Reg { reg_name = GP _; index = rd },
+          Reg { reg_name = Neon (Vector vec); index = rn } ),
+      SMOV (elem_constraint, lane_idx) ) ->
+    let q =
+      match elem_constraint with
+      | Smov_element_to_GP.B_to_W | Smov_element_to_GP.H_to_W -> 0
+      | Smov_element_to_GP.B_to_X | Smov_element_to_GP.H_to_X
+      | Smov_element_to_GP.S_to_X ->
+        1
+    in
+    let lane_int = Neon_reg_name.Lane_index.to_int lane_idx in
+    let imm5 = Simd_helpers.simd_copy_imm5 vec lane_int in
+    (* SMOV: op=0, imm4=0101 *)
+    Simd_helpers.encode_simd_copy ~q ~op:0 ~imm5 ~imm4:0b0101 ~rn ~rd
+  | Triple (Reg rd, Reg rn, Reg rm), SMULH ->
+    (* SMULH is 64-bit only. Ra is encoded as 11111 (ignored for multiply-high) *)
+    (* Encoding: sf=1 op54=00 11011 op31=010 Rm o0=0 Ra=11111 Rn Rd *)
+    let ra = Reg.xzr in
+    Data_proc_helpers.encode_data_proc_3_source ~sf:1 ~op54:0b00 ~op31:0b010
+      ~o0:0 ~rm ~ra ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      SMULL2_vector _ ) ->
+    let size = Simd_helpers.vector_widening_size vec in
+    (* SMULL2: U=0, opcode=1100, Q=1 for "2" variant *)
+    Simd_helpers.encode_simd_three_different ~q:1 ~u:0 ~size ~rm ~opcode:0b1100
+      ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      SMULL_vector _ ) ->
+    let size = Simd_helpers.vector_widening_size vec in
+    (* SMULL: U=0, opcode=1100, Q=0 for basic variant *)
+    Simd_helpers.encode_simd_three_different ~q:0 ~u:0 ~size ~rm ~opcode:0b1100
+      ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      SQADD_vector ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* SQADD: U=0, opcode=00001 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:0 ~size ~rm ~opcode:0b00001 ~rn
+      ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      SQXTN _ ) ->
+    let _, size = Simd_helpers.vector_q_size vec in
+    (* SQXTN: U=0, opcode=10100, Q=0 for SQXTN *)
+    Simd_helpers.encode_simd_two_reg_misc ~q:0 ~u:0 ~size ~opcode:0b10100 ~rn
+      ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      SQXTN2 _ ) ->
+    let _, size = Simd_helpers.vector_q_size vec in
+    (* SQXTN2: U=0, opcode=10100, Q=1 for SQXTN2 *)
+    Simd_helpers.encode_simd_two_reg_misc ~q:1 ~u:0 ~size ~opcode:0b10100 ~rn
+      ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      SQSUB_vector ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* SQSUB: U=0, opcode=00101 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:0 ~size ~rm ~opcode:0b00101 ~rn
+      ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      SSHL_vector ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* SSHL: U=0, opcode=01000 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:0 ~size ~rm ~opcode:0b01000 ~rn
+      ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Shift_by_element_width shift ),
+      SSHR ) ->
+    let q, _ = Simd_helpers.vector_q_size vec in
+    let shift_amount = Operand.Shift_by_element_width.to_int shift in
+    let immh, immb = Shift_immh_immb_helpers.shr_immh_immb vec shift_amount in
+    (* SSHR: U=0, opcode=00000 *)
+    Simd_helpers.encode_simd_shift_imm ~q ~u:0 ~immh ~immb ~opcode:0b00000 ~rn
+      ~rd
+  | Triple (Reg rt1, Reg rt2, Mem addressing), STP _ ->
+    Load_store_helpers.encode_load_store_pair_gp ~instr_name:"STP" ~l:0 ~rt1
+      ~rt2 addressing
+  | Pair (Reg rd, Mem addressing), STR ->
+    Load_store_helpers.encode_load_store_gp ~all_sections state
+      ~instr_name:"STR" ~opc:0b00 ~rd addressing
+  | ( Pair (Reg ({ reg_name = Neon (Scalar _); _ } as rd), Mem addressing),
+      STR_simd_and_fp ) ->
+    Load_store_helpers.encode_load_store_simd_fp ~all_sections state
+      ~instr_name:"STR" ~is_load:false ~rd addressing
+  | Pair (Reg ({ reg_name = GP _; _ } as rd), Mem addressing), STRB ->
+    (* STRB: size=00, opc=00 *)
+    Load_store_helpers.encode_load_store_byte ~all_sections state
+      ~instr_name:"STRB" ~opc:0b00 ~rd addressing
+  | Pair (Reg ({ reg_name = GP _; _ } as rd), Mem addressing), STRH ->
+    (* STRH: size=01, opc=00 *)
+    Load_store_helpers.encode_load_store_halfword ~all_sections state
+      ~instr_name:"STRH" ~opc:0b00 ~rd addressing
+  | Quad (Reg rd, Reg rn, Imm (Twelve imm12), Optional shift), SUB_immediate ->
+    Add_sub_helpers.encode_add_sub_imm_auto_shift ~op:1 ~s:0 ~imm12
+      ~shift_opt:shift ~rn ~rd
+  | ( Quad
+        ( Reg ({ reg_name = GP _; _ } as rd),
+          Reg ({ reg_name = GP _; _ } as rn),
+          Reg ({ reg_name = GP _; _ } as rm),
+          Optional shift_opt ),
+      SUB_shifted_register ) ->
+    let shift, imm6 =
+      match shift_opt with
+      | None -> 0, 0
+      | Some (Shift { kind; amount }) ->
+        ( Add_sub_helpers.decode_shift_kind_int kind,
+          Add_sub_helpers.decode_shift_amount_six amount )
+    in
+    Add_sub_helpers.encode_add_sub_shifted_reg ~op:1 ~s:0 ~shift ~imm6 ~rd ~rn
+      ~rm
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      SUB_vector ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* SUB: U=1, opcode=10000 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:1 ~size ~rm ~opcode:0b10000 ~rn
+      ~rd
+  | Quad (Reg rd, Reg rn, Imm (Twelve imm12), Optional shift), SUBS_immediate ->
+    Add_sub_helpers.encode_add_sub_imm_auto_shift ~op:1 ~s:1 ~imm12
+      ~shift_opt:shift ~rn ~rd
+  | ( Quad
+        ( Reg ({ reg_name = GP _; _ } as rd),
+          Reg ({ reg_name = GP _; _ } as rn),
+          Reg ({ reg_name = GP _; _ } as rm),
+          Optional shift_opt ),
+      SUBS_shifted_register ) ->
+    let shift, imm6 =
+      match shift_opt with
+      | None -> 0, 0
+      | Some (Shift { kind; amount }) ->
+        ( Add_sub_helpers.decode_shift_kind_int kind,
+          Add_sub_helpers.decode_shift_amount_six amount )
+    in
+    Add_sub_helpers.encode_add_sub_shifted_reg ~op:1 ~s:1 ~shift ~imm6 ~rd ~rn
+      ~rm
+  (* TODO: SXTL is an alias; this should be removed from Instruction_name.t and
+     handled via a rewrite rule. *)
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      SXTL _ ) ->
+    let immh = Shift_immh_immb_helpers.sxtl_immh vec in
+    (* SXTL is alias for SSHLL with shift=0: U=0, opcode=10100, Q=0 *)
+    Simd_helpers.encode_simd_shift_imm ~q:0 ~u:0 ~immh ~immb:0 ~opcode:0b10100
+      ~rn ~rd
+  | ( Triple (Reg ({ reg_name = GP _; _ } as rt), Imm (Six bit), Imm (Sym sym)),
+      TBNZ ) ->
+    let imm14 =
+      Branch_helpers.compute_branch_imm14 state ~instr_name:"TBNZ" sym
+    in
+    let b5 = (bit lsr 5) land 1 in
+    let b40 = bit land 0b11111 in
+    let rt_enc = Reg.gp_encoding rt in
+    Branch_helpers.encode_test_branch ~b5 ~op:1 ~b40 ~imm14 ~rt:rt_enc
+  | ( Triple (Reg ({ reg_name = GP _; _ } as rt), Imm (Six bit), Imm (Sym sym)),
+      TBZ ) ->
+    let imm14 =
+      Branch_helpers.compute_branch_imm14 state ~instr_name:"TBZ" sym
+    in
+    let b5 = (bit lsr 5) land 1 in
+    let b40 = bit land 0b11111 in
+    let rt_enc = Reg.gp_encoding rt in
+    Branch_helpers.encode_test_branch ~b5 ~op:0 ~b40 ~imm14 ~rt:rt_enc
+  (* TODO: TST is an alias; this should be removed from Instruction_name.t and
+     handled via a rewrite rule. *)
+  | Pair (Reg ({ reg_name = GP _; _ } as rn), Bitmask bitmask), TST ->
+    (* TST is an alias for ANDS with XZR/WZR as destination (rd=31) *)
+    let n, immr, imms = Operand.Bitmask.decode_n_immr_imms bitmask in
+    let rn_enc = Reg.gp_encoding rn in
+    let open Int32 in
+    let result = zero in
+    (* sf=1 for 64-bit, opc=11 for ANDS *)
+    let result = logor result (shift_left (of_int 1) 31) in
+    let result = logor result (shift_left (of_int 0b11) 29) in
+    let result = logor result (shift_left (of_int 0b100100) 23) in
+    let result = logor result (shift_left (of_int n) 22) in
+    let result = logor result (shift_left (of_int immr) 16) in
+    let result = logor result (shift_left (of_int imms) 10) in
+    let result = logor result (shift_left (of_int rn_enc) 5) in
+    let result = logor result (of_int 31) in
+    result
+  | Quad (Reg rd, Reg rn, Imm (Six immr), Imm (Six imms)), UBFM ->
+    let sf = Reg.gp_sf rd in
+    let n = sf in
+    Bitfield_helpers.encode_bitfield ~sf ~opc:0b10 ~n ~immr ~imms ~rn ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      UADDLP_vector ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* UADDLP: U=1, opcode=00010 *)
+    Simd_helpers.encode_simd_two_reg_misc ~q ~u:1 ~size ~opcode:0b00010 ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      UMAX_vector ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* UMAX: U=1, opcode=01100 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:1 ~size ~rm ~opcode:0b01100 ~rn
+      ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      UMIN_vector ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* UMIN: U=1, opcode=01101 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:1 ~size ~rm ~opcode:0b01101 ~rn
+      ~rd
+  | ( Pair
+        ( Reg { reg_name = GP _; index = rd },
+          Reg { reg_name = Neon (Vector vec); index = rn } ),
+      UMOV (elem_constraint, lane_idx) ) ->
+    let q =
+      match elem_constraint with
+      | Element_to_GP.B | Element_to_GP.H | Element_to_GP.S -> 0
+      | Element_to_GP.D -> 1
+    in
+    let lane_int = Neon_reg_name.Lane_index.to_int lane_idx in
+    let imm5 = Simd_helpers.simd_copy_imm5 vec lane_int in
+    (* UMOV: op=0, imm4=0111 *)
+    Simd_helpers.encode_simd_copy ~q ~op:0 ~imm5 ~imm4:0b0111 ~rn ~rd
+  | Triple (Reg rd, Reg rn, Reg rm), UMULH ->
+    (* UMULH is 64-bit only. Ra is encoded as 11111 (ignored for multiply-high) *)
+    (* Encoding: sf=1 op54=00 11011 op31=110 Rm o0=0 Ra=11111 Rn Rd *)
+    let ra = Reg.xzr in
+    Data_proc_helpers.encode_data_proc_3_source ~sf:1 ~op54:0b00 ~op31:0b110
+      ~o0:0 ~rm ~ra ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      UMULL2_vector _ ) ->
+    let size = Simd_helpers.vector_widening_size vec in
+    (* UMULL2: U=1, opcode=1100, Q=1 for "2" variant *)
+    Simd_helpers.encode_simd_three_different ~q:1 ~u:1 ~size ~rm ~opcode:0b1100
+      ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      UMULL_vector _ ) ->
+    let size = Simd_helpers.vector_widening_size vec in
+    (* UMULL: U=1, opcode=1100, Q=0 for basic variant *)
+    Simd_helpers.encode_simd_three_different ~q:0 ~u:1 ~size ~rm ~opcode:0b1100
+      ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      UQADD_vector ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* UQADD: U=1, opcode=00001 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:1 ~size ~rm ~opcode:0b00001 ~rn
+      ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      UQXTN _ ) ->
+    let _, size = Simd_helpers.vector_q_size vec in
+    (* UQXTN: U=1, opcode=10100, Q=0 for UQXTN *)
+    Simd_helpers.encode_simd_two_reg_misc ~q:0 ~u:1 ~size ~opcode:0b10100 ~rn
+      ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      UQXTN2 _ ) ->
+    let _, size = Simd_helpers.vector_q_size vec in
+    (* UQXTN2: U=1, opcode=10100, Q=1 for UQXTN2 *)
+    Simd_helpers.encode_simd_two_reg_misc ~q:1 ~u:1 ~size ~opcode:0b10100 ~rn
+      ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      UQSUB_vector ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* UQSUB: U=1, opcode=00101 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:1 ~size ~rm ~opcode:0b00101 ~rn
+      ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      USHL_vector ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* USHL: U=1, opcode=01000 *)
+    Simd_helpers.encode_simd_three_same ~q ~u:1 ~size ~rm ~opcode:0b01000 ~rn
+      ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Shift_by_element_width shift ),
+      USHR ) ->
+    let q, _ = Simd_helpers.vector_q_size vec in
+    let shift_amount = Operand.Shift_by_element_width.to_int shift in
+    let immh, immb = Shift_immh_immb_helpers.shr_immh_immb vec shift_amount in
+    (* USHR: U=1, opcode=00000 *)
+    Simd_helpers.encode_simd_shift_imm ~q ~u:1 ~immh ~immb ~opcode:0b00000 ~rn
+      ~rd
+  (* TODO: UXTL is an alias; this should be removed from Instruction_name.t and
+     handled via a rewrite rule. *)
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      UXTL _ ) ->
+    let immh = Shift_immh_immb_helpers.sxtl_immh vec in
+    (* UXTL is alias for USHLL with shift=0: U=1, opcode=10100, Q=0 *)
+    Simd_helpers.encode_simd_shift_imm ~q:0 ~u:1 ~immh ~immb:0 ~opcode:0b10100
+      ~rn ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      XTN _ ) ->
+    let _q, size = Simd_helpers.vector_q_size vec in
+    (* XTN: U=0, opcode=10010, Q=0 for XTN *)
+    Simd_helpers.encode_simd_two_reg_misc ~q:0 ~u:0 ~size ~opcode:0b10010 ~rn
+      ~rd
+  | ( Pair
+        (Reg { reg_name = Neon (Vector vec); index = rd }, Reg { index = rn; _ }),
+      XTN2 _ ) ->
+    let _, size = Simd_helpers.vector_q_size vec in
+    (* XTN2: U=0, opcode=10010, Q=1 for XTN2 *)
+    Simd_helpers.encode_simd_two_reg_misc ~q:1 ~u:0 ~size ~opcode:0b10010 ~rn
+      ~rd
+  | _, YIELD -> Yield_helpers.encode_yield ()
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      ZIP1 ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* ZIP1: opcode=011 *)
+    Simd_helpers.encode_simd_permute ~q ~size ~rm ~opcode:0b011 ~rn ~rd
+  | ( Triple
+        ( Reg { reg_name = Neon (Vector vec); index = rd },
+          Reg { index = rn; _ },
+          Reg { index = rm; _ } ),
+      ZIP2 ) ->
+    let q, size = Simd_helpers.vector_q_size vec in
+    (* ZIP2: opcode=111 *)
+    Simd_helpers.encode_simd_permute ~q ~size ~rm ~opcode:0b111 ~rn ~rd

--- a/backend/arm64/binary_emitter/encode_instruction.mli
+++ b/backend/arm64/binary_emitter/encode_instruction.mli
@@ -1,0 +1,37 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+val encode_instruction :
+  all_sections:All_section_states.t ->
+  Section_state.t ->
+  ('num, 'operands) Instruction_name.t ->
+  ('num, 'operands) many ->
+  int32

--- a/backend/arm64/binary_emitter/for_jit.ml
+++ b/backend/arm64/binary_emitter/for_jit.ml
@@ -1,0 +1,150 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+(* For_jit module implementing Binary_emitter_intf.S *)
+
+module Symbol = Arm64_ast.Ast.Symbol
+
+(* Convert from Arm64_ast.Ast.Symbol.target to Binary_emitter_intf.target *)
+let convert_target (t : Symbol.target) : Binary_emitter_intf.target =
+  match t with
+  | Symbol.Symbol sym -> Binary_emitter_intf.Symbol sym
+  | Symbol.Label lbl -> Binary_emitter_intf.Label lbl
+
+module Relocation = struct
+  type t = Relocation.t
+
+  let offset_from_section_beginning = Relocation.offset_from_section_beginning
+
+  let size = Relocation.size
+
+  let target_symbol r = convert_target (Relocation.primary_target r)
+
+  let target_symbols r = List.map convert_target (Relocation.all_targets r)
+
+  let target_symbols_with_addends r =
+    List.map
+      (fun (t, addend) -> convert_target t, addend)
+      (Relocation.all_targets_with_addends r)
+
+  let is_got_reloc = Relocation.is_got_reloc
+
+  let is_plt_reloc = Relocation.is_plt_reloc
+
+  let compute_value (r : Relocation.t) ~place_address ~lookup_target
+      ~read_instruction =
+    let target = Relocation.primary_target r in
+    (* Wrap lookup_target to convert from Symbol.target to
+       Binary_emitter_intf.target *)
+    let lookup_target_inner t = lookup_target (convert_target t) in
+    match lookup_target_inner target with
+    | None ->
+      Error (Format.asprintf "Symbol not found: %a" Symbol.print_target target)
+    | Some sym_addr ->
+      let addend = Relocation.get_addend r.kind in
+      let target_addr = Int64.add sym_addr (Int64.of_int addend) in
+      Relocation.compute_value r ~target_addr ~place_address ~read_instruction
+        ~lookup_target:lookup_target_inner
+end
+
+module Assembled_section = struct
+  type t = Section_state.t
+
+  type relocation = Relocation.t
+
+  let size t = Buffer.length (Section_state.buffer t)
+
+  let contents t = Section_state.contents t
+
+  let contents_mut t = Section_state.contents_mut t
+
+  let relocations t = Section_state.relocations t
+
+  let find_symbol_offset t sym = Section_state.find_symbol_offset_in_bytes t sym
+
+  let find_label_offset t lbl = Section_state.find_label_offset_in_bytes t lbl
+
+  let iter_labels_and_symbols t ~f =
+    (* For JIT, we need to export both global symbols and local labels. Local
+       labels like _camlFoo__immstring51 need to be resolvable. *)
+    Section_state.iter_symbols t ~f:(fun sym offset ->
+        f (Binary_emitter_intf.Symbol sym) ~offset);
+    Section_state.iter_labels t ~f:(fun lbl offset ->
+        f (Binary_emitter_intf.Label lbl) ~offset)
+
+  let add_patch t ~offset ~size:(sz : Binary_emitter_intf.data_size) ~data =
+    let sz =
+      match sz with
+      | B8 -> Section_state.P8
+      | B16 -> Section_state.P16
+      | B32 -> Section_state.P32
+      | B64 -> Section_state.P64
+    in
+    Section_state.add_patch t ~offset ~size:sz ~data
+end
+
+module Plt = struct
+  (* ARM64 PLT entry: ldr x16, .+8 ; 58000050 - load address from next 8 bytes
+     br x16 ; d61f0200 - branch to x16 .quad <address> ; 8 bytes of address
+     Total: 16 bytes *)
+  let entry_size = 16
+
+  let write_entry buf address =
+    (* ldr x16, .+8 - PC-relative load from 8 bytes ahead *)
+    Buffer.add_char buf '\x50';
+    Buffer.add_char buf '\x00';
+    Buffer.add_char buf '\x00';
+    Buffer.add_char buf '\x58';
+    (* br x16 - branch to register *)
+    Buffer.add_char buf '\x00';
+    Buffer.add_char buf '\x02';
+    Buffer.add_char buf '\x1f';
+    Buffer.add_char buf '\xd6';
+    (* 8-byte address (little-endian) *)
+    for i = 0 to 7 do
+      let byte =
+        Int64.(to_int (logand (shift_right_logical address (i * 8)) 0xFFL))
+      in
+      Buffer.add_char buf (Char.chr byte)
+    done
+end
+
+module Internal_assembler = struct
+  type assembled_section = Assembled_section.t
+
+  type hook = (string * assembled_section) list -> string -> unit
+
+  let current_hook : hook option ref = ref None
+
+  let register h = current_hook := Some h
+
+  let unregister () = current_hook := None
+
+  let get () = !current_hook
+end

--- a/backend/arm64/binary_emitter/for_jit.mli
+++ b/backend/arm64/binary_emitter/for_jit.mli
@@ -1,0 +1,35 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+(** For_jit module implementing Binary_emitter_intf.S *)
+
+include
+  Binary_emitter_intf.S
+    with type Assembled_section.t = Section_state.t
+     and type Relocation.t = Relocation.t

--- a/backend/arm64/binary_emitter/fp_helpers.ml
+++ b/backend/arm64/binary_emitter/fp_helpers.ml
@@ -1,0 +1,166 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+(* Helper to extract ftype from scalar precision: S=0, D=1 *)
+let scalar_ftype (type a) (s : [`Scalar of a] Neon_reg_name.t) : int =
+  match s with
+  | Scalar S -> 0
+  | Scalar D -> 1
+  | Scalar B | Scalar H | Scalar Q ->
+    Misc.fatal_error "scalar_ftype: unsupported scalar precision"
+
+(* Floating-point data-processing (1 source) - C4.1.95.34
+
+   Format: M=0 | 0 | S=0 | 11110 | ftype | 1 | opcode | 10000 | Rn | Rd
+
+   opcode: 000001=FABS, 000010=FNEG, 000011=FSQRT *)
+let encode_fp_1_source ~ftype ~opcode ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int 0b11110) 24) in
+  let result = logor result (shift_left (of_int ftype) 22) in
+  let result = logor result (shift_left (of_int 0b1) 21) in
+  let result = logor result (shift_left (of_int opcode) 15) in
+  let result = logor result (shift_left (of_int 0b10000) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rd) in
+  result
+
+(* Floating-point data-processing (2 source) - C4.1.95.38 *)
+let encode_fp_2_source ~ftype ~rm ~opcode ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int 0b11110) 24) in
+  let result = logor result (shift_left (of_int ftype) 22) in
+  let result = logor result (shift_left (of_int 0b1) 21) in
+  let result = logor result (shift_left (of_int rm) 16) in
+  let result = logor result (shift_left (of_int opcode) 12) in
+  let result = logor result (shift_left (of_int 0b10) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rd) in
+  result
+
+(* Floating-point conditional select - C4.1.95.39 *)
+let encode_fp_cond_select ~ftype ~rm ~cond ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int 0b11110) 24) in
+  let result = logor result (shift_left (of_int ftype) 22) in
+  let result = logor result (shift_left (of_int 0b1) 21) in
+  let result = logor result (shift_left (of_int rm) 16) in
+  let result = logor result (shift_left (of_int cond) 12) in
+  let result = logor result (shift_left (of_int 0b11) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rd) in
+  result
+
+(* Floating-point data-processing (3 source) - C4.1.95.40 *)
+let encode_fp_3_source ~ftype ~o1 ~rm ~o0 ~ra ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int 0b11111) 24) in
+  let result = logor result (shift_left (of_int ftype) 22) in
+  let result = logor result (shift_left (of_int o1) 21) in
+  let result = logor result (shift_left (of_int rm) 16) in
+  let result = logor result (shift_left (of_int o0) 15) in
+  let result = logor result (shift_left (of_int ra) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rd) in
+  result
+
+(* Floating-point compare - C4.1.95.35
+
+   Format: M=0 | 0 | S=0 | 11110 | ftype | 1 | Rm | op=00 | 1000 | Rn | opcode2
+
+   opcode2: 00000=FCMP(reg), 01000=FCMP(zero), 10000=FCMPE(reg),
+   11000=FCMPE(zero) *)
+let encode_fp_compare ~ftype ~rm ~opc2 ~rn =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int 0b11110) 24) in
+  let result = logor result (shift_left (of_int ftype) 22) in
+  let result = logor result (shift_left (of_int 0b1) 21) in
+  let result = logor result (shift_left (of_int rm) 16) in
+  let result = logor result (shift_left (of_int 0b00) 14) in
+  let result = logor result (shift_left (of_int 0b1000) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int opc2) in
+  result
+
+(* Floating-point <-> integer conversion - C4.1.95.33
+
+   Format: sf | 0 | S=0 | 11110 | ftype | 1 | rmode | opcode | 000000 | Rn | Rd
+
+   Common opcodes:
+
+   - SCVTF (int->FP): rmode=00, opcode=010
+
+   - UCVTF (int->FP): rmode=00, opcode=011
+
+   - FCVTNS (FP->int, nearest): rmode=00, opcode=000
+
+   - FCVTPS (FP->int, +inf): rmode=01, opcode=000
+
+   - FCVTMS (FP->int, -inf): rmode=10, opcode=000
+
+   - FCVTZS (FP->int, zero): rmode=11, opcode=000
+
+   - FCVTNU (FP->int, nearest unsigned): rmode=00, opcode=001
+
+   - FCVTZU (FP->int, zero unsigned): rmode=11, opcode=001
+
+   - FMOV (FP->GP or GP->FP): rmode=00, opcode=110/111 *)
+let encode_fp_int_conv ~sf ~ftype ~rmode ~opcode ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int sf) 31) in
+  let result = logor result (shift_left (of_int 0b11110) 24) in
+  let result = logor result (shift_left (of_int ftype) 22) in
+  let result = logor result (shift_left (of_int 0b1) 21) in
+  let result = logor result (shift_left (of_int rmode) 19) in
+  let result = logor result (shift_left (of_int opcode) 16) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rd) in
+  result
+
+(* Floating-point immediate - C4.1.95.36
+
+   Format: M=0 | 0 | S=0 | 11110 | ftype | 1 | imm8 | 100 | imm5=00000 | Rd *)
+let encode_fp_immediate ~ftype ~imm8 ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int 0b11110) 24) in
+  let result = logor result (shift_left (of_int ftype) 22) in
+  let result = logor result (shift_left (of_int 0b1) 21) in
+  let result = logor result (shift_left (of_int imm8) 13) in
+  let result = logor result (shift_left (of_int 0b100) 10) in
+  let result = logor result (of_int rd) in
+  result

--- a/backend/arm64/binary_emitter/fp_helpers.mli
+++ b/backend/arm64/binary_emitter/fp_helpers.mli
@@ -1,0 +1,52 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+(** Extract ftype from scalar precision: S=0, D=1. Only valid for S and D scalar
+    types. *)
+val scalar_ftype : [`Scalar of 'a] Neon_reg_name.t -> int
+
+val encode_fp_1_source : ftype:int -> opcode:int -> rn:int -> rd:int -> int32
+
+val encode_fp_2_source :
+  ftype:int -> rm:int -> opcode:int -> rn:int -> rd:int -> int32
+
+val encode_fp_cond_select :
+  ftype:int -> rm:int -> cond:int -> rn:int -> rd:int -> int32
+
+val encode_fp_3_source :
+  ftype:int -> o1:int -> rm:int -> o0:int -> ra:int -> rn:int -> rd:int -> int32
+
+val encode_fp_compare : ftype:int -> rm:int -> opc2:int -> rn:int -> int32
+
+val encode_fp_int_conv :
+  sf:int -> ftype:int -> rmode:int -> opcode:int -> rn:int -> rd:int -> int32
+
+val encode_fp_immediate : ftype:int -> imm8:int -> rd:int -> int32

--- a/backend/arm64/binary_emitter/load_store_helpers.ml
+++ b/backend/arm64/binary_emitter/load_store_helpers.ml
@@ -1,0 +1,573 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+(* Load register (literal) - C4.1.96.19 *)
+let encode_load_literal ~opc ~v ~imm19 ~rt =
+  assert (imm19 >= 0 && imm19 <= 0x7ffff);
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int opc) 30) in
+  let result = logor result (shift_left (of_int 0b011) 27) in
+  let result = logor result (shift_left (of_int v) 26) in
+  let result = logor result (shift_left (of_int imm19) 5) in
+  let result = logor result (of_int rt) in
+  result
+
+(* Load/store register (unscaled immediate) - C4.1.96.25 *)
+let encode_load_store_unscaled ~size ~vr ~opc ~imm9 ~rn ~rt =
+  assert (imm9 >= 0 && imm9 <= 0x1ff);
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int size) 30) in
+  let result = logor result (shift_left (of_int 0b111) 27) in
+  let result = logor result (shift_left (of_int vr) 26) in
+  let result = logor result (shift_left (of_int opc) 22) in
+  let result = logor result (shift_left (of_int imm9) 12) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rt) in
+  result
+
+(* Load/store register (immediate post-indexed) - C4.1.96.26 *)
+let encode_load_store_post_indexed ~size ~vr ~opc ~imm9 ~rn ~rt =
+  assert (imm9 >= 0 && imm9 <= 0x1ff);
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int size) 30) in
+  let result = logor result (shift_left (of_int 0b111) 27) in
+  let result = logor result (shift_left (of_int vr) 26) in
+  let result = logor result (shift_left (of_int opc) 22) in
+  let result = logor result (shift_left (of_int imm9) 12) in
+  let result = logor result (shift_left (of_int 0b01) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rt) in
+  result
+
+(* Load/store register (immediate pre-indexed) - C4.1.96.28 *)
+let encode_load_store_pre_indexed ~size ~vr ~opc ~imm9 ~rn ~rt =
+  assert (imm9 >= 0 && imm9 <= 0x1ff);
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int size) 30) in
+  let result = logor result (shift_left (of_int 0b111) 27) in
+  let result = logor result (shift_left (of_int vr) 26) in
+  let result = logor result (shift_left (of_int opc) 22) in
+  let result = logor result (shift_left (of_int imm9) 12) in
+  let result = logor result (shift_left (of_int 0b11) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rt) in
+  result
+
+(* Load/store register (unsigned immediate) - C4.1.96.27 *)
+let encode_load_store_unsigned_offset ~size ~vr ~opc ~imm12 ~rn ~rt =
+  assert (imm12 >= 0 && imm12 <= 0xfff);
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int size) 30) in
+  let result = logor result (shift_left (of_int 0b111) 27) in
+  let result = logor result (shift_left (of_int vr) 26) in
+  let result = logor result (shift_left (of_int 0b01) 24) in
+  let result = logor result (shift_left (of_int opc) 22) in
+  let result = logor result (shift_left (of_int imm12) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rt) in
+  result
+
+(* Load/store pair (post-indexed) - C4.1.96.15
+
+   Encoding: opc[1:0] | 101 | V | 001 | L | imm7 | Rt2 | Rn | Rt *)
+let encode_load_store_pair_post_indexed ~opc ~v ~l ~imm7 ~rt2 ~rn ~rt =
+  assert (imm7 >= -0x40 && imm7 <= 0x3f);
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int opc) 30) in
+  let result = logor result (shift_left (of_int 0b101) 27) in
+  let result = logor result (shift_left (of_int v) 26) in
+  let result = logor result (shift_left (of_int 0b001) 23) in
+  let result = logor result (shift_left (of_int l) 22) in
+  let result = logor result (shift_left (of_int (imm7 land 0x7F)) 15) in
+  let result = logor result (shift_left (of_int rt2) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rt) in
+  result
+
+(* Load/store pair (pre-indexed) - C4.1.96.17
+
+   Encoding: opc[1:0] | 101 | V | 011 | L | imm7 | Rt2 | Rn | Rt *)
+let encode_load_store_pair_pre_indexed ~opc ~v ~l ~imm7 ~rt2 ~rn ~rt =
+  assert (imm7 >= -0x40 && imm7 <= 0x3f);
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int opc) 30) in
+  let result = logor result (shift_left (of_int 0b101) 27) in
+  let result = logor result (shift_left (of_int v) 26) in
+  let result = logor result (shift_left (of_int 0b011) 23) in
+  let result = logor result (shift_left (of_int l) 22) in
+  let result = logor result (shift_left (of_int (imm7 land 0x7F)) 15) in
+  let result = logor result (shift_left (of_int rt2) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rt) in
+  result
+
+(* Load/store pair (signed offset) - C4.1.96.16
+
+   Encoding: opc[1:0] | 101 | V | 010 | L | imm7 | Rt2 | Rn | Rt *)
+let encode_load_store_pair_signed_offset ~opc ~v ~l ~imm7 ~rt2 ~rn ~rt =
+  assert (imm7 >= -0x40 && imm7 <= 0x3f);
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int opc) 30) in
+  let result = logor result (shift_left (of_int 0b101) 27) in
+  let result = logor result (shift_left (of_int v) 26) in
+  let result = logor result (shift_left (of_int 0b010) 23) in
+  let result = logor result (shift_left (of_int l) 22) in
+  let result = logor result (shift_left (of_int (imm7 land 0x7F)) 15) in
+  let result = logor result (shift_left (of_int rt2) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rt) in
+  result
+
+(* Generalized load/store encoding for byte/halfword/word/doubleword operations.
+   size: 00=byte, 01=halfword, 10=word, 11=doubleword opc encodes the operation
+   (load/store and signed extension) *)
+let encode_load_store_gp_sized : type a.
+    all_sections:All_section_states.t ->
+    Section_state.t ->
+    instr_name:string ->
+    size:int ->
+    opc:int ->
+    rd:[`GP of a] Reg.t ->
+    [ `Base_reg
+    | `Offset_twelve_unsigned_scaled
+    | `Offset_nine_signed_unscaled
+    | `Offset_sym
+    | `Literal
+    | `Pre
+    | `Post ]
+    Addressing_mode.t ->
+    int32 =
+ fun ~all_sections:_ state ~instr_name ~size ~opc ~rd addressing ->
+  let vr = 0 in
+  let rt = Reg.gp_encoding rd in
+  match addressing with
+  | Reg rn ->
+    (* Use unsigned offset encoding with imm12=0 to match assembler behavior *)
+    let rn = Reg.gp_encoding rn in
+    encode_load_store_unsigned_offset ~size ~vr ~opc ~imm12:0 ~rn ~rt
+  | Offset_nine_signed_unscaled (rn, Nine_signed_unscaled imm) ->
+    (* Prefer unsigned offset encoding when the offset is non-negative and
+       properly aligned for the access size. This matches assembler behavior and
+       provides a larger range for positive offsets. scale = 1 << size (1 for
+       byte, 2 for half, 4 for word, 8 for double) *)
+    let scale = 1 lsl size in
+    let rn = Reg.gp_encoding rn in
+    if imm >= 0 && imm mod scale = 0 && imm / scale <= 0xFFF
+    then
+      let imm12 = imm / scale in
+      encode_load_store_unsigned_offset ~size ~vr ~opc ~imm12 ~rn ~rt
+    else
+      let imm9 = imm land 0x1FF in
+      encode_load_store_unscaled ~size ~vr ~opc ~imm9 ~rn ~rt
+  | Literal sym -> (
+    (* This is encoded as "LDR (literal)" - only valid for word/doubleword *)
+    if size < 0b10
+    then Misc.fatal_errorf "%s does not support literal addressing" instr_name;
+    match Section_state.find_target_offset_in_bytes state sym.target with
+    | None ->
+      Misc.fatal_errorf "%s (literal) references undefined symbol '%a' (rd=%s)"
+        instr_name Symbol.print_target sym.target (Reg.name rd)
+    | Some target_offset ->
+      let pc_relative_offset =
+        target_offset - Section_state.offset_in_bytes state
+      in
+      assert (pc_relative_offset > 0);
+      if pc_relative_offset mod 4 <> 0
+      then
+        Misc.fatal_errorf
+          "%s (literal) offset %d to symbol '%a' must be 4-byte aligned"
+          instr_name pc_relative_offset Symbol.print_target sym.target;
+      let imm19_unmasked = pc_relative_offset / 4 in
+      if imm19_unmasked < -0x40000 || imm19_unmasked > 0x3ffff
+      then
+        Misc.fatal_errorf
+          "%s (literal) offset %d to symbol '%a' out of range (max ±1MB)"
+          instr_name pc_relative_offset Symbol.print_target sym.target;
+      let imm19 = imm19_unmasked land 0x7FFFF in
+      let v = 0 in
+      encode_load_literal ~opc ~v ~imm19 ~rt)
+  | Offset_twelve_unsigned_scaled (rn, Twelve_unsigned_scaled imm12) ->
+    let max_imm12 = 0xfff in
+    (* Scale depends on size: byte=1, half=2, word=4, double=8 *)
+    let scale = 1 lsl size in
+    if imm12 mod scale <> 0
+    then
+      Misc.fatal_errorf
+        "%s offset %d must be aligned to %d-byte access size (rd=%s, rn=%s)"
+        instr_name imm12 scale (Reg.name rd) (Reg.name rn);
+    let rn = Reg.gp_encoding rn in
+    let imm12_scaled = imm12 / scale in
+    if imm12_scaled < 0 || imm12_scaled > max_imm12
+    then
+      Misc.fatal_errorf
+        "%s offset %d (scaled: %d) out of range (max 0x%x * %d = 0x%x bytes)"
+        instr_name imm12 imm12_scaled max_imm12 scale (max_imm12 * scale);
+    encode_load_store_unsigned_offset ~size ~vr ~opc ~imm12:imm12_scaled ~rn ~rt
+  | Offset_sym (rn, sym) -> (
+    match sym.reloc with
+    | Needs_reloc reloc ->
+      let max_imm12 = 0xfff in
+      let reloc_kind : Relocation.Kind.t =
+        let r = { Relocation.Kind.target = sym.target; addend = sym.offset } in
+        match reloc with
+        | GOT_PAGE_OFF | GOT_LOWER_TWELVE -> R_AARCH64_LD64_GOT_LO12_NC r
+        | PAGE_OFF | LOWER_TWELVE ->
+          (* Use LDST64 relocation for 64-bit load/store instructions. The
+             immediate encoding differs from ADD: it's scaled by 8. *)
+          if size = 0b11 (* XXX should this ever be an "ADD" one? *)
+          then R_AARCH64_LDST64_ABS_LO12_NC r
+          else R_AARCH64_ADD_ABS_LO12_NC r
+      in
+      Section_state.add_relocation_at_current_offset state ~reloc_kind;
+      let rn = Reg.gp_encoding rn in
+      (* On RELA platforms (Linux), encode 0 in instruction - addend is in
+         relocation. On REL platforms (macOS), encode addend in instruction. *)
+      let offset =
+        if Encode_directive.is_rela_platform () then 0 else sym.offset
+      in
+      let imm12_unmasked = offset lsr size in
+      if imm12_unmasked < 0 || imm12_unmasked > max_imm12
+      then
+        Misc.fatal_errorf
+          "%s symbol offset %d (shifted by %d) out of range (max 0x%x)"
+          instr_name offset size max_imm12;
+      let imm12 = imm12_unmasked land 0xFFF in
+      encode_load_store_unsigned_offset ~size ~vr ~opc ~imm12 ~rn ~rt)
+  | Pre (rn, Imm (Nine_signed_unscaled imm)) ->
+    let imm9 = imm land 0x1FF in
+    let rn = Reg.gp_encoding rn in
+    encode_load_store_pre_indexed ~size ~vr ~opc ~imm9 ~rn ~rt
+  | Post (rn, Imm (Nine_signed_unscaled imm)) ->
+    let imm9 = imm land 0x1FF in
+    let rn = Reg.gp_encoding rn in
+    encode_load_store_post_indexed ~size ~vr ~opc ~imm9 ~rn ~rt
+
+let encode_load_store_gp : type a.
+    all_sections:All_section_states.t ->
+    Section_state.t ->
+    instr_name:string ->
+    opc:int ->
+    rd:[`GP of a] Reg.t ->
+    [ `Base_reg
+    | `Offset_twelve_unsigned_scaled
+    | `Offset_nine_signed_unscaled
+    | `Offset_sym
+    | `Literal
+    | `Pre
+    | `Post ]
+    Addressing_mode.t ->
+    int32 =
+ fun ~all_sections state ~instr_name ~opc ~rd addressing ->
+  let size =
+    match rd.reg_name with
+    | GP W | GP WZR | GP WSP -> 0b10
+    | GP X | GP XZR | GP SP | GP LR | GP FP -> 0b11
+  in
+  encode_load_store_gp_sized ~all_sections state ~instr_name ~size ~opc ~rd
+    addressing
+
+(* Byte load/store - size=00 *)
+let encode_load_store_byte : type a.
+    all_sections:All_section_states.t ->
+    Section_state.t ->
+    instr_name:string ->
+    opc:int ->
+    rd:[`GP of a] Reg.t ->
+    [ `Base_reg
+    | `Offset_twelve_unsigned_scaled
+    | `Offset_nine_signed_unscaled
+    | `Offset_sym
+    | `Literal
+    | `Pre
+    | `Post ]
+    Addressing_mode.t ->
+    int32 =
+ fun ~all_sections state ~instr_name ~opc ~rd addressing ->
+  encode_load_store_gp_sized ~all_sections state ~instr_name ~size:0b00 ~opc ~rd
+    addressing
+
+(* Halfword load/store - size=01 *)
+let encode_load_store_halfword : type a.
+    all_sections:All_section_states.t ->
+    Section_state.t ->
+    instr_name:string ->
+    opc:int ->
+    rd:[`GP of a] Reg.t ->
+    [ `Base_reg
+    | `Offset_twelve_unsigned_scaled
+    | `Offset_nine_signed_unscaled
+    | `Offset_sym
+    | `Literal
+    | `Pre
+    | `Post ]
+    Addressing_mode.t ->
+    int32 =
+ fun ~all_sections state ~instr_name ~opc ~rd addressing ->
+  encode_load_store_gp_sized ~all_sections state ~instr_name ~size:0b01 ~opc ~rd
+    addressing
+
+(* Load-Acquire (LDAR) encoding. Format: size[31:30] | 001000 | o2[23] | L[22] |
+   o1[21] | Rs[20:16] | o0[15] | Rt2[14:10] | Rn[9:5] | Rt[4:0] For LDAR: o2=1,
+   L=1, o1=0, Rs=11111, o0=1, Rt2=11111 size: 10 for 32-bit, 11 for 64-bit *)
+let encode_load_acquire : type a.
+    rd:[`GP of a] Reg.t -> rn:[`GP of _] Reg.t -> int32 =
+ fun ~rd ~rn ->
+  let size =
+    match rd.reg_name with
+    | GP W | GP WZR | GP WSP -> 0b10
+    | GP X | GP XZR | GP SP | GP LR | GP FP -> 0b11
+  in
+  let rt = Reg.gp_encoding rd in
+  let rn_enc = Reg.gp_encoding rn in
+  let o2 = 1 in
+  let l = 1 in
+  let o1 = 0 in
+  let o0 = 1 in
+  let rs = 0b11111 in
+  let rt2 = 0b11111 in
+  let open Int32 in
+  let result = shift_left (of_int size) 30 in
+  let result = logor result (shift_left (of_int 0b001000) 24) in
+  let result = logor result (shift_left (of_int o2) 23) in
+  let result = logor result (shift_left (of_int l) 22) in
+  let result = logor result (shift_left (of_int o1) 21) in
+  let result = logor result (shift_left (of_int rs) 16) in
+  let result = logor result (shift_left (of_int o0) 15) in
+  let result = logor result (shift_left (of_int rt2) 10) in
+  let result = logor result (shift_left (of_int rn_enc) 5) in
+  let result = logor result (of_int rt) in
+  result
+
+(* Memory barrier encoding. Format: 1101 0101 0000 0011 0011 | CRm[11:8] |
+   op2[7:5] | 11111
+
+   - DMB: op2=101
+
+   - DSB: op2=100 *)
+let encode_memory_barrier ~op2 (barrier : Memory_barrier.t) =
+  let crm =
+    match barrier with
+    | SY -> 0b1111
+    | ST -> 0b1110
+    | LD -> 0b1101
+    | ISH -> 0b1011
+    | ISHST -> 0b1010
+    | ISHLD -> 0b1001
+    | NSH -> 0b0111
+    | NSHST -> 0b0110
+    | NSHLD -> 0b0101
+    | OSH -> 0b0011
+    | OSHST -> 0b0010
+    | OSHLD -> 0b0001
+  in
+  let open Int32 in
+  (* 1101 0101 0000 0011 0011 = 0xD503_30 shifted appropriately *)
+  let result = of_int 0b11010101000000110011 in
+  let result = shift_left result 12 in
+  let result = logor result (shift_left (of_int crm) 8) in
+  let result = logor result (shift_left (of_int op2) 5) in
+  let result = logor result (of_int 0b11111) in
+  result
+
+(* Encode LDP/STP instructions for GP registers. l=1 for load (LDP), l=0 for
+   store (STP). opc: 00 for 32-bit (W), 10 for 64-bit (X) *)
+let encode_load_store_pair_gp : type a b.
+    instr_name:string ->
+    l:int ->
+    rt1:[`GP of a] Reg.t ->
+    rt2:[`GP of b] Reg.t ->
+    [< `Offset_pair | `Pre_pair | `Post_pair] Addressing_mode.t ->
+    int32 =
+ fun ~instr_name ~l ~rt1 ~rt2 addressing ->
+  let opc =
+    match rt1.reg_name with
+    | GP W | GP WZR | GP WSP -> 0b00
+    | GP X | GP XZR | GP SP | GP LR | GP FP -> 0b10
+  in
+  let scale = if opc = 0b10 then 8 else 4 in
+  let v = 0 in
+  let rt1_enc = Reg.gp_encoding rt1 in
+  let rt2_enc = Reg.gp_encoding rt2 in
+  let encode_with_alignment_check encode_fn rn imm =
+    if imm mod scale <> 0
+    then
+      Misc.fatal_errorf "%s offset %d must be aligned to %d bytes" instr_name
+        imm scale;
+    let imm7 = imm / scale in
+    let rn = Reg.gp_encoding rn in
+    encode_fn ~opc ~v ~l ~imm7 ~rt2:rt2_enc ~rn ~rt:rt1_enc
+  in
+  match addressing with
+  | Offset_pair (rn, Imm (Seven_signed_scaled imm)) ->
+    encode_with_alignment_check encode_load_store_pair_signed_offset rn imm
+  | Pre_pair (rn, Imm (Seven_signed_scaled imm)) ->
+    encode_with_alignment_check encode_load_store_pair_pre_indexed rn imm
+  | Post_pair (rn, Imm (Seven_signed_scaled imm)) ->
+    encode_with_alignment_check encode_load_store_pair_post_indexed rn imm
+
+(* Encode load/store for SIMD&FP registers.
+
+   For LDR: S->opc=01, D->opc=01, Q->opc=11
+
+   For STR: S->opc=00, D->opc=00, Q->opc=10
+
+   size: S->10, D->11, Q->00 *)
+let encode_load_store_simd_fp : type s.
+    all_sections:All_section_states.t ->
+    Section_state.t ->
+    instr_name:string ->
+    is_load:bool ->
+    rd:[`Neon of [`Scalar of s]] Reg.t ->
+    [ `Base_reg
+    | `Offset_twelve_unsigned_scaled
+    | `Offset_nine_signed_unscaled
+    | `Offset_sym
+    | `Literal
+    | `Pre
+    | `Post ]
+    Addressing_mode.t ->
+    int32 =
+ fun ~all_sections:_ state ~instr_name ~is_load ~rd addressing ->
+  let vr = 1 in
+  let size, opc, scale =
+    match rd.reg_name with
+    | Neon (Scalar S) -> 0b10, (if is_load then 0b01 else 0b00), 4
+    | Neon (Scalar D) -> 0b11, (if is_load then 0b01 else 0b00), 8
+    | Neon (Scalar Q) -> 0b00, (if is_load then 0b11 else 0b10), 16
+    | Neon (Scalar B) -> 0b00, (if is_load then 0b01 else 0b00), 1
+    | Neon (Scalar H) -> 0b01, (if is_load then 0b01 else 0b00), 2
+  in
+  let rt = rd.index in
+  match addressing with
+  | Reg rn ->
+    (* Use unsigned offset encoding with imm12=0 to match assembler behavior *)
+    let rn = Reg.gp_encoding rn in
+    encode_load_store_unsigned_offset ~size ~vr ~opc ~imm12:0 ~rn ~rt
+  | Offset_nine_signed_unscaled (rn, Nine_signed_unscaled imm) ->
+    (* Prefer unsigned offset encoding when the offset is non-negative and
+       properly aligned for the access size. This matches assembler behavior. *)
+    let rn = Reg.gp_encoding rn in
+    if imm >= 0 && imm mod scale = 0 && imm / scale <= 0xFFF
+    then
+      let imm12 = imm / scale in
+      encode_load_store_unsigned_offset ~size ~vr ~opc ~imm12 ~rn ~rt
+    else
+      let imm9 = imm land 0x1FF in
+      encode_load_store_unscaled ~size ~vr ~opc ~imm9 ~rn ~rt
+  | Literal sym -> (
+    match Section_state.find_target_offset_in_bytes state sym.target with
+    | None ->
+      Misc.fatal_errorf "%s (literal) references undefined symbol '%a'"
+        instr_name Symbol.print_target sym.target
+    | Some target_offset ->
+      let pc_relative_offset =
+        target_offset - Section_state.offset_in_bytes state
+      in
+      if pc_relative_offset mod 4 <> 0
+      then
+        Misc.fatal_errorf
+          "%s (literal) offset %d to symbol '%a' must be 4-byte aligned"
+          instr_name pc_relative_offset Symbol.print_target sym.target;
+      let imm19_unmasked = pc_relative_offset / 4 in
+      if imm19_unmasked < -0x40000 || imm19_unmasked > 0x3ffff
+      then
+        Misc.fatal_errorf
+          "%s (literal) offset %d to symbol '%a' out of range (max ±1MB)"
+          instr_name pc_relative_offset Symbol.print_target sym.target;
+      let imm19 = imm19_unmasked land 0x7FFFF in
+      let opc_lit =
+        match rd.reg_name with
+        | Neon (Scalar S) -> 0b00
+        | Neon (Scalar D) -> 0b01
+        | Neon (Scalar Q) -> 0b10
+        | Neon (Scalar B) | Neon (Scalar H) ->
+          Misc.fatal_errorf "%s (literal) not supported for B/H registers"
+            instr_name
+      in
+      encode_load_literal ~opc:opc_lit ~v:1 ~imm19 ~rt)
+  | Offset_twelve_unsigned_scaled (rn, Twelve_unsigned_scaled imm12) ->
+    if imm12 mod scale <> 0
+    then
+      Misc.fatal_errorf "%s offset %d must be aligned to %d-byte access size"
+        instr_name imm12 scale;
+    let imm12_scaled = imm12 / scale in
+    if imm12_scaled < 0 || imm12_scaled > 0xfff
+    then
+      Misc.fatal_errorf "%s offset %d (scaled: %d) out of range" instr_name
+        imm12 imm12_scaled;
+    let rn = Reg.gp_encoding rn in
+    encode_load_store_unsigned_offset ~size ~vr ~opc ~imm12:imm12_scaled ~rn ~rt
+  | Offset_sym (rn, sym) -> (
+    match sym.reloc with
+    | Needs_reloc reloc ->
+      let max_imm12 = 0xfff in
+      let reloc_kind : Relocation.Kind.t =
+        let r = { Relocation.Kind.target = sym.target; addend = sym.offset } in
+        match reloc with
+        | GOT_PAGE_OFF | GOT_LOWER_TWELVE -> R_AARCH64_LD64_GOT_LO12_NC r
+        | PAGE_OFF | LOWER_TWELVE ->
+          (* Use LDST64 relocation for 64-bit load/store instructions. The
+             immediate encoding differs from ADD: it's scaled by 8. *)
+          if size = 0b11
+          then R_AARCH64_LDST64_ABS_LO12_NC r
+          else R_AARCH64_ADD_ABS_LO12_NC r
+      in
+      Section_state.add_relocation_at_current_offset state ~reloc_kind;
+      let rn = Reg.gp_encoding rn in
+      (* On RELA platforms (Linux), encode 0 in instruction - addend is in
+         relocation. On REL platforms (macOS), encode addend in instruction. *)
+      let offset =
+        if Encode_directive.is_rela_platform () then 0 else sym.offset
+      in
+      let imm12_unmasked = offset / scale in
+      if imm12_unmasked < 0 || imm12_unmasked > max_imm12
+      then
+        Misc.fatal_errorf
+          "%s symbol offset %d (scaled by %d) out of range (max 0x%x)"
+          instr_name offset scale max_imm12;
+      let imm12 = imm12_unmasked land 0xFFF in
+      encode_load_store_unsigned_offset ~size ~vr ~opc ~imm12 ~rn ~rt)
+  | Pre (rn, Imm (Nine_signed_unscaled imm)) ->
+    let imm9 = imm land 0x1FF in
+    let rn = Reg.gp_encoding rn in
+    encode_load_store_pre_indexed ~size ~vr ~opc ~imm9 ~rn ~rt
+  | Post (rn, Imm (Nine_signed_unscaled imm)) ->
+    let imm9 = imm land 0x1FF in
+    let rn = Reg.gp_encoding rn in
+    encode_load_store_post_indexed ~size ~vr ~opc ~imm9 ~rn ~rt

--- a/backend/arm64/binary_emitter/load_store_helpers.mli
+++ b/backend/arm64/binary_emitter/load_store_helpers.mli
@@ -1,0 +1,146 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+val encode_load_literal : opc:int -> v:int -> imm19:int -> rt:int -> int32
+
+val encode_load_store_unscaled :
+  size:int -> vr:int -> opc:int -> imm9:int -> rn:int -> rt:int -> int32
+
+val encode_load_store_post_indexed :
+  size:int -> vr:int -> opc:int -> imm9:int -> rn:int -> rt:int -> int32
+
+val encode_load_store_pre_indexed :
+  size:int -> vr:int -> opc:int -> imm9:int -> rn:int -> rt:int -> int32
+
+val encode_load_store_unsigned_offset :
+  size:int -> vr:int -> opc:int -> imm12:int -> rn:int -> rt:int -> int32
+
+val encode_load_store_pair_post_indexed :
+  opc:int -> v:int -> l:int -> imm7:int -> rt2:int -> rn:int -> rt:int -> int32
+
+val encode_load_store_pair_pre_indexed :
+  opc:int -> v:int -> l:int -> imm7:int -> rt2:int -> rn:int -> rt:int -> int32
+
+val encode_load_store_pair_signed_offset :
+  opc:int -> v:int -> l:int -> imm7:int -> rt2:int -> rn:int -> rt:int -> int32
+
+val encode_load_store_gp_sized :
+  all_sections:All_section_states.t ->
+  Section_state.t ->
+  instr_name:string ->
+  size:int ->
+  opc:int ->
+  rd:[`GP of 'a] Reg.t ->
+  [ `Base_reg
+  | `Offset_twelve_unsigned_scaled
+  | `Offset_nine_signed_unscaled
+  | `Offset_sym
+  | `Literal
+  | `Pre
+  | `Post ]
+  Addressing_mode.t ->
+  int32
+
+val encode_load_store_gp :
+  all_sections:All_section_states.t ->
+  Section_state.t ->
+  instr_name:string ->
+  opc:int ->
+  rd:[`GP of 'a] Reg.t ->
+  [ `Base_reg
+  | `Offset_twelve_unsigned_scaled
+  | `Offset_nine_signed_unscaled
+  | `Offset_sym
+  | `Literal
+  | `Pre
+  | `Post ]
+  Addressing_mode.t ->
+  int32
+
+val encode_load_store_byte :
+  all_sections:All_section_states.t ->
+  Section_state.t ->
+  instr_name:string ->
+  opc:int ->
+  rd:[`GP of 'a] Reg.t ->
+  [ `Base_reg
+  | `Offset_twelve_unsigned_scaled
+  | `Offset_nine_signed_unscaled
+  | `Offset_sym
+  | `Literal
+  | `Pre
+  | `Post ]
+  Addressing_mode.t ->
+  int32
+
+val encode_load_store_halfword :
+  all_sections:All_section_states.t ->
+  Section_state.t ->
+  instr_name:string ->
+  opc:int ->
+  rd:[`GP of 'a] Reg.t ->
+  [ `Base_reg
+  | `Offset_twelve_unsigned_scaled
+  | `Offset_nine_signed_unscaled
+  | `Offset_sym
+  | `Literal
+  | `Pre
+  | `Post ]
+  Addressing_mode.t ->
+  int32
+
+val encode_load_acquire : rd:[`GP of 'a] Reg.t -> rn:[`GP of 'b] Reg.t -> int32
+
+val encode_memory_barrier : op2:int -> Memory_barrier.t -> int32
+
+val encode_load_store_pair_gp :
+  instr_name:string ->
+  l:int ->
+  rt1:[`GP of 'a] Reg.t ->
+  rt2:[`GP of 'b] Reg.t ->
+  [`Offset_pair | `Pre_pair | `Post_pair] Addressing_mode.t ->
+  int32
+
+val encode_load_store_simd_fp :
+  all_sections:All_section_states.t ->
+  Section_state.t ->
+  instr_name:string ->
+  is_load:bool ->
+  rd:[`Neon of [`Scalar of 's]] Reg.t ->
+  [ `Base_reg
+  | `Offset_twelve_unsigned_scaled
+  | `Offset_nine_signed_unscaled
+  | `Offset_sym
+  | `Literal
+  | `Pre
+  | `Post ]
+  Addressing_mode.t ->
+  int32

--- a/backend/arm64/binary_emitter/logical_helpers.ml
+++ b/backend/arm64/binary_emitter/logical_helpers.ml
@@ -1,0 +1,70 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+(* Logical (immediate) - C4.1.92.6 *)
+let encode_logical_immediate ~sf ~opc ~n ~immr ~imms ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int sf) 31) in
+  let result = logor result (shift_left (of_int opc) 29) in
+  let result = logor result (shift_left (of_int 0b100100) 23) in
+  let result = logor result (shift_left (of_int n) 22) in
+  let result = logor result (shift_left (of_int immr) 16) in
+  let result = logor result (shift_left (of_int imms) 10) in
+  let result = logor result (shift_left (of_int (Reg.gp_encoding rn)) 5) in
+  let result = logor result (of_int (Reg.gp_encoding rd)) in
+  result
+
+(* Logical (shifted register) - C4.1.94.3 *)
+let encode_logical_shifted_register ~sf ~opc ~shift ~n ~rm ~imm6 ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int sf) 31) in
+  let result = logor result (shift_left (of_int opc) 29) in
+  let result = logor result (shift_left (of_int 0b01010) 24) in
+  let result = logor result (shift_left (of_int shift) 22) in
+  let result = logor result (shift_left (of_int n) 21) in
+  let result = logor result (shift_left (of_int rm) 16) in
+  let result = logor result (shift_left (of_int imm6) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rd) in
+  result
+
+(* Helper to encode logical shifted register instructions.
+
+   - opc: 00=AND, 01=ORR, 10=EOR, 11=ANDS *)
+let encode_logical_shifted_reg ~opc ~shift ~imm6 ~rd ~rn ~rm =
+  let sf = Reg.gp_sf rd in
+  let rd_enc = Reg.gp_encoding rd in
+  let rn_enc = Reg.gp_encoding rn in
+  let rm_enc = Reg.gp_encoding rm in
+  encode_logical_shifted_register ~sf ~opc ~shift ~n:0 ~rm:rm_enc ~imm6
+    ~rn:rn_enc ~rd:rd_enc

--- a/backend/arm64/binary_emitter/logical_helpers.mli
+++ b/backend/arm64/binary_emitter/logical_helpers.mli
@@ -1,0 +1,60 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+val encode_logical_immediate :
+  sf:int ->
+  opc:int ->
+  n:int ->
+  immr:int ->
+  imms:int ->
+  rn:[`GP of 'a] Reg.t ->
+  rd:[`GP of 'b] Reg.t ->
+  int32
+
+val encode_logical_shifted_register :
+  sf:int ->
+  opc:int ->
+  shift:int ->
+  n:int ->
+  rm:int ->
+  imm6:int ->
+  rn:int ->
+  rd:int ->
+  int32
+
+val encode_logical_shifted_reg :
+  opc:int ->
+  shift:int ->
+  imm6:int ->
+  rd:[`GP of 'a] Reg.t ->
+  rn:[`GP of 'b] Reg.t ->
+  rm:[`GP of 'c] Reg.t ->
+  int32

--- a/backend/arm64/binary_emitter/mov_helpers.ml
+++ b/backend/arm64/binary_emitter/mov_helpers.ml
@@ -1,0 +1,49 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+let encode_six_bit_shift (shift_opt : [`Shift of _ * [`Six]] Operand.t option) =
+  match shift_opt with
+  | Some (Shift shift) -> (match shift.amount with Six n -> n) / 16
+  | None -> 0
+
+(* Move wide (immediate) encoding - C4.1.92.7 Used for MOVN, MOVZ, MOVK *)
+let encode_move_wide ~sf ~opc ~hw ~imm16 ~rd =
+  let open Int32 in
+  if imm16 < 0 || imm16 > 0xFFFF
+  then Misc.fatal_errorf "MOVZ/MOVN/MOVK immediate out of range: %d" imm16 ();
+  let result = zero in
+  let result = logor result (shift_left (of_int sf) 31) in
+  let result = logor result (shift_left (of_int opc) 29) in
+  let result = logor result (shift_left (of_int 0b100101) 23) in
+  let result = logor result (shift_left (of_int hw) 21) in
+  let result = logor result (shift_left (of_int imm16) 5) in
+  let result = logor result (of_int (Reg.gp_encoding rd)) in
+  result

--- a/backend/arm64/binary_emitter/mov_helpers.mli
+++ b/backend/arm64/binary_emitter/mov_helpers.mli
@@ -1,0 +1,35 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+val encode_six_bit_shift : [`Shift of 'a * [`Six]] Operand.t option -> int
+
+val encode_move_wide :
+  sf:int -> opc:int -> hw:int -> imm16:int -> rd:[`GP of 'a] Reg.t -> int32

--- a/backend/arm64/binary_emitter/nop_helpers.ml
+++ b/backend/arm64/binary_emitter/nop_helpers.ml
@@ -1,0 +1,31 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+(* NOP encoding: 1101 0101 0000 0011 0010 0000 000 11111 = 0xD503201F *)
+let encode_nop () = Int32.of_int 0xD503201F

--- a/backend/arm64/binary_emitter/nop_helpers.mli
+++ b/backend/arm64/binary_emitter/nop_helpers.mli
@@ -1,0 +1,30 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+val encode_nop : unit -> int32

--- a/backend/arm64/binary_emitter/relocation.ml
+++ b/backend/arm64/binary_emitter/relocation.ml
@@ -1,0 +1,284 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+module Symbol = Arm64_ast.Ast.Symbol
+
+module Kind = struct
+  (** Relocation with symbol/label target and addend. On RELA platforms (Linux
+      ELF), the addend is stored in the relocation entry. On REL platforms
+      (macOS Mach-O), the addend is encoded in the instruction/data. *)
+  type target_with_addend =
+    { target : Symbol.target;
+      addend : int
+    }
+
+  type t =
+    | R_AARCH64_ADR_PREL_LO21 of target_with_addend
+    | R_AARCH64_ADR_PREL_PG_HI21 of target_with_addend
+    (* ADRP targeting the GOT entry page (for @GOTPAGE on macOS) *)
+    | R_AARCH64_ADR_GOT_PAGE of target_with_addend
+    | R_AARCH64_LD64_GOT_LO12_NC of target_with_addend
+    | R_AARCH64_ADD_ABS_LO12_NC of target_with_addend
+    | R_AARCH64_LDST64_ABS_LO12_NC of target_with_addend
+    | R_AARCH64_CALL26 of target_with_addend
+    | R_AARCH64_JUMP26 of target_with_addend
+    (* Absolute 64-bit data reference (ARM64_RELOC_UNSIGNED on macOS) *)
+    | R_AARCH64_ABS64 of target_with_addend
+    (* Cross-section relative reference (SUBTRACTOR + UNSIGNED pair on macOS)
+       Used for expressions like (Label - This) where Label and This are in
+       different sections. The addend is stored in the data, and the linker will
+       compute: addend + plus_symbol - minus_symbol *)
+    | R_AARCH64_PREL32_PAIR of
+        { plus_target : Symbol.target;
+          minus_target : Symbol.target
+        }
+    (* ELF section-relative 32-bit PC-relative reference. Used on ELF for
+       cross-section references when function sections are enabled. The section
+       is the target section (e.g., Text or Function_text ".text.caml.func") and
+       addend is the offset within that section. The linker computes:
+       section_address + addend - relocation_address *)
+    | R_AARCH64_PREL32 of
+        { section : Asm_targets.Asm_section.t;
+          addend : int
+        }
+end
+
+type t =
+  { offset_from_section_beginning : int;
+    kind : Kind.t
+  }
+
+let offset_from_section_beginning (r : t) = r.offset_from_section_beginning
+
+let size (r : t) : Binary_emitter_intf.data_size =
+  match r.kind with
+  | R_AARCH64_ABS64 _ -> Binary_emitter_intf.B64
+  | R_AARCH64_ADR_PREL_LO21 _ | R_AARCH64_ADR_PREL_PG_HI21 _
+  | R_AARCH64_ADR_GOT_PAGE _ | R_AARCH64_LD64_GOT_LO12_NC _
+  | R_AARCH64_ADD_ABS_LO12_NC _ | R_AARCH64_LDST64_ABS_LO12_NC _
+  | R_AARCH64_CALL26 _ | R_AARCH64_JUMP26 _ | R_AARCH64_PREL32_PAIR _
+  | R_AARCH64_PREL32 _ ->
+    Binary_emitter_intf.B32
+
+let primary_target (r : t) : Symbol.target =
+  match r.kind with
+  | R_AARCH64_ADR_PREL_LO21 { target; _ }
+  | R_AARCH64_ADR_PREL_PG_HI21 { target; _ }
+  | R_AARCH64_ADR_GOT_PAGE { target; _ }
+  | R_AARCH64_LD64_GOT_LO12_NC { target; _ }
+  | R_AARCH64_ADD_ABS_LO12_NC { target; _ }
+  | R_AARCH64_LDST64_ABS_LO12_NC { target; _ }
+  | R_AARCH64_CALL26 { target; _ }
+  | R_AARCH64_JUMP26 { target; _ }
+  | R_AARCH64_ABS64 { target; _ } ->
+    target
+  | R_AARCH64_PREL32_PAIR { plus_target; _ } -> plus_target
+  | R_AARCH64_PREL32 { section; _ } ->
+    (* Section names are treated as global symbols. Use create_without_encoding
+       since section names from Function_text are already encoded. *)
+    let section_name = Asm_targets.Asm_section.to_string section in
+    Symbol
+      (Asm_targets.Asm_symbol.create_without_encoding ~visibility:Global
+         section_name)
+
+let all_targets (r : t) : Symbol.target list =
+  match r.kind with
+  | R_AARCH64_ADR_PREL_LO21 { target; _ }
+  | R_AARCH64_ADR_PREL_PG_HI21 { target; _ }
+  | R_AARCH64_ADR_GOT_PAGE { target; _ }
+  | R_AARCH64_LD64_GOT_LO12_NC { target; _ }
+  | R_AARCH64_ADD_ABS_LO12_NC { target; _ }
+  | R_AARCH64_LDST64_ABS_LO12_NC { target; _ }
+  | R_AARCH64_CALL26 { target; _ }
+  | R_AARCH64_JUMP26 { target; _ }
+  | R_AARCH64_ABS64 { target; _ } ->
+    [target]
+  | R_AARCH64_PREL32_PAIR { plus_target; minus_target } ->
+    [plus_target; minus_target]
+  | R_AARCH64_PREL32 { section; _ } ->
+    let section_name = Asm_targets.Asm_section.to_string section in
+    [ Symbol
+        (Asm_targets.Asm_symbol.create_without_encoding ~visibility:Global
+           section_name) ]
+
+let all_targets_with_addends (r : t) : (Symbol.target * int) list =
+  match r.kind with
+  | R_AARCH64_ADR_PREL_LO21 { target; addend }
+  | R_AARCH64_ADR_PREL_PG_HI21 { target; addend }
+  | R_AARCH64_ADR_GOT_PAGE { target; addend }
+  | R_AARCH64_LD64_GOT_LO12_NC { target; addend }
+  | R_AARCH64_ADD_ABS_LO12_NC { target; addend }
+  | R_AARCH64_LDST64_ABS_LO12_NC { target; addend }
+  | R_AARCH64_CALL26 { target; addend }
+  | R_AARCH64_JUMP26 { target; addend }
+  | R_AARCH64_ABS64 { target; addend } ->
+    [target, addend]
+  | R_AARCH64_PREL32_PAIR { plus_target; minus_target } ->
+    [plus_target, 0; minus_target, 0]
+  | R_AARCH64_PREL32 { section; addend } ->
+    let section_name = Asm_targets.Asm_section.to_string section in
+    [ ( Symbol
+          (Asm_targets.Asm_symbol.create_without_encoding ~visibility:Global
+             section_name),
+        addend ) ]
+
+let is_got_reloc (r : t) =
+  match r.kind with
+  | R_AARCH64_ADR_GOT_PAGE _ | R_AARCH64_LD64_GOT_LO12_NC _ -> true
+  | R_AARCH64_ADR_PREL_LO21 _ | R_AARCH64_ADR_PREL_PG_HI21 _
+  | R_AARCH64_ADD_ABS_LO12_NC _ | R_AARCH64_LDST64_ABS_LO12_NC _
+  | R_AARCH64_CALL26 _ | R_AARCH64_JUMP26 _ | R_AARCH64_ABS64 _
+  | R_AARCH64_PREL32_PAIR _ | R_AARCH64_PREL32 _ ->
+    false
+
+let is_plt_reloc (r : t) =
+  match r.kind with
+  | R_AARCH64_CALL26 _ | R_AARCH64_JUMP26 _ -> true
+  | R_AARCH64_ADR_PREL_LO21 _ | R_AARCH64_ADR_PREL_PG_HI21 _
+  | R_AARCH64_ADR_GOT_PAGE _ | R_AARCH64_LD64_GOT_LO12_NC _
+  | R_AARCH64_ADD_ABS_LO12_NC _ | R_AARCH64_LDST64_ABS_LO12_NC _
+  | R_AARCH64_ABS64 _ | R_AARCH64_PREL32_PAIR _ | R_AARCH64_PREL32 _ ->
+    false
+
+let get_addend (kind : Kind.t) : int =
+  match kind with
+  | R_AARCH64_ADR_PREL_LO21 { addend; _ }
+  | R_AARCH64_ADR_PREL_PG_HI21 { addend; _ }
+  | R_AARCH64_ADR_GOT_PAGE { addend; _ }
+  | R_AARCH64_LD64_GOT_LO12_NC { addend; _ }
+  | R_AARCH64_ADD_ABS_LO12_NC { addend; _ }
+  | R_AARCH64_LDST64_ABS_LO12_NC { addend; _ }
+  | R_AARCH64_CALL26 { addend; _ }
+  | R_AARCH64_JUMP26 { addend; _ }
+  | R_AARCH64_ABS64 { addend; _ }
+  | R_AARCH64_PREL32 { addend; _ } ->
+    addend
+  | R_AARCH64_PREL32_PAIR _ -> 0
+
+(* Instruction patching helpers for JIT relocation.
+
+   These functions are defined here rather than in the *_helpers.ml files (e.g.,
+   adr_helpers.ml, branch_helpers.ml) to avoid a dependency cycle. The helpers
+   depend on Section_state, which depends on Relocation, so Relocation cannot
+   depend on the helpers. These are pure bit-manipulation functions with no
+   state dependencies. *)
+
+let int64_of_int32_unsigned (x : int32) : int64 =
+  Int64.logand (Int64.of_int32 x) 0xFFFFFFFFL
+
+let patch_adr_offset (insn : int32) (offset : int64) : int64 =
+  let imm21 = Int64.to_int offset in
+  let immlo = imm21 land 0b11 in
+  let immhi = (imm21 lsr 2) land 0x7ffff in
+  let open Int32 in
+  let insn = logand insn (lognot 0x60ffffe0l) in
+  let insn = logor insn (shift_left (of_int immlo) 29) in
+  let insn = logor insn (shift_left (of_int immhi) 5) in
+  int64_of_int32_unsigned insn
+
+let patch_adrp_offset (insn : int32) (page_offset : int64) : int64 =
+  let page_diff = Int64.shift_right page_offset 12 in
+  let imm21 = Int64.to_int page_diff in
+  let immlo = imm21 land 0b11 in
+  let immhi = (imm21 lsr 2) land 0x7ffff in
+  let open Int32 in
+  let insn = logand insn (lognot 0x60ffffe0l) in
+  let insn = logor insn (shift_left (of_int immlo) 29) in
+  let insn = logor insn (shift_left (of_int immhi) 5) in
+  int64_of_int32_unsigned insn
+
+let patch_add_imm12 (insn : int32) (offset12 : int64) : int64 =
+  let imm = Int64.to_int offset12 in
+  let open Int32 in
+  let insn = logand insn (lognot 0x003ffc00l) in
+  let insn = logor insn (shift_left (of_int imm) 10) in
+  int64_of_int32_unsigned insn
+
+let patch_ldr_imm12 (insn : int32) (offset12 : int64) ~(scale : int) : int64 =
+  let open Int32 in
+  let existing_scaled = to_int (logand (shift_right_logical insn 10) 0xfffl) in
+  let new_scaled = Int64.to_int offset12 / scale in
+  let combined_scaled = existing_scaled + new_scaled in
+  if combined_scaled > 0xfff
+  then
+    Misc.fatal_errorf
+      "patch_ldr_imm12: combined offset 0x%x exceeds 12-bit limit (existing \
+       scaled=%d, new scaled=%d)"
+      combined_scaled existing_scaled new_scaled;
+  let insn = logand insn (lognot 0x003ffc00l) in
+  let insn = logor insn (shift_left (of_int combined_scaled) 10) in
+  int64_of_int32_unsigned insn
+
+let patch_branch26 (insn : int32) (offset : int64) : int64 =
+  let imm26 = Int64.to_int offset / 4 in
+  let open Int32 in
+  let insn = logand insn (lognot 0x03ffffffl) in
+  let insn = logor insn (of_int (imm26 land 0x03ffffff)) in
+  int64_of_int32_unsigned insn
+
+let target_to_string (target : Symbol.target) : string =
+  match target with
+  | Label lbl -> Asm_targets.Asm_label.encode lbl
+  | Symbol sym -> Asm_targets.Asm_symbol.encode sym
+
+let compute_value (r : t) ~target_addr ~place_address ~read_instruction
+    ~lookup_target =
+  match r.kind with
+  | R_AARCH64_ADR_PREL_LO21 _ ->
+    let offset = Int64.sub target_addr place_address in
+    let insn = read_instruction () in
+    Ok (patch_adr_offset insn offset)
+  | R_AARCH64_ADR_PREL_PG_HI21 _ | R_AARCH64_ADR_GOT_PAGE _ ->
+    let page_mask = Int64.lognot 0xFFF_L in
+    let target_page = Int64.logand target_addr page_mask in
+    let place_page = Int64.logand place_address page_mask in
+    let page_offset = Int64.sub target_page place_page in
+    let insn = read_instruction () in
+    Ok (patch_adrp_offset insn page_offset)
+  | R_AARCH64_ADD_ABS_LO12_NC _ ->
+    let low12 = Int64.logand target_addr 0xFFF_L in
+    let insn = read_instruction () in
+    Ok (patch_add_imm12 insn low12)
+  | R_AARCH64_LDST64_ABS_LO12_NC _ | R_AARCH64_LD64_GOT_LO12_NC _ ->
+    let low12 = Int64.logand target_addr 0xFFF_L in
+    let insn = read_instruction () in
+    Ok (patch_ldr_imm12 insn low12 ~scale:8)
+  | R_AARCH64_CALL26 _ | R_AARCH64_JUMP26 _ ->
+    let offset = Int64.sub target_addr place_address in
+    let insn = read_instruction () in
+    Ok (patch_branch26 insn offset)
+  | R_AARCH64_ABS64 _ -> Ok target_addr
+  | R_AARCH64_PREL32_PAIR { plus_target = _; minus_target } -> (
+    match lookup_target minus_target with
+    | None ->
+      Error
+        (Printf.sprintf "Minus target not found: %s"
+           (target_to_string minus_target))
+    | Some minus_addr -> Ok (Int64.sub target_addr minus_addr))
+  | R_AARCH64_PREL32 _ -> Ok (Int64.sub target_addr place_address)

--- a/backend/arm64/binary_emitter/relocation.mli
+++ b/backend/arm64/binary_emitter/relocation.mli
@@ -1,0 +1,99 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+module Kind : sig
+  (** Relocation with symbol/label target and addend. On RELA platforms (Linux
+      ELF), the addend is stored in the relocation entry. On REL platforms
+      (macOS Mach-O), the addend is encoded in the instruction/data. *)
+  type target_with_addend =
+    { target : Arm64_ast.Ast.Symbol.target;
+      addend : int
+    }
+
+  type t =
+    | R_AARCH64_ADR_PREL_LO21 of target_with_addend
+    | R_AARCH64_ADR_PREL_PG_HI21 of target_with_addend
+    | R_AARCH64_ADR_GOT_PAGE of target_with_addend
+    | R_AARCH64_LD64_GOT_LO12_NC of target_with_addend
+    | R_AARCH64_ADD_ABS_LO12_NC of target_with_addend
+    | R_AARCH64_LDST64_ABS_LO12_NC of target_with_addend
+    | R_AARCH64_CALL26 of target_with_addend
+    | R_AARCH64_JUMP26 of target_with_addend
+    | R_AARCH64_ABS64 of target_with_addend
+    (* Cross-section relative reference (SUBTRACTOR + UNSIGNED pair on macOS)
+       Used for expressions like (Label - This) where Label and This are in
+       different sections. The addend is stored in the data, and the linker will
+       compute: addend + plus_symbol - minus_symbol *)
+    | R_AARCH64_PREL32_PAIR of
+        { plus_target : Arm64_ast.Ast.Symbol.target;
+          minus_target : Arm64_ast.Ast.Symbol.target
+        }
+    (* ELF section-relative 32-bit PC-relative reference. Used on ELF for
+       cross-section references when function sections are enabled. The section
+       is the target section (e.g., Text or Function_text ".text.caml.func") and
+       addend is the offset within that section. The linker computes:
+       section_address + addend - relocation_address *)
+    | R_AARCH64_PREL32 of
+        { section : Asm_targets.Asm_section.t;
+          addend : int
+        }
+end
+
+type t =
+  { offset_from_section_beginning : int;
+    kind : Kind.t
+  }
+
+val offset_from_section_beginning : t -> int
+
+val size : t -> Binary_emitter_intf.data_size
+
+val primary_target : t -> Arm64_ast.Ast.Symbol.target
+
+val all_targets : t -> Arm64_ast.Ast.Symbol.target list
+
+val all_targets_with_addends : t -> (Arm64_ast.Ast.Symbol.target * int) list
+
+val is_got_reloc : t -> bool
+
+val is_plt_reloc : t -> bool
+
+val get_addend : Kind.t -> int
+
+(** Convert a target to its string representation for use as a lookup key or in
+    error messages. *)
+val target_to_string : Arm64_ast.Ast.Symbol.target -> string
+
+val compute_value :
+  t ->
+  target_addr:int64 ->
+  place_address:int64 ->
+  read_instruction:(unit -> int32) ->
+  lookup_target:(Arm64_ast.Ast.Symbol.target -> int64 option) ->
+  (int64, string) result

--- a/backend/arm64/binary_emitter/section_state.ml
+++ b/backend/arm64/binary_emitter/section_state.ml
@@ -1,0 +1,209 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+module Asm_label = Asm_targets.Asm_label
+module Asm_section = Asm_targets.Asm_section
+module Asm_symbol = Asm_targets.Asm_symbol
+module Symbol = Arm64_ast.Ast.Symbol
+
+type patch_size =
+  | P8
+  | P16
+  | P32
+  | P64
+
+type t =
+  { buffer : Buffer.t;
+    mutable offset_in_bytes : int;
+    symbol_offset_tbl : int Asm_symbol.Tbl.t;
+    label_offset_tbl : int Asm_label.Tbl.t;
+    (* Tracks symbols that are explicitly global (via Global/Weak directives).
+       These get symbol table entries in ELF. File-scope symbols defined only
+       via New_label are not in this set. *)
+    global_symbols : Asm_symbol.Set.t ref;
+    mutable relocations : Relocation.t list;
+    mutable patches : (int * patch_size * int64) list
+  }
+
+let create () =
+  { buffer = Buffer.create 1024;
+    offset_in_bytes = 0;
+    symbol_offset_tbl = Asm_symbol.Tbl.create 16;
+    label_offset_tbl = Asm_label.Tbl.create 16;
+    global_symbols = ref Asm_symbol.Set.empty;
+    relocations = [];
+    patches = []
+  }
+
+let buffer t = t.buffer
+
+let offset_in_bytes t = t.offset_in_bytes
+
+let set_offset_in_bytes t offset = t.offset_in_bytes <- offset
+
+let add_relocation_at_current_offset t ~reloc_kind =
+  t.relocations
+    <- { Relocation.offset_from_section_beginning = t.offset_in_bytes;
+         kind = reloc_kind
+       }
+       :: t.relocations
+
+let add_relocation t (reloc : Relocation.t) =
+  t.relocations <- reloc :: t.relocations
+
+let define_symbol t sym =
+  Asm_symbol.Tbl.replace t.symbol_offset_tbl sym t.offset_in_bytes
+
+let define_label t lbl =
+  Asm_label.Tbl.replace t.label_offset_tbl lbl t.offset_in_bytes
+
+(* Mark a symbol as global. Called for Global and Weak directives. *)
+let mark_global t sym =
+  t.global_symbols := Asm_symbol.Set.add sym !(t.global_symbols)
+
+(* Check if a symbol is explicitly global (has Global or Weak directive) *)
+let is_global t sym = Asm_symbol.Set.mem sym !(t.global_symbols)
+
+let find_symbol_offset_in_bytes t sym =
+  Asm_symbol.Tbl.find_opt t.symbol_offset_tbl sym
+
+let find_label_offset_in_bytes t lbl =
+  Asm_label.Tbl.find_opt t.label_offset_tbl lbl
+
+(* Find a global symbol at the exact offset, if one exists. When multiple global
+   symbols are at the same offset, prefer the one that sorts later
+   alphabetically - this matches the assembler's behavior of using the
+   last-defined symbol. *)
+let find_global_symbol_at t offset =
+  let result = ref None in
+  Asm_symbol.Tbl.iter
+    (fun sym sym_offset ->
+      if sym_offset = offset && is_global t sym
+      then
+        match !result with
+        | None -> result := Some (sym, offset)
+        | Some (prev_sym, _) ->
+          (* Prefer alphabetically later symbol to match assembler behavior *)
+          if Asm_symbol.compare sym prev_sym > 0
+          then result := Some (sym, offset))
+    t.symbol_offset_tbl;
+  !result
+
+(* Find the nearest global symbol strictly before a given offset. Returns
+   (symbol, symbol_offset) or None.
+
+   NOTE: This is a somewhat surprising design choice. For cross-section
+   relocations (e.g., frame table entries in DATA referencing labels in TEXT),
+   we could create local symbols at exact positions and use addend=0. However,
+   the system assembler instead uses existing global symbols (like
+   _camlFoo__frametable and _camlFoo__fib_code) and computes a non-zero addend.
+   We match this behavior to produce byte-identical output for testing purposes.
+   Both approaches are correct for linking - the linker computes the same final
+   value either way.
+
+   We use strict < rather than <= because the assembler doesn't use symbols that
+   are at the exact target offset (e.g., _code_end at a return address).
+
+   When multiple global symbols are at the same offset, prefer the one that
+   sorts later alphabetically - this matches the assembler's behavior of using
+   the last-defined symbol. *)
+let find_nearest_symbol_before t offset =
+  let best = ref None in
+  Asm_symbol.Tbl.iter
+    (fun sym sym_offset ->
+      if sym_offset < offset && is_global t sym
+      then
+        match !best with
+        | None -> best := Some (sym, sym_offset)
+        | Some (_, best_offset) when sym_offset > best_offset ->
+          best := Some (sym, sym_offset)
+        | Some (prev_sym, best_offset) when sym_offset = best_offset ->
+          (* Same offset - prefer alphabetically later symbol *)
+          if Asm_symbol.compare sym prev_sym > 0
+          then best := Some (sym, sym_offset)
+        | Some _ -> ())
+    t.symbol_offset_tbl;
+  !best
+
+(* Find a global symbol at the exact offset if one exists, otherwise find the
+   nearest global symbol before the offset. This is used to match assembler
+   behavior for local label references on macOS: - If a label is co-located with
+   a global symbol (like function entry points), use that symbol directly with
+   addend=0 - Otherwise, find the nearest global symbol before and compute the
+   addend *)
+let find_global_symbol_at_or_before t offset =
+  match find_global_symbol_at t offset with
+  | Some result -> Some result
+  | None -> find_nearest_symbol_before t offset
+
+(* Look up a target (symbol or label) by its typed value *)
+let find_target_offset_in_bytes t (target : Symbol.target) =
+  match target with
+  | Symbol sym -> find_symbol_offset_in_bytes t sym
+  | Label lbl -> find_label_offset_in_bytes t lbl
+
+let relocations t = List.rev t.relocations
+
+let iter_symbols t ~f = Asm_symbol.Tbl.iter f t.symbol_offset_tbl
+
+let iter_labels t ~f = Asm_label.Tbl.iter f t.label_offset_tbl
+
+let add_patch t ~offset ~size ~data =
+  t.patches <- (offset, size, data) :: t.patches
+
+let contents_mut t =
+  let buf = Buffer.to_bytes t.buffer in
+  let set_int8 pos v =
+    Bytes.set buf pos (Char.chr (Int64.to_int v land 0xFF))
+  in
+  List.iter
+    (fun (pos, size, v) ->
+      match size with
+      | P8 -> set_int8 pos v
+      | P16 ->
+        set_int8 pos v;
+        set_int8 (pos + 1) (Int64.shift_right_logical v 8)
+      | P32 ->
+        set_int8 pos v;
+        set_int8 (pos + 1) (Int64.shift_right_logical v 8);
+        set_int8 (pos + 2) (Int64.shift_right_logical v 16);
+        set_int8 (pos + 3) (Int64.shift_right_logical v 24)
+      | P64 ->
+        set_int8 pos v;
+        set_int8 (pos + 1) (Int64.shift_right_logical v 8);
+        set_int8 (pos + 2) (Int64.shift_right_logical v 16);
+        set_int8 (pos + 3) (Int64.shift_right_logical v 24);
+        set_int8 (pos + 4) (Int64.shift_right_logical v 32);
+        set_int8 (pos + 5) (Int64.shift_right_logical v 40);
+        set_int8 (pos + 6) (Int64.shift_right_logical v 48);
+        set_int8 (pos + 7) (Int64.shift_right_logical v 56))
+    t.patches;
+  buf
+
+let contents t = Bytes.to_string (contents_mut t)

--- a/backend/arm64/binary_emitter/section_state.mli
+++ b/backend/arm64/binary_emitter/section_state.mli
@@ -1,0 +1,101 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+module Asm_label = Asm_targets.Asm_label
+module Asm_section = Asm_targets.Asm_section
+module Asm_symbol = Asm_targets.Asm_symbol
+module Symbol = Arm64_ast.Ast.Symbol
+
+type patch_size =
+  | P8
+  | P16
+  | P32
+  | P64
+
+type t
+
+val create : unit -> t
+
+val buffer : t -> Buffer.t
+
+val offset_in_bytes : t -> int
+
+val set_offset_in_bytes : t -> int -> unit
+
+val add_relocation_at_current_offset : t -> reloc_kind:Relocation.Kind.t -> unit
+
+val add_relocation : t -> Relocation.t -> unit
+
+(** Define a symbol at the current offset. *)
+val define_symbol : t -> Asm_symbol.t -> unit
+
+(** Define a label at the current offset. *)
+val define_label : t -> Asm_label.t -> unit
+
+(** Mark a symbol as global (called for Global and Weak directives). Global
+    symbols get symbol table entries in ELF. *)
+val mark_global : t -> Asm_symbol.t -> unit
+
+(** Check if a symbol is explicitly global (has Global or Weak directive).
+    File-scope symbols defined only via New_label return false. *)
+val is_global : t -> Asm_symbol.t -> bool
+
+(** Find the offset of a symbol. *)
+val find_symbol_offset_in_bytes : t -> Asm_symbol.t -> int option
+
+(** Find the offset of a label. *)
+val find_label_offset_in_bytes : t -> Asm_label.t -> int option
+
+(** Find a global symbol at the exact offset, if one exists. *)
+val find_global_symbol_at : t -> int -> (Asm_symbol.t * int) option
+
+(** Find the nearest global symbol strictly before a given offset. Returns the
+    symbol and its offset. *)
+val find_nearest_symbol_before : t -> int -> (Asm_symbol.t * int) option
+
+(** Find a global symbol at the exact offset if one exists, otherwise find the
+    nearest global symbol before the offset. *)
+val find_global_symbol_at_or_before : t -> int -> (Asm_symbol.t * int) option
+
+(** Look up a target (symbol or label). *)
+val find_target_offset_in_bytes : t -> Symbol.target -> int option
+
+val relocations : t -> Relocation.t list
+
+(** Iterate over all defined symbols with their offsets. *)
+val iter_symbols : t -> f:(Asm_symbol.t -> int -> unit) -> unit
+
+(** Iterate over all defined labels with their offsets. *)
+val iter_labels : t -> f:(Asm_label.t -> int -> unit) -> unit
+
+val add_patch : t -> offset:int -> size:patch_size -> data:int64 -> unit
+
+val contents_mut : t -> bytes
+
+val contents : t -> string

--- a/backend/arm64/binary_emitter/shift_immh_immb_helpers.ml
+++ b/backend/arm64/binary_emitter/shift_immh_immb_helpers.ml
@@ -1,0 +1,73 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+(* Helper to compute immh and immb for SHL instruction *)
+(* For SHL: shift = (immh:immb) - element_width *)
+(* So (immh:immb) = shift + element_width *)
+let shl_immh_immb (type v s) (vec : (v, s) Neon_reg_name.Vector.t) shift =
+  let esize, immh_base =
+    match vec with
+    | V8B | V16B -> 8, 0b0001
+    | V4H | V8H -> 16, 0b0010
+    | V2S | V4S -> 32, 0b0100
+    | V1D | V2D -> 64, 0b1000
+  in
+  let immh_immb = shift + esize in
+  let immh = (immh_immb lsr 3) lor immh_base in
+  let immb = immh_immb land 0b111 in
+  immh, immb
+
+(* Helper to compute immh and immb for SSHR/USHR instructions *)
+(* For SSHR/USHR: shift = element_width*2 - (immh:immb) *)
+(* So (immh:immb) = element_width*2 - shift *)
+let shr_immh_immb (type v s) (vec : (v, s) Neon_reg_name.Vector.t) shift =
+  let esize =
+    match vec with
+    | V8B | V16B -> 8
+    | V4H | V8H -> 16
+    | V2S | V4S -> 32
+    | V1D | V2D -> 64
+  in
+  let immh_immb = (esize * 2) - shift in
+  let immh = immh_immb lsr 3 in
+  let immb = immh_immb land 0b111 in
+  immh, immb
+
+(* Helper to compute immh for SXTL/UXTL (SSHLL/USHLL with shift=0) *)
+(* immh encodes source element size: 0001=8b, 0010=16b, 0100=32b *)
+(* Destination has 2x wider elements than source *)
+let sxtl_immh (type v s) (vec : (v, s) Neon_reg_name.Vector.t) =
+  match vec with
+  | V8H -> 0b0001 (* 16-bit dest -> 8-bit source *)
+  | V4S -> 0b0010 (* 32-bit dest -> 16-bit source *)
+  | V2D -> 0b0100 (* 64-bit dest -> 32-bit source *)
+  | V8B | V16B | V4H | V2S | V1D ->
+    Misc.fatal_error "SXTL/UXTL requires H, S, or D destination elements"

--- a/backend/arm64/binary_emitter/shift_immh_immb_helpers.mli
+++ b/backend/arm64/binary_emitter/shift_immh_immb_helpers.mli
@@ -1,0 +1,38 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+val shl_immh_immb : ('v, 's) Neon_reg_name.Vector.t -> int -> int * int
+
+val shr_immh_immb : ('v, 's) Neon_reg_name.Vector.t -> int -> int * int
+
+(** Compute immh for SXTL/UXTL instructions. Only valid for V8H, V4S, V2D
+    destination vector types. *)
+val sxtl_immh : (_, _) Neon_reg_name.Vector.t -> int

--- a/backend/arm64/binary_emitter/simd_helpers.ml
+++ b/backend/arm64/binary_emitter/simd_helpers.ml
@@ -1,0 +1,255 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+(* Helper to extract Q (vector width) and size (element size) from vector
+   type *)
+let vector_q_size (type v s) (vec : (v, s) Neon_reg_name.Vector.t) : int * int =
+  match vec with
+  | V8B -> 0, 0b00 (* 64-bit, B elements *)
+  | V16B -> 1, 0b00 (* 128-bit, B elements *)
+  | V4H -> 0, 0b01 (* 64-bit, H elements *)
+  | V8H -> 1, 0b01 (* 128-bit, H elements *)
+  | V2S -> 0, 0b10 (* 64-bit, S elements *)
+  | V4S -> 1, 0b10 (* 128-bit, S elements *)
+  | V1D -> 0, 0b11 (* 64-bit, D elements *)
+  | V2D -> 1, 0b11 (* 128-bit, D elements *)
+
+(* Helper for FP vector operations - returns Q and the FP precision bit (sz) *)
+let vector_q_fp_sz (type v s) (vec : (v, s) Neon_reg_name.Vector.t) : int * int
+    =
+  match vec with
+  | V2S -> 0, 0 (* 64-bit, single-precision *)
+  | V4S -> 1, 0 (* 128-bit, single-precision *)
+  | V2D -> 1, 1 (* 128-bit, double-precision *)
+  | V8B | V16B | V4H | V8H | V1D ->
+    Misc.fatal_error "FP vector operations only support S and D element types"
+
+(* Helper to compute imm5 for SIMD copy instructions (DUP, INS, SMOV, UMOV).
+   imm5 encodes element size and lane index:
+
+   - B: xxxx1 (index in bits 4:1)
+
+   - H: xxx10 (index in bits 4:2)
+
+   - S: xx100 (index in bits 4:3)
+
+   - D: x1000 (index in bit 4) *)
+let simd_copy_imm5 (type v s) (vec : (v, s) Neon_reg_name.Vector.t) lane_idx =
+  match vec with
+  | V8B | V16B -> (lane_idx lsl 1) lor 0b00001
+  | V4H | V8H -> (lane_idx lsl 2) lor 0b00010
+  | V2S | V4S -> (lane_idx lsl 3) lor 0b00100
+  | V1D | V2D -> (lane_idx lsl 4) lor 0b01000
+
+(* Helper to compute imm4 for INS (element) source index. imm4 encodes the
+   source element index in the same size-dependent way as imm5, but with one
+   fewer bit (4 bits instead of 5):
+
+   - B: xxxx (index in bits 3:0)
+
+   - H: xxx0 (index in bits 3:1)
+
+   - S: xx00 (index in bits 3:2)
+
+   - D: x000 (index in bit 3) *)
+let simd_ins_element_imm4 (type v s) (vec : (v, s) Neon_reg_name.Vector.t)
+    lane_idx =
+  match vec with
+  | V8B | V16B -> lane_idx
+  | V4H | V8H -> lane_idx lsl 1
+  | V2S | V4S -> lane_idx lsl 2
+  | V1D | V2D -> lane_idx lsl 3
+
+(* Advanced SIMD copy - C4.1.95.17 *)
+(* Encoding: 0 Q op 01110 00 imm5 0 imm4 1 Rn Rd *)
+let encode_simd_copy ~q ~op ~imm5 ~imm4 ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  (* bit 31 = 0, Q at bit 30, op at bit 29 *)
+  let result = logor result (shift_left (of_int q) 30) in
+  let result = logor result (shift_left (of_int op) 29) in
+  let result = logor result (shift_left (of_int 0b01110) 24) in
+  (* bits 23:22 = 00 *)
+  let result = logor result (shift_left (of_int imm5) 16) in
+  (* bit 15 = 0 *)
+  let result = logor result (shift_left (of_int imm4) 11) in
+  let result = logor result (shift_left (of_int 0b1) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rd) in
+  result
+
+(* Advanced SIMD extract - C4.1.95.16 *)
+(* Encoding: 0 Q 101110 op2 0 Rm 0 imm4 0 Rn Rd *)
+let encode_simd_extract ~q ~rm ~imm4 ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int q) 30) in
+  let result = logor result (shift_left (of_int 0b101110) 24) in
+  (* op2=00, bit 21=0 *)
+  let result = logor result (shift_left (of_int rm) 16) in
+  (* bit 15=0 *)
+  let result = logor result (shift_left (of_int imm4) 11) in
+  (* bit 10=0 *)
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rd) in
+  result
+
+(* Advanced SIMD modified immediate - C4.1.95.19 *)
+(* Encoding: 0 Q op 0111100000 a b c cmode 01 d e f g h Rd *)
+(* For MOVI: op=0, cmode determines the variant *)
+let encode_simd_modified_imm ~q ~op ~abc ~cmode ~defgh ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int q) 30) in
+  let result = logor result (shift_left (of_int op) 29) in
+  let result = logor result (shift_left (of_int 0b0111100000) 19) in
+  let result = logor result (shift_left (of_int abc) 16) in
+  let result = logor result (shift_left (of_int cmode) 12) in
+  let result = logor result (shift_left (of_int 0b01) 10) in
+  let result = logor result (shift_left (of_int defgh) 5) in
+  let result = logor result (of_int rd) in
+  result
+
+(* Advanced SIMD across lanes - C4.1.95.22 *)
+(* Encoding: 0 Q U 01110 size 11000 opcode 10 Rn Rd *)
+let encode_simd_across_lanes ~q ~u ~size ~opcode ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int q) 30) in
+  let result = logor result (shift_left (of_int u) 29) in
+  let result = logor result (shift_left (of_int 0b01110) 24) in
+  let result = logor result (shift_left (of_int size) 22) in
+  let result = logor result (shift_left (of_int 0b11000) 17) in
+  let result = logor result (shift_left (of_int opcode) 12) in
+  let result = logor result (shift_left (of_int 0b10) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rd) in
+  result
+
+(* Advanced SIMD permute *)
+(* Encoding: 0 Q 0 01110 size 0 Rm 0 opcode 10 Rn Rd *)
+let encode_simd_permute ~q ~size ~rm ~opcode ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  (* bit 31 = 0 (implicit), Q at bit 30, bit 29 = 0 *)
+  let result = logor result (shift_left (of_int q) 30) in
+  let result = logor result (shift_left (of_int 0b01110) 24) in
+  let result = logor result (shift_left (of_int size) 22) in
+  (* bit 21 = 0 *)
+  let result = logor result (shift_left (of_int rm) 16) in
+  (* bit 15 = 0 *)
+  let result = logor result (shift_left (of_int opcode) 12) in
+  let result = logor result (shift_left (of_int 0b10) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rd) in
+  result
+
+(* Helper for widening operations - returns source element size from dest type *)
+(* For SMULL/UMULL: dest has 2x wider elements than source *)
+let vector_widening_size (type v s) (vec : (v, s) Neon_reg_name.Vector.t) : int
+    =
+  match vec with
+  | V8H -> 0b00 (* 16-bit dest -> 8-bit source *)
+  | V4S -> 0b01 (* 32-bit dest -> 16-bit source *)
+  | V2D -> 0b10 (* 64-bit dest -> 32-bit source *)
+  | V8B | V16B | V4H | V2S | V1D ->
+    Misc.fatal_error
+      "Widening operations require H, S, or D destination elements"
+
+(* Advanced SIMD two-register miscellaneous - C4.1.95.21 *)
+let encode_simd_two_reg_misc ~q ~u ~size ~opcode ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  let result = logor result (shift_left (of_int q) 30) in
+  let result = logor result (shift_left (of_int u) 29) in
+  let result = logor result (shift_left (of_int 0b01110) 24) in
+  let result = logor result (shift_left (of_int size) 22) in
+  let result = logor result (shift_left (of_int 0b10000) 17) in
+  let result = logor result (shift_left (of_int opcode) 12) in
+  let result = logor result (shift_left (of_int 0b10) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rd) in
+  result
+
+(* Advanced SIMD three same - C4.1.95.24 *)
+(* Encoding: 0 Q U 01110 size 1 Rm opcode 1 Rn Rd *)
+let encode_simd_three_same ~q ~u ~size ~rm ~opcode ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  (* Bit 31 is always 0, Q at bit 30, U at bit 29 *)
+  let result = logor result (shift_left (of_int q) 30) in
+  let result = logor result (shift_left (of_int u) 29) in
+  let result = logor result (shift_left (of_int 0b01110) 24) in
+  let result = logor result (shift_left (of_int size) 22) in
+  let result = logor result (shift_left (of_int 0b1) 21) in
+  let result = logor result (shift_left (of_int rm) 16) in
+  let result = logor result (shift_left (of_int opcode) 11) in
+  let result = logor result (shift_left (of_int 0b1) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rd) in
+  result
+
+(* Advanced SIMD three different - C4.1.95.23 *)
+(* Encoding: 0 Q U 01110 size 1 Rm opcode 00 Rn Rd *)
+let encode_simd_three_different ~q ~u ~size ~rm ~opcode ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  (* bit 31 = 0 (implicit), Q at bit 30, U at bit 29 *)
+  let result = logor result (shift_left (of_int q) 30) in
+  let result = logor result (shift_left (of_int u) 29) in
+  let result = logor result (shift_left (of_int 0b01110) 24) in
+  let result = logor result (shift_left (of_int size) 22) in
+  let result = logor result (shift_left (of_int 0b1) 21) in
+  let result = logor result (shift_left (of_int rm) 16) in
+  let result = logor result (shift_left (of_int opcode) 12) in
+  (* bits 11-10 = 00 *)
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rd) in
+  result
+
+(* Advanced SIMD shift by immediate - C4.1.95.26 *)
+(* Encoding: 0 Q U 01111 0 immh immb opcode 1 Rn Rd *)
+(* immh encodes element size: 0001=8b, 001x=16b, 01xx=32b, 1xxx=64b *)
+let encode_simd_shift_imm ~q ~u ~immh ~immb ~opcode ~rn ~rd =
+  let open Int32 in
+  let result = zero in
+  (* bit 31 = 0 (implicit), Q at bit 30, U at bit 29 *)
+  let result = logor result (shift_left (of_int q) 30) in
+  let result = logor result (shift_left (of_int u) 29) in
+  let result = logor result (shift_left (of_int 0b01111) 24) in
+  (* bit 23 = 0 *)
+  let result = logor result (shift_left (of_int immh) 19) in
+  let result = logor result (shift_left (of_int immb) 16) in
+  let result = logor result (shift_left (of_int opcode) 11) in
+  let result = logor result (shift_left (of_int 0b1) 10) in
+  let result = logor result (shift_left (of_int rn) 5) in
+  let result = logor result (of_int rd) in
+  result

--- a/backend/arm64/binary_emitter/simd_helpers.mli
+++ b/backend/arm64/binary_emitter/simd_helpers.mli
@@ -1,0 +1,90 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+open Arm64_ast.Ast
+
+val vector_q_size : ('v, 's) Neon_reg_name.Vector.t -> int * int
+
+(** Returns Q and the FP precision bit (sz) for FP vector operations. Only valid
+    for V2S, V4S, V2D vector types. *)
+val vector_q_fp_sz : (_, _) Neon_reg_name.Vector.t -> int * int
+
+val simd_copy_imm5 : ('v, 's) Neon_reg_name.Vector.t -> int -> int
+
+val simd_ins_element_imm4 : ('v, 's) Neon_reg_name.Vector.t -> int -> int
+
+val encode_simd_copy :
+  q:int -> op:int -> imm5:int -> imm4:int -> rn:int -> rd:int -> int32
+
+val encode_simd_extract :
+  q:int -> rm:int -> imm4:int -> rn:int -> rd:int -> int32
+
+val encode_simd_modified_imm :
+  q:int -> op:int -> abc:int -> cmode:int -> defgh:int -> rd:int -> int32
+
+val encode_simd_across_lanes :
+  q:int -> u:int -> size:int -> opcode:int -> rn:int -> rd:int -> int32
+
+val encode_simd_permute :
+  q:int -> size:int -> rm:int -> opcode:int -> rn:int -> rd:int -> int32
+
+val vector_widening_size : ('v, 's) Neon_reg_name.Vector.t -> int
+
+val encode_simd_two_reg_misc :
+  q:int -> u:int -> size:int -> opcode:int -> rn:int -> rd:int -> int32
+
+val encode_simd_three_same :
+  q:int ->
+  u:int ->
+  size:int ->
+  rm:int ->
+  opcode:int ->
+  rn:int ->
+  rd:int ->
+  int32
+
+val encode_simd_three_different :
+  q:int ->
+  u:int ->
+  size:int ->
+  rm:int ->
+  opcode:int ->
+  rn:int ->
+  rd:int ->
+  int32
+
+val encode_simd_shift_imm :
+  q:int ->
+  u:int ->
+  immh:int ->
+  immb:int ->
+  opcode:int ->
+  rn:int ->
+  rd:int ->
+  int32

--- a/backend/arm64/binary_emitter/yield_helpers.ml
+++ b/backend/arm64/binary_emitter/yield_helpers.ml
@@ -1,0 +1,31 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+(* YIELD encoding: 1101 0101 0000 0011 0010 0000 001 11111 = 0xD503203F *)
+let encode_yield () = Int32.of_int 0xD503203F

--- a/backend/arm64/binary_emitter/yield_helpers.mli
+++ b/backend/arm64/binary_emitter/yield_helpers.mli
@@ -1,0 +1,30 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(* CR mshinwell: This file has not yet been code reviewed *)
+
+val encode_yield : unit -> int32

--- a/backend/arm64/binary_emitter_helpers.ml
+++ b/backend/arm64/binary_emitter_helpers.ml
@@ -1,0 +1,194 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(** CR mshinwell: Adapt the binary sections saving to x86 in due course. *)
+
+module BE = Arm64_binary_emitter.Binary_emitter
+
+(* Binary emitter for JIT mode *)
+let jit_emitter : BE.t option ref = ref None
+
+let should_use_binary_emitter () =
+  Option.is_some (BE.For_jit.Internal_assembler.get ())
+  || !Oxcaml_flags.verify_binary_emitter
+
+let should_save_binary_sections () = !Oxcaml_flags.verify_binary_emitter
+
+let begin_emission () =
+  if should_use_binary_emitter ()
+  then (
+    (* When saving binary sections (for verification), emit relocations for all
+       symbol references to match assembler behavior *)
+    if should_save_binary_sections ()
+    then BE.emit_relocs_for_all_symbol_refs := true;
+    let emitter = BE.create () in
+    jit_emitter := Some emitter;
+    Arm64_ast.Ast.DSL.Acc.set_emit_instruction
+      ~emit_instruction:(BE.add_instruction emitter);
+    fun d -> BE.add_directive emitter d)
+  else fun _ -> ()
+
+(* Aggregate all .text.* sections into a single .text section for JIT *)
+let aggregate_text_sections sections =
+  let is_text_section sec_name =
+    let len = String.length sec_name in
+    len >= 5 && String.equal (String.sub sec_name 0 5) ".text"
+  in
+  let text_sections, other_sections =
+    List.partition (fun (sec_name, _) -> is_text_section sec_name) sections
+  in
+  match text_sections with
+  | [] -> sections
+  | [(sec_name, _)] when String.equal sec_name ".text" -> sections
+  | _ ->
+    (* Aggregate all text sections into one .text section. Sort by name for
+       deterministic ordering. *)
+    let sorted_text =
+      List.sort (fun (a, _) (b, _) -> String.compare a b) text_sections
+    in
+    let module SS = BE.Section_state in
+    let aggregated = SS.create () in
+    List.iter
+      (fun (_name, state) ->
+        let content = SS.contents state in
+        let base_offset = Buffer.length (SS.buffer aggregated) in
+        Buffer.add_string (SS.buffer aggregated) content;
+        (* Copy relocations with adjusted offsets *)
+        List.iter
+          (fun (reloc : Arm64_binary_emitter.Relocation.t) ->
+            let adjusted =
+              { reloc with
+                offset_from_section_beginning =
+                  reloc.offset_from_section_beginning + base_offset
+              }
+            in
+            SS.add_relocation aggregated adjusted)
+          (SS.relocations state))
+      sorted_text;
+    (".text", aggregated) :: other_sections
+
+(* Convert section table to list of (name, section) pairs *)
+let sections_to_list section_tbl =
+  let from_standard =
+    Arm64_binary_emitter.All_section_states.fold section_tbl ~init:[]
+      ~f:(fun section state acc ->
+        let name = Asm_targets.Asm_section.to_string section in
+        (name, state) :: acc)
+  in
+  let from_individual =
+    Arm64_binary_emitter.All_section_states.fold_individual section_tbl ~init:[]
+      ~f:(fun name state acc -> (name, state) :: acc)
+  in
+  from_standard @ from_individual
+
+(* Save sections to files for verification *)
+let save_sections_to_files sections section_tbl =
+  let dir = !Emitaux.output_prefix ^ ".binary-sections" in
+  (try Sys.mkdir dir 0o755 with Sys_error _ -> ());
+  List.iter
+    (fun (name, state) ->
+      (* Convert section name like ".text" to "section_text" *)
+      let safe_name =
+        if String.length name > 0 && Char.equal (String.get name 0) '.'
+        then "section_" ^ String.sub name 1 (String.length name - 1)
+        else "section_" ^ name
+      in
+      (* Save binary content *)
+      let bin_filename = Filename.concat dir (safe_name ^ ".bin") in
+      let oc = open_out_bin bin_filename in
+      output_string oc (BE.Section_state.contents state);
+      close_out oc;
+      (* Save relocations if any *)
+      let relocs = BE.Section_state.relocations state in
+      match relocs with
+      | [] -> ()
+      | _ ->
+        let reloc_filename = Filename.concat dir (safe_name ^ ".relocs") in
+        let oc = open_out reloc_filename in
+        let module R = Arm64_binary_emitter.Relocation in
+        let module ED = BE.Encode_directive in
+        List.iter
+          (fun reloc ->
+            (* For paired relocations (SUBTRACTOR + UNSIGNED), write both
+               symbols as separate lines at the same offset. On RELA platforms
+               (Linux), include addends for proper verification. Also convert
+               local/file- scope symbols to section+offset. *)
+            let offset = R.offset_from_section_beginning reloc in
+            List.iter
+              (fun (target, addend) ->
+                (* For verification output, convert local/file-scope symbols to
+                   section+offset format to match assembler behavior *)
+                let resolved_sym, resolved_addend =
+                  ED.resolve_local_label_for_elf ~all_sections:section_tbl
+                    ~target ~sym_offset:addend
+                in
+                if resolved_addend = 0
+                then Printf.fprintf oc "%d %s\n" offset resolved_sym
+                else
+                  Printf.fprintf oc "%d %s %d\n" offset resolved_sym
+                    resolved_addend)
+              (R.all_targets_with_addends reloc))
+          relocs;
+        close_out oc)
+    sections
+
+let end_emission () =
+  match !jit_emitter with
+  | None -> ()
+  | Some emitter -> (
+    (* Clear the instruction emission callback *)
+    Arm64_ast.Ast.DSL.Acc.clear_emit_instruction ();
+    jit_emitter := None;
+    (* Dump instructions if JIT debug is enabled *)
+    (match Sys.getenv_opt "OCAML_JIT_DEBUG" with
+    | Some ("true" | "1") -> BE.dump_instructions emitter
+    | _ -> ());
+    (* Get assembled sections. for_jit is true only when there's a JIT hook
+       registered (actual JIT compilation). When we're just saving binary
+       sections for verification, we're generating an object file and should use
+       for_jit:false to match ELF relocation format. *)
+    let for_jit = Option.is_some (BE.For_jit.Internal_assembler.get ()) in
+    let section_tbl = BE.emit ~for_jit emitter in
+    (* Convert to list of (name, section) pairs. Include both standard sections
+       (by Asm_section.t) and individual sections (by name string, for function
+       sections like .text.caml.<funcname>). *)
+    let sections = sections_to_list section_tbl in
+    (* For JIT, we need to aggregate all .text.* sections into a single .text
+       section because the JIT loader expects exactly one .text section. *)
+    let sections_for_jit = aggregate_text_sections sections in
+    (* Save sections to files if needed for verification or explicit saving *)
+    if should_save_binary_sections ()
+    then save_sections_to_files sections section_tbl;
+    (* Call the JIT hook if registered *)
+    match BE.For_jit.Internal_assembler.get () with
+    | None -> ()
+    | Some hook ->
+      (* The hook expects (string * assembled_section) list and returns a file
+         writer function. We ignore the file writer for JIT. Use the aggregated
+         sections where all .text.* are merged into .text. *)
+      let _file_writer = hook sections_for_jit in
+      ())

--- a/backend/arm64/binary_emitter_helpers.mli
+++ b/backend/arm64/binary_emitter_helpers.mli
@@ -1,0 +1,45 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2025 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(** Hooks for connecting the ARM64 binary emitter to the emit process. This
+    module handles JIT compilation and binary section saving for verification.
+
+    CR mshinwell: Adapt the binary sections saving to x86 in due course. *)
+
+(** Returns true if the binary emitter should be enabled for this compilation
+    (either for JIT or for saving binary sections for verification). *)
+val should_use_binary_emitter : unit -> bool
+
+(** Initialize the binary emitter if needed. Call this at the start of assembly.
+    Returns a directive emission callback that should be passed to the
+    Asm_directives initialization. *)
+val begin_emission : unit -> Asm_targets.Asm_directives.Directive.t -> unit
+
+(** Finalize the binary emitter if it was enabled. This handles section
+    aggregation, file saving for verification, and JIT hook invocation. Call
+    this at the end of assembly. *)
+val end_emission : unit -> unit

--- a/backend/binary_emitter_intf/binary_emitter_intf.ml
+++ b/backend/binary_emitter_intf/binary_emitter_intf.ml
@@ -52,13 +52,13 @@ module type Relocation = sig
   val target_symbol : t -> target
 
   (** For paired relocations (e.g., SUBTRACTOR + UNSIGNED), returns all symbols.
-      For single relocations, returns a singleton list.
-      Used for saving relocations to files for verification. *)
+      For single relocations, returns a singleton list. Used for saving
+      relocations to files for verification. *)
   val target_symbols : t -> target list
 
-  (** For paired relocations, returns all symbols with their addends.
-      On RELA platforms (Linux ELF), addends are stored in relocations.
-      On REL platforms (macOS), addends are encoded in instructions. *)
+  (** For paired relocations, returns all symbols with their addends. On RELA
+      platforms (Linux ELF), addends are stored in relocations. On REL platforms
+      (macOS), addends are encoded in instructions. *)
   val target_symbols_with_addends : t -> (target * int) list
 
   (** Is this a GOT relocation? (JIT needs to know for GOT table building) *)
@@ -71,8 +71,8 @@ module type Relocation = sig
       - [place_address]: where the relocation site is in memory
       - [lookup_target]: resolve symbol/label -> address
       - [read_instruction]: read the 32-bit instruction at the relocation site
-        (used by ARM64 to read-modify-write instruction bit fields)
-      Returns the value to write at the relocation site, or an error. *)
+        (used by ARM64 to read-modify-write instruction bit fields) Returns the
+        value to write at the relocation site, or an error. *)
   val compute_value :
     t ->
     place_address:int64 ->
@@ -108,9 +108,9 @@ module type Assembled_section = sig
   val add_patch : t -> offset:int -> size:data_size -> data:int64 -> unit
 end
 
-(** Internal assembler hook for JIT support.
-    When set, the binary emitter will call this function with assembled sections
-    instead of (or in addition to) writing to a file. *)
+(** Internal assembler hook for JIT support. When set, the binary emitter will
+    call this function with assembled sections instead of (or in addition to)
+    writing to a file. *)
 module type Internal_assembler_hook = sig
   type assembled_section
 
@@ -135,14 +135,14 @@ module type S = sig
   module Assembled_section :
     Assembled_section with type relocation = Relocation.t
 
-  (** PLT (Procedure Linkage Table) stub generation for JIT. Each PLT entry is
-      a small piece of machine code that jumps to an address. *)
+  (** PLT (Procedure Linkage Table) stub generation for JIT. Each PLT entry is a
+      small piece of machine code that jumps to an address. *)
   module Plt : sig
     (** Size in bytes of each PLT entry *)
     val entry_size : int
 
-    (** Write a PLT entry to the buffer that will jump to the given address.
-        The address is the absolute target address to jump to. *)
+    (** Write a PLT entry to the buffer that will jump to the given address. The
+        address is the absolute target address to jump to. *)
     val write_entry : Buffer.t -> int64 -> unit
   end
 

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -28,6 +28,8 @@ exception Error of error
 
 let output_channel = ref stdout
 
+let output_prefix = ref ""
+
 let emit_string s = output_string !output_channel s
 
 let emit_buffer b = Buffer.output_buffer !output_channel b

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -19,6 +19,8 @@
 
 val output_channel : out_channel ref
 
+val output_prefix : string ref
+
 val emit_string : string -> unit
 
 val emit_buffer : Buffer.t -> unit

--- a/backend/jit_backend.mli
+++ b/backend/jit_backend.mli
@@ -46,8 +46,8 @@ type packed_sections =
 type callback = packed_sections -> unit
 
 (** Register a JIT callback. When code is generated, the callback will be
-    invoked with the assembled sections packed with their emitter module.
-    This handles architecture dispatch internally. *)
+    invoked with the assembled sections packed with their emitter module. This
+    handles architecture dispatch internally. *)
 val register : callback -> unit
 
 (** Unregister the JIT callback and restore previous state. *)

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -420,7 +420,7 @@ let mk_verify_binary_emitter f =
   ( "-verify-binary-emitter",
     Arg.Unit f,
     " Verify binary emitter output matches system assembler output. Exits with \
-     error on mismatch." )
+     error on mismatch. (ARM64 only)" )
 
 let mk_gc_timings f =
   ("-dgc-timings", Arg.Unit f, "Output information about time spent in the GC")

--- a/dune
+++ b/dune
@@ -573,6 +573,7 @@
   cmmgen_state
   CSE
   dsl_helpers
+  binary_emitter_helpers
   emit
   emitaux
   fdo_info
@@ -745,7 +746,12 @@
   (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (instrumentation
   (backend bisect_ppx))
- (libraries ocamlcommon dwarf_flags asm_targets)
+ (libraries
+  ocamlcommon
+  dwarf_flags
+  asm_targets
+  arm64_ast
+  arm64_binary_emitter)
  (modules oxcaml_args oxcaml_flags))
 
 (executable
@@ -818,6 +824,7 @@
    %{dep:backend/debug/dwarf/dwarf_flags/dwarf_flags.a}
    %{dep:backend/asm_targets/asm_targets.a}
    %{dep:backend/arm64/ast/arm64_ast.a}
+   %{dep:backend/arm64/binary_emitter/arm64_binary_emitter.a}
    %{dep:backend/binary_emitter_intf/binary_emitter_intf.a}
    %{dep:backend/debug/dwarf/dwarf_low/dwarf_low.a}
    %{dep:backend/debug/dwarf/dwarf_high/dwarf_high.a}
@@ -859,6 +866,7 @@
    %{dep:backend/debug/dwarf/dwarf_flags/dwarf_flags.cma}
    %{dep:backend/asm_targets/asm_targets.cma}
    %{dep:backend/arm64/ast/arm64_ast.cma}
+   %{dep:backend/arm64/binary_emitter/arm64_binary_emitter.cma}
    %{dep:backend/binary_emitter_intf/binary_emitter_intf.cma}
    %{dep:backend/debug/dwarf/dwarf_low/dwarf_low.cma}
    %{dep:backend/debug/dwarf/dwarf_high/dwarf_high.cma}
@@ -900,6 +908,7 @@
    %{dep:backend/debug/dwarf/dwarf_flags/dwarf_flags.cmxa}
    %{dep:backend/asm_targets/asm_targets.cmxa}
    %{dep:backend/arm64/ast/arm64_ast.cmxa}
+   %{dep:backend/arm64/binary_emitter/arm64_binary_emitter.cmxa}
    %{dep:backend/binary_emitter_intf/binary_emitter_intf.cmxa}
    %{dep:backend/debug/dwarf/dwarf_low/dwarf_low.cmxa}
    %{dep:backend/debug/dwarf/dwarf_high/dwarf_high.cmxa}

--- a/otherlibs/camlinternaleval/dune
+++ b/otherlibs/camlinternaleval/dune
@@ -31,9 +31,6 @@
  (name camlinternaleval)
  (modes byte native)
  (libraries jit ocamlcommon)
- ; CR mshinwell: Enable metaprogramming on arm64.  Needs the binary emitter
- (enabled_if
-  (= %{architecture} "amd64"))
  (flags
   (:standard
    -strict-sequence
@@ -50,8 +47,6 @@
   (names eval_stubs)))
 
 (install
- (enabled_if
-  (= %{architecture} "amd64"))
  (files
   (.camlinternaleval.objs/native/camlinternaleval.cmx
    as

--- a/testsuite/tests/quotation/eval/eval.compilers.reference
+++ b/testsuite/tests/quotation/eval/eval.compilers.reference
@@ -1,4 +1,4 @@
-File "eval.ml", line 58, characters 9-22:
-58 |     let[@tail_mod_cons] rec foo x = exclave_
+File "eval.ml", line 61, characters 9-22:
+61 |     let[@tail_mod_cons] rec foo x = exclave_
               ^^^^^^^^^^^^^
 Warning 53 [misplaced-attribute]: the "tail_mod_cons" attribute cannot appear in this context

--- a/testsuite/tests/quotation/eval/eval.ml
+++ b/testsuite/tests/quotation/eval/eval.ml
@@ -1,8 +1,11 @@
 (* TEST
-  flags = "-extension runtime_metaprogramming";
-  arch_amd64;
+  flags = "-extension runtime_metaprogramming -gno-upstream-dwarf -g";
   native;
 *)
+
+(* We add extra debugging flags above in case of failure, when this test
+   can be hard to debug *)
+
 
 #syntax quotations on
 

--- a/testsuite/tests/quotation/eval/no_stdlib.ml
+++ b/testsuite/tests/quotation/eval/no_stdlib.ml
@@ -1,6 +1,5 @@
 (* TEST
   flags = "-extension runtime_metaprogramming";
-  arch_amd64;
   native;
 *)
 

--- a/testsuite/tests/quotation/eval/plus.ml
+++ b/testsuite/tests/quotation/eval/plus.ml
@@ -1,6 +1,5 @@
 (* TEST
   flags = "-extension runtime_metaprogramming";
-  arch_amd64;
   native;
 *)
 

--- a/testsuite/tests/quotation/typing/inspection/labeled_args.ml
+++ b/testsuite/tests/quotation/typing/inspection/labeled_args.ml
@@ -1,7 +1,6 @@
 (* TEST
  modules = "labeled_args_types.ml util.ml";
  flags = "-extension runtime_metaprogramming";
- arch_amd64;
  native;
 *)
 

--- a/testsuite/tests/quotation/typing/inspection/labels.ml
+++ b/testsuite/tests/quotation/typing/inspection/labels.ml
@@ -1,7 +1,6 @@
 (* TEST
  modules = "labels_types.ml util.ml";
  flags = "-extension runtime_metaprogramming";
- arch_amd64;
  native;
 *)
 

--- a/testsuite/tests/quotation/typing/inspection/miscs.ml
+++ b/testsuite/tests/quotation/typing/inspection/miscs.ml
@@ -1,7 +1,6 @@
 (* TEST
  modules = "miscs_types.ml util.ml";
  flags = "-extension runtime_metaprogramming";
- arch_amd64;
  native;
 *)
 

--- a/testsuite/tests/quotation/typing/inspection/poly.ml
+++ b/testsuite/tests/quotation/typing/inspection/poly.ml
@@ -1,7 +1,6 @@
 (* TEST
  modules = "poly_types.ml util.ml";
  flags = "-extension runtime_metaprogramming";
- arch_amd64;
  native;
 *)
 


### PR DESCRIPTION
This is a "binary emitter" (machine code emitter) for arm64, including the new typed DSL, and associated refactorings.  We'll probably have to split this up for review and/or merging in due course.

This also contains changes to make the `ocaml-jit` library architecture independent, using a new binary emitter interface, also implemented by the x86 version.