### PR TITLE
Tweak regalloc CI step to test bit matrix (IRC allocator)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -437,6 +437,8 @@ jobs:
             ./_build/main/tools/regalloc/regalloc.exe _build \
               -validate -summary -regalloc $allocator || exit 1; \
           done
+          ./_build/main/tools/regalloc/regalloc.exe _build \
+            -validate -summary -regalloc irc -param BIT_MATRIX_THRESHOLD:8192
           for allocator in irc ls gi; do \
             ./_build/main/tools/regalloc/regalloc.exe _build \
               -validate -insert-prologue -regalloc $allocator || exit 1; \


### PR DESCRIPTION
As per title; to ensure that bit matrix is actually tested by the CI.