### PR TITLE
Fixes and test cases for symbol projections involving unboxed numbers

### DIFF
--- a/middle_end/flambda2/kinds/flambda_kind.mli
+++ b/middle_end/flambda2/kinds/flambda_kind.mli
@@ -122,6 +122,8 @@ module Mixed_block_shape : sig
   val equal : t -> t -> bool
 
   val compare : t -> t -> int
+
+  val print : Format.formatter -> t -> unit
 end
 
 module Scannable_block_shape : sig

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -381,30 +381,12 @@ let create_let_symbols uacc lifted_constant ~body =
         | None ->
           let prim : P.t =
             let symbol = Simple.symbol (Symbol_projection.symbol proj) in
-            let kind = Symbol_projection.kind proj in
+            let result_kind = Symbol_projection.kind proj in
             match Symbol_projection.projection proj with
-            | Block_load { index } ->
-              let block_access_kind : P.Block_access_kind.t =
-                match Flambda_kind.With_subkind.kind kind with
-                | Value ->
-                  let field_kind : P.Block_access_field_kind.t =
-                    if
-                      Flambda_kind.With_subkind.equal kind
-                        Flambda_kind.With_subkind.tagged_immediate
-                    then Immediate
-                    else Any_value
-                  in
-                  Values { tag = Unknown; size = Unknown; field_kind }
-                | Naked_number Naked_float -> Naked_floats { size = Unknown }
-                | Naked_number
-                    ( Naked_float32 | Naked_immediate | Naked_nativeint
-                    | Naked_int8 | Naked_int16 | Naked_int32 | Naked_vec128
-                    | Naked_vec256 | Naked_vec512 | Naked_int64 )
-                | Region | Rec_info ->
-                  Misc.fatal_errorf
-                    "Unexpected kind %a for symbol projection: %a"
-                    Flambda_kind.With_subkind.print kind Symbol_projection.print
-                    proj
+            | Block_load { index; block_shape } ->
+              let block_access_kind =
+                P.Block_access_kind.from_block_shape block_shape ~index
+                  ~result_kind
               in
               Unary
                 ( Block_load

--- a/middle_end/flambda2/simplify/lifting/lifted_constant.ml
+++ b/middle_end/flambda2/simplify/lifting/lifted_constant.ml
@@ -291,7 +291,7 @@ let apply_projection t proj =
     let typing_env = DE.typing_env denv in
     let meet_shortcut =
       match Symbol_projection.projection proj with
-      | Block_load { index } ->
+      | Block_load { index; block_shape = _ } ->
         let field_kind =
           Symbol_projection.kind proj |> Flambda_kind.With_subkind.kind
         in

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -934,8 +934,14 @@ let simplify_immutable_block_load access_kind ~field ~min_name_mode dacc
   in
   SPR.map_dacc result (fun dacc ->
       let kind = P.Block_access_kind.element_subkind_for_load access_kind in
+      let block_shape : Flambda_kind.Block_shape.t =
+        match (access_kind : P.Block_access_kind.t) with
+        | Values _ -> Scannable Value_only
+        | Naked_floats _ -> Float_record
+        | Mixed { shape; _ } -> Scannable (Mixed_record shape)
+      in
       Simplify_common.add_symbol_projection dacc ~projected_from:arg
-        (Symbol_projection.Projection.block_load ~index:field)
+        (Symbol_projection.Projection.block_load ~index:field ~block_shape)
         ~projection_bound_to:result_var ~kind)
 
 let simplify_mutable_block_load _access_kind ~field:_ ~original_prim dacc

--- a/middle_end/flambda2/term_basics/symbol_projection.mli
+++ b/middle_end/flambda2/term_basics/symbol_projection.mli
@@ -14,13 +14,17 @@
 
 module Projection : sig
   type t = private
-    | Block_load of { index : Target_ocaml_int.t }
+    | Block_load of
+        { index : Target_ocaml_int.t;
+          block_shape : Flambda_kind.Block_shape.t
+        }
     | Project_value_slot of
         { project_from : Function_slot.t;
           value_slot : Value_slot.t
         }
 
-  val block_load : index:Target_ocaml_int.t -> t
+  val block_load :
+    index:Target_ocaml_int.t -> block_shape:Flambda_kind.Block_shape.t -> t
 
   val project_value_slot : Function_slot.t -> Value_slot.t -> t
 end

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -242,6 +242,12 @@ module Block_access_kind : sig
   val element_subkind_for_load : t -> Flambda_kind.With_subkind.t
 
   val to_block_shape : t -> Flambda_kind.Block_shape.t
+
+  val from_block_shape :
+    Flambda_kind.Block_shape.t ->
+    index:Target_ocaml_int.t ->
+    result_kind:Flambda_kind.With_subkind.t ->
+    t
 end
 
 (* CR-someday mshinwell: We should have unboxed arrays of int32, int64 and

--- a/testsuite/tests/flambda2/symbol_projections/symbol_projections.ml
+++ b/testsuite/tests/flambda2/symbol_projections/symbol_projections.ml
@@ -1,0 +1,19 @@
+(* TEST
+   compile_only = "true";
+   flambda2;
+   setup-ocamlopt.opt-build-env;
+   ocamlopt.opt;
+   check-ocamlopt.opt-output;
+*)
+
+[@@@ocaml.flambda_o3]
+
+external getenv : string -> string = "caml_sys_getenv"
+
+external ( + ) : int -> int -> int = "%addint"
+
+let foo = match getenv "FOO" with exception _ -> false | _ -> true
+
+let f x =
+  let g y = if foo then y + y else y in
+  x, g

--- a/testsuite/tests/flambda2/symbol_projections/symbol_projections2.ml
+++ b/testsuite/tests/flambda2/symbol_projections/symbol_projections2.ml
@@ -1,0 +1,24 @@
+(* TEST
+   compile_only = "true";
+   flambda2;
+   setup-ocamlopt.opt-build-env;
+   ocamlopt.opt;
+   check-ocamlopt.opt-output;
+*)
+
+(* From pchambart 2020-07-22, ocaml-flambda/ocaml issue #214 *)
+
+[@@@ocaml.flambda_o3]
+
+external opaque_identity : 'a -> 'a = "%opaque"
+
+external ( + ) : int -> int -> int = "%addint"
+
+let[@inline never] ignore _ = ()
+
+let v = opaque_identity 33
+
+let g () =
+  let () = ignore () in
+  let f x = x + v in
+  f

--- a/testsuite/tests/flambda2/symbol_projections/symbol_projections3.ml
+++ b/testsuite/tests/flambda2/symbol_projections/symbol_projections3.ml
@@ -1,0 +1,20 @@
+(* TEST
+   compile_only = "true";
+   flambda2;
+   setup-ocamlopt.opt-build-env;
+   ocamlopt.opt;
+   check-ocamlopt.opt-output;
+*)
+
+[@@@ocaml.flambda_o3]
+
+external getenv : string -> string = "caml_sys_getenv"
+
+external ( + ) : int -> int -> int = "%addint"
+
+let foo = match getenv "FOO" with exception _ -> false | _ -> true
+
+let f x =
+  let g y = if foo then y + y else y in
+  let block_to_lift = foo, foo in
+  x, g, block_to_lift

--- a/testsuite/tests/flambda2/symbol_projections/symbol_projections4.ml
+++ b/testsuite/tests/flambda2/symbol_projections/symbol_projections4.ml
@@ -1,0 +1,24 @@
+(* TEST
+   compile_only = "true";
+   flambda2;
+   setup-ocamlopt.opt-build-env;
+   ocamlopt.opt;
+   check-ocamlopt.opt-output;
+*)
+
+[@@@ocaml.flambda_o3]
+
+external getenv : string -> string = "caml_sys_getenv"
+
+external ( + ) : int -> int -> int = "%addint"
+
+let foo = match getenv "FOO" with exception _ -> false | _ -> true
+
+let f x b =
+  if b
+  then
+    let g y = if foo then y + y else y in
+    x, g
+  else
+    let h y = if foo then y + y + y else y in
+    x, h

--- a/testsuite/tests/flambda2/symbol_projections/symbol_projections5.ml
+++ b/testsuite/tests/flambda2/symbol_projections/symbol_projections5.ml
@@ -1,0 +1,32 @@
+(* TEST
+   compile_only = "true";
+   flambda2;
+   setup-ocamlopt.opt-build-env;
+   ocamlopt.opt;
+   check-ocamlopt.opt-output;
+*)
+
+[@@@ocaml.flambda_o3]
+
+external getenv : string -> string = "caml_sys_getenv"
+
+external ( + ) : int -> int -> int = "%addint"
+
+external ( < ) : int -> int -> bool = "%lessthan"
+
+external ( && ) : bool -> bool -> bool = "%sequand"
+
+let foo = match getenv "FOO" with exception _ -> false | _ -> true
+
+type t =
+  | S of (int -> t)
+  | T of (int -> t)
+
+let f b =
+  if b
+  then
+    let rec g y = if y < 0 then S g else T g in
+    g
+  else
+    let rec h z = if z < 0 then S h else T h in
+    h

--- a/testsuite/tests/flambda2/symbol_projections/symbol_projections6.ml
+++ b/testsuite/tests/flambda2/symbol_projections/symbol_projections6.ml
@@ -1,0 +1,32 @@
+(* TEST
+   compile_only = "true";
+   flambda2;
+   setup-ocamlopt.opt-build-env;
+   ocamlopt.opt;
+   check-ocamlopt.opt-output;
+*)
+
+[@@@ocaml.flambda_o3]
+
+external getenv : string -> string = "caml_sys_getenv"
+
+external ( + ) : int -> int -> int = "%addint"
+
+external ( < ) : int -> int -> bool = "%lessthan"
+
+external ( && ) : bool -> bool -> bool = "%sequand"
+
+let foo = match getenv "FOO" with exception _ -> false | _ -> true
+
+type t =
+  | S of (int -> t * bool)
+  | T of (int -> t * bool)
+
+let f b =
+  if b
+  then
+    let rec g y = if y < 0 && foo then S g, foo else T g, foo in
+    g
+  else
+    let rec h z = if z < 0 && foo then S h, foo else T h, foo in
+    h

--- a/testsuite/tests/flambda2/symbol_projections/symbol_projections7.ml
+++ b/testsuite/tests/flambda2/symbol_projections/symbol_projections7.ml
@@ -1,0 +1,23 @@
+(* TEST
+   compile_only = "true";
+   flambda2;
+   setup-ocamlopt.opt-build-env;
+   ocamlopt.opt;
+   check-ocamlopt.opt-output;
+*)
+
+[@@@ocaml.flambda_o3]
+
+external word_size : unit -> int = "%word_size"
+
+external ( + ) : int -> int -> int = "%addint"
+
+external opaque : 'a -> 'a = "%opaque"
+
+let foo =
+  match word_size () with
+  | 32 -> fun x -> x + 1
+  | 64 ->
+    let y = opaque 2 in
+    fun x -> x + y
+  | _ -> assert false

--- a/testsuite/tests/flambda2/symbol_projections/symbol_projections8.ml
+++ b/testsuite/tests/flambda2/symbol_projections/symbol_projections8.ml
@@ -1,0 +1,27 @@
+(* TEST
+   compile_only = "true";
+   flambda2;
+   setup-ocamlopt.opt-build-env;
+   ocamlopt.opt;
+   check-ocamlopt.opt-output;
+*)
+
+[@@@ocaml.flambda_o3]
+
+external getenv : string -> string = "caml_sys_getenv"
+
+external ( + ) : int -> int -> int = "%addint"
+
+let foo = match getenv "FOO" with exception _ -> false | _ -> true
+
+(* f is lifted first, captures foo *)
+let f x =
+  let g y = if foo then y + y else y in
+  x, g
+
+(* h calls f, gets g, then creates another closure using something from g's environment *)
+let h z =
+  let (_, g) = f z in
+  (* Now we need to access something from g that would create a projection *)
+  let result = g z in
+  result

--- a/testsuite/tests/flambda2/symbol_projections/symbol_projections_mixed_blocks.ml
+++ b/testsuite/tests/flambda2/symbol_projections/symbol_projections_mixed_blocks.ml
@@ -1,0 +1,37 @@
+(* TEST
+   modules = "symbol_projections_mixed_blocks_dep.ml";
+   compile_only = "true";
+   flambda2;
+   setup-ocamlopt.opt-build-env;
+   ocamlopt.opt;
+   check-ocamlopt.opt-output;
+*)
+
+[@@@ocaml.flambda_o3]
+
+module D = Symbol_projections_mixed_blocks_dep
+
+let f_int64 (z : int) =
+  let v = D.the_unboxed_int64 in
+  let g () = v in
+  z, g
+
+let f_int32 (z : int) =
+  let v = D.the_unboxed_int32 in
+  let g () = v in
+  z, g
+
+let f_nativeint (z : int) =
+  let v = D.the_unboxed_nativeint in
+  let g () = v in
+  z, g
+
+let f_float (z : int) =
+  let v = D.the_unboxed_float in
+  let g () = v in
+  z, g
+
+let f_float32 (z : int) =
+  let v = D.the_unboxed_float32 in
+  let g () = v in
+  z, g

--- a/testsuite/tests/flambda2/symbol_projections/symbol_projections_mixed_blocks_dep.ml
+++ b/testsuite/tests/flambda2/symbol_projections/symbol_projections_mixed_blocks_dep.ml
@@ -1,0 +1,40 @@
+[@@@ocaml.flambda_o3]
+
+external getenv : string -> string = "caml_sys_getenv"
+
+type t_int64 = { x : int64#; y : int }
+type t_int32 = { x : int32#; y : int }
+type t_nativeint = { x : nativeint#; y : int }
+type t_float = { x : float#; y : int }
+type t_float32 = { x : float32#; y : int }
+
+let unboxed_int64 : t_int64 =
+  match getenv "FOO" with
+  | exception _ -> { x = #1L; y = 1 }
+  | _ -> { x = #2L; y = 2 }
+
+let unboxed_int32 : t_int32 =
+  match getenv "FOO" with
+  | exception _ -> { x = #1l; y = 1 }
+  | _ -> { x = #2l; y = 2 }
+
+let unboxed_nativeint : t_nativeint =
+  match getenv "FOO" with
+  | exception _ -> { x = #1n; y = 1 }
+  | _ -> { x = #2n; y = 2 }
+
+let unboxed_float : t_float =
+  match getenv "FOO" with
+  | exception _ -> { x = #1.0; y = 1 }
+  | _ -> { x = #2.0; y = 2 }
+
+let unboxed_float32 : t_float32 =
+  match getenv "FOO" with
+  | exception _ -> { x = #1.0s; y = 1 }
+  | _ -> { x = #2.0s; y = 2 }
+
+let the_unboxed_int64 : int64# = unboxed_int64.x
+let the_unboxed_int32 : int32# = unboxed_int32.x
+let the_unboxed_nativeint : nativeint# = unboxed_nativeint.x
+let the_unboxed_float : float# = unboxed_float.x
+let the_unboxed_float32 : float32# = unboxed_float32.x


### PR DESCRIPTION
This does the following:
* stops producing fatal errors when unboxed numbers are involved in symbol projections
* adds the original symbol projection test files from `mlexamples/` as proper `ocamltest` tests
* adds new test cases, based on one of the existing ones, to exercise the unboxed number changes above.  These test cases currently fail on `main`.

cc @jra4 @lthls 