### PR TITLE
Fix mistake with args for Cfg.Raise, version for main

### DIFF
--- a/backend/cfg/cfg_invariants.ml
+++ b/backend/cfg/cfg_invariants.ml
@@ -120,6 +120,17 @@ let check_tailrec_position t =
            followingsuccessors:@.%a@."
           Label.print tailrec_label Label.Set.print successors
 
+let check_terminator_arity t _label block =
+  match block.Cfg.terminator.desc with
+  | Raise _ ->
+    let len = Array.length block.Cfg.terminator.arg in
+    if len != 1 then report t "Raise with %d arguments" len
+  | Tailcall_self _ | Call _ | Prim _ | Tailcall_func _ | Never | Always _
+  | Parity_test _ | Truth_test _ | Float_test _ | Int_test _ | Switch _ | Return
+  | Call_no_return _ | Invalid _ ->
+    (* CR-soon xclerc for xclerc: extend check *)
+    ()
+
 let check_tailrec t _label block =
   (* check all Tailrec Self agree on the successor label *)
   match block.Cfg.terminator.desc with
@@ -262,6 +273,7 @@ let check_stack_offset t label (block : Cfg.basic_block) =
   ()
 
 let check_block t label (block : Cfg.basic_block) =
+  check_terminator_arity t label block;
   check_tailrec t label block;
   check_can_raise t label block;
   (* exn and normal successors are disjoint *)

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -883,11 +883,12 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     in
     (* Populate the distinguished extra args registers, for the current
        exception handler, with the extra args for this particular raise. *)
-    let rd = Array.concat ([| Proc.loc_exn_bucket |] :: extra_args_regs) in
+    let exn_bucket = [| Proc.loc_exn_bucket |] in
+    let rd = Array.concat (exn_bucket :: extra_args_regs) in
     Array.iter2
       (fun r1 rd -> SU.insert env sub_cfg (Op Move) [| r1 |] [| rd |])
       r1 rd;
-    SU.insert_debug' env sub_cfg (Cfg.Raise k) dbg rd [||];
+    SU.insert_debug' env sub_cfg (Cfg.Raise k) dbg exn_bucket [||];
     SU.set_traps_for_raise env;
     Never_returns
 


### PR DESCRIPTION
As for #5313 , but for `main`.  The only difference in the diff should be the addition of the `Invalid` case.