### PR TITLE
Normal form morphisms

### DIFF
--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -90,7 +90,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
           sort value
-          value_mode global,many,portable,forkable,unyielding,stateful;imply_const(unique,uncontended,read_write,static)(modevar#3[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
           alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#9[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -90,7 +90,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern 
           Tpat_var "fib"
           sort value
-          value_mode global,many,portable,forkable,unyielding,stateful;imply_const(unique,uncontended,read_write,static)(modevar#3[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression 
           Texp_function
           alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#9[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])

--- a/testsuite/tests/typing-local/crossing.ml
+++ b/testsuite/tests/typing-local/crossing.ml
@@ -161,8 +161,7 @@ Line 2, characters 13-14:
                  ^
 Error: This value is "local" to the parent region
        but is expected to be "global"
-         because it is an element of the array at line 2, characters 11-19
-         which is expected to be "global".
+         because it is an element (with some modality) of the array at line 2, characters 11-19.
 |}]
 
 (* after discussion with sdolan, we agree that

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -2588,11 +2588,7 @@ Line 2, characters 8-9:
             ^
 Error: This value is "local" to the parent region
        but is expected to be "global"
-         because it is contained (via constructor "GFoo") in the value at line 2, characters 2-17
-         which is expected to be "global" because it is an allocation
-         which is expected to be "local" to the parent region or "global"
-         because it is a function return value.
-         Hint: Use exclave_ to return a local value.
+         because it is contained (via constructor "GFoo") (with some modality) in the value at line 2, characters 2-17.
 |}]
 
 let f =

--- a/testsuite/tests/typing-modes/test_morph_compose.ml
+++ b/testsuite/tests/typing-modes/test_morph_compose.ml
@@ -4,7 +4,15 @@
 *)
 
 let () =
-  Printf.printf
-    "running allowed composition checks with partial coverage (spanning values \
-     cover each axis element at least once; not every product combination)\n%!";
-  Mode.For_testing.check_jobs ~full:false () |> List.iter (fun job -> job ())
+  Mode.For_testing.check_composition_jobs ~full:false ()
+  |> List.iter (fun job ->
+    match job () with
+    | Ok () -> ()
+    | Error error ->
+      failwith
+        (Format_doc.asprintf "%a"
+           Mode.For_testing.print_error
+           error));
+  print_endline
+    "All partial-coverage morphism composition checks succeeded: composed \
+     morphisms agree with applying each morphism in sequence."

--- a/testsuite/tests/typing-modes/test_morph_compose.ml
+++ b/testsuite/tests/typing-modes/test_morph_compose.ml
@@ -1,0 +1,10 @@
+(* TEST
+ include ocamlcommon;
+ native;
+*)
+
+let () =
+  Printf.printf
+    "running allowed composition checks with partial coverage (spanning values \
+     cover each axis element at least once; not every product combination)\n%!";
+  Mode.For_testing.check_jobs ~full:false () |> List.iter (fun job -> job ())

--- a/testsuite/tests/typing-modes/test_morph_compose.reference
+++ b/testsuite/tests/typing-modes/test_morph_compose.reference
@@ -1,0 +1,1 @@
+running allowed composition checks with partial coverage (spanning values cover each axis element at least once; not every product combination)

--- a/testsuite/tests/typing-modes/test_morph_compose.reference
+++ b/testsuite/tests/typing-modes/test_morph_compose.reference
@@ -1,1 +1,1 @@
-running allowed composition checks with partial coverage (spanning values cover each axis element at least once; not every product combination)
+All partial-coverage morphism composition checks succeeded: composed morphisms agree with applying each morphism in sequence.

--- a/typing/allowance.ml
+++ b/typing/allowance.ml
@@ -22,6 +22,8 @@ type right_only = disallowed * allowed
 
 type both = allowed * allowed
 
+type neither = disallowed * disallowed
+
 type 'a pos = 'b * 'c constraint 'a = 'b * 'c
 
 type 'a neg = 'c * 'b constraint 'a = 'b * 'c

--- a/typing/allowance.mli
+++ b/typing/allowance.mli
@@ -47,6 +47,8 @@ type right_only = disallowed * allowed
 
 type both = allowed * allowed
 
+type neither = disallowed * disallowed
+
 (** Arrange the permissions appropriately for a positive lattice, by doing
     nothing. *)
 type 'a pos = 'b * 'c constraint 'a = 'b * 'c

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -8577,10 +8577,9 @@ let check_constructor_crossing_destruction
         (fun () -> Ok min_bound))
     env lid tag ~res ~args held_locks
 
-let apply_is_contained_by is_contained_by ?(modalities = Modality.Const.id)
-  mode =
-  let hint =
-    { monadic = Hint.Is_contained_by (Monadic, is_contained_by);
-      comonadic = Hint.Is_contained_by (Comonadic, is_contained_by) }
-  in
-  Modality.Const.apply ~hint modalities mode
+let apply_left_is_contained_by is_contained_by ?(modalities = Modality.Const.id)
+  mode = Modality.Const.apply_left ~is_contained_by modalities mode
+
+let apply_right_is_contained_by is_contained_by
+  ?(modalities = Modality.Const.id) mode =
+  Modality.Const.apply_right ~is_contained_by modalities mode

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -892,6 +892,10 @@ val check_constructor_crossing_destruction :
 
 (** Takes the mode of a container, a child's relation to it, and an optional
     modality, returns the mode of the child. *)
-val apply_is_contained_by : Mode.Hint.is_contained_by
+val apply_left_is_contained_by : Mode.Hint.is_contained_by
   -> ?modalities:Mode.Modality.Const.t
-  -> ('l * 'r) Mode.Value.t -> ('l * 'r) Mode.Value.t
+  -> (allowed * 'r) Mode.Value.t -> Mode.Value.l
+
+val apply_right_is_contained_by : Mode.Hint.is_contained_by
+  -> ?modalities:Mode.Modality.Const.t
+  -> ('l * allowed) Mode.Value.t -> Mode.Value.r

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1081,7 +1081,7 @@ module Normalize_mode = struct
     | Assert_normalized, true -> modality, mode
     | (Normalize | Normalize_exn), false ->
         Mode.Modality.undefined,
-        Mode.Modality.apply ~hint:{monadic = Unknown; comonadic = Unknown}
+        Mode.Modality.apply_left
           modality mode
     | Assert_normalized, false ->
         Misc.fatal_error "mode is not already normalized but expected otherwise"
@@ -4671,7 +4671,7 @@ let lookup_settable_variable ?(use=true) ~loc name env =
           let mode =
             m0
             |> walk_locks_for_mutable_mode ~errors:true ~loc ~env locks
-            |> Mode.Modality.Const.apply
+            |> Mode.Modality.Const.apply_right
                 Typemode.let_mutable_modalities
           in
           mutate_value ~use ~loc path vda;

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -89,8 +89,8 @@ let child_modes_with_modalities id ~modalities:(moda0, moda1) = function
       (* For children, we only check modality inclusion *)
       Ok All
     | Some moda1 ->
-      let m0 = Mode.Modality.apply moda0 m0 in
-      let m1 = Mode.Modality.Const.apply moda1 m1 in
+      let m0 = Mode.Modality.apply_left moda0 m0 in
+      let m1 = Mode.Modality.Const.apply_right moda1 m1 in
       Ok (Specific ((m0, c), m1))
     end
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1533,56 +1533,57 @@ module Lattices_mono = struct
       | Visibility -> { t with visibility = r }
       | Staticity -> { t with staticity = r }
 
-    type 'a from = Ps : ('a, 'b) t -> 'a from
+    type 'a from = From : ('a, 'b) t -> 'a from
 
     let from : type a. a obj -> a from list = function
       | Comonadic_with_locality ->
-        [ Ps Areality;
-          Ps Forkable;
-          Ps Yielding;
-          Ps Linearity;
-          Ps Statefulness;
-          Ps Portability ]
+        [ From Areality;
+          From Forkable;
+          From Yielding;
+          From Linearity;
+          From Statefulness;
+          From Portability ]
       | Comonadic_with_regionality ->
-        [ Ps Areality;
-          Ps Forkable;
-          Ps Yielding;
-          Ps Linearity;
-          Ps Statefulness;
-          Ps Portability ]
-      | Monadic_op -> [Ps Uniqueness; Ps Visibility; Ps Contention; Ps Staticity]
+        [ From Areality;
+          From Forkable;
+          From Yielding;
+          From Linearity;
+          From Statefulness;
+          From Portability ]
+      | Monadic_op ->
+        [From Uniqueness; From Visibility; From Contention; From Staticity]
       | Locality | Regionality | Uniqueness_op | Linearity | Portability
       | Forkable | Yielding | Statefulness | Contention_op | Visibility_op
       | Staticity_op ->
         []
 
-    type 'b to_ = Pb : 'a obj * ('a, 'b) t -> 'b to_
+    type 'b to_ = To : 'a obj * ('a, 'b) t -> 'b to_
 
     let to_ : type b. b obj -> b to_ list = function
       | Comonadic_with_locality -> []
       | Comonadic_with_regionality -> []
       | Monadic_op -> []
-      | Locality -> [Pb (Comonadic_with_locality, Areality)]
-      | Regionality -> [Pb (Comonadic_with_regionality, Areality)]
-      | Uniqueness_op -> [Pb (Monadic_op, Uniqueness)]
+      | Locality -> [To (Comonadic_with_locality, Areality)]
+      | Regionality -> [To (Comonadic_with_regionality, Areality)]
+      | Uniqueness_op -> [To (Monadic_op, Uniqueness)]
       | Linearity ->
-        [ Pb (Comonadic_with_locality, Linearity);
-          Pb (Comonadic_with_regionality, Linearity) ]
+        [ To (Comonadic_with_locality, Linearity);
+          To (Comonadic_with_regionality, Linearity) ]
       | Portability ->
-        [ Pb (Comonadic_with_locality, Portability);
-          Pb (Comonadic_with_regionality, Portability) ]
+        [ To (Comonadic_with_locality, Portability);
+          To (Comonadic_with_regionality, Portability) ]
       | Forkable ->
-        [ Pb (Comonadic_with_locality, Forkable);
-          Pb (Comonadic_with_regionality, Forkable) ]
+        [ To (Comonadic_with_locality, Forkable);
+          To (Comonadic_with_regionality, Forkable) ]
       | Yielding ->
-        [ Pb (Comonadic_with_locality, Yielding);
-          Pb (Comonadic_with_regionality, Yielding) ]
+        [ To (Comonadic_with_locality, Yielding);
+          To (Comonadic_with_regionality, Yielding) ]
       | Statefulness ->
-        [ Pb (Comonadic_with_locality, Statefulness);
-          Pb (Comonadic_with_regionality, Statefulness) ]
-      | Contention_op -> [Pb (Monadic_op, Contention)]
-      | Visibility_op -> [Pb (Monadic_op, Visibility)]
-      | Staticity_op -> [Pb (Monadic_op, Staticity)]
+        [ To (Comonadic_with_locality, Statefulness);
+          To (Comonadic_with_regionality, Statefulness) ]
+      | Contention_op -> [To (Monadic_op, Contention)]
+      | Visibility_op -> [To (Monadic_op, Visibility)]
+      | Staticity_op -> [To (Monadic_op, Staticity)]
 
     type ('a, 'p) owner =
       | Monadic : (Monadic_op.t, 'p) t -> (Monadic_op.t, 'p) owner
@@ -1652,7 +1653,8 @@ module Lattices_mono = struct
 
   module Locality_morph = struct
     (* Following is a chain of adjunctions (this can be extended one
-       further, but we never need the missing operation). *)
+	       further, but we never need the missing operation). *)
+    (* New morphisms must be added to [left_to] and [right_to]. *)
     type ('a, 'b, 'd) t =
       | Local_to_regional : (Locality.t, Regionality.t, 'l * disallowed) t
           (** Maps local to regional, global to global *)
@@ -1945,6 +1947,7 @@ module Lattices_mono = struct
   end
 
   module Core_morph = struct
+    (* New morphisms must be added to [left_to] and [right_to]. *)
     type ('a, 'b, 'd) t =
       | Locality_restricted :
           ('a, 'b, 'l * 'r) Locality_morph.t
@@ -2740,10 +2743,9 @@ module Lattices_mono = struct
       | _, _, _, _, _ -> .
     [@@warning "-4"]
 
-    type ('b, 'd) packed_to = To : ('a, 'b, 'd) t -> ('b, 'd) packed_to
-    [@@unboxed]
+    type ('b, 'd) to_ = To : ('a, 'b, 'd) t -> ('b, 'd) to_ [@@unboxed]
 
-    let left_to : type b. b obj -> (b, left_only) packed_to list = function
+    let left_to : type b. b obj -> (b, left_only) to_ list = function
       | Locality -> [To (Locality_restricted Regional_to_local)]
       | Regionality ->
         [ To (Locality_restricted Local_to_regional);
@@ -2771,7 +2773,7 @@ module Lattices_mono = struct
           To (Locality_full Regional_to_local_regionality);
           To Monadic_to_comonadic_min ]
 
-    let right_to : type b. b obj -> (b, right_only) packed_to list = function
+    let right_to : type b. b obj -> (b, right_only) to_ list = function
       | Locality ->
         [ To (Locality_restricted Regional_to_local);
           To (Locality_restricted Regional_to_global) ]
@@ -2827,6 +2829,7 @@ module Lattices_mono = struct
   let max_with dst ax a = Axis.set ax a (max dst)
 
   module Simple_morph = struct
+    (* New morphisms must be added to [left_to] and [right_to]. *)
     type ('a, 'b, 'd) t =
       | Id : ('a, 'a, 'd) t  (** identity morphism *)
       | Core : ('a, 'b, 'd) Core_morph.t -> ('a, 'b, 'd) t
@@ -3395,10 +3398,9 @@ module Lattices_mono = struct
 
     let ( let+ ) xs f = List.map f xs
 
-    type ('b, 'd) packed_to = To : ('a, 'b, 'd) t -> ('b, 'd) packed_to
-    [@@unboxed]
+    type ('b, 'd) to_ = To : ('a, 'b, 'd) t -> ('b, 'd) to_ [@@unboxed]
 
-    let left_to : type b. full:bool -> b obj -> (b, left_only) packed_to list =
+    let left_to : type b. full:bool -> b obj -> (b, left_only) to_ list =
      fun ~full dst ->
       let constants =
         List.map (fun c -> To (Meet_const c)) (get_elements ~full dst)
@@ -3412,8 +3414,7 @@ module Lattices_mono = struct
       in
       (To Id :: core_morphs) @ constants @ meet_const_cores
 
-    let right_to : type b. full:bool -> b obj -> (b, right_only) packed_to list
-        =
+    let right_to : type b. full:bool -> b obj -> (b, right_only) to_ list =
      fun ~full dst ->
       let constants =
         List.map (fun c -> To (Imply_const c)) (get_elements ~full dst)
@@ -3429,6 +3430,7 @@ module Lattices_mono = struct
       (To Id :: core_morphs) @ constants @ core_imply_consts
   end
 
+  (* New morphisms must be added to [left_to] and [right_to]. *)
   type ('a, 'b, 'd) morph =
     | Simple : ('a, 'b, 'd) Simple_morph.t -> ('a, 'b, 'd) morph
     | Const_max : 'a obj -> ('a, 'c, disallowed * 'r) morph
@@ -4014,9 +4016,9 @@ module Lattices_mono = struct
 
   let ( let+ ) xs f = List.map f xs
 
-  type 'b packed_to = To : ('a, 'b, neither) morph -> 'b packed_to [@@unboxed]
+  type 'b to_ = To : ('a, 'b, neither) morph -> 'b to_ [@@unboxed]
 
-  let generate_left_morphs_to : type b. full:bool -> b obj -> b packed_to list =
+  let left_to : type b. full:bool -> b obj -> b to_ list =
    fun ~full dst ->
     let simple_morphs = Simple_morph.left_to ~full dst in
     let simple =
@@ -4027,11 +4029,11 @@ module Lattices_mono = struct
     let projections =
       let* (Simple_morph.To m) = simple_morphs in
       let src = Simple_morph.src dst m in
-      let+ (Axis.Pb (src, ax)) = Axis.to_ src in
+      let+ (Axis.To (src, ax)) = Axis.to_ src in
       To (disallow_left (Simple_proj (m, ax, src)))
     in
     let min_with =
-      let* (Axis.Ps ax) = Axis.from dst in
+      let* (Axis.From ax) = Axis.from dst in
       let projected = proj_obj ax dst in
       let+ (Simple_morph.To m) = Simple_morph.left_to ~full projected in
       To (disallow_left (Min_with_simple (ax, m)))
@@ -4041,8 +4043,7 @@ module Lattices_mono = struct
     in
     simple @ projections @ min_with @ const_min
 
-  let generate_right_morphs_to : type b. full:bool -> b obj -> b packed_to list
-      =
+  let right_to : type b. full:bool -> b obj -> b to_ list =
    fun ~full dst ->
     let simple_morphs = Simple_morph.right_to ~full dst in
     let simple =
@@ -4053,11 +4054,11 @@ module Lattices_mono = struct
     let projections =
       let* (Simple_morph.To m) = simple_morphs in
       let projected = Simple_morph.src dst m in
-      let+ (Axis.Pb (src, ax)) = Axis.to_ projected in
+      let+ (Axis.To (src, ax)) = Axis.to_ projected in
       To (disallow_right (Simple_proj (m, ax, src)))
     in
     let max_with =
-      let* (Axis.Ps ax) = Axis.from dst in
+      let* (Axis.From ax) = Axis.from dst in
       let projected = proj_obj ax dst in
       let+ (Simple_morph.To m) = Simple_morph.right_to ~full projected in
       To (disallow_right (Max_with_simple (ax, m)))
@@ -4067,8 +4068,7 @@ module Lattices_mono = struct
     in
     simple @ projections @ max_with @ const_max
 
-  let generate_morphs_to ~full dst =
-    generate_left_morphs_to ~full dst @ generate_right_morphs_to ~full dst
+  let generate_morphs_to ~full dst = left_to ~full dst @ right_to ~full dst
 
   type 'a covered =
     { full_coverage : 'a;
@@ -4112,7 +4112,7 @@ module Lattices_mono = struct
   let morphs_to_comonadic_with_regionality =
     morphs_to_obj Comonadic_with_regionality
 
-  let morphs_to : type b. full:bool -> b obj -> b packed_to list =
+  let morphs_to : type b. full:bool -> b obj -> b to_ list =
    fun ~full -> function
     | Locality -> force_by_coverage ~full morphs_to_locality
     | Regionality -> force_by_coverage ~full morphs_to_regionality

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3809,29 +3809,72 @@ module For_testing = struct
   let values_for_check_staticity_op = [Staticity.Static; Staticity.Dynamic]
 
   let values_for_check_monadic_op =
-    let* uniqueness = values_for_check_uniqueness_op in
-    let* contention = values_for_check_contention_op in
-    let* visibility = values_for_check_visibility_op in
-    let+ staticity = values_for_check_staticity_op in
-    { uniqueness; contention; visibility; staticity }
+    let with_base base =
+      List.concat
+        [ List.map
+            (fun uniqueness -> { base with uniqueness })
+            values_for_check_uniqueness_op;
+          List.map
+            (fun contention -> { base with contention })
+            values_for_check_contention_op;
+          List.map
+            (fun visibility -> { base with visibility })
+            values_for_check_visibility_op;
+          List.map
+            (fun staticity -> { base with staticity })
+            values_for_check_staticity_op ]
+    in
+    with_base Monadic_op.min @ with_base Monadic_op.max
 
   let values_for_check_comonadic_with_locality =
-    let* areality = values_for_check_locality in
-    let* linearity = values_for_check_linearity in
-    let* portability = values_for_check_portability in
-    let* forkable = values_for_check_forkable in
-    let* yielding = values_for_check_yielding in
-    let+ statefulness = values_for_check_statefulness in
-    { areality; linearity; portability; forkable; yielding; statefulness }
+    let with_base base =
+      List.concat
+        [ List.map
+            (fun areality -> { base with areality })
+            values_for_check_locality;
+          List.map
+            (fun linearity -> { base with linearity })
+            values_for_check_linearity;
+          List.map
+            (fun portability -> { base with portability })
+            values_for_check_portability;
+          List.map
+            (fun forkable -> { base with forkable })
+            values_for_check_forkable;
+          List.map
+            (fun yielding -> { base with yielding })
+            values_for_check_yielding;
+          List.map
+            (fun statefulness -> { base with statefulness })
+            values_for_check_statefulness ]
+    in
+    with_base Comonadic_with_locality.min
+    @ with_base Comonadic_with_locality.max
 
   let values_for_check_comonadic_with_regionality =
-    let* areality = values_for_check_regionality in
-    let* linearity = values_for_check_linearity in
-    let* portability = values_for_check_portability in
-    let* forkable = values_for_check_forkable in
-    let* yielding = values_for_check_yielding in
-    let+ statefulness = values_for_check_statefulness in
-    { areality; linearity; portability; forkable; yielding; statefulness }
+    let with_base base =
+      List.concat
+        [ List.map
+            (fun areality -> { base with areality })
+            values_for_check_regionality;
+          List.map
+            (fun linearity -> { base with linearity })
+            values_for_check_linearity;
+          List.map
+            (fun portability -> { base with portability })
+            values_for_check_portability;
+          List.map
+            (fun forkable -> { base with forkable })
+            values_for_check_forkable;
+          List.map
+            (fun yielding -> { base with yielding })
+            values_for_check_yielding;
+          List.map
+            (fun statefulness -> { base with statefulness })
+            values_for_check_statefulness ]
+    in
+    with_base Comonadic_with_regionality.min
+    @ with_base Comonadic_with_regionality.max
 
   let all_values_for_check : type a. a obj -> a list = function
     | Locality -> values_for_check_locality
@@ -4148,62 +4191,21 @@ module For_testing = struct
           failwith msg)
       (all_values_for_check src)
 
-  let domain_count_for_jobs job_count =
-    Int.min (Domain.recommended_domain_count ()) job_count
-
-  let run_jobs_in_parallel jobs =
-    let job_count = Array.length jobs in
-    let domain_count = domain_count_for_jobs job_count in
-    if domain_count <= 1
-    then Array.iter (fun job -> job ()) jobs
-    else
-      let worker worker_index =
-        let rec loop job_index =
-          if job_index < job_count
-          then (
-            jobs.(job_index) ();
-            loop (job_index + domain_count))
-        in
-        match loop worker_index with
-        | () -> None
-        | exception exn -> Some (exn, Printexc.get_raw_backtrace ())
-      in
-      let domains =
-        Array.init (domain_count - 1) (fun worker_index ->
-            (Domain.spawn
-            [@ocaml.alert "-do_not_spawn_domains"]
-            [@ocaml.alert "-unsafe_multidomain"]) (fun () ->
-                worker (worker_index + 1)))
-      in
-      let first_error =
-        Array.fold_left
-          (fun first_error domain ->
-            match first_error, Domain.join domain with
-            | Some _, _ -> first_error
-            | None, error -> error)
-          (worker 0) domains
-      in
-      match first_error with
-      | None -> ()
-      | Some (exn, backtrace) -> Printexc.raise_with_backtrace exn backtrace
+  let run_jobs jobs = List.iter (fun job -> job ()) jobs
 
   let check_jobs () =
-    let jobs =
-      let* (Obj dst) = all_objs in
-      let+ (Morph_to (mid, f)) = morphs_to dst in
-      let morphs_to_mid = morphs_to mid in
-      fun () ->
-        List.iter
-          (fun (Morph_to (src, g)) -> check_compose src mid dst f g)
-          morphs_to_mid
-    in
-    Array.of_list jobs
+    let* (Obj dst) = all_objs in
+    let+ (Morph_to (mid, f)) = morphs_to dst in
+    let morphs_to_mid = morphs_to mid in
+    fun () ->
+      List.iter
+        (fun (Morph_to (src, g)) -> check_compose src mid dst f g)
+        morphs_to_mid
 
   let check_all_allowed_compositions () =
     let jobs = check_jobs () in
-    Printf.printf "allowed checks running on %d domain(s)\n%!"
-      (domain_count_for_jobs (Array.length jobs));
-    run_jobs_in_parallel jobs
+    Printf.printf "running allowed composition checks\n%!";
+    run_jobs jobs
 end
 
 module C = Lattices_mono

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -4207,6 +4207,38 @@ module For_testing = struct
 
   let ( let+ ) xs f = List.map f xs
 
+  type error =
+    | Composition_check_failed :
+        { source : 'a obj;
+          middle : 'b obj;
+          target : 'c obj;
+          f : ('b, 'c, neither) morph;
+          g : ('a, 'b, neither) morph;
+          result : ('a, 'c, neither) morph;
+          input : 'a;
+          expected : 'c;
+          actual : 'c
+        }
+        -> error
+
+  let print_error ppf
+      (Composition_check_failed
+         { source; middle; target; f; g; result; input; expected; actual }) =
+    Fmt.fprintf ppf
+      "@[<v>Lattices_mono compose check failed:@,\
+       source: %a@,\
+       middle: %a@,\
+       target: %a@,\
+       f: %a@,\
+       g: %a@,\
+       result: %a@,\
+       input: %a@,\
+       expected: %a@,\
+       actual: %a@]"
+      print_obj source print_obj middle print_obj target (print_morph target) f
+      (print_morph middle) g (print_morph target) result (print source) input
+      (print target) expected (print target) actual
+
   let check_compose : type a b c.
       full:bool ->
       a obj ->
@@ -4214,45 +4246,48 @@ module For_testing = struct
       c obj ->
       (b, c, neither) morph ->
       (a, b, neither) morph ->
-      unit =
+      (unit, error) result =
    fun ~full src mid dst f g ->
     let result = compose dst f g in
-    List.iter
-      (fun input ->
+    let rec check_inputs = function
+      | [] -> Ok ()
+      | input :: inputs ->
         let expected = apply dst f (apply mid g input) in
         let actual = apply dst result input in
         if not (equal dst expected actual)
         then
-          let msg =
-            Fmt.asprintf
-              "@[<v>Lattices_mono compose check failed:@,\
-               source: %a@,\
-               middle: %a@,\
-               target: %a@,\
-               f: %a@,\
-               g: %a@,\
-               result: %a@,\
-               input: %a@,\
-               expected: %a@,\
-               actual: %a@]"
-              print_obj src print_obj mid print_obj dst (print_morph dst) f
-              (print_morph mid) g (print_morph dst) result (print src) input
-              (print dst) expected (print dst) actual
-          in
-          failwith msg)
-      (get_elements ~full src)
+          Error
+            (Composition_check_failed
+               { source = src;
+                 middle = mid;
+                 target = dst;
+                 f;
+                 g;
+                 result;
+                 input;
+                 expected;
+                 actual
+               })
+        else check_inputs inputs
+    in
+    check_inputs (get_elements ~full src)
 
-  let check_jobs ~full () =
+  let check_composition_jobs ~full () =
     let* (Obj dst) = all_objs in
     let+ (To f) = morphs_to ~full dst in
     let mid = src dst f in
     let morphs_to_mid = morphs_to ~full mid in
     fun () ->
-      List.iter
-        (fun (To g) ->
+      let rec check_morphs = function
+        | [] -> Ok ()
+        | To g :: morphs ->
           let src = src mid g in
-          check_compose ~full src mid dst f g)
-        morphs_to_mid
+          begin match check_compose ~full src mid dst f g with
+          | Ok () -> check_morphs morphs
+          | Error _ as error -> error
+          end
+      in
+      check_morphs morphs_to_mid
 end
 
 module C = Lattices_mono

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -458,8 +458,6 @@ module Lattices = struct
     include Heyting with type t := t
 
     val areality : t areality
-
-    val all : t list
   end
 
   module Locality = struct
@@ -479,7 +477,7 @@ module Lattices = struct
 
     let legacy = Global
 
-    let all = [Global; Local]
+    let all = lazy [Global; Local]
 
     let print ppf = function
       | Global -> Fmt.fprintf ppf "global"
@@ -506,7 +504,7 @@ module Lattices = struct
 
     let legacy = Global
 
-    let all = [Global; Regional; Local]
+    let all = lazy [Global; Regional; Local]
 
     let print ppf = function
       | Global -> Fmt.fprintf ppf "global"
@@ -533,7 +531,7 @@ module Lattices = struct
 
     let legacy = Aliased
 
-    let all = [Unique; Aliased]
+    let all = lazy [Unique; Aliased]
 
     let print ppf = function
       | Aliased -> Fmt.fprintf ppf "aliased"
@@ -557,7 +555,7 @@ module Lattices = struct
 
     let legacy = Many
 
-    let all = [Many; Once]
+    let all = lazy [Many; Once]
 
     let print ppf = function
       | Once -> Fmt.fprintf ppf "once"
@@ -586,7 +584,7 @@ module Lattices = struct
 
     let legacy = Nonportable
 
-    let all = [Portable; Shareable; Corruptible; Nonportable]
+    let all = lazy [Portable; Shareable; Corruptible; Nonportable]
 
     let print ppf = function
       | Portable -> Fmt.fprintf ppf "portable"
@@ -617,7 +615,7 @@ module Lattices = struct
 
     let legacy = Uncontended
 
-    let all = [Uncontended; Corrupted; Shared; Contended]
+    let all = lazy [Uncontended; Corrupted; Shared; Contended]
 
     let print ppf = function
       | Contended -> Fmt.fprintf ppf "contended"
@@ -643,7 +641,7 @@ module Lattices = struct
 
     let legacy = Forkable
 
-    let all = [Forkable; Unforkable]
+    let all = lazy [Forkable; Unforkable]
 
     let print ppf = function
       | Unforkable -> Fmt.fprintf ppf "unforkable"
@@ -667,7 +665,7 @@ module Lattices = struct
 
     let legacy = Unyielding
 
-    let all = [Unyielding; Yielding]
+    let all = lazy [Unyielding; Yielding]
 
     let print ppf = function
       | Yielding -> Fmt.fprintf ppf "yielding"
@@ -696,7 +694,7 @@ module Lattices = struct
 
     let legacy = Stateful
 
-    let all = [Stateless; Writing; Reading; Stateful]
+    let all = lazy [Stateless; Writing; Reading; Stateful]
 
     let print ppf = function
       | Stateless -> Fmt.fprintf ppf "stateless"
@@ -727,7 +725,7 @@ module Lattices = struct
 
     let legacy = Read_write
 
-    let all = [Read_write; Read; Write; Immutable]
+    let all = lazy [Read_write; Read; Write; Immutable]
 
     let print ppf = function
       | Immutable -> Fmt.fprintf ppf "immutable"
@@ -753,7 +751,7 @@ module Lattices = struct
 
     let legacy = Dynamic
 
-    let all = [Static; Dynamic]
+    let all = lazy [Static; Dynamic]
 
     let print ppf = function
       | Dynamic -> Fmt.fprintf ppf "dynamic"
@@ -796,10 +794,10 @@ module Lattices = struct
       lazy
         (let ( let* ) xs f = List.concat_map f xs in
          let ( let+ ) xs f = List.map f xs in
-         let* uniqueness = Uniqueness.all in
-         let* contention = Contention.all in
-         let* visibility = Visibility.all in
-         let+ staticity = Staticity.all in
+         let* uniqueness = Lazy.force Uniqueness.all in
+         let* contention = Lazy.force Contention.all in
+         let* visibility = Lazy.force Visibility.all in
+         let+ staticity = Lazy.force Staticity.all in
          { uniqueness; contention; visibility; staticity })
 
     (** Product values that cover every element of every axis at least once,
@@ -809,13 +807,13 @@ module Lattices = struct
         (let with_base base =
            let ( let+ ) xs f = List.map f xs in
            List.concat
-             [ (let+ uniqueness = Uniqueness.all in
+             [ (let+ uniqueness = Lazy.force Uniqueness.all in
                 { base with uniqueness });
-               (let+ contention = Contention.all in
+               (let+ contention = Lazy.force Contention.all in
                 { base with contention });
-               (let+ visibility = Visibility.all in
+               (let+ visibility = Lazy.force Visibility.all in
                 { base with visibility });
-               (let+ staticity = Staticity.all in
+               (let+ staticity = Lazy.force Staticity.all in
                 { base with staticity }) ]
          in
          with_base min @ with_base max)
@@ -945,12 +943,12 @@ module Lattices = struct
       lazy
         (let ( let* ) xs f = List.concat_map f xs in
          let ( let+ ) xs f = List.map f xs in
-         let* areality = Areality.all in
-         let* linearity = Linearity.all in
-         let* portability = Portability.all in
-         let* forkable = Forkable.all in
-         let* yielding = Yielding.all in
-         let+ statefulness = Statefulness.all in
+         let* areality = Lazy.force Areality.all in
+         let* linearity = Lazy.force Linearity.all in
+         let* portability = Lazy.force Portability.all in
+         let* forkable = Lazy.force Forkable.all in
+         let* yielding = Lazy.force Yielding.all in
+         let+ statefulness = Lazy.force Statefulness.all in
          { areality; linearity; portability; forkable; yielding; statefulness })
 
     (** Product values that cover every element of every axis at least once,
@@ -960,17 +958,17 @@ module Lattices = struct
         (let with_base base =
            let ( let+ ) xs f = List.map f xs in
            List.concat
-             [ (let+ areality = Areality.all in
+             [ (let+ areality = Lazy.force Areality.all in
                 { base with areality });
-               (let+ linearity = Linearity.all in
+               (let+ linearity = Lazy.force Linearity.all in
                 { base with linearity });
-               (let+ portability = Portability.all in
+               (let+ portability = Lazy.force Portability.all in
                 { base with portability });
-               (let+ forkable = Forkable.all in
+               (let+ forkable = Lazy.force Forkable.all in
                 { base with forkable });
-               (let+ yielding = Yielding.all in
+               (let+ yielding = Lazy.force Yielding.all in
                 { base with yielding });
-               (let+ statefulness = Statefulness.all in
+               (let+ statefulness = Lazy.force Statefulness.all in
                 { base with statefulness }) ]
          in
          with_base min @ with_base max)
@@ -1588,30 +1586,31 @@ module Lattices_mono = struct
       Obj Comonadic_with_regionality ]
 
   let get_elements : type a. full:bool -> a obj -> a list =
-   fun ~full -> function
-    | Locality -> Locality.all
-    | Regionality -> Regionality.all
-    | Uniqueness_op -> Uniqueness.all
-    | Linearity -> Linearity.all
-    | Portability -> Portability.all
-    | Forkable -> Forkable.all
-    | Yielding -> Yielding.all
-    | Statefulness -> Statefulness.all
-    | Contention_op -> Contention.all
-    | Visibility_op -> Visibility.all
-    | Staticity_op -> Staticity.all
-    | Monadic_op ->
-      Lazy.force (if full then Monadic.all else Monadic.spanning_elements)
-    | Comonadic_with_locality ->
-      Lazy.force
-        (if full
-         then Comonadic_with_locality.all
-         else Comonadic_with_locality.spanning_elements)
-    | Comonadic_with_regionality ->
-      Lazy.force
-        (if full
-         then Comonadic_with_regionality.all
-         else Comonadic_with_regionality.spanning_elements)
+   fun ~full obj ->
+    let elements : a list Lazy.t =
+      match obj with
+      | Locality -> Locality.all
+      | Regionality -> Regionality.all
+      | Uniqueness_op -> Uniqueness.all
+      | Linearity -> Linearity.all
+      | Portability -> Portability.all
+      | Forkable -> Forkable.all
+      | Yielding -> Yielding.all
+      | Statefulness -> Statefulness.all
+      | Contention_op -> Contention.all
+      | Visibility_op -> Visibility.all
+      | Staticity_op -> Staticity.all
+      | Monadic_op -> if full then Monadic.all else Monadic.spanning_elements
+      | Comonadic_with_locality ->
+        if full
+        then Comonadic_with_locality.all
+        else Comonadic_with_locality.spanning_elements
+      | Comonadic_with_regionality ->
+        if full
+        then Comonadic_with_regionality.all
+        else Comonadic_with_regionality.spanning_elements
+    in
+    Lazy.force elements
 
   module Locality_morph = struct
     (* Following is a chain of adjunctions (this can be extended one
@@ -6025,6 +6024,14 @@ module Value_with (Areality : Areality) = struct
     let legacy =
       merge
         { comonadic = Comonadic.Const.legacy; monadic = Monadic.Const.legacy }
+
+    let all =
+      lazy
+        (let ( let* ) xs f = List.concat_map f xs in
+         let ( let+ ) xs f = List.map f xs in
+         let* comonadic = Lazy.force Comonadic.Const.all in
+         let+ monadic = Lazy.force Monadic.Const.all in
+         merge { comonadic; monadic })
 
     let meet m1 m2 =
       let m1 = split m1 in

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2382,12 +2382,6 @@ module Lattices_mono = struct
     (* Commutes a meet through a morphism from the right, such that:
        [apply dst m (meet_const c x)] is equivalent to
        [meet_const (commute_meet_const_from_right dst m c) (apply dst m x)]
-
-       PRECONDITION: All [Core_morph.t] preserves binary meets:
-        m(x meet y) == m(x) meet m(y). Without this precondition,
-        [commute_meet_const_from_right] may no longer be implementable, and
-        we will need to change the implementation of [Simple_morph.compose], as well as
-        add the missing cases in [Simple_morph.t].
     *)
     let commute_meet_const_from_right : type a b d.
         b obj -> (a, b, d) t -> a -> b =
@@ -2397,7 +2391,7 @@ module Lattices_mono = struct
         | Local_to_regional | Regional_to_local | Locality_as_regionality
         | Regional_to_global | Local_to_regional_regionality
         | Regional_to_local_regionality | Regional_to_global_regionality ->
-          (* same explanation as below *)
+          (* See explanation below *)
           apply dst m c
       in
       match m with
@@ -2408,7 +2402,14 @@ module Lattices_mono = struct
       | Visibility_op_to_statefulness | Statefulness_to_visibility_op
       | Monadic_to_comonadic_min | Comonadic_to_monadic_min _
       | Monadic_to_comonadic_max | Comonadic_to_monadic_max _ ->
-        (* If all morphisms preserve binary meets, the correctness argument
+        (* The following proof depends on the fact that [Core_morph.t] preserves binary
+           meets: m(x meet y) == m(x) meet m(y).
+
+           Without this condition, [commute_meet_const_from_right] may no longer be
+           implementable, and we will need to change the implementation of
+           [Simple_morph.compose], as well as add the missing cases in [Simple_morph.t].
+
+           If all morphisms preserve binary meets, the correctness argument
            goes as follows:
 
            Consider [apply dst m (meet_const c x)].

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2749,31 +2749,23 @@ module Lattices_mono = struct
         if c <> 0 then c else Core_morph.compare m1 m2
       | Meet_const_core _, _ -> -1
       | _, Meet_const_core _ -> 1
-      | Core_imply_const (m1, c1), Core_imply_const (m2, c2) -> (
+      | Core_imply_const (m1, c1), Core_imply_const (m2, c2) ->
         let c = Core_morph.compare m1 m2 in
         if c <> 0
         then c
         else
-          match Core_morph.equal m1 m2 with
-          | Misc.Is_not_eq ->
-            Misc.fatal_error
-              "Mode.Lattices_mono.Simple_morph.compare: inconsistent core \
-               morph equality"
-          | Misc.Is_eq ->
-            let src = Core_morph.src m1 in
-            compare_total src c1 c2)
+          let Refl = Core_morph.equal m1 m2 |> Misc.get_eq_exn in
+          let src = Core_morph.src m1 in
+          compare_total src c1 c2
       | Core_imply_const _, _ -> -1
       | _, Core_imply_const _ -> 1
-      | Compose (mb1, ma1), Compose (mb2, ma2) -> (
+      | Compose (mb1, ma1), Compose (mb2, ma2) ->
         let c = compare dst mb1 mb2 in
         if c <> 0
         then c
         else
-          match equal dst mb1 mb2 with
-          | Misc.Is_not_eq ->
-            Misc.fatal_error
-              "Mode.Lattices_mono.Simple_morph.compare: inconsistent equality"
-          | Misc.Is_eq -> compare (src dst mb1) ma1 ma2)
+          let Refl = equal dst mb1 mb2 |> Misc.get_eq_exn in
+          compare (src dst mb1) ma1 ma2
       | Compose _, _ -> .
       | _, Compose _ -> .
 
@@ -3425,61 +3417,45 @@ module Lattices_mono = struct
       if c <> 0 then c else compare_total dst c1 c2
     | Const _, _ -> -1
     | _, Const _ -> 1
-    | Simple_proj (m1, ax1, src1), Simple_proj (m2, ax2, src2) -> (
+    | Simple_proj (m1, ax1, src1), Simple_proj (m2, ax2, src2) ->
       let c = compare_obj src1 src2 in
       if c <> 0
       then c
       else
-        match equal_obj src1 src2 with
-        | Misc.Is_not_eq ->
-          Misc.fatal_error
-            "Mode.Lattices_mono.compare_morph: inconsistent object equality"
-        | Misc.Is_eq -> (
-          let c = Axis.compare ax1 ax2 in
-          if c <> 0
-          then c
-          else
-            match Axis.equal ax1 ax2 with
-            | Misc.Is_not_eq ->
-              Misc.fatal_error
-                "Mode.Lattices_mono.compare_morph: inconsistent axis equality"
-            | Misc.Is_eq -> Simple_morph.compare dst m1 m2))
+        let Refl = equal_obj src1 src2 |> Misc.get_eq_exn in
+        let c = Axis.compare ax1 ax2 in
+        if c <> 0
+        then c
+        else
+          let Refl = Axis.equal ax1 ax2 |> Misc.get_eq_exn in
+          Simple_morph.compare dst m1 m2
     | Simple_proj _, _ -> -1
     | _, Simple_proj _ -> 1
-    | Max_with_simple (ax1, m1), Max_with_simple (ax2, m2) -> (
+    | Max_with_simple (ax1, m1), Max_with_simple (ax2, m2) ->
       let c = Axis.compare ax1 ax2 in
       if c <> 0
       then c
       else
-        match Axis.equal ax1 ax2 with
-        | Misc.Is_not_eq ->
-          Misc.fatal_error
-            "Mode.Lattices_mono.compare_morph: inconsistent axis equality"
-        | Misc.Is_eq -> Simple_morph.compare (proj_obj ax1 dst) m1 m2)
+        let Refl = Axis.equal ax1 ax2 |> Misc.get_eq_exn in
+        Simple_morph.compare (proj_obj ax1 dst) m1 m2
     | Max_with_simple _, _ -> -1
     | _, Max_with_simple _ -> 1
-    | Min_with_simple (ax1, m1), Min_with_simple (ax2, m2) -> (
+    | Min_with_simple (ax1, m1), Min_with_simple (ax2, m2) ->
       let c = Axis.compare ax1 ax2 in
       if c <> 0
       then c
       else
-        match Axis.equal ax1 ax2 with
-        | Misc.Is_not_eq ->
-          Misc.fatal_error
-            "Mode.Lattices_mono.compare_morph: inconsistent axis equality"
-        | Misc.Is_eq -> Simple_morph.compare (proj_obj ax1 dst) m1 m2)
+        let Refl = Axis.equal ax1 ax2 |> Misc.get_eq_exn in
+        Simple_morph.compare (proj_obj ax1 dst) m1 m2
     | Min_with_simple _, _ -> -1
     | _, Min_with_simple _ -> 1
-    | Compose (mb1, ma1), Compose (mb2, ma2) -> (
+    | Compose (mb1, ma1), Compose (mb2, ma2) ->
       let c = compare_morph dst mb1 mb2 in
       if c <> 0
       then c
       else
-        match equal_morph dst mb1 mb2 with
-        | Misc.Is_not_eq ->
-          Misc.fatal_error
-            "Mode.Lattices_mono.compare_morph: inconsistent equality"
-        | Misc.Is_eq -> compare_morph (src dst mb1) ma1 ma2)
+        let Refl = equal_morph dst mb1 mb2 |> Misc.get_eq_exn in
+        compare_morph (src dst mb1) ma1 ma2
     | Compose _, _ -> .
     | _, Compose _ -> .
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1515,9 +1515,9 @@ module Lattices_mono = struct
       | Visibility -> { t with visibility = r }
       | Staticity -> { t with staticity = r }
 
-    type 'a packed_small = Ps : ('a, 'b) t -> 'a packed_small
+    type 'a from = Ps : ('a, 'b) t -> 'a from
 
-    let all : type a. a obj -> a packed_small list = function
+    let from : type a. a obj -> a from list = function
       | Comonadic_with_locality ->
         [ Ps Areality;
           Ps Forkable;
@@ -1538,9 +1538,9 @@ module Lattices_mono = struct
       | Staticity_op ->
         []
 
-    type 'b packed_big = Pb : 'a obj * ('a, 'b) t -> 'b packed_big
+    type 'b to_ = Pb : 'a obj * ('a, 'b) t -> 'b to_
 
-    let axis_to : type b. b obj -> b packed_big list = function
+    let to_ : type b. b obj -> b to_ list = function
       | Comonadic_with_locality -> []
       | Comonadic_with_regionality -> []
       | Monadic_op -> []
@@ -3974,11 +3974,11 @@ module Lattices_mono = struct
     let projections =
       let* (Simple_morph.To m) = simple_morphs in
       let src = Simple_morph.src dst m in
-      let+ (Axis.Pb (src, ax)) = Axis.axis_to src in
+      let+ (Axis.Pb (src, ax)) = Axis.to_ src in
       To (disallow_left (Simple_proj (m, ax, src)))
     in
     let min_with =
-      let* (Axis.Ps ax) = Axis.all dst in
+      let* (Axis.Ps ax) = Axis.from dst in
       let projected = proj_obj ax dst in
       let+ (Simple_morph.To m) = Simple_morph.left_to ~full projected in
       To (disallow_left (Min_with_simple (ax, m)))
@@ -4000,11 +4000,11 @@ module Lattices_mono = struct
     let projections =
       let* (Simple_morph.To m) = simple_morphs in
       let projected = Simple_morph.src dst m in
-      let+ (Axis.Pb (src, ax)) = Axis.axis_to projected in
+      let+ (Axis.Pb (src, ax)) = Axis.to_ projected in
       To (disallow_right (Simple_proj (m, ax, src)))
     in
     let max_with =
-      let* (Axis.Ps ax) = Axis.all dst in
+      let* (Axis.Ps ax) = Axis.from dst in
       let projected = proj_obj ax dst in
       let+ (Simple_morph.To m) = Simple_morph.right_to ~full projected in
       To (disallow_right (Max_with_simple (ax, m)))

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2372,10 +2372,27 @@ module Lattices_mono = struct
     let commute_imply_from_left : type a b l.
         b obj -> b -> (a, b, l * allowed) t -> a =
      fun dst c m ->
-      (* As all our morphisms preserve binary meets, implications can be
-         pushed inside of [m] by applying the left adjoint of [m] to the
-         implicant. *)
-      apply (src m) (left_adjoint dst m) c
+      (* The correctness argument for [commute_imply_from_the_left] follows from the
+         correctness argument for [commute_meet_const_from_the_right] as follows:
+
+         Consider [imply_const c (apply dst m x)]. Recall that [imply_const] is only
+         allowed on the right-hand side of a constraint; say
+         [y < imply_const c (apply dst m x)]
+         <=> [meet_const c y < apply dst m x] ;; the left adjoint of imply is meet.
+         <=> [apply src m' (meet_const c y) < x] ;; where [m'] is the left adoint of [m]
+
+         We can now apply the correctness criteria of [commute_meet_const_from_right] and
+         commute the meet through [m']:
+         <=> [meet_const (commute_meet_const_from_right src m' c) (apply src m' y) < x]
+         <=> [apply src m' y < imply_const (commute_meet_const_from_right src m' c) x]
+          ;; the right adjoint of meet is imply
+         <=> [y < apply dst m (imply_const (commute_meet_const_from_right src m' c) x)]
+          ;; the right adjoint of [m'] is [m]
+
+         We have [apply dst m (imply_const (commute_meet_const_from_right src m' c) x)]
+         equivalent to [imply_const c (apply dst m x)] as desired.
+      *)
+      commute_meet_const_from_right (src m) (left_adjoint dst m) c
 
     type ('a, 'b, 'd) compose_proj_result =
       | Proj_core :

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1634,7 +1634,13 @@ module Lattices_mono = struct
 
   module Locality_morph = struct
     (* Following is a chain of adjunctions (this can be extended one
-       further, but we never need the missing operation) *)
+       further, but we never need the missing operation).
+
+      INVARIANT: each locality morphism below must preserve binary meets:
+        lm(x meet y) == lm(x) meet lm(y). If the invariant is broken,
+        [commute_meet_const_from_right] may no longer be correct (or implementable), and
+        we may need to change [Simple_morph.compose] and add the missing case in
+        [Simple_morph.t] *)
     type ('a, 'b, 'd) t =
       | Local_to_regional : (Locality.t, Regionality.t, 'l * disallowed) t
           (** Maps local to regional, global to global *)
@@ -1941,6 +1947,11 @@ module Lattices_mono = struct
   end
 
   module Core_morph = struct
+    (* INVARIANT: each core morphism below must preserve binary meets:
+        cm(x meet y) == cm(x) meet cm(y). If the invariant is broken,
+        [commute_meet_const_from_right] may no longer be correct (or implementable), and
+        we may need to change [Simple_morph.compose] and add the missing case in
+        [Simple_morph.t] *)
     type ('a, 'b, 'd) t =
       | Locality_restricted :
           ('a, 'b, 'l * 'r) Locality_morph.t
@@ -2362,7 +2373,15 @@ module Lattices_mono = struct
     let commute_meet_const_from_right : type a b d.
         b obj -> (a, b, d) t -> a -> b =
      fun dst m c ->
-      (* All our morphisms preserve binary meets *)
+      (* All morphisms preserve binary meets. The correctness argument
+         thus goes as follows:
+
+         Consider [apply dst m (meet_const c x)].
+         [apply dst m (meet_const c x)]
+         == meet (apply dst m c) (apply dst m x) ;; [m] preserves binary meets
+         == meet_const (apply dst m c) (apply dst m x) ;; by definition of meet_const
+
+         The correct result for [commute_meet_const_from_right] is thus [apply dst m c] *)
       apply dst m c
 
     (* Commutes an implication through a morphism from the left, such that:

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1927,35 +1927,21 @@ module Lattices_mono = struct
       | Regional_to_global_regionality, Local_to_regional_regionality ->
         Disallowed
 
-    let id_with_regional_to_locality : type a b l r.
-        (Regionality.t, Locality.t, l * r) t ->
+    (** Closest-to-identity morphism between comonadic_with axes, mapping
+        Regional to Local when the source source object is
+        Comonadic_with_regionality and the target is Comonadic_with_locality *)
+    let id_r2l : type a b l r.
         a comonadic_with obj ->
         b comonadic_with obj ->
         (a, b, l * r) compose_result =
-     fun regional_to_locality src dst ->
+     fun src dst ->
       match src, dst with
       | Comonadic_with_regionality, Comonadic_with_locality ->
-        Morph regional_to_locality
+        Morph Regional_to_local
       | Comonadic_with_locality, Comonadic_with_regionality ->
         Morph Locality_as_regionality
       | Comonadic_with_regionality, Comonadic_with_regionality -> Id
       | Comonadic_with_locality, Comonadic_with_locality -> Id
-
-    (** Closest-to-identity morphism between comonadic_with axes, using r2g for
-        regionality-to-locality. *)
-    let id_r2g : type a b.
-        a comonadic_with obj ->
-        b comonadic_with obj ->
-        (a, b, disallowed * allowed) compose_result =
-     fun src dst -> id_with_regional_to_locality Regional_to_global src dst
-
-    (** Closest-to-identity morphism between comonadic_with axes, using r2l for
-        regionality-to-locality. *)
-    let id_r2l : type a b.
-        a comonadic_with obj ->
-        b comonadic_with obj ->
-        (a, b, allowed * disallowed) compose_result =
-     fun src dst -> id_with_regional_to_locality Regional_to_local src dst
   end
 
   module Core_morph = struct
@@ -2678,31 +2664,14 @@ module Lattices_mono = struct
       | Locality_morph.Disallowed -> Disallowed
 
     (** Closest-to-identity morphism between full product objects, as enforced
-        by the [Axis.t] arguments. Uses r2g for comonadic areality and plain
-        identity for monadic axes. *)
-    let id_r2g : type a b p.
+        by the [Axis.t] arguments. No guarantees can be made over the behavior
+        of the Areality axis if the source and target Areality differ. *)
+    let id_except_for_areality : type l r a b p.
         a obj ->
         b obj ->
         (a, p) Axis.t ->
         (b, p) Axis.t ->
-        (a, b, disallowed * allowed) compose_result =
-     fun src dst ax0 ax1 ->
-      match Axis.owner src ax0, Axis.owner dst ax1 with
-      | Axis.Monadic _, Axis.Monadic _ -> Id
-      | Axis.Comonadic (src, _), Axis.Comonadic (dst, _) ->
-        Locality_morph.id_r2g src dst |> lift_locality_compose_result
-      | Axis.Monadic _, Axis.Comonadic _ -> .
-      | Axis.Comonadic _, Axis.Monadic _ -> .
-
-    (** Closest-to-identity morphism between full product objects, as enforced
-        by the [Axis.t] arguments. Uses r2l for comonadic areality and plain
-        identity for monadic axes. *)
-    let id_r2l : type a b p.
-        a obj ->
-        b obj ->
-        (a, p) Axis.t ->
-        (b, p) Axis.t ->
-        (a, b, allowed * disallowed) compose_result =
+        (a, b, l * r) compose_result =
      fun src dst ax0 ax1 ->
       match Axis.owner src ax0, Axis.owner dst ax1 with
       | Axis.Monadic _, Axis.Monadic _ -> Id
@@ -2711,15 +2680,17 @@ module Lattices_mono = struct
       | Axis.Monadic _, Axis.Comonadic _ -> .
       | Axis.Comonadic _, Axis.Monadic _ -> .
 
-    (** Lift a core morphism between projected axes to a core morphism between
-        the enclosing objects. Goes to max for axes with no dual. *)
-    let lift_max : type a b p q.
+    (** Takes a core morphism between projected axes to a core morphism between
+        product axes, such that the behavior on the projected axes is preserved.
+        There are no guarantees for all other axes in the product. Produces a
+        morphism that is not allowed on the left. *)
+    let lift_r : type l r a b p q.
         a obj ->
         b obj ->
-        (p, q, disallowed * allowed) t ->
+        (p, q, l * r) t ->
         (a, p) Axis.t ->
         (b, q) Axis.t ->
-        (a, b, disallowed * allowed) compose_result =
+        (a, b, disallowed * r) compose_result =
      fun src dst m ax0 ax1 ->
       match m, ax0, ax1, src, dst with
       | Uniqueness_op_to_linearity, Uniqueness, Linearity, _, _ ->
@@ -2735,19 +2706,21 @@ module Lattices_mono = struct
       | Statefulness_to_visibility_op, Statefulness, Visibility, _, _ ->
         Morph (Comonadic_to_monadic_max (comonadic_obj_areality src))
       | Locality_restricted lm, Areality, Areality, _, _ ->
-        Morph (Locality_full lm)
+        Morph (Locality_full (Locality_morph.disallow_left lm))
       | _, _, _, _, _ -> .
     [@@warning "-4"]
 
-    (** Lift a core morphism between projected axes to a core morphism between
-        the enclosing objects. Goes to min for axes with no dual. *)
-    let lift_min : type a b p q.
+    (** Takes a core morphism between projected axes to a core morphism between
+        product axes, such that the behavior on the projected axes is preserved.
+        There are no guarantees for all other axes in the product. Produces a
+        morphism that is not allowed on the right. *)
+    let lift_l : type l r a b p q.
         a obj ->
         b obj ->
-        (p, q, allowed * disallowed) t ->
+        (p, q, l * r) t ->
         (a, p) Axis.t ->
         (b, q) Axis.t ->
-        (a, b, allowed * disallowed) compose_result =
+        (a, b, l * disallowed) compose_result =
      fun src dst m ax0 ax1 ->
       match m, ax0, ax1, src, dst with
       | Uniqueness_op_to_linearity, Uniqueness, Linearity, _, _ ->
@@ -2763,7 +2736,7 @@ module Lattices_mono = struct
       | Statefulness_to_visibility_op, Statefulness, Visibility, _, _ ->
         Morph (Comonadic_to_monadic_min (comonadic_obj_areality src))
       | Locality_restricted lm, Areality, Areality, _, _ ->
-        Morph (Locality_full lm)
+        Morph (Locality_full (Locality_morph.disallow_right lm))
       | _, _, _, _, _ -> .
     [@@warning "-4"]
 
@@ -3360,25 +3333,29 @@ module Lattices_mono = struct
         (b, q) Axis.t ->
         (a, b, disallowed * allowed) t =
      fun src dst m ax0 ax1 ->
-      let m : (a, b, disallowed * allowed) t =
-        match m with
-        | Id -> Core_morph.id_r2g src dst ax0 ax1 |> lift_core_compose_result_r
-        | Core m ->
-          Core_morph.lift_max src dst m ax0 ax1 |> lift_core_compose_result_r
-        | Imply_const c ->
-          let c = Axis.set ax1 c (arbitrary dst) in
-          let m =
-            Core_morph.id_r2g src dst ax0 ax1 |> lift_core_compose_result_r
-          in
-          compose dst (Imply_const c) m
-        | Core_imply_const (m, c) ->
-          let m = lift_max src dst (Core m) ax0 ax1 in
-          let c = Axis.set ax0 c (arbitrary src) in
-          compose dst m (Imply_const c)
+      let push_to_max m =
+        let q_obj = proj_obj ax1 dst in
+        let c = min_with dst ax1 (max q_obj) in
+        compose dst (Imply_const c) m
       in
-      let q_obj = proj_obj ax1 dst in
-      let c = min_with dst ax1 (max q_obj) in
-      compose dst (Imply_const c) m
+      match m with
+      | Id ->
+        Core_morph.id_except_for_areality src dst ax0 ax1
+        |> lift_core_compose_result_r |> push_to_max
+      | Core m ->
+        Core_morph.lift_r src dst m ax0 ax1
+        |> lift_core_compose_result_r |> push_to_max
+      | Imply_const c ->
+        let c = Axis.set ax1 c (min dst) in
+        let m =
+          Core_morph.id_except_for_areality src dst ax0 ax1
+          |> lift_core_compose_result_r
+        in
+        compose dst (Imply_const c) m
+      | Core_imply_const (m, c) ->
+        let m = lift_max src dst (Core m) ax0 ax1 in
+        let c = Axis.set ax0 c (arbitrary src) in
+        compose dst m (Imply_const c)
     [@@warning "-4"]
 
     let rec lift_min : type a b p q.
@@ -3389,25 +3366,29 @@ module Lattices_mono = struct
         (b, q) Axis.t ->
         (a, b, allowed * disallowed) t =
      fun src dst m ax0 ax1 ->
-      let m : (a, b, allowed * disallowed) t =
-        match m with
-        | Id -> Core_morph.id_r2l src dst ax0 ax1 |> lift_core_compose_result_l
-        | Core m ->
-          Core_morph.lift_min src dst m ax0 ax1 |> lift_core_compose_result_l
-        | Meet_const c ->
-          let c = Axis.set ax1 c (arbitrary dst) in
-          let m =
-            Core_morph.id_r2l src dst ax0 ax1 |> lift_core_compose_result_l
-          in
-          compose dst (Meet_const c) m
-        | Meet_const_core (c, m) ->
-          let m = lift_min src dst (Core m) ax0 ax1 in
-          let c = Axis.set ax1 c (arbitrary dst) in
-          compose dst (Meet_const c) m
+      let push_to_min m =
+        let q_obj = proj_obj ax1 dst in
+        let c = min_with dst ax1 (max q_obj) in
+        compose dst (Meet_const c) m
       in
-      let q_obj = proj_obj ax1 dst in
-      let c = min_with dst ax1 (max q_obj) in
-      compose dst (Meet_const c) m
+      match m with
+      | Id ->
+        Core_morph.id_except_for_areality src dst ax0 ax1
+        |> lift_core_compose_result_l |> push_to_min
+      | Core m ->
+        Core_morph.lift_l src dst m ax0 ax1
+        |> lift_core_compose_result_l |> push_to_min
+      | Meet_const c ->
+        let c = Axis.set ax1 c (min dst) in
+        let m =
+          Core_morph.id_except_for_areality src dst ax0 ax1
+          |> lift_core_compose_result_l
+        in
+        compose dst (Meet_const c) m
+      | Meet_const_core (c, m) ->
+        let m = lift_min src dst (Core m) ax0 ax1 in
+        let c = Axis.set ax1 c (arbitrary dst) in
+        compose dst (Meet_const c) m
     [@@warning "-4"]
 
     let ( let* ) xs f = List.concat_map f xs

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1156,15 +1156,16 @@ module Lattices = struct
     | Comonadic_with_locality -> Locality
     | Comonadic_with_regionality -> Regionality
 
-  let comonadic_with_obj : type a. a obj -> a comonadic_with obj =
-   fun a0 ->
-    match a0 with
-    | Locality -> Comonadic_with_locality
-    | Regionality -> Comonadic_with_regionality
+  let to_areality : type a. a obj -> a areality = function
+    | Locality -> Locality
+    | Regionality -> Regionality
     | Uniqueness_op | Linearity | Monadic_op | Comonadic_with_regionality
     | Comonadic_with_locality | Contention_op | Visibility_op | Portability
     | Forkable | Yielding | Statefulness | Staticity_op ->
       assert false
+
+  let comonadic_with_obj : type a. a obj -> a comonadic_with obj =
+   fun a0 -> to_areality a0 |> areality_comonadic_obj
 
   let is_opposite : type a. a obj -> bool = function
     | Locality -> false

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3391,7 +3391,9 @@ module Lattices_mono = struct
         Max_with_simple
           (ax1, Simple_morph.compose obj0 (Core_imply_const (m0, c0)) m1)
       | Const_max_core -> Const_max a_obj
-      | And_max_id ax1 -> Max_with_simple (ax1, m1)
+      | And_max_id ax1 ->
+        let obj0 = proj_obj ax1 dst in
+        Max_with_simple (ax1, Simple_morph.compose obj0 (Imply_const c0) m1)
       | Disallowed -> Compose (Simple sm0, Max_with_simple (ax1, m1))
       end
     | Meet_const_core _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
@@ -3430,7 +3432,10 @@ module Lattices_mono = struct
         Min_with_simple
           (ax1, Simple_morph.compose obj0 (Meet_const_core (c0, m0)) m1)
       | Const_min_core -> Const_min a_obj
-      | And_min_id ax1 -> Min_with_simple (ax1, m1)
+      | And_min_id ax1 ->
+        let obj0 = proj_obj ax1 dst in
+        let c0 = Axis.proj ax1 c0 in
+        Min_with_simple (ax1, Simple_morph.compose obj0 (Meet_const c0) m1)
       | Disallowed -> Compose (Simple sm0, Min_with_simple (ax1, m1))
       end
     | Imply_const _ -> Compose (Simple sm0, Min_with_simple (ax1, m1))

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3744,6 +3744,468 @@ module Lattices_mono = struct
   end
 end
 
+module For_testing = struct
+  open Lattices_mono
+
+  type packed_obj = Obj : 'a obj -> packed_obj
+
+  let all_objs =
+    [ Obj Locality;
+      Obj Regionality;
+      Obj Uniqueness_op;
+      Obj Linearity;
+      Obj Portability;
+      Obj Forkable;
+      Obj Yielding;
+      Obj Statefulness;
+      Obj Contention_op;
+      Obj Visibility_op;
+      Obj Staticity_op;
+      Obj Monadic_op;
+      Obj Comonadic_with_locality;
+      Obj Comonadic_with_regionality ]
+
+  let ( let* ) xs f = List.concat_map f xs
+
+  let ( let+ ) xs f = List.map f xs
+
+  let values_for_check_locality = [Locality.Global; Locality.Local]
+
+  let values_for_check_regionality =
+    [Regionality.Global; Regionality.Regional; Regionality.Local]
+
+  let values_for_check_uniqueness_op = [Uniqueness.Unique; Uniqueness.Aliased]
+
+  let values_for_check_linearity = [Linearity.Many; Linearity.Once]
+
+  let values_for_check_portability =
+    [ Portability.Portable;
+      Portability.Shareable;
+      Portability.Corruptible;
+      Portability.Nonportable ]
+
+  let values_for_check_forkable = [Forkable.Forkable; Forkable.Unforkable]
+
+  let values_for_check_yielding = [Yielding.Unyielding; Yielding.Yielding]
+
+  let values_for_check_statefulness =
+    [ Statefulness.Stateless;
+      Statefulness.Writing;
+      Statefulness.Reading;
+      Statefulness.Stateful ]
+
+  let values_for_check_contention_op =
+    [ Contention.Uncontended;
+      Contention.Corrupted;
+      Contention.Shared;
+      Contention.Contended ]
+
+  let values_for_check_visibility_op =
+    [ Visibility.Read_write;
+      Visibility.Read;
+      Visibility.Write;
+      Visibility.Immutable ]
+
+  let values_for_check_staticity_op = [Staticity.Static; Staticity.Dynamic]
+
+  let values_for_check_monadic_op =
+    let* uniqueness = values_for_check_uniqueness_op in
+    let* contention = values_for_check_contention_op in
+    let* visibility = values_for_check_visibility_op in
+    let+ staticity = values_for_check_staticity_op in
+    { uniqueness; contention; visibility; staticity }
+
+  let values_for_check_comonadic_with_locality =
+    let* areality = values_for_check_locality in
+    let* linearity = values_for_check_linearity in
+    let* portability = values_for_check_portability in
+    let* forkable = values_for_check_forkable in
+    let* yielding = values_for_check_yielding in
+    let+ statefulness = values_for_check_statefulness in
+    { areality; linearity; portability; forkable; yielding; statefulness }
+
+  let values_for_check_comonadic_with_regionality =
+    let* areality = values_for_check_regionality in
+    let* linearity = values_for_check_linearity in
+    let* portability = values_for_check_portability in
+    let* forkable = values_for_check_forkable in
+    let* yielding = values_for_check_yielding in
+    let+ statefulness = values_for_check_statefulness in
+    { areality; linearity; portability; forkable; yielding; statefulness }
+
+  let all_values_for_check : type a. a obj -> a list = function
+    | Locality -> values_for_check_locality
+    | Regionality -> values_for_check_regionality
+    | Uniqueness_op -> values_for_check_uniqueness_op
+    | Linearity -> values_for_check_linearity
+    | Portability -> values_for_check_portability
+    | Forkable -> values_for_check_forkable
+    | Yielding -> values_for_check_yielding
+    | Statefulness -> values_for_check_statefulness
+    | Contention_op -> values_for_check_contention_op
+    | Visibility_op -> values_for_check_visibility_op
+    | Staticity_op -> values_for_check_staticity_op
+    | Monadic_op -> values_for_check_monadic_op
+    | Comonadic_with_locality -> values_for_check_comonadic_with_locality
+    | Comonadic_with_regionality -> values_for_check_comonadic_with_regionality
+
+  type 'a packed_axis = Axis : ('a, 'b) Axis.t -> 'a packed_axis
+
+  let axes : type a. a obj -> a packed_axis list = function
+    | Comonadic_with_locality ->
+      [ Axis Areality;
+        Axis Forkable;
+        Axis Yielding;
+        Axis Linearity;
+        Axis Statefulness;
+        Axis Portability ]
+    | Comonadic_with_regionality ->
+      [ Axis Areality;
+        Axis Forkable;
+        Axis Yielding;
+        Axis Linearity;
+        Axis Statefulness;
+        Axis Portability ]
+    | Monadic_op ->
+      [Axis Uniqueness; Axis Visibility; Axis Contention; Axis Staticity]
+    | Locality | Regionality | Uniqueness_op | Linearity | Portability
+    | Forkable | Yielding | Statefulness | Contention_op | Visibility_op
+    | Staticity_op ->
+      []
+
+  type ('b, 'd) packed_core_to =
+    | Core_to : 'a obj * ('a, 'b, 'd) Core_morph.t -> ('b, 'd) packed_core_to
+
+  let core_to : type a b d. (a, b, d) Core_morph.t -> (b, d) packed_core_to =
+   fun m -> Core_to (Core_morph.src m, m)
+
+  let left_cores_to : type b. b obj -> (b, left_only) packed_core_to list =
+    function
+    | Locality -> [core_to (Locality_restricted Regional_to_local)]
+    | Regionality ->
+      [ core_to (Locality_restricted Local_to_regional);
+        core_to (Locality_restricted Locality_as_regionality);
+        core_to (Locality_restricted Local_to_regional_regionality);
+        core_to (Locality_restricted Regional_to_local_regionality) ]
+    | Uniqueness_op -> [core_to Linearity_to_uniqueness_op]
+    | Linearity -> [core_to Uniqueness_op_to_linearity]
+    | Portability -> [core_to Contention_op_to_portability]
+    | Forkable -> []
+    | Yielding -> []
+    | Statefulness -> [core_to Visibility_op_to_statefulness]
+    | Contention_op -> [core_to Portability_to_contention_op]
+    | Visibility_op -> [core_to Statefulness_to_visibility_op]
+    | Staticity_op -> []
+    | Monadic_op ->
+      [ core_to (Comonadic_to_monadic_min Locality);
+        core_to (Comonadic_to_monadic_min Regionality) ]
+    | Comonadic_with_locality ->
+      [ core_to (Locality_full Regional_to_local);
+        core_to Monadic_to_comonadic_min ]
+    | Comonadic_with_regionality ->
+      [ core_to (Locality_full Local_to_regional);
+        core_to (Locality_full Locality_as_regionality);
+        core_to (Locality_full Local_to_regional_regionality);
+        core_to (Locality_full Regional_to_local_regionality);
+        core_to Monadic_to_comonadic_min ]
+
+  let right_cores_to : type b. b obj -> (b, right_only) packed_core_to list =
+    function
+    | Locality ->
+      [ core_to (Locality_restricted Regional_to_local);
+        core_to (Locality_restricted Regional_to_global) ]
+    | Regionality ->
+      [ core_to (Locality_restricted Locality_as_regionality);
+        core_to (Locality_restricted Regional_to_local_regionality);
+        core_to (Locality_restricted Regional_to_global_regionality) ]
+    | Uniqueness_op -> [core_to Linearity_to_uniqueness_op]
+    | Linearity -> [core_to Uniqueness_op_to_linearity]
+    | Portability -> [core_to Contention_op_to_portability]
+    | Forkable -> []
+    | Yielding -> []
+    | Statefulness -> [core_to Visibility_op_to_statefulness]
+    | Contention_op -> [core_to Portability_to_contention_op]
+    | Visibility_op -> [core_to Statefulness_to_visibility_op]
+    | Staticity_op -> []
+    | Monadic_op ->
+      [ core_to (Comonadic_to_monadic_max Locality);
+        core_to (Comonadic_to_monadic_max Regionality) ]
+    | Comonadic_with_locality ->
+      [ core_to (Locality_full Regional_to_local);
+        core_to (Locality_full Regional_to_global);
+        core_to Monadic_to_comonadic_max ]
+    | Comonadic_with_regionality ->
+      [ core_to (Locality_full Locality_as_regionality);
+        core_to (Locality_full Regional_to_local_regionality);
+        core_to (Locality_full Regional_to_global_regionality);
+        core_to Monadic_to_comonadic_max ]
+
+  type ('b, 'd) packed_simple_to =
+    | Simple_to :
+        'a obj * ('a, 'b, 'd) Simple_morph.t
+        -> ('b, 'd) packed_simple_to
+
+  let simple_to : type a b d.
+      b obj -> (a, b, d) Simple_morph.t -> (b, d) packed_simple_to =
+   fun dst m -> Simple_to (Simple_morph.src dst m, m)
+
+  let simple_left_to : type b. b obj -> (b, left_only) packed_simple_to list =
+   fun dst ->
+    let constants =
+      List.map
+        (fun c -> simple_to dst (Simple_morph.Meet_const c))
+        (all_values_for_check dst)
+    in
+    let cores = left_cores_to dst in
+    let core_morphs =
+      List.map
+        (fun (Core_to (_, m)) -> simple_to dst (Simple_morph.Core m))
+        cores
+    in
+    let meet_const_cores =
+      let* c = all_values_for_check dst in
+      let+ (Core_to (_, m)) = cores in
+      simple_to dst (Simple_morph.Meet_const_core (c, m))
+    in
+    (simple_to dst Id :: core_morphs) @ constants @ meet_const_cores
+
+  let simple_right_to : type b. b obj -> (b, right_only) packed_simple_to list =
+   fun dst ->
+    let constants =
+      List.map
+        (fun c -> simple_to dst (Simple_morph.Imply_const c))
+        (all_values_for_check dst)
+    in
+    let cores = right_cores_to dst in
+    let core_morphs =
+      List.map
+        (fun (Core_to (_, m)) -> simple_to dst (Simple_morph.Core m))
+        cores
+    in
+    let core_imply_consts =
+      let* (Core_to (src, m)) = cores in
+      let+ c = all_values_for_check src in
+      simple_to dst (Simple_morph.Core_imply_const (m, c))
+    in
+    (simple_to dst Id :: core_morphs) @ constants @ core_imply_consts
+
+  let filter_simple_src : type a b d.
+      a obj -> (b, d) packed_simple_to list -> (a, b, d) Simple_morph.t list =
+   fun src simple_morphs ->
+    let filter : (b, d) packed_simple_to -> (a, b, d) Simple_morph.t option =
+     fun (Simple_to (src', m)) ->
+      match equal_obj src src' with
+      | Misc.Is_eq -> Some m
+      | Misc.Is_not_eq -> None
+    in
+    List.filter_map filter simple_morphs
+
+  let simple_left_from_to src dst = filter_simple_src src (simple_left_to dst)
+
+  let simple_right_from_to src dst = filter_simple_src src (simple_right_to dst)
+
+  type 'b packed_morph_to =
+    | Morph_to : 'a obj * ('a, 'b, neither) morph -> 'b packed_morph_to
+
+  let left_morph_to : type a b.
+      a obj -> (a, b, left_only) morph -> b packed_morph_to =
+   fun src morph -> Morph_to (src, disallow_left morph)
+
+  let right_morph_to : type a b.
+      a obj -> (a, b, right_only) morph -> b packed_morph_to =
+   fun src morph -> Morph_to (src, disallow_right morph)
+
+  let generate_left_morphs_to : type b. b obj -> b packed_morph_to list =
+   fun dst ->
+    let simple_morphs =
+      List.map
+        (fun (Simple_to (src, m)) -> left_morph_to src (Simple m))
+        (simple_left_to dst)
+    in
+    let projections =
+      let* (Obj src) = all_objs in
+      let* (Axis ax) = axes src in
+      let projected = proj_obj ax src in
+      let+ m = simple_left_from_to projected dst in
+      left_morph_to src (Simple_proj (m, ax, src))
+    in
+    let min_with =
+      let* (Axis ax) = axes dst in
+      let projected = proj_obj ax dst in
+      let+ (Simple_to (src, m)) = simple_left_to projected in
+      left_morph_to src (Min_with_simple (ax, m))
+    in
+    let const_min =
+      List.map (fun (Obj src) -> left_morph_to src (Const_min src)) all_objs
+    in
+    simple_morphs @ projections @ min_with @ const_min
+
+  let generate_right_morphs_to : type b. b obj -> b packed_morph_to list =
+   fun dst ->
+    let simple_morphs =
+      List.map
+        (fun (Simple_to (src, m)) -> right_morph_to src (Simple m))
+        (simple_right_to dst)
+    in
+    let projections =
+      let* (Obj src) = all_objs in
+      let* (Axis ax) = axes src in
+      let projected = proj_obj ax src in
+      let+ m = simple_right_from_to projected dst in
+      right_morph_to src (Simple_proj (m, ax, src))
+    in
+    let max_with =
+      let* (Axis ax) = axes dst in
+      let projected = proj_obj ax dst in
+      let+ (Simple_to (src, m)) = simple_right_to projected in
+      right_morph_to src (Max_with_simple (ax, m))
+    in
+    let const_max =
+      List.map (fun (Obj src) -> right_morph_to src (Const_max src)) all_objs
+    in
+    simple_morphs @ projections @ max_with @ const_max
+
+  let generate_morphs_to dst =
+    generate_left_morphs_to dst @ generate_right_morphs_to dst
+
+  let morphs_to_locality = generate_morphs_to Locality
+
+  let morphs_to_regionality = generate_morphs_to Regionality
+
+  let morphs_to_uniqueness_op = generate_morphs_to Uniqueness_op
+
+  let morphs_to_linearity = generate_morphs_to Linearity
+
+  let morphs_to_portability = generate_morphs_to Portability
+
+  let morphs_to_forkable = generate_morphs_to Forkable
+
+  let morphs_to_yielding = generate_morphs_to Yielding
+
+  let morphs_to_statefulness = generate_morphs_to Statefulness
+
+  let morphs_to_contention_op = generate_morphs_to Contention_op
+
+  let morphs_to_visibility_op = generate_morphs_to Visibility_op
+
+  let morphs_to_staticity_op = generate_morphs_to Staticity_op
+
+  let morphs_to_monadic_op = generate_morphs_to Monadic_op
+
+  let morphs_to_comonadic_with_locality =
+    generate_morphs_to Comonadic_with_locality
+
+  let morphs_to_comonadic_with_regionality =
+    generate_morphs_to Comonadic_with_regionality
+
+  let morphs_to : type b. b obj -> b packed_morph_to list = function
+    | Locality -> morphs_to_locality
+    | Regionality -> morphs_to_regionality
+    | Uniqueness_op -> morphs_to_uniqueness_op
+    | Linearity -> morphs_to_linearity
+    | Portability -> morphs_to_portability
+    | Forkable -> morphs_to_forkable
+    | Yielding -> morphs_to_yielding
+    | Statefulness -> morphs_to_statefulness
+    | Contention_op -> morphs_to_contention_op
+    | Visibility_op -> morphs_to_visibility_op
+    | Staticity_op -> morphs_to_staticity_op
+    | Monadic_op -> morphs_to_monadic_op
+    | Comonadic_with_locality -> morphs_to_comonadic_with_locality
+    | Comonadic_with_regionality -> morphs_to_comonadic_with_regionality
+
+  let check_compose : type a b c.
+      a obj ->
+      b obj ->
+      c obj ->
+      (b, c, neither) morph ->
+      (a, b, neither) morph ->
+      unit =
+   fun src mid dst f g ->
+    let result = compose dst f g in
+    List.iter
+      (fun input ->
+        let expected = apply dst f (apply mid g input) in
+        let actual = apply dst result input in
+        if not (equal dst expected actual)
+        then
+          let msg =
+            Fmt.asprintf
+              "@[<v>Lattices_mono compose check failed:@,\
+               source: %a@,\
+               middle: %a@,\
+               target: %a@,\
+               f: %a@,\
+               g: %a@,\
+               result: %a@,\
+               input: %a@,\
+               expected: %a@,\
+               actual: %a@]"
+              print_obj src print_obj mid print_obj dst (print_morph dst) f
+              (print_morph mid) g (print_morph dst) result (print src) input
+              (print dst) expected (print dst) actual
+          in
+          failwith msg)
+      (all_values_for_check src)
+
+  let domain_count_for_jobs job_count =
+    Int.min (Domain.recommended_domain_count ()) job_count
+
+  let run_jobs_in_parallel jobs =
+    let job_count = Array.length jobs in
+    let domain_count = domain_count_for_jobs job_count in
+    if domain_count <= 1
+    then Array.iter (fun job -> job ()) jobs
+    else
+      let worker worker_index =
+        let rec loop job_index =
+          if job_index < job_count
+          then (
+            jobs.(job_index) ();
+            loop (job_index + domain_count))
+        in
+        match loop worker_index with
+        | () -> None
+        | exception exn -> Some (exn, Printexc.get_raw_backtrace ())
+      in
+      let domains =
+        Array.init (domain_count - 1) (fun worker_index ->
+            (Domain.spawn
+            [@ocaml.alert "-do_not_spawn_domains"]
+            [@ocaml.alert "-unsafe_multidomain"]) (fun () ->
+                worker (worker_index + 1)))
+      in
+      let first_error =
+        Array.fold_left
+          (fun first_error domain ->
+            match first_error, Domain.join domain with
+            | Some _, _ -> first_error
+            | None, error -> error)
+          (worker 0) domains
+      in
+      match first_error with
+      | None -> ()
+      | Some (exn, backtrace) -> Printexc.raise_with_backtrace exn backtrace
+
+  let check_jobs () =
+    let jobs =
+      let* (Obj dst) = all_objs in
+      let+ (Morph_to (mid, f)) = morphs_to dst in
+      let morphs_to_mid = morphs_to mid in
+      fun () ->
+        List.iter
+          (fun (Morph_to (src, g)) -> check_compose src mid dst f g)
+          morphs_to_mid
+    in
+    Array.of_list jobs
+
+  let check_all_allowed_compositions () =
+    let jobs = check_jobs () in
+    Printf.printf "allowed checks running on %d domain(s)\n%!"
+      (domain_count_for_jobs (Array.length jobs));
+    run_jobs_in_parallel jobs
+end
+
 module C = Lattices_mono
 module S = Solver_mono (Hint_for_solver) (C)
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1517,29 +1517,56 @@ module Lattices_mono = struct
       | Visibility -> { t with visibility = r }
       | Staticity -> { t with staticity = r }
 
-    type 'a packed = Axis : ('a, 'b) t -> 'a packed
+    type 'a packed_small = Ps : ('a, 'b) t -> 'a packed_small
 
-    let all : type a. a obj -> a packed list = function
+    let all : type a. a obj -> a packed_small list = function
       | Comonadic_with_locality ->
-        [ Axis Areality;
-          Axis Forkable;
-          Axis Yielding;
-          Axis Linearity;
-          Axis Statefulness;
-          Axis Portability ]
+        [ Ps Areality;
+          Ps Forkable;
+          Ps Yielding;
+          Ps Linearity;
+          Ps Statefulness;
+          Ps Portability ]
       | Comonadic_with_regionality ->
-        [ Axis Areality;
-          Axis Forkable;
-          Axis Yielding;
-          Axis Linearity;
-          Axis Statefulness;
-          Axis Portability ]
-      | Monadic_op ->
-        [Axis Uniqueness; Axis Visibility; Axis Contention; Axis Staticity]
+        [ Ps Areality;
+          Ps Forkable;
+          Ps Yielding;
+          Ps Linearity;
+          Ps Statefulness;
+          Ps Portability ]
+      | Monadic_op -> [Ps Uniqueness; Ps Visibility; Ps Contention; Ps Staticity]
       | Locality | Regionality | Uniqueness_op | Linearity | Portability
       | Forkable | Yielding | Statefulness | Contention_op | Visibility_op
       | Staticity_op ->
         []
+
+    type 'b packed_big = Pb : 'a obj * ('a, 'b) t -> 'b packed_big
+
+    let axis_to : type b. b obj -> b packed_big list = function
+      | Comonadic_with_locality -> []
+      | Comonadic_with_regionality -> []
+      | Monadic_op -> []
+      | Locality -> [Pb (Comonadic_with_locality, Areality)]
+      | Regionality -> [Pb (Comonadic_with_regionality, Areality)]
+      | Uniqueness_op -> [Pb (Monadic_op, Uniqueness)]
+      | Linearity ->
+        [ Pb (Comonadic_with_locality, Linearity);
+          Pb (Comonadic_with_regionality, Linearity) ]
+      | Portability ->
+        [ Pb (Comonadic_with_locality, Portability);
+          Pb (Comonadic_with_regionality, Portability) ]
+      | Forkable ->
+        [ Pb (Comonadic_with_locality, Forkable);
+          Pb (Comonadic_with_regionality, Forkable) ]
+      | Yielding ->
+        [ Pb (Comonadic_with_locality, Yielding);
+          Pb (Comonadic_with_regionality, Yielding) ]
+      | Statefulness ->
+        [ Pb (Comonadic_with_locality, Statefulness);
+          Pb (Comonadic_with_regionality, Statefulness) ]
+      | Contention_op -> [Pb (Monadic_op, Contention)]
+      | Visibility_op -> [Pb (Monadic_op, Visibility)]
+      | Staticity_op -> [Pb (Monadic_op, Staticity)]
   end
 
   type packed_obj = Obj : 'a obj -> packed_obj
@@ -3286,21 +3313,6 @@ module Lattices_mono = struct
         to_ dst (Core_imply_const (m, c))
       in
       (to_ dst Id :: core_morphs) @ constants @ core_imply_consts
-
-    let filter_src : type a b d.
-        a obj -> (b, d) packed_to list -> (a, b, d) t list =
-     fun src simple_morphs ->
-      let filter : (b, d) packed_to -> (a, b, d) t option =
-       fun (To (src', m)) ->
-        match equal_obj src src' with
-        | Misc.Is_eq -> Some m
-        | Misc.Is_not_eq -> None
-      in
-      List.filter_map filter simple_morphs
-
-    let left_from_to ~full src dst = filter_src src (left_to ~full dst)
-
-    let right_from_to ~full src dst = filter_src src (right_to ~full dst)
   end
 
   type ('a, 'b, 'd) morph =
@@ -3918,20 +3930,19 @@ module Lattices_mono = struct
   let generate_left_morphs_to : type b.
       full:bool -> b obj -> b packed_morph_to list =
    fun ~full dst ->
-    let simple_morphs =
+    let simple_morphs = Simple_morph.left_to ~full dst in
+    let simple =
       List.map
         (fun (Simple_morph.To (src, m)) -> left_morph_to src (Simple m))
-        (Simple_morph.left_to ~full dst)
+        simple_morphs
     in
     let projections =
-      let* (Obj src) = all_objs in
-      let* (Axis.Axis ax) = Axis.all src in
-      let projected = proj_obj ax src in
-      let+ m = Simple_morph.left_from_to ~full projected dst in
+      let* (Simple_morph.To (projected, m)) = simple_morphs in
+      let+ (Axis.Pb (src, ax)) = Axis.axis_to projected in
       left_morph_to src (Simple_proj (m, ax, src))
     in
     let min_with =
-      let* (Axis.Axis ax) = Axis.all dst in
+      let* (Axis.Ps ax) = Axis.all dst in
       let projected = proj_obj ax dst in
       let+ (Simple_morph.To (src, m)) = Simple_morph.left_to ~full projected in
       left_morph_to src (Min_with_simple (ax, m))
@@ -3939,25 +3950,24 @@ module Lattices_mono = struct
     let const_min =
       List.map (fun (Obj src) -> left_morph_to src (Const_min src)) all_objs
     in
-    simple_morphs @ projections @ min_with @ const_min
+    simple @ projections @ min_with @ const_min
 
   let generate_right_morphs_to : type b.
       full:bool -> b obj -> b packed_morph_to list =
    fun ~full dst ->
-    let simple_morphs =
+    let simple_morphs = Simple_morph.right_to ~full dst in
+    let simple =
       List.map
         (fun (Simple_morph.To (src, m)) -> right_morph_to src (Simple m))
-        (Simple_morph.right_to ~full dst)
+        simple_morphs
     in
     let projections =
-      let* (Obj src) = all_objs in
-      let* (Axis.Axis ax) = Axis.all src in
-      let projected = proj_obj ax src in
-      let+ m = Simple_morph.right_from_to ~full projected dst in
+      let* (Simple_morph.To (projected, m)) = simple_morphs in
+      let+ (Axis.Pb (src, ax)) = Axis.axis_to projected in
       right_morph_to src (Simple_proj (m, ax, src))
     in
     let max_with =
-      let* (Axis.Axis ax) = Axis.all dst in
+      let* (Axis.Ps ax) = Axis.all dst in
       let projected = proj_obj ax dst in
       let+ (Simple_morph.To (src, m)) = Simple_morph.right_to ~full projected in
       right_morph_to src (Max_with_simple (ax, m))
@@ -3965,7 +3975,7 @@ module Lattices_mono = struct
     let const_max =
       List.map (fun (Obj src) -> right_morph_to src (Const_max src)) all_objs
     in
-    simple_morphs @ projections @ max_with @ const_max
+    simple @ projections @ max_with @ const_max
 
   let generate_morphs_to ~full dst =
     generate_left_morphs_to ~full dst @ generate_right_morphs_to ~full dst
@@ -4212,8 +4222,6 @@ module For_testing = struct
           failwith msg)
       (get_elements ~full src)
 
-  let run_jobs jobs = List.iter (fun job -> job ()) jobs
-
   let check_jobs ~full () =
     let* (Obj dst) = all_objs in
     let+ (Morph_to (mid, f)) = morphs_to ~full dst in
@@ -4222,11 +4230,6 @@ module For_testing = struct
       List.iter
         (fun (Morph_to (src, g)) -> check_compose ~full src mid dst f g)
         morphs_to_mid
-
-  let check_all_allowed_compositions ~full () =
-    let jobs = check_jobs ~full () in
-    Printf.printf "running allowed composition checks\n%!";
-    run_jobs jobs
 end
 
 module C = Lattices_mono

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1944,6 +1944,23 @@ module Lattices_mono = struct
         Morph Locality_as_regionality
       | Comonadic_with_regionality, Comonadic_with_regionality -> Id
       | Comonadic_with_locality, Comonadic_with_locality -> Id
+
+    type ('b, 'd) to_ = To : ('a, 'b, 'd) t -> ('b, 'd) to_ [@@unboxed]
+
+    let left_to : type b. b areality -> (b, left_only) to_ list = function
+      | Locality -> [To Regional_to_local]
+      | Regionality ->
+        [ To Local_to_regional;
+          To Locality_as_regionality;
+          To Local_to_regional_regionality;
+          To Regional_to_local_regionality ]
+
+    let right_to : type b. b areality -> (b, right_only) to_ list = function
+      | Locality -> [To Regional_to_local; To Regional_to_global]
+      | Regionality ->
+        [ To Locality_as_regionality;
+          To Regional_to_local_regionality;
+          To Regional_to_global_regionality ]
   end
 
   module Core_morph = struct
@@ -2745,13 +2762,15 @@ module Lattices_mono = struct
 
     type ('b, 'd) to_ = To : ('a, 'b, 'd) t -> ('b, 'd) to_ [@@unboxed]
 
+    let ( let+ ) xs f = List.map f xs
+
     let left_to : type b. b obj -> (b, left_only) to_ list = function
-      | Locality -> [To (Locality_restricted Regional_to_local)]
+      | Locality ->
+        let+ (Locality_morph.To lm) = Locality_morph.left_to Locality in
+        To (Locality_restricted lm)
       | Regionality ->
-        [ To (Locality_restricted Local_to_regional);
-          To (Locality_restricted Locality_as_regionality);
-          To (Locality_restricted Local_to_regional_regionality);
-          To (Locality_restricted Regional_to_local_regionality) ]
+        let+ (Locality_morph.To lm) = Locality_morph.left_to Regionality in
+        To (Locality_restricted lm)
       | Uniqueness_op -> [To Linearity_to_uniqueness_op]
       | Linearity -> [To Uniqueness_op_to_linearity]
       | Portability -> [To Contention_op_to_portability]
@@ -2765,22 +2784,21 @@ module Lattices_mono = struct
         [ To (Comonadic_to_monadic_min Locality);
           To (Comonadic_to_monadic_min Regionality) ]
       | Comonadic_with_locality ->
-        [To (Locality_full Regional_to_local); To Monadic_to_comonadic_min]
+        (let+ (Locality_morph.To lm) = Locality_morph.left_to Locality in
+         To (Locality_full lm))
+        @ [To Monadic_to_comonadic_min]
       | Comonadic_with_regionality ->
-        [ To (Locality_full Local_to_regional);
-          To (Locality_full Locality_as_regionality);
-          To (Locality_full Local_to_regional_regionality);
-          To (Locality_full Regional_to_local_regionality);
-          To Monadic_to_comonadic_min ]
+        (let+ (Locality_morph.To lm) = Locality_morph.left_to Regionality in
+         To (Locality_full lm))
+        @ [To Monadic_to_comonadic_min]
 
     let right_to : type b. b obj -> (b, right_only) to_ list = function
       | Locality ->
-        [ To (Locality_restricted Regional_to_local);
-          To (Locality_restricted Regional_to_global) ]
+        let+ (Locality_morph.To lm) = Locality_morph.right_to Locality in
+        To (Locality_restricted lm)
       | Regionality ->
-        [ To (Locality_restricted Locality_as_regionality);
-          To (Locality_restricted Regional_to_local_regionality);
-          To (Locality_restricted Regional_to_global_regionality) ]
+        let+ (Locality_morph.To lm) = Locality_morph.right_to Regionality in
+        To (Locality_restricted lm)
       | Uniqueness_op -> [To Linearity_to_uniqueness_op]
       | Linearity -> [To Uniqueness_op_to_linearity]
       | Portability -> [To Contention_op_to_portability]
@@ -2794,14 +2812,13 @@ module Lattices_mono = struct
         [ To (Comonadic_to_monadic_max Locality);
           To (Comonadic_to_monadic_max Regionality) ]
       | Comonadic_with_locality ->
-        [ To (Locality_full Regional_to_local);
-          To (Locality_full Regional_to_global);
-          To Monadic_to_comonadic_max ]
+        (let+ (Locality_morph.To lm) = Locality_morph.right_to Locality in
+         To (Locality_full lm))
+        @ [To Monadic_to_comonadic_max]
       | Comonadic_with_regionality ->
-        [ To (Locality_full Locality_as_regionality);
-          To (Locality_full Regional_to_local_regionality);
-          To (Locality_full Regional_to_global_regionality);
-          To Monadic_to_comonadic_max ]
+        (let+ (Locality_morph.To lm) = Locality_morph.right_to Regionality in
+         To (Locality_full lm))
+        @ [To Monadic_to_comonadic_max]
   end
 
   let proj_obj : type t r. (t, r) Axis.t -> t obj -> r obj =

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1686,31 +1686,18 @@ module Lattices_mono = struct
       | Regional_to_local_regionality -> Comonadic_with_regionality
       | Regional_to_global_regionality -> Comonadic_with_regionality
 
-    let compare : type a1 l1 r1 a2 b l2 r2.
+    let ord : type a b d. (a, b, d) t -> int = function
+      | Local_to_regional -> 0
+      | Regional_to_local -> 1
+      | Locality_as_regionality -> 2
+      | Regional_to_global -> 3
+      | Local_to_regional_regionality -> 4
+      | Regional_to_local_regionality -> 5
+      | Regional_to_global_regionality -> 6
+
+    let compare_total : type a1 l1 r1 a2 b l2 r2.
         (a1, b, l1 * r1) t -> (a2, b, l2 * r2) t -> int =
-     fun m1 m2 ->
-      match m1, m2 with
-      | Local_to_regional, Local_to_regional -> 0
-      | Local_to_regional, _ -> -1
-      | _, Local_to_regional -> 1
-      | Regional_to_local, Regional_to_local -> 0
-      | Regional_to_local, _ -> -1
-      | _, Regional_to_local -> 1
-      | Locality_as_regionality, Locality_as_regionality -> 0
-      | Locality_as_regionality, _ -> -1
-      | _, Locality_as_regionality -> 1
-      | Regional_to_global, Regional_to_global -> 0
-      | Regional_to_global, _ -> .
-      | _, Regional_to_global -> .
-      | Local_to_regional_regionality, Local_to_regional_regionality -> 0
-      | Local_to_regional_regionality, _ -> -1
-      | _, Local_to_regional_regionality -> 1
-      | Regional_to_local_regionality, Regional_to_local_regionality -> 0
-      | Regional_to_local_regionality, _ -> -1
-      | _, Regional_to_local_regionality -> 1
-      | Regional_to_global_regionality, Regional_to_global_regionality -> 0
-      | Regional_to_global_regionality, _ -> .
-      | _, Regional_to_global_regionality -> .
+     fun m1 m2 -> Int.compare (ord m1) (ord m2)
 
     let equal : type a1 l1 r1 a2 b l2 r2.
         (a1, b, l1 * r1) t -> (a2, b, l2 * r2) t -> (a1, a2) Misc.is_eq =
@@ -1840,13 +1827,13 @@ module Lattices_mono = struct
       | Regional_to_global -> Not_allowed_left
       | Regional_to_global_regionality -> Not_allowed_left
 
-    type ('a, 'b, 'd) composition =
-      | Id : ('a, 'a, 'd) composition
-      | Morph : ('a, 'b, 'd) t -> ('a, 'b, 'd) composition
-      | Disallowed : ('a, 'b, neither) composition
+    type ('a, 'b, 'd) compose_result =
+      | Id : ('a, 'a, 'd) compose_result
+      | Morph : ('a, 'b, 'd) t -> ('a, 'b, 'd) compose_result
+      | Disallowed : ('a, 'b, neither) compose_result
 
     let compose : type a b c d.
-        (b, c, d) t -> (a, b, d) t -> (a, c, d) composition =
+        (b, c, d) t -> (a, b, d) t -> (a, c, d) compose_result =
      fun m1 m2 ->
       match m1, m2 with
       | Local_to_regional, Regional_to_local ->
@@ -2014,14 +2001,15 @@ module Lattices_mono = struct
       | Monadic_to_comonadic_max -> Monadic_op
       | Comonadic_to_monadic_max ar -> areality_comonadic_obj ar
 
-    let compare : type a1 d1 a2 b d2. (a1, b, d1) t -> (a2, b, d2) t -> int =
+    let compare_total : type a1 d1 a2 b d2.
+        (a1, b, d1) t -> (a2, b, d2) t -> int =
      fun m1 m2 ->
       match m1, m2 with
       | Locality_restricted l1, Locality_restricted l2 ->
-        Locality_morph.compare l1 l2
+        Locality_morph.compare_total l1 l2
       | Locality_restricted _, _ -> .
       | _, Locality_restricted _ -> .
-      | Locality_full l1, Locality_full l2 -> Locality_morph.compare l1 l2
+      | Locality_full l1, Locality_full l2 -> Locality_morph.compare_total l1 l2
       | Locality_full _, _ -> -1
       | _, Locality_full _ -> 1
       | Uniqueness_op_to_linearity, Uniqueness_op_to_linearity -> 0
@@ -2349,11 +2337,11 @@ module Lattices_mono = struct
       | Proj_const_max : 'a obj -> ('a, 'b, disallowed * 'r) compose_proj_result
       | Proj_const_min : 'a obj -> ('a, 'b, 'l * disallowed) compose_proj_result
 
-    let compose_projection_locality_morph : type a b p l r.
-        (a, b, l * r) Locality_morph.t ->
+    let compose_projection_locality_full : type a b p l r.
         (b comonadic_with, p) Axis.t ->
+        (a, b, l * r) Locality_morph.t ->
         (a comonadic_with, p, l * r) compose_proj_result =
-     fun lm1 ax0 ->
+     fun ax0 lm1 ->
       let src = Locality_morph.src_full lm1 in
       match ax0 with
       | Forkable -> Proj_id (Forkable, src)
@@ -2419,7 +2407,7 @@ module Lattices_mono = struct
             areality_comonadic_obj areality )
       | Comonadic_to_monadic_max areality, Staticity ->
         Proj_const_max (areality_comonadic_obj areality)
-      | Locality_full lm, (_ as ax0) -> compose_projection_locality_morph lm ax0
+      | Locality_full lm, (_ as ax0) -> compose_projection_locality_full ax0 lm
       | _, _ -> .
     [@@warning "-4"]
 
@@ -2433,7 +2421,7 @@ module Lattices_mono = struct
           -> ('q, 'c comonadic_with, 'd) compose_and_max_result
       | Disallowed : ('a, 'b, neither) compose_and_max_result
 
-    let compose_max_with_simple_locality_morph : type b c q r.
+    let compose_locality_full_max_with : type b c q r.
         (b, c, disallowed * r) Locality_morph.t ->
         (b comonadic_with, q) Axis.t ->
         (q, c comonadic_with, disallowed * r) compose_and_max_result =
@@ -2476,11 +2464,11 @@ module Lattices_mono = struct
           And_max_id Portability)
       | Areality -> And_max_core (Areality, Locality_restricted lm1)
 
-    let compose_max_with_simple_core : type b c q r.
-        (b, q) Axis.t ->
+    let compose_core_max_with : type b c q r.
         (b, c, disallowed * r) t ->
+        (b, q) Axis.t ->
         (q, c, disallowed * r) compose_and_max_result =
-     fun ax1 m0 ->
+     fun m0 ax1 ->
       match (m0 : (b, c, disallowed * r) t), (ax1 : (b, q) Axis.t) with
       | Comonadic_to_monadic_max _, Portability ->
         And_max_core (Contention, Portability_to_contention_op)
@@ -2498,8 +2486,7 @@ module Lattices_mono = struct
         And_max_core (Statefulness, Visibility_op_to_statefulness)
       | Monadic_to_comonadic_max, Uniqueness ->
         And_max_core (Linearity, Uniqueness_op_to_linearity)
-      | Locality_full lm, (_ as ax0) ->
-        compose_max_with_simple_locality_morph lm ax0
+      | Locality_full lm, (_ as ax0) -> compose_locality_full_max_with lm ax0
       | Monadic_to_comonadic_min, _ -> Disallowed
       | Comonadic_to_monadic_min _, _ -> Disallowed
       | _, _ -> .
@@ -2515,7 +2502,7 @@ module Lattices_mono = struct
           -> ('q, 'c comonadic_with, 'd) compose_and_min_result
       | Disallowed : ('a, 'b, neither) compose_and_min_result
 
-    let compose_min_with_simple_locality_morph : type b c q l.
+    let compose_locality_full_min_with : type b c q l.
         (b, c, l * disallowed) Locality_morph.t ->
         (b comonadic_with, q) Axis.t ->
         (q, c comonadic_with, l * disallowed) compose_and_min_result =
@@ -2528,11 +2515,11 @@ module Lattices_mono = struct
       | Portability -> And_min_id Portability
       | Areality -> And_min_core (Areality, Locality_restricted lm1)
 
-    let compose_min_with_simple_core : type b c q l.
-        (b, q) Axis.t ->
+    let compose_core_min_with : type b c q l.
         (b, c, l * disallowed) t ->
+        (b, q) Axis.t ->
         (q, c, l * disallowed) compose_and_min_result =
-     fun ax1 m0 ->
+     fun m0 ax1 ->
       match (m0 : (b, c, l * disallowed) t), (ax1 : (b, q) Axis.t) with
       | Comonadic_to_monadic_min _, Portability ->
         And_min_core (Contention, Portability_to_contention_op)
@@ -2550,8 +2537,7 @@ module Lattices_mono = struct
         And_min_core (Statefulness, Visibility_op_to_statefulness)
       | Monadic_to_comonadic_min, Uniqueness ->
         And_min_core (Linearity, Uniqueness_op_to_linearity)
-      | Locality_full lm, (_ as ax0) ->
-        compose_min_with_simple_locality_morph lm ax0
+      | Locality_full lm, (_ as ax0) -> compose_locality_full_min_with lm ax0
       | Monadic_to_comonadic_max, _ -> Disallowed
       | Comonadic_to_monadic_max _, _ -> Disallowed
       | _, _ -> .
@@ -2728,44 +2714,44 @@ module Lattices_mono = struct
 
     let equal_val = equal
 
-    let rec compare : type a1 d1 a2 b d2.
+    let rec compare_total : type a1 d1 a2 b d2.
         b obj -> (a1, b, d1) t -> (a2, b, d2) t -> int =
      fun dst m1 m2 ->
       match m1, m2 with
       | Id, Id -> 0
       | Id, _ -> -1
       | _, Id -> 1
-      | Core m1, Core m2 -> Core_morph.compare m1 m2
+      | Core m1, Core m2 -> Core_morph.compare_total m1 m2
       | Core _, _ -> -1
       | _, Core _ -> 1
-      | Meet_const c1, Meet_const c2 -> compare_total dst c1 c2
+      | Meet_const c1, Meet_const c2 -> Lattices.compare_total dst c1 c2
       | Meet_const _, _ -> -1
       | _, Meet_const _ -> 1
-      | Imply_const c1, Imply_const c2 -> compare_total dst c1 c2
+      | Imply_const c1, Imply_const c2 -> Lattices.compare_total dst c1 c2
       | Imply_const _, _ -> -1
       | _, Imply_const _ -> 1
       | Meet_const_core (c1, m1), Meet_const_core (c2, m2) ->
-        let c = compare_total dst c1 c2 in
-        if c <> 0 then c else Core_morph.compare m1 m2
+        let c = Lattices.compare_total dst c1 c2 in
+        if c <> 0 then c else Core_morph.compare_total m1 m2
       | Meet_const_core _, _ -> -1
       | _, Meet_const_core _ -> 1
       | Core_imply_const (m1, c1), Core_imply_const (m2, c2) ->
-        let c = Core_morph.compare m1 m2 in
+        let c = Core_morph.compare_total m1 m2 in
         if c <> 0
         then c
         else
           let Refl = Core_morph.equal m1 m2 |> Misc.get_eq_exn in
           let src = Core_morph.src m1 in
-          compare_total src c1 c2
+          Lattices.compare_total src c1 c2
       | Core_imply_const _, _ -> -1
       | _, Core_imply_const _ -> 1
       | Compose (mb1, ma1), Compose (mb2, ma2) ->
-        let c = compare dst mb1 mb2 in
+        let c = compare_total dst mb1 mb2 in
         if c <> 0
         then c
         else
           let Refl = equal dst mb1 mb2 |> Misc.get_eq_exn in
-          compare (src dst mb1) ma1 ma2
+          compare_total (src dst mb1) ma1 ma2
       | Compose _, _ -> .
       | _, Compose _ -> .
 
@@ -3403,7 +3389,7 @@ module Lattices_mono = struct
       b obj -> (a1, b, d1) morph -> (a2, b, d2) morph -> int =
    fun dst m1 m2 ->
     match m1, m2 with
-    | Simple m1, Simple m2 -> Simple_morph.compare dst m1 m2
+    | Simple m1, Simple m2 -> Simple_morph.compare_total dst m1 m2
     | Simple _, _ -> -1
     | _, Simple _ -> 1
     | Const_max obj1, Const_max obj2 -> compare_obj obj1 obj2
@@ -3428,7 +3414,7 @@ module Lattices_mono = struct
         then c
         else
           let Refl = Axis.equal ax1 ax2 |> Misc.get_eq_exn in
-          Simple_morph.compare dst m1 m2
+          Simple_morph.compare_total dst m1 m2
     | Simple_proj _, _ -> -1
     | _, Simple_proj _ -> 1
     | Max_with_simple (ax1, m1), Max_with_simple (ax2, m2) ->
@@ -3437,7 +3423,7 @@ module Lattices_mono = struct
       then c
       else
         let Refl = Axis.equal ax1 ax2 |> Misc.get_eq_exn in
-        Simple_morph.compare (proj_obj ax1 dst) m1 m2
+        Simple_morph.compare_total (proj_obj ax1 dst) m1 m2
     | Max_with_simple _, _ -> -1
     | _, Max_with_simple _ -> 1
     | Min_with_simple (ax1, m1), Min_with_simple (ax2, m2) ->
@@ -3446,7 +3432,7 @@ module Lattices_mono = struct
       then c
       else
         let Refl = Axis.equal ax1 ax2 |> Misc.get_eq_exn in
-        Simple_morph.compare (proj_obj ax1 dst) m1 m2
+        Simple_morph.compare_total (proj_obj ax1 dst) m1 m2
     | Min_with_simple _, _ -> -1
     | _, Min_with_simple _ -> 1
     | Compose (mb1, ma1), Compose (mb2, ma2) ->
@@ -3681,7 +3667,7 @@ module Lattices_mono = struct
     match sm0 with
     | Id -> Max_with_simple (ax1, m1)
     | Core m0 ->
-      begin match Core_morph.compose_max_with_simple_core ax1 m0 with
+      begin match Core_morph.compose_core_max_with m0 ax1 with
       | And_max_core (ax1, m0) ->
         let obj0 = proj_obj ax1 dst in
         Max_with_simple (ax1, Simple_morph.compose obj0 (Core m0) m1)
@@ -3695,7 +3681,7 @@ module Lattices_mono = struct
       Max_with_simple (ax1, Simple_morph.compose obj0 (Imply_const c0) m1)
     | Core_imply_const (m0, c0) -> begin
       let c0 = Axis.proj ax1 c0 in
-      match Core_morph.compose_max_with_simple_core ax1 m0 with
+      match Core_morph.compose_core_max_with m0 ax1 with
       | And_max_core (ax1, m0) ->
         let obj0 = proj_obj ax1 dst in
         Max_with_simple
@@ -3722,7 +3708,7 @@ module Lattices_mono = struct
     match sm0 with
     | Id -> Min_with_simple (ax1, m1)
     | Core m0 ->
-      begin match Core_morph.compose_min_with_simple_core ax1 m0 with
+      begin match Core_morph.compose_core_min_with m0 ax1 with
       | And_min_core (ax1, m0) ->
         let obj0 = proj_obj ax1 dst in
         Min_with_simple (ax1, Simple_morph.compose obj0 (Core m0) m1)
@@ -3735,7 +3721,7 @@ module Lattices_mono = struct
       let obj0 = proj_obj ax1 dst in
       Min_with_simple (ax1, Simple_morph.compose obj0 (Meet_const c0) m1)
     | Meet_const_core (c0, m0) ->
-      begin match Core_morph.compose_min_with_simple_core ax1 m0 with
+      begin match Core_morph.compose_core_min_with m0 ax1 with
       | And_min_core (ax1, m0) ->
         let obj0 = proj_obj ax1 dst in
         let c0 = Axis.proj ax1 c0 in

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -189,6 +189,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Spliced Monadic -> Spliced Monadic
         | Spliced Comonadic -> Spliced Comonadic
         | Lpoly_inst -> Lpoly_inst
+        | Contained_by c -> Contained_by c
 
       let allow_right : type l r. (l * allowed) t -> (l * r) t =
        fun (type l r) (h : (l * allowed) t) : (l * r) t ->
@@ -209,6 +210,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Escape_region x -> Escape_region x
         | Spliced Monadic -> Spliced Monadic
         | Spliced Comonadic -> Spliced Comonadic
+        | Contained_by c -> Contained_by c
 
       let disallow_left : type l r. (l * r) t -> (disallowed * r) t =
        fun (type l r) (h : (l * r) t) : (disallowed * r) t ->
@@ -235,6 +237,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Lpoly_inst -> Lpoly_inst
         | Spliced Monadic -> Spliced Monadic
         | Spliced Comonadic -> Spliced Comonadic
+        | Contained_by c -> Contained_by c
 
       let disallow_right : type l r. (l * r) t -> (l * disallowed) t =
        fun (type l r) (h : (l * r) t) : (l * disallowed) t ->
@@ -261,6 +264,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Quoted_computation -> Quoted_computation
         | Spliced Monadic -> Spliced Monadic
         | Spliced Comonadic -> Spliced Comonadic
+        | Contained_by c -> Contained_by c
     end)
   end
 end
@@ -420,18 +424,44 @@ module Lattices = struct
   end
   [@@inline]
 
-  (* Make the type of [Locality] and [Regionality] below distinguishable,
-     so that we can be sure [Comonadic_with] is applied correctly. *)
+  type locality =
+    | Global
+    | Local
+
+  type regionality =
+    | Global
+    | Regional
+    | Local
+
+  type 'a areality =
+    | Locality : locality areality
+    | Regionality : regionality areality
+
+  let compare_areality : type a b. a areality -> b areality -> int =
+   fun a b ->
+    match a, b with
+    | Locality, Locality -> 0
+    | Locality, _ -> -1
+    | _, Locality -> 1
+    | Regionality, Regionality -> 0
+
+  let equal_areality : type a b. a areality -> b areality -> (a, b) Misc.is_eq =
+   fun a b ->
+    match a, b with
+    | Locality, Locality -> Misc.Is_eq
+    | Regionality, Regionality -> Misc.Is_eq
+    | (Locality | Regionality), _ -> Misc.Is_not_eq
+
   module type Areality = sig
     include Const
 
     include Heyting with type t := t
 
-    val _is_areality : unit
+    val areality : t areality
   end
 
   module Locality = struct
-    type t =
+    type t = locality =
       | Global
       | Local
 
@@ -451,11 +481,11 @@ module Lattices = struct
       | Global -> Fmt.fprintf ppf "global"
       | Local -> Fmt.fprintf ppf "local"
 
-    let _is_areality = ()
+    let areality = Locality
   end
 
   module Regionality = struct
-    type t =
+    type t = regionality =
       | Global
       | Regional
       | Local
@@ -477,7 +507,7 @@ module Lattices = struct
       | Regional -> Fmt.fprintf ppf "regional"
       | Local -> Fmt.fprintf ppf "local"
 
-    let _is_areality = ()
+    let areality = Regionality
   end
 
   module Uniqueness = struct
@@ -1030,6 +1060,26 @@ module Lattices = struct
     | Comonadic_with_regionality : Comonadic_with_regionality.t obj
     | Comonadic_with_locality : Comonadic_with_locality.t obj
 
+  let areality_comonadic_obj : type a. a areality -> a comonadic_with obj =
+    function
+    | Locality -> Comonadic_with_locality
+    | Regionality -> Comonadic_with_regionality
+
+  let comonadic_obj_areality : type a. a comonadic_with obj -> a areality =
+    function
+    | Comonadic_with_locality -> Locality
+    | Comonadic_with_regionality -> Regionality
+
+  let comonadic_with_obj : type a. a obj -> a comonadic_with obj =
+   fun a0 ->
+    match a0 with
+    | Locality -> Comonadic_with_locality
+    | Regionality -> Comonadic_with_regionality
+    | Uniqueness_op | Linearity | Monadic_op | Comonadic_with_regionality
+    | Comonadic_with_locality | Contention_op | Visibility_op | Portability
+    | Forkable | Yielding | Statefulness | Staticity_op ->
+      assert false
+
   let is_opposite : type a. a obj -> bool = function
     | Locality -> false
     | Regionality -> false
@@ -1380,156 +1430,921 @@ module Lattices_mono = struct
       | Staticity -> { t with staticity = r }
   end
 
-  type ('a, 'b, 'd) morph =
-    | Id : ('a, 'a, 'l * 'r) morph  (** identity morphism *)
-    | Meet_const : 'a -> ('a, 'a, 'l * 'r) morph
-        (** Meet the input with the parameter *)
-    | Imply_const : 'a -> ('a, 'a, disallowed * 'r) morph
-        (** The right adjoint of [Meet_const] *)
-    | Proj : 't obj * ('t, 'r_) Axis.t -> ('t, 'r_, 'l * 'r) morph
-        (** Project from a product to an axis *)
-    | Max_with : ('t, 'r_) Axis.t -> ('r_, 't, disallowed * 'r) morph
-        (** Combine an axis with maxima along other axes *)
-    | Min_with : ('t, 'r_) Axis.t -> ('r_, 't, 'l * disallowed) morph
-        (** Combine an axis with minima along other axes *)
-    | Map_comonadic :
-        ('a1, 'a2, 'l * 'r) morph
-        -> ('a1 comonadic_with, 'a2 comonadic_with, 'l * 'r) morph
-        (** Lift an morphism on areality to a morphism on the comonadic fragment
-        *)
-    | Monadic_to_comonadic_min :
-        (Monadic_op.t, 'a comonadic_with, 'l * disallowed) morph
-        (** Dualize the monadic fragment to the comonadic fragment. The areality
-            is set to min. *)
-    | Comonadic_to_monadic_min :
-        'a comonadic_with obj
-        -> ('a comonadic_with, Monadic_op.t, 'l * disallowed) morph
-        (** Dualize the comonadic fragment to the monadic fragment. The
-            staticity_op is set to min. *)
-    | Monadic_to_comonadic_max :
-        (Monadic_op.t, 'a comonadic_with, disallowed * 'r) morph
-        (** Dualize the monadic fragment to the comonadic fragment. The areality
-            is set to max. *)
-    | Comonadic_to_monadic_max :
-        'a comonadic_with obj
-        -> ('a comonadic_with, Monadic_op.t, disallowed * 'r) morph
-        (** Dualize the comonadic fragment to the monadic fragment. The
-            staticity_op is set to max. *)
-    (* Following is a chain of adjunction (complete and cannot extend in
-       either direction) *)
-    | Local_to_regional : (Locality.t, Regionality.t, 'l * disallowed) morph
-        (** Maps local to regional, global to global *)
-    | Regional_to_local : (Regionality.t, Locality.t, 'l * 'r) morph
-        (** Maps regional to local, identity otherwise *)
-    | Locality_as_regionality : (Locality.t, Regionality.t, 'l * 'r) morph
-        (** Inject locality into regionality *)
-    | Regional_to_global : (Regionality.t, Locality.t, 'l * 'r) morph
-        (** Maps regional to global, identity otherwise *)
-    | Global_to_regional : (Locality.t, Regionality.t, disallowed * 'r) morph
-        (** Maps global to regional, local to local *)
-    | Compose :
-        ('b, 'c, 'l * 'r) morph * ('a, 'b, 'l * 'r) morph
-        -> ('a, 'c, 'l * 'r) morph  (** Compoistion of two morphisms *)
-    constraint 'd = _ * _
-  [@@ocaml.warning "-62"]
+  module Locality_morph = struct
+    (* Following is a chain of adjunctions (this can be extended one
+       further, but we never need the missing operation) *)
+    type ('a, 'b, 'd) t =
+      | Local_to_regional : (Locality.t, Regionality.t, 'l * disallowed) t
+          (** Maps local to regional, global to global *)
+      | Regional_to_local : (Regionality.t, Locality.t, 'l * 'r) t
+          (** Maps regional to local, identity otherwise *)
+      | Locality_as_regionality : (Locality.t, Regionality.t, 'l * 'r) t
+          (** Inject locality into regionality *)
+      | Regional_to_global : (Regionality.t, Locality.t, disallowed * 'r) t
+          (** Maps regional to global, identity otherwise *)
+      (* Versions of the above morphisms operating on regionality. *)
+      | Local_to_regional_regionality :
+          (Regionality.t, Regionality.t, 'l * disallowed) t
+          (** Maps regional to local, identity otherwise. *)
+      | Regional_to_local_regionality :
+          (Regionality.t, Regionality.t, 'l * 'r) t
+          (** Maps regional to local, identity otherwise. *)
+      | Regional_to_global_regionality :
+          (Regionality.t, Regionality.t, disallowed * 'r) t
+          (** Maps regional to global, identity otherwise. *)
 
-  include Magic_allow_disallow (struct
-    type ('a, 'b, 'd) sided = ('a, 'b, 'd) morph constraint 'd = 'l * 'r
+    let local_to_regional = function
+      | Locality.Global -> Regionality.Global
+      | Locality.Local -> Regionality.Regional
 
-    let rec allow_left : type a b l r.
-        (a, b, allowed * r) morph -> (a, b, l * r) morph = function
-      | Id -> Id
-      | Proj (src, ax) -> Proj (src, ax)
-      | Min_with ax -> Min_with ax
-      | Meet_const c -> Meet_const c
-      | Compose (f, g) ->
-        let f = allow_left f in
-        let g = allow_left g in
-        Compose (f, g)
-      | Monadic_to_comonadic_min -> Monadic_to_comonadic_min
-      | Comonadic_to_monadic_min a -> Comonadic_to_monadic_min a
+    let regional_to_local = function
+      | Regionality.Global -> Locality.Global
+      | Regionality.Regional -> Locality.Local
+      | Regionality.Local -> Locality.Local
+
+    let locality_as_regionality = function
+      | Locality.Global -> Regionality.Global
+      | Locality.Local -> Regionality.Local
+
+    let regional_to_global = function
+      | Regionality.Global -> Locality.Global
+      | Regionality.Regional -> Locality.Global
+      | Regionality.Local -> Locality.Local
+
+    let local_to_regional_regionality = function
+      | Regionality.Global -> Regionality.Global
+      | Regionality.Regional -> Regionality.Regional
+      | Regionality.Local -> Regionality.Regional
+
+    let regional_to_local_regionality = function
+      | Regionality.Global -> Regionality.Global
+      | Regionality.Regional -> Regionality.Local
+      | Regionality.Local -> Regionality.Local
+
+    let regional_to_global_regionality = function
+      | Regionality.Global -> Regionality.Global
+      | Regionality.Regional -> Regionality.Global
+      | Regionality.Local -> Regionality.Local
+
+    let src_restricted : type a b d. (a, b, d) t -> a obj = function
+      | Local_to_regional -> Locality
+      | Regional_to_local -> Regionality
+      | Locality_as_regionality -> Locality
+      | Regional_to_global -> Regionality
+      | Local_to_regional_regionality -> Regionality
+      | Regional_to_local_regionality -> Regionality
+      | Regional_to_global_regionality -> Regionality
+
+    let src_full : type a b d. (a, b, d) t -> a comonadic_with obj = function
+      | Local_to_regional -> Comonadic_with_locality
+      | Regional_to_local -> Comonadic_with_regionality
+      | Locality_as_regionality -> Comonadic_with_locality
+      | Regional_to_global -> Comonadic_with_regionality
+      | Local_to_regional_regionality -> Comonadic_with_regionality
+      | Regional_to_local_regionality -> Comonadic_with_regionality
+      | Regional_to_global_regionality -> Comonadic_with_regionality
+
+    let compare : type a1 l1 r1 a2 b l2 r2.
+        (a1, b, l1 * r1) t -> (a2, b, l2 * r2) t -> int =
+     fun m1 m2 ->
+      match m1, m2 with
+      | Local_to_regional, Local_to_regional -> 0
+      | Local_to_regional, _ -> -1
+      | _, Local_to_regional -> 1
+      | Regional_to_local, Regional_to_local -> 0
+      | Regional_to_local, _ -> -1
+      | _, Regional_to_local -> 1
+      | Locality_as_regionality, Locality_as_regionality -> 0
+      | Locality_as_regionality, _ -> -1
+      | _, Locality_as_regionality -> 1
+      | Regional_to_global, Regional_to_global -> 0
+      | Regional_to_global, _ -> .
+      | _, Regional_to_global -> .
+      | Local_to_regional_regionality, Local_to_regional_regionality -> 0
+      | Local_to_regional_regionality, _ -> -1
+      | _, Local_to_regional_regionality -> 1
+      | Regional_to_local_regionality, Regional_to_local_regionality -> 0
+      | Regional_to_local_regionality, _ -> -1
+      | _, Regional_to_local_regionality -> 1
+      | Regional_to_global_regionality, Regional_to_global_regionality -> 0
+      | Regional_to_global_regionality, _ -> .
+      | _, Regional_to_global_regionality -> .
+
+    let equal : type a1 l1 r1 a2 b l2 r2.
+        (a1, b, l1 * r1) t -> (a2, b, l2 * r2) t -> (a1, a2) Misc.is_eq =
+     fun m1 m2 ->
+      match m1, m2 with
+      | Local_to_regional, Local_to_regional -> Misc.Is_eq
+      | Regional_to_local, Regional_to_local -> Misc.Is_eq
+      | Locality_as_regionality, Locality_as_regionality -> Misc.Is_eq
+      | Regional_to_global, Regional_to_global -> Misc.Is_eq
+      | Local_to_regional_regionality, Local_to_regional_regionality ->
+        Misc.Is_eq
+      | Regional_to_local_regionality, Regional_to_local_regionality ->
+        Misc.Is_eq
+      | Regional_to_global_regionality, Regional_to_global_regionality ->
+        Misc.Is_eq
+      | ( ( Local_to_regional | Regional_to_local | Locality_as_regionality
+          | Regional_to_global | Local_to_regional_regionality
+          | Regional_to_local_regionality | Regional_to_global_regionality ),
+          _ ) ->
+        Misc.Is_not_eq
+
+    let print : type a b d. Fmt.formatter -> (a, b, d) t -> unit =
+     fun ppf -> function
+      | Local_to_regional -> Fmt.fprintf ppf "local_to_regional"
+      | Regional_to_local -> Fmt.fprintf ppf "regional_to_local"
+      | Locality_as_regionality -> Fmt.fprintf ppf "locality_as_regionality"
+      | Regional_to_global -> Fmt.fprintf ppf "regional_to_global"
+      | Local_to_regional_regionality ->
+        Fmt.fprintf ppf "local_to_regional_regionality"
+      | Regional_to_local_regionality ->
+        Fmt.fprintf ppf "regional_to_local_regionality"
+      | Regional_to_global_regionality ->
+        Fmt.fprintf ppf "regional_to_global_regionality"
+
+    let apply : type a b d. (a, b, d) t -> a -> b =
+     fun f a ->
+      match f with
+      | Local_to_regional -> local_to_regional a
+      | Regional_to_local -> regional_to_local a
+      | Locality_as_regionality -> locality_as_regionality a
+      | Regional_to_global -> regional_to_global a
+      | Local_to_regional_regionality -> local_to_regional_regionality a
+      | Regional_to_local_regionality -> regional_to_local_regionality a
+      | Regional_to_global_regionality -> regional_to_global_regionality a
+
+    let right_adjoint : type a b r.
+        (a, b, allowed * r) t -> (b, a, disallowed * allowed) t = function
+      | Local_to_regional -> Regional_to_local
+      | Regional_to_local -> Locality_as_regionality
+      | Locality_as_regionality -> Regional_to_global
+      | Local_to_regional_regionality -> Regional_to_local_regionality
+      | Regional_to_local_regionality -> Regional_to_global_regionality
+
+    let left_adjoint : type a b l.
+        (a, b, l * allowed) t -> (b, a, allowed * disallowed) t = function
+      | Regional_to_local -> Local_to_regional
+      | Locality_as_regionality -> Regional_to_local
+      | Regional_to_global -> Locality_as_regionality
+      | Regional_to_local_regionality -> Local_to_regional_regionality
+      | Regional_to_global_regionality -> Regional_to_local_regionality
+
+    let allow_left : type a b l r. (a, b, allowed * r) t -> (a, b, l * r) t =
+      function
       | Local_to_regional -> Local_to_regional
       | Locality_as_regionality -> Locality_as_regionality
       | Regional_to_local -> Regional_to_local
-      | Regional_to_global -> Regional_to_global
-      | Map_comonadic f ->
-        let f = allow_left f in
-        Map_comonadic f
+      | Local_to_regional_regionality -> Local_to_regional_regionality
+      | Regional_to_local_regionality -> Regional_to_local_regionality
 
-    let rec allow_right : type a b l r.
-        (a, b, l * allowed) morph -> (a, b, l * r) morph = function
-      | Id -> Id
-      | Proj (src, ax) -> Proj (src, ax)
-      | Max_with ax -> Max_with ax
-      | Meet_const c -> Meet_const c
-      | Imply_const c -> Imply_const c
-      | Compose (f, g) ->
-        let f = allow_right f in
-        let g = allow_right g in
-        Compose (f, g)
+    let allow_right : type a b l r. (a, b, l * allowed) t -> (a, b, l * r) t =
+      function
+      | Regional_to_local -> Regional_to_local
+      | Locality_as_regionality -> Locality_as_regionality
+      | Regional_to_global -> Regional_to_global
+      | Regional_to_local_regionality -> Regional_to_local_regionality
+      | Regional_to_global_regionality -> Regional_to_global_regionality
+
+    let disallow_left : type a b l r.
+        (a, b, l * r) t -> (a, b, disallowed * r) t = function
+      | Local_to_regional -> Local_to_regional
+      | Regional_to_local -> Regional_to_local
+      | Locality_as_regionality -> Locality_as_regionality
+      | Regional_to_global -> Regional_to_global
+      | Local_to_regional_regionality -> Local_to_regional_regionality
+      | Regional_to_local_regionality -> Regional_to_local_regionality
+      | Regional_to_global_regionality -> Regional_to_global_regionality
+
+    let disallow_right : type a b l r.
+        (a, b, l * r) t -> (a, b, l * disallowed) t = function
+      | Local_to_regional -> Local_to_regional
+      | Regional_to_local -> Regional_to_local
+      | Locality_as_regionality -> Locality_as_regionality
+      | Regional_to_global -> Regional_to_global
+      | Local_to_regional_regionality -> Local_to_regional_regionality
+      | Regional_to_local_regionality -> Regional_to_local_regionality
+      | Regional_to_global_regionality -> Regional_to_global_regionality
+
+    type ('a, 'b, 'd) maybe_allowed_right =
+      | Allowed_right :
+          ('a, 'b, 'l * allowed) t
+          -> ('a, 'b, 'l * 'r) maybe_allowed_right
+      | Not_allowed_right : ('a, 'b, 'l * disallowed) maybe_allowed_right
+
+    let maybe_allowed_right : type a b d.
+        (a, b, d) t -> (a, b, d) maybe_allowed_right = function
+      | Regional_to_local as m -> Allowed_right m
+      | Locality_as_regionality as m -> Allowed_right m
+      | Regional_to_global as m -> Allowed_right m
+      | Regional_to_local_regionality as m -> Allowed_right m
+      | Regional_to_global_regionality as m -> Allowed_right m
+      | Local_to_regional -> Not_allowed_right
+      | Local_to_regional_regionality -> Not_allowed_right
+
+    type ('a, 'b, 'd) maybe_allowed_left =
+      | Allowed_left :
+          ('a, 'b, allowed * 'r) t
+          -> ('a, 'b, 'l * 'r) maybe_allowed_left
+      | Not_allowed_left : ('a, 'b, disallowed * 'r) maybe_allowed_left
+
+    let maybe_allowed_left : type a b d.
+        (a, b, d) t -> (a, b, d) maybe_allowed_left = function
+      | Local_to_regional as m -> Allowed_left m
+      | Regional_to_local as m -> Allowed_left m
+      | Locality_as_regionality as m -> Allowed_left m
+      | Local_to_regional_regionality as m -> Allowed_left m
+      | Regional_to_local_regionality as m -> Allowed_left m
+      | Regional_to_global -> Not_allowed_left
+      | Regional_to_global_regionality -> Not_allowed_left
+
+    type ('a, 'b, 'd) composition =
+      | Id : ('a, 'a, 'd) composition
+      | Morph : ('a, 'b, 'd) t -> ('a, 'b, 'd) composition
+      | Disallowed : ('a, 'b, neither) composition
+
+    let compose : type a b c d.
+        (b, c, d) t -> (a, b, d) t -> (a, c, d) composition =
+     fun m1 m2 ->
+      match m1, m2 with
+      | Local_to_regional, Regional_to_local ->
+        Morph Local_to_regional_regionality
+      | Regional_to_local, Local_to_regional -> Id
+      | Regional_to_local, Locality_as_regionality -> Id
+      | Regional_to_local, Local_to_regional_regionality ->
+        Morph Regional_to_local
+      | Regional_to_local, Regional_to_local_regionality ->
+        Morph Regional_to_local
+      | Regional_to_local, Regional_to_global_regionality ->
+        Morph Regional_to_global
+      | Locality_as_regionality, Regional_to_local ->
+        Morph Regional_to_local_regionality
+      | Locality_as_regionality, Regional_to_global ->
+        Morph Regional_to_global_regionality
+      | Regional_to_global, Locality_as_regionality -> Id
+      | Regional_to_global, Regional_to_local_regionality ->
+        Morph Regional_to_local
+      | Regional_to_global, Regional_to_global_regionality ->
+        Morph Regional_to_global
+      | Local_to_regional_regionality, Local_to_regional ->
+        Morph Local_to_regional
+      | Local_to_regional_regionality, Locality_as_regionality ->
+        Morph Local_to_regional
+      | Local_to_regional_regionality, Local_to_regional_regionality ->
+        Morph Local_to_regional_regionality
+      | Local_to_regional_regionality, Regional_to_local_regionality ->
+        Morph Local_to_regional_regionality
+      | Regional_to_local_regionality, Local_to_regional ->
+        Morph Locality_as_regionality
+      | Regional_to_local_regionality, Locality_as_regionality ->
+        Morph Locality_as_regionality
+      | Regional_to_local_regionality, Local_to_regional_regionality ->
+        Morph Regional_to_local_regionality
+      | Regional_to_local_regionality, Regional_to_local_regionality ->
+        Morph Regional_to_local_regionality
+      | Regional_to_local_regionality, Regional_to_global_regionality ->
+        Morph Regional_to_global_regionality
+      | Regional_to_global_regionality, Locality_as_regionality ->
+        Morph Locality_as_regionality
+      | Regional_to_global_regionality, Regional_to_local_regionality ->
+        Morph Regional_to_local_regionality
+      | Regional_to_global_regionality, Regional_to_global_regionality ->
+        Morph Regional_to_global_regionality
+      (* Operations that cannot appear on the same side *)
+      | Local_to_regional, Regional_to_global -> Disallowed
+      | Regional_to_global, Local_to_regional -> Disallowed
+      | Regional_to_global, Local_to_regional_regionality -> Disallowed
+      | Local_to_regional_regionality, Regional_to_global_regionality ->
+        Disallowed
+      | Regional_to_global_regionality, Local_to_regional -> Disallowed
+      | Regional_to_global_regionality, Local_to_regional_regionality ->
+        Disallowed
+  end
+
+  module Core_morph = struct
+    type ('a, 'b, 'd) t =
+      | Locality_restricted :
+          ('a, 'b, 'l * 'r) Locality_morph.t
+          -> ('a, 'b, 'l * 'r) t
+      | Locality_full :
+          ('a, 'b, 'l * 'r) Locality_morph.t
+          -> ('a comonadic_with, 'b comonadic_with, 'l * 'r) t
+      | Uniqueness_op_to_linearity : (Uniqueness_op.t, Linearity.t, 'l * 'r) t
+      | Linearity_to_uniqueness_op : (Linearity.t, Uniqueness_op.t, 'l * 'r) t
+      | Contention_op_to_portability :
+          (Contention_op.t, Portability.t, 'l * 'r) t
+      | Portability_to_contention_op :
+          (Portability.t, Contention_op.t, 'l * 'r) t
+      | Visibility_op_to_statefulness :
+          (Visibility_op.t, Statefulness.t, 'l * 'r) t
+      | Statefulness_to_visibility_op :
+          (Statefulness.t, Visibility_op.t, 'l * 'r) t
+      | Monadic_to_comonadic_min :
+          (Monadic_op.t, 'a comonadic_with, 'l * disallowed) t
+          (** Dualize the monadic fragment to the comonadic fragment. The
+              areality is set to min. *)
+      | Comonadic_to_monadic_min :
+          'a areality
+          -> ('a comonadic_with, Monadic_op.t, 'l * disallowed) t
+          (** Dualize the comonadic fragment to the monadic fragment. The
+              areality axis is ignored, the staticity axis is set to min. *)
+      | Monadic_to_comonadic_max :
+          (Monadic_op.t, 'a comonadic_with, disallowed * 'r) t
+          (** Dualize the monadic fragment to the comonadic fragment. The
+              areality is set to max. *)
+      | Comonadic_to_monadic_max :
+          'a areality
+          -> ('a comonadic_with, Monadic_op.t, disallowed * 'r) t
+          (** Dualize the comonadic fragment to the monadic fragment. The
+              areality axis is ignored. *)
+
+    let allow_left : type a b l r. (a, b, allowed * r) t -> (a, b, l * r) t =
+      function
+      | Locality_restricted m ->
+        Locality_restricted (Locality_morph.allow_left m)
+      | Locality_full m -> Locality_full (Locality_morph.allow_left m)
+      | Uniqueness_op_to_linearity -> Uniqueness_op_to_linearity
+      | Linearity_to_uniqueness_op -> Linearity_to_uniqueness_op
+      | Contention_op_to_portability -> Contention_op_to_portability
+      | Portability_to_contention_op -> Portability_to_contention_op
+      | Visibility_op_to_statefulness -> Visibility_op_to_statefulness
+      | Statefulness_to_visibility_op -> Statefulness_to_visibility_op
+      | Monadic_to_comonadic_min -> Monadic_to_comonadic_min
+      | Comonadic_to_monadic_min a -> Comonadic_to_monadic_min a
+
+    let allow_right : type a b l r. (a, b, l * allowed) t -> (a, b, l * r) t =
+      function
+      | Locality_restricted m ->
+        Locality_restricted (Locality_morph.allow_right m)
+      | Locality_full m -> Locality_full (Locality_morph.allow_right m)
+      | Uniqueness_op_to_linearity -> Uniqueness_op_to_linearity
+      | Linearity_to_uniqueness_op -> Linearity_to_uniqueness_op
+      | Contention_op_to_portability -> Contention_op_to_portability
+      | Portability_to_contention_op -> Portability_to_contention_op
+      | Visibility_op_to_statefulness -> Visibility_op_to_statefulness
+      | Statefulness_to_visibility_op -> Statefulness_to_visibility_op
       | Comonadic_to_monadic_max a -> Comonadic_to_monadic_max a
       | Monadic_to_comonadic_max -> Monadic_to_comonadic_max
-      | Global_to_regional -> Global_to_regional
-      | Locality_as_regionality -> Locality_as_regionality
-      | Regional_to_local -> Regional_to_local
-      | Regional_to_global -> Regional_to_global
-      | Map_comonadic f ->
-        let f = allow_right f in
-        Map_comonadic f
 
-    let rec disallow_left : type a b l r.
-        (a, b, l * r) morph -> (a, b, disallowed * r) morph = function
-      | Id -> Id
-      | Proj (src, ax) -> Proj (src, ax)
-      | Min_with ax -> Min_with ax
-      | Max_with ax -> Max_with ax
-      | Meet_const c -> Meet_const c
-      | Imply_const c -> Imply_const c
-      | Compose (f, g) ->
-        let f = disallow_left f in
-        let g = disallow_left g in
-        Compose (f, g)
+    let disallow_left : type a b l r.
+        (a, b, l * r) t -> (a, b, disallowed * r) t = function
+      | Locality_restricted m ->
+        Locality_restricted (Locality_morph.disallow_left m)
+      | Locality_full m -> Locality_full (Locality_morph.disallow_left m)
+      | Uniqueness_op_to_linearity -> Uniqueness_op_to_linearity
+      | Linearity_to_uniqueness_op -> Linearity_to_uniqueness_op
+      | Contention_op_to_portability -> Contention_op_to_portability
+      | Portability_to_contention_op -> Portability_to_contention_op
+      | Visibility_op_to_statefulness -> Visibility_op_to_statefulness
+      | Statefulness_to_visibility_op -> Statefulness_to_visibility_op
       | Monadic_to_comonadic_min -> Monadic_to_comonadic_min
       | Comonadic_to_monadic_min a -> Comonadic_to_monadic_min a
       | Monadic_to_comonadic_max -> Monadic_to_comonadic_max
       | Comonadic_to_monadic_max a -> Comonadic_to_monadic_max a
-      | Local_to_regional -> Local_to_regional
-      | Global_to_regional -> Global_to_regional
-      | Locality_as_regionality -> Locality_as_regionality
-      | Regional_to_local -> Regional_to_local
-      | Regional_to_global -> Regional_to_global
-      | Map_comonadic f ->
-        let f = disallow_left f in
-        Map_comonadic f
 
-    let rec disallow_right : type a b l r.
-        (a, b, l * r) morph -> (a, b, l * disallowed) morph = function
-      | Id -> Id
-      | Proj (src, ax) -> Proj (src, ax)
-      | Min_with ax -> Min_with ax
-      | Max_with ax -> Max_with ax
-      | Meet_const c -> Meet_const c
-      | Imply_const c -> Imply_const c
-      | Compose (f, g) ->
-        let f = disallow_right f in
-        let g = disallow_right g in
-        Compose (f, g)
+    let disallow_right : type a b l r.
+        (a, b, l * r) t -> (a, b, l * disallowed) t = function
+      | Locality_restricted m ->
+        Locality_restricted (Locality_morph.disallow_right m)
+      | Locality_full m -> Locality_full (Locality_morph.disallow_right m)
+      | Uniqueness_op_to_linearity -> Uniqueness_op_to_linearity
+      | Linearity_to_uniqueness_op -> Linearity_to_uniqueness_op
+      | Contention_op_to_portability -> Contention_op_to_portability
+      | Portability_to_contention_op -> Portability_to_contention_op
+      | Visibility_op_to_statefulness -> Visibility_op_to_statefulness
+      | Statefulness_to_visibility_op -> Statefulness_to_visibility_op
       | Monadic_to_comonadic_min -> Monadic_to_comonadic_min
       | Comonadic_to_monadic_min a -> Comonadic_to_monadic_min a
       | Monadic_to_comonadic_max -> Monadic_to_comonadic_max
       | Comonadic_to_monadic_max a -> Comonadic_to_monadic_max a
-      | Local_to_regional -> Local_to_regional
-      | Global_to_regional -> Global_to_regional
-      | Locality_as_regionality -> Locality_as_regionality
-      | Regional_to_local -> Regional_to_local
-      | Regional_to_global -> Regional_to_global
-      | Map_comonadic f ->
-        let f = disallow_right f in
-        Map_comonadic f
-  end)
 
-  let set_areality : type a1 a2. a2 -> a1 comonadic_with -> a2 comonadic_with =
-   fun r t -> { t with areality = r }
+    let src : type a b d. (a, b, d) t -> a obj = function
+      | Locality_restricted m -> Locality_morph.src_restricted m
+      | Locality_full m -> Locality_morph.src_full m
+      | Uniqueness_op_to_linearity -> Uniqueness_op
+      | Linearity_to_uniqueness_op -> Linearity
+      | Contention_op_to_portability -> Contention_op
+      | Portability_to_contention_op -> Portability
+      | Visibility_op_to_statefulness -> Visibility_op
+      | Statefulness_to_visibility_op -> Statefulness
+      | Monadic_to_comonadic_min -> Monadic_op
+      | Comonadic_to_monadic_min ar -> areality_comonadic_obj ar
+      | Monadic_to_comonadic_max -> Monadic_op
+      | Comonadic_to_monadic_max ar -> areality_comonadic_obj ar
+
+    let compare : type a1 d1 a2 b d2. (a1, b, d1) t -> (a2, b, d2) t -> int =
+     fun m1 m2 ->
+      match m1, m2 with
+      | Locality_restricted l1, Locality_restricted l2 ->
+        Locality_morph.compare l1 l2
+      | Locality_restricted _, _ -> .
+      | _, Locality_restricted _ -> .
+      | Locality_full l1, Locality_full l2 -> Locality_morph.compare l1 l2
+      | Locality_full _, _ -> -1
+      | _, Locality_full _ -> 1
+      | Uniqueness_op_to_linearity, Uniqueness_op_to_linearity -> 0
+      | Uniqueness_op_to_linearity, _ -> .
+      | _, Uniqueness_op_to_linearity -> .
+      | Linearity_to_uniqueness_op, Linearity_to_uniqueness_op -> 0
+      | Linearity_to_uniqueness_op, _ -> .
+      | _, Linearity_to_uniqueness_op -> .
+      | Contention_op_to_portability, Contention_op_to_portability -> 0
+      | Contention_op_to_portability, _ -> .
+      | _, Contention_op_to_portability -> .
+      | Portability_to_contention_op, Portability_to_contention_op -> 0
+      | Portability_to_contention_op, _ -> .
+      | _, Portability_to_contention_op -> .
+      | Visibility_op_to_statefulness, Visibility_op_to_statefulness -> 0
+      | Visibility_op_to_statefulness, _ -> .
+      | _, Visibility_op_to_statefulness -> .
+      | Statefulness_to_visibility_op, Statefulness_to_visibility_op -> 0
+      | Statefulness_to_visibility_op, _ -> .
+      | _, Statefulness_to_visibility_op -> .
+      | Monadic_to_comonadic_min, Monadic_to_comonadic_min -> 0
+      | Monadic_to_comonadic_min, _ -> -1
+      | _, Monadic_to_comonadic_min -> 1
+      | Comonadic_to_monadic_min ar1, Comonadic_to_monadic_min ar2 ->
+        compare_areality ar1 ar2
+      | Comonadic_to_monadic_min _, _ -> -1
+      | _, Comonadic_to_monadic_min _ -> 1
+      | Monadic_to_comonadic_max, Monadic_to_comonadic_max -> 0
+      | Monadic_to_comonadic_max, _ -> .
+      | _, Monadic_to_comonadic_max -> .
+      | Comonadic_to_monadic_max ar1, Comonadic_to_monadic_max ar2 ->
+        compare_areality ar1 ar2
+      | Comonadic_to_monadic_max _, _ -> .
+      | _, Comonadic_to_monadic_max _ -> .
+
+    let equal : type a1 d1 a2 b d2.
+        (a1, b, d1) t -> (a2, b, d2) t -> (a1, a2) Misc.is_eq =
+     fun m1 m2 ->
+      match m1, m2 with
+      | Locality_restricted l1, Locality_restricted l2 ->
+        Locality_morph.equal l1 l2
+      | Locality_restricted _, _ -> .
+      | _, Locality_restricted _ -> .
+      | Locality_full l1, Locality_full l2 -> (
+        match Locality_morph.equal l1 l2 with
+        | Misc.Is_eq -> Misc.Is_eq
+        | Misc.Is_not_eq -> Misc.Is_not_eq)
+      | Uniqueness_op_to_linearity, Uniqueness_op_to_linearity -> Misc.Is_eq
+      | Uniqueness_op_to_linearity, _ -> .
+      | _, Uniqueness_op_to_linearity -> .
+      | Linearity_to_uniqueness_op, Linearity_to_uniqueness_op -> Misc.Is_eq
+      | Linearity_to_uniqueness_op, _ -> .
+      | _, Linearity_to_uniqueness_op -> .
+      | Contention_op_to_portability, Contention_op_to_portability -> Misc.Is_eq
+      | Contention_op_to_portability, _ -> .
+      | _, Contention_op_to_portability -> .
+      | Portability_to_contention_op, Portability_to_contention_op -> Misc.Is_eq
+      | Portability_to_contention_op, _ -> .
+      | _, Portability_to_contention_op -> .
+      | Visibility_op_to_statefulness, Visibility_op_to_statefulness ->
+        Misc.Is_eq
+      | Visibility_op_to_statefulness, _ -> .
+      | _, Visibility_op_to_statefulness -> .
+      | Statefulness_to_visibility_op, Statefulness_to_visibility_op ->
+        Misc.Is_eq
+      | Statefulness_to_visibility_op, _ -> .
+      | _, Statefulness_to_visibility_op -> .
+      | Monadic_to_comonadic_min, Monadic_to_comonadic_min -> Misc.Is_eq
+      | Monadic_to_comonadic_min, _ -> Misc.Is_not_eq
+      | _, Monadic_to_comonadic_min -> Misc.Is_not_eq
+      | Comonadic_to_monadic_min ar1, Comonadic_to_monadic_min ar2 -> (
+        match equal_areality ar1 ar2 with
+        | Misc.Is_eq -> Misc.Is_eq
+        | Misc.Is_not_eq -> Misc.Is_not_eq)
+      | Comonadic_to_monadic_min _, _ -> Misc.Is_not_eq
+      | _, Comonadic_to_monadic_min _ -> Misc.Is_not_eq
+      | Monadic_to_comonadic_max, Monadic_to_comonadic_max -> Misc.Is_eq
+      | Monadic_to_comonadic_max, _ -> Misc.Is_not_eq
+      | _, Monadic_to_comonadic_max -> Misc.Is_not_eq
+      | Comonadic_to_monadic_max ar1, Comonadic_to_monadic_max ar2 -> (
+        match equal_areality ar1 ar2 with
+        | Misc.Is_eq -> Misc.Is_eq
+        | Misc.Is_not_eq -> Misc.Is_not_eq)
+      | Comonadic_to_monadic_max _, _ -> .
+      | _, Comonadic_to_monadic_max _ -> .
+
+    let print : type a b d. Fmt.formatter -> (a, b, d) t -> unit =
+     fun ppf -> function
+      | Locality_restricted l -> Locality_morph.print ppf l
+      | Locality_full l -> Fmt.fprintf ppf "%a_full" Locality_morph.print l
+      | Uniqueness_op_to_linearity ->
+        Fmt.fprintf ppf "uniqueness_op_to_linearity"
+      | Linearity_to_uniqueness_op ->
+        Fmt.fprintf ppf "linearity_to_uniqueness_op"
+      | Contention_op_to_portability ->
+        Fmt.fprintf ppf "contention_op_to_portability"
+      | Portability_to_contention_op ->
+        Fmt.fprintf ppf "portability_to_contention_op"
+      | Visibility_op_to_statefulness ->
+        Fmt.fprintf ppf "visibility_op_to_statefulness"
+      | Statefulness_to_visibility_op ->
+        Fmt.fprintf ppf "statefulnes_to_visibility_op"
+      | Monadic_to_comonadic_min -> Fmt.fprintf ppf "monadic_to_comonadic_min"
+      | Comonadic_to_monadic_min _ -> Fmt.fprintf ppf "comonadic_to_monadic_min"
+      | Monadic_to_comonadic_max -> Fmt.fprintf ppf "monadic_to_comonadic_max"
+      | Comonadic_to_monadic_max _ -> Fmt.fprintf ppf "comonadic_to_monadic_max"
+
+    let uniqueness_op_to_linearity = function
+      | Uniqueness.Unique -> Linearity.Once
+      | Uniqueness.Aliased -> Linearity.Many
+
+    let linearity_to_uniqueness_op = function
+      | Linearity.Many -> Uniqueness.Aliased
+      | Linearity.Once -> Uniqueness.Unique
+
+    let contention_op_to_portability = function
+      | Contention.Contended -> Portability.Portable
+      | Contention.Shared -> Portability.Shareable
+      | Contention.Corrupted -> Portability.Corruptible
+      | Contention.Uncontended -> Portability.Nonportable
+
+    let portability_to_contention_op = function
+      | Portability.Portable -> Contention.Contended
+      | Portability.Shareable -> Contention.Shared
+      | Portability.Corruptible -> Contention.Corrupted
+      | Portability.Nonportable -> Contention.Uncontended
+
+    let visibility_op_to_statefulness = function
+      | Visibility.Immutable -> Statefulness.Stateless
+      | Visibility.Read -> Statefulness.Reading
+      | Visibility.Write -> Statefulness.Writing
+      | Visibility.Read_write -> Statefulness.Stateful
+
+    let statefulness_to_visibility_op = function
+      | Statefulness.Stateless -> Visibility.Immutable
+      | Statefulness.Writing -> Visibility.Write
+      | Statefulness.Reading -> Visibility.Read
+      | Statefulness.Stateful -> Visibility.Read_write
+
+    let monadic_to_comonadic_min : type a.
+        a comonadic_with obj -> Monadic_op.t -> a comonadic_with =
+     fun obj m ->
+      let areality : a =
+        match obj with
+        | Comonadic_with_locality -> Locality.min
+        | Comonadic_with_regionality -> Regionality.min
+      in
+      let linearity = uniqueness_op_to_linearity m.uniqueness in
+      let portability = contention_op_to_portability m.contention in
+      let forkable = Forkable.min in
+      let yielding = Yielding.min in
+      let statefulness = visibility_op_to_statefulness m.visibility in
+      { areality; linearity; portability; forkable; yielding; statefulness }
+
+    let comonadic_to_monadic_min : type a.
+        a areality -> a comonadic_with -> Monadic_op.t =
+     fun _ m ->
+      let uniqueness = linearity_to_uniqueness_op m.linearity in
+      let contention = portability_to_contention_op m.portability in
+      let visibility = statefulness_to_visibility_op m.statefulness in
+      let staticity = Staticity_op.min in
+      { uniqueness; contention; visibility; staticity }
+
+    let monadic_to_comonadic_max : type a.
+        a comonadic_with obj -> Monadic_op.t -> a comonadic_with =
+     fun obj m ->
+      let areality : a =
+        match obj with
+        | Comonadic_with_locality -> Locality.max
+        | Comonadic_with_regionality -> Regionality.max
+      in
+      let linearity = uniqueness_op_to_linearity m.uniqueness in
+      let portability = contention_op_to_portability m.contention in
+      let forkable = Forkable.max in
+      let yielding = Yielding.max in
+      let statefulness = visibility_op_to_statefulness m.visibility in
+      { areality; linearity; portability; forkable; yielding; statefulness }
+
+    let comonadic_to_monadic_max : type a.
+        a areality -> a comonadic_with -> Monadic_op.t =
+     fun _ m ->
+      let uniqueness = linearity_to_uniqueness_op m.linearity in
+      let contention = portability_to_contention_op m.portability in
+      let visibility = statefulness_to_visibility_op m.statefulness in
+      let staticity = Staticity_op.max in
+      { uniqueness; contention; visibility; staticity }
+
+    let apply : type a b d. b obj -> (a, b, d) t -> a -> b =
+     fun dst f a ->
+      match f with
+      | Locality_restricted m -> Locality_morph.apply m a
+      | Locality_full m ->
+        let areality = Locality_morph.apply m a.areality in
+        { a with areality }
+      | Uniqueness_op_to_linearity -> uniqueness_op_to_linearity a
+      | Linearity_to_uniqueness_op -> linearity_to_uniqueness_op a
+      | Contention_op_to_portability -> contention_op_to_portability a
+      | Portability_to_contention_op -> portability_to_contention_op a
+      | Visibility_op_to_statefulness -> visibility_op_to_statefulness a
+      | Statefulness_to_visibility_op -> statefulness_to_visibility_op a
+      | Monadic_to_comonadic_min -> monadic_to_comonadic_min dst a
+      | Comonadic_to_monadic_min ar -> comonadic_to_monadic_min ar a
+      | Monadic_to_comonadic_max -> monadic_to_comonadic_max dst a
+      | Comonadic_to_monadic_max ar -> comonadic_to_monadic_max ar a
+
+    let right_adjoint : type a b r.
+        b obj -> (a, b, allowed * r) t -> (b, a, disallowed * allowed) t =
+     fun dst -> function
+      | Locality_restricted m ->
+        Locality_restricted (Locality_morph.right_adjoint m)
+      | Locality_full m -> Locality_full (Locality_morph.right_adjoint m)
+      | Uniqueness_op_to_linearity -> Linearity_to_uniqueness_op
+      | Linearity_to_uniqueness_op -> Uniqueness_op_to_linearity
+      | Contention_op_to_portability -> Portability_to_contention_op
+      | Portability_to_contention_op -> Contention_op_to_portability
+      | Visibility_op_to_statefulness -> Statefulness_to_visibility_op
+      | Statefulness_to_visibility_op -> Visibility_op_to_statefulness
+      | Monadic_to_comonadic_min ->
+        Comonadic_to_monadic_max (comonadic_obj_areality dst)
+      | Comonadic_to_monadic_min _ -> Monadic_to_comonadic_max
+
+    let left_adjoint : type a b l.
+        b obj -> (a, b, l * allowed) t -> (b, a, allowed * disallowed) t =
+     fun dst -> function
+      | Locality_restricted m ->
+        Locality_restricted (Locality_morph.left_adjoint m)
+      | Locality_full m -> Locality_full (Locality_morph.left_adjoint m)
+      | Uniqueness_op_to_linearity -> Linearity_to_uniqueness_op
+      | Linearity_to_uniqueness_op -> Uniqueness_op_to_linearity
+      | Contention_op_to_portability -> Portability_to_contention_op
+      | Portability_to_contention_op -> Contention_op_to_portability
+      | Visibility_op_to_statefulness -> Statefulness_to_visibility_op
+      | Statefulness_to_visibility_op -> Visibility_op_to_statefulness
+      | Monadic_to_comonadic_max ->
+        Comonadic_to_monadic_min (comonadic_obj_areality dst)
+      | Comonadic_to_monadic_max _ -> Monadic_to_comonadic_min
+
+    type ('a, 'b, 'd) maybe_allowed_right =
+      | Allowed_right :
+          ('a, 'b, 'l * allowed) t
+          -> ('a, 'b, 'l * 'r) maybe_allowed_right
+      | Not_allowed_right : ('a, 'b, 'l * disallowed) maybe_allowed_right
+
+    let maybe_allowed_right : type a b d.
+        (a, b, d) t -> (a, b, d) maybe_allowed_right = function
+      | Locality_restricted lm ->
+        begin match Locality_morph.maybe_allowed_right lm with
+        | Allowed_right lm -> Allowed_right (Locality_restricted lm)
+        | Not_allowed_right -> Not_allowed_right
+        end
+      | Locality_full lm ->
+        begin match Locality_morph.maybe_allowed_right lm with
+        | Allowed_right lm -> Allowed_right (Locality_full lm)
+        | Not_allowed_right -> Not_allowed_right
+        end
+      | Uniqueness_op_to_linearity as m -> Allowed_right m
+      | Linearity_to_uniqueness_op as m -> Allowed_right m
+      | Contention_op_to_portability as m -> Allowed_right m
+      | Portability_to_contention_op as m -> Allowed_right m
+      | Visibility_op_to_statefulness as m -> Allowed_right m
+      | Statefulness_to_visibility_op as m -> Allowed_right m
+      | Monadic_to_comonadic_min -> Not_allowed_right
+      | Comonadic_to_monadic_min _ -> Not_allowed_right
+      | Monadic_to_comonadic_max as m -> Allowed_right m
+      | Comonadic_to_monadic_max a -> Allowed_right (Comonadic_to_monadic_max a)
+
+    type ('a, 'b, 'd) maybe_allowed_left =
+      | Allowed_left :
+          ('a, 'b, allowed * 'r) t
+          -> ('a, 'b, 'l * 'r) maybe_allowed_left
+      | Not_allowed_left : ('a, 'b, disallowed * 'r) maybe_allowed_left
+
+    let maybe_allowed_left : type a b d.
+        (a, b, d) t -> (a, b, d) maybe_allowed_left = function
+      | Locality_restricted lm ->
+        begin match Locality_morph.maybe_allowed_left lm with
+        | Allowed_left lm -> Allowed_left (Locality_restricted lm)
+        | Not_allowed_left -> Not_allowed_left
+        end
+      | Locality_full lm ->
+        begin match Locality_morph.maybe_allowed_left lm with
+        | Allowed_left lm -> Allowed_left (Locality_full lm)
+        | Not_allowed_left -> Not_allowed_left
+        end
+      | Uniqueness_op_to_linearity as m -> Allowed_left m
+      | Linearity_to_uniqueness_op as m -> Allowed_left m
+      | Contention_op_to_portability as m -> Allowed_left m
+      | Portability_to_contention_op as m -> Allowed_left m
+      | Visibility_op_to_statefulness as m -> Allowed_left m
+      | Statefulness_to_visibility_op as m -> Allowed_left m
+      | Monadic_to_comonadic_min as m -> Allowed_left m
+      | Comonadic_to_monadic_min a -> Allowed_left (Comonadic_to_monadic_min a)
+      | Monadic_to_comonadic_max -> Not_allowed_left
+      | Comonadic_to_monadic_max _ -> Not_allowed_left
+
+    (* Commutes a meet through a morphism from the right, such that:
+       [apply dst m (meet_const c x)] is equivalent to
+       [meet_const (commute_meet_const_from_right dst m c) (apply dst m x)]
+    *)
+    let commute_meet_const_from_right : type a b d.
+        b obj -> (a, b, d) t -> a -> b =
+     fun dst m c ->
+      (* All our morphisms preserve binary meets *)
+      apply dst m c
+
+    (* Commutes an implication through a morphism from the left, such that:
+       [apply dst m (meet_const c x)] is equivalent to
+       [meet_const (commute_imply_from_left dst m c) (apply dst m x)]
+    *)
+    let commute_imply_from_left : type a b l.
+        b obj -> b -> (a, b, l * allowed) t -> a =
+     fun dst c m ->
+      (* As all our morphisms preserve binary meets, implications can be
+         pushed inside of [m] by applying the left adjoint of [m] to the
+         implicant. *)
+      apply (src m) (left_adjoint dst m) c
+
+    type ('a, 'b, 'd) compose_proj_result =
+      | Proj_core :
+          ('p, 'b, 'd) t * ('a, 'p) Axis.t * 'a obj
+          -> ('a, 'b, 'd) compose_proj_result
+      | Proj_id :
+          ('a comonadic_with, 'p) Axis.t * 'a comonadic_with obj
+          -> ('a comonadic_with, 'p, 'd) compose_proj_result
+      | Proj_const_max : 'a obj -> ('a, 'b, disallowed * 'r) compose_proj_result
+      | Proj_const_min : 'a obj -> ('a, 'b, 'l * disallowed) compose_proj_result
+
+    let compose_projection_locality_morph : type a b p l r.
+        (a, b, l * r) Locality_morph.t ->
+        (b comonadic_with, p) Axis.t ->
+        (a comonadic_with, p, l * r) compose_proj_result =
+     fun lm1 ax0 ->
+      let src = Locality_morph.src_full lm1 in
+      match ax0 with
+      | Forkable -> Proj_id (Forkable, src)
+      | Yielding -> Proj_id (Yielding, src)
+      | Linearity -> Proj_id (Linearity, src)
+      | Statefulness -> Proj_id (Statefulness, src)
+      | Portability -> Proj_id (Portability, src)
+      | Areality -> Proj_core (Locality_restricted lm1, Areality, src)
+
+    let compose_projection_core : type a b p d.
+        (b, p) Axis.t -> (a, b, d) t -> (a, p, d) compose_proj_result =
+     fun ax0 m1 ->
+      match (m1 : (a, b, d) t), (ax0 : (b, p) Axis.t) with
+      | Monadic_to_comonadic_min, Areality -> Proj_const_min Monadic_op
+      | Monadic_to_comonadic_min, Forkable -> Proj_const_min Monadic_op
+      | Monadic_to_comonadic_min, Yielding -> Proj_const_min Monadic_op
+      | Monadic_to_comonadic_min, Linearity ->
+        Proj_core (Uniqueness_op_to_linearity, Uniqueness, Monadic_op)
+      | Monadic_to_comonadic_min, Statefulness ->
+        Proj_core (Visibility_op_to_statefulness, Visibility, Monadic_op)
+      | Monadic_to_comonadic_min, Portability ->
+        Proj_core (Contention_op_to_portability, Contention, Monadic_op)
+      | Comonadic_to_monadic_min areality, Uniqueness ->
+        Proj_core
+          ( Linearity_to_uniqueness_op,
+            Linearity,
+            areality_comonadic_obj areality )
+      | Comonadic_to_monadic_min areality, Visibility ->
+        Proj_core
+          ( Statefulness_to_visibility_op,
+            Statefulness,
+            areality_comonadic_obj areality )
+      | Comonadic_to_monadic_min areality, Contention ->
+        Proj_core
+          ( Portability_to_contention_op,
+            Portability,
+            areality_comonadic_obj areality )
+      | Comonadic_to_monadic_min areality, Staticity ->
+        Proj_const_min (areality_comonadic_obj areality)
+      | Monadic_to_comonadic_max, Areality -> Proj_const_max Monadic_op
+      | Monadic_to_comonadic_max, Forkable -> Proj_const_max Monadic_op
+      | Monadic_to_comonadic_max, Yielding -> Proj_const_max Monadic_op
+      | Monadic_to_comonadic_max, Linearity ->
+        Proj_core (Uniqueness_op_to_linearity, Uniqueness, Monadic_op)
+      | Monadic_to_comonadic_max, Statefulness ->
+        Proj_core (Visibility_op_to_statefulness, Visibility, Monadic_op)
+      | Monadic_to_comonadic_max, Portability ->
+        Proj_core (Contention_op_to_portability, Contention, Monadic_op)
+      | Comonadic_to_monadic_max areality, Uniqueness ->
+        Proj_core
+          ( Linearity_to_uniqueness_op,
+            Linearity,
+            areality_comonadic_obj areality )
+      | Comonadic_to_monadic_max areality, Visibility ->
+        Proj_core
+          ( Statefulness_to_visibility_op,
+            Statefulness,
+            areality_comonadic_obj areality )
+      | Comonadic_to_monadic_max areality, Contention ->
+        Proj_core
+          ( Portability_to_contention_op,
+            Portability,
+            areality_comonadic_obj areality )
+      | Comonadic_to_monadic_max areality, Staticity ->
+        Proj_const_max (areality_comonadic_obj areality)
+      | Locality_full lm, (_ as ax0) -> compose_projection_locality_morph lm ax0
+      | _, _ -> .
+    [@@warning "-4"]
+
+    type ('a, 'b, 'd) compose_and_max_result =
+      | And_max_core :
+          ('s, 'q) Axis.t * ('p, 'q, disallowed * 'r) t
+          -> ('p, 's, disallowed * 'r) compose_and_max_result
+      | Const_max_core : ('a, 'b, disallowed * 'r) compose_and_max_result
+      | And_max_id :
+          ('c comonadic_with, 'q) Axis.t
+          -> ('q, 'c comonadic_with, 'd) compose_and_max_result
+      | Disallowed : ('a, 'b, neither) compose_and_max_result
+
+    let compose_max_with_simple_locality_morph : type b c q r.
+        (b, c, disallowed * r) Locality_morph.t ->
+        (b comonadic_with, q) Axis.t ->
+        (q, c comonadic_with, disallowed * r) compose_and_max_result =
+     fun lm1 ax0 ->
+      match ax0 with
+      | Forkable -> And_max_id Forkable
+      | Yielding -> And_max_id Yielding
+      | Linearity -> And_max_id Linearity
+      | Statefulness -> And_max_id Statefulness
+      | Portability -> And_max_id Portability
+      | Areality -> And_max_core (Areality, Locality_restricted lm1)
+
+    let compose_max_with_simple_core : type b c q r.
+        (b, q) Axis.t ->
+        (b, c, disallowed * r) t ->
+        (q, c, disallowed * r) compose_and_max_result =
+     fun ax1 m0 ->
+      match (m0 : (b, c, disallowed * r) t), (ax1 : (b, q) Axis.t) with
+      | Comonadic_to_monadic_max _, Portability ->
+        And_max_core (Contention, Portability_to_contention_op)
+      | Comonadic_to_monadic_max _, Statefulness ->
+        And_max_core (Visibility, Statefulness_to_visibility_op)
+      | Comonadic_to_monadic_max _, Linearity ->
+        And_max_core (Uniqueness, Linearity_to_uniqueness_op)
+      | Comonadic_to_monadic_max _, Yielding -> Const_max_core
+      | Comonadic_to_monadic_max _, Forkable -> Const_max_core
+      | Comonadic_to_monadic_max _, Areality -> Const_max_core
+      | Monadic_to_comonadic_max, Staticity -> Const_max_core
+      | Monadic_to_comonadic_max, Contention ->
+        And_max_core (Portability, Contention_op_to_portability)
+      | Monadic_to_comonadic_max, Visibility ->
+        And_max_core (Statefulness, Visibility_op_to_statefulness)
+      | Monadic_to_comonadic_max, Uniqueness ->
+        And_max_core (Linearity, Uniqueness_op_to_linearity)
+      | Locality_full lm, (_ as ax0) ->
+        compose_max_with_simple_locality_morph lm ax0
+      | Monadic_to_comonadic_min, _ -> Disallowed
+      | Comonadic_to_monadic_min _, _ -> Disallowed
+      | _, _ -> .
+    [@@warning "-4"]
+
+    type ('a, 'b, 'd) compose_and_min_result =
+      | And_min_core :
+          ('s, 'q) Axis.t * ('p, 'q, 'l * disallowed) t
+          -> ('p, 's, 'l * disallowed) compose_and_min_result
+      | Const_min_core : ('a, 'b, 'l * disallowed) compose_and_min_result
+      | And_min_id :
+          ('c comonadic_with, 'q) Axis.t
+          -> ('q, 'c comonadic_with, 'd) compose_and_min_result
+      | Disallowed : ('a, 'b, neither) compose_and_min_result
+
+    let compose_min_with_simple_locality_morph : type b c q l.
+        (b, c, l * disallowed) Locality_morph.t ->
+        (b comonadic_with, q) Axis.t ->
+        (q, c comonadic_with, l * disallowed) compose_and_min_result =
+     fun lm1 ax0 ->
+      match ax0 with
+      | Forkable -> And_min_id Forkable
+      | Yielding -> And_min_id Yielding
+      | Linearity -> And_min_id Linearity
+      | Statefulness -> And_min_id Statefulness
+      | Portability -> And_min_id Portability
+      | Areality -> And_min_core (Areality, Locality_restricted lm1)
+
+    let compose_min_with_simple_core : type b c q l.
+        (b, q) Axis.t ->
+        (b, c, l * disallowed) t ->
+        (q, c, l * disallowed) compose_and_min_result =
+     fun ax1 m0 ->
+      match (m0 : (b, c, l * disallowed) t), (ax1 : (b, q) Axis.t) with
+      | Comonadic_to_monadic_min _, Portability ->
+        And_min_core (Contention, Portability_to_contention_op)
+      | Comonadic_to_monadic_min _, Statefulness ->
+        And_min_core (Visibility, Statefulness_to_visibility_op)
+      | Comonadic_to_monadic_min _, Linearity ->
+        And_min_core (Uniqueness, Linearity_to_uniqueness_op)
+      | Comonadic_to_monadic_min _, Yielding -> Const_min_core
+      | Comonadic_to_monadic_min _, Forkable -> Const_min_core
+      | Comonadic_to_monadic_min _, Areality -> Const_min_core
+      | Monadic_to_comonadic_min, Staticity -> Const_min_core
+      | Monadic_to_comonadic_min, Contention ->
+        And_min_core (Portability, Contention_op_to_portability)
+      | Monadic_to_comonadic_min, Visibility ->
+        And_min_core (Statefulness, Visibility_op_to_statefulness)
+      | Monadic_to_comonadic_min, Uniqueness ->
+        And_min_core (Linearity, Uniqueness_op_to_linearity)
+      | Locality_full lm, (_ as ax0) ->
+        compose_min_with_simple_locality_morph lm ax0
+      | Monadic_to_comonadic_max, _ -> Disallowed
+      | Comonadic_to_monadic_max _, _ -> Disallowed
+      | _, _ -> .
+    [@@warning "-4"]
+  end
 
   let proj_obj : type t r. (t, r) Axis.t -> t obj -> r obj =
    fun ax obj ->
@@ -1551,338 +2366,1222 @@ module Lattices_mono = struct
     | Visibility, Monadic_op -> Visibility_op
     | Staticity, Monadic_op -> Staticity_op
 
-  let comonadic_with_obj : type a. a obj -> a comonadic_with obj =
-   fun a0 ->
-    match a0 with
-    | Locality -> Comonadic_with_locality
-    | Regionality -> Comonadic_with_regionality
-    | Uniqueness_op | Linearity | Monadic_op | Comonadic_with_regionality
-    | Comonadic_with_locality | Contention_op | Visibility_op | Portability
-    | Forkable | Yielding | Statefulness | Staticity_op ->
-      assert false
+  let min_with dst ax a = Axis.set ax a (min dst)
 
-  let rec src : type a b l r. b obj -> (a, b, l * r) morph -> a obj =
+  let max_with dst ax a = Axis.set ax a (max dst)
+
+  module Simple_morph = struct
+    type ('a, 'b, 'd) t =
+      | Id : ('a, 'a, 'd) t  (** identity morphism *)
+      | Core : ('a, 'b, 'd) Core_morph.t -> ('a, 'b, 'd) t
+      | Meet_const : 'a -> ('a, 'a, 'l * disallowed) t
+          (** Meet the input with the parameter *)
+      | Imply_const : 'a -> ('a, 'a, disallowed * 'r) t
+          (** The right adjoint of [Meet_const] *)
+      | Meet_const_core :
+          'b * ('a, 'b, 'l * disallowed) Core_morph.t
+          -> ('a, 'b, 'l * disallowed) t
+          (** Composition of [Core] and [Meet_const]. We only need to include
+              one order of composition because currently all our core left
+              morphisms preserve binary meets. *)
+      | Core_imply_const :
+          ('a, 'b, disallowed * 'r) Core_morph.t * 'a
+          -> ('a, 'b, disallowed * 'r) t
+          (** Composition of [Core] and [Imply_const]. We only need to include
+              one order of composition because currently all our core right
+              morphisms commute with implication. *)
+      | Compose :
+          ('b, 'c, neither) t * ('a, 'b, neither) t
+          -> ('a, 'c, neither) t
+          (** Compoistion of two morphisms. We don't allow compositions to
+              appear on either side to ensure that there are a finite number of
+              morphisms we can encounter in practice. *)
+
+    let allow_left : type a b l r. (a, b, allowed * r) t -> (a, b, l * r) t =
+      function
+      | Id -> Id
+      | Core m -> Core (Core_morph.allow_left m)
+      | Meet_const c -> Meet_const c
+      | Meet_const_core (c, m) -> Meet_const_core (c, Core_morph.allow_left m)
+
+    let allow_right : type a b l r. (a, b, l * allowed) t -> (a, b, l * r) t =
+      function
+      | Id -> Id
+      | Core m -> Core (Core_morph.allow_right m)
+      | Imply_const c -> Imply_const c
+      | Core_imply_const (m, c) -> Core_imply_const (Core_morph.allow_right m, c)
+
+    let rec disallow_left : type a b l r.
+        (a, b, l * r) t -> (a, b, disallowed * r) t = function
+      | Id -> Id
+      | Core m -> Core (Core_morph.disallow_left m)
+      | Meet_const c -> Meet_const c
+      | Imply_const c -> Imply_const c
+      | Meet_const_core (c, m) -> Meet_const_core (c, Core_morph.disallow_left m)
+      | Core_imply_const (m, c) ->
+        Core_imply_const (Core_morph.disallow_left m, c)
+      | Compose (mb, ma) ->
+        let mb = disallow_left mb in
+        let ma = disallow_left ma in
+        Compose (mb, ma)
+
+    let rec disallow_right : type a b l r.
+        (a, b, l * r) t -> (a, b, l * disallowed) t = function
+      | Id -> Id
+      | Core m -> Core (Core_morph.disallow_right m)
+      | Meet_const c -> Meet_const c
+      | Imply_const c -> Imply_const c
+      | Meet_const_core (c, m) ->
+        Meet_const_core (c, Core_morph.disallow_right m)
+      | Core_imply_const (m, c) ->
+        Core_imply_const (Core_morph.disallow_right m, c)
+      | Compose (mb, ma) ->
+        let mb = disallow_right mb in
+        let ma = disallow_right ma in
+        Compose (mb, ma)
+
+    let rec src : type a b d. b obj -> (a, b, d) t -> a obj =
+     fun dst f ->
+      match f with
+      | Id -> dst
+      | Core m -> Core_morph.src m
+      | Meet_const _ -> dst
+      | Imply_const _ -> dst
+      | Meet_const_core (_, m) -> Core_morph.src m
+      | Core_imply_const (m, _) -> Core_morph.src m
+      | Compose (mb, ma) ->
+        let mid = src dst mb in
+        src mid ma
+
+    let equal_val = equal
+
+    let rec compare : type a1 d1 a2 b d2.
+        b obj -> (a1, b, d1) t -> (a2, b, d2) t -> int =
+     fun dst m1 m2 ->
+      match m1, m2 with
+      | Id, Id -> 0
+      | Id, _ -> -1
+      | _, Id -> 1
+      | Core m1, Core m2 -> Core_morph.compare m1 m2
+      | Core _, _ -> -1
+      | _, Core _ -> 1
+      | Meet_const c1, Meet_const c2 -> compare_total dst c1 c2
+      | Meet_const _, _ -> -1
+      | _, Meet_const _ -> 1
+      | Imply_const c1, Imply_const c2 -> compare_total dst c1 c2
+      | Imply_const _, _ -> -1
+      | _, Imply_const _ -> 1
+      | Meet_const_core (c1, m1), Meet_const_core (c2, m2) ->
+        let c = compare_total dst c1 c2 in
+        if c <> 0 then c else Core_morph.compare m1 m2
+      | Meet_const_core _, _ -> -1
+      | _, Meet_const_core _ -> 1
+      | Core_imply_const (m1, c1), Core_imply_const (m2, c2) -> (
+        let c = Core_morph.compare m1 m2 in
+        if c <> 0
+        then c
+        else
+          match Core_morph.equal m1 m2 with
+          | Misc.Is_not_eq ->
+            Misc.fatal_error
+              "Mode.Lattices_mono.Simple_morph.compare: inconsistent core \
+               morph equality"
+          | Misc.Is_eq ->
+            let src = Core_morph.src m1 in
+            compare_total src c1 c2)
+      | Core_imply_const _, _ -> -1
+      | _, Core_imply_const _ -> 1
+      | Compose (mb1, ma1), Compose (mb2, ma2) -> (
+        let c = compare dst mb1 mb2 in
+        if c <> 0
+        then c
+        else
+          match equal dst mb1 mb2 with
+          | Misc.Is_not_eq ->
+            Misc.fatal_error
+              "Mode.Lattices_mono.Simple_morph.compare: inconsistent equality"
+          | Misc.Is_eq -> compare (src dst mb1) ma1 ma2)
+      | Compose _, _ -> .
+      | _, Compose _ -> .
+
+    and equal : type a1 d1 a2 b d2.
+        b obj -> (a1, b, d1) t -> (a2, b, d2) t -> (a1, a2) Misc.is_eq =
+     fun dst m1 m2 ->
+      match m1, m2 with
+      | Id, Id -> Misc.Is_eq
+      | Core m1, Core m2 -> Core_morph.equal m1 m2
+      | Meet_const c1, Meet_const c2 ->
+        if equal_val dst c1 c2 then Misc.Is_eq else Misc.Is_not_eq
+      | Imply_const c1, Imply_const c2 ->
+        if equal_val dst c1 c2 then Misc.Is_eq else Misc.Is_not_eq
+      | Meet_const_core (c1, m1), Meet_const_core (c2, m2) ->
+        if equal_val dst c1 c2 then Core_morph.equal m1 m2 else Misc.Is_not_eq
+      | Core_imply_const (m1, c1), Core_imply_const (m2, c2) -> (
+        match Core_morph.equal m1 m2 with
+        | Misc.Is_not_eq -> Misc.Is_not_eq
+        | Misc.Is_eq ->
+          if equal_val (Core_morph.src m1) c1 c2
+          then Misc.Is_eq
+          else Misc.Is_not_eq)
+      | Compose (mb1, ma1), Compose (mb2, ma2) -> (
+        match equal dst mb1 mb2 with
+        | Misc.Is_not_eq -> Misc.Is_not_eq
+        | Misc.Is_eq -> equal (src dst mb1) ma1 ma2)
+      | ( ( Id | Core _ | Meet_const _ | Imply_const _ | Meet_const_core _
+          | Core_imply_const _ | Compose _ ),
+          _ ) ->
+        Misc.Is_not_eq
+
+    let print_val = print
+
+    let rec print : type a b d. b obj -> Fmt.formatter -> (a, b, d) t -> unit =
+     fun dst ppf -> function
+      | Id -> Fmt.fprintf ppf "id"
+      | Core m -> Core_morph.print ppf m
+      | Meet_const c -> Fmt.fprintf ppf "meet(%a)" (print_val dst) c
+      | Imply_const c -> Fmt.fprintf ppf "imply(%a)" (print_val dst) c
+      | Meet_const_core (c, m) ->
+        Fmt.fprintf ppf "meet(%a) . %a" (print_val dst) c Core_morph.print m
+      | Core_imply_const (m, c) ->
+        Fmt.fprintf ppf "%a . imply(%a)" Core_morph.print m
+          (print_val (Core_morph.src m))
+          c
+      | Compose (mb, ma) ->
+        let mid = src dst mb in
+        Fmt.fprintf ppf "%a . %a" (print dst) mb (print mid) ma
+
+    let rec apply : type a b d. b obj -> (a, b, d) t -> a -> b =
+     fun dst f a ->
+      match f with
+      | Id -> a
+      | Core m -> Core_morph.apply dst m a
+      | Meet_const c -> meet dst c a
+      | Imply_const c -> imply dst c a
+      | Meet_const_core (c, m) -> meet dst c (Core_morph.apply dst m a)
+      | Core_imply_const (m, c) ->
+        Core_morph.apply dst m (imply (Core_morph.src m) c a)
+      | Compose (mb, ma) ->
+        let mid = src dst mb in
+        apply dst mb (apply mid ma a)
+
+    let right_adjoint : type a b r.
+        b obj -> (a, b, allowed * r) t -> (b, a, disallowed * allowed) t =
+     fun dst f ->
+      match f with
+      | Id -> Id
+      | Core m -> Core (Core_morph.right_adjoint dst m)
+      | Meet_const c -> Imply_const c
+      | Meet_const_core (c, m) ->
+        Core_imply_const (Core_morph.right_adjoint dst m, c)
+
+    let left_adjoint : type a b l.
+        b obj -> (a, b, l * allowed) t -> (b, a, allowed * disallowed) t =
+     fun dst f ->
+      match f with
+      | Id -> Id
+      | Core m -> Core (Core_morph.left_adjoint dst m)
+      | Imply_const c -> Meet_const c
+      | Core_imply_const (m, c) ->
+        Meet_const_core (c, Core_morph.left_adjoint dst m)
+
+    type ('a, 'b, 'd) maybe_allowed_right =
+      | Allowed_right :
+          ('a, 'b, 'l * allowed) t
+          -> ('a, 'b, 'l * 'r) maybe_allowed_right
+      | Not_allowed_right : ('a, 'b, 'l * disallowed) maybe_allowed_right
+
+    let maybe_allowed_right : type a b l r.
+        (a, b, l * r) t -> (a, b, l * r) maybe_allowed_right = function
+      | Id -> Allowed_right Id
+      | Core m ->
+        begin match Core_morph.maybe_allowed_right m with
+        | Allowed_right m -> Allowed_right (Core m)
+        | Not_allowed_right -> Not_allowed_right
+        end
+      | Meet_const _ -> Not_allowed_right
+      | Imply_const c -> Allowed_right (Imply_const c)
+      | Meet_const_core _ -> Not_allowed_right
+      | Core_imply_const (m, c) ->
+        begin match Core_morph.maybe_allowed_right m with
+        | Allowed_right m -> Allowed_right (Core_imply_const (m, c))
+        | Not_allowed_right -> Not_allowed_right
+        end
+      | Compose _ -> Not_allowed_right
+
+    type ('a, 'b, 'd) maybe_allowed_left =
+      | Allowed_left :
+          ('a, 'b, allowed * 'r) t
+          -> ('a, 'b, 'l * 'r) maybe_allowed_left
+      | Not_allowed_left : ('a, 'b, disallowed * 'r) maybe_allowed_left
+
+    let maybe_allowed_left : type a b l r.
+        (a, b, l * r) t -> (a, b, l * r) maybe_allowed_left = function
+      | Id -> Allowed_left Id
+      | Core m ->
+        begin match Core_morph.maybe_allowed_left m with
+        | Allowed_left m -> Allowed_left (Core m)
+        | Not_allowed_left -> Not_allowed_left
+        end
+      | Meet_const c -> Allowed_left (Meet_const c)
+      | Imply_const _ -> Not_allowed_left
+      | Meet_const_core (c, m) ->
+        begin match Core_morph.maybe_allowed_left m with
+        | Allowed_left m -> Allowed_left (Meet_const_core (c, m))
+        | Not_allowed_left -> Not_allowed_left
+        end
+      | Core_imply_const _ -> Not_allowed_left
+      | Compose _ -> Not_allowed_left
+
+    let compose_meet_const_left : type a b l.
+        b obj -> b -> (a, b, l * disallowed) t -> (a, b, l * disallowed) t =
+     fun dst c m ->
+      match m with
+      | Id -> Meet_const c
+      | Core m -> Meet_const_core (c, m)
+      | Meet_const c' -> Meet_const (meet dst c c')
+      | Meet_const_core (c', m) -> Meet_const_core (meet dst c c', m)
+      | Imply_const _ as m -> Compose (Meet_const c, m)
+      | Core_imply_const _ as m -> Compose (Meet_const c, m)
+      | Compose _ as m -> Compose (Meet_const c, m)
+
+    let compose_imply_const_right : type a b r.
+        b obj -> (a, b, disallowed * r) t -> a -> (a, b, disallowed * r) t =
+     fun dst m c ->
+      match m with
+      | Id -> Imply_const c
+      | Core m -> Core_imply_const (m, c)
+      | Imply_const c' -> Imply_const (meet dst c c')
+      | Core_imply_const (m, c') ->
+        Core_imply_const (m, meet (Core_morph.src m) c' c)
+      | Meet_const _ as m -> Compose (m, Imply_const c)
+      | Meet_const_core _ as m -> Compose (m, Imply_const c)
+      | Compose _ as m -> Compose (m, Imply_const c)
+
+    let compose_meet_const_right : type a b l.
+        b obj -> (a, b, l * disallowed) t -> a -> (a, b, l * disallowed) t =
+     fun dst m c ->
+      match m with
+      | Id -> Meet_const c
+      | Core m ->
+        let c = Core_morph.commute_meet_const_from_right dst m c in
+        Meet_const_core (c, m)
+      | Meet_const c' -> Meet_const (meet dst c' c)
+      | Meet_const_core (c', m) ->
+        let c = Core_morph.commute_meet_const_from_right dst m c in
+        Meet_const_core (meet dst c' c, m)
+      | Imply_const _ as m -> Compose (m, Meet_const c)
+      | Core_imply_const _ as m -> Compose (m, Meet_const c)
+      | Compose _ as m -> Compose (m, Meet_const c)
+
+    let compose_imply_const_left : type a b r.
+        b obj -> b -> (a, b, disallowed * r) t -> (a, b, disallowed * r) t =
+     fun dst c m ->
+      match m with
+      | Id -> Imply_const c
+      | Core m ->
+        begin match Core_morph.maybe_allowed_right m with
+        | Not_allowed_right -> Compose (Imply_const c, Core m)
+        | Allowed_right m' ->
+          let c = Core_morph.commute_imply_from_left dst c m' in
+          Core_imply_const (m, c)
+        end
+      | Imply_const c' -> Imply_const (meet dst c c')
+      | Core_imply_const (m, c') ->
+        begin match Core_morph.maybe_allowed_right m with
+        | Not_allowed_right -> Compose (Imply_const c, Core_imply_const (m, c'))
+        | Allowed_right m' ->
+          let c = Core_morph.commute_imply_from_left dst c m' in
+          Core_imply_const (m, meet (Core_morph.src m) c c')
+        end
+      | Meet_const _ as m -> Compose (Imply_const c, m)
+      | Meet_const_core _ as m -> Compose (Imply_const c, m)
+      | Compose _ as m -> Compose (Imply_const c, m)
+
+    let compose_core : type a b c d.
+        c obj -> (b, c, d) Core_morph.t -> (a, b, d) Core_morph.t -> (a, c, d) t
+        =
+     fun dst m1 m2 ->
+      match m1, m2 with
+      | Locality_restricted lm1, Locality_restricted lm2 ->
+        begin match Locality_morph.compose lm1 lm2 with
+        | Id -> Id
+        | Morph lm -> Core (Locality_restricted lm)
+        | Disallowed -> Compose (Core m1, Core m2)
+        end
+      | Locality_full lm1, Locality_full lm2 ->
+        begin match Locality_morph.compose lm1 lm2 with
+        | Id -> Id
+        | Morph lm -> Core (Locality_full lm)
+        | Disallowed -> Compose (Core m1, Core m2)
+        end
+      | Uniqueness_op_to_linearity, Linearity_to_uniqueness_op -> Id
+      | Linearity_to_uniqueness_op, Uniqueness_op_to_linearity -> Id
+      | Contention_op_to_portability, Portability_to_contention_op -> Id
+      | Portability_to_contention_op, Contention_op_to_portability -> Id
+      | Visibility_op_to_statefulness, Statefulness_to_visibility_op -> Id
+      | Statefulness_to_visibility_op, Visibility_op_to_statefulness -> Id
+      | Comonadic_to_monadic_min areality, Monadic_to_comonadic_min ->
+        let c =
+          match areality with
+          | Locality ->
+            Core_morph.apply dst (Comonadic_to_monadic_min Locality)
+              Comonadic_with_locality.max
+          | Regionality ->
+            Core_morph.apply dst (Comonadic_to_monadic_min Regionality)
+              Comonadic_with_regionality.max
+        in
+        Meet_const c
+      | Monadic_to_comonadic_min, Comonadic_to_monadic_min areality -> begin
+        let c = Core_morph.apply dst Monadic_to_comonadic_min Monadic_op.max in
+        match areality, dst with
+        | Locality, Comonadic_with_locality -> Meet_const c
+        | Regionality, Comonadic_with_locality ->
+          Meet_const_core (c, Locality_full Regional_to_local)
+        | Locality, Comonadic_with_regionality ->
+          Meet_const_core (c, Locality_full Locality_as_regionality)
+        | Regionality, Comonadic_with_regionality -> Meet_const c
+        end
+      | Monadic_to_comonadic_max, Comonadic_to_monadic_max areality -> begin
+        let src = areality_comonadic_obj areality in
+        let c = Core_morph.apply src Monadic_to_comonadic_min Monadic_op.max in
+        match areality, dst with
+        | Locality, Comonadic_with_locality -> Imply_const c
+        | Regionality, Comonadic_with_locality ->
+          Core_imply_const (Locality_full Regional_to_local, c)
+        | Locality, Comonadic_with_regionality ->
+          Core_imply_const (Locality_full Locality_as_regionality, c)
+        | Regionality, Comonadic_with_regionality -> Imply_const c
+        end
+      | Comonadic_to_monadic_max areality, Monadic_to_comonadic_max ->
+        let c =
+          match areality with
+          | Locality ->
+            Core_morph.apply dst (Comonadic_to_monadic_min Locality)
+              Comonadic_with_locality.max
+          | Regionality ->
+            Core_morph.apply dst (Comonadic_to_monadic_min Regionality)
+              Comonadic_with_regionality.max
+        in
+        Imply_const c
+      | Comonadic_to_monadic_min _, Monadic_to_comonadic_max ->
+        Compose (Core m1, Core m2)
+      | Monadic_to_comonadic_max, Comonadic_to_monadic_min _ ->
+        Compose (Core m1, Core m2)
+      | Comonadic_to_monadic_max _, Monadic_to_comonadic_min ->
+        Compose (Core m1, Core m2)
+      | Monadic_to_comonadic_min, Comonadic_to_monadic_max _ ->
+        Compose (Core m1, Core m2)
+      | Comonadic_to_monadic_min _, Locality_full m2 ->
+        let src = Locality_morph.src_full m2 in
+        Core (Comonadic_to_monadic_min (comonadic_obj_areality src))
+      | Comonadic_to_monadic_max _, Locality_full m2 ->
+        let src = Locality_morph.src_full m2 in
+        Core (Comonadic_to_monadic_max (comonadic_obj_areality src))
+      | Locality_full lm1, Monadic_to_comonadic_min ->
+        begin match Locality_morph.maybe_allowed_left lm1 with
+        | Allowed_left _ ->
+          (* Has a right adjoint so it preserves min *)
+          Core Monadic_to_comonadic_min
+        | Not_allowed_left -> Compose (Core m1, Core Monadic_to_comonadic_min)
+        end
+      | Locality_full lm1, Monadic_to_comonadic_max ->
+        begin match Locality_morph.maybe_allowed_right lm1 with
+        | Allowed_right _ ->
+          (* Has a left adjoint so it preserves max *)
+          Core Monadic_to_comonadic_max
+        | Not_allowed_right -> Compose (Core m1, Core Monadic_to_comonadic_max)
+        end
+      | Locality_restricted _, _ -> .
+      | _, Locality_restricted _ -> .
+      | Locality_full _, _ -> .
+      | _, Locality_full _ -> .
+
+    let compose_core_right : type a b c d.
+        c obj -> (b, c, d) t -> (a, b, d) Core_morph.t -> (a, c, d) t =
+     fun dst m1 m2 ->
+      match m1 with
+      | Id -> Core m2
+      | Core m1 -> compose_core dst m1 m2
+      | Imply_const c1 ->
+        begin match Core_morph.maybe_allowed_right m2 with
+        | Not_allowed_right -> Compose (Imply_const c1, Core m2)
+        | Allowed_right m2' ->
+          let c1 = Core_morph.commute_imply_from_left dst c1 m2' in
+          Core_imply_const (m2, c1)
+        end
+      | Core_imply_const (m1, c1) ->
+        begin match Core_morph.maybe_allowed_right m2 with
+        | Not_allowed_right -> Compose (Core_imply_const (m1, c1), Core m2)
+        | Allowed_right m2' ->
+          let mid = Core_morph.src m1 in
+          let c1 = Core_morph.commute_imply_from_left mid c1 m2' in
+          let m = compose_core dst m1 m2 in
+          compose_imply_const_right dst m c1
+        end
+      | Meet_const c1 -> Meet_const_core (c1, m2)
+      | Meet_const_core (c1, m1) ->
+        compose_meet_const_left dst c1 (compose_core dst m1 m2)
+      | Compose _ as m1 -> Compose (m1, Core m2)
+
+    let compose_core_left : type a b c d.
+        c obj -> (b, c, d) Core_morph.t -> (a, b, d) t -> (a, c, d) t =
+     fun dst m1 m2 ->
+      match m2 with
+      | Id -> Core m1
+      | Core m2 -> compose_core dst m1 m2
+      | Imply_const c2 -> Core_imply_const (m1, c2)
+      | Core_imply_const (m2, c2) ->
+        compose_imply_const_right dst (compose_core dst m1 m2) c2
+      | Meet_const c2 ->
+        let c2 = Core_morph.commute_meet_const_from_right dst m1 c2 in
+        Meet_const_core (c2, m1)
+      | Meet_const_core (c2, m2) ->
+        let c2 = Core_morph.commute_meet_const_from_right dst m1 c2 in
+        let m = compose_core dst m1 m2 in
+        compose_meet_const_left dst c2 m
+      | Compose _ as m2 -> Compose (Core m1, m2)
+
+    let compose : type a b c d.
+        c obj -> (b, c, d) t -> (a, b, d) t -> (a, c, d) t =
+     fun dst m1 m2 ->
+      match m1, m2 with
+      | m1, Id -> m1
+      | Id, m2 -> m2
+      | m1, Meet_const c2 -> compose_meet_const_right dst m1 c2
+      | Meet_const c1, m2 -> compose_meet_const_left dst c1 m2
+      | m1, Imply_const c2 -> compose_imply_const_right dst m1 c2
+      | Imply_const c1, m2 -> compose_imply_const_left dst c1 m2
+      | m1, Core m2 -> compose_core_right dst m1 m2
+      | Core m1, m2 -> compose_core_left dst m1 m2
+      | m1, Meet_const_core (c2, m2) ->
+        compose_core_right dst (compose_meet_const_right dst m1 c2) m2
+      | Meet_const_core (c1, m1), m2 ->
+        compose_meet_const_left dst c1 (compose_core_left dst m1 m2)
+      | m1, Core_imply_const (m2, c2) ->
+        compose_imply_const_right dst (compose_core_right dst m1 m2) c2
+      | Core_imply_const (m1, c1), m2 ->
+        let mid = Core_morph.src m1 in
+        compose_core_left dst m1 (compose_imply_const_left mid c1 m2)
+      | (Compose _ as m1), m2 -> Compose (m1, m2)
+      | _, Compose _ -> .
+
+    let rec lift_max : type a b p q.
+        a obj ->
+        b obj ->
+        (p, q, disallowed * allowed) t ->
+        (a, p) Axis.t ->
+        (b, q) Axis.t ->
+        (a, b, disallowed * allowed) t =
+     fun src dst m ax0 ax1 ->
+      let m : (a, b, disallowed * allowed) t =
+        match m with
+        | Id ->
+          begin match src, dst, ax0, ax1 with
+          | Comonadic_with_regionality, Comonadic_with_locality, _, _ ->
+            Core (Locality_full Regional_to_global)
+          | Comonadic_with_locality, Comonadic_with_regionality, _, _ ->
+            Core (Locality_full Locality_as_regionality)
+          | Comonadic_with_regionality, Comonadic_with_regionality, _, _ -> Id
+          | Comonadic_with_locality, Comonadic_with_locality, _, _ -> Id
+          | Monadic_op, Monadic_op, _, _ -> Id
+          | _, _, _, _ -> .
+          end
+        | Core m ->
+          begin match m, ax0, ax1, src, dst with
+          | Uniqueness_op_to_linearity, Uniqueness, Linearity, _, _ ->
+            Core Monadic_to_comonadic_max
+          | Linearity_to_uniqueness_op, Linearity, Uniqueness, _, _ ->
+            Core (Comonadic_to_monadic_max (comonadic_obj_areality src))
+          | Contention_op_to_portability, Contention, Portability, _, _ ->
+            Core Monadic_to_comonadic_max
+          | Portability_to_contention_op, Portability, Contention, _, _ ->
+            Core (Comonadic_to_monadic_max (comonadic_obj_areality src))
+          | Visibility_op_to_statefulness, Visibility, Statefulness, _, _ ->
+            Core Monadic_to_comonadic_max
+          | Statefulness_to_visibility_op, Statefulness, Visibility, _, _ ->
+            Core (Comonadic_to_monadic_max (comonadic_obj_areality src))
+          | Locality_restricted lm, Areality, Areality, _, _ ->
+            Core (Locality_full lm)
+          | _, _, _, _, _ -> .
+          end
+        | Imply_const c ->
+          let c = Axis.set ax1 c (max dst) in
+          begin match src, dst, ax0, ax1 with
+          | Comonadic_with_regionality, Comonadic_with_locality, _, _ ->
+            compose dst (Imply_const c)
+              (Core (Locality_full Regional_to_global))
+          | Comonadic_with_locality, Comonadic_with_regionality, _, _ ->
+            compose dst (Imply_const c)
+              (Core (Locality_full Locality_as_regionality))
+          | Comonadic_with_regionality, Comonadic_with_regionality, _, _ ->
+            Imply_const c
+          | Comonadic_with_locality, Comonadic_with_locality, _, _ ->
+            Imply_const c
+          | Monadic_op, Monadic_op, _, _ -> Imply_const c
+          | _, _, _, _ -> .
+          end
+        | Core_imply_const (m, c) ->
+          let m = lift_max src dst (Core m) ax0 ax1 in
+          let c = Axis.set ax0 c (max src) in
+          compose dst m (Imply_const c)
+      in
+      let q_obj = proj_obj ax1 dst in
+      let c = min_with dst ax1 (max q_obj) in
+      compose dst (Imply_const c) m
+    [@@warning "-4"]
+
+    let rec lift_min : type a b p q.
+        a obj ->
+        b obj ->
+        (p, q, allowed * disallowed) t ->
+        (a, p) Axis.t ->
+        (b, q) Axis.t ->
+        (a, b, allowed * disallowed) t =
+     fun src dst m ax0 ax1 ->
+      let m : (a, b, allowed * disallowed) t =
+        match m with
+        | Id ->
+          begin match src, dst, ax0, ax1 with
+          | Comonadic_with_regionality, Comonadic_with_locality, _, _ ->
+            Core (Locality_full Regional_to_local)
+          | Comonadic_with_locality, Comonadic_with_regionality, _, _ ->
+            Core (Locality_full Locality_as_regionality)
+          | Comonadic_with_regionality, Comonadic_with_regionality, _, _ -> Id
+          | Comonadic_with_locality, Comonadic_with_locality, _, _ -> Id
+          | Monadic_op, Monadic_op, _, _ -> Id
+          | _, _, _, _ -> .
+          end
+        | Core m ->
+          begin match m, ax0, ax1, src, dst with
+          | Uniqueness_op_to_linearity, Uniqueness, Linearity, _, _ ->
+            Core Monadic_to_comonadic_min
+          | Linearity_to_uniqueness_op, Linearity, Uniqueness, _, _ ->
+            Core (Comonadic_to_monadic_min (comonadic_obj_areality src))
+          | Contention_op_to_portability, Contention, Portability, _, _ ->
+            Core Monadic_to_comonadic_min
+          | Portability_to_contention_op, Portability, Contention, _, _ ->
+            Core (Comonadic_to_monadic_min (comonadic_obj_areality src))
+          | Visibility_op_to_statefulness, Visibility, Statefulness, _, _ ->
+            Core Monadic_to_comonadic_min
+          | Statefulness_to_visibility_op, Statefulness, Visibility, _, _ ->
+            Core (Comonadic_to_monadic_min (comonadic_obj_areality src))
+          | Locality_restricted lm, Areality, Areality, _, _ ->
+            Core (Locality_full lm)
+          | _, _, _, _, _ -> .
+          end
+        | Meet_const c ->
+          let c = Axis.set ax1 c (min dst) in
+          begin match src, dst, ax0, ax1 with
+          | Comonadic_with_regionality, Comonadic_with_locality, _, _ ->
+            compose dst (Meet_const c) (Core (Locality_full Regional_to_local))
+          | Comonadic_with_locality, Comonadic_with_regionality, _, _ ->
+            compose dst (Meet_const c)
+              (Core (Locality_full Locality_as_regionality))
+          | Comonadic_with_regionality, Comonadic_with_regionality, _, _ ->
+            Meet_const c
+          | Comonadic_with_locality, Comonadic_with_locality, _, _ ->
+            Meet_const c
+          | Monadic_op, Monadic_op, _, _ -> Meet_const c
+          | _, _, _, _ -> .
+          end
+        | Meet_const_core (c, m) ->
+          let m = lift_min src dst (Core m) ax0 ax1 in
+          let c = Axis.set ax1 c (min dst) in
+          compose dst (Meet_const c) m
+      in
+      let q_obj = proj_obj ax1 dst in
+      let c = min_with dst ax1 (max q_obj) in
+      compose dst (Meet_const c) m
+    [@@warning "-4"]
+  end
+
+  type ('a, 'b, 'd) morph =
+    | Simple : ('a, 'b, 'd) Simple_morph.t -> ('a, 'b, 'd) morph
+    | Const_max : 'a obj -> ('a, 'c, disallowed * 'r) morph
+        (** Discards an arbitrary input and apply a simple morphism to the
+            maximum of a lattice *)
+    | Const_min : 'a obj -> ('a, 'c, 'l * disallowed) morph
+        (** Discards an arbitrary input and apply a simple morphism to the
+            minimum of a lattice *)
+    | Const : 'a obj * 'c -> ('a, 'c, neither) morph
+        (** A constant function on any constant: we don't allow arbitrary
+            constant functions to appear on either side *)
+    | Simple_proj :
+        ('p, 'q, 'd) Simple_morph.t * ('s, 'p) Axis.t * 's obj
+        -> ('s, 'q, 'd) morph
+        (** Composition of projecting out an axis and a simple morphism. *)
+    | Max_with_simple :
+        ('s, 'q) Axis.t * ('p, 'q, disallowed * 'r) Simple_morph.t
+        -> ('p, 's, disallowed * 'r) morph
+        (** Composition of a morphism and combining an axis with the maxima
+            along other axes. *)
+    | Min_with_simple :
+        ('s, 'q) Axis.t * ('p, 'q, 'l * disallowed) Simple_morph.t
+        -> ('p, 's, 'l * disallowed) morph
+        (** Composition of a morphism and combining an axis with the minima
+            along other axes. *)
+    | Compose :
+        ('b, 'c, neither) morph * ('a, 'b, neither) morph
+        -> ('a, 'c, neither) morph
+        (** Compoistion of two morphisms. We don't allow compositions to appear
+            on either side to ensure that there are a finite number of morphisms
+            we can encounter in practice. *)
+
+  include Magic_allow_disallow (struct
+    type ('a, 'b, 'd) sided = ('a, 'b, 'd) morph constraint 'd = _ * _
+
+    let allow_left : type a b l r.
+        (a, b, allowed * r) morph -> (a, b, l * r) morph = function
+      | Simple m -> Simple (Simple_morph.allow_left m)
+      | Simple_proj (m, ax, src) ->
+        Simple_proj (Simple_morph.allow_left m, ax, src)
+      | Min_with_simple (ax, m) ->
+        Min_with_simple (ax, Simple_morph.allow_left m)
+      | Const_min src -> Const_min src
+
+    let allow_right : type a b l r.
+        (a, b, l * allowed) morph -> (a, b, l * r) morph = function
+      | Simple m -> Simple (Simple_morph.allow_right m)
+      | Simple_proj (m, ax, src) ->
+        Simple_proj (Simple_morph.allow_right m, ax, src)
+      | Max_with_simple (ax, m) ->
+        Max_with_simple (ax, Simple_morph.allow_right m)
+      | Const_max src -> Const_max src
+
+    let rec disallow_left : type a b l r.
+        (a, b, l * r) morph -> (a, b, disallowed * r) morph = function
+      | Simple m -> Simple (Simple_morph.disallow_left m)
+      | Simple_proj (m, ax, src) ->
+        Simple_proj (Simple_morph.disallow_left m, ax, src)
+      | Max_with_simple (ax, m) ->
+        Max_with_simple (ax, Simple_morph.disallow_left m)
+      | Min_with_simple (ax, m) ->
+        Min_with_simple (ax, Simple_morph.disallow_left m)
+      | Const_max src -> Const_max src
+      | Const_min src -> Const_min src
+      | Const (src, c) -> Const (src, c)
+      | Compose (mb, ma) ->
+        let mb = disallow_left mb in
+        let ma = disallow_left ma in
+        Compose (mb, ma)
+
+    let rec disallow_right : type a b l r.
+        (a, b, l * r) morph -> (a, b, l * disallowed) morph = function
+      | Simple m -> Simple (Simple_morph.disallow_right m)
+      | Simple_proj (m, ax, src) ->
+        Simple_proj (Simple_morph.disallow_right m, ax, src)
+      | Max_with_simple (ax, m) ->
+        Max_with_simple (ax, Simple_morph.disallow_right m)
+      | Min_with_simple (ax, m) ->
+        Min_with_simple (ax, Simple_morph.disallow_right m)
+      | Const_max src -> Const_max src
+      | Const_min src -> Const_min src
+      | Const (src, c) -> Const (src, c)
+      | Compose (mb, ma) ->
+        let mb = disallow_right mb in
+        let ma = disallow_right ma in
+        Compose (mb, ma)
+  end)
+
+  let rec src : type a b d. b obj -> (a, b, d) morph -> a obj =
    fun dst f ->
     match f with
-    | Id -> dst
-    | Proj (src, _) -> src
-    | Max_with ax -> proj_obj ax dst
-    | Min_with ax -> proj_obj ax dst
-    | Meet_const _ -> dst
-    | Imply_const _ -> dst
-    | Compose (f, g) ->
-      let mid = src dst f in
-      src mid g
-    | Monadic_to_comonadic_min -> Monadic_op
-    | Comonadic_to_monadic_min src -> src
-    | Comonadic_to_monadic_max src -> src
-    | Monadic_to_comonadic_max -> Monadic_op
-    | Local_to_regional -> Locality
-    | Locality_as_regionality -> Locality
-    | Global_to_regional -> Locality
-    | Regional_to_local -> Regionality
-    | Regional_to_global -> Regionality
-    | Map_comonadic f ->
-      let dst0 = proj_obj Areality dst in
-      let src0 = src dst0 f in
-      comonadic_with_obj src0
+    | Simple m -> Simple_morph.src dst m
+    | Simple_proj (_, _, src) -> src
+    | Max_with_simple (ax, m) -> Simple_morph.src (proj_obj ax dst) m
+    | Min_with_simple (ax, m) -> Simple_morph.src (proj_obj ax dst) m
+    | Const_min src -> src
+    | Const_max src -> src
+    | Const (src, _) -> src
+    | Compose (mb, ma) ->
+      let mid = src dst mb in
+      src mid ma
 
-  let rec compare_morph : type a1 l1 r1 a2 b l2 r2.
-      b obj -> (a1, b, l1 * r1) morph -> (a2, b, l2 * r2) morph -> int =
-   fun dst f1 f2 ->
-    match f1, f2 with
-    | Id, Id -> 0
-    | Id, _ -> -1
-    | _, Id -> 1
-    | Proj (src1, ax1), Proj (src2, ax2) -> (
+  let rec compare_morph : type a1 d1 a2 b d2.
+      b obj -> (a1, b, d1) morph -> (a2, b, d2) morph -> int =
+   fun dst m1 m2 ->
+    match m1, m2 with
+    | Simple m1, Simple m2 -> Simple_morph.compare dst m1 m2
+    | Simple _, _ -> -1
+    | _, Simple _ -> 1
+    | Const_max obj1, Const_max obj2 -> compare_obj obj1 obj2
+    | Const_max _, _ -> -1
+    | _, Const_max _ -> 1
+    | Const_min obj1, Const_min obj2 -> compare_obj obj1 obj2
+    | Const_min _, _ -> -1
+    | _, Const_min _ -> 1
+    | Const (obj1, c1), Const (obj2, c2) ->
+      let c = compare_obj obj1 obj2 in
+      if c <> 0 then c else compare_total dst c1 c2
+    | Const _, _ -> -1
+    | _, Const _ -> 1
+    | Simple_proj (m1, ax1, src1), Simple_proj (m2, ax2, src2) -> (
       let c = compare_obj src1 src2 in
       if c <> 0
       then c
       else
         match equal_obj src1 src2 with
-        | Misc.Is_eq -> Axis.compare ax1 ax2
         | Misc.Is_not_eq ->
           Misc.fatal_error
-            "Mode.Lattices_mono.compare_morph: inconsistent object equality")
-    | Proj _, _ -> -1
-    | _, Proj _ -> 1
-    | Max_with ax1, Max_with ax2 -> Axis.compare ax1 ax2
-    | Max_with _, _ -> -1
-    | _, Max_with _ -> 1
-    | Min_with ax1, Min_with ax2 -> Axis.compare ax1 ax2
-    | Min_with _, _ -> -1
-    | _, Min_with _ -> 1
-    | Meet_const c1, Meet_const c2 -> compare_total dst c1 c2
-    | Meet_const _, _ -> -1
-    | _, Meet_const _ -> 1
-    | Imply_const c1, Imply_const c2 -> compare_total dst c1 c2
-    | Imply_const _, _ -> -1
-    | _, Imply_const _ -> 1
-    | Monadic_to_comonadic_min, Monadic_to_comonadic_min -> 0
-    | Monadic_to_comonadic_min, _ -> -1
-    | _, Monadic_to_comonadic_min -> 1
-    | Comonadic_to_monadic_min a1, Comonadic_to_monadic_min a2 ->
-      compare_obj a1 a2
-    | Comonadic_to_monadic_min _, _ -> -1
-    | _, Comonadic_to_monadic_min _ -> 1
-    | Monadic_to_comonadic_max, Monadic_to_comonadic_max -> 0
-    | Monadic_to_comonadic_max, _ -> -1
-    | _, Monadic_to_comonadic_max -> 1
-    | Comonadic_to_monadic_max a1, Comonadic_to_monadic_max a2 ->
-      compare_obj a1 a2
-    | Comonadic_to_monadic_max _, _ -> -1
-    | _, Comonadic_to_monadic_max _ -> 1
-    | Local_to_regional, Local_to_regional -> 0
-    | Local_to_regional, _ -> -1
-    | _, Local_to_regional -> 1
-    | Locality_as_regionality, Locality_as_regionality -> 0
-    | Locality_as_regionality, _ -> -1
-    | _, Locality_as_regionality -> 1
-    | Global_to_regional, Global_to_regional -> 0
-    | Global_to_regional, _ -> -1
-    | _, Global_to_regional -> 1
-    | Regional_to_local, Regional_to_local -> 0
-    | Regional_to_local, _ -> -1
-    | _, Regional_to_local -> 1
-    | Regional_to_global, Regional_to_global -> 0
-    | Regional_to_global, _ -> -1
-    | _, Regional_to_global -> 1
-    | Compose (f1, g1), Compose (f2, g2) -> (
-      let c = compare_morph dst f1 f2 in
+            "Mode.Lattices_mono.compare_morph: inconsistent object equality"
+        | Misc.Is_eq -> (
+          let c = Axis.compare ax1 ax2 in
+          if c <> 0
+          then c
+          else
+            match Axis.equal ax1 ax2 with
+            | Misc.Is_not_eq ->
+              Misc.fatal_error
+                "Mode.Lattices_mono.compare_morph: inconsistent axis equality"
+            | Misc.Is_eq -> Simple_morph.compare dst m1 m2))
+    | Simple_proj _, _ -> -1
+    | _, Simple_proj _ -> 1
+    | Max_with_simple (ax1, m1), Max_with_simple (ax2, m2) -> (
+      let c = Axis.compare ax1 ax2 in
       if c <> 0
       then c
       else
-        match equal_morph dst f1 f2 with
-        | Misc.Is_eq -> compare_morph (src dst f1) g1 g2
+        match Axis.equal ax1 ax2 with
         | Misc.Is_not_eq ->
           Misc.fatal_error
-            "Mode.Lattices_mono.compare_morph: inconsistent equality")
-    | Compose _, _ -> -1
-    | _, Compose _ -> 1
-    | Map_comonadic f, Map_comonadic g ->
-      compare_morph (proj_obj Areality dst) f g
+            "Mode.Lattices_mono.compare_morph: inconsistent axis equality"
+        | Misc.Is_eq -> Simple_morph.compare (proj_obj ax1 dst) m1 m2)
+    | Max_with_simple _, _ -> -1
+    | _, Max_with_simple _ -> 1
+    | Min_with_simple (ax1, m1), Min_with_simple (ax2, m2) -> (
+      let c = Axis.compare ax1 ax2 in
+      if c <> 0
+      then c
+      else
+        match Axis.equal ax1 ax2 with
+        | Misc.Is_not_eq ->
+          Misc.fatal_error
+            "Mode.Lattices_mono.compare_morph: inconsistent axis equality"
+        | Misc.Is_eq -> Simple_morph.compare (proj_obj ax1 dst) m1 m2)
+    | Min_with_simple _, _ -> -1
+    | _, Min_with_simple _ -> 1
+    | Compose (mb1, ma1), Compose (mb2, ma2) -> (
+      let c = compare_morph dst mb1 mb2 in
+      if c <> 0
+      then c
+      else
+        match equal_morph dst mb1 mb2 with
+        | Misc.Is_not_eq ->
+          Misc.fatal_error
+            "Mode.Lattices_mono.compare_morph: inconsistent equality"
+        | Misc.Is_eq -> compare_morph (src dst mb1) ma1 ma2)
+    | Compose _, _ -> .
+    | _, Compose _ -> .
 
-  and equal_morph : type a1 l1 r1 a2 b l2 r2.
-      b obj ->
-      (a1, b, l1 * r1) morph ->
-      (a2, b, l2 * r2) morph ->
-      (a1, a2) Misc.is_eq =
-   fun dst f1 f2 ->
-    match f1, f2 with
-    | Id, Id -> Misc.Is_eq
-    | Proj (src1, ax1), Proj (src2, ax2) -> (
+  and equal_morph : type a1 d1 a2 b d2.
+      b obj -> (a1, b, d1) morph -> (a2, b, d2) morph -> (a1, a2) Misc.is_eq =
+   fun dst m1 m2 ->
+    match m1, m2 with
+    | Simple m1, Simple m2 -> Simple_morph.equal dst m1 m2
+    | Const_max obj1, Const_max obj2 -> equal_obj obj1 obj2
+    | Const_min obj1, Const_min obj2 -> equal_obj obj1 obj2
+    | Const (obj1, c1), Const (obj2, c2) -> (
+      match equal_obj obj1 obj2 with
+      | Misc.Is_not_eq -> Misc.Is_not_eq
+      | Misc.Is_eq -> if equal dst c1 c2 then Misc.Is_eq else Misc.Is_not_eq)
+    | Simple_proj (m1, ax1, src1), Simple_proj (m2, ax2, src2) -> (
       match equal_obj src1 src2 with
       | Misc.Is_not_eq -> Misc.Is_not_eq
       | Misc.Is_eq -> (
         match Axis.equal ax1 ax2 with
-        | Misc.Is_eq -> Misc.Is_eq
-        | Misc.Is_not_eq -> Misc.Is_not_eq))
-    | Max_with ax1, Max_with ax2 -> Axis.equal ax1 ax2
-    | Min_with ax1, Min_with ax2 -> Axis.equal ax1 ax2
-    | Meet_const c1, Meet_const c2 ->
-      if equal dst c1 c2 then Misc.Is_eq else Misc.Is_not_eq
-    | Imply_const c1, Imply_const c2 ->
-      if equal dst c1 c2 then Misc.Is_eq else Misc.Is_not_eq
-    | Monadic_to_comonadic_min, Monadic_to_comonadic_min -> Misc.Is_eq
-    | Comonadic_to_monadic_min a1, Comonadic_to_monadic_min a2 ->
-      equal_obj a1 a2
-    | Monadic_to_comonadic_max, Monadic_to_comonadic_max -> Misc.Is_eq
-    | Comonadic_to_monadic_max a1, Comonadic_to_monadic_max a2 ->
-      equal_obj a1 a2
-    | Local_to_regional, Local_to_regional -> Misc.Is_eq
-    | Locality_as_regionality, Locality_as_regionality -> Misc.Is_eq
-    | Global_to_regional, Global_to_regional -> Misc.Is_eq
-    | Regional_to_local, Regional_to_local -> Misc.Is_eq
-    | Regional_to_global, Regional_to_global -> Misc.Is_eq
-    | Compose (f1, g1), Compose (f2, g2) -> (
-      match equal_morph dst f1 f2 with
+        | Misc.Is_not_eq -> Misc.Is_not_eq
+        | Misc.Is_eq -> (
+          match Simple_morph.equal dst m1 m2 with
+          | Misc.Is_eq -> Misc.Is_eq
+          | Misc.Is_not_eq -> Misc.Is_not_eq)))
+    | Max_with_simple (ax1, m1), Max_with_simple (ax2, m2) -> (
+      match Axis.equal ax1 ax2 with
       | Misc.Is_not_eq -> Misc.Is_not_eq
-      | Misc.Is_eq -> equal_morph (src dst f1) g1 g2)
-    | Map_comonadic f, Map_comonadic g ->
-      begin match equal_morph (proj_obj Areality dst) f g with
+      | Misc.Is_eq -> Simple_morph.equal (proj_obj ax1 dst) m1 m2)
+    | Min_with_simple (ax1, m1), Min_with_simple (ax2, m2) -> (
+      match Axis.equal ax1 ax2 with
       | Misc.Is_not_eq -> Misc.Is_not_eq
-      | Misc.Is_eq -> Misc.Is_eq
-      end
-    | ( ( Id | Proj _ | Max_with _ | Min_with _ | Meet_const _ | Imply_const _
-        | Monadic_to_comonadic_min | Comonadic_to_monadic_min _
-        | Monadic_to_comonadic_max | Comonadic_to_monadic_max _
-        | Local_to_regional | Locality_as_regionality | Global_to_regional
-        | Regional_to_local | Regional_to_global | Compose _ | Map_comonadic _
-          ),
+      | Misc.Is_eq -> Simple_morph.equal (proj_obj ax1 dst) m1 m2)
+    | Compose (mb1, ma1), Compose (mb2, ma2) -> (
+      match equal_morph dst mb1 mb2 with
+      | Misc.Is_not_eq -> Misc.Is_not_eq
+      | Misc.Is_eq -> equal_morph (src dst mb1) ma1 ma2)
+    | ( ( Simple _ | Const_max _ | Const_min _ | Const _ | Simple_proj _
+        | Max_with_simple _ | Min_with_simple _ | Compose _ ),
         _ ) ->
       Misc.Is_not_eq
 
-  let rec print_morph : type a b l r.
-      b obj -> Fmt.formatter -> (a, b, l * r) morph -> unit =
+  let rec print_morph : type a b d.
+      b obj -> Fmt.formatter -> (a, b, d) morph -> unit =
    fun dst ppf -> function
-    | Id -> Fmt.fprintf ppf "id"
-    | Meet_const c -> Fmt.fprintf ppf "meet_const(%a)" (print dst) c
-    | Imply_const c -> Fmt.fprintf ppf "imply_const(%a)" (print dst) c
-    | Proj (_, ax) -> Fmt.fprintf ppf "proj_%a" Axis.print ax
-    | Max_with ax -> Fmt.fprintf ppf "max_with_%a" Axis.print ax
-    | Min_with ax -> Fmt.fprintf ppf "min_with_%a" Axis.print ax
-    | Map_comonadic f ->
-      let dst0 = proj_obj Areality dst in
-      Fmt.fprintf ppf "map_comonadic(%a)" (print_morph dst0) f
-    | Monadic_to_comonadic_min -> Fmt.fprintf ppf "monadic_to_comonadic_min"
-    | Comonadic_to_monadic_min _ -> Fmt.fprintf ppf "comonadic_to_monadic_min"
-    | Comonadic_to_monadic_max _ -> Fmt.fprintf ppf "comonadic_to_monadic_max"
-    | Monadic_to_comonadic_max -> Fmt.fprintf ppf "monadic_to_comonadic_max"
-    | Local_to_regional -> Fmt.fprintf ppf "local_to_regional"
-    | Regional_to_local -> Fmt.fprintf ppf "regional_to_local"
-    | Locality_as_regionality -> Fmt.fprintf ppf "locality_as_regionality"
-    | Regional_to_global -> Fmt.fprintf ppf "regional_to_global"
-    | Global_to_regional -> Fmt.fprintf ppf "global_to_regional"
-    | Compose (f1, f2) ->
-      let mid = src dst f1 in
-      Fmt.fprintf ppf "%a ∘ %a" (print_morph dst) f1 (print_morph mid) f2
+    | Simple m -> Simple_morph.print dst ppf m
+    | Simple_proj (Id, ax, src) ->
+      Fmt.fprintf ppf "proj_%a" print_obj (proj_obj ax src)
+    | Simple_proj (m, ax, src) ->
+      Fmt.fprintf ppf "%a . proj_%a" (Simple_morph.print dst) m print_obj
+        (proj_obj ax src)
+    | Max_with_simple (ax, Id) ->
+      Fmt.fprintf ppf "max_with_%a" print_obj (proj_obj ax dst)
+    | Max_with_simple (ax, m) ->
+      let mid = proj_obj ax dst in
+      Fmt.fprintf ppf "max_with_%a . %a" print_obj mid (Simple_morph.print mid)
+        m
+    | Min_with_simple (ax, Id) ->
+      Fmt.fprintf ppf "min_with_%a" print_obj (proj_obj ax dst)
+    | Min_with_simple (ax, m) ->
+      let mid = proj_obj ax dst in
+      Fmt.fprintf ppf "min_with_%a . %a" print_obj mid (Simple_morph.print mid)
+        m
+    | Const_max _ -> Fmt.fprintf ppf "const_%a" (print dst) (max dst)
+    | Const_min _ -> Fmt.fprintf ppf "const_%a" (print dst) (min dst)
+    | Const (_, c) -> Fmt.fprintf ppf "const_%a" (print dst) c
+    | Compose (mb, ma) ->
+      let mid = src dst mb in
+      Fmt.fprintf ppf "%a . %a" (print_morph dst) mb (print_morph mid) ma
+  [@@warning "-4"]
 
-  let id = Id
+  let id = Simple Id
 
-  let linear_to_unique = function
-    | Linearity.Many -> Uniqueness.Aliased
-    | Linearity.Once -> Uniqueness.Unique
-
-  let unique_to_linear = function
-    | Uniqueness.Unique -> Linearity.Once
-    | Uniqueness.Aliased -> Linearity.Many
-
-  let portable_to_contended = function
-    | Portability.Portable -> Contention.Contended
-    | Portability.Shareable -> Contention.Shared
-    | Portability.Corruptible -> Contention.Corrupted
-    | Portability.Nonportable -> Contention.Uncontended
-
-  let contended_to_portable = function
-    | Contention.Contended -> Portability.Portable
-    | Contention.Shared -> Portability.Shareable
-    | Contention.Corrupted -> Portability.Corruptible
-    | Contention.Uncontended -> Portability.Nonportable
-
-  let local_to_regional = function
-    | Locality.Global -> Regionality.Global
-    | Locality.Local -> Regionality.Regional
-
-  let regional_to_local = function
-    | Regionality.Local -> Locality.Local
-    | Regionality.Regional -> Locality.Local
-    | Regionality.Global -> Locality.Global
-
-  let locality_as_regionality = function
-    | Locality.Local -> Regionality.Local
-    | Locality.Global -> Regionality.Global
-
-  let regional_to_global = function
-    | Regionality.Local -> Locality.Local
-    | Regionality.Regional -> Locality.Global
-    | Regionality.Global -> Locality.Global
-
-  let global_to_regional = function
-    | Locality.Local -> Regionality.Local
-    | Locality.Global -> Regionality.Regional
-
-  let statefulness_to_visibility = function
-    | Statefulness.Stateless -> Visibility.Immutable
-    | Statefulness.Writing -> Visibility.Write
-    | Statefulness.Reading -> Visibility.Read
-    | Statefulness.Stateful -> Visibility.Read_write
-
-  let visibility_to_statefulness = function
-    | Visibility.Immutable -> Statefulness.Stateless
-    | Visibility.Read -> Statefulness.Reading
-    | Visibility.Write -> Statefulness.Writing
-    | Visibility.Read_write -> Statefulness.Stateful
-
-  let min_with dst ax a = Axis.set ax a (min dst)
-
-  let max_with dst ax a = Axis.set ax a (max dst)
-
-  let monadic_to_comonadic_min : type a.
-      a comonadic_with obj -> Monadic_op.t -> a comonadic_with =
-   fun obj m ->
-    let areality : a =
-      match obj with
-      | Comonadic_with_locality -> Locality.min
-      | Comonadic_with_regionality -> Regionality.min
-    in
-    let linearity = unique_to_linear m.uniqueness in
-    let portability = contended_to_portable m.contention in
-    let forkable = Forkable.min in
-    let yielding = Yielding.min in
-    let statefulness = visibility_to_statefulness m.visibility in
-    { areality; linearity; portability; forkable; yielding; statefulness }
-
-  let comonadic_to_monadic_min : type a.
-      a comonadic_with obj -> a comonadic_with -> Monadic_op.t =
-   fun _ m ->
-    let uniqueness = linear_to_unique m.linearity in
-    let contention = portable_to_contended m.portability in
-    let visibility = statefulness_to_visibility m.statefulness in
-    let staticity = Staticity_op.min in
-    { uniqueness; contention; visibility; staticity }
-
-  let comonadic_to_monadic_max : type a.
-      a comonadic_with obj -> a comonadic_with -> Monadic_op.t =
-   fun _ m ->
-    let uniqueness = linear_to_unique m.linearity in
-    let contention = portable_to_contended m.portability in
-    let visibility = statefulness_to_visibility m.statefulness in
-    let staticity = Staticity_op.max in
-    { uniqueness; contention; visibility; staticity }
-
-  let monadic_to_comonadic_max : type a.
-      a comonadic_with obj -> Monadic_op.t -> a comonadic_with =
-   fun obj m ->
-    let areality : a =
-      match obj with
-      | Comonadic_with_locality -> Locality.max
-      | Comonadic_with_regionality -> Regionality.max
-    in
-    let linearity = unique_to_linear m.uniqueness in
-    let portability = contended_to_portable m.contention in
-    let forkable = Forkable.max in
-    let yielding = Yielding.max in
-    let statefulness = visibility_to_statefulness m.visibility in
-    { areality; linearity; portability; forkable; yielding; statefulness }
-
-  let rec apply : type a b l r. b obj -> (a, b, l * r) morph -> a -> b =
+  let rec apply : type a b d. b obj -> (a, b, d) morph -> a -> b =
    fun dst f a ->
     match f with
-    | Compose (f, g) ->
-      let mid = src dst f in
-      let g' = apply mid g in
-      let f' = apply dst f in
-      f' (g' a)
-    | Id -> a
-    | Proj (_, ax) -> Axis.proj ax a
-    | Max_with ax -> max_with dst ax a
-    | Min_with ax -> min_with dst ax a
-    | Meet_const c -> meet dst c a
-    | Imply_const c -> imply dst c a
-    | Monadic_to_comonadic_min -> monadic_to_comonadic_min dst a
-    | Comonadic_to_monadic_min src -> comonadic_to_monadic_min src a
-    | Comonadic_to_monadic_max src -> comonadic_to_monadic_max src a
-    | Monadic_to_comonadic_max -> monadic_to_comonadic_max dst a
-    | Local_to_regional -> local_to_regional a
-    | Regional_to_local -> regional_to_local a
-    | Locality_as_regionality -> locality_as_regionality a
-    | Regional_to_global -> regional_to_global a
-    | Global_to_regional -> global_to_regional a
-    | Map_comonadic f ->
-      let dst0 = proj_obj Areality dst in
-      let a0 = Axis.proj Areality a in
-      set_areality (apply dst0 f a0) a
+    | Simple m -> Simple_morph.apply dst m a
+    | Simple_proj (m, ax, _) -> Simple_morph.apply dst m (Axis.proj ax a)
+    | Max_with_simple (ax, m) ->
+      let mid = proj_obj ax dst in
+      max_with dst ax (Simple_morph.apply mid m a)
+    | Min_with_simple (ax, m) ->
+      let mid = proj_obj ax dst in
+      min_with dst ax (Simple_morph.apply mid m a)
+    | Const_max _ -> max dst
+    | Const_min _ -> min dst
+    | Const (_, c) -> c
+    | Compose (mb, ma) ->
+      let mid = src dst mb in
+      apply dst mb (apply mid ma a)
+
+  let right_adjoint : type a b r.
+      b obj -> (a, b, allowed * r) morph -> (b, a, disallowed * allowed) morph =
+   fun dst f ->
+    match f with
+    | Simple m -> Simple (Simple_morph.right_adjoint dst m)
+    | Simple_proj (m, ax, _) ->
+      Max_with_simple (ax, Simple_morph.right_adjoint dst m)
+    | Min_with_simple (ax, m) ->
+      let mid = proj_obj ax dst in
+      Simple_proj (Simple_morph.right_adjoint mid m, ax, dst)
+    | Const_min _ -> Const_max dst
+
+  let left_adjoint : type a b l.
+      b obj -> (a, b, l * allowed) morph -> (b, a, allowed * disallowed) morph =
+   fun dst f ->
+    match f with
+    | Simple m -> Simple (Simple_morph.left_adjoint dst m)
+    | Simple_proj (m, ax, _) ->
+      Min_with_simple (ax, Simple_morph.left_adjoint dst m)
+    | Max_with_simple (ax, m) ->
+      let mid = proj_obj ax dst in
+      Simple_proj (Simple_morph.left_adjoint mid m, ax, dst)
+    | Const_max _ -> Const_min dst
+
+  let compose_simple_with_proj_core : type a c p d.
+      c obj ->
+      (p, c, d) Simple_morph.t ->
+      (a, p, d) Core_morph.compose_proj_result ->
+      (a, c, d) morph =
+   fun dst m0 pm1 ->
+    match pm1 with
+    | Proj_core (m1, ax1, obj1) ->
+      Simple_proj (Simple_morph.compose dst m0 (Core m1), ax1, obj1)
+    | Proj_id (ax1, obj1) -> Simple_proj (m0, ax1, obj1)
+    | Proj_const_max obj1 -> Const_max obj1
+    | Proj_const_min obj1 -> Const_min obj1
+
+  let compose_simple_with_proj_meet_const_core : type a c p l.
+      c obj ->
+      (p, c, l * disallowed) Simple_morph.t ->
+      p ->
+      (a, p, l * disallowed) Core_morph.compose_proj_result ->
+      (a, c, l * disallowed) morph =
+   fun dst m0 c1 pm1 ->
+    match pm1 with
+    | Proj_core (m1, ax1, obj1) ->
+      Simple_proj
+        (Simple_morph.compose dst m0 (Meet_const_core (c1, m1)), ax1, obj1)
+    | Proj_id (ax1, obj1) ->
+      Simple_proj (Simple_morph.compose dst m0 (Meet_const c1), ax1, obj1)
+    | Proj_const_max obj1 -> Const_max obj1
+    | Proj_const_min obj1 -> Const_min obj1
+
+  let compose_simple_with_proj_core_imply_const : type a c p r.
+      c obj ->
+      (p, c, disallowed * r) Simple_morph.t ->
+      a ->
+      (a, p, disallowed * r) Core_morph.compose_proj_result ->
+      (a, c, disallowed * r) morph =
+   fun dst m0 c1 pm1 ->
+    match pm1 with
+    | Proj_core (m1, ax1, obj1) ->
+      let c1 = Axis.proj ax1 c1 in
+      Simple_proj
+        (Simple_morph.compose dst m0 (Core_imply_const (m1, c1)), ax1, obj1)
+    | Proj_id (ax1, obj1) ->
+      let c1 = Axis.proj ax1 c1 in
+      Simple_proj (Simple_morph.compose dst m0 (Imply_const c1), ax1, obj1)
+    | Proj_const_max obj1 -> Const_max obj1
+    | Proj_const_min obj1 -> Const_min obj1
+
+  let compose_simple_proj_with_simple : type a b c p d.
+      c obj ->
+      (p, c, d) Simple_morph.t ->
+      (b, p) Axis.t ->
+      b obj ->
+      (a, b, d) Simple_morph.t ->
+      (a, c, d) morph =
+   fun dst m0 ax0 obj0 m1 ->
+    match m1 with
+    | Id -> Simple_proj (m0, ax0, obj0)
+    | Core m1 ->
+      let pm1 = Core_morph.compose_projection_core ax0 m1 in
+      compose_simple_with_proj_core dst m0 pm1
+    | Meet_const c1 ->
+      let c1 = Axis.proj ax0 c1 in
+      Simple_proj (Simple_morph.compose dst m0 (Meet_const c1), ax0, obj0)
+    | Imply_const c1 ->
+      let c1 = Axis.proj ax0 c1 in
+      Simple_proj (Simple_morph.compose dst m0 (Imply_const c1), ax0, obj0)
+    | Meet_const_core (c1, m1) ->
+      let c1 = Axis.proj ax0 c1 in
+      let pm1 = Core_morph.compose_projection_core ax0 m1 in
+      compose_simple_with_proj_meet_const_core dst m0 c1 pm1
+    | Core_imply_const (m1, c1) ->
+      let pm1 = Core_morph.compose_projection_core ax0 m1 in
+      compose_simple_with_proj_core_imply_const dst m0 c1 pm1
+    | Compose _ -> Compose (Simple_proj (m0, ax0, obj0), Simple m1)
+
+  let compose_simple_with_and_max : type a b c q r.
+      c obj ->
+      (b, c, disallowed * r) Simple_morph.t ->
+      (b, q) Axis.t ->
+      (a, q, disallowed * r) Simple_morph.t ->
+      (a, c, disallowed * r) morph =
+   fun dst sm0 ax1 m1 ->
+    let b_obj = Simple_morph.src dst sm0 in
+    let a_obj = src b_obj (Max_with_simple (ax1, m1)) in
+    match sm0 with
+    | Id -> Max_with_simple (ax1, m1)
+    | Core m0 ->
+      begin match Core_morph.compose_max_with_simple_core ax1 m0 with
+      | And_max_core (ax1, m0) ->
+        let obj0 = proj_obj ax1 dst in
+        Max_with_simple (ax1, Simple_morph.compose obj0 (Core m0) m1)
+      | Const_max_core -> Const_max a_obj
+      | And_max_id ax1 -> Max_with_simple (ax1, m1)
+      | Disallowed -> Compose (Simple sm0, Max_with_simple (ax1, m1))
+      end
+    | Imply_const c0 ->
+      let c0 = Axis.proj ax1 c0 in
+      let obj0 = proj_obj ax1 dst in
+      Max_with_simple (ax1, Simple_morph.compose obj0 (Imply_const c0) m1)
+    | Core_imply_const (m0, c0) -> begin
+      let c0 = Axis.proj ax1 c0 in
+      match Core_morph.compose_max_with_simple_core ax1 m0 with
+      | And_max_core (ax1, m0) ->
+        let obj0 = proj_obj ax1 dst in
+        Max_with_simple
+          (ax1, Simple_morph.compose obj0 (Core_imply_const (m0, c0)) m1)
+      | Const_max_core -> Const_max a_obj
+      | And_max_id ax1 -> Max_with_simple (ax1, m1)
+      | Disallowed -> Compose (Simple sm0, Max_with_simple (ax1, m1))
+      end
+    | Meet_const_core _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
+    | Meet_const _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
+    | Compose _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
+
+  let compose_simple_with_and_min : type a b c q l.
+      c obj ->
+      (b, c, l * disallowed) Simple_morph.t ->
+      (b, q) Axis.t ->
+      (a, q, l * disallowed) Simple_morph.t ->
+      (a, c, l * disallowed) morph =
+   fun dst sm0 ax1 m1 ->
+    let b_obj = Simple_morph.src dst sm0 in
+    let a_obj = src b_obj (Min_with_simple (ax1, m1)) in
+    match sm0 with
+    | Id -> Min_with_simple (ax1, m1)
+    | Core m0 ->
+      begin match Core_morph.compose_min_with_simple_core ax1 m0 with
+      | And_min_core (ax1, m0) ->
+        let obj0 = proj_obj ax1 dst in
+        Min_with_simple (ax1, Simple_morph.compose obj0 (Core m0) m1)
+      | Const_min_core -> Const_min a_obj
+      | And_min_id ax1 -> Min_with_simple (ax1, m1)
+      | Disallowed -> Compose (Simple sm0, Min_with_simple (ax1, m1))
+      end
+    | Meet_const c0 ->
+      let c0 = Axis.proj ax1 c0 in
+      let obj0 = proj_obj ax1 dst in
+      Min_with_simple (ax1, Simple_morph.compose obj0 (Meet_const c0) m1)
+    | Meet_const_core (c0, m0) ->
+      begin match Core_morph.compose_min_with_simple_core ax1 m0 with
+      | And_min_core (ax1, m0) ->
+        let obj0 = proj_obj ax1 dst in
+        let c0 = Axis.proj ax1 c0 in
+        Min_with_simple
+          (ax1, Simple_morph.compose obj0 (Meet_const_core (c0, m0)) m1)
+      | Const_min_core -> Const_min a_obj
+      | And_min_id ax1 -> Min_with_simple (ax1, m1)
+      | Disallowed -> Compose (Simple sm0, Min_with_simple (ax1, m1))
+      end
+    | Imply_const _ -> Compose (Simple sm0, Min_with_simple (ax1, m1))
+    | Core_imply_const _ -> Compose (Simple sm0, Min_with_simple (ax1, m1))
+    | Compose _ -> Compose (Simple sm0, Min_with_simple (ax1, m1))
+
+  let refute_compose_and_with : type a b c q0 q1 d.
+      c obj ->
+      (c, q0) Axis.t ->
+      (b, q0, d) Simple_morph.t ->
+      (b, q1) Axis.t ->
+      (b, c, d) morph ->
+      (a, b, d) morph ->
+      (a, c, d) morph =
+   fun dst ax0 m0' ax1 m0 m1 ->
+    match ax0, m0', ax1, dst with
+    | _, Core (Locality_restricted _), _, _ -> .
+    | _, Meet_const_core (_, Locality_restricted _), _, _ -> .
+    | _, Core_imply_const (Locality_restricted _, _), _, _ -> .
+    | _, Compose _, _, _ -> Compose (m0, m1)
+    | _, _, _, _ -> .
+  [@@warning "-4"]
+
+  let compose : type a b c d.
+      c obj -> (b, c, d) morph -> (a, b, d) morph -> (a, c, d) morph =
+   fun dst m0 m1 ->
+    match m0, m1 with
+    | Simple m0, Simple m1 -> Simple (Simple_morph.compose dst m0 m1)
+    | Const_max b_obj, _ -> Const_max (src b_obj m1)
+    | Const_min b_obj, _ -> Const_min (src b_obj m1)
+    | Const (b_obj, c), _ -> Const (src b_obj m1, c)
+    | Simple m0, Simple_proj (m1, ax1, obj1) ->
+      Simple_proj (Simple_morph.compose dst m0 m1, ax1, obj1)
+    | Simple_proj (m0, ax0, obj0), Simple m1 ->
+      compose_simple_proj_with_simple dst m0 ax0 obj0 m1
+    | Max_with_simple (ax0, m0), Simple m1 ->
+      let dst = proj_obj ax0 dst in
+      Max_with_simple (ax0, Simple_morph.compose dst m0 m1)
+    | Simple m0, Max_with_simple (ax1, m1) ->
+      compose_simple_with_and_max dst m0 ax1 m1
+    | Min_with_simple (ax0, m0), Simple m1 ->
+      let dst = proj_obj ax0 dst in
+      Min_with_simple (ax0, Simple_morph.compose dst m0 m1)
+    | Simple m0, Min_with_simple (ax1, m1) ->
+      compose_simple_with_and_min dst m0 ax1 m1
+    | Simple_proj (m0, ax0, obj1), Max_with_simple (ax1, m1) ->
+      begin match Axis.equal ax0 ax1 with
+      | Misc.Is_eq -> Simple (Simple_morph.compose dst m0 m1)
+      | Misc.Is_not_eq ->
+        let b_obj = src dst (Simple_proj (m0, ax0, obj1)) in
+        let a_obj = src b_obj (Max_with_simple (ax1, m1)) in
+        Const_max a_obj
+      end
+    | Simple_proj (m0, ax0, obj1), Min_with_simple (ax1, m1) ->
+      begin match Axis.equal ax0 ax1 with
+      | Misc.Is_eq -> Simple (Simple_morph.compose dst m0 m1)
+      | Misc.Is_not_eq ->
+        let b_obj = src dst (Simple_proj (m0, ax0, obj1)) in
+        let a_obj = src b_obj (Min_with_simple (ax1, m1)) in
+        Const_min a_obj
+      end
+    | (Max_with_simple (ax0, m0) as m0'), (Simple_proj (m1, ax1, obj1) as m1')
+      ->
+      let q_obj = proj_obj ax0 dst in
+      let b_obj = src dst (Max_with_simple (ax0, m0)) in
+      let a_obj = src b_obj (Simple_proj (m1, ax1, obj1)) in
+      let m0m1 = Simple_morph.compose q_obj m0 m1 in
+      begin match Simple_morph.maybe_allowed_right m0m1 with
+      | Allowed_right m0m1 ->
+        allow_right (Simple (Simple_morph.lift_max a_obj dst m0m1 ax1 ax0))
+      | Not_allowed_right -> Compose (m0', m1')
+      end
+    | (Min_with_simple (ax0, m0) as m0'), (Simple_proj (m1, ax1, obj1) as m1')
+      ->
+      let q_obj = proj_obj ax0 dst in
+      let b_obj = src dst (Min_with_simple (ax0, m0)) in
+      let a_obj = src b_obj (Simple_proj (m1, ax1, obj1)) in
+      let m0m1 = Simple_morph.compose q_obj m0 m1 in
+      begin match Simple_morph.maybe_allowed_left m0m1 with
+      | Allowed_left m0m1 ->
+        allow_left (Simple (Simple_morph.lift_min a_obj dst m0m1 ax1 ax0))
+      | Not_allowed_left -> Compose (m0', m1')
+      end
+    | Simple m0, Const_max a_obj ->
+      begin match Simple_morph.maybe_allowed_right m0 with
+      | Allowed_right _ -> Const_max a_obj
+      | Not_allowed_right ->
+        let b_obj = Simple_morph.src dst m0 in
+        Const (a_obj, Simple_morph.apply dst m0 (max b_obj))
+      end
+    | Simple m0, Const_min a_obj ->
+      begin match Simple_morph.maybe_allowed_left m0 with
+      | Allowed_left _ -> Const_min a_obj
+      | Not_allowed_left ->
+        let b_obj = Simple_morph.src dst m0 in
+        Const (a_obj, Simple_morph.apply dst m0 (min b_obj))
+      end
+    | Simple_proj (_m0, _ax0, _obj0), Const_max obj1 -> Const_max obj1
+    | Simple_proj (_m0, _ax0, _obj0), Const_min obj1 -> Const_min obj1
+    | Min_with_simple (ax0, m0), Const_max obj1 ->
+      let q_obj = proj_obj ax0 dst in
+      let b_obj = Simple_morph.src q_obj m0 in
+      Const (obj1, min_with dst ax0 (Simple_morph.apply q_obj m0 (max b_obj)))
+    | Min_with_simple (ax0, m0), Const_min obj1 ->
+      begin match Simple_morph.maybe_allowed_left m0 with
+      | Allowed_left _ -> Const_min obj1
+      | Not_allowed_left ->
+        let q_obj = proj_obj ax0 dst in
+        let b_obj = Simple_morph.src q_obj m0 in
+        Const (obj1, min_with dst ax0 (Simple_morph.apply q_obj m0 (min b_obj)))
+      end
+    | Max_with_simple (ax0, m0), Const_max obj1 ->
+      begin match Simple_morph.maybe_allowed_right m0 with
+      | Allowed_right _ -> Const_max obj1
+      | Not_allowed_right ->
+        let q_obj = proj_obj ax0 dst in
+        let b_obj = Simple_morph.src q_obj m0 in
+        Const (obj1, max_with dst ax0 (Simple_morph.apply q_obj m0 (max b_obj)))
+      end
+    | Max_with_simple (ax0, m0), Const_min obj1 ->
+      let q_obj = proj_obj ax0 dst in
+      let b_obj = Simple_morph.src q_obj m0 in
+      Const (obj1, max_with dst ax0 (Simple_morph.apply q_obj m0 (min b_obj)))
+    | (_ as m0), Const (obj1, c1) -> Const (obj1, apply dst m0 c1)
+    | (_ as m0), Compose (m1, m2) -> Compose (Compose (m0, m1), m2)
+    | Compose (m0, m1), (_ as m2) -> Compose (Compose (m0, m1), m2)
+    (* The remaining cases are unreachable by looking at the axes and objects *)
+    | _, Simple_proj (Core (Locality_restricted _), _, _) -> .
+    | _, Simple_proj (Meet_const_core (_, Locality_restricted _), _, _) -> .
+    | _, Simple_proj (Core_imply_const (Locality_restricted _, _), _, _) -> .
+    | _, Simple_proj (Compose _, _, _) -> Compose (m0, m1)
+    | Max_with_simple (ax0, m0'), Max_with_simple (ax1, _) ->
+      refute_compose_and_with dst ax0 m0' ax1 m0 m1
+    | Max_with_simple (ax0, m0'), Min_with_simple (ax1, _) ->
+      refute_compose_and_with dst ax0 m0' ax1 m0 m1
+    | Min_with_simple (ax0, m0'), Max_with_simple (ax1, _) ->
+      refute_compose_and_with dst ax0 m0' ax1 m0 m1
+    | Min_with_simple (ax0, m0'), Min_with_simple (ax1, _) ->
+      refute_compose_and_with dst ax0 m0' ax1 m0 m1
+    | _, _ -> .
+  [@@warning "-4"]
 
   module For_hint = struct
     (** Describes the portion of the input that's responsible for a portion of
         the output of a morphism *)
     type 'a responsible_axis =
-      | NoneResponsible : 'a responsible_axis
+      | None_responsible : 'a responsible_axis
           (** The input is not responsible for the output; instead, the morphism
               is solely responsible for the output. *)
-      | SourceIsSingle : 'a responsible_axis
-          (** The input of the morphism is single axis, and is responsible for
-              the output. *)
+      | All_responsible : 'a responsible_axis
+          (** The input of the morphism is all responsible for the output. *)
       | Axis : ('a, 'a_x) Axis.t -> 'a responsible_axis
           (** The specified axis of the input object is responsible for the
               output. *)
@@ -1897,265 +3596,103 @@ module Lattices_mono = struct
        no axis of [a] being responsible, in which case the morphism is solely
        respoonsible. *)
 
-    (** Given a morphism either from a single axis to a single axis, or from a
-        product object to a single axis, return the portion of the input that's
-        responsible for the output. *)
-    let rec find_responsible_axis_single : type a b l r.
-        (a, b, l * r) morph -> a responsible_axis = function
-      | Proj (_a_obj, ax) -> Axis ax
-      | Compose (g, f) -> (
-        match find_responsible_axis_single g with
-        | NoneResponsible -> NoneResponsible
-        | SourceIsSingle -> find_responsible_axis_single f
-        | Axis c_ax -> find_responsible_axis_prod f c_ax)
-      | Id | Meet_const _ | Imply_const _ -> SourceIsSingle
-      | Max_with _ | Min_with _ | Map_comonadic _ | Monadic_to_comonadic_min
-      | Comonadic_to_monadic_min _ | Monadic_to_comonadic_max
-      | Comonadic_to_monadic_max _ ->
-        assert false
-      | Local_to_regional | Regional_to_local | Locality_as_regionality
-      | Regional_to_global | Global_to_regional ->
-        SourceIsSingle
+    let find_responsible_axis_proj_core : type a b b_ax l r.
+        (a, b, l * r) Core_morph.t -> (b, b_ax) Axis.t -> a responsible_axis =
+     fun m ax ->
+      match m, ax with
+      | Locality_restricted _, _ -> .
+      | Uniqueness_op_to_linearity, _ -> .
+      | Linearity_to_uniqueness_op, _ -> .
+      | Contention_op_to_portability, _ -> .
+      | Portability_to_contention_op, _ -> .
+      | Visibility_op_to_statefulness, _ -> .
+      | Statefulness_to_visibility_op, _ -> .
+      | Locality_full _, (Areality as ax) -> Axis ax
+      | Locality_full _, (Forkable as ax) -> Axis ax
+      | Locality_full _, (Yielding as ax) -> Axis ax
+      | Locality_full _, (Linearity as ax) -> Axis ax
+      | Locality_full _, (Statefulness as ax) -> Axis ax
+      | Locality_full _, (Portability as ax) -> Axis ax
+      | Locality_full _, _ -> .
+      | Monadic_to_comonadic_min, Areality -> None_responsible
+      | Monadic_to_comonadic_min, Forkable -> None_responsible
+      | Monadic_to_comonadic_min, Yielding -> None_responsible
+      | Monadic_to_comonadic_min, Linearity -> Axis Uniqueness
+      | Monadic_to_comonadic_min, Statefulness -> Axis Visibility
+      | Monadic_to_comonadic_min, Portability -> Axis Contention
+      | Comonadic_to_monadic_min _, Uniqueness -> Axis Linearity
+      | Comonadic_to_monadic_min _, Visibility -> Axis Statefulness
+      | Comonadic_to_monadic_min _, Contention -> Axis Portability
+      | Comonadic_to_monadic_min _, Staticity -> None_responsible
+      | Monadic_to_comonadic_max, Areality -> None_responsible
+      | Monadic_to_comonadic_max, Forkable -> None_responsible
+      | Monadic_to_comonadic_max, Yielding -> None_responsible
+      | Monadic_to_comonadic_max, Linearity -> Axis Uniqueness
+      | Monadic_to_comonadic_max, Statefulness -> Axis Visibility
+      | Monadic_to_comonadic_max, Portability -> Axis Contention
+      | Comonadic_to_monadic_max _, Uniqueness -> Axis Linearity
+      | Comonadic_to_monadic_max _, Visibility -> Axis Statefulness
+      | Comonadic_to_monadic_max _, Contention -> Axis Portability
+      | Comonadic_to_monadic_max _, Staticity -> None_responsible
 
-    (** Given a morphism either from a single axis to a product, or from a
-        product to a product, return the portion of the input that's responsible
-        for the specified axis of the output. *)
-    and find_responsible_axis_prod : type a b b_ax l r.
+    let rec find_responsible_axis_proj_simple : type a b b_ax l r.
+        (a, b, l * r) Simple_morph.t -> (b, b_ax) Axis.t -> a responsible_axis =
+     fun m ax ->
+      match m with
+      | Id -> Axis ax
+      | Meet_const _ -> Axis ax
+      | Imply_const _ -> Axis ax
+      | Core m
+      | Meet_const_core (_, (m : (_, _, l * r) Core_morph.t))
+      | Core_imply_const ((m : (_, _, l * r) Core_morph.t), _) ->
+        find_responsible_axis_proj_core m ax
+      | Compose (mb, ma) ->
+        begin match find_responsible_axis_proj_simple mb ax with
+        | None_responsible -> None_responsible
+        | All_responsible -> All_responsible
+        | Axis ax -> find_responsible_axis_proj_simple ma ax
+        end
+
+    (** Given a morphism and an axis, return the portion of the input that's
+        responsible for the specified axis of the output. *)
+    let rec find_responsible_axis_proj : type a b b_ax l r.
         (a, b, l * r) morph -> (b, b_ax) Axis.t -> a responsible_axis =
      fun m ax ->
-      let handle_monadic_to_comonadic (type x y)
-          (ax : (x comonadic_with, y) Axis.t) =
-        (* See [Lattices_mono.monadic_to_comonadic_min] for why these are as they are *)
-        match ax with
-        | Areality -> NoneResponsible
-        | Linearity -> Axis Uniqueness
-        | Portability -> Axis Contention
-        | Forkable -> NoneResponsible
-        | Yielding -> NoneResponsible
-        | Statefulness -> Axis Visibility
-      in
-      let handle_comonadic_to_monadic (type y) (ax : (monadic, y) Axis.t) =
-        (* See [Lattices_mono.comonadic_to_monadic_min] for why these are as they are *)
-        match ax with
-        | Uniqueness -> Axis Linearity
-        | Contention -> Axis Portability
-        | Visibility -> Axis Statefulness
-        | Staticity -> NoneResponsible
-      in
-      match m, ax with
-      | Compose (g, f), ax -> (
-        (* Operates similarly to the equivalent branch in [find_responsible_axis_single] *)
-        match find_responsible_axis_prod g ax with
-        | NoneResponsible -> NoneResponsible
-        | SourceIsSingle -> find_responsible_axis_single f
-        | Axis c_ax -> find_responsible_axis_prod f c_ax)
-      | Id, ax -> Axis ax
-      | Meet_const _, ax -> Axis ax
-      | Imply_const _, ax -> Axis ax
-      | Map_comonadic _, ax -> (
-        (* The [Map_comonadic] morphism applies a morphsim to the areality axis and
-           the result is put back into the areality axis. See [Lattices_mono.apply] *)
-        match ax with
-        | Areality -> Axis Areality
-        | Forkable -> Axis Forkable
-        | Yielding -> Axis Yielding
-        | Linearity -> Axis Linearity
-        | Statefulness -> Axis Statefulness
-        | Portability -> Axis Portability)
-      | Max_with m_ax, ax | Min_with m_ax, ax -> (
-        match Axis.equal m_ax ax with
-        | Is_not_eq -> NoneResponsible
-        | Is_eq -> SourceIsSingle)
-      | Monadic_to_comonadic_min, ax -> handle_monadic_to_comonadic ax
-      | Monadic_to_comonadic_max, ax -> handle_monadic_to_comonadic ax
-      | Comonadic_to_monadic_min _, ax -> handle_comonadic_to_monadic ax
-      | Comonadic_to_monadic_max _, ax -> handle_comonadic_to_monadic ax
-      | Proj _, _
-      | Local_to_regional, _
-      | Regional_to_local, _
-      | Locality_as_regionality, _
-      | Regional_to_global, _
-      | Global_to_regional, _ ->
-        .
+      match m with
+      | Simple m -> find_responsible_axis_proj_simple m ax
+      | Simple_proj (_, ax, _) -> Axis ax
+      | Max_with_simple (m_ax, _) ->
+        begin match Axis.equal m_ax ax with
+        | Misc.Is_not_eq -> None_responsible
+        | Misc.Is_eq -> All_responsible
+        end
+      | Min_with_simple (m_ax, _) ->
+        begin match Axis.equal m_ax ax with
+        | Misc.Is_not_eq -> None_responsible
+        | Misc.Is_eq -> All_responsible
+        end
+      | Const_max _ | Const_min _ | Const _ -> None_responsible
+      | Compose (mb, ma) ->
+        begin match find_responsible_axis_proj mb ax with
+        | None_responsible -> None_responsible
+        | All_responsible -> All_responsible
+        | Axis ax -> find_responsible_axis_proj ma ax
+        end
+
+    (** Given a morphism return the portion of the input that's responsible for
+        all of the output. *)
+    let rec find_responsible_axis_all : type a b l r.
+        (a, b, l * r) morph -> a responsible_axis = function
+      | Simple _ -> All_responsible
+      | Simple_proj (_, ax, _) -> Axis ax
+      | Max_with_simple _ | Min_with_simple _ -> All_responsible
+      | Const_max _ | Const_min _ | Const _ -> None_responsible
+      | Compose (mb, ma) -> (
+        match find_responsible_axis_all mb with
+        | None_responsible -> None_responsible
+        | All_responsible -> find_responsible_axis_all ma
+        | Axis ax -> find_responsible_axis_proj ma ax)
   end
-
-  (** Compose m1 after m2. Returns [Some f] if the composition can be
-      represented by [f] instead of [Compose m1 m2]. [None] otherwise. *)
-  let rec maybe_compose : type a b c l r.
-      c obj ->
-      (b, c, l * r) morph ->
-      (a, b, l * r) morph ->
-      (a, c, l * r) morph option =
-   fun dst m1 m2 ->
-    let is_max c = le dst (max dst) c in
-    let is_mid_max c =
-      let mid = src dst m1 in
-      le mid (max mid) c
-    in
-    match m1, m2 with
-    | Id, m -> Some m
-    | m, Id -> Some m
-    | Meet_const c1, Meet_const c2 -> Some (Meet_const (meet dst c1 c2))
-    | Imply_const c1, Imply_const c2 -> Some (Imply_const (meet dst c1 c2))
-    | Imply_const c1, Meet_const c2 when le dst c1 c2 -> Some (Imply_const c1)
-    | Meet_const c1, m2 when is_max c1 -> Some m2
-    | Imply_const c1, m2 when is_max c1 -> Some m2
-    | m2, Meet_const c1 when is_mid_max c1 -> Some m2
-    | m2, Imply_const c1 when is_mid_max c1 -> Some m2
-    | Compose (f1, f2), g -> (
-      let mid = src dst f1 in
-      match maybe_compose mid f2 g with
-      | Some m -> Some (compose dst f1 m)
-      (* the check needed to prevent infinite loop *)
-      | None -> None)
-    | f, Compose (g1, g2) -> (
-      match maybe_compose dst f g1 with
-      | Some m -> Some (compose dst m g2)
-      | None -> None)
-    | Proj (mid, ax), Meet_const c ->
-      Some (compose dst (Meet_const (Axis.proj ax c)) (Proj (mid, ax)))
-    | Proj (_, ax1), Max_with ax2 -> (
-      match Axis.equal ax1 ax2 with Is_not_eq -> None | Is_eq -> Some Id)
-    | Proj (_, ax1), Min_with ax2 -> (
-      match Axis.equal ax1 ax2 with Is_not_eq -> None | Is_eq -> Some Id)
-    | Proj (mid, ax), Map_comonadic f -> (
-      let src' = src mid m2 in
-      match ax with
-      | Areality -> Some (compose dst f (Proj (src', Areality)))
-      | Linearity -> Some (Proj (src', Linearity))
-      | Portability -> Some (Proj (src', Portability))
-      | Forkable -> Some (Proj (src', Forkable))
-      | Yielding -> Some (Proj (src', Yielding))
-      | Statefulness -> Some (Proj (src', Statefulness)))
-    | Proj _, Monadic_to_comonadic_min -> None
-    | Proj _, Monadic_to_comonadic_max -> None
-    | Proj _, Comonadic_to_monadic_min _ -> None
-    | Proj _, Comonadic_to_monadic_max _ -> None
-    | Map_comonadic f, Map_comonadic g ->
-      let dst0 = proj_obj Areality dst in
-      Some (Map_comonadic (compose dst0 f g))
-    | Regional_to_local, Local_to_regional -> Some Id
-    | Regional_to_local, Global_to_regional ->
-      Some (Imply_const Locality.Global)
-    | Regional_to_local, Locality_as_regionality -> Some Id
-    | Regional_to_local, Meet_const c ->
-      Some (compose dst (Meet_const (regional_to_local c)) Regional_to_local)
-    | Regional_to_global, Meet_const c ->
-      Some (compose dst (Meet_const (regional_to_global c)) Regional_to_global)
-    | Local_to_regional, Meet_const c ->
-      Some (compose dst (Meet_const (local_to_regional c)) Local_to_regional)
-    | Global_to_regional, Meet_const c ->
-      Some (compose dst (Meet_const (global_to_regional c)) Global_to_regional)
-    | Locality_as_regionality, Meet_const c ->
-      Some
-        (compose dst
-           (Meet_const (locality_as_regionality c))
-           Locality_as_regionality)
-    | Map_comonadic f, Meet_const c ->
-      let dst0 = proj_obj Areality dst in
-      let areality = Axis.proj Areality c in
-      Some
-        (compose dst
-           (Meet_const (set_areality (max dst0) c))
-           (Map_comonadic (compose dst0 f (Meet_const areality))))
-    | Map_comonadic f, Imply_const c ->
-      let dst0 = proj_obj Areality dst in
-      let areality = Axis.proj Areality c in
-      Some
-        (compose dst
-           (Imply_const (set_areality (max dst0) c))
-           (Map_comonadic (compose dst0 f (Imply_const areality))))
-    | Regional_to_global, Locality_as_regionality -> Some Id
-    | Regional_to_global, Local_to_regional -> Some (Meet_const Locality.Global)
-    | Local_to_regional, Regional_to_local -> None
-    | Local_to_regional, Regional_to_global -> None
-    | Locality_as_regionality, Regional_to_local -> None
-    | Locality_as_regionality, Regional_to_global -> None
-    | Global_to_regional, Regional_to_local -> None
-    | Regional_to_global, Global_to_regional -> Some Id
-    | Global_to_regional, Regional_to_global -> None
-    | Min_with _, _ -> None
-    | Max_with _, _ -> None
-    | _, Meet_const _ -> None
-    | Meet_const _, _ -> None
-    | _, Imply_const _ -> None
-    | Imply_const _, _ -> None
-    | _, Proj _ -> None
-    | Map_comonadic _, _ -> None
-    | Monadic_to_comonadic_min, _ -> None
-    | Monadic_to_comonadic_max, _ -> None
-    | Comonadic_to_monadic_min _, _ -> None
-    | Comonadic_to_monadic_max _, _ -> None
-    | ( Proj _,
-        ( Local_to_regional | Regional_to_local | Locality_as_regionality
-        | Regional_to_global | Global_to_regional ) ) ->
-      .
-    | ( ( Local_to_regional | Regional_to_local | Locality_as_regionality
-        | Regional_to_global | Global_to_regional ),
-        Min_with _ ) ->
-      .
-    | ( ( Local_to_regional | Regional_to_local | Locality_as_regionality
-        | Regional_to_global | Global_to_regional ),
-        Max_with _ ) ->
-      .
-
-  and compose : type a b c l r.
-      c obj -> (b, c, l * r) morph -> (a, b, l * r) morph -> (a, c, l * r) morph
-      =
-   fun dst f g ->
-    match maybe_compose dst f g with Some m -> m | None -> Compose (f, g)
-
-  let rec left_adjoint : type a b l.
-      b obj -> (a, b, l * allowed) morph -> (b, a, allowed * disallowed) morph =
-   fun dst f ->
-    match f with
-    | Id -> Id
-    | Proj (_, ax) -> Min_with ax
-    | Max_with ax -> Proj (dst, ax)
-    | Compose (f, g) ->
-      let mid = src dst f in
-      let f' = left_adjoint dst f in
-      let g' = left_adjoint mid g in
-      Compose (g', f')
-    | Meet_const _c ->
-      (* The downward closure of [Meet_const c]'s image is all [x <= c].
-         For those, [x <= meet c y] is equivalent to [x <= y]. *)
-      Id
-    | Imply_const c -> Meet_const c
-    | Comonadic_to_monadic_max _ -> Monadic_to_comonadic_min
-    | Monadic_to_comonadic_max -> Comonadic_to_monadic_min dst
-    | Global_to_regional -> Regional_to_global
-    | Regional_to_global -> Locality_as_regionality
-    | Locality_as_regionality -> Regional_to_local
-    | Regional_to_local -> Local_to_regional
-    | Map_comonadic f ->
-      let dst0 = proj_obj Areality dst in
-      let f' = left_adjoint dst0 f in
-      Map_comonadic f'
-
-  and right_adjoint : type a b r.
-      b obj -> (a, b, allowed * r) morph -> (b, a, disallowed * allowed) morph =
-   fun dst f ->
-    match f with
-    | Id -> Id
-    | Proj (_, ax) -> Max_with ax
-    | Min_with ax -> Proj (dst, ax)
-    | Compose (f, g) ->
-      let mid = src dst f in
-      let f' = right_adjoint dst f in
-      let g' = right_adjoint mid g in
-      Compose (g', f')
-    | Meet_const c -> Imply_const c
-    | Comonadic_to_monadic_min _ -> Monadic_to_comonadic_max
-    | Monadic_to_comonadic_min -> Comonadic_to_monadic_max dst
-    | Local_to_regional -> Regional_to_local
-    | Regional_to_local -> Locality_as_regionality
-    | Locality_as_regionality -> Regional_to_global
-    | Regional_to_global -> Global_to_regional
-    | Map_comonadic f ->
-      let dst0 = proj_obj Areality dst in
-      let f' = right_adjoint dst0 f in
-      Map_comonadic f'
 end
 
 module C = Lattices_mono
@@ -2276,24 +3813,24 @@ module Report = struct
      fun obj side a morph_hint morph ~other ahint res ->
       let src = C.src obj morph in
       match res with
-      | NoneResponsible -> a, Irrelevant
-      | SourceIsSingle ->
+      | None_responsible -> a, Irrelevant
+      | All_responsible ->
         let morph' = adjoint obj side morph in
         let other = C.apply src morph' other in
-        let ahint = hint_axis src side ~other ahint in
+        let ahint = hint_all src side ~other ahint in
         let ma = C.apply obj morph (fst ahint) in
         ma, Apply (morph_hint, src, ahint)
       | Axis ax ->
         let b, hint = ahint in
         let morph' = adjoint obj side morph in
         let other = C.apply src morph' other in
-        let x, hint = hint_prod src side ax ~other (b, hint) in
+        let x, hint = hint_proj src side ax ~other (b, hint) in
         let b = C.Axis.set ax x b in
         let a = C.apply obj morph b in
         let src = C.proj_obj ax src in
         a, Apply (morph_hint, src, (x, hint))
 
-    and hint_prod : type t a l r.
+    and hint_proj : type t a l r.
         t C.obj ->
         (l * r) side ->
         (t, a) Axis.t ->
@@ -2305,7 +3842,7 @@ module Report = struct
       | Apply (morph_hint, morph, ahint) ->
         let t, hint =
           hint_apply obj side a morph_hint morph ~other ahint
-            (C.For_hint.find_responsible_axis_prod morph ax)
+            (C.For_hint.find_responsible_axis_proj morph ax)
         in
         Axis.proj ax t, hint
       | Const c -> Axis.proj ax a, Const c
@@ -2319,11 +3856,11 @@ module Report = struct
           | `First -> a1, hint1
           | `Second -> a2, hint2
         in
-        hint_prod obj side ax ~other chosen_ahint
+        hint_proj obj side ax ~other chosen_ahint
 
     (** Given a solver hint on a single axis lattice, returns a human-readible
         hint. *)
-    and hint_axis : type a l r.
+    and hint_all : type a l r.
         a C.obj ->
         (l * r) side ->
         other:a ->
@@ -2333,7 +3870,7 @@ module Report = struct
       match hint with
       | Apply (morph_hint, morph, ahint) ->
         hint_apply obj side a morph_hint morph ~other ahint
-          (C.For_hint.find_responsible_axis_single morph)
+          (C.For_hint.find_responsible_axis_all morph)
       | Const c -> a, Const c
       | Branch (b, (a1, hint1), (a2, hint2)) ->
         let chosen_ahint =
@@ -2341,9 +3878,9 @@ module Report = struct
           | `First -> a1, hint1
           | `Second -> a2, hint2
         in
-        hint_axis obj side ~other chosen_ahint
+        hint_all obj side ~other chosen_ahint
 
-    let hint_prod_loosening : type t a l r.
+    let hint_proj_loosening : type t a l r.
         t C.obj ->
         (l * r) side ->
         (t, a) Axis.t ->
@@ -2352,7 +3889,7 @@ module Report = struct
         loosening * (a, l * r) ahint =
      fun obj side ax ~other ((t, _) as ahint) ->
       let axis_obj = C.proj_obj ax obj in
-      let a, hint = hint_prod obj side ax ~other ahint in
+      let a, hint = hint_proj obj side ax ~other ahint in
       let loosening =
         if Misc.Le_result.equal ~le:(C.le axis_obj) a (Axis.proj ax t)
         then Not_loosened
@@ -2360,14 +3897,14 @@ module Report = struct
       in
       loosening, (a, hint)
 
-    let hint_axis_loosening : type a l r.
+    let hint_all_loosening : type a l r.
         a C.obj ->
         (l * r) side ->
         other:a ->
         (a, l * r) S.ahint ->
         loosening * (a, l * r) ahint =
      fun obj side ~other ((original, _) as ahint) ->
-      let a, hint = hint_axis obj side ~other ahint in
+      let a, hint = hint_all obj side ~other ahint in
       let loosening =
         if Misc.Le_result.equal ~le:(C.le obj) a original
         then Not_loosened
@@ -2375,20 +3912,20 @@ module Report = struct
       in
       loosening, (a, hint)
 
-    let error_prod : type r a. r C.obj -> (r, a) Axis.t -> r S.error -> a t =
+    let error_proj : type r a. r C.obj -> (r, a) Axis.t -> r S.error -> a t =
      fun obj axis { left; right } ->
-      let left = hint_prod_loosening obj Left axis ~other:(fst right) left in
+      let left = hint_proj_loosening obj Left axis ~other:(fst right) left in
       let right =
-        hint_prod_loosening obj Right axis
+        hint_proj_loosening obj Right axis
           ~other:(Axis.set axis (fst (snd left)) (fst right))
           right
       in
       { left; right }
 
-    let error_axis : type a. a C.obj -> a S.error -> a t =
+    let error_all : type a. a C.obj -> a S.error -> a t =
      fun obj { left; right } ->
-      let left = hint_axis_loosening obj Left ~other:(fst right) left in
-      let right = hint_axis_loosening obj Right ~other:(fst (snd left)) right in
+      let left = hint_all_loosening obj Left ~other:(fst right) left in
+      let right = hint_all_loosening obj Right ~other:(fst (snd left)) right in
       { left; right }
   end
 
@@ -2501,6 +4038,34 @@ module Report = struct
       (Location.Doc.loc ~capitalize_first:false)
       loc
 
+  let print_containing maybe_modality { containing; container } =
+    let container = fst container in
+    match containing with
+    | Tuple ->
+      Fmt.dprintf "is an element of the tuple at %a"
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+    | Record (s, moda) ->
+      Fmt.dprintf "is the field %a%a of the record at %a" Misc.Style.inline_code
+        s maybe_modality moda
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+    | Array moda ->
+      Fmt.dprintf "is an element%a of the array at %a" maybe_modality moda
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+    | Constructor (s, moda) ->
+      Fmt.dprintf "is contained (via constructor %a)%a in the value at %a"
+        Misc.Style.inline_code s maybe_modality moda
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+    | Structure (x, moda) ->
+      Fmt.dprintf "is %t%a in the structure at %a"
+        (print_structure_item ~capitalize:false x)
+        maybe_modality moda
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+
   (** Given a pinpoint and a const, where the pinpoint has been expressed,
       prints the const to explain the mode on the pinpoint. *)
   let print_const (type l r) ((_, pp_desc) : pinpoint) ppf :
@@ -2569,6 +4134,9 @@ module Report = struct
       Fmt.pp_print_string ppf
         "it is layout-polymorphic and being instantiated here"
     | Spliced _ -> Fmt.fprintf ppf "it is spliced"
+    | Contained_by c ->
+      let print_mod ppf Modality = Fmt.fprintf ppf " (with some modality)" in
+      Fmt.fprintf ppf "it %t" (print_containing print_mod c)
 
   let print_allocation_l : allocation -> Fmt.formatter -> unit =
    fun { txt; loc } ->
@@ -2803,7 +4371,16 @@ module Report = struct
    fun a_obj b_obj a b ->
     match C.equal_obj a_obj b_obj with
     | Misc.Is_eq -> Misc.Le_result.equal ~le:(C.le a_obj) a b
-    | Misc.Is_not_eq -> false
+    | Misc.Is_not_eq -> (
+      match a_obj, b_obj with
+      | Locality, Regionality ->
+        Misc.Le_result.equal ~le:(C.le b_obj)
+          (C.Locality_morph.apply Locality_as_regionality a)
+          b
+      | Regionality, Locality ->
+        Misc.Le_result.equal ~le:(C.le a_obj) a
+          (C.Locality_morph.apply Locality_as_regionality b)
+      | _, _ -> false)
 
   let rec print_ahint : type a l r.
       ?sub:bool ->
@@ -2909,27 +4486,27 @@ module Error = struct
   type 'a t = 'a S.error_raw
 
   type packed =
-    | Product : 'r C.obj * ('r, 'a) Axis.t * 'r t -> packed
-    | Axis : 'a C.obj * 'a t -> packed
+    | Proj : 'r C.obj * ('r, 'a) Axis.t * 'r t -> packed
+    | All : 'a C.obj * 'a t -> packed
 
-  let print_product : type r a.
+  let print_proj : type r a.
       Hint.pinpoint -> r C.obj -> (r, a) Axis.t -> r t -> print_error =
    fun pp obj ax err ->
     let err = S.populate_error obj err in
-    let err = Report.Of_solver.error_prod obj ax err in
+    let err = Report.Of_solver.error_proj obj ax err in
     let obj = C.proj_obj ax obj in
     Report.print pp obj err
 
-  let print_axis : type a. Hint.pinpoint -> a C.obj -> a t -> print_error =
+  let print_all : type a. Hint.pinpoint -> a C.obj -> a t -> print_error =
    fun pp obj err ->
     let err = S.populate_error obj err in
-    let err = Report.Of_solver.error_axis obj err in
+    let err = Report.Of_solver.error_all obj err in
     Report.print pp obj err
 
   let print_packed : Hint.pinpoint -> packed -> print_error =
    fun pp -> function
-    | Product (obj, ax, err) -> print_product pp obj ax err
-    | Axis (obj, err) -> print_axis pp obj err
+    | Proj (obj, ax, err) -> print_proj pp obj ax err
+    | All (obj, err) -> print_all pp obj err
 
   let print_packed_simple_context : Hint.pinpoint -> packed -> Location.error =
    fun pp packed ->
@@ -3039,7 +4616,7 @@ let equate_from_submode' submode m1 m2 =
 module Comonadic_gen (Obj : Obj) = struct
   open Obj
 
-  type 'd t = (const, 'l * 'r) S.mode constraint 'd = 'l * 'r
+  type 'd t = (const, 'd) S.mode
 
   type l = (allowed * disallowed) t
 
@@ -3065,9 +4642,9 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let newvar () = S.newvar obj
 
-  let min = S.min obj
+  let min : lr = S.min obj
 
-  let max = S.max obj
+  let max : lr = S.max obj
 
   let newvar_above m = S.newvar_above obj m
 
@@ -3084,9 +4661,9 @@ module Comonadic_gen (Obj : Obj) = struct
   let submode_err pp a b =
     match submode ~pp a b with
     | Ok () -> ()
-    | Error e -> raise (Submode_error_simple_context (pp, Axis (obj, e)))
+    | Error e -> raise (Submode_error_simple_context (pp, All (obj, e)))
 
-  let print_error pp err = Error.print_axis pp obj err
+  let print_error pp err = Error.print_all pp obj err
 
   let join l = S.join obj l
 
@@ -3117,11 +4694,11 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let apply_hint hint m = wrap ~hint Fun.id m
 
-  let meet_const_unhint c m = S.Unhint.apply obj (Meet_const c) m
+  let meet_const_unhint c m = S.Unhint.apply obj (Simple (Meet_const c)) m
 
-  let meet_const ?hint c m = wrap ?hint (meet_const_unhint c) m
+  let meet_const ?hint c m = wrap ?hint (meet_const_unhint c) (disallow_right m)
 
-  let imply_const_unhint c m = S.Unhint.apply obj (Imply_const c) m
+  let imply_const_unhint c m = S.Unhint.apply obj (Simple (Imply_const c)) m
 
   let imply_const c m = m |> disallow_left |> wrap (imply_const_unhint c)
 
@@ -3167,9 +4744,9 @@ module Monadic_gen (Obj : Obj) = struct
 
   let newvar () = S.newvar obj
 
-  let min = S.max obj
+  let min : lr = S.allow_left (S.max obj)
 
-  let max = S.min obj
+  let max : lr = S.allow_right (S.min obj)
 
   let newvar_above m = S.newvar_below obj m
 
@@ -3186,9 +4763,9 @@ module Monadic_gen (Obj : Obj) = struct
   let submode_err pp a b =
     match submode ~pp a b with
     | Ok () -> ()
-    | Error e -> raise (Submode_error_simple_context (pp, Axis (obj, e)))
+    | Error e -> raise (Submode_error_simple_context (pp, All (obj, e)))
 
-  let print_error pp err = Error.print_axis pp obj err
+  let print_error pp err = Error.print_all pp obj err
 
   let join l = S.meet obj l
 
@@ -3219,11 +4796,11 @@ module Monadic_gen (Obj : Obj) = struct
 
   let apply_hint hint m = wrap ~hint Fun.id m
 
-  let join_const_unhint c m = S.Unhint.apply Obj.obj (Meet_const c) m
+  let join_const_unhint c m = S.Unhint.apply Obj.obj (Simple (Meet_const c)) m
 
-  let join_const ?hint c m = wrap ?hint (join_const_unhint c) m
+  let join_const ?hint c m = wrap ?hint (join_const_unhint c) (disallow_left m)
 
-  let subtract_const_unhint c m = S.Unhint.apply obj (Imply_const c) m
+  let subtract_const_unhint c m = S.Unhint.apply obj (Simple (Imply_const c)) m
 
   let subtract_const c m = m |> disallow_right |> wrap (subtract_const_unhint c)
 
@@ -3485,13 +5062,6 @@ module Staticity = struct
   let zap_to_legacy = zap_to_ceil
 end
 
-let regional_to_local m = S.apply Locality.Obj.obj C.Regional_to_local m
-
-let locality_as_regionality m =
-  S.apply Regionality.Obj.obj C.Locality_as_regionality m
-
-let regional_to_global m = S.apply Locality.Obj.obj C.Regional_to_global m
-
 module type Areality = sig
   module Const : C.Areality
 
@@ -3591,7 +5161,8 @@ module Comonadic_with (Areality : Areality) = struct
     end
   end
 
-  let proj ax m = S.apply ~hint:Skip (proj_obj ax) (Proj (Obj.obj, ax)) m
+  let proj ax m =
+    S.apply ~hint:Skip (proj_obj ax) (Simple_proj (Id, ax, Obj.obj)) m
 
   module Per_axis = struct
     let zap_to_floor ax m =
@@ -3604,12 +5175,12 @@ module Comonadic_with (Areality : Areality) = struct
   end
 
   let min_with ax m =
-    S.apply ~hint:Skip Obj.obj (Min_with ax) (S.disallow_right m)
+    S.apply ~hint:Skip Obj.obj (Min_with_simple (ax, Id)) (disallow_right m)
 
   let max_with ax m =
-    S.apply ~hint:Skip Obj.obj (Max_with ax) (S.disallow_left m)
+    S.apply ~hint:Skip Obj.obj (Max_with_simple (ax, Id)) (disallow_left m)
 
-  let meet_const_with ax c m = meet_const (Const.max_with ax c) m
+  let meet_const_with ax c m = meet_const (C.max_with Obj.obj ax c) m
 
   let zap_to_legacy m : Const.t =
     let areality = proj Areality m |> Areality.zap_to_legacy in
@@ -3618,7 +5189,7 @@ module Comonadic_with (Areality : Areality) = struct
     let portability =
       proj Portability m |> Portability.zap_to_legacy ~statefulness
     in
-    let global = Areality.Const.(equal areality legacy) in
+    let global = Areality.Const.equal areality Areality.Const.legacy in
     let forkable = proj Forkable m |> Forkable.zap_to_legacy ~global in
     let yielding = proj Yielding m |> Yielding.zap_to_legacy ~global in
     { areality; linearity; portability; forkable; yielding; statefulness }
@@ -3647,11 +5218,11 @@ module Comonadic_with (Areality : Areality) = struct
     | Ok () -> ()
     | Error e ->
       let (Error (ax, _)) = to_simple_error e in
-      raise (Submode_error_simple_context (pp, Product (Obj.obj, ax, e)))
+      raise (Submode_error_simple_context (pp, Proj (Obj.obj, ax, e)))
 
   let print_error pp err =
     let (Error (ax, _)) = to_simple_error err in
-    Error.print_product pp Obj.obj ax err
+    Error.print_proj pp Obj.obj ax err
 end
 [@@inline]
 
@@ -3736,7 +5307,8 @@ module Monadic = struct
     end
   end
 
-  let proj ax m = S.apply ~hint:Skip (proj_obj ax) (Proj (Obj.obj, ax)) m
+  let proj ax m =
+    S.apply ~hint:Skip (proj_obj ax) (Simple_proj (Id, ax, Obj.obj)) m
 
   module Per_axis = struct
     let zap_to_floor ax m =
@@ -3750,10 +5322,10 @@ module Monadic = struct
 
   (* The monadic fragment is inverted. *)
 
-  let join_const_with ax c m = join_const (Const.min_with ax c) m
+  let join_const_with ax c m = join_const (C.min_with Obj.obj ax c) m
 
   let min_with ax m =
-    S.apply ~hint:Skip Obj.obj (Max_with ax) (S.disallow_left m)
+    S.apply ~hint:Skip Obj.obj (Max_with_simple (ax, Id)) (S.disallow_left m)
 
   let zap_to_legacy m : Const.t =
     let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy in
@@ -3789,11 +5361,11 @@ module Monadic = struct
     | Ok () -> ()
     | Error e ->
       let (Error (ax, _)) = to_simple_error e in
-      raise (Submode_error_simple_context (pp, Product (Obj.obj, ax, e)))
+      raise (Submode_error_simple_context (pp, Proj (Obj.obj, ax, e)))
 
   let print_error pp err =
     let (Error (ax, _)) = to_simple_error err in
-    Error.print_product pp Obj.obj ax err
+    Error.print_proj pp Obj.obj ax err
 end
 
 type ('mo, 'como) monadic_comonadic =
@@ -3933,11 +5505,6 @@ module Value_with (Areality : Areality) = struct
     t |> unhint |> f |> hint ?monadic ?comonadic
 
   module Const = struct
-    let comonadic_to_monadic_min = C.comonadic_to_monadic_min Comonadic.Obj.obj
-
-    module Monadic = Monadic.Const
-    module Comonadic = Comonadic.Const
-
     (* CR-soon zqian: make a functor [Mode.Value.Const.Make] to generalize over any type
        operator applied on each mode constants. *)
     type t =
@@ -3953,40 +5520,45 @@ module Value_with (Areality : Areality) = struct
         Staticity.Const.t )
       modes
 
-    let min = merge { comonadic = Comonadic.min; monadic = Monadic.min }
+    let min =
+      merge { comonadic = Comonadic.Const.min; monadic = Monadic.Const.min }
 
-    let max = merge { comonadic = Comonadic.max; monadic = Monadic.max }
+    let max =
+      merge { comonadic = Comonadic.Const.max; monadic = Monadic.Const.max }
 
     let le m1 m2 =
       let m1 = split m1 in
       let m2 = split m2 in
-      Comonadic.le m1.comonadic m2.comonadic && Monadic.le m1.monadic m2.monadic
+      Comonadic.Const.le m1.comonadic m2.comonadic
+      && Monadic.Const.le m1.monadic m2.monadic
 
     let equal m1 m2 =
       let m1 = split m1 in
       let m2 = split m2 in
-      Comonadic.equal m1.comonadic m2.comonadic
-      && Monadic.equal m1.monadic m2.monadic
+      Comonadic.Const.equal m1.comonadic m2.comonadic
+      && Monadic.Const.equal m1.monadic m2.monadic
 
     let print ppf m =
       let { monadic; comonadic } = split m in
-      Fmt.fprintf ppf "%a,%a" Comonadic.print comonadic Monadic.print monadic
+      Fmt.fprintf ppf "%a,%a" Comonadic.Const.print comonadic
+        Monadic.Const.print monadic
 
     let legacy =
-      merge { comonadic = Comonadic.legacy; monadic = Monadic.legacy }
+      merge
+        { comonadic = Comonadic.Const.legacy; monadic = Monadic.Const.legacy }
 
     let meet m1 m2 =
       let m1 = split m1 in
       let m2 = split m2 in
-      let monadic = Monadic.meet m1.monadic m2.monadic in
-      let comonadic = Comonadic.meet m1.comonadic m2.comonadic in
+      let monadic = Monadic.Const.meet m1.monadic m2.monadic in
+      let comonadic = Comonadic.Const.meet m1.comonadic m2.comonadic in
       merge { monadic; comonadic }
 
     let join m1 m2 =
       let m1 = split m1 in
       let m2 = split m2 in
-      let monadic = Monadic.join m1.monadic m2.monadic in
-      let comonadic = Comonadic.join m1.comonadic m2.comonadic in
+      let monadic = Monadic.Const.join m1.monadic m2.monadic in
+      let comonadic = Comonadic.Const.join m1.comonadic m2.comonadic in
       merge { monadic; comonadic }
 
     module Option = struct
@@ -4152,13 +5724,17 @@ module Value_with (Areality : Areality) = struct
         staticity
       }
 
+    let comonadic_to_monadic_min =
+      C.Core_morph.comonadic_to_monadic_min Areality.Const.areality
+
+    let monadic_to_comonadic_min =
+      C.Core_morph.monadic_to_comonadic_min
+        (C.comonadic_with_obj Areality.Obj.obj)
+
     (** See [Alloc.close_over] for explanation. *)
     let close_over m =
       let { monadic; comonadic } = split m in
-      Comonadic.join comonadic
-        (C.monadic_to_comonadic_min
-           (C.comonadic_with_obj Areality.Obj.obj)
-           monadic)
+      Comonadic.Const.join comonadic (monadic_to_comonadic_min monadic)
 
     (** See [Alloc.partial_apply] for explanation. *)
     let partial_apply m =
@@ -4173,16 +5749,16 @@ module Value_with (Areality : Areality) = struct
     let le_axis : type a. a Axis.t -> a -> a -> bool =
      fun ax m1 m2 ->
       match ax with
-      | Comonadic ax -> Comonadic.Per_axis.le ax m1 m2
-      | Monadic ax -> Monadic.Per_axis.le ax m1 m2
+      | Comonadic ax -> Comonadic.Const.Per_axis.le ax m1 m2
+      | Monadic ax -> Monadic.Const.Per_axis.le ax m1 m2
 
     let min_axis : type a. a Axis.t -> a = function
-      | Comonadic ax -> Comonadic.Per_axis.min ax
-      | Monadic ax -> Monadic.Per_axis.min ax
+      | Comonadic ax -> Comonadic.Const.Per_axis.min ax
+      | Monadic ax -> Monadic.Const.Per_axis.min ax
 
     let max_axis : type a. a Axis.t -> a = function
-      | Comonadic ax -> Comonadic.Per_axis.max ax
-      | Monadic ax -> Monadic.Per_axis.max ax
+      | Comonadic ax -> Comonadic.Const.Per_axis.max ax
+      | Monadic ax -> Monadic.Const.Per_axis.max ax
 
     let is_max : type a. a Axis.t -> a -> bool =
      fun ax m -> le_axis ax (max_axis ax) m
@@ -4200,7 +5776,7 @@ module Value_with (Areality : Areality) = struct
   let max = { comonadic = Comonadic.max; monadic = Monadic.max }
 
   include Magic_allow_disallow (struct
-    type (_, _, 'd) sided = 'd t constraint 'd = 'l * 'r
+    type (_, _, 'd) sided = 'd t
 
     let allow_left { monadic; comonadic } =
       let monadic = Monadic.allow_left monadic in
@@ -4316,9 +5892,11 @@ module Value_with (Areality : Areality) = struct
 
   let join_const_with ax c { monadic; comonadic } =
     let monadic = Monadic.join_const_with ax c monadic in
+    let comonadic = Comonadic.disallow_left comonadic in
     { monadic; comonadic }
 
   let meet_const_with ax c { monadic; comonadic } =
+    let monadic = Monadic.disallow_right monadic in
     let comonadic = Comonadic.meet_const_with ax c comonadic in
     { comonadic; monadic }
 
@@ -4345,22 +5923,26 @@ module Value_with (Areality : Areality) = struct
     { comonadic; monadic }
 
   let comonadic_to_monadic_min ?hint m =
-    S.apply ?hint Monadic.Obj.obj (Comonadic_to_monadic_max Comonadic.Obj.obj)
+    S.apply ?hint Monadic.Obj.obj
+      (Simple (Core (Comonadic_to_monadic_max Areality.Const.areality)))
       (Comonadic.disallow_left m)
 
   let monadic_to_comonadic_min m =
-    S.apply Comonadic.Obj.obj Monadic_to_comonadic_min (Monadic.disallow_left m)
+    S.apply Comonadic.Obj.obj (Simple (Core Monadic_to_comonadic_min))
+      (Monadic.disallow_left m)
 
   let monadic_to_comonadic_max m =
-    S.apply Comonadic.Obj.obj Monadic_to_comonadic_max
+    S.apply Comonadic.Obj.obj (Simple (Core Monadic_to_comonadic_max))
       (Monadic.disallow_right m)
 
   let meet_const c { comonadic; monadic } =
+    let monadic = Monadic.disallow_right monadic in
     let comonadic = Comonadic.meet_const c comonadic in
     { monadic; comonadic }
 
   let join_const c { comonadic; monadic } =
     let monadic = Monadic.join_const c monadic in
+    let comonadic = Comonadic.disallow_left comonadic in
     { monadic; comonadic }
 
   let zap_to_ceil { comonadic; monadic } =
@@ -4384,9 +5966,9 @@ module Value_with (Areality : Areality) = struct
   let close_over { comonadic; monadic } =
     let comonadic = Comonadic.disallow_right comonadic in
     (* The comonadic of the returned function is constrained by the monadic of the closed argument via the dualizing morphism. *)
-    let comonadic1 = monadic_to_comonadic_min monadic in
+    let comonadic_dual = monadic_to_comonadic_min monadic in
     (* It's also constrained by the comonadic of the closed argument. *)
-    let comonadic = Comonadic.join [comonadic; comonadic1] in
+    let comonadic = Comonadic.join [comonadic; comonadic_dual] in
     (* The closure will access [A] at the specified monadic modes, and thus the
        monadic mode of the closure itself is not constrained by it. *)
     let monadic = Monadic.disallow_right Monadic.min in
@@ -4406,7 +5988,7 @@ module Value_with (Areality : Areality) = struct
     type nonrec 'd t = 'd t list
 
     include Magic_allow_disallow (struct
-      type (_, _, 'd) sided = 'd t constraint 'd = 'l * 'r
+      type (_, _, 'd) sided = 'd t
 
       let allow_left l = List.map allow_left l
 
@@ -4424,6 +6006,8 @@ module Value = Value_with (Regionality)
 module Alloc = Value_with (Locality)
 
 module Const = struct
+  let locality_as_regionality = C.Locality_morph.apply Locality_as_regionality
+
   let alloc_as_value
       ({ areality;
          linearity;
@@ -4437,7 +6021,7 @@ module Const = struct
          staticity
        } :
         Alloc.Const.t) : Value.Const.t =
-    let areality = C.locality_as_regionality areality in
+    let areality = locality_as_regionality areality in
     { areality;
       linearity;
       portability;
@@ -4471,34 +6055,43 @@ module Const = struct
       | Left Refl -> P (Comonadic Areality)
       | Right ax -> P ax
   end
-
-  let locality_as_regionality = C.locality_as_regionality
 end
 
 (* CR-someday zqian: all the function that converts between [Alloc] and [Value] should
    operate on [Unhint] so they can be composed and assigned hint as a whole. *)
 
 let comonadic_locality_as_regionality comonadic =
-  S.Unhint.apply Value.Comonadic.Obj.obj (Map_comonadic Locality_as_regionality)
-    comonadic
+  S.Unhint.apply Value.Comonadic.Obj.obj
+    (Simple (Core (Locality_full Locality_as_regionality))) comonadic
 
 let comonadic_regional_to_local comonadic =
-  S.Unhint.apply Alloc.Comonadic.Obj.obj (Map_comonadic Regional_to_local)
-    comonadic
+  S.Unhint.apply Alloc.Comonadic.Obj.obj
+    (Simple (Core (Locality_full Regional_to_local))) comonadic
+
+let locality_as_regionality_unhint l =
+  S.Unhint.apply C.Regionality
+    (Simple (Core (Locality_restricted Locality_as_regionality))) l
+
+let locality_as_regionality m =
+  m |> Locality.unhint |> locality_as_regionality_unhint |> Regionality.hint
 
 let alloc_as_value_unhint m =
   let { comonadic; monadic } = m in
-  let comonadic = comonadic_locality_as_regionality comonadic in
+  let comonadic =
+    S.Unhint.apply Value.Comonadic.Obj.obj
+      (Simple (Core (Locality_full Locality_as_regionality))) comonadic
+  in
   { comonadic; monadic }
 
-let alloc_as_value m =
-  m |> Alloc.unhint |> alloc_as_value_unhint |> Value.hint ~monadic:Skip
+let alloc_as_value ?hint m =
+  m |> Alloc.unhint |> alloc_as_value_unhint
+  |> Value.hint ~monadic:Skip ?comonadic:hint
 
 let alloc_to_value_l2r_unhint m =
   let { comonadic; monadic } = m in
   let comonadic =
-    S.Unhint.apply Value.Comonadic.Obj.obj (Map_comonadic Local_to_regional)
-      comonadic
+    S.Unhint.apply Value.Comonadic.Obj.obj
+      (Simple (Core (Locality_full Local_to_regional))) comonadic
   in
   { comonadic; monadic }
 
@@ -4509,26 +6102,31 @@ let alloc_to_value_l2r m =
 let value_to_alloc_r2g_unhint m =
   let { comonadic; monadic } = m in
   let comonadic =
-    S.Unhint.apply Alloc.Comonadic.Obj.obj (Map_comonadic Regional_to_global)
-      comonadic
+    S.Unhint.apply Alloc.Comonadic.Obj.obj
+      (Simple (Core (Locality_full Regional_to_global))) comonadic
   in
   { comonadic; monadic }
 
-let value_to_alloc_r2g m =
-  m |> Value.unhint |> value_to_alloc_r2g_unhint |> Alloc.hint ~monadic:Skip
+let value_to_alloc_r2g ?hint m =
+  m |> Value.disallow_left |> Value.unhint |> value_to_alloc_r2g_unhint
+  |> Alloc.hint ~monadic:Skip ?comonadic:hint
 
 let value_r2g ?hint m =
   Value.wrap ~monadic:Skip ?comonadic:hint
     (fun m -> m |> value_to_alloc_r2g_unhint |> alloc_as_value_unhint)
-    m
+    (Value.disallow_left m)
 
 let value_to_alloc_r2l_unhint m =
   let { comonadic; monadic } = m in
-  let comonadic = comonadic_regional_to_local comonadic in
+  let comonadic =
+    S.Unhint.apply Alloc.Comonadic.Obj.obj
+      (Simple (Core (Locality_full Regional_to_local))) comonadic
+  in
   { comonadic; monadic }
 
-let value_to_alloc_r2l m =
-  m |> Value.unhint |> value_to_alloc_r2l_unhint |> Alloc.hint ~monadic:Skip
+let value_to_alloc_r2l ?hint m =
+  m |> Value.unhint |> value_to_alloc_r2l_unhint
+  |> Alloc.hint ~monadic:Skip ?comonadic:hint
 
 module Modality = struct
   (* Inferred modalities
@@ -4625,11 +6223,41 @@ module Modality = struct
         match then_, t with
         | Join_const c1, Join_const c2 -> Join_const (Mode.Const.join c1 c2)
 
-      let apply : type l r.
-          ?hint:(l * r) neg Hint.morph -> t -> (l * r) Mode.t -> (l * r) Mode.t
-          =
-       fun ?(hint = Hint.Unknown) t x ->
-        match t with Join_const c -> Mode.join_const ~hint c x
+      let apply_right : type l.
+          ?is_contained_by:Hint.is_contained_by ->
+          t ->
+          (l * allowed) Mode.t ->
+          Mode.r =
+       fun ?is_contained_by t x ->
+        match t with
+        | Join_const c ->
+          let hint =
+            Option.map
+              (fun c -> Hint.Is_contained_by (Monadic, c))
+              is_contained_by
+          in
+          Mode.join_const ?hint c (Mode.disallow_left x)
+
+      let apply_left : type r.
+          ?is_contained_by:Hint.is_contained_by ->
+          t ->
+          (allowed * r) Mode.t ->
+          Mode.l =
+       fun ?is_contained_by t x ->
+        match t with
+        | Join_const c ->
+          let morph_hint =
+            Option.map
+              (fun c -> Hint.Is_contained_by (Monadic, c))
+              is_contained_by
+          in
+          let morph_hint = Option.value ~default:Hint.Unknown morph_hint in
+          let hint =
+            Option.map (fun c -> Hint.Contained_by c) is_contained_by
+          in
+          Mode.join
+            [ Mode.disallow_right (Mode.of_const ?hint c);
+              Mode.disallow_right (Mode.apply_hint morph_hint x) ]
 
       let proj ax (Join_const c) : _ Atom.t = Join_const (Axis.proj ax c)
 
@@ -4652,7 +6280,9 @@ module Modality = struct
         (* Check that for any x >= mm, join(x, m) <= join(x, c), which (by
            definition of join) is equivalent to m <= join(x, c). This has to
            hold for all x >= mm, so we check m <= join(mm, c). *)
-        match Mode.submode_log m (Mode.join_const c mm) ~log with
+        match
+          Mode.submode_log m (Mode.join_const c (Mode.disallow_left mm)) ~log
+        with
         | Ok () -> Ok ()
         | Error err ->
           let (Error (ax, { left; _ })) = Mode.to_simple_error err in
@@ -4674,14 +6304,14 @@ module Modality = struct
       | Undefined, _ | _, Undefined ->
         Misc.fatal_error "modality Undefined should not be in sub."
 
-    let apply : type r.
-        ?hint:(allowed * r) neg Hint.morph ->
+    let apply_left : type r.
+        ?is_contained_by:Hint.is_contained_by ->
         t ->
         (allowed * r) Mode.t ->
         Mode.l =
-     fun ?hint t x ->
+     fun ?is_contained_by t x ->
       match t with
-      | Const c -> Const.apply ?hint c x |> Mode.disallow_right
+      | Const c -> Const.apply_left ?is_contained_by c x |> Mode.disallow_right
       | Undefined ->
         Misc.fatal_error "modality Undefined should not be applied."
       | Diff (_, m) -> Mode.join [Mode.allow_right m; x]
@@ -4715,7 +6345,7 @@ module Modality = struct
            [subtract_mm m <= c], equivalently [m <= join_mm c], which is
            achieved by the following [submode].
         *)
-        Mode.submode_exn m (Mode.join_const c mm);
+        Mode.submode_exn m (Mode.join_const c (Mode.disallow_left mm));
         Const.Join_const c
 
     let zap_to_id = zap_to_floor
@@ -4771,11 +6401,41 @@ module Modality = struct
         match then_, t with
         | Meet_const c1, Meet_const c2 -> Meet_const (Mode.Const.meet c1 c2)
 
-      let apply : type l r.
-          ?hint:(l * r) pos Hint.morph -> t -> (l * r) Mode.t -> (l * r) Mode.t
-          =
-       fun ?(hint = Hint.Unknown) t x ->
-        match t with Meet_const c -> Mode.meet_const ~hint c x
+      let apply_left : type r.
+          ?is_contained_by:Hint.is_contained_by ->
+          t ->
+          (allowed * r) Mode.t ->
+          Mode.l =
+       fun ?is_contained_by t x ->
+        match t with
+        | Meet_const c ->
+          let hint =
+            Option.map
+              (fun c -> Hint.Is_contained_by (Comonadic, c))
+              is_contained_by
+          in
+          Mode.meet_const ?hint c (Mode.disallow_right x)
+
+      let apply_right : type l.
+          ?is_contained_by:Hint.is_contained_by ->
+          t ->
+          (l * allowed) Mode.t ->
+          Mode.r =
+       fun ?is_contained_by t x ->
+        match t with
+        | Meet_const c ->
+          let morph_hint =
+            Option.map
+              (fun c -> Hint.Is_contained_by (Comonadic, c))
+              is_contained_by
+          in
+          let morph_hint = Option.value ~default:Hint.Unknown morph_hint in
+          let hint =
+            Option.map (fun c -> Hint.Contained_by c) is_contained_by
+          in
+          Mode.meet
+            [ Mode.disallow_left (Mode.of_const ?hint c);
+              Mode.disallow_left (Mode.apply_hint morph_hint x) ]
 
       let proj ax (Meet_const c) : _ Atom.t = Meet_const (Axis.proj ax c)
 
@@ -4823,14 +6483,14 @@ module Modality = struct
       | Undefined, _ | _, Undefined ->
         Misc.fatal_error "modality Undefined should not be in sub."
 
-    let apply : type r.
-        ?hint:(allowed * r) pos Hint.morph ->
+    let apply_left : type r.
+        ?is_contained_by:Hint.is_contained_by ->
         t ->
         (allowed * r) Mode.t ->
         Mode.l =
-     fun ?hint t x ->
+     fun ?is_contained_by t x ->
       match t with
-      | Const c -> Const.apply ?hint c x |> Mode.disallow_right
+      | Const c -> Const.apply_left ?is_contained_by c x |> Mode.disallow_right
       | Undefined ->
         Misc.fatal_error "modality Undefined should not be applied."
       | Exactly (_mm, m) ->
@@ -4873,7 +6533,7 @@ module Modality = struct
            [imply_mm m >= c], equivalently [m >= meet_mm c], which is achieved
            by the following [submode].
         *)
-        Mode.submode_exn (Mode.meet_const c mm) m;
+        Mode.submode_exn (Mode.meet_const c (Mode.disallow_right mm)) m;
         Const.Meet_const c
 
     let zap_to_id = zap_to_ceil
@@ -4969,16 +6629,17 @@ module Modality = struct
 
     let equate = equate_from_submode' sub
 
-    let apply ?hint t { monadic; comonadic } =
-      let monadic =
-        Monadic.apply
-          ?hint:(Option.map (fun { monadic; _ } -> monadic) hint)
-          t.monadic monadic
-      in
+    let apply_left ?is_contained_by t { monadic; comonadic } =
+      let monadic = Monadic.apply_left ?is_contained_by t.monadic monadic in
       let comonadic =
-        Comonadic.apply
-          ?hint:(Option.map (fun { comonadic; _ } -> comonadic) hint)
-          t.comonadic comonadic
+        Comonadic.apply_left ?is_contained_by t.comonadic comonadic
+      in
+      { monadic; comonadic }
+
+    let apply_right ?is_contained_by t { monadic; comonadic } =
+      let monadic = Monadic.apply_right ?is_contained_by t.monadic monadic in
+      let comonadic =
+        Comonadic.apply_right ?is_contained_by t.comonadic comonadic
       in
       { monadic; comonadic }
 
@@ -5019,16 +6680,10 @@ module Modality = struct
     | _ -> false
   [@@ocaml.warning "-4"]
 
-  let apply ?hint t { monadic; comonadic } =
-    let monadic =
-      Monadic.apply
-        ?hint:(Option.map (fun { monadic; _ } -> monadic) hint)
-        t.monadic monadic
-    in
+  let apply_left ?is_contained_by t { monadic; comonadic } =
+    let monadic = Monadic.apply_left ?is_contained_by t.monadic monadic in
     let comonadic =
-      Comonadic.apply
-        ?hint:(Option.map (fun { comonadic; _ } -> comonadic) hint)
-        t.comonadic comonadic
+      Comonadic.apply_left ?is_contained_by t.comonadic comonadic
     in
     { monadic; comonadic }
 
@@ -5089,7 +6744,7 @@ module Crossing = struct
   (* The mode crossing capability of a type [t] is characterized by a monotone
      function [f] from modes to some lattice [L], in the following way:
 
-     To check [e : t @ m1<= m2], we should instead check [f m1 <= f m2] to
+     To check [e : t @ m1 <= m2], we should instead check [f m1 <= f m2] to
      allow more programs.
 
      For example, if [f] is the identity function, then [t] does not cross modes
@@ -5173,7 +6828,8 @@ module Crossing = struct
     let modality m (Modality t) = Modality (Modality.Const.concat ~then_:t m)
 
     let apply_left (Modality (Join_const c)) m =
-      Mode.subtract_const_unhint c (Mode.join_const_unhint c m)
+      Mode.subtract_const_unhint c
+        (Mode.unhint (Mode.join [Mode.of_const c; m]))
 
     let apply_right (Modality (Join_const c)) m =
       (* The right adjoint of join is a restriction of identity *)
@@ -5275,7 +6931,7 @@ module Crossing = struct
       Mode.meet_const_unhint c m
 
     let apply_right (Modality (Meet_const c)) m =
-      Mode.imply_const_unhint c (Mode.meet_const_unhint c m)
+      Mode.imply_const_unhint c (Mode.unhint (Mode.meet [Mode.of_const c; m]))
 
     let le (Modality (Meet_const c1)) (Modality (Meet_const c2)) =
       Mode.Const.le c1 c2
@@ -5390,21 +7046,23 @@ module Crossing = struct
 
   let apply_left_unhint t { monadic; comonadic } =
     let monadic = Monadic.apply_left t.monadic monadic in
-    let comonadic = Comonadic.apply_left t.comonadic comonadic in
+    let comonadic =
+      Comonadic.apply_left t.comonadic (S.Unhint.unhint comonadic)
+    in
     { monadic; comonadic }
 
   let apply_left t m =
-    m |> Value.disallow_right |> Value.unhint |> apply_left_unhint t
-    |> Value.hint ~monadic:Crossing ~comonadic:Crossing
+    Value.hint ~monadic:Crossing ~comonadic:Crossing
+      (apply_left_unhint t (Value.disallow_right m))
 
   let apply_right_unhint t { monadic; comonadic } =
-    let monadic = Monadic.apply_right t.monadic monadic in
+    let monadic = Monadic.apply_right t.monadic (S.Unhint.unhint monadic) in
     let comonadic = Comonadic.apply_right t.comonadic comonadic in
     { monadic; comonadic }
 
   let apply_right t m =
-    m |> Value.disallow_left |> Value.unhint |> apply_right_unhint t
-    |> Value.hint ~monadic:Crossing ~comonadic:Crossing
+    Value.hint ~monadic:Crossing ~comonadic:Crossing
+      (apply_right_unhint t (Value.disallow_left m))
 
   (* Our mode crossing is for [Value] modes, but can be extended to [Alloc]
      modes via [alloc_as_value], defined as follows:
@@ -5420,13 +7078,11 @@ module Crossing = struct
      [regional_to_local] the left adjoint. *)
 
   let apply_left_alloc t m =
-    m |> Alloc.unhint |> alloc_as_value_unhint |> apply_left_unhint t
-    |> value_to_alloc_r2l_unhint
+    m |> alloc_as_value |> apply_left_unhint t |> value_to_alloc_r2l_unhint
     |> Alloc.hint ~comonadic:Crossing ~monadic:Crossing
 
   let apply_right_alloc t m =
-    m |> Alloc.unhint |> alloc_as_value_unhint |> apply_right_unhint t
-    |> value_to_alloc_r2g_unhint
+    m |> alloc_as_value |> apply_right_unhint t |> value_to_alloc_r2g_unhint
     |> Alloc.hint ~comonadic:Crossing ~monadic:Crossing
 
   let apply_left_right_alloc t m =

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3284,7 +3284,7 @@ module Lattices_mono = struct
       Simple_proj (Simple_morph.left_adjoint mid m, ax, dst)
     | Const_max _ -> Const_min dst
 
-  let compose_simple_with_proj_core : type a c p d.
+  let compose_simple_proj_core : type a c p d.
       c obj ->
       (p, c, d) Simple_morph.t ->
       (a, p, d) Core_morph.compose_proj_result ->
@@ -3297,7 +3297,7 @@ module Lattices_mono = struct
     | Proj_const_max obj1 -> Const_max obj1
     | Proj_const_min obj1 -> Const_min obj1
 
-  let compose_simple_with_proj_meet_const_core : type a c p l.
+  let compose_simple_proj_meet_const_core : type a c p l.
       c obj ->
       (p, c, l * disallowed) Simple_morph.t ->
       p ->
@@ -3313,7 +3313,7 @@ module Lattices_mono = struct
     | Proj_const_max obj1 -> Const_max obj1
     | Proj_const_min obj1 -> Const_min obj1
 
-  let compose_simple_with_proj_core_imply_const : type a c p r.
+  let compose_simple_proj_core_imply_const : type a c p r.
       c obj ->
       (p, c, disallowed * r) Simple_morph.t ->
       a ->
@@ -3343,7 +3343,7 @@ module Lattices_mono = struct
     | Id -> Simple_proj (m0, ax0, obj0)
     | Core m1 ->
       let pm1 = Core_morph.compose_projection_core ax0 m1 in
-      compose_simple_with_proj_core dst m0 pm1
+      compose_simple_proj_core dst m0 pm1
     | Meet_const c1 ->
       let c1 = Axis.proj ax0 c1 in
       Simple_proj (Simple_morph.compose dst m0 (Meet_const c1), ax0, obj0)
@@ -3353,13 +3353,13 @@ module Lattices_mono = struct
     | Meet_const_core (c1, m1) ->
       let c1 = Axis.proj ax0 c1 in
       let pm1 = Core_morph.compose_projection_core ax0 m1 in
-      compose_simple_with_proj_meet_const_core dst m0 c1 pm1
+      compose_simple_proj_meet_const_core dst m0 c1 pm1
     | Core_imply_const (m1, c1) ->
       let pm1 = Core_morph.compose_projection_core ax0 m1 in
-      compose_simple_with_proj_core_imply_const dst m0 c1 pm1
+      compose_simple_proj_core_imply_const dst m0 c1 pm1
     | Compose _ -> Compose (Simple_proj (m0, ax0, obj0), Simple m1)
 
-  let compose_simple_with_and_max : type a b c q r.
+  let compose_simple_max_with_simple : type a b c q r.
       c obj ->
       (b, c, disallowed * r) Simple_morph.t ->
       (b, q) Axis.t ->
@@ -3398,7 +3398,7 @@ module Lattices_mono = struct
     | Meet_const _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
     | Compose _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
 
-  let compose_simple_with_and_min : type a b c q l.
+  let compose_simple_min_with_simple : type a b c q l.
       c obj ->
       (b, c, l * disallowed) Simple_morph.t ->
       (b, q) Axis.t ->
@@ -3470,12 +3470,12 @@ module Lattices_mono = struct
       let dst = proj_obj ax0 dst in
       Max_with_simple (ax0, Simple_morph.compose dst m0 m1)
     | Simple m0, Max_with_simple (ax1, m1) ->
-      compose_simple_with_and_max dst m0 ax1 m1
+      compose_simple_max_with_simple dst m0 ax1 m1
     | Min_with_simple (ax0, m0), Simple m1 ->
       let dst = proj_obj ax0 dst in
       Min_with_simple (ax0, Simple_morph.compose dst m0 m1)
     | Simple m0, Min_with_simple (ax1, m1) ->
-      compose_simple_with_and_min dst m0 ax1 m1
+      compose_simple_min_with_simple dst m0 ax1 m1
     | Simple_proj (m0, ax0, obj1), Max_with_simple (ax1, m1) ->
       begin match Axis.equal ax0 ax1 with
       | Misc.Is_eq -> Simple (Simple_morph.compose dst m0 m1)

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -458,6 +458,8 @@ module Lattices = struct
     include Heyting with type t := t
 
     val areality : t areality
+
+    val all : t list
   end
 
   module Locality = struct
@@ -476,6 +478,8 @@ module Lattices = struct
     end)
 
     let legacy = Global
+
+    let all = [Global; Local]
 
     let print ppf = function
       | Global -> Fmt.fprintf ppf "global"
@@ -502,6 +506,8 @@ module Lattices = struct
 
     let legacy = Global
 
+    let all = [Global; Regional; Local]
+
     let print ppf = function
       | Global -> Fmt.fprintf ppf "global"
       | Regional -> Fmt.fprintf ppf "regional"
@@ -527,6 +533,8 @@ module Lattices = struct
 
     let legacy = Aliased
 
+    let all = [Unique; Aliased]
+
     let print ppf = function
       | Aliased -> Fmt.fprintf ppf "aliased"
       | Unique -> Fmt.fprintf ppf "unique"
@@ -548,6 +556,8 @@ module Lattices = struct
     end)
 
     let legacy = Many
+
+    let all = [Many; Once]
 
     let print ppf = function
       | Once -> Fmt.fprintf ppf "once"
@@ -575,6 +585,8 @@ module Lattices = struct
     end)
 
     let legacy = Nonportable
+
+    let all = [Portable; Shareable; Corruptible; Nonportable]
 
     let print ppf = function
       | Portable -> Fmt.fprintf ppf "portable"
@@ -605,6 +617,8 @@ module Lattices = struct
 
     let legacy = Uncontended
 
+    let all = [Uncontended; Corrupted; Shared; Contended]
+
     let print ppf = function
       | Contended -> Fmt.fprintf ppf "contended"
       | Corrupted -> Fmt.fprintf ppf "corrupted"
@@ -629,6 +643,8 @@ module Lattices = struct
 
     let legacy = Forkable
 
+    let all = [Forkable; Unforkable]
+
     let print ppf = function
       | Unforkable -> Fmt.fprintf ppf "unforkable"
       | Forkable -> Fmt.fprintf ppf "forkable"
@@ -650,6 +666,8 @@ module Lattices = struct
     end)
 
     let legacy = Unyielding
+
+    let all = [Unyielding; Yielding]
 
     let print ppf = function
       | Yielding -> Fmt.fprintf ppf "yielding"
@@ -677,6 +695,8 @@ module Lattices = struct
     end)
 
     let legacy = Stateful
+
+    let all = [Stateless; Writing; Reading; Stateful]
 
     let print ppf = function
       | Stateless -> Fmt.fprintf ppf "stateless"
@@ -707,6 +727,8 @@ module Lattices = struct
 
     let legacy = Read_write
 
+    let all = [Read_write; Read; Write; Immutable]
+
     let print ppf = function
       | Immutable -> Fmt.fprintf ppf "immutable"
       | Read -> Fmt.fprintf ppf "read"
@@ -730,6 +752,8 @@ module Lattices = struct
     end)
 
     let legacy = Dynamic
+
+    let all = [Static; Dynamic]
 
     let print ppf = function
       | Dynamic -> Fmt.fprintf ppf "dynamic"
@@ -766,6 +790,35 @@ module Lattices = struct
       let visibility = Visibility.legacy in
       let staticity = Staticity.legacy in
       { uniqueness; contention; visibility; staticity }
+
+    (** All product values, including every combination of axis values. *)
+    let all =
+      lazy
+        (let ( let* ) xs f = List.concat_map f xs in
+         let ( let+ ) xs f = List.map f xs in
+         let* uniqueness = Uniqueness.all in
+         let* contention = Contention.all in
+         let* visibility = Visibility.all in
+         let+ staticity = Staticity.all in
+         { uniqueness; contention; visibility; staticity })
+
+    (** Product values that cover every element of every axis at least once,
+        without enumerating every product combination. *)
+    let spanning_elements =
+      lazy
+        (let with_base base =
+           let ( let+ ) xs f = List.map f xs in
+           List.concat
+             [ (let+ uniqueness = Uniqueness.all in
+                { base with uniqueness });
+               (let+ contention = Contention.all in
+                { base with contention });
+               (let+ visibility = Visibility.all in
+                { base with visibility });
+               (let+ staticity = Staticity.all in
+                { base with staticity }) ]
+         in
+         with_base min @ with_base max)
 
     let le m1 m2 =
       let { uniqueness = uniqueness1;
@@ -886,6 +939,41 @@ module Lattices = struct
       let yielding = Yielding.legacy in
       let statefulness = Statefulness.legacy in
       { areality; linearity; portability; forkable; yielding; statefulness }
+
+    (** All product values, including every combination of axis values. *)
+    let all =
+      lazy
+        (let ( let* ) xs f = List.concat_map f xs in
+         let ( let+ ) xs f = List.map f xs in
+         let* areality = Areality.all in
+         let* linearity = Linearity.all in
+         let* portability = Portability.all in
+         let* forkable = Forkable.all in
+         let* yielding = Yielding.all in
+         let+ statefulness = Statefulness.all in
+         { areality; linearity; portability; forkable; yielding; statefulness })
+
+    (** Product values that cover every element of every axis at least once,
+        without enumerating every product combination. *)
+    let spanning_elements =
+      lazy
+        (let with_base base =
+           let ( let+ ) xs f = List.map f xs in
+           List.concat
+             [ (let+ areality = Areality.all in
+                { base with areality });
+               (let+ linearity = Linearity.all in
+                { base with linearity });
+               (let+ portability = Portability.all in
+                { base with portability });
+               (let+ forkable = Forkable.all in
+                { base with forkable });
+               (let+ yielding = Yielding.all in
+                { base with yielding });
+               (let+ statefulness = Statefulness.all in
+                { base with statefulness }) ]
+         in
+         with_base min @ with_base max)
 
     let le m1 m2 =
       let { areality = areality1;
@@ -1428,7 +1516,75 @@ module Lattices_mono = struct
       | Contention -> { t with contention = r }
       | Visibility -> { t with visibility = r }
       | Staticity -> { t with staticity = r }
+
+    type 'a packed = Axis : ('a, 'b) t -> 'a packed
+
+    let all : type a. a obj -> a packed list = function
+      | Comonadic_with_locality ->
+        [ Axis Areality;
+          Axis Forkable;
+          Axis Yielding;
+          Axis Linearity;
+          Axis Statefulness;
+          Axis Portability ]
+      | Comonadic_with_regionality ->
+        [ Axis Areality;
+          Axis Forkable;
+          Axis Yielding;
+          Axis Linearity;
+          Axis Statefulness;
+          Axis Portability ]
+      | Monadic_op ->
+        [Axis Uniqueness; Axis Visibility; Axis Contention; Axis Staticity]
+      | Locality | Regionality | Uniqueness_op | Linearity | Portability
+      | Forkable | Yielding | Statefulness | Contention_op | Visibility_op
+      | Staticity_op ->
+        []
   end
+
+  type packed_obj = Obj : 'a obj -> packed_obj
+
+  let all_objs =
+    [ Obj Locality;
+      Obj Regionality;
+      Obj Uniqueness_op;
+      Obj Linearity;
+      Obj Portability;
+      Obj Forkable;
+      Obj Yielding;
+      Obj Statefulness;
+      Obj Contention_op;
+      Obj Visibility_op;
+      Obj Staticity_op;
+      Obj Monadic_op;
+      Obj Comonadic_with_locality;
+      Obj Comonadic_with_regionality ]
+
+  let get_elements : type a. full:bool -> a obj -> a list =
+   fun ~full -> function
+    | Locality -> Locality.all
+    | Regionality -> Regionality.all
+    | Uniqueness_op -> Uniqueness.all
+    | Linearity -> Linearity.all
+    | Portability -> Portability.all
+    | Forkable -> Forkable.all
+    | Yielding -> Yielding.all
+    | Statefulness -> Statefulness.all
+    | Contention_op -> Contention.all
+    | Visibility_op -> Visibility.all
+    | Staticity_op -> Staticity.all
+    | Monadic_op ->
+      Lazy.force (if full then Monadic.all else Monadic.spanning_elements)
+    | Comonadic_with_locality ->
+      Lazy.force
+        (if full
+         then Comonadic_with_locality.all
+         else Comonadic_with_locality.spanning_elements)
+    | Comonadic_with_regionality ->
+      Lazy.force
+        (if full
+         then Comonadic_with_regionality.all
+         else Comonadic_with_regionality.spanning_elements)
 
   module Locality_morph = struct
     (* Following is a chain of adjunctions (this can be extended one
@@ -2374,6 +2530,70 @@ module Lattices_mono = struct
       | Comonadic_to_monadic_max _, _ -> Disallowed
       | _, _ -> .
     [@@warning "-4"]
+
+    type ('b, 'd) packed_to =
+      | To : 'a obj * ('a, 'b, 'd) t -> ('b, 'd) packed_to
+
+    let to_ : type a b d. (a, b, d) t -> (b, d) packed_to =
+     fun m -> To (src m, m)
+
+    let left_to : type b. b obj -> (b, left_only) packed_to list = function
+      | Locality -> [to_ (Locality_restricted Regional_to_local)]
+      | Regionality ->
+        [ to_ (Locality_restricted Local_to_regional);
+          to_ (Locality_restricted Locality_as_regionality);
+          to_ (Locality_restricted Local_to_regional_regionality);
+          to_ (Locality_restricted Regional_to_local_regionality) ]
+      | Uniqueness_op -> [to_ Linearity_to_uniqueness_op]
+      | Linearity -> [to_ Uniqueness_op_to_linearity]
+      | Portability -> [to_ Contention_op_to_portability]
+      | Forkable -> []
+      | Yielding -> []
+      | Statefulness -> [to_ Visibility_op_to_statefulness]
+      | Contention_op -> [to_ Portability_to_contention_op]
+      | Visibility_op -> [to_ Statefulness_to_visibility_op]
+      | Staticity_op -> []
+      | Monadic_op ->
+        [ to_ (Comonadic_to_monadic_min Locality);
+          to_ (Comonadic_to_monadic_min Regionality) ]
+      | Comonadic_with_locality ->
+        [to_ (Locality_full Regional_to_local); to_ Monadic_to_comonadic_min]
+      | Comonadic_with_regionality ->
+        [ to_ (Locality_full Local_to_regional);
+          to_ (Locality_full Locality_as_regionality);
+          to_ (Locality_full Local_to_regional_regionality);
+          to_ (Locality_full Regional_to_local_regionality);
+          to_ Monadic_to_comonadic_min ]
+
+    let right_to : type b. b obj -> (b, right_only) packed_to list = function
+      | Locality ->
+        [ to_ (Locality_restricted Regional_to_local);
+          to_ (Locality_restricted Regional_to_global) ]
+      | Regionality ->
+        [ to_ (Locality_restricted Locality_as_regionality);
+          to_ (Locality_restricted Regional_to_local_regionality);
+          to_ (Locality_restricted Regional_to_global_regionality) ]
+      | Uniqueness_op -> [to_ Linearity_to_uniqueness_op]
+      | Linearity -> [to_ Uniqueness_op_to_linearity]
+      | Portability -> [to_ Contention_op_to_portability]
+      | Forkable -> []
+      | Yielding -> []
+      | Statefulness -> [to_ Visibility_op_to_statefulness]
+      | Contention_op -> [to_ Portability_to_contention_op]
+      | Visibility_op -> [to_ Statefulness_to_visibility_op]
+      | Staticity_op -> []
+      | Monadic_op ->
+        [ to_ (Comonadic_to_monadic_max Locality);
+          to_ (Comonadic_to_monadic_max Regionality) ]
+      | Comonadic_with_locality ->
+        [ to_ (Locality_full Regional_to_local);
+          to_ (Locality_full Regional_to_global);
+          to_ Monadic_to_comonadic_max ]
+      | Comonadic_with_regionality ->
+        [ to_ (Locality_full Locality_as_regionality);
+          to_ (Locality_full Regional_to_local_regionality);
+          to_ (Locality_full Regional_to_global_regionality);
+          to_ Monadic_to_comonadic_max ]
   end
 
   let proj_obj : type t r. (t, r) Axis.t -> t obj -> r obj =
@@ -3023,6 +3243,64 @@ module Lattices_mono = struct
       let c = min_with dst ax1 (max q_obj) in
       compose dst (Meet_const c) m
     [@@warning "-4"]
+
+    let ( let* ) xs f = List.concat_map f xs
+
+    let ( let+ ) xs f = List.map f xs
+
+    type ('b, 'd) packed_to =
+      | To : 'a obj * ('a, 'b, 'd) t -> ('b, 'd) packed_to
+
+    let to_ : type a b d. b obj -> (a, b, d) t -> (b, d) packed_to =
+     fun dst m -> To (src dst m, m)
+
+    let left_to : type b. full:bool -> b obj -> (b, left_only) packed_to list =
+     fun ~full dst ->
+      let constants =
+        List.map (fun c -> to_ dst (Meet_const c)) (get_elements ~full dst)
+      in
+      let cores = Core_morph.left_to dst in
+      let core_morphs =
+        List.map (fun (Core_morph.To (_, m)) -> to_ dst (Core m)) cores
+      in
+      let meet_const_cores =
+        let* c = get_elements ~full dst in
+        let+ (Core_morph.To (_, m)) = cores in
+        to_ dst (Meet_const_core (c, m))
+      in
+      (to_ dst Id :: core_morphs) @ constants @ meet_const_cores
+
+    let right_to : type b. full:bool -> b obj -> (b, right_only) packed_to list
+        =
+     fun ~full dst ->
+      let constants =
+        List.map (fun c -> to_ dst (Imply_const c)) (get_elements ~full dst)
+      in
+      let cores = Core_morph.right_to dst in
+      let core_morphs =
+        List.map (fun (Core_morph.To (_, m)) -> to_ dst (Core m)) cores
+      in
+      let core_imply_consts =
+        let* (Core_morph.To (src, m)) = cores in
+        let+ c = get_elements ~full src in
+        to_ dst (Core_imply_const (m, c))
+      in
+      (to_ dst Id :: core_morphs) @ constants @ core_imply_consts
+
+    let filter_src : type a b d.
+        a obj -> (b, d) packed_to list -> (a, b, d) t list =
+     fun src simple_morphs ->
+      let filter : (b, d) packed_to -> (a, b, d) t option =
+       fun (To (src', m)) ->
+        match equal_obj src src' with
+        | Misc.Is_eq -> Some m
+        | Misc.Is_not_eq -> None
+      in
+      List.filter_map filter simple_morphs
+
+    let left_from_to ~full src dst = filter_src src (left_to ~full dst)
+
+    let right_from_to ~full src dst = filter_src src (right_to ~full dst)
   end
 
   type ('a, 'b, 'd) morph =
@@ -3622,6 +3900,154 @@ module Lattices_mono = struct
     | _, _ -> .
   [@@warning "-4"]
 
+  let ( let* ) xs f = List.concat_map f xs
+
+  let ( let+ ) xs f = List.map f xs
+
+  type 'b packed_morph_to =
+    | Morph_to : 'a obj * ('a, 'b, neither) morph -> 'b packed_morph_to
+
+  let left_morph_to : type a b.
+      a obj -> (a, b, left_only) morph -> b packed_morph_to =
+   fun src morph -> Morph_to (src, disallow_left morph)
+
+  let right_morph_to : type a b.
+      a obj -> (a, b, right_only) morph -> b packed_morph_to =
+   fun src morph -> Morph_to (src, disallow_right morph)
+
+  let generate_left_morphs_to : type b.
+      full:bool -> b obj -> b packed_morph_to list =
+   fun ~full dst ->
+    let simple_morphs =
+      List.map
+        (fun (Simple_morph.To (src, m)) -> left_morph_to src (Simple m))
+        (Simple_morph.left_to ~full dst)
+    in
+    let projections =
+      let* (Obj src) = all_objs in
+      let* (Axis.Axis ax) = Axis.all src in
+      let projected = proj_obj ax src in
+      let+ m = Simple_morph.left_from_to ~full projected dst in
+      left_morph_to src (Simple_proj (m, ax, src))
+    in
+    let min_with =
+      let* (Axis.Axis ax) = Axis.all dst in
+      let projected = proj_obj ax dst in
+      let+ (Simple_morph.To (src, m)) = Simple_morph.left_to ~full projected in
+      left_morph_to src (Min_with_simple (ax, m))
+    in
+    let const_min =
+      List.map (fun (Obj src) -> left_morph_to src (Const_min src)) all_objs
+    in
+    simple_morphs @ projections @ min_with @ const_min
+
+  let generate_right_morphs_to : type b.
+      full:bool -> b obj -> b packed_morph_to list =
+   fun ~full dst ->
+    let simple_morphs =
+      List.map
+        (fun (Simple_morph.To (src, m)) -> right_morph_to src (Simple m))
+        (Simple_morph.right_to ~full dst)
+    in
+    let projections =
+      let* (Obj src) = all_objs in
+      let* (Axis.Axis ax) = Axis.all src in
+      let projected = proj_obj ax src in
+      let+ m = Simple_morph.right_from_to ~full projected dst in
+      right_morph_to src (Simple_proj (m, ax, src))
+    in
+    let max_with =
+      let* (Axis.Axis ax) = Axis.all dst in
+      let projected = proj_obj ax dst in
+      let+ (Simple_morph.To (src, m)) = Simple_morph.right_to ~full projected in
+      right_morph_to src (Max_with_simple (ax, m))
+    in
+    let const_max =
+      List.map (fun (Obj src) -> right_morph_to src (Const_max src)) all_objs
+    in
+    simple_morphs @ projections @ max_with @ const_max
+
+  let generate_morphs_to ~full dst =
+    generate_left_morphs_to ~full dst @ generate_right_morphs_to ~full dst
+
+  let force_by_coverage ~full (full_list, partial_list) =
+    Lazy.force (if full then full_list else partial_list)
+
+  let morphs_to_locality =
+    ( lazy (generate_morphs_to ~full:true Locality),
+      lazy (generate_morphs_to ~full:false Locality) )
+
+  let morphs_to_regionality =
+    ( lazy (generate_morphs_to ~full:true Regionality),
+      lazy (generate_morphs_to ~full:false Regionality) )
+
+  let morphs_to_uniqueness_op =
+    ( lazy (generate_morphs_to ~full:true Uniqueness_op),
+      lazy (generate_morphs_to ~full:false Uniqueness_op) )
+
+  let morphs_to_linearity =
+    ( lazy (generate_morphs_to ~full:true Linearity),
+      lazy (generate_morphs_to ~full:false Linearity) )
+
+  let morphs_to_portability =
+    ( lazy (generate_morphs_to ~full:true Portability),
+      lazy (generate_morphs_to ~full:false Portability) )
+
+  let morphs_to_forkable =
+    ( lazy (generate_morphs_to ~full:true Forkable),
+      lazy (generate_morphs_to ~full:false Forkable) )
+
+  let morphs_to_yielding =
+    ( lazy (generate_morphs_to ~full:true Yielding),
+      lazy (generate_morphs_to ~full:false Yielding) )
+
+  let morphs_to_statefulness =
+    ( lazy (generate_morphs_to ~full:true Statefulness),
+      lazy (generate_morphs_to ~full:false Statefulness) )
+
+  let morphs_to_contention_op =
+    ( lazy (generate_morphs_to ~full:true Contention_op),
+      lazy (generate_morphs_to ~full:false Contention_op) )
+
+  let morphs_to_visibility_op =
+    ( lazy (generate_morphs_to ~full:true Visibility_op),
+      lazy (generate_morphs_to ~full:false Visibility_op) )
+
+  let morphs_to_staticity_op =
+    ( lazy (generate_morphs_to ~full:true Staticity_op),
+      lazy (generate_morphs_to ~full:false Staticity_op) )
+
+  let morphs_to_monadic_op =
+    ( lazy (generate_morphs_to ~full:true Monadic_op),
+      lazy (generate_morphs_to ~full:false Monadic_op) )
+
+  let morphs_to_comonadic_with_locality =
+    ( lazy (generate_morphs_to ~full:true Comonadic_with_locality),
+      lazy (generate_morphs_to ~full:false Comonadic_with_locality) )
+
+  let morphs_to_comonadic_with_regionality =
+    ( lazy (generate_morphs_to ~full:true Comonadic_with_regionality),
+      lazy (generate_morphs_to ~full:false Comonadic_with_regionality) )
+
+  let morphs_to : type b. full:bool -> b obj -> b packed_morph_to list =
+   fun ~full -> function
+    | Locality -> force_by_coverage ~full morphs_to_locality
+    | Regionality -> force_by_coverage ~full morphs_to_regionality
+    | Uniqueness_op -> force_by_coverage ~full morphs_to_uniqueness_op
+    | Linearity -> force_by_coverage ~full morphs_to_linearity
+    | Portability -> force_by_coverage ~full morphs_to_portability
+    | Forkable -> force_by_coverage ~full morphs_to_forkable
+    | Yielding -> force_by_coverage ~full morphs_to_yielding
+    | Statefulness -> force_by_coverage ~full morphs_to_statefulness
+    | Contention_op -> force_by_coverage ~full morphs_to_contention_op
+    | Visibility_op -> force_by_coverage ~full morphs_to_visibility_op
+    | Staticity_op -> force_by_coverage ~full morphs_to_staticity_op
+    | Monadic_op -> force_by_coverage ~full morphs_to_monadic_op
+    | Comonadic_with_locality ->
+      force_by_coverage ~full morphs_to_comonadic_with_locality
+    | Comonadic_with_regionality ->
+      force_by_coverage ~full morphs_to_comonadic_with_regionality
+
   module For_hint = struct
     (** Describes the portion of the input that's responsible for a portion of
         the output of a morphism *)
@@ -3747,474 +4173,19 @@ end
 module For_testing = struct
   open Lattices_mono
 
-  type packed_obj = Obj : 'a obj -> packed_obj
-
-  let all_objs =
-    lazy
-      [ Obj Locality;
-        Obj Regionality;
-        Obj Uniqueness_op;
-        Obj Linearity;
-        Obj Portability;
-        Obj Forkable;
-        Obj Yielding;
-        Obj Statefulness;
-        Obj Contention_op;
-        Obj Visibility_op;
-        Obj Staticity_op;
-        Obj Monadic_op;
-        Obj Comonadic_with_locality;
-        Obj Comonadic_with_regionality ]
-
   let ( let* ) xs f = List.concat_map f xs
 
   let ( let+ ) xs f = List.map f xs
 
-  let values_for_check_locality = lazy [Locality.Global; Locality.Local]
-
-  let values_for_check_regionality =
-    lazy [Regionality.Global; Regionality.Regional; Regionality.Local]
-
-  let values_for_check_uniqueness_op =
-    lazy [Uniqueness.Unique; Uniqueness.Aliased]
-
-  let values_for_check_linearity = lazy [Linearity.Many; Linearity.Once]
-
-  let values_for_check_portability =
-    lazy
-      [ Portability.Portable;
-        Portability.Shareable;
-        Portability.Corruptible;
-        Portability.Nonportable ]
-
-  let values_for_check_forkable = lazy [Forkable.Forkable; Forkable.Unforkable]
-
-  let values_for_check_yielding = lazy [Yielding.Unyielding; Yielding.Yielding]
-
-  let values_for_check_statefulness =
-    lazy
-      [ Statefulness.Stateless;
-        Statefulness.Writing;
-        Statefulness.Reading;
-        Statefulness.Stateful ]
-
-  let values_for_check_contention_op =
-    lazy
-      [ Contention.Uncontended;
-        Contention.Corrupted;
-        Contention.Shared;
-        Contention.Contended ]
-
-  let values_for_check_visibility_op =
-    lazy
-      [ Visibility.Read_write;
-        Visibility.Read;
-        Visibility.Write;
-        Visibility.Immutable ]
-
-  let values_for_check_staticity_op = lazy [Staticity.Static; Staticity.Dynamic]
-
-  let values_for_check_monadic_op =
-    lazy
-      (let values_for_check_uniqueness_op =
-         Lazy.force values_for_check_uniqueness_op
-       in
-       let values_for_check_contention_op =
-         Lazy.force values_for_check_contention_op
-       in
-       let values_for_check_visibility_op =
-         Lazy.force values_for_check_visibility_op
-       in
-       let values_for_check_staticity_op =
-         Lazy.force values_for_check_staticity_op
-       in
-       let with_base base =
-         List.concat
-           [ List.map
-               (fun uniqueness -> { base with uniqueness })
-               values_for_check_uniqueness_op;
-             List.map
-               (fun contention -> { base with contention })
-               values_for_check_contention_op;
-             List.map
-               (fun visibility -> { base with visibility })
-               values_for_check_visibility_op;
-             List.map
-               (fun staticity -> { base with staticity })
-               values_for_check_staticity_op ]
-       in
-       with_base Monadic_op.min @ with_base Monadic_op.max)
-
-  let values_for_check_comonadic_with_locality =
-    lazy
-      (let values_for_check_locality = Lazy.force values_for_check_locality in
-       let values_for_check_linearity = Lazy.force values_for_check_linearity in
-       let values_for_check_portability =
-         Lazy.force values_for_check_portability
-       in
-       let values_for_check_forkable = Lazy.force values_for_check_forkable in
-       let values_for_check_yielding = Lazy.force values_for_check_yielding in
-       let values_for_check_statefulness =
-         Lazy.force values_for_check_statefulness
-       in
-       let with_base base =
-         List.concat
-           [ List.map
-               (fun areality -> { base with areality })
-               values_for_check_locality;
-             List.map
-               (fun linearity -> { base with linearity })
-               values_for_check_linearity;
-             List.map
-               (fun portability -> { base with portability })
-               values_for_check_portability;
-             List.map
-               (fun forkable -> { base with forkable })
-               values_for_check_forkable;
-             List.map
-               (fun yielding -> { base with yielding })
-               values_for_check_yielding;
-             List.map
-               (fun statefulness -> { base with statefulness })
-               values_for_check_statefulness ]
-       in
-       with_base Comonadic_with_locality.min
-       @ with_base Comonadic_with_locality.max)
-
-  let values_for_check_comonadic_with_regionality =
-    lazy
-      (let values_for_check_regionality =
-         Lazy.force values_for_check_regionality
-       in
-       let values_for_check_linearity = Lazy.force values_for_check_linearity in
-       let values_for_check_portability =
-         Lazy.force values_for_check_portability
-       in
-       let values_for_check_forkable = Lazy.force values_for_check_forkable in
-       let values_for_check_yielding = Lazy.force values_for_check_yielding in
-       let values_for_check_statefulness =
-         Lazy.force values_for_check_statefulness
-       in
-       let with_base base =
-         List.concat
-           [ List.map
-               (fun areality -> { base with areality })
-               values_for_check_regionality;
-             List.map
-               (fun linearity -> { base with linearity })
-               values_for_check_linearity;
-             List.map
-               (fun portability -> { base with portability })
-               values_for_check_portability;
-             List.map
-               (fun forkable -> { base with forkable })
-               values_for_check_forkable;
-             List.map
-               (fun yielding -> { base with yielding })
-               values_for_check_yielding;
-             List.map
-               (fun statefulness -> { base with statefulness })
-               values_for_check_statefulness ]
-       in
-       with_base Comonadic_with_regionality.min
-       @ with_base Comonadic_with_regionality.max)
-
-  let all_values_for_check : type a. a obj -> a list = function
-    | Locality -> Lazy.force values_for_check_locality
-    | Regionality -> Lazy.force values_for_check_regionality
-    | Uniqueness_op -> Lazy.force values_for_check_uniqueness_op
-    | Linearity -> Lazy.force values_for_check_linearity
-    | Portability -> Lazy.force values_for_check_portability
-    | Forkable -> Lazy.force values_for_check_forkable
-    | Yielding -> Lazy.force values_for_check_yielding
-    | Statefulness -> Lazy.force values_for_check_statefulness
-    | Contention_op -> Lazy.force values_for_check_contention_op
-    | Visibility_op -> Lazy.force values_for_check_visibility_op
-    | Staticity_op -> Lazy.force values_for_check_staticity_op
-    | Monadic_op -> Lazy.force values_for_check_monadic_op
-    | Comonadic_with_locality ->
-      Lazy.force values_for_check_comonadic_with_locality
-    | Comonadic_with_regionality ->
-      Lazy.force values_for_check_comonadic_with_regionality
-
-  type 'a packed_axis = Axis : ('a, 'b) Axis.t -> 'a packed_axis
-
-  let axes : type a. a obj -> a packed_axis list = function
-    | Comonadic_with_locality ->
-      [ Axis Areality;
-        Axis Forkable;
-        Axis Yielding;
-        Axis Linearity;
-        Axis Statefulness;
-        Axis Portability ]
-    | Comonadic_with_regionality ->
-      [ Axis Areality;
-        Axis Forkable;
-        Axis Yielding;
-        Axis Linearity;
-        Axis Statefulness;
-        Axis Portability ]
-    | Monadic_op ->
-      [Axis Uniqueness; Axis Visibility; Axis Contention; Axis Staticity]
-    | Locality | Regionality | Uniqueness_op | Linearity | Portability
-    | Forkable | Yielding | Statefulness | Contention_op | Visibility_op
-    | Staticity_op ->
-      []
-
-  type ('b, 'd) packed_core_to =
-    | Core_to : 'a obj * ('a, 'b, 'd) Core_morph.t -> ('b, 'd) packed_core_to
-
-  let core_to : type a b d. (a, b, d) Core_morph.t -> (b, d) packed_core_to =
-   fun m -> Core_to (Core_morph.src m, m)
-
-  let left_cores_to : type b. b obj -> (b, left_only) packed_core_to list =
-    function
-    | Locality -> [core_to (Locality_restricted Regional_to_local)]
-    | Regionality ->
-      [ core_to (Locality_restricted Local_to_regional);
-        core_to (Locality_restricted Locality_as_regionality);
-        core_to (Locality_restricted Local_to_regional_regionality);
-        core_to (Locality_restricted Regional_to_local_regionality) ]
-    | Uniqueness_op -> [core_to Linearity_to_uniqueness_op]
-    | Linearity -> [core_to Uniqueness_op_to_linearity]
-    | Portability -> [core_to Contention_op_to_portability]
-    | Forkable -> []
-    | Yielding -> []
-    | Statefulness -> [core_to Visibility_op_to_statefulness]
-    | Contention_op -> [core_to Portability_to_contention_op]
-    | Visibility_op -> [core_to Statefulness_to_visibility_op]
-    | Staticity_op -> []
-    | Monadic_op ->
-      [ core_to (Comonadic_to_monadic_min Locality);
-        core_to (Comonadic_to_monadic_min Regionality) ]
-    | Comonadic_with_locality ->
-      [ core_to (Locality_full Regional_to_local);
-        core_to Monadic_to_comonadic_min ]
-    | Comonadic_with_regionality ->
-      [ core_to (Locality_full Local_to_regional);
-        core_to (Locality_full Locality_as_regionality);
-        core_to (Locality_full Local_to_regional_regionality);
-        core_to (Locality_full Regional_to_local_regionality);
-        core_to Monadic_to_comonadic_min ]
-
-  let right_cores_to : type b. b obj -> (b, right_only) packed_core_to list =
-    function
-    | Locality ->
-      [ core_to (Locality_restricted Regional_to_local);
-        core_to (Locality_restricted Regional_to_global) ]
-    | Regionality ->
-      [ core_to (Locality_restricted Locality_as_regionality);
-        core_to (Locality_restricted Regional_to_local_regionality);
-        core_to (Locality_restricted Regional_to_global_regionality) ]
-    | Uniqueness_op -> [core_to Linearity_to_uniqueness_op]
-    | Linearity -> [core_to Uniqueness_op_to_linearity]
-    | Portability -> [core_to Contention_op_to_portability]
-    | Forkable -> []
-    | Yielding -> []
-    | Statefulness -> [core_to Visibility_op_to_statefulness]
-    | Contention_op -> [core_to Portability_to_contention_op]
-    | Visibility_op -> [core_to Statefulness_to_visibility_op]
-    | Staticity_op -> []
-    | Monadic_op ->
-      [ core_to (Comonadic_to_monadic_max Locality);
-        core_to (Comonadic_to_monadic_max Regionality) ]
-    | Comonadic_with_locality ->
-      [ core_to (Locality_full Regional_to_local);
-        core_to (Locality_full Regional_to_global);
-        core_to Monadic_to_comonadic_max ]
-    | Comonadic_with_regionality ->
-      [ core_to (Locality_full Locality_as_regionality);
-        core_to (Locality_full Regional_to_local_regionality);
-        core_to (Locality_full Regional_to_global_regionality);
-        core_to Monadic_to_comonadic_max ]
-
-  type ('b, 'd) packed_simple_to =
-    | Simple_to :
-        'a obj * ('a, 'b, 'd) Simple_morph.t
-        -> ('b, 'd) packed_simple_to
-
-  let simple_to : type a b d.
-      b obj -> (a, b, d) Simple_morph.t -> (b, d) packed_simple_to =
-   fun dst m -> Simple_to (Simple_morph.src dst m, m)
-
-  let simple_left_to : type b. b obj -> (b, left_only) packed_simple_to list =
-   fun dst ->
-    let constants =
-      List.map
-        (fun c -> simple_to dst (Simple_morph.Meet_const c))
-        (all_values_for_check dst)
-    in
-    let cores = left_cores_to dst in
-    let core_morphs =
-      List.map
-        (fun (Core_to (_, m)) -> simple_to dst (Simple_morph.Core m))
-        cores
-    in
-    let meet_const_cores =
-      let* c = all_values_for_check dst in
-      let+ (Core_to (_, m)) = cores in
-      simple_to dst (Simple_morph.Meet_const_core (c, m))
-    in
-    (simple_to dst Id :: core_morphs) @ constants @ meet_const_cores
-
-  let simple_right_to : type b. b obj -> (b, right_only) packed_simple_to list =
-   fun dst ->
-    let constants =
-      List.map
-        (fun c -> simple_to dst (Simple_morph.Imply_const c))
-        (all_values_for_check dst)
-    in
-    let cores = right_cores_to dst in
-    let core_morphs =
-      List.map
-        (fun (Core_to (_, m)) -> simple_to dst (Simple_morph.Core m))
-        cores
-    in
-    let core_imply_consts =
-      let* (Core_to (src, m)) = cores in
-      let+ c = all_values_for_check src in
-      simple_to dst (Simple_morph.Core_imply_const (m, c))
-    in
-    (simple_to dst Id :: core_morphs) @ constants @ core_imply_consts
-
-  let filter_simple_src : type a b d.
-      a obj -> (b, d) packed_simple_to list -> (a, b, d) Simple_morph.t list =
-   fun src simple_morphs ->
-    let filter : (b, d) packed_simple_to -> (a, b, d) Simple_morph.t option =
-     fun (Simple_to (src', m)) ->
-      match equal_obj src src' with
-      | Misc.Is_eq -> Some m
-      | Misc.Is_not_eq -> None
-    in
-    List.filter_map filter simple_morphs
-
-  let simple_left_from_to src dst = filter_simple_src src (simple_left_to dst)
-
-  let simple_right_from_to src dst = filter_simple_src src (simple_right_to dst)
-
-  type 'b packed_morph_to =
-    | Morph_to : 'a obj * ('a, 'b, neither) morph -> 'b packed_morph_to
-
-  let left_morph_to : type a b.
-      a obj -> (a, b, left_only) morph -> b packed_morph_to =
-   fun src morph -> Morph_to (src, disallow_left morph)
-
-  let right_morph_to : type a b.
-      a obj -> (a, b, right_only) morph -> b packed_morph_to =
-   fun src morph -> Morph_to (src, disallow_right morph)
-
-  let generate_left_morphs_to : type b. b obj -> b packed_morph_to list =
-   fun dst ->
-    let simple_morphs =
-      List.map
-        (fun (Simple_to (src, m)) -> left_morph_to src (Simple m))
-        (simple_left_to dst)
-    in
-    let projections =
-      let* (Obj src) = Lazy.force all_objs in
-      let* (Axis ax) = axes src in
-      let projected = proj_obj ax src in
-      let+ m = simple_left_from_to projected dst in
-      left_morph_to src (Simple_proj (m, ax, src))
-    in
-    let min_with =
-      let* (Axis ax) = axes dst in
-      let projected = proj_obj ax dst in
-      let+ (Simple_to (src, m)) = simple_left_to projected in
-      left_morph_to src (Min_with_simple (ax, m))
-    in
-    let const_min =
-      List.map
-        (fun (Obj src) -> left_morph_to src (Const_min src))
-        (Lazy.force all_objs)
-    in
-    simple_morphs @ projections @ min_with @ const_min
-
-  let generate_right_morphs_to : type b. b obj -> b packed_morph_to list =
-   fun dst ->
-    let simple_morphs =
-      List.map
-        (fun (Simple_to (src, m)) -> right_morph_to src (Simple m))
-        (simple_right_to dst)
-    in
-    let projections =
-      let* (Obj src) = Lazy.force all_objs in
-      let* (Axis ax) = axes src in
-      let projected = proj_obj ax src in
-      let+ m = simple_right_from_to projected dst in
-      right_morph_to src (Simple_proj (m, ax, src))
-    in
-    let max_with =
-      let* (Axis ax) = axes dst in
-      let projected = proj_obj ax dst in
-      let+ (Simple_to (src, m)) = simple_right_to projected in
-      right_morph_to src (Max_with_simple (ax, m))
-    in
-    let const_max =
-      List.map
-        (fun (Obj src) -> right_morph_to src (Const_max src))
-        (Lazy.force all_objs)
-    in
-    simple_morphs @ projections @ max_with @ const_max
-
-  let generate_morphs_to dst =
-    generate_left_morphs_to dst @ generate_right_morphs_to dst
-
-  let morphs_to_locality = lazy (generate_morphs_to Locality)
-
-  let morphs_to_regionality = lazy (generate_morphs_to Regionality)
-
-  let morphs_to_uniqueness_op = lazy (generate_morphs_to Uniqueness_op)
-
-  let morphs_to_linearity = lazy (generate_morphs_to Linearity)
-
-  let morphs_to_portability = lazy (generate_morphs_to Portability)
-
-  let morphs_to_forkable = lazy (generate_morphs_to Forkable)
-
-  let morphs_to_yielding = lazy (generate_morphs_to Yielding)
-
-  let morphs_to_statefulness = lazy (generate_morphs_to Statefulness)
-
-  let morphs_to_contention_op = lazy (generate_morphs_to Contention_op)
-
-  let morphs_to_visibility_op = lazy (generate_morphs_to Visibility_op)
-
-  let morphs_to_staticity_op = lazy (generate_morphs_to Staticity_op)
-
-  let morphs_to_monadic_op = lazy (generate_morphs_to Monadic_op)
-
-  let morphs_to_comonadic_with_locality =
-    lazy (generate_morphs_to Comonadic_with_locality)
-
-  let morphs_to_comonadic_with_regionality =
-    lazy (generate_morphs_to Comonadic_with_regionality)
-
-  let morphs_to : type b. b obj -> b packed_morph_to list = function
-    | Locality -> Lazy.force morphs_to_locality
-    | Regionality -> Lazy.force morphs_to_regionality
-    | Uniqueness_op -> Lazy.force morphs_to_uniqueness_op
-    | Linearity -> Lazy.force morphs_to_linearity
-    | Portability -> Lazy.force morphs_to_portability
-    | Forkable -> Lazy.force morphs_to_forkable
-    | Yielding -> Lazy.force morphs_to_yielding
-    | Statefulness -> Lazy.force morphs_to_statefulness
-    | Contention_op -> Lazy.force morphs_to_contention_op
-    | Visibility_op -> Lazy.force morphs_to_visibility_op
-    | Staticity_op -> Lazy.force morphs_to_staticity_op
-    | Monadic_op -> Lazy.force morphs_to_monadic_op
-    | Comonadic_with_locality -> Lazy.force morphs_to_comonadic_with_locality
-    | Comonadic_with_regionality ->
-      Lazy.force morphs_to_comonadic_with_regionality
-
   let check_compose : type a b c.
+      full:bool ->
       a obj ->
       b obj ->
       c obj ->
       (b, c, neither) morph ->
       (a, b, neither) morph ->
       unit =
-   fun src mid dst f g ->
+   fun ~full src mid dst f g ->
     let result = compose dst f g in
     List.iter
       (fun input ->
@@ -4239,21 +4210,21 @@ module For_testing = struct
               (print dst) expected (print dst) actual
           in
           failwith msg)
-      (all_values_for_check src)
+      (get_elements ~full src)
 
   let run_jobs jobs = List.iter (fun job -> job ()) jobs
 
-  let check_jobs () =
-    let* (Obj dst) = Lazy.force all_objs in
-    let+ (Morph_to (mid, f)) = morphs_to dst in
-    let morphs_to_mid = morphs_to mid in
+  let check_jobs ~full () =
+    let* (Obj dst) = all_objs in
+    let+ (Morph_to (mid, f)) = morphs_to ~full dst in
+    let morphs_to_mid = morphs_to ~full mid in
     fun () ->
       List.iter
-        (fun (Morph_to (src, g)) -> check_compose src mid dst f g)
+        (fun (Morph_to (src, g)) -> check_compose ~full src mid dst f g)
         morphs_to_mid
 
-  let check_all_allowed_compositions () =
-    let jobs = check_jobs () in
+  let check_all_allowed_compositions ~full () =
+    let jobs = check_jobs ~full () in
     Printf.printf "running allowed composition checks\n%!";
     run_jobs jobs
 end

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1357,6 +1357,23 @@ module Lattices = struct
     | Comonadic_with_locality -> Comonadic_with_locality.print
     | Comonadic_with_regionality -> Comonadic_with_regionality.print
 
+  (* Returns an arbitrary element of a given object *)
+  let arbitrary : type a. a obj -> a = function
+    | Locality -> Locality.min
+    | Regionality -> Regionality.min
+    | Uniqueness_op -> Uniqueness_op.min
+    | Contention_op -> Contention_op.min
+    | Visibility_op -> Visibility_op.min
+    | Linearity -> Linearity.min
+    | Portability -> Portability.min
+    | Forkable -> Forkable.min
+    | Yielding -> Yielding.min
+    | Statefulness -> Statefulness.min
+    | Staticity_op -> Staticity_op.min
+    | Monadic_op -> Monadic_op.min
+    | Comonadic_with_locality -> Comonadic_with_locality.min
+    | Comonadic_with_regionality -> Comonadic_with_regionality.min
+
   let compare_obj : type a b. a obj -> b obj -> int =
    fun a b ->
     match a, b with
@@ -3349,14 +3366,14 @@ module Lattices_mono = struct
         | Core m ->
           Core_morph.lift_max src dst m ax0 ax1 |> lift_core_compose_result_r
         | Imply_const c ->
-          let c = Axis.set ax1 c (max dst) in
+          let c = Axis.set ax1 c (arbitrary dst) in
           let m =
             Core_morph.id_r2g src dst ax0 ax1 |> lift_core_compose_result_r
           in
           compose dst (Imply_const c) m
         | Core_imply_const (m, c) ->
           let m = lift_max src dst (Core m) ax0 ax1 in
-          let c = Axis.set ax0 c (max src) in
+          let c = Axis.set ax0 c (arbitrary src) in
           compose dst m (Imply_const c)
       in
       let q_obj = proj_obj ax1 dst in
@@ -3378,14 +3395,14 @@ module Lattices_mono = struct
         | Core m ->
           Core_morph.lift_min src dst m ax0 ax1 |> lift_core_compose_result_l
         | Meet_const c ->
-          let c = Axis.set ax1 c (min dst) in
+          let c = Axis.set ax1 c (arbitrary dst) in
           let m =
             Core_morph.id_r2l src dst ax0 ax1 |> lift_core_compose_result_l
           in
           compose dst (Meet_const c) m
         | Meet_const_core (c, m) ->
           let m = lift_min src dst (Core m) ax0 ax1 in
-          let c = Axis.set ax1 c (min dst) in
+          let c = Axis.set ax1 c (arbitrary dst) in
           compose dst (Meet_const c) m
       in
       let q_obj = proj_obj ax1 dst in

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3750,147 +3750,192 @@ module For_testing = struct
   type packed_obj = Obj : 'a obj -> packed_obj
 
   let all_objs =
-    [ Obj Locality;
-      Obj Regionality;
-      Obj Uniqueness_op;
-      Obj Linearity;
-      Obj Portability;
-      Obj Forkable;
-      Obj Yielding;
-      Obj Statefulness;
-      Obj Contention_op;
-      Obj Visibility_op;
-      Obj Staticity_op;
-      Obj Monadic_op;
-      Obj Comonadic_with_locality;
-      Obj Comonadic_with_regionality ]
+    lazy
+      [ Obj Locality;
+        Obj Regionality;
+        Obj Uniqueness_op;
+        Obj Linearity;
+        Obj Portability;
+        Obj Forkable;
+        Obj Yielding;
+        Obj Statefulness;
+        Obj Contention_op;
+        Obj Visibility_op;
+        Obj Staticity_op;
+        Obj Monadic_op;
+        Obj Comonadic_with_locality;
+        Obj Comonadic_with_regionality ]
 
   let ( let* ) xs f = List.concat_map f xs
 
   let ( let+ ) xs f = List.map f xs
 
-  let values_for_check_locality = [Locality.Global; Locality.Local]
+  let values_for_check_locality = lazy [Locality.Global; Locality.Local]
 
   let values_for_check_regionality =
-    [Regionality.Global; Regionality.Regional; Regionality.Local]
+    lazy [Regionality.Global; Regionality.Regional; Regionality.Local]
 
-  let values_for_check_uniqueness_op = [Uniqueness.Unique; Uniqueness.Aliased]
+  let values_for_check_uniqueness_op =
+    lazy [Uniqueness.Unique; Uniqueness.Aliased]
 
-  let values_for_check_linearity = [Linearity.Many; Linearity.Once]
+  let values_for_check_linearity = lazy [Linearity.Many; Linearity.Once]
 
   let values_for_check_portability =
-    [ Portability.Portable;
-      Portability.Shareable;
-      Portability.Corruptible;
-      Portability.Nonportable ]
+    lazy
+      [ Portability.Portable;
+        Portability.Shareable;
+        Portability.Corruptible;
+        Portability.Nonportable ]
 
-  let values_for_check_forkable = [Forkable.Forkable; Forkable.Unforkable]
+  let values_for_check_forkable = lazy [Forkable.Forkable; Forkable.Unforkable]
 
-  let values_for_check_yielding = [Yielding.Unyielding; Yielding.Yielding]
+  let values_for_check_yielding = lazy [Yielding.Unyielding; Yielding.Yielding]
 
   let values_for_check_statefulness =
-    [ Statefulness.Stateless;
-      Statefulness.Writing;
-      Statefulness.Reading;
-      Statefulness.Stateful ]
+    lazy
+      [ Statefulness.Stateless;
+        Statefulness.Writing;
+        Statefulness.Reading;
+        Statefulness.Stateful ]
 
   let values_for_check_contention_op =
-    [ Contention.Uncontended;
-      Contention.Corrupted;
-      Contention.Shared;
-      Contention.Contended ]
+    lazy
+      [ Contention.Uncontended;
+        Contention.Corrupted;
+        Contention.Shared;
+        Contention.Contended ]
 
   let values_for_check_visibility_op =
-    [ Visibility.Read_write;
-      Visibility.Read;
-      Visibility.Write;
-      Visibility.Immutable ]
+    lazy
+      [ Visibility.Read_write;
+        Visibility.Read;
+        Visibility.Write;
+        Visibility.Immutable ]
 
-  let values_for_check_staticity_op = [Staticity.Static; Staticity.Dynamic]
+  let values_for_check_staticity_op = lazy [Staticity.Static; Staticity.Dynamic]
 
   let values_for_check_monadic_op =
-    let with_base base =
-      List.concat
-        [ List.map
-            (fun uniqueness -> { base with uniqueness })
-            values_for_check_uniqueness_op;
-          List.map
-            (fun contention -> { base with contention })
-            values_for_check_contention_op;
-          List.map
-            (fun visibility -> { base with visibility })
-            values_for_check_visibility_op;
-          List.map
-            (fun staticity -> { base with staticity })
-            values_for_check_staticity_op ]
-    in
-    with_base Monadic_op.min @ with_base Monadic_op.max
+    lazy
+      (let values_for_check_uniqueness_op =
+         Lazy.force values_for_check_uniqueness_op
+       in
+       let values_for_check_contention_op =
+         Lazy.force values_for_check_contention_op
+       in
+       let values_for_check_visibility_op =
+         Lazy.force values_for_check_visibility_op
+       in
+       let values_for_check_staticity_op =
+         Lazy.force values_for_check_staticity_op
+       in
+       let with_base base =
+         List.concat
+           [ List.map
+               (fun uniqueness -> { base with uniqueness })
+               values_for_check_uniqueness_op;
+             List.map
+               (fun contention -> { base with contention })
+               values_for_check_contention_op;
+             List.map
+               (fun visibility -> { base with visibility })
+               values_for_check_visibility_op;
+             List.map
+               (fun staticity -> { base with staticity })
+               values_for_check_staticity_op ]
+       in
+       with_base Monadic_op.min @ with_base Monadic_op.max)
 
   let values_for_check_comonadic_with_locality =
-    let with_base base =
-      List.concat
-        [ List.map
-            (fun areality -> { base with areality })
-            values_for_check_locality;
-          List.map
-            (fun linearity -> { base with linearity })
-            values_for_check_linearity;
-          List.map
-            (fun portability -> { base with portability })
-            values_for_check_portability;
-          List.map
-            (fun forkable -> { base with forkable })
-            values_for_check_forkable;
-          List.map
-            (fun yielding -> { base with yielding })
-            values_for_check_yielding;
-          List.map
-            (fun statefulness -> { base with statefulness })
-            values_for_check_statefulness ]
-    in
-    with_base Comonadic_with_locality.min
-    @ with_base Comonadic_with_locality.max
+    lazy
+      (let values_for_check_locality = Lazy.force values_for_check_locality in
+       let values_for_check_linearity = Lazy.force values_for_check_linearity in
+       let values_for_check_portability =
+         Lazy.force values_for_check_portability
+       in
+       let values_for_check_forkable = Lazy.force values_for_check_forkable in
+       let values_for_check_yielding = Lazy.force values_for_check_yielding in
+       let values_for_check_statefulness =
+         Lazy.force values_for_check_statefulness
+       in
+       let with_base base =
+         List.concat
+           [ List.map
+               (fun areality -> { base with areality })
+               values_for_check_locality;
+             List.map
+               (fun linearity -> { base with linearity })
+               values_for_check_linearity;
+             List.map
+               (fun portability -> { base with portability })
+               values_for_check_portability;
+             List.map
+               (fun forkable -> { base with forkable })
+               values_for_check_forkable;
+             List.map
+               (fun yielding -> { base with yielding })
+               values_for_check_yielding;
+             List.map
+               (fun statefulness -> { base with statefulness })
+               values_for_check_statefulness ]
+       in
+       with_base Comonadic_with_locality.min
+       @ with_base Comonadic_with_locality.max)
 
   let values_for_check_comonadic_with_regionality =
-    let with_base base =
-      List.concat
-        [ List.map
-            (fun areality -> { base with areality })
-            values_for_check_regionality;
-          List.map
-            (fun linearity -> { base with linearity })
-            values_for_check_linearity;
-          List.map
-            (fun portability -> { base with portability })
-            values_for_check_portability;
-          List.map
-            (fun forkable -> { base with forkable })
-            values_for_check_forkable;
-          List.map
-            (fun yielding -> { base with yielding })
-            values_for_check_yielding;
-          List.map
-            (fun statefulness -> { base with statefulness })
-            values_for_check_statefulness ]
-    in
-    with_base Comonadic_with_regionality.min
-    @ with_base Comonadic_with_regionality.max
+    lazy
+      (let values_for_check_regionality =
+         Lazy.force values_for_check_regionality
+       in
+       let values_for_check_linearity = Lazy.force values_for_check_linearity in
+       let values_for_check_portability =
+         Lazy.force values_for_check_portability
+       in
+       let values_for_check_forkable = Lazy.force values_for_check_forkable in
+       let values_for_check_yielding = Lazy.force values_for_check_yielding in
+       let values_for_check_statefulness =
+         Lazy.force values_for_check_statefulness
+       in
+       let with_base base =
+         List.concat
+           [ List.map
+               (fun areality -> { base with areality })
+               values_for_check_regionality;
+             List.map
+               (fun linearity -> { base with linearity })
+               values_for_check_linearity;
+             List.map
+               (fun portability -> { base with portability })
+               values_for_check_portability;
+             List.map
+               (fun forkable -> { base with forkable })
+               values_for_check_forkable;
+             List.map
+               (fun yielding -> { base with yielding })
+               values_for_check_yielding;
+             List.map
+               (fun statefulness -> { base with statefulness })
+               values_for_check_statefulness ]
+       in
+       with_base Comonadic_with_regionality.min
+       @ with_base Comonadic_with_regionality.max)
 
   let all_values_for_check : type a. a obj -> a list = function
-    | Locality -> values_for_check_locality
-    | Regionality -> values_for_check_regionality
-    | Uniqueness_op -> values_for_check_uniqueness_op
-    | Linearity -> values_for_check_linearity
-    | Portability -> values_for_check_portability
-    | Forkable -> values_for_check_forkable
-    | Yielding -> values_for_check_yielding
-    | Statefulness -> values_for_check_statefulness
-    | Contention_op -> values_for_check_contention_op
-    | Visibility_op -> values_for_check_visibility_op
-    | Staticity_op -> values_for_check_staticity_op
-    | Monadic_op -> values_for_check_monadic_op
-    | Comonadic_with_locality -> values_for_check_comonadic_with_locality
-    | Comonadic_with_regionality -> values_for_check_comonadic_with_regionality
+    | Locality -> Lazy.force values_for_check_locality
+    | Regionality -> Lazy.force values_for_check_regionality
+    | Uniqueness_op -> Lazy.force values_for_check_uniqueness_op
+    | Linearity -> Lazy.force values_for_check_linearity
+    | Portability -> Lazy.force values_for_check_portability
+    | Forkable -> Lazy.force values_for_check_forkable
+    | Yielding -> Lazy.force values_for_check_yielding
+    | Statefulness -> Lazy.force values_for_check_statefulness
+    | Contention_op -> Lazy.force values_for_check_contention_op
+    | Visibility_op -> Lazy.force values_for_check_visibility_op
+    | Staticity_op -> Lazy.force values_for_check_staticity_op
+    | Monadic_op -> Lazy.force values_for_check_monadic_op
+    | Comonadic_with_locality ->
+      Lazy.force values_for_check_comonadic_with_locality
+    | Comonadic_with_regionality ->
+      Lazy.force values_for_check_comonadic_with_regionality
 
   type 'a packed_axis = Axis : ('a, 'b) Axis.t -> 'a packed_axis
 
@@ -4066,7 +4111,7 @@ module For_testing = struct
         (simple_left_to dst)
     in
     let projections =
-      let* (Obj src) = all_objs in
+      let* (Obj src) = Lazy.force all_objs in
       let* (Axis ax) = axes src in
       let projected = proj_obj ax src in
       let+ m = simple_left_from_to projected dst in
@@ -4079,7 +4124,9 @@ module For_testing = struct
       left_morph_to src (Min_with_simple (ax, m))
     in
     let const_min =
-      List.map (fun (Obj src) -> left_morph_to src (Const_min src)) all_objs
+      List.map
+        (fun (Obj src) -> left_morph_to src (Const_min src))
+        (Lazy.force all_objs)
     in
     simple_morphs @ projections @ min_with @ const_min
 
@@ -4091,7 +4138,7 @@ module For_testing = struct
         (simple_right_to dst)
     in
     let projections =
-      let* (Obj src) = all_objs in
+      let* (Obj src) = Lazy.force all_objs in
       let* (Axis ax) = axes src in
       let projected = proj_obj ax src in
       let+ m = simple_right_from_to projected dst in
@@ -4104,58 +4151,61 @@ module For_testing = struct
       right_morph_to src (Max_with_simple (ax, m))
     in
     let const_max =
-      List.map (fun (Obj src) -> right_morph_to src (Const_max src)) all_objs
+      List.map
+        (fun (Obj src) -> right_morph_to src (Const_max src))
+        (Lazy.force all_objs)
     in
     simple_morphs @ projections @ max_with @ const_max
 
   let generate_morphs_to dst =
     generate_left_morphs_to dst @ generate_right_morphs_to dst
 
-  let morphs_to_locality = generate_morphs_to Locality
+  let morphs_to_locality = lazy (generate_morphs_to Locality)
 
-  let morphs_to_regionality = generate_morphs_to Regionality
+  let morphs_to_regionality = lazy (generate_morphs_to Regionality)
 
-  let morphs_to_uniqueness_op = generate_morphs_to Uniqueness_op
+  let morphs_to_uniqueness_op = lazy (generate_morphs_to Uniqueness_op)
 
-  let morphs_to_linearity = generate_morphs_to Linearity
+  let morphs_to_linearity = lazy (generate_morphs_to Linearity)
 
-  let morphs_to_portability = generate_morphs_to Portability
+  let morphs_to_portability = lazy (generate_morphs_to Portability)
 
-  let morphs_to_forkable = generate_morphs_to Forkable
+  let morphs_to_forkable = lazy (generate_morphs_to Forkable)
 
-  let morphs_to_yielding = generate_morphs_to Yielding
+  let morphs_to_yielding = lazy (generate_morphs_to Yielding)
 
-  let morphs_to_statefulness = generate_morphs_to Statefulness
+  let morphs_to_statefulness = lazy (generate_morphs_to Statefulness)
 
-  let morphs_to_contention_op = generate_morphs_to Contention_op
+  let morphs_to_contention_op = lazy (generate_morphs_to Contention_op)
 
-  let morphs_to_visibility_op = generate_morphs_to Visibility_op
+  let morphs_to_visibility_op = lazy (generate_morphs_to Visibility_op)
 
-  let morphs_to_staticity_op = generate_morphs_to Staticity_op
+  let morphs_to_staticity_op = lazy (generate_morphs_to Staticity_op)
 
-  let morphs_to_monadic_op = generate_morphs_to Monadic_op
+  let morphs_to_monadic_op = lazy (generate_morphs_to Monadic_op)
 
   let morphs_to_comonadic_with_locality =
-    generate_morphs_to Comonadic_with_locality
+    lazy (generate_morphs_to Comonadic_with_locality)
 
   let morphs_to_comonadic_with_regionality =
-    generate_morphs_to Comonadic_with_regionality
+    lazy (generate_morphs_to Comonadic_with_regionality)
 
   let morphs_to : type b. b obj -> b packed_morph_to list = function
-    | Locality -> morphs_to_locality
-    | Regionality -> morphs_to_regionality
-    | Uniqueness_op -> morphs_to_uniqueness_op
-    | Linearity -> morphs_to_linearity
-    | Portability -> morphs_to_portability
-    | Forkable -> morphs_to_forkable
-    | Yielding -> morphs_to_yielding
-    | Statefulness -> morphs_to_statefulness
-    | Contention_op -> morphs_to_contention_op
-    | Visibility_op -> morphs_to_visibility_op
-    | Staticity_op -> morphs_to_staticity_op
-    | Monadic_op -> morphs_to_monadic_op
-    | Comonadic_with_locality -> morphs_to_comonadic_with_locality
-    | Comonadic_with_regionality -> morphs_to_comonadic_with_regionality
+    | Locality -> Lazy.force morphs_to_locality
+    | Regionality -> Lazy.force morphs_to_regionality
+    | Uniqueness_op -> Lazy.force morphs_to_uniqueness_op
+    | Linearity -> Lazy.force morphs_to_linearity
+    | Portability -> Lazy.force morphs_to_portability
+    | Forkable -> Lazy.force morphs_to_forkable
+    | Yielding -> Lazy.force morphs_to_yielding
+    | Statefulness -> Lazy.force morphs_to_statefulness
+    | Contention_op -> Lazy.force morphs_to_contention_op
+    | Visibility_op -> Lazy.force morphs_to_visibility_op
+    | Staticity_op -> Lazy.force morphs_to_staticity_op
+    | Monadic_op -> Lazy.force morphs_to_monadic_op
+    | Comonadic_with_locality -> Lazy.force morphs_to_comonadic_with_locality
+    | Comonadic_with_regionality ->
+      Lazy.force morphs_to_comonadic_with_regionality
 
   let check_compose : type a b c.
       a obj ->
@@ -4194,7 +4244,7 @@ module For_testing = struct
   let run_jobs jobs = List.iter (fun job -> job ()) jobs
 
   let check_jobs () =
-    let* (Obj dst) = all_objs in
+    let* (Obj dst) = Lazy.force all_objs in
     let+ (Morph_to (mid, f)) = morphs_to dst in
     let morphs_to_mid = morphs_to mid in
     fun () ->

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2366,8 +2366,8 @@ module Lattices_mono = struct
       apply dst m c
 
     (* Commutes an implication through a morphism from the left, such that:
-       [apply dst m (meet_const c x)] is equivalent to
-       [meet_const (commute_imply_from_left dst m c) (apply dst m x)]
+       [imply_const c (apply dst m x)] is equivalent to
+       [apply dst m (imply_const (commute_imply_from_left dst c m) x)]
     *)
     let commute_imply_from_left : type a b l.
         b obj -> b -> (a, b, l * allowed) t -> a =

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2392,21 +2392,17 @@ module Lattices_mono = struct
     let commute_meet_const_from_right : type a b d.
         b obj -> (a, b, d) t -> a -> b =
      fun dst m c ->
+      let commute_locality_morph : type r s d. (r, s, d) Locality_morph.t -> b =
+        function
+        | Local_to_regional | Regional_to_local | Locality_as_regionality
+        | Regional_to_global | Local_to_regional_regionality
+        | Regional_to_local_regionality | Regional_to_global_regionality ->
+          (* same explanation as below *)
+          apply dst m c
+      in
       match m with
-      | Locality_restricted Local_to_regional
-      | Locality_restricted Regional_to_local
-      | Locality_restricted Locality_as_regionality
-      | Locality_restricted Regional_to_global
-      | Locality_restricted Local_to_regional_regionality
-      | Locality_restricted Regional_to_local_regionality
-      | Locality_restricted Regional_to_global_regionality
-      | Locality_full Local_to_regional
-      | Locality_full Regional_to_local
-      | Locality_full Locality_as_regionality
-      | Locality_full Regional_to_global
-      | Locality_full Local_to_regional_regionality
-      | Locality_full Regional_to_local_regionality
-      | Locality_full Regional_to_global_regionality
+      | Locality_restricted lm -> commute_locality_morph lm
+      | Locality_full lm -> commute_locality_morph lm
       | Uniqueness_op_to_linearity | Linearity_to_uniqueness_op
       | Contention_op_to_portability | Portability_to_contention_op
       | Visibility_op_to_statefulness | Statefulness_to_visibility_op

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5013,6 +5013,10 @@ module Report = struct
     match C.equal_obj a_obj b_obj with
     | Misc.Is_eq -> Misc.Le_result.equal ~le:(C.le a_obj) a b
     | Misc.Is_not_eq -> (
+      (* CR-someday ageorges: Strictly speaking, these are not in fact equal. Here we
+         are doing a hack so that we in fact skip the Skip hint of an alloc_as_value
+         morphism. However, a proper solution is to instead define a specific hint for
+         this morphism. *)
       match a_obj, b_obj with
       | Locality, Regionality ->
         Misc.Le_result.equal ~le:(C.le b_obj)

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -4038,106 +4038,6 @@ module Report = struct
       (Location.Doc.loc ~capitalize_first:false)
       loc
 
-  let print_containing maybe_modality { containing; container } =
-    let container = fst container in
-    match containing with
-    | Tuple ->
-      Fmt.dprintf "is an element of the tuple at %a"
-        (Location.Doc.loc ~capitalize_first:false)
-        container
-    | Record (s, moda) ->
-      Fmt.dprintf "is the field %a%a of the record at %a" Misc.Style.inline_code
-        s maybe_modality moda
-        (Location.Doc.loc ~capitalize_first:false)
-        container
-    | Array moda ->
-      Fmt.dprintf "is an element%a of the array at %a" maybe_modality moda
-        (Location.Doc.loc ~capitalize_first:false)
-        container
-    | Constructor (s, moda) ->
-      Fmt.dprintf "is contained (via constructor %a)%a in the value at %a"
-        Misc.Style.inline_code s maybe_modality moda
-        (Location.Doc.loc ~capitalize_first:false)
-        container
-    | Structure (x, moda) ->
-      Fmt.dprintf "is %t%a in the structure at %a"
-        (print_structure_item ~capitalize:false x)
-        maybe_modality moda
-        (Location.Doc.loc ~capitalize_first:false)
-        container
-
-  (** Given a pinpoint and a const, where the pinpoint has been expressed,
-      prints the const to explain the mode on the pinpoint. *)
-  let print_const (type l r) ((_, pp_desc) : pinpoint) ppf :
-      (l * r) const -> unit = function
-    | Unknown -> Misc.fatal_error "Unknown hint should not be printed"
-    | Lazy_allocated_on_heap ->
-      (match pp_desc with
-      | Lazy ->
-        (* if we already said it's a lazy, we don't need to emphasize it again. *)
-        Fmt.pp_print_string ppf "lazy expressions always need"
-      | _ -> Fmt.pp_print_string ppf "it is a lazy expression and thus needs");
-      Fmt.pp_print_string ppf " to be allocated on the heap"
-    | Legacy m ->
-      (match pp_desc, m with
-      | ( (Ident { category = Class; _ } | Class | Structure_item (Class, _)),
-          Class ) ->
-        (* if we already said it's a class, we don't need to emphasize it again. *)
-        Fmt.pp_print_string ppf "classes are always"
-      | _ ->
-        Fmt.fprintf ppf "it is %t and thus always"
-          (print_legacy m ~definite:false ~capitalize:false));
-      Fmt.pp_print_string ppf " at the legacy modes"
-    | Toplevel_expression ->
-      Fmt.pp_print_string ppf "it is a top-level expression"
-    | Tailcall_function ->
-      Fmt.pp_print_string ppf "it is the function in a tail call"
-    | Tailcall_argument ->
-      Fmt.pp_print_string ppf "it is an argument in a tail call"
-    | Mutable_read m ->
-      Fmt.fprintf ppf "its %a is being read" print_mutable_part m
-    | Mutable_write m ->
-      Fmt.fprintf ppf "its %a is being written" print_mutable_part m
-    | Lazy_forced -> (
-      match pp_desc with
-      | Lazy ->
-        (* if we already said it's a lazy, we don't need to emphasize it again. *)
-        Fmt.pp_print_string ppf "it is being forced"
-      | _ -> Fmt.pp_print_string ppf "it is a lazy value being forced")
-    | Function_return ->
-      Fmt.fprintf ppf
-        "it is a function return value.@ Hint: Use exclave_ to return a local \
-         value"
-    | Stack_expression ->
-      Fmt.fprintf ppf "it is %a-allocated" Misc.Style.inline_code "stack_"
-    | Module_allocated_on_heap ->
-      (match pp_desc with
-      | Ident { category = Module; _ }
-      | Functor | Module | Structure
-      | Structure_item (Module, _) ->
-        (* if we already said it's a module, we don't need to emphasize it again. *)
-        Fmt.pp_print_string ppf "modules always need"
-      | _ -> Fmt.pp_print_string ppf "it is a module and thus needs");
-      Fmt.pp_print_string ppf " to be allocated on the heap"
-    | Is_used_in pp ->
-      let print_pp = print_pinpoint pp |> Option.get in
-      Fmt.fprintf ppf "it is used in %t"
-        (print_pp ~definite:false ~capitalize:false)
-    | Always_dynamic x ->
-      Fmt.fprintf ppf "%t are always dynamic" (print_always_dynamic x)
-    | Branching -> Fmt.fprintf ppf "it has branches"
-    | Borrowed _ -> Fmt.fprintf ppf "it is borrowed"
-    | Escape_region reg ->
-      Fmt.fprintf ppf "it escapes %t" (print_region ~capitalize:false reg)
-    | Quoted_computation -> Fmt.fprintf ppf "it is the quote of a computation"
-    | Lpoly_inst ->
-      Fmt.pp_print_string ppf
-        "it is layout-polymorphic and being instantiated here"
-    | Spliced _ -> Fmt.fprintf ppf "it is spliced"
-    | Contained_by c ->
-      let print_mod ppf Modality = Fmt.fprintf ppf " (with some modality)" in
-      Fmt.fprintf ppf "it %t" (print_containing print_mod c)
-
   let print_allocation_l : allocation -> Fmt.formatter -> unit =
    fun { txt; loc } ->
     match txt with
@@ -4225,6 +4125,34 @@ module Report = struct
         in
         pr, contained)
 
+  let print_containing maybe_modality { containing; container } =
+    let container = fst container in
+    match containing with
+    | Tuple ->
+      Fmt.dprintf "is an element of the tuple at %a"
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+    | Record (s, moda) ->
+      Fmt.dprintf "is the field %a%a of the record at %a" Misc.Style.inline_code
+        s maybe_modality moda
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+    | Array moda ->
+      Fmt.dprintf "is an element%a of the array at %a" maybe_modality moda
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+    | Constructor (s, moda) ->
+      Fmt.dprintf "is contained (via constructor %a)%a in the value at %a"
+        Misc.Style.inline_code s maybe_modality moda
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+    | Structure (x, moda) ->
+      Fmt.dprintf "is %t%a in the structure at %a"
+        (print_structure_item ~capitalize:false x)
+        maybe_modality moda
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+
   let print_is_contained_by :
       fixpoint:bool -> is_contained_by -> (Fmt.formatter -> unit) * pinpoint =
    fun ~fixpoint { containing; container } ->
@@ -4232,35 +4160,80 @@ module Report = struct
     (* CR-someday zqian: Use the full [container] to improve the printing below.
        E.g., insted of printing "the tuple at XXX", we can print "the tuple
        pattern at XXX" or "the tuple expression at XXX". *)
-    let container = fst container in
-    let pr =
-      match containing with
-      | Tuple ->
-        Fmt.dprintf "is an element of the tuple at %a"
-          (Location.Doc.loc ~capitalize_first:false)
-          container
-      | Record (s, moda) ->
-        Fmt.dprintf "is the field %a%a of the record at %a"
-          Misc.Style.inline_code s maybe_modality moda
-          (Location.Doc.loc ~capitalize_first:false)
-          container
-      | Array moda ->
-        Fmt.dprintf "is an element%a of the array at %a" maybe_modality moda
-          (Location.Doc.loc ~capitalize_first:false)
-          container
-      | Constructor (s, moda) ->
-        Fmt.dprintf "is contained (via constructor %a)%a in the value at %a"
-          Misc.Style.inline_code s maybe_modality moda
-          (Location.Doc.loc ~capitalize_first:false)
-          container
-      | Structure (x, moda) ->
-        Fmt.dprintf "is %t%a in the structure at %a"
-          (print_structure_item ~capitalize:false x)
-          maybe_modality moda
-          (Location.Doc.loc ~capitalize_first:false)
-          container
-    in
+    let pr = print_containing maybe_modality { containing; container } in
     pr, pp
+
+  (** Given a pinpoint and a const, where the pinpoint has been expressed,
+      prints the const to explain the mode on the pinpoint. *)
+  let print_const (type l r) ((_, pp_desc) : pinpoint) ppf :
+      (l * r) const -> unit = function
+    | Unknown -> Misc.fatal_error "Unknown hint should not be printed"
+    | Lazy_allocated_on_heap ->
+      (match pp_desc with
+      | Lazy ->
+        (* if we already said it's a lazy, we don't need to emphasize it again. *)
+        Fmt.pp_print_string ppf "lazy expressions always need"
+      | _ -> Fmt.pp_print_string ppf "it is a lazy expression and thus needs");
+      Fmt.pp_print_string ppf " to be allocated on the heap"
+    | Legacy m ->
+      (match pp_desc, m with
+      | ( (Ident { category = Class; _ } | Class | Structure_item (Class, _)),
+          Class ) ->
+        (* if we already said it's a class, we don't need to emphasize it again. *)
+        Fmt.pp_print_string ppf "classes are always"
+      | _ ->
+        Fmt.fprintf ppf "it is %t and thus always"
+          (print_legacy m ~definite:false ~capitalize:false));
+      Fmt.pp_print_string ppf " at the legacy modes"
+    | Toplevel_expression ->
+      Fmt.pp_print_string ppf "it is a top-level expression"
+    | Tailcall_function ->
+      Fmt.pp_print_string ppf "it is the function in a tail call"
+    | Tailcall_argument ->
+      Fmt.pp_print_string ppf "it is an argument in a tail call"
+    | Mutable_read m ->
+      Fmt.fprintf ppf "its %a is being read" print_mutable_part m
+    | Mutable_write m ->
+      Fmt.fprintf ppf "its %a is being written" print_mutable_part m
+    | Lazy_forced -> (
+      match pp_desc with
+      | Lazy ->
+        (* if we already said it's a lazy, we don't need to emphasize it again. *)
+        Fmt.pp_print_string ppf "it is being forced"
+      | _ -> Fmt.pp_print_string ppf "it is a lazy value being forced")
+    | Function_return ->
+      Fmt.fprintf ppf
+        "it is a function return value.@ Hint: Use exclave_ to return a local \
+         value"
+    | Stack_expression ->
+      Fmt.fprintf ppf "it is %a-allocated" Misc.Style.inline_code "stack_"
+    | Module_allocated_on_heap ->
+      (match pp_desc with
+      | Ident { category = Module; _ }
+      | Functor | Module | Structure
+      | Structure_item (Module, _) ->
+        (* if we already said it's a module, we don't need to emphasize it again. *)
+        Fmt.pp_print_string ppf "modules always need"
+      | _ -> Fmt.pp_print_string ppf "it is a module and thus needs");
+      Fmt.pp_print_string ppf " to be allocated on the heap"
+    | Is_used_in pp ->
+      let print_pp = print_pinpoint pp |> Option.get in
+      Fmt.fprintf ppf "it is used in %t"
+        (print_pp ~definite:false ~capitalize:false)
+    | Always_dynamic x ->
+      Fmt.fprintf ppf "%t are always dynamic" (print_always_dynamic x)
+    | Branching -> Fmt.fprintf ppf "it has branches"
+    | Borrowed _ -> Fmt.fprintf ppf "it is borrowed"
+    | Escape_region reg ->
+      Fmt.fprintf ppf "it escapes %t" (print_region ~capitalize:false reg)
+    | Quoted_computation -> Fmt.fprintf ppf "it is the quote of a computation"
+    | Lpoly_inst ->
+      Fmt.pp_print_string ppf
+        "it is layout-polymorphic and being instantiated here"
+    | Spliced _ -> Fmt.fprintf ppf "it is spliced"
+    | Contained_by c ->
+      let print_mod ppf Modality = Fmt.fprintf ppf " (with some modality)" in
+      Fmt.fprintf ppf "it %t" (print_containing print_mod c)
 
   (** Given a pinpoint and a morph, where the pinpoint is the destination of the
       morph and have been expressed already, print the morph and return the

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2257,11 +2257,41 @@ module Lattices_mono = struct
         (q, c comonadic_with, disallowed * r) compose_and_max_result =
      fun lm1 ax0 ->
       match ax0 with
-      | Forkable -> And_max_id Forkable
-      | Yielding -> And_max_id Yielding
-      | Linearity -> And_max_id Linearity
-      | Statefulness -> And_max_id Statefulness
-      | Portability -> And_max_id Portability
+      | Forkable -> (
+        match lm1 with
+        | Local_to_regional -> Disallowed
+        | Local_to_regional_regionality -> Disallowed
+        | Regional_to_local | Locality_as_regionality | Regional_to_global
+        | Regional_to_local_regionality | Regional_to_global_regionality ->
+          And_max_id Forkable)
+      | Yielding -> (
+        match lm1 with
+        | Local_to_regional -> Disallowed
+        | Local_to_regional_regionality -> Disallowed
+        | Regional_to_local | Locality_as_regionality | Regional_to_global
+        | Regional_to_local_regionality | Regional_to_global_regionality ->
+          And_max_id Yielding)
+      | Linearity -> (
+        match lm1 with
+        | Local_to_regional -> Disallowed
+        | Local_to_regional_regionality -> Disallowed
+        | Regional_to_local | Locality_as_regionality | Regional_to_global
+        | Regional_to_local_regionality | Regional_to_global_regionality ->
+          And_max_id Linearity)
+      | Statefulness -> (
+        match lm1 with
+        | Local_to_regional -> Disallowed
+        | Local_to_regional_regionality -> Disallowed
+        | Regional_to_local | Locality_as_regionality | Regional_to_global
+        | Regional_to_local_regionality | Regional_to_global_regionality ->
+          And_max_id Statefulness)
+      | Portability -> (
+        match lm1 with
+        | Local_to_regional -> Disallowed
+        | Local_to_regional_regionality -> Disallowed
+        | Regional_to_local | Locality_as_regionality | Regional_to_global
+        | Regional_to_local_regionality | Regional_to_global_regionality ->
+          And_max_id Portability)
       | Areality -> And_max_core (Areality, Locality_restricted lm1)
 
     let compose_max_with_simple_core : type b c q r.
@@ -3284,6 +3314,30 @@ module Lattices_mono = struct
       Simple_proj (Simple_morph.left_adjoint mid m, ax, dst)
     | Const_max _ -> Const_min dst
 
+  let const_max_or_apply : type a c p r.
+      c obj ->
+      (p, c, disallowed * r) Simple_morph.t ->
+      a obj ->
+      (a, c, disallowed * r) morph =
+   fun dst m obj ->
+    match Simple_morph.maybe_allowed_right m with
+    | Allowed_right _ -> Const_max obj
+    | Not_allowed_right ->
+      let src = Simple_morph.src dst m in
+      Const (obj, Simple_morph.apply dst m (max src))
+
+  let const_min_or_apply : type a c p l.
+      c obj ->
+      (p, c, l * disallowed) Simple_morph.t ->
+      a obj ->
+      (a, c, l * disallowed) morph =
+   fun dst m obj ->
+    match Simple_morph.maybe_allowed_left m with
+    | Allowed_left _ -> Const_min obj
+    | Not_allowed_left ->
+      let src = Simple_morph.src dst m in
+      Const (obj, Simple_morph.apply dst m (min src))
+
   let compose_simple_proj_core : type a c p d.
       c obj ->
       (p, c, d) Simple_morph.t ->
@@ -3294,8 +3348,8 @@ module Lattices_mono = struct
     | Proj_core (m1, ax1, obj1) ->
       Simple_proj (Simple_morph.compose dst m0 (Core m1), ax1, obj1)
     | Proj_id (ax1, obj1) -> Simple_proj (m0, ax1, obj1)
-    | Proj_const_max obj1 -> Const_max obj1
-    | Proj_const_min obj1 -> Const_min obj1
+    | Proj_const_max obj1 -> const_max_or_apply dst m0 obj1
+    | Proj_const_min obj1 -> const_min_or_apply dst m0 obj1
 
   let compose_simple_proj_meet_const_core : type a c p l.
       c obj ->
@@ -3310,8 +3364,8 @@ module Lattices_mono = struct
         (Simple_morph.compose dst m0 (Meet_const_core (c1, m1)), ax1, obj1)
     | Proj_id (ax1, obj1) ->
       Simple_proj (Simple_morph.compose dst m0 (Meet_const c1), ax1, obj1)
-    | Proj_const_max obj1 -> Const_max obj1
-    | Proj_const_min obj1 -> Const_min obj1
+    | Proj_const_max obj1 -> Const (obj1, Simple_morph.apply dst m0 c1)
+    | Proj_const_min obj1 -> const_min_or_apply dst m0 obj1
 
   let compose_simple_proj_core_imply_const : type a c p r.
       c obj ->
@@ -3328,8 +3382,8 @@ module Lattices_mono = struct
     | Proj_id (ax1, obj1) ->
       let c1 = Axis.proj ax1 c1 in
       Simple_proj (Simple_morph.compose dst m0 (Imply_const c1), ax1, obj1)
-    | Proj_const_max obj1 -> Const_max obj1
-    | Proj_const_min obj1 -> Const_min obj1
+    | Proj_const_max obj1 -> const_max_or_apply dst m0 obj1
+    | Proj_const_min obj1 -> const_min_or_apply dst m0 obj1
 
   let compose_simple_proj_with_simple : type a b c p d.
       c obj ->
@@ -3487,7 +3541,7 @@ module Lattices_mono = struct
       | Misc.Is_not_eq ->
         let b_obj = src dst (Simple_proj (m0, ax0, obj1)) in
         let a_obj = src b_obj (Max_with_simple (ax1, m1)) in
-        Const_max a_obj
+        const_max_or_apply dst m0 a_obj
       end
     | Simple_proj (m0, ax0, obj1), Min_with_simple (ax1, m1) ->
       begin match Axis.equal ax0 ax1 with
@@ -3495,7 +3549,7 @@ module Lattices_mono = struct
       | Misc.Is_not_eq ->
         let b_obj = src dst (Simple_proj (m0, ax0, obj1)) in
         let a_obj = src b_obj (Min_with_simple (ax1, m1)) in
-        Const_min a_obj
+        const_min_or_apply dst m0 a_obj
       end
     | (Max_with_simple (ax0, m0) as m0'), (Simple_proj (m1, ax1, obj1) as m1')
       ->
@@ -3519,22 +3573,12 @@ module Lattices_mono = struct
         allow_left (Simple (Simple_morph.lift_min a_obj dst m0m1 ax1 ax0))
       | Not_allowed_left -> Compose (m0', m1')
       end
-    | Simple m0, Const_max a_obj ->
-      begin match Simple_morph.maybe_allowed_right m0 with
-      | Allowed_right _ -> Const_max a_obj
-      | Not_allowed_right ->
-        let b_obj = Simple_morph.src dst m0 in
-        Const (a_obj, Simple_morph.apply dst m0 (max b_obj))
-      end
-    | Simple m0, Const_min a_obj ->
-      begin match Simple_morph.maybe_allowed_left m0 with
-      | Allowed_left _ -> Const_min a_obj
-      | Not_allowed_left ->
-        let b_obj = Simple_morph.src dst m0 in
-        Const (a_obj, Simple_morph.apply dst m0 (min b_obj))
-      end
-    | Simple_proj (_m0, _ax0, _obj0), Const_max obj1 -> Const_max obj1
-    | Simple_proj (_m0, _ax0, _obj0), Const_min obj1 -> Const_min obj1
+    | Simple m0, Const_max a_obj -> const_max_or_apply dst m0 a_obj
+    | Simple m0, Const_min a_obj -> const_min_or_apply dst m0 a_obj
+    | Simple_proj (m0, _ax0, _obj0), Const_max obj1 ->
+      const_max_or_apply dst m0 obj1
+    | Simple_proj (m0, _ax0, _obj0), Const_min obj1 ->
+      const_min_or_apply dst m0 obj1
     | Min_with_simple (ax0, m0), Const_max obj1 ->
       let q_obj = proj_obj ax0 dst in
       let b_obj = Simple_morph.src q_obj m0 in

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1565,6 +1565,26 @@ module Lattices_mono = struct
       | Contention_op -> [Pb (Monadic_op, Contention)]
       | Visibility_op -> [Pb (Monadic_op, Visibility)]
       | Staticity_op -> [Pb (Monadic_op, Staticity)]
+
+    type ('a, 'p) owner =
+      | Monadic : (Monadic_op.t, 'p) t -> (Monadic_op.t, 'p) owner
+      | Comonadic :
+          'ar comonadic_with obj * ('ar comonadic_with, 'p) t
+          -> ('ar comonadic_with, 'p) owner
+
+    let owner : type a p. a obj -> (a, p) t -> (a, p) owner =
+     fun obj ax ->
+      match ax with
+      | Areality -> Comonadic (obj, ax)
+      | Forkable -> Comonadic (obj, ax)
+      | Yielding -> Comonadic (obj, ax)
+      | Linearity -> Comonadic (obj, ax)
+      | Statefulness -> Comonadic (obj, ax)
+      | Portability -> Comonadic (obj, ax)
+      | Uniqueness -> Monadic ax
+      | Visibility -> Monadic ax
+      | Contention -> Monadic ax
+      | Staticity -> Monadic ax
   end
 
   type packed_obj = Obj : 'a obj -> packed_obj
@@ -1888,6 +1908,36 @@ module Lattices_mono = struct
       | Regional_to_global_regionality, Local_to_regional -> Disallowed
       | Regional_to_global_regionality, Local_to_regional_regionality ->
         Disallowed
+
+    let id_with_regional_to_locality : type a b l r.
+        (Regionality.t, Locality.t, l * r) t ->
+        a comonadic_with obj ->
+        b comonadic_with obj ->
+        (a, b, l * r) compose_result =
+     fun regional_to_locality src dst ->
+      match src, dst with
+      | Comonadic_with_regionality, Comonadic_with_locality ->
+        Morph regional_to_locality
+      | Comonadic_with_locality, Comonadic_with_regionality ->
+        Morph Locality_as_regionality
+      | Comonadic_with_regionality, Comonadic_with_regionality -> Id
+      | Comonadic_with_locality, Comonadic_with_locality -> Id
+
+    (** Closest-to-identity morphism between comonadic_with axes, using r2g for
+        regionality-to-locality. *)
+    let id_r2g : type a b.
+        a comonadic_with obj ->
+        b comonadic_with obj ->
+        (a, b, disallowed * allowed) compose_result =
+     fun src dst -> id_with_regional_to_locality Regional_to_global src dst
+
+    (** Closest-to-identity morphism between comonadic_with axes, using r2l for
+        regionality-to-locality. *)
+    let id_r2l : type a b.
+        a comonadic_with obj ->
+        b comonadic_with obj ->
+        (a, b, allowed * disallowed) compose_result =
+     fun src dst -> id_with_regional_to_locality Regional_to_local src dst
   end
 
   module Core_morph = struct
@@ -2543,6 +2593,108 @@ module Lattices_mono = struct
       | _, _ -> .
     [@@warning "-4"]
 
+    type ('a, 'b, 'd) compose_result =
+      | Id : ('a, 'a, 'd) compose_result
+      | Morph : ('a, 'b, 'd) t -> ('a, 'b, 'd) compose_result
+      | Disallowed : ('a, 'b, neither) compose_result
+
+    let lift_locality_compose_result : type a b l r.
+        (a, b, l * r) Locality_morph.compose_result ->
+        (a comonadic_with, b comonadic_with, l * r) compose_result = function
+      | Locality_morph.Id -> Id
+      | Locality_morph.Morph lm -> Morph (Locality_full lm)
+      | Locality_morph.Disallowed -> Disallowed
+
+    (** Closest-to-identity morphism between full product objects, as enforced
+        by the [Axis.t] arguments. Uses r2g for comonadic areality and plain
+        identity for monadic axes. *)
+    let id_r2g : type a b p.
+        a obj ->
+        b obj ->
+        (a, p) Axis.t ->
+        (b, p) Axis.t ->
+        (a, b, disallowed * allowed) compose_result =
+     fun src dst ax0 ax1 ->
+      match Axis.owner src ax0, Axis.owner dst ax1 with
+      | Axis.Monadic _, Axis.Monadic _ -> Id
+      | Axis.Comonadic (src, _), Axis.Comonadic (dst, _) ->
+        Locality_morph.id_r2g src dst |> lift_locality_compose_result
+      | Axis.Monadic _, Axis.Comonadic _ -> .
+      | Axis.Comonadic _, Axis.Monadic _ -> .
+
+    (** Closest-to-identity morphism between full product objects, as enforced
+        by the [Axis.t] arguments. Uses r2l for comonadic areality and plain
+        identity for monadic axes. *)
+    let id_r2l : type a b p.
+        a obj ->
+        b obj ->
+        (a, p) Axis.t ->
+        (b, p) Axis.t ->
+        (a, b, allowed * disallowed) compose_result =
+     fun src dst ax0 ax1 ->
+      match Axis.owner src ax0, Axis.owner dst ax1 with
+      | Axis.Monadic _, Axis.Monadic _ -> Id
+      | Axis.Comonadic (src, _), Axis.Comonadic (dst, _) ->
+        Locality_morph.id_r2l src dst |> lift_locality_compose_result
+      | Axis.Monadic _, Axis.Comonadic _ -> .
+      | Axis.Comonadic _, Axis.Monadic _ -> .
+
+    (** Lift a core morphism between projected axes to a core morphism between
+        the enclosing objects. Goes to max for axes with no dual. *)
+    let lift_max : type a b p q.
+        a obj ->
+        b obj ->
+        (p, q, disallowed * allowed) t ->
+        (a, p) Axis.t ->
+        (b, q) Axis.t ->
+        (a, b, disallowed * allowed) compose_result =
+     fun src dst m ax0 ax1 ->
+      match m, ax0, ax1, src, dst with
+      | Uniqueness_op_to_linearity, Uniqueness, Linearity, _, _ ->
+        Morph Monadic_to_comonadic_max
+      | Linearity_to_uniqueness_op, Linearity, Uniqueness, _, _ ->
+        Morph (Comonadic_to_monadic_max (comonadic_obj_areality src))
+      | Contention_op_to_portability, Contention, Portability, _, _ ->
+        Morph Monadic_to_comonadic_max
+      | Portability_to_contention_op, Portability, Contention, _, _ ->
+        Morph (Comonadic_to_monadic_max (comonadic_obj_areality src))
+      | Visibility_op_to_statefulness, Visibility, Statefulness, _, _ ->
+        Morph Monadic_to_comonadic_max
+      | Statefulness_to_visibility_op, Statefulness, Visibility, _, _ ->
+        Morph (Comonadic_to_monadic_max (comonadic_obj_areality src))
+      | Locality_restricted lm, Areality, Areality, _, _ ->
+        Morph (Locality_full lm)
+      | _, _, _, _, _ -> .
+    [@@warning "-4"]
+
+    (** Lift a core morphism between projected axes to a core morphism between
+        the enclosing objects. Goes to min for axes with no dual. *)
+    let lift_min : type a b p q.
+        a obj ->
+        b obj ->
+        (p, q, allowed * disallowed) t ->
+        (a, p) Axis.t ->
+        (b, q) Axis.t ->
+        (a, b, allowed * disallowed) compose_result =
+     fun src dst m ax0 ax1 ->
+      match m, ax0, ax1, src, dst with
+      | Uniqueness_op_to_linearity, Uniqueness, Linearity, _, _ ->
+        Morph Monadic_to_comonadic_min
+      | Linearity_to_uniqueness_op, Linearity, Uniqueness, _, _ ->
+        Morph (Comonadic_to_monadic_min (comonadic_obj_areality src))
+      | Contention_op_to_portability, Contention, Portability, _, _ ->
+        Morph Monadic_to_comonadic_min
+      | Portability_to_contention_op, Portability, Contention, _, _ ->
+        Morph (Comonadic_to_monadic_min (comonadic_obj_areality src))
+      | Visibility_op_to_statefulness, Visibility, Statefulness, _, _ ->
+        Morph Monadic_to_comonadic_min
+      | Statefulness_to_visibility_op, Statefulness, Visibility, _, _ ->
+        Morph (Comonadic_to_monadic_min (comonadic_obj_areality src))
+      | Locality_restricted lm, Areality, Areality, _, _ ->
+        Morph (Locality_full lm)
+      | _, _, _, _, _ -> .
+    [@@warning "-4"]
+
     type ('b, 'd) packed_to = To : ('a, 'b, 'd) t -> ('b, 'd) packed_to
     [@@unboxed]
 
@@ -3116,6 +3268,18 @@ module Lattices_mono = struct
       | (Compose _ as m1), m2 -> Compose (m1, m2)
       | _, Compose _ -> .
 
+    let lift_core_compose_result_r : type a b l.
+        (a, b, l * allowed) Core_morph.compose_result -> (a, b, l * allowed) t =
+      function
+      | Core_morph.Id -> Id
+      | Core_morph.Morph m -> Core m
+
+    let lift_core_compose_result_l : type a b r.
+        (a, b, allowed * r) Core_morph.compose_result -> (a, b, allowed * r) t =
+      function
+      | Core_morph.Id -> Id
+      | Core_morph.Morph m -> Core m
+
     let rec lift_max : type a b p q.
         a obj ->
         b obj ->
@@ -3126,51 +3290,15 @@ module Lattices_mono = struct
      fun src dst m ax0 ax1 ->
       let m : (a, b, disallowed * allowed) t =
         match m with
-        | Id ->
-          begin match src, dst, ax0, ax1 with
-          | Comonadic_with_regionality, Comonadic_with_locality, _, _ ->
-            Core (Locality_full Regional_to_global)
-          | Comonadic_with_locality, Comonadic_with_regionality, _, _ ->
-            Core (Locality_full Locality_as_regionality)
-          | Comonadic_with_regionality, Comonadic_with_regionality, _, _ -> Id
-          | Comonadic_with_locality, Comonadic_with_locality, _, _ -> Id
-          | Monadic_op, Monadic_op, _, _ -> Id
-          | _, _, _, _ -> .
-          end
+        | Id -> Core_morph.id_r2g src dst ax0 ax1 |> lift_core_compose_result_r
         | Core m ->
-          begin match m, ax0, ax1, src, dst with
-          | Uniqueness_op_to_linearity, Uniqueness, Linearity, _, _ ->
-            Core Monadic_to_comonadic_max
-          | Linearity_to_uniqueness_op, Linearity, Uniqueness, _, _ ->
-            Core (Comonadic_to_monadic_max (comonadic_obj_areality src))
-          | Contention_op_to_portability, Contention, Portability, _, _ ->
-            Core Monadic_to_comonadic_max
-          | Portability_to_contention_op, Portability, Contention, _, _ ->
-            Core (Comonadic_to_monadic_max (comonadic_obj_areality src))
-          | Visibility_op_to_statefulness, Visibility, Statefulness, _, _ ->
-            Core Monadic_to_comonadic_max
-          | Statefulness_to_visibility_op, Statefulness, Visibility, _, _ ->
-            Core (Comonadic_to_monadic_max (comonadic_obj_areality src))
-          | Locality_restricted lm, Areality, Areality, _, _ ->
-            Core (Locality_full lm)
-          | _, _, _, _, _ -> .
-          end
+          Core_morph.lift_max src dst m ax0 ax1 |> lift_core_compose_result_r
         | Imply_const c ->
           let c = Axis.set ax1 c (max dst) in
-          begin match src, dst, ax0, ax1 with
-          | Comonadic_with_regionality, Comonadic_with_locality, _, _ ->
-            compose dst (Imply_const c)
-              (Core (Locality_full Regional_to_global))
-          | Comonadic_with_locality, Comonadic_with_regionality, _, _ ->
-            compose dst (Imply_const c)
-              (Core (Locality_full Locality_as_regionality))
-          | Comonadic_with_regionality, Comonadic_with_regionality, _, _ ->
-            Imply_const c
-          | Comonadic_with_locality, Comonadic_with_locality, _, _ ->
-            Imply_const c
-          | Monadic_op, Monadic_op, _, _ -> Imply_const c
-          | _, _, _, _ -> .
-          end
+          let m =
+            Core_morph.id_r2g src dst ax0 ax1 |> lift_core_compose_result_r
+          in
+          compose dst (Imply_const c) m
         | Core_imply_const (m, c) ->
           let m = lift_max src dst (Core m) ax0 ax1 in
           let c = Axis.set ax0 c (max src) in
@@ -3191,50 +3319,15 @@ module Lattices_mono = struct
      fun src dst m ax0 ax1 ->
       let m : (a, b, allowed * disallowed) t =
         match m with
-        | Id ->
-          begin match src, dst, ax0, ax1 with
-          | Comonadic_with_regionality, Comonadic_with_locality, _, _ ->
-            Core (Locality_full Regional_to_local)
-          | Comonadic_with_locality, Comonadic_with_regionality, _, _ ->
-            Core (Locality_full Locality_as_regionality)
-          | Comonadic_with_regionality, Comonadic_with_regionality, _, _ -> Id
-          | Comonadic_with_locality, Comonadic_with_locality, _, _ -> Id
-          | Monadic_op, Monadic_op, _, _ -> Id
-          | _, _, _, _ -> .
-          end
+        | Id -> Core_morph.id_r2l src dst ax0 ax1 |> lift_core_compose_result_l
         | Core m ->
-          begin match m, ax0, ax1, src, dst with
-          | Uniqueness_op_to_linearity, Uniqueness, Linearity, _, _ ->
-            Core Monadic_to_comonadic_min
-          | Linearity_to_uniqueness_op, Linearity, Uniqueness, _, _ ->
-            Core (Comonadic_to_monadic_min (comonadic_obj_areality src))
-          | Contention_op_to_portability, Contention, Portability, _, _ ->
-            Core Monadic_to_comonadic_min
-          | Portability_to_contention_op, Portability, Contention, _, _ ->
-            Core (Comonadic_to_monadic_min (comonadic_obj_areality src))
-          | Visibility_op_to_statefulness, Visibility, Statefulness, _, _ ->
-            Core Monadic_to_comonadic_min
-          | Statefulness_to_visibility_op, Statefulness, Visibility, _, _ ->
-            Core (Comonadic_to_monadic_min (comonadic_obj_areality src))
-          | Locality_restricted lm, Areality, Areality, _, _ ->
-            Core (Locality_full lm)
-          | _, _, _, _, _ -> .
-          end
+          Core_morph.lift_min src dst m ax0 ax1 |> lift_core_compose_result_l
         | Meet_const c ->
           let c = Axis.set ax1 c (min dst) in
-          begin match src, dst, ax0, ax1 with
-          | Comonadic_with_regionality, Comonadic_with_locality, _, _ ->
-            compose dst (Meet_const c) (Core (Locality_full Regional_to_local))
-          | Comonadic_with_locality, Comonadic_with_regionality, _, _ ->
-            compose dst (Meet_const c)
-              (Core (Locality_full Locality_as_regionality))
-          | Comonadic_with_regionality, Comonadic_with_regionality, _, _ ->
-            Meet_const c
-          | Comonadic_with_locality, Comonadic_with_locality, _, _ ->
-            Meet_const c
-          | Monadic_op, Monadic_op, _, _ -> Meet_const c
-          | _, _, _, _ -> .
-          end
+          let m =
+            Core_morph.id_r2l src dst ax0 ax1 |> lift_core_compose_result_l
+          in
+          compose dst (Meet_const c) m
         | Meet_const_core (c, m) ->
           let m = lift_min src dst (Core m) ax0 ax1 in
           let c = Axis.set ax1 c (min dst) in

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -800,6 +800,9 @@ module Lattices = struct
          let+ staticity = Lazy.force Staticity.all in
          { uniqueness; contention; visibility; staticity })
 
+    (* CR-someday ageorges: the following code manually enumerates axes. It would be nice
+       to use the later definition of Lattices.Monadic.Axis.all *)
+
     (** Product values that cover every element of every axis at least once,
         without enumerating every product combination. *)
     let spanning_elements =
@@ -950,6 +953,9 @@ module Lattices = struct
          let* yielding = Lazy.force Yielding.all in
          let+ statefulness = Lazy.force Statefulness.all in
          { areality; linearity; portability; forkable; yielding; statefulness })
+
+    (* CR-someday ageorges: the following code manually enumerates axes. It would be nice
+       to use the later definition of Lattices.Comonadic_with.Axis.all *)
 
     (** Product values that cover every element of every axis at least once,
         without enumerating every product combination. *)

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1635,13 +1635,7 @@ module Lattices_mono = struct
 
   module Locality_morph = struct
     (* Following is a chain of adjunctions (this can be extended one
-       further, but we never need the missing operation).
-
-      INVARIANT: each locality morphism below must preserve binary meets:
-        lm(x meet y) == lm(x) meet lm(y). If the invariant is broken,
-        [commute_meet_const_from_right] may no longer be correct (or implementable), and
-        we may need to change [Simple_morph.compose] and add the missing case in
-        [Simple_morph.t] *)
+       further, but we never need the missing operation). *)
     type ('a, 'b, 'd) t =
       | Local_to_regional : (Locality.t, Regionality.t, 'l * disallowed) t
           (** Maps local to regional, global to global *)
@@ -1948,11 +1942,6 @@ module Lattices_mono = struct
   end
 
   module Core_morph = struct
-    (* INVARIANT: each core morphism below must preserve binary meets:
-        cm(x meet y) == cm(x) meet cm(y). If the invariant is broken,
-        [commute_meet_const_from_right] may no longer be correct (or implementable), and
-        we may need to change [Simple_morph.compose] and add the missing case in
-        [Simple_morph.t] *)
     type ('a, 'b, 'd) t =
       | Locality_restricted :
           ('a, 'b, 'l * 'r) Locality_morph.t
@@ -2370,20 +2359,49 @@ module Lattices_mono = struct
     (* Commutes a meet through a morphism from the right, such that:
        [apply dst m (meet_const c x)] is equivalent to
        [meet_const (commute_meet_const_from_right dst m c) (apply dst m x)]
+
+       PRECONDITION: All [Core_morph.t] preserves binary meets:
+        m(x meet y) == m(x) meet m(y). Without this precondition,
+        [commute_meet_const_from_right] may no longer be implementable, and
+        we will need to change the implementation of [Simple_morph.compose], as well as
+        add the missing cases in [Simple_morph.t].
     *)
     let commute_meet_const_from_right : type a b d.
         b obj -> (a, b, d) t -> a -> b =
      fun dst m c ->
-      (* All morphisms preserve binary meets. The correctness argument
-         thus goes as follows:
+      match m with
+      | Locality_restricted Local_to_regional
+      | Locality_restricted Regional_to_local
+      | Locality_restricted Locality_as_regionality
+      | Locality_restricted Regional_to_global
+      | Locality_restricted Local_to_regional_regionality
+      | Locality_restricted Regional_to_local_regionality
+      | Locality_restricted Regional_to_global_regionality
+      | Locality_full Local_to_regional
+      | Locality_full Regional_to_local
+      | Locality_full Locality_as_regionality
+      | Locality_full Regional_to_global
+      | Locality_full Local_to_regional_regionality
+      | Locality_full Regional_to_local_regionality
+      | Locality_full Regional_to_global_regionality
+      | Uniqueness_op_to_linearity | Linearity_to_uniqueness_op
+      | Contention_op_to_portability | Portability_to_contention_op
+      | Visibility_op_to_statefulness | Statefulness_to_visibility_op
+      | Monadic_to_comonadic_min | Comonadic_to_monadic_min _
+      | Monadic_to_comonadic_max | Comonadic_to_monadic_max _ ->
+        (* If all morphisms preserve binary meets, the correctness argument
+           goes as follows:
 
-         Consider [apply dst m (meet_const c x)].
-         [apply dst m (meet_const c x)]
-         == meet (apply dst m c) (apply dst m x) ;; [m] preserves binary meets
-         == meet_const (apply dst m c) (apply dst m x) ;; by definition of meet_const
+           Consider [apply dst m (meet_const c x)].
+           [apply dst m (meet_const c x)]
+           == meet (apply dst m c) (apply dst m x) ;; [m] preserves binary
+           meets
+           == meet_const (apply dst m c) (apply dst m x) ;; by definition of
+           meet_const
 
-         The correct result for [commute_meet_const_from_right] is thus [apply dst m c] *)
-      apply dst m c
+           The correct result for [commute_meet_const_from_right] is thus
+           [apply dst m c]. *)
+        apply dst m c
 
     (* Commutes an implication through a morphism from the left, such that:
        [imply_const c (apply dst m x)] is equivalent to

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2558,69 +2558,66 @@ module Lattices_mono = struct
       | _, _ -> .
     [@@warning "-4"]
 
-    type ('b, 'd) packed_to =
-      | To : 'a obj * ('a, 'b, 'd) t -> ('b, 'd) packed_to
-
-    let to_ : type a b d. (a, b, d) t -> (b, d) packed_to =
-     fun m -> To (src m, m)
+    type ('b, 'd) packed_to = To : ('a, 'b, 'd) t -> ('b, 'd) packed_to
+    [@@unboxed]
 
     let left_to : type b. b obj -> (b, left_only) packed_to list = function
-      | Locality -> [to_ (Locality_restricted Regional_to_local)]
+      | Locality -> [To (Locality_restricted Regional_to_local)]
       | Regionality ->
-        [ to_ (Locality_restricted Local_to_regional);
-          to_ (Locality_restricted Locality_as_regionality);
-          to_ (Locality_restricted Local_to_regional_regionality);
-          to_ (Locality_restricted Regional_to_local_regionality) ]
-      | Uniqueness_op -> [to_ Linearity_to_uniqueness_op]
-      | Linearity -> [to_ Uniqueness_op_to_linearity]
-      | Portability -> [to_ Contention_op_to_portability]
+        [ To (Locality_restricted Local_to_regional);
+          To (Locality_restricted Locality_as_regionality);
+          To (Locality_restricted Local_to_regional_regionality);
+          To (Locality_restricted Regional_to_local_regionality) ]
+      | Uniqueness_op -> [To Linearity_to_uniqueness_op]
+      | Linearity -> [To Uniqueness_op_to_linearity]
+      | Portability -> [To Contention_op_to_portability]
       | Forkable -> []
       | Yielding -> []
-      | Statefulness -> [to_ Visibility_op_to_statefulness]
-      | Contention_op -> [to_ Portability_to_contention_op]
-      | Visibility_op -> [to_ Statefulness_to_visibility_op]
+      | Statefulness -> [To Visibility_op_to_statefulness]
+      | Contention_op -> [To Portability_to_contention_op]
+      | Visibility_op -> [To Statefulness_to_visibility_op]
       | Staticity_op -> []
       | Monadic_op ->
-        [ to_ (Comonadic_to_monadic_min Locality);
-          to_ (Comonadic_to_monadic_min Regionality) ]
+        [ To (Comonadic_to_monadic_min Locality);
+          To (Comonadic_to_monadic_min Regionality) ]
       | Comonadic_with_locality ->
-        [to_ (Locality_full Regional_to_local); to_ Monadic_to_comonadic_min]
+        [To (Locality_full Regional_to_local); To Monadic_to_comonadic_min]
       | Comonadic_with_regionality ->
-        [ to_ (Locality_full Local_to_regional);
-          to_ (Locality_full Locality_as_regionality);
-          to_ (Locality_full Local_to_regional_regionality);
-          to_ (Locality_full Regional_to_local_regionality);
-          to_ Monadic_to_comonadic_min ]
+        [ To (Locality_full Local_to_regional);
+          To (Locality_full Locality_as_regionality);
+          To (Locality_full Local_to_regional_regionality);
+          To (Locality_full Regional_to_local_regionality);
+          To Monadic_to_comonadic_min ]
 
     let right_to : type b. b obj -> (b, right_only) packed_to list = function
       | Locality ->
-        [ to_ (Locality_restricted Regional_to_local);
-          to_ (Locality_restricted Regional_to_global) ]
+        [ To (Locality_restricted Regional_to_local);
+          To (Locality_restricted Regional_to_global) ]
       | Regionality ->
-        [ to_ (Locality_restricted Locality_as_regionality);
-          to_ (Locality_restricted Regional_to_local_regionality);
-          to_ (Locality_restricted Regional_to_global_regionality) ]
-      | Uniqueness_op -> [to_ Linearity_to_uniqueness_op]
-      | Linearity -> [to_ Uniqueness_op_to_linearity]
-      | Portability -> [to_ Contention_op_to_portability]
+        [ To (Locality_restricted Locality_as_regionality);
+          To (Locality_restricted Regional_to_local_regionality);
+          To (Locality_restricted Regional_to_global_regionality) ]
+      | Uniqueness_op -> [To Linearity_to_uniqueness_op]
+      | Linearity -> [To Uniqueness_op_to_linearity]
+      | Portability -> [To Contention_op_to_portability]
       | Forkable -> []
       | Yielding -> []
-      | Statefulness -> [to_ Visibility_op_to_statefulness]
-      | Contention_op -> [to_ Portability_to_contention_op]
-      | Visibility_op -> [to_ Statefulness_to_visibility_op]
+      | Statefulness -> [To Visibility_op_to_statefulness]
+      | Contention_op -> [To Portability_to_contention_op]
+      | Visibility_op -> [To Statefulness_to_visibility_op]
       | Staticity_op -> []
       | Monadic_op ->
-        [ to_ (Comonadic_to_monadic_max Locality);
-          to_ (Comonadic_to_monadic_max Regionality) ]
+        [ To (Comonadic_to_monadic_max Locality);
+          To (Comonadic_to_monadic_max Regionality) ]
       | Comonadic_with_locality ->
-        [ to_ (Locality_full Regional_to_local);
-          to_ (Locality_full Regional_to_global);
-          to_ Monadic_to_comonadic_max ]
+        [ To (Locality_full Regional_to_local);
+          To (Locality_full Regional_to_global);
+          To Monadic_to_comonadic_max ]
       | Comonadic_with_regionality ->
-        [ to_ (Locality_full Locality_as_regionality);
-          to_ (Locality_full Regional_to_local_regionality);
-          to_ (Locality_full Regional_to_global_regionality);
-          to_ Monadic_to_comonadic_max ]
+        [ To (Locality_full Locality_as_regionality);
+          To (Locality_full Regional_to_local_regionality);
+          To (Locality_full Regional_to_global_regionality);
+          To Monadic_to_comonadic_max ]
   end
 
   let proj_obj : type t r. (t, r) Axis.t -> t obj -> r obj =
@@ -3275,44 +3272,38 @@ module Lattices_mono = struct
 
     let ( let+ ) xs f = List.map f xs
 
-    type ('b, 'd) packed_to =
-      | To : 'a obj * ('a, 'b, 'd) t -> ('b, 'd) packed_to
-
-    let to_ : type a b d. b obj -> (a, b, d) t -> (b, d) packed_to =
-     fun dst m -> To (src dst m, m)
+    type ('b, 'd) packed_to = To : ('a, 'b, 'd) t -> ('b, 'd) packed_to
+    [@@unboxed]
 
     let left_to : type b. full:bool -> b obj -> (b, left_only) packed_to list =
      fun ~full dst ->
       let constants =
-        List.map (fun c -> to_ dst (Meet_const c)) (get_elements ~full dst)
+        List.map (fun c -> To (Meet_const c)) (get_elements ~full dst)
       in
       let cores = Core_morph.left_to dst in
-      let core_morphs =
-        List.map (fun (Core_morph.To (_, m)) -> to_ dst (Core m)) cores
-      in
+      let core_morphs = List.map (fun (Core_morph.To m) -> To (Core m)) cores in
       let meet_const_cores =
         let* c = get_elements ~full dst in
-        let+ (Core_morph.To (_, m)) = cores in
-        to_ dst (Meet_const_core (c, m))
+        let+ (Core_morph.To m) = cores in
+        To (Meet_const_core (c, m))
       in
-      (to_ dst Id :: core_morphs) @ constants @ meet_const_cores
+      (To Id :: core_morphs) @ constants @ meet_const_cores
 
     let right_to : type b. full:bool -> b obj -> (b, right_only) packed_to list
         =
      fun ~full dst ->
       let constants =
-        List.map (fun c -> to_ dst (Imply_const c)) (get_elements ~full dst)
+        List.map (fun c -> To (Imply_const c)) (get_elements ~full dst)
       in
       let cores = Core_morph.right_to dst in
-      let core_morphs =
-        List.map (fun (Core_morph.To (_, m)) -> to_ dst (Core m)) cores
-      in
+      let core_morphs = List.map (fun (Core_morph.To m) -> To (Core m)) cores in
       let core_imply_consts =
-        let* (Core_morph.To (src, m)) = cores in
+        let* (Core_morph.To m) = cores in
+        let src = Core_morph.src m in
         let+ c = get_elements ~full src in
-        to_ dst (Core_imply_const (m, c))
+        To (Core_imply_const (m, c))
       in
-      (to_ dst Id :: core_morphs) @ constants @ core_imply_consts
+      (To Id :: core_morphs) @ constants @ core_imply_consts
   end
 
   type ('a, 'b, 'd) morph =
@@ -3916,130 +3907,105 @@ module Lattices_mono = struct
 
   let ( let+ ) xs f = List.map f xs
 
-  type 'b packed_morph_to =
-    | Morph_to : 'a obj * ('a, 'b, neither) morph -> 'b packed_morph_to
+  type 'b packed_to = To : ('a, 'b, neither) morph -> 'b packed_to [@@unboxed]
 
-  let left_morph_to : type a b.
-      a obj -> (a, b, left_only) morph -> b packed_morph_to =
-   fun src morph -> Morph_to (src, disallow_left morph)
-
-  let right_morph_to : type a b.
-      a obj -> (a, b, right_only) morph -> b packed_morph_to =
-   fun src morph -> Morph_to (src, disallow_right morph)
-
-  let generate_left_morphs_to : type b.
-      full:bool -> b obj -> b packed_morph_to list =
+  let generate_left_morphs_to : type b. full:bool -> b obj -> b packed_to list =
    fun ~full dst ->
     let simple_morphs = Simple_morph.left_to ~full dst in
     let simple =
       List.map
-        (fun (Simple_morph.To (src, m)) -> left_morph_to src (Simple m))
+        (fun (Simple_morph.To m) -> To (disallow_left (Simple m)))
         simple_morphs
     in
     let projections =
-      let* (Simple_morph.To (projected, m)) = simple_morphs in
-      let+ (Axis.Pb (src, ax)) = Axis.axis_to projected in
-      left_morph_to src (Simple_proj (m, ax, src))
+      let* (Simple_morph.To m) = simple_morphs in
+      let src = Simple_morph.src dst m in
+      let+ (Axis.Pb (src, ax)) = Axis.axis_to src in
+      To (disallow_left (Simple_proj (m, ax, src)))
     in
     let min_with =
       let* (Axis.Ps ax) = Axis.all dst in
       let projected = proj_obj ax dst in
-      let+ (Simple_morph.To (src, m)) = Simple_morph.left_to ~full projected in
-      left_morph_to src (Min_with_simple (ax, m))
+      let+ (Simple_morph.To m) = Simple_morph.left_to ~full projected in
+      To (disallow_left (Min_with_simple (ax, m)))
     in
     let const_min =
-      List.map (fun (Obj src) -> left_morph_to src (Const_min src)) all_objs
+      List.map (fun (Obj src) -> To (disallow_left (Const_min src))) all_objs
     in
     simple @ projections @ min_with @ const_min
 
-  let generate_right_morphs_to : type b.
-      full:bool -> b obj -> b packed_morph_to list =
+  let generate_right_morphs_to : type b. full:bool -> b obj -> b packed_to list
+      =
    fun ~full dst ->
     let simple_morphs = Simple_morph.right_to ~full dst in
     let simple =
       List.map
-        (fun (Simple_morph.To (src, m)) -> right_morph_to src (Simple m))
+        (fun (Simple_morph.To m) -> To (disallow_right (Simple m)))
         simple_morphs
     in
     let projections =
-      let* (Simple_morph.To (projected, m)) = simple_morphs in
+      let* (Simple_morph.To m) = simple_morphs in
+      let projected = Simple_morph.src dst m in
       let+ (Axis.Pb (src, ax)) = Axis.axis_to projected in
-      right_morph_to src (Simple_proj (m, ax, src))
+      To (disallow_right (Simple_proj (m, ax, src)))
     in
     let max_with =
       let* (Axis.Ps ax) = Axis.all dst in
       let projected = proj_obj ax dst in
-      let+ (Simple_morph.To (src, m)) = Simple_morph.right_to ~full projected in
-      right_morph_to src (Max_with_simple (ax, m))
+      let+ (Simple_morph.To m) = Simple_morph.right_to ~full projected in
+      To (disallow_right (Max_with_simple (ax, m)))
     in
     let const_max =
-      List.map (fun (Obj src) -> right_morph_to src (Const_max src)) all_objs
+      List.map (fun (Obj src) -> To (disallow_right (Const_max src))) all_objs
     in
     simple @ projections @ max_with @ const_max
 
   let generate_morphs_to ~full dst =
     generate_left_morphs_to ~full dst @ generate_right_morphs_to ~full dst
 
-  let force_by_coverage ~full (full_list, partial_list) =
-    Lazy.force (if full then full_list else partial_list)
+  type 'a covered =
+    { full_coverage : 'a;
+      partial_coverage : 'a
+    }
 
-  let morphs_to_locality =
-    ( lazy (generate_morphs_to ~full:true Locality),
-      lazy (generate_morphs_to ~full:false Locality) )
+  let force_by_coverage ~full { full_coverage; partial_coverage } =
+    Lazy.force (if full then full_coverage else partial_coverage)
 
-  let morphs_to_regionality =
-    ( lazy (generate_morphs_to ~full:true Regionality),
-      lazy (generate_morphs_to ~full:false Regionality) )
+  let morphs_to_obj obj =
+    let full_coverage = lazy (generate_morphs_to ~full:true obj) in
+    let partial_coverage = lazy (generate_morphs_to ~full:false obj) in
+    { full_coverage; partial_coverage }
 
-  let morphs_to_uniqueness_op =
-    ( lazy (generate_morphs_to ~full:true Uniqueness_op),
-      lazy (generate_morphs_to ~full:false Uniqueness_op) )
+  let morphs_to_locality = morphs_to_obj Locality
 
-  let morphs_to_linearity =
-    ( lazy (generate_morphs_to ~full:true Linearity),
-      lazy (generate_morphs_to ~full:false Linearity) )
+  let morphs_to_regionality = morphs_to_obj Regionality
 
-  let morphs_to_portability =
-    ( lazy (generate_morphs_to ~full:true Portability),
-      lazy (generate_morphs_to ~full:false Portability) )
+  let morphs_to_uniqueness_op = morphs_to_obj Uniqueness_op
 
-  let morphs_to_forkable =
-    ( lazy (generate_morphs_to ~full:true Forkable),
-      lazy (generate_morphs_to ~full:false Forkable) )
+  let morphs_to_linearity = morphs_to_obj Linearity
 
-  let morphs_to_yielding =
-    ( lazy (generate_morphs_to ~full:true Yielding),
-      lazy (generate_morphs_to ~full:false Yielding) )
+  let morphs_to_portability = morphs_to_obj Portability
 
-  let morphs_to_statefulness =
-    ( lazy (generate_morphs_to ~full:true Statefulness),
-      lazy (generate_morphs_to ~full:false Statefulness) )
+  let morphs_to_forkable = morphs_to_obj Forkable
 
-  let morphs_to_contention_op =
-    ( lazy (generate_morphs_to ~full:true Contention_op),
-      lazy (generate_morphs_to ~full:false Contention_op) )
+  let morphs_to_yielding = morphs_to_obj Yielding
 
-  let morphs_to_visibility_op =
-    ( lazy (generate_morphs_to ~full:true Visibility_op),
-      lazy (generate_morphs_to ~full:false Visibility_op) )
+  let morphs_to_statefulness = morphs_to_obj Statefulness
 
-  let morphs_to_staticity_op =
-    ( lazy (generate_morphs_to ~full:true Staticity_op),
-      lazy (generate_morphs_to ~full:false Staticity_op) )
+  let morphs_to_contention_op = morphs_to_obj Contention_op
 
-  let morphs_to_monadic_op =
-    ( lazy (generate_morphs_to ~full:true Monadic_op),
-      lazy (generate_morphs_to ~full:false Monadic_op) )
+  let morphs_to_visibility_op = morphs_to_obj Visibility_op
 
-  let morphs_to_comonadic_with_locality =
-    ( lazy (generate_morphs_to ~full:true Comonadic_with_locality),
-      lazy (generate_morphs_to ~full:false Comonadic_with_locality) )
+  let morphs_to_staticity_op = morphs_to_obj Staticity_op
+
+  let morphs_to_monadic_op = morphs_to_obj Monadic_op
+
+  let morphs_to_comonadic_with_locality = morphs_to_obj Comonadic_with_locality
 
   let morphs_to_comonadic_with_regionality =
-    ( lazy (generate_morphs_to ~full:true Comonadic_with_regionality),
-      lazy (generate_morphs_to ~full:false Comonadic_with_regionality) )
+    morphs_to_obj Comonadic_with_regionality
 
-  let morphs_to : type b. full:bool -> b obj -> b packed_morph_to list =
+  let morphs_to : type b. full:bool -> b obj -> b packed_to list =
    fun ~full -> function
     | Locality -> force_by_coverage ~full morphs_to_locality
     | Regionality -> force_by_coverage ~full morphs_to_regionality
@@ -4224,11 +4190,14 @@ module For_testing = struct
 
   let check_jobs ~full () =
     let* (Obj dst) = all_objs in
-    let+ (Morph_to (mid, f)) = morphs_to ~full dst in
+    let+ (To f) = morphs_to ~full dst in
+    let mid = src dst f in
     let morphs_to_mid = morphs_to ~full mid in
     fun () ->
       List.iter
-        (fun (Morph_to (src, g)) -> check_compose ~full src mid dst f g)
+        (fun (To g) ->
+          let src = src mid g in
+          check_compose ~full src mid dst f g)
         morphs_to_mid
 end
 

--- a/typing/mode_hint.mli
+++ b/typing/mode_hint.mli
@@ -74,6 +74,30 @@ type ('d0, 'd1) polarity =
   constraint 'd0 = _ * _ constraint 'd1 = _ * _
 [@@warning "-62"]
 
+(* CR-someday zqian: Put [Modality.Const.t] here, once the dependency circle is
+   resolved. To fix that, we can move [Modality.Const] to in front of [Hint],
+   while [Modality] stays in place. *)
+type modality = Modality
+
+type containing =
+  | Tuple
+  | Record of string * modality
+  | Array of modality
+  | Constructor of string * modality
+  | Structure of structure_item * modality
+(* Some structure items (such as classes) don't have modalities. We gloss over
+     for simplicity. *)
+
+type contains =
+  { containing : containing;
+    contained : pinpoint
+  }
+
+type is_contained_by =
+  { containing : containing;
+    container : pinpoint
+  }
+
 (* CR-soon zqian: add the const hint for "min on the LHS", and one for "max on
 the RHS". They are similiar to the [Skip] morph hint and should raise when being
 printed. *)
@@ -103,36 +127,13 @@ type 'd const =
   | Escape_region : region -> (disallowed * 'r) const
   | Quoted_computation : ('l * disallowed) pos const
   | Spliced : ('l * 'r, 'd) polarity -> 'd const
+  | Contained_by : is_contained_by -> ('l * 'r) const
   constraint 'd = _ * _
 [@@ocaml.warning "-62"]
 
 type closure_details =
   { closure : pinpoint;
     closed : pinpoint
-  }
-
-(* CR-someday zqian: Put [Modality.Const.t] here, once the dependency circle is
-   resolved. To fix that, we can move [Modality.Const] to in front of [Hint],
-   while [Modality] stays in place. *)
-type modality = Modality
-
-type containing =
-  | Tuple
-  | Record of string * modality
-  | Array of modality
-  | Constructor of string * modality
-  | Structure of structure_item * modality
-(* Some structure items (such as classes) don't have modalities. We gloss over
-     for simplicity. *)
-
-type contains =
-  { containing : containing;
-    contained : pinpoint
-  }
-
-type is_contained_by =
-  { containing : containing;
-    container : pinpoint
   }
 
 type allocation_desc =

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -284,6 +284,10 @@ module type S = sig
     end
   end
 
+  module For_testing : sig
+    val check_all_allowed_compositions : unit -> unit
+  end
+
   val print_longident : (Fmt.formatter -> Longident.t -> unit) ref
 
   (* CR-someday zqian: find a better stroy to erase bounds (and hints) that incorporates

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -286,8 +286,26 @@ module type S = sig
     end
   end
 
+  (** Module for tests that validate internal mode lattice invariants. *)
   module For_testing : sig
-    val check_jobs : full:bool -> unit -> (unit -> unit) list
+    (** A failed internal invariant check. *)
+    type error
+
+    (** Print a detailed description of a failed check. *)
+    val print_error : Fmt.formatter -> error -> unit
+
+    (** Validates that morphism composition is sound.
+
+        For a selected subset of generated pair of morphisms [f : b -> c] and
+        [g : a -> b], this checks that [compose f g] and [fun x -> f (g x)]
+        agree on every selected element of [a].
+
+        The selected elements are either every possible lattice element (when
+        [full] is [true]) or a smaller spanning set where each axis value is
+        covered at least once, but every combination is not (when [full] is
+        [false]). *)
+    val check_composition_jobs :
+      full:bool -> unit -> (unit -> (unit, error) result) list
   end
 
   val print_longident : (Fmt.formatter -> Longident.t -> unit) ref

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -749,9 +749,15 @@ module type S = sig
 
     val proj_monadic : 'a Monadic.Axis.t -> ('l * 'r) t -> ('a, 'r * 'l) mode
 
-    val meet_const : Comonadic.Const.t -> ('l * 'r) t -> ('l * 'r) t
+    val meet_const : Comonadic.Const.t -> ('l * 'r) t -> ('l * disallowed) t
 
-    val join_const : Monadic.Const.t -> ('l * 'r) t -> ('l * 'r) t
+    val join_const : Monadic.Const.t -> ('l * 'r) t -> (disallowed * 'r) t
+
+    val meet_const_with :
+      'a Comonadic.Axis.t -> 'a -> ('l * 'r) t -> ('l * disallowed) t
+
+    val join_const_with :
+      'a Monadic.Axis.t -> 'a -> ('l * 'r) t -> (disallowed * 'r) t
 
     (** [max_with ax elt] returns [max] but with the axis [ax] set to [elt]. *)
     val max_with_comonadic :
@@ -764,11 +770,6 @@ module type S = sig
     (* [min_with_monadic ax elt] returns [min] but with the monadic axis [ax] set to [elt]. *)
     val min_with_monadic :
       'a Monadic.Axis.t -> ('a, 'l * 'r) mode -> ('r * disallowed) t
-
-    val meet_const_with :
-      'a Comonadic.Axis.t -> 'a -> ('l * 'r) t -> ('l * 'r) t
-
-    val join_const_with : 'a Monadic.Axis.t -> 'a -> ('l * 'r) t -> ('l * 'r) t
 
     val zap_to_legacy : lr -> Const.t
 
@@ -817,30 +818,31 @@ module type S = sig
     val locality_as_regionality : Locality.Const.t -> Regionality.Const.t
   end
 
-  (** Converts regional to local, identity otherwise *)
-  val regional_to_local : ('l * 'r) Regionality.t -> ('l * 'r) Locality.t
-
   (** Inject locality into regionality *)
-  val locality_as_regionality : ('l * 'r) Locality.t -> ('l * 'r) Regionality.t
-
-  (** Converts regional to global, identity otherwise *)
-  val regional_to_global : ('l * 'r) Regionality.t -> ('l * 'r) Locality.t
+  val locality_as_regionality : Locality.l -> Regionality.l
 
   (** Similar to [locality_as_regionality], behaves as identity on other axes *)
-  val alloc_as_value : ('l * 'r) Alloc.t -> ('l * 'r) Value.t
+  val alloc_as_value :
+    ?hint:('l * 'r) Hint.morph -> ('l * 'r) Alloc.t -> ('l * 'r) Value.t
 
   (** Similar to [local_to_regional], behaves as identity in other axes *)
   val alloc_to_value_l2r : ('l * 'r) Alloc.t -> ('l * disallowed) Value.t
 
   (** Similar to [regional_to_local], behaves as identity on other axes *)
-  val value_to_alloc_r2l : ('l * 'r) Value.t -> ('l * 'r) Alloc.t
+  val value_to_alloc_r2l :
+    ?hint:('l * 'r) Hint.morph -> ('l * 'r) Value.t -> ('l * 'r) Alloc.t
 
   (** Similar to [regional_to_global], behaves as identity on other axes *)
-  val value_to_alloc_r2g : ('l * 'r) Value.t -> ('l * 'r) Alloc.t
+  val value_to_alloc_r2g :
+    ?hint:(disallowed * 'r) Hint.morph ->
+    ('l * 'r) Value.t ->
+    (disallowed * 'r) Alloc.t
 
   (** Similar to [value_to_alloc_r2g], but followed by [alloc_as_value]. *)
   val value_r2g :
-    ?hint:('l * 'r) Hint.morph -> ('l * 'r) Value.t -> ('l * 'r) Value.t
+    ?hint:(disallowed * 'r) Hint.morph ->
+    ('l * 'r) Value.t ->
+    (disallowed * 'r) Value.t
 
   module Modality : sig
     module Comonadic : sig
@@ -918,13 +920,19 @@ module type S = sig
 
       (* CR-soon zqian: make the [hint] below mandatory *)
 
-      (** Apply a modality on mode. *)
-      val apply :
-        ?hint:
-          (('l * 'r) neg Hint.morph, ('l * 'r) pos Hint.morph) monadic_comonadic ->
+      (** Apply a modality on left mode. *)
+      val apply_left :
+        ?is_contained_by:Hint.is_contained_by ->
         t ->
-        ('l * 'r) Value.t ->
-        ('l * 'r) Value.t
+        (allowed * 'r) Value.t ->
+        Value.l
+
+      (** Apply a modality on right mode. *)
+      val apply_right :
+        ?is_contained_by:Hint.is_contained_by ->
+        t ->
+        ('l * allowed) Value.t ->
+        Value.r
 
       (** [concat ~then t] returns the modality that is [then_] after [t]. *)
       val concat : then_:t -> t -> t
@@ -967,11 +975,8 @@ module type S = sig
     (** Apply a modality on a left mode. The calller should ensure that
         [apply t m] is only called for [m >= md_mode] for inferred modalities.
     *)
-    val apply :
-      ?hint:
-        ( (allowed * 'r) neg Hint.morph,
-          (allowed * 'r) pos Hint.morph )
-        monadic_comonadic ->
+    val apply_left :
+      ?is_contained_by:Hint.is_contained_by ->
       t ->
       (allowed * 'r) Value.t ->
       Value.l
@@ -1168,10 +1173,10 @@ module type S = sig
     val to_modality : t -> Modality.Const.t
 
     (** Apply mode crossing on a left mode, making it stronger. *)
-    val apply_left : t -> ('l * 'r) Value.t -> ('l * disallowed) Value.t
+    val apply_left : t -> (allowed * 'r) Value.t -> Value.l
 
     (** Apply mode crossing on a right mode, making it more permissive. *)
-    val apply_right : t -> ('l * 'r) Value.t -> (disallowed * 'r) Value.t
+    val apply_right : t -> ('l * allowed) Value.t -> Value.r
 
     (* We extend mode crossing on [Value] to [Alloc] via [alloc_as_value].
        Concretely, two [Alloc] modes are indistinguishable if their images under

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -285,7 +285,7 @@ module type S = sig
   end
 
   module For_testing : sig
-    val check_all_allowed_compositions : unit -> unit
+    val check_all_allowed_compositions : full:bool -> unit -> unit
   end
 
   val print_longident : (Fmt.formatter -> Longident.t -> unit) ref

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -42,6 +42,8 @@ module type Const = sig
   include Lattice
 
   val legacy : t
+
+  val all : t list lazy_t
 end
 
 module type Const_product = sig

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -285,7 +285,7 @@ module type S = sig
   end
 
   module For_testing : sig
-    val check_all_allowed_compositions : full:bool -> unit -> unit
+    val check_jobs : full:bool -> unit -> (unit -> unit) list
   end
 
   val print_longident : (Fmt.formatter -> Longident.t -> unit) ref

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -73,7 +73,7 @@ module type Lattices_mono = sig
         adjoint.
       - [disallowed], meaning the morphism cannot be on the left because it does
         not have right adjoint. Similar for ['r]. *)
-  type ('a, 'b, 'd) morph constraint 'd = 'l * 'r
+  type ('a, 'b, 'd) morph
 
   (* Due to the implementation in [solver.ml], a mode doesn't have sufficient
      information to infer the object it lives in,  whether at compile-time or
@@ -187,7 +187,7 @@ module type Solver_mono = sig
 
   (** The morphism type from the [Lattices_mono] we're working with. See
       comments on [Lattices_mono.morph]. *)
-  type ('a, 'b, 'd) morph constraint 'd = 'l * 'r
+  type ('a, 'b, 'd) morph
 
   (** The object type from the [Lattices_mono] we're working with *)
   type 'a obj

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -567,12 +567,12 @@ let mode_morph f expected_mode =
 (** Similiar to [apply_is_contained_by] but for [expected_mode]. *)
 let mode_is_contained_by is_contained_by ?modalities expected_mode =
   as_single_mode expected_mode
-  |> apply_is_contained_by is_contained_by ?modalities
+  |> apply_right_is_contained_by is_contained_by ?modalities
   |> mode_default
 
 let mode_modality modality expected_mode =
   as_single_mode expected_mode
-  |> Modality.Const.apply modality
+  |> Modality.Const.apply_right modality
   |> mode_default
 
 (* used when entering a function;
@@ -763,6 +763,22 @@ let register_allocation_value_mode ~loc
       (Mode.Value.disallow_left mode)
   in
   alloc_mode, mode
+
+(* Unlike most allocations, which can be the highest mode allowed by
+   [expected_mode], functions have more constraints. For example, a two
+   parameter function needs to be made global if its partial application
+   to one argument must be global. As a result, a function gets an
+   [Alloc.lr] allocation mode that can be further constrained. *)
+let register_closure_allocation (mode : Value.r) ~loc : Alloc.lr * Value.r =
+  let hint = Hint.Allocation_r {loc; txt = Unknown} in
+  let (alloc_mode : Alloc.lr), _ =
+    Alloc.newvar_below (value_to_alloc_r2g ~hint mode)
+  in
+  register_allocation_mode (Alloc.disallow_left alloc_mode);
+  let closed_over_mode =
+    alloc_as_value ~hint:Skip (Alloc.disallow_left alloc_mode)
+  in
+  alloc_mode, closed_over_mode
 
 (** Register as allocation the expression constrained by the given
     [expected_mode]. Returns the mode of the allocation, and the expected mode
@@ -1839,7 +1855,7 @@ let solve_Ppat_tuple ~refine ~alloc_mode loc env args expected_ty =
         { containing = Tuple;
           container = (loc, Pattern) }
       in
-      let mode = apply_is_contained_by is_contained_by alloc_mode.mode in
+      let mode = apply_left_is_contained_by is_contained_by alloc_mode.mode in
       List.init arity (fun _ -> mode)
   in
   let ann =
@@ -1870,7 +1886,7 @@ let solve_Ppat_unboxed_tuple ~refine ~alloc_mode loc env args expected_ty =
         { containing = Tuple;
           container = (loc, Pattern) }
       in
-      let mode = apply_is_contained_by is_contained_by alloc_mode.mode in
+      let mode = apply_left_is_contained_by is_contained_by alloc_mode.mode in
       List.init arity (fun _ -> mode)
   in
   let ann =
@@ -3066,7 +3082,7 @@ and type_pat_aux
       {containing = Array Modality; container = (loc, Pattern)}
     in
     let alloc_mode =
-      apply_is_contained_by is_contained_by ~modalities alloc_mode.mode
+      apply_left_is_contained_by is_contained_by ~modalities alloc_mode.mode
     in
     let alloc_mode = simple_pat_mode alloc_mode in
     let pl =
@@ -3186,8 +3202,8 @@ and type_pat_aux
             container = (loc, Pattern) }
         in
         let mode =
-          apply_is_contained_by is_contained_by ~modalities:label.lbl_modalities
-            alloc_mode.mode
+          apply_left_is_contained_by is_contained_by
+            ~modalities:label.lbl_modalities alloc_mode.mode
         in
         let alloc_mode = simple_pat_mode mode in
         let ty_sort =
@@ -3499,7 +3515,7 @@ and type_pat_aux
         List.map2
           (fun p (arg : Types.constructor_argument) ->
              let alloc_mode =
-              apply_is_contained_by is_contained_by
+              apply_left_is_contained_by is_contained_by
                 ~modalities:arg.ca_modalities alloc_mode.mode
              in
              let alloc_mode =
@@ -5894,15 +5910,8 @@ let split_function_ty
     env (expected_mode : expected_mode) ty_expected loc ~arg_label ~has_poly
     ~mode_annots ~ret_mode_annots ~in_function ~is_first_val_param ~is_final_val_param
   =
-  let alloc_mode, mode =
-      (* Unlike most allocations which can be the highest mode allowed by
-         [expected_mode] and their [alloc_mode] identical to [expected_mode] ,
-         functions have more constraints. For example, an outer function needs
-         to be made global if its inner function is global. As a result, a
-         function deserves a separate allocation mode.
-      *)
-      let mode, _ = Value.newvar_below (as_single_mode expected_mode) in
-      register_allocation_value_mode ~loc mode
+  let alloc_mode, closed_over_mode =
+    register_closure_allocation ~loc (as_single_mode expected_mode)
   in
   if expected_mode.strictly_local then
     Locality.submode_exn ~pp:(loc, Function) Locality.local
@@ -5945,7 +5954,7 @@ let split_function_ty
         let env =
           Env.add_closure_lock
             (loc, Function)
-            mode.comonadic
+            closed_over_mode.comonadic
             env
         in
         Env.add_region_lock env
@@ -6357,7 +6366,7 @@ and type_expect_
           (fun loc ty mode -> (* only change mode here, see type_label_exp *)
              List.map (fun (_, label, _) ->
                let mode =
-                apply_is_contained_by
+                apply_left_is_contained_by
                   { containing = Record (label.lbl_name, Modality);
                     container = (loc, Expression) }
                   ~modalities:label.lbl_modalities mode
@@ -6405,7 +6414,7 @@ and type_expect_
                   container = (extended_expr_loc, Expression) }
               in
               let mode =
-                apply_is_contained_by is_contained_by
+                apply_left_is_contained_by is_contained_by
                   ~modalities:lbl.lbl_modalities mode
               in
               let mode = cross_left env lbl.lbl_arg mode in
@@ -6598,7 +6607,7 @@ and type_expect_
             match path with
             | Path.Pident id ->
               let modalities = Typemode.let_mutable_modalities in
-              let mode = Modality.Const.apply modalities actual_mode in
+              let mode = Modality.Const.apply_left modalities actual_mode in
               submode ~loc ~env mode expected_mode;
               Texp_mutvar {loc = lid.loc; txt = id}
             | _ ->
@@ -7110,8 +7119,8 @@ and type_expect_
           container = (record.exp_loc, Expression) }
       in
       let mode =
-        apply_is_contained_by is_contained_by ~modalities:label.lbl_modalities
-          rmode
+        apply_left_is_contained_by is_contained_by
+          ~modalities:label.lbl_modalities rmode
       in
       let boxing : texp_field_boxing =
         let is_float_boxing =
@@ -7178,8 +7187,8 @@ and type_expect_
           container = (record.exp_loc, Expression) }
       in
       let mode =
-        apply_is_contained_by is_contained_by ~modalities:label.lbl_modalities
-          rmode
+        apply_left_is_contained_by is_contained_by
+          ~modalities:label.lbl_modalities rmode
       in
       let mode = cross_left env ty_arg mode in
       submode ~loc ~env mode expected_mode;
@@ -7238,8 +7247,9 @@ and type_expect_
           record_repres;
           record_sorts;
           modality =
-            Locality.disallow_right (regional_to_local
-              (Value.proj_comonadic Areality rmode));
+            Locality.disallow_right
+              (Alloc.proj_comonadic Areality
+               (value_to_alloc_r2l rmode));
           lid = label_loc;
           label;
           newval;
@@ -9636,16 +9646,13 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
          cases, look toward the end of
          typing-layouts-missing-cmi/function_arg.ml *)
       let func texp =
-        let ret_mode = alloc_as_value mret in
         let e =
           {texp with exp_type = ty_res; exp_desc =
            Texp_apply
              (texp,
-              args @ [Nolabel, Arg (eta_var, arg_sort)], Nontail,
-              ret_mode
-              |> Value.proj_comonadic Areality
-              |> regional_to_global
-              |> Locality.disallow_right,
+              args @ [Nolabel, Arg (eta_var, arg_sort)],
+              Nontail,
+              Alloc.proj_comonadic Areality (Alloc.disallow_right mret),
               None)}
         in
         let e = {texp with exp_type = ty_res; exp_desc = Texp_exclave e} in
@@ -9880,7 +9887,7 @@ and type_tuple ~overwrite ~loc ~env ~(expected_mode : expected_mode) ~ty_expecte
   in
   let argument_mode =
     value_mode
-    |> apply_is_contained_by
+    |> apply_right_is_contained_by
       {containing = Tuple; container = (loc, Expression)}
   in
   (* CR layouts v5: non-values in tuples *)
@@ -9949,7 +9956,8 @@ and type_unboxed_tuple ~loc ~env ~(expected_mode : expected_mode) ~ty_expected
     (Misc.repeated_label sexpl);
   let argument_mode =
     expected_mode.mode
-    |> apply_is_contained_by {containing = Tuple; container = (loc, Expression)}
+    |> apply_right_is_contained_by
+      {containing = Tuple; container = (loc, Expression)}
   in
   (* elements must be representable *)
   let labels_types_and_sorts =
@@ -10135,7 +10143,7 @@ and type_construct ~overwrite env (expected_mode : expected_mode) loc lid sarg
          let ty_args, _, _ = unify_as_construct ty in
          List.map (fun ty_arg ->
            let mode =
-            apply_is_contained_by
+            apply_left_is_contained_by
               { containing = Constructor (constr.cstr_name, Modality);
                 container = (loc, Expression) }
               ~modalities:ty_arg.Types.ca_modalities mode

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -114,13 +114,23 @@ let new_mode_var_from_annots (m : Alloc.Const.Option.t) =
   Value.submode_exn mode (max |> Alloc.of_const |> alloc_as_value);
   mode
 
-let register_allocation () =
-  let m, _ =
-    Value.(newvar_below (of_const
+let register_module_allocation () =
+  let upper_bound =
+    Value.of_const
       ~hint_comonadic:Module_allocated_on_heap
-      { Const.max with areality = Global }))
+      { Value.Const.max with areality = Global }
   in
-  value_to_alloc_r2g m, m
+  fst (Value.newvar_below upper_bound)
+
+let register_closure_allocation () : Alloc.lr * Value.lr =
+  let upper_bound =
+    Alloc.of_const
+      ~hint_comonadic:Module_allocated_on_heap
+      { Alloc.Const.max with areality = Global }
+  in
+  let alloc_mode, _ = Alloc.newvar_below upper_bound in
+  let closed_over_mode = alloc_as_value ~hint:Skip alloc_mode in
+  alloc_mode, closed_over_mode
 
 open Typedtree
 
@@ -143,7 +153,7 @@ let apply_is_contained_by ~loc_md item ?modalities mode =
     { containing = Structure (item, Modality);
       container = (loc_md, Structure) }
   in
-  Ctype.apply_is_contained_by is_contained_by ?modalities mode
+  Ctype.apply_right_is_contained_by is_contained_by ?modalities mode
 
 (** Given a value whose location in the source code is described by [pp] and at
 [mode], infer the modalities on the value when it's placed as an [item] in a
@@ -190,11 +200,7 @@ let rebase_modalities ~loc ~loc_md item ~md_mode ~mode modalities =
     { containing = Structure (item, Modality);
       container = (loc, Structure)}
   in
-  let hint =
-    { monadic = Hint.Is_contained_by (Monadic, is_contained_by);
-      comonadic = Hint.Is_contained_by (Comonadic, is_contained_by) }
-  in
-  let mode = Modality.apply ~hint modalities mode in
+  let mode = Modality.apply_left ~is_contained_by modalities mode in
   infer_modalities pp ~loc_md item ~md_mode ~mode
 
 (** Similiar to [rebase_modalities] but lifted to signatures. *)
@@ -3154,9 +3160,13 @@ and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
       in
       md, shape
   | Pmod_functor(arg_opt, sbody) ->
-      let alloc_mode, mode = register_allocation () in
+      let alloc_mode, closed_over_mode =
+        register_closure_allocation ()
+      in
       let newenv =
-        Env.add_closure_lock (smod.pmod_loc, Functor) mode.comonadic env
+        Env.add_closure_lock
+          (smod.pmod_loc, Functor)
+          closed_over_mode.comonadic env
       in
       let t_arg, ty_arg, newenv, funct_shape_param, funct_body =
         match arg_opt with
@@ -3209,7 +3219,7 @@ and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
        | _ -> ());
       { mod_desc = Tmod_functor(t_arg, body);
         mod_type = Mty_functor(ty_arg, body.mod_type, ret_mode);
-        mod_mode = Value.disallow_right mode, None;
+        mod_mode = Value.disallow_right closed_over_mode, None;
         mod_env = env;
         mod_attributes = smod.pmod_attributes;
         mod_loc = smod.pmod_loc },
@@ -3612,7 +3622,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
   (* CR implicit-types: implement implicit variable jkinds in structures. *)
   let env = Env.clear_implicit_jkinds env in
   let names = Signature_names.create () in
-  let _, md_mode = register_allocation () in
+  let md_mode = register_module_allocation () in
   let loc_md = location_of_structure sstr in
 
   let type_str_include ~loc env shape_map sincl sig_acc =
@@ -4272,7 +4282,7 @@ let type_package env m p fl =
       with Ctype.Unify _ ->
         raise (Error(modl.mod_loc, env, Scoping_pack (n,ty))))
     fl';
-  let _, mode = register_allocation () in
+  let mode = register_module_allocation () in
   let modl =
     wrap_constraint_package env true modl mty mode Tmodtype_implicit
   in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -114,15 +114,7 @@ let new_mode_var_from_annots (m : Alloc.Const.Option.t) =
   Value.submode_exn mode (max |> Alloc.of_const |> alloc_as_value);
   mode
 
-let register_module_allocation () =
-  let upper_bound =
-    Value.of_const
-      ~hint_comonadic:Module_allocated_on_heap
-      { Value.Const.max with areality = Global }
-  in
-  fst (Value.newvar_below upper_bound)
-
-let register_closure_allocation () : Alloc.lr * Value.lr =
+let register_allocation () : Alloc.lr * Value.lr =
   let upper_bound =
     Alloc.of_const
       ~hint_comonadic:Module_allocated_on_heap
@@ -3161,7 +3153,7 @@ and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
       md, shape
   | Pmod_functor(arg_opt, sbody) ->
       let alloc_mode, closed_over_mode =
-        register_closure_allocation ()
+        register_allocation ()
       in
       let newenv =
         Env.add_closure_lock
@@ -3622,7 +3614,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
   (* CR implicit-types: implement implicit variable jkinds in structures. *)
   let env = Env.clear_implicit_jkinds env in
   let names = Signature_names.create () in
-  let md_mode = register_module_allocation () in
+  let _, md_mode = register_allocation () in
   let loc_md = location_of_structure sstr in
 
   let type_str_include ~loc env shape_map sincl sig_acc =
@@ -4282,7 +4274,7 @@ let type_package env m p fl =
       with Ctype.Unify _ ->
         raise (Error(modl.mod_loc, env, Scoping_pack (n,ty))))
     fl';
-  let mode = register_module_allocation () in
+  let _, mode = register_allocation () in
   let modl =
     wrap_constraint_package env true modl mty mode Tmodtype_implicit
   in

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -1941,6 +1941,10 @@ type (_, _) is_eq =
   | Is_eq : ('a, 'a) is_eq
   | Is_not_eq : ('a, 'b) is_eq
 
+let get_eq_exn : type a b. (a, b) is_eq -> (a, b) eq = function
+  | Is_eq -> Refl
+  | Is_not_eq -> fatal_error "Propositional equality does not hold"
+
 (*********************************************)
 (* Fancy modules *)
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -1130,6 +1130,9 @@ type (_, _) is_eq =
   | Is_eq : ('a, 'a) is_eq
   | Is_not_eq : ('a, 'b) is_eq
 
+(** Raises an exception if propositional equality test does not hold *)
+val get_eq_exn : ('a, 'b) is_eq -> ('a, 'b) eq
+
 (** Utilities for module-level programming *)
 module type T = sig
   type t


### PR DESCRIPTION
Puts mode morphisms in normal form to ensure a finite number of left- or right-allowed morphisms (if a morphism is disallowed on both sides, there is no such guarantee).

The new representation of morphisms is divided into three layers: 
- core morphisms `core_morph`: the core transformations over modes -- preserves the "size" of the input; each core morphism either goes from a single mode axis to a single mode axis, or from a full product to a full product.
- simple morphisms `simple_morph`: extends core morphisms with meets and joins.
- full morphisms `morph`: extends simple morphisms with morphisms that can change the "size" of the input, either by projecting out an axis, or extending an axis to the full product.