### PR TITLE
Disable `testsuite/tests/lib-threads/beat.ml`

### DIFF
--- a/testsuite/tests/lib-threads/beat.ml.disabled
+++ b/testsuite/tests/lib-threads/beat.ml.disabled
@@ -1,3 +1,5 @@
+(* Disabled due to fundamental and persistent flakiness. *)
+
 (* TEST
  {
    not-macos;


### PR DESCRIPTION
Title. Disabled instead of outright deletion because it's an upstream test and we don't want to forget why we disabled it when rebasing to newer upstream OCaml versions.