### PR TITLE
Allow builtin prims of more than 5 args to not have a native_name

### DIFF
--- a/testsuite/tests/effects/dynamic.ml
+++ b/testsuite/tests/effects/dynamic.ml
@@ -34,7 +34,7 @@ end = struct
     'd ->
     ('e -> 'a) ->
     'e ->
-    'b = "%with_stack_bind" "%with_stack_bind"
+    'b = "%with_stack_bind"
 
   external make : 'a -> 'a t = "caml_dynamic_make"
   external get : 'a t -> 'a = "caml_dynamic_get"

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -3985,6 +3985,7 @@ let transl_value_decl env loc ~modal ~why valdecl =
       if !Clflags.native_code
       && prim.prim_arity > 5
       && prim.prim_native_name = ""
+      && not (String.starts_with ~prefix:"%" prim.prim_name)
       then raise(Error(valdecl.pval_type.ptyp_loc, Missing_native_external));
       check_unboxable env loc ty;
       { val_type = ty; val_kind = Val_prim prim; Types.val_loc = loc;


### PR DESCRIPTION
Only throw an error for prims that have more than 5 args lacking a prim_native_name if the prim is not builtin (its name does not start with `%`). Builtin prims are handled directly by bytegen, and so don't need to have a second impl for bytecode in the way user-defined prims do.

This was never necessary before mostly because we'd never had a builtin prim with more than 5 arguments before, but `%with_stack_bind` went over the limit (and more primitives I'm planning on adding soon also go over the limit)