### PR TITLE
Improve debug location tracking for partially-applied functions

### DIFF
--- a/lambda/debuginfo.ml
+++ b/lambda/debuginfo.ml
@@ -119,7 +119,8 @@ module Scoped_location = struct
   let enter_lazy ~scopes = cons scopes Sc_lazy (str scopes) ""
                              ~assume_zero_alloc:ZA.Assume_info.none
 
-  let enter_partial_or_eta_wrapper ~scopes =
+  let enter_partial_or_eta_wrapper ~scopes ~loc =
+    ignore loc; (* CR sspies: [loc] will be used in subsequent PRs. *)
     cons scopes Sc_partial_or_eta_wrapper (dot ~no_parens:() scopes "(partial)") ""
       ~assume_zero_alloc:ZA.Assume_info.none
 
@@ -199,7 +200,7 @@ module Scoped_location = struct
   let map_scopes f t =
     match t with
     | Loc_unknown -> Loc_unknown
-    | Loc_known { loc; scopes } -> Loc_known { loc; scopes = f ~scopes }
+    | Loc_known { loc; scopes } -> Loc_known { loc; scopes = f ~scopes ~loc }
 end
 
 type item = {

--- a/lambda/debuginfo.mli
+++ b/lambda/debuginfo.mli
@@ -53,7 +53,7 @@ module Scoped_location : sig
   val enter_class_definition : scopes:scopes -> Ident.t -> scopes
   val enter_method_definition : scopes:scopes -> Asttypes.label -> scopes
   val enter_lazy : scopes:scopes -> scopes
-  val enter_partial_or_eta_wrapper : scopes:scopes -> scopes
+  val enter_partial_or_eta_wrapper : scopes:scopes -> loc:Location.t -> scopes
   val update_assume_zero_alloc :
     scopes:scopes -> assume_zero_alloc:ZA.Assume_info.t -> scopes
   val get_assume_zero_alloc : scopes:scopes -> ZA.Assume_info.t
@@ -68,7 +68,7 @@ module Scoped_location : sig
   val to_location : t -> Location.t
   val string_of_scoped_location : include_zero_alloc:bool -> t -> string
 
-  val map_scopes : (scopes:scopes -> scopes) -> t -> t
+  val map_scopes : (scopes:scopes -> loc:Location.t -> scopes) -> t -> t
 end
 
 type item = private {

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -436,7 +436,9 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
       in
       let lam =
         let loc =
-          map_scopes (update_assume_zero_alloc ~assume_zero_alloc)
+          map_scopes
+            (fun ~scopes ~loc:_ ->
+              update_assume_zero_alloc ~assume_zero_alloc ~scopes)
             (of_location ~scopes e.exp_loc)
         in
         Translprim.transl_primitive_application
@@ -1447,7 +1449,10 @@ and transl_apply ~scopes
          It's fine for [Lsend] cases because [assume_zero_alloc] is
          always false currently for them. *)
         let loc =
-          map_scopes (update_assume_zero_alloc ~assume_zero_alloc) loc
+          map_scopes
+            (fun ~scopes ~loc:_ ->
+              update_assume_zero_alloc ~assume_zero_alloc ~scopes)
+            loc
         in
         Lapply {
           ap_loc=loc;

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -2231,8 +2231,8 @@ let transl_primitive loc p env ty ~poly_mode ~poly_sort path =
   | [] -> lambda_of_prim p.prim_name prim loc args None
   | _ ->
      let loc =
-       Debuginfo.Scoped_location.map_scopes (fun ~scopes ->
-         Debuginfo.Scoped_location.enter_partial_or_eta_wrapper ~scopes)
+       Debuginfo.Scoped_location.map_scopes
+         Debuginfo.Scoped_location.enter_partial_or_eta_wrapper
          loc
      in
      let body = lambda_of_prim p.prim_name prim loc args None in


### PR DESCRIPTION
Complete the work in #5098 to track the location for partially-applied functions just like what is done for anonymous functions and modules. This is intended to be used in #5099.