### PR TITLE
Add missing dependency on `domain_state.tbl`

### DIFF
--- a/runtime/dune
+++ b/runtime/dune
@@ -55,7 +55,7 @@
    simd.c
    blake2.c
    misc.c
-   build_config.h sync_posix.h caml/jumptbl.h)
+   build_config.h sync_posix.h caml/jumptbl.h caml/domain_state.tbl)
  (action
    (progn
      (run %{dep:gen_primitives.sh} primitives %{deps})


### PR DESCRIPTION
On a clean checkout, after `autoconf` and `configure`, I got the following error from `make`:

```
File "runtime/dune", lines 43-62, characters 0-725:
43 | (rule
44 |  (targets primitives prims.c)
45 |  (mode    fallback)
....
60 |    (progn
61 |      (run %{dep:gen_primitives.sh} primitives %{deps})
62 |      (with-stdout-to prims.c (run bash %{dep:gen_primsc.sh} primitives %{deps})))))
Context: main
In file included from caml/mlvalues.h:71,
                 from caml/alloc.h:21,
                 from alloc.c:26:
caml/domain_state.h:32:10: fatal error: domain_state.tbl: No such file or directory
 #include "domain_state.tbl"
          ^~~~~~~~~~~~~~~~~~
compilation terminated.
```

That is due to the missing dependency on `domain_state.tbl`.