### PR TITLE
Warn on imprecise kind annotations

### DIFF
--- a/testsuite/tests/flambda/incompatible_arrays.ml
+++ b/testsuite/tests/flambda/incompatible_arrays.ml
@@ -4,7 +4,7 @@
 *)
 
 
-type nonrec ('a : any) array = 'a array
+type nonrec ('a : any mod separable) array = 'a array
 
 type t1 = int64# array
 type t2 = float32# array

--- a/testsuite/tests/implicit-types/implicit_kinds.ml
+++ b/testsuite/tests/implicit-types/implicit_kinds.ml
@@ -637,6 +637,13 @@ end
 Line 3, characters 10-36:
 3 |   val i : ('a : value mod external_) -> 'a
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value mod external_'
+but was inferred to have kind `value mod immutable external_'.
+
+Line 3, characters 10-36:
+3 |   val i : ('a : value mod external_) -> 'a
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The universal type variable 'a was declared to have kind value
                                                                   mod
                                                                   immutable.
@@ -653,6 +660,13 @@ module type S18 = sig
 end
 
 [%%expect{|
+Line 4, characters 10-22:
+4 |   val i : ('a : value) -> 'a
+              ^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `value mod immutable'.
+
 module type S18 = sig val i : ('a : value mod immutable). 'a -> 'a end
 |}]
 
@@ -941,6 +955,13 @@ module type S35_fail = sig
 end
 
 [%%expect{|
+Line 4, characters 34-44:
+4 |   external[@layout_poly] ignore : ('a : any) -> unit = "%ignore"
+                                      ^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `any'
+but was inferred to have kind `word'.
+
 Line 4, characters 34-52:
 4 |   external[@layout_poly] ignore : ('a : any) -> unit = "%ignore"
                                       ^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/implicit-types/implicit_kinds.ml
+++ b/testsuite/tests/implicit-types/implicit_kinds.ml
@@ -637,7 +637,7 @@ end
 Line 3, characters 10-36:
 3 |   val i : ('a : value mod external_) -> 'a
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
 was annotated with kind `value mod external_'
 but was inferred to have kind `value mod immutable external_'.
 
@@ -663,7 +663,7 @@ end
 Line 4, characters 10-22:
 4 |   val i : ('a : value) -> 'a
               ^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
 was annotated with kind `value'
 but was inferred to have kind `value mod immutable'.
 
@@ -958,7 +958,7 @@ end
 Line 4, characters 34-44:
 4 |   external[@layout_poly] ignore : ('a : any) -> unit = "%ignore"
                                       ^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
 was annotated with kind `any'
 but was inferred to have kind `word'.
 

--- a/testsuite/tests/implicit-types/implicit_kinds.ml
+++ b/testsuite/tests/implicit-types/implicit_kinds.ml
@@ -638,8 +638,8 @@ Line 3, characters 10-36:
 3 |   val i : ('a : value mod external_) -> 'a
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value mod external_'
-but was inferred to have kind `value mod immutable external_'.
+  was annotated with kind `value mod external_'
+  but was inferred to have kind `value mod immutable external_'.
 
 Line 3, characters 10-36:
 3 |   val i : ('a : value mod external_) -> 'a
@@ -664,8 +664,8 @@ Line 4, characters 10-22:
 4 |   val i : ('a : value) -> 'a
               ^^^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `value mod immutable'.
+  was annotated with kind `value'
+  but was inferred to have kind `value mod immutable'.
 
 module type S18 = sig val i : ('a : value mod immutable). 'a -> 'a end
 |}]
@@ -959,8 +959,7 @@ Line 4, characters 34-44:
 4 |   external[@layout_poly] ignore : ('a : any) -> unit = "%ignore"
                                       ^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `any'
-but was inferred to have kind `word'.
+  was annotated with kind `any' but was inferred to have kind `word'.
 
 Line 4, characters 34-52:
 4 |   external[@layout_poly] ignore : ('a : any) -> unit = "%ignore"

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-extension-universe alpha -w -220";
+   flags = "-extension-universe alpha -w -181-220";
    include stdlib_upstream_compatible;
    include stdlib_stable;
    expect;
@@ -172,20 +172,6 @@ type t17b : value & value
 type ('a : value mod external_ stateless many unyielding non_float) t18 =
   ('a : value mod immutable global aliased)
 [%%expect{|
-Line 2, characters 2-43:
-2 |   ('a : value mod immutable global aliased)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value mod global immutable'
-but was inferred to have kind `value mod everything non_float'.
-
-Line 1, characters 6-66:
-1 | type ('a : value mod external_ stateless many unyielding non_float) t18 =
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value non_float mod unyielding many stateless external_'
-but was inferred to have kind `value mod everything non_float'.
-
 type ('a : value mod everything non_float) t18 = 'a
 |}]
 

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -172,6 +172,20 @@ type t17b : value & value
 type ('a : value mod external_ stateless many unyielding non_float) t18 =
   ('a : value mod immutable global aliased)
 [%%expect{|
+Line 2, characters 2-43:
+2 |   ('a : value mod immutable global aliased)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value mod global immutable'
+but was inferred to have kind `value mod everything non_float'.
+
+Line 1, characters 6-66:
+1 | type ('a : value mod external_ stateless many unyielding non_float) t18 =
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value non_float mod unyielding many stateless external_'
+but was inferred to have kind `value mod everything non_float'.
+
 type ('a : value mod everything non_float) t18 = 'a
 |}]
 

--- a/testsuite/tests/parsetree/test_ppx.compilers.reference
+++ b/testsuite/tests/parsetree/test_ppx.compilers.reference
@@ -3,22 +3,8 @@ File "source_jane_street.ml", line 159, characters 12-39:
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 184 [ignored-kind-modifier]: The kind modifier(s) non_pointer have no effect on the kind value & value.
 
-File "source_jane_street.ml", line 173, characters 2-43:
-173 |   ('a : value mod immutable global aliased)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 221 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value mod global immutable'
-but was inferred to have kind `value mod everything non_float'.
-
-File "source_jane_street.ml", line 172, characters 6-66:
-172 | type ('a : value mod external_ stateless many unyielding non_float) t18 =
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 221 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value non_float mod unyielding many stateless external_'
-but was inferred to have kind `value mod everything non_float'.
-
-File "source_jane_street.ml", line 192, characters 0-24:
-192 | type t = #(int * float#)
+File "source_jane_street.ml", line 178, characters 0-24:
+178 | type t = #(int * float#)
       ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Multiple definition of the type name t.
        Names must be unique in a given structure or signature.

--- a/testsuite/tests/parsetree/test_ppx.compilers.reference
+++ b/testsuite/tests/parsetree/test_ppx.compilers.reference
@@ -3,8 +3,22 @@ File "source_jane_street.ml", line 159, characters 12-39:
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 184 [ignored-kind-modifier]: The kind modifier(s) non_pointer have no effect on the kind value & value.
 
-File "source_jane_street.ml", line 178, characters 0-24:
-178 | type t = #(int * float#)
+File "source_jane_street.ml", line 173, characters 2-43:
+173 |   ('a : value mod immutable global aliased)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 221 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value mod global immutable'
+but was inferred to have kind `value mod everything non_float'.
+
+File "source_jane_street.ml", line 172, characters 6-66:
+172 | type ('a : value mod external_ stateless many unyielding non_float) t18 =
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 221 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value non_float mod unyielding many stateless external_'
+but was inferred to have kind `value mod everything non_float'.
+
+File "source_jane_street.ml", line 192, characters 0-24:
+192 | type t = #(int * float#)
       ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Multiple definition of the type name t.
        Names must be unique in a given structure or signature.

--- a/testsuite/tests/parsetree/test_ppx.ml
+++ b/testsuite/tests/parsetree/test_ppx.ml
@@ -8,7 +8,7 @@
  ocamlc.byte;
  module = "source_jane_street.ml";
  ocamlc_byte_exit_status = "2";
- flags = "-I ${test_build_directory} -w -26 -extension-universe alpha -ppx ${program}";
+ flags = "-I ${test_build_directory} -w -26-181 -extension-universe alpha -ppx ${program}";
  ocamlc.byte;
  check-ocamlc.byte-output;
 *)

--- a/testsuite/tests/typing-abstract-kinds-missing-cmi/test.ml
+++ b/testsuite/tests/typing-abstract-kinds-missing-cmi/test.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-no-ikinds";
+ flags = "-no-ikinds -w -181";
  readonly_files = "a1.ml a2.ml b.ml c_sub1.ml c_sub2.ml c_inter.ml";
  setup-ocamlc.byte-build-env;
  module = "a1.ml";

--- a/testsuite/tests/typing-abstract-kinds-missing-cmi/test_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds-missing-cmi/test_ikinds.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags = "-w -181";
  readonly_files = "a1.ml a2.ml b.ml c_sub1.ml c_sub2.ml c_inter.ml";
  setup-ocamlc.byte-build-env;
  module = "a1.ml";

--- a/testsuite/tests/typing-abstract-kinds-missing-cmi/test_sub1.missing.reference
+++ b/testsuite/tests/typing-abstract-kinds-missing-cmi/test_sub1.missing.reference
@@ -1,3 +1,9 @@
+File "c_inter.ml", line 2, characters 6-15:
+2 | type ('a : B.k3) s = 'a t
+          ^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `value mod portable'.
 File "c_sub1.ml", line 13, characters 0-32:
 13 | type s2 : value mod portable = t
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-abstract-kinds-missing-cmi/test_sub1.missing.reference
+++ b/testsuite/tests/typing-abstract-kinds-missing-cmi/test_sub1.missing.reference
@@ -1,9 +1,3 @@
-File "c_inter.ml", line 2, characters 6-15:
-2 | type ('a : B.k3) s = 'a t
-          ^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `value mod portable'.
 File "c_sub1.ml", line 13, characters 0-32:
 13 | type s2 : value mod portable = t
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-jkind-bounds/annots.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots.ml
@@ -464,8 +464,29 @@ let f : ('a : value) t2_imm -> ('a : value) t2_imm = fun x -> x
 let f : ('a : value) t2_global -> ('a : value) t2_global = fun x -> x
 let f : ('a : word) t2_complex -> ('a : word) t2_complex = fun x -> x
 [%%expect {|
+Line 1, characters 8-20:
+1 | let f : ('a : value) t2_imm -> ('a : value) t2_imm = fun x -> x
+            ^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
 val f : ('a : immediate). 'a t2_imm -> 'a t2_imm = <fun>
+Line 2, characters 8-20:
+2 | let f : ('a : value) t2_global -> ('a : value) t2_global = fun x -> x
+            ^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `value mod global'.
+
 val f : ('a : value mod global). 'a t2_global -> 'a t2_global = <fun>
+Line 3, characters 8-19:
+3 | let f : ('a : word) t2_complex -> ('a : word) t2_complex = fun x -> x
+            ^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `word'
+but was inferred to have kind `word mod many aliased'.
+
 val f : ('a : word mod many aliased). 'a t2_complex -> 'a t2_complex = <fun>
 |}]
 
@@ -521,8 +542,29 @@ type ('a : value) t = 'a t2_imm
 type ('a : value) t = 'a t2_global
 type ('a : word) t = 'a t2_complex
 [%%expect {|
+Line 1, characters 6-16:
+1 | type ('a : value) t = 'a t2_imm
+          ^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
 type ('a : immediate) t = 'a t2_imm
+Line 2, characters 6-16:
+2 | type ('a : value) t = 'a t2_global
+          ^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `value mod global'.
+
 type ('a : value mod global) t = 'a t2_global
+Line 3, characters 6-15:
+3 | type ('a : word) t = 'a t2_complex
+          ^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `word'
+but was inferred to have kind `word mod many aliased'.
+
 type ('a : word mod many aliased) t = 'a t2_complex
 |}]
 
@@ -545,10 +587,31 @@ let f : (_ : word) t2_complex -> unit = fun _ -> ()
 let g : (_ : word mod external_ many aliased) t2_complex -> unit = fun _ -> ()
 
 [%%expect {|
+Line 1, characters 8-19:
+1 | let f : (_ : value) t2_imm -> unit = fun _ -> ()
+            ^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `_'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
 val f : ('a : immediate). 'a t2_imm -> unit = <fun>
 val g : ('a : immediate). 'a t2_imm -> unit = <fun>
+Line 4, characters 8-19:
+4 | let f : (_ : value) t2_global -> unit = fun _ -> ()
+            ^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `_'
+was annotated with kind `value'
+but was inferred to have kind `value mod global'.
+
 val f : ('a : value mod global). 'a t2_global -> unit = <fun>
 val g : ('a : value mod global). 'a t2_global -> unit = <fun>
+Line 7, characters 8-18:
+7 | let f : (_ : word) t2_complex -> unit = fun _ -> ()
+            ^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `_'
+was annotated with kind `word'
+but was inferred to have kind `word mod many aliased'.
+
 val f : ('a : word mod many aliased). 'a t2_complex -> unit = <fun>
 val g : ('a : word mod many aliased). 'a t2_complex -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-jkind-bounds/annots.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots.ml
@@ -1,10 +1,10 @@
 (* TEST
  include stdlib_upstream_compatible;
  {
-   flags = "-no-ikinds";
+   flags = "-no-ikinds -w -181";
    expect;
  }{
-   flags = "-extension layouts_beta -no-ikinds";
+   flags = "-extension layouts_beta -no-ikinds -w -181";
    expect;
  }
 *)
@@ -464,29 +464,8 @@ let f : ('a : value) t2_imm -> ('a : value) t2_imm = fun x -> x
 let f : ('a : value) t2_global -> ('a : value) t2_global = fun x -> x
 let f : ('a : word) t2_complex -> ('a : word) t2_complex = fun x -> x
 [%%expect {|
-Line 1, characters 8-20:
-1 | let f : ('a : value) t2_imm -> ('a : value) t2_imm = fun x -> x
-            ^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
-
 val f : ('a : immediate). 'a t2_imm -> 'a t2_imm = <fun>
-Line 2, characters 8-20:
-2 | let f : ('a : value) t2_global -> ('a : value) t2_global = fun x -> x
-            ^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `value mod global'.
-
 val f : ('a : value mod global). 'a t2_global -> 'a t2_global = <fun>
-Line 3, characters 8-19:
-3 | let f : ('a : word) t2_complex -> ('a : word) t2_complex = fun x -> x
-            ^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `word'
-but was inferred to have kind `word mod many aliased'.
-
 val f : ('a : word mod many aliased). 'a t2_complex -> 'a t2_complex = <fun>
 |}]
 
@@ -542,29 +521,8 @@ type ('a : value) t = 'a t2_imm
 type ('a : value) t = 'a t2_global
 type ('a : word) t = 'a t2_complex
 [%%expect {|
-Line 1, characters 6-16:
-1 | type ('a : value) t = 'a t2_imm
-          ^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
-
 type ('a : immediate) t = 'a t2_imm
-Line 2, characters 6-16:
-2 | type ('a : value) t = 'a t2_global
-          ^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `value mod global'.
-
 type ('a : value mod global) t = 'a t2_global
-Line 3, characters 6-15:
-3 | type ('a : word) t = 'a t2_complex
-          ^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `word'
-but was inferred to have kind `word mod many aliased'.
-
 type ('a : word mod many aliased) t = 'a t2_complex
 |}]
 
@@ -587,31 +545,10 @@ let f : (_ : word) t2_complex -> unit = fun _ -> ()
 let g : (_ : word mod external_ many aliased) t2_complex -> unit = fun _ -> ()
 
 [%%expect {|
-Line 1, characters 8-19:
-1 | let f : (_ : value) t2_imm -> unit = fun _ -> ()
-            ^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `_'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
-
 val f : ('a : immediate). 'a t2_imm -> unit = <fun>
 val g : ('a : immediate). 'a t2_imm -> unit = <fun>
-Line 4, characters 8-19:
-4 | let f : (_ : value) t2_global -> unit = fun _ -> ()
-            ^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `_'
-was annotated with kind `value'
-but was inferred to have kind `value mod global'.
-
 val f : ('a : value mod global). 'a t2_global -> unit = <fun>
 val g : ('a : value mod global). 'a t2_global -> unit = <fun>
-Line 7, characters 8-18:
-7 | let f : (_ : word) t2_complex -> unit = fun _ -> ()
-            ^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `_'
-was annotated with kind `word'
-but was inferred to have kind `word mod many aliased'.
-
 val f : ('a : word mod many aliased). 'a t2_complex -> unit = <fun>
 val g : ('a : word mod many aliased). 'a t2_complex -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
@@ -1,9 +1,10 @@
 (* TEST
  include stdlib_upstream_compatible;
  {
+   flags = "-w -181";
    expect;
  }{
-   flags = "-extension layouts_beta";
+   flags = "-extension layouts_beta -w -181";
    expect;
  }
 *)
@@ -461,29 +462,8 @@ let f : ('a : value) t2_imm -> ('a : value) t2_imm = fun x -> x
 let f : ('a : value) t2_global -> ('a : value) t2_global = fun x -> x
 let f : ('a : word) t2_complex -> ('a : word) t2_complex = fun x -> x
 [%%expect {|
-Line 1, characters 8-20:
-1 | let f : ('a : value) t2_imm -> ('a : value) t2_imm = fun x -> x
-            ^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
-
 val f : ('a : immediate). 'a t2_imm -> 'a t2_imm = <fun>
-Line 2, characters 8-20:
-2 | let f : ('a : value) t2_global -> ('a : value) t2_global = fun x -> x
-            ^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `value mod global'.
-
 val f : ('a : value mod global). 'a t2_global -> 'a t2_global = <fun>
-Line 3, characters 8-19:
-3 | let f : ('a : word) t2_complex -> ('a : word) t2_complex = fun x -> x
-            ^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `word'
-but was inferred to have kind `word mod many aliased'.
-
 val f : ('a : word mod many aliased). 'a t2_complex -> 'a t2_complex = <fun>
 |}]
 
@@ -539,29 +519,8 @@ type ('a : value) t = 'a t2_imm
 type ('a : value) t = 'a t2_global
 type ('a : word) t = 'a t2_complex
 [%%expect {|
-Line 1, characters 6-16:
-1 | type ('a : value) t = 'a t2_imm
-          ^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
-
 type ('a : immediate) t = 'a t2_imm
-Line 2, characters 6-16:
-2 | type ('a : value) t = 'a t2_global
-          ^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `value mod global'.
-
 type ('a : value mod global) t = 'a t2_global
-Line 3, characters 6-15:
-3 | type ('a : word) t = 'a t2_complex
-          ^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `word'
-but was inferred to have kind `word mod many aliased'.
-
 type ('a : word mod many aliased) t = 'a t2_complex
 |}]
 
@@ -584,31 +543,10 @@ let f : (_ : word) t2_complex -> unit = fun _ -> ()
 let g : (_ : word mod external_ many aliased) t2_complex -> unit = fun _ -> ()
 
 [%%expect {|
-Line 1, characters 8-19:
-1 | let f : (_ : value) t2_imm -> unit = fun _ -> ()
-            ^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `_'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
-
 val f : ('a : immediate). 'a t2_imm -> unit = <fun>
 val g : ('a : immediate). 'a t2_imm -> unit = <fun>
-Line 4, characters 8-19:
-4 | let f : (_ : value) t2_global -> unit = fun _ -> ()
-            ^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `_'
-was annotated with kind `value'
-but was inferred to have kind `value mod global'.
-
 val f : ('a : value mod global). 'a t2_global -> unit = <fun>
 val g : ('a : value mod global). 'a t2_global -> unit = <fun>
-Line 7, characters 8-18:
-7 | let f : (_ : word) t2_complex -> unit = fun _ -> ()
-            ^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `_'
-was annotated with kind `word'
-but was inferred to have kind `word mod many aliased'.
-
 val f : ('a : word mod many aliased). 'a t2_complex -> unit = <fun>
 val g : ('a : word mod many aliased). 'a t2_complex -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
@@ -461,8 +461,29 @@ let f : ('a : value) t2_imm -> ('a : value) t2_imm = fun x -> x
 let f : ('a : value) t2_global -> ('a : value) t2_global = fun x -> x
 let f : ('a : word) t2_complex -> ('a : word) t2_complex = fun x -> x
 [%%expect {|
+Line 1, characters 8-20:
+1 | let f : ('a : value) t2_imm -> ('a : value) t2_imm = fun x -> x
+            ^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
 val f : ('a : immediate). 'a t2_imm -> 'a t2_imm = <fun>
+Line 2, characters 8-20:
+2 | let f : ('a : value) t2_global -> ('a : value) t2_global = fun x -> x
+            ^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `value mod global'.
+
 val f : ('a : value mod global). 'a t2_global -> 'a t2_global = <fun>
+Line 3, characters 8-19:
+3 | let f : ('a : word) t2_complex -> ('a : word) t2_complex = fun x -> x
+            ^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `word'
+but was inferred to have kind `word mod many aliased'.
+
 val f : ('a : word mod many aliased). 'a t2_complex -> 'a t2_complex = <fun>
 |}]
 
@@ -518,8 +539,29 @@ type ('a : value) t = 'a t2_imm
 type ('a : value) t = 'a t2_global
 type ('a : word) t = 'a t2_complex
 [%%expect {|
+Line 1, characters 6-16:
+1 | type ('a : value) t = 'a t2_imm
+          ^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
 type ('a : immediate) t = 'a t2_imm
+Line 2, characters 6-16:
+2 | type ('a : value) t = 'a t2_global
+          ^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `value mod global'.
+
 type ('a : value mod global) t = 'a t2_global
+Line 3, characters 6-15:
+3 | type ('a : word) t = 'a t2_complex
+          ^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `word'
+but was inferred to have kind `word mod many aliased'.
+
 type ('a : word mod many aliased) t = 'a t2_complex
 |}]
 
@@ -542,10 +584,31 @@ let f : (_ : word) t2_complex -> unit = fun _ -> ()
 let g : (_ : word mod external_ many aliased) t2_complex -> unit = fun _ -> ()
 
 [%%expect {|
+Line 1, characters 8-19:
+1 | let f : (_ : value) t2_imm -> unit = fun _ -> ()
+            ^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `_'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
 val f : ('a : immediate). 'a t2_imm -> unit = <fun>
 val g : ('a : immediate). 'a t2_imm -> unit = <fun>
+Line 4, characters 8-19:
+4 | let f : (_ : value) t2_global -> unit = fun _ -> ()
+            ^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `_'
+was annotated with kind `value'
+but was inferred to have kind `value mod global'.
+
 val f : ('a : value mod global). 'a t2_global -> unit = <fun>
 val g : ('a : value mod global). 'a t2_global -> unit = <fun>
+Line 7, characters 8-18:
+7 | let f : (_ : word) t2_complex -> unit = fun _ -> ()
+            ^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `_'
+was annotated with kind `word'
+but was inferred to have kind `word mod many aliased'.
+
 val f : ('a : word mod many aliased). 'a t2_complex -> unit = <fun>
 val g : ('a : word mod many aliased). 'a t2_complex -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-extension small_numbers -no-ikinds -w -220";
+ flags = "-extension small_numbers -no-ikinds -w -181-220";
  expect;
 *)
 

--- a/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-extension small_numbers -w -220";
+ flags = "-extension small_numbers -w -181-220";
  expect;
 *)
 
@@ -1273,68 +1273,12 @@ type ('a : value) t = ('a : any)
 type ('a : value) t = ('a : value)
 type ('a : bits32 mod aliased) t = ('a : any mod global)
 [%%expect {|
-Line 1, characters 6-28:
-1 | type ('a : value mod aliased) t = ('a : value mod global)
-          ^^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value mod aliased'
-but was inferred to have kind `value mod global'.
-
 type ('a : value mod global) t = 'a
-Line 2, characters 26-38:
-2 | type ('a : immediate) t = ('a : value)
-                              ^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
-
 type ('a : immediate) t = 'a
-Line 3, characters 6-16:
-3 | type ('a : value) t = ('a : immediate)
-          ^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
-
 type ('a : immediate) t = 'a
-Line 4, characters 72-113:
-4 | type ('a : value mod external_ stateless many unyielding non_float) t = ('a : value mod immutable global aliased)
-                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value mod global immutable'
-but was inferred to have kind `value mod everything non_float'.
-
-Line 4, characters 6-66:
-4 | type ('a : value mod external_ stateless many unyielding non_float) t = ('a : value mod immutable global aliased)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value non_float mod unyielding many stateless external_'
-but was inferred to have kind `value mod everything non_float'.
-
 type ('a : value mod everything non_float) t = 'a
-Line 5, characters 22-32:
-5 | type ('a : value) t = ('a : any)
-                          ^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `any'
-but was inferred to have kind `value'.
-
 type 'a t = 'a
 type 'a t = 'a
-Line 7, characters 35-56:
-7 | type ('a : bits32 mod aliased) t = ('a : any mod global)
-                                       ^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `any mod global'
-but was inferred to have kind `bits32 mod global'.
-
-Line 7, characters 6-29:
-7 | type ('a : bits32 mod aliased) t = ('a : any mod global)
-          ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `bits32 mod aliased'
-but was inferred to have kind `bits32 mod global'.
-
 type ('a : bits32 mod global) t = 'a
 |}]
 
@@ -1354,29 +1298,8 @@ let f : ('a : any mod global aliased) -> ('a: any mod contended) = fun x -> x
 let f : ('a : value mod external64) -> ('a: any mod external_) = fun x -> x
 let f : ('a : value) -> ('a: immediate) = fun x -> x
 [%%expect {|
-Line 1, characters 8-37:
-1 | let f : ('a : any mod global aliased) -> ('a: any mod contended) = fun x -> x
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `any mod global'
-but was inferred to have kind `any mod global contended'.
-
 val f : ('a : value_or_null mod global contended). 'a -> 'a = <fun>
-Line 2, characters 8-35:
-2 | let f : ('a : value mod external64) -> ('a: any mod external_) = fun x -> x
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value mod external64'
-but was inferred to have kind `value mod external_'.
-
 val f : ('a : value mod external_). 'a -> 'a = <fun>
-Line 3, characters 8-20:
-3 | let f : ('a : value) -> ('a: immediate) = fun x -> x
-            ^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
-
 val f : ('a : immediate). 'a -> 'a = <fun>
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
@@ -1273,12 +1273,68 @@ type ('a : value) t = ('a : any)
 type ('a : value) t = ('a : value)
 type ('a : bits32 mod aliased) t = ('a : any mod global)
 [%%expect {|
+Line 1, characters 6-28:
+1 | type ('a : value mod aliased) t = ('a : value mod global)
+          ^^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value mod aliased'
+but was inferred to have kind `value mod global'.
+
 type ('a : value mod global) t = 'a
+Line 2, characters 26-38:
+2 | type ('a : immediate) t = ('a : value)
+                              ^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
 type ('a : immediate) t = 'a
+Line 3, characters 6-16:
+3 | type ('a : value) t = ('a : immediate)
+          ^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
 type ('a : immediate) t = 'a
+Line 4, characters 72-113:
+4 | type ('a : value mod external_ stateless many unyielding non_float) t = ('a : value mod immutable global aliased)
+                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value mod global immutable'
+but was inferred to have kind `value mod everything non_float'.
+
+Line 4, characters 6-66:
+4 | type ('a : value mod external_ stateless many unyielding non_float) t = ('a : value mod immutable global aliased)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value non_float mod unyielding many stateless external_'
+but was inferred to have kind `value mod everything non_float'.
+
 type ('a : value mod everything non_float) t = 'a
+Line 5, characters 22-32:
+5 | type ('a : value) t = ('a : any)
+                          ^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `any'
+but was inferred to have kind `value'.
+
 type 'a t = 'a
 type 'a t = 'a
+Line 7, characters 35-56:
+7 | type ('a : bits32 mod aliased) t = ('a : any mod global)
+                                       ^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `any mod global'
+but was inferred to have kind `bits32 mod global'.
+
+Line 7, characters 6-29:
+7 | type ('a : bits32 mod aliased) t = ('a : any mod global)
+          ^^^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `bits32 mod aliased'
+but was inferred to have kind `bits32 mod global'.
+
 type ('a : bits32 mod global) t = 'a
 |}]
 
@@ -1298,8 +1354,29 @@ let f : ('a : any mod global aliased) -> ('a: any mod contended) = fun x -> x
 let f : ('a : value mod external64) -> ('a: any mod external_) = fun x -> x
 let f : ('a : value) -> ('a: immediate) = fun x -> x
 [%%expect {|
+Line 1, characters 8-37:
+1 | let f : ('a : any mod global aliased) -> ('a: any mod contended) = fun x -> x
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `any mod global'
+but was inferred to have kind `any mod global contended'.
+
 val f : ('a : value_or_null mod global contended). 'a -> 'a = <fun>
+Line 2, characters 8-35:
+2 | let f : ('a : value mod external64) -> ('a: any mod external_) = fun x -> x
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value mod external64'
+but was inferred to have kind `value mod external_'.
+
 val f : ('a : value mod external_). 'a -> 'a = <fun>
+Line 3, characters 8-20:
+3 | let f : ('a : value) -> ('a: immediate) = fun x -> x
+            ^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
 val f : ('a : immediate). 'a -> 'a = <fun>
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/misc.ml
+++ b/testsuite/tests/typing-jkind-bounds/misc.ml
@@ -14,6 +14,13 @@ type ('a : immutable_data) t
 type ('a : value) u = 'a t
 [%%expect {|
 type ('a : immutable_data) t
+Line 2, characters 6-16:
+2 | type ('a : value) u = 'a t
+          ^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immutable_data'.
+
 type ('a : immutable_data) u = 'a t
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/misc.ml
+++ b/testsuite/tests/typing-jkind-bounds/misc.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-no-ikinds";
+ flags = "-no-ikinds -w -181";
  expect;
 *)
 
@@ -14,13 +14,6 @@ type ('a : immutable_data) t
 type ('a : value) u = 'a t
 [%%expect {|
 type ('a : immutable_data) t
-Line 2, characters 6-16:
-2 | type ('a : value) u = 'a t
-          ^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immutable_data'.
-
 type ('a : immutable_data) u = 'a t
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/misc_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/misc_ikinds.ml
@@ -1,4 +1,5 @@
 (* TEST
+   flags = "-w -181";
    expect;
 *)
 
@@ -13,13 +14,6 @@ type ('a : immutable_data) t
 type ('a : value) u = 'a t
 [%%expect {|
 type ('a : immutable_data) t
-Line 2, characters 6-16:
-2 | type ('a : value) u = 'a t
-          ^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immutable_data'.
-
 type ('a : immutable_data) u = 'a t
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/misc_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/misc_ikinds.ml
@@ -13,6 +13,13 @@ type ('a : immutable_data) t
 type ('a : value) u = 'a t
 [%%expect {|
 type ('a : immutable_data) t
+Line 2, characters 6-16:
+2 | type ('a : value) u = 'a t
+          ^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immutable_data'.
+
 type ('a : immutable_data) u = 'a t
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
@@ -75,6 +75,20 @@ end = struct
   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b
 end
 [%%expect{|
+Line 4, characters 8-31:
+4 |   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b
+            ^^^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value mod portable'
+but was inferred to have kind `value mod portable contended'.
+
+Line 2, characters 8-31:
+2 |   type ('a : value mod portable, 'b : value mod contended) t : value mod portable contended constraint 'a = 'b
+            ^^^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value mod portable'
+but was inferred to have kind `value mod portable contended'.
+
 module M :
   sig
     type ('b : value mod portable contended, 'a) t
@@ -88,6 +102,20 @@ end = struct
   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b
 end
 [%%expect{|
+Line 4, characters 8-31:
+4 |   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b
+            ^^^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value mod portable'
+but was inferred to have kind `value mod portable contended'.
+
+Line 2, characters 8-31:
+2 |   type ('a : value mod portable, 'b : value mod contended) t : value mod many constraint 'a = 'b
+            ^^^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value mod portable'
+but was inferred to have kind `value mod portable contended'.
+
 Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b

--- a/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags = "-extension layouts_alpha -no-ikinds";
+    flags = "-extension layouts_alpha -no-ikinds -w -181";
     expect;
 *)
 
@@ -75,20 +75,6 @@ end = struct
   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b
 end
 [%%expect{|
-Line 4, characters 8-31:
-4 |   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b
-            ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value mod portable'
-but was inferred to have kind `value mod portable contended'.
-
-Line 2, characters 8-31:
-2 |   type ('a : value mod portable, 'b : value mod contended) t : value mod portable contended constraint 'a = 'b
-            ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value mod portable'
-but was inferred to have kind `value mod portable contended'.
-
 module M :
   sig
     type ('b : value mod portable contended, 'a) t
@@ -102,20 +88,6 @@ end = struct
   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b
 end
 [%%expect{|
-Line 4, characters 8-31:
-4 |   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b
-            ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value mod portable'
-but was inferred to have kind `value mod portable contended'.
-
-Line 2, characters 8-31:
-2 |   type ('a : value mod portable, 'b : value mod contended) t : value mod many constraint 'a = 'b
-            ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value mod portable'
-but was inferred to have kind `value mod portable contended'.
-
 Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b

--- a/testsuite/tests/typing-jkind-bounds/subsumption/constraint_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/constraint_ikinds.ml
@@ -75,6 +75,20 @@ end = struct
   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b
 end
 [%%expect{|
+Line 4, characters 8-31:
+4 |   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b
+            ^^^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value mod portable'
+but was inferred to have kind `value mod portable contended'.
+
+Line 2, characters 8-31:
+2 |   type ('a : value mod portable, 'b : value mod contended) t : value mod portable contended constraint 'a = 'b
+            ^^^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value mod portable'
+but was inferred to have kind `value mod portable contended'.
+
 module M :
   sig
     type ('b : value mod portable contended, 'a) t
@@ -88,6 +102,20 @@ end = struct
   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b
 end
 [%%expect{|
+Line 4, characters 8-31:
+4 |   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b
+            ^^^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value mod portable'
+but was inferred to have kind `value mod portable contended'.
+
+Line 2, characters 8-31:
+2 |   type ('a : value mod portable, 'b : value mod contended) t : value mod many constraint 'a = 'b
+            ^^^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value mod portable'
+but was inferred to have kind `value mod portable contended'.
+
 Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b

--- a/testsuite/tests/typing-jkind-bounds/subsumption/constraint_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/constraint_ikinds.ml
@@ -1,5 +1,5 @@
 (* TEST
-    flags = "-extension layouts_alpha";
+    flags = "-extension layouts_alpha -w -181";
     expect;
 *)
 
@@ -75,20 +75,6 @@ end = struct
   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b
 end
 [%%expect{|
-Line 4, characters 8-31:
-4 |   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b
-            ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value mod portable'
-but was inferred to have kind `value mod portable contended'.
-
-Line 2, characters 8-31:
-2 |   type ('a : value mod portable, 'b : value mod contended) t : value mod portable contended constraint 'a = 'b
-            ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value mod portable'
-but was inferred to have kind `value mod portable contended'.
-
 module M :
   sig
     type ('b : value mod portable contended, 'a) t
@@ -102,20 +88,6 @@ end = struct
   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b
 end
 [%%expect{|
-Line 4, characters 8-31:
-4 |   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b
-            ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value mod portable'
-but was inferred to have kind `value mod portable contended'.
-
-Line 2, characters 8-31:
-2 |   type ('a : value mod portable, 'b : value mod contended) t : value mod many constraint 'a = 'b
-            ^^^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value mod portable'
-but was inferred to have kind `value mod portable contended'.
-
 Lines 3-5, characters 6-3:
 3 | ......struct
 4 |   type ('a : value mod portable, 'b : value mod contended) t = 'a constraint 'a = 'b

--- a/testsuite/tests/typing-layouts-arrays/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-arrays/basics_alpha.ml
@@ -371,7 +371,7 @@ external makearray_dynamic_uninit : ('a : any separable). int -> 'a array
   = "%makearray_dynamic_uninit" [@@layout_poly]
 |}]
 
-type ('a : any) with_i64s = #( int64# * 'a * int64# )
+type ('a : any mod separable) with_i64s = #( int64# * 'a * int64# )
 
 type ok_1 = #(int64# * int32#)
 type ok_2 = float# with_i64s
@@ -384,7 +384,19 @@ type bad_5 = bad_3 with_i64s
 type bad_6 = #(float * #(float * float) * #(float * #(float * float * float)))
 type bad_7 = #{ i : int64# ; bad_4 : bad_4 ; j : int64# }
 [%%expect{|
-type ('a : any) with_i64s = #(int64# * 'a * int64#)
+type ('a : any separable) with_i64s = #(int64# * 'a * int64#)
+type ok_1 = #(int64# * int32#)
+type ok_2 = float# with_i64s
+type bad_1 = #(int * int32#)
+type bad_2 = int
+type bad_3 = A | B | C
+type bad_4 = #{ a : int64#; enum : bad_3; }
+type bad_5 = bad_3 with_i64s
+type bad_6 =
+    #(float * #(float * float) * #(float * #(float * float * float)))
+type bad_7 = #{ i : int64#; bad_4 : bad_4; j : int64#; }
+|}, Principal{|
+type ('a : any separable) with_i64s = #(int64# * 'a * int64#)
 type ok_1 = #(int64# * int32#)
 type ok_2 = float# with_i64s
 type bad_1 = #(int * int32#)

--- a/testsuite/tests/typing-layouts-arrays/test_float32_u_array.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_float32_u_array.ml
@@ -40,10 +40,10 @@ module _ = Test_gen_u_array.Test (Float32_array)
 
 module Float32_u_array0 : Gen_u_array.S0
                         with type element_t = float32#
-                        and type ('a : any) array_t = 'a array = struct
+                        and type ('a : any mod separable) array_t = 'a array = struct
 
   type element_t = float32#
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
   type element_arg = unit -> element_t
   type t = element_t array
   let max_length = Sys.max_unboxed_float32_array_length

--- a/testsuite/tests/typing-layouts-arrays/test_float_u_array.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_float_u_array.ml
@@ -37,10 +37,10 @@ module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
 
 module Float_u_array0 :
   Gen_u_array.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a array = struct
+                  and type ('a : any mod separable) array_t = 'a array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
 
   type element_arg = unit -> element_t
   type t = element_t array

--- a/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_1.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_1.ml
@@ -36,10 +36,10 @@ module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_array.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a array = struct
+                  and type ('a : any mod separable) array_t = 'a array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
 
   type element_arg = unit -> element_t
   type t = element_t array

--- a/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_2.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_2.ml
@@ -57,10 +57,10 @@ module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_array.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a array = struct
+                  and type ('a : any mod separable) array_t = 'a array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
 
   type element_arg = unit -> element_t
   type t = element_t array

--- a/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_3.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_3.ml
@@ -35,10 +35,10 @@ module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_array.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a array = struct
+                  and type ('a : any mod separable) array_t = 'a array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
 
   type element_arg = unit -> element_t
   type t = element_t array

--- a/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_4.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_4.ml
@@ -36,10 +36,10 @@ module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_array.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a array = struct
+                  and type ('a : any mod separable) array_t = 'a array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
 
   type element_arg = unit -> element_t
   type t = element_t array

--- a/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_with_uninit_1.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_with_uninit_1.ml
@@ -36,10 +36,10 @@ module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_array.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a array = struct
+                  and type ('a : any mod separable) array_t = 'a array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
 
   type element_arg = unit -> element_t
   type t = element_t array

--- a/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_with_uninit_2.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_with_uninit_2.ml
@@ -58,10 +58,10 @@ module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_array.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a array = struct
+                  and type ('a : any mod separable) array_t = 'a array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
 
   type element_arg = unit -> element_t
   type t = element_t array

--- a/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_with_uninit_3.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_with_uninit_3.ml
@@ -35,10 +35,10 @@ module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_array.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a array = struct
+                  and type ('a : any mod separable) array_t = 'a array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
 
   type element_arg = unit -> element_t
   type t = element_t array

--- a/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_with_uninit_4.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_ignorable_product_array_with_uninit_4.ml
@@ -36,10 +36,10 @@ module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_array.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a array = struct
+                  and type ('a : any mod separable) array_t = 'a array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
 
   type element_arg = unit -> element_t
   type t = element_t array

--- a/testsuite/tests/typing-layouts-arrays/test_ignoreable_or_null_product_array.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_ignoreable_or_null_product_array.ml
@@ -50,10 +50,10 @@ module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_array.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a array = struct
+                  and type ('a : any mod separable) array_t = 'a array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
 
   type element_arg = unit -> element_t
   type t = element_t array

--- a/testsuite/tests/typing-layouts-arrays/test_int16_u_array.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_int16_u_array.ml
@@ -46,10 +46,10 @@ module _ = Test_gen_u_array.Test (Int16_array)
 
 module Int16_u_array0 : Gen_u_array.S0
                         with type element_t = int16#
-                        and type ('a : any) array_t = 'a array = struct
+                        and type ('a : any mod separable) array_t = 'a array = struct
 
   type element_t = int16#
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
   type element_arg = unit -> element_t
   type t = element_t array
   let max_length = Sys.max_untagged_int16_array_length

--- a/testsuite/tests/typing-layouts-arrays/test_int32_u_array.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_int32_u_array.ml
@@ -40,10 +40,10 @@ module _ = Test_gen_u_array.Test (Int32_array)
 
 module Int32_u_array0 : Gen_u_array.S0
                         with type element_t = int32#
-                        and type ('a : any) array_t = 'a array = struct
+                        and type ('a : any mod separable) array_t = 'a array = struct
 
   type element_t = int32#
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
   type element_arg = unit -> element_t
   type t = element_t array
   let max_length = Sys.max_unboxed_int32_array_length

--- a/testsuite/tests/typing-layouts-arrays/test_int64_u_array.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_int64_u_array.ml
@@ -40,10 +40,10 @@ module _ = Test_gen_u_array.Test (Int64_array)
 
 module Int64_u_array0 : Gen_u_array.S0
                         with type element_t = int64#
-                        and type ('a : any) array_t = 'a array = struct
+                        and type ('a : any mod separable) array_t = 'a array = struct
 
   type element_t = int64#
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
   type element_arg = unit -> element_t
   type t = element_t array
   let max_length = Sys.max_unboxed_int64_array_length

--- a/testsuite/tests/typing-layouts-arrays/test_int8_u_array.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_int8_u_array.ml
@@ -46,10 +46,10 @@ module _ = Test_gen_u_array.Test (Int8_array)
 
 module Int8_u_array0 : Gen_u_array.S0
                         with type element_t = int8#
-                        and type ('a : any) array_t = 'a array = struct
+                        and type ('a : any mod separable) array_t = 'a array = struct
 
   type element_t = int8#
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
   type element_arg = unit -> element_t
   type t = element_t array
   let max_length = Sys.max_untagged_int8_array_length

--- a/testsuite/tests/typing-layouts-arrays/test_int_or_null_array.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_int_or_null_array.ml
@@ -53,10 +53,10 @@ module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_array.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a array = struct
+                  and type ('a : any mod separable) array_t = 'a array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
 
   type element_arg = unit -> element_t
   type t = element_t array

--- a/testsuite/tests/typing-layouts-arrays/test_int_u_array.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_int_u_array.ml
@@ -44,10 +44,10 @@ module _ = Test_gen_u_array.Test (Int_array)
 
 module Int_u_array0 : Gen_u_array.S0
                         with type element_t = int#
-                        and type ('a : any) array_t = 'a array = struct
+                        and type ('a : any mod separable) array_t = 'a array = struct
 
   type element_t = int#
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
   type element_arg = unit -> element_t
   type t = element_t array
   let max_length = Sys.max_untagged_int_array_length

--- a/testsuite/tests/typing-layouts-arrays/test_nativeint_u_array.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_nativeint_u_array.ml
@@ -41,10 +41,10 @@ module _ = Test_gen_u_array.Test (Nativeint_array)
 
 module Nativeint_u_array0 : Gen_u_array.S0
                             with type element_t = nativeint#
-                            and type ('a : any) array_t = 'a array = struct
+                            and type ('a : any mod separable) array_t = 'a array = struct
 
   type element_t = nativeint#
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
   type element_arg = unit -> element_t
   type t = element_t array
   let max_length = Sys.max_unboxed_nativeint_array_length

--- a/testsuite/tests/typing-layouts-arrays/test_or_null_product_array.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_or_null_product_array.ml
@@ -47,10 +47,10 @@ module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_array.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a array = struct
+                  and type ('a : any mod separable) array_t = 'a array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
 
   type element_arg = unit -> element_t
   type t = element_t array

--- a/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_1.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_1.ml
@@ -38,10 +38,10 @@ module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_array.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a array = struct
+                  and type ('a : any mod separable) array_t = 'a array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
 
   type element_arg = unit -> element_t
   type t = element_t array

--- a/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_2.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_2.ml
@@ -60,10 +60,10 @@ module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_array.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a array = struct
+                  and type ('a : any mod separable) array_t = 'a array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
 
   type element_arg = unit -> element_t
   type t = element_t array

--- a/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_3.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_3.ml
@@ -39,10 +39,10 @@ module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_array.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a array = struct
+                  and type ('a : any mod separable) array_t = 'a array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
 
   type element_arg = unit -> element_t
   type t = element_t array

--- a/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_4.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_scannable_product_array_4.ml
@@ -43,10 +43,10 @@ module Element_ops = (val Gen_product_array_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_array.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a array = struct
+                  and type ('a : any mod separable) array_t = 'a array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
 
   type element_arg = unit -> element_t
   type t = element_t array

--- a/testsuite/tests/typing-layouts-arrays/test_vec128_u_array.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_vec128_u_array.ml
@@ -38,10 +38,10 @@ module _ = Test_gen_u_array.Test (Int64x2_array)
 
 module Int64x2_u_array0 : Gen_u_array.S0
                         with type element_t = int64x2#
-                        and type ('a : any) array_t = 'a array = struct
+                        and type ('a : any mod separable) array_t = 'a array = struct
 
   type element_t = int64x2#
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
   type element_arg = unit -> element_t
   type t = element_t array
   let max_length = Sys.max_unboxed_vec128_array_length

--- a/testsuite/tests/typing-layouts-arrays/test_vec256_u_array.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_vec256_u_array.ml
@@ -35,10 +35,10 @@ module _ = Test_gen_u_array.Test (Int64x4_array)
 
 module Int64x4_u_array0 : Gen_u_array.S0
                         with type element_t = int64x4#
-                        and type ('a : any) array_t = 'a array = struct
+                        and type ('a : any mod separable) array_t = 'a array = struct
 
   type element_t = int64x4#
-  type ('a : any) array_t = 'a array
+  type ('a : any mod separable) array_t = 'a array
   type element_arg = unit -> element_t
   type t = element_t array
   let max_length = Sys.max_unboxed_vec256_array_length

--- a/testsuite/tests/typing-layouts-iarrays/gen_iarray_test.sh
+++ b/testsuite/tests/typing-layouts-iarrays/gen_iarray_test.sh
@@ -74,11 +74,11 @@ module Element_ops = (val Gen_product_iarray_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_iarray.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a iarray
+                  and type ('a : any mod separable) array_t = 'a iarray
                   and type mutable_t = unboxed_t array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a iarray
+  type ('a : any mod separable) array_t = 'a iarray
   type mutable_t = unboxed_t array
 
   type element_arg = unit -> element_t

--- a/testsuite/tests/typing-layouts-iarrays/test_float32_u_iarray.ml
+++ b/testsuite/tests/typing-layouts-iarrays/test_float32_u_iarray.ml
@@ -22,11 +22,11 @@ open Stdlib_upstream_compatible
 
 module Float32_u_array0 :
   Gen_u_iarray.S0 with type element_t = float32#
-                   and type ('a : any) array_t = 'a iarray 
+                   and type ('a : any mod separable) array_t = 'a iarray 
                    and type mutable_t = float32# array = struct
   type element_t = float32#
 
-  type ('a : any) array_t = 'a iarray
+  type ('a : any mod separable) array_t = 'a iarray
   type mutable_t = float32# array
 
   type element_arg = unit -> element_t

--- a/testsuite/tests/typing-layouts-iarrays/test_float_u_iarray.ml
+++ b/testsuite/tests/typing-layouts-iarrays/test_float_u_iarray.ml
@@ -22,11 +22,11 @@ open Stdlib_upstream_compatible
 
 module Float_u_array0 :
   Gen_u_iarray.S0 with type element_t = float#
-                   and type ('a : any) array_t = 'a iarray 
+                   and type ('a : any mod separable) array_t = 'a iarray 
                    and type mutable_t = float# array = struct
   type element_t = float#
 
-  type ('a : any) array_t = 'a iarray
+  type ('a : any mod separable) array_t = 'a iarray
   type mutable_t = float# array
 
   type element_arg = unit -> element_t

--- a/testsuite/tests/typing-layouts-iarrays/test_ignorable_product_iarray_1.ml
+++ b/testsuite/tests/typing-layouts-iarrays/test_ignorable_product_iarray_1.ml
@@ -40,11 +40,11 @@ module Element_ops = (val Gen_product_iarray_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_iarray.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a iarray
+                  and type ('a : any mod separable) array_t = 'a iarray
                   and type mutable_t = unboxed_t array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a iarray
+  type ('a : any mod separable) array_t = 'a iarray
   type mutable_t = unboxed_t array
 
   type element_arg = unit -> element_t

--- a/testsuite/tests/typing-layouts-iarrays/test_ignorable_product_iarray_2.ml
+++ b/testsuite/tests/typing-layouts-iarrays/test_ignorable_product_iarray_2.ml
@@ -61,11 +61,11 @@ module Element_ops = (val Gen_product_iarray_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_iarray.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a iarray
+                  and type ('a : any mod separable) array_t = 'a iarray
                   and type mutable_t = unboxed_t array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a iarray
+  type ('a : any mod separable) array_t = 'a iarray
   type mutable_t = unboxed_t array
 
   type element_arg = unit -> element_t

--- a/testsuite/tests/typing-layouts-iarrays/test_ignoreable_or_null_product_array.ml
+++ b/testsuite/tests/typing-layouts-iarrays/test_ignoreable_or_null_product_array.ml
@@ -45,11 +45,11 @@ module Element_ops = (val Gen_product_iarray_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_iarray.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a iarray
+                  and type ('a : any mod separable) array_t = 'a iarray
                   and type mutable_t = unboxed_t array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a iarray
+  type ('a : any mod separable) array_t = 'a iarray
   type mutable_t = unboxed_t array
 
   type element_arg = unit -> element_t

--- a/testsuite/tests/typing-layouts-iarrays/test_int32_u_iarray.ml
+++ b/testsuite/tests/typing-layouts-iarrays/test_int32_u_iarray.ml
@@ -22,11 +22,11 @@ open Stdlib_upstream_compatible
 
 module Int32_u_array0 :
   Gen_u_iarray.S0 with type element_t = int32#
-                   and type ('a : any) array_t = 'a iarray 
+                   and type ('a : any mod separable) array_t = 'a iarray 
                    and type mutable_t = int32# array = struct
   type element_t = int32#
 
-  type ('a : any) array_t = 'a iarray
+  type ('a : any mod separable) array_t = 'a iarray
   type mutable_t = int32# array
 
   type element_arg = unit -> element_t

--- a/testsuite/tests/typing-layouts-iarrays/test_int64_u_iarray.ml
+++ b/testsuite/tests/typing-layouts-iarrays/test_int64_u_iarray.ml
@@ -22,11 +22,11 @@ open Stdlib_upstream_compatible
 
 module Int64_u_array0 :
   Gen_u_iarray.S0 with type element_t = int64#
-                   and type ('a : any) array_t = 'a iarray 
+                   and type ('a : any mod separable) array_t = 'a iarray 
                    and type mutable_t = int64# array = struct
   type element_t = int64#
 
-  type ('a : any) array_t = 'a iarray
+  type ('a : any mod separable) array_t = 'a iarray
   type mutable_t = int64# array
 
   type element_arg = unit -> element_t

--- a/testsuite/tests/typing-layouts-iarrays/test_int_or_null_array.ml
+++ b/testsuite/tests/typing-layouts-iarrays/test_int_or_null_array.ml
@@ -56,11 +56,11 @@ module Element_ops = (val Gen_product_iarray_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_iarray.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a iarray
+                  and type ('a : any mod separable) array_t = 'a iarray
                   and type mutable_t = unboxed_t array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a iarray
+  type ('a : any mod separable) array_t = 'a iarray
   type mutable_t = unboxed_t array
 
   type element_arg = unit -> element_t

--- a/testsuite/tests/typing-layouts-iarrays/test_nativeint_u_iarray.ml
+++ b/testsuite/tests/typing-layouts-iarrays/test_nativeint_u_iarray.ml
@@ -22,11 +22,11 @@ open Stdlib_upstream_compatible
 
 module Nativeint_u_array0 :
   Gen_u_iarray.S0 with type element_t = nativeint#
-                   and type ('a : any) array_t = 'a iarray 
+                   and type ('a : any mod separable) array_t = 'a iarray 
                    and type mutable_t = nativeint# array = struct
   type element_t = nativeint#
 
-  type ('a : any) array_t = 'a iarray
+  type ('a : any mod separable) array_t = 'a iarray
   type mutable_t = nativeint# array
 
   type element_arg = unit -> element_t

--- a/testsuite/tests/typing-layouts-iarrays/test_or_null_product_iarray.ml
+++ b/testsuite/tests/typing-layouts-iarrays/test_or_null_product_iarray.ml
@@ -42,11 +42,11 @@ module Element_ops = (val Gen_product_iarray_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_iarray.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a iarray
+                  and type ('a : any mod separable) array_t = 'a iarray
                   and type mutable_t = unboxed_t array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a iarray
+  type ('a : any mod separable) array_t = 'a iarray
   type mutable_t = unboxed_t array
 
   type element_arg = unit -> element_t

--- a/testsuite/tests/typing-layouts-iarrays/test_scannable_product_iarray_1.ml
+++ b/testsuite/tests/typing-layouts-iarrays/test_scannable_product_iarray_1.ml
@@ -40,11 +40,11 @@ module Element_ops = (val Gen_product_iarray_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_iarray.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a iarray
+                  and type ('a : any mod separable) array_t = 'a iarray
                   and type mutable_t = unboxed_t array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a iarray
+  type ('a : any mod separable) array_t = 'a iarray
   type mutable_t = unboxed_t array
 
   type element_arg = unit -> element_t

--- a/testsuite/tests/typing-layouts-iarrays/test_scannable_product_iarray_2.ml
+++ b/testsuite/tests/typing-layouts-iarrays/test_scannable_product_iarray_2.ml
@@ -62,11 +62,11 @@ module Element_ops = (val Gen_product_iarray_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_iarray.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a iarray
+                  and type ('a : any mod separable) array_t = 'a iarray
                   and type mutable_t = unboxed_t array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a iarray
+  type ('a : any mod separable) array_t = 'a iarray
   type mutable_t = unboxed_t array
 
   type element_arg = unit -> element_t

--- a/testsuite/tests/typing-layouts-iarrays/test_scannable_product_iarray_3.ml
+++ b/testsuite/tests/typing-layouts-iarrays/test_scannable_product_iarray_3.ml
@@ -42,11 +42,11 @@ module Element_ops = (val Gen_product_iarray_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_iarray.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a iarray
+                  and type ('a : any mod separable) array_t = 'a iarray
                   and type mutable_t = unboxed_t array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a iarray
+  type ('a : any mod separable) array_t = 'a iarray
   type mutable_t = unboxed_t array
 
   type element_arg = unit -> element_t

--- a/testsuite/tests/typing-layouts-iarrays/test_scannable_product_iarray_4.ml
+++ b/testsuite/tests/typing-layouts-iarrays/test_scannable_product_iarray_4.ml
@@ -46,11 +46,11 @@ module Element_ops = (val Gen_product_iarray_helpers.make_element_ops elem)
 
 module UTuple_array0 :
   Gen_u_iarray.S0 with type element_t = unboxed_t
-                  and type ('a : any) array_t = 'a iarray
+                  and type ('a : any mod separable) array_t = 'a iarray
                   and type mutable_t = unboxed_t array = struct
   type element_t = unboxed_t
 
-  type ('a : any) array_t = 'a iarray
+  type ('a : any mod separable) array_t = 'a iarray
   type mutable_t = unboxed_t array
 
   type element_arg = unit -> element_t

--- a/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -442,6 +442,13 @@ type should_work = t_value t1
 
 [%%expect{|
 type (_, _) two
+Line 3, characters 6-14:
+3 | type ('a : any) t1 = ('a id_any_mod_separable, 'a id_value_or_null) two
+          ^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `any'
+but was inferred to have kind `value'.
+
 type 'a t1 = ('a id_any_mod_separable, 'a id_value_or_null) two
 type should_work = t_value t1
 |}]

--- a/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags += "-extension comprehensions -extension layouts_beta";
+ flags += "-extension comprehensions -extension layouts_beta -w -181";
  expect;
 *)
 
@@ -442,13 +442,6 @@ type should_work = t_value t1
 
 [%%expect{|
 type (_, _) two
-Line 3, characters 6-14:
-3 | type ('a : any) t1 = ('a id_any_mod_separable, 'a id_value_or_null) two
-          ^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `any'
-but was inferred to have kind `value'.
-
 type 'a t1 = ('a id_any_mod_separable, 'a id_value_or_null) two
 type should_work = t_value t1
 |}]

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -460,6 +460,13 @@ type ('a : any) widened_bad_jkind =
   | B of 'a
 [@@or_null]
 [%%expect{|
+Line 1, characters 6-14:
+1 | type ('a : any) widened_bad_jkind =
+          ^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `any'
+but was inferred to have kind `value_maybe_separable'.
+
 type ('a : value_maybe_separable) widened_bad_jkind = A | B of 'a [@@or_null]
 |}]
 
@@ -469,6 +476,13 @@ type ('a : value_or_null) widened_bad_jkind =
 [@@or_null]
 
 [%%expect{|
+Line 1, characters 6-24:
+1 | type ('a : value_or_null) widened_bad_jkind =
+          ^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value_or_null'
+but was inferred to have kind `value_maybe_separable'.
+
 type ('a : value_maybe_separable) widened_bad_jkind = A | B of 'a [@@or_null]
 |}]
 
@@ -478,6 +492,13 @@ type ('a : any) widened_any : value_or_null =
 [@@or_null]
 
 [%%expect{|
+Line 1, characters 6-14:
+1 | type ('a : any) widened_any : value_or_null =
+          ^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `any'
+but was inferred to have kind `value_maybe_separable'.
+
 type ('a : value_maybe_separable) widened_any = A | B of 'a [@@or_null]
 |}]
 
@@ -487,6 +508,13 @@ type ('a : value_or_null) widened_nullable : value_or_null =
 [@@or_null]
 
 [%%expect{|
+Line 1, characters 6-24:
+1 | type ('a : value_or_null) widened_nullable : value_or_null =
+          ^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value_or_null'
+but was inferred to have kind `value_maybe_separable'.
+
 type ('a : value_maybe_separable) widened_nullable = A | B of 'a [@@or_null]
 |}]
 
@@ -505,6 +533,13 @@ type ('a : immediate_or_null) widened_immediate_or_null : value_or_null =
 [@@or_null]
 
 [%%expect{|
+Line 1, characters 6-28:
+1 | type ('a : immediate_or_null) widened_immediate_or_null : value_or_null =
+          ^^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `immediate_or_null'
+but was inferred to have kind `immediate'.
+
 type ('a : immediate) widened_immediate_or_null = A | B of 'a [@@or_null]
 |}]
 

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags = "-w -181";
  expect;
 *)
 
@@ -460,13 +461,6 @@ type ('a : any) widened_bad_jkind =
   | B of 'a
 [@@or_null]
 [%%expect{|
-Line 1, characters 6-14:
-1 | type ('a : any) widened_bad_jkind =
-          ^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `any'
-but was inferred to have kind `value_maybe_separable'.
-
 type ('a : value_maybe_separable) widened_bad_jkind = A | B of 'a [@@or_null]
 |}]
 
@@ -476,13 +470,6 @@ type ('a : value_or_null) widened_bad_jkind =
 [@@or_null]
 
 [%%expect{|
-Line 1, characters 6-24:
-1 | type ('a : value_or_null) widened_bad_jkind =
-          ^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value_or_null'
-but was inferred to have kind `value_maybe_separable'.
-
 type ('a : value_maybe_separable) widened_bad_jkind = A | B of 'a [@@or_null]
 |}]
 
@@ -492,13 +479,6 @@ type ('a : any) widened_any : value_or_null =
 [@@or_null]
 
 [%%expect{|
-Line 1, characters 6-14:
-1 | type ('a : any) widened_any : value_or_null =
-          ^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `any'
-but was inferred to have kind `value_maybe_separable'.
-
 type ('a : value_maybe_separable) widened_any = A | B of 'a [@@or_null]
 |}]
 
@@ -508,13 +488,6 @@ type ('a : value_or_null) widened_nullable : value_or_null =
 [@@or_null]
 
 [%%expect{|
-Line 1, characters 6-24:
-1 | type ('a : value_or_null) widened_nullable : value_or_null =
-          ^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value_or_null'
-but was inferred to have kind `value_maybe_separable'.
-
 type ('a : value_maybe_separable) widened_nullable = A | B of 'a [@@or_null]
 |}]
 
@@ -533,13 +506,6 @@ type ('a : immediate_or_null) widened_immediate_or_null : value_or_null =
 [@@or_null]
 
 [%%expect{|
-Line 1, characters 6-28:
-1 | type ('a : immediate_or_null) widened_immediate_or_null : value_or_null =
-          ^^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `immediate_or_null'
-but was inferred to have kind `immediate'.
-
 type ('a : immediate) widened_immediate_or_null = A | B of 'a [@@or_null]
 |}]
 

--- a/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -162,6 +162,13 @@ end
 let fail = Or_null.This (Or_null.This 5)
 
 [%%expect{|
+Line 2, characters 8-26:
+2 |   type ('a : value_or_null) t = 'a or_null [@@or_null_reexport]
+            ^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value_or_null'
+but was inferred to have kind `value_maybe_separable'.
+
 module Or_null :
   sig
     type ('a : value_maybe_separable) t = 'a or_null = Null | This of 'a [@@or_null_reexport]

--- a/testsuite/tests/typing-layouts-or-null/reexport.ml
+++ b/testsuite/tests/typing-layouts-or-null/reexport.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags = "-w -181";
  expect;
 *)
 
@@ -162,13 +163,6 @@ end
 let fail = Or_null.This (Or_null.This 5)
 
 [%%expect{|
-Line 2, characters 8-26:
-2 |   type ('a : value_or_null) t = 'a or_null [@@or_null_reexport]
-            ^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value_or_null'
-but was inferred to have kind `value_maybe_separable'.
-
 module Or_null :
   sig
     type ('a : value_maybe_separable) t = 'a or_null = Null | This of 'a [@@or_null_reexport]

--- a/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -14,6 +14,13 @@ end
 (* Ideally the above would simply fail. Test that at least we don't actually
    allow ['a] to have kind [any] *)
 [%%expect {|
+Line 2, characters 8-16:
+2 |   type ('a : any) t : value_or_null = 'a or_null [@@or_null_reexport]
+            ^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `any'
+but was inferred to have kind `value_maybe_separable'.
+
 module Test_with_any :
   sig
     type ('a : value_maybe_separable) t = 'a or_null = Null | This of 'a [@@or_null_reexport]

--- a/testsuite/tests/typing-layouts-or-null/test_or_null.ml
+++ b/testsuite/tests/typing-layouts-or-null/test_or_null.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags = "-w -181";
  expect;
 *)
 
@@ -14,13 +15,6 @@ end
 (* Ideally the above would simply fail. Test that at least we don't actually
    allow ['a] to have kind [any] *)
 [%%expect {|
-Line 2, characters 8-16:
-2 |   type ('a : any) t : value_or_null = 'a or_null [@@or_null_reexport]
-            ^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `any'
-but was inferred to have kind `value_maybe_separable'.
-
 module Test_with_any :
   sig
     type ('a : value_maybe_separable) t = 'a or_null = Null | This of 'a [@@or_null_reexport]

--- a/testsuite/tests/typing-layouts-or-null/variables.ml
+++ b/testsuite/tests/typing-layouts-or-null/variables.ml
@@ -292,6 +292,13 @@ end = struct
 end
 
 [%%expect{|
+Line 2, characters 10-30:
+2 |   val f : ('a : value_or_null) -> 'a
+              ^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value_or_null'
+but was inferred to have kind `value'.
+
 module M : sig val f : 'a -> 'a end
 |}]
 
@@ -311,6 +318,13 @@ type t = Packed : 'a dummy -> t
    set ['a : value_or_null]. *)
 type t = Packed : ('a : value_or_null) dummy -> t
 [%%expect{|
+Line 1, characters 18-38:
+1 | type t = Packed : ('a : value_or_null) dummy -> t
+                      ^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value_or_null'
+but was inferred to have kind `value'.
+
 type t = Packed : 'a dummy -> t
 |}]
 
@@ -365,6 +379,13 @@ type ('c : value_or_null) constrained' = bool
   constraint 'c = ('a : value_or_null) dummy
 
 [%%expect{|
+Line 2, characters 18-38:
+2 |   constraint 'c = ('a : value_or_null) dummy
+                      ^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value_or_null'
+but was inferred to have kind `value'.
+
 type 'b constrained' = bool constraint 'b = 'a dummy
 |}]
 

--- a/testsuite/tests/typing-layouts-or-null/variables.ml
+++ b/testsuite/tests/typing-layouts-or-null/variables.ml
@@ -1,4 +1,5 @@
 (* TEST
+ flags = "-w -181";
  expect;
 *)
 
@@ -292,13 +293,6 @@ end = struct
 end
 
 [%%expect{|
-Line 2, characters 10-30:
-2 |   val f : ('a : value_or_null) -> 'a
-              ^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value_or_null'
-but was inferred to have kind `value'.
-
 module M : sig val f : 'a -> 'a end
 |}]
 
@@ -318,13 +312,6 @@ type t = Packed : 'a dummy -> t
    set ['a : value_or_null]. *)
 type t = Packed : ('a : value_or_null) dummy -> t
 [%%expect{|
-Line 1, characters 18-38:
-1 | type t = Packed : ('a : value_or_null) dummy -> t
-                      ^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value_or_null'
-but was inferred to have kind `value'.
-
 type t = Packed : 'a dummy -> t
 |}]
 
@@ -379,13 +366,6 @@ type ('c : value_or_null) constrained' = bool
   constraint 'c = ('a : value_or_null) dummy
 
 [%%expect{|
-Line 2, characters 18-38:
-2 |   constraint 'c = ('a : value_or_null) dummy
-                      ^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value_or_null'
-but was inferred to have kind `value'.
-
 type 'b constrained' = bool constraint 'b = 'a dummy
 |}]
 

--- a/testsuite/tests/typing-layouts-scannable/abstract_kinds.ml
+++ b/testsuite/tests/typing-layouts-scannable/abstract_kinds.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-extension layouts_alpha";
+ flags = "-extension layouts_alpha -w -181";
  expect;
 *)
 

--- a/testsuite/tests/typing-layouts/hash_types.ml
+++ b/testsuite/tests/typing-layouts/hash_types.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-extension layouts_beta -w -220";
+ flags = "-extension layouts_beta -w -181-220";
  expect;
 *)
 

--- a/testsuite/tests/typing-layouts/imprecise_annot.ml
+++ b/testsuite/tests/typing-layouts/imprecise_annot.ml
@@ -1,6 +1,6 @@
 (* TEST
  include stdlib_upstream_compatible;
- flags = "-w +219";
+ flags = "-w +181";
  expect;
 *)
 
@@ -20,7 +20,7 @@ end
 Line 3, characters 8-18:
 3 |   type ('a : value) t = 'a imm_t
             ^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
 was annotated with kind `value'
 but was inferred to have kind `immediate'.
 
@@ -37,7 +37,7 @@ end
 Line 3, characters 8-16:
 3 |   type ('a : any) t = 'a list_t
             ^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
 was annotated with kind `any'
 but was inferred to have kind `value'.
 
@@ -85,7 +85,7 @@ end
 Line 2, characters 10-22:
 2 |   val f : ('a : value) -> ('a : immediate) -> unit
               ^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
 was annotated with kind `value'
 but was inferred to have kind `immediate'.
 
@@ -100,7 +100,7 @@ end
 Line 2, characters 10-20:
 2 |   val f : ('a : any) -> ('a : value) -> unit
               ^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
 was annotated with kind `any'
 but was inferred to have kind `value'.
 
@@ -118,7 +118,7 @@ end
 Line 2, characters 10-30:
 2 |   val f : ('a : value_or_null) -> 'a list
               ^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
 was annotated with kind `value_or_null'
 but was inferred to have kind `value'.
 
@@ -156,7 +156,7 @@ type ('a : immediate) imm_t = 'a
 Line 2, characters 6-16:
 2 | type ('a : value) t6 = 'a imm_t
           ^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
 was annotated with kind `value'
 but was inferred to have kind `immediate'.
 
@@ -169,7 +169,7 @@ type ('a : any) t6b = 'a list
 Line 1, characters 6-14:
 1 | type ('a : any) t6b = 'a list
           ^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
 was annotated with kind `any'
 but was inferred to have kind `value_or_null'.
 
@@ -189,7 +189,7 @@ type ('a : immediate) imm_list = 'a list
 Line 4, characters 9-21:
 4 | let f7 : ('a : value) -> 'a imm_list = fun x -> [x]
              ^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
 was annotated with kind `value'
 but was inferred to have kind `immediate'.
 
@@ -208,7 +208,7 @@ let f7c : ('a : value) -> ('a : immediate) -> unit = fun _ _ -> ()
 Line 1, characters 10-22:
 1 | let f7c : ('a : value) -> ('a : immediate) -> unit = fun _ _ -> ()
               ^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
 was annotated with kind `value'
 but was inferred to have kind `immediate'.
 
@@ -252,7 +252,7 @@ end
 Line 3, characters 8-18:
 3 |   type ('a : value) t = 'a imm_t
             ^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
 was annotated with kind `value'
 but was inferred to have kind `immediate'.
 
@@ -271,14 +271,14 @@ end
 Line 6, characters 8-18:
 6 |   type ('a : value) t = 'a imm_t
             ^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
 was annotated with kind `value'
 but was inferred to have kind `immediate'.
 
 Line 3, characters 8-18:
 3 |   type ('a : value) t = 'a imm_t
             ^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
 was annotated with kind `value'
 but was inferred to have kind `immediate'.
 
@@ -296,7 +296,7 @@ let _ =
 Line 2, characters 10-22:
 2 |   let x : ('a : value) -> 'a imm_list = fun y -> [y] in
               ^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
 was annotated with kind `value'
 but was inferred to have kind `immediate'.
 
@@ -328,7 +328,7 @@ type ('a : any) variant10 = A of 'a list | B
 Line 1, characters 6-14:
 1 | type ('a : any) variant10 = A of 'a list | B
           ^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
 was annotated with kind `any'
 but was inferred to have kind `value_or_null'.
 
@@ -362,7 +362,7 @@ end
 Line 2, characters 10-21:
 2 |   val f : (_ : value) imm_list -> unit
               ^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `_'
+Warning 181 [imprecise-kind-annotation]: The type variable `_'
 was annotated with kind `value'
 but was inferred to have kind `immediate'.
 
@@ -381,7 +381,7 @@ end
 Line 2, characters 10-35:
 2 |   val f : ('a : value mod portable) -> ('a : value mod contended) -> unit
               ^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
 was annotated with kind `value mod portable'
 but was inferred to have kind `value mod portable contended'.
 
@@ -399,7 +399,7 @@ end
 Line 2, characters 8-18:
 2 |   type ('a : value, 'b : immediate) t constraint 'a = 'b
             ^^^^^^^^^^
-Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
 was annotated with kind `value'
 but was inferred to have kind `immediate'.
 
@@ -440,4 +440,82 @@ type ('a : immediate) imm16
 type 'a t16 =
     Value : 'a value16 -> 'a t16
   | Imm : ('a : immediate). 'a imm16 -> 'a t16
+|}]
+
+(*********************************************************)
+(* Test 17: Use-site annotations on univars *)
+
+(* The binder is precise, but the use-site annotation is weaker. *)
+type t17 = { x : ('a : immediate). ('a : value) -> 'a }
+[%%expect{|
+Line 1, characters 35-47:
+1 | type t17 = { x : ('a : immediate). ('a : value) -> 'a }
+                                       ^^^^^^^^^^^^
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
+type t17 = { x : ('a : immediate). 'a -> 'a; }
+|}]
+
+module type S17 = sig
+  val f : ('a : immediate). ('a : value) -> 'a
+end
+[%%expect{|
+Line 2, characters 28-40:
+2 |   val f : ('a : immediate). ('a : value) -> 'a
+                                ^^^^^^^^^^^^
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
+module type S17 = sig val f : ('a : immediate). 'a -> 'a end
+|}]
+
+(* An unannotated binder defaults to [value]; the use-site annotation
+   is weaker than the default. *)
+module type S17b = sig
+  val f : 'a. ('a : value_or_null) -> 'a list
+end
+[%%expect{|
+Line 2, characters 14-34:
+2 |   val f : 'a. ('a : value_or_null) -> 'a list
+                  ^^^^^^^^^^^^^^^^^^^^
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value_or_null'
+but was inferred to have kind `value'.
+
+module type S17b = sig val f : 'a -> 'a list end
+|}]
+
+(* Both use-site annotations are imprecise; each warns separately. *)
+module type S17c = sig
+  val f : ('a : immediate). ('a : value) -> ('a : value_or_null) -> 'a
+end
+[%%expect{|
+Line 2, characters 28-40:
+2 |   val f : ('a : immediate). ('a : value) -> ('a : value_or_null) -> 'a
+                                ^^^^^^^^^^^^
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
+Line 2, characters 44-64:
+2 |   val f : ('a : immediate). ('a : value) -> ('a : value_or_null) -> 'a
+                                                ^^^^^^^^^^^^^^^^^^^^
+Warning 181 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value_or_null'
+but was inferred to have kind `immediate'.
+
+module type S17c = sig val f : ('a : immediate). 'a -> 'a -> 'a end
+|}]
+
+(* Precise use-site annotations on univars do not warn. *)
+module type S17d = sig
+  val f : ('a : immediate). ('a : immediate) -> 'a
+  val g : 'a. ('a : value) -> 'a list
+end
+[%%expect{|
+module type S17d =
+  sig val f : ('a : immediate). 'a -> 'a val g : 'a -> 'a list end
 |}]

--- a/testsuite/tests/typing-layouts/imprecise_annot.ml
+++ b/testsuite/tests/typing-layouts/imprecise_annot.ml
@@ -21,8 +21,7 @@ Line 3, characters 8-18:
 3 |   type ('a : value) t = 'a imm_t
             ^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
+  was annotated with kind `value' but was inferred to have kind `immediate'.
 
 module type S1 =
   sig type ('a : immediate) imm_t type ('a : immediate) t = 'a imm_t end
@@ -38,8 +37,7 @@ Line 3, characters 8-16:
 3 |   type ('a : any) t = 'a list_t
             ^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `any'
-but was inferred to have kind `value'.
+  was annotated with kind `any' but was inferred to have kind `value'.
 
 module type S1b = sig type 'a list_t type 'a t = 'a list_t end
 |}]
@@ -86,8 +84,7 @@ Line 2, characters 10-22:
 2 |   val f : ('a : value) -> ('a : immediate) -> unit
               ^^^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
+  was annotated with kind `value' but was inferred to have kind `immediate'.
 
 module type S3 = sig val f : ('a : immediate). 'a -> 'a -> unit end
 |}]
@@ -101,8 +98,7 @@ Line 2, characters 10-20:
 2 |   val f : ('a : any) -> ('a : value) -> unit
               ^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `any'
-but was inferred to have kind `value'.
+  was annotated with kind `any' but was inferred to have kind `value'.
 
 module type S3b = sig val f : 'a -> 'a -> unit end
 |}]
@@ -119,8 +115,8 @@ Line 2, characters 10-30:
 2 |   val f : ('a : value_or_null) -> 'a list
               ^^^^^^^^^^^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value_or_null'
-but was inferred to have kind `value'.
+  was annotated with kind `value_or_null'
+  but was inferred to have kind `value'.
 
 module type S4 = sig val f : 'a -> 'a list end
 |}]
@@ -157,8 +153,7 @@ Line 2, characters 6-16:
 2 | type ('a : value) t6 = 'a imm_t
           ^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
+  was annotated with kind `value' but was inferred to have kind `immediate'.
 
 type ('a : immediate) t6 = 'a imm_t
 |}]
@@ -170,8 +165,8 @@ Line 1, characters 6-14:
 1 | type ('a : any) t6b = 'a list
           ^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `any'
-but was inferred to have kind `value_or_null'.
+  was annotated with kind `any'
+  but was inferred to have kind `value_or_null'.
 
 type ('a : value_or_null) t6b = 'a list
 |}]
@@ -190,8 +185,7 @@ Line 4, characters 9-21:
 4 | let f7 : ('a : value) -> 'a imm_list = fun x -> [x]
              ^^^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
+  was annotated with kind `value' but was inferred to have kind `immediate'.
 
 val f7 : ('a : immediate). 'a -> 'a imm_list = <fun>
 |}]
@@ -209,8 +203,7 @@ Line 1, characters 10-22:
 1 | let f7c : ('a : value) -> ('a : immediate) -> unit = fun _ _ -> ()
               ^^^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
+  was annotated with kind `value' but was inferred to have kind `immediate'.
 
 val f7c : ('a : immediate). 'a -> 'a -> unit = <fun>
 |}]
@@ -253,8 +246,7 @@ Line 3, characters 8-18:
 3 |   type ('a : value) t = 'a imm_t
             ^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
+  was annotated with kind `value' but was inferred to have kind `immediate'.
 
 module M8 :
   sig type ('a : immediate) imm_t = 'a type ('a : immediate) t = 'a imm_t end
@@ -272,15 +264,13 @@ Line 6, characters 8-18:
 6 |   type ('a : value) t = 'a imm_t
             ^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
+  was annotated with kind `value' but was inferred to have kind `immediate'.
 
 Line 3, characters 8-18:
 3 |   type ('a : value) t = 'a imm_t
             ^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
+  was annotated with kind `value' but was inferred to have kind `immediate'.
 
 module M8b :
   sig type ('a : immediate) imm_t type ('a : immediate) t = 'a imm_t end
@@ -297,8 +287,7 @@ Line 2, characters 10-22:
 2 |   let x : ('a : value) -> 'a imm_list = fun y -> [y] in
               ^^^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
+  was annotated with kind `value' but was inferred to have kind `immediate'.
 
 - : int imm_list = [42]
 |}]
@@ -329,8 +318,8 @@ Line 1, characters 6-14:
 1 | type ('a : any) variant10 = A of 'a list | B
           ^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `any'
-but was inferred to have kind `value_or_null'.
+  was annotated with kind `any'
+  but was inferred to have kind `value_or_null'.
 
 type ('a : value_or_null) variant10 = A of 'a list | B
 |}]
@@ -363,8 +352,7 @@ Line 2, characters 10-21:
 2 |   val f : (_ : value) imm_list -> unit
               ^^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `_'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
+  was annotated with kind `value' but was inferred to have kind `immediate'.
 
 module type S12 = sig val f : ('a : immediate). 'a imm_list -> unit end
 |}]
@@ -382,8 +370,8 @@ Line 2, characters 10-35:
 2 |   val f : ('a : value mod portable) -> ('a : value mod contended) -> unit
               ^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value mod portable'
-but was inferred to have kind `value mod portable contended'.
+  was annotated with kind `value mod portable'
+  but was inferred to have kind `value mod portable contended'.
 
 module type S13 =
   sig val f : ('a : value mod portable contended). 'a -> 'a -> unit end
@@ -400,8 +388,7 @@ Line 2, characters 8-18:
 2 |   type ('a : value, 'b : immediate) t constraint 'a = 'b
             ^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
+  was annotated with kind `value' but was inferred to have kind `immediate'.
 
 module type S14 = sig type ('b : immediate, 'a) t constraint 'a = 'b end
 |}]
@@ -452,8 +439,7 @@ Line 1, characters 35-47:
 1 | type t17 = { x : ('a : immediate). ('a : value) -> 'a }
                                        ^^^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
+  was annotated with kind `value' but was inferred to have kind `immediate'.
 
 type t17 = { x : ('a : immediate). 'a -> 'a; }
 |}]
@@ -466,8 +452,7 @@ Line 2, characters 28-40:
 2 |   val f : ('a : immediate). ('a : value) -> 'a
                                 ^^^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
+  was annotated with kind `value' but was inferred to have kind `immediate'.
 
 module type S17 = sig val f : ('a : immediate). 'a -> 'a end
 |}]
@@ -482,8 +467,8 @@ Line 2, characters 14-34:
 2 |   val f : 'a. ('a : value_or_null) -> 'a list
                   ^^^^^^^^^^^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value_or_null'
-but was inferred to have kind `value'.
+  was annotated with kind `value_or_null'
+  but was inferred to have kind `value'.
 
 module type S17b = sig val f : 'a -> 'a list end
 |}]
@@ -497,15 +482,14 @@ Line 2, characters 28-40:
 2 |   val f : ('a : immediate). ('a : value) -> ('a : value_or_null) -> 'a
                                 ^^^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value'
-but was inferred to have kind `immediate'.
+  was annotated with kind `value' but was inferred to have kind `immediate'.
 
 Line 2, characters 44-64:
 2 |   val f : ('a : immediate). ('a : value) -> ('a : value_or_null) -> 'a
                                                 ^^^^^^^^^^^^^^^^^^^^
 Warning 181 [imprecise-kind-annotation]: The type variable `'a'
-was annotated with kind `value_or_null'
-but was inferred to have kind `immediate'.
+  was annotated with kind `value_or_null'
+  but was inferred to have kind `immediate'.
 
 module type S17c = sig val f : ('a : immediate). 'a -> 'a -> 'a end
 |}]

--- a/testsuite/tests/typing-layouts/imprecise_annot.ml
+++ b/testsuite/tests/typing-layouts/imprecise_annot.ml
@@ -1,0 +1,443 @@
+(* TEST
+ include stdlib_upstream_compatible;
+ flags = "-w +219";
+ expect;
+*)
+
+(* Test cases for warnings about imprecise kind annotations.
+   These tests check cases where a kind annotation is weaker than
+   the resulting kind. Only testing signatures for now. *)
+
+(*********************************************************)
+(* Test 1: Type constructor restricts kind to stricter one *)
+
+(* Annotation says 'value' but type constructor requires 'immediate' *)
+module type S1 = sig
+  type ('a : immediate) imm_t
+  type ('a : value) t = 'a imm_t
+end
+[%%expect{|
+Line 3, characters 8-18:
+3 |   type ('a : value) t = 'a imm_t
+            ^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
+module type S1 =
+  sig type ('a : immediate) imm_t type ('a : immediate) t = 'a imm_t end
+|}]
+
+(* Annotation says 'any' but type constructor requires 'value' *)
+module type S1b = sig
+  type 'a list_t
+  type ('a : any) t = 'a list_t
+end
+[%%expect{|
+Line 3, characters 8-16:
+3 |   type ('a : any) t = 'a list_t
+            ^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `any'
+but was inferred to have kind `value'.
+
+module type S1b = sig type 'a list_t type 'a t = 'a list_t end
+|}]
+
+(*********************************************************)
+(* Test 2: Universal quantification with stricter annotation elsewhere *)
+(* Note: These examples will give errors, which is expected behavior *)
+
+(* Binding site says 'value' but usage site requires 'immediate' *)
+module type S2 = sig
+  val f : ('a : value). 'a -> (('a : immediate) -> unit) -> unit
+end
+[%%expect{|
+Line 2, characters 10-64:
+2 |   val f : ('a : value). 'a -> (('a : immediate) -> unit) -> unit
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The universal type variable 'a was declared to have kind value.
+       But it was inferred to have kind immediate
+         because of the annotation on the type variable 'a.
+|}]
+
+(* Binding site says 'any' but usage site requires 'value' *)
+module type S2b = sig
+  val f : ('a : any). 'a -> (('a : value) -> unit) -> unit
+end
+[%%expect{|
+Line 2, characters 10-58:
+2 |   val f : ('a : any). 'a -> (('a : value) -> unit) -> unit
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The universal type variable 'a was declared to have kind any.
+       But it was inferred to have kind value
+         because of the annotation on the type variable 'a.
+|}]
+
+(*********************************************************)
+(* Test 3: Conflicting annotations on same variable *)
+
+(* First annotation says 'value', second says 'immediate' *)
+module type S3 = sig
+  val f : ('a : value) -> ('a : immediate) -> unit
+end
+[%%expect{|
+Line 2, characters 10-22:
+2 |   val f : ('a : value) -> ('a : immediate) -> unit
+              ^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
+module type S3 = sig val f : ('a : immediate). 'a -> 'a -> unit end
+|}]
+
+(* any vs value *)
+module type S3b = sig
+  val f : ('a : any) -> ('a : value) -> unit
+end
+[%%expect{|
+Line 2, characters 10-20:
+2 |   val f : ('a : any) -> ('a : value) -> unit
+              ^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `any'
+but was inferred to have kind `value'.
+
+module type S3b = sig val f : 'a -> 'a -> unit end
+|}]
+
+(*********************************************************)
+(* Test 4: Type variable at weaker nullability than required *)
+
+(* value_or_null in val declaration where value is inferred *)
+module type S4 = sig
+  val f : ('a : value_or_null) -> 'a list
+end
+[%%expect{|
+Line 2, characters 10-30:
+2 |   val f : ('a : value_or_null) -> 'a list
+              ^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value_or_null'
+but was inferred to have kind `value'.
+
+module type S4 = sig val f : 'a -> 'a list end
+|}]
+
+(*********************************************************)
+(* Test 5: Constraint clause does not trigger warning *)
+
+(* Annotation says 'value' but constraint restricts to int (immediate).
+   This does not warn since the variable is unified to int. Should it? *)
+module type S5 = sig
+  type ('a : value) t constraint 'a = int
+end
+[%%expect{|
+module type S5 = sig type 'a t constraint 'a = int end
+|}]
+
+(* Same with 'any' annotation constrained to a value type *)
+module type S5b = sig
+  type ('a : any) t constraint 'a = string
+end
+[%%expect{|
+module type S5b = sig type 'a t constraint 'a = string end
+|}]
+
+(*********************************************************)
+(* Test 6: Structure-level type definitions *)
+
+(* Type definition in structure with imprecise annotation *)
+type ('a : immediate) imm_t = 'a
+type ('a : value) t6 = 'a imm_t
+[%%expect{|
+type ('a : immediate) imm_t = 'a
+Line 2, characters 6-16:
+2 | type ('a : value) t6 = 'a imm_t
+          ^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
+type ('a : immediate) t6 = 'a imm_t
+|}]
+
+(* any -> value in structure *)
+type ('a : any) t6b = 'a list
+[%%expect{|
+Line 1, characters 6-14:
+1 | type ('a : any) t6b = 'a list
+          ^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `any'
+but was inferred to have kind `value_or_null'.
+
+type ('a : value_or_null) t6b = 'a list
+|}]
+
+(*********************************************************)
+(* Test 7: Let bindings with imprecise annotations *)
+
+(* First, define a type that requires immediate *)
+type ('a : immediate) imm_list = 'a list
+
+(* Simple let with imprecise annotation - value -> immediate *)
+let f7 : ('a : value) -> 'a imm_list = fun x -> [x]
+[%%expect{|
+type ('a : immediate) imm_list = 'a list
+Line 4, characters 9-21:
+4 | let f7 : ('a : value) -> 'a imm_list = fun x -> [x]
+             ^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
+val f7 : ('a : immediate). 'a -> 'a imm_list = <fun>
+|}]
+
+(* Ignored, since those two ['a]s have different scopes. *)
+let f7b (x : ('a : any)) : 'a imm_list = [x]
+[%%expect{|
+val f7b : ('a : immediate). 'a -> 'a imm_list = <fun>
+|}]
+
+(* Let with conflicting annotations - first weaker *)
+let f7c : ('a : value) -> ('a : immediate) -> unit = fun _ _ -> ()
+[%%expect{|
+Line 1, characters 10-22:
+1 | let f7c : ('a : value) -> ('a : immediate) -> unit = fun _ _ -> ()
+              ^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
+val f7c : ('a : immediate). 'a -> 'a -> unit = <fun>
+|}]
+
+(* Let with explicit forall and imprecise annotation - value -> immediate *)
+let f7d : type (a : value). a -> a imm_list = fun x -> [x]
+[%%expect{|
+Line 1, characters 28-43:
+1 | let f7d : type (a : value). a -> a imm_list = fun x -> [x]
+                                ^^^^^^^^^^^^^^^
+Error: The universal type variable 'a was declared to have kind value.
+       But it was inferred to have kind immediate
+         because of the definition of imm_list at line 1, characters 0-40.
+|}]
+
+(* Let with newtypes in parameter position *)
+let f7e (type (a : any)) (x : a) : a list = [x]
+[%%expect{|
+Line 1, characters 25-32:
+1 | let f7e (type (a : any)) (x : a) : a list = [x]
+                             ^^^^^^^
+Error: This pattern matches values of type "a"
+       but a pattern was expected which matches values of type
+         "('a : '_representable_layout_1)"
+       The layout of a is any
+         because of the annotation on the abstract type declaration for a.
+       But the layout of a must be representable
+         because we must know concretely how to pass a function argument.
+|}]
+
+(*********************************************************)
+(* Test 8: Module definitions with imprecise annotations *)
+
+module M8 = struct
+  type ('a : immediate) imm_t = 'a
+  type ('a : value) t = 'a imm_t
+end
+[%%expect{|
+Line 3, characters 8-18:
+3 |   type ('a : value) t = 'a imm_t
+            ^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
+module M8 :
+  sig type ('a : immediate) imm_t = 'a type ('a : immediate) t = 'a imm_t end
+|}]
+
+module M8b : sig
+  type ('a : immediate) imm_t
+  type ('a : value) t = 'a imm_t
+end = struct
+  type ('a : immediate) imm_t = 'a
+  type ('a : value) t = 'a imm_t
+end
+[%%expect{|
+Line 6, characters 8-18:
+6 |   type ('a : value) t = 'a imm_t
+            ^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
+Line 3, characters 8-18:
+3 |   type ('a : value) t = 'a imm_t
+            ^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
+module M8b :
+  sig type ('a : immediate) imm_t type ('a : immediate) t = 'a imm_t end
+|}]
+
+(*********************************************************)
+(* Test 9: Local type annotations in expressions *)
+
+let _ =
+  let x : ('a : value) -> 'a imm_list = fun y -> [y] in
+  x 42
+[%%expect{|
+Line 2, characters 10-22:
+2 |   let x : ('a : value) -> 'a imm_list = fun y -> [y] in
+              ^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
+- : int imm_list = [42]
+|}]
+
+let _ =
+  let f : type (a : value). a -> a imm_list = fun x -> [x] in
+  f 42
+[%%expect{|
+Line 2, characters 28-43:
+2 |   let f : type (a : value). a -> a imm_list = fun x -> [x] in
+                                ^^^^^^^^^^^^^^^
+Error: The universal type variable 'a was declared to have kind value.
+       But it was inferred to have kind immediate
+         because of the definition of imm_list at line 1, characters 0-40.
+|}]
+
+(*********************************************************)
+(* Test 10: Record and variant definitions *)
+
+type ('a : value) record10 = { field : 'a list }
+[%%expect{|
+type 'a record10 = { field : 'a list; }
+|}]
+
+type ('a : any) variant10 = A of 'a list | B
+[%%expect{|
+Line 1, characters 6-14:
+1 | type ('a : any) variant10 = A of 'a list | B
+          ^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `any'
+but was inferred to have kind `value_or_null'.
+
+type ('a : value_or_null) variant10 = A of 'a list | B
+|}]
+
+(*********************************************************)
+(* Test 11: Anonymous type parameters *)
+
+(* It's (seemingly?) impossible to constrain anonymous type parameters,
+   since they are never used and thus can't be constrained by anything else.
+   Test included for completeness.  *)
+
+type (_ : immediate) imm11
+type (_ : value) t11 = int imm11
+[%%expect{|
+type (_ : immediate) imm11
+type _ t11 = int imm11
+|}]
+
+(*********************************************************)
+(* Test 12: Anonymous type variables in val declarations *)
+
+(* Anonymous type variables are tracked separately from named ones
+   in TyVarEnv and also trigger warnings. *)
+
+module type S12 = sig
+  val f : (_ : value) imm_list -> unit
+end
+[%%expect{|
+Line 2, characters 10-21:
+2 |   val f : (_ : value) imm_list -> unit
+              ^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `_'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
+module type S12 = sig val f : ('a : immediate). 'a imm_list -> unit end
+|}]
+
+(*********************************************************)
+(* Test 13: Two conflicting mod annotations on the same variable *)
+
+(* Only the first annotation of a variable is remembered, so only it
+   triggers a warning. *)
+module type S13 = sig
+  val f : ('a : value mod portable) -> ('a : value mod contended) -> unit
+end
+[%%expect{|
+Line 2, characters 10-35:
+2 |   val f : ('a : value mod portable) -> ('a : value mod contended) -> unit
+              ^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value mod portable'
+but was inferred to have kind `value mod portable contended'.
+
+module type S13 =
+  sig val f : ('a : value mod portable contended). 'a -> 'a -> unit end
+|}]
+
+(*********************************************************)
+(* Test 14: Constraint between two annotated type parameters *)
+
+module type S14 = sig
+  type ('a : value, 'b : immediate) t constraint 'a = 'b
+end
+[%%expect{|
+Line 2, characters 8-18:
+2 |   type ('a : value, 'b : immediate) t constraint 'a = 'b
+            ^^^^^^^^^^
+Warning 219 [imprecise-kind-annotation]: The type variable `'a'
+was annotated with kind `value'
+but was inferred to have kind `immediate'.
+
+module type S14 = sig type ('b : immediate, 'a) t constraint 'a = 'b end
+|}]
+
+(*********************************************************)
+(* Test 15: Annotations in function definitions constrained by the body *)
+
+(* The check runs right after each type annotation is translated, before
+   the function body is typed, so the unification with [require_immediate]
+   is not seen by the check and no warning is given. *)
+let require_immediate (x : (_ : immediate)) = x
+let f15 (x : (_ : value)) = require_immediate x
+[%%expect{|
+val require_immediate : ('a : immediate). 'a -> 'a = <fun>
+val f15 : ('a : immediate). 'a -> 'a = <fun>
+|}]
+
+(* Same for named type variables. *)
+let f15b (x : ('a : value)) = require_immediate x
+[%%expect{|
+val f15b : ('a : immediate). 'a -> 'a = <fun>
+|}]
+
+(*********************************************************)
+(* Test 16: GADTs *)
+
+type 'a value16
+type ('a : immediate) imm16
+
+type ('a : value) t16 =
+  | Value : 'a value16 -> 'a t16
+  | Imm : 'a imm16 -> 'a t16
+[%%expect{|
+type 'a value16
+type ('a : immediate) imm16
+type 'a t16 =
+    Value : 'a value16 -> 'a t16
+  | Imm : ('a : immediate). 'a imm16 -> 'a t16
+|}]

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1271,6 +1271,8 @@ let rec out_jkind_of_desc env (desc : 'd Jkind.Desc.t) =
     | Some c -> out_jkind_of_const_jkind env c
     | None -> assert false (* handled above *)
 
+let out_jkind_of_jkind env jkind = out_jkind_of_desc env (Jkind.get jkind)
+
 (* returns None for [value], according to (C2.1) from
    Note [When to print jkind annotations] *)
 (* CR layouts v2.8: This should use the annotation in the jkind, if there

--- a/typing/out_type.mli
+++ b/typing/out_type.mli
@@ -102,6 +102,11 @@ val tree_of_type_scheme: type_expr -> out_type
 val tree_of_modalities:
   Types.mutability -> Mode.Modality.Const.t -> Outcometree.out_mode list
 
+(** [out_jkind_of_jkind env jkind] converts a jkind to an [out_jkind]
+    for printing. This uses the same naming scheme as error messages (e.g.,
+    ['_representable_layout_N] for sort variables). *)
+val out_jkind_of_jkind: Env.t -> 'd Types.jkind -> out_jkind
+
 
 val prepared_type_scheme: type_expr printer
 val prepared_type_expr: type_expr printer

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1715,7 +1715,7 @@ let class_infos define_class kind
         let make_param (sty, v) =
           try
             let jkind = Jkind.Builtin.value ~why:Class_type_argument in
-            let param = transl_type_param env (Pident ty_id) jkind sty in
+            let param, _ = transl_type_param env (Pident ty_id) jkind sty in
             (* CR layouts: we require class type parameters to be values, but
                we should lift this restriction. Doing so causes bad error messages
                today, so we wait for tomorrow. *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -932,6 +932,33 @@ let shape_extension_constructor ext =
   | Debugging_shapes ->
     Type_shape.Type_decl_shape.of_extension_constructor_merlin_only ext
 
+let check_imprecise_type_param_annotation env path (cty, _) =
+  match cty.ctyp_desc, get_desc cty.ctyp_type with
+  | Ttyp_var (name_opt, Some annot), Tvar { jkind; _ }
+    when not (Jkind.History.has_warned jkind) ->
+    let annotated_jkind =
+      Jkind.of_annotation env ~context:(Type_parameter (path, name_opt)) annot
+    in
+    if not (Jkind.equate env jkind annotated_jkind) then begin
+      let format_jkind jkind =
+        Format_doc.asprintf "%a" !Oprint.out_jkind
+          (Out_type.out_jkind_of_jkind env jkind)
+      in
+      let name =
+        match name_opt with
+        | Some name -> Pprintast.tyvar_of_name name
+        | None -> "anonymous type parameter"
+      in
+      Location.prerr_warning cty.ctyp_loc
+        (Warnings.Imprecise_kind_annotation {
+          name;
+          annotated = format_jkind annotated_jkind;
+          inferred = format_jkind jkind;
+        });
+      Types.set_var_jkind cty.ctyp_type (Jkind.History.with_warning jkind)
+    end
+  | _ -> ()
+
 let transl_declaration env sdecl (id, uid) =
   (* Bind type parameters *)
   Ctype.with_local_level begin fun () ->
@@ -1246,6 +1273,8 @@ let transl_declaration env sdecl (id, uid) =
         try Ctype.unify env ty ty' with Ctype.Unify err ->
           raise(Error(loc, Inconsistent_constraint (env, err))))
       cstrs;
+  (* Check for imprecise type parameter annotations *)
+    List.iter (check_imprecise_type_param_annotation env path) tparams;
   (* Add abstract row *)
     if is_fixed_type sdecl then begin
       let p, _ =

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -258,11 +258,12 @@ let make_params env path params =
         ~level:(Ctype.get_current_level ())
     in
     try
-      (transl_type_param env path jkind sty, v)
+      let cty, annotated_jkind = transl_type_param env path jkind sty in
+      ((cty, v), annotated_jkind)
     with Already_bound ->
       raise(Error(sty.ptyp_loc, Repeated_parameter))
   in
-    List.map make_param params
+    List.split (List.map make_param params)
 
 (* Enter all declared types in the environment as abstract types *)
 
@@ -932,13 +933,10 @@ let shape_extension_constructor ext =
   | Debugging_shapes ->
     Type_shape.Type_decl_shape.of_extension_constructor_merlin_only ext
 
-let check_imprecise_type_param_annotation env path (cty, _) =
-  match cty.ctyp_desc, get_desc cty.ctyp_type with
-  | Ttyp_var (name_opt, Some annot), Tvar { jkind; _ }
+let check_imprecise_type_param_annotation env (cty, _) annotated_jkind =
+  match cty.ctyp_desc, get_desc cty.ctyp_type, annotated_jkind with
+  | Ttyp_var (name_opt, Some _), Tvar { jkind; _ }, Some annotated_jkind
     when not (Jkind.History.has_warned jkind) ->
-    let annotated_jkind =
-      Jkind.of_annotation env ~context:(Type_parameter (path, name_opt)) annot
-    in
     if not (Jkind.equate env jkind annotated_jkind) then begin
       let format_jkind jkind =
         Format_doc.asprintf "%a" !Oprint.out_jkind
@@ -965,7 +963,9 @@ let transl_declaration env sdecl (id, uid) =
   TyVarEnv.reset();
   let or_null, or_null_reexport = get_or_null_attributes sdecl in
   let path = Path.Pident id in
-  let tparams = make_params env path sdecl.ptype_params in
+  let tparams, param_annotated_jkinds =
+    make_params env path sdecl.ptype_params
+  in
   let params = List.map (fun (cty, _) -> cty.ctyp_type) tparams in
   let cstrs = List.map
     (fun (sty, sty', loc) ->
@@ -1274,7 +1274,8 @@ let transl_declaration env sdecl (id, uid) =
           raise(Error(loc, Inconsistent_constraint (env, err))))
       cstrs;
   (* Check for imprecise type parameter annotations *)
-    List.iter (check_imprecise_type_param_annotation env path) tparams;
+    List.iter2 (check_imprecise_type_param_annotation env)
+      tparams param_annotated_jkinds;
   (* Add abstract row *)
     if is_fixed_type sdecl then begin
       let p, _ =
@@ -4105,7 +4106,7 @@ let transl_type_extension extend env loc styext =
     let scope = Ctype.create_scope () in
     Ctype.with_local_level_generalize begin fun () ->
       TyVarEnv.reset();
-      let ttype_params = make_params env type_path styext.ptyext_params in
+      let ttype_params, _ = make_params env type_path styext.ptyext_params in
       let type_params = List.map (fun (cty, _) -> cty.ctyp_type) ttype_params in
       List.iter2 (Ctype.unify_var env)
         (Ctype.instance_list type_decl.type_params)
@@ -4843,7 +4844,7 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
   let env = outer_env in
   let decl_path = Path.Pident id in
   let loc = sdecl.ptype_loc in
-  let tparams = make_params env (Pident id) sdecl.ptype_params in
+  let tparams, _ = make_params env (Pident id) sdecl.ptype_params in
   let params = List.map (fun (cty, _) -> cty.ctyp_type) tparams in
   let arity = List.length params in
   let constraints =

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -242,10 +242,19 @@ module TyVarEnv : sig
 
   val remember_used :
     ?check:Location.t -> rigid:jkind_lr option
+    -> annotated_jkind:jkind_lr option
     -> string -> type_expr -> Location.t -> Env.stage -> unit
     (* Remember that a given name is bound to a given type.
 
-       If [rigid] is set, also remember that it's fixed at the given jkind. *)
+       If [rigid] is set, also remember that it's fixed at the given jkind.
+       [annotated_jkind] is the translated original jkind annotation,
+       if any. *)
+
+  val remember_used_anonymous :
+    type_expr -> jkind_lr -> Location.t -> unit
+    (* Remember an anonymous type variable [(_ : kind)] together with the
+       translation of its jkind annotation, so that imprecise annotations
+       on it can be detected. *)
 
   val globalize_used_variables : policy -> Env.t -> unit -> unit
   (* after finishing with a type signature, used variables are unified to the
@@ -287,10 +296,21 @@ end = struct
     *)
     rigid : jkind_lr option;
     stage : Env.stage;
+    annotated_jkind : jkind_lr option;
   }
 
   let used_variables =
     ref (TyVarMap.empty : used_info TyVarMap.t)
+
+  (* Anonymous type variables with a jkind annotation ([(_ : kind)]) that
+     have been used in the currently-being-checked type. Tracked separately
+     from [used_variables] (which is keyed by name) so that imprecise
+     annotations on them can be detected in [globalize_used_variables]. *)
+  let used_anonymous_variables =
+    ref ([] : (type_expr * jkind_lr * Location.t) list)
+
+  module LocSet = Set.Make(Location)
+  let warned_imprecise_locs = ref LocSet.empty
 
   (* These are variables that will become univars when we're done with the
      current type. Used to force free variables in method types to become
@@ -300,7 +320,8 @@ end = struct
 
   let reset () =
     reset_global_level ();
-    type_variables := TyVarMap.empty
+    type_variables := TyVarMap.empty;
+    warned_imprecise_locs := LocSet.empty
 
   let is_in_scope name =
     TyVarMap.mem name !type_variables
@@ -503,7 +524,8 @@ end = struct
   let reset_locals ?univars:(uvs=[]) () =
     assert_univars uvs;
     univars := uvs;
-    used_variables := TyVarMap.empty
+    used_variables := TyVarMap.empty;
+    used_anonymous_variables := []
 
   let associate row_context p =
     let add l x = if List.memq x l then l else x :: l in
@@ -523,12 +545,12 @@ end = struct
          inserted into [used_variables] are non-generic, but some
          might get generalized. *)
 
-  let remember_used ?check ~rigid name v loc stage =
+  let remember_used ?check ~rigid ~annotated_jkind name v loc stage =
     assert (not_generic v);
-    let rigid =
+    let rigid, annotated_jkind =
       match TyVarMap.find name !used_variables with
-      | info -> info.rigid
-      | exception Not_found -> rigid
+      | info -> info.rigid, info.annotated_jkind
+      | exception Not_found -> rigid, annotated_jkind
     in
     let unused = match check with
       | Some check_loc
@@ -543,8 +565,13 @@ end = struct
         unused
       | _ -> ref false
     in
-    let info = { ty = v; unused; loc; rigid; stage } in
+    let info = { ty = v; unused; loc; rigid; stage; annotated_jkind } in
     used_variables := TyVarMap.add name info !used_variables
+
+  let remember_used_anonymous v annotated_jkind loc =
+    assert (not_generic v);
+    used_anonymous_variables :=
+      (v, annotated_jkind, loc) :: !used_anonymous_variables
 
 
   type flavor = Unification | Universal
@@ -602,11 +629,43 @@ end = struct
       raise(Error(loc, env, No_type_wildcards (Some Upstream_compatibility)))
     | policy -> new_var jkind policy
 
+  let check_imprecise_annotation env loc name ty annotated_jkind =
+    match get_desc ty with
+    | Tvar { jkind; _ }
+      (* This can be called multiple times (with different variable ids
+         for different levels) for the same location (see internal ticket
+         6461). Therefore, we track the locations instead of using
+         [Jkind.History.has_warned]. *)
+      when not (LocSet.mem loc !warned_imprecise_locs) ->
+      if not (Jkind.equate env jkind annotated_jkind) then begin
+        warned_imprecise_locs := LocSet.add loc !warned_imprecise_locs;
+        let format_jkind jkind =
+          Format_doc.asprintf "%a" !Oprint.out_jkind
+            (Out_type.out_jkind_of_jkind env jkind)
+        in
+        Location.prerr_warning loc
+          (Warnings.Imprecise_kind_annotation {
+            name;
+            annotated = format_jkind annotated_jkind;
+            inferred = format_jkind jkind;
+          })
+      end
+    | _ -> ()
+
   let globalize_used_variables
       { flavor; unbound_variable_policy; _ } env =
     let r = ref [] in
+    List.iter
+      (fun (ty, annotated_jkind, loc) ->
+        check_imprecise_annotation env loc "_" ty annotated_jkind)
+      !used_anonymous_variables;
+    used_anonymous_variables := [];
     TyVarMap.iter
-      (fun name { ty; unused; rigid; loc; stage = s } ->
+      (fun name { ty; unused; rigid; loc; stage = s; annotated_jkind } ->
+        Option.iter
+          (check_imprecise_annotation env loc
+             (Pprintast.tyvar_of_name name) ty)
+          annotated_jkind;
         (match rigid with
         | Some original_jkind ->
           check_jkind env loc name ty { original_jkind; defaulted = false }
@@ -884,6 +943,9 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
             tjkind, Some jkind
       in
       let ty = TyVarEnv.new_any_var loc env tjkind policy in
+      (match tjkind_annot with
+       | Some _ -> TyVarEnv.remember_used_anonymous ty tjkind loc
+       | None -> ());
       ctyp (Ttyp_var (None, tjkind_annot)) ty
   | Ptyp_var (name, jkind) ->
       let desc, typ =
@@ -1250,6 +1312,11 @@ and transl_type_var env ~policy ~row_context attrs loc name jkind_annot_opt =
   let print_name = "'" ^ name in
   check_tyvar_name env loc name;
   let of_annot = jkind_of_annotation env (Type_variable print_name) attrs in
+  (* Translate the annotation exactly once: it is both remembered (for the
+     imprecise-annotation check) and used to constrain the variable below. *)
+  let annotated = Option.map (fun annot -> annot, of_annot annot)
+                    jkind_annot_opt in
+  let annotated_jkind = Option.map snd annotated in
   let ty, stage = try
       TyVarEnv.lookup_local ~row_context name
     with Not_found ->
@@ -1262,7 +1329,8 @@ and transl_type_var env ~policy ~row_context attrs loc name jkind_annot_opt =
           | None -> TyVarEnv.new_jkind ~is_named:true policy, None
       in
       let ty = TyVarEnv.new_var ~name jkind policy in
-      TyVarEnv.remember_used ~rigid name ty loc (Env.stage env);
+      TyVarEnv.remember_used ~rigid ~annotated_jkind
+        name ty loc (Env.stage env);
       ty, Env.stage env
   in
   if Env.stage env <> stage then
@@ -1272,10 +1340,9 @@ and transl_type_var env ~policy ~row_context attrs loc name jkind_annot_opt =
                                       intro_stage = stage;
                                       usage_stage = Env.stage env}));
   let jkind_annot =
-    match jkind_annot_opt with
+    match annotated with
     | None -> None
-    | Some jkind_annot ->
-      let jkind = of_annot jkind_annot in
+    | Some (jkind_annot, jkind) ->
       match constrain_type_jkind env ty jkind with
       | Ok () -> Some jkind_annot
       | Error err ->
@@ -1375,9 +1442,14 @@ and transl_type_alias env ~row_context ~policy mode attrs styp_loc styp name_opt
             let jkind, rigid =
               jkind_for_fresh_var env alias alias_loc attrs jkind_annot_opt
             in
+            (* If there is an annotation, [jkind_for_fresh_var] returns its
+               translation, so we can remember it without re-translating. *)
+            let annotated_jkind =
+              Option.map (fun _ -> jkind) jkind_annot_opt
+            in
             let t = newvar jkind in
             (* Use the whole location, which is used by [Type_mismatch]. *)
-            TyVarEnv.remember_used ~check:alias_loc ~rigid
+            TyVarEnv.remember_used ~check:alias_loc ~rigid ~annotated_jkind
               alias t styp_loc (Env.stage env);
             let ty = transl_type env ~policy ~row_context mode styp in
             begin try unify_var env t ty.ctyp_type with Unify err ->

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -828,11 +828,15 @@ let transl_type_param env path jkind_default styp =
     Ptyp_any jkind ->
       let name = None in
       let jkind, jkind_annot = transl_jkind_and_annot_opt jkind name in
-      transl_type_param_var env loc attrs name jkind jkind_annot
+      let annotated_jkind = Option.map (fun _ -> jkind) jkind_annot in
+      transl_type_param_var env loc attrs name jkind jkind_annot,
+      annotated_jkind
   | Ptyp_var (name, jkind) ->
       let name = Some name in
       let jkind, jkind_annot = transl_jkind_and_annot_opt jkind name in
-      transl_type_param_var env loc attrs name jkind jkind_annot
+      let annotated_jkind = Option.map (fun _ -> jkind) jkind_annot in
+      transl_type_param_var env loc attrs name jkind jkind_annot,
+      annotated_jkind
   | _ -> assert false
 
 let transl_type_param env path jkind_default styp =

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -256,6 +256,11 @@ module TyVarEnv : sig
        translation of its jkind annotation, so that imprecise annotations
        on it can be detected. *)
 
+  val remember_univar_use : string -> jkind_lr -> Location.t -> unit
+    (* Remember a use-site kind annotation on an in-scope univar, so that
+       imprecise annotations on it can be detected in [check_poly_univars].
+       Does nothing if the name does not refer to an in-scope univar. *)
+
   val globalize_used_variables : policy -> Env.t -> unit -> unit
   (* after finishing with a type signature, used variables are unified to the
      corresponding global type variables if they exist. Otherwise, in function
@@ -371,7 +376,10 @@ end = struct
     mutable associated: type_expr option ref list;
      (** associated references to row variables that we want to generalize
        if possible *)
-    jkind_info : jkind_info (** the original kind *)
+    jkind_info : jkind_info (** the original kind *);
+    mutable annotated_uses : (jkind_lr * Location.t) list
+     (** use-site kind annotations on this univar, for the
+       imprecise-annotation check in [check_poly_univars] *)
   }
 
   type poly_univars = (string * pending_univar * Env.stage) list
@@ -402,7 +410,8 @@ end = struct
       poly_univars
 
   let mk_pending_univar name jkind jkind_info =
-    { univar = newvar ~name jkind; associated = []; jkind_info }
+    { univar = newvar ~name jkind; associated = []; jkind_info;
+      annotated_uses = [] }
 
   let mk_poly_univars_tuple_with_jkind env ~context var jkind_annot stage =
     let { txt = name; loc } = var in
@@ -476,6 +485,29 @@ end = struct
       raise (Error (loc, env, reason))
     | _ -> ()
 
+  let check_imprecise_annotation env loc name ty annotated_jkind =
+    match get_desc ty with
+    | Tvar { jkind; _ } | Tunivar { jkind; _ }
+      (* This can be called multiple times (with different variable ids
+         for different levels) for the same location (see internal ticket
+         6461). Therefore, we track the locations instead of using
+         [Jkind.History.has_warned]. *)
+      when not (LocSet.mem loc !warned_imprecise_locs) ->
+      if not (Jkind.equate env jkind annotated_jkind) then begin
+        warned_imprecise_locs := LocSet.add loc !warned_imprecise_locs;
+        let format_jkind jkind =
+          Format_doc.asprintf "%a" !Oprint.out_jkind
+            (Out_type.out_jkind_of_jkind env jkind)
+        in
+        Location.prerr_warning loc
+          (Warnings.Imprecise_kind_annotation {
+            name;
+            annotated = format_jkind annotated_jkind;
+            inferred = format_jkind jkind;
+          })
+      end
+    | _ -> ()
+
   let quantify env loc name v =
     let cant_quantify reason =
       raise (Error (loc, env, Cannot_quantify(name, reason)))
@@ -495,9 +527,16 @@ end = struct
   let check_poly_univars env loc vars =
     vars |> List.iter (fun (_, p, _) -> generalize p.univar);
     let univars =
-      vars |> List.map (fun (name, {univar=ty1; jkind_info; _ }, _) ->
+      vars |> List.map (fun (name, {univar=ty1; jkind_info; annotated_uses;
+                                     _ }, _) ->
         let v = Btype.proxy ty1 in
         check_jkind env loc name v jkind_info;
+        List.iter
+          (fun (annotated_jkind, use_loc) ->
+            check_imprecise_annotation env use_loc
+              (Pprintast.tyvar_of_name name) v annotated_jkind)
+          (* Uses are consed on, so reverse to warn in source order. *)
+          (List.rev annotated_uses);
         quantify env loc name v)
     in
     (* Since we are promoting variables to univars in
@@ -544,6 +583,12 @@ end = struct
       (* This call to instance might be redundant; all variables
          inserted into [used_variables] are non-generic, but some
          might get generalized. *)
+
+  let remember_univar_use name annotated_jkind loc =
+    match find_poly_univars name !univars with
+    | p, _stage ->
+      p.annotated_uses <- (annotated_jkind, loc) :: p.annotated_uses
+    | exception Not_found -> ()
 
   let remember_used ?check ~rigid ~annotated_jkind name v loc stage =
     assert (not_generic v);
@@ -628,29 +673,6 @@ end = struct
     | { unbound_variable_policy = Closed_for_upstream_compatibility; _ } ->
       raise(Error(loc, env, No_type_wildcards (Some Upstream_compatibility)))
     | policy -> new_var jkind policy
-
-  let check_imprecise_annotation env loc name ty annotated_jkind =
-    match get_desc ty with
-    | Tvar { jkind; _ }
-      (* This can be called multiple times (with different variable ids
-         for different levels) for the same location (see internal ticket
-         6461). Therefore, we track the locations instead of using
-         [Jkind.History.has_warned]. *)
-      when not (LocSet.mem loc !warned_imprecise_locs) ->
-      if not (Jkind.equate env jkind annotated_jkind) then begin
-        warned_imprecise_locs := LocSet.add loc !warned_imprecise_locs;
-        let format_jkind jkind =
-          Format_doc.asprintf "%a" !Oprint.out_jkind
-            (Out_type.out_jkind_of_jkind env jkind)
-        in
-        Location.prerr_warning loc
-          (Warnings.Imprecise_kind_annotation {
-            name;
-            annotated = format_jkind annotated_jkind;
-            inferred = format_jkind jkind;
-          })
-      end
-    | _ -> ()
 
   let globalize_used_variables
       { flavor; unbound_variable_policy; _ } env =
@@ -1339,6 +1361,9 @@ and transl_type_var env ~policy ~row_context attrs loc name jkind_annot_opt =
               Invalid_variable_stage {name = print_name;
                                       intro_stage = stage;
                                       usage_stage = Env.stage env}));
+  Option.iter
+    (fun jkind -> TyVarEnv.remember_univar_use name jkind loc)
+    annotated_jkind;
   let jkind_annot =
     match annotated with
     | None -> None

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -135,10 +135,14 @@ val transl_type_scheme:
         Env.t -> Parsetree.core_type -> valdecl_lpoly_flag ->
         Jkind_types.Sort.var list * Typedtree.core_type
 val transl_type_param:
-  Env.t -> Path.t -> jkind_lr -> Parsetree.core_type -> Typedtree.core_type
+  Env.t -> Path.t -> jkind_lr -> Parsetree.core_type ->
+  Typedtree.core_type * jkind_lr option
 (* the Path.t above is of the type/class whose param we are processing;
    the level defaults to the current level. The jkind_lr is the jkind to
-   use if no annotation is provided. *)
+   use if no annotation is provided. Also returns the translation of the
+   parameter's jkind annotation, if there was one, so that callers can
+   compare against it without re-translating (which would re-trigger
+   alerts and other side effects of translation). *)
 
 val get_type_param_jkind: Env.t -> Path.t -> Parsetree.core_type -> jkind_lr
 (* [get_type_param_jkind] is only used in contexts where the jkind will be

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -136,6 +136,11 @@ type t =
   | Degraded_to_partial_match               (* 74 *)
   | Unnecessarily_partial_tuple_pattern     (* 75 *)
   (* Oxcaml specific warnings: numbers should go down from 199 *)
+  | Imprecise_kind_annotation of {
+      name : string;
+      annotated : string;
+      inferred : string;
+    }                                       (* 181 *)
   | Untagged_external_small_int_return      (* 182 *)
   | Redundant_kind_modifier of string       (* 183 *)
   | Ignored_kind_modifier of string * string list (* 184 *)
@@ -145,11 +150,6 @@ type t =
   (* 189 was [Unnecessarily_partial_tuple_pattern], now upstream as 75 *)
   | Probe_name_too_long of string           (* 190 *)
   | Unused_kind_declaration of string       (* 191 *)
-  | Imprecise_kind_annotation of {
-      name : string;
-      annotated : string;
-      inferred : string;
-    }                                       (* 221 *)
   | Zero_alloc_all_hidden_arrow of string   (* 198 *)
   | Unchecked_zero_alloc_attribute          (* 199 *)
   | Unboxing_impossible                     (* 210 *)
@@ -244,6 +244,7 @@ let number = function
   | Unused_tmc_attribute -> 71
   | Tmc_breaks_tailcall -> 72
   | Generative_application_expects_unit -> 73
+  | Imprecise_kind_annotation _ -> 181
   | Untagged_external_small_int_return -> 182
   | Redundant_kind_modifier _ -> 183
   | Ignored_kind_modifier _ -> 184
@@ -254,7 +255,6 @@ let number = function
   | Unerasable_position_argument -> 188 (* 189 is now upstream as 75 *)
   | Probe_name_too_long _ -> 190
   | Unused_kind_declaration _ -> 191
-  | Imprecise_kind_annotation _ -> 221
   | Zero_alloc_all_hidden_arrow _ -> 198
   | Unchecked_zero_alloc_attribute -> 199
   | Unboxing_impossible -> 210
@@ -620,6 +620,10 @@ let descriptions = [
     description = "A tuple pattern ends in .. but fully matches its expected \
                    type.";
     since = since 5 4 };
+  { number = 181;
+    names = ["imprecise-kind-annotation"];
+    description = "A kind annotation is less precise than the inferred kind.";
+    since = since 5 2 };
   { number = 182;
     names = ["untagged-external-small-int-return"];
     description = "An external declaration returns an (int8[@untagged]) or \
@@ -696,10 +700,6 @@ let descriptions = [
   { number = 220;
     names = ["redundant-modality"];
     description = "Modality is redundant with the default.";
-    since = since 5 2 };
-  { number = 221;
-    names = ["imprecise-kind-annotation"];
-    description = "A kind annotation is less precise than the inferred kind.";
     since = since 5 2 };
 ]
 

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -145,6 +145,11 @@ type t =
   (* 189 was [Unnecessarily_partial_tuple_pattern], now upstream as 75 *)
   | Probe_name_too_long of string           (* 190 *)
   | Unused_kind_declaration of string       (* 191 *)
+  | Imprecise_kind_annotation of {
+      name : string;
+      annotated : string;
+      inferred : string;
+    }                                       (* 221 *)
   | Zero_alloc_all_hidden_arrow of string   (* 198 *)
   | Unchecked_zero_alloc_attribute          (* 199 *)
   | Unboxing_impossible                     (* 210 *)
@@ -249,6 +254,7 @@ let number = function
   | Unerasable_position_argument -> 188 (* 189 is now upstream as 75 *)
   | Probe_name_too_long _ -> 190
   | Unused_kind_declaration _ -> 191
+  | Imprecise_kind_annotation _ -> 221
   | Zero_alloc_all_hidden_arrow _ -> 198
   | Unchecked_zero_alloc_attribute -> 199
   | Unboxing_impossible -> 210
@@ -690,6 +696,10 @@ let descriptions = [
   { number = 220;
     names = ["redundant-modality"];
     description = "Modality is redundant with the default.";
+    since = since 5 2 };
+  { number = 221;
+    names = ["imprecise-kind-annotation"];
+    description = "A kind annotation is less precise than the inferred kind.";
     since = since 5 2 };
 ]
 
@@ -1459,6 +1469,12 @@ let message = function
         Style.inline_code name
   | Unused_kind_declaration s ->
       msg "unused kind %a." Style.inline_code s
+  | Imprecise_kind_annotation { name; annotated; inferred } ->
+      msg
+        "The type variable `%s'@ \
+         was annotated with kind `%s'@ \
+         but was inferred to have kind `%s'."
+        name annotated inferred
   | Zero_alloc_all_hidden_arrow s ->
       msg "The type of this item is an@ alias of a function type,@ \
            but the %a attribute for@ this signature does not apply to it@ \

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -140,6 +140,11 @@ type t =
   | Degraded_to_partial_match               (* 74 *)
   | Unnecessarily_partial_tuple_pattern     (* 75 *)
 (* Oxcaml specific warnings: numbers should go down from 199 *)
+  | Imprecise_kind_annotation of {
+      name : string;
+      annotated : string;
+      inferred : string;
+    }                                       (* 181 *)
   | Untagged_external_small_int_return      (* 182 *)
   | Redundant_kind_modifier of string       (* 183 *)
   | Ignored_kind_modifier of string * string list (* 184 *)
@@ -149,11 +154,6 @@ type t =
   (* 189 was [Unnecessarily_partial_tuple_pattern], now upstream as 75 *)
   | Probe_name_too_long of string           (* 190 *)
   | Unused_kind_declaration of string       (* 191 *)
-  | Imprecise_kind_annotation of {
-      name : string;
-      annotated : string;
-      inferred : string;
-    }                                       (* 221 *)
   | Zero_alloc_all_hidden_arrow of string   (* 198 *)
   | Unchecked_zero_alloc_attribute          (* 199 *)
   | Unboxing_impossible                     (* 210 *)

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -149,6 +149,11 @@ type t =
   (* 189 was [Unnecessarily_partial_tuple_pattern], now upstream as 75 *)
   | Probe_name_too_long of string           (* 190 *)
   | Unused_kind_declaration of string       (* 191 *)
+  | Imprecise_kind_annotation of {
+      name : string;
+      annotated : string;
+      inferred : string;
+    }                                       (* 221 *)
   | Zero_alloc_all_hidden_arrow of string   (* 198 *)
   | Unchecked_zero_alloc_attribute          (* 199 *)
   | Unboxing_impossible                     (* 210 *)


### PR DESCRIPTION
Title. Warn each time a type variable ends up with a jkind different from its annotation. Works on annotations on both type and value declarations, in both signatures and structures. Example warnings:

```ocaml
(* Annotation says 'value' but type constructor requires 'immediate' *)
module type S1 = sig
  type ('a : immediate) imm_t
  type ('a : value) t = 'a imm_t
end
[%%expect{|
Line 3, characters 8-18:
3 |   type ('a : value) t = 'a imm_t
            ^^^^^^^^^^
Warning 191 [imprecise-kind-annotation]: the kind annotation on 'a is imprecise.
Annotated kind: value
Inferred kind: immediate
```

```ocaml
(* First annotation says 'value', second says 'immediate' *)
module type S3 = sig
  val f : ('a : value) -> ('a : immediate) -> unit
end
[%%expect{|
Line 2, characters 10-22:
2 |   val f : ('a : value) -> ('a : immediate) -> unit
              ^^^^^^^^^^^^
Warning 191 [imprecise-kind-annotation]: the kind annotation on 'a is imprecise.
Annotated kind: value
Inferred kind: immediate

module type S3 = sig val f : ('a : immediate). 'a -> 'a -> unit end
|}]
```

Track whether in `typetexp.ml` and `typedecl.ml`. Note that this check is only enabled for variables, `int : value` and other annotations won't trigger anything. A variable unified with `int` also does not raise any checks. Maybe this behavior is wrong, but for now it's consistent with implicit jkinds. 

Update array tests to use `any mod separable`. Promote other tests. I thought about disabling the warning in some of them, but I find it makes the output more informative, so I'm fine with the changes.

Enabling this by default will require marking a lot of places in the tree as disabling this warning. I think that's good, and we should go over and fix them later.