### PR TITLE
enable CI tests in nix builds

### DIFF
--- a/.github/workflows/nix-github-actions.yml
+++ b/.github/workflows/nix-github-actions.yml
@@ -31,8 +31,9 @@ jobs:
     name: ${{ matrix.name }} (${{ matrix.system }})
     needs: nix-matrix
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix: ${{fromJSON(needs.nix-matrix.outputs.matrix)}}
 
     permissions:

--- a/default.nix
+++ b/default.nix
@@ -241,9 +241,8 @@ stdenv.mkDerivation {
     autoconf --force
   '';
 
-  checkPhase = lib.optionalString ocamltest ''
-    make ci
-  '';
+  checkTarget = "ci";
+  doCheck = ocamltest;
 
   postInstall =
     # Get rid of unused artifacts


### PR DESCRIPTION
We were not running the tests in CI for the nixbuild because `doCheck` defaults to false in nix builds. Enable it so it does build.

However... There are failing tests.

Also, it seems that the CI process never exits when there are failures.