### PR TITLE
Build fixes when using OxCaml as system compiler

### DIFF
--- a/duneconf/dune
+++ b/duneconf/dune
@@ -9,8 +9,17 @@
  (targets camlinternalquote_if_missing_from_stdlib)
  (enabled_if
   (= %{context_name} "default"))
+ ; Use runtime detection to also support the case where the system compiler
+ ; *does* have camlinternalQuote in its stdlib (e.g. the system compiler is
+ ; oxcaml).
  (action
-  (write-file %{targets} "camlinternalQuote")))
+  (with-stdout-to %{targets}
+   (bash "
+     if ocaml -e 'open CamlinternalQuote' 2>/dev/null
+     then echo '()'
+     else echo 'camlinternalQuote'
+     fi
+   "))))
 
 (rule
  (targets camlinternalquote_if_missing_from_stdlib)

--- a/ocamltest/ocamltest_unix_real.ml
+++ b/ocamltest/ocamltest_unix_real.ml
@@ -26,5 +26,16 @@ let wrap f x =
     in
       raise (Sys_error msg)
 
-let symlink ?to_dir source = wrap (Unix.symlink ?to_dir source)
-let chmod file = wrap (Unix.chmod file)
+(* These must be eta-expanded otherwise we get the following error when using
+   OxCaml's stdlib:
+
+   Error: This value is local
+       but is expected to be local to the parent region or global
+       because it is an argument in a tail call.
+   Hint: This is a partial application
+         Adding 1 more argument will make the value non-local
+ *)
+let symlink ?to_dir source =
+  wrap (fun dest -> Unix.symlink ?to_dir source dest)
+let chmod file =
+  wrap (fun perms -> Unix.chmod file perms)


### PR DESCRIPTION
When the system compiler is (a recent version of) OxCaml:

 - The system stdlib does have a camlinternalQuote module, and we shouldn't bundle it into ocamlcommon;

 - Two partial applications in `ocamltest_unix_real.ml` do not typecheck with the `local` annotations in the `Unix` module.

This patch fixes these two issues, making the build compatible with using a recent version of OxCaml as the system compiler.