### PR TITLE
More accurate and informative Gc.stat and Gc.quick_stat

### DIFF
--- a/runtime/caml/gc_stats.h
+++ b/runtime/caml/gc_stats.h
@@ -49,6 +49,7 @@ struct heap_stats {
 struct global_heap_stats {
   uintnat chunk_words;       /* total words in "chunks", including free pools */
   uintnat max_chunk_words;   /* maximum of chunk_words over time */
+  uintnat chunks;            /* count of pool chunks. */
 };
 
 /* Note: accumulating stats then removing them is not a no-op, as

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -81,22 +81,22 @@ CAMLprim value caml_gc_quick_stat(value v)
   Store_field (res, 3, Val_long (mincoll));
   Store_field (res, 4, Val_long (majcoll));
   Store_field (res, 5, Val_long (
-    s.heap_stats.pool_words + s.heap_stats.large_words));
-  Store_field (res, 6, Val_long (0));
+    s.global_stats.chunk_words + s.heap_stats.large_words));
+  Store_field (res, 6, Val_long (s.global_stats.chunks));
   Store_field (res, 7, Val_long (
     s.heap_stats.pool_live_words + s.heap_stats.large_words));
   Store_field (res, 8, Val_long (
     s.heap_stats.pool_live_blocks + s.heap_stats.large_blocks));
   Store_field (res, 9, Val_long (
-    s.heap_stats.pool_words - s.heap_stats.pool_live_words
+    s.global_stats.chunk_words - s.heap_stats.pool_live_words
     - s.heap_stats.pool_frag_words));
-  Store_field (res, 10, Val_long (0));
-  Store_field (res, 11, Val_long (0));
+  Store_field (res, 10, Val_long (0)); /* free_blocks */
+  Store_field (res, 11, Val_long (0)); /* largest_free */
   Store_field (res, 12, Val_long (s.heap_stats.pool_frag_words));
   Store_field (res, 13, Val_long (compactions));
   Store_field (res, 14, Val_long (
     s.heap_stats.pool_max_words + s.heap_stats.large_max_words));
-  Store_field (res, 15, Val_long (0));
+  Store_field (res, 15, Val_long (0)); /* stack_size */
   Store_field (res, 16, Val_long (s.alloc_stats.forced_major_collections));
   CAMLreturn (res);
 }


### PR DESCRIPTION
This reports `heap_chunks` for runtime 5, and includes free pools in both `heap_words` and `free_words`. This is a closer match to the runtime 4 semantics.