### PR TITLE
Ensure `requested_external_interrupt` is initialized before reading

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -671,7 +671,8 @@ static void domain_create(uintnat initial_minor_heap_wsize,
   domain_state->unique_id = d->unique_id;
   domain_state->requested_external_interrupt = 0;
 
-  /* Synchronized with [caml_interrupt_all_signal_safe], so that the
+  /* Synchronized with [caml_interrupt_all_signal_safe] and
+     [caml_external_interrupt_all_signal_safe], so that the
      initializing writes of young_limit and requested_external_interrupt happen
      before any interrupt.
   */


### PR DESCRIPTION
Fix a potential race in `caml_external_interrupt_all_signal_safe`, by making sure that the `requested_external_interrupt` field is initialized *before* `caml_external_interrupt_all_signal_safe` has a chance to write to it (it doesn't write to it if `interrupt_word` is NULL, which gives us somewhere to fence the store behind).

I have not observed this race happen in practice (it seems quite hard to trigger; you'd need to be spawning a new domain at the same time `caml_external_interrupt_all_signal_safe` is called); I just found it by reading the code.