### PR TITLE
Bump dune language version to 3.20

### DIFF
--- a/.github/workflows/ocamlformat.yml
+++ b/.github/workflows/ocamlformat.yml
@@ -43,5 +43,19 @@ jobs:
         if: ${{ contains( github.event.pull_request.labels.*.name, 'skip 80ch') }}
         run: echo SKIP_80CH=y >> "$GITHUB_ENV"
 
+      - name: Set up Opam environment
+        # this command adds the opam environment to the PATH.
+        run: |
+          opam env --set-root --set-switch --shell=cmd | sed -n 's/^set //p' | tee -a "$GITHUB_ENV"
+
+      # We need to configure for formatting, because dune with language version
+      # 3.20 checks whether all files declared with [copy_files] exist. This
+      # matters for Makefile.config, which is generated during configuration.
+      - name: Configure compiler
+        run: |
+          autoconf
+          ./configure \
+            --enable-runtime5 --prefix=$GITHUB_WORKSPACE/_install
+
       - name: Check OCaml Formatting
         run: opam exec -- bash tools/ci/actions/check-fmt.sh

--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -15,7 +15,7 @@ else
 endif
 
 define dune_boot_context
-(lang dune 2.8)
+(lang dune 3.20)
 ; We need to call the boot context "default" so that dune selects it for merlin
 (context (default
   (name default)
@@ -40,7 +40,7 @@ ENV_VARS :=
 endif
 
 define dune_runtime_stdlib_context
-(lang dune 2.8)
+(lang dune 3.20)
 (context (default
   (name runtime_stdlib)
   (profile main)
@@ -53,7 +53,7 @@ define dune_runtime_stdlib_context
 endef
 
 define dune_main_context
-(lang dune 2.8)
+(lang dune 3.20)
 (context (default
   (name main)
   (profile $(main_build_profile))

--- a/default.nix
+++ b/default.nix
@@ -72,10 +72,10 @@ let
   # Over time, we should probably define something like a "boot environment" and build
   # dune and the other dependencies with the patched system compiler.
   dune = pkgs.ocaml-ng.ocamlPackages_4_14.dune_3.overrideAttrs rec {
-    version = "3.19.1";
+    version = "3.20.2";
     src = pkgs.fetchurl {
       url = "https://github.com/ocaml/dune/releases/download/${version}/dune-${version}.tbz";
-      hash = "sha256-oQOG+YDNqUF9FGVGa+1Q3SrvnJO50GoPf+7tsKFUEVg=";
+      hash = "sha256-sahrLWC9tKi5u2hhvfL58opufLXYM86Br+zOue+cpUk=";
     };
   };
 

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.13)
+(lang dune 3.20)
 (formatting (enabled_for ocaml))
 (wrapped_executables false)
 (using experimental_building_ocaml_compiler_with_dune 0.1)

--- a/dune-project.ox
+++ b/dune-project.ox
@@ -1,4 +1,4 @@
-(lang dune 2.8)
+(lang dune 3.20)
 (wrapped_executables false)
 (using experimental_building_ocaml_compiler_with_dune 0.1)
 (using menhir 2.1)

--- a/otherlibs/dynlink/dune
+++ b/otherlibs/dynlink/dune
@@ -272,8 +272,6 @@
 
 (copy_files ../../parsing/parser_types.ml)
 
-(copy_files ../../parsing/parser.ml)
-
 (copy_files ../../parsing/printast.ml)
 
 (copy_files ../../parsing/pprintast.ml)
@@ -486,8 +484,6 @@
 
 (copy_files ../../typing/jkind.mli)
 
-(copy_files ../../typing/jkind_intf.mli)
-
 (copy_files ../../typing/jkind_types.mli)
 
 (copy_files ../../typing/jkind_axis.mli)
@@ -547,8 +543,6 @@
 (copy_files ../../typing/predef.mli)
 
 (copy_files ../../typing/datarepr.mli)
-
-(copy_files ../../typing/unit_info.mli)
 
 (copy_files ../../typing/typedtree.mli)
 


### PR DESCRIPTION
This PR bumps the language version that we are using for dune files to `3.20`. This requires removing some dangling copy dependencies from the dune files.

This PR is in preparation of adding `(using oxcaml 0.1)`, which will allow us to use oxcaml specific dune stanzas in dune files. 