### PR TITLE
Tweak constant switch optimisations to work with jumps

### DIFF
--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -1054,3 +1054,9 @@ let is_addr (m : machtype_component) =
 
 let is_exn_handler (flag : ccatch_flag) =
   match flag with Exn_handler -> true | Normal | Recursive -> false
+
+let equal_exit_label (lbl1 : exit_label) (lbl2 : exit_label) =
+  match lbl1, lbl2 with
+  | Return_lbl, Return_lbl -> true
+  | Lbl lbl1, Lbl lbl2 -> Static_label.equal lbl1 lbl2
+  | Return_lbl, Lbl _ | Lbl _, Return_lbl -> false

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -686,3 +686,5 @@ val is_int : machtype_component -> bool
 val is_addr : machtype_component -> bool
 
 val is_exn_handler : ccatch_flag -> bool
+
+val equal_exit_label : exit_label -> exit_label -> bool

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3018,11 +3018,10 @@ let make_switch arg cases actions dbg =
   let extract_uconstant = function
     (* Constant integers loaded from a table should end in 1, so that Cload
        never produces untagged integers *)
-    | Cconst_int (n, _), _dbg when n land 1 = 1 ->
-      Some (Cint (Nativeint.of_int n))
-    | Cconst_natint (n, _), _dbg when Nativeint.(to_int (logand n one) = 1) ->
+    | Cconst_int (n, _) when n land 1 = 1 -> Some (Cint (Nativeint.of_int n))
+    | Cconst_natint (n, _) when Nativeint.(to_int (logand n one) = 1) ->
       Some (Cint n)
-    | Cconst_symbol (s, _), _dbg -> Some (Csymbol_address s)
+    | Cconst_symbol (s, _) -> Some (Csymbol_address s)
     | _ -> None
   in
   let extract_affine ~cases ~const_actions =
@@ -3061,12 +3060,58 @@ let make_switch arg cases actions dbg =
       (natint_const_untagged dbg offset)
       dbg
   in
-  match Misc.Stdlib.Array.all_somes (Array.map extract_uconstant actions) with
-  | None -> Cswitch (arg, cases, actions, dbg)
-  | Some const_actions -> (
+  let module Classify = struct
+    type elt =
+      | Not_constant
+      | Constant of Cmm.data_item
+      | Jump of Cmm.exit_label * Cmm.data_item
+
+    type array =
+      | Init
+      | Not_constant
+      | Constant_rev of Cmm.data_item list
+      | Jump_rev of Cmm.exit_label * Cmm.data_item list
+  end in
+  let classify (action, _dbg) : Classify.elt =
+    match action with
+    | Cexit (lbl, [arg], []) -> (
+      match extract_uconstant arg with
+      | None -> Not_constant
+      | Some uconst -> Jump (lbl, uconst))
+    | _ -> (
+      match extract_uconstant action with
+      | None -> Not_constant
+      | Some uconst -> Constant uconst)
+  in
+  let join (prev : Classify.array) (elt : Classify.elt) : Classify.array =
+    match prev, elt with
+    | Init, Not_constant -> Not_constant
+    | Init, Constant item -> Constant_rev [item]
+    | Init, Jump (lbl, item) -> Jump_rev (lbl, [item])
+    | Not_constant, _ | _, Not_constant -> Not_constant
+    | Constant_rev items, Constant item -> Constant_rev (item :: items)
+    | Jump_rev (lbl, items), Jump (lbl', item) ->
+      if Cmm.equal_exit_label lbl lbl'
+      then Jump_rev (lbl, item :: items)
+      else Not_constant
+    | Constant_rev _, Jump _ | Jump_rev _, Constant _ -> Not_constant
+  in
+  let transl_constant_switch ~items_rev =
+    let const_actions = Array.of_list (List.rev items_rev) in
     match extract_affine ~cases ~const_actions with
     | Some (offset, slope) -> make_affine_computation ~offset ~slope arg dbg
-    | None -> make_table_lookup ~cases ~const_actions arg dbg)
+    | None -> make_table_lookup ~cases ~const_actions arg dbg
+  in
+  match
+    Array.fold_left
+      (fun acc elt -> join acc (classify elt))
+      Classify.Init actions
+  with
+  | Init -> Misc.fatal_error "Empty switch"
+  | Not_constant -> Cswitch (arg, cases, actions, dbg)
+  | Constant_rev items_rev -> transl_constant_switch ~items_rev
+  | Jump_rev (lbl, items_rev) ->
+    Cexit (lbl, [transl_constant_switch ~items_rev], [])
 
 module SArgBlocks = struct
   type primitive = operation


### PR DESCRIPTION
As noted in #5197, the Cmm code to transform switches with constant branches into either affine functions or table lookups tends to not trigger after inlining. In the normal mode this isn't important, as Flambda 2 already performs the same optimisations, but in classic mode the missed optimisations can have noticeable consequences in terms of code size.

The reason is that the switches coming from flambda have branches that always jump to a continuation, but the Cmm version only handles cases where the branches directly return their result. These cases happen when the switch is in tail position in the function (the translation to Cmm will replace the jump to the return continuation by just the argument), but in many cases (and typically after inlining) the continuation remains.

This PR adds a bit of code to the Cmm switch translation to detect cases where all branches jump to the same continuation with a constant argument, and apply the same optimisations as for switches returning constants.

Fixes #5197.