### PR TITLE
Remove the now-empty "Build debug target" action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -440,10 +440,6 @@ jobs:
         if: matrix.check_arch == true
         run: make check_all_arches
 
-      - name: Build debug target
-        if: matrix.build_debug == true
-        run:
-
       - name: Build and test ocamldebug
         if: matrix.build_debug == true
         run: |


### PR DESCRIPTION
I accidentally let this slip through in #5465. Thanks @goldfirere for spotting it!
