### PR TITLE
Skip empty `Tpoly` for `unbox_once `and `estimate_type_jkind`

### DIFF
--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2330,6 +2330,8 @@ let unbox_once env ty =
         end
       end
     end
+  | Tpoly (ty, []) ->
+    Stepped { ty; modality = Mode.Modality.Const.id }
   | Tpoly (ty, univars) ->
     Stepped
       { ty = instance_poly_for_jkind univars ty
@@ -2469,6 +2471,8 @@ let rec estimate_type_jkind ~expand_component ~ignore_mod_bounds env ty =
   | Tvariant row ->
      Jkind.for_boxed_row row
   | Tunivar { jkind } -> Jkind.disallow_right jkind
+  | Tpoly (ty, []) ->
+    estimate_type_jkind ~expand_component ~ignore_mod_bounds env ty
   | Tpoly (ty, univars) ->
     (* The jkind of [ty] might mention the variables bound in this [Tpoly]
        node, and so just returning it here would be wrong. Instead, we need


### PR DESCRIPTION
This is a trivial change that leads to 10% fewer allocations (22.4G->20.0G) and 8% faster runtime on my machine (16.8s -> 15.5s) for type-checking `Base.Container_intf` -- mostly because `instance_poly_for_jkind` can get called much less often.