### PR TITLE
Syntactic sugar for fexpr

### DIFF
--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -297,9 +297,13 @@ type expr =
   | Apply_cont of apply_cont
   | Switch of
       { scrutinee : simple;
-        cases : (int * apply_cont) list
+        cases : (int * apply_or_inlined_cont) list
       }
   | Invalid of { message : string }
+
+and apply_or_inlined_cont =
+  | Inlined_goto of expr
+  | Named_cont of apply_cont
 
 and value_slots = one_value_slot list
 

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -422,22 +422,34 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
     let acc, ac = apply_cont env acc ac in
     acc, Flambda.Expr.create_apply_cont ac
   | Switch { scrutinee; cases } ->
-    let acc, arms =
+    let (acc, build_let_ks), arms =
       List.fold_left_map
-        (fun acc (case, apply) ->
-          (* CR mshinwell: Should get machine_width from fexpr context when
-             available *)
-          let acc, apply = apply_cont env acc apply in
-          acc, (Target_ocaml_int.of_int machine_width case, apply))
-        acc cases
+        (fun (acc, build_let_ks) (case, apply) ->
+          match (apply : Fexpr.apply_or_inlined_cont) with
+          | Named_cont apply ->
+            (* CR mshinwell: Should get machine_width from fexpr context when
+               available *)
+            let acc, apply = apply_cont env acc apply in
+            ( (acc, build_let_ks),
+              (Target_ocaml_int.of_int machine_width case, apply) )
+          | Inlined_goto body ->
+            let (acc : Acc.t), build_let, (apply : Apply_cont_expr.t) =
+              inlined_goto env acc body
+            in
+            let build_let_ks (acc : Acc.t) body =
+              let acc, let_k = build_let acc body in
+              build_let_ks acc let_k
+            in
+            ( (acc, build_let_ks),
+              (Target_ocaml_int.of_int machine_width case, apply) ))
+        (acc, fun acc e -> acc, e)
+        cases
     in
     let arms = Target_ocaml_int.Map.of_list arms in
-    let switch =
-      Flambda.Expr.create_switch
-        (Flambda.Switch.create ~condition_dbg:Debuginfo.none
-           ~scrutinee:(simple env scrutinee) ~arms)
-    in
-    acc, switch
+    build_let_ks acc
+    @@ Flambda.Expr.create_switch
+         (Flambda.Switch.create ~condition_dbg:Debuginfo.none
+            ~scrutinee:(simple env scrutinee) ~arms)
   | Let_symbol { bindings; value_slots; body } ->
     (* Desugar the abbreviated form for a single set of closures *)
     let found_explicit_set = ref false in
@@ -831,6 +843,23 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
     in
     acc, Flambda.Expr.create_apply apply
   | Invalid { message } -> acc, Flambda.Expr.create_invalid (Message message)
+
+and inlined_goto env acc (handler_body : Fexpr.expr) =
+  let acc, handler = expr env acc handler_body in
+  let handler =
+    Flambda.Continuation_handler.create Bound_parameters.empty
+      ~free_names_of_handler:Unknown ~is_exn_handler:false ~is_cold:false
+      ~handler
+  in
+  (* no need to propagate env, nothing here can nor should be used elsewhere *)
+  let cont = Continuation.create ~name:"branch_k" ~sort:Normal_or_exn () in
+  let apply = Flambda.Apply_cont.create cont ~args:[] ~dbg:Debuginfo.none in
+  let build_let acc body =
+    ( acc,
+      Flambda.Let_cont.create_non_recursive cont handler ~body
+        ~free_names_of_body:Unknown )
+  in
+  acc, build_let, apply
 
 let bind_all_code_ids env (unit : Fexpr.flambda_unit) =
   let rec go env (e : Fexpr.expr) =

--- a/middle_end/flambda2/parser/flambda_parser.messages
+++ b/middle_end/flambda2/parser/flambda_parser.messages
@@ -4,9 +4,9 @@
 
 flambda_unit: KWD_APPLY SYMBOL LPAREN RPAREN KWD_WITH
 ##
-## Ends in an error in state: 398.
+## Ends in an error in state: 396.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind option(inlined) option(inlining_state) simple simple_args
@@ -18,9 +18,9 @@ Example of an application:
 
 flambda_unit: KWD_APPLY SYMBOL MINUSGREATER IDENT KWD_WITH
 ##
-## Ends in an error in state: 400.
+## Ends in an error in state: 398.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation
@@ -32,9 +32,9 @@ Example of an application:
 
 flambda_unit: KWD_APPLY SYMBOL MINUSGREATER KWD_WITH
 ##
-## Ends in an error in state: 399.
+## Ends in an error in state: 397.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER
@@ -46,9 +46,9 @@ Example of an application:
 
 flambda_unit: KWD_APPLY SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 397.
+## Ends in an error in state: 395.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) simple . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) simple . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## simple -> simple . TILDE coercion [ TILDE MINUSGREATER LPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -63,9 +63,9 @@ Examples of applications:
 
 flambda_unit: KWD_APPLY KWD_WITH
 ##
-## Ends in an error in state: 327.
+## Ends in an error in state: 325.
 ##
-## atomic_expr -> KWD_APPLY . apply_expr [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## atomic_expr -> KWD_APPLY . apply_expr [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_APPLY
@@ -78,7 +78,7 @@ Example of an application:
 
 flambda_unit: KWD_CONT IDENT LPAREN SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 61.
+## Ends in an error in state: 141.
 ##
 ## separated_nonempty_list(COMMA,simple) -> simple . [ RPAREN ]
 ## separated_nonempty_list(COMMA,simple) -> simple . COMMA separated_nonempty_list(COMMA,simple) [ RPAREN ]
@@ -92,7 +92,7 @@ Expected a simple value (a symbol, variable, or literal).
 
 flambda_unit: KWD_CONT IDENT LPAREN KWD_WITH
 ##
-## Ends in an error in state: 60.
+## Ends in an error in state: 140.
 ##
 ## simple_args -> LPAREN . loption(separated_nonempty_list(COMMA,simple)) RPAREN [ RPAREN PIPE MINUSGREATER KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -109,7 +109,7 @@ Examples of continuation calls:
 
 flambda_unit: KWD_CONT IDENT KWD_VAL
 ##
-## Ends in an error in state: 44.
+## Ends in an error in state: 307.
 ##
 ## apply_cont_expr -> continuation . option(trap_action) simple_args [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -125,9 +125,9 @@ Examples of continuation calls:
 
 flambda_unit: KWD_CONT KWD_WITH
 ##
-## Ends in an error in state: 325.
+## Ends in an error in state: 302.
 ##
-## atomic_expr -> KWD_CONT . apply_cont_expr [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## atomic_expr -> KWD_CONT . apply_cont_expr [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_CONT
@@ -151,7 +151,7 @@ Example of a continuation call:
 
 flambda_unit: KWD_LET KWD_CODE IDENT KWD_WITH
 ##
-## Ends in an error in state: 153.
+## Ends in an error in state: 118.
 ##
 ## deleted_code -> KWD_CODE code_id . KWD_DELETED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -171,7 +171,7 @@ Examples of argument lists:
 
 flambda_unit: KWD_LET KWD_CODE KWD_REC KWD_HCF
 ##
-## Ends in an error in state: 112.
+## Ends in an error in state: 77.
 ##
 ## code_header -> KWD_CODE recursive . option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) code_id [ LPAREN IDENT ]
 ##
@@ -183,7 +183,7 @@ Expected a code id.
 
 flambda_unit: KWD_LET KWD_CODE KWD_WITH
 ##
-## Ends in an error in state: 110.
+## Ends in an error in state: 75.
 ##
 ## code_header -> KWD_CODE . recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) code_id [ LPAREN IDENT ]
 ## deleted_code -> KWD_CODE . code_id KWD_DELETED [ KWD_WITH KWD_IN KWD_AND ]
@@ -203,7 +203,7 @@ Examples of code definitions:
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_AND KWD_WITH
 ##
-## Ends in an error in state: 179.
+## Ends in an error in state: 151.
 ##
 ## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding KWD_AND . separated_nonempty_list(KWD_AND,symbol_binding) [ KWD_WITH KWD_IN ]
 ##
@@ -215,7 +215,7 @@ Expected "code" or "symbol".
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_END
 ##
-## Ends in an error in state: 178.
+## Ends in an error in state: 150.
 ##
 ## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding . [ KWD_WITH KWD_IN ]
 ## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding . KWD_AND separated_nonempty_list(KWD_AND,symbol_binding) [ KWD_WITH KWD_IN ]
@@ -227,18 +227,18 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_END
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 81, spurious reduction of production function_slot_opt ->
-## In state 85, spurious reduction of production alloc_mode_for_allocations_opt ->
-## In state 90, spurious reduction of production fun_decl -> KWD_CLOSURE code_id function_slot_opt alloc_mode_for_allocations_opt
-## In state 91, spurious reduction of production static_closure_binding -> symbol EQUAL fun_decl
-## In state 246, spurious reduction of production symbol_binding -> static_closure_binding
+## In state 45, spurious reduction of production function_slot_opt ->
+## In state 49, spurious reduction of production alloc_mode_for_allocations_opt ->
+## In state 54, spurious reduction of production fun_decl -> KWD_CLOSURE code_id function_slot_opt alloc_mode_for_allocations_opt
+## In state 55, spurious reduction of production static_closure_binding -> symbol EQUAL fun_decl
+## In state 218, spurious reduction of production symbol_binding -> static_closure_binding
 ##
 
 Expected "and", "with", or "in".
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_IN KWD_WITH
 ##
-## Ends in an error in state: 447.
+## Ends in an error in state: 298.
 ##
 ## let_symbol(expr) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -250,7 +250,7 @@ Expected an expression.
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_VAL
 ##
-## Ends in an error in state: 81.
+## Ends in an error in state: 45.
 ##
 ## fun_decl -> KWD_CLOSURE code_id . function_slot_opt alloc_mode_for_allocations_opt [ KWD_WITH KWD_IN KWD_END KWD_AND ]
 ##
@@ -262,7 +262,7 @@ Expected "with", "in", "end", or "and".
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_WITH
 ##
-## Ends in an error in state: 181.
+## Ends in an error in state: 153.
 ##
 ## static_closure_binding -> symbol EQUAL . fun_decl [ KWD_WITH KWD_IN KWD_AND ]
 ## static_data_binding -> symbol EQUAL . static_data [ KWD_WITH KWD_IN KWD_AND ]
@@ -279,7 +279,7 @@ Example of a block expression:
 
 flambda_unit: KWD_LET SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 180.
+## Ends in an error in state: 152.
 ##
 ## static_closure_binding -> symbol . EQUAL fun_decl [ KWD_WITH KWD_IN KWD_AND ]
 ## static_data_binding -> symbol . EQUAL static_data [ KWD_WITH KWD_IN KWD_AND ]
@@ -296,7 +296,7 @@ Example of a block expression:
 
 flambda_unit: KWD_LET KWD_WITH
 ##
-## Ends in an error in state: 75.
+## Ends in an error in state: 295.
 ##
 ## let_expr(expr) -> KWD_LET . let_(expr) [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ## let_symbol(expr) -> KWD_LET . separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
@@ -313,7 +313,7 @@ Examples of let expressions:
 
 flambda_unit: KWD_SWITCH SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 456.
+## Ends in an error in state: 471.
 ##
 ## flambda_unit -> module_ . EOF [ # ]
 ##
@@ -326,11 +326,11 @@ flambda_unit: KWD_SWITCH SYMBOL KWD_WITH
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 11, spurious reduction of production option(PIPE) ->
 ## In state 35, spurious reduction of production loption(separated_nonempty_list(PIPE,switch_case)) ->
-## In state 74, spurious reduction of production switch -> option(PIPE) loption(separated_nonempty_list(PIPE,switch_case))
-## In state 34, spurious reduction of production atomic_expr -> KWD_SWITCH simple switch
-## In state 444, spurious reduction of production inner_expr -> atomic_expr
-## In state 409, spurious reduction of production expr -> inner_expr
-## In state 459, spurious reduction of production module_ -> expr
+## In state 468, spurious reduction of production switch -> option(PIPE) loption(separated_nonempty_list(PIPE,switch_case))
+## In state 34, spurious reduction of production inlined_expr -> KWD_SWITCH simple switch
+## In state 442, spurious reduction of production inner_expr -> inlined_expr
+## In state 407, spurious reduction of production expr -> inner_expr
+## In state 474, spurious reduction of production module_ -> expr
 ##
 
 Expected one or more switch cases, separated by semicolons, surrounded by {}.
@@ -565,7 +565,7 @@ flambda_unit: LPAREN TILDE
 ##
 ## Ends in an error in state: 1.
 ##
-## atomic_expr -> LPAREN . expr RPAREN [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## atomic_expr -> LPAREN . expr RPAREN [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -577,7 +577,7 @@ flambda_unit: KWD_SWITCH TILDE
 ##
 ## Ends in an error in state: 3.
 ##
-## atomic_expr -> KWD_SWITCH . simple switch [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## inlined_expr -> KWD_SWITCH . simple switch [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_SWITCH
@@ -589,7 +589,7 @@ flambda_unit: KWD_SWITCH FLOAT SYMBOL
 ##
 ## Ends in an error in state: 11.
 ##
-## atomic_expr -> KWD_SWITCH simple . switch [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## inlined_expr -> KWD_SWITCH simple . switch [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## simple -> simple . TILDE coercion [ TILDE RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND INT EOF ]
 ##
 ## The known suffix of the stack is as follows:
@@ -723,6 +723,7 @@ flambda_unit: KWD_SWITCH FLOAT INT TILDE
 ## Ends in an error in state: 37.
 ##
 ## switch_case -> tag . MINUSGREATER apply_cont_expr [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## switch_case -> tag . MINUSGREATER atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## tag
@@ -735,6 +736,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER TILDE
 ## Ends in an error in state: 38.
 ##
 ## switch_case -> tag MINUSGREATER . apply_cont_expr [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## switch_case -> tag MINUSGREATER . atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## tag MINUSGREATER
@@ -742,142 +744,22 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_CONT IDENT KWD_PUSH TILDE
+flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET TILDE
 ##
-## Ends in an error in state: 45.
+## Ends in an error in state: 39.
 ##
-## trap_action -> KWD_PUSH . LPAREN continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-##
-## The known suffix of the stack is as follows:
-## KWD_PUSH
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN TILDE
-##
-## Ends in an error in state: 46.
-##
-## trap_action -> KWD_PUSH LPAREN . continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## let_expr(atomic_body) -> KWD_LET . let_(atomic_body) [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## let_symbol(atomic_body) -> KWD_LET . separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## KWD_PUSH LPAREN
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN IDENT TILDE
-##
-## Ends in an error in state: 47.
-##
-## trap_action -> KWD_PUSH LPAREN continuation . RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-##
-## The known suffix of the stack is as follows:
-## KWD_PUSH LPAREN continuation
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_CONT IDENT KWD_POP TILDE
-##
-## Ends in an error in state: 49.
-##
-## trap_action -> KWD_POP . LPAREN option(raise_kind) continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-##
-## The known suffix of the stack is as follows:
-## KWD_POP
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_CONT IDENT KWD_POP LPAREN TILDE
-##
-## Ends in an error in state: 50.
-##
-## trap_action -> KWD_POP LPAREN . option(raise_kind) continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-##
-## The known suffix of the stack is as follows:
-## KWD_POP LPAREN
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_CONT IDENT KWD_POP LPAREN KWD_NOTRACE TILDE
-##
-## Ends in an error in state: 55.
-##
-## trap_action -> KWD_POP LPAREN option(raise_kind) . continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-##
-## The known suffix of the stack is as follows:
-## KWD_POP LPAREN option(raise_kind)
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT TILDE
-##
-## Ends in an error in state: 56.
-##
-## trap_action -> KWD_POP LPAREN option(raise_kind) continuation . RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-##
-## The known suffix of the stack is as follows:
-## KWD_POP LPAREN option(raise_kind) continuation
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT RPAREN TILDE
-##
-## Ends in an error in state: 59.
-##
-## apply_cont_expr -> continuation option(trap_action) . simple_args [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-##
-## The known suffix of the stack is as follows:
-## continuation option(trap_action)
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_APPLY LPAREN FLOAT COMMA TILDE
-##
-## Ends in an error in state: 62.
-##
-## separated_nonempty_list(COMMA,simple) -> simple COMMA . separated_nonempty_list(COMMA,simple) [ RPAREN ]
-##
-## The known suffix of the stack is as follows:
-## simple COMMA
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER IDENT LPAREN RPAREN TILDE
-##
-## Ends in an error in state: 70.
-##
-## separated_nonempty_list(PIPE,switch_case) -> switch_case . [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-## separated_nonempty_list(PIPE,switch_case) -> switch_case . PIPE separated_nonempty_list(PIPE,switch_case) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-##
-## The known suffix of the stack is as follows:
-## switch_case
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER IDENT PIPE TILDE
-##
-## Ends in an error in state: 71.
-##
-## separated_nonempty_list(PIPE,switch_case) -> switch_case PIPE . separated_nonempty_list(PIPE,switch_case) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-##
-## The known suffix of the stack is as follows:
-## switch_case PIPE
+## KWD_LET
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_LET KWD_SET_OF_CLOSURES TILDE
 ##
-## Ends in an error in state: 76.
+## Ends in an error in state: 40.
 ##
 ## static_set_of_closures -> KWD_SET_OF_CLOSURES . separated_nonempty_list(KWD_AND,static_closure_binding) with_value_slots_opt KWD_END [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -889,7 +771,7 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES TILDE
 
 flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL TILDE
 ##
-## Ends in an error in state: 77.
+## Ends in an error in state: 41.
 ##
 ## static_closure_binding -> symbol . EQUAL fun_decl [ KWD_WITH KWD_END KWD_AND ]
 ##
@@ -901,7 +783,7 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL TILDE
 
 flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL TILDE
 ##
-## Ends in an error in state: 78.
+## Ends in an error in state: 42.
 ##
 ## static_closure_binding -> symbol EQUAL . fun_decl [ KWD_WITH KWD_END KWD_AND ]
 ##
@@ -913,7 +795,7 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE TILDE
 ##
-## Ends in an error in state: 79.
+## Ends in an error in state: 43.
 ##
 ## fun_decl -> KWD_CLOSURE . code_id function_slot_opt alloc_mode_for_allocations_opt [ KWD_WITH KWD_IN KWD_END KWD_AND ]
 ##
@@ -925,7 +807,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AT TILDE
 ##
-## Ends in an error in state: 82.
+## Ends in an error in state: 46.
 ##
 ## function_slot_opt -> AT . function_slot [ RPAREN KWD_WITH KWD_IN KWD_END KWD_AND AMP ]
 ##
@@ -937,7 +819,7 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AT IDENT TILDE
 ##
-## Ends in an error in state: 85.
+## Ends in an error in state: 49.
 ##
 ## fun_decl -> KWD_CLOSURE code_id function_slot_opt . alloc_mode_for_allocations_opt [ KWD_WITH KWD_IN KWD_END KWD_AND ]
 ##
@@ -949,7 +831,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AT IDENT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AMP TILDE
 ##
-## Ends in an error in state: 86.
+## Ends in an error in state: 50.
 ##
 ## alloc_mode_for_allocations_opt -> AMP . region [ KWD_WITH KWD_IN KWD_END KWD_AND ]
 ##
@@ -961,7 +843,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AMP TILDE
 
 flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT KWD_IN
 ##
-## Ends in an error in state: 92.
+## Ends in an error in state: 56.
 ##
 ## separated_nonempty_list(KWD_AND,static_closure_binding) -> static_closure_binding . [ KWD_WITH KWD_END ]
 ## separated_nonempty_list(KWD_AND,static_closure_binding) -> static_closure_binding . KWD_AND separated_nonempty_list(KWD_AND,static_closure_binding) [ KWD_WITH KWD_END ]
@@ -973,17 +855,17 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT KWD_IN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 81, spurious reduction of production function_slot_opt ->
-## In state 85, spurious reduction of production alloc_mode_for_allocations_opt ->
-## In state 90, spurious reduction of production fun_decl -> KWD_CLOSURE code_id function_slot_opt alloc_mode_for_allocations_opt
-## In state 91, spurious reduction of production static_closure_binding -> symbol EQUAL fun_decl
+## In state 45, spurious reduction of production function_slot_opt ->
+## In state 49, spurious reduction of production alloc_mode_for_allocations_opt ->
+## In state 54, spurious reduction of production fun_decl -> KWD_CLOSURE code_id function_slot_opt alloc_mode_for_allocations_opt
+## In state 55, spurious reduction of production static_closure_binding -> symbol EQUAL fun_decl
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT KWD_AND TILDE
 ##
-## Ends in an error in state: 93.
+## Ends in an error in state: 57.
 ##
 ## separated_nonempty_list(KWD_AND,static_closure_binding) -> static_closure_binding KWD_AND . separated_nonempty_list(KWD_AND,static_closure_binding) [ KWD_WITH KWD_END ]
 ##
@@ -995,7 +877,7 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT KWD_AND
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH TILDE
 ##
-## Ends in an error in state: 96.
+## Ends in an error in state: 60.
 ##
 ## with_value_slots_opt -> KWD_WITH . LBRACE loption(separated_nonempty_list(SEMICOLON,value_slot)) RBRACE [ KWD_IN KWD_END ]
 ##
@@ -1007,7 +889,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE TILDE
 ##
-## Ends in an error in state: 97.
+## Ends in an error in state: 61.
 ##
 ## with_value_slots_opt -> KWD_WITH LBRACE . loption(separated_nonempty_list(SEMICOLON,value_slot)) RBRACE [ KWD_IN KWD_END ]
 ##
@@ -1019,7 +901,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT TILDE
 ##
-## Ends in an error in state: 99.
+## Ends in an error in state: 63.
 ##
 ## value_slot -> value_slot_for_projection . EQUAL simple [ SEMICOLON RBRACE ]
 ##
@@ -1031,7 +913,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 100.
+## Ends in an error in state: 64.
 ##
 ## value_slot -> value_slot_for_projection EQUAL . simple [ SEMICOLON RBRACE ]
 ##
@@ -1043,7 +925,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL FLOAT SYMBOL
 ##
-## Ends in an error in state: 101.
+## Ends in an error in state: 65.
 ##
 ## simple -> simple . TILDE coercion [ TILDE SEMICOLON RBRACE ]
 ## value_slot -> value_slot_for_projection EQUAL simple . [ SEMICOLON RBRACE ]
@@ -1056,7 +938,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL FLOAT SYMBOL
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL FLOAT SEMICOLON TILDE
 ##
-## Ends in an error in state: 103.
+## Ends in an error in state: 68.
 ##
 ## separated_nonempty_list(SEMICOLON,value_slot) -> value_slot SEMICOLON . separated_nonempty_list(SEMICOLON,value_slot) [ RBRACE ]
 ##
@@ -1068,7 +950,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL FLOAT SEMICOL
 
 flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 108.
+## Ends in an error in state: 73.
 ##
 ## static_set_of_closures -> KWD_SET_OF_CLOSURES separated_nonempty_list(KWD_AND,static_closure_binding) with_value_slots_opt . KWD_END [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1080,7 +962,7 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT KWD_WIT
 
 flambda_unit: KWD_LET KWD_CODE KWD_UNROLL TILDE
 ##
-## Ends in an error in state: 113.
+## Ends in an error in state: 78.
 ##
 ## inline -> KWD_UNROLL . LPAREN plain_int RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1092,7 +974,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_UNROLL TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_UNROLL LPAREN TILDE
 ##
-## Ends in an error in state: 114.
+## Ends in an error in state: 79.
 ##
 ## inline -> KWD_UNROLL LPAREN . plain_int RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1104,7 +986,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_UNROLL LPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_UNROLL LPAREN INT TILDE
 ##
-## Ends in an error in state: 115.
+## Ends in an error in state: 80.
 ##
 ## inline -> KWD_UNROLL LPAREN plain_int . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1116,7 +998,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_UNROLL LPAREN INT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE TILDE
 ##
-## Ends in an error in state: 117.
+## Ends in an error in state: 82.
 ##
 ## inline -> KWD_INLINE . LPAREN KWD_ALWAYS RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ## inline -> KWD_INLINE . LPAREN KWD_AVAILABLE RPAREN [ KWD_SIZE KWD_LOOPIFY ]
@@ -1131,7 +1013,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN TILDE
 ##
-## Ends in an error in state: 118.
+## Ends in an error in state: 83.
 ##
 ## inline -> KWD_INLINE LPAREN . KWD_ALWAYS RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ## inline -> KWD_INLINE LPAREN . KWD_AVAILABLE RPAREN [ KWD_SIZE KWD_LOOPIFY ]
@@ -1146,7 +1028,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_NEVER TILDE
 ##
-## Ends in an error in state: 119.
+## Ends in an error in state: 84.
 ##
 ## inline -> KWD_INLINE LPAREN KWD_NEVER . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1158,7 +1040,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_NEVER TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_DEFAULT TILDE
 ##
-## Ends in an error in state: 121.
+## Ends in an error in state: 86.
 ##
 ## inline -> KWD_INLINE LPAREN KWD_DEFAULT . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1170,7 +1052,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_DEFAULT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_AVAILABLE TILDE
 ##
-## Ends in an error in state: 123.
+## Ends in an error in state: 88.
 ##
 ## inline -> KWD_INLINE LPAREN KWD_AVAILABLE . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1182,7 +1064,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_AVAILABLE TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_ALWAYS TILDE
 ##
-## Ends in an error in state: 125.
+## Ends in an error in state: 90.
 ##
 ## inline -> KWD_INLINE LPAREN KWD_ALWAYS . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1194,7 +1076,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_ALWAYS TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_ALWAYS RPAREN TILDE
 ##
-## Ends in an error in state: 127.
+## Ends in an error in state: 92.
 ##
 ## code_header -> KWD_CODE recursive option(inline) . loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) code_id [ LPAREN IDENT ]
 ##
@@ -1206,7 +1088,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_ALWAYS RPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY TILDE
 ##
-## Ends in an error in state: 128.
+## Ends in an error in state: 93.
 ##
 ## loopify_opt -> KWD_LOOPIFY . LPAREN loopify RPAREN [ KWD_SIZE ]
 ##
@@ -1218,7 +1100,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN TILDE
 ##
-## Ends in an error in state: 129.
+## Ends in an error in state: 94.
 ##
 ## loopify_opt -> KWD_LOOPIFY LPAREN . loopify RPAREN [ KWD_SIZE ]
 ##
@@ -1230,7 +1112,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_DEFAULT TILDE
 ##
-## Ends in an error in state: 132.
+## Ends in an error in state: 97.
 ##
 ## loopify -> KWD_DEFAULT . KWD_TAILREC [ RPAREN ]
 ## loopify -> KWD_DEFAULT . [ RPAREN ]
@@ -1243,7 +1125,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_DEFAULT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_ALWAYS TILDE
 ##
-## Ends in an error in state: 135.
+## Ends in an error in state: 100.
 ##
 ## loopify_opt -> KWD_LOOPIFY LPAREN loopify . RPAREN [ KWD_SIZE ]
 ##
@@ -1255,7 +1137,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_ALWAYS TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_ALWAYS RPAREN TILDE
 ##
-## Ends in an error in state: 137.
+## Ends in an error in state: 102.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt . KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) code_id [ LPAREN IDENT ]
 ##
@@ -1267,7 +1149,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_ALWAYS RPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE TILDE
 ##
-## Ends in an error in state: 138.
+## Ends in an error in state: 103.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE . LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) code_id [ LPAREN IDENT ]
 ##
@@ -1279,7 +1161,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN TILDE
 ##
-## Ends in an error in state: 139.
+## Ends in an error in state: 104.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN . code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) code_id [ LPAREN IDENT ]
 ##
@@ -1291,7 +1173,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT TILDE
 ##
-## Ends in an error in state: 141.
+## Ends in an error in state: 106.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size . RPAREN option(newer_version_of) boption(KWD_TUPLED) code_id [ LPAREN IDENT ]
 ##
@@ -1303,7 +1185,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN TILDE
 ##
-## Ends in an error in state: 142.
+## Ends in an error in state: 107.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN . option(newer_version_of) boption(KWD_TUPLED) code_id [ LPAREN IDENT ]
 ##
@@ -1315,7 +1197,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF TILDE
 ##
-## Ends in an error in state: 143.
+## Ends in an error in state: 108.
 ##
 ## newer_version_of -> KWD_NEWER_VERSION_OF . LPAREN code_id RPAREN [ KWD_TUPLED IDENT ]
 ##
@@ -1327,7 +1209,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF T
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF LPAREN TILDE
 ##
-## Ends in an error in state: 144.
+## Ends in an error in state: 109.
 ##
 ## newer_version_of -> KWD_NEWER_VERSION_OF LPAREN . code_id RPAREN [ KWD_TUPLED IDENT ]
 ##
@@ -1339,7 +1221,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF L
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 145.
+## Ends in an error in state: 110.
 ##
 ## newer_version_of -> KWD_NEWER_VERSION_OF LPAREN code_id . RPAREN [ KWD_TUPLED IDENT ]
 ##
@@ -1351,7 +1233,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF L
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 147.
+## Ends in an error in state: 112.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) . boption(KWD_TUPLED) code_id [ LPAREN IDENT ]
 ##
@@ -1363,7 +1245,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF L
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_TUPLED TILDE
 ##
-## Ends in an error in state: 149.
+## Ends in an error in state: 114.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) . code_id [ LPAREN IDENT ]
 ##
@@ -1375,7 +1257,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_TUPLED TILDE
 
 flambda_unit: KWD_LET IDENT TILDE
 ##
-## Ends in an error in state: 155.
+## Ends in an error in state: 120.
 ##
 ## let_binding -> variable . EQUAL named [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1387,7 +1269,7 @@ flambda_unit: KWD_LET IDENT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 156.
+## Ends in an error in state: 121.
 ##
 ## let_binding -> variable EQUAL . named [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1399,7 +1281,7 @@ flambda_unit: KWD_LET IDENT EQUAL TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM TILDE
 ##
-## Ends in an error in state: 157.
+## Ends in an error in state: 122.
 ##
 ## prim_op -> PRIM . list(prim_param) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1411,7 +1293,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT TILDE
 ##
-## Ends in an error in state: 158.
+## Ends in an error in state: 123.
 ##
 ## prim_param -> DOT . IDENT [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
 ## prim_param -> DOT . LBRACK prim_param_val RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
@@ -1425,7 +1307,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK TILDE
 ##
-## Ends in an error in state: 159.
+## Ends in an error in state: 124.
 ##
 ## prim_param -> DOT LBRACK . prim_param_val RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
 ##
@@ -1437,7 +1319,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT TILDE
 ##
-## Ends in an error in state: 162.
+## Ends in an error in state: 127.
 ##
 ## prim_param -> DOT LBRACK prim_param_val . RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
 ##
@@ -1449,7 +1331,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT TILDE
 ##
-## Ends in an error in state: 164.
+## Ends in an error in state: 129.
 ##
 ## prim_param -> DOT IDENT . [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
 ## prim_param -> DOT IDENT . LBRACK prim_param_val RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
@@ -1462,7 +1344,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT LBRACK TILDE
 ##
-## Ends in an error in state: 165.
+## Ends in an error in state: 130.
 ##
 ## prim_param -> DOT IDENT LBRACK . prim_param_val RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
 ##
@@ -1474,7 +1356,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT LBRACK TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT LBRACK IDENT TILDE
 ##
-## Ends in an error in state: 166.
+## Ends in an error in state: 131.
 ##
 ## prim_param -> DOT IDENT LBRACK prim_param_val . RBRACK [ LPAREN KWD_WITH KWD_IN KWD_AND DOT ]
 ##
@@ -1486,7 +1368,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT LBRACK IDENT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT RBRACK TILDE
 ##
-## Ends in an error in state: 168.
+## Ends in an error in state: 133.
 ##
 ## list(prim_param) -> prim_param . list(prim_param) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1498,7 +1380,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT RBRACK TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 171.
+## Ends in an error in state: 136.
 ##
 ## named -> KWD_REC_INFO . rec_info_atom [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1510,7 +1392,7 @@ flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL FLOAT SYMBOL
 ##
-## Ends in an error in state: 173.
+## Ends in an error in state: 138.
 ##
 ## named -> simple . [ KWD_WITH KWD_IN KWD_AND ]
 ## simple -> simple . TILDE coercion [ TILDE KWD_WITH KWD_IN KWD_AND ]
@@ -1521,9 +1403,21 @@ flambda_unit: KWD_LET IDENT EQUAL FLOAT SYMBOL
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+flambda_unit: KWD_APPLY LPAREN FLOAT COMMA TILDE
+##
+## Ends in an error in state: 142.
+##
+## separated_nonempty_list(COMMA,simple) -> simple COMMA . separated_nonempty_list(COMMA,simple) [ RPAREN ]
+##
+## The known suffix of the stack is as follows:
+## simple COMMA
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY TILDE
 ##
-## Ends in an error in state: 183.
+## Ends in an error in state: 155.
 ##
 ## static_data -> STATIC_CONST_VALUE_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,field_of_block)) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1535,7 +1429,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 184.
+## Ends in an error in state: 156.
 ##
 ## static_data -> STATIC_CONST_VALUE_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,field_of_block)) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1547,7 +1441,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE SYMBOL TILDE
 ##
-## Ends in an error in state: 191.
+## Ends in an error in state: 163.
 ##
 ## separated_nonempty_list(SEMICOLON,field_of_block) -> field_of_block . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,field_of_block) -> field_of_block . SEMICOLON separated_nonempty_list(SEMICOLON,field_of_block) [ RBRACKPIPE ]
@@ -1560,7 +1454,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE SYMBOL TI
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE SYMBOL SEMICOLON TILDE
 ##
-## Ends in an error in state: 192.
+## Ends in an error in state: 164.
 ##
 ## separated_nonempty_list(SEMICOLON,field_of_block) -> field_of_block SEMICOLON . separated_nonempty_list(SEMICOLON,field_of_block) [ RBRACKPIPE ]
 ##
@@ -1572,7 +1466,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE SYMBOL SE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK TILDE
 ##
-## Ends in an error in state: 194.
+## Ends in an error in state: 166.
 ##
 ## static_data -> STATIC_CONST_FLOAT_BLOCK . LPAREN loption(separated_nonempty_list(COMMA,float_or_variable)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1584,7 +1478,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN TILDE
 ##
-## Ends in an error in state: 195.
+## Ends in an error in state: 167.
 ##
 ## static_data -> STATIC_CONST_FLOAT_BLOCK LPAREN . loption(separated_nonempty_list(COMMA,float_or_variable)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1596,7 +1490,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 201.
+## Ends in an error in state: 173.
 ##
 ## separated_nonempty_list(COMMA,float_or_variable) -> float_or_variable . [ RPAREN ]
 ## separated_nonempty_list(COMMA,float_or_variable) -> float_or_variable . COMMA separated_nonempty_list(COMMA,float_or_variable) [ RPAREN ]
@@ -1609,7 +1503,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN IDENT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN IDENT COMMA TILDE
 ##
-## Ends in an error in state: 202.
+## Ends in an error in state: 174.
 ##
 ## separated_nonempty_list(COMMA,float_or_variable) -> float_or_variable COMMA . separated_nonempty_list(COMMA,float_or_variable) [ RPAREN ]
 ##
@@ -1621,7 +1515,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN IDENT COMMA T
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY TILDE
 ##
-## Ends in an error in state: 204.
+## Ends in an error in state: 176.
 ##
 ## static_data -> STATIC_CONST_FLOAT_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,float_or_variable)) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1633,7 +1527,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 205.
+## Ends in an error in state: 177.
 ##
 ## static_data -> STATIC_CONST_FLOAT_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,float_or_variable)) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1645,7 +1539,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE IDENT TILDE
 ##
-## Ends in an error in state: 209.
+## Ends in an error in state: 181.
 ##
 ## separated_nonempty_list(SEMICOLON,float_or_variable) -> float_or_variable . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,float_or_variable) -> float_or_variable . SEMICOLON separated_nonempty_list(SEMICOLON,float_or_variable) [ RBRACKPIPE ]
@@ -1658,7 +1552,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE IDENT TIL
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE IDENT SEMICOLON TILDE
 ##
-## Ends in an error in state: 210.
+## Ends in an error in state: 182.
 ##
 ## separated_nonempty_list(SEMICOLON,float_or_variable) -> float_or_variable SEMICOLON . separated_nonempty_list(SEMICOLON,float_or_variable) [ RBRACKPIPE ]
 ##
@@ -1670,7 +1564,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE IDENT SEM
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK TILDE
 ##
-## Ends in an error in state: 214.
+## Ends in an error in state: 186.
 ##
 ## static_data -> STATIC_CONST_BLOCK . mutability tag LPAREN loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1682,7 +1576,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK KWD_IMMUTABLE_UNIQUE TILDE
 ##
-## Ends in an error in state: 217.
+## Ends in an error in state: 189.
 ##
 ## static_data -> STATIC_CONST_BLOCK mutability . tag LPAREN loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1694,7 +1588,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK KWD_IMMUTABLE_UNIQUE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT TILDE
 ##
-## Ends in an error in state: 218.
+## Ends in an error in state: 190.
 ##
 ## static_data -> STATIC_CONST_BLOCK mutability tag . LPAREN loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1706,7 +1600,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN TILDE
 ##
-## Ends in an error in state: 219.
+## Ends in an error in state: 191.
 ##
 ## static_data -> STATIC_CONST_BLOCK mutability tag LPAREN . loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1718,7 +1612,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN SYMBOL TILDE
 ##
-## Ends in an error in state: 223.
+## Ends in an error in state: 195.
 ##
 ## separated_nonempty_list(COMMA,field_of_block) -> field_of_block . [ RPAREN ]
 ## separated_nonempty_list(COMMA,field_of_block) -> field_of_block . COMMA separated_nonempty_list(COMMA,field_of_block) [ RPAREN ]
@@ -1731,7 +1625,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN SYMBOL TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN SYMBOL COMMA TILDE
 ##
-## Ends in an error in state: 224.
+## Ends in an error in state: 196.
 ##
 ## separated_nonempty_list(COMMA,field_of_block) -> field_of_block COMMA . separated_nonempty_list(COMMA,field_of_block) [ RPAREN ]
 ##
@@ -1743,7 +1637,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN SYMBOL COMMA TI
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_MUTABLE TILDE
 ##
-## Ends in an error in state: 226.
+## Ends in an error in state: 198.
 ##
 ## static_data -> KWD_MUTABLE . STRING [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1755,7 +1649,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_MUTABLE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT TILDE
 ##
-## Ends in an error in state: 230.
+## Ends in an error in state: 202.
 ##
 ## static_data -> variable . COLON static_data_kind [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1767,7 +1661,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON TILDE
 ##
-## Ends in an error in state: 231.
+## Ends in an error in state: 203.
 ##
 ## static_data -> variable COLON . static_data_kind [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1779,7 +1673,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_NATIVEINT TILDE
 ##
-## Ends in an error in state: 232.
+## Ends in an error in state: 204.
 ##
 ## static_data_kind -> KWD_NATIVEINT . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1791,7 +1685,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_NATIVEINT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT64 TILDE
 ##
-## Ends in an error in state: 234.
+## Ends in an error in state: 206.
 ##
 ## static_data_kind -> KWD_INT64 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1803,7 +1697,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT64 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT32 TILDE
 ##
-## Ends in an error in state: 236.
+## Ends in an error in state: 208.
 ##
 ## static_data_kind -> KWD_INT32 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1815,7 +1709,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT32 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT32 TILDE
 ##
-## Ends in an error in state: 238.
+## Ends in an error in state: 210.
 ##
 ## static_data_kind -> KWD_FLOAT32 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1827,7 +1721,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT32 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT TILDE
 ##
-## Ends in an error in state: 240.
+## Ends in an error in state: 212.
 ##
 ## static_data_kind -> KWD_FLOAT . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1839,7 +1733,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT TILDE
 ##
-## Ends in an error in state: 249.
+## Ends in an error in state: 221.
 ##
 ## code -> code_header . kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1851,7 +1745,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN TILDE
 ##
-## Ends in an error in state: 250.
+## Ends in an error in state: 222.
 ##
 ## kinded_args -> LPAREN . separated_nonempty_list(COMMA,kinded_variable) RPAREN [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND IDENT EQUAL EOF ]
 ##
@@ -1863,7 +1757,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 251.
+## Ends in an error in state: 223.
 ##
 ## kinded_variable -> variable . kind_with_subkind_opt [ RPAREN COMMA ]
 ##
@@ -1875,7 +1769,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON TILDE
 ##
-## Ends in an error in state: 252.
+## Ends in an error in state: 224.
 ##
 ## kind_with_subkind_opt -> COLON . kind_with_subkind [ RPAREN COMMA ]
 ##
@@ -1887,7 +1781,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK TILDE
 ##
-## Ends in an error in state: 253.
+## Ends in an error in state: 225.
 ##
 ## subkind -> LBRACK . ctors RBRACK [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ##
@@ -1899,7 +1793,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT TILDE
 ##
-## Ends in an error in state: 254.
+## Ends in an error in state: 226.
 ##
 ## tag -> INT . [ KWD_OF ]
 ## targetint -> INT . [ RBRACK PIPE ]
@@ -1912,7 +1806,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT PIPE TILDE
 ##
-## Ends in an error in state: 256.
+## Ends in an error in state: 228.
 ##
 ## ctors_nonempty -> targetint PIPE . ctors_nonempty [ RBRACK ]
 ##
@@ -1924,7 +1818,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT PIPE TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT PIPE INT TILDE
 ##
-## Ends in an error in state: 257.
+## Ends in an error in state: 229.
 ##
 ## nonconst_ctor -> tag . KWD_OF kinds_with_subkinds_nonempty [ RBRACK PIPE ]
 ##
@@ -1936,7 +1830,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT PIPE INT 
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF TILDE
 ##
-## Ends in an error in state: 258.
+## Ends in an error in state: 230.
 ##
 ## nonconst_ctor -> tag KWD_OF . kinds_with_subkinds_nonempty [ RBRACK PIPE ]
 ##
@@ -1948,7 +1842,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_VAL TILDE
 ##
-## Ends in an error in state: 259.
+## Ends in an error in state: 231.
 ##
 ## subkind -> KWD_VAL . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_VAL . KWD_ARRAY [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -1961,7 +1855,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_VAL TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_NATIVEINT TILDE
 ##
-## Ends in an error in state: 263.
+## Ends in an error in state: 235.
 ##
 ## naked_number_kind -> KWD_NATIVEINT . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_NATIVEINT . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -1974,7 +1868,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_NATIVEINT TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_INT64 TILDE
 ##
-## Ends in an error in state: 265.
+## Ends in an error in state: 237.
 ##
 ## naked_number_kind -> KWD_INT64 . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_INT64 . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -1987,7 +1881,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_INT64 TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_INT32 TILDE
 ##
-## Ends in an error in state: 267.
+## Ends in an error in state: 239.
 ##
 ## naked_number_kind -> KWD_INT32 . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_INT32 . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -2000,7 +1894,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_INT32 TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_IMM TILDE
 ##
-## Ends in an error in state: 269.
+## Ends in an error in state: 241.
 ##
 ## naked_number_kind -> KWD_IMM . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_IMM . KWD_TAGGED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -2014,7 +1908,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_IMM TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT32 TILDE
 ##
-## Ends in an error in state: 272.
+## Ends in an error in state: 244.
 ##
 ## naked_number_kind -> KWD_FLOAT32 . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_FLOAT32 . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -2027,7 +1921,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT32 TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT TILDE
 ##
-## Ends in an error in state: 274.
+## Ends in an error in state: 246.
 ##
 ## naked_number_kind -> KWD_FLOAT . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ## subkind -> KWD_FLOAT . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
@@ -2042,7 +1936,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT CARET TILDE
 ##
-## Ends in an error in state: 277.
+## Ends in an error in state: 249.
 ##
 ## subkind -> KWD_FLOAT CARET . plain_int [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ##
@@ -2054,7 +1948,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT CARET TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_ANY TILDE
 ##
-## Ends in an error in state: 279.
+## Ends in an error in state: 251.
 ##
 ## subkind -> KWD_ANY . KWD_ARRAY [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
 ##
@@ -2066,7 +1960,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_ANY TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 285.
+## Ends in an error in state: 257.
 ##
 ## separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind . [ RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL ]
 ## separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind . STAR separated_nonempty_list(STAR,kind_with_subkind) [ RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL ]
@@ -2079,7 +1973,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_REC_INFO TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT STAR TILDE
 ##
-## Ends in an error in state: 286.
+## Ends in an error in state: 258.
 ##
 ## separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind STAR . separated_nonempty_list(STAR,kind_with_subkind) [ RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL ]
 ##
@@ -2091,7 +1985,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT STAR TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT RPAREN
 ##
-## Ends in an error in state: 290.
+## Ends in an error in state: 262.
 ##
 ## separated_nonempty_list(PIPE,nonconst_ctor) -> nonconst_ctor . [ RBRACK ]
 ## separated_nonempty_list(PIPE,nonconst_ctor) -> nonconst_ctor . PIPE separated_nonempty_list(PIPE,nonconst_ctor) [ RBRACK ]
@@ -2103,18 +1997,18 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 274, spurious reduction of production naked_number_kind -> KWD_FLOAT
-## In state 283, spurious reduction of production kind_with_subkind -> naked_number_kind
-## In state 285, spurious reduction of production separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind
-## In state 282, spurious reduction of production kinds_with_subkinds_nonempty -> separated_nonempty_list(STAR,kind_with_subkind)
-## In state 284, spurious reduction of production nonconst_ctor -> tag KWD_OF kinds_with_subkinds_nonempty
+## In state 246, spurious reduction of production naked_number_kind -> KWD_FLOAT
+## In state 255, spurious reduction of production kind_with_subkind -> naked_number_kind
+## In state 257, spurious reduction of production separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind
+## In state 254, spurious reduction of production kinds_with_subkinds_nonempty -> separated_nonempty_list(STAR,kind_with_subkind)
+## In state 256, spurious reduction of production nonconst_ctor -> tag KWD_OF kinds_with_subkinds_nonempty
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT PIPE TILDE
 ##
-## Ends in an error in state: 291.
+## Ends in an error in state: 263.
 ##
 ## separated_nonempty_list(PIPE,nonconst_ctor) -> nonconst_ctor PIPE . separated_nonempty_list(PIPE,nonconst_ctor) [ RBRACK ]
 ##
@@ -2126,7 +2020,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT PIPE TILD
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 301.
+## Ends in an error in state: 273.
 ##
 ## separated_nonempty_list(COMMA,kinded_variable) -> kinded_variable . [ RPAREN ]
 ## separated_nonempty_list(COMMA,kinded_variable) -> kinded_variable . COMMA separated_nonempty_list(COMMA,kinded_variable) [ RPAREN ]
@@ -2139,7 +2033,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON KWD_REC_INFO TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COMMA TILDE
 ##
-## Ends in an error in state: 302.
+## Ends in an error in state: 274.
 ##
 ## separated_nonempty_list(COMMA,kinded_variable) -> kinded_variable COMMA . separated_nonempty_list(COMMA,kinded_variable) [ RPAREN ]
 ##
@@ -2151,7 +2045,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COMMA TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 304.
+## Ends in an error in state: 276.
 ##
 ## code -> code_header kinded_args . variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2163,7 +2057,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT LPAREN IDENT RPA
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT TILDE
 ##
-## Ends in an error in state: 305.
+## Ends in an error in state: 277.
 ##
 ## code -> code_header kinded_args variable . variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2175,7 +2069,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT TILDE
 ##
-## Ends in an error in state: 306.
+## Ends in an error in state: 278.
 ##
 ## code -> code_header kinded_args variable variable . variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2187,7 +2081,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT TILD
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT TILDE
 ##
-## Ends in an error in state: 307.
+## Ends in an error in state: 279.
 ##
 ## code -> code_header kinded_args variable variable variable . variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2199,7 +2093,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT TILDE
 ##
-## Ends in an error in state: 308.
+## Ends in an error in state: 280.
 ##
 ## code -> code_header kinded_args variable variable variable variable . MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2211,7 +2105,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER TILDE
 ##
-## Ends in an error in state: 309.
+## Ends in an error in state: 281.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER . continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2223,7 +2117,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 310.
+## Ends in an error in state: 283.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id . exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2235,7 +2129,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR TILDE
 ##
-## Ends in an error in state: 311.
+## Ends in an error in state: 284.
 ##
 ## exn_continuation_id -> STAR . continuation_id [ KWD_LOCAL EQUAL COLON ]
 ##
@@ -2247,7 +2141,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT TILDE
 ##
-## Ends in an error in state: 313.
+## Ends in an error in state: 286.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id . return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2259,7 +2153,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT COLON TILDE
 ##
-## Ends in an error in state: 314.
+## Ends in an error in state: 287.
 ##
 ## return_arity -> COLON . kinds_with_subkinds [ KWD_LOCAL EQUAL ]
 ##
@@ -2271,7 +2165,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT COLON KWD_UNIT TILDE
 ##
-## Ends in an error in state: 318.
+## Ends in an error in state: 291.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity . boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2283,7 +2177,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT KWD_LOCAL TILDE
 ##
-## Ends in an error in state: 320.
+## Ends in an error in state: 293.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) . EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2295,7 +2189,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 321.
+## Ends in an error in state: 294.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL . expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2305,11 +2199,23 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
+##
+## Ends in an error in state: 297.
+##
+## let_symbol(expr) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 flambda_unit: KWD_INVALID TILDE
 ##
-## Ends in an error in state: 322.
+## Ends in an error in state: 299.
 ##
-## atomic_expr -> KWD_INVALID . STRING [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## atomic_expr -> KWD_INVALID . STRING [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_INVALID
@@ -2317,9 +2223,105 @@ flambda_unit: KWD_INVALID TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+flambda_unit: KWD_CONT IDENT KWD_PUSH TILDE
+##
+## Ends in an error in state: 308.
+##
+## trap_action -> KWD_PUSH . LPAREN continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## KWD_PUSH
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN TILDE
+##
+## Ends in an error in state: 309.
+##
+## trap_action -> KWD_PUSH LPAREN . continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## KWD_PUSH LPAREN
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN IDENT TILDE
+##
+## Ends in an error in state: 310.
+##
+## trap_action -> KWD_PUSH LPAREN continuation . RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## KWD_PUSH LPAREN continuation
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_CONT IDENT KWD_POP TILDE
+##
+## Ends in an error in state: 312.
+##
+## trap_action -> KWD_POP . LPAREN option(raise_kind) continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## KWD_POP
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_CONT IDENT KWD_POP LPAREN TILDE
+##
+## Ends in an error in state: 313.
+##
+## trap_action -> KWD_POP LPAREN . option(raise_kind) continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## KWD_POP LPAREN
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_CONT IDENT KWD_POP LPAREN KWD_NOTRACE TILDE
+##
+## Ends in an error in state: 318.
+##
+## trap_action -> KWD_POP LPAREN option(raise_kind) . continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## KWD_POP LPAREN option(raise_kind)
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT TILDE
+##
+## Ends in an error in state: 319.
+##
+## trap_action -> KWD_POP LPAREN option(raise_kind) continuation . RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## KWD_POP LPAREN option(raise_kind) continuation
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT RPAREN TILDE
+##
+## Ends in an error in state: 322.
+##
+## apply_cont_expr -> continuation option(trap_action) . simple_args [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## continuation option(trap_action)
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 flambda_unit: KWD_APPLY KWD_DIRECT TILDE
 ##
-## Ends in an error in state: 328.
+## Ends in an error in state: 326.
 ##
 ## call_kind -> KWD_DIRECT . LPAREN code_id function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2331,7 +2333,7 @@ flambda_unit: KWD_APPLY KWD_DIRECT TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN TILDE
 ##
-## Ends in an error in state: 329.
+## Ends in an error in state: 327.
 ##
 ## call_kind -> KWD_DIRECT LPAREN . code_id function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2343,7 +2345,7 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 330.
+## Ends in an error in state: 328.
 ##
 ## call_kind -> KWD_DIRECT LPAREN code_id . function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2355,7 +2357,7 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AT IDENT TILDE
 ##
-## Ends in an error in state: 331.
+## Ends in an error in state: 329.
 ##
 ## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt . alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2367,7 +2369,7 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AT IDENT TILDE
 
 flambda_unit: KWD_APPLY AMP TILDE
 ##
-## Ends in an error in state: 332.
+## Ends in an error in state: 330.
 ##
 ## alloc_mode_for_applications_opt -> AMP . region AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2379,7 +2381,7 @@ flambda_unit: KWD_APPLY AMP TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT TILDE
 ##
-## Ends in an error in state: 333.
+## Ends in an error in state: 331.
 ##
 ## alloc_mode_for_applications_opt -> AMP region . AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2391,7 +2393,7 @@ flambda_unit: KWD_APPLY AMP IDENT TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT AMP TILDE
 ##
-## Ends in an error in state: 334.
+## Ends in an error in state: 332.
 ##
 ## alloc_mode_for_applications_opt -> AMP region AMP . region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2403,7 +2405,7 @@ flambda_unit: KWD_APPLY AMP IDENT AMP TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AMP IDENT AMP IDENT TILDE
 ##
-## Ends in an error in state: 336.
+## Ends in an error in state: 334.
 ##
 ## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt alloc_mode_for_applications_opt . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2415,7 +2417,7 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AMP IDENT AMP IDENT TILDE
 
 flambda_unit: KWD_APPLY KWD_CCALL TILDE
 ##
-## Ends in an error in state: 338.
+## Ends in an error in state: 336.
 ##
 ## call_kind -> KWD_CCALL . boption(KWD_NOALLOC) [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2427,11 +2429,11 @@ flambda_unit: KWD_APPLY KWD_CCALL TILDE
 
 flambda_unit: KWD_APPLY KWD_CCALL KWD_NOALLOC TILDE
 ##
-## Ends in an error in state: 341.
+## Ends in an error in state: 339.
 ##
-## apply_expr -> call_kind . option(inlined) option(inlining_state) simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-## apply_expr -> call_kind . option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-## apply_expr -> call_kind . option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind . option(inlined) option(inlining_state) simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind . option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind . option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind
@@ -2441,7 +2443,7 @@ flambda_unit: KWD_APPLY KWD_CCALL KWD_NOALLOC TILDE
 
 flambda_unit: KWD_APPLY KWD_UNROLL TILDE
 ##
-## Ends in an error in state: 342.
+## Ends in an error in state: 340.
 ##
 ## inlined -> KWD_UNROLL . LPAREN plain_int RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2453,7 +2455,7 @@ flambda_unit: KWD_APPLY KWD_UNROLL TILDE
 
 flambda_unit: KWD_APPLY KWD_UNROLL LPAREN TILDE
 ##
-## Ends in an error in state: 343.
+## Ends in an error in state: 341.
 ##
 ## inlined -> KWD_UNROLL LPAREN . plain_int RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2465,7 +2467,7 @@ flambda_unit: KWD_APPLY KWD_UNROLL LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_UNROLL LPAREN INT TILDE
 ##
-## Ends in an error in state: 344.
+## Ends in an error in state: 342.
 ##
 ## inlined -> KWD_UNROLL LPAREN plain_int . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2477,7 +2479,7 @@ flambda_unit: KWD_APPLY KWD_UNROLL LPAREN INT TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED TILDE
 ##
-## Ends in an error in state: 346.
+## Ends in an error in state: 344.
 ##
 ## inlined -> KWD_INLINED . LPAREN KWD_ALWAYS RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ## inlined -> KWD_INLINED . LPAREN KWD_HINT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
@@ -2492,7 +2494,7 @@ flambda_unit: KWD_APPLY KWD_INLINED TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN TILDE
 ##
-## Ends in an error in state: 347.
+## Ends in an error in state: 345.
 ##
 ## inlined -> KWD_INLINED LPAREN . KWD_ALWAYS RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ## inlined -> KWD_INLINED LPAREN . KWD_HINT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
@@ -2507,7 +2509,7 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_NEVER TILDE
 ##
-## Ends in an error in state: 348.
+## Ends in an error in state: 346.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_NEVER . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2519,7 +2521,7 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_NEVER TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_HINT TILDE
 ##
-## Ends in an error in state: 350.
+## Ends in an error in state: 348.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_HINT . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2531,7 +2533,7 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_HINT TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_DEFAULT TILDE
 ##
-## Ends in an error in state: 352.
+## Ends in an error in state: 350.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_DEFAULT . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2543,7 +2545,7 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_DEFAULT TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS TILDE
 ##
-## Ends in an error in state: 354.
+## Ends in an error in state: 352.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_ALWAYS . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2555,11 +2557,11 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS RPAREN TILDE
 ##
-## Ends in an error in state: 356.
+## Ends in an error in state: 354.
 ##
-## apply_expr -> call_kind option(inlined) . option(inlining_state) simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-## apply_expr -> call_kind option(inlined) . option(inlining_state) simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-## apply_expr -> call_kind option(inlined) . option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) . option(inlining_state) simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) . option(inlining_state) simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) . option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind option(inlined)
@@ -2569,7 +2571,7 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS RPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE TILDE
 ##
-## Ends in an error in state: 357.
+## Ends in an error in state: 355.
 ##
 ## inlining_state -> KWD_INLINING_STATE . LPAREN inlining_state_depth RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL INT IDENT FLOAT ]
 ##
@@ -2581,7 +2583,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN TILDE
 ##
-## Ends in an error in state: 358.
+## Ends in an error in state: 356.
 ##
 ## inlining_state -> KWD_INLINING_STATE LPAREN . inlining_state_depth RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL INT IDENT FLOAT ]
 ##
@@ -2593,7 +2595,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH TILDE
 ##
-## Ends in an error in state: 359.
+## Ends in an error in state: 357.
 ##
 ## inlining_state_depth -> KWD_DEPTH . LPAREN plain_int RPAREN [ RPAREN ]
 ##
@@ -2605,7 +2607,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN TILDE
 ##
-## Ends in an error in state: 360.
+## Ends in an error in state: 358.
 ##
 ## inlining_state_depth -> KWD_DEPTH LPAREN . plain_int RPAREN [ RPAREN ]
 ##
@@ -2617,7 +2619,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT TILDE
 ##
-## Ends in an error in state: 361.
+## Ends in an error in state: 359.
 ##
 ## inlining_state_depth -> KWD_DEPTH LPAREN plain_int . RPAREN [ RPAREN ]
 ##
@@ -2629,7 +2631,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN TILDE
 ##
-## Ends in an error in state: 363.
+## Ends in an error in state: 361.
 ##
 ## inlining_state -> KWD_INLINING_STATE LPAREN inlining_state_depth . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL INT IDENT FLOAT ]
 ##
@@ -2641,11 +2643,11 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN TI
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 365.
+## Ends in an error in state: 363.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-## apply_expr -> call_kind option(inlined) option(inlining_state) . simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-## apply_expr -> call_kind option(inlined) option(inlining_state) . LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) . simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) . LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind option(inlined) option(inlining_state)
@@ -2655,9 +2657,9 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN RP
 
 flambda_unit: KWD_APPLY LPAREN TILDE
 ##
-## Ends in an error in state: 366.
+## Ends in an error in state: 364.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN . simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN . simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## simple_args -> LPAREN . loption(separated_nonempty_list(COMMA,simple)) RPAREN [ MINUSGREATER ]
 ##
 ## The known suffix of the stack is as follows:
@@ -2668,9 +2670,9 @@ flambda_unit: KWD_APPLY LPAREN TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT SYMBOL
 ##
-## Ends in an error in state: 367.
+## Ends in an error in state: 365.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple . COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple . COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## separated_nonempty_list(COMMA,simple) -> simple . [ RPAREN ]
 ## separated_nonempty_list(COMMA,simple) -> simple . COMMA separated_nonempty_list(COMMA,simple) [ RPAREN ]
 ## simple -> simple . TILDE coercion [ TILDE RPAREN COMMA COLON ]
@@ -2683,9 +2685,9 @@ flambda_unit: KWD_APPLY LPAREN FLOAT SYMBOL
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON TILDE
 ##
-## Ends in an error in state: 368.
+## Ends in an error in state: 366.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON . blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON . blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind option(inlined) option(inlining_state) LPAREN simple COLON
@@ -2695,9 +2697,9 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_UNIT TILDE
 ##
-## Ends in an error in state: 371.
+## Ends in an error in state: 369.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) . MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) . MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds)
@@ -2707,9 +2709,9 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_UNIT TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER TILDE
 ##
-## Ends in an error in state: 372.
+## Ends in an error in state: 370.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER . kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER . kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER
@@ -2719,9 +2721,9 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_UNIT TILDE
 ##
-## Ends in an error in state: 373.
+## Ends in an error in state: 371.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds . RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds . RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds
@@ -2731,9 +2733,9 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_UNIT TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN TILDE
 ##
-## Ends in an error in state: 374.
+## Ends in an error in state: 372.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN
@@ -2743,9 +2745,9 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN LPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 375.
+## Ends in an error in state: 373.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args
@@ -2755,9 +2757,9 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN MINUSGREATER TILDE
 ##
-## Ends in an error in state: 376.
+## Ends in an error in state: 374.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER
@@ -2767,9 +2769,9 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 378.
+## Ends in an error in state: 376.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation
@@ -2779,9 +2781,9 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR TILDE
 ##
-## Ends in an error in state: 379.
+## Ends in an error in state: 377.
 ##
-## exn_continuation -> STAR . continuation loption(exn_extra_args) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## exn_continuation -> STAR . continuation loption(exn_extra_args) [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## STAR
@@ -2791,9 +2793,9 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT TILDE
 ##
-## Ends in an error in state: 380.
+## Ends in an error in state: 378.
 ##
-## exn_continuation -> STAR continuation . loption(exn_extra_args) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## exn_continuation -> STAR continuation . loption(exn_extra_args) [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## STAR continuation
@@ -2803,9 +2805,9 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN TILDE
 ##
-## Ends in an error in state: 381.
+## Ends in an error in state: 379.
 ##
-## exn_extra_args -> LPAREN . separated_nonempty_list(COMMA,exn_extra_arg) RPAREN [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## exn_extra_args -> LPAREN . separated_nonempty_list(COMMA,exn_extra_arg) RPAREN [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -2815,7 +2817,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT SYMBOL
 ##
-## Ends in an error in state: 382.
+## Ends in an error in state: 380.
 ##
 ## exn_extra_arg -> simple . kind_with_subkind [ RPAREN COMMA ]
 ## simple -> simple . TILDE coercion [ TILDE LBRACK KWD_VAL KWD_REGION KWD_REC_INFO KWD_NATIVEINT KWD_INT64 KWD_INT32 KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY ]
@@ -2828,7 +2830,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT SYMBOL
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 386.
+## Ends in an error in state: 384.
 ##
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg . [ RPAREN ]
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg . COMMA separated_nonempty_list(COMMA,exn_extra_arg) [ RPAREN ]
@@ -2841,7 +2843,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_REC_INFO 
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_FLOAT COMMA TILDE
 ##
-## Ends in an error in state: 387.
+## Ends in an error in state: 385.
 ##
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg COMMA . separated_nonempty_list(COMMA,exn_extra_arg) [ RPAREN ]
 ##
@@ -2853,9 +2855,9 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_FLOAT COM
 
 flambda_unit: KWD_APPLY LPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 393.
+## Ends in an error in state: 391.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind option(inlined) option(inlining_state) simple_args
@@ -2865,9 +2867,9 @@ flambda_unit: KWD_APPLY LPAREN RPAREN TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER TILDE
 ##
-## Ends in an error in state: 394.
+## Ends in an error in state: 392.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER
@@ -2877,9 +2879,9 @@ flambda_unit: KWD_APPLY MINUSGREATER TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 395.
+## Ends in an error in state: 393.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER result_continuation
@@ -2889,7 +2891,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT TILDE
 
 flambda_unit: KWD_HCF TILDE
 ##
-## Ends in an error in state: 409.
+## Ends in an error in state: 407.
 ##
 ## expr -> inner_expr . [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ## where_expr -> inner_expr . KWD_WHERE cont_recursive loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
@@ -2902,7 +2904,7 @@ flambda_unit: KWD_HCF TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE TILDE
 ##
-## Ends in an error in state: 410.
+## Ends in an error in state: 408.
 ##
 ## where_expr -> inner_expr KWD_WHERE . cont_recursive loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ##
@@ -2914,7 +2916,7 @@ flambda_unit: KWD_HCF KWD_WHERE TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC TILDE
 ##
-## Ends in an error in state: 411.
+## Ends in an error in state: 409.
 ##
 ## cont_recursive -> KWD_REC . kinded_args [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND IDENT EOF ]
 ##
@@ -2926,7 +2928,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 413.
+## Ends in an error in state: 411.
 ##
 ## where_expr -> inner_expr KWD_WHERE cont_recursive . loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ##
@@ -2938,7 +2940,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT RPAREN TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT TILDE
 ##
-## Ends in an error in state: 416.
+## Ends in an error in state: 414.
 ##
 ## continuation_binding -> continuation_id . continuation_sort kinded_args EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2950,7 +2952,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT KWD_DEFINE_ROOT_SYMBOL TILDE
 ##
-## Ends in an error in state: 419.
+## Ends in an error in state: 417.
 ##
 ## continuation_binding -> continuation_id continuation_sort . kinded_args EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2962,7 +2964,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT KWD_DEFINE_ROOT_SYMBOL TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 420.
+## Ends in an error in state: 418.
 ##
 ## continuation_binding -> continuation_id continuation_sort kinded_args . EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2974,7 +2976,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT LPAREN IDENT RPAREN TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 421.
+## Ends in an error in state: 419.
 ##
 ## continuation_binding -> continuation_id continuation_sort kinded_args EQUAL . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2986,7 +2988,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET TILDE
 ##
-## Ends in an error in state: 422.
+## Ends in an error in state: 420.
 ##
 ## let_expr(continuation_body) -> KWD_LET . let_(continuation_body) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## let_symbol(continuation_body) -> KWD_LET . separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -2999,7 +3001,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 424.
+## Ends in an error in state: 422.
 ##
 ## let_symbol(continuation_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3011,7 +3013,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED K
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED KWD_IN TILDE
 ##
-## Ends in an error in state: 425.
+## Ends in an error in state: 423.
 ##
 ## let_symbol(continuation_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3023,7 +3025,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED K
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 431.
+## Ends in an error in state: 430.
 ##
 ## let_(continuation_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3035,7 +3037,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_WITH LB
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 ##
-## Ends in an error in state: 432.
+## Ends in an error in state: 431.
 ##
 ## let_(continuation_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3047,7 +3049,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_IN TILD
 
 flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO INT TILDE
 ##
-## Ends in an error in state: 434.
+## Ends in an error in state: 433.
 ##
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding . [ KWD_WITH KWD_IN ]
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding . KWD_AND separated_nonempty_list(KWD_AND,let_binding) [ KWD_WITH KWD_IN ]
@@ -3060,7 +3062,7 @@ flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO INT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_AND TILDE
 ##
-## Ends in an error in state: 435.
+## Ends in an error in state: 434.
 ##
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding KWD_AND . separated_nonempty_list(KWD_AND,let_binding) [ KWD_WITH KWD_IN ]
 ##
@@ -3072,7 +3074,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_AND TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF TILDE
 ##
-## Ends in an error in state: 440.
+## Ends in an error in state: 439.
 ##
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding . [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding . KWD_ANDWHERE separated_nonempty_list(KWD_ANDWHERE,continuation_binding) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
@@ -3085,7 +3087,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF KWD_ANDWHERE TILDE
 ##
-## Ends in an error in state: 441.
+## Ends in an error in state: 440.
 ##
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding KWD_ANDWHERE . separated_nonempty_list(KWD_ANDWHERE,continuation_binding) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ##
@@ -3095,21 +3097,9 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF KWD_ANDWHERE TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
-##
-## Ends in an error in state: 446.
-##
-## let_symbol(expr) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
-##
-## The known suffix of the stack is as follows:
-## KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 450.
+## Ends in an error in state: 445.
 ##
 ## let_(expr) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -3121,7 +3111,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 ##
-## Ends in an error in state: 451.
+## Ends in an error in state: 446.
 ##
 ## let_(expr) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -3131,11 +3121,84 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
+##
+## Ends in an error in state: 451.
+##
+## let_symbol(atomic_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELETED KWD_IN TILDE
+##
+## Ends in an error in state: 452.
+##
+## let_symbol(atomic_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
+##
+## Ends in an error in state: 458.
+##
+## let_(atomic_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
+##
+## Ends in an error in state: 459.
+##
+## let_(atomic_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_HCF TILDE
+##
+## Ends in an error in state: 464.
+##
+## separated_nonempty_list(PIPE,switch_case) -> switch_case . [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## separated_nonempty_list(PIPE,switch_case) -> switch_case . PIPE separated_nonempty_list(PIPE,switch_case) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## switch_case
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER IDENT PIPE TILDE
+##
+## Ends in an error in state: 465.
+##
+## separated_nonempty_list(PIPE,switch_case) -> switch_case PIPE . separated_nonempty_list(PIPE,switch_case) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## switch_case PIPE
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 flambda_unit: LPAREN KWD_HCF KWD_WITH
 ##
-## Ends in an error in state: 454.
+## Ends in an error in state: 469.
 ##
-## atomic_expr -> LPAREN expr . RPAREN [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## atomic_expr -> LPAREN expr . RPAREN [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN expr
@@ -3144,7 +3207,7 @@ flambda_unit: LPAREN KWD_HCF KWD_WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 409, spurious reduction of production expr -> inner_expr
+## In state 407, spurious reduction of production expr -> inner_expr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>

--- a/middle_end/flambda2/parser/flambda_parser.mly
+++ b/middle_end/flambda2/parser/flambda_parser.mly
@@ -342,8 +342,10 @@ named:
   | KWD_REC_INFO; ri = rec_info_atom { Rec_info ri }
 ;
 
+
 switch_case:
-  | i = tag; MINUSGREATER; ac = apply_cont_expr { i,ac }
+  | i = tag; MINUSGREATER; ac = apply_cont_expr { i, Named_cont ac }
+  | i = tag; MINUSGREATER; b = atomic_body { i, Inlined_goto b }
 ;
 
 switch:
@@ -439,7 +441,7 @@ let_expr(body):
 
 inner_expr:
   | w = where_expr { w }
-  | a = atomic_expr { a }
+  | s = inlined_expr { s }
 ;
 
 where_expr:
@@ -450,7 +452,17 @@ where_expr:
 
 continuation_body:
   | l = let_expr(continuation_body) { l }
+  | s = inlined_expr { s }
+;
+
+atomic_body:
+  | l = let_expr(atomic_body) { l }
   | a = atomic_expr { a }
+
+inlined_expr:
+  | a = atomic_expr { a }
+  | KWD_SWITCH; scrutinee = simple; cases = switch
+    { Switch {scrutinee; cases} }
 ;
 
 atomic_expr:
@@ -458,7 +470,6 @@ atomic_expr:
   | KWD_UNREACHABLE { Invalid { message =  "treat-as-unreachable" } }
   | KWD_INVALID; message = STRING { Invalid { message } }
   | KWD_CONT; ac = apply_cont_expr { Apply_cont ac }
-  | KWD_SWITCH; scrutinee = simple; cases = switch { Switch {scrutinee; cases} }
   | KWD_APPLY e = apply_expr { Apply e }
   | LPAREN; e = expr; RPAREN { e }
 ;

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -700,7 +700,7 @@ and switch_expr env switch : Fexpr.expr =
           |> Targetint_32_64.to_int
         in
         let app_cont = apply_cont env app_cont in
-        tag, app_cont)
+        tag, Fexpr.Named_cont app_cont)
       (Switch_expr.arms switch |> Target_ocaml_int.Map.bindings)
   in
   Switch { scrutinee; cases }

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -637,6 +637,18 @@ let rec expr scope ppf = function
       (simple_args ~space:Before ~omit_if_empty:true)
       args result_continuation ret exn_continuation ek
 
+(* CR keryan/bclement: Printing inlined goto only occurs when reprinting parsed
+   fexpr, conversion to and from flambda does not preserve this.
+
+   To do so without breaking scoping, it requires three properties to inline:
+   single use goto, last one declared yet to be inlined, no let expression
+   between declaration and use.
+
+   We could use a stack of declared single use gotos to preserve scoping order,
+   droping it when meeting lets or out of order use. But since a switch is
+   almost always preceded by a get_tag of is_int, we would never inline in
+   practice, except for converted inlining written by hand (which does add let
+   conts right above switches). We deem this not worth the effort for now. *)
 and apply_or_inlined_cont ppf (ac : Fexpr.apply_or_inlined_cont) =
   match ac with
   | Named_cont ac -> apply_cont ppf ac

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -450,16 +450,12 @@ let trap_action ppf = function
       (pp_option ~space:After raise_kind)
       rk continuation exn_handler
 
-let apply_cont ppf (ac : Fexpr.apply_cont) =
-  match ac with
-  | { cont; trap_action = action; args } ->
-    Format.fprintf ppf "@[<hv2>%a%a%a@]" continuation cont
-      (pp_option ~space:Before trap_action)
-      action
-      (simple_args ~space:Before ~omit_if_empty:true)
-      args
-
-let switch_case ppf (v, c) = Format.fprintf ppf "@;| %i -> %a" v apply_cont c
+let apply_cont ppf ({ cont; trap_action = action; args } : Fexpr.apply_cont) =
+  Format.fprintf ppf "@[<hv2>%a%a%a@]" continuation cont
+    (pp_option ~space:Before trap_action)
+    action
+    (simple_args ~space:Before ~omit_if_empty:true)
+    args
 
 let value_slots expr_or_static ppf = function
   | None -> ()
@@ -640,6 +636,14 @@ let rec expr scope ppf = function
       func_name_with_optional_arities (func, arities)
       (simple_args ~space:Before ~omit_if_empty:true)
       args result_continuation ret exn_continuation ek
+
+and apply_or_inlined_cont ppf (ac : Fexpr.apply_or_inlined_cont) =
+  match ac with
+  | Named_cont ac -> apply_cont ppf ac
+  | Inlined_goto e -> Format.fprintf ppf "(%a)" (expr Outer) e
+
+and switch_case ppf (v, c) =
+  Format.fprintf ppf "@;@[<hov 2>| %i ->@ %a@]" v apply_or_inlined_cont c
 
 and let_expr scope ppf : let_ -> unit = function
   | { bindings = first :: rest; body; value_slots = ces } ->

--- a/testsuite/tests/flambda2/examples/code_id_join_b.simplify.reference
+++ b/testsuite/tests/flambda2/examples/code_id_join_b.simplify.reference
@@ -15,16 +15,19 @@ cont self ($camlCode_id_join_b__const_block338)
          let Pfield = %block_load.[`0`] (param) in
          ((let prim_1 = %int_comp.ne (Pfield, 0) in
            switch prim_1
-             | 0 -> k1
-                      ($Code_id_join_a.`camlCode_id_join_a__fn[code_id_join_a.ml:9,24--35]_11`)
+             | 0 ->
+               k1
+                 ($Code_id_join_a.`camlCode_id_join_a__fn[code_id_join_a.ml:9,24--35]_11`)
              | 1 -> k2
              where k2 =
                let prim_2 = %int_comp.ne (Pfield, 1) in
                switch prim_2
-                 | 0 -> k1
-                          ($Code_id_join_a.`camlCode_id_join_a__fn[code_id_join_a.ml:9,24--35]_12`)
-                 | 1 -> k1
-                          ($Code_id_join_a.`camlCode_id_join_a__fn[code_id_join_a.ml:9,24--35]_13`))
+                 | 0 ->
+                   k1
+                     ($Code_id_join_a.`camlCode_id_join_a__fn[code_id_join_a.ml:9,24--35]_12`)
+                 | 1 ->
+                   k1
+                     ($Code_id_join_a.`camlCode_id_join_a__fn[code_id_join_a.ml:9,24--35]_13`))
             where k1 (full_apply) =
               (apply inlining_state(depth(20)) full_apply (42) -> k2 * error
                  where k2 (param_1 : imm tagged) =

--- a/testsuite/tests/flambda2/examples/string_switch.simplify.reference
+++ b/testsuite/tests/flambda2/examples/string_switch.simplify.reference
@@ -55,9 +55,10 @@ let code loopify(never) size(60) newer_version_of(of_string_0)
                                     let untagged = %untag_imm (Pccall_3) in
                                     switch untagged
                                       | 0 -> k (0)
-                                      | 1 -> k1
-                                               pop(regular k1)
-                                               ($camlString_switch__Pmakeblock35)))))))
+                                      | 1 ->
+                                        k1
+                                          pop(regular k1)
+                                          ($camlString_switch__Pmakeblock35)))))))
 in
 let $camlString_switch__of_string_1 = closure of_string_0_1 @of_string in
 let $camlString_switch = Block 0 ($camlString_switch__of_string_1) in

--- a/testsuite/tests/flambda2/examples/tests9.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests9.raw.reference
@@ -518,10 +518,8 @@
                                                                     (eq)
                                                                  in
                                                                  switch untagged
-                                                                   | 0 -> 
-                                                                   k10
-                                                                   | 1 -> 
-                                                                   k11)
+                                                                   | 0 -> k10
+                                                                   | 1 -> k11)
                                                                   where 
                                                                     k11 =
                                                                     cont k8
@@ -543,9 +541,9 @@
                                                                     (int_lessthan)
                                                                     in
                                                                     switch untagged
-                                                                    | 0 -> 
+                                                                    | 0 ->
                                                                     k11
-                                                                    | 1 -> 
+                                                                    | 1 ->
                                                                     k12)
                                                                     where 
                                                                     k12 =
@@ -688,10 +686,8 @@
                                                                     (eq)
                                                                  in
                                                                  switch untagged
-                                                                   | 0 -> 
-                                                                   k9
-                                                                   | 1 -> 
-                                                                   k10)
+                                                                   | 0 -> k9
+                                                                   | 1 -> k10)
                                                                   where 
                                                                     k10 =
                                                                     cont k7
@@ -713,9 +709,9 @@
                                                                     (int_lessthan)
                                                                     in
                                                                     switch untagged
-                                                                    | 0 -> 
+                                                                    | 0 ->
                                                                     k10
-                                                                    | 1 -> 
+                                                                    | 1 ->
                                                                     k11)
                                                                     where 
                                                                     k11 =
@@ -1104,10 +1100,8 @@
                                                                     (eq)
                                                                  in
                                                                  switch untagged
-                                                                   | 0 -> 
-                                                                   k10
-                                                                   | 1 -> 
-                                                                   k11)
+                                                                   | 0 -> k10
+                                                                   | 1 -> k11)
                                                                   where 
                                                                     k11 =
                                                                     cont k8
@@ -1129,9 +1123,9 @@
                                                                     (int_greaterthan)
                                                                     in
                                                                     switch untagged
-                                                                    | 0 -> 
+                                                                    | 0 ->
                                                                     k11
-                                                                    | 1 -> 
+                                                                    | 1 ->
                                                                     k12)
                                                                     where 
                                                                     k12 =
@@ -1274,10 +1268,8 @@
                                                                     (eq)
                                                                  in
                                                                  switch untagged
-                                                                   | 0 -> 
-                                                                   k9
-                                                                   | 1 -> 
-                                                                   k10)
+                                                                   | 0 -> k9
+                                                                   | 1 -> k10)
                                                                   where 
                                                                     k10 =
                                                                     cont k7
@@ -1299,9 +1291,9 @@
                                                                     (int_greaterthan)
                                                                     in
                                                                     switch untagged
-                                                                    | 0 -> 
+                                                                    | 0 ->
                                                                     k10
-                                                                    | 1 -> 
+                                                                    | 1 ->
                                                                     k11)
                                                                     where 
                                                                     k11 =

--- a/testsuite/tests/flambda2/examples/tests9.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests9.simplify.reference
@@ -355,10 +355,8 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                                   (c_2, 0)
                                                               in
                                                               (switch prim_9
-                                                                 | 0 -> 
-                                                                 k5
-                                                                 | 1 -> 
-                                                                 k6
+                                                                 | 0 -> k5
+                                                                 | 1 -> k6
                                                                  where 
                                                                    k6 =
                                                                    let Pmakeblock =
@@ -380,10 +378,8 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                                     (c_2, 0)
                                                                    in
                                                                    (switch prim_10
-                                                                    | 0 -> 
-                                                                    k5
-                                                                    | 1 -> 
-                                                                    k6
+                                                                    | 0 -> k5
+                                                                    | 1 -> k6
                                                                     where 
                                                                     k6 =
                                                                     let Pmakeblock =
@@ -476,10 +472,8 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                                   (c_2, 0)
                                                               in
                                                               (switch prim_9
-                                                                 | 0 -> 
-                                                                 k4
-                                                                 | 1 -> 
-                                                                 k5
+                                                                 | 0 -> k4
+                                                                 | 1 -> k5
                                                                  where 
                                                                    k5 =
                                                                    let Pmakeblock =
@@ -501,10 +495,8 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                                     (c_2, 0)
                                                                    in
                                                                    (switch prim_10
-                                                                    | 0 -> 
-                                                                    k4
-                                                                    | 1 -> 
-                                                                    k5
+                                                                    | 0 -> k4
+                                                                    | 1 -> k5
                                                                     where 
                                                                     k5 =
                                                                     let Pmakeblock =
@@ -752,10 +744,8 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                                   (c_2, 0)
                                                               in
                                                               (switch prim_9
-                                                                 | 0 -> 
-                                                                 k5
-                                                                 | 1 -> 
-                                                                 k6
+                                                                 | 0 -> k5
+                                                                 | 1 -> k6
                                                                  where 
                                                                    k6 =
                                                                    let Pmakeblock =
@@ -777,10 +767,8 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                                     (c_2, 0)
                                                                    in
                                                                    (switch prim_10
-                                                                    | 0 -> 
-                                                                    k5
-                                                                    | 1 -> 
-                                                                    k6
+                                                                    | 0 -> k5
+                                                                    | 1 -> k6
                                                                     where 
                                                                     k6 =
                                                                     let Pmakeblock =
@@ -873,10 +861,8 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                                   (c_2, 0)
                                                               in
                                                               (switch prim_9
-                                                                 | 0 -> 
-                                                                 k4
-                                                                 | 1 -> 
-                                                                 k5
+                                                                 | 0 -> k4
+                                                                 | 1 -> k5
                                                                  where 
                                                                    k5 =
                                                                    let Pmakeblock =
@@ -898,10 +884,8 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                                     (c_2, 0)
                                                                    in
                                                                    (switch prim_10
-                                                                    | 0 -> 
-                                                                    k4
-                                                                    | 1 -> 
-                                                                    k5
+                                                                    | 0 -> k4
+                                                                    | 1 -> k5
                                                                     where 
                                                                     k5 =
                                                                     let Pmakeblock =

--- a/testsuite/tests/flambda2/examples/unknown/data_flow_bug.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/data_flow_bug.simplify.reference
@@ -147,10 +147,8 @@ let Popaque = %opaque ($camlData_flow_bug__immstring19) in
                                                                     0)
                                                                 in
                                                                 (switch prim_2
-                                                                   | 0 -> 
-                                                                   k2
-                                                                   | 1 -> 
-                                                                   k
+                                                                   | 0 -> k2
+                                                                   | 1 -> k
                                                                    where 
                                                                     k2 =
                                                                     let Pfield_1 =

--- a/testsuite/tests/flambda2/examples/unknown/local.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/local.simplify.reference
@@ -139,9 +139,8 @@ apply direct(length_2_1)
                  where k1 (apply_result : imm tagged) =
                    let prim = %phys_eq (apply_result, 3) in
                    switch prim
-                     | 0 -> error
-                              pop(regular error)
-                              ($camlLocal__Pmakeblock96)
+                     | 0 ->
+                       error pop(regular error) ($camlLocal__Pmakeblock96)
                      | 1 -> k)
             where k =
               let `unit` = %end_region (`region`) in
@@ -312,9 +311,10 @@ apply direct(length_2_1)
                       where k1 (apply_result : imm tagged) =
                         let prim = %phys_eq (apply_result, 3) in
                         switch prim
-                          | 0 -> error
-                                   pop(regular error)
-                                   ($camlLocal__Pmakeblock186)
+                          | 0 ->
+                            error
+                              pop(regular error)
+                              ($camlLocal__Pmakeblock186)
                           | 1 -> k)
                  where k =
                    let unit_2 = %end_region (region_1) in

--- a/testsuite/tests/flambda2/examples/value_slot_c.simplify.reference
+++ b/testsuite/tests/flambda2/examples/value_slot_c.simplify.reference
@@ -40,17 +40,15 @@ let code loopify(never) size(59) newer_version_of(f_3)
                where k3 =
                  let prim_1 = %phys_eq (x, 1) in
                  switch prim_1
-                   | 0 -> k1
-                            pop(regular k1)
-                            ($camlValue_slot_c__Pmakeblock121)
+                   | 0 ->
+                     k1 pop(regular k1) ($camlValue_slot_c__Pmakeblock121)
                    | 1 -> k2)
               where k2 =
                 let Pfield = %block_load.[`1`] (`*match*`) in
                 let prim = %phys_eq (Pfield, 3) in
                 switch prim
-                  | 0 -> k1
-                           pop(regular k1)
-                           ($camlValue_slot_c__Pmakeblock132)
+                  | 0 ->
+                    k1 pop(regular k1) ($camlValue_slot_c__Pmakeblock132)
                   | 1 -> k (0)))
 in
 let $camlValue_slot_c__f_4 = closure f_3_1 @f in

--- a/testsuite/tests/flambda2/examples/wrong/local_exns_to_jumps.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/local_exns_to_jumps.simplify.reference
@@ -35,9 +35,10 @@ apply ccall noalloc
                          let naked_immediate = unboxed_field in
                          switch naked_immediate
                            | 0 -> k4
-                           | 1 -> k2
-                                    pop(regular k2)
-                                    ($camlLocal_exns_to_jumps__Exit209)
+                           | 1 ->
+                             k2
+                               pop(regular k2)
+                               ($camlLocal_exns_to_jumps__Exit209)
                        where k4 =
                          let int_add = %int_barith.add (r_290_unboxed0, 1) in
                          cont k3 (int_add))))

--- a/testsuite/tests/flambda2/examples/wrong/unused_bucket_switch.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/unused_bucket_switch.simplify.reference
@@ -31,9 +31,8 @@ let ghost_region = %begin_ghost_region () in
          where k5 (unboxed_field : imm) =
            let naked_immediate = unboxed_field in
            switch naked_immediate
-             | 0 -> k4
-                      pop(reraise k4)
-                      ($camlUnused_bucket_switch__Pmakeblock68)
+             | 0 ->
+               k4 pop(reraise k4) ($camlUnused_bucket_switch__Pmakeblock68)
              | 1 -> k3 (42)
      in
      let $camlUnused_bucket_switch__f_3 = closure f_1_1 @f in

--- a/testsuite/tests/reaper/result_types_of_identity.simplify.no-result-types.reference
+++ b/testsuite/tests/reaper/result_types_of_identity.simplify.no-result-types.reference
@@ -22,9 +22,8 @@ let code loopify(never) size(16) newer_version_of(always_0_0)
     where k2 (apply_result : imm tagged) =
       let prim = %phys_eq (apply_result, 0) in
       switch prim
-        | 0 -> k1
-                 pop(regular k1)
-                 ($camlResult_types_of_identity__Pmakeblock21)
+        | 0 ->
+          k1 pop(regular k1) ($camlResult_types_of_identity__Pmakeblock21)
         | 1 -> k (0)
 in
 let $camlResult_types_of_identity__always_0_1 =


### PR DESCRIPTION
This allows to inline goto handler code in switch branches.

```
switch s
| 0 -> k 0
| 1 -> let x = 1 in cont k x
```
is sugar for
```
switch s
| 0 -> k 0
| 1 -> branch_k
where branch_k =
  let x = 1 in
  cont k x
```