### PR TITLE
remove `Unknown_non_rigid`

### DIFF
--- a/testsuite/tests/typing-local/let_mutable.ml
+++ b/testsuite/tests/typing-local/let_mutable.ml
@@ -265,8 +265,8 @@ let foo4_8 () =
 Line 4, characters 2-3:
 4 |   x
       ^
-Error: This value is "local" because it is "stack_"-allocated.
-       However, the highlighted expression is expected to be "local" to the parent region or "global"
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
          because it is a function return value.
          Hint: Use exclave_ to return a local value.
 |}]
@@ -281,8 +281,8 @@ let foo4_9 b =
 Line 4, characters 2-3:
 4 |   x
       ^
-Error: This value is "local" because it is "stack_"-allocated.
-       However, the highlighted expression is expected to be "local" to the parent region or "global"
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
          because it is a function return value.
          Hint: Use exclave_ to return a local value.
 |}]
@@ -491,10 +491,7 @@ let disallowed_13_6 =
 Line 4, characters 19-20:
 4 |   require_portable f
                        ^
-Error: This value is "nonportable"
-         because it contains a usage (of the value "x_13_3" at Line 3, characters 17-23)
-         which is expected to be "uncontended".
-       However, the highlighted expression is expected to be "portable".
+Error: This value is "nonportable" but is expected to be "portable".
 |}]
 
 (* [f] remains non-portable even if a portable function is reassigned *)
@@ -507,10 +504,7 @@ let disallowed_13_7 =
 Line 5, characters 19-20:
 5 |   require_portable f
                        ^
-Error: This value is "nonportable"
-         because it contains a usage (of the value "x_13_3" at Line 3, characters 17-23)
-         which is expected to be "uncontended".
-       However, the highlighted expression is expected to be "portable".
+Error: This value is "nonportable" but is expected to be "portable".
 |}]
 
 
@@ -639,8 +633,8 @@ let foo_20 y =
 Line 4, characters 2-3:
 4 |   x
       ^
-Error: This value is "local" because it is "stack_"-allocated.
-       However, the highlighted expression is expected to be "local" to the parent region or "global"
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
          because it is a function return value.
          Hint: Use exclave_ to return a local value.
 |}]

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -46,7 +46,6 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
       | Captured_by_partial_application ->
         (Location.none, Expression), Adj_captured_by_partial_application
       | Crossing -> pp, Crossing
-      | Unknown_non_rigid -> (Location.none, Unknown), Unknown_non_rigid
       | Unknown -> (Location.none, Unknown), Unknown
       | Allocation_r loc -> pp, Allocation_l loc
       | Contains_r (Comonadic, { containing; contained }) ->
@@ -73,7 +72,6 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
       | Adj_captured_by_partial_application ->
         (Location.none, Expression), Captured_by_partial_application
       | Crossing -> pp, Crossing
-      | Unknown_non_rigid -> (Location.none, Unknown), Unknown_non_rigid
       | Unknown -> (Location.none, Unknown), Unknown
       | Allocation_l loc -> pp, Allocation_r loc
       | Contains_l (Comonadic, { containing; contained }) ->
@@ -101,7 +99,6 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Adj_captured_by_partial_application ->
           Adj_captured_by_partial_application
         | Crossing -> Crossing
-        | Unknown_non_rigid -> Unknown_non_rigid
         | Allocation_l loc -> Allocation_l loc
         | Contains_l (Comonadic, x) -> Contains_l (Comonadic, x)
         | Contains_r (Monadic, x) -> Contains_r (Monadic, x)
@@ -117,7 +114,6 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Is_closed_by (Comonadic, x) -> Is_closed_by (Comonadic, x)
         | Captured_by_partial_application -> Captured_by_partial_application
         | Crossing -> Crossing
-        | Unknown_non_rigid -> Unknown_non_rigid
         | Allocation_r loc -> Allocation_r loc
         | Contains_r (Comonadic, x) -> Contains_r (Comonadic, x)
         | Contains_l (Monadic, x) -> Contains_l (Monadic, x)
@@ -137,7 +133,6 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Adj_captured_by_partial_application ->
           Adj_captured_by_partial_application
         | Crossing -> Crossing
-        | Unknown_non_rigid -> Unknown_non_rigid
         | Allocation_r loc -> Allocation_r loc
         | Allocation_l loc -> Allocation_l loc
         | Contains_r (Comonadic, x) -> Contains_r (Comonadic, x)
@@ -160,7 +155,6 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Adj_captured_by_partial_application ->
           Adj_captured_by_partial_application
         | Crossing -> Crossing
-        | Unknown_non_rigid -> Unknown_non_rigid
         | Allocation_l loc -> Allocation_l loc
         | Allocation_r loc -> Allocation_r loc
         | Contains_l (Comonadic, x) -> Contains_l (Comonadic, x)
@@ -2258,7 +2252,7 @@ module Report = struct
       ((formatter -> unit) * pinpoint) option =
    fun ~fixpoint pp -> function
     | Skip -> Misc.fatal_error "Skip hint should not be printed"
-    | Unknown | Unknown_non_rigid -> None
+    | Unknown -> None
     | Close_over (Comonadic, { closed = pp; _ }) ->
       print_pinpoint pp
       |> Option.map (fun print_pp ->
@@ -2343,8 +2337,7 @@ module Report = struct
     | Contains_l _ | Contains_r _ | Is_contained_by _
     | Adj_captured_by_partial_application ->
       true
-    | Allocation_r _ | Allocation_l _ | Skip | Crossing | Unknown_non_rigid ->
-      false
+    | Allocation_r _ | Allocation_l _ | Skip | Crossing -> false
 
   let eq_mode : type a b. a C.obj -> b C.obj -> a -> b -> bool =
    fun a_obj b_obj a b ->
@@ -4129,7 +4122,7 @@ module Modality = struct
       let apply : type l r.
           ?hint:(l * r) neg Hint.morph -> t -> (l * r) Mode.t -> (l * r) Mode.t
           =
-       fun ?(hint = Hint.Unknown_non_rigid) t x ->
+       fun ?(hint = Hint.Unknown) t x ->
         match t with Join_const c -> Mode.join_const ~hint c x
 
       let proj ax (Join_const c) : _ Atom.t = Join_with (Axis.proj ax c)
@@ -4275,7 +4268,7 @@ module Modality = struct
       let apply : type l r.
           ?hint:(l * r) pos Hint.morph -> t -> (l * r) Mode.t -> (l * r) Mode.t
           =
-       fun ?(hint = Hint.Unknown_non_rigid) t x ->
+       fun ?(hint = Hint.Unknown) t x ->
         match t with Meet_const c -> Mode.meet_const ~hint c x
 
       let proj ax (Meet_const c) : _ Atom.t = Meet_with (Axis.proj ax c)

--- a/typing/mode_hint.mli
+++ b/typing/mode_hint.mli
@@ -111,11 +111,6 @@ type allocation = allocation_desc Location.loc
     [Mode.Report.print_morph] for what each non-trivial constructor means. *)
 type 'd morph =
   | Unknown : ('l * 'r) morph  (** The morphism is not explained. *)
-  | Unknown_non_rigid : ('l * 'r) morph
-      (** Similiar to [Unknown], but in the special case where the morph doesn't
-          change the bound, it can be skipped. *)
-  (* CR-soon zqian: usages of [Unknown_non_rigid] should be replaced with
-     corresponding proper hints *)
   | Skip : ('l * 'r) morph
       (** The morphism doesn't change the bound and should be skipped in
           printing. *)


### PR DESCRIPTION
In the same spirit as #5190 , this PR removes `Unknown_non_rigid`, which represents a mode morph hint that we don't know, but can be skipped if the underlying morphism behaves as an id.

This was the default for `Mode.Modality.Const.apply` which is a bad default, since modality is coupled with record fields/structure items, and this containining relation shouldn't be skipped even for identity modality.

This does remove some hints for `let mutable` variables, but note that those hints are not good anyway (which is another example of inappropriate `Unknown_non_rigid`). Future PRs should add proper hints for `let mutable` (internal ticket 5157)
