### PR TITLE
Avoid partial applications in `mode.ml` `Per_axis` dispatch

### DIFF
--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -4485,13 +4485,17 @@ module Modality = struct
       module Comonadic = Comonadic.Atom
     end
 
-    let is_id : type a. a Axis.t -> a -> bool = function
-      | Monadic ax -> Monadic.is_id ax
-      | Comonadic ax -> Comonadic.is_id ax
+    let is_id : type a. a Axis.t -> a -> bool =
+     fun ax t ->
+      match ax with
+      | Monadic ax -> Monadic.is_id ax t
+      | Comonadic ax -> Comonadic.is_id ax t
 
-    let is_constant : type a. a Axis.t -> a -> bool = function
-      | Monadic ax -> Monadic.is_constant ax
-      | Comonadic ax -> Comonadic.is_constant ax
+    let is_constant : type a. a Axis.t -> a -> bool =
+     fun ax t ->
+      match ax with
+      | Monadic ax -> Monadic.is_constant ax t
+      | Comonadic ax -> Comonadic.is_constant ax t
 
     let print (type a) (ax : a Axis.t) ppf (t : a) =
       match ax, t with

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -55,6 +55,7 @@ module type Const_product = sig
   (** [max_with ax elt] returns [max] but with the axis [ax] set to [elt]. *)
   val max_with : 'a axis -> 'a -> t
 
+  (** For interfacing with the user only; potentially slow. *)
   module Per_axis :
     Solver_intf.Lattices with type 'a obj := 'a axis and type 'a elt := 'a
 end
@@ -545,6 +546,7 @@ module type S = sig
 
       val proj : 'a Axis.t -> ('r * 'l) t -> ('a, 'l * 'r) mode
 
+      (** For interfacing with the user only; potentially slow. *)
       module Per_axis : sig
         val zap_to_floor : 'a Axis.t -> ('a, 'l * allowed) mode -> 'a
 
@@ -564,6 +566,7 @@ module type S = sig
 
       val proj : 'a Axis.t -> ('l * 'r) t -> ('a, 'l * 'r) mode
 
+      (** For interfacing with the user only; potentially slow. *)
       module Per_axis : sig
         val zap_to_floor : 'a Axis.t -> ('a, allowed * 'r) mode -> 'a
 
@@ -831,6 +834,7 @@ module type S = sig
 
     type atom = Atom : 'a Axis.t * 'a -> atom
 
+    (** For interfacing with the user only; potentially slow. *)
     module Per_axis : sig
       (** Test if the given modality is the identity modality. *)
       val is_id : 'a Axis.t -> 'a -> bool
@@ -1082,6 +1086,7 @@ module type S = sig
       val to_modality : packed -> Modality.Axis.packed
     end
 
+    (** For interfacing with the user only; potentially slow. *)
     module Per_axis :
       Solver_intf.Lattices with type 'a elt := 'a and type 'a obj := 'a Axis.t
 


### PR DESCRIPTION
`Modality.Per_axis.is_id` and `is_constant` were defined using `function`, consuming only the first argument and returning partial applications of `Monadic.is_id`/`is_constant` as closures on each call. Eta-expand to take both arguments explicitly.

Also annotate all `Per_axis` module declarations in `mode_intf.mli` as intended for user-facing use only and potentially slow, to discourage hot-path usage.