### PR TITLE
Refactor bigstring get/set safety properties

### DIFF
--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -259,7 +259,7 @@ type primitive =
       mode : locality_mode; boxed : bool }
   | Pbigstring_load_vec of {
       size : boxed_vector;
-      safety : (len:int * align:int) option;
+      checks : (len:int * align:int) option;
       index_kind : array_index_kind;
       mode : locality_mode;
       aligned : bool;
@@ -273,7 +273,7 @@ type primitive =
       boxed : bool }
   | Pbigstring_set_vec of {
       size : boxed_vector;
-      safety : (len:int * align:int) option;
+      checks : (len:int * align:int) option;
       index_kind : array_index_kind;
       aligned : bool;
       boxed : bool }
@@ -2210,12 +2210,12 @@ let primitive_can_raise prim =
   | Pbigstring_load_32 { unsafe = false; index_kind = _; mode = _; boxed = _ }
   | Pbigstring_load_f32 { unsafe = false; index_kind = _; mode = _; boxed = _ }
   | Pbigstring_load_64 { unsafe = false; index_kind = _; mode = _; boxed = _ }
-  | Pbigstring_load_vec { safety = Some _; _ }
+  | Pbigstring_load_vec { checks = Some _; _ }
   | Pbigstring_set_16 { unsafe = false; index_kind = _ }
   | Pbigstring_set_32 { unsafe = false; index_kind = _; boxed = _ }
   | Pbigstring_set_f32 { unsafe = false; index_kind = _; boxed = _ }
   | Pbigstring_set_64 { unsafe = false; index_kind = _; boxed = _ }
-  | Pbigstring_set_vec { safety = Some _; _ }
+  | Pbigstring_set_vec { checks = Some _; _ }
   | Pfloatarray_load_vec { unsafe = false; _ }
   | Pfloat_array_load_vec { unsafe = false; _ }
   | Pint_array_load_vec { unsafe = false; _ }
@@ -2291,12 +2291,12 @@ let primitive_can_raise prim =
   | Pbigstring_load_32 { unsafe = true; index_kind = _; mode = _; boxed = _ }
   | Pbigstring_load_f32 { unsafe = true; index_kind = _; mode = _; boxed = _ }
   | Pbigstring_load_64 { unsafe = true; index_kind = _; mode = _; boxed = _ }
-  | Pbigstring_load_vec { safety = None; _ }
+  | Pbigstring_load_vec { checks = None; _ }
   | Pbigstring_set_16 { unsafe = true; _ }
   | Pbigstring_set_32 { unsafe = true; index_kind = _; boxed = _ }
   | Pbigstring_set_f32 { unsafe = true; index_kind = _; boxed = _ }
   | Pbigstring_set_64 { unsafe = true; index_kind = _; boxed = _ }
-  | Pbigstring_set_vec { safety = None; _ }
+  | Pbigstring_set_vec { checks = None; _ }
   | Pfloatarray_load_vec { unsafe = true; _ }
   | Pfloat_array_load_vec { unsafe = true; _ }
   | Pint_array_load_vec { unsafe = true; _ }

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -257,7 +257,8 @@ type primitive =
       mode : locality_mode; boxed : bool }
   | Pbigstring_load_vec of {
       size : boxed_vector;
-      safety : (len:int * align:int) option;
+      (* Check [len] bytes are in bounds / base is aligned to [align] bytes. *)
+      checks : (len:int * align:int) option;
       index_kind : array_index_kind;
       mode : locality_mode;
       aligned : bool;
@@ -271,7 +272,8 @@ type primitive =
       boxed : bool }
   | Pbigstring_set_vec of {
       size : boxed_vector;
-      safety : (len:int * align:int) option;
+      (* Check [len] bytes are in bounds / base is aligned to [align] bytes. *)
+      checks : (len:int * align:int) option;
       index_kind : array_index_kind;
       aligned : bool;
       boxed : bool }

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -697,9 +697,9 @@ let primitive ppf = function
      fprintf ppf "bigarray.array1.%sget64%s%s[indexed by %a]"
        (if unsafe then "unsafe_" else "") (if boxed then "" else "#")
        (locality_kind mode) array_index_kind index_kind
-  | Pbigstring_load_vec { size; safety; aligned; mode; boxed; index_kind } ->
+  | Pbigstring_load_vec { size; checks; aligned; mode; boxed; index_kind } ->
      fprintf ppf "bigarray.array1.%s%sget%s%s%s[indexed by %a]"
-       (if Option.is_none safety then "unsafe_" else "")
+       (if Option.is_none checks then "unsafe_" else "")
        (if aligned then "aligned_" else "unaligned_")
        (vector_width size)
        (if boxed then "" else "#") (locality_kind mode)
@@ -719,9 +719,9 @@ let primitive ppf = function
      fprintf ppf "bigarray.array1.%sset64%s[indexed by %a]"
        (if unsafe then "unsafe_" else "") (if boxed then "" else "#")
        array_index_kind index_kind
-  | Pbigstring_set_vec { size; safety; aligned; boxed; index_kind } ->
+  | Pbigstring_set_vec { size; checks; aligned; boxed; index_kind } ->
      fprintf ppf "bigarray.array1.%s%sset%s%s[indexed by %a]"
-       (if Option.is_none safety then "unsafe_" else "")
+       (if Option.is_none checks then "unsafe_" else "")
        (if aligned then "aligned_" else "unaligned_")
        (vector_width size)
        (if boxed then "" else "#") array_index_kind index_kind

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -228,6 +228,19 @@ let to_lambda_prim prim ~poly_sort =
     ~native_repr_res
     ~is_layout_poly:prim.prim_is_layout_poly
 
+let bigstring_checks ~unsafe ~aligned size =
+  if unsafe
+  then None
+  else
+    let len =
+      match size with
+      | Boxed_vec128 -> 16
+      | Boxed_vec256 -> 32
+      | Boxed_vec512 -> 64
+    in
+    let align = if aligned then len else 0 in
+    Some (~len, ~align)
+
 let indexing_primitives =
   let types_and_widths =
     [
@@ -246,15 +259,15 @@ let indexing_primitives =
           Pbigstring_load_64 { unsafe; index_kind; mode; boxed } );
       ( Printf.sprintf "%%caml_bigstring_getu128%s%s%s",
         fun ~unsafe ~boxed ~index_kind ~mode ->
-          let safety = if unsafe then None else Some (~len:16, ~align:0) in
+          let checks = bigstring_checks ~unsafe ~aligned:false Boxed_vec128 in
           Pbigstring_load_vec
-            { size = Boxed_vec128; safety; index_kind; mode;
+            { size = Boxed_vec128; checks; index_kind; mode;
               aligned = false; boxed } );
       ( Printf.sprintf "%%caml_bigstring_geta128%s%s%s",
         fun ~unsafe ~boxed ~index_kind ~mode ->
-          let safety = if unsafe then None else Some (~len:16, ~align:16) in
+          let checks = bigstring_checks ~unsafe ~aligned:true Boxed_vec128 in
           Pbigstring_load_vec
-            { size = Boxed_vec128; safety; index_kind; mode;
+            { size = Boxed_vec128; checks; index_kind; mode;
               aligned = true; boxed } );
       ( (fun unsafe _boxed index_kind ->
           Printf.sprintf "%%caml_bigstring_set16%s%s" unsafe index_kind),
@@ -271,63 +284,63 @@ let indexing_primitives =
           Pbigstring_set_64 { unsafe; index_kind; boxed } );
       ( Printf.sprintf "%%caml_bigstring_setu128%s%s%s",
         fun ~unsafe ~boxed ~index_kind ~mode:_ ->
-          let safety = if unsafe then None else Some (~len:16, ~align:0) in
+          let checks = bigstring_checks ~unsafe ~aligned:false Boxed_vec128 in
           Pbigstring_set_vec
-            { size = Boxed_vec128; safety; index_kind;
+            { size = Boxed_vec128; checks; index_kind;
               aligned = false; boxed } );
       ( Printf.sprintf "%%caml_bigstring_seta128%s%s%s",
         fun ~unsafe ~boxed ~index_kind ~mode:_ ->
-          let safety = if unsafe then None else Some (~len:16, ~align:16) in
+          let checks = bigstring_checks ~unsafe ~aligned:true Boxed_vec128 in
           Pbigstring_set_vec
-            { size = Boxed_vec128; safety; index_kind;
+            { size = Boxed_vec128; checks; index_kind;
               aligned = true; boxed } );
       ( Printf.sprintf "%%caml_bigstring_getu256%s%s%s",
         fun ~unsafe ~boxed ~index_kind ~mode ->
-          let safety = if unsafe then None else Some (~len:32, ~align:0) in
+          let checks = bigstring_checks ~unsafe ~aligned:false Boxed_vec256 in
           Pbigstring_load_vec
-            { size = Boxed_vec256; safety; index_kind; mode;
+            { size = Boxed_vec256; checks; index_kind; mode;
               aligned = false; boxed } );
       ( Printf.sprintf "%%caml_bigstring_geta256%s%s%s",
         fun ~unsafe ~boxed ~index_kind ~mode ->
-          let safety = if unsafe then None else Some (~len:32, ~align:32) in
+          let checks = bigstring_checks ~unsafe ~aligned:true Boxed_vec256 in
           Pbigstring_load_vec
-            { size = Boxed_vec256; safety; index_kind; mode;
+            { size = Boxed_vec256; checks; index_kind; mode;
               aligned = true; boxed } );
       ( Printf.sprintf "%%caml_bigstring_setu256%s%s%s",
         fun ~unsafe ~boxed ~index_kind ~mode:_ ->
-          let safety = if unsafe then None else Some (~len:32, ~align:0) in
+          let checks = bigstring_checks ~unsafe ~aligned:false Boxed_vec256 in
           Pbigstring_set_vec
-            { size = Boxed_vec256; safety; index_kind;
+            { size = Boxed_vec256; checks; index_kind;
               aligned = false; boxed } );
       ( Printf.sprintf "%%caml_bigstring_seta256%s%s%s",
         fun ~unsafe ~boxed ~index_kind ~mode:_ ->
-          let safety = if unsafe then None else Some (~len:32, ~align:32) in
+          let checks = bigstring_checks ~unsafe ~aligned:true Boxed_vec256 in
           Pbigstring_set_vec
-            { size = Boxed_vec256; safety; index_kind;
+            { size = Boxed_vec256; checks; index_kind;
               aligned = true; boxed } );
       ( Printf.sprintf "%%caml_bigstring_getu512%s%s%s",
         fun ~unsafe ~boxed ~index_kind ~mode ->
-          let safety = if unsafe then None else Some (~len:64, ~align:0) in
+          let checks = bigstring_checks ~unsafe ~aligned:false Boxed_vec512 in
           Pbigstring_load_vec
-            { size = Boxed_vec512; safety; index_kind; mode;
+            { size = Boxed_vec512; checks; index_kind; mode;
               aligned = false; boxed } );
       ( Printf.sprintf "%%caml_bigstring_geta512%s%s%s",
         fun ~unsafe ~boxed ~index_kind ~mode ->
-          let safety = if unsafe then None else Some (~len:64, ~align:64) in
+          let checks = bigstring_checks ~unsafe ~aligned:true Boxed_vec512 in
           Pbigstring_load_vec
-            { size = Boxed_vec512; safety; index_kind; mode;
+            { size = Boxed_vec512; checks; index_kind; mode;
               aligned = true; boxed } );
       ( Printf.sprintf "%%caml_bigstring_setu512%s%s%s",
         fun ~unsafe ~boxed ~index_kind ~mode:_ ->
-          let safety = if unsafe then None else Some (~len:64, ~align:0) in
+          let checks = bigstring_checks ~unsafe ~aligned:false Boxed_vec512 in
           Pbigstring_set_vec
-            { size = Boxed_vec512; safety; index_kind;
+            { size = Boxed_vec512; checks; index_kind;
               aligned = false; boxed } );
       ( Printf.sprintf "%%caml_bigstring_seta512%s%s%s",
         fun ~unsafe ~boxed ~index_kind ~mode:_ ->
-          let safety = if unsafe then None else Some (~len:64, ~align:64) in
+          let checks = bigstring_checks ~unsafe ~aligned:true Boxed_vec512 in
           Pbigstring_set_vec
-            { size = Boxed_vec512; safety; index_kind;
+            { size = Boxed_vec512; checks; index_kind;
               aligned = true; boxed } );
       ( (fun unsafe _boxed index_kind ->
           Printf.sprintf "%%caml_bytes_get16%s%s" unsafe index_kind),


### PR DESCRIPTION
Makes the `Pbigstring_get/set_vec` primitives explicitly record the length and alignment safety constraints. This is used in #5291 to preserve exception behavior after splitting 256-bit loads/stores into two operations.

Updates the checks in lambda_to_flambda_primitives to take an access length (and alignment for bigstrings) instead of an accessor width.