### PR TITLE
Rename fill_x86_bin_emitter -> fill

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -233,7 +233,7 @@ let emit_imp_table ~section () =
   in
   D.data ();
   D.comment "relocation table start";
-  D.align ~fill_x86_bin_emitter:Zero ~bytes:8;
+  D.align ~fill:Zero ~bytes:8;
   Hashtbl.iter f imp_table;
   D.comment "relocation table end"
 
@@ -370,8 +370,7 @@ let emit_Llabel fallthrough lbl section_name =
          emit_function_or_basic_block_section_name ();
          D.cfi_startproc ())
      | None -> ());
-  if (not fallthrough) && !fastcode_flag
-  then D.align ~fill_x86_bin_emitter:Nop ~bytes:4;
+  if (not fallthrough) && !fastcode_flag then D.align ~fill:Nop ~bytes:4;
   D.define_label lbl
 
 (* Output a pseudo-register *)
@@ -706,7 +705,7 @@ let emit_jump_table t =
   done
 
 let emit_jump_tables () =
-  D.align ~fill_x86_bin_emitter:Zero ~bytes:4;
+  D.align ~fill:Zero ~bytes:4;
   List.iter emit_jump_table !jump_tables;
   jump_tables := []
 
@@ -2526,7 +2525,7 @@ let fundecl fundecl =
   current_basic_block_section
     := Option.value fundecl.fun_section_name ~default:"";
   emit_function_or_basic_block_section_name ();
-  D.align ~fill_x86_bin_emitter:Nop ~bytes:16;
+  D.align ~fill:Nop ~bytes:16;
   add_def_symbol fundecl.fun_name;
   let fundecl_sym = S.create_global fundecl.fun_name in
   if
@@ -2630,11 +2629,11 @@ let emit_item : Cmm.data_item -> unit = function
       D.label_plus_offset l ~offset_in_bytes:(Targetint.of_int_exn o))
   | Cstring s -> D.string s
   | Cskip n -> D.space ~bytes:n
-  | Calign n -> D.align ~fill_x86_bin_emitter:Zero ~bytes:n
+  | Calign n -> D.align ~fill:Zero ~bytes:n
 
 let data l =
   D.data ();
-  D.align ~fill_x86_bin_emitter:Zero ~bytes:8;
+  D.align ~fill:Zero ~bytes:8;
   List.iter emit_item l
 
 (* Beginning / end of an assembly file *)
@@ -2694,11 +2693,11 @@ let begin_assembly unix =
   then (
     (* from amd64.S; could emit these constants on demand *)
     D.switch_to_section Sixteen_byte_literals;
-    D.align ~fill_x86_bin_emitter:Zero ~bytes:16;
+    D.align ~fill:Zero ~bytes:16;
     D.define_symbol_label ~section:Sixteen_byte_literals S.Predef.caml_negf_mask;
     D.int64 0x8000000000000000L;
     D.int64 0L;
-    D.align ~fill_x86_bin_emitter:Zero ~bytes:16;
+    D.align ~fill:Zero ~bytes:16;
     D.define_symbol_label ~section:Sixteen_byte_literals S.Predef.caml_absf_mask;
     D.int64 0x7FFFFFFFFFFFFFFFL;
     D.int64 0xFFFFFFFFFFFFFFFFL;
@@ -2706,7 +2705,7 @@ let begin_assembly unix =
       S.Predef.caml_negf32_mask;
     D.int64 0x80000000L;
     D.int64 0L;
-    D.align ~fill_x86_bin_emitter:Zero ~bytes:16;
+    D.align ~fill:Zero ~bytes:16;
     D.define_symbol_label ~section:Sixteen_byte_literals
       S.Predef.caml_absf32_mask;
     D.int64 0xFFFFFFFF7FFFFFFFL;
@@ -2835,7 +2834,7 @@ let emit_probe_handler_wrapper (p : Probe_emission.probe) =
   (* Emit function entry code *)
   D.comment (Printf.sprintf "probe %s %s" probe_name handler_code_sym);
   emit_named_text_section (S.encode wrap_label);
-  D.align ~fill_x86_bin_emitter:Nop ~bytes:16;
+  D.align ~fill:Nop ~bytes:16;
   D.define_symbol_label ~section:Text wrap_label;
   D.cfi_startproc ();
   if fp
@@ -2964,22 +2963,22 @@ let end_assembly () =
   if not (Misc.Stdlib.List.is_empty !float_constants)
   then (
     D.switch_to_section Eight_byte_literals;
-    D.align ~fill_x86_bin_emitter:Zero ~bytes:8;
+    D.align ~fill:Zero ~bytes:8;
     List.iter (fun (cst, lbl) -> emit_float_constant cst lbl) !float_constants);
   if not (Misc.Stdlib.List.is_empty !vec128_constants)
   then (
     D.switch_to_section Sixteen_byte_literals;
-    D.align ~fill_x86_bin_emitter:Zero ~bytes:16;
+    D.align ~fill:Zero ~bytes:16;
     List.iter (fun (cst, lbl) -> emit_vec128_constant cst lbl) !vec128_constants);
   if not (Misc.Stdlib.List.is_empty !vec256_constants)
   then (
     D.switch_to_section Thirtytwo_byte_literals;
-    D.align ~fill_x86_bin_emitter:Zero ~bytes:32;
+    D.align ~fill:Zero ~bytes:32;
     List.iter (fun (cst, lbl) -> emit_vec256_constant cst lbl) !vec256_constants);
   if not (Misc.Stdlib.List.is_empty !vec512_constants)
   then (
     D.switch_to_section Sixtyfour_byte_literals;
-    D.align ~fill_x86_bin_emitter:Zero ~bytes:64;
+    D.align ~fill:Zero ~bytes:64;
     List.iter (fun (cst, lbl) -> emit_vec512_constant cst lbl) !vec512_constants);
   (* Emit probe handler wrappers *)
   List.iter emit_probe_handler_wrapper (Probe_emission.get_probes ());
@@ -2998,16 +2997,16 @@ let end_assembly () =
   D.int64 0L;
   D.text ();
   (* We align to 8 bytes before the frame table. Perhaps somewhat
-     counterintuitively, we use [~fill_x86_bin_emitter:Zero] even though we are
+     counterintuitively, we use [~fill:Zero] even though we are
      now in the text section. The reason is that the additional padding will
      never be executed, so there is no need to pad it with nops in the X86
      binary emitter. *)
   (* CR sspies: We should just determine the filling based on the current
      section for the binary emitter and then remove the argument
-     [fill_x86_bin_emitter]. This is the only place, where it does not seem to
+     [fill]. This is the only place, where it does not seem to
      match the current section, and it seems it does not matter whether we pad
      with zeros or nops here. *)
-  D.align ~fill_x86_bin_emitter:Zero ~bytes:8;
+  D.align ~fill:Zero ~bytes:8;
   (* PR#7591 *)
   emit_global_label ~section:Text "frametable";
   (* CR sspies: Share the [emit_frames] code with the Arm backend. *)
@@ -3027,7 +3026,7 @@ let end_assembly () =
       efa_u16 = (fun n -> D.uint16 n);
       efa_u32 = (fun n -> D.uint32 n);
       efa_word = (fun n -> D.targetint (Targetint.of_int_exn n));
-      efa_align = (fun n -> D.align ~fill_x86_bin_emitter:Zero ~bytes:n);
+      efa_align = (fun n -> D.align ~fill:Zero ~bytes:n);
       efa_label_rel =
         (fun lbl ofs ->
           let lbl = label_to_asm_label ~section:Text lbl in

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -869,7 +869,7 @@ let emit_literals p align emit_literal =
        ref does not support named text sections yet. Fix this when cleaning up
        the section mechanism. *)
     D.unsafe_set_internal_section_ref Text;
-    D.align ~fill_x86_bin_emitter:Nop ~bytes:align;
+    D.align ~fill:Nop ~bytes:align;
     List.iter emit_literal !p;
     p := [])
 
@@ -2163,7 +2163,7 @@ let fundecl fundecl =
   contains_calls := fundecl.fun_contains_calls;
   emit_named_text_section !function_name;
   let fun_sym = S.create_global fundecl.fun_name in
-  D.align ~fill_x86_bin_emitter:Nop ~bytes:8;
+  D.align ~fill:Nop ~bytes:8;
   global_maybe_protected fun_sym;
   D.type_symbol ~ty:Function fun_sym;
   (* Define both a symbol and a label so the function can be referenced either
@@ -2243,11 +2243,11 @@ let emit_item (d : Cmm.data_item) =
         (L.create_string_unchecked Data (S.encode sym)))
   | Cstring s -> D.string s
   | Cskip n -> D.space ~bytes:n
-  | Calign n -> D.align ~fill_x86_bin_emitter:Zero ~bytes:n
+  | Calign n -> D.align ~fill:Zero ~bytes:n
 
 let data l =
   D.data ();
-  D.align ~fill_x86_bin_emitter:Zero ~bytes:8;
+  D.align ~fill:Zero ~bytes:8;
   List.iter emit_item l
 
 let file_emitter ~file_num ~file_name =
@@ -2287,7 +2287,7 @@ let begin_assembly _unix =
   if macosx
   then (
     A.ins0 NOP;
-    D.align ~fill_x86_bin_emitter:Nop ~bytes:8);
+    D.align ~fill:Nop ~bytes:8);
   let code_end = Cmm_helpers.make_symbol "code_end" in
   Emitaux.Dwarf_helpers.begin_dwarf ~code_begin ~code_end ~file_emitter
 
@@ -2305,7 +2305,7 @@ let end_assembly () =
   global_maybe_protected data_end_sym;
   D.define_symbol_label ~section:Data data_end_sym;
   D.int64 0L;
-  D.align ~fill_x86_bin_emitter:Zero ~bytes:8;
+  D.align ~fill:Zero ~bytes:8;
   (* #7887 *)
   let frametable = Cmm_helpers.make_symbol "frametable" in
   let frametable_sym = S.create_global frametable in
@@ -2330,7 +2330,7 @@ let end_assembly () =
       efa_u16 = (fun n -> D.uint16 n);
       efa_u32 = (fun n -> D.uint32 n);
       efa_word = (fun n -> D.targetint (Targetint.of_int_exn n));
-      efa_align = (fun n -> D.align ~fill_x86_bin_emitter:Zero ~bytes:n);
+      efa_align = (fun n -> D.align ~fill:Zero ~bytes:n);
       efa_label_rel =
         (fun lbl ofs ->
           let lbl = label_to_asm_label ~section:Data lbl in

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -192,7 +192,7 @@ module Directive = struct
   type t =
     | Align of
         { bytes : int;
-          fill_x86_bin_emitter : align_padding
+          fill : align_padding
         }
     | Bytes of
         { str : string;
@@ -336,8 +336,8 @@ module Directive = struct
         | Some comment -> Printf.sprintf "\t/* %s */" comment
     in
     match t with
-    | Align { bytes = n; fill_x86_bin_emitter = _ } ->
-      (* The flag [fill_x86_bin_emitter] is only relevant for the binary
+    | Align { bytes = n; fill = _ } ->
+      (* The flag [fill] is only relevant for the binary
          emitter. On GAS, we can ignore it and just use [.align] in both
          cases. *)
       (* Some assemblers interpret the integer n as a 2^n alignment and others
@@ -487,9 +487,9 @@ module Directive = struct
         | Some comment -> Printf.sprintf "\t; %s" comment
     in
     match t with
-    | Align { bytes; fill_x86_bin_emitter = _ } ->
-      (* The flag [fill_x86_bin_emitter] is only relevant for the x86 binary
-         emitter. On MASM, we can ignore it. *)
+    | Align { bytes; fill = _ } ->
+      (* The flag [fill] is only relevant for the x86 binary emitter. On MASM,
+         we can ignore it. *)
       bprintf buf "\tALIGN\t%d" bytes
     | Bytes { str; comment } ->
       buf_bytes_directive buf ~directive:"BYTE" str;
@@ -603,8 +603,7 @@ let emit (d : Directive.t) =
 let emit_non_masm (d : Directive.t) =
   match TS.assembler () with MASM -> () | MacOS | GAS_like -> emit d
 
-let align ~fill_x86_bin_emitter ~bytes =
-  emit (Align { bytes; fill_x86_bin_emitter })
+let align ~fill ~bytes = emit (Align { bytes; fill })
 
 let should_generate_cfi () =
   (* We generate CFI info even if we're not generating any other debugging

--- a/backend/asm_targets/asm_directives.mli
+++ b/backend/asm_targets/asm_directives.mli
@@ -168,12 +168,12 @@ type align_padding =
   | Nop
   | Zero
 
-(** Leave as much space as is required to achieve the given alignment. On x86 in
-    the binary emitter, it is important what the space is filled with: in the
-    text section, one would typically fill it with [nop] instructions and in the
-    data section, one would typically fill it with zeros. This is controlled by
-    the parameter [fill_x86_bin_emitter]. *)
-val align : fill_x86_bin_emitter:align_padding -> bytes:int -> unit
+(** Leave as much space as is required to achieve the given alignment. In the
+    binary emitters, it is important what the space is filled with: in the text
+    section, one would typically fill it with [nop] instructions and in the data
+    section, one would typically fill it with zeros. This is controlled by the
+    parameter [fill]. *)
+val align : fill:align_padding -> bytes:int -> unit
 
 (** Emit a directive giving the displacement between the given symbol and the
     current position. This should only be used to state sizes of blocks (e.g.
@@ -398,9 +398,9 @@ module Directive : sig
         { bytes : int;
               (** The number of bytes to align to. This will be taken log2 by
                   the emitter on Arm and macOS platforms.*)
-          fill_x86_bin_emitter : align_padding
-              (** The [fill_x86_bin_emitter] flag controls whether the binary
-                  emitter emits NOP instructions or null bytes. *)
+          fill : align_padding
+              (** The [fill] flag controls whether the binary emitter emits NOP
+                  instructions or null bytes. *)
         }
     | Bytes of
         { str : string;

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -603,7 +603,7 @@ let emit_elf_note ~section ~owner ~typ ~emit_desc =
   let module D = Asm_targets.Asm_directives in
   let module L = Asm_targets.Asm_label in
   let bytes = if Target_system.is_macos () then 8 else 4 in
-  D.align ~fill_x86_bin_emitter:Zero ~bytes;
+  D.align ~fill:Zero ~bytes;
   let a = L.create section in
   let b = L.create section in
   let c = L.create section in
@@ -614,11 +614,11 @@ let emit_elf_note ~section ~owner ~typ ~emit_desc =
   D.define_label a;
   D.string (owner ^ "\000");
   D.define_label b;
-  D.align ~fill_x86_bin_emitter:Zero ~bytes;
+  D.align ~fill:Zero ~bytes;
   D.define_label c;
   emit_desc ();
   D.define_label d;
-  D.align ~fill_x86_bin_emitter:Zero ~bytes
+  D.align ~fill:Zero ~bytes
 
 let reset () =
   reset_debug_info ();

--- a/backend/probe_emission.ml
+++ b/backend/probe_emission.ml
@@ -174,8 +174,7 @@ let emit_probe_semaphores ~add_def_symbol =
     Emitaux.emit_stapsdt_base_section ();
     D.switch_to_section Probes
   | true -> D.switch_to_section Probes);
-  D.align ~fill_x86_bin_emitter:Zero
-    ~bytes:(if Target_system.is_macos () then 8 else 2);
+  D.align ~fill:Zero ~bytes:(if Target_system.is_macos () then 8 else 2);
   String.Map.iter
     (fun _ (label, label_sym, enabled_at_init) ->
       (* Unresolved weak symbols have a zero value regardless of the following

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -1474,7 +1474,7 @@ let assemble_line b loc ins =
             (get_symbol b (Asm_symbol.encode sym)).sy_size
               <- Some (Int64.to_int n)
         | _ -> assert false)
-    | Directive (D.Align { fill_x86_bin_emitter=data; bytes = n}) -> (
+    | Directive (D.Align { fill=data; bytes = n}) -> (
         (* TODO: Buffer.length = 0 => set section align *)
         let pos = Buffer.length b.buf in
         let current = pos mod n in


### PR DESCRIPTION
This renames a parameter whose name would no longer be appropriate after the merging of the arm64 binary emitter.  There is also one comment change in `asm_directives.mli`.