### PR TITLE
Allow r10 and r11 to be live across allocations (heap and stack)

### DIFF
--- a/backend/asm_targets/asm_symbol.ml
+++ b/backend/asm_targets/asm_symbol.ml
@@ -128,62 +128,7 @@ end)
 (* We predefine several common symbols that violate the standard escaping done
    by [encode]. All predefined symbols are global (runtime functions). *)
 module Predef = struct
-  let caml_call_gc = create_without_encoding ~visibility:Global "caml_call_gc"
-
-  let caml_call_gc_sse =
-    create_without_encoding ~visibility:Global "caml_call_gc_sse"
-
-  let caml_call_gc_avx =
-    create_without_encoding ~visibility:Global "caml_call_gc_avx"
-
-  let caml_call_gc_avx512 =
-    create_without_encoding ~visibility:Global "caml_call_gc_avx512"
-
   let caml_c_call = create_without_encoding ~visibility:Global "caml_c_call"
-
-  let caml_allocN = create_without_encoding ~visibility:Global "caml_allocN"
-
-  let caml_allocN_sse =
-    create_without_encoding ~visibility:Global "caml_allocN_sse"
-
-  let caml_allocN_avx =
-    create_without_encoding ~visibility:Global "caml_allocN_avx"
-
-  let caml_allocN_avx512 =
-    create_without_encoding ~visibility:Global "caml_allocN_avx512"
-
-  let caml_alloc1 = create_without_encoding ~visibility:Global "caml_alloc1"
-
-  let caml_alloc1_sse =
-    create_without_encoding ~visibility:Global "caml_alloc1_sse"
-
-  let caml_alloc1_avx =
-    create_without_encoding ~visibility:Global "caml_alloc1_avx"
-
-  let caml_alloc1_avx512 =
-    create_without_encoding ~visibility:Global "caml_alloc1_avx512"
-
-  let caml_alloc2 = create_without_encoding ~visibility:Global "caml_alloc2"
-
-  let caml_alloc2_sse =
-    create_without_encoding ~visibility:Global "caml_alloc2_sse"
-
-  let caml_alloc2_avx =
-    create_without_encoding ~visibility:Global "caml_alloc2_avx"
-
-  let caml_alloc2_avx512 =
-    create_without_encoding ~visibility:Global "caml_alloc2_avx512"
-
-  let caml_alloc3 = create_without_encoding ~visibility:Global "caml_alloc3"
-
-  let caml_alloc3_sse =
-    create_without_encoding ~visibility:Global "caml_alloc3_sse"
-
-  let caml_alloc3_avx =
-    create_without_encoding ~visibility:Global "caml_alloc3_avx"
-
-  let caml_alloc3_avx512 =
-    create_without_encoding ~visibility:Global "caml_alloc3_avx512"
 
   let caml_ml_array_bound_error =
     create_without_encoding ~visibility:Global "caml_ml_array_bound_error"

--- a/backend/asm_targets/asm_symbol.mli
+++ b/backend/asm_targets/asm_symbol.mli
@@ -68,47 +68,7 @@ val is_local : t -> bool
 
 (** We predefine several non-user generated symbols. *)
 module Predef : sig
-  val caml_call_gc : t
-
-  val caml_call_gc_sse : t
-
-  val caml_call_gc_avx : t
-
-  val caml_call_gc_avx512 : t
-
   val caml_c_call : t
-
-  val caml_allocN : t
-
-  val caml_allocN_sse : t
-
-  val caml_allocN_avx : t
-
-  val caml_allocN_avx512 : t
-
-  val caml_alloc1 : t
-
-  val caml_alloc1_sse : t
-
-  val caml_alloc1_avx : t
-
-  val caml_alloc1_avx512 : t
-
-  val caml_alloc2 : t
-
-  val caml_alloc2_sse : t
-
-  val caml_alloc2_avx : t
-
-  val caml_alloc2_avx512 : t
-
-  val caml_alloc3 : t
-
-  val caml_alloc3_sse : t
-
-  val caml_alloc3_avx : t
-
-  val caml_alloc3_avx512 : t
 
   val caml_ml_array_bound_error : t
 

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -674,6 +674,7 @@ G(caml_system__code_begin):
 
 #define Make_call_realloc_stack(suffix, simd)        \
     FUNCTION(G(caml_call_realloc_stack ## suffix))   \
+    LBL(caml_call_realloc_stack ## suffix):          \
     CFI_STARTPROC                                  ; \
         CFI_SIGNAL_FRAME;                            \
         ENTER_FUNCTION;                              \
@@ -705,10 +706,11 @@ Make_call_realloc_stack(_avx512, ZMM)
 
 #define Make_call_gc(suffix, simd)                   \
     FUNCTION(G(caml_call_gc##suffix)) ;              \
+    LBL(caml_call_gc ## suffix):                     \
     CFI_STARTPROC                     ;              \
         CFI_SIGNAL_FRAME;                            \
         ENTER_FUNCTION;                              \
-LBL(caml_call_gc ## suffix):                         \
+LBL(_caml_call_gc ## suffix):                        \
         SAVE_ALL_REGS(simd);                         \
         movq    %r15, Caml_state(gc_regs);           \
         TSAN_ENTER_FUNCTION(0);                      \
@@ -750,11 +752,12 @@ ENDFUNCTION(G(caml_raise_stack_overflow_nat))
 
 #define Make_alloc_fun(base_name, words, simd) \
 FUNCTION(G(base_name ## simd))                 \
+LBL(base_name ## simd):                        \
 CFI_STARTPROC;                                 \
         ENTER_FUNCTION;                        \
         r15_sub_ ## words ;                    \
         cmpq    Caml_state(young_limit), %r15; \
-        jb      LBL(caml_call_gc ## simd);     \
+        jb      LBL(_caml_call_gc ## simd);     \
         LEAVE_FUNCTION;                        \
         ret;                                   \
 CFI_ENDPROC ;                                  \
@@ -773,6 +776,7 @@ Make_alloc_funs(N) /* caml_allocN* */
 
 #define Make_call_local_realloc(suffix, simd)        \
     FUNCTION(G(caml_call_local_realloc ## suffix)) ; \
+    LBL(caml_call_local_realloc ## suffix):          \
     CFI_STARTPROC               ;                    \
         CFI_SIGNAL_FRAME;                            \
         ENTER_FUNCTION;                              \
@@ -1558,6 +1562,31 @@ CFI_STARTPROC
 1:      ret
 CFI_ENDPROC
 ENDFUNCTION(G(caml_assert_stack_invariants))
+
+FUNCTION(G(caml_init_gc_entrypoints))
+CFI_STARTPROC
+        ENTER_FUNCTION
+#define Init_one(name, simd, vec) \
+        leaq LBL(name ## simd)(%rip), %rax; \
+        movq %rax, (8*domain_field_caml_##name##vec)(C_ARG_1)
+#define Init(name) \
+        Init_one(name, ,); \
+        Init_one(name, _sse, _simd0); \
+        Init_one(name, _avx, _simd1); \
+        Init_one(name, _avx512, _simd2)
+        Init(caml_call_gc)
+        Init(caml_alloc1)
+        Init(caml_alloc2)
+        Init(caml_alloc3)
+        Init(caml_allocN)
+        Init(caml_call_realloc_stack)
+        Init(caml_call_local_realloc)
+#undef  Init
+#undef  Init_one
+        LEAVE_FUNCTION
+        ret
+CFI_ENDPROC
+ENDFUNCTION(G(caml_init_gc_entrypoints))
 
         TEXT_SECTION(caml_system__code_end)
         .globl  G(caml_system__code_end)

--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -25,6 +25,8 @@
 #define NUM_EXTRA_PARAMS 64
 typedef value extra_params_area[NUM_EXTRA_PARAMS];
 
+typedef void (*caml_gc_entrypoint)(void);
+
 /* This structure sits in the TLS area and is also accessed efficiently
  * via native code, which is why the indices are important */
 typedef struct {

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -202,5 +202,41 @@ DOMAIN_STATE(struct caml_exception_context*, external_raise_async)
 DOMAIN_STATE(struct memprof_domain_s *, memprof)
 DOMAIN_STATE(value *, memprof_young_trigger)
 
+/* Assembly stubs that require all registers to be preserved.  These cannot be
+   called using standard linker symbols, since on at least Linux amd64 these
+   might go through a lazy-binding PLT stub that clobbers some registers.
+
+   These come in up to 4 variants according to the amount of float/SIMD register
+   state that must be preserved, which varies by architecture.
+   On amd64, simd0 = SSE, simd1 = AVX, simd2 = AVX512. */
+DOMAIN_STATE(caml_gc_entrypoint, caml_call_gc)
+DOMAIN_STATE(caml_gc_entrypoint, caml_call_gc_simd0)
+DOMAIN_STATE(caml_gc_entrypoint, caml_call_gc_simd1)
+DOMAIN_STATE(caml_gc_entrypoint, caml_call_gc_simd2)
+DOMAIN_STATE(caml_gc_entrypoint, caml_alloc1)
+DOMAIN_STATE(caml_gc_entrypoint, caml_alloc1_simd0)
+DOMAIN_STATE(caml_gc_entrypoint, caml_alloc1_simd1)
+DOMAIN_STATE(caml_gc_entrypoint, caml_alloc1_simd2)
+DOMAIN_STATE(caml_gc_entrypoint, caml_alloc2)
+DOMAIN_STATE(caml_gc_entrypoint, caml_alloc2_simd0)
+DOMAIN_STATE(caml_gc_entrypoint, caml_alloc2_simd1)
+DOMAIN_STATE(caml_gc_entrypoint, caml_alloc2_simd2)
+DOMAIN_STATE(caml_gc_entrypoint, caml_alloc3)
+DOMAIN_STATE(caml_gc_entrypoint, caml_alloc3_simd0)
+DOMAIN_STATE(caml_gc_entrypoint, caml_alloc3_simd1)
+DOMAIN_STATE(caml_gc_entrypoint, caml_alloc3_simd2)
+DOMAIN_STATE(caml_gc_entrypoint, caml_allocN)
+DOMAIN_STATE(caml_gc_entrypoint, caml_allocN_simd0)
+DOMAIN_STATE(caml_gc_entrypoint, caml_allocN_simd1)
+DOMAIN_STATE(caml_gc_entrypoint, caml_allocN_simd2)
+DOMAIN_STATE(caml_gc_entrypoint, caml_call_realloc_stack)
+DOMAIN_STATE(caml_gc_entrypoint, caml_call_realloc_stack_simd0)
+DOMAIN_STATE(caml_gc_entrypoint, caml_call_realloc_stack_simd1)
+DOMAIN_STATE(caml_gc_entrypoint, caml_call_realloc_stack_simd2)
+DOMAIN_STATE(caml_gc_entrypoint, caml_call_local_realloc)
+DOMAIN_STATE(caml_gc_entrypoint, caml_call_local_realloc_simd0)
+DOMAIN_STATE(caml_gc_entrypoint, caml_call_local_realloc_simd1)
+DOMAIN_STATE(caml_gc_entrypoint, caml_call_local_realloc_simd2)
+
 DOMAIN_STATE(extra_params_area, extra_params)
 /* This member must occur last, because it is an array, not a scalar */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -692,6 +692,11 @@ static void domain_create(uintnat initial_minor_heap_wsize,
   domain_state->young_ptr = NULL;
   domain_state->young_trigger = NULL;
 
+#ifdef NATIVE_CODE
+  extern void caml_init_gc_entrypoints(caml_domain_state*);
+  caml_init_gc_entrypoints(domain_state);
+#endif
+
   domain_state->minor_tables = caml_alloc_minor_tables();
   if(domain_state->minor_tables == NULL) {
     goto fail_minor_tables;


### PR DESCRIPTION
These may be clobbered by PLT stubs, but by avoiding those stubs (by putting the entrypoint addresses in Caml_state) we can guarantee that no registers are harmed on the way into the GC.

This is another approach along the lines of #5160 and #5165, see there for more discussion.

cc @NicolasT @NegativeMjark