### PR TITLE
Trigger CI on merge_group event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
     tags:
       - '*'
   pull_request:
+  merge_group:
 jobs:
   build:
     name: ${{ matrix.name }}


### PR DESCRIPTION
This is required to try using merge queues:
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
