### PR TITLE
Add -dfexpr-annot flag to dump fexpr alongside cmx

### DIFF
--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -960,6 +960,11 @@ let mk_dfexpr f =
     Arg.Unit f,
     " Like -dflambda but outputs fexpr language\n     (Flambda 2 only)" )
 
+let mk_dfexpr_annot f =
+  ( "-dfexpr-annot",
+    Arg.Unit f,
+    " Dump fexpr alongside each compilation unit\n     (Flambda 2 only)" )
+
 let mk_dfexpr_after f =
   let passes = [ "simplify"; "reaper" ] in
   ( "-dfexpr-after",
@@ -1270,6 +1275,7 @@ module type Oxcaml_options = sig
   val dfexpr_to : string -> unit
   val dfexpr_after : string -> unit
   val dflexpect_to : string -> unit
+  val dfexpr_annot : unit -> unit
   val dslot_offsets : unit -> unit
   val dfreshen : unit -> unit
   val dflow : unit -> unit
@@ -1459,6 +1465,7 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_dfexpr_to F.dfexpr_to;
       mk_dfexpr_after F.dfexpr_after;
       mk_dflexpect_to F.dflexpect_to;
+      mk_dfexpr_annot F.dfexpr_annot;
       mk_dslot_offsets F.dslot_offsets;
       mk_dfreshen F.dfreshen;
       mk_dflow F.dflow;
@@ -1846,6 +1853,7 @@ module Oxcaml_options_impl = struct
 
   let dfexpr_to file = Flambda2.Dump.fexpr := Flambda2.Dump.File file
   let dflexpect_to file = Flambda2.Dump.flexpect := Flambda2.Dump.File file
+  let dfexpr_annot () = Flambda2.Dump.fexpr_annot := true
   let dslot_offsets = set' Flambda2.Dump.slot_offsets
   let dfreshen = set' Flambda2.Dump.freshen
   let dflow = set' Flambda2.Dump.flow

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -168,6 +168,7 @@ module type Oxcaml_options = sig
   val dfexpr_to : string -> unit
   val dfexpr_after : string -> unit
   val dflexpect_to : string -> unit
+  val dfexpr_annot : unit -> unit
   val dslot_offsets : unit -> unit
   val dfreshen : unit -> unit
   val dflow : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -252,6 +252,7 @@ module Flambda2 = struct
     let fexpr = ref Nowhere
     let fexpr_after = ref Last_pass
     let flexpect = ref Nowhere
+    let fexpr_annot = ref false
     let slot_offsets = ref false
     let freshen = ref false
     let flow = ref false

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -193,6 +193,7 @@ module Flambda2 : sig
     val fexpr : target ref
     val fexpr_after : pass ref
     val flexpect : target ref
+    val fexpr_annot : bool ref
     val slot_offsets : bool ref
     val freshen : bool ref
     val flow : bool ref

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -149,6 +149,8 @@ let dump_flambda () = !Clflags.dump_flambda
 
 let dump_rawfexpr () = !Oxcaml_flags.Flambda2.Dump.rawfexpr
 
+let dump_fexpr_annot () = !Oxcaml_flags.Flambda2.Dump.fexpr_annot
+
 type pass = Oxcaml_flags.Flambda2.Dump.pass =
   | Last_pass
   | This_pass of string

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -101,6 +101,8 @@ val dump_flambda : unit -> bool
 
 val dump_rawfexpr : unit -> dump_target
 
+val dump_fexpr_annot : unit -> bool
+
 type pass = Oxcaml_flags.Flambda2.Dump.pass =
   | Last_pass
   | This_pass of string


### PR DESCRIPTION
When `-dfexpr-annot` is provided, files `prog.raw.fl`, `prog.simplify.fl` and `prog.reaper.fl` (if the reaper is enabled) are produced alongside `prog.cmx` (similar to how a `prog.cmt` is produced when `-bin-annot` is provided).

This provides a convenient way to dump the fexpr representation at multiple stages of the pipeline into separate files by simply adding `-dfexpr-annot` to the `ocamlopt_flags` (rather than having to parse "After XXX:" headers from the standard output).

Note that compiling the compiler with `-dfexpr-annot` is currently broken because of (many) missing primitives in the `fexpr` printer/parser, but that is being worked on separately.