### PR TITLE
Fix simplify terminator bug (non-empty `arg` for `Always`)

### DIFF
--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -50,8 +50,8 @@ let simplify_switch (block : C.basic_block) labels =
   match labels_with_counts with
   | [(l, _)] ->
     (* All labels are the same and equal to l *)
-    block.terminator <-
-      { block.terminator with desc = Always l; arg = [||]; res = [||] }
+    block.terminator
+      <- { block.terminator with desc = Always l; arg = [||]; res = [||] }
   | [(l0, n); (ln, k)] ->
     assert (Label.equal labels.(0) l0);
     assert (Label.equal labels.(n) ln);
@@ -274,8 +274,8 @@ let block_known_values (block : C.basic_block) ~(is_after_regalloc : bool)
     match evaluate_terminator known_values block.terminator with
     | None -> false
     | Some succ ->
-      block.terminator <-
-        { block.terminator with desc = Always succ; arg = [||]; res = [||] };
+      block.terminator
+        <- { block.terminator with desc = Always succ; arg = [||]; res = [||] };
       true)
   else false
 
@@ -321,7 +321,11 @@ let block (cfg : C.t) (block : C.basic_block) : bool =
       match new_successor with
       | Some succ ->
         block.terminator
-          <- { block.terminator with desc = Always succ; arg = [||]; res = [||] };
+          <- { block.terminator with
+               desc = Always succ;
+               arg = [||];
+               res = [||]
+             };
         true
       | None -> (
         if


### PR DESCRIPTION
As per title. This was spotted while working on #5388.
I think the only consequence is a live  range slightly
longer than it should, but we should nevertheless merge
the fix sooner than later.