### PR TITLE
Add prefetch to pool_sweep

### DIFF
--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -664,6 +664,8 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
 
     while (p + wh <= end) {
       header_t hd = (header_t)atomic_load_relaxed((atomic_uintnat*)p);
+      /* TODO: optimize prefetch displacement; possibly a multiple of wh? */
+      caml_prefetchr((char*)p + caml_plat_pagesize);
       if (hd == 0) {
         /* already on freelist */
         all_used = 0;


### PR DESCRIPTION
I dropped this from the work to speed up the major GC because I wanted to gather measurements to optimize the prefetch displacement (`caml_plat_pagesize` here). Those measurements should still be made but in the meantime we should get this merged.