### PR TITLE
Generalize and generalize structure

### DIFF
--- a/external/merlin/src/ocaml/typing/solver.ml
+++ b/external/merlin/src/ocaml/typing/solver.ml
@@ -326,7 +326,11 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
            but not necessarily [v.upper <= f u.upper].
          - for all [f u \in v.vlower] and [g w \in v.vupper] we
            have either [g'f \in w.vlower] or [f'g \in u.vupper]. *)
-      id : int  (** For identification/printing *)
+      id : int;  (** For identification/printing *)
+      mutable gencopy : 'a var option
+          (** Calls to [generalize_structure] creates additional copies to make
+              sure the bounds of a generalize structure is rigid: [gencopy]
+              caches such copies *)
     }
 
   and 'b lmorphvar = ('b, left_only) morphvar
@@ -352,6 +356,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | Cvlower : 'a var * 'a lmorphvar VarMap.t -> change
     | Cvupper : 'a var * 'a rmorphvar VarMap.t -> change
     | Clevel : 'a var * int -> change
+    | Cgencopy : 'a var * 'a var option -> change
 
   type changes = change list
 
@@ -365,6 +370,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | Cvlower (v, vlower) -> v.vlower <- vlower
     | Cvupper (v, vupper) -> v.vupper <- vupper
     | Clevel (v, level) -> v.level <- level
+    | Cgencopy (v, copy) -> v.gencopy <- copy
 
   let empty_changes = []
 
@@ -397,6 +403,9 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
             morphvars have their own hints). *)
     constraint 'd = _ * _
   [@@ocaml.warning "-62"]
+
+  (** Levels *)
+  let generic_level = Ident.highest_scope
 
   (** Prints a mode variable, including the set of variables related to it
       (recursively). To handle cycles, [traversed] is the set of variables that
@@ -678,6 +687,14 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | None -> ()
     | Some log -> log := Cvupper (v, v.vupper) :: !log);
     v.vupper <- vupper
+
+  (** Function used internally by generalize_structure to cache newly created
+      copies *)
+  let set_gencopy ~log v copy =
+    (match log with
+    | None -> ()
+    | Some log -> log := Cgencopy (v, v.gencopy) :: !log);
+    v.gencopy <- copy
 
   (** When called, graph must be fixed so maintain INVARIANT *)
   let set_level ~log v level =
@@ -1219,8 +1236,18 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     in
     let vlower = Option.value vlower ~default:VarMap.empty in
     let vupper = Option.value vupper ~default:VarMap.empty in
+    let gencopy = None in
     let var =
-      { level; upper; upper_hint; lower; lower_hint; vlower; vupper; id }
+      { level;
+        upper;
+        upper_hint;
+        lower;
+        lower_hint;
+        vlower;
+        vupper;
+        id;
+        gencopy
+      }
     in
     vars := id + 1, Var var :: l;
     var
@@ -1246,6 +1273,170 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       right : 'a;
       right_hint : ('a, right_only) hint_raw
     }
+
+  (* Moves every reachable variable from [u] such that
+  [current_level] < [u.level] < [generic_level] to
+  [generic_level + (u.level - current_level)], preserving the exact topology
+
+  PRECONDITIONS: None
+  POSTCONDITIONS:
+    current_level < u.level < generic_level ==>
+      Forall v in the reachable set of variables from u:
+        v.level = generic_level + (v.level - current_level) *)
+  let rec generalize_topology : type a.
+      log:_ -> current_level:int -> a var -> unit =
+   fun ~log ~current_level u ->
+    if u.level <= current_level || u.level >= generic_level
+    then ()
+    else begin
+      let new_level = generic_level + (u.level - current_level) in
+      set_level ~log u new_level;
+      let do_gen _ (Amorphvar (v, _f, _f_hint)) =
+        generalize_topology ~log ~current_level v
+      in
+      VarMap.iter do_gen u.vupper;
+      VarMap.iter do_gen u.vlower
+    end
+
+  (* creates a copy of the variable [u] such that [u] < [copy] and [copy] < [u] via
+  submode, and lowers the [copy] to [current_level].
+  The [copy] is cached in the [gencopy] of [u] *)
+  let create_gencopy : type a.
+      log:_ -> a C.obj -> current_level:int -> a var -> unit =
+   fun ~log dst ~current_level u ->
+    (* If bounds are already tight, there is no need to create a copy *)
+    if (not (C.le dst u.upper u.lower)) && u.level = generic_level
+    then begin
+      let copy = fresh ~upper:u.upper ~lower:u.lower ~level:current_level dst in
+      let ok1 =
+        submode_mvmv ~log H.Pinpoint.unknown dst
+          (Amorphvar (copy, C.id, Comp_hint.Morph_hint.Id))
+          (Amorphvar (u, C.id, Comp_hint.Morph_hint.Id))
+      in
+      let ok2 =
+        submode_mvmv ~log H.Pinpoint.unknown dst
+          (Amorphvar (u, C.id, Comp_hint.Morph_hint.Id))
+          (Amorphvar (copy, C.id, Comp_hint.Morph_hint.Id))
+      in
+      assert (Result.is_ok ok1 && Result.is_ok ok2);
+      set_gencopy ~log copy u.gencopy;
+      set_gencopy ~log u (Some copy)
+    end
+
+  let generalize_v : type a.
+      log:_ -> a C.obj -> current_level:int -> a var -> unit =
+   fun ~log dst ~current_level u ->
+    generalize_topology ~log ~current_level u;
+    update_level_v ~log dst generic_level u
+
+  (* generalize_structure first moves a variable to generic_level (like generalize does).
+     It then has three cases:
+    (1) if bounds are tight, leave it as is
+    (2) if bounds are fully open --- by virtue of having no
+        vupper/vlower at or above the current level, and fully open
+        conservative bounds --- we move it to current level
+    (3) if bounds are non-trivial (neither tight nor fully open) we make a copy, keep the
+        original var at generic_level, and mark the two variables as equivalent by adding
+        constraint arrows via [add_vlower] and [add_vupper]
+
+    PRECONDITIONS: None
+    POSTCONDITIONS:
+      u.level <= current_level ==> no changes to u
+      current_level < u.level ==>
+        ( (u.upper <= u.lower
+              ==> u.vlower = Ø && u.vupper = Ø && u.level = generic_level)
+          && (u.lower = min && u.upper = max
+              && u does not have children at or above current_level
+              ==> u.level = current_level)
+          && (u.lower < u.upper
+              && (u.lower != min || u.upper != max
+                  || u has children at or above current_level)
+              ==> u.level = generic_level && u.gencopy = v where v is a copy of u
+                  where v.level = current_level && v <= u && u <= v)
+        ) *)
+  let generalize_structure_v : type a.
+      log:_ -> a C.obj -> current_level:int -> a var -> unit =
+   fun ~log dst ~current_level u ->
+    (* if the following does not hold:
+        current_level < u.level || u.level = generic_level
+      [generalize_topology] and [update_level] do nothing. We check it here to optimize
+      away the subsequent checks *)
+    if u.level <= current_level || u.level = generic_level
+    then ()
+    else begin
+      (* we optimize away vlower and vuppers if bounds are tight *)
+      if C.le dst u.upper u.lower
+      then begin
+        set_vlower ~log u VarMap.empty;
+        set_vupper ~log u VarMap.empty
+      end;
+      generalize_topology ~log ~current_level u;
+      update_level_v ~log dst generic_level u;
+      let vlower_above_current =
+        VarMap.filter
+          (fun _ (Amorphvar (v, _, _)) -> v.level >= current_level)
+          u.vlower
+      in
+      let vupper_above_current =
+        VarMap.filter
+          (fun _ (Amorphvar (v, _, _)) -> v.level >= current_level)
+          u.vupper
+      in
+      if C.le dst u.upper u.lower
+      then ()
+      else if
+        C.le dst (C.max dst) u.upper
+        && C.le dst u.lower (C.min dst)
+        && VarMap.is_empty vlower_above_current
+        && VarMap.is_empty vupper_above_current
+      then
+        (* the bounds are fully open *)
+        update_level_v ~log dst current_level u
+      else begin
+        (* we create a copy of the now generalized variable at [current_level] *)
+        create_gencopy ~log dst ~current_level u
+      end
+    end
+
+  let generalize (type a l r) ~current_level (obj : a C.obj)
+      (a : (a, l * r) mode) ~log =
+    match a with
+    | Amodevar (Amorphvar (v, f, _f_hint)) ->
+      let obj = C.src obj f in
+      generalize_v ~log obj ~current_level v
+    | Amode _ -> ()
+    | Amodejoin (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, f, _f_hint)) ->
+          let obj = C.src obj f in
+          generalize_v ~log obj ~current_level v)
+        mvs
+    | Amodemeet (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, f, _f_hint)) ->
+          let obj = C.src obj f in
+          generalize_v ~log obj ~current_level v)
+        mvs
+
+  let generalize_structure (type a l r) ~current_level (obj : a C.obj)
+      (a : (a, l * r) mode) ~log =
+    match a with
+    | Amodevar (Amorphvar (v, f, _f_hint)) ->
+      let obj = C.src obj f in
+      generalize_structure_v ~log obj ~current_level v
+    | Amode _ -> ()
+    | Amodejoin (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, f, _f_hint)) ->
+          let obj = C.src obj f in
+          generalize_structure_v ~log obj ~current_level v)
+        mvs
+    | Amodemeet (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, f, _f_hint)) ->
+          let obj = C.src obj f in
+          generalize_structure_v ~log obj ~current_level v)
+        mvs
 
   let update_level (type a l r) (level : int) (obj : a C.obj)
       (a : (a, l * r) mode) ~log =

--- a/external/merlin/src/ocaml/typing/solver_intf.mli
+++ b/external/merlin/src/ocaml/typing/solver_intf.mli
@@ -238,6 +238,9 @@ module type Solver_mono = sig
   (** The maximum mode in the lattice *)
   val max : 'a obj -> ('a, 'l * 'r) mode
 
+  (** The level of generic variables *)
+  val generic_level : int
+
   (* CR-someday zqian: [zap_*] should take optional hint, pointing to the location in
      the source code where zapping happens *)
 
@@ -293,6 +296,26 @@ module type Solver_mono = sig
   (** Lowers a level of a variable. *)
   val update_level :
     int -> 'a obj -> ('a, 'l * 'r) mode -> log:changes ref option -> unit
+
+  (** Generalizes a variable whose level is above [current_level], by putting
+      its level to [generic_level], and all its children above [current_level]
+      to [generic_level + i] for some nonzero [i]. *)
+  val generalize :
+    current_level:int ->
+    'a obj ->
+    ('a, 'l * 'r) mode ->
+    log:changes ref option ->
+    unit
+
+  (** Generalizes all reachable variables whose level is above [current_level],
+      whose value is fully determined, by putting their level to
+      [generic_level].*)
+  val generalize_structure :
+    current_level:int ->
+    'a obj ->
+    ('a, 'l * 'r) mode ->
+    log:changes ref option ->
+    unit
 
   (** Creates a new mode variable above the given mode and returns [true]. In
       the speical case where the given mode is top, returns the constant top and

--- a/external/merlin/upstream/ocaml_flambda/typing/solver.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/solver.ml
@@ -326,7 +326,11 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
            but not necessarily [v.upper <= f u.upper].
          - for all [f u \in v.vlower] and [g w \in v.vupper] we
            have either [g'f \in w.vlower] or [f'g \in u.vupper]. *)
-      id : int  (** For identification/printing *)
+      id : int;  (** For identification/printing *)
+      mutable gencopy : 'a var option
+          (** Calls to [generalize_structure] creates additional copies to make
+              sure the bounds of a generalize structure is rigid: [gencopy]
+              caches such copies *)
     }
 
   and 'b lmorphvar = ('b, left_only) morphvar
@@ -352,6 +356,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | Cvlower : 'a var * 'a lmorphvar VarMap.t -> change
     | Cvupper : 'a var * 'a rmorphvar VarMap.t -> change
     | Clevel : 'a var * int -> change
+    | Cgencopy : 'a var * 'a var option -> change
 
   type changes = change list
 
@@ -365,6 +370,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | Cvlower (v, vlower) -> v.vlower <- vlower
     | Cvupper (v, vupper) -> v.vupper <- vupper
     | Clevel (v, level) -> v.level <- level
+    | Cgencopy (v, copy) -> v.gencopy <- copy
 
   let empty_changes = []
 
@@ -397,6 +403,9 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
             morphvars have their own hints). *)
     constraint 'd = _ * _
   [@@ocaml.warning "-62"]
+
+  (** Levels *)
+  let generic_level = Ident.highest_scope
 
   (** Prints a mode variable, including the set of variables related to it
       (recursively). To handle cycles, [traversed] is the set of variables that
@@ -678,6 +687,14 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | None -> ()
     | Some log -> log := Cvupper (v, v.vupper) :: !log);
     v.vupper <- vupper
+
+  (** Function used internally by generalize_structure to cache newly created
+      copies *)
+  let set_gencopy ~log v copy =
+    (match log with
+    | None -> ()
+    | Some log -> log := Cgencopy (v, v.gencopy) :: !log);
+    v.gencopy <- copy
 
   (** When called, graph must be fixed so maintain INVARIANT *)
   let set_level ~log v level =
@@ -1219,8 +1236,18 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     in
     let vlower = Option.value vlower ~default:VarMap.empty in
     let vupper = Option.value vupper ~default:VarMap.empty in
+    let gencopy = None in
     let var =
-      { level; upper; upper_hint; lower; lower_hint; vlower; vupper; id }
+      { level;
+        upper;
+        upper_hint;
+        lower;
+        lower_hint;
+        vlower;
+        vupper;
+        id;
+        gencopy
+      }
     in
     vars := id + 1, Var var :: l;
     var
@@ -1246,6 +1273,170 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       right : 'a;
       right_hint : ('a, right_only) hint_raw
     }
+
+  (* Moves every reachable variable from [u] such that
+  [current_level] < [u.level] < [generic_level] to
+  [generic_level + (u.level - current_level)], preserving the exact topology
+
+  PRECONDITIONS: None
+  POSTCONDITIONS:
+    current_level < u.level < generic_level ==>
+      Forall v in the reachable set of variables from u:
+        v.level = generic_level + (v.level - current_level) *)
+  let rec generalize_topology : type a.
+      log:_ -> current_level:int -> a var -> unit =
+   fun ~log ~current_level u ->
+    if u.level <= current_level || u.level >= generic_level
+    then ()
+    else begin
+      let new_level = generic_level + (u.level - current_level) in
+      set_level ~log u new_level;
+      let do_gen _ (Amorphvar (v, _f, _f_hint)) =
+        generalize_topology ~log ~current_level v
+      in
+      VarMap.iter do_gen u.vupper;
+      VarMap.iter do_gen u.vlower
+    end
+
+  (* creates a copy of the variable [u] such that [u] < [copy] and [copy] < [u] via
+  submode, and lowers the [copy] to [current_level].
+  The [copy] is cached in the [gencopy] of [u] *)
+  let create_gencopy : type a.
+      log:_ -> a C.obj -> current_level:int -> a var -> unit =
+   fun ~log dst ~current_level u ->
+    (* If bounds are already tight, there is no need to create a copy *)
+    if (not (C.le dst u.upper u.lower)) && u.level = generic_level
+    then begin
+      let copy = fresh ~upper:u.upper ~lower:u.lower ~level:current_level dst in
+      let ok1 =
+        submode_mvmv ~log H.Pinpoint.unknown dst
+          (Amorphvar (copy, C.id, Comp_hint.Morph_hint.Id))
+          (Amorphvar (u, C.id, Comp_hint.Morph_hint.Id))
+      in
+      let ok2 =
+        submode_mvmv ~log H.Pinpoint.unknown dst
+          (Amorphvar (u, C.id, Comp_hint.Morph_hint.Id))
+          (Amorphvar (copy, C.id, Comp_hint.Morph_hint.Id))
+      in
+      assert (Result.is_ok ok1 && Result.is_ok ok2);
+      set_gencopy ~log copy u.gencopy;
+      set_gencopy ~log u (Some copy)
+    end
+
+  let generalize_v : type a.
+      log:_ -> a C.obj -> current_level:int -> a var -> unit =
+   fun ~log dst ~current_level u ->
+    generalize_topology ~log ~current_level u;
+    update_level_v ~log dst generic_level u
+
+  (* generalize_structure first moves a variable to generic_level (like generalize does).
+     It then has three cases:
+    (1) if bounds are tight, leave it as is
+    (2) if bounds are fully open --- by virtue of having no
+        vupper/vlower at or above the current level, and fully open
+        conservative bounds --- we move it to current level
+    (3) if bounds are non-trivial (neither tight nor fully open) we make a copy, keep the
+        original var at generic_level, and mark the two variables as equivalent by adding
+        constraint arrows via [add_vlower] and [add_vupper]
+
+    PRECONDITIONS: None
+    POSTCONDITIONS:
+      u.level <= current_level ==> no changes to u
+      current_level < u.level ==>
+        ( (u.upper <= u.lower
+              ==> u.vlower = Ø && u.vupper = Ø && u.level = generic_level)
+          && (u.lower = min && u.upper = max
+              && u does not have children at or above current_level
+              ==> u.level = current_level)
+          && (u.lower < u.upper
+              && (u.lower != min || u.upper != max
+                  || u has children at or above current_level)
+              ==> u.level = generic_level && u.gencopy = v where v is a copy of u
+                  where v.level = current_level && v <= u && u <= v)
+        ) *)
+  let generalize_structure_v : type a.
+      log:_ -> a C.obj -> current_level:int -> a var -> unit =
+   fun ~log dst ~current_level u ->
+    (* if the following does not hold:
+        current_level < u.level || u.level = generic_level
+      [generalize_topology] and [update_level] do nothing. We check it here to optimize
+      away the subsequent checks *)
+    if u.level <= current_level || u.level = generic_level
+    then ()
+    else begin
+      (* we optimize away vlower and vuppers if bounds are tight *)
+      if C.le dst u.upper u.lower
+      then begin
+        set_vlower ~log u VarMap.empty;
+        set_vupper ~log u VarMap.empty
+      end;
+      generalize_topology ~log ~current_level u;
+      update_level_v ~log dst generic_level u;
+      let vlower_above_current =
+        VarMap.filter
+          (fun _ (Amorphvar (v, _, _)) -> v.level >= current_level)
+          u.vlower
+      in
+      let vupper_above_current =
+        VarMap.filter
+          (fun _ (Amorphvar (v, _, _)) -> v.level >= current_level)
+          u.vupper
+      in
+      if C.le dst u.upper u.lower
+      then ()
+      else if
+        C.le dst (C.max dst) u.upper
+        && C.le dst u.lower (C.min dst)
+        && VarMap.is_empty vlower_above_current
+        && VarMap.is_empty vupper_above_current
+      then
+        (* the bounds are fully open *)
+        update_level_v ~log dst current_level u
+      else begin
+        (* we create a copy of the now generalized variable at [current_level] *)
+        create_gencopy ~log dst ~current_level u
+      end
+    end
+
+  let generalize (type a l r) ~current_level (obj : a C.obj)
+      (a : (a, l * r) mode) ~log =
+    match a with
+    | Amodevar (Amorphvar (v, f, _f_hint)) ->
+      let obj = C.src obj f in
+      generalize_v ~log obj ~current_level v
+    | Amode _ -> ()
+    | Amodejoin (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, f, _f_hint)) ->
+          let obj = C.src obj f in
+          generalize_v ~log obj ~current_level v)
+        mvs
+    | Amodemeet (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, f, _f_hint)) ->
+          let obj = C.src obj f in
+          generalize_v ~log obj ~current_level v)
+        mvs
+
+  let generalize_structure (type a l r) ~current_level (obj : a C.obj)
+      (a : (a, l * r) mode) ~log =
+    match a with
+    | Amodevar (Amorphvar (v, f, _f_hint)) ->
+      let obj = C.src obj f in
+      generalize_structure_v ~log obj ~current_level v
+    | Amode _ -> ()
+    | Amodejoin (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, f, _f_hint)) ->
+          let obj = C.src obj f in
+          generalize_structure_v ~log obj ~current_level v)
+        mvs
+    | Amodemeet (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, f, _f_hint)) ->
+          let obj = C.src obj f in
+          generalize_structure_v ~log obj ~current_level v)
+        mvs
 
   let update_level (type a l r) (level : int) (obj : a C.obj)
       (a : (a, l * r) mode) ~log =

--- a/external/merlin/upstream/ocaml_flambda/typing/solver_intf.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/solver_intf.mli
@@ -238,6 +238,9 @@ module type Solver_mono = sig
   (** The maximum mode in the lattice *)
   val max : 'a obj -> ('a, 'l * 'r) mode
 
+  (** The level of generic variables *)
+  val generic_level : int
+
   (* CR-someday zqian: [zap_*] should take optional hint, pointing to the location in
      the source code where zapping happens *)
 
@@ -293,6 +296,26 @@ module type Solver_mono = sig
   (** Lowers a level of a variable. *)
   val update_level :
     int -> 'a obj -> ('a, 'l * 'r) mode -> log:changes ref option -> unit
+
+  (** Generalizes a variable whose level is above [current_level], by putting
+      its level to [generic_level], and all its children above [current_level]
+      to [generic_level + i] for some nonzero [i]. *)
+  val generalize :
+    current_level:int ->
+    'a obj ->
+    ('a, 'l * 'r) mode ->
+    log:changes ref option ->
+    unit
+
+  (** Generalizes all reachable variables whose level is above [current_level],
+      whose value is fully determined, by putting their level to
+      [generic_level].*)
+  val generalize_structure :
+    current_level:int ->
+    'a obj ->
+    ('a, 'l * 'r) mode ->
+    log:changes ref option ->
+    unit
 
   (** Creates a new mode variable above the given mode and returns [true]. In
       the speical case where the given mode is top, returns the constant top and

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -1302,23 +1302,19 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     (* If bounds are already tight, there is no need to create a copy *)
     if not (C.le dst u.upper u.lower)
     then begin
-      match u.gencopy with
-      | Some _ -> ()
-      | None ->
-        let copy = fresh ~upper:u.upper ~lower:u.lower ~level:u.level dst in
-        let ok1 =
-          submode_mvmv ~log H.Pinpoint.unknown dst
-            (Amorphvar (copy, C.id, Comp_hint.Morph_hint.Id))
-            (Amorphvar (u, C.id, Comp_hint.Morph_hint.Id))
-        in
-        let ok2 =
-          submode_mvmv ~log H.Pinpoint.unknown dst
-            (Amorphvar (u, C.id, Comp_hint.Morph_hint.Id))
-            (Amorphvar (copy, C.id, Comp_hint.Morph_hint.Id))
-        in
-        assert (Result.is_ok ok1 && Result.is_ok ok2);
-        update_level_v ~log dst current_level copy;
-        set_gencopy ~log u (Some copy)
+      let copy = fresh ~upper:u.upper ~lower:u.lower ~level:current_level dst in
+      let ok1 =
+        submode_mvmv ~log H.Pinpoint.unknown dst
+          (Amorphvar (copy, C.id, Comp_hint.Morph_hint.Id))
+          (Amorphvar (u, C.id, Comp_hint.Morph_hint.Id))
+      in
+      let ok2 =
+        submode_mvmv ~log H.Pinpoint.unknown dst
+          (Amorphvar (u, C.id, Comp_hint.Morph_hint.Id))
+          (Amorphvar (copy, C.id, Comp_hint.Morph_hint.Id))
+      in
+      assert (Result.is_ok ok1 && Result.is_ok ok2);
+      set_gencopy ~log u (Some copy)
     end
 
   let generalize_v : type a.

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -326,7 +326,11 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
            but not necessarily [v.upper <= f u.upper].
          - for all [f u \in v.vlower] and [g w \in v.vupper] we
            have either [g'f \in w.vlower] or [f'g \in u.vupper]. *)
-      id : int  (** For identification/printing *)
+      id : int;  (** For identification/printing *)
+      mutable gencopy : 'a var option
+          (** Calls to [generalize_structure] creates additional copies to make
+              sure the bounds of a generalize structure is rigid: [gencopy]
+              caches such copies *)
     }
 
   and 'b lmorphvar = ('b, left_only) morphvar
@@ -352,6 +356,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | Cvlower : 'a var * 'a lmorphvar VarMap.t -> change
     | Cvupper : 'a var * 'a rmorphvar VarMap.t -> change
     | Clevel : 'a var * int -> change
+    | Cgencopy : 'a var * 'a var option -> change
 
   type changes = change list
 
@@ -365,6 +370,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | Cvlower (v, vlower) -> v.vlower <- vlower
     | Cvupper (v, vupper) -> v.vupper <- vupper
     | Clevel (v, level) -> v.level <- level
+    | Cgencopy (v, copy) -> v.gencopy <- copy
 
   let empty_changes = []
 
@@ -397,6 +403,9 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
             morphvars have their own hints). *)
     constraint 'd = _ * _
   [@@ocaml.warning "-62"]
+
+  (** Levels *)
+  let generic_level = Ident.highest_scope
 
   (** Prints a mode variable, including the set of variables related to it
       (recursively). To handle cycles, [traversed] is the set of variables that
@@ -678,6 +687,14 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | None -> ()
     | Some log -> log := Cvupper (v, v.vupper) :: !log);
     v.vupper <- vupper
+
+  (** Function used internally by generalize_structure to cache newly created
+      copies *)
+  let set_gencopy ~log v copy =
+    (match log with
+    | None -> ()
+    | Some log -> log := Cgencopy (v, v.gencopy) :: !log);
+    v.gencopy <- copy
 
   (** When called, graph must be fixed so maintain INVARIANT *)
   let set_level ~log v level =
@@ -1219,8 +1236,18 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     in
     let vlower = Option.value vlower ~default:VarMap.empty in
     let vupper = Option.value vupper ~default:VarMap.empty in
+    let gencopy = None in
     let var =
-      { level; upper; upper_hint; lower; lower_hint; vlower; vupper; id }
+      { level;
+        upper;
+        upper_hint;
+        lower;
+        lower_hint;
+        vlower;
+        vupper;
+        id;
+        gencopy
+      }
     in
     vars := id + 1, Var var :: l;
     var
@@ -1246,6 +1273,130 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       right : 'a;
       right_hint : ('a, right_only) hint_raw
     }
+
+  (* Moves every reachable variable from [u] such that
+  [current_level] < [u.level] < [generic_level] to
+  [generic_level + (u.level - current_level)], preserving the exact topology *)
+  let rec generalize_topology : type a.
+      log:_ -> a C.obj -> current_level:int -> a var -> unit =
+   fun ~log dst ~current_level u ->
+    if u.level <= current_level || u.level >= generic_level
+    then ()
+    else begin
+      let new_level = generic_level + (u.level - current_level) in
+      set_level ~log u new_level;
+      let do_gen _ (Amorphvar (v, f, _f_hint)) =
+        let src = C.src dst f in
+        generalize_topology ~log src ~current_level v
+      in
+      VarMap.iter do_gen u.vupper;
+      VarMap.iter do_gen u.vlower
+    end
+
+  (* creates a copy of the variable [u] such that [u] < [copy] and [copy] < [u] via
+  submode, and lowers the [copy] to [current_level].
+  The [copy] is cached in the [gencopy] of [u] *)
+  let create_gencopy : type a.
+      log:_ -> a C.obj -> current_level:int -> a var -> unit =
+   fun ~log dst ~current_level u ->
+    (* If bounds are already tight, there is no need to create a copy *)
+    if not (C.le dst u.upper u.lower)
+    then begin
+      match u.gencopy with
+      | Some _ -> ()
+      | None ->
+        let copy = fresh ~upper:u.upper ~lower:u.lower ~level:u.level dst in
+        let ok1 =
+          submode_mvmv ~log H.Pinpoint.unknown dst
+            (Amorphvar (copy, C.id, Comp_hint.Morph_hint.Id))
+            (Amorphvar (u, C.id, Comp_hint.Morph_hint.Id))
+        in
+        let ok2 =
+          submode_mvmv ~log H.Pinpoint.unknown dst
+            (Amorphvar (u, C.id, Comp_hint.Morph_hint.Id))
+            (Amorphvar (copy, C.id, Comp_hint.Morph_hint.Id))
+        in
+        assert (Result.is_ok ok1 && Result.is_ok ok2);
+        update_level_v ~log dst current_level copy;
+        set_gencopy ~log u (Some copy)
+    end
+
+  let generalize_v : type a.
+      log:_ -> a C.obj -> current_level:int -> a var -> unit =
+   fun ~log dst ~current_level u ->
+    generalize_topology ~log dst ~current_level u;
+    update_level_v ~log dst generic_level u
+
+  (* generalize_structure has three cases:
+    (1) if bounds are tight, the var is moved to generic_level
+    (2) if bounds are fully open, do nothing --- we consider only the case where bounds
+        are precise by virtue of having no vupper/vlower
+    (3) if bounds are non-trivial (neither tight nor fully open) we make a copy, move the
+        original var to generic_level, and mark the two variables as equivalent by adding
+        constraint arrows via [add_vlower] and [add_vupper]
+  *)
+  let generalize_structure_v : type a.
+      log:_ -> a C.obj -> current_level:int -> a var -> unit =
+   fun ~log dst ~current_level u ->
+    if C.le dst u.upper u.lower
+    then begin
+      (* the bounds are tight *)
+      generalize_topology ~log dst ~current_level u;
+      update_level_v ~log dst generic_level u
+    end
+    else if
+      C.le dst (C.max dst) u.upper
+      && C.le dst u.lower (C.min dst)
+      && VarMap.is_empty u.vlower && VarMap.is_empty u.vupper
+    then
+      (* the bounds are fully open *)
+      update_level_v ~log dst current_level u
+    else begin
+      (* the bounds are non-trivial *)
+      generalize_topology ~log dst ~current_level u;
+      update_level_v ~log dst generic_level u;
+      create_gencopy ~log dst ~current_level u
+    end
+
+  let generalize (type a l r) ~current_level (obj : a C.obj)
+      (a : (a, l * r) mode) ~log =
+    match a with
+    | Amodevar (Amorphvar (v, f, _f_hint)) ->
+      let obj = C.src obj f in
+      generalize_v ~log obj ~current_level v
+    | Amode _ -> ()
+    | Amodejoin (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, f, _f_hint)) ->
+          let obj = C.src obj f in
+          generalize_v ~log obj ~current_level v)
+        mvs
+    | Amodemeet (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, f, _f_hint)) ->
+          let obj = C.src obj f in
+          generalize_v ~log obj ~current_level v)
+        mvs
+
+  let generalize_structure (type a l r) ~current_level (obj : a C.obj)
+      (a : (a, l * r) mode) ~log =
+    match a with
+    | Amodevar (Amorphvar (v, f, _f_hint)) ->
+      let obj = C.src obj f in
+      generalize_structure_v ~log obj ~current_level v
+    | Amode _ -> ()
+    | Amodejoin (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, f, _f_hint)) ->
+          let obj = C.src obj f in
+          generalize_structure_v ~log obj ~current_level v)
+        mvs
+    | Amodemeet (_, _, mvs) ->
+      VarMap.iter
+        (fun _ (Amorphvar (v, f, _f_hint)) ->
+          let obj = C.src obj f in
+          generalize_structure_v ~log obj ~current_level v)
+        mvs
 
   let update_level (type a l r) (level : int) (obj : a C.obj)
       (a : (a, l * r) mode) ~log =

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -1276,18 +1276,23 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
 
   (* Moves every reachable variable from [u] such that
   [current_level] < [u.level] < [generic_level] to
-  [generic_level + (u.level - current_level)], preserving the exact topology *)
+  [generic_level + (u.level - current_level)], preserving the exact topology
+
+  PRECONDITIONS: None
+  POSTCONDITIONS:
+    current_level < u.level < generic_level ==>
+      Forall v in the reachable set of variables from u:
+        v.level = generic_level + (v.level - current_level) *)
   let rec generalize_topology : type a.
-      log:_ -> a C.obj -> current_level:int -> a var -> unit =
-   fun ~log dst ~current_level u ->
+      log:_ -> current_level:int -> a var -> unit =
+   fun ~log ~current_level u ->
     if u.level <= current_level || u.level >= generic_level
     then ()
     else begin
       let new_level = generic_level + (u.level - current_level) in
       set_level ~log u new_level;
-      let do_gen _ (Amorphvar (v, f, _f_hint)) =
-        let src = C.src dst f in
-        generalize_topology ~log src ~current_level v
+      let do_gen _ (Amorphvar (v, _f, _f_hint)) =
+        generalize_topology ~log ~current_level v
       in
       VarMap.iter do_gen u.vupper;
       VarMap.iter do_gen u.vlower
@@ -1321,55 +1326,75 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let generalize_v : type a.
       log:_ -> a C.obj -> current_level:int -> a var -> unit =
    fun ~log dst ~current_level u ->
-    generalize_topology ~log dst ~current_level u;
+    generalize_topology ~log ~current_level u;
     update_level_v ~log dst generic_level u
 
-  (* generalize_structure first moves a variable generic_level.
+  (* generalize_structure first moves a variable to generic_level (like generalize does).
      It then has three cases:
     (1) if bounds are tight, leave it as is
     (2) if bounds are fully open --- by virtue of having no
         vupper/vlower at or above the current level, and fully open
         conservative bounds --- we move it to current level
-    (3) if bounds are non-trivial (neither tight nor fully open) we make a copy, move the
-        original var to generic_level, and mark the two variables as equivalent by adding
+    (3) if bounds are non-trivial (neither tight nor fully open) we make a copy, keep the
+        original var at generic_level, and mark the two variables as equivalent by adding
         constraint arrows via [add_vlower] and [add_vupper]
-  *)
+
+    PRECONDITIONS: None
+    POSTCONDITIONS:
+      u.level <= current_level ==> no changes to u
+      current_level < u.level ==>
+        ( (u.upper <= u.lower
+              ==> u.vlower = Ø && u.vupper = Ø && u.level = generic_level)
+          && (u.lower = min && u.upper = max
+              && u does not have children at or above current_level
+              ==> u.level = current_level)
+          && (u.lower < u.upper
+              && (u.lower != min || u.upper != max
+                  || u has children at or above current_level)
+              ==> u.level = generic_level && u.gencopy = v where v is a copy of u
+                  where v.level = current_level && v <= u && u <= v)
+        ) *)
   let generalize_structure_v : type a.
       log:_ -> a C.obj -> current_level:int -> a var -> unit =
    fun ~log dst ~current_level u ->
-    (* we optimize away vlower and vuppers if bounds are tight *)
-    if C.le dst u.upper u.lower
-    then begin
-      set_vlower ~log u VarMap.empty;
-      set_vupper ~log u VarMap.empty
-    end;
-    let old_level = u.level in
-    generalize_topology ~log dst ~current_level u;
-    update_level_v ~log dst generic_level u;
-    let vlower_above_current =
-      VarMap.filter
-        (fun _ (Amorphvar (v, _, _)) -> v.level >= current_level)
-        u.vlower
-    in
-    let vupper_above_current =
-      VarMap.filter
-        (fun _ (Amorphvar (v, _, _)) -> v.level >= current_level)
-        u.vupper
-    in
-    if C.le dst u.upper u.lower
+    (* if the following does not hold: current_level < u.level
+      [generalize_topology] and [update_level] do nothing. We check it here to optimize
+      away the subsequent checks *)
+    if u.level <= current_level
     then ()
-    else if
-      C.le dst (C.max dst) u.upper
-      && C.le dst u.lower (C.min dst)
-      && VarMap.is_empty vlower_above_current
-      && VarMap.is_empty vupper_above_current
-    then
-      (* the bounds are fully open *)
-      update_level_v ~log dst current_level u
-    else if old_level <> generic_level && u.level = generic_level
-    then begin
-      (* we only create a copy if the variable was generalized *)
-      create_gencopy ~log dst ~current_level u
+    else begin
+      (* we optimize away vlower and vuppers if bounds are tight *)
+      if C.le dst u.upper u.lower
+      then begin
+        set_vlower ~log u VarMap.empty;
+        set_vupper ~log u VarMap.empty
+      end;
+      generalize_topology ~log ~current_level u;
+      update_level_v ~log dst generic_level u;
+      let vlower_above_current =
+        VarMap.filter
+          (fun _ (Amorphvar (v, _, _)) -> v.level >= current_level)
+          u.vlower
+      in
+      let vupper_above_current =
+        VarMap.filter
+          (fun _ (Amorphvar (v, _, _)) -> v.level >= current_level)
+          u.vupper
+      in
+      if C.le dst u.upper u.lower
+      then ()
+      else if
+        C.le dst (C.max dst) u.upper
+        && C.le dst u.lower (C.min dst)
+        && VarMap.is_empty vlower_above_current
+        && VarMap.is_empty vupper_above_current
+      then
+        (* the bounds are fully open *)
+        update_level_v ~log dst current_level u
+      else begin
+        (* we create a copy of the now generalized variable at [current_level] *)
+        create_gencopy ~log dst ~current_level u
+      end
     end
 
   let generalize (type a l r) ~current_level (obj : a C.obj)

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -1324,10 +1324,12 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     generalize_topology ~log dst ~current_level u;
     update_level_v ~log dst generic_level u
 
-  (* generalize_structure has three cases:
-    (1) if bounds are tight, the var is moved to generic_level
-    (2) if bounds are fully open, do nothing --- we consider only the case where bounds
-        are precise by virtue of having no vupper/vlower
+  (* generalize_structure first moves a variable generic_level.
+     It then has three cases:
+    (1) if bounds are tight, leave it as is
+    (2) if bounds are fully open --- by virtue of having no
+        vupper/vlower at or above the current level, and fully open
+        conservative bounds --- we move it to current level
     (3) if bounds are non-trivial (neither tight nor fully open) we make a copy, move the
         original var to generic_level, and mark the two variables as equivalent by adding
         constraint arrows via [add_vlower] and [add_vupper]
@@ -1335,28 +1337,39 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let generalize_structure_v : type a.
       log:_ -> a C.obj -> current_level:int -> a var -> unit =
    fun ~log dst ~current_level u ->
+    (* we optimize away vlower and vuppers if bounds are tight *)
     if C.le dst u.upper u.lower
     then begin
-      (* the bounds are tight *)
-      generalize_topology ~log dst ~current_level u;
-      update_level_v ~log dst generic_level u
-    end
+      set_vlower ~log u VarMap.empty;
+      set_vupper ~log u VarMap.empty
+    end;
+    let old_level = u.level in
+    generalize_topology ~log dst ~current_level u;
+    update_level_v ~log dst generic_level u;
+    let vlower_above_current =
+      VarMap.filter
+        (fun _ (Amorphvar (v, _, _)) -> v.level >= current_level)
+        u.vlower
+    in
+    let vupper_above_current =
+      VarMap.filter
+        (fun _ (Amorphvar (v, _, _)) -> v.level >= current_level)
+        u.vupper
+    in
+    if C.le dst u.upper u.lower
+    then ()
     else if
       C.le dst (C.max dst) u.upper
       && C.le dst u.lower (C.min dst)
-      && VarMap.is_empty u.vlower && VarMap.is_empty u.vupper
+      && VarMap.is_empty vlower_above_current
+      && VarMap.is_empty vupper_above_current
     then
       (* the bounds are fully open *)
       update_level_v ~log dst current_level u
-    else begin
-      (* the bounds are non-trivial *)
-      let old_level = u.level in
-      generalize_topology ~log dst ~current_level u;
-      update_level_v ~log dst generic_level u;
-      if old_level > current_level && old_level < generic_level
-      then begin
-        create_gencopy ~log dst ~current_level u
-      end
+    else if old_level <> generic_level && u.level = generic_level
+    then begin
+      (* we only create a copy if the variable was generalized *)
+      create_gencopy ~log dst ~current_level u
     end
 
   let generalize (type a l r) ~current_level (obj : a C.obj)

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -1357,10 +1357,11 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   let generalize_structure_v : type a.
       log:_ -> a C.obj -> current_level:int -> a var -> unit =
    fun ~log dst ~current_level u ->
-    (* if the following does not hold: current_level < u.level
+    (* if the following does not hold:
+        current_level < u.level || u.level = generic_level
       [generalize_topology] and [update_level] do nothing. We check it here to optimize
       away the subsequent checks *)
-    if u.level <= current_level
+    if u.level <= current_level || u.level = generic_level
     then ()
     else begin
       (* we optimize away vlower and vuppers if bounds are tight *)

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -1300,7 +1300,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       log:_ -> a C.obj -> current_level:int -> a var -> unit =
    fun ~log dst ~current_level u ->
     (* If bounds are already tight, there is no need to create a copy *)
-    if not (C.le dst u.upper u.lower)
+    if (not (C.le dst u.upper u.lower)) && u.level = generic_level
     then begin
       let copy = fresh ~upper:u.upper ~lower:u.lower ~level:current_level dst in
       let ok1 =
@@ -1314,6 +1314,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           (Amorphvar (copy, C.id, Comp_hint.Morph_hint.Id))
       in
       assert (Result.is_ok ok1 && Result.is_ok ok2);
+      set_gencopy ~log copy u.gencopy;
       set_gencopy ~log u (Some copy)
     end
 
@@ -1349,9 +1350,13 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       update_level_v ~log dst current_level u
     else begin
       (* the bounds are non-trivial *)
+      let old_level = u.level in
       generalize_topology ~log dst ~current_level u;
       update_level_v ~log dst generic_level u;
-      create_gencopy ~log dst ~current_level u
+      if old_level > current_level && old_level < generic_level
+      then begin
+        create_gencopy ~log dst ~current_level u
+      end
     end
 
   let generalize (type a l r) ~current_level (obj : a C.obj)

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -229,8 +229,7 @@ module type Solver_mono = sig
   (* CR-soon zqian: [to_const_exn] should return hints as well. *)
 
   (** Given a mode whose lower and upper bounds are equal, returns that bound.
-      Raises exception if the condition does not hold, or if the variable is
-      generic *)
+      Raises exception if the condition does not hold. *)
   val to_const_exn : 'a obj -> ('a, allowed * allowed) mode -> 'a
 
   (** The minimum mode in the lattice *)
@@ -298,8 +297,9 @@ module type Solver_mono = sig
   val update_level :
     int -> 'a obj -> ('a, 'l * 'r) mode -> log:changes ref option -> unit
 
-  (** Generalizes all reachable variables whose level is above [current_level],
-      by putting their level to [generic_level]. *)
+  (** Generalizes a variable whose level is above [current_level], by putting
+      its level to [generic_level], and all its children above [current_level]
+      to [generic_level + i] for some nonzero [i]. *)
   val generalize :
     current_level:int ->
     'a obj ->

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -229,7 +229,8 @@ module type Solver_mono = sig
   (* CR-soon zqian: [to_const_exn] should return hints as well. *)
 
   (** Given a mode whose lower and upper bounds are equal, returns that bound.
-      Raises exception if the condition does not hold. *)
+      Raises exception if the condition does not hold, or if the variable is
+      generic *)
   val to_const_exn : 'a obj -> ('a, allowed * allowed) mode -> 'a
 
   (** The minimum mode in the lattice *)
@@ -237,6 +238,9 @@ module type Solver_mono = sig
 
   (** The maximum mode in the lattice *)
   val max : 'a obj -> ('a, 'l * 'r) mode
+
+  (** The level of generic variables *)
+  val generic_level : int
 
   (* CR-someday zqian: [zap_*] should take optional hint, pointing to the location in
      the source code where zapping happens *)
@@ -293,6 +297,25 @@ module type Solver_mono = sig
   (** Lowers a level of a variable. *)
   val update_level :
     int -> 'a obj -> ('a, 'l * 'r) mode -> log:changes ref option -> unit
+
+  (** Generalizes all reachable variables whose level is above [current_level],
+      by putting their level to [generic_level]. *)
+  val generalize :
+    current_level:int ->
+    'a obj ->
+    ('a, 'l * 'r) mode ->
+    log:changes ref option ->
+    unit
+
+  (** Generalizes all reachable variables whose level is above [current_level],
+      whose value is fully determined, by putting their level to
+      [generic_level].*)
+  val generalize_structure :
+    current_level:int ->
+    'a obj ->
+    ('a, 'l * 'r) mode ->
+    log:changes ref option ->
+    unit
 
   (** Creates a new mode variable above the given mode and returns [true]. In
       the speical case where the given mode is top, returns the constant top and


### PR DESCRIPTION
Added the `generalize` and `generalize_structure` operations, which takes all mode variables above the current level and sets them to the general level. 

We apply a "garbage collection" strategy where we first move a mode variable and all its children to `generic level + i` (where `i` is the difference between the current level and the mode variable's level), and then update the head mode variable to `generic level`. 

We implement `generalize` and `generalize_structure`, where the latter additionally creates a copy of the mode variable at `current level`, whose bounds will be flexible as opposed to the rigid bounds of the generalized variable. We remember this copy in a `gencopy` field which we can use down the line to optimize instantiation.
