### PR TITLE
chamelon: call `should_remove ()` before removing value bindings

### DIFF
--- a/chamelon/minimizer/removedeadcode.ml
+++ b/chamelon/minimizer/removedeadcode.ml
@@ -270,7 +270,10 @@ let minimize should_remove map cur_name =
                          let npat =
                            rem_in_pat cur_str vb.vb_pat should_remove
                          in
-                         if var_from_pat npat.pat_desc [] = [] then l
+                         if
+                           var_from_pat npat.pat_desc [] = []
+                           && should_remove ()
+                         then l
                          else { vb with vb_pat = npat } :: l)
                        [] vb_l)
                 in


### PR DESCRIPTION
We must call `should_remove ()` before deciding to remove a value binding, otherwise the removal might be ignored because we think there are "no changes remaining".

Without this patch, the following is not minimized:

```ocaml
let f x =
  let _ = x in
  buggy_expr ()
```

With this patch, it is correctly minimized to:

```ocaml
let f x =
  buggy_expr ()
```