### PR TITLE
Do not put normal .o files into the main partition

### DIFF
--- a/asmcomp/dissector/partition_object_files.ml
+++ b/asmcomp/dissector/partition_object_files.ml
@@ -112,7 +112,7 @@ let partition_files ~threshold file_sizes =
                 }));
       (* Check if adding this file would exceed the threshold *)
       let new_size = Int64.add current_size entry_size in
-      if new_size > threshold && current_partition <> []
+      if new_size > threshold
       then
         (* Start a new partition *)
         let partitions = List.rev current_partition :: partitions in


### PR DESCRIPTION
## Summary
- Fix the dissector's `partition_files` function to ensure normal OCaml object files are never placed in the Main partition
- Main partition now only contains files that must be there: files with probes, startup, and cached genfns
- Normal object files always start in `Large_code 1`, even if there would be space remaining in Main

🤖 Generated with [Claude Code](https://claude.ai/code)