### PR TITLE
Redundant modifier warning

### DIFF
--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -170,7 +170,7 @@ type t17b : value & value
 |}]
 
 type ('a : value mod external_ stateless many unyielding non_float) t18 =
-  ('a : value mod immutable global aliased)
+  ('a : value mod immutable global)
 [%%expect{|
 type ('a : value mod everything non_float) t18 = 'a
 |}]
@@ -1348,15 +1348,15 @@ type existential_abstract =
 |}]
 
 module M : sig
-  kind_ immediate = value mod global many uncontended
-  kind_ immutable_data = value mod uncontended many
-  kind_ immutable = value mod uncontended
+  kind_ immediate = value mod global many
+  kind_ immutable_data = value mod many
+  kind_ immutable = value
   kind_ data = value mod many
   kind_ abstract
 end = struct
-  kind_ immediate = value mod global many uncontended
-  kind_ immutable_data = value mod uncontended many
-  kind_ immutable = value mod uncontended
+  kind_ immediate = value mod global many
+  kind_ immutable_data = value mod many
+  kind_ immutable = value
   kind_ data = value mod many
   kind_ abstract
 end

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -170,7 +170,7 @@ type t17b : value & value
 |}]
 
 type ('a : value mod external_ stateless many unyielding non_float) t18 =
-  ('a : value mod immutable global aliased)
+  ('a : value mod immutable global)
 [%%expect{|
 type ('a : value mod everything non_float) t18 = 'a
 |}]
@@ -1347,15 +1347,15 @@ type existential_abstract =
 |}]
 
 module M : sig
-  kind_ immediate = value mod global many uncontended
-  kind_ immutable_data = value mod uncontended many
-  kind_ immutable = value mod uncontended
+  kind_ immediate = value mod global many
+  kind_ immutable_data = value mod many
+  kind_ immutable = value
   kind_ data = value mod many
   kind_ abstract
 end = struct
-  kind_ immediate = value mod global many uncontended
-  kind_ immutable_data = value mod uncontended many
-  kind_ immutable = value mod uncontended
+  kind_ immediate = value mod global many
+  kind_ immutable_data = value mod many
+  kind_ immutable = value
   kind_ data = value mod many
   kind_ abstract
 end

--- a/testsuite/tests/typing-jkind-bounds/annots.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots.ml
@@ -206,7 +206,7 @@ Error: Unrecognized modifier fizzbuzz.
 let x : int as ('a: value) = 5
 let x : int as ('a : immediate) = 5
 let x : int as ('a : any) = 5;;
-let x : int as ('a: value mod global aliased many contended portable external_) = 5
+let x : int as ('a: value mod global many contended portable external_) = 5
 
 [%%expect{|
 val x : int = 5

--- a/testsuite/tests/typing-jkind-bounds/annots.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots.ml
@@ -9,6 +9,12 @@
  }
 *)
 
+(* These tests enumerate modifiers, including redundant ones, so silence the
+   redundant-modifier warning throughout. *)
+[@@@warning "-211"]
+[%%expect{|
+|}]
+
 type t_value : value
 type t_imm : immediate
 type t_imm64 : immediate64

--- a/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
@@ -9,6 +9,12 @@
  }
 *)
 
+(* These tests enumerate modifiers, including redundant ones, so silence the
+   redundant-modifier warning throughout. *)
+[@@@warning "-211"]
+[%%expect{|
+|}]
+
 type t_value : value
 type t_imm : immediate
 type t_imm64 : immediate64

--- a/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
@@ -204,7 +204,7 @@ Error: Unrecognized modifier fizzbuzz.
 let x : int as ('a: value) = 5
 let x : int as ('a : immediate) = 5
 let x : int as ('a : any) = 5;;
-let x : int as ('a: value mod global aliased many contended portable external_) = 5
+let x : int as ('a: value mod global many contended portable external_) = 5
 
 [%%expect{|
 val x : int = 5

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -3,13 +3,14 @@
  expect;
 *)
 
-(* Many tests below use deliberately redundant modifiers; silence the warning. *)
+(******************)
+(* Test 1: Syntax *)
+
+(* The syntax tests below spell out kind abbreviations in full, including
+   deliberately redundant modifiers; silence the warning for this section. *)
 [@@@warning "-211"]
 [%%expect{|
 |}]
-
-(******************)
-(* Test 1: Syntax *)
 
 type 'a list : immutable_data with 'a
 
@@ -85,6 +86,10 @@ Line 4, characters 16-27:
 4 |   type 'a gel : kind_of_ 'a mod global
                     ^^^^^^^^^^^
 Error: Unimplemented kind syntax
+|}]
+
+[@@@warning "+211"]
+[%%expect{|
 |}]
 
 (**************************************)
@@ -1299,7 +1304,7 @@ Error: Bad layout annotation:
            because of the annotation on the type variable 'a.
 |}]
 
-let f : ('a : any mod global aliased) -> ('a: any mod contended) = fun x -> x
+let f : ('a : any mod global) -> ('a: any mod contended) = fun x -> x
 let f : ('a : value mod external64) -> ('a: any mod external_) = fun x -> x
 let f : ('a : value) -> ('a: immediate) = fun x -> x
 [%%expect {|

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -3,6 +3,11 @@
  expect;
 *)
 
+(* Many tests below use deliberately redundant modifiers; silence the warning. *)
+[@@@warning "-211"]
+[%%expect{|
+|}]
+
 (******************)
 (* Test 1: Syntax *)
 
@@ -200,9 +205,9 @@ type a : value mod global
 type b : float32 = a
 [%%expect{|
 type a : value mod global
-Line 2, characters 0-30:
-2 | type b : float32 mod local = a
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 0-20:
+2 | type b : float32 = a
+    ^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type "a" is value
          because of the definition of a at line 1, characters 0-25.
        But the layout of type "a" must be a sublayout of float32
@@ -220,9 +225,9 @@ type a : value mod global contended portable external_
 type b : value mod many contended = a
 [%%expect{|
 type a : value mod global portable contended external_
-Line 2, characters 0-71:
-2 | type b : value mod local unique many contended nonportable internal = a
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 0-37:
+2 | type b : value mod many contended = a
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "a" is value mod global portable contended external_
          because of the definition of a at line 1, characters 0-54.
        But the kind of type "a" must be a subkind of value mod many contended

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -155,15 +155,15 @@ Error: The layout of type "a" is float32
          because of the definition of b at line 2, characters 0-17.
 |}]
 
-type a : value mod local
-type b : value mod local = a
+type a : value
+type b : value = a
 [%%expect{|
 type a
 type b = a
 |}]
 
 type a : value mod global
-type b : value mod local = a
+type b : value = a
 [%%expect{|
 type a : value mod global
 type b = a
@@ -176,7 +176,7 @@ type a : value mod global
 type b = a
 |}]
 
-type a : value mod local
+type a : value
 type b : value mod global = a
 [%%expect{|
 type a
@@ -184,20 +184,20 @@ Line 2, characters 0-29:
 2 | type b : value mod global = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "a" is value
-         because of the definition of a at line 1, characters 0-24.
+         because of the definition of a at line 1, characters 0-14.
        But the kind of type "a" must be a subkind of value mod global
          because of the definition of b at line 2, characters 0-29.
 |}]
 
 type a : value mod global
-type b : any mod local = a
+type b : any = a
 [%%expect{|
 type a : value mod global
 type b = a
 |}]
 
 type a : value mod global
-type b : float32 mod local = a
+type b : float32 = a
 [%%expect{|
 type a : value mod global
 Line 2, characters 0-30:
@@ -206,27 +206,27 @@ Line 2, characters 0-30:
 Error: The layout of type "a" is value
          because of the definition of a at line 1, characters 0-25.
        But the layout of type "a" must be a sublayout of float32
-         because of the definition of b at line 2, characters 0-30.
+         because of the definition of b at line 2, characters 0-20.
 |}]
 
-type a : value non_pointer mod global aliased many immutable stateless external_ unyielding
-type b : value mod local unique once contended nonportable internal = a
+type a : value non_pointer mod global many immutable stateless external_
+type b : value mod contended = a
 [%%expect{|
 type a : immediate
 type b = a
 |}]
 
-type a : value mod global aliased once contended portable external_
-type b : value mod local unique many contended nonportable internal = a
+type a : value mod global contended portable external_
+type b : value mod many contended = a
 [%%expect{|
 type a : value mod global portable contended external_
 Line 2, characters 0-71:
 2 | type b : value mod local unique many contended nonportable internal = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "a" is value mod global portable contended external_
-         because of the definition of a at line 1, characters 0-67.
+         because of the definition of a at line 1, characters 0-54.
        But the kind of type "a" must be a subkind of value mod many contended
-         because of the definition of b at line 2, characters 0-71.
+         because of the definition of b at line 2, characters 0-37.
 |}]
 
 (********************************************************)
@@ -234,8 +234,8 @@ Error: The kind of type "a" is value mod global portable contended external_
 (* CR layouts: when we have abbreviations, these tests can become less verbose *)
 
 type a : any
-type b : any mod local unique once uncontended nonportable internal = a
-type c : any mod local unique once uncontended nonportable internal
+type b : any = a
+type c : any
 type d : any = c
 [%%expect{|
 type a : any
@@ -245,8 +245,8 @@ type d = c
 |}]
 
 type a : value
-type b : value mod local unique once uncontended nonportable internal = a
-type c : value mod local unique once uncontended nonportable internal
+type b : value = a
+type c : value
 type d : value = c
 [%%expect{|
 type a
@@ -256,8 +256,8 @@ type d = c
 |}]
 
 type a : void
-type b : void mod local unique once uncontended nonportable internal = a
-type c : void mod local unique once uncontended nonportable internal
+type b : void = a
+type c : void
 type d : void = c
 [%%expect{|
 type a : void
@@ -267,8 +267,8 @@ type d = c
 |}]
 
 type a : immediate
-type b : value non_pointer mod global aliased many immutable stateless unyielding external_= a
-type c : value non_pointer mod global aliased many immutable stateless unyielding external_
+type b : value non_pointer mod global many immutable stateless external_ = a
+type c : value non_pointer mod global many immutable stateless external_
 type d : immediate = c
 [%%expect{|
 type a : immediate
@@ -278,8 +278,8 @@ type d = c
 |}]
 
 type a : immediate64
-type b : value non_pointer64 mod global aliased many immutable stateless unyielding external64 = a
-type c : value non_pointer64 mod global aliased many immutable stateless unyielding external64
+type b : value non_pointer64 mod global many immutable stateless external64 = a
+type c : value non_pointer64 mod global many immutable stateless external64
 type d : immediate64 = c
 [%%expect{|
 type a : immediate64
@@ -289,8 +289,8 @@ type d = c
 |}]
 
 type a : float64 = float#
-type b : float64 mod global aliased many immutable stateless external_ = a
-type c : float64 mod global aliased many immutable stateless external_
+type b : float64 mod global many immutable stateless external_ = a
+type c : float64 mod global many immutable stateless external_
 type d : float64 = c
 [%%expect{|
 type a = float#
@@ -300,8 +300,8 @@ type d = c
 |}]
 
 type a : float32 = float32#
-type b : float32 mod global aliased many immutable stateless external_ = a
-type c : float32 mod global aliased many immutable stateless external_
+type b : float32 mod global many immutable stateless external_ = a
+type c : float32 mod global many immutable stateless external_
 type d : float32 = c
 [%%expect{|
 type a = float32#
@@ -311,8 +311,8 @@ type d = c
 |}]
 
 type a : word
-type b : word mod local unique once uncontended nonportable internal = a
-type c : word mod local unique once uncontended nonportable internal
+type b : word = a
+type c : word
 type d : word = c
 [%%expect{|
 type a : word
@@ -322,8 +322,8 @@ type d = c
 |}]
 
 type a : bits32
-type b : bits32 mod local unique once uncontended nonportable internal = a
-type c : bits32 mod local unique once uncontended nonportable internal
+type b : bits32 = a
+type c : bits32
 type d : bits32 = c
 [%%expect{|
 type a : bits32
@@ -333,8 +333,8 @@ type d = c
 |}]
 
 type a : bits64
-type b : bits64 mod local unique once uncontended nonportable internal = a
-type c : bits64 mod local unique once uncontended nonportable internal
+type b : bits64 = a
+type c : bits64
 type d : bits64 = c
 [%%expect{|
 type a : bits64
@@ -346,68 +346,68 @@ type d = c
 (****************************************)
 (* Test 4: Appropriate types mode cross *)
 
-type t : any mod global aliased many immutable stateless external_ = int
+type t : any mod global many immutable stateless external_ = int
 [%%expect{|
 type t = int
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = float#
+type t : any mod global many immutable stateless external_ = float#
 [%%expect{|
 type t = float#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = float32#
+type t : any mod global many immutable stateless external_ = float32#
 [%%expect{|
 type t = float32#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = int64#
+type t : any mod global many immutable stateless external_ = int64#
 [%%expect{|
 type t = int64#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = int32#
+type t : any mod global many immutable stateless external_ = int32#
 [%%expect{|
 type t = int32#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = nativeint#
+type t : any mod global many immutable stateless external_ = nativeint#
 [%%expect{|
 type t = nativeint#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = int8x16#
+type t : any mod global many immutable stateless external_ = int8x16#
 [%%expect{|
 type t = int8x16#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = int16x8#
+type t : any mod global many immutable stateless external_ = int16x8#
 [%%expect{|
 type t = int16x8#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = int32x4#
+type t : any mod global many immutable stateless external_ = int32x4#
 [%%expect{|
 type t = int32x4#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = int64x2#
+type t : any mod global many immutable stateless external_ = int64x2#
 [%%expect{|
 type t = int64x2#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = float32x4#
+type t : any mod global many immutable stateless external_ = float32x4#
 [%%expect{|
 type t = float32x4#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = float64x2#
+type t : any mod global many immutable stateless external_ = float64x2#
 [%%expect{|
 type t = float64x2#
 |}]
 
 type indirect_int = int
-type t : any mod global aliased many immutable stateless external_ = indirect_int
+type t : any mod global many immutable stateless external_ = indirect_int
 [%%expect{|
 type indirect_int = int
 type t = indirect_int
@@ -1148,17 +1148,17 @@ Error: The kind of type "t" is value
 (***********************************************)
 (* Test 7: Inference with modality annotations *)
 
-type 'a t : value mod global portable contended many aliased unyielding =
+type 'a t : value mod global portable contended many =
   { x : 'a @@ global portable contended many aliased } [@@unboxed]
 [%%expect {|
 type 'a t = { x : 'a @@ global many portable contended; } [@@unboxed]
 |}]
 
-type 'a t : value mod global immutable stateless many aliased unyielding non_float =
+type 'a t : value mod global immutable stateless many non_float =
   Foo of 'a @@ global immutable stateless many aliased [@@unboxed]
 [%%expect {|
 Lines 1-2, characters 0-66:
-1 | type 'a t : value mod global immutable stateless many aliased unyielding non_float =
+1 | type 'a t : value mod global immutable stateless many non_float =
 2 |   Foo of 'a @@ global immutable stateless many aliased [@@unboxed]
 Error: The layout of type "t" is value
          because it instantiates an unannotated type parameter of t,
@@ -1268,7 +1268,7 @@ Error: The kind of type "t" is immutable_data with 'a @@ forkable unyielding
 type ('a : value mod aliased) t = ('a : value mod global)
 type ('a : immediate) t = ('a : value)
 type ('a : value) t = ('a : immediate)
-type ('a : value mod external_ stateless many unyielding non_float) t = ('a : value mod immutable global aliased)
+type ('a : value mod external_ stateless many unyielding non_float) t = ('a : value mod immutable global)
 type ('a : value) t = ('a : any)
 type ('a : value) t = ('a : value)
 type ('a : bits32 mod aliased) t = ('a : any mod global)

--- a/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
@@ -3,13 +3,14 @@
  expect;
 *)
 
-(* Many tests below use deliberately redundant modifiers; silence the warning. *)
+(******************)
+(* Test 1: Syntax *)
+
+(* The syntax tests below spell out kind abbreviations in full, including
+   deliberately redundant modifiers; silence the warning for this section. *)
 [@@@warning "-211"]
 [%%expect{|
 |}]
-
-(******************)
-(* Test 1: Syntax *)
 
 type 'a list : immutable_data with 'a
 
@@ -85,6 +86,10 @@ Line 4, characters 16-27:
 4 |   type 'a gel : kind_of_ 'a mod global
                     ^^^^^^^^^^^
 Error: Unimplemented kind syntax
+|}]
+
+[@@@warning "+211"]
+[%%expect{|
 |}]
 
 (**************************************)
@@ -1299,7 +1304,7 @@ Error: Bad layout annotation:
            because of the annotation on the type variable 'a.
 |}]
 
-let f : ('a : any mod global aliased) -> ('a: any mod contended) = fun x -> x
+let f : ('a : any mod global) -> ('a: any mod contended) = fun x -> x
 let f : ('a : value mod external64) -> ('a: any mod external_) = fun x -> x
 let f : ('a : value) -> ('a: immediate) = fun x -> x
 [%%expect {|

--- a/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
@@ -3,6 +3,11 @@
  expect;
 *)
 
+(* Many tests below use deliberately redundant modifiers; silence the warning. *)
+[@@@warning "-211"]
+[%%expect{|
+|}]
+
 (******************)
 (* Test 1: Syntax *)
 
@@ -200,9 +205,9 @@ type a : value mod global
 type b : float32 = a
 [%%expect{|
 type a : value mod global
-Line 2, characters 0-30:
-2 | type b : float32 mod local = a
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 0-20:
+2 | type b : float32 = a
+    ^^^^^^^^^^^^^^^^^^^^
 Error: The layout of type "a" is value
          because of the definition of a at line 1, characters 0-25.
        But the layout of type "a" must be a sublayout of float32
@@ -220,9 +225,9 @@ type a : value mod global contended portable external_
 type b : value mod many contended = a
 [%%expect{|
 type a : value mod global portable contended external_
-Line 2, characters 0-71:
-2 | type b : value mod local unique many contended nonportable internal = a
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 0-37:
+2 | type b : value mod many contended = a
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "a" is value mod global portable contended external_
          because of the definition of a at line 1, characters 0-54.
        But the kind of type "a" must be a subkind of value mod many contended

--- a/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
@@ -155,15 +155,15 @@ Error: The layout of type "a" is float32
          because of the definition of b at line 2, characters 0-17.
 |}]
 
-type a : value mod local
-type b : value mod local = a
+type a : value
+type b : value = a
 [%%expect{|
 type a
 type b = a
 |}]
 
 type a : value mod global
-type b : value mod local = a
+type b : value = a
 [%%expect{|
 type a : value mod global
 type b = a
@@ -176,7 +176,7 @@ type a : value mod global
 type b = a
 |}]
 
-type a : value mod local
+type a : value
 type b : value mod global = a
 [%%expect{|
 type a
@@ -184,20 +184,20 @@ Line 2, characters 0-29:
 2 | type b : value mod global = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "a" is value
-         because of the definition of a at line 1, characters 0-24.
+         because of the definition of a at line 1, characters 0-14.
        But the kind of type "a" must be a subkind of value mod global
          because of the definition of b at line 2, characters 0-29.
 |}]
 
 type a : value mod global
-type b : any mod local = a
+type b : any = a
 [%%expect{|
 type a : value mod global
 type b = a
 |}]
 
 type a : value mod global
-type b : float32 mod local = a
+type b : float32 = a
 [%%expect{|
 type a : value mod global
 Line 2, characters 0-30:
@@ -206,27 +206,27 @@ Line 2, characters 0-30:
 Error: The layout of type "a" is value
          because of the definition of a at line 1, characters 0-25.
        But the layout of type "a" must be a sublayout of float32
-         because of the definition of b at line 2, characters 0-30.
+         because of the definition of b at line 2, characters 0-20.
 |}]
 
-type a : value non_pointer mod global aliased many immutable stateless external_ unyielding
-type b : value mod local unique once contended nonportable internal = a
+type a : value non_pointer mod global many immutable stateless external_
+type b : value mod contended = a
 [%%expect{|
 type a : immediate
 type b = a
 |}]
 
-type a : value mod global aliased once contended portable external_
-type b : value mod local unique many contended nonportable internal = a
+type a : value mod global contended portable external_
+type b : value mod many contended = a
 [%%expect{|
 type a : value mod global portable contended external_
 Line 2, characters 0-71:
 2 | type b : value mod local unique many contended nonportable internal = a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "a" is value mod global portable contended external_
-         because of the definition of a at line 1, characters 0-67.
+         because of the definition of a at line 1, characters 0-54.
        But the kind of type "a" must be a subkind of value mod many contended
-         because of the definition of b at line 2, characters 0-71.
+         because of the definition of b at line 2, characters 0-37.
 |}]
 
 (********************************************************)
@@ -234,8 +234,8 @@ Error: The kind of type "a" is value mod global portable contended external_
 (* CR layouts: when we have abbreviations, these tests can become less verbose *)
 
 type a : any
-type b : any mod local unique once uncontended nonportable internal = a
-type c : any mod local unique once uncontended nonportable internal
+type b : any = a
+type c : any
 type d : any = c
 [%%expect{|
 type a : any
@@ -245,8 +245,8 @@ type d = c
 |}]
 
 type a : value
-type b : value mod local unique once uncontended nonportable internal = a
-type c : value mod local unique once uncontended nonportable internal
+type b : value = a
+type c : value
 type d : value = c
 [%%expect{|
 type a
@@ -256,8 +256,8 @@ type d = c
 |}]
 
 type a : void
-type b : void mod local unique once uncontended nonportable internal = a
-type c : void mod local unique once uncontended nonportable internal
+type b : void = a
+type c : void
 type d : void = c
 [%%expect{|
 type a : void
@@ -267,8 +267,8 @@ type d = c
 |}]
 
 type a : immediate
-type b : value non_pointer mod global aliased many immutable stateless unyielding external_ = a
-type c : value non_pointer mod global aliased many immutable stateless unyielding external_
+type b : value non_pointer mod global many immutable stateless external_ = a
+type c : value non_pointer mod global many immutable stateless external_
 type d : immediate = c
 [%%expect{|
 type a : immediate
@@ -278,8 +278,8 @@ type d = c
 |}]
 
 type a : immediate64
-type b : value non_pointer64 mod global aliased many immutable stateless unyielding external64 = a
-type c : value non_pointer64 mod global aliased many immutable stateless unyielding external64
+type b : value non_pointer64 mod global many immutable stateless external64 = a
+type c : value non_pointer64 mod global many immutable stateless external64
 type d : immediate64 = c
 [%%expect{|
 type a : immediate64
@@ -289,8 +289,8 @@ type d = c
 |}]
 
 type a : float64 = float#
-type b : float64 mod global aliased many immutable stateless external_ = a
-type c : float64 mod global aliased many immutable stateless external_
+type b : float64 mod global many immutable stateless external_ = a
+type c : float64 mod global many immutable stateless external_
 type d : float64 = c
 [%%expect{|
 type a = float#
@@ -300,8 +300,8 @@ type d = c
 |}]
 
 type a : float32 = float32#
-type b : float32 mod global aliased many immutable stateless external_ = a
-type c : float32 mod global aliased many immutable stateless external_
+type b : float32 mod global many immutable stateless external_ = a
+type c : float32 mod global many immutable stateless external_
 type d : float32 = c
 [%%expect{|
 type a = float32#
@@ -311,8 +311,8 @@ type d = c
 |}]
 
 type a : word
-type b : word mod local unique once uncontended nonportable internal = a
-type c : word mod local unique once uncontended nonportable internal
+type b : word = a
+type c : word
 type d : word = c
 [%%expect{|
 type a : word
@@ -322,8 +322,8 @@ type d = c
 |}]
 
 type a : bits32
-type b : bits32 mod local unique once uncontended nonportable internal = a
-type c : bits32 mod local unique once uncontended nonportable internal
+type b : bits32 = a
+type c : bits32
 type d : bits32 = c
 [%%expect{|
 type a : bits32
@@ -333,8 +333,8 @@ type d = c
 |}]
 
 type a : bits64
-type b : bits64 mod local unique once uncontended nonportable internal = a
-type c : bits64 mod local unique once uncontended nonportable internal
+type b : bits64 = a
+type c : bits64
 type d : bits64 = c
 [%%expect{|
 type a : bits64
@@ -346,68 +346,68 @@ type d = c
 (****************************************)
 (* Test 4: Appropriate types mode cross *)
 
-type t : any mod global aliased many immutable stateless external_ = int
+type t : any mod global many immutable stateless external_ = int
 [%%expect{|
 type t = int
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = float#
+type t : any mod global many immutable stateless external_ = float#
 [%%expect{|
 type t = float#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = float32#
+type t : any mod global many immutable stateless external_ = float32#
 [%%expect{|
 type t = float32#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = int64#
+type t : any mod global many immutable stateless external_ = int64#
 [%%expect{|
 type t = int64#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = int32#
+type t : any mod global many immutable stateless external_ = int32#
 [%%expect{|
 type t = int32#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = nativeint#
+type t : any mod global many immutable stateless external_ = nativeint#
 [%%expect{|
 type t = nativeint#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = int8x16#
+type t : any mod global many immutable stateless external_ = int8x16#
 [%%expect{|
 type t = int8x16#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = int16x8#
+type t : any mod global many immutable stateless external_ = int16x8#
 [%%expect{|
 type t = int16x8#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = int32x4#
+type t : any mod global many immutable stateless external_ = int32x4#
 [%%expect{|
 type t = int32x4#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = int64x2#
+type t : any mod global many immutable stateless external_ = int64x2#
 [%%expect{|
 type t = int64x2#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = float32x4#
+type t : any mod global many immutable stateless external_ = float32x4#
 [%%expect{|
 type t = float32x4#
 |}]
 
-type t : any mod global aliased many immutable stateless external_ = float64x2#
+type t : any mod global many immutable stateless external_ = float64x2#
 [%%expect{|
 type t = float64x2#
 |}]
 
 type indirect_int = int
-type t : any mod global aliased many immutable stateless external_ = indirect_int
+type t : any mod global many immutable stateless external_ = indirect_int
 [%%expect{|
 type indirect_int = int
 type t = indirect_int
@@ -1148,17 +1148,17 @@ Error: The kind of type "t" is value
 (***********************************************)
 (* Test 7: Inference with modality annotations *)
 
-type 'a t : value mod global portable contended many aliased unyielding =
+type 'a t : value mod global portable contended many =
   { x : 'a @@ global portable contended many aliased } [@@unboxed]
 [%%expect {|
 type 'a t = { x : 'a @@ global many portable contended; } [@@unboxed]
 |}]
 
-type 'a t : value mod global immutable stateless many aliased unyielding non_float =
+type 'a t : value mod global immutable stateless many non_float =
   Foo of 'a @@ global immutable stateless many aliased [@@unboxed]
 [%%expect {|
 Lines 1-2, characters 0-66:
-1 | type 'a t : value mod global immutable stateless many aliased unyielding non_float =
+1 | type 'a t : value mod global immutable stateless many non_float =
 2 |   Foo of 'a @@ global immutable stateless many aliased [@@unboxed]
 Error: The layout of type "t" is value
          because it instantiates an unannotated type parameter of t,
@@ -1268,7 +1268,7 @@ Error: The kind of type "t" is immutable_data with 'a @@ forkable unyielding
 type ('a : value mod aliased) t = ('a : value mod global)
 type ('a : immediate) t = ('a : value)
 type ('a : value) t = ('a : immediate)
-type ('a : value mod external_ stateless many unyielding non_float) t = ('a : value mod immutable global aliased)
+type ('a : value mod external_ stateless many unyielding non_float) t = ('a : value mod immutable global)
 type ('a : value) t = ('a : any)
 type ('a : value) t = ('a : value)
 type ('a : bits32 mod aliased) t = ('a : any mod global)

--- a/testsuite/tests/typing-jkind-bounds/redundant_modifiers.ml
+++ b/testsuite/tests/typing-jkind-bounds/redundant_modifiers.ml
@@ -1,0 +1,279 @@
+(* TEST
+    flags = "-extension mode_alpha -no-ikinds";
+    expect;
+*)
+
+(* This file tests the behavior of redundant or conflicting modifiers.
+
+   Unlike modalities, multiple modifiers on the same axis are an error rather
+   than a warning. Warning 211 is triggered by a modifier that has no effect.
+*)
+
+(**************************************************************************)
+(* Part 1: Two modifiers on the same axis *)
+(**************************************************************************)
+
+type t : value mod portable nonportable
+[%%expect{|
+Line 1, characters 28-39:
+1 | type t : value mod portable nonportable
+                                ^^^^^^^^^^^
+Error: The portability axis has already been specified.
+|}]
+
+type t : value mod contended uncontended
+[%%expect{|
+Line 1, characters 29-40:
+1 | type t : value mod contended uncontended
+                                 ^^^^^^^^^^^
+Error: The contention axis has already been specified.
+|}]
+
+type t : value mod portable shareable
+[%%expect{|
+Line 1, characters 28-37:
+1 | type t : value mod portable shareable
+                                ^^^^^^^^^
+Error: The portability axis has already been specified.
+|}]
+
+type t : value mod static static
+[%%expect{|
+Line 1, characters 26-32:
+1 | type t : value mod static static
+                              ^^^^^^
+Error: The staticity axis has already been specified.
+|}]
+
+(**************************************************************************)
+(* Part 2: Modifiers that match the default bounds *)
+(**************************************************************************)
+
+type t : value mod local
+[%%expect{|
+Line 1, characters 19-24:
+1 | type t : value mod local
+                       ^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t
+|}]
+
+type t : value mod unique
+[%%expect{|
+Line 1, characters 19-25:
+1 | type t : value mod unique
+                       ^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t
+|}]
+
+type t : value mod uncontended
+[%%expect{|
+Line 1, characters 19-30:
+1 | type t : value mod uncontended
+                       ^^^^^^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t
+|}]
+
+type t : value mod internal
+[%%expect{|
+Line 1, characters 19-27:
+1 | type t : value mod internal
+                       ^^^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t
+|}]
+
+type t : value mod static
+[%%expect{|
+Line 1, characters 19-25:
+1 | type t : value mod static
+                       ^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t
+|}]
+
+(**************************************************************************)
+(* Part 3: Implied modifiers, in either order *)
+(**************************************************************************)
+
+type t : value mod global aliased
+[%%expect{|
+Line 1, characters 26-33:
+1 | type t : value mod global aliased
+                              ^^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t : value mod global
+|}]
+
+type t : value mod aliased global
+[%%expect{|
+Line 1, characters 19-26:
+1 | type t : value mod aliased global
+                       ^^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t : value mod global
+|}]
+
+type t : value mod stateless portable
+[%%expect{|
+Line 1, characters 29-37:
+1 | type t : value mod stateless portable
+                                 ^^^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t : value mod stateless
+|}]
+
+type t : value mod portable stateless
+[%%expect{|
+Line 1, characters 19-27:
+1 | type t : value mod portable stateless
+                       ^^^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t : value mod stateless
+|}]
+
+type t : value mod immutable contended
+[%%expect{|
+Line 1, characters 29-38:
+1 | type t : value mod immutable contended
+                                 ^^^^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t : value mod immutable
+|}]
+
+type t : value mod contended immutable
+[%%expect{|
+Line 1, characters 19-28:
+1 | type t : value mod contended immutable
+                       ^^^^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t : value mod immutable
+|}]
+
+(**************************************************************************)
+(* Part 4: Conflicting modifiers, in either order *)
+(**************************************************************************)
+
+type t : value mod global unique
+[%%expect{|
+Line 1, characters 19-32:
+1 | type t : value mod global unique
+                       ^^^^^^^^^^^^^
+Error: The modifier "global" can't be used together with "unique"
+|}]
+
+type t : value mod unique global
+[%%expect{|
+Line 1, characters 19-32:
+1 | type t : value mod unique global
+                       ^^^^^^^^^^^^^
+Error: The modifier "global" can't be used together with "unique"
+|}]
+
+(**************************************************************************)
+(* Part 5: [everything] *)
+(**************************************************************************)
+
+type t : value mod everything
+[%%expect{|
+type t : value mod everything
+|}]
+
+(* [everything] conflicts with modal modifiers on either side. *)
+
+type t : value mod everything portable
+[%%expect{|
+Line 1, characters 30-38:
+1 | type t : value mod everything portable
+                                  ^^^^^^^^
+Error: The portability axis has already been specified.
+|}]
+
+type t : value mod portable everything
+[%%expect{|
+Line 1, characters 28-38:
+1 | type t : value mod portable everything
+                                ^^^^^^^^^^
+Error: The portability axis has already been specified.
+|}]
+
+(* ... and with externality modifiers. *)
+
+type t : value mod everything external_
+[%%expect{|
+Line 1, characters 30-39:
+1 | type t : value mod everything external_
+                                  ^^^^^^^^^
+Error: The externality axis has already been specified.
+|}]
+
+type t : value mod external_ everything
+[%%expect{|
+Line 1, characters 29-39:
+1 | type t : value mod external_ everything
+                                 ^^^^^^^^^^
+Error: The externality axis has already been specified.
+|}]
+
+type t : value mod everything everything
+[%%expect{|
+Line 1, characters 30-40:
+1 | type t : value mod everything everything
+                                  ^^^^^^^^^^
+Error: The externality axis has already been specified.
+|}]
+
+(* [everything] does not specify staticity, so [static] is allowed (but
+   redundant) on either side. *)
+
+type t : value mod everything static
+[%%expect{|
+Line 1, characters 30-36:
+1 | type t : value mod everything static
+                                  ^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t : value mod everything
+|}]
+
+type t : value mod static everything
+[%%expect{|
+Line 1, characters 19-25:
+1 | type t : value mod static everything
+                       ^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t : value mod everything
+|}]
+
+(* [everything] does not conflict with nullability or separability. *)
+
+type t : value mod everything non_float
+[%%expect{|
+type t : value mod everything non_float
+|}]
+
+(**************************************************************************)
+(* Part 6: Nonmodal modifiers *)
+(**************************************************************************)
+
+type t : value mod external_ external64
+[%%expect{|
+Line 1, characters 29-39:
+1 | type t : value mod external_ external64
+                                 ^^^^^^^^^^
+Error: The externality axis has already been specified.
+|}]

--- a/testsuite/tests/typing-jkind-bounds/redundant_modifiers.ml
+++ b/testsuite/tests/typing-jkind-bounds/redundant_modifiers.ml
@@ -290,3 +290,52 @@ Line 1, characters 29-39:
                                  ^^^^^^^^^^
 Error: The externality axis has already been specified.
 |}]
+
+(**************************************************************************)
+(* Part 7: Kind abbreviations and abstract kinds *)
+(**************************************************************************)
+
+(* The redundancy check runs on the modifier list alone and does not consult
+   the base kind, so modifiers that are redundant with the bounds of a
+   built-in abbreviation, a user-defined abbreviation, or an abstract kind
+   are not reported. *)
+
+type t : immutable_data mod portable
+[%%expect{|
+type t : immutable_data
+|}]
+
+type t : immutable_data mod contended
+[%%expect{|
+type t : immutable_data
+|}]
+
+kind_ portable_value = value mod portable
+
+type t : portable_value mod portable
+[%%expect{|
+kind_ portable_value = value mod portable
+type t : value mod portable
+|}]
+
+kind_ abstract
+
+type t : abstract mod portable
+[%%expect{|
+kind_ abstract
+type t : abstract mod portable
+|}]
+
+(* Scannable axes, by contrast, are checked against the base kind: a
+   scannable modifier already implied by the kind triggers warning 183. *)
+
+type t : immediate non_pointer
+[%%expect{|
+Line 1, characters 19-30:
+1 | type t : immediate non_pointer
+                       ^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
+  is already implied by the kind "immediate".
+
+type t : immediate
+|}]

--- a/testsuite/tests/typing-jkind-bounds/redundant_modifiers.ml
+++ b/testsuite/tests/typing-jkind-bounds/redundant_modifiers.ml
@@ -54,7 +54,8 @@ type t : value mod local
 Line 1, characters 19-24:
 1 | type t : value mod local
                        ^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant:
+  "local" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -64,7 +65,8 @@ type t : value mod unique
 Line 1, characters 19-25:
 1 | type t : value mod unique
                        ^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant:
+  "unique" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -74,7 +76,8 @@ type t : value mod uncontended
 Line 1, characters 19-30:
 1 | type t : value mod uncontended
                        ^^^^^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant:
+  "uncontended" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -84,7 +87,8 @@ type t : value mod internal
 Line 1, characters 19-27:
 1 | type t : value mod internal
                        ^^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant:
+  "internal" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -94,7 +98,8 @@ type t : value mod static
 Line 1, characters 19-25:
 1 | type t : value mod static
                        ^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant:
+  "static" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -108,7 +113,8 @@ type t : value mod global aliased
 Line 1, characters 26-33:
 1 | type t : value mod global aliased
                               ^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because it is implied by "global".
 
 type t : value mod global
 |}]
@@ -118,7 +124,8 @@ type t : value mod aliased global
 Line 1, characters 19-26:
 1 | type t : value mod aliased global
                        ^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because it is implied by "global".
 
 type t : value mod global
 |}]
@@ -128,7 +135,8 @@ type t : value mod stateless portable
 Line 1, characters 29-37:
 1 | type t : value mod stateless portable
                                  ^^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because it is implied by "stateless".
 
 type t : value mod stateless
 |}]
@@ -138,7 +146,8 @@ type t : value mod portable stateless
 Line 1, characters 19-27:
 1 | type t : value mod portable stateless
                        ^^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because it is implied by "stateless".
 
 type t : value mod stateless
 |}]
@@ -148,7 +157,8 @@ type t : value mod immutable contended
 Line 1, characters 29-38:
 1 | type t : value mod immutable contended
                                  ^^^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because it is implied by "immutable".
 
 type t : value mod immutable
 |}]
@@ -158,7 +168,8 @@ type t : value mod contended immutable
 Line 1, characters 19-28:
 1 | type t : value mod contended immutable
                        ^^^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because it is implied by "immutable".
 
 type t : value mod immutable
 |}]
@@ -244,7 +255,8 @@ type t : value mod everything static
 Line 1, characters 30-36:
 1 | type t : value mod everything static
                                   ^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant:
+  "static" is the default bound on its axis, so it has no effect.
 
 type t : value mod everything
 |}]
@@ -254,7 +266,8 @@ type t : value mod static everything
 Line 1, characters 19-25:
 1 | type t : value mod static everything
                        ^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant:
+  "static" is the default bound on its axis, so it has no effect.
 
 type t : value mod everything
 |}]

--- a/testsuite/tests/typing-jkind-bounds/redundant_modifiers.ml
+++ b/testsuite/tests/typing-jkind-bounds/redundant_modifiers.ml
@@ -54,8 +54,8 @@ type t : value mod local
 Line 1, characters 19-24:
 1 | type t : value mod local
                        ^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant:
-  "local" is the default bound on its axis, so it has no effect.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because "local" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -65,8 +65,8 @@ type t : value mod unique
 Line 1, characters 19-25:
 1 | type t : value mod unique
                        ^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant:
-  "unique" is the default bound on its axis, so it has no effect.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because "unique" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -76,8 +76,8 @@ type t : value mod uncontended
 Line 1, characters 19-30:
 1 | type t : value mod uncontended
                        ^^^^^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant:
-  "uncontended" is the default bound on its axis, so it has no effect.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because "uncontended" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -87,8 +87,8 @@ type t : value mod internal
 Line 1, characters 19-27:
 1 | type t : value mod internal
                        ^^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant:
-  "internal" is the default bound on its axis, so it has no effect.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because "internal" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -98,8 +98,8 @@ type t : value mod static
 Line 1, characters 19-25:
 1 | type t : value mod static
                        ^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant:
-  "static" is the default bound on its axis, so it has no effect.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because "static" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -255,8 +255,8 @@ type t : value mod everything static
 Line 1, characters 30-36:
 1 | type t : value mod everything static
                                   ^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant:
-  "static" is the default bound on its axis, so it has no effect.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because "static" is the default bound on its axis, so it has no effect.
 
 type t : value mod everything
 |}]
@@ -266,8 +266,8 @@ type t : value mod static everything
 Line 1, characters 19-25:
 1 | type t : value mod static everything
                        ^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant:
-  "static" is the default bound on its axis, so it has no effect.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because "static" is the default bound on its axis, so it has no effect.
 
 type t : value mod everything
 |}]

--- a/testsuite/tests/typing-jkind-bounds/redundant_modifiers_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/redundant_modifiers_ikinds.ml
@@ -290,3 +290,52 @@ Line 1, characters 29-39:
                                  ^^^^^^^^^^
 Error: The externality axis has already been specified.
 |}]
+
+(**************************************************************************)
+(* Part 7: Kind abbreviations and abstract kinds *)
+(**************************************************************************)
+
+(* The redundancy check runs on the modifier list alone and does not consult
+   the base kind, so modifiers that are redundant with the bounds of a
+   built-in abbreviation, a user-defined abbreviation, or an abstract kind
+   are not reported. *)
+
+type t : immutable_data mod portable
+[%%expect{|
+type t : immutable_data
+|}]
+
+type t : immutable_data mod contended
+[%%expect{|
+type t : immutable_data
+|}]
+
+kind_ portable_value = value mod portable
+
+type t : portable_value mod portable
+[%%expect{|
+kind_ portable_value = value mod portable
+type t : value mod portable
+|}]
+
+kind_ abstract
+
+type t : abstract mod portable
+[%%expect{|
+kind_ abstract
+type t : abstract mod portable
+|}]
+
+(* Scannable axes, by contrast, are checked against the base kind: a
+   scannable modifier already implied by the kind triggers warning 183. *)
+
+type t : immediate non_pointer
+[%%expect{|
+Line 1, characters 19-30:
+1 | type t : immediate non_pointer
+                       ^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
+  is already implied by the kind "immediate".
+
+type t : immediate
+|}]

--- a/testsuite/tests/typing-jkind-bounds/redundant_modifiers_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/redundant_modifiers_ikinds.ml
@@ -1,0 +1,279 @@
+(* TEST
+    flags = "-extension mode_alpha";
+    expect;
+*)
+
+(* This file tests the behavior of redundant or conflicting modifiers.
+
+   Unlike modalities, multiple modifiers on the same axis are an error rather
+   than a warning. Warning 211 is triggered by a modifier that has no effect.
+*)
+
+(**************************************************************************)
+(* Part 1: Two modifiers on the same axis *)
+(**************************************************************************)
+
+type t : value mod portable nonportable
+[%%expect{|
+Line 1, characters 28-39:
+1 | type t : value mod portable nonportable
+                                ^^^^^^^^^^^
+Error: The portability axis has already been specified.
+|}]
+
+type t : value mod contended uncontended
+[%%expect{|
+Line 1, characters 29-40:
+1 | type t : value mod contended uncontended
+                                 ^^^^^^^^^^^
+Error: The contention axis has already been specified.
+|}]
+
+type t : value mod portable shareable
+[%%expect{|
+Line 1, characters 28-37:
+1 | type t : value mod portable shareable
+                                ^^^^^^^^^
+Error: The portability axis has already been specified.
+|}]
+
+type t : value mod static static
+[%%expect{|
+Line 1, characters 26-32:
+1 | type t : value mod static static
+                              ^^^^^^
+Error: The staticity axis has already been specified.
+|}]
+
+(**************************************************************************)
+(* Part 2: Modifiers that match the default bounds *)
+(**************************************************************************)
+
+type t : value mod local
+[%%expect{|
+Line 1, characters 19-24:
+1 | type t : value mod local
+                       ^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t
+|}]
+
+type t : value mod unique
+[%%expect{|
+Line 1, characters 19-25:
+1 | type t : value mod unique
+                       ^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t
+|}]
+
+type t : value mod uncontended
+[%%expect{|
+Line 1, characters 19-30:
+1 | type t : value mod uncontended
+                       ^^^^^^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t
+|}]
+
+type t : value mod internal
+[%%expect{|
+Line 1, characters 19-27:
+1 | type t : value mod internal
+                       ^^^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t
+|}]
+
+type t : value mod static
+[%%expect{|
+Line 1, characters 19-25:
+1 | type t : value mod static
+                       ^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t
+|}]
+
+(**************************************************************************)
+(* Part 3: Implied modifiers, in either order *)
+(**************************************************************************)
+
+type t : value mod global aliased
+[%%expect{|
+Line 1, characters 26-33:
+1 | type t : value mod global aliased
+                              ^^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t : value mod global
+|}]
+
+type t : value mod aliased global
+[%%expect{|
+Line 1, characters 19-26:
+1 | type t : value mod aliased global
+                       ^^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t : value mod global
+|}]
+
+type t : value mod stateless portable
+[%%expect{|
+Line 1, characters 29-37:
+1 | type t : value mod stateless portable
+                                 ^^^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t : value mod stateless
+|}]
+
+type t : value mod portable stateless
+[%%expect{|
+Line 1, characters 19-27:
+1 | type t : value mod portable stateless
+                       ^^^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t : value mod stateless
+|}]
+
+type t : value mod immutable contended
+[%%expect{|
+Line 1, characters 29-38:
+1 | type t : value mod immutable contended
+                                 ^^^^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t : value mod immutable
+|}]
+
+type t : value mod contended immutable
+[%%expect{|
+Line 1, characters 19-28:
+1 | type t : value mod contended immutable
+                       ^^^^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t : value mod immutable
+|}]
+
+(**************************************************************************)
+(* Part 4: Conflicting modifiers, in either order *)
+(**************************************************************************)
+
+type t : value mod global unique
+[%%expect{|
+Line 1, characters 19-32:
+1 | type t : value mod global unique
+                       ^^^^^^^^^^^^^
+Error: The modifier "global" can't be used together with "unique"
+|}]
+
+type t : value mod unique global
+[%%expect{|
+Line 1, characters 19-32:
+1 | type t : value mod unique global
+                       ^^^^^^^^^^^^^
+Error: The modifier "global" can't be used together with "unique"
+|}]
+
+(**************************************************************************)
+(* Part 5: [everything] *)
+(**************************************************************************)
+
+type t : value mod everything
+[%%expect{|
+type t : value mod everything
+|}]
+
+(* [everything] conflicts with modal modifiers on either side. *)
+
+type t : value mod everything portable
+[%%expect{|
+Line 1, characters 30-38:
+1 | type t : value mod everything portable
+                                  ^^^^^^^^
+Error: The portability axis has already been specified.
+|}]
+
+type t : value mod portable everything
+[%%expect{|
+Line 1, characters 28-38:
+1 | type t : value mod portable everything
+                                ^^^^^^^^^^
+Error: The portability axis has already been specified.
+|}]
+
+(* ... and with externality modifiers. *)
+
+type t : value mod everything external_
+[%%expect{|
+Line 1, characters 30-39:
+1 | type t : value mod everything external_
+                                  ^^^^^^^^^
+Error: The externality axis has already been specified.
+|}]
+
+type t : value mod external_ everything
+[%%expect{|
+Line 1, characters 29-39:
+1 | type t : value mod external_ everything
+                                 ^^^^^^^^^^
+Error: The externality axis has already been specified.
+|}]
+
+type t : value mod everything everything
+[%%expect{|
+Line 1, characters 30-40:
+1 | type t : value mod everything everything
+                                  ^^^^^^^^^^
+Error: The externality axis has already been specified.
+|}]
+
+(* [everything] does not specify staticity, so [static] is allowed (but
+   redundant) on either side. *)
+
+type t : value mod everything static
+[%%expect{|
+Line 1, characters 30-36:
+1 | type t : value mod everything static
+                                  ^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t : value mod everything
+|}]
+
+type t : value mod static everything
+[%%expect{|
+Line 1, characters 19-25:
+1 | type t : value mod static everything
+                       ^^^^^^
+Warning 211 [redundant-modifier]: This modifier is redundant.
+
+type t : value mod everything
+|}]
+
+(* [everything] does not conflict with nullability or separability. *)
+
+type t : value mod everything non_float
+[%%expect{|
+type t : value mod everything non_float
+|}]
+
+(**************************************************************************)
+(* Part 6: Nonmodal modifiers *)
+(**************************************************************************)
+
+type t : value mod external_ external64
+[%%expect{|
+Line 1, characters 29-39:
+1 | type t : value mod external_ external64
+                                 ^^^^^^^^^^
+Error: The externality axis has already been specified.
+|}]

--- a/testsuite/tests/typing-jkind-bounds/redundant_modifiers_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/redundant_modifiers_ikinds.ml
@@ -54,7 +54,8 @@ type t : value mod local
 Line 1, characters 19-24:
 1 | type t : value mod local
                        ^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant:
+  "local" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -64,7 +65,8 @@ type t : value mod unique
 Line 1, characters 19-25:
 1 | type t : value mod unique
                        ^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant:
+  "unique" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -74,7 +76,8 @@ type t : value mod uncontended
 Line 1, characters 19-30:
 1 | type t : value mod uncontended
                        ^^^^^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant:
+  "uncontended" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -84,7 +87,8 @@ type t : value mod internal
 Line 1, characters 19-27:
 1 | type t : value mod internal
                        ^^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant:
+  "internal" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -94,7 +98,8 @@ type t : value mod static
 Line 1, characters 19-25:
 1 | type t : value mod static
                        ^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant:
+  "static" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -108,7 +113,8 @@ type t : value mod global aliased
 Line 1, characters 26-33:
 1 | type t : value mod global aliased
                               ^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because it is implied by "global".
 
 type t : value mod global
 |}]
@@ -118,7 +124,8 @@ type t : value mod aliased global
 Line 1, characters 19-26:
 1 | type t : value mod aliased global
                        ^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because it is implied by "global".
 
 type t : value mod global
 |}]
@@ -128,7 +135,8 @@ type t : value mod stateless portable
 Line 1, characters 29-37:
 1 | type t : value mod stateless portable
                                  ^^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because it is implied by "stateless".
 
 type t : value mod stateless
 |}]
@@ -138,7 +146,8 @@ type t : value mod portable stateless
 Line 1, characters 19-27:
 1 | type t : value mod portable stateless
                        ^^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because it is implied by "stateless".
 
 type t : value mod stateless
 |}]
@@ -148,7 +157,8 @@ type t : value mod immutable contended
 Line 1, characters 29-38:
 1 | type t : value mod immutable contended
                                  ^^^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because it is implied by "immutable".
 
 type t : value mod immutable
 |}]
@@ -158,7 +168,8 @@ type t : value mod contended immutable
 Line 1, characters 19-28:
 1 | type t : value mod contended immutable
                        ^^^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because it is implied by "immutable".
 
 type t : value mod immutable
 |}]
@@ -244,7 +255,8 @@ type t : value mod everything static
 Line 1, characters 30-36:
 1 | type t : value mod everything static
                                   ^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant:
+  "static" is the default bound on its axis, so it has no effect.
 
 type t : value mod everything
 |}]
@@ -254,7 +266,8 @@ type t : value mod static everything
 Line 1, characters 19-25:
 1 | type t : value mod static everything
                        ^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant.
+Warning 211 [redundant-modifier]: This modifier is redundant:
+  "static" is the default bound on its axis, so it has no effect.
 
 type t : value mod everything
 |}]

--- a/testsuite/tests/typing-jkind-bounds/redundant_modifiers_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/redundant_modifiers_ikinds.ml
@@ -54,8 +54,8 @@ type t : value mod local
 Line 1, characters 19-24:
 1 | type t : value mod local
                        ^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant:
-  "local" is the default bound on its axis, so it has no effect.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because "local" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -65,8 +65,8 @@ type t : value mod unique
 Line 1, characters 19-25:
 1 | type t : value mod unique
                        ^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant:
-  "unique" is the default bound on its axis, so it has no effect.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because "unique" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -76,8 +76,8 @@ type t : value mod uncontended
 Line 1, characters 19-30:
 1 | type t : value mod uncontended
                        ^^^^^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant:
-  "uncontended" is the default bound on its axis, so it has no effect.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because "uncontended" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -87,8 +87,8 @@ type t : value mod internal
 Line 1, characters 19-27:
 1 | type t : value mod internal
                        ^^^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant:
-  "internal" is the default bound on its axis, so it has no effect.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because "internal" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -98,8 +98,8 @@ type t : value mod static
 Line 1, characters 19-25:
 1 | type t : value mod static
                        ^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant:
-  "static" is the default bound on its axis, so it has no effect.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because "static" is the default bound on its axis, so it has no effect.
 
 type t
 |}]
@@ -255,8 +255,8 @@ type t : value mod everything static
 Line 1, characters 30-36:
 1 | type t : value mod everything static
                                   ^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant:
-  "static" is the default bound on its axis, so it has no effect.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because "static" is the default bound on its axis, so it has no effect.
 
 type t : value mod everything
 |}]
@@ -266,8 +266,8 @@ type t : value mod static everything
 Line 1, characters 19-25:
 1 | type t : value mod static everything
                        ^^^^^^
-Warning 211 [redundant-modifier]: This modifier is redundant:
-  "static" is the default bound on its axis, so it has no effect.
+Warning 211 [redundant-modifier]: This modifier is redundant
+  because "static" is the default bound on its axis, so it has no effect.
 
 type t : value mod everything
 |}]

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
@@ -3,6 +3,11 @@
     expect;
 *)
 
+(* Some tests below use deliberately redundant modifiers; silence the warning. *)
+[@@@warning "-211"]
+[%%expect{|
+|}]
+
 module M : sig
   type ('a, 'b) t : immutable_data with 'a
 end = struct

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
@@ -119,7 +119,7 @@ module M : sig type 'a t : value mod aliased end
 |}]
 
 module M : sig
-  type 'a t : value mod global aliased many portable contended
+  type 'a t : value mod global many portable contended
 end = struct
   type 'a t : immediate with 'a @@ aliased many contended global portable
 end

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities_ikinds.ml
@@ -3,6 +3,11 @@
     expect;
 *)
 
+(* Some tests below use deliberately redundant modifiers; silence the warning. *)
+[@@@warning "-211"]
+[%%expect{|
+|}]
+
 module M : sig
   type ('a, 'b) t : immutable_data with 'a
 end = struct

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities_ikinds.ml
@@ -119,7 +119,7 @@ module M : sig type 'a t : value mod aliased end
 |}]
 
 module M : sig
-  type 'a t : value mod global aliased many portable contended
+  type 'a t : value mod global many portable contended
 end = struct
   type 'a t : immediate with 'a @@ aliased many contended global portable
 end

--- a/testsuite/tests/typing-layouts/allow_any.ml
+++ b/testsuite/tests/typing-layouts/allow_any.ml
@@ -31,11 +31,11 @@ val f : t @ contended -> t = <fun>
 |}]
 
 (* If we set the attribute but *don't* get a kind mismatch, we ought to be fine *)
-type t : value mod many portable uncontended = string
+type t : value mod many portable = string
 [@@unsafe_allow_any_mode_crossing]
 [%%expect{|
 Lines 1-2, characters 0-34:
-1 | type t : value mod many portable uncontended = string
+1 | type t : value mod many portable = string
 2 | [@@unsafe_allow_any_mode_crossing]
 Error: [@@unsafe_allow_any_mode_crossing] is not allowed on this kind of type declaration.
        Only records, unboxed products, and variants are supported.
@@ -336,7 +336,7 @@ Error: Signature mismatch:
 |}]
 
 module A : sig
-  type t : value mod external_ global portable many uncontended unyielding
+  type t : value mod external_ global portable many
 end = struct
   type t = int
 end

--- a/testsuite/tests/typing-layouts/basics.ml
+++ b/testsuite/tests/typing-layouts/basics.ml
@@ -2914,7 +2914,7 @@ Error: This function application uses an expression with type "'a"
 |}]
 
 let f (x : ('a : value)) = x ()
-let f (x : ('a : value mod uncontended)) = x ()
+let f (x : ('a : value)) = x ()
 
 [%%expect{|
 val f : (unit -> 'a) -> 'a = <fun>

--- a/testsuite/tests/typing-layouts/basics.ml
+++ b/testsuite/tests/typing-layouts/basics.ml
@@ -2914,7 +2914,7 @@ Error: This function application uses an expression with type "'a"
 |}]
 
 let f (x : ('a : value)) = x ()
-let f (x : ('a : value)) = x ()
+let f (x : ('a : value mod aliased)) = x ()
 
 [%%expect{|
 val f : (unit -> 'a) -> 'a = <fun>

--- a/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/testsuite/tests/typing-modal-kinds/basics.ml
@@ -19,7 +19,7 @@ end = struct
 end
 
 module Hidden_float_u : sig
-  type t : float64 mod global many aliased
+  type t : float64 mod global many
   val hide : float# -> t
 end = struct
   type t = float#
@@ -27,7 +27,7 @@ end = struct
 end
 
 module Hidden_int64_u : sig
-  type t : bits64 mod global many aliased
+  type t : bits64 mod global many
   val hide : int64# -> t
 end = struct
   type t = int64#

--- a/testsuite/tests/typing-modal-kinds/expected_mode.ml
+++ b/testsuite/tests/typing-modal-kinds/expected_mode.ml
@@ -19,7 +19,7 @@ end = struct
 end
 
 module Hidden_float_u : sig
-  type t : float64 mod global many aliased
+  type t : float64 mod global many
   val hide : float# -> t
 end = struct
   type t = float#

--- a/testsuite/tests/typing-modes/crossing.ml
+++ b/testsuite/tests/typing-modes/crossing.ml
@@ -2,6 +2,11 @@
  expect;
 *)
 
+(* Some tests below use deliberately redundant modifiers; silence the warning. *)
+[@@@warning "-211"]
+[%%expect{|
+|}]
+
 (* mode crossing during inclusion check is according to the written type, not
 the inferred type. *)
 

--- a/testsuite/tests/typing-modes/forkable.ml
+++ b/testsuite/tests/typing-modes/forkable.ml
@@ -3,6 +3,11 @@
  expect;
 *)
 
+(* Some tests below use deliberately redundant modifiers; silence the warning. *)
+[@@@warning "-211"]
+[%%expect{|
+|}]
+
 let my_unforkable : (unit -> unit) @ unforkable = print_endline "Hello, world!"
 [%%expect{|
 Line 1, characters 4-79:

--- a/testsuite/tests/typing-modes/yielding.ml
+++ b/testsuite/tests/typing-modes/yielding.ml
@@ -3,6 +3,11 @@
  expect;
 *)
 
+(* Some tests below use deliberately redundant modifiers; silence the warning. *)
+[@@@warning "-211"]
+[%%expect{|
+|}]
+
 (* CR dkalinichenko: allow [yielding] at toplevel? *)
 let my_effect : (unit -> unit) @ yielding = print_endline "Hello, world!"
 [%%expect{|

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2372,9 +2372,11 @@ let of_type_decl ?use_abstract_jkinds ?warn ~context ~transl_type env decl =
 
 let of_type_decl_overapproximate_unknown ~context env
     (decl : Parsetree.type_declaration) =
-  (* Warnings are emitted in [of_type_decl] rather than here *)
-  of_type_decl_gen ~use_abstract_jkinds:false ~warn:false ~context
-    ~transl:Context_with_transl.Overapproximate_to_top env decl
+  (* CR with-kinds: any warnings we get while parsing here will
+     be raised again when doing the non-approximated jkind computation. *)
+  Warnings.without_warnings (fun () ->
+      of_type_decl_gen ~use_abstract_jkinds:false ~warn:false ~context
+        ~transl:Context_with_transl.Overapproximate_to_top env decl)
   |> Option.map fst
 
 let for_unboxed_record_with_updates lbls =

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2092,7 +2092,7 @@ module Const = struct
       (* for each mode, lower the corresponding modal bound to be that
          mode *)
       let mod_bounds, (nullability, separability) =
-        Typemode.transl_mod_bounds modifiers
+        Typemode.transl_mod_bounds ~warn modifiers
       in
       let mod_bounds = Mod_bounds.meet base.mod_bounds mod_bounds in
       { base = base.base; mod_bounds; with_bounds = No_with_bounds }
@@ -2372,11 +2372,11 @@ let of_type_decl ?use_abstract_jkinds ?warn ~context ~transl_type env decl =
 
 let of_type_decl_overapproximate_unknown ~context env
     (decl : Parsetree.type_declaration) =
-  (* CR with-kinds: any warnings we get while parsing here will
-     be raised again when doing the non-approximated jkind computation. *)
-  Warnings.without_warnings (fun () ->
-      of_type_decl_gen ~use_abstract_jkinds:false ~warn:false ~context
-        ~transl:Context_with_transl.Overapproximate_to_top env decl)
+  (* Suppress redundant-modifier/-kind-modifier warnings here: this is an
+     approximation pass, and the same annotation is parsed again (with
+     [~warn:true]) during the non-approximated jkind computation. *)
+  of_type_decl_gen ~use_abstract_jkinds:false ~warn:false ~context
+    ~transl:Context_with_transl.Overapproximate_to_top env decl
   |> Option.map fst
 
 let for_unboxed_record_with_updates lbls =

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2123,7 +2123,7 @@ module Const = struct
       (* for each mode, lower the corresponding modal bound to be that
          mode *)
       let mod_bounds, (nullability, separability) =
-        Typemode.transl_mod_bounds modifiers
+        Typemode.transl_mod_bounds ~warn modifiers
       in
       let mod_bounds = Mod_bounds.meet base.mod_bounds mod_bounds in
       { base = base.base; mod_bounds; with_bounds = No_with_bounds }
@@ -2403,11 +2403,11 @@ let of_type_decl ?use_abstract_jkinds ?warn ~context ~transl_type env decl =
 
 let of_type_decl_overapproximate_unknown ~context env
     (decl : Parsetree.type_declaration) =
-  (* CR with-kinds: any warnings we get while parsing here will
-     be raised again when doing the non-approximated jkind computation. *)
-  Warnings.without_warnings (fun () ->
-      of_type_decl_gen ~use_abstract_jkinds:false ~warn:false ~context
-        ~transl:Context_with_transl.Overapproximate_to_top env decl)
+  (* Suppress redundant-modifier/-kind-modifier warnings here: this is an
+     approximation pass, and the same annotation is parsed again (with
+     [~warn:true]) during the non-approximated jkind computation. *)
+  of_type_decl_gen ~use_abstract_jkinds:false ~warn:false ~context
+    ~transl:Context_with_transl.Overapproximate_to_top env decl
   |> Option.map fst
 
 let for_unboxed_record_with_updates lbls =

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2403,9 +2403,11 @@ let of_type_decl ?use_abstract_jkinds ?warn ~context ~transl_type env decl =
 
 let of_type_decl_overapproximate_unknown ~context env
     (decl : Parsetree.type_declaration) =
-  (* Warnings are emitted in [of_type_decl] rather than here *)
-  of_type_decl_gen ~use_abstract_jkinds:false ~warn:false ~context
-    ~transl:Context_with_transl.Overapproximate_to_top env decl
+  (* CR with-kinds: any warnings we get while parsing here will
+     be raised again when doing the non-approximated jkind computation. *)
+  Warnings.without_warnings (fun () ->
+      of_type_decl_gen ~use_abstract_jkinds:false ~warn:false ~context
+        ~transl:Context_with_transl.Overapproximate_to_top env decl)
   |> Option.map fst
 
 let for_unboxed_record_with_updates lbls =

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -463,7 +463,10 @@ val of_annotation_option_default :
     Raises if a disallowed or unknown jkind is present.
 
     [use_abstract_jkinds] controls whether references to other kinds here count
-    as uses of them for unused abstract kind warnings. *)
+    as uses of them for unused abstract kind warnings.
+
+    [warn] controls whether redundant-modifier and redundant-kind-modifier
+    warnings are emitted while parsing the annotation. *)
 val of_type_decl :
   ?use_abstract_jkinds:bool ->
   ?warn:bool ->

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -467,7 +467,10 @@ val of_annotation_option_default :
     Raises if a disallowed or unknown jkind is present.
 
     [use_abstract_jkinds] controls whether references to other kinds here count
-    as uses of them for unused abstract kind warnings. *)
+    as uses of them for unused abstract kind warnings.
+
+    [warn] controls whether redundant-modifier and redundant-kind-modifier
+    warnings are emitted while parsing the annotation. *)
 val of_type_decl :
   ?use_abstract_jkinds:bool ->
   ?warn:bool ->

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -263,130 +263,6 @@ let enforce_forbidden_modalities ~loc annot_type m =
     raise (Error (loc, Forbidden_modality (annot_type, Global_and_unique)))
   | _ -> ()
 
-let transl_mod_bounds annots =
-  let bounds_loc =
-    match List.map (fun { loc; _ } -> loc) annots with
-    | [] -> Location.none
-    | _ :: _ as locs -> Location.merge locs
-  in
-  let step bounds_so_far { txt = Parsetree.Mode txt; loc } =
-    match Modifier_axis_pair.of_string txt with
-    | P (type a) ((axis, mode) : a Axis.t * a) ->
-      let is_top = Per_axis.(le axis (max axis) mode) in
-      if is_top
-      then
-        (* CR layouts v2.8: This warning is disabled for now because transl_type_decl
-           results in 3 calls to transl_annots per user-written annotation. This results
-           in the warning being reported 3 times. Internal ticket 2801. *)
-        (* Location.prerr_warning new_raw.loc (Warnings.Mod_by_top new_raw.txt) *)
-        ();
-      let is_dup =
-        Option.is_some (Transled_modifiers.get ~axis bounds_so_far)
-      in
-      if is_dup then raise (Error (loc, Duplicated_axis (Modifier, axis)));
-      Transled_modifiers.set ~axis bounds_so_far (Some { txt = mode; loc })
-    | exception Not_found -> (
-      match txt with
-      (* CR layouts-scannable: This should be removed once the new syntax for
-         separability is adopted. There is no warning raised currently for dupes
-         because the warnings would be reported 3 times. If this is fixed before
-         the syntax is deprecated, dupes really should raise warnings! *)
-      | "non_pointer" ->
-        Transled_modifiers.meet_separability bounds_so_far
-          { txt = Non_pointer; loc }
-      | "non_pointer64" ->
-        Transled_modifiers.meet_separability bounds_so_far
-          { txt = Non_pointer64; loc }
-      | "non_float" ->
-        Transled_modifiers.meet_separability bounds_so_far
-          { txt = Non_float; loc }
-      | "separable" ->
-        Transled_modifiers.meet_separability bounds_so_far
-          { txt = Separable; loc }
-      | "maybe_separable" ->
-        Transled_modifiers.meet_separability bounds_so_far
-          { txt = Maybe_separable; loc }
-      | "non_null" ->
-        Transled_modifiers.meet_nullability bounds_so_far
-          { txt = Non_null; loc }
-      | "maybe_null" ->
-        Transled_modifiers.meet_nullability bounds_so_far
-          { txt = Maybe_null; loc }
-      | "everything" ->
-        Transled_modifiers.
-          { areality =
-              Some { txt = Per_axis.min (Modal (Comonadic Areality)); loc };
-            linearity =
-              Some { txt = Per_axis.min (Modal (Comonadic Linearity)); loc };
-            uniqueness =
-              Some { txt = Per_axis.min (Modal (Monadic Uniqueness)); loc };
-            portability =
-              Some { txt = Per_axis.min (Modal (Comonadic Portability)); loc };
-            contention =
-              Some { txt = Per_axis.min (Modal (Monadic Contention)); loc };
-            forkable =
-              Some { txt = Per_axis.min (Modal (Comonadic Forkable)); loc };
-            yielding =
-              Some { txt = Per_axis.min (Modal (Comonadic Yielding)); loc };
-            externality = Some { txt = Externality.min; loc };
-            statefulness =
-              Some { txt = Per_axis.min (Modal (Comonadic Statefulness)); loc };
-            visibility =
-              Some { txt = Per_axis.min (Modal (Monadic Visibility)); loc };
-            staticity = None;
-            nullability = bounds_so_far.nullability;
-            separability = bounds_so_far.separability
-          }
-      | _ -> raise (Error (loc, Unrecognized_modifier (Modifier, txt))))
-  in
-  let raw_modifiers = List.fold_left step Transled_modifiers.empty annots in
-  let modality =
-    let open Modality in
-    let has_explicit axis =
-      let (P axis) = Crossing.Axis.of_modality (P axis) in
-      Option.is_some (Transled_modifiers.get ~axis:(Modal axis) raw_modifiers)
-    in
-    let add_implied axis value acc =
-      List.fold_left
-        (fun acc (Atom (axis', value')) ->
-          if has_explicit axis' then acc else Const.set axis' value' acc)
-        acc
-        (implied_modalities (Atom (axis, value)))
-    in
-    let add_comonadic acc axis =
-      match
-        Transled_modifiers.get ~axis:(Modal (Comonadic axis)) raw_modifiers
-      with
-      | None -> acc
-      | Some { txt = Modality value; _ } ->
-        let acc = Const.set (Comonadic axis) value acc in
-        add_implied (Comonadic axis) value acc
-    in
-    let add_monadic acc axis =
-      match
-        Transled_modifiers.get ~axis:(Modal (Monadic axis)) raw_modifiers
-      with
-      | None -> acc
-      | Some { txt = Modality value; _ } ->
-        let acc = Const.set (Monadic axis) value acc in
-        add_implied (Monadic axis) value acc
-    in
-    let add acc = function
-      | Value.Axis.P (Comonadic axis) -> add_comonadic acc axis
-      | Value.Axis.P (Monadic axis) -> add_monadic acc axis
-    in
-    List.fold_left add Const.id Value.Axis.all
-  in
-  enforce_forbidden_modalities Modifier ~loc:bounds_loc modality;
-  let open Jkind.Mod_bounds in
-  let externality =
-    Option.fold ~some:Location.get_txt ~none:Externality.max
-      raw_modifiers.externality
-  in
-  let crossing = Crossing.modality modality Crossing.max in
-  ( create crossing ~externality,
-    (raw_modifiers.nullability, raw_modifiers.separability) )
-
 let default_mode_annots (annots : Alloc.Const.Option.t) =
   (* [forkable] has a different default depending on whether [areality]
      is [global] or [local]. *)
@@ -568,62 +444,6 @@ let least_modalities ~include_implied ~mut (t : Modality.Const.t) =
   in
   exclude_implied @ overridden
 
-let untransl_mod_bounds ?(verbose = false) (bounds : Jkind.Mod_bounds.t) :
-    Parsetree.modes =
-  let crossing = Jkind.Mod_bounds.crossing bounds in
-  let modality = Crossing.to_modality crossing in
-  let least_modalities =
-    least_modalities ~include_implied:verbose ~mut:Immutable modality
-  in
-  let modality_annots =
-    List.map
-      (fun (Atom (ax, m) : Modality.atom) ->
-        let s = Format_doc.asprintf "%a" (Modality.Per_axis.print ax) m in
-        { Location.txt = Parsetree.Mode s; loc = Location.none })
-      least_modalities
-  in
-  (* These mod-bounds are top ones, which are redundant to print. But we
-     include them when printing verbosely. *)
-  let top_modality_annots () =
-    List.filter_map
-      (fun ax ->
-        let (P ax) = Modality.Axis.of_value ax in
-        let included_in_nonverbose =
-          List.exists
-            (fun (Atom (ax2, _) : Modality.atom) ->
-              Modality.Axis.P ax = Modality.Axis.P ax2)
-            least_modalities
-        in
-        match included_in_nonverbose with
-        | true -> None
-        | false ->
-          let s =
-            Format_doc.asprintf "%a"
-              (Modality.Per_axis.print ax)
-              (Modality.Const.proj ax modality)
-          in
-          Some { Location.txt = Parsetree.Mode s; loc = Location.none })
-      Value.Axis.all
-  in
-  let nonmodal_annots, top_nonmodal_annots =
-    let open Jkind.Mod_bounds in
-    let mk_annot top print value =
-      let only_when_verbose = value = top in
-      let s = Format_doc.asprintf "%a" print value in
-      ( { Location.txt = Parsetree.Mode s; loc = Location.none },
-        only_when_verbose )
-    in
-    [mk_annot Externality.max Externality.print (externality bounds)]
-    |> List.partition_map (fun (annot, only_when_verbose) ->
-        match only_when_verbose with false -> Left annot | true -> Right annot)
-  in
-  let verbose_annots =
-    match verbose with
-    | true -> top_modality_annots () @ top_nonmodal_annots
-    | false -> []
-  in
-  modality_annots @ nonmodal_annots @ verbose_annots
-
 let sort_dedup_modalities l =
   let open Modality in
   let compare { txt = Atom (ax0, _); loc = _ } { txt = Atom (ax1, _); loc = _ }
@@ -746,6 +566,186 @@ let transl_alloc_mode annots =
   in
   let modes = Alloc.Const.Option.value opt_modes ~default:Alloc.Const.legacy in
   { mode_modes = modes; mode_desc = annots }
+
+let transl_mod_bounds annots =
+  let bounds_loc =
+    match List.map (fun { loc; _ } -> loc) annots with
+    | [] -> Location.none
+    | _ :: _ as locs -> Location.merge locs
+  in
+  let step bounds_so_far { txt = Parsetree.Mode txt; loc } =
+    match Modifier_axis_pair.of_string txt with
+    | P (type a) ((axis, mode) : a Axis.t * a) ->
+      let is_top = Per_axis.(le axis (max axis) mode) in
+      if is_top
+      then
+        (* CR layouts v2.8: This warning is disabled for now because transl_type_decl
+           results in 3 calls to transl_annots per user-written annotation. This results
+           in the warning being reported 3 times. Internal ticket 2801. *)
+        (* Location.prerr_warning new_raw.loc (Warnings.Mod_by_top new_raw.txt) *)
+        ();
+      let is_dup =
+        Option.is_some (Transled_modifiers.get ~axis bounds_so_far)
+      in
+      if is_dup then raise (Error (loc, Duplicated_axis (Modifier, axis)));
+      Transled_modifiers.set ~axis bounds_so_far (Some { txt = mode; loc })
+    | exception Not_found -> (
+      match txt with
+      (* CR layouts-scannable: This should be removed once the new syntax for
+         separability is adopted. There is no warning raised currently for dupes
+         because the warnings would be reported 3 times. If this is fixed before
+         the syntax is deprecated, dupes really should raise warnings! *)
+      | "non_pointer" ->
+        Transled_modifiers.meet_separability bounds_so_far
+          { txt = Non_pointer; loc }
+      | "non_pointer64" ->
+        Transled_modifiers.meet_separability bounds_so_far
+          { txt = Non_pointer64; loc }
+      | "non_float" ->
+        Transled_modifiers.meet_separability bounds_so_far
+          { txt = Non_float; loc }
+      | "separable" ->
+        Transled_modifiers.meet_separability bounds_so_far
+          { txt = Separable; loc }
+      | "maybe_separable" ->
+        Transled_modifiers.meet_separability bounds_so_far
+          { txt = Maybe_separable; loc }
+      | "non_null" ->
+        Transled_modifiers.meet_nullability bounds_so_far
+          { txt = Non_null; loc }
+      | "maybe_null" ->
+        Transled_modifiers.meet_nullability bounds_so_far
+          { txt = Maybe_null; loc }
+      | "everything" ->
+        Transled_modifiers.
+          { areality =
+              Some { txt = Per_axis.min (Modal (Comonadic Areality)); loc };
+            linearity =
+              Some { txt = Per_axis.min (Modal (Comonadic Linearity)); loc };
+            uniqueness =
+              Some { txt = Per_axis.min (Modal (Monadic Uniqueness)); loc };
+            portability =
+              Some { txt = Per_axis.min (Modal (Comonadic Portability)); loc };
+            contention =
+              Some { txt = Per_axis.min (Modal (Monadic Contention)); loc };
+            forkable =
+              Some { txt = Per_axis.min (Modal (Comonadic Forkable)); loc };
+            yielding =
+              Some { txt = Per_axis.min (Modal (Comonadic Yielding)); loc };
+            externality = Some { txt = Externality.min; loc };
+            statefulness =
+              Some { txt = Per_axis.min (Modal (Comonadic Statefulness)); loc };
+            visibility =
+              Some { txt = Per_axis.min (Modal (Monadic Visibility)); loc };
+            staticity = None;
+            nullability = bounds_so_far.nullability;
+            separability = bounds_so_far.separability
+          }
+      | _ -> raise (Error (loc, Unrecognized_modifier (Modifier, txt))))
+  in
+  let raw_modifiers = List.fold_left step Transled_modifiers.empty annots in
+  let modality =
+    let open Modality in
+    let has_explicit axis =
+      let (P axis) = Crossing.Axis.of_modality (P axis) in
+      Option.is_some (Transled_modifiers.get ~axis:(Modal axis) raw_modifiers)
+    in
+    let add_implied axis value acc =
+      List.fold_left
+        (fun acc (Atom (axis', value')) ->
+          if has_explicit axis' then acc else Const.set axis' value' acc)
+        acc
+        (implied_modalities (Atom (axis, value)))
+    in
+    let add_comonadic acc axis =
+      match
+        Transled_modifiers.get ~axis:(Modal (Comonadic axis)) raw_modifiers
+      with
+      | None -> acc
+      | Some { txt = Modality value; _ } ->
+        let acc = Const.set (Comonadic axis) value acc in
+        add_implied (Comonadic axis) value acc
+    in
+    let add_monadic acc axis =
+      match
+        Transled_modifiers.get ~axis:(Modal (Monadic axis)) raw_modifiers
+      with
+      | None -> acc
+      | Some { txt = Modality value; _ } ->
+        let acc = Const.set (Monadic axis) value acc in
+        add_implied (Monadic axis) value acc
+    in
+    let add acc = function
+      | Value.Axis.P (Comonadic axis) -> add_comonadic acc axis
+      | Value.Axis.P (Monadic axis) -> add_monadic acc axis
+    in
+    List.fold_left add Const.id Value.Axis.all
+  in
+  enforce_forbidden_modalities Modifier ~loc:bounds_loc modality;
+  let open Jkind.Mod_bounds in
+  let externality =
+    Option.fold ~some:Location.get_txt ~none:Externality.max
+      raw_modifiers.externality
+  in
+  let crossing = Crossing.modality modality Crossing.max in
+  ( create crossing ~externality,
+    (raw_modifiers.nullability, raw_modifiers.separability) )
+
+let untransl_mod_bounds ?(verbose = false) (bounds : Jkind.Mod_bounds.t) :
+    Parsetree.modes =
+  let crossing = Jkind.Mod_bounds.crossing bounds in
+  let modality = Crossing.to_modality crossing in
+  let least_modalities =
+    least_modalities ~include_implied:verbose ~mut:Immutable modality
+  in
+  let modality_annots =
+    List.map
+      (fun (Atom (ax, m) : Modality.atom) ->
+        let s = Format_doc.asprintf "%a" (Modality.Per_axis.print ax) m in
+        { Location.txt = Parsetree.Mode s; loc = Location.none })
+      least_modalities
+  in
+  (* These mod-bounds are top ones, which are redundant to print. But we
+     include them when printing verbosely. *)
+  let top_modality_annots () =
+    List.filter_map
+      (fun ax ->
+        let (P ax) = Modality.Axis.of_value ax in
+        let included_in_nonverbose =
+          List.exists
+            (fun (Atom (ax2, _) : Modality.atom) ->
+              Modality.Axis.P ax = Modality.Axis.P ax2)
+            least_modalities
+        in
+        match included_in_nonverbose with
+        | true -> None
+        | false ->
+          let s =
+            Format_doc.asprintf "%a"
+              (Modality.Per_axis.print ax)
+              (Modality.Const.proj ax modality)
+          in
+          Some { Location.txt = Parsetree.Mode s; loc = Location.none })
+      Value.Axis.all
+  in
+  let nonmodal_annots, top_nonmodal_annots =
+    let open Jkind.Mod_bounds in
+    let mk_annot top print value =
+      let only_when_verbose = value = top in
+      let s = Format_doc.asprintf "%a" print value in
+      ( { Location.txt = Parsetree.Mode s; loc = Location.none },
+        only_when_verbose )
+    in
+    [mk_annot Externality.max Externality.print (externality bounds)]
+    |> List.partition_map (fun (annot, only_when_verbose) ->
+        match only_when_verbose with false -> Left annot | true -> Right annot)
+  in
+  let verbose_annots =
+    match verbose with
+    | true -> top_modality_annots () @ top_nonmodal_annots
+    | false -> []
+  in
+  modality_annots @ nonmodal_annots @ verbose_annots
 
 (* Error reporting *)
 

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -543,7 +543,7 @@ let everything_modality =
         | Modality value -> Modality.Const.set (Monadic axis) value acc))
     Modality.Const.id Value.Axis.all
 
-let transl_mod_bounds annots =
+let transl_mod_bounds ?(warn = true) annots =
   let bounds_loc =
     match List.map (fun { loc; _ } -> loc) annots with
     | [] -> Location.none
@@ -567,7 +567,8 @@ let transl_mod_bounds annots =
     | P (type a) ((ax, mode) : a Axis.Nonmodal.t * a) ->
       let axis = Axis.Nonmodal ax in
       let is_top = Per_axis.(le axis (max axis) mode) in
-      if is_top then Location.prerr_warning loc Warnings.Redundant_modifier;
+      if is_top && warn
+      then Location.prerr_warning loc Warnings.Redundant_modifier;
       if Option.is_some (Nonmodal_bounds.get ax nonmodal)
       then raise (Error (loc, Duplicated_axis (Modifier, axis)));
       Nonmodal_bounds.set ax (Some { txt = mode; loc }) nonmodal
@@ -641,7 +642,7 @@ let transl_mod_bounds annots =
     nm, base, sort_dedup_modalities_with_locs (List.rev atoms)
   in
   let warn_redundant loc (_ : Modality.atom) =
-    Location.prerr_warning loc Warnings.Redundant_modifier
+    if warn then Location.prerr_warning loc Warnings.Redundant_modifier
   in
   let modality =
     transl_modality_atoms ~warn_redundant ~default:base_modality ~loc:bounds_loc

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -408,17 +408,28 @@ let sort_dedup_modalities_with_locs l =
 let transl_modality_atoms ~warn_redundant ~default ~loc ~annot_type
     (atoms : Modality.atom Location.loc list) =
   let open Modality in
-  let modalities =
+  (* [implied] maps each axis set by an implied modality to the printed form
+     of the modality that implied it, for reporting redundancy reasons. *)
+  let modalities, _ =
     List.fold_left
-      (fun m { txt = Atom (ax, a) as t; loc } ->
+      (fun (m, implied) { txt = Atom (ax, a) as t; loc } ->
         let current_a = Const.proj ax m in
-        if Misc.Le_result.equal ~le:(Per_axis.le ax) a current_a
-        then warn_redundant loc t;
+        (if Misc.Le_result.equal ~le:(Per_axis.le ax) a current_a
+         then
+           let implied_by =
+             List.find_opt
+               (fun (p, _) -> Axis.compare p (Axis.P ax) = 0)
+               implied
+             |> Option.map snd
+           in
+           warn_redundant loc t ~implied_by);
+        let name = Format_doc.asprintf "%a" (Per_axis.print ax) a in
         let m = Const.set ax a m in
         List.fold_left
-          (fun m (Atom (ax, a)) -> Const.set ax a m)
-          m (implied_modalities t))
-      default atoms
+          (fun (m, implied) (Atom (ax, a)) ->
+            Const.set ax a m, (Axis.P ax, name) :: implied)
+          (m, implied) (implied_modalities t))
+      (default, []) atoms
   in
   enforce_forbidden_modalities annot_type ~loc modalities;
   modalities
@@ -568,7 +579,9 @@ let transl_mod_bounds ?(warn = true) annots =
       let axis = Axis.Nonmodal ax in
       let is_top = Per_axis.(le axis (max axis) mode) in
       if is_top && warn
-      then Location.prerr_warning loc Warnings.Redundant_modifier;
+      then
+        Location.prerr_warning loc
+          (Warnings.Redundant_modifier { modifier = txt; implied_by = None });
       if Option.is_some (Nonmodal_bounds.get ax nonmodal)
       then raise (Error (loc, Duplicated_axis (Modifier, axis)));
       Nonmodal_bounds.set ax (Some { txt = mode; loc }) nonmodal
@@ -641,8 +654,12 @@ let transl_mod_bounds ?(warn = true) annots =
     (* axes listed in the order of implication. *)
     nm, base, sort_dedup_modalities_with_locs (List.rev atoms)
   in
-  let warn_redundant loc (_ : Modality.atom) =
-    if warn then Location.prerr_warning loc Warnings.Redundant_modifier
+  let warn_redundant loc (Modality.Atom (ax, a)) ~implied_by =
+    if warn
+    then
+      let modifier = Format_doc.asprintf "%a" (Modality.Per_axis.print ax) a in
+      Location.prerr_warning loc
+        (Warnings.Redundant_modifier { modifier; implied_by })
   in
   let modality =
     transl_modality_atoms ~warn_redundant ~default:base_modality ~loc:bounds_loc

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -416,13 +416,16 @@ let transl_modality_atoms ~warn_redundant ~default ~loc ~annot_type
         let current_a = Const.proj ax m in
         (if Misc.Le_result.equal ~le:(Per_axis.le ax) a current_a
          then
-           let implied_by =
-             List.find_opt
-               (fun (p, _) -> Axis.compare p (Axis.P ax) = 0)
-               implied
-             |> Option.map snd
+           let reason : Warnings.redundant_modifier_reason =
+             match
+               List.find_opt
+                 (fun (p, _) -> Axis.compare p (Axis.P ax) = 0)
+                 implied
+             with
+             | Some (_, implying) -> Implied_by implying
+             | None -> Default_bound
            in
-           warn_redundant loc t ~implied_by);
+           warn_redundant loc t ~reason);
         let name = Format_doc.asprintf "%a" (Per_axis.print ax) a in
         let m = Const.set ax a m in
         List.fold_left
@@ -581,7 +584,8 @@ let transl_mod_bounds ?(warn = true) annots =
       if is_top && warn
       then
         Location.prerr_warning loc
-          (Warnings.Redundant_modifier { modifier = txt; implied_by = None });
+          (Warnings.Redundant_modifier
+             { modifier = txt; reason = Default_bound });
       if Option.is_some (Nonmodal_bounds.get ax nonmodal)
       then raise (Error (loc, Duplicated_axis (Modifier, axis)));
       Nonmodal_bounds.set ax (Some { txt = mode; loc }) nonmodal
@@ -654,12 +658,12 @@ let transl_mod_bounds ?(warn = true) annots =
     (* axes listed in the order of implication. *)
     nm, base, sort_dedup_modalities_with_locs (List.rev atoms)
   in
-  let warn_redundant loc (Modality.Atom (ax, a)) ~implied_by =
+  let warn_redundant loc (Modality.Atom (ax, a)) ~reason =
     if warn
     then
       let modifier = Format_doc.asprintf "%a" (Modality.Per_axis.print ax) a in
       Location.prerr_warning loc
-        (Warnings.Redundant_modifier { modifier; implied_by })
+        (Warnings.Redundant_modifier { modifier; reason })
   in
   let modality =
     transl_modality_atoms ~warn_redundant ~default:base_modality ~loc:bounds_loc

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -112,94 +112,34 @@ module Modality_axis_pair = struct
     | Atom (Comonadic ax, mode) -> Atom (Comonadic ax, Meet_const mode)
 end
 
-module Modifier_axis_pair = struct
-  type t = P : 'a Axis.t * 'a -> t
+module Nonmodal_axis_pair = struct
+  type t = P : 'a Axis.Nonmodal.t * 'a -> t
 
   let of_string s : t =
-    match[@warning "-18"] Modality_axis_pair.of_string s with
-    | Atom (Monadic ax, m) -> P (Modal (Monadic ax), Modality m)
-    | Atom (Comonadic ax, m) -> P (Modal (Comonadic ax), Modality m)
-    | exception Not_found -> (
-      let nonmodal (type a) (ax : a Axis.Nonmodal.t) (a : a) : t =
-        P (Nonmodal ax, a)
-      in
-      match s with
-      | "internal" -> nonmodal Externality Internal
-      | "external64" -> nonmodal Externality External64
-      | "external_" -> nonmodal Externality External
-      | _ -> raise Not_found)
+    match[@warning "-18"] s with
+    | "internal" -> P (Externality, Internal)
+    | "external64" -> P (Externality, External64)
+    | "external_" -> P (Externality, External)
+    | _ -> raise Not_found
 end
 
-module Transled_modifiers = struct
-  module Monadic = Mode.Crossing.Monadic
-  module Comonadic = Mode.Crossing.Comonadic
-
+module Nonmodal_bounds = struct
   type t =
-    { areality : Mode.Regionality.Const.t Comonadic.Atom.t Location.loc option;
-      linearity : Mode.Linearity.Const.t Comonadic.Atom.t Location.loc option;
-      uniqueness : Mode.Uniqueness.Const.t Monadic.Atom.t Location.loc option;
-      portability :
-        Mode.Portability.Const.t Comonadic.Atom.t Location.loc option;
-      contention : Mode.Contention.Const.t Monadic.Atom.t Location.loc option;
-      forkable : Mode.Forkable.Const.t Comonadic.Atom.t Location.loc option;
-      yielding : Mode.Yielding.Const.t Comonadic.Atom.t Location.loc option;
-      statefulness :
-        Mode.Statefulness.Const.t Comonadic.Atom.t Location.loc option;
-      visibility : Mode.Visibility.Const.t Monadic.Atom.t Location.loc option;
-      staticity : Mode.Staticity.Const.t Monadic.Atom.t Location.loc option;
-      (* CR-soon zqian: Create a functor [Mode.Value.Const.Make] to generate
-         different type operators applied on mode constants. *)
-      externality : Jkind_axis.Externality.t Location.loc option;
+    { externality : Externality.t Location.loc option;
       (* CR layouts-scannable: This is a temporary hack to support the previous
          syntax. The location is not being used for anything currently. *)
-      nullability : Jkind_axis.Nullability.t Location.loc option;
-      separability : Jkind_axis.Separability.t Location.loc option
+      nullability : Nullability.t Location.loc option;
+      separability : Separability.t Location.loc option
     }
 
-  let empty =
-    { areality = None;
-      linearity = None;
-      uniqueness = None;
-      portability = None;
-      contention = None;
-      forkable = None;
-      yielding = None;
-      statefulness = None;
-      visibility = None;
-      externality = None;
-      nullability = None;
-      separability = None;
-      staticity = None
-    }
+  let empty = { externality = None; nullability = None; separability = None }
 
-  let get (type a) ~(axis : a Axis.t) (t : t) : a Location.loc option =
-    match axis with
-    | Modal (Comonadic Areality) -> t.areality
-    | Modal (Comonadic Linearity) -> t.linearity
-    | Modal (Monadic Uniqueness) -> t.uniqueness
-    | Modal (Comonadic Portability) -> t.portability
-    | Modal (Monadic Contention) -> t.contention
-    | Modal (Comonadic Forkable) -> t.forkable
-    | Modal (Comonadic Yielding) -> t.yielding
-    | Modal (Comonadic Statefulness) -> t.statefulness
-    | Modal (Monadic Visibility) -> t.visibility
-    | Modal (Monadic Staticity) -> t.staticity
-    | Nonmodal Externality -> t.externality
+  let get (type a) (ax : a Axis.Nonmodal.t) (t : t) : a Location.loc option =
+    match ax with Externality -> t.externality
 
-  let set (type a) ~(axis : a Axis.t) (t : t) (value : a Location.loc option) :
-      t =
-    match axis with
-    | Modal (Comonadic Areality) -> { t with areality = value }
-    | Modal (Comonadic Linearity) -> { t with linearity = value }
-    | Modal (Monadic Uniqueness) -> { t with uniqueness = value }
-    | Modal (Comonadic Portability) -> { t with portability = value }
-    | Modal (Monadic Contention) -> { t with contention = value }
-    | Modal (Comonadic Forkable) -> { t with forkable = value }
-    | Modal (Comonadic Yielding) -> { t with yielding = value }
-    | Modal (Comonadic Statefulness) -> { t with statefulness = value }
-    | Modal (Monadic Visibility) -> { t with visibility = value }
-    | Modal (Monadic Staticity) -> { t with staticity = value }
-    | Nonmodal Externality -> { t with externality = value }
+  let set (type a) (ax : a Axis.Nonmodal.t) (v : a Location.loc option) (t : t)
+      : t =
+    match ax with Externality -> { t with externality = v }
 
   let meet_nullability t (nullability : Nullability.t loc) =
     match t.nullability with
@@ -444,7 +384,7 @@ let least_modalities ~include_implied ~mut (t : Modality.Const.t) =
   in
   exclude_implied @ overridden
 
-let sort_dedup_modalities l =
+let sort_dedup_modalities_with_locs l =
   let open Modality in
   let compare { txt = Atom (ax0, _); loc = _ } { txt = Atom (ax1, _); loc = _ }
       =
@@ -459,6 +399,29 @@ let sort_dedup_modalities l =
     function [] -> [] | x :: xs -> loop x xs
   in
   l |> List.stable_sort compare |> dedup
+
+(* - default is applied before explicit atoms.
+   - explicit atoms can override default.
+   - For the same axis, later atoms override earlier atoms, and implied
+     atoms override explicit ones; pass atoms sorted in the order of
+     implication to make explicit atoms win. *)
+let transl_modality_atoms ~warn_redundant ~default ~loc ~annot_type
+    (atoms : Modality.atom Location.loc list) =
+  let open Modality in
+  let modalities =
+    List.fold_left
+      (fun m { txt = Atom (ax, a) as t; loc } ->
+        let current_a = Const.proj ax m in
+        if Misc.Le_result.equal ~le:(Per_axis.le ax) a current_a
+        then warn_redundant loc t;
+        let m = Const.set ax a m in
+        List.fold_left
+          (fun m (Atom (ax, a)) -> Const.set ax a m)
+          m (implied_modalities t))
+      default atoms
+  in
+  enforce_forbidden_modalities annot_type ~loc modalities;
+  modalities
 
 let transl_modalities_with_default ?(allow_redundant_staticity = false)
     ~maturity ~default annots =
@@ -480,7 +443,7 @@ let transl_modalities_with_default ?(allow_redundant_staticity = false)
           (fun m (Atom (ax, a)) -> Const.set ax a m)
           m (implied_modalities t))
       default
-      (sort_dedup_modalities atoms)
+      (sort_dedup_modalities_with_locs atoms)
   in
   let modalities = build annots in
   (* Don't warn on [@@ static] on interface toplevel,
@@ -536,7 +499,7 @@ let sort_dedup_modalities modalities =
   (* CR-someday lstevenson: Improve this. It's not great that we're just passing
      a none location. We should find a nicer solution. *)
   List.map (fun x -> { txt = x; loc = Location.none }) modalities
-  |> sort_dedup_modalities
+  |> sort_dedup_modalities_with_locs
   |> List.map (fun x -> x.txt)
 
 let untransl_modalities t = List.map untransl_modality t.moda_desc
@@ -546,12 +509,13 @@ let transl_with_bound_modifiers annots =
     List.fold_left
       (fun (modal_annots, externality)
            ({ txt = Parsetree.Modality modality; loc } as annot) ->
-        match Modifier_axis_pair.of_string modality with
-        | P (Modal _, _) -> annot :: modal_annots, externality
-        | P (Nonmodal Externality, (value : Externality.t)) ->
-          modal_annots, Some value
-        | exception Not_found ->
-          raise (Error (loc, Unrecognized_modifier (Modality, modality))))
+        match Modality_axis_pair.of_string modality with
+        | Atom (_, _) -> annot :: modal_annots, externality
+        | exception Not_found -> (
+          match Nonmodal_axis_pair.of_string modality with
+          | P (Externality, (value : Externality.t)) -> modal_annots, Some value
+          | exception Not_found ->
+            raise (Error (loc, Unrecognized_modifier (Modality, modality)))))
       ([], None) annots
   in
   let modality =
@@ -567,28 +531,46 @@ let transl_alloc_mode annots =
   let modes = Alloc.Const.Option.value opt_modes ~default:Alloc.Const.legacy in
   { mode_modes = modes; mode_desc = annots }
 
+let everything_modality =
+  List.fold_left
+    (fun acc -> function
+      | Value.Axis.P (Monadic Staticity) -> acc
+      | Value.Axis.P (Comonadic axis) -> (
+        match Per_axis.min (Modal (Comonadic axis)) with
+        | Modality value -> Modality.Const.set (Comonadic axis) value acc)
+      | Value.Axis.P (Monadic axis) -> (
+        match Per_axis.min (Modal (Monadic axis)) with
+        | Modality value -> Modality.Const.set (Monadic axis) value acc))
+    Modality.Const.id Value.Axis.all
+
 let transl_mod_bounds annots =
   let bounds_loc =
     match List.map (fun { loc; _ } -> loc) annots with
     | [] -> Location.none
     | _ :: _ as locs -> Location.merge locs
   in
-  let step bounds_so_far { txt = Parsetree.Mode txt; loc } =
-    match Modifier_axis_pair.of_string txt with
-    | P (type a) ((axis, mode) : a Axis.t * a) ->
+  let has_modal_axis (Modality.Atom (ax, _)) atoms =
+    List.exists
+      (fun { txt = Modality.Atom (ax2, _); _ } ->
+        Modality.Axis.P ax = Modality.Axis.P ax2)
+      atoms
+  in
+  let raise_dup_modal loc (Modality.Atom (ax, _)) =
+    match[@warning "-18"] ax with
+    | Comonadic ax ->
+      raise (Error (loc, Duplicated_axis (Modifier, Modal (Comonadic ax))))
+    | Monadic ax ->
+      raise (Error (loc, Duplicated_axis (Modifier, Modal (Monadic ax))))
+  in
+  let transl_nonmodal_modifier ~loc txt nonmodal =
+    match Nonmodal_axis_pair.of_string txt with
+    | P (type a) ((ax, mode) : a Axis.Nonmodal.t * a) ->
+      let axis = Axis.Nonmodal ax in
       let is_top = Per_axis.(le axis (max axis) mode) in
-      if is_top
-      then
-        (* CR layouts v2.8: This warning is disabled for now because transl_type_decl
-           results in 3 calls to transl_annots per user-written annotation. This results
-           in the warning being reported 3 times. Internal ticket 2801. *)
-        (* Location.prerr_warning new_raw.loc (Warnings.Mod_by_top new_raw.txt) *)
-        ();
-      let is_dup =
-        Option.is_some (Transled_modifiers.get ~axis bounds_so_far)
-      in
-      if is_dup then raise (Error (loc, Duplicated_axis (Modifier, axis)));
-      Transled_modifiers.set ~axis bounds_so_far (Some { txt = mode; loc })
+      if is_top then Location.prerr_warning loc Warnings.Redundant_modifier;
+      if Option.is_some (Nonmodal_bounds.get ax nonmodal)
+      then raise (Error (loc, Duplicated_axis (Modifier, axis)));
+      Nonmodal_bounds.set ax (Some { txt = mode; loc }) nonmodal
     | exception Not_found -> (
       match txt with
       (* CR layouts-scannable: This should be removed once the new syntax for
@@ -596,100 +578,82 @@ let transl_mod_bounds annots =
          because the warnings would be reported 3 times. If this is fixed before
          the syntax is deprecated, dupes really should raise warnings! *)
       | "non_pointer" ->
-        Transled_modifiers.meet_separability bounds_so_far
-          { txt = Non_pointer; loc }
+        Nonmodal_bounds.meet_separability nonmodal { txt = Non_pointer; loc }
       | "non_pointer64" ->
-        Transled_modifiers.meet_separability bounds_so_far
-          { txt = Non_pointer64; loc }
+        Nonmodal_bounds.meet_separability nonmodal { txt = Non_pointer64; loc }
       | "non_float" ->
-        Transled_modifiers.meet_separability bounds_so_far
-          { txt = Non_float; loc }
+        Nonmodal_bounds.meet_separability nonmodal { txt = Non_float; loc }
       | "separable" ->
-        Transled_modifiers.meet_separability bounds_so_far
-          { txt = Separable; loc }
+        Nonmodal_bounds.meet_separability nonmodal { txt = Separable; loc }
       | "maybe_separable" ->
-        Transled_modifiers.meet_separability bounds_so_far
+        Nonmodal_bounds.meet_separability nonmodal
           { txt = Maybe_separable; loc }
       | "non_null" ->
-        Transled_modifiers.meet_nullability bounds_so_far
-          { txt = Non_null; loc }
+        Nonmodal_bounds.meet_nullability nonmodal { txt = Non_null; loc }
       | "maybe_null" ->
-        Transled_modifiers.meet_nullability bounds_so_far
-          { txt = Maybe_null; loc }
+        Nonmodal_bounds.meet_nullability nonmodal { txt = Maybe_null; loc }
       | "everything" ->
-        Transled_modifiers.
-          { areality =
-              Some { txt = Per_axis.min (Modal (Comonadic Areality)); loc };
-            linearity =
-              Some { txt = Per_axis.min (Modal (Comonadic Linearity)); loc };
-            uniqueness =
-              Some { txt = Per_axis.min (Modal (Monadic Uniqueness)); loc };
-            portability =
-              Some { txt = Per_axis.min (Modal (Comonadic Portability)); loc };
-            contention =
-              Some { txt = Per_axis.min (Modal (Monadic Contention)); loc };
-            forkable =
-              Some { txt = Per_axis.min (Modal (Comonadic Forkable)); loc };
-            yielding =
-              Some { txt = Per_axis.min (Modal (Comonadic Yielding)); loc };
-            externality = Some { txt = Externality.min; loc };
-            statefulness =
-              Some { txt = Per_axis.min (Modal (Comonadic Statefulness)); loc };
-            visibility =
-              Some { txt = Per_axis.min (Modal (Monadic Visibility)); loc };
-            staticity = None;
-            nullability = bounds_so_far.nullability;
-            separability = bounds_so_far.separability
-          }
+        if Option.is_some (Nonmodal_bounds.get Externality nonmodal)
+        then
+          raise
+            (Error
+               ( loc,
+                 Duplicated_axis
+                   (Modifier, Axis.Nonmodal Axis.Nonmodal.Externality) ));
+        Nonmodal_bounds.set Externality
+          (Some { txt = Externality.min; loc })
+          nonmodal
       | _ -> raise (Error (loc, Unrecognized_modifier (Modifier, txt))))
   in
-  let raw_modifiers = List.fold_left step Transled_modifiers.empty annots in
-  let modality =
-    let open Modality in
-    let has_explicit axis =
-      let (P axis) = Crossing.Axis.of_modality (P axis) in
-      Option.is_some (Transled_modifiers.get ~axis:(Modal axis) raw_modifiers)
-    in
-    let add_implied axis value acc =
-      List.fold_left
-        (fun acc (Atom (axis', value')) ->
-          if has_explicit axis' then acc else Const.set axis' value' acc)
-        acc
-        (implied_modalities (Atom (axis, value)))
-    in
-    let add_comonadic acc axis =
-      match
-        Transled_modifiers.get ~axis:(Modal (Comonadic axis)) raw_modifiers
-      with
-      | None -> acc
-      | Some { txt = Modality value; _ } ->
-        let acc = Const.set (Comonadic axis) value acc in
-        add_implied (Comonadic axis) value acc
-    in
-    let add_monadic acc axis =
-      match
-        Transled_modifiers.get ~axis:(Modal (Monadic axis)) raw_modifiers
-      with
-      | None -> acc
-      | Some { txt = Modality value; _ } ->
-        let acc = Const.set (Monadic axis) value acc in
-        add_implied (Monadic axis) value acc
-    in
-    let add acc = function
-      | Value.Axis.P (Comonadic axis) -> add_comonadic acc axis
-      | Value.Axis.P (Monadic axis) -> add_monadic acc axis
-    in
-    List.fold_left add Const.id Value.Axis.all
+  (* [everything] specifies every modal axis except staticity, so it conflicts
+     with any non-staticity modal modifier on either side. *)
+  let is_staticity (Modality.Atom (ax, _)) =
+    match[@warning "-18"] ax with Monadic Staticity -> true | _ -> false
   in
-  enforce_forbidden_modalities Modifier ~loc:bounds_loc modality;
+  let nonmodal, base_modality, modal_atoms =
+    List.fold_left
+      (fun (nonmodal, base, atoms, seen_ev) { txt = Parsetree.Mode txt; loc } ->
+        match Modality_axis_pair.of_string txt with
+        | Atom (_, _) as atom ->
+          if (seen_ev && not (is_staticity atom)) || has_modal_axis atom atoms
+          then raise_dup_modal loc atom;
+          nonmodal, base, { txt = atom; loc } :: atoms, seen_ev
+        | exception Not_found ->
+          let nonmodal = transl_nonmodal_modifier ~loc txt nonmodal in
+          let base, seen_ev =
+            if String.equal txt "everything"
+            then (
+              (match
+                 List.find_opt
+                   (fun { Location.txt = atom; _ } -> not (is_staticity atom))
+                   atoms
+               with
+              | Some { txt = atom; _ } -> raise_dup_modal loc atom
+              | None -> ());
+              everything_modality, true)
+            else base, seen_ev
+          in
+          nonmodal, base, atoms, seen_ev)
+      (Nonmodal_bounds.empty, Modality.Const.id, [], false)
+      annots
+    |> fun (nm, base, atoms, _) ->
+    (* axes listed in the order of implication. *)
+    nm, base, sort_dedup_modalities_with_locs (List.rev atoms)
+  in
+  let warn_redundant loc (_ : Modality.atom) =
+    Location.prerr_warning loc Warnings.Redundant_modifier
+  in
+  let modality =
+    transl_modality_atoms ~warn_redundant ~default:base_modality ~loc:bounds_loc
+      ~annot_type:Modifier modal_atoms
+  in
   let open Jkind.Mod_bounds in
   let externality =
     Option.fold ~some:Location.get_txt ~none:Externality.max
-      raw_modifiers.externality
+      nonmodal.externality
   in
   let crossing = Crossing.modality modality Crossing.max in
-  ( create crossing ~externality,
-    (raw_modifiers.nullability, raw_modifiers.separability) )
+  create crossing ~externality, (nonmodal.nullability, nonmodal.separability)
 
 let untransl_mod_bounds ?(verbose = false) (bounds : Jkind.Mod_bounds.t) :
     Parsetree.modes =

--- a/typing/typemode.mli
+++ b/typing/typemode.mli
@@ -75,6 +75,7 @@ val transl_with_bound_modifiers :
 
 (** Interpret a mod-bounds. *)
 val transl_mod_bounds :
+  ?warn:bool ->
   Parsetree.modes ->
   Jkind.Mod_bounds.t
   * (Jkind_axis.Nullability.t Location.loc option

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -55,6 +55,10 @@ type type_declaration_usage_warning =
   | Declaration
   | Alias
 
+type redundant_modifier_reason =
+  | Default_bound
+  | Implied_by of string
+
 type t =
   | Comment_start                           (*  1 *)
   | Comment_not_end                         (*  2 *)
@@ -155,7 +159,7 @@ type t =
   | Unboxing_impossible                     (* 210 *)
   | Redundant_modifier of
       { modifier : string;
-        implied_by : string option }          (* 211 *)
+        reason : redundant_modifier_reason }  (* 211 *)
   (* 212 taken *)
   (* 213 was [Modal_axis_specified_twice], now subsumed by
      [Redundant_modality] (220) *)
@@ -1496,14 +1500,14 @@ let message = function
       msg "This %a attribute cannot be used.@ \
            The type of this value does not allow unboxing."
         Style.inline_code "[@unboxed]"
-  | Redundant_modifier { modifier; implied_by } ->
-      (match implied_by with
-       | Some implying ->
+  | Redundant_modifier { modifier; reason } ->
+      (match reason with
+       | Implied_by implying ->
            msg "This modifier is redundant@ because it is implied by %a."
              Style.inline_code implying
-       | None ->
-           msg "This modifier is redundant:@ %a is the default bound on its@ \
-                axis, so it has no effect."
+       | Default_bound ->
+           msg "This modifier is redundant@ because %a is the default bound@ \
+                on its axis, so it has no effect."
              Style.inline_code modifier)
   (* 213 was [Modal_axis_specified_twice] *)
   | Atomic_float_record_boxed ->

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -153,7 +153,7 @@ type t =
   | Zero_alloc_all_hidden_arrow of string   (* 198 *)
   | Unchecked_zero_alloc_attribute          (* 199 *)
   | Unboxing_impossible                     (* 210 *)
-  | Mod_by_top of string                    (* 211 *)
+  | Redundant_modifier                      (* 211 *)
   (* 212 taken *)
   (* 213 was [Modal_axis_specified_twice], now subsumed by
      [Redundant_modality] (220) *)
@@ -258,7 +258,7 @@ let number = function
   | Zero_alloc_all_hidden_arrow _ -> 198
   | Unchecked_zero_alloc_attribute -> 199
   | Unboxing_impossible -> 210
-  | Mod_by_top _ -> 211
+  | Redundant_modifier -> 211
   | Atomic_float_record_boxed -> 214
   | Implied_attribute _ -> 215
   | Use_during_borrowing -> 216
@@ -681,8 +681,8 @@ let descriptions = [
     description = "The parameter or return value corresponding @unboxed attribute cannot be unboxed.";
     since = since 4 14 };
   { number = 211;
-    names = ["mod-by-top"];
-    description = "Including the top-most element of an axis in a kind's modifiers is a no-op.";
+    names = ["redundant-modifier"];
+    description = "Modifier is redundant with the default.";
     since = since 4 14 };
   { number = 214;
     names = ["atomic-float-record-boxed"];
@@ -1493,9 +1493,8 @@ let message = function
       msg "This %a attribute cannot be used.@ \
            The type of this value does not allow unboxing."
         Style.inline_code "[@unboxed]"
-  | Mod_by_top modifier ->
-      msg "%s is the top-most modifier.@ \
-           Modifying by a top element is a no-op." modifier
+  | Redundant_modifier ->
+      msg "This modifier is redundant."
   (* 213 was [Modal_axis_specified_twice] *)
   | Atomic_float_record_boxed ->
       msg "This record contains atomic float fields,@ \

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -153,7 +153,9 @@ type t =
   | Zero_alloc_all_hidden_arrow of string   (* 198 *)
   | Unchecked_zero_alloc_attribute          (* 199 *)
   | Unboxing_impossible                     (* 210 *)
-  | Redundant_modifier                      (* 211 *)
+  | Redundant_modifier of
+      { modifier : string;
+        implied_by : string option }          (* 211 *)
   (* 212 taken *)
   (* 213 was [Modal_axis_specified_twice], now subsumed by
      [Redundant_modality] (220) *)
@@ -258,7 +260,7 @@ let number = function
   | Zero_alloc_all_hidden_arrow _ -> 198
   | Unchecked_zero_alloc_attribute -> 199
   | Unboxing_impossible -> 210
-  | Redundant_modifier -> 211
+  | Redundant_modifier _ -> 211
   | Atomic_float_record_boxed -> 214
   | Implied_attribute _ -> 215
   | Use_during_borrowing -> 216
@@ -682,7 +684,8 @@ let descriptions = [
     since = since 4 14 };
   { number = 211;
     names = ["redundant-modifier"];
-    description = "Modifier is redundant with the default.";
+    description = "Modifier is redundant with the default or implied by \
+                   another modifier.";
     since = since 4 14 };
   { number = 214;
     names = ["atomic-float-record-boxed"];
@@ -1493,8 +1496,15 @@ let message = function
       msg "This %a attribute cannot be used.@ \
            The type of this value does not allow unboxing."
         Style.inline_code "[@unboxed]"
-  | Redundant_modifier ->
-      msg "This modifier is redundant."
+  | Redundant_modifier { modifier; implied_by } ->
+      (match implied_by with
+       | Some implying ->
+           msg "This modifier is redundant@ because it is implied by %a."
+             Style.inline_code implying
+       | None ->
+           msg "This modifier is redundant:@ %a is the default bound on its@ \
+                axis, so it has no effect."
+             Style.inline_code modifier)
   (* 213 was [Modal_axis_specified_twice] *)
   | Atomic_float_record_boxed ->
       msg "This record contains atomic float fields,@ \

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -153,7 +153,9 @@ type t =
   | Zero_alloc_all_hidden_arrow of string   (* 198 *)
   | Unchecked_zero_alloc_attribute          (* 199 *)
   | Unboxing_impossible                     (* 210 *)
-  | Redundant_modifier                      (* 211 *)
+  | Redundant_modifier of
+      { modifier : string;
+        implied_by : string option }          (* 211 *)
   (* 212 taken *)
   (* 213 was [Modal_axis_specified_twice], now subsumed by
      [Redundant_modality] (220) *)
@@ -259,7 +261,7 @@ let number = function
   | Zero_alloc_all_hidden_arrow _ -> 198
   | Unchecked_zero_alloc_attribute -> 199
   | Unboxing_impossible -> 210
-  | Redundant_modifier -> 211
+  | Redundant_modifier _ -> 211
   | Atomic_float_record_boxed -> 214
   | Implied_attribute _ -> 215
   | Use_during_borrowing -> 216
@@ -684,7 +686,8 @@ let descriptions = [
     since = since 4 14 };
   { number = 211;
     names = ["redundant-modifier"];
-    description = "Modifier is redundant with the default.";
+    description = "Modifier is redundant with the default or implied by \
+                   another modifier.";
     since = since 4 14 };
   { number = 214;
     names = ["atomic-float-record-boxed"];
@@ -1578,8 +1581,15 @@ let message = function
       msg "This %a attribute cannot be used.@ \
            The type of this value does not allow unboxing."
         Style.inline_code "[@unboxed]"
-  | Redundant_modifier ->
-      msg "This modifier is redundant."
+  | Redundant_modifier { modifier; implied_by } ->
+      (match implied_by with
+       | Some implying ->
+           msg "This modifier is redundant@ because it is implied by %a."
+             Style.inline_code implying
+       | None ->
+           msg "This modifier is redundant:@ %a is the default bound on its@ \
+                axis, so it has no effect."
+             Style.inline_code modifier)
   (* 213 was [Modal_axis_specified_twice] *)
   | Atomic_float_record_boxed ->
       msg "This record contains atomic float fields,@ \

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -153,7 +153,7 @@ type t =
   | Zero_alloc_all_hidden_arrow of string   (* 198 *)
   | Unchecked_zero_alloc_attribute          (* 199 *)
   | Unboxing_impossible                     (* 210 *)
-  | Mod_by_top of string                    (* 211 *)
+  | Redundant_modifier                      (* 211 *)
   (* 212 taken *)
   (* 213 was [Modal_axis_specified_twice], now subsumed by
      [Redundant_modality] (220) *)
@@ -259,7 +259,7 @@ let number = function
   | Zero_alloc_all_hidden_arrow _ -> 198
   | Unchecked_zero_alloc_attribute -> 199
   | Unboxing_impossible -> 210
-  | Mod_by_top _ -> 211
+  | Redundant_modifier -> 211
   | Atomic_float_record_boxed -> 214
   | Implied_attribute _ -> 215
   | Use_during_borrowing -> 216
@@ -683,8 +683,8 @@ let descriptions = [
     description = "The parameter or return value corresponding @unboxed attribute cannot be unboxed.";
     since = since 4 14 };
   { number = 211;
-    names = ["mod-by-top"];
-    description = "Including the top-most element of an axis in a kind's modifiers is a no-op.";
+    names = ["redundant-modifier"];
+    description = "Modifier is redundant with the default.";
     since = since 4 14 };
   { number = 214;
     names = ["atomic-float-record-boxed"];
@@ -1578,9 +1578,8 @@ let message = function
       msg "This %a attribute cannot be used.@ \
            The type of this value does not allow unboxing."
         Style.inline_code "[@unboxed]"
-  | Mod_by_top modifier ->
-      msg "%s is the top-most modifier.@ \
-           Modifying by a top element is a no-op." modifier
+  | Redundant_modifier ->
+      msg "This modifier is redundant."
   (* 213 was [Modal_axis_specified_twice] *)
   | Atomic_float_record_boxed ->
       msg "This record contains atomic float fields,@ \

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -55,6 +55,10 @@ type type_declaration_usage_warning =
   | Declaration
   | Alias
 
+type redundant_modifier_reason =
+  | Default_bound
+  | Implied_by of string
+
 type t =
   | Comment_start                           (*  1 *)
   | Comment_not_end                         (*  2 *)
@@ -155,7 +159,7 @@ type t =
   | Unboxing_impossible                     (* 210 *)
   | Redundant_modifier of
       { modifier : string;
-        implied_by : string option }          (* 211 *)
+        reason : redundant_modifier_reason }  (* 211 *)
   (* 212 taken *)
   (* 213 was [Modal_axis_specified_twice], now subsumed by
      [Redundant_modality] (220) *)
@@ -1581,14 +1585,14 @@ let message = function
       msg "This %a attribute cannot be used.@ \
            The type of this value does not allow unboxing."
         Style.inline_code "[@unboxed]"
-  | Redundant_modifier { modifier; implied_by } ->
-      (match implied_by with
-       | Some implying ->
+  | Redundant_modifier { modifier; reason } ->
+      (match reason with
+       | Implied_by implying ->
            msg "This modifier is redundant@ because it is implied by %a."
              Style.inline_code implying
-       | None ->
-           msg "This modifier is redundant:@ %a is the default bound on its@ \
-                axis, so it has no effect."
+       | Default_bound ->
+           msg "This modifier is redundant@ because %a is the default bound@ \
+                on its axis, so it has no effect."
              Style.inline_code modifier)
   (* 213 was [Modal_axis_specified_twice] *)
   | Atomic_float_record_boxed ->

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -157,7 +157,9 @@ type t =
   | Zero_alloc_all_hidden_arrow of string   (* 198 *)
   | Unchecked_zero_alloc_attribute          (* 199 *)
   | Unboxing_impossible                     (* 210 *)
-  | Redundant_modifier                      (* 211 *)
+  | Redundant_modifier of
+      { modifier : string;
+        implied_by : string option }          (* 211 *)
   (* 213 was [Modal_axis_specified_twice], now subsumed by
      [Redundant_modality] (220) *)
   | Atomic_float_record_boxed               (* 214 *)

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -54,6 +54,10 @@ type type_declaration_usage_warning =
   | Declaration
   | Alias
 
+type redundant_modifier_reason =
+  | Default_bound
+  | Implied_by of string
+
 type t =
   | Comment_start                           (*  1 *)
   | Comment_not_end                         (*  2 *)
@@ -159,7 +163,7 @@ type t =
   | Unboxing_impossible                     (* 210 *)
   | Redundant_modifier of
       { modifier : string;
-        implied_by : string option }          (* 211 *)
+        reason : redundant_modifier_reason }  (* 211 *)
   (* 213 was [Modal_axis_specified_twice], now subsumed by
      [Redundant_modality] (220) *)
   | Atomic_float_record_boxed               (* 214 *)

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -157,7 +157,7 @@ type t =
   | Zero_alloc_all_hidden_arrow of string   (* 198 *)
   | Unchecked_zero_alloc_attribute          (* 199 *)
   | Unboxing_impossible                     (* 210 *)
-  | Mod_by_top of string                    (* 211 *)
+  | Redundant_modifier                      (* 211 *)
   (* 213 was [Modal_axis_specified_twice], now subsumed by
      [Redundant_modality] (220) *)
   | Atomic_float_record_boxed               (* 214 *)


### PR DESCRIPTION
Warn on redundant kind modifiers. Reuses the existing logic for modalities and adds a warning for non-modal modifiers.

Best reviewed commit by commit:

- https://github.com/oxcaml/oxcaml/pull/5436/commits/bf879fe3aff763b651404ad346dbaca1607805fb moves around functions in `typemode.ml` for subsequent rework
- https://github.com/oxcaml/oxcaml/pull/5436/commits/e9918e5e58e8792b7ecd6fbc54a734ff8b3610b1 adds warnings on redundant modifiers
- https://github.com/oxcaml/oxcaml/pull/5436/commits/55063d5d533c80e7bcc74d5d38a4f85d1c7d7a91 removes superfluous redundant modifier annotations from tests
- https://github.com/oxcaml/oxcaml/pull/5436/commits/c41567aaee6e91acdfc7282e4f6df7e703680243 silences some warnings and promotes the tests
- https://github.com/oxcaml/oxcaml/pull/5436/commits/f38d33955f0da689da89d807576e02c046841237 adds new tests
- https://github.com/oxcaml/oxcaml/pull/5436/commits/f027a9783caa028e96a02131501202ff00ff7f75 updates code to avoid warning twice when we parse modifiers twice. Fixing it to parse just once is out of scope for now.