### PR TITLE
Backport (#13487) "Add Format_doc.deprecated{,1} to ease transformations from Format to Format_doc by users of compiler-libs"

### DIFF
--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -182,19 +182,19 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                 (fun x -> Oval_int64 (O.obj x : int64)) ))
     ] : (Path.t * printer) list)
 
-    let exn_printer ppf path exn =
+    let exn_printer path ppf exn =
       Format_doc.fprintf ppf "<printer %a raised an exception: %s>"
         Printtyp.path path
         (Printexc.to_string exn)
 
     let out_exn path exn =
-      Oval_printer (fun ppf -> exn_printer ppf path exn)
+      Oval_printer (fun ppf -> exn_printer path ppf exn)
 
     let user_printer path f ppf x =
       Format_doc.deprecated_printer
         (fun ppf ->
            try f ppf x with
-           | exn -> Format_doc.compat (fun ppf -> exn_printer ppf path) ppf exn
+           | exn -> Format_doc.compat1 exn_printer path ppf exn
         )
         ppf
 

--- a/typing/includeclass.ml
+++ b/typing/includeclass.ml
@@ -110,4 +110,4 @@ let report_error_doc mode ppf = function
         List.iter (fun err -> fprintf ppf "@ %a" (include_err mode) err) errs in
       fprintf ppf "@[<v>%a%a@]" (include_err mode) err print_errs errs
 
-let report_error mode = Format_doc.compat (report_error_doc mode)
+let report_error = Format_doc.compat1 report_error_doc

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1840,4 +1840,4 @@ let () =
         None
     )
 
-let report_error env = Format_doc.compat (report_error_doc env)
+let report_error = Format_doc.compat1 report_error_doc

--- a/utils/format_doc.ml
+++ b/utils/format_doc.ml
@@ -491,3 +491,7 @@ let pp_two_columns ?(sep = "|") ?max_lines ppf (lines: (string * string) list) =
   fprintf ppf "@]"
 
 let deprecated_printer pr ppf = ppf := Doc.add !ppf (Doc.Deprecated pr)
+let deprecated pr ppf x =
+  ppf := Doc.add !ppf (Doc.Deprecated (fun ppf -> pr ppf x))
+let deprecated1 pr p1 ppf x =
+  ppf := Doc.add !ppf (Doc.Deprecated (fun ppf -> pr p1 ppf x))

--- a/utils/format_doc.mli
+++ b/utils/format_doc.mli
@@ -167,6 +167,8 @@ val compat2: ('p1 -> 'p2 -> 'a printer) -> ('p1 -> 'p2 -> 'a format_printer)
 (** If necessary, embbed a {!Format} printer inside a formatting instruction
     stream. This breaks every guarantees provided by {!Format_doc}. *)
 val deprecated_printer: (Format.formatter -> unit) -> formatter -> unit
+val deprecated: 'a format_printer -> 'a printer
+val deprecated1: ('p1 -> 'a format_printer) -> ('p1 -> 'a printer)
 
 
 (** {2 Format string interpreters }*)


### PR DESCRIPTION
Clean commit, no changes necessary.