### PR TITLE
Box types

### DIFF
--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -2845,6 +2845,9 @@ let type_for_annotation ~env ~loc typ =
           in
           Ttyp_variant (fields, (if closed then Closed else Open), tags)
         | Tquote ty -> Ttyp_quote (go ty)
+        | Tbox ty ->
+          let lident = Untypeast.lident_of_path Predef.path_box in
+          Ttyp_constr (Predef.path_box, mkloc lident loc, [go ty])
         | Tsplice _ ->
           fatal_errorf
             "Translquote [at %a]:@ Explicitly quantified type variables@ \

--- a/ocamldoc/odoc_misc.ml
+++ b/ocamldoc/odoc_misc.ml
@@ -511,7 +511,8 @@ let remove_option typ =
     | Tnil
     | Tvariant _
     | Tpackage _
-    | Tof_kind _ -> t
+    | Tof_kind _
+    | Tbox _ -> t
     | Tlink t2 -> trim (get_desc t2)
     | Tsubst _ -> assert false
   in

--- a/ocamldoc/odoc_str.ml
+++ b/ocamldoc/odoc_str.ml
@@ -43,7 +43,8 @@ let rec is_arrow_type t =
   | Types.Tunboxed_tuple _
   | Types.Tconstr _
   | Types.Tvar _ | Types.Tunivar _ | Types.Tobject _ | Types.Tpoly _
-  | Types.Tquote _ | Types.Tsplice _ | Types.Tquote_eval _ | Types.Trepr _
+  | Types.Tquote _ | Types.Tsplice _ | Types.Tquote_eval _ | Types.Tbox _
+  | Types.Trepr _
   | Types.Tfield _ | Types.Tnil | Types.Tvariant _ | Types.Tpackage _
   | Types.Tof_kind _ -> false
   | Types.Tsubst _ -> assert false
@@ -56,6 +57,7 @@ let rec need_parent t =
   | Types.Tconstr _
   | Types.Tvar _ | Types.Tunivar _ | Types.Tobject _ | Types.Tpoly _
   | Types.Tquote _ | Types.Tsplice _ | Types.Tquote_eval _ | Types.Trepr _
+  | Types.Tbox _
   | Types.Tfield _ | Types.Tnil | Types.Tvariant _ | Types.Tpackage _
   | Types.Tof_kind _ -> false
   | Types.Tsubst _ -> assert false

--- a/ocamldoc/odoc_value.ml
+++ b/ocamldoc/odoc_value.ml
@@ -80,7 +80,8 @@ let parameter_list_from_arrows typ =
     | Types.Tunivar _
     | Types.Tpackage _
     | Types.Tvariant _
-    | Types.Tof_kind _ ->
+    | Types.Tof_kind _
+    | Types.Tbox _ ->
         []
     | Types.Tsubst _ ->
         assert false

--- a/testsuite/tests/codegen/arrays.ml
+++ b/testsuite/tests/codegen/arrays.ml
@@ -620,3 +620,14 @@ int32_safe_get:
   popq  %r11
   jmp   *%r11
 |}]
+
+(* [float# box] gets optimized like [float] *)
+let float_u_box_unsafe_set (a : float# box array) (i : int) (v : float# box) =
+  Array.unsafe_set a i v
+[%%expect_asm X86_64{|
+float_u_box_unsafe_set:
+  vmovsd (%rdi), %xmm0
+  vmovsd %xmm0, -4(%rax,%rbx,4)
+  movl  $1, %eax
+  ret
+|}]

--- a/testsuite/tests/ppx-empty-cases/test.compilers.reference
+++ b/testsuite/tests/ppx-empty-cases/test.compilers.reference
@@ -2,35 +2,35 @@
   (empty_cases_returning_string/280 =
      (function {nlocal = 0} param/282?
        (raise
-         (makeblock 0 (getpredef Match_failure/52!!) [0: "test.ml" 28 50])))
+         (makeblock 0 (getpredef Match_failure/53!!) [0: "test.ml" 28 50])))
    empty_cases_returning_float64/283 =
      (function {nlocal = 0} param/285? : unboxed_float
        (raise
-         (makeblock 0 (getpredef Match_failure/52!!) [0: "test.ml" 29 50])))
+         (makeblock 0 (getpredef Match_failure/53!!) [0: "test.ml" 29 50])))
    empty_cases_accepting_string/286 =
      (function {nlocal = 0} param/288?
        (raise
-         (makeblock 0 (getpredef Match_failure/52!!) [0: "test.ml" 30 50])))
+         (makeblock 0 (getpredef Match_failure/53!!) [0: "test.ml" 30 50])))
    empty_cases_accepting_float64/289 =
      (function {nlocal = 0} param/291[float]
        (raise
-         (makeblock 0 (getpredef Match_failure/52!!) [0: "test.ml" 31 50])))
+         (makeblock 0 (getpredef Match_failure/53!!) [0: "test.ml" 31 50])))
    non_empty_cases_returning_string/292 =
      (function {nlocal = 0} param/294
        (raise
-         (makeblock 0 (getpredef Assert_failure/63!!) [0: "test.ml" 32 68])))
+         (makeblock 0 (getpredef Assert_failure/64!!) [0: "test.ml" 32 68])))
    non_empty_cases_returning_float64/295 =
      (function {nlocal = 0} param/297 : unboxed_float
        (raise
-         (makeblock 0 (getpredef Assert_failure/63!!) [0: "test.ml" 33 68])))
+         (makeblock 0 (getpredef Assert_failure/64!!) [0: "test.ml" 33 68])))
    non_empty_cases_accepting_string/298 =
      (function {nlocal = 0} param/300
        (raise
-         (makeblock 0 (getpredef Assert_failure/63!!) [0: "test.ml" 34 68])))
+         (makeblock 0 (getpredef Assert_failure/64!!) [0: "test.ml" 34 68])))
    non_empty_cases_accepting_float64/301 =
      (function {nlocal = 0} param/303[float]
        (raise
-         (makeblock 0 (getpredef Assert_failure/63!!) [0: "test.ml" 35 68]))))
+         (makeblock 0 (getpredef Assert_failure/64!!) [0: "test.ml" 35 68]))))
   (makeblock 0 empty_cases_returning_string/280
     empty_cases_returning_float64/283 empty_cases_accepting_string/286
     empty_cases_accepting_float64/289 non_empty_cases_returning_string/292

--- a/testsuite/tests/typing-layouts-box/box.ml
+++ b/testsuite/tests/typing-layouts-box/box.ml
@@ -1,0 +1,1587 @@
+(* TEST
+   include stdlib_upstream_compatible;
+   expect;
+*)
+
+(* Test 1: box on unboxed types - the manifest is stored as Tbox but
+   expands to the boxed type during unification *)
+
+type t1 = float# box
+type t2 = int32# box
+type t3 = int64# box
+type t4 = nativeint# box
+type t5 = int# box
+type t6 = #(int64# * string) box
+type 'a t7 = 'a ref# box
+[%%expect{|
+type t1 = float
+type t2 = int32
+type t3 = int64
+type t4 = nativeint
+type t5 = int
+type t6 = int64# * string
+type 'a t7 = 'a ref
+|}]
+
+let g (x : float# box) : float# box = x;;
+[%%expect{|
+val g : float -> float = <fun>
+|}]
+
+(* Test 2: box through type aliases *)
+
+type u = float#
+type t = u box;;
+let f (x : t) : float = x;;
+[%%expect{|
+type u = float#
+type t = u box
+val f : t -> float = <fun>
+|}]
+
+type ('a : any) b = 'a box
+type t1' = float# b
+let check : float -> t1' = fun x -> x
+[%%expect{|
+type ('a : any) b = 'a box
+type t1' = float# b
+val check : float -> t1' = <fun>
+|}]
+
+let g' (x : float# b) : float# b = x;;
+[%%expect{|
+val g' : float# b -> float# b = <fun>
+|}]
+
+(* Test 3: [float# box] unifies with [float] *)
+
+let h (x : 'a box) (y : 'a) : #(float * float#) = #(x, (y : float#))
+[%%expect{|
+val h : float -> float# -> #(float * float#) = <fun>
+|}]
+
+let i (x : float) : float# box = x;;
+[%%expect{|
+val i : float -> float = <fun>
+|}]
+
+(* Test 4: records too *)
+
+type r = { x : int }
+let r_id (rub : r# box) : r = rub;;
+[%%expect{|
+type r = { x : int; }
+val r_id : r -> r = <fun>
+|}]
+
+(* but records are still nominally typed *)
+type u = #{ x : int }
+let bad (ub : u box) : r = ub;;
+[%%expect{|
+type u = #{ x : int; }
+Line 2, characters 27-29:
+2 | let bad (ub : u box) : r = ub;;
+                               ^^
+Error: The value "ub" has type "u box" but an expression was expected of type "r"
+       Type "u" is not compatible with type "r#"
+|}]
+
+(* and float records don't get unboxed versions *)
+type r_float = { x : float }
+let r_id (rub : _ box) : r_float = rub;;
+[%%expect{|
+type r_float = { x : float; }
+Line 2, characters 35-38:
+2 | let r_id (rub : _ box) : r_float = rub;;
+                                       ^^^
+Error: The value "rub" has type "'a box" but an expression was expected of type
+         "r_float"
+|}]
+
+(* Test 5: box types unify with themselves in function types *)
+
+let eq_box (x : int box) (y : int box) = x = y;;
+[%%expect{|
+val eq_box : int box -> int box -> bool = <fun>
+|}]
+
+let eq_float_box (x : float# box) (y : float# box) = x = y;;
+[%%expect{|
+val eq_float_box : float -> float -> bool = <fun>
+|}]
+
+(* Test 6: box in module signatures *)
+
+module type S = sig
+  type t = float# box
+  val x : t
+end;;
+[%%expect{|
+module type S = sig type t = float val x : t end
+|}]
+
+module M : S = struct
+  type t = float# box
+  let x = 1.0
+end;;
+[%%expect{|
+module M : S
+|}]
+
+(* Test 7: Using the module's type *)
+
+let use_m : float = M.x;;
+[%%expect{|
+val use_m : float = 1.
+|}]
+
+
+(* Test 8: Polymorphic box with explicit jkind annotation *)
+
+let check_boxed_by : type (a : float64). a -> a box -> unit =
+  fun _ _ -> ();;
+[%%expect{|
+val check_boxed_by : ('a : float64). 'a -> 'a box -> unit = <fun>
+|}]
+
+type uf = float#
+let test_check (u : uf) (f : float) = check_boxed_by u f;;
+[%%expect{|
+type uf = float#
+val test_check : uf -> float -> unit = <fun>
+|}]
+
+(* Test 9: Multiple levels of type aliasing - the inner type of box
+   must be fully expanded to find the unboxed type *)
+
+type f = float#
+type g = f
+let test_multi_alias (x : g box) : float = x;;
+[%%expect{|
+type f = float#
+type g = f
+val test_multi_alias : g box -> float = <fun>
+|}]
+
+type h = g
+let test_three_levels (x : h box) : float = x;;
+[%%expect{|
+type h = g
+val test_three_levels : h box -> float = <fun>
+|}]
+
+(* Test 10: box on types without unboxed versions *)
+
+type abstract_type
+type boxed_abstract = abstract_type box;;
+[%%expect{|
+type abstract_type
+type boxed_abstract = abstract_type box
+|}]
+
+(* Test 11: float32# box = float32 *)
+
+type t_f32 = float32# box;;
+[%%expect{|
+type t_f32 = float32
+|}]
+
+let f_f32 (x : t_f32) : float32 = x;;
+[%%expect{|
+val f_f32 : t_f32 -> float32 = <fun>
+|}]
+
+let g_f32 (x : float32) : float32# box = x;;
+[%%expect{|
+val g_f32 : float32 -> float32 = <fun>
+|}]
+
+(* Test 12: Implicit unboxed records - t# box = t
+   Mixed records (not float-only) have implicit unboxed versions *)
+
+type mixed_record = { i : int; s : string };;
+[%%expect{|
+type mixed_record = { i : int; s : string; }
+|}]
+
+let mixed_of_unboxed (p : mixed_record# box) : mixed_record = p;;
+[%%expect{|
+val mixed_of_unboxed : mixed_record -> mixed_record = <fun>
+|}]
+
+let unboxed_of_mixed (p : mixed_record) : mixed_record# box = p;;
+[%%expect{|
+val unboxed_of_mixed : mixed_record -> mixed_record = <fun>
+|}]
+
+type umixed = mixed_record#
+type boxed_umixed = umixed box;;
+[%%expect{|
+type umixed = mixed_record#
+type boxed_umixed = umixed box
+|}]
+
+let convert_alias (x : boxed_umixed) : mixed_record = x;;
+[%%expect{|
+val convert_alias : boxed_umixed -> mixed_record = <fun>
+|}]
+
+(* Float-only records don't have unboxed versions *)
+type float_point = { fx : float#; fy : float# };;
+[%%expect{|
+type float_point = { fx : float#; fy : float#; }
+|}]
+
+let float_point_no_unboxed (p : float_point# box) : float_point = p;;
+[%%expect{|
+val float_point_no_unboxed : float_point -> float_point = <fun>
+|}]
+
+(* Test 13: Boxing unboxed tuples *)
+
+type ut = #(int * string);;
+[%%expect{|
+type ut = #(int * string)
+|}]
+
+type boxed_ut = ut box;;
+let check : int * string -> boxed_ut = fun x -> x;;
+[%%expect{|
+type boxed_ut = ut box
+val check : int * string -> boxed_ut = <fun>
+|}]
+
+let eq_ut (x : #(int * string) box) (y : ut box) = x = y;;
+[%%expect{|
+val eq_ut : int * string -> ut box -> bool = <fun>
+|}]
+
+(* Test 14: Additional jkinds - bits32, bits64, word *)
+
+let check_bits32 : type (a : bits32). a -> a box -> unit =
+  fun _ _ -> ();;
+[%%expect{|
+val check_bits32 : ('a : bits32). 'a -> 'a box -> unit = <fun>
+|}]
+
+type ui32 = int32#
+let test_bits32 (u : ui32) (b : int32) = check_bits32 u b;;
+[%%expect{|
+type ui32 = int32#
+val test_bits32 : ui32 -> int32 -> unit = <fun>
+|}]
+
+let check_bits64 : type (a : bits64). a -> a box -> unit =
+  fun _ _ -> ();;
+[%%expect{|
+val check_bits64 : ('a : bits64). 'a -> 'a box -> unit = <fun>
+|}]
+
+type ui64 = int64#
+let test_bits64 (u : ui64) (b : int64) = check_bits64 u b;;
+[%%expect{|
+type ui64 = int64#
+val test_bits64 : ui64 -> int64 -> unit = <fun>
+|}]
+
+let check_word : type (a : word). a -> a box -> unit =
+  fun _ _ -> ();;
+[%%expect{|
+val check_word : ('a : word). 'a -> 'a box -> unit = <fun>
+|}]
+
+type unat = nativeint#
+let test_word (u : unat) (b : nativeint) = check_word u b;;
+[%%expect{|
+type unat = nativeint#
+val test_word : unat -> nativeint -> unit = <fun>
+|}]
+
+(* Test 15: Parameterized box type alias *)
+
+type ('a : float64) boxed = 'a box;;
+[%%expect{|
+type ('a : float64) boxed = 'a box
+|}]
+
+let use_boxed (x : float# boxed) : float = x;;
+[%%expect{|
+val use_boxed : float# boxed -> float = <fun>
+|}]
+
+type alias_float = float#
+let use_boxed_alias (x : alias_float boxed) : float = x;;
+[%%expect{|
+type alias_float = float#
+val use_boxed_alias : alias_float boxed -> float = <fun>
+|}]
+
+(* Test 16: Nested box - float# box expands to float, but float is not an
+   unboxed version, so float box does NOT expand further to float.
+   This tests that box only expands for actual unboxed versions. *)
+
+type nested = float# box box;;
+[%%expect{|
+type nested = float box
+|}]
+
+(* nested = float# box box = float box, which does NOT equal float *)
+let nested_to_float (x : nested) : float = x;;
+[%%expect{|
+Line 1, characters 43-44:
+1 | let nested_to_float (x : nested) : float = x;;
+                                               ^
+Error: The value "x" has type "nested" = "float box"
+       but an expression was expected of type "float"
+       Type "float" is not compatible with type "float#"
+|}]
+
+(* But nested types still unify with each other *)
+let nested_eq (x : nested) (y : float# box box) = x = y;;
+[%%expect{|
+val nested_eq : nested -> float box -> bool = <fun>
+|}]
+
+(* Test 17: Type error cases *)
+
+let mismatch1 (x : float# box) : int = x;;
+[%%expect{|
+Line 1, characters 39-40:
+1 | let mismatch1 (x : float# box) : int = x;;
+                                           ^
+Error: The value "x" has type "float# box" = "float"
+       but an expression was expected of type "int"
+|}]
+
+let mismatch2 (x : int32# box) : int64 = x;;
+[%%expect{|
+Line 1, characters 41-42:
+1 | let mismatch2 (x : int32# box) : int64 = x;;
+                                             ^
+Error: The value "x" has type "int32# box" = "int32"
+       but an expression was expected of type "int64"
+|}]
+
+type uf1 = float#
+type uf2 = int64#
+let mismatch3 (x : uf1 box) : uf2 box = x;;
+[%%expect{|
+type uf1 = float#
+type uf2 = int64#
+Line 3, characters 40-41:
+3 | let mismatch3 (x : uf1 box) : uf2 box = x;;
+                                            ^
+Error: The value "x" has type "uf1 box" = "float"
+       but an expression was expected of type "uf2 box" = "int64"
+|}]
+
+(* Test 18: Type inference *)
+
+let infer1 x = (x : float# box);;
+[%%expect{|
+val infer1 : float -> float = <fun>
+|}]
+
+let infer2 () =
+  let f (x : float# box) = x in
+  f 1.0;;
+[%%expect{|
+val infer2 : unit -> float = <fun>
+|}]
+
+type ufl = float#
+let infer3 (x : ufl box) = x +. 1.0;;
+[%%expect{|
+type ufl = float#
+val infer3 : ufl box -> float = <fun>
+|}]
+
+(* Test 19: Distinct vs same underlying box types *)
+
+type t_float_box = float# box
+type t_int32_box = int32# box;;
+[%%expect{|
+type t_float_box = float
+type t_int32_box = int32
+|}]
+
+let distinct1 (x : t_float_box) (y : t_int32_box) = x = y;;
+[%%expect{|
+Line 1, characters 56-57:
+1 | let distinct1 (x : t_float_box) (y : t_int32_box) = x = y;;
+                                                            ^
+Error: The value "y" has type "t_int32_box" = "int32"
+       but an expression was expected of type "t_float_box" = "float"
+|}]
+
+type ua = float#
+type ub = float#
+type ta = ua box
+type tb = ub box;;
+[%%expect{|
+type ua = float#
+type ub = float#
+type ta = ua box
+type tb = ub box
+|}]
+
+let same_underlying (x : ta) (y : tb) = x = y;;
+[%%expect{|
+val same_underlying : ta -> tb -> bool = <fun>
+|}]
+
+(* Test 20: With constraints in module types *)
+
+module type S_box = sig
+  type t
+  val x : t
+end;;
+[%%expect{|
+module type S_box = sig type t val x : t end
+|}]
+
+module type S_float_box = S_box with type t = float# box;;
+[%%expect{|
+module type S_float_box = sig type t = float val x : t end
+|}]
+
+module M_float_box : S_float_box = struct
+  type t = float# box
+  let x = 1.0
+end;;
+[%%expect{|
+module M_float_box : S_float_box
+|}]
+
+let use_m_float_box : float = M_float_box.x;;
+[%%expect{|
+val use_m_float_box : float = 1.
+|}]
+
+(* Test 21: Functors with box *)
+
+module type UNBOXED = sig
+  type t : float64
+  val zero : t
+end;;
+[%%expect{|
+module type UNBOXED = sig type t : float64 val zero : t end
+|}]
+
+(* Can't yet convert U.t to U.t box generically *)
+module type BOXED = sig
+  type unboxed : float64
+  type t = unboxed box
+  (* CR box: once we have the box primitive, change to [val zero : t] *)
+  val zero : unboxed
+end;;
+[%%expect{|
+module type BOXED =
+  sig type unboxed : float64 type t = unboxed box val zero : unboxed end
+|}]
+
+module MakeBoxed (U : UNBOXED) : BOXED with type unboxed = U.t = struct
+  type unboxed = U.t
+  type t = unboxed box
+  let zero = U.zero
+end;;
+[%%expect{|
+module MakeBoxed :
+  functor (U : UNBOXED) ->
+    sig type unboxed = U.t type t = unboxed box val zero : unboxed end
+|}]
+
+
+(* Test 22: First-class modules *)
+
+module type T_FCM = sig
+  type u : any
+  type t = u box
+  val value : t
+end;;
+[%%expect{|
+module type T_FCM = sig type u : any type t = u box val value : t end
+|}]
+
+let fcm : (module T_FCM with type u = float#) =
+  (module struct
+    type u = float#
+    type t = float# box
+    let value = 3.14
+  end);;
+[%%expect{|
+val fcm : (module T_FCM with type u = float#) = <module>
+|}]
+
+let extract_fcm () =
+  let module M = (val fcm) in
+  M.value;;
+[%%expect{|
+val extract_fcm : unit -> float = <fun>
+|}]
+
+let fcm_as_float : float = extract_fcm ();;
+[%%expect{|
+val fcm_as_float : float = 3.14
+|}]
+
+(* Test 23: box on value types (int, string)
+
+   Values like int and string are NOT "unboxed versions" of anything,
+   but they can still be extra-boxed. *)
+
+type boxed_int = int box;;
+[%%expect{|
+type boxed_int = int box
+|}]
+
+(* int box is not equal to int *)
+let int_box_is_int (x : int box) : int = x;;
+[%%expect{|
+Line 1, characters 41-42:
+1 | let int_box_is_int (x : int box) : int = x;;
+                                             ^
+Error: The value "x" has type "int box" but an expression was expected of type
+         "int"
+       Type "int" is not compatible with type "int#"
+|}]
+
+let int_is_int_box (x : int) : int box = x;;
+[%%expect{|
+Line 1, characters 41-42:
+1 | let int_is_int_box (x : int) : int box = x;;
+                                             ^
+Error: The value "x" has type "int" but an expression was expected of type
+         "int box"
+       Type "int#" is not compatible with type "int"
+|}]
+
+type boxed_string = string box;;
+[%%expect{|
+type boxed_string = string box
+|}]
+
+(* string box is NOT equal to string *)
+let string_box_roundtrip (x : string) : string box = x;;
+[%%expect{|
+Line 1, characters 53-54:
+1 | let string_box_roundtrip (x : string) : string box = x;;
+                                                         ^
+Error: The value "x" has type "string" but an expression was expected of type
+         "string box"
+|}]
+
+(* But box types still unify with themselves *)
+let int_box_eq (x : int box) (y : int box) = x = y;;
+[%%expect{|
+val int_box_eq : int box -> int box -> bool = <fun>
+|}]
+
+(* Test 24: Recursive types with box *)
+
+type ('a : any) box_tree = Leaf | Node of 'a box * 'a box_tree * 'a box_tree
+
+type float_tree = float# box_tree;;
+[%%expect{|
+type ('a : any) box_tree = Leaf | Node of 'a box * 'a box_tree * 'a box_tree
+type float_tree = float# box_tree
+|}]
+
+let make_float_tree () : float_tree =
+  Node (1.0, Node (2.0, Leaf, Leaf), Leaf);;
+[%%expect{|
+val make_float_tree : unit -> float_tree = <fun>
+|}]
+
+let sum_tree t =
+  let rec go acc = function
+    | Leaf -> acc
+    | Node (x, l, r) -> go (go (acc +. x) l) r
+  in go 0.0 t;;
+[%%expect{|
+val sum_tree : float# box_tree -> float = <fun>
+|}]
+
+let sum_float_tree (t : float_tree) = sum_tree t;;
+[%%expect{|
+val sum_float_tree : float_tree -> float = <fun>
+|}]
+
+(* Test 25: Polymorphic box unification with concrete boxed types *)
+
+let f_box : 'a box -> 'a box = fun x -> x;;
+[%%expect{|
+val f_box : ('a : any). 'a box -> 'a box = <fun>
+|}]
+
+let _ = f_box 5.;;
+[%%expect{|
+- : float = 5.
+|}]
+
+let _ = f_box 42l;;
+[%%expect{|
+- : int32 = 42l
+|}]
+
+let _ = f_box 42L;;
+[%%expect{|
+- : int64 = 42L
+|}]
+
+(* int also has an unboxed version (int#) *)
+let _ = f_box 42;;
+[%%expect{|
+- : int = 42
+|}]
+
+(* Test that this does NOT work for types without unboxed versions *)
+let _ = f_box "hello";;
+[%%expect{|
+Line 1, characters 14-21:
+1 | let _ = f_box "hello";;
+                  ^^^^^^^
+Error: This constant has type "string" but an expression was expected of type
+         "'a box"
+|}]
+
+(* Test 26: Subtyping with polymorphic variants and box *)
+
+type ab = [ `A | `B ]
+type a  = [ `A ];;
+[%%expect{|
+type ab = [ `A | `B ]
+type a = [ `A ]
+|}]
+
+let coerce_box (x : a box) : ab box = (x :> ab box);;
+[%%expect{|
+val coerce_box : a box -> ab box = <fun>
+|}]
+
+(* Also test the other direction fails *)
+let coerce_box_fail (x : ab box) : a box = (x :> a box);;
+[%%expect{|
+Line 1, characters 43-55:
+1 | let coerce_box_fail (x : ab box) : a box = (x :> a box);;
+                                               ^^^^^^^^^^^^
+Error: Type "ab box" = "[ `A | `B ] box" is not a subtype of "a box" = "[ `A ] box"
+       Type "ab" = "[ `A | `B ]" is not a subtype of "a" = "[ `A ]"
+       The second variant type does not allow tag(s) "`B"
+|}]
+
+(* [int32# box] unifies with [int32] across a subtype coercion *)
+let coerce_unbox (x : [ `A of int32# box ]) =
+  (x :> [ `A of int32 | `B ]);;
+[%%expect{|
+val coerce_unbox : [ `A of int32 ] -> [ `A of int32 | `B ] = <fun>
+|}]
+
+(* Test 27: Recursive type declarations with box
+   These test well-foundedness and infinite size checks *)
+
+type a_rec = { a_rec : a_rec box } [@@unboxed];;
+[%%expect{|
+type a_rec = { a_rec : a_rec box; } [@@unboxed]
+|}]
+
+type t1_rec = { t2_rec : t2_rec box } [@@unboxed]
+and t2_rec = t1_rec box;;
+[%%expect{|
+type t1_rec = { t2_rec : t2_rec box; } [@@unboxed]
+and t2_rec = t1_rec box
+|}]
+
+(* Recursive types with box that are NOT unboxed also work *)
+type b_rec = { b_rec_field : b_rec box };;
+[%%expect{|
+type b_rec = { b_rec_field : b_rec box; }
+|}]
+
+(* Mutually recursive with box *)
+type c1 = { c2_field : c2 box }
+and c2 = { c1_field : c1 box };;
+[%%expect{|
+type c1 = { c2_field : c2 box; }
+and c2 = { c1_field : c1 box; }
+|}]
+
+
+(* Test 28: [any] in [box] is representable *)
+
+type t : any
+type foo = t box
+let f (foo : foo) = foo
+
+[%%expect{|
+type t : any
+type foo = t box
+val f : foo -> foo = <fun>
+|}]
+
+
+(* Test 29: GADTs *)
+
+let require_boxed (_ : _ box) = ()
+type 'a st = T : string st
+type 'a ft = T : float ft
+type 'a bt = T : _ box bt
+[%%expect{|
+val require_boxed : ('a : any). 'a box -> unit = <fun>
+type 'a st = T : string st
+type 'a ft = T : float ft
+type 'a bt = T : 'b box bt
+|}]
+
+(* We can match on a GADT to learn that something is boxed *)
+let ok_bt (type a) (a : a) (x : a bt) =
+  match x with
+  | T -> require_boxed a
+[%%expect{|
+val ok_bt : 'a -> 'a bt -> unit = <fun>
+|}]
+
+let ok_ft (type a) (a : a) (x : a ft) =
+  match x with
+  | T -> require_boxed a
+[%%expect{|
+val ok_ft : 'a -> 'a ft -> unit = <fun>
+|}]
+
+let bad_st (type a) (a : a) (x : a st) =
+  match x with
+  | T -> require_boxed a
+[%%expect{|
+Line 3, characters 23-24:
+3 |   | T -> require_boxed a
+                           ^
+Error: The value "a" has type "a" = "string" but an expression was expected of type
+         "'a box"
+|}]
+
+(* We can't discover something is boxed, then lower the GADT type (this would be
+   unsound) *)
+
+let bad (x : 'a st) (a : 'a) =
+  require_boxed a;
+  match x with
+  | T ->
+    ()
+[%%expect{|
+Line 4, characters 4-5:
+4 |   | T ->
+        ^
+Error: This pattern matches values of type "string st"
+       but a pattern was expected which matches values of type "$0 box st"
+       Type "string" is not compatible with type "$0 box"
+       The type constructor "$0" would escape its scope
+|}]
+
+(* Test 30: [(T box)#] = [T] -- the unboxed version of a [_ box] alias is
+   the inner type. *)
+
+type t = int box
+type u = t#
+let u_is_int (x : u) : int = x
+let int_is_u (x : int) : u = x
+[%%expect{|
+type t = int box
+type u = t#
+val u_is_int : u -> int = <fun>
+val int_is_u : int -> u = <fun>
+|}]
+
+(* The same property holds parametrically. *)
+
+type ('a : any) my_box = 'a box
+type 'a uu = 'a my_box#
+let probe (x : 'a uu) : 'a = x
+let probe_inv (x : 'a) : 'a uu = x
+[%%expect{|
+type ('a : any) my_box = 'a box
+type 'a uu = 'a my_box#
+val probe : 'a uu -> 'a = <fun>
+val probe_inv : 'a -> 'a uu = <fun>
+|}]
+
+(* Test 31: [box] on object types *)
+
+type obj = < m : int >
+type t_obj_box = obj box;;
+[%%expect{|
+type obj = < m : int >
+type t_obj_box = obj box
+|}]
+
+let obj_box_eq (x : obj box) (y : obj box) = x = y;;
+[%%expect{|
+val obj_box_eq : obj box -> obj box -> bool = <fun>
+|}]
+
+(* Object subtyping is preserved through [box] *)
+type obj_more = < m : int; n : int >
+let widen (x : obj_more box) = (x :> obj box);;
+[%%expect{|
+type obj_more = < m : int; n : int >
+val widen : obj_more box -> obj box = <fun>
+|}]
+
+(* Test 32: Box creates an unboxed version *)
+
+type t = string box
+type u = t#
+let check : u -> string = fun x -> x
+[%%expect{|
+type t = string box
+type u = t#
+val check : u -> string = <fun>
+|}]
+
+type 'a t = 'a box
+type 'a u = 'a t#
+let check : 'a -> 'a u = fun x -> x
+[%%expect{|
+type 'a t = 'a box
+type 'a u = 'a t#
+val check : 'a -> 'a u = <fun>
+|}]
+
+type i = int t#
+let check : i -> int = fun x -> x
+[%%expect{|
+type i = int t#
+val check : i -> int = <fun>
+|}]
+
+module M : sig
+  type ('a : any) b = 'a box
+  type ('a : any) t = 'a
+  type ('a : any) t2 = 'a
+  type s = string
+  type tup = int * int
+end = struct
+  type ('a : any) b = 'a box
+  type ('a : any) t = 'a b#
+  type ('a : any) t2 = 'a box#
+  type s = string b#
+  type tup = #(int * int) b
+end
+[%%expect{|
+module M :
+  sig
+    type ('a : any) b = 'a box
+    type ('a : any) t = 'a
+    type ('a : any) t2 = 'a
+    type s = string
+    type tup = int * int
+  end
+|}]
+
+module M : sig
+  type ('a : any) b = 'a box
+  type ('a : any) t = 'a b#
+  type ('a : any) t2 = 'a box#
+  type s = string b#
+  type tup = #(int * int) b
+end = struct
+  type ('a : any) b = 'a box
+  type ('a : any) t = 'a
+  type ('a : any) t2 = 'a
+  type s = string
+  type tup = int * int
+end
+[%%expect{|
+module M :
+  sig
+    type ('a : any) b = 'a box
+    type ('a : any) t = 'a b#
+    type ('a : any) t2 = 'a box#
+    type s = string b#
+    type tup = #(int * int) b
+  end
+|}]
+
+(* Test 33: multiple layers of [box] *)
+
+type int_b = int box
+type int_b_b = int_b box
+type int_b_b_u = int_b_b#
+let check : int_b_b_u -> int_b = fun x -> x
+(* CR box rtjoa: Unboxing is approximate. This should typecheck *)
+type int_b_b_u_u = int_b_b_u#
+let check : int_b_b_u_u -> int = fun x -> x
+type int_b_b_u_u_u = int_b_b_u_u#
+let check : int_b_b_u_u_u -> int# = fun x -> x
+[%%expect{|
+type int_b = int box
+type int_b_b = int_b box
+type int_b_b_u = int_b_b#
+val check : int_b_b_u -> int_b = <fun>
+Line 6, characters 19-29:
+6 | type int_b_b_u_u = int_b_b_u#
+                       ^^^^^^^^^^
+Error: The type "int_b_b_u" has no unboxed version.
+|}]
+
+module M : sig
+  type t
+  type t_box_unbox_box_unbox = t
+end = struct
+  type t
+  type t_box = t box
+  type t_box_unbox = t_box#
+  type t_box_unbox_box = t_box_unbox box
+  type t_box_unbox_box_unbox = t_box_unbox_box#
+end
+[%%expect{|
+module M : sig type t type t_box_unbox_box_unbox = t end
+|}]
+
+(* Test 34: shadowing the predef [box] disambiguates with [box/2] *)
+
+module Shadowing = struct
+  let id_box (x : 'a box) : 'a box = x
+  type 'a box = Mine of 'a
+  let still_id = id_box
+end
+[%%expect{|
+module Shadowing :
+  sig
+    val id_box : ('a : any). 'a box -> 'a box
+    type 'a box = Mine of 'a
+    val still_id : ('a : any). 'a box/2 -> 'a box/2
+  end
+|}]
+
+(* Test 35: type compatibility *)
+
+module Inst_value : sig
+  type t
+end = struct
+  type t
+end
+[%%expect{|
+module Inst_value : sig type t end
+|}]
+
+module NonInst_value : sig
+  type _ t
+end = struct
+  type _ t
+end
+[%%expect{|
+module NonInst_value : sig type _ t end
+|}]
+
+module Inst_value_value : sig
+  type t : value & value
+end = struct
+  type t : value & value
+end
+[%%expect{|
+module Inst_value_value : sig type t : value & value end
+|}]
+
+module NonInst_value_value : sig
+  type _ t : value & value
+end = struct
+  type _ t : value & value
+end
+[%%expect{|
+module NonInst_value_value : sig type _ t : value & value end
+|}]
+
+module Inst_value2 : sig
+  type t
+end = struct
+  type t
+end
+[%%expect{|
+module Inst_value2 : sig type t end
+|}]
+
+module Inst_untagged_immediate : sig
+  type t : untagged_immediate
+end = struct
+  type t : untagged_immediate
+end
+[%%expect{|
+module Inst_untagged_immediate : sig type t : untagged_immediate end
+|}]
+
+module Inst_bits64 : sig
+  type t : bits64
+end = struct
+  type t = int64#
+end
+[%%expect{|
+module Inst_bits64 : sig type t : bits64 end
+|}]
+
+module Comp = struct
+  type _ t  = |
+  type _ t' = |
+end
+
+(* Comparing box with other type constructors *)
+
+(* A boxed aliasable type is compatible with a type with an unboxed version
+   (thus [eq] can't be refuted) *)
+let f (eq : (Inst_untagged_immediate.t box, int) Type.eq) : unit =
+  match eq with _ -> .
+[%%expect{|
+module Comp : sig type _ t = | type _ t' = | end
+Line 11, characters 16-17:
+11 |   match eq with _ -> .
+                     ^
+Error: This match case could not be refuted.
+       Here is an example of a value that would reach it: "Equal"
+|}]
+
+(* as well as *aliasable* type that could be hiding an unboxed version.
+   (Techically, this exact test case is conservative, as a type cannot be the
+   unboxed version of itself due to the cyclic type check) *)
+let f (eq : (Inst_value.t box, Inst_value.t) Type.eq) : unit =
+  match eq with _ -> .
+[%%expect{|
+Line 2, characters 16-17:
+2 |   match eq with _ -> .
+                    ^
+Error: This match case could not be refuted.
+       Here is an example of a value that would reach it: "Equal"
+|}]
+
+(* We can refute the below, as we can see that the unboxed version of [int]
+   isn't [value] *)
+let f (eq : (Inst_value.t box, int) Type.eq) : unit =
+  match eq with _ -> .
+[%%expect{|
+val f : (Inst_value.t box, int) Type.eq -> unit = <fun>
+|}]
+
+(* Boxed types are also incompatible with un-aliasable type without unboxed
+   versions *)
+let f (eq : (Inst_value.t box, string) Type.eq) : unit =
+  match eq with _ -> .
+[%%expect{|
+val f : (Inst_value.t box, string) Type.eq -> unit = <fun>
+|}]
+
+(* ['a box] and ['b box] are compatible if ['a] and ['b] are *)
+
+let f (eq : (Inst_value.t box, Inst_value2.t box) Type.eq) : unit =
+  match eq with _ -> .
+[%%expect{|
+Line 2, characters 16-17:
+2 |   match eq with _ -> .
+                    ^
+Error: This match case could not be refuted.
+       Here is an example of a value that would reach it: "Equal"
+|}]
+
+let f (eq : (int box, string box) Type.eq) : unit =
+  match eq with _ -> .
+[%%expect{|
+val f : (int box, string box) Type.eq -> unit = <fun>
+|}]
+
+
+let f (eq : (Inst_value.t box, Inst_bits64.t box) Type.eq) : unit =
+  match eq with _ -> .
+[%%expect{|
+val f : (Inst_value.t box, Inst_bits64.t box) Type.eq -> unit = <fun>
+|}]
+
+(* ['a box] is compatible with tuples *)
+
+let f (eq : (Inst_value_value.t box, int * int) Type.eq) : unit =
+  match eq with _ -> .
+[%%expect{|
+Line 2, characters 16-17:
+2 |   match eq with _ -> .
+                    ^
+Error: This match case could not be refuted.
+       Here is an example of a value that would reach it: "Equal"
+|}]
+let f (eq : (_ NonInst_value_value.t box, int * int) Type.eq) : unit =
+  match eq with _ -> .
+[%%expect{|
+Line 2, characters 16-17:
+2 |   match eq with _ -> .
+                    ^
+Error: This match case could not be refuted.
+       Here is an example of a value that would reach it: "Equal"
+|}]
+let f (eq : (_ NonInst_value_value.t box Comp.t, (int * int) Comp.t') Type.eq) : unit =
+  match eq with _ -> .
+[%%expect{|
+Line 2, characters 16-17:
+2 |   match eq with _ -> .
+                    ^
+Error: This match case could not be refuted.
+       Here is an example of a value that would reach it: "Equal"
+|}]
+
+(* We refute this one because #(int * int) is not [value] *)
+let f (eq : (Inst_value.t box, int * int) Type.eq) : unit =
+  match eq with _ -> .
+[%%expect{|
+val f : (Inst_value.t box, int * int) Type.eq -> unit = <fun>
+|}]
+let f (eq : (_ NonInst_value.t box, int * int) Type.eq) : unit =
+  match eq with _ -> .
+[%%expect{|
+val f : ('a NonInst_value.t box, int * int) Type.eq -> unit = <fun>
+|}]
+let f (eq : (_ NonInst_value.t box Comp.t, (int * int) Comp.t') Type.eq) : unit =
+  match eq with _ -> .
+[%%expect{|
+val f : ('a NonInst_value.t box Comp.t, (int * int) Comp.t') Type.eq -> unit =
+  <fun>
+|}]
+
+(* Test 36: preliminary testing of boxing primitives *)
+
+(* Incorrect versions of boxing primitives, to test typechecking. *)
+
+(* float *)
+open (struct
+  external box : float# -> float = "%box_float"
+  external unbox : float -> float# = "%unbox_float"
+  let box = Obj.magic box
+  let unbox = Obj.magic unbox
+end : sig
+  val box : ('a : any). 'a -> 'a box
+  val unbox : ('a : any). 'a box -> 'a
+end)
+[%%expect{|
+val box : ('a : any). 'a -> 'a box = <fun>
+val unbox : ('a : any). 'a box -> 'a = <fun>
+|}]
+
+let box_float : float# -> float = box
+let unbox_float : float -> float# = unbox
+let float_0_via_box = box #0.
+let float_0_unbox = unbox 0.
+[%%expect{|
+val box_float : float# -> float = <fun>
+val unbox_float : float -> float# = <fun>
+val float_0_via_box : float = 0.
+val float_0_unbox : float# = <abstr>
+|}]
+
+(* ref *)
+open (struct
+  let box contents = { contents }
+  let unbox { contents } = contents
+  let box = Obj.magic box
+  let unbox = Obj.magic unbox
+end : sig
+  val box : ('a : any). 'a -> 'a box
+  val unbox : ('a : any). 'a box -> 'a
+end)
+[%%expect{|
+val box : ('a : any). 'a -> 'a box = <fun>
+val unbox : ('a : any). 'a box -> 'a = <fun>
+|}]
+
+let box_ref : 'a ref# -> 'a ref = box
+let unbox_ref : 'a ref -> 'a ref# = unbox
+let ref_0_via_box = box #{ contents = 0 }
+let ref_0_unbox = unbox { contents = 0 }
+[%%expect{|
+val box_ref : 'a ref# -> 'a ref = <fun>
+val unbox_ref : 'a ref -> 'a ref# = <fun>
+val ref_0_via_box : int ref = {contents = 0}
+val ref_0_unbox : int ref# = #{contents = 0}
+|}]
+
+(* Test 37: Private type abbreviations *)
+
+type t = private int box
+(* The implied unboxed definition is [type t# = private int] *)
+[%%expect{|
+type t = private int box
+|}]
+
+(* hence [t# =/= int] *)
+let id (x : t#) = (x : int)
+[%%expect{|
+Line 1, characters 19-20:
+1 | let id (x : t#) = (x : int)
+                       ^
+Error: The value "x" has type "t#" but an expression was expected of type "int"
+|}]
+
+(* but [t#] is coercible to [int] *)
+let id (x : t#) = (x :> int)
+[%%expect{|
+val id : t# -> int = <fun>
+|}]
+
+(* Test 38: Unboxing through abbreviations *)
+
+(* CR box rtjoa: Unboxing is approximate. This should typecheck *)
+type dummy
+type ('a, 'b) box' = 'b box
+type a = (dummy, (dummy, int) box') box'
+type b = a#
+type c = b#
+[%%expect{|
+type dummy
+type ('a, 'b) box' = 'b box
+type a = (dummy, (dummy, int) box') box'
+type b = a#
+Line 5, characters 9-11:
+5 | type c = b#
+             ^^
+Error: The type "b" has no unboxed version.
+|}]
+
+(* ... *)
+
+type 'x id = 'x
+
+type 'x s1 = 'x id box
+type 'x s2 = 'x s1 box
+[%%expect{|
+type 'x id = 'x
+type 'x s1 = 'x id box
+type 'x s2 = 'x s1 box
+|}]
+
+type ('a, 'b) t = ('a * 'b) s1
+type ('a, 'b) t' = ('a, 'b) t#
+
+let id (x : (int, string) t') : int * string = x
+[%%expect{|
+type ('a, 'b) t = ('a * 'b) s1
+type ('a, 'b) t' = ('a, 'b) t#
+val id : (int, string) t' -> int * string = <fun>
+|}]
+
+type ('a, 'b) t'' = ('a, 'b) t'#
+[%%expect{|
+Line 1, characters 29-32:
+1 | type ('a, 'b) t'' = ('a, 'b) t'#
+                                 ^^^
+Error: The type "t'" has no unboxed version.
+|}]
+
+type ('a, 'b) t = ('a * 'b) s2
+type ('a, 'b) t' = ('a, 'b) t#
+type ('a, 'b) t'' = ('a, 'b) t'#
+
+(* CR box rtjoa: this should typecheck, but unboxing is approximate *)
+let id (x : (int, string) t'') : int * string = x
+[%%expect{|
+type ('a, 'b) t = ('a * 'b) s2
+type ('a, 'b) t' = ('a, 'b) t#
+Line 3, characters 29-32:
+3 | type ('a, 'b) t'' = ('a, 'b) t'#
+                                 ^^^
+Error: The type "t'" has no unboxed version.
+|}]
+
+(* CR box rtjoa: this should typecheck, but unboxing is approximate *)
+type ('a, 'b) t'' = ('a, 'b) t'#
+[%%expect{|
+Line 1, characters 29-32:
+1 | type ('a, 'b) t'' = ('a, 'b) t'#
+                                 ^^^
+Error: The type "t'" has no unboxed version.
+|}]
+
+type ('a, 'b) t'' = ('a, 'b) t''#
+[%%expect{|
+Line 1, characters 0-33:
+1 | type ('a, 'b) t'' = ('a, 'b) t''#
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The type "t''" has no unboxed version.
+|}]
+
+(* Test 38: Unboxing through tuple type abbreviation *)
+
+type ('a, 'b) t = 'a * 'b
+type 'a t' = ('a, 'a) t#
+
+let id (x : int t') : #(int * int) = x
+[%%expect{|
+type ('a, 'b) t = 'a * 'b
+type 'a t' = ('a, 'a) t#
+val id : int t' -> #(int * int) = <fun>
+|}]
+
+(* Test 39: Cycles *)
+
+type s = t box
+and t = s#
+[%%expect{|
+Line 1, characters 0-14:
+1 | type s = t box
+    ^^^^^^^^^^^^^^
+Error: The definition of "s" contains a cycle:
+         "s" = "t box",
+         "t box" = "t box",
+         "t box" contains "t",
+         "t" = "s#",
+         "s#" = "t box#",
+         "t box#" = "t",
+         "t" = "s#"
+|}]
+
+(* CR box jbachurski: This should probably complain about the cycle instead
+   once we expand abbreviations when determining unboxed versions. *)
+type s1 = t2 box
+type s2 = s1 box
+and t1 = s2#
+and t2 = t1#
+[%%expect{|
+type s1 = t2 box
+Line 4, characters 0-12:
+4 | and t2 = t1#
+    ^^^^^^^^^^^^
+Error: The type "t1" has no unboxed version.
+|}]
+
+(* Test 40: GADT equations commute *)
+
+(* Typechecking for [box] does not depend on the order in which GADT equations
+   are introduced: learning [a = au box] and [a = float] (hence [au = float#])
+   typechecks regardless of which equation comes first. *)
+
+type (_, _ : any) boxes = Boxes : ('a : any). ('a box, 'a) boxes
+[%%expect{|
+type (_, _ : any) boxes = Boxes : ('a : any). ('a box, 'a) boxes
+|}]
+
+(* Matching [Boxes] before [Equal] *)
+let f (type a) (type (au : float64))
+      (Boxes : (a, au) boxes) (Equal : (a, float) Type.eq)
+      (au : au) : au =
+  let z : a# = au in z
+[%%expect{|
+val f :
+  'a ('au : float64). ('a, 'au) boxes -> ('a, float) Type.eq -> 'au -> 'au =
+  <fun>
+|}]
+
+(* Matching [Equal] before [Boxes] *)
+let f (type a) (type (au : float64))
+      (Equal : (a, float) Type.eq) (Boxes : (a, au) boxes)
+      (au : au) : au =
+  let z : a# = au in z
+[%%expect{|
+val f :
+  'a ('au : float64). ('a, float) Type.eq -> ('a, 'au) boxes -> 'au -> 'au =
+  <fun>
+|}]
+
+(* Same examples, using intermediate modules *)
+
+(* Matching [Boxes] before [Equal] *)
+let f (type a) (type (au : float64))
+      (eq : (a, float) Type.eq) (boxes : (a, au) boxes) (au : au) : au =
+  let Boxes = boxes in
+  let Equal = eq in
+  let module M = struct
+    type b = a
+    let z : b# = au
+  end in
+  M.z
+[%%expect{|
+val f :
+  'a ('au : float64). ('a, float) Type.eq -> ('a, 'au) boxes -> 'au -> 'au =
+  <fun>
+|}]
+
+(* Matching [Equal] before [Boxes] *)
+let f (type a) (type (au : float64))
+      (eq : (a, float) Type.eq) (boxes : (a, au) boxes) (au : au) : au =
+  let Equal = eq in
+  let Boxes = boxes in
+  let module M = struct
+    type b = a
+    let z : b# = au
+  end in
+  M.z
+[%%expect{|
+val f :
+  'a ('au : float64). ('a, float) Type.eq -> ('a, 'au) boxes -> 'au -> 'au =
+  <fun>
+|}]
+
+(* Test 41: GADTs refine unboxed versions *)
+
+(* We can learn that types have an unboxed version from GADT equations *)
+
+module M : sig
+  type t
+  type r
+  type r_box
+end = struct
+  type nonrec t = float
+  type nonrec r = r
+  type r_box = r box
+end
+
+(* The lookup for [M.t#] cannot succeed until we match on [Equal] *)
+let f (Equal : (M.t, float) Type.eq) (x : float#) = (x : M.t#)
+[%%expect{|
+module M : sig type t type r type r_box end
+val f : (M.t, float) Type.eq -> float# -> M.t# = <fun>
+|}]
+
+let f (Equal : (M.r, r) Type.eq) (x : r#) = (x : M.r#)
+[%%expect{|
+val f : (M.r, r) Type.eq -> r# -> M.r# = <fun>
+|}]
+
+let f (Equal : (M.r_box, r box) Type.eq) (x : r) = (x : M.r_box#)
+[%%expect{|
+val f : (M.r_box, r box) Type.eq -> r -> M.r_box# = <fun>
+|}]
+
+(* Introducing unboxed versions with a GADT equation *)
+
+(* CR box jbachurski: I think it's doable to support these, but requires
+   some modifications in [add_gadt_equation]. *)
+
+let f (Equal : (M.t#, float#) Type.eq) (x : float#) = (x : M.t#)
+[%%expect{|
+Line 1, characters 16-20:
+1 | let f (Equal : (M.t#, float#) Type.eq) (x : float#) = (x : M.t#)
+                    ^^^^
+Error: The type "M.t" has no unboxed version.
+|}]
+
+let f (Equal : (M.t#, float#) Type.eq) (x : float) = (x : M.t)
+[%%expect{|
+Line 1, characters 16-20:
+1 | let f (Equal : (M.t#, float#) Type.eq) (x : float) = (x : M.t)
+                    ^^^^
+Error: The type "M.t" has no unboxed version.
+|}]
+
+let f (Equal : (M.t#, string) Type.eq) (x : string box) = (x : M.t)
+[%%expect{|
+Line 1, characters 16-20:
+1 | let f (Equal : (M.t#, string) Type.eq) (x : string box) = (x : M.t)
+                    ^^^^
+Error: The type "M.t" has no unboxed version.
+|}]
+
+(* Test 42: Subsumption checks with [box] *)
+
+(* [box] is total *)
+module M : sig
+  val f : 'a box -> 'c
+end = struct
+  let f (x : 'b) : 'c = Obj.magic x
+end
+[%%expect{|
+module M : sig val f : 'a box -> 'c end
+|}]
+
+(* [box] is not surjective *)
+module M : sig
+  val f : 'b -> 'c
+end = struct
+  let f (x : 'a box) : 'c = Obj.magic x
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f (x : 'a box) : 'c = Obj.magic x
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : ('a : any) 'c. 'a box -> 'c end
+       is not included in
+         sig val f : 'b -> 'c end
+       Values do not match:
+         val f : ('a : any) 'c. 'a box -> 'c
+       is not included in
+         val f : 'b -> 'c
+       The type "'a box -> 'b" is not compatible with the type "'c -> 'd"
+       Type "'a box" is not compatible with type "'c"
+|}]
+
+(* [box] is covariant *)
+module M : sig
+  type +'a t
+end = struct
+  type 'a t = 'a box
+end
+[%%expect{|
+module M : sig type +'a t end
+|}]
+
+(* [box] can reduce [moregen]s via unboxing - [int * string < 'a box] *)
+module M : sig
+  val unbox : int * string -> #(int * string)
+end = struct
+  let unbox (x : 'a box) : 'a = Obj.magic Obj.magic x
+end
+[%%expect{|
+module M : sig val unbox : int * string -> #(int * string) end
+|}]
+
+(* same test, simpler unification order - [#(int * string) < a] happens first *)
+module M : sig
+  val unbox : #(int * string) -> int * string
+end = struct
+  let unbox (x : 'a) : 'a box = Obj.magic Obj.magic x
+end
+[%%expect{|
+module M : sig val unbox : #(int * string) -> int * string end
+|}]
+
+(* Test 43: Type equality checks with [box] *)
+
+(* trivial *)
+module M : sig
+  type 'a t = 'a box
+end = struct
+  type 'a t = 'a box
+end
+[%%expect{|
+module M : sig type 'a t = 'a box end
+|}]
+
+(* reductions still happen *)
+module M : sig
+  type t = float
+end = struct
+  type t = float# box
+end
+
+[%%expect{|
+module M : sig type t = float end
+|}]
+
+(* Test 44: Signature avoidance can cause errors at functor application *)
+
+module type S = sig
+  type t
+end
+module F(X : S) = struct
+  type x = X.t
+  type y = X.t box
+  type yu = y#
+end
+
+module M = F(struct
+  type t
+end)
+[%%expect{|
+module type S = sig type t end
+module F :
+  functor (X : S) -> sig type x = X.t type y = X.t box type yu = y# end
+Lines 10-12, characters 11-4:
+10 | ...........F(struct
+11 |   type t
+12 | end)
+Error: In the signature of this functor application: The type "y"
+       has no unboxed version.
+|}]

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -482,6 +482,14 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                 Oval_stuff "<eval>"
               | ty -> tree_of_val depth obj ty
               end
+          | Tbox _ -> begin
+              (* CR box: print the inner value once we support the box
+                 primitive *)
+              match Ctype.expand_head env ty with
+              | ty' when eq_type ty ty' ->
+                Oval_stuff "<box>"
+              | ty -> tree_of_val depth obj ty
+              end
           | Tsubst _ | Tfield(_, _, _, _) | Tnil | Tlink _ | Tof_kind _ ->
               fatal_error "Printval.outval_of_value"
           | Tpoly (ty, _) ->

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -175,6 +175,7 @@ let newgenstub ~scope jkind =
 let new_splice_ty t = newty2 ~level:(get_level t) (Tsplice t)
 let new_quote_ty t = newty2 ~level:(get_level t) (Tquote t)
 let new_quote_eval_ty t = newty2 ~level:(get_level t) (Tquote_eval t)
+let new_box_ty t = newty2 ~level:(get_level t) (Tbox t)
 
 (**** Check some types ****)
 
@@ -376,6 +377,7 @@ let fold_type_expr f init ty =
   | Tpackage pack ->
     List.fold_left (fun result (_n, ty) -> f result ty) init pack.pack_cstrs
   | Tof_kind _ -> init
+  | Tbox ty -> f init ty
 
 let iter_type_expr f ty =
   fold_type_expr (fun () v -> f v) () ty
@@ -617,6 +619,7 @@ let rec copy_type_desc ?(keep_names=false) f = function
       Tpackage {pack with
         pack_cstrs = List.map (fun (n, ty) -> (n, f ty)) pack.pack_cstrs}
   | Tof_kind jk -> Tof_kind jk
+  | Tbox ty -> Tbox (f ty)
 
 (* TODO: rename to [module Copy_scope] *)
 module For_copy : sig
@@ -892,6 +895,16 @@ let tpoly_get_mono ty =
   match get_desc ty with
   | Tpoly(ty, []) -> ty
   | _ -> assert false
+
+                  (*******************************)
+                  (*  Utilities for box types    *)
+                  (*******************************)
+
+let simple_unbox_ty ty =
+  match get_desc ty with
+  | Ttuple tys -> Some (newty2 ~level:(get_level ty) (Tunboxed_tuple tys))
+  | Tbox ty -> Some ty
+  | _ -> None
 
                   (************)
                   (*  Jkinds  *)

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -91,6 +91,8 @@ val new_splice_ty: type_expr -> type_expr
         (* Splice a type expression *)
 val new_quote_eval_ty: type_expr -> type_expr
         (* Quote-eval a type expression *)
+val new_box_ty: type_expr -> type_expr
+        (* Box a type expression *)
 
 (**** Types ****)
 
@@ -139,6 +141,10 @@ val proxy: type_expr -> type_expr
 val tpoly_is_mono : type_expr -> bool
 val tpoly_get_mono : type_expr -> type_expr
 val tpoly_get_poly : type_expr -> type_expr * type_expr list
+
+(* Create an expression for the unboxing of the given type
+   if one exists in an empty environment *)
+val simple_unbox_ty : type_expr -> type_expr option
 
 (**** Utilities for private abbreviations with fixed rows ****)
 val row_of_type: type_expr -> type_expr

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1039,7 +1039,8 @@ let rec copy_spine copy_scope ty =
   | Tquote _
   | Tsplice _
   | Tquote_eval _
-  | Tof_kind _ -> ty
+  | Tof_kind _
+  | Tbox _ -> ty
   | ( Tarrow _ | Tpoly _ | Trepr _ | Ttuple _ | Tunboxed_tuple _ | Tpackage _
     | Tconstr _ ) as desc ->
       let level = get_level ty in
@@ -1500,7 +1501,8 @@ let rec copy ?partial ?keep_names copy_scope ty =
                   Tsubst (ty, None) -> ty
                   (* TODO: is this case possible?
                      possibly an interaction with (copy more) below? *)
-                | Tconstr _ | Tquote _ | Tsplice _ | Tnil | Tof_kind _ ->
+                | Tconstr _ | Tquote _ | Tsplice _ | Tnil | Tof_kind _
+                | Tbox _ ->
                     copy more
                 | Tvar _ | Tunivar _ ->
                     if keep then more else newty mored
@@ -2356,7 +2358,28 @@ let rec try_expand_once_gen expand_abbrev env ty =
       try_expand_once_gen expand_abbrev (decr_stage env) t |> new_splice_ty
   | Tquote_eval t ->
       try_expand_once_gen expand_abbrev (incr_stage env) t |> new_quote_eval_ty
+  | Tbox t ->
+      try_expand_once_gen expand_abbrev env t |> new_box_ty
   | _ -> raise Cannot_expand
+
+let unbox_ty env ty =
+  match get_desc ty with
+  | Tconstr (p, args, _) ->
+    let pu = Path.unboxed_version p in
+    begin match Env.find_type pu env with
+    | _ -> Some (newty2 ~level:(get_level ty) (Tconstr (pu, args, ref Mnil)))
+    | exception Not_found -> None
+    end
+  | _ ->
+    simple_unbox_ty ty
+
+let is_unboxable_ty env ty = unbox_ty env ty |> Option.is_some
+
+(* Only valid on types that pass [is_unboxable_ty] *)
+let unbox_ty_exn env ty =
+  match unbox_ty env ty with
+  | Some ty -> ty
+  | None -> invalid_arg "not unboxable"
 
 (* Expand the head of a type once.
    Raise Cannot_expand if the type cannot be expanded.
@@ -2401,110 +2424,14 @@ let try_expand_safe env ty =
 
 (* Perform one of the following head-position beta reductions via rewrites:
    * Reduce a quoted-eval through a concrete (top-level) type constructor.
-   * Cancel a quote-splice pair. *)
+   * Cancel a quote-splice pair.
+   * Simplify a [Tbox] over a type with a unboxed version. *)
 let rec try_reduce_once env t =
-  let path_must_be_toplevel env path =
-    if not (Env.path_is_toplevel_in_quotations env path) then
-      raise Cannot_expand
-  in
-  let try_reduce_poly env t = if is_Tpoly t then try_reduce_once env t else t in
   match get_desc t with
-  | Tquote_eval t -> begin
-    match get_desc t with
-    | Tvar _ | Tunivar _ -> raise Cannot_expand
-    (* [<[t1 -> t2]> eval]  ==>  [<[t1]> eval -> <[t2]> eval] *)
-    | Tarrow (a, t1, t2, c) ->
-      (* Reduce the parameter type's [Tpoly] immediately *)
-      let t1' = new_quote_eval_ty t1 |> try_reduce_once env in
-      let t2' = new_quote_eval_ty t2 in
-      Tarrow (a, t1', t2', c)
-    (* [<[t1 * t2]> eval]  ==>  [<[t1]> eval * <[t2]> eval] *)
-    | Ttuple tl ->
-      Ttuple (List.map (fun (l, t) -> (l, new_quote_eval_ty t)) tl)
-    (* [<[#(t1 * t2)]> eval]  ==>  [#(<[t1]> eval * <[t2]> eval)] *)
-    | Tunboxed_tuple tl ->
-      Tunboxed_tuple (List.map (fun (l, t) -> (l, new_quote_eval_ty t)) tl)
-    (* [<[(t1, t2) typ]> eval]  ==>  [(<[t1]> eval, <[t2]> eval) typ] *)
-    | Tconstr (p, tl, a) ->
-      path_must_be_toplevel env p;
-      Tconstr (p, List.map new_quote_eval_ty tl, a)
-    (* [<[ < .. > ]> eval]  ==>  [< <[..]> eval >] *)
-    | Tobject (t, ct) ->
-      (* Attempt to reduce the field list immediately:
-         - If the object type is open, then its tail ([Tvar] or [Tunivar])
-           will [raise Cannot_expand]. [Cannot_expand] propagates to here
-           so the [Tobject] does not reduce at all.
-           Alternatively, the object type has a private row type given by
-           a [Tconstr], in which case we will reduce if it is top-level.
-         - If the object type is closed, its final element is a [Tnil] and
-           the entire [Tobject] will reduce just fine. *)
-      (* CR metaprogramming jbachurski: As for [Tvariant], it would be nicer
-         to support open object types here. *)
-      Tobject (
-        try_reduce_once env (new_quote_eval_ty t),
-        ref (
-          Option.map
-            (fun (p, tl) ->
-              path_must_be_toplevel env p;
-              p, List.map new_quote_eval_ty tl)
-            !ct))
-    (* [<[ < a: t, .. > ]> eval] ==> [<a : <[t]> eval, <[..]> eval >] *)
-    | Tfield (s, k, t_method, t_rest) ->
-      Tfield (
-        s, k,
-        (* If the method type's [Tpoly] is present, we reduce it. *)
-        try_reduce_poly env (new_quote_eval_ty t_method),
-        (* Immediately reduce other fields to make sure we don't get stuck. *)
-        try_reduce_once env (new_quote_eval_ty t_rest))
-    | Tnil -> Tnil
-    (* reduce in subterm *)
-    | Tquote _ | Tsplice _ | Tquote_eval _ ->
-      Tquote_eval (try_reduce_once (incr_stage env) t)
-    (* [<[ < > ]> eval] ==> [< >] *)
-    (* [<[ [ `A of t ... ] | ]> eval] ==> [ [ `A of <[t]> eval | ... ] ] *)
-    | Tvariant row ->
-      (* Immediately beta-reduce [more] -- only reduces closed variant types *)
-      (* CR metaprogramming jbachurski: We should not need a restriction to
-         closed row types, and allow having [Tquote_eval] on row variables.
-         As is, this is incomplete and order-dependent. Same for [Tobject]. *)
-      let more = row_more row |> new_quote_eval_ty |> try_reduce_once env in
-      Tvariant (copy_row new_quote_eval_ty true row false more)
-    (* [<['a. t]> eval] ==> ['b. (<[{$'b/'a} t]> eval)],
-        where {t/x} is a substitution of t for x. *)
-    | Tpoly (t, tl) ->
-      (* We quantify again, but with the univars [tl'] at an outer stage.
-          This means all instances of univars [tl] have to be replaced
-          by a corresponding instance in [tl'] spliced. *)
-      let copy tv =
-        newty3 ~level:(get_level tv) ~scope:(get_scope tv) (get_desc tv)
-        |> new_splice_ty
-      in
-      let tl', t' =
-        For_copy.with_scope (fun copy_scope ->
-          instance_poly' copy_scope ~keep_names:true
-            ~fixed:false ~partial:true ~copy_var:(Some copy) tl t)
-      in
-      let tl' =
-        List.map
-          (fun t -> match get_desc t with Tsplice uv -> uv | _ -> assert false)
-          tl'
-      in
-      Tpoly (new_quote_eval_ty t', tl')
-    (* [<[(sort 'a). t]> eval] ==> [(sort 'a). <[t]> eval] *)
-    | Trepr (t, sl) ->
-      Trepr (new_quote_eval_ty t, sl)
-    (*     [<[ module S with type typ = t ]> eval]
-        ==> [module S with type typ = <[t]> eval] *)
-    | Tpackage { pack_path; pack_cstrs } ->
-      path_must_be_toplevel env pack_path;
-      Tpackage { pack_path;
-                 pack_cstrs =
-                   List.map (fun (n, t) -> n, new_quote_eval_ty t)
-                     pack_cstrs }
-    (* It is safe not to expand [Tof_kind], and we do not need to currently *)
-    | Tof_kind _ -> raise Cannot_expand
-    | Tlink _ | Tsubst _ -> assert false
-    end |> newty2 ~level:(get_level t)
+  | Tquote_eval t ->
+    try_reduce_quote_eval env t |> newty2 ~level:(get_level t)
+  | Tbox t ->
+    try_reduce_box t |> newty2 ~level:(get_level t)
   | Tsplice t -> begin
     match get_desc t with
     (* [$<[ t ]>] ==> [t] ]>] *)
@@ -2527,21 +2454,139 @@ let rec try_reduce_once env t =
     end
   | _ -> raise Cannot_expand
 
+and try_reduce_quote_eval env t =
+  let path_must_be_toplevel env path =
+    if not (Env.path_is_toplevel_in_quotations env path) then
+      raise Cannot_expand
+  in
+  let try_reduce_poly env t = if is_Tpoly t then try_reduce_once env t else t in
+  match get_desc t with
+  | Tvar _ | Tunivar _ -> raise Cannot_expand
+  (* [<[t1 -> t2]> eval]  ==>  [<[t1]> eval -> <[t2]> eval] *)
+  | Tarrow (a, t1, t2, c) ->
+    (* Reduce the parameter type's [Tpoly] immediately *)
+    let t1' = new_quote_eval_ty t1 |> try_reduce_once env in
+    let t2' = new_quote_eval_ty t2 in
+    Tarrow (a, t1', t2', c)
+  (* [<[t1 * t2]> eval]  ==>  [<[t1]> eval * <[t2]> eval] *)
+  | Ttuple tl ->
+    Ttuple (List.map (fun (l, t) -> (l, new_quote_eval_ty t)) tl)
+  (* [<[t box]> eval]  ==>  [<[t]> eval box] *)
+  | Tbox t ->
+    Tbox (new_quote_eval_ty t)
+  (* [<[#(t1 * t2)]> eval]  ==>  [#(<[t1]> eval * <[t2]> eval)] *)
+  | Tunboxed_tuple tl ->
+    Tunboxed_tuple (List.map (fun (l, t) -> (l, new_quote_eval_ty t)) tl)
+  (* [<[(t1, t2) typ]> eval]  ==>  [(<[t1]> eval, <[t2]> eval) typ] *)
+  | Tconstr (p, tl, a) ->
+    path_must_be_toplevel env p;
+    Tconstr (p, List.map new_quote_eval_ty tl, a)
+  (* [<[ < .. > ]> eval]  ==>  [< <[..]> eval >] *)
+  | Tobject (t, ct) ->
+    (* Attempt to reduce the field list immediately:
+       - If the object type is open, then its tail ([Tvar] or [Tunivar])
+         will [raise Cannot_expand]. [Cannot_expand] propagates to here
+         so the [Tobject] does not reduce at all.
+         Alternatively, the object type has a private row type given by
+         a [Tconstr], in which case we will reduce if it is top-level.
+       - If the object type is closed, its final element is a [Tnil] and
+         the entire [Tobject] will reduce just fine. *)
+    (* CR metaprogramming jbachurski: As for [Tvariant], it would be nicer
+       to support open object types here. *)
+    Tobject (
+      try_reduce_once env (new_quote_eval_ty t),
+      ref (
+        Option.map
+          (fun (p, tl) ->
+            path_must_be_toplevel env p;
+            p, List.map new_quote_eval_ty tl)
+          !ct))
+  (* [<[ < a: t, .. > ]> eval] ==> [<a : <[t]> eval, <[..]> eval >] *)
+  | Tfield (s, k, t_method, t_rest) ->
+    Tfield (
+      s, k,
+      (* If the method type's [Tpoly] is present, we reduce it. *)
+      try_reduce_poly env (new_quote_eval_ty t_method),
+      (* Immediately reduce other fields to make sure we don't get stuck. *)
+      try_reduce_once env (new_quote_eval_ty t_rest))
+  | Tnil -> Tnil
+  (* reduce in subterm *)
+  | Tquote _ | Tsplice _ | Tquote_eval _ ->
+    Tquote_eval (try_reduce_once (incr_stage env) t)
+  (* [<[ < > ]> eval] ==> [< >] *)
+  (* [<[ [ `A of t ... ] | ]> eval] ==> [ [ `A of <[t]> eval | ... ] ] *)
+  | Tvariant row ->
+    (* Immediately beta-reduce [more] -- only reduces closed variant types *)
+    (* CR metaprogramming jbachurski: We should not need a restriction to
+       closed row types, and allow having [Tquote_eval] on row variables.
+       As is, this is incomplete and order-dependent. Same for [Tobject]. *)
+    let more = row_more row |> new_quote_eval_ty |> try_reduce_once env in
+    Tvariant (copy_row new_quote_eval_ty true row false more)
+  (* [<['a. t]> eval] ==> ['b. (<[{$'b/'a} t]> eval)],
+      where {t/x} is a substitution of t for x. *)
+  | Tpoly (t, tl) ->
+    (* We quantify again, but with the univars [tl'] at an outer stage.
+        This means all instances of univars [tl] have to be replaced
+        by a corresponding instance in [tl'] spliced. *)
+    let copy tv =
+      newty3 ~level:(get_level tv) ~scope:(get_scope tv) (get_desc tv)
+      |> new_splice_ty
+    in
+    let tl', t' =
+      For_copy.with_scope (fun copy_scope ->
+        instance_poly' copy_scope ~keep_names:true
+          ~fixed:false ~partial:true ~copy_var:(Some copy) tl t)
+    in
+    let tl' =
+      List.map
+        (fun t -> match get_desc t with Tsplice uv -> uv | _ -> assert false)
+        tl'
+    in
+    Tpoly (new_quote_eval_ty t', tl')
+  (* [<[(sort 'a). t]> eval] ==> [(sort 'a). <[t]> eval] *)
+  | Trepr (t, sl) ->
+    Trepr (new_quote_eval_ty t, sl)
+  (*  [<[ module S with type typ = t ]> eval]
+      ==> [module S with type typ = <[t]> eval] *)
+  | Tpackage { pack_path; pack_cstrs } ->
+    path_must_be_toplevel env pack_path;
+    Tpackage { pack_path;
+               pack_cstrs =
+                 List.map (fun (n, t) -> n, new_quote_eval_ty t) pack_cstrs }
+  (* It is safe not to expand [Tof_kind], and we do not need to currently *)
+  | Tof_kind _ -> raise Cannot_expand
+  | Tlink _ | Tsubst _ -> assert false
+
+and try_reduce_box t =
+  match get_desc t with
+  (* [t# box] ==> [t] *)
+  | Tconstr (p, args, _) ->
+    begin match Path.boxed_version p with
+    | Some boxed_p -> Tconstr (boxed_p, args, ref Mnil)
+    | None -> raise Cannot_expand
+    end
+  (* [#(t1 * t2) box] ==> [t1 * t2] *)
+  | Tunboxed_tuple tys -> Ttuple tys
+  | _ -> raise Cannot_expand
+
 (* Perform head-position reductions exhaustively til the normal form. *)
 let rec try_reduce env ty =
   let ty' = try_reduce_once env ty in
   try try_reduce env ty'
   with Cannot_expand -> ty'
 
-(* [Predef]'s [eval] is special -- we want to always expand it in [reduce_head],
-   so we special-case its abbreviation expansion there. *)
-let expand_eval_abbrev env ty =
+(* [Predef]'s [eval] and [box] are special -- we want to always expand it in
+   [reduce_head], so we special-case its abbreviation expansion there. *)
+let expand_reducible_abbrevs env ty =
   match get_desc ty with
-  | Tconstr (path, [_], _) when Path.same path Predef.path_eval ->
+  | Tconstr (path, [_], _) when Path.same path Predef.path_eval
+                             || Path.same path Predef.path_box ->
     try_expand_once env ty
   | _ -> raise Cannot_expand
 
-let try_expand_eval_once = try_expand_once_gen expand_eval_abbrev
+
+let try_expand_reducible_abbrevs_once =
+   try_expand_once_gen expand_reducible_abbrevs
 
 (* Fully expand the head of a type. *)
 let try_expand_head
@@ -2556,10 +2601,10 @@ let try_expand_head
   try loop try_once env ty
   with Cannot_expand -> try_reduce env ty
 
-let reduce_head ~expand_eval env ty =
+let reduce_head ~expand_reducible_abbrevs env ty =
   let try_once =
-    if expand_eval
-    then try_expand_eval_once
+    if expand_reducible_abbrevs
+    then try_expand_reducible_abbrevs_once
     else (fun _env _ty -> raise Cannot_expand)
   in
   try try_expand_head try_once env ty
@@ -2613,6 +2658,7 @@ let rec extract_concrete_typedecl env ty =
   | Tquote ty -> extract_concrete_typedecl (incr_stage env) ty
   | Tsplice ty -> extract_concrete_typedecl (decr_stage env) ty
   | Tquote_eval ty -> extract_concrete_typedecl (incr_stage env) ty
+  | Tbox ty -> extract_concrete_typedecl env ty
   | Tarrow _ | Ttuple _ | Tunboxed_tuple _ | Tobject _ | Tfield _ | Tnil
   | Tvariant _ | Tpackage _ | Tof_kind _ -> Has_no_typedecl
   | Tvar _ | Tunivar _ -> May_have_typedecl
@@ -2765,7 +2811,7 @@ let contained_without_boxing env ty =
   | Tpoly (ty, _) -> [ty]
   | Trepr (_, _) ->  Misc.fatal_error "Ctype.contained_without_boxing: repr"
   | Tvar _ | Tarrow _ | Ttuple _ | Tobject _ | Tfield _ | Tnil | Tlink _
-  | Tsubst _ | Tvariant _ | Tunivar _ | Tpackage _ | Tof_kind _
+  | Tsubst _ | Tvariant _ | Tunivar _ | Tpackage _ | Tof_kind _ | Tbox _
   | Tquote _ | Tsplice _ | Tquote_eval _ -> []
 
 (* We use ty_prev to track the last type for which we found a definition,
@@ -2994,6 +3040,7 @@ and estimate_type_jkind ~expand_components ~ignore_mod_bounds env ty =
     estimate_type_jkind ~expand_components ~ignore_mod_bounds (incr_stage env)
       ty
     |> Jkind.map_type_expr new_quote_ty
+  | Tbox _ -> Jkind.Builtin.value ~why:Boxed
   | Tnil -> Jkind.Builtin.value ~why:Tnil
   | Tlink _ | Tsubst _ -> assert false
   | Tvariant row ->
@@ -4313,14 +4360,20 @@ let rec mcomp type_pairs env t1 t2 =
             mcomp_fields type_pairs env fi1 fi2
         | (Tfield _, Tfield _, _, _) ->       (* Actually unused *)
             mcomp_fields type_pairs env t1' t2'
+        | (Tnil, Tnil, _, _) ->
+            ()
         | (Tquote t1, Tquote t2, _, _) ->
             mcomp type_pairs (incr_stage env) t1 t2
         | (Tsplice t1, Tsplice t2, _, _) ->
             mcomp type_pairs (decr_stage env) t1 t2
         | (Tquote_eval t1, Tquote_eval t2, _, _) ->
             mcomp type_pairs (incr_stage env) t1 t2
-        | (Tnil, Tnil, _, _) ->
-            ()
+        | (Tbox t1, Tbox t2, _, _) ->
+            mcomp type_pairs env t1 t2
+        | (Tbox t, _, _, _) when is_unboxable_ty env t2' ->
+          mcomp type_pairs env t (unbox_ty_exn env t2')
+        | (_, Tbox t, _, _) when is_unboxable_ty env t1' ->
+          mcomp type_pairs env (unbox_ty_exn env t1') t
         | (Tpoly (t1, []), Tpoly (t2, []), _, _) ->
             mcomp type_pairs env t1 t2
         | (Tpoly (t1, tl1), Tpoly (t2, tl2), _, _) ->
@@ -4974,6 +5027,12 @@ and unify3 uenv t1 t1' t2 t2' =
       unify_with_decr_stage uenv (fun uenv -> unify uenv (new_quote_ty t1') s2)
   | (_, Tquote s2) when is_flexible_ty s2 ->
       unify_with_incr_stage uenv (fun uenv -> unify uenv (new_splice_ty t1') s2)
+  | (Tbox t1, Tbox t2) ->
+      unify uenv t1 t2
+  | (_, Tbox t2) when is_unboxable_ty (get_env uenv) t1' ->
+      unify uenv (unbox_ty_exn (get_env uenv) t1') t2
+  | (Tbox t1, _) when is_unboxable_ty (get_env uenv) t2' ->
+      unify uenv t1 (unbox_ty_exn (get_env uenv) t2)
   | (Tfield _, Tfield _) -> (* special case for GADTs *)
       unify_fields uenv t1' t2'
   | _ ->
@@ -6261,7 +6320,7 @@ let rec moregen inst_nongen variance type_pairs env t1 t2 =
           TypePairs.add pairs (t1', t2');
           match (get_desc t1', get_desc t2') with
             (Tvar { jkind }, _) when may_instantiate inst_nongen t1' ->
-              let t2 = reduce_head ~expand_eval:false env t2 in
+              let t2 = reduce_head ~expand_reducible_abbrevs:false env t2 in
               moregen_occur env (get_level t1') t2;
               update_scope_for Moregen (get_scope t1') t2;
               (* use [check], not [constrain], here because [constrain] would be like
@@ -6338,6 +6397,14 @@ let rec moregen inst_nongen variance type_pairs env t1 t2 =
           | (Tquote_eval t1, Tquote_eval t2) ->
               moregen inst_nongen variance type_pairs
                 (incr_stage env) t1 t2
+          | (Tbox t1, Tbox t2) ->
+              moregen inst_nongen variance type_pairs env t1 t2
+          | (Tbox t, _) when is_unboxable_ty env t2' ->
+              moregen inst_nongen variance type_pairs
+                env t (unbox_ty_exn env t2')
+          | (_, Tbox t) when is_unboxable_ty env t1' ->
+              moregen inst_nongen variance type_pairs
+                env (unbox_ty_exn env t1') t
           | (_, _) ->
               raise_unexplained_for Moregen
         end
@@ -6843,6 +6910,8 @@ let rec eqtype rename type_pairs subst env ~do_jkind_check t1 t2 =
           | (Tquote_eval t1, Tquote_eval t2) ->
               eqtype rename type_pairs subst
                 (incr_stage env) ~do_jkind_check t1 t2
+          | (Tbox t1, Tbox t2) ->
+              eqtype rename type_pairs subst env ~do_jkind_check t1 t2
           | (_, _) ->
               raise_unexplained_for Equality
         end
@@ -7574,6 +7643,10 @@ let rec build_subtype env (visited : transient_expr list)
       in
       if c > Unchanged then (newty (Tquote_eval t1'), c)
       else (t, Unchanged)
+  | Tbox t1 ->
+      let (t1', c) = build_subtype env visited loops posi level t1 in
+      if c > Unchanged then (newty (Tbox t1'), c)
+      else (t, Unchanged)
   | Tnil ->
       if posi then
         let v = newvar (Jkind.Builtin.value ~why:Tnil) in
@@ -7762,6 +7835,12 @@ let rec subtype_rec env trace t1 t2 cstrs =
          subtype_rec (decr_stage env) trace t1 t2 cstrs
     | (Tquote_eval t1, Tquote_eval t2) ->
          subtype_rec (incr_stage env) trace t1 t2 cstrs
+    | (Tbox t1, Tbox t2) ->
+         subtype_rec
+           env
+           (Subtype.Diff {got = t1; expected = t2} :: trace)
+           t1 t2
+           cstrs
     | (_, _) ->
         (trace, t1, t2, !univar_pairs)::cstrs
   end

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -288,10 +288,11 @@ val apply:
            set to true.
            Exception [Cannot_apply] is raised in case of failure. *)
 
-val reduce_head: expand_eval:bool -> Env.t -> type_expr -> type_expr
-(** Exhaustively beta-reduce head-position quotes, splices and quote-evals.
-    If [expand_eval] is true, expands [Predef]'s [eval]s into [Tquote_eval]
-    enabling further reductions. *)
+val reduce_head:
+  expand_reducible_abbrevs:bool -> Env.t -> type_expr -> type_expr
+(** Exhaustively beta-reduce head-position quotes, splices, quote-evals, and
+    boxes. If [expand_reducible_abbrevs] is true, expands [Predef]'s [eval]s and
+    [box]es into [Tquote_eval] and [Tbox], enabling further reductions. *)
 
 val try_expand_once_opt: Env.t -> type_expr -> type_expr
 val try_expand_safe_opt: Env.t -> type_expr -> type_expr

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1523,6 +1523,7 @@ let type_of_cstr path = function
 type unboxed_version_step =
   | Lacks_unboxed_version
   | Aliases of Path.t * type_expr list
+  | Boxes of type_expr
   | Has_unboxed_version of type_declaration
 let step_find_unboxed_version decl =
   match decl.type_unboxed_version with
@@ -1540,9 +1541,12 @@ let step_find_unboxed_version decl =
       match decl.type_manifest with
       | None -> Lacks_unboxed_version
       | Some ty ->
-        match get_desc ty with
-        | Tconstr (path, args, _) -> Aliases (path, args)
-        | _ -> Lacks_unboxed_version
+        match Btype.simple_unbox_ty ty with
+        | Some ty -> Boxes ty
+        | None ->
+          match get_desc ty with
+          | Tconstr (path, args, _) -> Aliases (path, args)
+          | _ -> Lacks_unboxed_version
 
 let rec find_type_data path env seen =
   match
@@ -1590,11 +1594,44 @@ and find_type_unboxed_version path env seen =
   match step_find_unboxed_version decl with
   | Has_unboxed_version ud -> ud
   | Lacks_unboxed_version -> raise Not_found
+  | Boxes inner ->
+    {
+      type_params = decl.type_params;
+      type_arity = decl.type_arity;
+      type_kind = Type_abstract Definition;
+      type_jkind = Jkind.Builtin.any ~why:Dummy_jkind;
+      type_ikind =
+        Types.ikinds_todo
+          (Format_doc.asprintf
+             "env unboxed Tbox manifest path=%a" Path.print path);
+      type_private = decl.type_private;
+      type_manifest = Some inner;
+      type_variance = decl.type_variance;
+      type_separability =
+        Types.Separability.default_signature ~arity:decl.type_arity;
+      type_is_newtype = false;
+      type_expansion_scope = Btype.lowest_level;
+      type_loc = decl.type_loc;
+      type_attributes = decl.type_attributes;
+      type_unboxed_default = false;
+      type_uid = Uid.unboxed_version decl.type_uid;
+      type_unboxed_version = None;
+    }
   | Aliases (path, args) ->
+    (* CR box rtjoa: Here, we are approximate. Say we have [type 'a id = 'a],
+       and we try to find the unboxed version of [type t = float id]. We'll step
+       to [Aliases (id, [float])], and then mistakenly assume here that [id]
+       doesn't have an unboxed version, because we look up its path - even
+       though it could, depending on the arguments.
+
+       Nested boxed types fail for the same reason, as [box#] is like [id] (the
+       unboxed version of ['a box] is ['a]).
+    *)
     let ud = find_type_unboxed_version path env seen in
     let man =
       Btype.newgenty
-        (Tconstr (Path.unboxed_version path, args, ref Mnil)) in
+        (Tconstr (Path.unboxed_version path, args, ref Mnil))
+    in
     let jkind = ud.type_jkind in
     (* CR layouts v7.2: compute the exact separability *)
     (* As this unboxed version aliases [ud], its params' separabilities can

--- a/typing/gprinttyp.ml
+++ b/typing/gprinttyp.ml
@@ -762,6 +762,8 @@ module Digraph = struct
         |> numbered types
     | Types.Tof_kind _ ->
         mk "[Kind]"
+    | Types.Tbox t ->
+        mk "[Box]" |> std_edge t
   and variant params id0 (elts,main,fields) (name,rf)  =
     let id = Index.subnode ~name id0 in
     let fnode = Node id in

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -440,6 +440,9 @@ module Solver = struct
         kind ~check_principality:false ~use_tables:true ctx ty
       | Types.Tof_kind jkind -> ckind_of_jkind ctx jkind
       | Types.Tobject _ -> Ldd.const Axis_lattice.object_legacy
+      | Types.Tbox t ->
+        let base = Ldd.const Axis_lattice.mutable_data in
+        Ldd.join base (kind ~use_tables:true ctx t)
       | Types.Tfield _ -> failwith "Tfield shouldn't appear in kind"
       | Types.Tnil -> failwith "Tnil shouldn't appear in kind"
       | Types.Tquote _ | Types.Tsplice _ | Types.Tquote_eval _ ->

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1176,7 +1176,7 @@ module Base_and_axes = struct
              belong in the next case. What is the right behaviour here? *)
           | Tquote _ | Tsplice _ | Tquote_eval _ -> Skip
           | Tvar _ | Tarrow _ | Tunboxed_tuple _ | Tobject _ | Tfield _ | Tnil
-          | Tunivar _ | Tpackage _ | Tof_kind _ ->
+          | Tunivar _ | Tpackage _ | Tof_kind _ | Tbox _ ->
             (* these cases either cannot be infinitely recursive or their jkinds
                do not have with_bounds *)
             (* CR layouts v2.8: Some of these might get with-bounds someday. We
@@ -3027,6 +3027,7 @@ module Format_history = struct
     | Class_field -> fprintf ppf "it's the type of a class field"
     | Boxed_record -> fprintf ppf "it's a boxed record type"
     | Boxed_variant -> fprintf ppf "it's a boxed variant type"
+    | Boxed -> fprintf ppf "it's a boxed type"
     | Extensible_variant -> fprintf ppf "it's an extensible variant type"
     | Primitive id ->
       fprintf ppf "it is the primitive value type %s" (Ident.name id)
@@ -4041,6 +4042,7 @@ module Debug_printers = struct
     | Class_field -> fprintf ppf "Class_field"
     | Boxed_record -> fprintf ppf "Boxed_record"
     | Boxed_variant -> fprintf ppf "Boxed_variant"
+    | Boxed -> fprintf ppf "Boxed"
     | Extensible_variant -> fprintf ppf "Extensible_variant"
     | Primitive id -> fprintf ppf "Primitive %s" (Ident.unique_name id)
     | Type_argument { parent_path; position; arity } ->

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -413,6 +413,7 @@ module History = struct
     | Class_field
     | Boxed_record
     | Boxed_variant
+    | Boxed
     | Extensible_variant
     | Primitive of Ident.t
     | Type_argument of

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1242,10 +1242,10 @@ let add_type_to_preparation = prepare_type
 let print_labels = ref true
 let with_labels b f = Misc.protect_refs [R (print_labels,b)] f
 
-(* Whether to expand [eval] in types for reductions before printing.
+(* Whether to expand [eval] and [box] in types for reductions before printing.
    Disabled when printing errors, as they usually contain an expansion trace. *)
-let print_reduced_evals = ref true
-let with_reduced_evals b f = Misc.protect_refs [R (print_reduced_evals,b)] f
+let print_reduced_abbrevs = ref true
+let with_reduced_abbrevs b f = Misc.protect_refs [R (print_reduced_abbrevs,b)] f
 
 let out_jkind_of_const_jkind env jkind =
   Ojkind_const (Jkind.Const.to_out_jkind_const env jkind)
@@ -1411,7 +1411,8 @@ let rec tree_of_modal_typexp mode modal ty =
     | Other _ -> tree
   in
   let ty =
-    Ctype.reduce_head ~expand_eval:!print_reduced_evals !printing_env ty
+    Ctype.reduce_head ~expand_reducible_abbrevs:!print_reduced_abbrevs
+      !printing_env ty
   in
   let px = proxy ty in
   if Aliases.is_printed_proxy px && not (Aliases.is_delayed px) then
@@ -1583,6 +1584,13 @@ let rec tree_of_modal_typexp mode modal ty =
         Otyp_module pack
     | Tof_kind jkind ->
       Otyp_of_kind (out_jkind_of_desc !printing_env (Jkind.get jkind))
+    | Tbox ty ->
+      (* Render as if a regular Tconstr application of Predef.path_box,
+         so path shortening and shadowing (e.g. [box/2]) work uniformly. *)
+      let p', s = best_type_path Predef.path_box in
+      let tyl' = apply_subst s [ty] in
+      Internal_names.add p';
+      Otyp_constr (tree_of_path (Some Type) p', tree_of_typlist mode tyl')
   in
   Aliases.remove_delay px;
   alias_nongen_row mode px ty;
@@ -2821,8 +2829,8 @@ let trees_of_type_expansion'
     (* beware order matter due to side effect,
        e.g. when printing object types *)
     let first =
-      (* preserve unreduced eval in types *)
-      with_reduced_evals false (fun () -> tree_of_typexp' t)
+      (* preserve unreduced abbrevs in types *)
+      with_reduced_abbrevs false (fun () -> tree_of_typexp' t)
     in
     let second = tree_of_typexp' t' in
     if first = second then Same first

--- a/typing/path.ml
+++ b/typing/path.ml
@@ -23,24 +23,16 @@ and extra_ty =
   | Pext_ty
   | Punboxed_ty
 
-(* Create the unboxed version of a path, ensuring the invariant that there
-   are no "twice unboxed" paths. (It would be nice to enforce this at the type
-   level, but that would be a pervasive change.) *)
-let unboxed_version t =
-  match t with
-  | Pident _ | Pdot _ | Papply _
-  | Pextra_ty (_, (Pcstr_ty _ | Pext_ty)) ->
-    Pextra_ty (t, Punboxed_ty)
-  | Pextra_ty (_, Punboxed_ty) ->
-    Misc.fatal_error "Path.unboxed_version"
+let unboxed_version t = Pextra_ty (t, Punboxed_ty)
 
-let is_unboxed_version t =
+let boxed_version t =
   match t with
+  | Pextra_ty (inner, Punboxed_ty) -> Some inner
   | Pident _ | Pdot _ | Papply _
   | Pextra_ty (_, (Pcstr_ty _ | Pext_ty)) ->
-    false
-  | Pextra_ty (_, Punboxed_ty) ->
-    true
+    None
+
+let is_unboxed_version t = Option.is_some (boxed_version t)
 
 let rec same p1 p2 =
   p1 == p2

--- a/typing/path.mli
+++ b/typing/path.mli
@@ -62,6 +62,7 @@ and extra_ty =
   *)
 
 val unboxed_version : t -> t
+val boxed_version : t -> t option
 val is_unboxed_version : t -> bool
 
 val same: t -> t -> bool

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -52,6 +52,7 @@ type abstract_type_constr = [
   | `Lexing_position
   | `Code
   | `Eval
+  | `Box
   | `Float32
   | `Int8
   | `Int16
@@ -119,6 +120,7 @@ let base_type_constrs : type_constr list = [
   `Iarray;
   `Atomic_loc;
   `Lexing_position;
+  `Box;
   `Idx_imm;
   `Idx_mut;
 ]
@@ -206,6 +208,7 @@ and ident_lexing_position = ident_create "lexing_position"
    keep `expr` for now instead of `code` *)
 and ident_code = ident_create "expr"
 and ident_eval = ident_create "eval"
+and ident_box = ident_create "box"
 
 and ident_or_null = ident_create "or_null"
 and ident_idx_imm = ident_create "idx_imm"
@@ -258,6 +261,7 @@ let ident_of_type_constr : type_constr -> Ident.t = function
   | `Lexing_position -> ident_lexing_position
   | `Code -> ident_code
   | `Eval -> ident_eval
+  | `Box -> ident_box
   | `Float32 -> ident_float32
   | `Int8 -> ident_int8
   | `Int16 -> ident_int16
@@ -315,6 +319,7 @@ and path_idx_imm = Pident ident_idx_imm
 and path_idx_mut = Pident ident_idx_mut
 and path_code = Pident ident_code
 and path_eval = Pident ident_eval
+and path_box = Pident ident_box
 
 and path_or_null = Pident ident_or_null
 
@@ -938,6 +943,19 @@ let decl_of_type_constr tconstr =
        ~param_jkind:(
          Jkind.Builtin.any ~why:(Type_argument {
            parent_path = Path.Pident ident_eval;
+           position = 1;
+           arity = 1;
+         }))
+       ()
+  | `Box ->
+    decl1
+       ~variance:Variance.covariant
+       ~separability:Separability.Ind
+       ~manifest:(fun param -> newgenty (Tbox param))
+       ~jkind:(fun _ -> Jkind.Builtin.value ~why:Boxed)
+       ~param_jkind:(
+         Jkind.Builtin.any ~why:(Type_argument {
+           parent_path = Path.Pident ident_box;
            position = 1;
            arity = 1;
          }))

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -36,6 +36,7 @@ type abstract_type_constr = [
   | `Lexing_position
   | `Code
   | `Eval
+  | `Box
   | `Float32
   | `Int8
   | `Int16
@@ -194,6 +195,7 @@ val path_continuation: Path.t
 val path_lexing_position: Path.t
 val path_code: Path.t
 val path_eval: Path.t
+val path_box: Path.t
 
 val path_unboxed_unit : Path.t
 val path_unboxed_bool : Path.t

--- a/typing/rawprinttyp.ml
+++ b/typing/rawprinttyp.ml
@@ -162,6 +162,9 @@ and raw_type_desc ppf ty =
       raw_lid_type_list pack.pack_cstrs
   | Tof_kind jkind ->
     fprintf ppf "Tof_kind@ %a" (Format_doc.compat (Jkind.format env)) jkind
+  | Tbox t ->
+    fprintf ppf "@[Tbox@ %a@]" raw_type t
+
 and raw_row_fixed ppf = function
 | None -> fprintf ppf "None"
 | Some Types.Fixed_private -> fprintf ppf "Some Fixed_private"

--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -101,11 +101,7 @@ module Uid = struct
 
   let internal_not_actually_unique = Internal
 
-  let unboxed_version t =
-    match t with
-    | Unboxed_version _ ->
-      Misc.fatal_error "Shape.unboxed_version"
-    | _ -> Unboxed_version t
+  let unboxed_version t = Unboxed_version t
 
   let for_actual_declaration = function
     | Item _ -> true

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -325,7 +325,7 @@ module Type_shape = struct
                 | Tpoly (_, _)
                 | Trepr (_, _)
                 | Tpackage _ | Tquote _ | Tsplice _ | Tquote_eval _ | Tof_kind _
-                  ->
+                | Tbox _ ->
                   assert false
               in
               Misc.fatal_errorf
@@ -366,6 +366,7 @@ module Type_shape = struct
           | Tquote_eval _ -> unknown_shape_any
           | Tunivar _ -> unknown_shape_any
           | Tof_kind _ -> unknown_shape_any
+          | Tbox _ -> unknown_shape_value
           | Tpackage _ -> unknown_shape_value
           (* CR sspies: Support first-class modules. *)
         in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1350,12 +1350,12 @@ let gets_unboxed_version decl =
        (you'll want to consult [update_record_kind]). *)
     true
   | Type_record (lbls, repr, _) -> record_gets_unboxed_version lbls repr
+
 let derive_unboxed_version env path_in_group_has_unboxed_version decl =
   (* This must be kept in sync with the match in [gets_unboxed_version] *)
   match decl.type_kind with
   | Type_abstract _ | Type_open | Type_record_unboxed_product _
-  | Type_variant _ ->
-    None
+  | Type_variant _ -> None
   | Type_record (lbls, repr, _)
     when not (record_gets_unboxed_version lbls repr) ->
     None

--- a/typing/typedecl_separability.ml
+++ b/typing/typedecl_separability.ml
@@ -147,7 +147,7 @@ let rec immediate_subtypes : type_expr -> type_expr list = fun ty ->
       (* these should only occur under Tobject and not at the toplevel,
          but "better safe than sorry" *)
       immediate_subtypes_object_row [] ty
-  | Tquote ty | Tsplice ty | Tquote_eval ty -> [ty]
+  | Tquote ty | Tsplice ty | Tquote_eval ty | Tbox ty -> [ty]
   | Tlink _ | Tsubst _ -> assert false (* impossible due to Ctype.repr *)
   | Tvar _ | Tunivar _ -> []
   | Tof_kind _ -> []
@@ -427,6 +427,7 @@ let check_type
     | (Tquote(_)          , Sep    )
     | (Tsplice(_)         , Sep    )
     | (Tquote_eval(_)     , Sep    )
+    | (Tbox(_)            , Sep    )
     | (Tpackage _         , Sep    )
     | (Tof_kind(_)        , Sep    ) -> empty
     (* "Deeply separable" case for these same constructors. *)
@@ -439,6 +440,7 @@ let check_type
     | (Tquote(_)          , Deepsep)
     | (Tsplice(_)         , Deepsep)
     | (Tquote_eval(_)     , Deepsep)
+    | (Tbox(_)            , Deepsep)
     | (Tpackage _         , Deepsep) ->
         let tys = immediate_subtypes ty in
         let on_subtype context ty =

--- a/typing/typedecl_variance.ml
+++ b/typing/typedecl_variance.ml
@@ -95,6 +95,8 @@ let compute_variance env visited vari ty =
         compute_variance_rec (Env.enter_splice ~loc:Location.none env) vari ty
     | Tquote_eval ty ->
         compute_variance_rec (Env.enter_quotation env) vari ty
+    | Tbox ty ->
+        compute_same ty
     | Tfield (_, _, ty1, ty2) ->
         compute_same ty1;
         compute_same ty2

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -247,7 +247,7 @@ let classify ~classify_product env ty layout : _ classification =
              | `Float64x8
              )
         -> Addr
-      | Some (`Lexing_position | `Code | `Eval)
+      | Some (`Lexing_position | `Code | `Eval | `Box)
       | Some (#Predef.data_type_constr | #Predef.abstract_non_value_type_constr)
       | None ->
         try
@@ -268,7 +268,7 @@ let classify ~classify_product env ty layout : _ classification =
       Addr
   (* Quotes are not representable, but it's safe to say they are [Any].
      Unreduced splices and evals might stand for anything. *)
-  | Tquote _ | Tsplice _ | Tquote_eval _ ->
+  | Tquote _ | Tsplice _ | Tquote_eval _ | Tbox _ ->
       Any
   | Tlink _ | Tsubst _ | Tpoly _ | Tfield _ | Tunboxed_tuple _
   | Trepr _ ->
@@ -858,7 +858,8 @@ and value_kind_mixed_block_field env ~loc ~visited ~depth ~num_nodes_visited
           end
         | Tvar _ | Tarrow _ | Ttuple _ | Tobject _ | Tfield _ | Tnil
         | Tlink _ | Tsubst _ | Tvariant _ | Tunivar _ | Tpoly _ | Tpackage _
-        | Tquote _ | Tsplice _ | Tquote_eval _ | Tof_kind _ -> unknown ()
+        | Tquote _ | Tsplice _ | Tquote_eval _ | Tof_kind _ | Tbox _ ->
+          unknown ()
         | Trepr _ -> Misc.fatal_error "value_kind_mixed_block_field: Trepr"
         end
     in

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -164,6 +164,7 @@ and type_desc =
   | Trepr of type_expr * Jkind_types.Sort.univar list
   | Tpackage of package
   | Tof_kind of jkind_lr
+  | Tbox of type_expr
 
 and arg_label =
   | Nolabel
@@ -1347,6 +1348,7 @@ let best_effort_compare_type_expr te1 te2 =
         | Tquote _
         | Tsplice _
         | Tquote_eval _
+        | Tbox _
         (* CR layouts v2.8: we can actually see Tsubst here in certain cases, eg during
            [Ctype.copy] when copying the types inside of with_bounds. We also can't
            compare Tsubst structurally, because the Tsubsts that are created in

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -274,6 +274,9 @@ and type_desc =
       They are only used to represent the kinds of existentially-quantified types
       mentioned in with-bounds. See test typing-jkind-bounds/gadt.ml *)
 
+  | Tbox of type_expr
+  (** [Tbox ty] ==> [ty box] *)
+
 (** This is used in the Typedtree. It is distinct from
     {{!Asttypes.arg_label}[arg_label]} because Position argument labels are
     discovered through typechecking. *)
@@ -856,10 +859,8 @@ type type_declaration =
        records (besides records that flattens floats or have with atomic
        fields), but [None] for aliases of these types
 
-       invariants:
-       1. there are no "twice-unboxed" types: the [type_declaration] stored here
-          itself has [type_unboxed_version = None].
-       2. the Uid of the unboxed version is [Uid.unboxed_version <uid of boxed>]
+       invariant:
+       the Uid of the unboxed version is [Uid.unboxed_version <uid of boxed>]
     *)
   }
 

--- a/typing/vicuna_traverse_typed_tree.ml
+++ b/typing/vicuna_traverse_typed_tree.ml
@@ -151,6 +151,8 @@ let classify env ty : classification =
         (Vicuna_unsupported (Other "Unexpected type constructor Tquote_eval"))
     | Trepr _ ->
       raise (Vicuna_unsupported (Other "Unexpected type constructor Trepr"))
+    | Tbox _ ->
+      raise (Vicuna_unsupported (Other "Unexpected type constructor Tbox"))
 
 type can_be_float_array =
   | YesFloatArray
@@ -283,6 +285,8 @@ let rec value_kind env (subst : value_shape Subst.t) ~visited ~depth ty :
     raise (Vicuna_unsupported (Other "Unexpected type constructor Tquote_eval"))
   | Trepr _ ->
     raise (Vicuna_unsupported (Other "Unexpected type constructor Trepr"))
+  | Tbox _ ->
+    raise (Vicuna_unsupported (Other "Unexpected type constructor Tbox"))
   | Tpackage _ -> Block None
 
 and value_kind_variant env subst ~visited ~depth


### PR DESCRIPTION
Adds the `box` type operator.
- It's structural and reduces with unboxed versions of types (`t# box = t`) and unboxed tuples (`#(a * b) box = a * b`).
- A type declaration that aliases it gets an unboxed version: if `type t = foo box`, `t# = foo` (regardless of `foo`'s layout or whether it has an unboxed version).
- It's used via a predefined type whose manifest is `Tbox 'a` (where `Tbox` is added to the type algebra).

### Notes for review
* Implementation: in most places, `Tbox` is treated similarly to how a single-component `Ttuple` would be, or to `Tquote`/`Tsplice` (which can also reduce).
* To review commit [Merge try_simplifying_box into try_reduce_once](https://github.com/oxcaml/oxcaml/pull/5342/commits/933122b2c023d00df3c42e6ca3cccd7fd947be6b), `git diff --color-moved -w 933122^!` may be useful.