### PR TITLE
Avoid switching stacks on noalloc C calls

### DIFF
--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -434,7 +434,11 @@ let int_regs_destroyed_at_c_call_win64 =
   if Config.runtime5 then [|0;1;4;5;6;7;10;11;12|] else [|0;4;5;6;7;10;11|]
 
 let int_regs_destroyed_at_c_call =
-  if Config.runtime5 then [|0;1;2;3;4;5;6;7;10;11|] else [|0;2;3;4;5;6;7;10;11|]
+  if Config.runtime5 && not Config.no_stack_checks then
+    (* Clobbers r13 (9) to hold stack pointer. See emit.ml *)
+    [|0;2;3;4;5;6;7;9;10;11|]
+  else
+    [|0;2;3;4;5;6;7;10;11|]
 
 let destroyed_at_c_call_win64 =
   (* Win64: rbx, rbp, rsi, rdi, r12-r15, xmm6-xmm15 preserved *)


### PR DESCRIPTION
In no-stack-checks builds, stack switching is not necessary on noalloc C calls.

In stack-checks builds, use r13 instead of rbx to hold the OCaml stack pointer (it's less likely to have something useful in it that needs to be spilled)