### PR TITLE
Fix printing in coerce typing error

### DIFF
--- a/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
+++ b/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
@@ -322,7 +322,7 @@ let coerce_mut_bad (idx : (_, [ `A ]) idx_mut) =
 Line 2, characters 3-6:
 2 |   (idx :> (_, [ `A | `B ]) idx_mut)
        ^^^
-Error: This expression cannot be coerced to type ""('a, [ `A | `B ]) idx_mut"";
+Error: This expression cannot be coerced to type ""('b, [ `A | `B ]) idx_mut"";
        it has type "('a, [ `A ]) idx_mut" but is here used with type
          "('a, [ `A | `B ]) idx_mut"
        The first variant type does not allow tag(s) "`B"

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -11727,23 +11727,13 @@ let report_error ~loc env =
         "The instance variable %a is overridden several times"
         Style.inline_code v
   | Coercion_failure (ty_exp, err, b) ->
-      Location.error_of_printer ~loc (fun ppf () ->
-          (* Use deprecated_printer to defer prepare_expansion until after
-             reset() is called inside report_unification_error. This ensures
-             consistent type variable naming between the intro and trace. *)
-          let intro =
-            doc_printf "%t" (fun fmt_doc ->
-              deprecated_printer (fun fmt ->
-                let ty_exp = Printtyp.prepare_expansion ty_exp in
-                Format.fprintf fmt
-                  "This expression cannot be coerced to type@;<1 2>%a;@ \
-                   it has type"
-                  (Fmt.compat
-                     (Style.as_inline_code @@ Printtyp.type_expansion Type))
-                  ty_exp
-              ) fmt_doc
-            )
-          in
+    Location.error_of_printer ~loc (fun ppf () ->
+        let intro =
+          let ty_exp = Printtyp.prepare_expansion ty_exp in
+          doc_printf "This expression cannot be coerced to type@;<1 2>%a;@ \
+                      it has type"
+            (Style.as_inline_code @@ Printtyp.type_expansion Type) ty_exp
+        in
         Printtyp.report_unification_error ppf env err
           intro
           (Fmt.doc_printf "but is here used with type");


### PR DESCRIPTION
This PR fixes an evaluation order bug in an error message printer that was recently introduced as part of #5357. We now take roughly the version that upstream uses.