### PR TITLE
Minor fix to major GC ephemeron marking.

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1464,12 +1464,11 @@ static intnat ephe_mark (intnat budget, uintnat for_cycle,
               goto ephemeron_again;
             }
           }
+        } else if (Tag_val (key) == Infix_tag) {
+          key -= Infix_offset_val (key);
         }
-        else {
-          if (Tag_val (key) == Infix_tag) key -= Infix_offset_val (key);
-          if (is_unmarked (key))
-            alive_data = 0;
-        }
+        if (is_unmarked (key))
+          alive_data = 0;
       }
     }
     budget -= Whsize_wosize(i);


### PR DESCRIPTION
Port from ocaml/ocaml#14338. Ephemerons with dead non-shortcut Forward-tagged keys were not getting cleared.