### PR TITLE
Fix prefetching feature detection macros

### DIFF
--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -161,21 +161,6 @@ CAMLdeprecated_typedef(addr, char *);
 #define CAMLthread_local _Thread_local
 #endif
 
-/* Prefetching */
-
-#ifdef CAML_INTERNALS
-#if (defined(__GNUC__) || defined(__clang__)) \
-     && __has_builtin(__builtin_prefetch)
-#define caml_prefetchr(p) __builtin_prefetch((p), 0, 3)
-/* 0 = intent to read; 3 = all cache levels */
-#define caml_prefetchw(p) __builtin_prefetch((p), 1, 3)
-/* 1 = intent to write; 3 = all cache levels */
-#else
-#define caml_prefetchr(p)
-#define caml_prefetchw(p)
-#endif
-#endif /* CAML_INTERNALS */
-
 /* CAMLunused is preserved for compatibility reasons.
    Instead of the legacy GCC/Clang-only
      CAMLunused foo;
@@ -336,6 +321,18 @@ CAMLnoreturn_end;
 #define Caml_has_builtin(x) __has_builtin(x)
 #else
 #define Caml_has_builtin(x) 0
+#endif
+
+/* Prefetching */
+
+#if defined(__GNUC__) || Caml_has_builtin(__builtin_prefetch)
+#define caml_prefetchr(p) __builtin_prefetch((p), 0, 3)
+/* 0 = intent to read; 3 = all cache levels */
+#define caml_prefetchw(p) __builtin_prefetch((p), 1, 3)
+/* 1 = intent to write; 3 = all cache levels */
+#else
+#define caml_prefetchr(p)
+#define caml_prefetchw(p)
 #endif
 
 /* Integer arithmetic with overflow detection.


### PR DESCRIPTION
Sadly, GCC only began supporting __has_builtin recently, so we need a slightly different test to check for __builtin_prefetch.

(Fixes the build on older GCC, which was broken by #5163 )