### PR TITLE
Disable the fallback inlining heuristic in classic mode

### DIFF
--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -304,7 +304,6 @@ module Flambda2 = struct
 
     let oclassic = {
       default with
-      fallback_inlining_heuristic = true;
       shorten_symbol_names = true;
     }
 


### PR DESCRIPTION
Classic mode currently enables the "fallback inlining heuristic", which prevents inlining of functions containing other functions.  This was originally implemented to keep the amount of inlining done by classic mode comparable to that performed by the upstream Closure middle end.  At this point, however, it seems reasonable to remove the restriction.  People hit confusing errors caused by this relatively frequently, and it will allow various patterns to be optimized more effectively.  There will be more inlining, but I think not that much more.