### PR TITLE
Introduce `Compilation_unit.full_path_with_arguments_as_string`

### DIFF
--- a/utils/compilation_unit.ml
+++ b/utils/compilation_unit.ml
@@ -546,6 +546,48 @@ let base_filename t =
   String.concat "" ((name |> Name.to_string) :: arg_segments)
   |> String.uncapitalize_ascii
 
+let instance_separator = "____"
+
+let instance_separator_depth_char = '_'
+
+let mangle_for_linkage_name ~pack_separator t =
+  (* Returns a string to be part of the linkage name, not the full linkage name
+     yet; see {!Symbol.linkage_name_for_compilation_unit} for the resulting
+     linkage name. *)
+  (* CR-someday lmaurer: If at all possible, just use square brackets instead of
+     this unholy underscore encoding. For now I'm following the original
+     practice of avoiding non-identifier characters. *)
+  let for_pack_prefix, name, flattened_instance_args = flatten t in
+  let name = Name.to_string name in
+  let suffix =
+    if not (Prefix.is_empty for_pack_prefix)
+    then begin
+      assert (match flattened_instance_args with [] -> true | _ -> false);
+      let pack_names =
+        Prefix.to_list for_pack_prefix |> List.map Name.to_string
+      in
+      String.concat (pack_separator ()) (pack_names @ [name])
+    end
+    else begin
+      let arg_segments =
+        List.map
+          (fun (depth, _param, value) ->
+            let extra_separators =
+              String.make depth instance_separator_depth_char
+            in
+            let value = value |> Name.to_string in
+            String.concat "" [instance_separator; extra_separators; value])
+          flattened_instance_args
+      in
+      String.concat "" arg_segments
+    end
+  in
+  (* Note that [name] is prepended unconditionnally here, so it ends up being
+     duplicated in the case of a [-for-pack] prefix, as it appears both at the
+     beginning and at the end of the mangled name. This differs from the
+     upstream compiler, which doesn't add it at the beginning. *)
+  name ^ suffix
+
 let is_parent t ~child =
   List.equal Name.equal (full_path t) (Prefix.to_list (for_pack_prefix child))
 

--- a/utils/compilation_unit.mli
+++ b/utils/compilation_unit.mli
@@ -235,6 +235,12 @@ val full_path : t -> Name.t list
     conventions. *)
 val full_path_as_string : t -> string
 
+(** Returns the full path of the compilation unit including its arguments in the
+    mangled form suitable to create its linkage name and using the given
+    [pack_separator] when relevant. (See at the finishing steps in
+    {!Symbol.linkage_name_for_compilation_unit}). *)
+val mangle_for_linkage_name : pack_separator:(unit -> string) -> t -> string
+
 (** Returns the string that should form the base of the .cmx/o file for this
     unit. Usually just [name_as_string t] uncapitalized, but if there are
     instance arguments, they're encoded in a Bash-friendly but otherwise

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -137,6 +137,8 @@ module Stdlib : sig
         is returned with the [xs] being the contents of those [Some]s, with
         order preserved.  Otherwise return [None]. *)
 
+    val map : ('a -> 'b) -> 'a t -> 'b t
+
     val map_option : ('a -> 'b option) -> 'a t -> 'b t option
     (** [map_option f l] is [some_if_all_elements_are_some (map f l)], but with
         short circuiting. *)

--- a/utils/symbol.ml
+++ b/utils/symbol.ml
@@ -69,8 +69,6 @@ let this_is_ocamlc () = this_is_ocamlc := true
 let force_runtime4_symbols () = force_runtime4_symbols := true
 
 let pack_separator = separator
-let instance_separator = "____"
-let instance_separator_depth_char = '_'
 let member_separator = separator
 
 let linkage_name t = t.linkage_name
@@ -86,39 +84,8 @@ let linkage_name_for_ocamlobjinfo t =
 
 let compilation_unit t = t.compilation_unit
 
-(* CR-someday lmaurer: Would be nicer to have some of this logic in
-   [Linkage_name]; among other things, we could then define
-   [Linkage_name.for_current_unit] *)
-
 let linkage_name_for_compilation_unit comp_unit =
-  (* CR-someday lmaurer: If at all possible, just use square brackets instead of
-     this unholy underscore encoding. For now I'm following the original
-     practice of avoiding non-identifier characters. *)
-  let for_pack_prefix, name, flattened_instance_args = CU.flatten comp_unit in
-  let name = CU.Name.to_string name in
-  let suffix =
-    if not (CU.Prefix.is_empty for_pack_prefix)
-    then begin
-      assert (flattened_instance_args = []);
-      let pack_names =
-        CU.Prefix.to_list for_pack_prefix |> List.map CU.Name.to_string
-      in
-      String.concat (pack_separator ()) (pack_names @ [name])
-    end else begin
-      let arg_segments =
-        List.map
-          (fun (depth, _param, value) ->
-             let extra_separators =
-               String.make depth instance_separator_depth_char
-             in
-             let value = value |> CU.Name.to_string in
-             String.concat "" [instance_separator; extra_separators; value])
-          flattened_instance_args
-      in
-      String.concat "" arg_segments
-    end
-  in
-  caml_symbol_prefix ^ name ^ suffix
+  caml_symbol_prefix ^ CU.mangle_for_linkage_name ~pack_separator comp_unit
   |> Linkage_name.of_string
 
 let for_predef_ident id =


### PR DESCRIPTION
Refactor the logic in `Symbol.linkage_name_for_compilation_unit` and move most of it into `Compilation_unit` where it is really similar to `base_filename`.
This move enables to share that logic with a new mangling scheme, to be introduced by #5099.

**Dropped during review:** Along with the code move, this changes the result for compilation units with a for-pack prefix by dropping the extra (base) module name at the start.

For instance `ocamlopt -c -for-pack Packed -o forpack.cmx x.ml` creates:
- before this patch: `camlForpackPacked__Forpack__code_begin`
- after this patch: `camlPacked__Forpack__code_begin`

Note that upstream OCaml 5.4 creates `camlPacked.Forpack.code_begin` on Unix. I assumed that this difference with upstream was not intended and could be changed here; the behaviour can be maintained, obviously, by adding back the extra prefix to avoid any behaviour change.