### PR TITLE
Update locality docs to make them more detached from allocation

### DIFF
--- a/jane/doc/extensions/_05-modes/intro.md
+++ b/jane/doc/extensions/_05-modes/intro.md
@@ -87,7 +87,7 @@ function's body is a region, as are loop bodies.
 The type checker does not allow values that are *local* to escape their scope
 (for example, by being returned from a function or stored in a global
 ref). Values that are *global* may freely escape their scope. The compiler may
-stack allocate values that are local (but is not required to do so).
+stack allocate values that are local (but does not guarantee to do so).
 
 There is a caveat to the scoping restriction: for some types such as `int`, the
 type system does allow *local* values to escape (i.e., they may be used as


### PR DESCRIPTION
This PR updates the documentation of the locality axis to make it less tied to stack allocation. Locality is a useful concept (e.g., for dealing with resources) even when no allocation is involved.