### PR TITLE
 chamelon: Add scheduling combinators for iterators

### DIFF
--- a/chamelon/lib/iterator.mli
+++ b/chamelon/lib/iterator.mli
@@ -1,0 +1,47 @@
+(******************************************************************************
+ *                                 Chamelon                                   *
+ *                         Milla Valnet, OCamlPro                             *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2023 OCamlPro                                                *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+type strategy
+
+val basic : strategy
+val dichotomy : strategy
+val test : pos:int -> len:int -> strategy
+
+type ('a, 'b) schedule
+
+val minimizer : ('a, 'b) Utils.minimizer -> ('a, 'b) schedule
+val list : ('a, 'b) schedule list -> ('a, 'b) schedule
+val with_strategy : strategy -> ('a, 'b) schedule list -> ('a, 'b) schedule
+val fix : ('a, 'b) schedule list -> ('a, 'b) schedule
+
+val run :
+  ?strategy:strategy ->
+  check:('a -> bool) ->
+  ('a, 'b) schedule ->
+  'a ->
+  'b ->
+  'a * bool


### PR DESCRIPTION
This patch provides a nicer API on top of the existing iterator
functions, allowing to combine minimizers in a more flexible way without
having to manually write loops or sequencing logic which can easily be
incorrect.

Note: this PR includes #5353 ; only the last commit is new.