### PR TITLE
Add `[%%expect.ignore_echo]`

### DIFF
--- a/testsuite/tests/tool-expect-test/ignore_echo.ml
+++ b/testsuite/tests/tool-expect-test/ignore_echo.ml
@@ -1,16 +1,16 @@
 (* TEST
    (*
      These are the same test steps as [expect;] (see `ocaml_tests.ml`), but
-     the reference file is changed to `ignore_feedback.reference` so we can
+     the reference file is changed to `ignore_echo.reference` so we can
      test cases where [expect;] changes the input program.
    *)
    setup-simple-build-env;
    run-expect;
-   reference = "${test_source_directory}/ignore_feedback.reference";
+   reference = "${test_source_directory}/ignore_echo.reference";
    check-program-output;
 *)
 
-(* Feedback is printed *)
+(* Echo *)
 type t = A | B of int
 let x = B 5
 [%%expect{|
@@ -18,14 +18,23 @@ type t = A | B of int
 val x : t = B 5
 |}]
 
-(* Feedback is not printed *)
+(* No echo *)
 type t = A | B of int
 let x = B 5
-[%%expect.ignore_feedback]
+[%%expect.ignore_echo]
 
 (* Warnings are not ignored *)
 let x = let x = 5 in 5
-[%%expect.ignore_feedback]
+[%%expect.ignore_echo{|
+Line 1, characters 12-13:
+1 | let x = let x = 5 in 5
+                ^
+Warning 26 [unused-var]: unused variable x.
+|}]
+
+(* Warnings are added if they are not in the expect output *)
+let x = let x = 5 in 5
+[%%expect.ignore_echo]
 
 (* Trailing output is still captured *)
 type t = A | B of int

--- a/testsuite/tests/tool-expect-test/ignore_echo.reference
+++ b/testsuite/tests/tool-expect-test/ignore_echo.reference
@@ -1,16 +1,16 @@
 (* TEST
    (*
      These are the same test steps as [expect;] (see `ocaml_tests.ml`), but
-     the reference file is changed to `ignore_feedback.reference` so we can
+     the reference file is changed to `ignore_echo.reference` so we can
      test cases where [expect;] changes the input program.
    *)
    setup-simple-build-env;
    run-expect;
-   reference = "${test_source_directory}/ignore_feedback.reference";
+   reference = "${test_source_directory}/ignore_echo.reference";
    check-program-output;
 *)
 
-(* Feedback is printed *)
+(* Echo *)
 type t = A | B of int
 let x = B 5
 [%%expect{|
@@ -18,14 +18,23 @@ type t = A | B of int
 val x : t = B 5
 |}]
 
-(* Feedback is not printed *)
+(* No echo *)
 type t = A | B of int
 let x = B 5
-[%%expect.ignore_feedback]
+[%%expect.ignore_echo]
 
 (* Warnings are not ignored *)
 let x = let x = 5 in 5
-[%%expect.ignore_feedback{|
+[%%expect.ignore_echo{|
+Line 1, characters 12-13:
+1 | let x = let x = 5 in 5
+                ^
+Warning 26 [unused-var]: unused variable x.
+|}]
+
+(* Warnings are added if they are not in the expect output *)
+let x = let x = 5 in 5
+[%%expect.ignore_echo{|
 Line 1, characters 12-13:
 1 | let x = let x = 5 in 5
                 ^

--- a/testsuite/tests/typing-local/let_mutable.ml
+++ b/testsuite/tests/typing-local/let_mutable.ml
@@ -20,7 +20,7 @@ val foo1 : int -> int = <fun>
 
 (* Test 1.2: basic usage with a nested record returning string *)
 type t_1_2 = { str_1_2 : string ref }
-[%%expect.ignore_feedback]
+[%%expect.ignore_echo]
 let x_1_2 =
   let mutable x = { str_1_2 = ref "Hi" } in
   x <- { str_1_2 = ref "Bye" };
@@ -31,7 +31,7 @@ val x_1_2 : string = "Bye"
 
 (* Test 1.3: returning an immutable record *)
 type t_1_3 = { str_1_3 : string }
-[%%expect.ignore_feedback]
+[%%expect.ignore_echo]
 let x_1_3 =
   let mutable x = { str_1_3 = "Hi" } in
   x <- { str_1_3 = "Bye" };
@@ -42,7 +42,7 @@ val x_1_3 : t_1_3 = {str_1_3 = "Bye"}
 
 (* Test 1.4: returning a mutable nested record *)
 type t_1_4 = { str_1_4 : string ref }
-[%%expect.ignore_feedback]
+[%%expect.ignore_echo]
 let x_1_4 =
   let mutable x = { str_1_4 = ref "Hi" } in
   x <- { str_1_4 = ref "Bye" };
@@ -115,7 +115,7 @@ let [@warning "-26"] m_3_3 =
   let mutable y = 42 in
   (module (struct module F () = struct let x = y end end) : S_3_3)
 
-[%%expect.ignore_feedback{|
+[%%expect.ignore_echo{|
 Line 5, characters 47-48:
 5 |   (module (struct module F () = struct let x = y end end) : S_3_3)
                                                    ^
@@ -393,7 +393,7 @@ val f_11 : unit -> int * int = <fun>
 
 (* Test 12: like Test 11, but with a constructor *)
 type t_12 = Foo_12 of int
-[%%expect.ignore_feedback]
+[%%expect.ignore_echo]
 
 let y_12 =
   let mutable x = 42 in
@@ -459,7 +459,7 @@ val y_13_3 : int ref = {contents = 0}
 |}]
 
 let require_portable (f : (int -> unit) @ portable) = ()
-[%%expect.ignore_feedback]
+[%%expect.ignore_echo]
 
 (* Tests 13.4 to 13.7: Notice the [@ portable] does not prevent future values
    from being non-portable, but the portability of future values of [f] is still


### PR DESCRIPTION
Add `[%expect.ignore_echo {|..|}]` to expect tests, which ignores REPL echoes like `val - : int = 5`. This is functionally a way to ignore expect test output you don't care about without silencing warnings or errors.

See `testsuite/tests/typing-local/let_mutable.ml` for an example.

`expect` has also been changed in 2 ways to make `expect.ignore_echo` easier to use:

  - The default payload is now "\\n" instead of the empty string.
  - If both normal and principal output is "\\n", the expect payload isn't printed.

This means "expect no warnings or errors" can be written as

    [%expect.ignore_echo]

instead of

    [%expect.ignore_echo {|
    |}]
