### PR TITLE
Fix bug with saving ymm registers

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -503,7 +503,7 @@ let must_save_simd_regs live : Reg_class.Save_simd_regs.t =
   else if !v256
   then (
     I.require_vec256 ();
-    Save_zmm)
+    Save_ymm)
   else if !v128
   then Save_xmm
   else Save_none


### PR DESCRIPTION
There have been some recent CI failures causing `SIGILL`.  @TheNumbat does this fix look right?