### PR TITLE
Sort-polymorphic value declarations & generalization

### DIFF
--- a/chamelon/compat/compat.ox.ml
+++ b/chamelon/compat/compat.ox.ml
@@ -321,7 +321,13 @@ type tpat_var_identifier = Jkind.Sort.t * Value.l
 let mkTpat_var ?id:(sort, mode = dummy_value_sort, dummy_value_mode)
     (ident, name) =
   Tpat_var
-    { id = ident; name; uid = Uid.internal_not_actually_unique; sort; mode }
+    { id = ident;
+      name;
+      uid = Uid.internal_not_actually_unique;
+      sort;
+      mode;
+      lpoly = Val_lpoly.determined []
+    }
 
 type tpat_alias_identifier = Jkind.Sort.t * Value.l * Types.type_expr
 
@@ -333,7 +339,8 @@ let mkTpat_alias ~id:(sort, mode, ty) (p, ident, name) =
       uid = Uid.internal_not_actually_unique;
       sort;
       mode;
-      type_expr = ty
+      type_expr = ty;
+      lpoly = Val_lpoly.determined []
     }
 
 type tpat_array_identifier = mutability * Jkind.sort
@@ -454,7 +461,7 @@ let mk_value_description ~val_type ~val_kind ~val_attributes =
     val_attributes;
     val_uid = Uid.internal_not_actually_unique;
     val_zero_alloc = Zero_alloc.default;
-    val_lpoly = []
+    val_lpoly = Val_lpoly.determined []
   }
 
 let mkTtyp_any = Ttyp_var (None, None)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -222,10 +222,10 @@ end = struct
     | Tpat_var _ ->
         p
     | Tpat_alias { pattern = q; id; name = s; uid; sort; mode;
-                   type_expr = ty } ->
+                   type_expr = ty; lpoly } ->
         { p with pat_desc =
             Tpat_alias { pattern = simpl_under_orpat q; id; name = s;
-                         uid; sort; mode; type_expr = ty } }
+                         uid; sort; mode; type_expr = ty; lpoly } }
     | Tpat_or (p1, p2, o) ->
         let p1, p2 = (simpl_under_orpat p1, simpl_under_orpat p2) in
         if le_pat p1 p2 then
@@ -251,9 +251,10 @@ end = struct
       in
       match p.pat_desc with
       | `Any -> stop p `Any
-      | `Var (id, s, uid, sort, mode) ->
-        continue p (`Alias (Patterns.omega, id, s, uid, sort, mode, p.pat_type))
-      | `Alias (p, id, _, duid, sort, _, _) ->
+      | `Var (id, s, uid, sort, mode, lpoly) ->
+        continue p (`Alias (Patterns.omega, id, s, uid, sort, mode, p.pat_type,
+                            lpoly))
+      | `Alias (p, id, _, duid, sort, _, _, _) ->
           aux
             ( (General.view p, patl),
               bind_alias p id duid ~arg
@@ -363,11 +364,12 @@ end = struct
       match p.pat_desc with
       | `Or (p1, p2, _) ->
           split_explode p1 aliases (split_explode p2 aliases rem)
-      | `Alias (p, id, _, _, _, _, _) -> split_explode p (id :: aliases) rem
-      | `Var (id, str, uid, sort, mode) ->
+      | `Alias (p, id, _, _, _, _, _, _) -> split_explode p (id :: aliases) rem
+      | `Var (id, str, uid, sort, mode, lpoly) ->
           explode
             { p with pat_desc =
-                `Alias (Patterns.omega, id, str, uid, sort, mode, p.pat_type) }
+                `Alias (Patterns.omega, id, str, uid, sort, mode, p.pat_type,
+                        lpoly) }
             aliases rem
       | #view as view ->
           (* We are doing two things here:
@@ -616,7 +618,8 @@ end = struct
           match p.pat_desc with
           | `Or (p1, p2, _) ->
               filter_rec ((left, p1, right) :: (left, p2, right) :: rem)
-          | `Alias (p, _, _, _, _, _, _) -> filter_rec ((left, p, right) :: rem)
+          | `Alias (p, _, _, _, _, _, _, _) ->
+              filter_rec ((left, p, right) :: rem)
           | `Var _ -> filter_rec ((left, Patterns.omega, right) :: rem)
           | #Simple.view as view -> (
               let p = { p with pat_desc = view } in
@@ -744,7 +747,7 @@ end = struct
       | (p, ps) :: rem -> (
           let p = General.view p in
           match p.pat_desc with
-          | `Alias (p, _, _, _, _, _, _) -> filter_rec ((p, ps) :: rem)
+          | `Alias (p, _, _, _, _, _, _, _) -> filter_rec ((p, ps) :: rem)
           | `Var _ -> filter_rec ((Patterns.omega, ps) :: rem)
           | `Or (p1, p2, _) -> filter_rec_or p1 p2 ps rem
           | #Simple.view as view -> (

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -722,6 +722,7 @@ let expr_of_let_bindings ~loc lbs body =
     List.map
       (fun lb ->
          Vb.mk ~loc:lb.lb_loc ~attrs:lb.lb_attributes
+          ~poly:lb.lb_is_poly
           ~modes:lb.lb_modes
           ?value_constraint:lb.lb_constraint  lb.lb_pattern lb.lb_expression)
       lbs.lbs_bindings
@@ -742,6 +743,7 @@ let class_of_let_bindings ~loc lbs body =
     List.map
       (fun lb ->
          Vb.mk ~loc:lb.lb_loc ~attrs:lb.lb_attributes
+          ~poly:lb.lb_is_poly
           ~modes:lb.lb_modes
           ?value_constraint:lb.lb_constraint lb.lb_pattern lb.lb_expression)
       lbs.lbs_bindings

--- a/testsuite/tests/typing-layouts/let_poly.ml
+++ b/testsuite/tests/typing-layouts/let_poly.ml
@@ -1,0 +1,388 @@
+(* TEST
+ flags = "-extension layout_poly_alpha";
+ expect;
+*)
+
+(* CR-soon zqian: Layout poly currently raises in lambda and middle-end.
+Therefore, in the following typing tests, we intentionally write the wrong
+signature such that the inferred signature can be printed and inspected, and we
+never go to lambda. We should fix those tests once they can go through lambda
+and middle-end. *)
+
+(* Simple let poly_ with a polymorphic function *)
+module _ : sig
+  val id : int
+end = struct
+  let poly_ id x = x
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let poly_ id x = x
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val id : layout_ l. ('a : l). 'a -> 'a end
+       is not included in
+         sig val id : int end
+       Values do not match:
+         val id : layout_ l. ('a : l). 'a -> 'a
+       is not included in
+         val id : int
+       The number of locally abstract layouts differs.
+|}]
+
+(* Let poly_ with multiple bindings - all must be poly_ *)
+module _ : sig
+  val const : int
+  val apply : int
+end = struct
+  let poly_ const x y = x
+  and poly_ apply f x = f x
+end
+[%%expect{|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   let poly_ const x y = x
+6 |   and poly_ apply f x = f x
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val const : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> 'a
+           val apply :
+             layout_ l l0. ('a : l) ('b : l0). ('a -> 'b) -> 'a -> 'b
+         end
+       is not included in
+         sig val const : int val apply : int end
+       Values do not match:
+         val const : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> 'a
+       is not included in
+         val const : int
+       The number of locally abstract layouts differs.
+|}]
+
+(* Tuple pattern - both bindings have separate univars *)
+module _ : sig
+  val f : int
+  val g : int
+end = struct
+  let poly_ (f, g) = ((fun a b -> a), (fun c d -> d))
+end
+[%%expect{|
+Lines 4-6, characters 6-3:
+4 | ......struct
+5 |   let poly_ (f, g) = ((fun a b -> a), (fun c d -> d))
+6 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> 'a
+           val g : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> 'b
+         end
+       is not included in
+         sig val f : int val g : int end
+       Values do not match:
+         val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> 'a
+       is not included in
+         val f : int
+       The number of locally abstract layouts differs.
+|}]
+
+(* Regular let cannot be given a layout_ type *)
+module _ : sig
+  val regular_id : layout_ x. ('a : x). 'a -> 'a
+end = struct
+  let regular_id x = x
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let regular_id x = x
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val regular_id : 'a -> 'a end
+       is not included in
+         sig val regular_id : layout_ x. ('a : x). 'a -> 'a end
+       Values do not match:
+         val regular_id : 'a -> 'a
+       is not included in
+         val regular_id : layout_ x. ('a : x). 'a -> 'a
+       The number of locally abstract layouts differs.
+|}]
+
+(* Layout-polymorphic values cannot be used in expression position:
+   instantiation is not yet supported *)
+module _ : sig
+  val foo : layout_ x. ('a : x). 'a -> 'a
+  val bar : layout_ p q. ('a : p) ('b : q). 'a -> 'b -> 'a
+end = struct
+  let foo, bar =
+    let poly_ foo x = x in
+    let poly_ bar x _y = x in
+    (foo, bar)
+end
+[%%expect{|
+Line 8, characters 5-8:
+8 |     (foo, bar)
+         ^^^
+Error: Instantiation of layout-polymorphic values is not yet supported.
+|}]
+
+(* CR-someday zqian: Mixing poly_ and non-poly_ in let ... and ... is a type
+   error for now, but we may want to allow this in the future. *)
+module _ = struct
+  let poly_ f x = x
+  and g x = x
+end
+[%%expect{|
+Line 3, characters 2-13:
+3 |   and g x = x
+      ^^^^^^^^^^^
+Error: All bindings in a "let" must be either all "poly_" or all non-"poly_"
+|}]
+
+(* Warning when poly_ binding generalizes no layout variables *)
+module M = struct
+  let poly_ f = 42
+end
+[%%expect{|
+Line 2, characters 12-13:
+2 |   let poly_ f = 42
+                ^
+Warning 217: This "let poly_" binding generalizes no layout variables. Consider using a regular "let" instead.
+
+module M : sig val f : int end
+|}]
+
+(* layout-polymorphic id is not included in regular id,
+   even though the former can be instantiated to the latter *)
+module _ : sig
+  val id : 'a -> 'a
+end = struct
+  let poly_ id x = x
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let poly_ id x = x
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val id : layout_ l. ('a : l). 'a -> 'a end
+       is not included in
+         sig val id : 'a -> 'a end
+       Values do not match:
+         val id : layout_ l. ('a : l). 'a -> 'a
+       is not included in
+         val id : 'a -> 'a
+       The number of locally abstract layouts differs.
+|}]
+
+(* Still works when the RHS is not immediately a function *)
+module M : sig
+  val pair : int
+end = struct
+  let poly_ pair = let y = 42 in fun x -> #(x, y)
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let poly_ pair = let y = 42 in fun x -> #(x, y)
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val pair : layout_ l. ('a : l). 'a -> #('a * int) end
+       is not included in
+         sig val pair : int end
+       Values do not match:
+         val pair : layout_ l. ('a : l). 'a -> #('a * int)
+       is not included in
+         val pair : int
+       The number of locally abstract layouts differs.
+|}]
+
+(* RHS might constrain a layout and makes it not polymorphic *)
+module M : sig
+  val f : int
+end = struct
+  let poly_ f x y = #(x, (y, y))
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let poly_ f x y = #(x, (y, y))
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val f : layout_ l. ('a : l) 'b. 'a -> 'b -> #('a * ('b * 'b))
+         end
+       is not included in
+         sig val f : int end
+       Values do not match:
+         val f : layout_ l. ('a : l) 'b. 'a -> 'b -> #('a * ('b * 'b))
+       is not included in
+         val f : int
+       The number of locally abstract layouts differs.
+|}]
+
+(* [any] doesn't really constrain the layout *)
+module M : sig
+  val f : int
+end = struct
+  let poly_ f x = (x : (_ : any))
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let poly_ f x = (x : (_ : any))
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : layout_ l. ('a : l). 'a -> 'a end
+       is not included in
+         sig val f : int end
+       Values do not match:
+         val f : layout_ l. ('a : l). 'a -> 'a
+       is not included in
+         val f : int
+       The number of locally abstract layouts differs.
+|}]
+
+(* [value] does constrain the layout *)
+module M : sig
+  val f : int
+end = struct
+  let poly_ f x = (x : (_ : value))
+end
+[%%expect{|
+Line 4, characters 12-13:
+4 |   let poly_ f x = (x : (_ : value))
+                ^
+Warning 217: This "let poly_" binding generalizes no layout variables. Consider using a regular "let" instead.
+
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let poly_ f x = (x : (_ : value))
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a -> 'a end
+       is not included in
+         sig val f : int end
+       Values do not match: val f : 'a -> 'a is not included in val f : int
+       The type "'a -> 'a" is not compatible with the type "int"
+|}]
+
+(* [assert false] is layout poly *)
+module M : sig
+  val f : int
+end = struct
+  let poly_ f () = assert false
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let poly_ f () = assert false
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : layout_ l. ('a : l). unit -> 'a end
+       is not included in
+         sig val f : int end
+       Values do not match:
+         val f : layout_ l. ('a : l). unit -> 'a
+       is not included in
+         val f : int
+       The number of locally abstract layouts differs.
+|}]
+
+(* CR-soon zqian: once we support instantiation, we should observe that foo is
+   polymorphic on two types sharing the same polymorphic layout. *)
+module M : sig
+  val foo : int
+end = struct
+  let poly_ foo x y =
+    let poly_ id z = z in
+    id x, id y
+end
+[%%expect{|
+Line 6, characters 4-6:
+6 |     id x, id y
+        ^^
+Error: Instantiation of layout-polymorphic values is not yet supported.
+|}]
+
+(* [rec] prevents layout polymorphism, even for fake recursion (no
+   self-reference). *)
+module M : sig
+  val f : 'a -> 'a
+end = struct
+  let rec poly_ f x = x
+end
+[%%expect{|
+Line 4, characters 16-17:
+4 |   let rec poly_ f x = x
+                    ^
+Warning 217: This "let poly_" binding generalizes no layout variables. Consider using a regular "let" instead.
+
+module M : sig val f : 'a -> 'a end
+|}]
+
+(* CR-someday zqian: [rec poly_] should work with explicit user annotations. *)
+module M : sig
+  val f : int
+end = struct
+  let rec poly_ f : layout_ l. ('a : l). 'a -> 'a = fun x -> x
+end
+[%%expect{|
+Line 4, characters 20-49:
+4 |   let rec poly_ f : layout_ l. ('a : l). 'a -> 'a = fun x -> x
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Sort polymorphism is not supported in this context
+|}]
+
+(* CR-soon zqian: should be layout poly, once we support instantiation. *)
+module M : sig
+  val f : int
+end = struct
+  let rec poly_ f : layout_ l. ('a : l). 'a -> 'a = fun x -> f x
+end
+[%%expect{|
+Line 4, characters 20-49:
+4 |   let rec poly_ f : layout_ l. ('a : l). 'a -> 'a = fun x -> f x
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Sort polymorphism is not supported in this context
+|}]
+
+(* CR-soon zqian: should be layout poly, once we support instantiation. *)
+module M : sig
+  val f : int
+  val g : int
+end = struct
+  let rec poly_ g : layout_ l. ('a : l). 'a -> 'a = fun x -> h x
+  and poly_ h : layout_ l. ('a : l). 'a -> 'a = fun x -> g x
+end
+[%%expect{|
+Line 5, characters 20-49:
+5 |   let rec poly_ g : layout_ l. ('a : l). 'a -> 'a = fun x -> h x
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Sort polymorphism is not supported in this context
+|}]
+
+(* either all poly, or none poly. *)
+module M : sig
+  val f : int
+  val g : int
+end = struct
+  let rec poly_ f x = g x
+  and g x = f x
+end
+[%%expect{|
+Line 6, characters 2-15:
+6 |   and g x = f x
+      ^^^^^^^^^^^^^
+Error: All bindings in a "let" must be either all "poly_" or all non-"poly_"
+|}]

--- a/toplevel/native/opttoploop.ml
+++ b/toplevel/native/opttoploop.ml
@@ -408,13 +408,14 @@ let name_expression ~loc ~attrs sort exp =
       val_zero_alloc = Zero_alloc.default;
       val_modalities = Mode.Modality.(Const.id |> of_const);
       val_uid = Uid.internal_not_actually_unique;
-      val_lpoly = []; }
+      val_lpoly = Val_lpoly.determined []; }
   in
   let sg = [Sig_value(id, vd, Exported)] in
   let pat =
     { pat_desc =
         Tpat_var { id; name = mknoloc name; uid = vd.val_uid; sort;
-                   mode = Mode.Value.disallow_right Mode.Value.legacy };
+                   mode = Mode.Value.disallow_right Mode.Value.legacy;
+                   lpoly = Val_lpoly.determined [] };
       pat_loc = loc;
       pat_extra = [];
       pat_type = exp.exp_type;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -293,19 +293,23 @@ module Pattern_env : sig
   type t = private
     { mutable env : Env.t;
       equations_scope : int;
-      allow_recursive_equations : bool; }
-  val make: Env.t -> equations_scope:int -> allow_recursive_equations:bool -> t
+      allow_recursive_equations : bool;
+      is_lpoly : bool; }
+  val make: ?is_lpoly:bool -> Env.t -> equations_scope:int
+    -> allow_recursive_equations:bool -> t
   val copy: ?equations_scope:int -> t -> t
   val set_env: t -> Env.t -> unit
 end = struct
   type t =
     { mutable env : Env.t;
       equations_scope : int;
-      allow_recursive_equations : bool; }
-  let make env ~equations_scope ~allow_recursive_equations =
+      allow_recursive_equations : bool;
+      is_lpoly : bool; }
+  let make ?(is_lpoly=false) env ~equations_scope ~allow_recursive_equations =
     { env;
       equations_scope;
-      allow_recursive_equations; }
+      allow_recursive_equations;
+      is_lpoly; }
   let copy ?equations_scope penv =
     let equations_scope =
       match equations_scope with None -> penv.equations_scope | Some s -> s in
@@ -824,7 +828,9 @@ let rec generalize stage_offset ty =
     set_level ty generic_level;
     (* recur into abbrev for the speed *)
     begin match get_desc ty with
-    | Tvar name -> update_variable_stage stage_offset ty name.name name.jkind
+    | Tvar name ->
+        update_variable_stage stage_offset ty name.name name.jkind;
+        Jkind.generalize ~current_level:!current_level name.jkind
     | Tvariant row ->
         if stage_offset <> 0 && is_Tvar (row_more row) then
           lower_all ty

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -192,8 +192,11 @@ module Pattern_env : sig
       (* scope for local type declarations *)
       allow_recursive_equations : bool;
       (* true iff checking counter examples *)
+      is_lpoly : bool;
+      (* true iff the pattern is under let poly_ *)
     }
-  val make: Env.t -> equations_scope:int -> allow_recursive_equations:bool -> t
+  val make: ?is_lpoly:bool -> Env.t -> equations_scope:int
+    -> allow_recursive_equations:bool -> t
   val copy: ?equations_scope:int -> t -> t
   val set_env: t -> Env.t -> unit
 end

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -170,12 +170,14 @@ let value_descriptions ~loc env name
   | Error e -> raise (Dont_match (Mode e))
   end;
   let lpairs =
-    try List.combine vd1.val_lpoly vd2.val_lpoly
+    try List.combine
+          (Val_lpoly.get_exn vd1.val_lpoly)
+          (Val_lpoly.get_exn vd2.val_lpoly)
     with Invalid_argument _ -> raise (Dont_match Poly_arity_mismatch)
   in
   match vd1.val_kind with
   | Val_prim p1 -> begin
-     assert (List.is_empty vd1.val_lpoly);
+     assert (List.is_empty (Val_lpoly.get_exn vd1.val_lpoly));
      match vd2.val_kind with
      | Val_prim p2 -> begin
          let locality = [ Mode.Locality.global; Mode.Locality.local ] in

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -366,6 +366,11 @@ module Layout = struct
         Fmt.pp_nested_list ~nested ~pp_element ~pp_sep ppf ts
     in
     pp_element ~nested:false ppf layout
+
+  let rec generalize ~current_level : _ Layout.t -> unit = function
+    | Sort (sort, _) -> Sort.generalize ~current_level sort
+    | Product layouts -> List.iter (generalize ~current_level) layouts
+    | Any _ -> ()
 end
 
 module Externality = Externality
@@ -2400,6 +2405,12 @@ let default_to_value t =
   match t.jkind.base with
   | Kconstr _ -> ()
   | Layout l -> ignore (Layout.default_to_value_and_get l)
+
+let generalize ~current_level t =
+  (* Expanding unnecessary in the case of a Kconstr, which is constant. *)
+  match t.jkind.base with
+  | Kconstr _ -> ()
+  | Layout l -> Layout.generalize ~current_level l
 
 let get t = Jkind_desc.get t.jkind
 

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -547,6 +547,10 @@ val default_to_value : 'd Types.jkind -> unit
    these three functions to default to void - it's the most efficient thing
    when we have a choice. *)
 
+(** Generalize the sorts in a jkind when in sort generalization context. Only
+    has an effect when called within {!Sort.with_generalize}. *)
+val generalize : current_level:int -> 'd Types.jkind -> unit
+
 (** Returns the sort corresponding to the jkind. Call only on representable
     jkinds - raises on Any. *)
 val sort_of_jkind : Env.t -> Types.jkind_l -> sort

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -555,6 +555,51 @@ module Sort = struct
         (* path compression *)
         result)
 
+  (* Sort generalization context for let poly_ *)
+  let in_sort_generalization_context : univar list ref option ref = ref None
+
+  (* Generalize sort variables when in sort generalization context.
+     This is called from Ctype.generalize when processing let poly_ bindings.
+     For each free sort variable, a fresh univar is created and the var is
+     set to point to it, so subsequent lookups resolve to the univar.
+     The level is set to Ident.highest_scope to mark the variable as visited,
+     avoiding infinite loops when traversing sort variable graphs. *)
+  let rec generalize_rec ~current_level ~univars_ref sort =
+    match sort with
+    | Var v ->
+      if v.level > current_level && v.level <> Ident.highest_scope
+      then begin
+        (* Mark as visited to avoid infinite loops *)
+        v.level <- Ident.highest_scope;
+        match v.contents with
+        | Some s -> generalize_rec ~current_level ~univars_ref s
+        | None ->
+          (* Create a univar, link the var to it, and accumulate the univar *)
+          let uv = new_univar () in
+          set v (Some (Univar uv));
+          univars_ref := uv :: !univars_ref
+      end
+    | Product sorts ->
+      List.iter (generalize_rec ~current_level ~univars_ref) sorts
+    | Base _ | Univar _ -> ()
+
+  let generalize ~current_level sort =
+    match !in_sort_generalization_context with
+    | None -> () (* Not in generalization context *)
+    | Some univars_ref -> generalize_rec ~current_level ~univars_ref sort
+
+  (* Wrapper to run a function in sort generalization context. Returns the
+     result of [f] and the univars created for each generalized sort variable. *)
+  let with_generalize f =
+    let univars_ref = ref [] in
+    let old_context = !in_sort_generalization_context in
+    in_sort_generalization_context := Some univars_ref;
+    let result =
+      Misc.try_finally f ~always:(fun () ->
+          in_sort_generalization_context := old_context)
+    in
+    result, List.rev !univars_ref
+
   let rec default_to_value_and_get : t -> Const.t = function
     | Base b -> Static.Const.of_base b
     | Product ts -> Product (List.map default_to_value_and_get ts)

--- a/typing/jkind_types.mli
+++ b/typing/jkind_types.mli
@@ -104,6 +104,17 @@ module Sort : sig
   *)
   val decompose_into_product : level:int -> t -> int -> t list option
 
+  (** Run a function with sort generalization enabled (for let poly_ support).
+      Returns the result of [f] and the list of univars created for each
+      generalized sort variable. *)
+  val with_generalize : (unit -> 'a) -> 'a * univar list
+
+  (** Generalize sort variables when in sort generalization context. Sets the
+      level of sort variables to Ident.highest_scope and accumulates them. This
+      should be called from Ctype.generalize. Only has an effect when called
+      within {!with_generalize}. *)
+  val generalize : current_level:int -> t -> unit
+
   module Flat : sig
     type t =
       | Var of Var.id

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -64,7 +64,8 @@ let extra_pat =
     (Tpat_var { id = Ident.create_local "+"; name = mknoloc "+";
       uid = Uid.internal_not_actually_unique;
       sort = Jkind.Sort.(of_const Const.for_boxed_variant);
-      mode = Mode.Value.disallow_right Mode.Value.max })
+      mode = Mode.Value.disallow_right Mode.Value.max;
+      lpoly = Val_lpoly.determined [] })
     Ctype.none Env.empty
 
 
@@ -1110,7 +1111,8 @@ let build_other ext env =
                        name = {txt="*extension*"; loc = d.pat_loc};
                        uid = Uid.internal_not_actually_unique;
                        sort = Jkind.Sort.(of_const Const.for_constructor);
-                       mode = Mode.Value.disallow_right Mode.Value.max })
+                       mode = Mode.Value.disallow_right Mode.Value.max;
+                       lpoly = Val_lpoly.determined [] })
             Ctype.none Env.empty
       | Construct _ ->
           begin match ext with
@@ -1123,7 +1125,7 @@ let build_other ext env =
           | _ ->
               build_other_constrs env d
           end
-      | Unboxed_bool b -> 
+      | Unboxed_bool b ->
         make_pat (Tpat_unboxed_bool (not b)) d.pat_type Env.empty
       | Variant { cstr_row; type_row } ->
           let tags =
@@ -2498,9 +2500,9 @@ type amb_row = { row : pattern list ; varsets : Ident.Set.t list; }
 let simplify_head_amb_pat head_bound_variables varsets ~add_column p ps k =
   let rec simpl head_bound_variables varsets p ps k =
     match (Patterns.General.view p).pat_desc with
-    | `Alias (p,x,_,_,_,_,_) ->
+    | `Alias (p,x,_,_,_,_,_,_) ->
       simpl (Ident.Set.add x head_bound_variables) varsets p ps k
-    | `Var (x, _, _, _, _) ->
+    | `Var (x, _, _, _, _, _) ->
       simpl (Ident.Set.add x head_bound_variables) varsets Patterns.omega ps k
     | `Or (p1,p2,_) ->
       simpl head_bound_variables varsets p1 ps

--- a/typing/patterns.ml
+++ b/typing/patterns.ml
@@ -87,19 +87,21 @@ module General = struct
   type view = [
     | Half_simple.view
     | `Var of Ident.t * string loc * Uid.t * Jkind.Sort.t * Mode.Value.l
+              * Val_lpoly.t
     | `Alias of pattern * Ident.t * string loc
                 * Uid.t * Jkind.Sort.t * Mode.Value.l * Types.type_expr
+                * Val_lpoly.t
   ]
   type pattern = view pattern_data
 
   let view_desc = function
     | Tpat_any ->
        `Any
-    | Tpat_var { id; name = str; uid; sort; mode } ->
-       `Var (id, str, uid, sort, mode)
+    | Tpat_var { id; name = str; uid; sort; mode; lpoly } ->
+       `Var (id, str, uid, sort, mode, lpoly)
     | Tpat_alias { pattern = p; id; name = str; uid; sort; mode;
-                   type_expr = ty } ->
-       `Alias (p, id, str, uid, sort, mode, ty)
+                   type_expr = ty; lpoly } ->
+       `Alias (p, id, str, uid, sort, mode, ty, lpoly)
     | Tpat_constant cst ->
        `Constant cst
     | Tpat_unboxed_unit ->
@@ -127,11 +129,11 @@ module General = struct
 
   let erase_desc = function
     | `Any -> Tpat_any
-    | `Var (id, str, uid, sort, mode) ->
-       Tpat_var { id; name = str; uid; sort; mode }
-    | `Alias (p, id, str, uid, sort, mode, ty) ->
+    | `Var (id, str, uid, sort, mode, lpoly) ->
+       Tpat_var { id; name = str; uid; sort; mode; lpoly }
+    | `Alias (p, id, str, uid, sort, mode, ty, lpoly) ->
        Tpat_alias { pattern = p; id; name = str; uid; sort; mode;
-                    type_expr = ty }
+                    type_expr = ty; lpoly }
     | `Constant cst -> Tpat_constant cst
     | `Unboxed_unit -> Tpat_unboxed_unit
     | `Unboxed_bool b -> Tpat_unboxed_bool b
@@ -154,7 +156,7 @@ module General = struct
 
   let rec strip_vars (p : pattern) : Half_simple.pattern =
     match p.pat_desc with
-    | `Alias (p, _, _, _, _, _, _) -> strip_vars (view p)
+    | `Alias (p, _, _, _, _, _, _, _) -> strip_vars (view p)
     | `Var _ -> { p with pat_desc = `Any }
     | #Half_simple.view as view -> { p with pat_desc = view }
 end

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -71,8 +71,10 @@ module General : sig
   type view = [
     | Half_simple.view
     | `Var of Ident.t * string loc * Uid.t * Jkind.Sort.t * Mode.Value.l
+              * Types.Val_lpoly.t
     | `Alias of pattern * Ident.t * string loc * Uid.t
                 * Jkind.Sort.t * Mode.Value.l * Types.type_expr
+                * Types.Val_lpoly.t
   ]
   type pattern = view pattern_data
 

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2387,8 +2387,8 @@ let tree_of_value_description id decl =
     (* Important: process the fvs *after* the type; tree_of_type_scheme
        resets the naming context. Both must be inside print_with_univars
        so that sort univar names are registered when jkinds are printed. *)
-    Jkind_types.Sort.print_with_univars decl.val_lpoly (fun names ->
-      names, extract_qtvs [decl.val_type])
+    Jkind_types.Sort.print_with_univars (Val_lpoly.get_exn decl.val_lpoly)
+      (fun names -> names, extract_qtvs [decl.val_type])
   in
   let apparent_arity =
     let rec count n typ =

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -338,8 +338,8 @@ let pat
     | Tpat_constant _
     | Tpat_unboxed_unit
     | Tpat_unboxed_bool _ -> x.pat_desc
-    | Tpat_var { id; name; uid; sort; mode } ->
-      Tpat_var { id; name = map_loc sub name; uid; sort; mode }
+    | Tpat_var { id; name; uid; sort; mode; lpoly } ->
+      Tpat_var { id; name = map_loc sub name; uid; sort; mode; lpoly }
     | Tpat_tuple l ->
         Tpat_tuple (List.map (fun (label, p) -> label, sub.pat sub p) l)
     | Tpat_unboxed_tuple l ->
@@ -361,10 +361,10 @@ let pat
         Tpat_record_unboxed_product
           (List.map (tuple3 (map_loc sub) id (sub.pat sub)) l, closed)
     | Tpat_array (am, arg_sort, l) -> Tpat_array (am, arg_sort, List.map (sub.pat sub) l)
-    | Tpat_alias { pattern; id; name; uid; sort; mode; type_expr } ->
+    | Tpat_alias { pattern; id; name; uid; sort; mode; type_expr; lpoly } ->
         Tpat_alias { pattern = sub.pat sub pattern; id;
                      name = map_loc sub name; uid;
-                     sort; mode; type_expr }
+                     sort; mode; type_expr; lpoly }
     | Tpat_lazy p -> Tpat_lazy (sub.pat sub p)
     | Tpat_value p ->
        (as_computation_pattern (sub.pat sub (p :> pattern))).pat_desc

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -490,7 +490,7 @@ let enter_ancestor_met ~loc name ~sign ~meths ~cl_num ~ty ~attrs met_env =
   let kind = Val_anc (sign, meths, cl_num) in
   let desc =
     { val_type = ty; val_modalities = Modality.undefined; val_kind = kind;
-      val_lpoly = [];
+      val_lpoly = Val_lpoly.determined [];
       val_attributes = attrs;
       val_zero_alloc = Zero_alloc.default;
       Types.val_loc = loc;
@@ -507,7 +507,7 @@ let add_self_met loc id sign self_var_kind vars cl_num
   let kind = Val_self (sign, self_var_kind, vars, cl_num) in
   let desc =
     { val_type = ty; val_modalities = Modality.undefined; val_kind = kind;
-      val_lpoly = [];
+      val_lpoly = Val_lpoly.determined [];
       val_attributes = attrs;
       val_zero_alloc = Zero_alloc.default;
       Types.val_loc = loc;
@@ -524,7 +524,7 @@ let add_instance_var_met loc label id sign cl_num attrs met_env =
   let kind = Val_ivar (mut, cl_num) in
   let desc =
     { val_type = ty; val_modalities = Modality.undefined; val_kind = kind;
-      val_lpoly = [];
+      val_lpoly = Val_lpoly.determined [];
       val_attributes = attrs;
       Types.val_loc = loc;
       val_zero_alloc = Zero_alloc.default;
@@ -1483,7 +1483,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                {val_type = expr.exp_type;
                 val_modalities = Modality.undefined;
                 val_kind = Val_ivar (Immutable, cl_num);
-                val_lpoly = [];
+                val_lpoly = Val_lpoly.determined [];
                 val_attributes = [];
                 val_zero_alloc = Zero_alloc.default;
                 Types.val_loc = vd.val_loc;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -253,6 +253,7 @@ type error =
   | Illegal_letrec_pat
   | Illegal_letrec_expr
   | Illegal_mutable_pat
+  | Mixed_poly_nonpoly_bindings
   | Illegal_class_expr
   | Letop_type_clash of string * Errortrace.unification_error
   | Andop_type_clash of string * Errortrace.unification_error
@@ -1279,6 +1280,7 @@ type pattern_variable =
     pv_as_var: bool;
     pv_attributes: attributes;
     pv_sort: Jkind_types.Sort.t;
+    pv_lpoly: Val_lpoly.t;
   }
 
 type module_variable =
@@ -1372,18 +1374,18 @@ let iter_pattern_variables_type f : pattern_variable list -> unit =
   List.iter (fun {pv_type; _} -> f pv_type)
 
 let iter_pattern_variables_type_mut ~f_immut ~f_mut pvs =
-  List.iter (fun {pv_type; pv_kind; _ } ->
+  List.iter (fun {pv_type; pv_kind; pv_lpoly; _} ->
     match pv_kind with
     | Val_mut _ -> f_mut pv_type
-    | _ -> f_immut pv_type) pvs
+    | _ -> f_immut pv_lpoly pv_type) pvs
 
 let add_pattern_variables ?check ?check_as env pv =
   List.fold_right
     (fun {pv_id; pv_mode; pv_kind; pv_type; pv_loc; pv_as_var;
-          pv_attributes; pv_uid} env ->
+          pv_attributes; pv_uid; pv_lpoly} env ->
        let check = if pv_as_var then check_as else check in
        Env.add_value ?check ~mode:pv_mode pv_id
-         {val_type = pv_type; val_kind = pv_kind; val_lpoly = [];
+         {val_type = pv_type; val_kind = pv_kind; val_lpoly = pv_lpoly;
           Types.val_loc = pv_loc;
           val_attributes = pv_attributes; val_modalities = Modality.undefined;
           val_zero_alloc = Zero_alloc.default;
@@ -1433,6 +1435,7 @@ let add_module_variables env module_variables =
   ) env module_variables_as_list
 
 let enter_variable ?(is_module=false) ?(is_as_variable=false) tps loc name mode
+    ?(lpoly=Val_lpoly.determined [])
     ~kind ty attrs sort =
   if List.exists (fun {pv_id; _} -> Ident.name pv_id = name.txt)
       tps.tps_pattern_variables
@@ -1472,7 +1475,8 @@ let enter_variable ?(is_module=false) ?(is_as_variable=false) tps loc name mode
      pv_as_var = is_as_variable;
      pv_attributes = attrs;
      pv_uid;
-     pv_sort = sort} :: tps.tps_pattern_variables;
+     pv_sort = sort;
+     pv_lpoly = lpoly} :: tps.tps_pattern_variables;
   id, pv_uid
 
 let sort_pattern_variables vs =
@@ -2112,7 +2116,8 @@ let type_for_loop_index ~loc ~env ~param =
                 pv_kind = Val_reg Jkind.Sort.(of_const Const.for_loop_index);
                 pv_type; pv_loc; pv_as_var;
                 pv_attributes;
-                pv_sort = Jkind.Sort.(of_const Const.for_loop_index)
+                pv_sort = Jkind.Sort.(of_const Const.for_loop_index);
+                pv_lpoly = Val_lpoly.determined [];
                 }
             in
             (pv_id, pv_uid), add_pattern_variables ~check ~check_as:check env [pv])
@@ -3069,11 +3074,16 @@ and type_pat_aux
             let kind = Val_mut (m0, sort) in
             mode, kind
       in
+      let lpoly =
+        if (penv : Pattern_env.t).is_lpoly
+        then Val_lpoly.to_generalize ~loc
+        else Val_lpoly.determined []
+      in
       let id, uid =
-        enter_variable tps loc name mode ~kind ty sp.ppat_attributes sort
+        enter_variable ~lpoly tps loc name mode ~kind ty sp.ppat_attributes sort
       in
       rvp {
-        pat_desc = Tpat_var { id; name; uid; sort; mode = alloc_mode };
+        pat_desc = Tpat_var { id; name; uid; sort; mode = alloc_mode; lpoly };
         pat_loc = loc; pat_extra=[];
         pat_type = ty;
         pat_attributes = sp.ppat_attributes;
@@ -3102,8 +3112,10 @@ and type_pat_aux
               ~kind:(Val_reg sort) sp.ppat_attributes sort
           in
           rvp {
-            pat_desc = Tpat_var { id; name = v; uid; sort;
-                                  mode = alloc_mode.mode };
+            pat_desc =
+              Tpat_var
+                { id; name = v; uid; sort;
+                  mode = alloc_mode.mode; lpoly = Val_lpoly.determined [] };
             pat_loc = sp.ppat_loc;
             pat_extra=[Tpat_unpack, loc, sp.ppat_attributes];
             pat_type = t;
@@ -3115,13 +3127,19 @@ and type_pat_aux
       let q = type_pat tps Value sq expected_ty sort in
       let ty_var, mode = solve_Ppat_alias ~mode:alloc_mode.mode !!penv q in
       let mode = cross_left !!penv expected_ty mode in
+      let lpoly =
+        if (penv : Pattern_env.t).is_lpoly
+        then Val_lpoly.to_generalize ~loc
+        else Val_lpoly.determined []
+      in
       let id, uid =
-        enter_variable ~is_as_variable:true
+        enter_variable ~is_as_variable:true ~lpoly
           ~kind:(Val_reg sort) tps name.loc name mode
           ty_var sp.ppat_attributes sort
       in
       rvp { pat_desc = Tpat_alias { pattern = q; id; name; uid;
-                                    sort; mode; type_expr = ty_var };
+                                    sort; mode; type_expr = ty_var;
+                                    lpoly };
             pat_loc = loc; pat_extra=[];
             pat_type = q.pat_type;
             pat_attributes = sp.ppat_attributes;
@@ -3498,12 +3516,12 @@ let type_pattern
 
 let type_pattern_list
     category no_existentials env mutable_flag spatl expected_tys expected_sorts
-    allow_modules
+    allow_modules ~is_lpoly
   =
   let tps = create_type_pat_state allow_modules in
   let equations_scope = get_current_level () in
   let new_penv = Pattern_env.make env
-      ~equations_scope ~allow_recursive_equations:false in
+      ~is_lpoly ~equations_scope ~allow_recursive_equations:false in
   let type_pat (attrs, pat_mode, exp_mode, pat) ty sort =
     Builtin_attributes.warning_scope ~ppwarning:false attrs
       (fun () ->
@@ -3560,7 +3578,7 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
           Env.add_value ~mode:Mode.Value.legacy pv_id
             { val_type = pv_type
             ; val_kind = Val_reg pv_sort
-            ; val_lpoly = []
+            ; val_lpoly = Val_lpoly.determined []
             ; val_attributes = pv_attributes
             ; val_zero_alloc = Zero_alloc.default
             ; val_modalities = Modality.undefined
@@ -3573,7 +3591,7 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
           Env.add_value ~mode:Mode.Value.legacy id' ~check
             { val_type = pv_type
             ; val_kind = Val_ivar (Immutable, cl_num)
-            ; val_lpoly = []
+            ; val_lpoly = Val_lpoly.determined []
             ; val_attributes = pv_attributes
             ; val_zero_alloc = Zero_alloc.default
             ; val_modalities = Modality.undefined
@@ -5731,13 +5749,7 @@ let vb_exp_constraint {pvb_expr=expr; pvb_pat=pat; pvb_constraint=ct; pvb_modes=
       List.fold_right mk_newtype locally_abstract_univars expr
 
 let vb_pat_constraint
-      ({pvb_pat=pat; pvb_expr = exp; pvb_modes = modes; pvb_is_poly;
-        pvb_loc; _ } as vb) =
-  if pvb_is_poly then begin
-    Language_extension.assert_enabled ~loc:pvb_loc Layout_poly
-      Language_extension.Alpha;
-    raise (Error (pvb_loc, Env.empty, Let_poly_not_yet_implemented))
-  end;
+      ({pvb_pat=pat; pvb_expr = exp; pvb_modes = modes; _ } as vb) =
   let spat =
     let open Ast_helper in
     let loc =
@@ -6255,7 +6267,8 @@ and type_expect_
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_let(Immutable, Nonrecursive,
-             [{pvb_pat=spat; pvb_attributes=[]; _ } as vb], sbody)
+        [{pvb_pat=spat; pvb_attributes=[]; pvb_is_poly=false; _ } as vb],
+        sbody )
     when turn_let_into_match spat ->
       (* TODO: allow non-empty attributes? *)
       let sval = vb_exp_constraint vb in
@@ -8128,7 +8141,7 @@ and type_ident env ?(recarg=Rejected) lid =
 
   Therefore, we need to cross modes upon look-up. Ideally that should be done in
   [Env], but that is difficult due to cyclic dependency between jkind and env. *)
-  if not @@ List.is_empty desc.val_lpoly then
+  if not @@ List.is_empty (Val_lpoly.get_exn desc.val_lpoly) then
     raise (Error (lid.loc, env, Layout_poly_inst_not_yet_supported));
   let mode = cross_left env desc.val_type mode in
   (* There can be locks between the definition and a use of a value. For
@@ -9125,7 +9138,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
         let id = Ident.create_local name in
         let desc =
           { val_type = ty; val_kind = Val_reg sort;
-            val_lpoly = [];
+            val_lpoly = Val_lpoly.determined [];
             val_attributes = [];
             val_zero_alloc = Zero_alloc.default;
             val_modalities = Modality.undefined;
@@ -9137,7 +9150,8 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
         let uu = unique_use ~loc:sarg.pexp_loc ~env mode mode in
         {pat_desc = Tpat_var { id; name = mknoloc name;
                                uid = desc.val_uid; sort;
-                               mode = Value.disallow_right mode };
+                               mode = Value.disallow_right mode;
+                               lpoly = Val_lpoly.determined [] };
          pat_type = ty;
          pat_extra=[];
          pat_attributes = [];
@@ -10195,6 +10209,17 @@ and type_function_cases_expect
 
 and type_let ?check ?check_strict ?(force_toplevel = false)
     existential_context env mutable_flag rec_flag spat_sexp_list allow_modules =
+  (* Check that all bindings are either all poly or all non-poly *)
+  let is_lpoly =
+    match spat_sexp_list with
+    | [] -> false
+    | first :: rest ->
+      List.iter (fun binding ->
+        if binding.pvb_is_poly <> first.pvb_is_poly then
+          raise (Error(binding.pvb_loc, env, Mixed_poly_nonpoly_bindings))
+      ) rest;
+      first.pvb_is_poly
+  in
   let rec sexp_is_fun sexp =
     match sexp.pexp_desc with
     | Pexp_function _ -> true
@@ -10237,7 +10262,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
           let (pat_list, _new_env, _force, pvs, _mvs as res) =
             with_local_level_if is_recursive (fun () ->
               type_pattern_list Value existential_context env mutable_flag spatl
-                nvs sorts allow_modules
+                nvs sorts allow_modules ~is_lpoly
             ) ~post:(fun (_, _, _, pvs, _) ->
                        iter_pattern_variables_type generalize pvs)
           in
@@ -10256,6 +10281,17 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
                 let bound_expr = vb_exp_constraint binding in
                 type_approx env bound_expr pat.pat_type)
               pat_list spat_sexp_list;
+          (* CR-someday zqian: if recursive, unify [pv_lpoly] with user
+             annotations of layout poly. *)
+          (* If recursive, values don't enjoy layout polymorphism, unless
+             specified in its types (incorperated above). *)
+          if is_recursive then
+            List.iter (fun { pv_lpoly; _ } ->
+              Val_lpoly.generalize
+                ~on_to_generalize:(fun loc ->
+                  Location.prerr_warning loc Warnings.Useless_poly; [])
+                pv_lpoly
+            ) pvs;
           (* If recursive, all pattern variables must have layout value. This
              could be relaxed in some cases, like let recs that aren't actually
              recusive. But, if making that change, delete [Lambda.layout_letrec]
@@ -10361,7 +10397,17 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
           if maybe_expansive exp then lower_contravariant env pat.pat_type)
         mode_pat_typ_list exp_list;
       iter_pattern_variables_type_mut
-        ~f_immut:generalize
+        ~f_immut:(fun pv_lpoly ty ->
+          Val_lpoly.generalize
+            ~on_determined:(fun () -> generalize ty)
+            ~on_to_generalize:(fun loc ->
+              let _, univars =
+                Jkind_types.Sort.with_generalize (fun () -> generalize ty)
+              in
+              if List.is_empty univars then
+                Location.prerr_warning loc Warnings.Useless_poly;
+              univars)
+            pv_lpoly)
         ~f_mut:(unify_var env (newvar (Jkind.Builtin.any ~why:Dummy_jkind)))
         pvs;
       (* update pattern variable jkind reasons *)
@@ -11992,6 +12038,11 @@ let report_error ~loc env =
       Location.errorf ~loc
         "Only variables are allowed as the left-hand side of %a"
         Style.inline_code "let mutable"
+  | Mixed_poly_nonpoly_bindings ->
+      Location.errorf ~loc
+        "All bindings in a %a must be either all %a or all non-%a"
+        Style.inline_code "let"
+        Style.inline_code "poly_" Style.inline_code "poly_"
   | Illegal_letrec_expr ->
       Location.errorf ~loc
         "This kind of expression is not allowed as right-hand side of %a"

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -71,6 +71,7 @@ type pattern_variable =
     pv_as_var: bool;
     pv_attributes: Typedtree.attributes;
     pv_sort: Jkind.Sort.t;
+    pv_lpoly: Types.Val_lpoly.t;
   }
 
 val mk_expected:
@@ -299,6 +300,7 @@ type error =
   | Illegal_letrec_pat
   | Illegal_letrec_expr
   | Illegal_mutable_pat
+  | Mixed_poly_nonpoly_bindings
   | Illegal_class_expr
   | Letop_type_clash of string * Errortrace.unification_error
   | Andop_type_clash of string * Errortrace.unification_error

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -3977,7 +3977,7 @@ let transl_value_decl env loc ~modal ~why valdecl =
       in
       { val_type = ty;
         val_kind = Val_reg sort;
-        val_lpoly = lpoly;
+        val_lpoly = Val_lpoly.determined lpoly;
         Types.val_loc = loc;
         val_attributes = valdecl.pval_attributes; val_modalities;
         val_zero_alloc = zero_alloc;
@@ -4021,7 +4021,8 @@ let transl_value_decl env loc ~modal ~why valdecl =
       && not (String.starts_with ~prefix:"%" prim.prim_name)
       then raise(Error(valdecl.pval_type.ptyp_loc, Missing_native_external));
       check_unboxable env loc ty;
-      { val_type = ty; val_kind = Val_prim prim; val_lpoly = lpoly;
+      { val_type = ty; val_kind = Val_prim prim;
+        val_lpoly = Val_lpoly.determined lpoly;
         Types.val_loc = loc;
         val_attributes = valdecl.pval_attributes; val_modalities;
         val_zero_alloc = Zero_alloc.default;

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -183,6 +183,7 @@ and 'k pattern_desc =
       uid: Uid.t;
       sort: Jkind_types.Sort.t;
       mode: Mode.Value.l;
+      lpoly: Val_lpoly.t;
     } -> value pattern_desc
   | Tpat_alias : {
       pattern: value general_pattern;
@@ -192,6 +193,7 @@ and 'k pattern_desc =
       sort: Jkind_types.Sort.t;
       mode: Mode.Value.l;
       type_expr: Types.type_expr;
+      lpoly: Val_lpoly.t;
     } -> value pattern_desc
   | Tpat_constant : constant -> value pattern_desc
   | Tpat_unboxed_unit : value pattern_desc
@@ -1131,9 +1133,9 @@ let shallow_map_pattern_desc
   : type k . pattern_transformation -> k pattern_desc -> k pattern_desc
   = fun f d -> match d with
   | Tpat_alias { pattern = p1; id; name = s; uid; sort; mode = m;
-                 type_expr = ty } ->
+                 type_expr = ty; lpoly } ->
       Tpat_alias { pattern = f.f p1; id; name = s; uid; sort; mode = m;
-                   type_expr = ty }
+                   type_expr = ty; lpoly }
   | Tpat_tuple pats ->
       Tpat_tuple (List.map (fun (label, pat) -> label, f.f pat) pats)
   | Tpat_unboxed_tuple pats ->
@@ -1361,18 +1363,19 @@ let alpha_var env id = List.assoc id env
 let rec alpha_pat
   : type k . _ -> k general_pattern -> k general_pattern
   = fun env p -> match p.pat_desc with
-  | Tpat_var { id; name = s; uid; sort; mode } ->
+  | Tpat_var { id; name = s; uid; sort; mode; lpoly } ->
       (* note the ``Not_found'' case *)
       {p with pat_desc =
-       try Tpat_var { id = alpha_var env id; name = s; uid; sort; mode } with
+       try Tpat_var { id = alpha_var env id; name = s; uid; sort; mode;
+                      lpoly } with
        | Not_found -> Tpat_any}
   | Tpat_alias { pattern = p1; id; name = s; uid; sort; mode;
-                 type_expr = ty } ->
+                 type_expr = ty; lpoly } ->
       let new_p =  alpha_pat env p1 in
       begin try
         {p with pat_desc =
            Tpat_alias { pattern = new_p; id = alpha_var env id;
-                        name = s; uid; sort; mode; type_expr = ty }}
+                        name = s; uid; sort; mode; type_expr = ty; lpoly }}
       with
       | Not_found -> new_p
       end

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -215,6 +215,7 @@ and 'k pattern_desc =
       uid: Uid.t;
       sort: Jkind_types.Sort.t;
       mode: Mode.Value.l;
+      lpoly: Types.Val_lpoly.t;
     } -> value pattern_desc
         (** x *)
   | Tpat_alias : {
@@ -225,6 +226,7 @@ and 'k pattern_desc =
       sort: Jkind_types.Sort.t;
       mode: Mode.Value.l;
       type_expr: Types.type_expr;
+      lpoly: Types.Val_lpoly.t;
     } -> value pattern_desc
         (** P as a *)
   | Tpat_constant : constant -> value pattern_desc

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -567,6 +567,26 @@ module type Wrap = sig
   type 'a t
 end
 
+module Val_lpoly = struct
+  type state =
+    | To_generalize of Location.t
+    | Determined of Jkind_types.Sort.univar list
+
+  type t = state ref
+
+  let get_exn t = match !t with
+    | To_generalize _ -> Misc.fatal_error "layouts has not been generalized"
+    | Determined l -> l
+
+  let determined l = ref (Determined l)
+  let to_generalize ~loc = ref (To_generalize loc)
+
+  let generalize ?(on_determined = fun () -> ()) ~on_to_generalize t =
+    match !t with
+    | To_generalize loc -> t := Determined (on_to_generalize loc)
+    | Determined _ -> on_determined ()
+end
+
 module type Wrapped = sig
   type 'a wrapped
 
@@ -574,7 +594,7 @@ module type Wrapped = sig
     { val_type: type_expr wrapped;                (* Type of the value *)
       val_modalities : Mode.Modality.t;     (* Modalities on the value *)
       val_kind: value_kind;
-      val_lpoly: Jkind_types.Sort.univar list;
+      val_lpoly: Val_lpoly.t;
       val_loc: Location.t;
       val_zero_alloc: Zero_alloc.t;
       val_attributes: Parsetree.attributes;

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -1033,6 +1033,42 @@ module type Wrap = sig
   type 'a t
 end
 
+(** Tracks layout polymorphism state for a value binding. A value is either
+    pending generalization ([to_generalize]) or has a finalized list of layout
+    univars ([determined]). An empty univar list means the value is not
+    layout-polymorphic.
+
+    Layout poly cannot be inferred from usages, so a value description should
+    have determined layout poly. However, in [type_let] we add variables to the
+    environment before type-checking the RHS and generalizing. Therefore, the
+    value description uses a mutable cell that is filled in during
+    generalization. After filling, layout poly is determined and should not be
+    mutated again. We explicitly distinguish the two stages for extra safety. *)
+module Val_lpoly : sig
+  type t
+
+  (** [determined univars] creates a finalized value with the given layout
+      univars. Pass [[]] for a non-layout-polymorphic value. *)
+  val determined : Jkind_types.Sort.univar list -> t
+
+  (** [to_generalize ~loc] creates a value pending layout generalization,
+      where [loc] is the source location that requested polymorphism. *)
+  val to_generalize : loc:Location.t -> t
+
+  (** Assert that layout poly is determined and return the univars. *)
+  val get_exn : t -> Jkind_types.Sort.univar list
+
+  (** Dispatch on the state of [t]:
+      - If pending ([to_generalize loc]), call [on_to_generalize loc],
+        transition to finalized with the returned univars.
+      - If finalized ([determined _]), call [on_determined] (default: no-op). *)
+  val generalize
+    :  ?on_determined:(unit -> unit)
+    -> on_to_generalize:(Location.t -> Jkind_types.Sort.univar list)
+    -> t
+    -> unit
+end
+
 module type Wrapped = sig
   type 'a wrapped
 
@@ -1048,9 +1084,7 @@ module type Wrapped = sig
       have been applied and we have the real mode of the value. The original
       modalities shouldn't be looked again and is replaced by [undefined]. *)
       val_kind: value_kind;
-      val_lpoly: Jkind_types.Sort.univar list;
-      (** layout univars that the value is layout-polymorphic on; empty list
-          means not layout polymorphic. *)
+      val_lpoly: Val_lpoly.t; (** see [Val_lpoly] *)
       val_loc: Location.t;
       val_zero_alloc: Zero_alloc.t;
       val_attributes: Parsetree.attributes;

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -152,6 +152,7 @@ type t =
   | Atomic_float_record_boxed               (* 214 *)
   | Implied_attribute of { implying: string; implied : string} (* 215 *)
   | Use_during_borrowing                    (* 216 *)
+  | Useless_poly                            (* 217 *)
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
    the numbers of existing warnings.
@@ -250,6 +251,7 @@ let number = function
   | Atomic_float_record_boxed -> 214
   | Implied_attribute _ -> 215
   | Use_during_borrowing -> 216
+  | Useless_poly -> 217
 ;;
 (* DO NOT REMOVE the ;; above: it is used by
    the testsuite/ests/warnings/mnemonics.mll test to determine where
@@ -1370,6 +1372,9 @@ let message = function
       implied implying
   | Use_during_borrowing ->
       "This value is used while being borrowed."
+  | Useless_poly ->
+      "This \"let poly_\" binding generalizes no layout variables. \
+       Consider using a regular \"let\" instead."
 ;;
 
 let nerrors = ref 0

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -154,6 +154,7 @@ type t =
   | Atomic_float_record_boxed               (* 214 *)
   | Implied_attribute of { implying: string; implied : string} (* 215 *)
   | Use_during_borrowing                    (* 216 *)
+  | Useless_poly                            (* 217 *)
 
 type alert = {kind:string; message:string; def:loc; use:loc}
 


### PR DESCRIPTION
**_This is some AI slop that needs to be cleaned up and splitted into several PRs. For now please only look at the tests._**

Introduces two new syntactic forms for sort polymorphism:

- **`val f : sort_ x y. ('a : x) ('b : y). 'a -> 'b`** in module signatures — declares a value that is polymorphic over sorts. The `sort_` keyword introduces abstract sort variables scoped over the type.
- **`let poly_ id x = x`** at top-level bindings — marks a let binding as sort-polymorphic (code generation not implemented and will crash).

### Key changes

- New `sort_` keyword (`SORT` token) in the lexer/parser; produces `Ptyp_newsort` in the parsetree
- `includecore.value_descriptions` now checks sort-poly arity and equates sort univars via `Jkind_types.Sort.enter_repr` around the `Ctype.moregeneral` call, giving a clean `Poly_arity_mismatch` error on arity mismatch
- Test files: `val_poly.ml` (signature inclusion, ordering) and `let_poly.ml` (they work fine if stopped before middle-end; need to find a way to do that in expect tests).
