### PR TITLE
Optimize Sort.set to avoid closure allocation

### DIFF
--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -336,7 +336,6 @@ module Sort = struct
    fun v t_op ->
     log_change (v, Ccontents v.contents);
     v.contents <- t_op;
-    (* avoid allocating closure *)
     match t_op with
     | None -> ()
     | Some t -> t_iter ~f:(fun u -> update_level u v) t


### PR DESCRIPTION
Inline the function and replace Option.iter with explicit pattern matching to avoid allocating a closure on each call.