### PR TITLE
Add test for gadt mode-crossing

### DIFF
--- a/testsuite/tests/typing-jkind-bounds/gadt.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt.ml
@@ -742,21 +742,24 @@ Error: The kind of type "t" is immutable_data with (type : value) t
 |}]
 
 type zero
-type 'a succ
+type !'a succ
 type _ t : immutable_data =
   | Zero : zero t
   | Succ : 'a t -> 'a succ t
 (* CR: This should be accepted. Internal ticket 6194. *)
 [%%expect {|
 type zero
-type 'a succ
+type !'a succ
 Lines 3-5, characters 0-28:
 3 | type _ t : immutable_data =
 4 |   | Zero : zero t
 5 |   | Succ : 'a t -> 'a succ t
-Error: In the GADT constructor
-         "Succ : 'a t -> 'a succ t"
-       the type variable "'a" cannot be deduced from the type parameters.
+Error: The kind of type "t" is immutable_data with (type : value) t
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of immutable_data
+         because of the annotation on the declaration of the type t.
+       Note: I gave up trying to find the simplest kind for the first,
+       as it is very large or deeply recursive.
 |}]
 
 type _ t : value mod portable =


### PR DESCRIPTION
This PR adds a couple tests for a gadt that could mode-cross but currently doesn't.