### PR TITLE
Add project-wide Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+    "permissions": {
+        "allow": [
+            "Bash(make:*)",
+            "Bash(rg:*)",
+            "Bash(cat:*)"
+        ]
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,7 @@ _profile/
 /_install
 /_runtest
 /_opam
-/.claude
+/.claude/*.local.*
 
 /oc_cflags.sexp
 /oc_cppflags.sexp


### PR DESCRIPTION
Instead of `.gitignore`ing the entire `.claude` folder, only ignore the `*.local.*` files which contain per-user configuration. Add `.claude/settings.json` with project-wide settings.

To start, we add some permissions.