### PR TITLE
make instruction ordering in r4 match that of r5

### DIFF
--- a/runtime4/caml/instruct.h
+++ b/runtime4/caml/instruct.h
@@ -62,8 +62,9 @@ enum instructions {
   RERAISE, RAISE_NOTRACE,
   GETSTRINGCHAR,
   PERFORM, RESUME, RESUMETERM, REPERFORMTERM,
-  WITH_STACK, WITH_STACK_BIND,
   MAKE_FAUX_MIXEDBLOCK,
+  WITH_STACK,
+  WITH_STACK_BIND,
 FIRST_UNIMPLEMENTED_OP};
 
 // Think carefully before adding a new bytecode instruction. In general,


### PR DESCRIPTION
The order of instructions in r4 does not match that of r5...
This was causing failures when compiling with r4