### PR TITLE
Optimize `Sort.set` to avoid allocation

### DIFF
--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -332,11 +332,14 @@ module Sort = struct
       log_change (u, Clevel u.level);
       u.level <- new_level)
 
-  let set : var -> t option -> unit =
+  let[@inline] set : var -> t option -> unit =
    fun v t_op ->
     log_change (v, Ccontents v.contents);
     v.contents <- t_op;
-    Option.iter (t_iter ~f:(fun u -> update_level u v)) t_op
+    (* avoid allocating closure *)
+    match t_op with
+    | None -> ()
+    | Some t -> t_iter ~f:(fun u -> update_level u v) t
 
   module Static = struct
     (* Statically allocated values of various consts and sorts to save


### PR DESCRIPTION
What the title says. The original code might be attempting to reduce allocation, but note that to deal with the `t option` it had to allocate a closure, which is removed in this PR. Therefore, this PR probably doesn't worsen the allocation behavior, while providing a more correct interface, and removes lots of code.