### PR TITLE
Add `Invalid` construct through `Flambda -> Cmm -> Cfg -> Linear`

### DIFF
--- a/backend/afl_instrument.ml
+++ b/backend/afl_instrument.ml
@@ -102,7 +102,7 @@ and instrument = function
   (* these are base cases and have no logging *)
   | Cconst_int _ | Cconst_natint _ | Cconst_float32 _ | Cconst_float _
   | Cconst_vec128 _ | Cconst_vec256 _ | Cconst_vec512 _ | Cconst_symbol _
-  | Cvar _ as c -> c
+  | Cvar _ | Cinvalid _ as c -> c
 
 let instrument_function c dbg =
   with_afl_logging c dbg

--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -298,7 +298,8 @@ let select_store' ~is_assign addr (exp : Cmm.expression) :
   | Cifthenelse (_, _, _, _, _, _)
   | Cswitch (_, _, _, _)
   | Ccatch (_, _, _)
-  | Cexit (_, _, _) ->
+  | Cexit (_, _, _)
+  | Cinvalid _ ->
     Use_default
 
 let select_store ~is_assign addr (exp : Cmm.expression) :

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -652,6 +652,9 @@ let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
                           stack_ofs; stack_align = _; effects = _; }; _} ->
     assert (stack_ofs >= 0);
     if alloc || stack_ofs > 0 then all_phys_regs else destroyed_at_c_call
+  | Invalid { message = _; stack_ofs; stack_align = _; label_after = _ } ->
+    assert (stack_ofs >= 0);
+    if stack_ofs > 0 then all_phys_regs else destroyed_at_c_call
   | Call {op = Indirect _ | Direct _; _} -> all_phys_regs
 
 (* CR-soon xclerc for xclerc: consider having more destruction points.
@@ -675,6 +678,7 @@ let is_destruction_point ~(more_destruction_points : bool) (terminator : Cfg_int
       true
     else
       if alloc then true else false
+  | Invalid _ -> more_destruction_points
   | Call {op = Indirect _ | Direct _; _} ->
     true
 
@@ -785,7 +789,7 @@ let expression_supported = function
   | Cconst_int _ | Cconst_natint _ | Cconst_float32 _ | Cconst_float _
   | Cconst_vec128 _ | Cconst_symbol _  | Cvar _ | Clet _ | Cphantom_let _
   | Ctuple _ | Cop _ | Csequence _ | Cifthenelse _ | Cswitch _ | Ccatch _
-  | Cexit _ -> true
+  | Cexit _ | Cinvalid _ -> true
   | Cconst_vec256 _ -> Arch.Extension.enabled_vec256 ()
   | Cconst_vec512 _ -> Arch.Extension.enabled_vec512 ()
 

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -305,7 +305,7 @@ let terminator (map : spilled_map) (term : Cfg.terminator Cfg.instruction) =
        the operands). *)
     May_still_have_spilled_registers
   | Always _ | Return | Raise _ | Switch _ | Tailcall_self _ | Tailcall_func _
-  | Call_no_return _
+  | Call_no_return _ | Invalid _
   | Prim { op = External _; _ }
   | Call { op = Indirect _ | Direct _; _ } ->
     (* no rewrite *)

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -102,7 +102,8 @@ let extract_constant args name ~max =
       | Cifthenelse (_, _, _, _, _, _)
       | Cswitch (_, _, _, _)
       | Ccatch (_, _, _)
-      | Cexit (_, _, _) ))
+      | Cexit (_, _, _)
+      | Cinvalid _ ))
     :: _ ->
     bad_immediate "Did not get integer immediate for %s" name
 

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -383,6 +383,8 @@ let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
   | Call_no_return { func_symbol = _; alloc; ty_res = _; ty_args = _; stack_ofs; _ }
   | Prim {op  = External { func_symbol = _; alloc; ty_res = _; ty_args = _; stack_ofs; _ }; _} ->
     if alloc || stack_ofs > 0 then all_phys_regs else destroyed_at_c_noalloc_call
+  | Invalid { message = _; stack_ofs; stack_align = _; label_after = _ } ->
+    if stack_ofs > 0 then all_phys_regs else destroyed_at_c_noalloc_call
 
 (* CR-soon xclerc for xclerc: consider having more destruction points.
    We current return `true` when `destroyed_at_terminator` returns
@@ -404,6 +406,7 @@ let is_destruction_point ~(more_destruction_points : bool) (terminator : Cfg_int
       true
     else
     if alloc then true else false
+  | Invalid _ -> more_destruction_points
 
 (* Layout of the stack *)
 
@@ -513,7 +516,7 @@ let expression_supported : Cmm.expression -> bool = function
   | Cconst_int _ | Cconst_natint _ | Cconst_float32 _ | Cconst_float _
   | Cconst_vec128 _ | Cconst_symbol _  | Cvar _ | Clet _ | Cphantom_let _
   | Ctuple _ | Cop _ | Csequence _ | Cifthenelse _ | Cswitch _ | Ccatch _
-  | Cexit _ -> true
+  | Cexit _ | Cinvalid _ -> true
   | Cconst_vec256 _ | Cconst_vec512 _ -> false
 
 

--- a/backend/arm64/regalloc_stack_operands.ml
+++ b/backend/arm64/regalloc_stack_operands.ml
@@ -55,6 +55,6 @@ let terminator (map : spilled_map) (term : Cfg.terminator Cfg.instruction) =
   | Prim { op = External _; _ }
   | Never | Return | Always _ | Parity_test _ | Truth_test _ | Float_test _
   | Int_test _ | Switch _ | Raise _ | Tailcall_self _ | Tailcall_func _
-  | Call_no_return _ | Call _ ->
+  | Call_no_return _ | Call _ | Invalid _ ->
     (* no rewrite *)
     May_still_have_spilled_registers

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -139,8 +139,11 @@ let successor_labels_normal ti =
     |> Label.Set.add uo
   | Int_test { lt; gt; eq; imm = _; is_signed = _ } ->
     Label.Set.singleton lt |> Label.Set.add gt |> Label.Set.add eq
-  | Call { op = _; label_after } | Prim { op = _; label_after } ->
+  | Call { op = _; label_after }
+  | Prim { op = _; label_after }
+  | Invalid { label_after = Some label_after; _ } ->
     Label.Set.singleton label_after
+  | Invalid { label_after = None; _ } -> Label.Set.empty
 
 let successor_labels ~normal ~exn block =
   match normal, exn with
@@ -189,10 +192,13 @@ let replace_successor_labels t ~normal ~exn block ~f =
         Tailcall_self { destination = f destination }
       | Tailcall_func (Indirect _)
       | Tailcall_func (Direct _)
-      | Return | Raise _ | Call_no_return _ ->
+      | Return | Raise _ | Call_no_return _
+      | Invalid { label_after = None; _ } ->
         block.terminator.desc
       | Call { op; label_after } -> Call { op; label_after = f label_after }
       | Prim { op; label_after } -> Prim { op; label_after = f label_after }
+      | Invalid ({ label_after = Some label_after; _ } as r) ->
+        Invalid { r with label_after = Some (f label_after) }
     in
     block.terminator <- { block.terminator with desc }
 
@@ -402,6 +408,9 @@ let dump_terminator' ?(print_reg = Printreg.reg) ?(res = [||]) ?(args = [||])
       | Probe { name; handler_code_sym; enabled_at_init } ->
         Linear.Lprobe { name; handler_code_sym; enabled_at_init });
     Format.fprintf ppf "%sgoto %a" sep Label.format label_after
+  | Invalid { message; label_after; _ } ->
+    Format.fprintf ppf "Invalid %S" message;
+    Option.iter (Format.fprintf ppf "%sgoto %a" sep Label.format) label_after
 
 let dump_terminator ?sep ppf terminator = dump_terminator' ?sep ppf terminator
 
@@ -437,10 +446,8 @@ let print_instruction ppf i = print_instruction' ppf i
 
 let can_raise_terminator (i : terminator) =
   match i with
-  | Call_no_return { func_symbol; _ } ->
-    not (String.equal func_symbol Cmm.caml_flambda2_invalid)
-  | Raise _ | Tailcall_func _ | Call _ | Prim { op = Probe _; label_after = _ }
-    ->
+  | Call_no_return _ | Raise _ | Tailcall_func _ | Call _
+  | Prim { op = Probe _; label_after = _ } ->
     true
   | Prim { op = External { alloc; effects; _ }; label_after = _ } -> (
     if not alloc
@@ -452,7 +459,7 @@ let can_raise_terminator (i : terminator) =
       | No_effects -> false
       | Arbitrary_effects -> true)
   | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-  | Switch _ | Return | Tailcall_self _ ->
+  | Switch _ | Return | Tailcall_self _ | Invalid _ ->
     false
 
 (* CR gyorsh: [is_pure_terminator] is not the same as [can_raise_terminator]
@@ -463,7 +470,7 @@ let can_raise_terminator (i : terminator) =
 let is_pure_terminator desc =
   match (desc : terminator) with
   | Return | Raise _ | Call_no_return _ | Tailcall_func _ | Tailcall_self _
-  | Call _ | Prim _ ->
+  | Call _ | Prim _ | Invalid _ ->
     false
   | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
   | Switch _ ->
@@ -475,7 +482,7 @@ let is_never_terminator desc =
   | Never -> true
   | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
   | Switch _ | Return | Raise _ | Tailcall_self _ | Tailcall_func _
-  | Call_no_return _ | Call _ | Prim _ ->
+  | Call_no_return _ | Call _ | Prim _ | Invalid _ ->
     false
 
 let is_return_terminator desc =
@@ -483,7 +490,7 @@ let is_return_terminator desc =
   | Return -> true
   | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
   | Switch _ | Raise _ | Tailcall_self _ | Tailcall_func _ | Call_no_return _
-  | Call _ | Prim _ ->
+  | Call _ | Prim _ | Invalid _ ->
     false
 
 let is_pure_basic : basic -> bool = function
@@ -672,7 +679,7 @@ let basic_block_contains_calls block =
     | Tailcall_func _ -> false
     | Call_no_return _ -> true
     | Call _ -> true
-    | Prim { op = External _; _ } -> true
+    | Prim { op = External _; _ } | Invalid _ -> true
     | Prim { op = Probe _; _ } -> true)
   || DLL.exists block.body ~f:is_alloc_or_poll
 
@@ -727,7 +734,7 @@ let remove_trap_instructions t removed_trap_handlers =
     | Tailcall_self _ -> assert (Int.equal stack_offset 0)
     | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
     | Int_test _ | Switch _ | Return | Raise _ | Tailcall_func _
-    | Call_no_return _ | Call _ | Prim _ ->
+    | Call_no_return _ | Call _ | Prim _ | Invalid _ ->
       ());
     update_instruction terminator ~stack_offset
   and update_block label ~stack_offset =

--- a/backend/cfg/cfg_available_regs.ml
+++ b/backend/cfg/cfg_available_regs.ml
@@ -389,7 +389,7 @@ module Transfer = struct
         | Never -> assert false
         | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
         | Switch _ | Call _ | Prim _ | Return | Raise _ | Tailcall_func _
-        | Call_no_return _ | Tailcall_self _ ->
+        | Call_no_return _ | Invalid _ | Tailcall_self _ ->
           common ~avail_before ~destroyed_at:Proc.destroyed_at_terminator
             ~is_interesting_constructor:
               Cfg.(
@@ -398,7 +398,7 @@ module Transfer = struct
                 | Call _ | Prim { op = Probe _; label_after = _ } -> true
                 | Always _ | Parity_test _ | Truth_test _ | Float_test _
                 | Int_test _ | Switch _ | Return | Raise _ | Tailcall_self _
-                | Tailcall_func _ | Call_no_return _
+                | Tailcall_func _ | Call_no_return _ | Invalid _
                 | Prim { op = External _; label_after = _ } ->
                   false)
             ~is_end_region:(fun _ -> false)

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -450,7 +450,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
     | Switch _ ->
       set_unknown_regs numbering (Proc.destroyed_at_terminator terminator.desc)
     | Return | Raise _ | Tailcall_self _ | Tailcall_func _ | Call_no_return _
-    | Call _ | Prim _ ->
+    | Call _ | Prim _ | Invalid _ ->
       (* For function calls and probes, we should at least forget: - equations
          involving memory loads, since the callee can perform arbitrary memory
          stores; - equations involving arithmetic operations that can produce

--- a/backend/cfg/cfg_intf.ml
+++ b/backend/cfg/cfg_intf.ml
@@ -145,8 +145,12 @@ module S = struct
     | Tailcall_func of func_call_operation
     | Call_no_return of external_call_operation
     (* CR mshinwell: [Call_no_return] should have "external" in the name *)
-    (* CR mshinwell: [Invalid] from flambda2 should have its own terminator, to
-       avoid the hack in [can_raise_terminator] *)
+    | Invalid of
+        { message : string;
+          stack_ofs : int;
+          stack_align : Cmm.stack_align;
+          label_after : Label.t Option.t
+        }
     | Call of func_call_operation with_label_after
     | Prim of prim_call_operation with_label_after
 

--- a/backend/cfg/cfg_invariants.ml
+++ b/backend/cfg/cfg_invariants.ml
@@ -133,7 +133,7 @@ let check_tailrec t _label block =
           Label.print l Label.print destination)
   | Call _ | Prim _ | Tailcall_func _ | Never | Always _ | Parity_test _
   | Truth_test _ | Float_test _ | Int_test _ | Switch _ | Return | Raise _
-  | Call_no_return _ ->
+  | Call_no_return _ | Invalid _ ->
     ()
 
 let check_can_raise t label (block : Cfg.basic_block) =

--- a/backend/cfg/cfg_liveness.ml
+++ b/backend/cfg/cfg_liveness.ml
@@ -89,7 +89,7 @@ module Transfer :
         ~exn Domain.bot instr
     | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
     | Switch _ | Return | Raise _ | Tailcall_func _ | Call_no_return _ | Call _
-    | Prim _ ->
+    | Prim _ | Invalid _ ->
       instruction
         ~can_raise:(Cfg.can_raise_terminator instr.desc)
         ~exn domain instr

--- a/backend/cfg/cfg_polling.ml
+++ b/backend/cfg/cfg_polling.ml
@@ -130,7 +130,7 @@ let is_safe_terminator : Cfg.terminator Cfg.instruction -> bool =
   | Switch _ ->
     false
   | Raise _ -> false
-  | Tailcall_self _ | Tailcall_func _ | Return -> true
+  | Tailcall_self _ | Tailcall_func _ | Return | Invalid _ -> true
   | Call_no_return _ | Call _ | Prim _ -> false
 
 let is_safe_block : Cfg.basic_block -> bool =
@@ -226,7 +226,7 @@ module Polls_before_prtc_transfer = struct
       then Ok Might_not_poll
       else Ok Always_polls
     | Return -> Ok Always_polls
-    | Call_no_return _ | Call _ | Prim _ ->
+    | Call_no_return _ | Call _ | Prim _ | Invalid _ ->
       if Cfg.can_raise_terminator term.desc
       then Ok (Polls_before_prtc_domain.join dom exn)
       else Ok dom
@@ -426,6 +426,7 @@ let add_calls_terminator :
       } ->
     (External_call, term.dbg) :: points
   | Prim { op = Probe _; label_after = _ } -> points
+  | Invalid _ -> points
 
 let find_poll_alloc_or_calls : Cfg.t -> polling_points =
  fun cfg ->

--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -68,7 +68,8 @@ module Instruction_requirements = struct
          need a prologue. *)
       | Call _ | Call_no_return _
       | Raise (Raise_regular | Raise_reraise)
-      | Prim { op = External _ | Probe _; _ } ->
+      | Prim { op = External _ | Probe _; _ }
+      | Invalid _ (* CR-soon vkarvonen: Does [Invalid] require prologue? *) ->
         Requires_prologue
       | Tailcall_func (Direct _)
       | Tailcall_self _

--- a/backend/cfg/cfg_stack_checks.ml
+++ b/backend/cfg/cfg_stack_checks.ml
@@ -39,7 +39,8 @@ let is_nontail_call : Cfg.terminator -> bool =
   match term_desc with
   | Call_no_return _ | Call _ -> true
   | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-  | Switch _ | Return | Raise _ | Tailcall_self _ | Tailcall_func _ | Prim _ ->
+  | Switch _ | Return | Raise _ | Tailcall_self _ | Tailcall_func _ | Prim _
+  | Invalid _ ->
     false
 
 (* Returns the stack check info, and the max of seen instruction ids. *)

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -260,7 +260,7 @@ let evaluate_terminator (known_values : known_value Reg.UsingLocEquality.Tbl.t)
         else None)
   | Never -> assert false
   | Always _ | Return | Raise _ | Tailcall_self _ | Tailcall_func _
-  | Call_no_return _ | Call _ | Prim _ ->
+  | Call_no_return _ | Call _ | Prim _ | Invalid _ ->
     None
 
 let block_known_values (block : C.basic_block) ~(is_after_regalloc : bool)
@@ -343,7 +343,7 @@ let block (cfg : C.t) (block : C.basic_block) : bool =
                  };
             true
           | Never | Always _ | Switch _ | Raise _ | Tailcall_self _
-          | Tailcall_func _ | Call_no_return _ | Call _ | Prim _ ->
+          | Tailcall_func _ | Call_no_return _ | Call _ | Prim _ | Invalid _ ->
             false)
     else false
   | Never ->
@@ -370,7 +370,7 @@ let block (cfg : C.t) (block : C.basic_block) : bool =
       simplify_switch block labels;
       false)
   | Raise _ | Return | Tailcall_self _ | Tailcall_func _ | Call_no_return _
-  | Call _ | Prim _ ->
+  | Call _ | Prim _ | Invalid _ ->
     false
 
 let run cfg =

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -77,7 +77,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       | Creinterpret_cast _ | Cstatic_cast _ | Ctuple_field _ | Ccmpf _
       | Cdls_get | Ctls_get ->
         List.for_all is_simple_expr args)
-    | Cifthenelse _ | Cswitch _ | Ccatch _ | Cexit _ -> false
+    | Cifthenelse _ | Cswitch _ | Ccatch _ | Cexit _ | Cinvalid _ -> false
 
   and is_simple_expr expr =
     match Target.is_simple_expr expr with
@@ -134,7 +134,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           EC.none
       in
       EC.join from_op (EC.join_list_map args effects_of)
-    | Cswitch _ | Ccatch _ | Cexit _ -> EC.arbitrary
+    | Cswitch _ | Ccatch _ | Cexit _ | Cinvalid _ -> EC.arbitrary
 
   and effects_of (expr : Cmm.expression) =
     match Target.effects_of expr with
@@ -804,6 +804,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     | Ccatch (rec_flag, handlers, body) ->
       emit_expr_catch env sub_cfg bound_name rec_flag handlers body
     | Cexit (lbl, args, traps) -> emit_expr_exit env sub_cfg lbl args traps
+    | Cinvalid { message; symbol } -> emit_invalid env sub_cfg message symbol
 
   (* Emit an expression in tail position of a function. *)
   and emit_tail env sub_cfg (exp : Cmm.expression) =
@@ -827,10 +828,46 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     | Ccatch (_, [], e1) -> emit_tail env sub_cfg e1
     | Ccatch (rec_flag, handlers, e1) ->
       emit_tail_catch env sub_cfg rec_flag handlers e1
+    | Cinvalid { message; symbol } ->
+      let ok = emit_invalid env sub_cfg message symbol in
+      insert_return env sub_cfg ok (SU.pop_all_traps env)
     | Cop _ | Cconst_int _ | Cconst_natint _ | Cconst_float32 _ | Cconst_float _
     | Cconst_symbol _ | Cconst_vec128 _ | Cconst_vec256 _ | Cconst_vec512 _
     | Cvar _ | Ctuple _ | Cexit _ ->
       emit_return env sub_cfg exp (SU.pop_all_traps env)
+
+  and emit_invalid env sub_cfg message symbol =
+    let arg_expr = Cmm.Cconst_symbol (symbol, Debuginfo.none) in
+    let* loc_arg, stack_ofs, stack_align =
+      (* Set up the argument for the call to caml_flambda2_invalid *)
+      emit_extcall_args env sub_cfg [Cmm.XInt] [arg_expr] Debuginfo.none
+    in
+    if !SU.current_function_is_check_enabled
+    then (
+      (* For zero alloc checking we need to treat [Invalid] as returning. *)
+      let label = Cmm.new_label () in
+      let label_after = Some label in
+      let ty = Cmm.typ_int in
+      let rd = Reg.createv ty in
+      let term = Cfg.Invalid { message; stack_ofs; stack_align; label_after } in
+      let loc_res =
+        SU.insert_op_debug' env sub_cfg term Debuginfo.none loc_arg
+          (Proc.loc_external_results (Reg.typv rd))
+      in
+      Sub_cfg.add_never_block sub_cfg ~label;
+      SU.insert_move_results env sub_cfg loc_res rd stack_ofs;
+      SU.set_traps_for_raise env;
+      Ok rd)
+    else
+      (* When not zero alloc checking we treat [Invalid] as non-returning. *)
+      let term =
+        Cfg.Invalid { message; stack_ofs; stack_align; label_after = None }
+      in
+      let (_ : Reg.t array) =
+        SU.insert_op_debug' env sub_cfg term Debuginfo.none loc_arg [||]
+      in
+      SU.set_traps_for_raise env;
+      Never_returns
 
   and emit_expr_raise (env : SU.environment) sub_cfg k
       (args : Cmm.expression list) dbg : _ Or_never_returns.t =
@@ -935,35 +972,19 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         SU.set_traps_for_raise env;
         Sub_cfg.add_never_block sub_cfg ~label:label_after;
         Ok rd
-      | Terminator (Call_no_return ({ func_symbol; ty_args; _ } as r)) ->
+      | Terminator (Call_no_return ({ ty_args; _ } as r)) ->
         let* loc_arg, stack_ofs, stack_align =
           emit_extcall_args env sub_cfg ty_args new_args dbg
         in
-        let keep_for_checking =
-          !SU.current_function_is_check_enabled
-          && String.equal func_symbol Cmm.caml_flambda2_invalid
-        in
-        let returns, ty =
-          if keep_for_checking then true, Cmm.typ_int else false, ty
-        in
         let rd = Reg.createv ty in
-        let label = Cmm.new_label () in
         let r = { r with stack_ofs; stack_align } in
-        let term : Cfg.terminator =
-          if keep_for_checking
-          then Prim { op = External r; label_after = label }
-          else Call_no_return r
-        in
+        let term : Cfg.terminator = Call_no_return r in
         let (_ : Reg.t array) =
           SU.insert_op_debug' env sub_cfg term dbg loc_arg
             (Proc.loc_external_results (Reg.typv rd))
         in
         SU.set_traps_for_raise env;
-        if returns
-        then (
-          Sub_cfg.add_never_block sub_cfg ~label;
-          Ok rd)
-        else Never_returns
+        Never_returns
       | Basic (Op (Alloc { bytes = _; mode; dbginfo = [placeholder] })) ->
         let rd = Reg.createv Cmm.typ_val in
         let bytes = SU.size_expr env (Ctuple new_args) in

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -556,6 +556,10 @@ and expression =
       expression * int array * (expression * Debuginfo.t) array * Debuginfo.t
   | Ccatch of ccatch_flag * static_handler list * expression
   | Cexit of exit_label * expression list * trap_action list
+  | Cinvalid of
+      { message : string;
+        symbol : symbol
+      }
 
 type codegen_option =
   | Reduce_code_size

--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -91,7 +91,8 @@ let shift32 make_op arg count dbg =
     | Cifthenelse (_, _, _, _, _, _)
     | Cswitch (_, _, _, _)
     | Ccatch (_, _, _)
-    | Cexit (_, _, _) ->
+    | Cexit (_, _, _)
+    | Cinvalid _ ->
       Cop (Cand, [count; Cconst_int (mask, dbg)], dbg)
   in
   Some (make_op arg count dbg)
@@ -987,7 +988,8 @@ let transl_builtin name args dbg typ_res =
         | Cifthenelse (_, _, _, _, _, _)
         | Cswitch (_, _, _, _)
         | Ccatch (_, _, _)
-        | Cexit (_, _, _) ->
+        | Cexit (_, _, _)
+        | Cinvalid _ ->
           Cop (op, [cond; ifso; ifnot], dbg))
   | "caml_int32_shift_left_by_int32_unboxed" ->
     let arg, count = two_args name args in

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -130,7 +130,7 @@ let rec check env (expr : Cmm.expression) =
   match expr with
   | Cconst_int _ | Cconst_natint _ | Cconst_float32 _ | Cconst_float _
   | Cconst_symbol _ | Cconst_vec128 _ | Cconst_vec256 _ | Cconst_vec512 _
-  | Cvar _ ->
+  | Cvar _ | Cinvalid _ ->
     ()
   | Clet (_, expr, body) ->
     check env expr;

--- a/backend/cmm_peephole_engine.ml
+++ b/backend/cmm_peephole_engine.ml
@@ -349,6 +349,9 @@ module Cmm_comparator = struct
       equal_exit_label lbl1 lbl2
       && List.equal equivalent args1 args2
       && List.equal equal_trap_action traps1 traps2
+    | ( Cinvalid { message = m1; symbol = s1 },
+        Cinvalid { message = m2; symbol = s2 } ) ->
+      String.equal m1 m2 && equal_symbol s1 s2
     | ( ( Cconst_int (_, _)
         | Cconst_natint (_, _)
         | Cconst_float32 (_, _)
@@ -366,7 +369,8 @@ module Cmm_comparator = struct
         | Cifthenelse (_, _, _, _, _, _)
         | Cswitch (_, _, _, _)
         | Ccatch (_, _, _)
-        | Cexit (_, _, _) ),
+        | Cexit (_, _, _)
+        | Cinvalid _ ),
         _ ) ->
       false
 end

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -808,6 +808,10 @@ let emit_terminator t (i : Cfg.terminator Cfg.instruction) =
     | External { func_symbol; alloc; stack_ofs; stack_align; _ } ->
       extcall t i ~func_symbol ~alloc ~stack_ofs ~stack_align;
       br_label t label_after)
+  | Invalid { message = _; stack_ofs; stack_align; label_after = _ } ->
+    extcall t i ~func_symbol:Cmm.caml_flambda2_invalid ~alloc:false ~stack_ofs
+      ~stack_align;
+    emit_ins_no_res t I.unreachable
 
 (* Basic instructions *)
 

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -458,6 +458,8 @@ let rec expr ppf = function
     fprintf ppf "@[<2>(exit%a %a" trap_action_list traps exit_label i;
     List.iter (fun e -> fprintf ppf "@ %a" expr e) el;
     fprintf ppf ")@]"
+  | Cinvalid { message; symbol = sym } ->
+    fprintf ppf "@[<2>(invalid@ %S@ %a)@]" message symbol sym
 
 and sequence ppf = function[@warning "-4"]
   | Csequence (e1, e2) -> fprintf ppf "%a@ %a" sequence e1 sequence e2

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -421,7 +421,7 @@ let insert_phi_moves : State.t -> Cfg_with_infos.t -> Substitution.map -> bool =
             add_phi_moves_to_instr_list ~instr_id ~before:predecessor_block
               ~phi:block substs to_unify predecessor_block.body
           | Switch _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-          | Call _ | Prim _ ->
+          | Call _ | Prim _ | Invalid _ ->
             let instrs = DLL.make_empty () in
             add_phi_moves_to_instr_list ~instr_id ~before:predecessor_block
               ~phi:block substs to_unify instrs;

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -441,7 +441,7 @@ module SpillCosts = struct
         | Prim { op = External _; _ }
         | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
         | Int_test _ | Switch _ | Return | Raise _ | Tailcall_self _
-        | Tailcall_func _ | Call_no_return _ | Call _ ->
+        | Tailcall_func _ | Call_no_return _ | Invalid _ | Call _ ->
           update_instr cost block.terminator);
     costs
 end

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -600,6 +600,14 @@ end = struct
     (* CR-someday azewierzejew: Avoid using polymorphic comparison. *)
       when Stdlib.compare prim1 prim2 = 0 ->
       compare_label l1 l2
+    | ( Invalid { message = m1; label_after = None; _ },
+        Invalid { message = m2; label_after = None; _ } )
+      when String.compare m1 m2 = 0 ->
+      ()
+    | ( Invalid { message = m1; label_after = Some l1; _ },
+        Invalid { message = m2; label_after = Some l2; _ } )
+      when String.compare m1 m2 = 0 ->
+      compare_label l1 l2
     | _ ->
       Regalloc_utils.fatal
         "The desc of terminator with id %a changed, before: %a, after: %a."

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -512,7 +512,7 @@ module Stack_offset_and_exn = struct
         InstructionId.format term.id
     | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
     | Int_test _ | Switch _ | Return | Raise _ | Tailcall_self _
-    | Tailcall_func _ | Call_no_return _ | Call _ | Prim _ ->
+    | Tailcall_func _ | Call_no_return _ | Invalid _ | Call _ | Prim _ ->
       stack_offset, traps
 
   let rec process_basic :

--- a/middle_end/flambda2/to_cmm/to_cmm_env.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_env.ml
@@ -472,7 +472,7 @@ let is_cmm_simple cmm =
   | Cvar _ ->
     true
   | Clet _ | Cphantom_let _ | Ctuple _ | Cop _ | Csequence _ | Cifthenelse _
-  | Cswitch _ | Ccatch _ | Cexit _ ->
+  | Cswitch _ | Ccatch _ | Cexit _ | Cinvalid _ ->
     false
 
 (* Helper function to create bindings *)

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -338,7 +338,6 @@ let function_bound_parameters env l =
   bound_parameters_aux ~f:machtype_of_kinded_parameter env l
 
 let invalid res ~message =
-  let dbg = Debuginfo.none in
   let message_sym, res =
     match To_cmm_result.invalid_message_symbol res ~message with
     | None ->
@@ -361,13 +360,8 @@ let invalid res ~message =
       message_sym, res
     | Some message_sym -> message_sym, res
   in
-  let call_expr =
-    extcall ~dbg ~alloc:false ~is_c_builtin:false ~effects:Arbitrary_effects
-      ~coeffects:Has_coeffects ~returns:false ~ty_args:[XInt]
-      Cmm.caml_flambda2_invalid Cmm.typ_void
-      [symbol ~dbg (To_cmm_result.symbol res message_sym)]
-  in
-  call_expr, res
+  let cmm_symbol = To_cmm_result.symbol res message_sym in
+  Cmm.Cinvalid { message; symbol = cmm_symbol }, res
 
 module Update_kind = struct
   type kind =


### PR DESCRIPTION
This avoids the special case handling of external calls to `caml_flambda2_invalid`.