### PR TITLE
Use prefetchr instead of prefetchw in the major GC

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -330,9 +330,14 @@ Caml_inline void prefetch_block(value v)
      already marked, not markable, or extremely short, then we waste
      somewhere between 1/8-1/2 of a prefetch operation (in expectation,
      depending on alignment, word size, and cache line size), which is
-     cheap enough to make this worthwhile. */
-  caml_prefetchw((const void *)Hp_val(v));
-  caml_prefetchw((const void *)&Field(v, 3));
+     cheap enough to make this worthwhile.
+
+     The prefetches are prefetchr (read), not prefetchw (write). The
+     major GC often writes mark bits but is readonly if no marking
+     need be done (because a block is already marked, or statically
+     allocated). In such cases, a prefetchw causes contention. */
+  caml_prefetchr((const void *)Hp_val(v));
+  caml_prefetchr((const void *)&Field(v, 3));
 }
 
 static void ephe_next_cycle (void)


### PR DESCRIPTION
The major GC is using the wrong prefetch type, doing a prefetch for write when it should do a prefetch for read.

This doesn't make any difference on amd64 at the moment, since our C compiler settings currently generate code compatible with old x86_64 boxes that didn't support `prefetchw`, so we currently generate the same instruction for both `caml_prefetchr` and `caml_prefetchw`. However, I'd like to fix this so that we don't start generating `prefetchw` in the major GC when we reconfigure the C compiler.

The reason it's better to use a read prefetch is that many major GC accesses are readonly, if the object happens to be already marked or not markable (static, etc.). If you do a prefetchw in such cases, you take an exclusive lock on the cacheline, which means multiple domains that refer to the same object become sequentialised. (The converse penalty, of doing a prefetchr and then needing to upgrade it to a write because you're modifying the data, is less costly because it happens asynchronously).

In the simple program that makes many binary trees that refer to the same string and does a few GCs in multiple domains, using `prefetchw` made the program go more than 2x slower:
```ocaml
type tree =
  | Leaf of string
  | Br of tree * string * tree

let rec make n s =
  if n <= 0 then Leaf s
  else Br (make (n-1) s, s, make (n-2) s)

let stop = Atomic.make false

let go counter str =
  let t = make 28 str in
  Atomic.incr counter;
  while not (Atomic.get stop) do Sys.poll_actions () done;
  ignore (Sys.opaque_identity t)

let () =
  let counter = Atomic.make 0 in
  let str = String.make 10 'j' in
  let n = 8 in
  let ds = List.init n (fun _ -> (Domain.Safe.spawn[@alert "-do_not_spawn_domains"]) (fun () -> go counter str)) in
  while Atomic.get counter < n do Sys.poll_actions () done;
  for i = 1 to 10 do
    Gc.full_major ();
    print_endline "gc"
  done;
  Atomic.set stop true;
  List.iter Domain.join ds
```