### PR TITLE
Fix locations given to ident in `let%xyz ident in ..`

### DIFF
--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -3330,8 +3330,8 @@ let_binding_body:
       { let p,e,c,modes = $2 in (p,e,c,modes,false,poly_flag) }
 /* BEGIN AVOID */
   | poly_flag = poly_flag val_ident %prec below_HASH
-      { (mkpatvar ~loc:$loc $2, ghexpvar ~loc:$loc $2, None, [], true,
-         poly_flag) }
+      { (mkpatvar ~loc:$loc($2) $2, ghexpvar ~loc:$loc($2) $2,
+         None, [], true, poly_flag) }
   (* The production that allows puns is marked so that [make list-parse-errors]
      does not attempt to exploit it. That would be problematic because it
      would then generate bindings such as [let x], which are rejected by the


### PR DESCRIPTION
This fixes a regression introduced in #5392, which adds the `let poly_` syntax. Adding `poly_flag` to the let-pun case of `let_binding_body` means `$loc` includes `poly_flag`, so `$loc($2)` should be passed to `mkpatvar` and `ghexpvar` instead.

Unlike `rec` and `mutable`, the `poly_` flag is attached to idents rather than let bindings. For example, `let%map poly_ x and poly_ y in ..` is valid syntax, but `let%map rec x and rec y in ..` is not. Hence why `poly_` is parsed in a differently from `rec` and `mutable`.