### PR TITLE
Add `-kind-verbosity` flag

### DIFF
--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -656,6 +656,11 @@ let mk_no_verbose_types f =
   "-no-verbose-types", Arg.Unit f,
   " Omit expert information within types (default)"
 
+let mk_kind_verbosity f =
+  "-kind-verbosity", Arg.Int f,
+  "<n>  Set the verbosity used for printing kinds (0=not verbose, \
+   1=expanded, 2=expanded with all mod bounds)"
+
 let mk_version f =
   "-version", Arg.Unit f, " Print version and exit"
 
@@ -1112,6 +1117,7 @@ module type Common_options = sig
   val _dump_debug_uid_tables : unit -> unit
   val _verbose_types : unit -> unit
   val _no_verbose_types : unit -> unit
+  val _kind_verbosity : int -> unit
   val _version : unit -> unit
   val _vnum : unit -> unit
   val _w : string -> unit
@@ -1494,6 +1500,7 @@ struct
     mk_verbose F._verbose;
     mk_verbose_types F._verbose_types;
     mk_no_verbose_types F._no_verbose_types;
+    mk_kind_verbosity F._kind_verbosity;
     mk_version F._version;
     mk__version F._version;
     mk_vmthread F._vmthread;
@@ -1593,6 +1600,7 @@ struct
     mk_unsafe F._unsafe;
     mk_verbose_types F._verbose_types;
     mk_no_verbose_types F._no_verbose_types;
+    mk_kind_verbosity F._kind_verbosity;
     mk_version F._version;
     mk__version F._version;
     mk_no_version F._no_version;
@@ -1763,6 +1771,7 @@ struct
     mk_verbose F._verbose;
     mk_verbose_types F._verbose_types;
     mk_no_verbose_types F._no_verbose_types;
+    mk_kind_verbosity F._kind_verbosity;
     mk_version F._version;
     mk__version F._version;
     mk_vnum F._vnum;
@@ -1914,6 +1923,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_verbose F._verbose;
     mk_verbose_types F._verbose_types;
     mk_no_verbose_types F._no_verbose_types;
+    mk_kind_verbosity F._kind_verbosity;
     mk_version F._version;
     mk__version F._version;
     mk_no_version F._no_version;
@@ -2049,6 +2059,7 @@ struct
     mk_verbose F._verbose;
     mk_verbose_types F._verbose_types;
     mk_no_verbose_types F._no_verbose_types;
+    mk_kind_verbosity F._kind_verbosity;
     mk_version F._version;
     mk__version F._version;
     mk_vnum F._vnum;
@@ -2166,6 +2177,7 @@ struct
     mk_verbose F._verbose;
     mk_verbose_types F._verbose_types;
     mk_no_verbose_types F._no_verbose_types;
+    mk_kind_verbosity F._kind_verbosity;
     mk_version F._version;
     mk__version F._version;
     mk_vmthread F._vmthread;
@@ -2270,6 +2282,7 @@ module Default = struct
     let _dump_debug_uids = set dump_debug_uids
     let _dump_debug_uid_tables = set dump_debug_uid_tables
     let _verbose_types = set verbose_types
+    let _kind_verbosity n = Clflags.kind_verbosity := n
     let _w s =
       Warnings.parse_options false s |> Option.iter Location.(prerr_alert none)
     let _debug_ocaml = set debug_ocaml

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -60,6 +60,7 @@ module type Common_options = sig
   val _dump_debug_uid_tables : unit -> unit
   val _verbose_types : unit -> unit
   val _no_verbose_types : unit -> unit
+  val _kind_verbosity : int -> unit
   val _version : unit -> unit
   val _vnum : unit -> unit
   val _w : string -> unit

--- a/testsuite/tests/typing-jkind-bounds/verbosity/verbosity0.ml
+++ b/testsuite/tests/typing-jkind-bounds/verbosity/verbosity0.ml
@@ -1,0 +1,44 @@
+(* TEST
+ flags = "-kind-verbosity 0";
+ expect;
+*)
+
+type t : value
+[%%expect {|
+type t
+|}]
+
+type t : immutable_data
+[%%expect {|
+type t : immutable_data
+|}]
+
+type t : immediate
+[%%expect {|
+type t : immediate
+|}]
+
+type t : float64
+[%%expect {|
+type t : float64
+|}]
+
+type t : any
+[%%expect {|
+type t : any
+|}]
+
+type t : value mod portable
+[%%expect {|
+type t : value mod portable
+|}]
+
+type t : value mod stateless
+[%%expect {|
+type t : value mod stateless
+|}]
+
+type 'a t : immutable_data with 'a
+[%%expect {|
+type 'a t : immutable_data with 'a
+|}]

--- a/testsuite/tests/typing-jkind-bounds/verbosity/verbosity1.ml
+++ b/testsuite/tests/typing-jkind-bounds/verbosity/verbosity1.ml
@@ -1,0 +1,45 @@
+(* TEST
+ flags = "-kind-verbosity 1";
+ expect;
+*)
+
+type t : value
+[%%expect {|
+type t
+|}]
+
+type t : immutable_data
+[%%expect {|
+type t : value mod forkable unyielding many stateless immutable non_float
+|}]
+
+type t : immediate
+[%%expect {|
+type t : value mod global many stateless immutable external_ non_float
+|}]
+
+type t : float64
+[%%expect {|
+type t : float64 mod external_ non_float
+|}]
+
+type t : any
+[%%expect {|
+type t : any
+|}]
+
+type t : value mod portable
+[%%expect {|
+type t : value mod portable
+|}]
+
+type t : value mod stateless
+[%%expect {|
+type t : value mod stateless
+|}]
+
+type 'a t : immutable_data with 'a
+[%%expect {|
+type 'a t
+  : value mod forkable unyielding many stateless immutable non_float with 'a
+|}]

--- a/testsuite/tests/typing-jkind-bounds/verbosity/verbosity2.ml
+++ b/testsuite/tests/typing-jkind-bounds/verbosity/verbosity2.ml
@@ -1,0 +1,68 @@
+(* TEST
+ flags = "-kind-verbosity 2";
+ expect;
+*)
+
+(* CR: We're failing to display top modal bounds and implied modal bounds. *)
+
+(* CR: We should show non-top modal bounds first. *)
+
+type t : value
+[%%expect {|
+type t
+|}]
+
+type t : immutable_data
+[%%expect {|
+type t
+  : value
+      mod forkable
+          unyielding
+          many
+          stateless
+          immutable
+          internal
+          non_null
+          non_float
+|}]
+
+type t : immediate
+[%%expect {|
+type t
+  : value mod global many stateless immutable external_ non_null non_float
+|}]
+
+type t : float64
+[%%expect {|
+type t : float64 mod external_ non_null non_float
+|}]
+
+type t : any
+[%%expect {|
+type t : any mod internal maybe_null maybe_separable
+|}]
+
+type t : value mod portable
+[%%expect {|
+type t : value mod portable internal non_null separable
+|}]
+
+type t : value mod stateless
+[%%expect {|
+type t : value mod stateless internal non_null separable
+|}]
+
+type 'a t : immutable_data with 'a
+[%%expect {|
+type 'a t
+  : value
+      mod forkable
+          unyielding
+          many
+          stateless
+          immutable
+          internal
+          non_null
+          non_float
+      with 'a
+|}]

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1067,6 +1067,14 @@ module Format_verbosity = struct
     | Not_verbose
     | Expanded
     | Expanded_with_all_mod_bounds
+
+  let default () =
+    match !Clflags.kind_verbosity with
+    | 0 -> Not_verbose
+    | 1 -> Expanded
+    | n ->
+      if n < 0 then failwith "Expected non-negative kind verbosity level";
+      Expanded_with_all_mod_bounds
 end
 
 module Const = struct
@@ -1314,7 +1322,7 @@ module Const = struct
   end
 
   let to_out_jkind_const jkind =
-    To_out_jkind_const.convert ~verbosity:Not_verbose jkind
+    To_out_jkind_const.convert ~verbosity:(Format_verbosity.default ()) jkind
 
   let format ~verbosity ppf jkind =
     To_out_jkind_const.convert ~verbosity jkind |> !Oprint.out_jkind_const ppf
@@ -1984,7 +1992,8 @@ let decompose_product ({ jkind; _ } as jk) =
 let format_verbose ~verbosity ppf jkind =
   Desc.format_verbose ~verbosity ppf (Jkind_desc.get jkind.jkind)
 
-let format ppf jkind = format_verbose ~verbosity:Not_verbose ppf jkind
+let format ppf jkind =
+  format_verbose ~verbosity:(Format_verbosity.default ()) ppf jkind
 
 let printtyp_path = ref (fun _ _ -> assert false)
 

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -261,6 +261,8 @@ let afl_inst_ratio = ref 100           (* -afl-inst-ratio *)
 let function_sections = ref false      (* -function-sections *)
 let probes = ref Config.probes         (* -probes *)
 
+let kind_verbosity = ref 0             (* -kind-verbosity *)
+
 let supports_optimized_probes =
   Config.probes
   && match Target_system.architecture () with

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -246,6 +246,7 @@ val afl_instrument : bool ref
 val afl_inst_ratio : int ref
 val function_sections : bool ref
 val probes : bool ref
+val kind_verbosity : int ref
 val emit_optimized_probes : bool ref
 val supports_optimized_probes : bool
 


### PR DESCRIPTION
Add a flag to allow increasing the verbosity of kinds printed in error messages, etc. I don't expect anyone will really use this flag. My motivation is only for testing the verbosity logic in kind printing, which is used by Merlin.

One of the tests demonstrates a bug in the current printing. I plan to make another PR shortly to address this.