### PR TITLE
Remove overzealous AS check for the dissector

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -753,8 +753,7 @@ AC_ARG_ENABLE([multidomain],
 AC_ARG_ENABLE([assembler-suitable-for-dissector],
   [AS_HELP_STRING([--enable-assembler-suitable-for-dissector@<:@=PATH@:>@],
     [Use LLVM assembler with large code mode for dissector. If PATH is not
-     specified, llvm-mc must be on the PATH.  Overrides any setting of AS,
-     but only when '-dissector' is specified])])
+     specified, llvm-mc must be on PATH.  Overrides any setting of AS])])
 
 AC_ARG_WITH([flexdll],
   [AS_HELP_STRING([--with-flexdll],


### PR DESCRIPTION
The check which complains if `AS` is set when using the special "dissector for the assembler" option is overzealous, and causes problems in certain build environments.  I think it can reasonably be suppressed with a minor adjustment to the help text.