### PR TITLE
Scrub the environment when running tests

### DIFF
--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -126,6 +126,11 @@ endif
 export OCAMLRUNPARAM?=v=0
 endif
 
+# Remove these from the environment to prevent text unexpectedly wrapping with
+# -d options.
+unexport ROWS
+unexport COLUMNS
+
 .PHONY: default
 default:
 	@echo "Available targets:"


### PR DESCRIPTION
It turns out Vim's integrated terminal actually sets the `COLUMNS` and `ROWS` environment variables - the former interacts badly with #344 in the testsuite.

This version just scrubs the two of them in the testsuite Makefile. More complex solutions might reset the widths in `-dcmm`, etc.