### PR TITLE
Fix types for degraded value slots

### DIFF
--- a/middle_end/flambda2/simplify/simplify_set_of_closures_context.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures_context.ml
@@ -76,7 +76,7 @@ let compute_value_slot_types_inside_function ~value_slot_types
       let type_prior_to_sets =
         (* See comment below about [degraded_value_slots]. *)
         if Value_slot.Set.mem value_slot degraded_value_slots
-        then T.any_value
+        then T.unknown (Value_slot.kind value_slot)
         else type_prior_to_sets
       in
       type_prior_to_sets)


### PR DESCRIPTION
The code for degraded value slots only worked for slots of kind `Value`. This PR fixes it to work with degraded variables of any kind.

Note that there is a comment about degraded variables claiming that we need them because we cannot know the kind of these variables (as we don't have access to the corresponding cmx file). This is not true anymore, as all variables carry their kind, so we should be able to get rid of degraded variables completely. This is not done in this PR.