### PR TITLE
Make the "Skip 80ch" PR label work again

### DIFF
--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -33,5 +33,7 @@ exit_code=0
 $opam_exec dune build @fmt --auto-promote || exit_code=1
 # Format owee files explicitly (external/ is vendored so dune skips it)
 $opam_exec ocamlformat -i external/owee/owee_archive.ml external/owee/owee_archive.mli || exit_code=1
-scripts/80ch.sh || exit_code=1
+if [[ ! -v SKIP_80CH ]]; then
+  scripts/80ch.sh || exit_code=1
+fi
 exit $exit_code

--- a/tools/ci/actions/check-fmt.sh
+++ b/tools/ci/actions/check-fmt.sh
@@ -31,5 +31,7 @@ touch dune.runtime_selection duneconf/dirs-to-ignore.inc duneconf/ox-extra.inc
 
 exit_code=0
 $opam_exec dune build @fmt || exit_code=1
-scripts/80ch.sh || exit_code=1
+if [[ ! -v SKIP_80CH ]]; then
+  scripts/80ch.sh || exit_code=1
+fi
 exit $exit_code


### PR DESCRIPTION
This regression was introduced with #4857.

See https://github.com/oxcaml/oxcaml/pull/5458 for an example of "skip 80ch" working again