### PR TITLE
Remove unnecessary call to get_header_val.

### DIFF
--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -874,7 +874,7 @@ static void custom_finalize_minor (caml_domain_state * domain)
        elt < domain->minor_tables->custom.ptr; elt++) {
     value *v = &elt->block;
     if (Is_block(*v) && Is_young(*v)) {
-      if (!Is_promoted_hd(get_header_val(*v))) { /* value not copied to major heap */
+      if (!Is_promoted_hd(Hd_val(*v))) { /* value not copied to major heap */
         void (*final_fun)(value) = Custom_ops_val(*v)->finalize;
         if (final_fun != NULL) final_fun(*v);
       }


### PR DESCRIPTION
When tidying up un-necessary calls to `get_header_val` and `caml_get_header_val` in #4189, I missed this one (despite @stedolan [pointing it out](https://github.com/oxcaml/oxcaml/pull/4189#issuecomment-3005474686)).