### PR TITLE
chamelon: module minimization

### DIFF
--- a/chamelon/lib/context.ml
+++ b/chamelon/lib/context.ml
@@ -1,0 +1,151 @@
+(******************************************************************************
+ *                                 Chamelon                                   *
+ *                         Milla Valnet, OCamlPro                             *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2023 OCamlPro                                                *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+type t = { modules : Utils.module_info Utils.Smap.t }
+
+type add_result =
+  { modname : string;
+    context : t
+  }
+
+let empty : t = { modules = Utils.Smap.empty }
+
+let of_modules modules = { modules }
+
+let is_safe_relative_path path =
+  (* Check that we are a relative path that doesn't escape the current directory
+     through the use of `..`. *)
+  if not (Filename.is_relative path)
+  then false
+  else
+    let rec loop path =
+      if path = Filename.current_dir_name
+      then true
+      else
+        let dirname = Filename.dirname path in
+        let basename = Filename.basename path in
+        if basename = Filename.parent_dir_name
+        then
+          if dirname = Filename.current_dir_name
+          then false
+          else loop (Filename.dirname dirname)
+        else loop dirname
+    in
+    loop path
+
+let add ?sourcefile (cmt_infos : Cmt_format.cmt_infos) context =
+  let modname = Compilation_unit.name_as_string cmt_infos.cmt_modname in
+  let path =
+    match sourcefile with
+    | Some filename -> filename
+    | None -> (
+      match cmt_infos.cmt_sourcefile with
+      | Some sourcefile ->
+        if not (is_safe_relative_path sourcefile)
+        then
+          failwith
+            (Format.asprintf
+               "from_cmt_files: refusing to process cmt with file path: `%s` \
+                to avoid accidentally overwriting data"
+               sourcefile);
+        sourcefile
+      | None -> invalid_arg "Context.add: no source file provided")
+  in
+  let implementation, interface =
+    match cmt_infos.cmt_annots with
+    | Implementation annots -> Some { Utils.cmt_infos; path; annots }, None
+    | Interface annots -> None, Some { Utils.cmt_infos; path; annots }
+    | Partial_implementation _ | Packed _ | Partial_interface _ ->
+      invalid_arg "Context.add: unsupported cmt annotations"
+  in
+  let modules =
+    Utils.Smap.update modname
+      (function
+        | None -> Some { Utils.name = modname; implementation; interface }
+        | Some module_info ->
+          Some
+            (Utils.merge_module_info module_info
+               { Utils.name = modname; implementation; interface }))
+      context.modules
+  in
+  let context = { modules } in
+  { modname; context }
+
+let structures { modules } =
+  Utils.Smap.fold
+    (fun _modname (modinfo : Utils.module_info) structures ->
+      match modinfo.implementation with
+      | Some { path; _ } -> Utils.Smap.add path modinfo structures
+      | None -> structures)
+    modules Utils.Smap.empty
+
+let write_to ?(with_open_out = Out_channel.with_open_bin) ~path ctx =
+  let with_open_out name f =
+    (* Make sure that the required file is cleared first to avoid permissions
+       issues when writing to it (frequent inside dune's build directory), and
+       that the parent directory exists. *)
+    let name = Filename.concat path name in
+    if Sys.file_exists name
+    then Sys.remove name
+    else
+      ignore
+        (Sys.command
+           (Filename.quote_command "mkdir" ["-p"; Filename.dirname name]));
+    with_open_out name f
+  in
+  let write_file_info write_annots { Utils.cmt_infos = _; path; annots } =
+    with_open_out path (fun oc -> write_annots oc annots)
+  in
+  Utils.Smap.iter
+    (fun _modname ({ implementation; interface; _ } : Utils.module_info) ->
+      Option.iter (write_file_info Utils.write_structure) implementation;
+      Option.iter (write_file_info Utils.write_signature) interface)
+    ctx.modules
+
+let print ppf t =
+  let str_item str_desc =
+    { Typedtree.str_desc; str_loc = Location.none; str_env = Env.empty }
+  in
+  let str_items =
+    Utils.Smap.fold
+      (fun _ module_info str_items ->
+        let module_binding = Utils.to_module_binding module_info in
+        str_item (Tstr_module module_binding) :: str_items)
+      t.modules []
+  in
+  let str = { Typedtree.str_items; str_type = []; str_final_env = Env.empty } in
+  Pprintast.structure ppf (Untypeast.untype_structure str)
+
+let minimizer m =
+  let minimizer_func = m.Utils.minimizer_func in
+  Iterator.minimizer
+    { m with
+      minimizer_func =
+        (fun should_remove ctx modname ->
+          let modules = minimizer_func should_remove ctx.modules modname in
+          { modules })
+    }

--- a/chamelon/lib/minimizer/deletelines.ml
+++ b/chamelon/lib/minimizer/deletelines.ml
@@ -36,35 +36,30 @@
 open Typedtree
 open Utils
 
-let minimize should_remove map cur_file =
-  let mapper =
-    { Tast_mapper.default with
-      structure =
-        (fun sub str ->
-          let rev_str_items =
-            List.filter_map
-              (fun str_item ->
-                if should_remove ()
-                then None
-                else Some (sub.structure_item sub str_item))
-              (List.rev str.str_items)
-          in
-          { str with str_items = List.rev rev_str_items });
-      signature =
-        (fun sub signature ->
-          let rev_sig_items =
-            List.filter_map
-              (fun sig_item ->
-                if should_remove ()
-                then None
-                else Some (sub.signature_item sub sig_item))
-              (List.rev signature.sig_items)
-          in
-          { signature with sig_items = List.rev rev_sig_items })
-    }
-  in
-  let str = Smap.find cur_file map in
-  let nstr = mapper.structure mapper str in
-  Smap.add cur_file nstr map
+let delete_lines_mapper should_remove =
+  { Tast_mapper.default with
+    structure =
+      (fun sub str ->
+        let rev_str_items =
+          List.filter_map
+            (fun str_item ->
+              if should_remove ()
+              then None
+              else Some (sub.structure_item sub str_item))
+            (List.rev str.str_items)
+        in
+        { str with str_items = List.rev rev_str_items });
+    signature =
+      (fun sub signature ->
+        let rev_sig_items =
+          List.filter_map
+            (fun sig_item ->
+              if should_remove ()
+              then None
+              else Some (sub.signature_item sub sig_item))
+            (List.rev signature.sig_items)
+        in
+        { signature with sig_items = List.rev rev_sig_items })
+  }
 
-let minimizer = { minimizer_name = "delete-lines"; minimizer_func = minimize }
+let minimizer = tast_mapper_minimizer "delete-lines" delete_lines_mapper

--- a/chamelon/lib/minimizer/flatteningmodules.ml
+++ b/chamelon/lib/minimizer/flatteningmodules.ml
@@ -265,12 +265,7 @@ let minimize should_remove map cur_name =
     let correcter nstr =
       List.fold_left
         (fun nstr id ->
-          let origin_file =
-            Pident
-              (create_local
-                 (String.capitalize_ascii
-                    (String.sub cur_name 0 (String.length cur_name - 3))))
-          in
+          let origin_file = Pident (create_local cur_name) in
           let to_find =
             Pdot
               ( Pdot (origin_file, String.capitalize_ascii mod_name),
@@ -291,5 +286,4 @@ let minimize should_remove map cur_name =
     let nmap = Smap.add cur_name nstr map in
     nmap
 
-let minimizer =
-  { minimizer_name = "flatten-modules"; minimizer_func = minimize }
+let minimizer = multifile_minimizer "flatten-modules" minimize

--- a/chamelon/lib/minimizer/inlinenever.ml
+++ b/chamelon/lib/minimizer/inlinenever.ml
@@ -69,40 +69,35 @@ let minimize_attrs should_remove attrs =
   in
   attrs
 
-let minimize should_remove map cur_name =
+let mapper should_remove =
   let minimize_vb_attrs vb =
     if is_function vb.vb_pat.pat_type
     then
       { vb with vb_attributes = minimize_attrs should_remove vb.vb_attributes }
     else vb
   in
-  let mapper =
-    { Tast_mapper.default with
-      structure_item =
-        (fun mapper str_it ->
-          Tast_mapper.default.structure_item mapper
-            (match str_it.str_desc with
-            | Tstr_value (r_f, vb_l) ->
-              { str_it with
-                str_desc = Tstr_value (r_f, List.map minimize_vb_attrs vb_l)
-              }
-            | _ -> str_it));
-      expr =
-        (fun mapper e ->
-          match e.exp_desc with
-          | Texp_let (r_f, vb_l, e) ->
-            { e with
-              exp_desc =
-                Texp_let
-                  ( r_f,
-                    List.map minimize_vb_attrs vb_l,
-                    Tast_mapper.default.expr mapper e )
+  { Tast_mapper.default with
+    structure_item =
+      (fun mapper str_it ->
+        Tast_mapper.default.structure_item mapper
+          (match str_it.str_desc with
+          | Tstr_value (r_f, vb_l) ->
+            { str_it with
+              str_desc = Tstr_value (r_f, List.map minimize_vb_attrs vb_l)
             }
-          | _ -> Tast_mapper.default.expr mapper e)
-    }
-  in
-  let str = Smap.find cur_name map in
-  let nstr = mapper.structure mapper str in
-  Smap.add cur_name nstr map
+          | _ -> str_it));
+    expr =
+      (fun mapper e ->
+        match e.exp_desc with
+        | Texp_let (r_f, vb_l, e) ->
+          { e with
+            exp_desc =
+              Texp_let
+                ( r_f,
+                  List.map minimize_vb_attrs vb_l,
+                  Tast_mapper.default.expr mapper e )
+          }
+        | _ -> Tast_mapper.default.expr mapper e)
+  }
 
-let minimizer = { minimizer_name = "inline-never"; minimizer_func = minimize }
+let minimizer = tast_mapper_minimizer "inline-never" mapper

--- a/chamelon/lib/minimizer/reducedef.ml
+++ b/chamelon/lib/minimizer/reducedef.ml
@@ -41,19 +41,13 @@ let is_dummy e =
     | _ -> false)
   | _ -> false
 
-let minimize should_remove map cur_name =
-  let reduce_def_mapper =
-    { Tast_mapper.default with
-      value_binding =
-        (fun mapper vb ->
-          if (not (is_dummy vb.vb_expr)) && should_remove ()
-          then { vb with vb_expr = apply_dummy2 }
-          else Tast_mapper.default.value_binding mapper vb)
-    }
-  in
-  let nstr =
-    reduce_def_mapper.structure reduce_def_mapper (Smap.find cur_name map)
-  in
-  Smap.add cur_name nstr map
+let reduce_def_mapper should_remove =
+  { Tast_mapper.default with
+    value_binding =
+      (fun mapper vb ->
+        if (not (is_dummy vb.vb_expr)) && should_remove ()
+        then { vb with vb_expr = apply_dummy2 }
+        else Tast_mapper.default.value_binding mapper vb)
+  }
 
-let minimizer = { minimizer_name = "reduce-def"; minimizer_func = minimize }
+let minimizer = tast_mapper_minimizer "reduce-def" reduce_def_mapper

--- a/chamelon/lib/minimizer/reduceexpr.ml
+++ b/chamelon/lib/minimizer/reduceexpr.ml
@@ -75,23 +75,17 @@ let simplify apply_dummy e =
     | _ -> apply_dummy)
   | _ -> apply_dummy
 
-let minimize apply_dummy should_remove map cur_name =
-  let reduce_def_mapper =
-    { Tast_mapper.default with
-      expr =
-        (fun mapper e ->
-          if (not (is_simplified e)) && should_remove ()
-          then simplify apply_dummy e
-          else Tast_mapper.default.expr mapper e)
-    }
-  in
-  let nstr =
-    reduce_def_mapper.structure reduce_def_mapper (Smap.find cur_name map)
-  in
-  Smap.add cur_name nstr map
+let reduce_def_mapper apply_dummy should_remove =
+  { Tast_mapper.default with
+    expr =
+      (fun mapper e ->
+        if (not (is_simplified e)) && should_remove ()
+        then simplify apply_dummy e
+        else Tast_mapper.default.expr mapper e)
+  }
 
 let minimizer =
-  { minimizer_name = "reduce-expr"; minimizer_func = minimize apply_dummy2 }
+  tast_mapper_minimizer "reduce-expr" (reduce_def_mapper apply_dummy2)
 
 let minimizer_dummy1 =
-  { minimizer_name = "reduce-expr-2"; minimizer_func = minimize apply_dummy1 }
+  tast_mapper_minimizer "reduce-expr-2" (reduce_def_mapper apply_dummy1)

--- a/chamelon/lib/minimizer/reducepat.ml
+++ b/chamelon/lib/minimizer/reducepat.ml
@@ -48,44 +48,38 @@ let reduce_case ~should_remove case =
   in
   match c_lhs with None -> None | Some c_lhs -> Some { case with c_lhs }
 
-let minimize should_remove map cur_name =
-  let reduce_pat_mapper =
-    { Tast_mapper.default with
-      expr =
-        (fun mapper e ->
-          Tast_mapper.default.expr mapper
-            (match view_texp e.exp_desc with
-            | Texp_match (e_match, cc_l, _partial, id) ->
-              E.match_ ~id e_match
-                (List.filter_map
-                   (fun case -> reduce_case ~should_remove case)
-                   cc_l)
-            | O (Texp_ifthenelse (e_if, e_then, e_else_opt)) ->
-              if should_remove ()
-              then
-                (* if e1 then e2 [else e3] -> __ignore__ e1; e2 *)
-                E.list [E.ignore e_if; e_then]
-              else if should_remove ()
-              then
-                match e_else_opt with
-                | None ->
-                  (* if e1 then e2 -> __ignore__ e1 *)
-                  E.ignore e_if
-                | Some e_else ->
-                  (* if e1 then e2 else e3 -> __ignore__ e1; e3 *)
-                  E.list [E.ignore e_if; e_else]
-              else e
-            | O (Texp_try (e_try, vc_l)) ->
-              E.try_ e_try
-                (List.filter_map
-                   (fun case -> reduce_case ~should_remove case)
-                   vc_l)
-            | _ -> e))
-    }
-  in
-  let nstr =
-    reduce_pat_mapper.structure reduce_pat_mapper (Smap.find cur_name map)
-  in
-  Smap.add cur_name nstr map
+let reduce_pat_mapper should_remove =
+  { Tast_mapper.default with
+    expr =
+      (fun mapper e ->
+        Tast_mapper.default.expr mapper
+          (match view_texp e.exp_desc with
+          | Texp_match (e_match, cc_l, _partial, id) ->
+            E.match_ ~id e_match
+              (List.filter_map
+                 (fun case -> reduce_case ~should_remove case)
+                 cc_l)
+          | O (Texp_ifthenelse (e_if, e_then, e_else_opt)) ->
+            if should_remove ()
+            then
+              (* if e1 then e2 [else e3] -> __ignore__ e1; e2 *)
+              E.list [E.ignore e_if; e_then]
+            else if should_remove ()
+            then
+              match e_else_opt with
+              | None ->
+                (* if e1 then e2 -> __ignore__ e1 *)
+                E.ignore e_if
+              | Some e_else ->
+                (* if e1 then e2 else e3 -> __ignore__ e1; e3 *)
+                E.list [E.ignore e_if; e_else]
+            else e
+          | O (Texp_try (e_try, vc_l)) ->
+            E.try_ e_try
+              (List.filter_map
+                 (fun case -> reduce_case ~should_remove case)
+                 vc_l)
+          | _ -> e))
+  }
 
-let minimizer = { minimizer_name = "reduce-pat"; minimizer_func = minimize }
+let minimizer = tast_mapper_minimizer "reduce-pat" reduce_pat_mapper

--- a/chamelon/lib/minimizer/remdef.ml
+++ b/chamelon/lib/minimizer/remdef.ml
@@ -31,18 +31,14 @@ open Utils
 open Tast_mapper
 open Typedtree
 
-let minimize should_remove map cur_name =
-  let remove_def =
-    { Tast_mapper.default with
-      structure =
-        (fun _mapper str ->
-          { str with
-            str_items =
-              List.filter (fun _ -> not (should_remove ())) str.str_items
-          })
-    }
-  in
-  let nstr = remove_def.structure remove_def (Smap.find cur_name map) in
-  Smap.add cur_name nstr map
+let remove_def should_remove =
+  { Tast_mapper.default with
+    structure =
+      (fun _mapper str ->
+        { str with
+          str_items =
+            List.filter (fun _ -> not (should_remove ())) str.str_items
+        })
+  }
 
-let minimizer = { minimizer_name = "rem-def"; minimizer_func = minimize }
+let minimizer = tast_mapper_minimizer "rem-def" remove_def

--- a/chamelon/lib/minimizer/removeattributes.ml
+++ b/chamelon/lib/minimizer/removeattributes.ml
@@ -41,139 +41,132 @@ let handle_attributes should_remove attributes =
     (fun attr -> is_inline attr || (is_local attr && not (should_remove ())))
     attributes
 
-let minimize should_remove map cur_name =
-  let remove_attributes_mapper =
-    { Tast_mapper.default with
-      structure =
-        (fun mapper str ->
-          { str with
-            str_items =
-              List.rev
-                (List.fold_left
-                   (fun l str_it ->
-                     match str_it.str_desc with
-                     | Tstr_attribute _ ->
-                       if should_remove () then l else str_it :: l
-                     | _ -> mapper.structure_item mapper str_it :: l)
-                   [] str.str_items)
+let remove_attributes_mapper should_remove =
+  { Tast_mapper.default with
+    structure =
+      (fun mapper str ->
+        { str with
+          str_items =
+            List.rev
+              (List.fold_left
+                 (fun l str_it ->
+                   match str_it.str_desc with
+                   | Tstr_attribute _ ->
+                     if should_remove () then l else str_it :: l
+                   | _ -> mapper.structure_item mapper str_it :: l)
+                 [] str.str_items)
+        });
+    type_declaration =
+      (fun mapper td ->
+        Tast_mapper.default.type_declaration mapper
+          (let td =
+             { td with
+               typ_attributes =
+                 handle_attributes should_remove td.typ_attributes
+             }
+           in
+           match td.typ_kind with
+           | Ttype_record ld_l ->
+             { td with
+               typ_kind =
+                 Ttype_record
+                   (List.map
+                      (fun ld ->
+                        { ld with
+                          ld_attributes =
+                            handle_attributes should_remove ld.ld_attributes
+                        })
+                      ld_l)
+             }
+           | Ttype_variant cd_l ->
+             { td with
+               typ_kind =
+                 Ttype_variant
+                   (List.map
+                      (fun cd ->
+                        let cd =
+                          { cd with
+                            cd_attributes =
+                              handle_attributes should_remove cd.cd_attributes
+                          }
+                        in
+                        match cd.cd_args with
+                        | Cstr_record ld_l ->
+                          { cd with
+                            cd_args =
+                              Cstr_record
+                                (List.map
+                                   (fun ld ->
+                                     { ld with
+                                       ld_attributes =
+                                         handle_attributes should_remove
+                                           ld.ld_attributes
+                                     })
+                                   ld_l)
+                          }
+                        | _ -> cd)
+                      cd_l)
+             }
+           | _ -> td));
+    value_binding =
+      (fun mapper vb ->
+        Tast_mapper.default.value_binding mapper
+          { vb with
+            vb_attributes = handle_attributes should_remove vb.vb_attributes
           });
-      type_declaration =
-        (fun mapper td ->
-          Tast_mapper.default.type_declaration mapper
-            (let td =
-               { td with
-                 typ_attributes =
-                   handle_attributes should_remove td.typ_attributes
-               }
-             in
-             match td.typ_kind with
-             | Ttype_record ld_l ->
-               { td with
-                 typ_kind =
-                   Ttype_record
-                     (List.map
-                        (fun ld ->
-                          { ld with
-                            ld_attributes =
-                              handle_attributes should_remove ld.ld_attributes
-                          })
-                        ld_l)
-               }
-             | Ttype_variant cd_l ->
-               { td with
-                 typ_kind =
-                   Ttype_variant
-                     (List.map
-                        (fun cd ->
-                          let cd =
-                            { cd with
-                              cd_attributes =
-                                handle_attributes should_remove cd.cd_attributes
-                            }
-                          in
-                          match cd.cd_args with
-                          | Cstr_record ld_l ->
-                            { cd with
-                              cd_args =
-                                Cstr_record
-                                  (List.map
-                                     (fun ld ->
-                                       { ld with
-                                         ld_attributes =
-                                           handle_attributes should_remove
-                                             ld.ld_attributes
-                                       })
-                                     ld_l)
-                            }
-                          | _ -> cd)
-                        cd_l)
-               }
-             | _ -> td));
-      value_binding =
-        (fun mapper vb ->
-          Tast_mapper.default.value_binding mapper
-            { vb with
-              vb_attributes = handle_attributes should_remove vb.vb_attributes
-            });
-      expr =
-        (fun mapper e ->
-          Tast_mapper.default.expr mapper
-            { e with
-              exp_attributes = handle_attributes should_remove e.exp_attributes
-            });
-      structure_item =
-        (fun mapper str_it ->
-          Tast_mapper.default.structure_item mapper
-            (match view_tstr str_it.str_desc with
-            | Tstr_eval (e, attrs, id) ->
-              { str_it with
-                str_desc =
-                  mkTstr_eval ~id (e, handle_attributes should_remove attrs)
-              }
-            | _ -> str_it));
-      module_binding =
-        (fun mapper mb ->
-          Tast_mapper.default.module_binding mapper
-            { mb with
-              mb_attributes = handle_attributes should_remove mb.mb_attributes
-            });
-      module_expr =
-        (fun mapper me ->
-          Tast_mapper.default.module_expr mapper
-            { me with
-              mod_attributes = handle_attributes should_remove me.mod_attributes
-            });
-      module_substitution =
-        (fun mapper ms ->
-          Tast_mapper.default.module_substitution mapper
-            { ms with
-              ms_attributes = handle_attributes should_remove ms.ms_attributes
-            });
-      module_type_declaration =
-        (fun mapper mtd ->
-          Tast_mapper.default.module_type_declaration mapper
-            { mtd with
-              mtd_attributes =
-                handle_attributes should_remove mtd.mtd_attributes
-            });
-      module_type =
-        (fun mapper mty ->
-          Tast_mapper.default.module_type mapper
-            { mty with
-              mty_attributes =
-                handle_attributes should_remove mty.mty_attributes
-            });
-      value_description =
-        (fun mapper vd ->
-          Tast_mapper.default.value_description mapper
-            { vd with
-              val_attributes = handle_attributes should_remove vd.val_attributes
-            })
-    }
-  in
-  let mapper = remove_attributes_mapper in
-  let nstr = mapper.structure mapper (Smap.find cur_name map) in
-  Smap.add cur_name nstr map
+    expr =
+      (fun mapper e ->
+        Tast_mapper.default.expr mapper
+          { e with
+            exp_attributes = handle_attributes should_remove e.exp_attributes
+          });
+    structure_item =
+      (fun mapper str_it ->
+        Tast_mapper.default.structure_item mapper
+          (match view_tstr str_it.str_desc with
+          | Tstr_eval (e, attrs, id) ->
+            { str_it with
+              str_desc =
+                mkTstr_eval ~id (e, handle_attributes should_remove attrs)
+            }
+          | _ -> str_it));
+    module_binding =
+      (fun mapper mb ->
+        Tast_mapper.default.module_binding mapper
+          { mb with
+            mb_attributes = handle_attributes should_remove mb.mb_attributes
+          });
+    module_expr =
+      (fun mapper me ->
+        Tast_mapper.default.module_expr mapper
+          { me with
+            mod_attributes = handle_attributes should_remove me.mod_attributes
+          });
+    module_substitution =
+      (fun mapper ms ->
+        Tast_mapper.default.module_substitution mapper
+          { ms with
+            ms_attributes = handle_attributes should_remove ms.ms_attributes
+          });
+    module_type_declaration =
+      (fun mapper mtd ->
+        Tast_mapper.default.module_type_declaration mapper
+          { mtd with
+            mtd_attributes = handle_attributes should_remove mtd.mtd_attributes
+          });
+    module_type =
+      (fun mapper mty ->
+        Tast_mapper.default.module_type mapper
+          { mty with
+            mty_attributes = handle_attributes should_remove mty.mty_attributes
+          });
+    value_description =
+      (fun mapper vd ->
+        Tast_mapper.default.value_description mapper
+          { vd with
+            val_attributes = handle_attributes should_remove vd.val_attributes
+          })
+  }
 
 let minimizer =
-  { minimizer_name = "remove-attributes"; minimizer_func = minimize }
+  tast_mapper_minimizer "remove-attributes" remove_attributes_mapper

--- a/chamelon/lib/minimizer/removeconsfields.ml
+++ b/chamelon/lib/minimizer/removeconsfields.ml
@@ -194,12 +194,11 @@ let minimize should_remove map cur_name =
       nstr !fields_to_remove
   in
   (* Replacing in multifiles *)
-  let name_clr = String.sub cur_name 0 (String.length cur_name - 3) in
   let mapper str =
     List.fold_left
       (fun nstr (i, cons, typ) ->
         let typ_mf =
-          Path.Pdot (Pident (Ident.create_local name_clr), Path.name typ)
+          Path.Pdot (Pident (Ident.create_local cur_name), Path.name typ)
         in
         let mapper_mf = remove_cons_mapper (i, cons, typ_mf) in
         mapper_mf.structure mapper_mf nstr)
@@ -209,5 +208,4 @@ let minimize should_remove map cur_name =
   (* Final result*)
   nmap
 
-let minimizer =
-  { minimizer_name = "remove-cons-fields"; minimizer_func = minimize }
+let minimizer = multifile_minimizer "remove-cons-fields" minimize

--- a/chamelon/lib/minimizer/removeunit.ml
+++ b/chamelon/lib/minimizer/removeunit.ml
@@ -51,19 +51,13 @@ let is_unit_typ (typ : type_expr) =
     match path with Path.Pident id -> name id = "unit" | _ -> false)
   | _ -> false
 
-let minimize should_remove map cur_name =
-  let remove_unit_mapper =
-    { Tast_mapper.default with
-      expr =
-        (fun mapper e ->
-          if is_unit_typ e.exp_type && (not (is_unit e)) && should_remove ()
-          then { e with exp_desc = eunit }
-          else Tast_mapper.default.expr mapper e)
-    }
-  in
-  let nstr =
-    remove_unit_mapper.structure remove_unit_mapper (Smap.find cur_name map)
-  in
-  Smap.add cur_name nstr map
+let remove_unit_mapper should_remove =
+  { Tast_mapper.default with
+    expr =
+      (fun mapper e ->
+        if is_unit_typ e.exp_type && (not (is_unit e)) && should_remove ()
+        then { e with exp_desc = eunit }
+        else Tast_mapper.default.expr mapper e)
+  }
 
-let minimizer = { minimizer_name = "remove-unit"; minimizer_func = minimize }
+let minimizer = tast_mapper_minimizer "remove-unit" remove_unit_mapper

--- a/chamelon/lib/minimizer/removeunusedargs.ml
+++ b/chamelon/lib/minimizer/removeunusedargs.ml
@@ -254,12 +254,11 @@ let minimize should_remove map cur_name =
   in
   let nmap = Smap.add cur_name nstr map in
   (* Replacing in multifiles *)
-  let name_clr = String.sub cur_name 0 (String.length cur_name - 1) in
   let global_replace str =
     List.fold_left
       (fun nstr (id_fun, depth, arg_list, arg_label) ->
         let id_fun_ext =
-          Path.Pdot (Pident (Ident.create_local name_clr), Ident.name id_fun)
+          Path.Pdot (Pident (Ident.create_local cur_name), Ident.name id_fun)
         in
         let to_replace_mf = fun_wrapper arg_list [] depth id_fun_ext 1 in
         let mapper_mf = replace_mapper id_fun to_replace_mf arg_label in
@@ -270,5 +269,4 @@ let minimize should_remove map cur_name =
   (* Final result *)
   nmap
 
-let minimizer =
-  { minimizer_name = "remove-unused-args"; minimizer_func = minimize }
+let minimizer = multifile_minimizer "remove-unused-args" minimize

--- a/chamelon/lib/minimizer/removeunusedrec.ml
+++ b/chamelon/lib/minimizer/removeunusedrec.ml
@@ -34,66 +34,61 @@ open Stdlib
 open Asttypes
 open Compat
 
-let minimize should_remove map cur_name =
-  let suppress_rec =
-    { Tast_mapper.default with
-      structure_item =
-        (fun mapper str_it ->
-          { str_it with
-            str_desc =
-              (match str_it.str_desc with
-              | Tstr_value (r, vb_l) ->
-                if
-                  r = Recursive
-                  && (not
-                        (List.exists
-                           (fun vb ->
-                             match view_tpat vb.vb_pat.pat_desc with
-                             | Tpat_var (id, _, _) ->
-                               let is_used = ref false in
-                               let mapper_used =
-                                 Removedeadcode.search_in_str is_used id
-                               in
-                               ignore
-                                 (mapper_used.structure_item mapper_used str_it);
-                               !is_used
-                             | _ -> false)
-                           vb_l))
-                  && should_remove ()
-                then Tstr_value (Nonrecursive, vb_l)
-                else (Tast_mapper.default.structure_item mapper str_it).str_desc
-              | _ -> (Tast_mapper.default.structure_item mapper str_it).str_desc)
-          });
-      expr =
-        (fun mapper e ->
-          { e with
-            exp_desc =
-              (match e.exp_desc with
-              | Texp_let (rf, vb_l, e_in) ->
-                if
-                  rf = Recursive
-                  && (not
-                        (List.exists
-                           (fun vb ->
-                             match view_tpat vb.vb_pat.pat_desc with
-                             | Tpat_var (id, _, _) ->
-                               let is_used = ref false in
-                               let mapper_used =
-                                 Removedeadcode.search_in_str is_used id
-                               in
-                               ignore (mapper_used.expr mapper_used vb.vb_expr);
-                               !is_used
-                             | _ -> false)
-                           vb_l))
-                  && should_remove ()
-                then Texp_let (Nonrecursive, vb_l, e_in)
-                else Texp_let (rf, vb_l, Tast_mapper.default.expr mapper e_in)
-              | _ -> (Tast_mapper.default.expr mapper e).exp_desc)
-          })
-    }
-  in
-  let nstr = suppress_rec.structure suppress_rec (Smap.find cur_name map) in
-  Smap.add cur_name nstr map
+let suppress_rec should_remove =
+  { Tast_mapper.default with
+    structure_item =
+      (fun mapper str_it ->
+        { str_it with
+          str_desc =
+            (match str_it.str_desc with
+            | Tstr_value (r, vb_l) ->
+              if
+                r = Recursive
+                && (not
+                      (List.exists
+                         (fun vb ->
+                           match view_tpat vb.vb_pat.pat_desc with
+                           | Tpat_var (id, _, _) ->
+                             let is_used = ref false in
+                             let mapper_used =
+                               Removedeadcode.search_in_str is_used id
+                             in
+                             ignore
+                               (mapper_used.structure_item mapper_used str_it);
+                             !is_used
+                           | _ -> false)
+                         vb_l))
+                && should_remove ()
+              then Tstr_value (Nonrecursive, vb_l)
+              else (Tast_mapper.default.structure_item mapper str_it).str_desc
+            | _ -> (Tast_mapper.default.structure_item mapper str_it).str_desc)
+        });
+    expr =
+      (fun mapper e ->
+        { e with
+          exp_desc =
+            (match e.exp_desc with
+            | Texp_let (rf, vb_l, e_in) ->
+              if
+                rf = Recursive
+                && (not
+                      (List.exists
+                         (fun vb ->
+                           match view_tpat vb.vb_pat.pat_desc with
+                           | Tpat_var (id, _, _) ->
+                             let is_used = ref false in
+                             let mapper_used =
+                               Removedeadcode.search_in_str is_used id
+                             in
+                             ignore (mapper_used.expr mapper_used vb.vb_expr);
+                             !is_used
+                           | _ -> false)
+                         vb_l))
+                && should_remove ()
+              then Texp_let (Nonrecursive, vb_l, e_in)
+              else Texp_let (rf, vb_l, Tast_mapper.default.expr mapper e_in)
+            | _ -> (Tast_mapper.default.expr mapper e).exp_desc)
+        })
+  }
 
-let minimizer =
-  { minimizer_name = "remove-unused-rec"; minimizer_func = minimize }
+let minimizer = tast_mapper_minimizer "remove-unused-rec" suppress_rec

--- a/chamelon/lib/minimizer/sequentializefunctions.ml
+++ b/chamelon/lib/minimizer/sequentializefunctions.ml
@@ -103,10 +103,5 @@ let seq_function_mapper should_remove =
           | _ -> e))
   }
 
-let minimize should_remove map cur_name =
-  let mapper = seq_function_mapper should_remove in
-  let nstr = mapper.structure mapper (Smap.find cur_name map) in
-  Smap.add cur_name nstr map
-
 let minimizer =
-  { minimizer_name = "sequentialize-functions"; minimizer_func = minimize }
+  tast_mapper_minimizer "sequentialize-functions" seq_function_mapper

--- a/chamelon/lib/minimizer/simplifyapplication.ml
+++ b/chamelon/lib/minimizer/simplifyapplication.ml
@@ -67,10 +67,4 @@ let simplify_app_mapper should_remove =
           | _ -> e))
   }
 
-let minimize should_remove map cur_name =
-  let mapper = simplify_app_mapper should_remove in
-  let nstr = mapper.structure mapper (Smap.find cur_name map) in
-  Smap.add cur_name nstr map
-
-let minimizer =
-  { minimizer_name = "simplify-application"; minimizer_func = minimize }
+let minimizer = tast_mapper_minimizer "simplify-application" simplify_app_mapper

--- a/chamelon/lib/minimizer/simplifymatch.ml
+++ b/chamelon/lib/minimizer/simplifymatch.ml
@@ -49,61 +49,52 @@ let replace_mapper id to_replace =
 let ignore_guard ~c_guard e =
   match c_guard with None -> e | Some guard -> E.list [E.ignore guard; e]
 
-let minimize should_remove map cur_name =
-  let simplify_match_mapper =
-    (* match e1 with x -> e2 => e2[x->e1] *)
-    (* match e1 with p -> e2 => let p = e1 in e2 *)
-    { Tast_mapper.default with
-      expr =
-        (fun mapper e ->
-          Tast_mapper.default.expr mapper
-            (match view_texp e.exp_desc with
-            | O (Texp_try (e_try, [{ c_lhs; c_guard; c_rhs }])) ->
-              (* try e1 with p -> e2 => e1 *)
-              (* try e1 with p -> e2 => let p = __dummy2__ () in e2 *)
-              if should_remove ()
-              then e_try
-              else if should_remove ()
-              then
-                E.let_
-                  [E.bind c_lhs Dummy.apply_dummy2]
-                  (ignore_guard ~c_guard c_rhs)
-              else e
-            | Texp_match
-                ( e_match,
-                  [ { c_lhs = { pat_desc = Tpat_value tva; _ } as c_lhs;
-                      c_guard;
-                      c_rhs
-                    } ],
-                  _partial,
-                  id ) -> (
-              match view_tpat (tva :> pattern).pat_desc, c_guard with
-              | Tpat_var (id, _, _), None when should_remove () ->
-                let rep_map = replace_mapper id e_match.exp_desc in
-                rep_map.expr rep_map c_rhs
-              | _ when should_remove () ->
-                let pat_desc = (tva :> pattern) in
-                let pat_desc =
-                  { pat_desc with
-                    pat_extra = c_lhs.pat_extra @ pat_desc.pat_extra
-                  }
-                in
-                let id =
-                  value_binding_identifier_from_texp_match_identifier id
-                in
-                E.let_
-                  [ E.bind ~attrs:c_lhs.pat_attributes ~id
-                      (pat_desc :> pattern)
-                      e_match ]
-                  (ignore_guard ~c_guard c_rhs)
-              | _ -> e)
-            | _ -> e))
-    }
-  in
-  let nstr =
-    simplify_match_mapper.structure simplify_match_mapper
-      (Smap.find cur_name map)
-  in
-  Smap.add cur_name nstr map
+let simplify_match_mapper should_remove =
+  (* match e1 with x -> e2 => e2[x->e1] *)
+  (* match e1 with p -> e2 => let p = e1 in e2 *)
+  { Tast_mapper.default with
+    expr =
+      (fun mapper e ->
+        Tast_mapper.default.expr mapper
+          (match view_texp e.exp_desc with
+          | O (Texp_try (e_try, [{ c_lhs; c_guard; c_rhs }])) ->
+            (* try e1 with p -> e2 => e1 *)
+            (* try e1 with p -> e2 => let p = __dummy2__ () in e2 *)
+            if should_remove ()
+            then e_try
+            else if should_remove ()
+            then
+              E.let_
+                [E.bind c_lhs Dummy.apply_dummy2]
+                (ignore_guard ~c_guard c_rhs)
+            else e
+          | Texp_match
+              ( e_match,
+                [ { c_lhs = { pat_desc = Tpat_value tva; _ } as c_lhs;
+                    c_guard;
+                    c_rhs
+                  } ],
+                _partial,
+                id ) -> (
+            match view_tpat (tva :> pattern).pat_desc, c_guard with
+            | Tpat_var (id, _, _), None when should_remove () ->
+              let rep_map = replace_mapper id e_match.exp_desc in
+              rep_map.expr rep_map c_rhs
+            | _ when should_remove () ->
+              let pat_desc = (tva :> pattern) in
+              let pat_desc =
+                { pat_desc with
+                  pat_extra = c_lhs.pat_extra @ pat_desc.pat_extra
+                }
+              in
+              let id = value_binding_identifier_from_texp_match_identifier id in
+              E.let_
+                [ E.bind ~attrs:c_lhs.pat_attributes ~id
+                    (pat_desc :> pattern)
+                    e_match ]
+                (ignore_guard ~c_guard c_rhs)
+            | _ -> e)
+          | _ -> e))
+  }
 
-let minimizer = { minimizer_name = "simplify-match"; minimizer_func = minimize }
+let minimizer = tast_mapper_minimizer "simplify-match" simplify_match_mapper

--- a/chamelon/lib/minimizer/simplifysequences.ml
+++ b/chamelon/lib/minimizer/simplifysequences.ml
@@ -66,84 +66,76 @@ let remove_dummy_mapper should_remove =
           | _ -> e))
   }
 
-let minimize should_remove map cur_name =
-  let simp_seq_mapper =
-    { Tast_mapper.default with
-      expr =
-        (fun mapper e ->
-          Tast_mapper.default.expr mapper
-            (match view_texp e.exp_desc with
-            | Texp_sequence (e1, e2, _) ->
-              if (Removeunit.is_unit e1 || is_dummy e1) && should_remove ()
-              then
-                e2
-                (* else if is_sequence e1 then let a, b = break_sequence e1 in {
-                   e with exp_desc = Texp_sequence(a, Layouts.Layout.value,{ e2
-                   with exp_desc = Texp_sequence(b,Layouts.Layout.value,e2)})
-                   } *)
-              else
-                e
-                (* {e with exp_desc = Texp_sequence(e1, Layouts.Layout.value,
-                   e2) } *)
-            | O (Texp_ifthenelse (e1, e2, Some e3)) ->
-              if
-                Reduceexpr.is_simplified e1
-                && (Removeunit.is_unit e2 || Removeunit.is_unit e3)
-                && should_remove ()
-              then
-                if Removeunit.is_unit e2
-                then e3
-                else { e with exp_desc = Texp_ifthenelse (e1, e2, None) }
-              else e
-            | Texp_apply (f, ael, id) ->
-              if is_dummy f
-              then
-                { e with
-                  exp_desc =
-                    mkTexp_apply ~id
-                      ( f,
-                        List.rev
-                          (List.fold_left
-                             (fun l (a, e) ->
-                               fold_arg_or_omitted
-                                 (fun l (e1, id) ->
-                                   if
-                                     Reduceexpr.is_simplified e1
-                                     && should_remove ()
-                                   then l
-                                   else (a, mkArg ~id e1) :: l)
-                                 l e)
-                             [] ael) )
-                }
-              else if is_ignore f
-              then
-                { e with
-                  exp_desc =
-                    mkTexp_apply ~id
-                      ( f,
-                        List.rev
-                          (List.fold_left
-                             (fun l (a, e) ->
-                               fold_arg_or_omitted
-                                 (fun l (e1, id) ->
-                                   if is_sequence e1
-                                   then
-                                     let rdm =
-                                       remove_dummy_mapper should_remove
-                                     in
-                                     (a, mkArg ~id (rdm.expr rdm e1)) :: l
-                                   else l)
-                                 l e)
-                             [] ael) )
-                }
-              else e
-            | _ -> e))
-    }
-  in
-  let nstr =
-    simp_seq_mapper.structure simp_seq_mapper (Smap.find cur_name map)
-  in
-  Smap.add cur_name nstr map
+let simp_seq_mapper should_remove =
+  { Tast_mapper.default with
+    expr =
+      (fun mapper e ->
+        Tast_mapper.default.expr mapper
+          (match view_texp e.exp_desc with
+          | Texp_sequence (e1, e2, _) ->
+            if (Removeunit.is_unit e1 || is_dummy e1) && should_remove ()
+            then
+              e2
+              (* else if is_sequence e1 then let a, b = break_sequence e1 in { e
+                 with exp_desc = Texp_sequence(a, Layouts.Layout.value,{ e2 with
+                 exp_desc = Texp_sequence(b,Layouts.Layout.value,e2)}) } *)
+            else
+              e
+              (* {e with exp_desc = Texp_sequence(e1, Layouts.Layout.value, e2)
+                 } *)
+          | O (Texp_ifthenelse (e1, e2, Some e3)) ->
+            if
+              Reduceexpr.is_simplified e1
+              && (Removeunit.is_unit e2 || Removeunit.is_unit e3)
+              && should_remove ()
+            then
+              if Removeunit.is_unit e2
+              then e3
+              else { e with exp_desc = Texp_ifthenelse (e1, e2, None) }
+            else e
+          | Texp_apply (f, ael, id) ->
+            if is_dummy f
+            then
+              { e with
+                exp_desc =
+                  mkTexp_apply ~id
+                    ( f,
+                      List.rev
+                        (List.fold_left
+                           (fun l (a, e) ->
+                             fold_arg_or_omitted
+                               (fun l (e1, id) ->
+                                 if
+                                   Reduceexpr.is_simplified e1
+                                   && should_remove ()
+                                 then l
+                                 else (a, mkArg ~id e1) :: l)
+                               l e)
+                           [] ael) )
+              }
+            else if is_ignore f
+            then
+              { e with
+                exp_desc =
+                  mkTexp_apply ~id
+                    ( f,
+                      List.rev
+                        (List.fold_left
+                           (fun l (a, e) ->
+                             fold_arg_or_omitted
+                               (fun l (e1, id) ->
+                                 if is_sequence e1
+                                 then
+                                   let rdm =
+                                     remove_dummy_mapper should_remove
+                                   in
+                                   (a, mkArg ~id (rdm.expr rdm e1)) :: l
+                                 else l)
+                               l e)
+                           [] ael) )
+              }
+            else e
+          | _ -> e))
+  }
 
-let minimizer =
-  { minimizer_name = "simplify-sequences"; minimizer_func = minimize }
+let minimizer = tast_mapper_minimizer "simplify-sequences" simp_seq_mapper

--- a/chamelon/lib/minimizer/simplifytypes.ml
+++ b/chamelon/lib/minimizer/simplifytypes.ml
@@ -259,9 +259,8 @@ let minimize should_remove map cur_name =
   in
   (* Replacing in multifiles *)
   let cons, typ = !name_to_remove in
-  let name_clr = String.sub cur_name 0 (String.length cur_name - 1) in
   let typ_mf =
-    Path.Pdot (Pident (Ident.create_local name_clr), Path.name typ)
+    Path.Pdot (Pident (Ident.create_local cur_name), Path.name typ)
   in
   let mapper_mf = remove_cons_mapper (cons, typ_mf) in
   let nmap =
@@ -270,4 +269,4 @@ let minimize should_remove map cur_name =
   (* Final result*)
   nmap
 
-let minimizer = { minimizer_name = "simplify-types"; minimizer_func = minimize }
+let minimizer = multifile_minimizer "simplify-types" minimize


### PR DESCRIPTION
This patch changes the internal representation of chamelon minimizers from minimizing "a set of files" to "a set of modules", where each module contains both a `.ml` and a `.mli` file.

Most minimizers are adapted to work with this new representation with minimal changes, since they are just applying a `Tast_mapper.mapper` on the structure and can now transparently use the new `tast_mapper_minimizer` helper.

Some minimizers (notably, the minimizers with multi-file support) still use the same interface, and use the `multi_file_minimizer` helper which converts from the new module-based representation to the legacy file-based representation. These minimizers are thus currently unable to minimize in interface files.

(I recommend turning off whitespace changes for the review of the minimizers)