### PR TITLE
build: Add `:standard` to `ocamlopt_flags`

### DIFF
--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -177,8 +177,10 @@ _build/_bootinstall: Makefile.config $(dune_config_targets)
 	echo -n '$(NATDYNLINKOPTS)' > $(ocamldir)/natdynlinkops
 
 # flags.sexp
-	echo '(:standard $(if $(filter true,$(FUNCTION_SECTIONS)),-function-sections,))' > ocamlopt_upstream_flags.sexp
-	echo '(:standard $(OXCAML_DWARF_FLAGS_FOR_COMPILER) -bin-annot-cms $(ASSEMBLY_FLAG_FOR_COMPILER) $(if $(filter true,$(FUNCTION_SECTIONS)),-function-sections,))' > ocamlopt_oxcaml_flags.sexp
+# Do not include :standard as it is ignored
+# See: https://github.com/ocaml/dune/issues/13225
+	echo '($(if $(filter true,$(FUNCTION_SECTIONS)),-function-sections,))' > ocamlopt_upstream_flags.sexp
+	echo '($(OXCAML_DWARF_FLAGS_FOR_COMPILER) -bin-annot-cms $(ASSEMBLY_FLAG_FOR_COMPILER) $(if $(filter true,$(FUNCTION_SECTIONS)),-function-sections,))' > ocamlopt_oxcaml_flags.sexp
 	echo '( )' > boot_oc_cflags.sexp
 	echo '( $(OC_CFLAGS) )' > oc_cflags.sexp
 	echo '( $(OC_CPPFLAGS) )' > oc_cppflags.sexp

--- a/dune
+++ b/dune
@@ -125,7 +125,7 @@
    ; -47 needed because [@inline available] is not recognized by the system compiler
    ))
  (ocamlopt_flags
-  (:include %{project_root}/ocamlopt_flags.sexp))
+  (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (preprocess
   (per_module
    ((action
@@ -359,7 +359,7 @@
  (flags
   (:standard -strict-sequence -w +67 -bin-annot -safe-string -strict-formats))
  (ocamlopt_flags
-  (:include %{project_root}/ocamlopt_flags.sexp))
+  (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (libraries ocamlcommon)
  (modules
   ;; bytecomp/
@@ -401,7 +401,7 @@
  (flags
   (:standard -strict-sequence -w +67 -bin-annot -safe-string -strict-formats))
  (ocamlopt_flags
-  (:include %{project_root}/ocamlopt_flags.sexp))
+  (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (libraries ocamlcommon flambda2)
  (modules jsmaindriver jscompile jslibrarian))
 
@@ -518,7 +518,7 @@
  (flags
   (:standard -w -27-32-33-34-37-39-60-69-70))
  (ocamlopt_flags
-  (:include %{project_root}/ocamlopt_flags.sexp))
+  (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (instrumentation
   (backend bisect_ppx))
  (modules_without_implementation
@@ -739,7 +739,7 @@
    ; remove -w -67 by adding the camlinternalMenhirLib hack like the Makefile
    ))
  (ocamlopt_flags
-  (:include %{project_root}/ocamlopt_flags.sexp))
+  (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (instrumentation
   (backend bisect_ppx))
  (libraries ocamlcommon dwarf_flags asm_targets)

--- a/lex/dune
+++ b/lex/dune
@@ -17,7 +17,7 @@
  (wrapped false)
  (modes byte native)
  (ocamlopt_flags
-  (:include %{project_root}/ocamlopt_flags.sexp))
+  (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (modules
   common
   compact

--- a/otherlibs/camlinternaleval/dune
+++ b/otherlibs/camlinternaleval/dune
@@ -42,7 +42,7 @@
    -safe-string
    -strict-formats))
  (ocamlopt_flags
-  (:include %{project_root}/ocamlopt_flags.sexp))
+  (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (library_flags
   (:standard -linkall -ccopt %{read:../../natdynlinkops}))
  (foreign_stubs

--- a/otherlibs/dynlink/dune
+++ b/otherlibs/dynlink/dune
@@ -72,7 +72,7 @@
    -safe-string
    -strict-formats))
  (ocamlopt_flags
-  (:include %{project_root}/ocamlopt_flags.sexp))
+  (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (modules
   binutils
   local_store

--- a/otherlibs/runtime_events/dune
+++ b/otherlibs/runtime_events/dune
@@ -23,7 +23,7 @@
    -bin-annot
    -safe-string
    -strict-formats))
- (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
+ (ocamlopt_flags (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (library_flags (:standard -linkall))
  (foreign_stubs (language c) (names runtime_events_consumer)
   (flags ((:include %{project_root}/oc_cflags.sexp)

--- a/otherlibs/stdlib_alpha/dune
+++ b/otherlibs/stdlib_alpha/dune
@@ -26,7 +26,7 @@
    -extension-universe
    alpha))
  (ocamlopt_flags
-  (:include %{project_root}/ocamlopt_flags.sexp))
+  (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (library_flags
   (:standard -linkall)))
 

--- a/otherlibs/stdlib_beta/dune
+++ b/otherlibs/stdlib_beta/dune
@@ -29,7 +29,7 @@
    small_numbers_beta
    ))
  (ocamlopt_flags
-  (:include %{project_root}/ocamlopt_flags.sexp))
+  (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (library_flags
   (:standard -linkall)))
 

--- a/otherlibs/stdlib_stable/dune
+++ b/otherlibs/stdlib_stable/dune
@@ -24,7 +24,7 @@
    -safe-string
    -strict-formats))
  (ocamlopt_flags
-  (:include %{project_root}/ocamlopt_flags.sexp))
+  (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (library_flags
   (:standard -linkall)))
 

--- a/otherlibs/stdlib_upstream_compatible/dune
+++ b/otherlibs/stdlib_upstream_compatible/dune
@@ -26,7 +26,7 @@
    -extension-universe
    upstream_compatible))
  (ocamlopt_flags
-  (:include %{project_root}/ocamlopt_flags.sexp))
+  (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (library_flags
   (:standard -linkall)))
 

--- a/otherlibs/str/dune
+++ b/otherlibs/str/dune
@@ -21,7 +21,7 @@
    -strict-sequence -absname -w +67+70
    -bin-annot -safe-string -strict-formats
  ))
- (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
+ (ocamlopt_flags (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (library_flags (:standard -linkall))
  (foreign_stubs (language c) (names strstubs)
   (flags ((:include %{project_root}/oc_cflags.sexp)

--- a/otherlibs/systhreads/byte/dune
+++ b/otherlibs/systhreads/byte/dune
@@ -10,7 +10,7 @@
  (flags
   (:standard -no-strict-sequence -g -bin-annot -w -27))
  (ocamlopt_flags
-  (:include %{project_root}/ocamlopt_flags.sexp))
+  (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (libraries unix)
  (library_flags -linkall)
  (c_library_flags -lpthread)

--- a/otherlibs/systhreads/native/dune
+++ b/otherlibs/systhreads/native/dune
@@ -10,7 +10,7 @@
  (flags
   (:standard -no-strict-sequence -g -bin-annot -w -27))
  (ocamlopt_flags
-  (:include %{project_root}/ocamlopt_flags.sexp))
+  (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (libraries unix)
  (library_flags -linkall)
  (c_library_flags -lpthread)

--- a/otherlibs/systhreads4/byte/dune
+++ b/otherlibs/systhreads4/byte/dune
@@ -8,6 +8,6 @@
  (flags
   (:standard -no-strict-sequence -g -bin-annot -safe-string -w -27))
  (ocamlopt_flags
-  (:include %{project_root}/ocamlopt_flags.sexp))
+  (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (libraries unix)
  (library_flags -linkall))

--- a/otherlibs/systhreads4/native/dune
+++ b/otherlibs/systhreads4/native/dune
@@ -8,6 +8,6 @@
  (flags
   (:standard -no-strict-sequence -g -bin-annot -safe-string -w -27))
  (ocamlopt_flags
-  (:include %{project_root}/ocamlopt_flags.sexp))
+  (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (libraries unix)
  (library_flags -linkall))

--- a/otherlibs/unix/dune
+++ b/otherlibs/unix/dune
@@ -28,7 +28,7 @@
    -strict-formats
    -nolabels ; for UnixLabels
    ))
- (ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))
+ (ocamlopt_flags (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (library_flags (:standard -linkall))
  (modules unix unixLabels)
  (foreign_stubs (language c) (names

--- a/stdlib/dune
+++ b/stdlib/dune
@@ -29,7 +29,7 @@
    -safe-string
    -strict-formats))
  (ocamlopt_flags
-  (:include %{project_root}/ocamlopt_flags.sexp))
+  (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (preprocess
   (per_module
    ((action

--- a/toplevel/native/dune
+++ b/toplevel/native/dune
@@ -21,7 +21,7 @@
  (flags
   (:standard -w -70))
  (ocamlopt_flags
-  (:include %{project_root}/ocamlopt_flags.sexp))
+  (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (libraries
   ocamlcommon
   ocamlbytecomp


### PR DESCRIPTION
It looks like `dune` is not correctly parsing `:standard` from within `:include` (bug: https://github.com/ocaml/dune/issues/13225 ).

We have many targets where we set `(ocamlopt_flags (:include %{project_root}/ocamlopt_flags.sexp))`, which removes the ability to add extra `ocamlopt_flags` from the environment (even though `ocamlopt_flags.sexp` contains `:standard`).

This patch explicitly adds the `:standard` atom when `ocamlopt_flags.sexp` is included (and `:standard` was not already present).

It also removes `:standard` from `ocamlopt_flags.sexp` to help avoid re-introducing the problematic pattern.