### PR TITLE
Always emit compilation unit die

### DIFF
--- a/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf.ml
@@ -27,6 +27,11 @@ type t =
   { state : DS.t;
     asm_directives : Asm_directives_dwarf.t;
     get_file_id : string -> int;
+    (* [None] when [restrict_to_upstream_dwarf] is set (i.e. only [-g]), since
+       then the CU does not need a fallback type DIE. [Some] when full DWARF is
+       enabled ([-gno-upstream-dwarf]), in which case it is used as the fallback
+       type for variables whose type cannot be determined. *)
+    value_type_proto_die : Proto_die.t option;
     mutable emitted : bool;
     mutable emitted_delayed : bool
   }
@@ -49,12 +54,17 @@ let create ~sourcefile ~unit_name ~asm_directives ~get_file_id ~code_layout =
   in
   let compilation_unit_header_label = Asm_label.create (DWARF Debug_info) in
   let value_type_proto_die =
-    Proto_die.create ~parent:(Some compilation_unit_proto_die) ~tag:Base_type
-      ~attribute_values:
-        [ DAH.create_name "ocaml_value";
-          DAH.create_encoding ~encoding:Encoding_attribute.signed;
-          DAH.create_byte_size_exn ~byte_size:Arch.size_addr ]
-      ()
+    if !Dwarf_flags.restrict_to_upstream_dwarf
+    then None
+    else
+      Some
+        (Proto_die.create ~parent:(Some compilation_unit_proto_die)
+           ~tag:Base_type
+           ~attribute_values:
+             [ DAH.create_name "ocaml_value";
+               DAH.create_encoding ~encoding:Encoding_attribute.signed;
+               DAH.create_byte_size_exn ~byte_size:Arch.size_addr ]
+           ())
   in
   let debug_loc_table = Debug_loc_table.create () in
   let debug_ranges_table = Debug_ranges_table.create () in
@@ -62,13 +72,14 @@ let create ~sourcefile ~unit_name ~asm_directives ~get_file_id ~code_layout =
   let location_list_table = Location_list_table.create () in
   let state =
     DS.create ~compilation_unit_header_label ~compilation_unit_proto_die
-      ~value_type_proto_die ~code_layout debug_loc_table debug_ranges_table
-      address_table location_list_table ~get_file_num:get_file_id ~sourcefile
+      ~code_layout debug_loc_table debug_ranges_table address_table
+      location_list_table ~get_file_num:get_file_id ~sourcefile
     (* CR mshinwell: does get_file_id successfully emit .file directives for
        files we haven't seen before? *)
   in
   { state;
     asm_directives;
+    value_type_proto_die;
     emitted = false;
     emitted_delayed = false;
     get_file_id
@@ -105,8 +116,8 @@ let dwarf_for_fundecl t fundecl ~fun_end_label ~ppf_dump =
         (fun fundecl -> Inlined_frame_ranges.create ~ppf_dump fundecl)
         ~accumulate:true fundecl
     in
-    Dwarf_concrete_instances.for_fundecl ~get_file_id:t.get_file_id t.state
-      fundecl
+    Dwarf_concrete_instances.for_fundecl ~get_file_id:t.get_file_id
+      ~value_type_proto_die:t.value_type_proto_die t.state fundecl
       ~fun_end_label:(Asm_label.create_int Text (fun_end_label |> Label.to_int))
       available_ranges_vars inlined_frame_ranges;
     { fun_end_label; fundecl }

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
@@ -21,8 +21,8 @@ module DAH = Dwarf_attribute_helpers
 module DS = Dwarf_state
 module L = Linear
 
-let for_fundecl ~get_file_id state (fundecl : L.fundecl) ~fun_end_label
-    available_ranges_vars inlined_frame_ranges =
+let for_fundecl ~get_file_id ~value_type_proto_die state (fundecl : L.fundecl)
+    ~fun_end_label available_ranges_vars inlined_frame_ranges =
   let parent = Dwarf_state.compilation_unit_proto_die state in
   let fun_name = fundecl.fun_name in
   let loc = Debuginfo.to_location fundecl.fun_dbg in
@@ -78,13 +78,16 @@ let for_fundecl ~get_file_id state (fundecl : L.fundecl) ~fun_end_label
           ~function_proto_die:concrete_instance_proto_die inlined_frame_ranges)
       ~accumulate:true ()
   in
-  if not !Dwarf_flags.restrict_to_upstream_dwarf
-  then
+  (match value_type_proto_die with
+  | None -> ()
+  | Some value_type_proto_die ->
+    assert (not !Dwarf_flags.restrict_to_upstream_dwarf);
     Profile.record "dwarf_variables_and_parameters"
       (fun () ->
-        Dwarf_variables_and_parameters.dwarf state ~function_symbol:start_sym
+        Dwarf_variables_and_parameters.dwarf state ~value_type_proto_die
+          ~function_symbol:start_sym
           ~function_proto_die:concrete_instance_proto_die available_ranges_vars)
-      ~accumulate:true ();
+      ~accumulate:true ());
   (* CR mshinwell: When cross-referencing of DIEs across files is necessary we
      need to be careful about symbol table size. let name = Printf.sprintf
      "__concrete_instance_%s" fun_name in Proto_die.set_name

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.mli
@@ -14,6 +14,7 @@
 
 val for_fundecl :
   get_file_id:(string -> int) ->
+  value_type_proto_die:Dwarf_high.Proto_die.t option ->
   Dwarf_state.t ->
   Linear.fundecl ->
   fun_end_label:Asm_targets.Asm_label.t ->

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_state.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_state.ml
@@ -53,7 +53,6 @@ end
 type t =
   { compilation_unit_header_label : Asm_label.t;
     compilation_unit_proto_die : Proto_die.t;
-    value_type_proto_die : Proto_die.t;
     code_layout : code_layout;
     debug_loc_table : Debug_loc_table.t;
     debug_ranges_table : Debug_ranges_table.t;
@@ -68,11 +67,10 @@ type t =
   }
 
 let create ~compilation_unit_header_label ~compilation_unit_proto_die
-    ~value_type_proto_die ~code_layout debug_loc_table debug_ranges_table
-    address_table location_list_table ~get_file_num ~sourcefile =
+    ~code_layout debug_loc_table debug_ranges_table address_table
+    location_list_table ~get_file_num ~sourcefile =
   { compilation_unit_header_label;
     compilation_unit_proto_die;
-    value_type_proto_die;
     code_layout;
     debug_loc_table;
     debug_ranges_table;
@@ -89,8 +87,6 @@ let create ~compilation_unit_header_label ~compilation_unit_proto_die
 let compilation_unit_header_label t = t.compilation_unit_header_label
 
 let compilation_unit_proto_die t = t.compilation_unit_proto_die
-
-let value_type_proto_die t = t.value_type_proto_die
 
 let debug_loc_table t = t.debug_loc_table
 

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_state.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_state.mli
@@ -56,7 +56,6 @@ type t
 val create :
   compilation_unit_header_label:Asm_label.t ->
   compilation_unit_proto_die:Proto_die.t ->
-  value_type_proto_die:Proto_die.t ->
   code_layout:code_layout ->
   Debug_loc_table.t ->
   Debug_ranges_table.t ->
@@ -69,8 +68,6 @@ val create :
 val compilation_unit_header_label : t -> Asm_label.t
 
 val compilation_unit_proto_die : t -> Proto_die.t
-
-val value_type_proto_die : t -> Proto_die.t
 
 val debug_loc_table : t -> Debug_loc_table.t
 

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
@@ -1545,10 +1545,9 @@ let runtime_shape_to_dwarf_die_with_aliased_name (type_name : string)
     create_typedef_die ~reference ~name:full_name ~parent_proto_die unnamed_die;
     reference
 
-let variable_to_die state (var_uid : Uid.t) ~parent_proto_die =
-  let fallback_value_die =
-    Proto_die.reference (DS.value_type_proto_die state)
-  in
+let variable_to_die state ~value_type_proto_die (var_uid : Uid.t)
+    ~parent_proto_die =
+  let fallback_value_die = Proto_die.reference value_type_proto_die in
   (* Once we reach the backend, layouts such as Product [Product [Bits64;
      Bits64]; Float64] have de facto been flattened into a sequence of base
      layouts [Bits64; Bits64; Float64]. Below, we compute the index into the

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_type.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_type.mli
@@ -19,4 +19,8 @@ open! Dwarf_high
 module Uid = Flambda2_identifiers.Flambda_debug_uid
 
 val variable_to_die :
-  Dwarf_state.t -> Uid.t -> parent_proto_die:Proto_die.t -> Proto_die.reference
+  Dwarf_state.t ->
+  value_type_proto_die:Proto_die.t ->
+  Uid.t ->
+  parent_proto_die:Proto_die.t ->
+  Proto_die.reference

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_variables_and_parameters.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_variables_and_parameters.mli
@@ -26,6 +26,7 @@ val normal_type_for_var :
 
 val dwarf :
   Dwarf_state.t ->
+  value_type_proto_die:Proto_die.t ->
   function_symbol:Asm_targets.Asm_symbol.t ->
   function_proto_die:Proto_die.t ->
   Available_ranges_vars.t ->

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -479,12 +479,7 @@ module Dwarf_helpers = struct
 
   let init ~ppf_dump ~disable_dwarf ~sourcefile =
     reset_dwarf ppf_dump;
-    let can_emit_dwarf =
-      !Clflags.debug
-      && ((not !Dwarf_flags.restrict_to_upstream_dwarf)
-         || !Dwarf_flags.dwarf_inlined_frames)
-      && not disable_dwarf
-    in
+    let can_emit_dwarf = !Clflags.debug && not disable_dwarf in
     match
       ( can_emit_dwarf,
         Target_system.architecture (),


### PR DESCRIPTION
Currently, the compiler only emits compilation unit dies into the DWARF in the binary when `-gno-upstream-dwarf` is specified. For regular `-g`, it relies on the assembler to create a compilation unit entry. This PR changes the behavior to always emit the compilation unit. 

To always emit a compilation unit, this PR has to change the behavior of `-gno-upstream-dwarf`: it now only controls whether we produce the debug information for function declarations (including variable information), and the code for creating compilation units runs only guarded by `-g`. 

**.debug_aranges** As far as I can tell, there is one potentially significant difference between auto-generated compilation units and the ones we produce now: the ones we produce now are missing the `.debug_aranges` section. 