### PR TITLE
Revert "Disable the fallback inlining heuristic in classic mode"

### DIFF
--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -306,6 +306,7 @@ module Flambda2 = struct
 
     let oclassic = {
       default with
+      fallback_inlining_heuristic = true;
       shorten_symbol_names = true;
     }
 


### PR DESCRIPTION
Reverts oxcaml/oxcaml#5383 since it seems to cause zero_alloc failures