### PR TITLE
chamelon: Check that printing from cmt is functional

### DIFF
--- a/chamelon/chamelon.ml
+++ b/chamelon/chamelon.ml
@@ -205,6 +205,38 @@ let main () =
       !Utils.error_str;
     exit 1);
 
+  (* CHECKING ERROR PRESENCE AFTER PRINTING *)
+  let () =
+    let cmd =
+      if !inplace then (
+        List.iter2 update_single file_names file_strs;
+        !command)
+      else
+        let file_names_min =
+          List.map
+            (fun path -> Filename.chop_extension path ^ "_min.ml")
+            file_names
+        in
+        List.iter2 update_single file_names_min file_strs;
+        List.fold_left
+          (fun c output -> c ^ " " ^ output)
+          !command file_names_min
+    in
+    if not (raise_error cmd) then (
+      Format.eprintf "@[<v 2>*** Printing error ***";
+      Format.eprintf "@ @[%a@ %S;@ %a@]@ " Format.pp_print_text
+        "This command raises the error" !Utils.error_str Format.pp_print_text
+        "however, printing the contents from the cmt file does not raise that \
+         same error.";
+      Format.eprintf "@ @[%a@]@ @;<1 2>%s@ " Format.pp_print_text
+        "The following command does *NOT* raise the error:" cmd;
+      Format.eprintf "@ @[%a@]" Format.pp_print_text
+        "Hint: This is likely due to a missing feature in either untypeast.ml \
+         or pprintast.ml.";
+      Format.eprintf "@]@.";
+      exit 1)
+  in
+
   if List.length file_names = 1 then (
     (* MONOFILE MINIMIZATION*)
     let input = List.hd file_names in


### PR DESCRIPTION
We have an existing check to ensure that the command provided by the user raises the error.

However, if the code involves features not correctly supported by untypeast/pprintast (see for instance #5203, or anything involving modes currently), it might be that re-printing the code from a `.cmt` file will produce unrelated typing errors that will effectively prevent minimization and result in a lot of "Removes error" outcomes.

This patch adds a second verification that after re-printing the full contents of the module (no minimization) from the loaded `.cmt` file we are still raising the error, and fails with an error message instructing the user to look at untypeast/pprintast (or the file printed from the `.cmt`) to investigate.

Note that it might seem like this is a non-issue and Chamelon should be able to eliminate the offending expressions (when they are not needed to reproduce the bug). However, this is not the case (unless the stars align and there is exactly one maximal subexpression involving unsupported features and that is not needed to reproduce the bug) because Chamelon only removes one (sub-)expression at a time.