### PR TITLE
Copy operation

### DIFF
--- a/external/merlin/src/ocaml/typing/solver.ml
+++ b/external/merlin/src/ocaml/typing/solver.ml
@@ -327,6 +327,9 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
          - for all [f u \in v.vlower] and [g w \in v.vupper] we
            have either [g'f \in w.vlower] or [f'g \in u.vupper]. *)
       id : int;  (** For identification/printing *)
+      mutable subst : 'a var option;
+          (** Similar to Tsubst in a type, the [subst] field holds an optional
+              copy used during instantiation *)
       mutable gencopy : 'a var option
           (** Calls to [generalize_structure] creates additional copies to make
               sure the bounds of a generalize structure is rigid: [gencopy]
@@ -379,6 +382,11 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   (** [append_changes l0 l1] returns a log that's equivalent to [l0] followed by
       [l1]. *)
   let append_changes l0 l1 = l1 @ l0
+
+  type copy_change =
+    | Coptcopy : 'a C.obj * int * 'a var * 'a var option -> copy_change
+
+  type copy_scope = { mutable saved_copies : copy_change list }
 
   type ('a, 'd) mode =
     | Amode :
@@ -687,6 +695,14 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | None -> ()
     | Some log -> log := Cvupper (v, v.vupper) :: !log);
     v.vupper <- vupper
+
+  (** Function used internally by copy, where [changes] maintains the cleanup
+      once the copy is done. Unlike other setters, the [changes] is here
+      mandatory *)
+  let set_optcopy ~changes obj ~target_level v copy =
+    changes.saved_copies
+      <- Coptcopy (obj, target_level, v, v.subst) :: changes.saved_copies;
+    v.subst <- copy
 
   (** Function used internally by generalize_structure to cache newly created
       copies *)
@@ -1216,10 +1232,30 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       update_level_finalize ~log dst level u
     end
 
-  let vars = ref (0, [])
+  let vars = ref []
 
-  let fresh ?upper ?upper_hint ?lower ?lower_hint ?vlower ?vupper ~level obj =
-    let id, l = !vars in
+  let live_id = ref 0
+
+  let next_live_id () =
+    let id = !live_id in
+    incr live_id;
+    id
+
+  (* Ids for persistent copies of variables (as stored in cmi files).
+     This mirrors [Subst.new_type_id] for types. *)
+  let persistent_id = ref (-1)
+
+  (* Resets the counter for persistent copies *)
+  let reset_persistent_id () = persistent_id := -1
+
+  let next_persistent_id () =
+    let id = !persistent_id in
+    decr persistent_id;
+    id
+
+  let fresh ?(persistent = false) ?upper ?upper_hint ?lower ?lower_hint ?vlower
+      ?vupper ~level obj =
+    let id = if persistent then next_persistent_id () else next_live_id () in
     let upper, upper_hint =
       match upper, upper_hint with
       | None, None -> C.max obj, Comp_hint.Max
@@ -1237,6 +1273,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     let vlower = Option.value vlower ~default:VarMap.empty in
     let vupper = Option.value vupper ~default:VarMap.empty in
     let gencopy = None in
+    let subst = None in
     let var =
       { level;
         upper;
@@ -1246,10 +1283,11 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         vlower;
         vupper;
         id;
-        gencopy
+        gencopy;
+        subst
       }
     in
-    vars := id + 1, Var var :: l;
+    vars := Var var :: !vars;
     var
 
   let unhint_morphvar (Amorphvar (v, f, _)) =
@@ -1261,9 +1299,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     v.vlower <- VarMap.map unhint_morphvar v.vlower;
     v.vupper <- VarMap.map unhint_morphvar v.vupper
 
-  let erase_hints () =
-    let _, l = !vars in
-    List.iter (fun (Var v) -> unhint_var v) l
+  let erase_hints () = List.iter (fun (Var v) -> unhint_var v) !vars
 
   type ('a, 'd) hint_raw = ('a, 'd) Comp_hint.t
 
@@ -1437,6 +1473,139 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           let obj = C.src obj f in
           generalize_structure_v ~log obj ~current_level v)
         mvs
+
+  let fresh_mode_copy_scope () = { saved_copies = [] }
+
+  let undo_copy_change = function
+    | Coptcopy (dst, update_to_level, v, copy) ->
+      Option.iter
+        (fun u -> update_level_finalize ~log:None dst update_to_level u)
+        v.subst;
+      v.subst <- copy
+
+  let cleanup_mode_copy_scope l = List.iter undo_copy_change l.saved_copies
+
+  let with_copy_scope f =
+    let scope = fresh_mode_copy_scope () in
+    Fun.protect
+      ~finally:(fun () -> cleanup_mode_copy_scope scope)
+      (fun () -> f scope)
+
+  let rec trace_gencopy ~target_level v =
+    match v.gencopy with
+    | None -> None
+    | Some v' when v'.level = target_level -> Some v'
+    | Some v' -> trace_gencopy ~target_level v'
+
+  let rec copy_v : type a.
+      copy_scope:_ ->
+      copy_from_level:int ->
+      copy_below_level:int ->
+      copy_to_level:int option ->
+      persistent:bool ->
+      a C.obj ->
+      a var ->
+      a var =
+   fun ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level ~persistent
+       obj v ->
+    let in_window = v.level >= copy_from_level && v.level < copy_below_level in
+    if not in_window
+    then v
+    else
+      (* generalize_structure might have already created a copy, cached in [gencopy].
+         If such a copy exist, we return it *)
+      let target_level = Option.value copy_to_level ~default:v.level in
+      let gencopy = trace_gencopy ~target_level v in
+      begin match gencopy with
+      | Some v' -> v'
+      | None -> (
+        match v.subst with
+        | Some v' -> v'
+        | None ->
+          let copy =
+            fresh ~persistent ~upper:v.upper ~lower:v.lower ~level:v.level obj
+          in
+          set_optcopy ~changes:copy_scope obj ~target_level v (Some copy);
+          let vupper =
+            VarMap.fold
+              (fun _ (Amorphvar (u, f, f_hint)) acc ->
+                let src = C.src obj f in
+                let ucopy =
+                  copy_v ~copy_scope ~copy_from_level ~copy_below_level
+                    ~copy_to_level ~persistent src u
+                in
+                let x = Amorphvar (ucopy, f, f_hint) in
+                VarMap.add (get_key obj x) x acc)
+              v.vupper VarMap.empty
+          in
+          let vlower =
+            VarMap.fold
+              (fun _ (Amorphvar (u, f, f_hint)) acc ->
+                let src = C.src obj f in
+                let ucopy =
+                  copy_v ~copy_scope ~copy_from_level ~copy_below_level
+                    ~copy_to_level ~persistent src u
+                in
+                let x = Amorphvar (ucopy, f, f_hint) in
+                VarMap.add (get_key obj x) x acc)
+              v.vlower VarMap.empty
+          in
+          copy.vupper <- vupper;
+          copy.vlower <- vlower;
+          set_level ~log:None copy target_level;
+          copy)
+      end
+
+  let copy (type a l r) ~copy_scope ~copy_from_level ~copy_below_level
+      ?copy_to_level ?(persistent = false) (obj : a C.obj) (a : (a, l * r) mode)
+      : (a, l * r) mode =
+    (* We never want to copy variables above [generic_level]. *)
+    assert (copy_below_level <= generic_level + 1);
+    Option.iter
+      (fun l ->
+        (* If we copy to a specific level, the copy window must be size 1 to
+       preserve graph invariants *)
+        assert (copy_below_level - copy_from_level = 1);
+        (* We never copy to levels above [generic_level] *)
+        assert (l <= generic_level))
+      copy_to_level;
+    match a with
+    | Amodevar (Amorphvar (v, f, f_hint)) ->
+      let obj = C.src obj f in
+      let vcopy =
+        copy_v ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level
+          ~persistent obj v
+      in
+      if vcopy == v then a else Amodevar (Amorphvar (vcopy, f, f_hint))
+    | Amode _ -> a
+    | Amodejoin (a, a_hint, mvs) ->
+      let mvscopy =
+        VarMap.fold
+          (fun _ (Amorphvar (v, f, f_hint)) acc ->
+            let src = C.src obj f in
+            let vcopy =
+              copy_v ~copy_scope ~copy_from_level ~copy_below_level
+                ~copy_to_level ~persistent src v
+            in
+            let x = Amorphvar (vcopy, f, f_hint) in
+            VarMap.add (get_key obj x) x acc)
+          mvs VarMap.empty
+      in
+      Amodejoin (a, a_hint, mvscopy)
+    | Amodemeet (a, a_hint, mvs) ->
+      let mvscopy =
+        VarMap.fold
+          (fun _ (Amorphvar (v, f, f_hint)) acc ->
+            let src = C.src obj f in
+            let vcopy =
+              copy_v ~copy_scope ~copy_from_level ~copy_below_level
+                ~copy_to_level ~persistent src v
+            in
+            let x = Amorphvar (vcopy, f, f_hint) in
+            VarMap.add (get_key obj x) x acc)
+          mvs VarMap.empty
+      in
+      Amodemeet (a, a_hint, mvscopy)
 
   let update_level (type a l r) (level : int) (obj : a C.obj)
       (a : (a, l * r) mode) ~log =

--- a/external/merlin/src/ocaml/typing/solver_intf.mli
+++ b/external/merlin/src/ocaml/typing/solver_intf.mli
@@ -194,6 +194,15 @@ module type Solver_mono = sig
 
   type pinpoint
 
+  (** Represents a sequence of local changes to the copying scope of a mode
+      variable. Copying a mode takes a [copy_scope], and it is up to the caller
+      to create a new copy scope, and reset it once all copies have been made *)
+  type copy_scope
+
+  (** Runs a function [f] in a fresh mode copy scope, which gets cleaned up once
+      [f] is finished *)
+  val with_copy_scope : (copy_scope -> 'a) -> 'a
+
   type 'd hint_morph constraint 'd = 'l * 'r
 
   type 'd hint_const constraint 'd = 'l * 'r
@@ -316,6 +325,29 @@ module type Solver_mono = sig
     ('a, 'l * 'r) mode ->
     log:changes ref option ->
     unit
+
+  (** Resets the counter used to allocate the (negative) ids of persistent
+      copies of mode variables. Mirrors [Subst.reset_additional_action_id] for
+      types, and is called at the start of every cmi save. *)
+  val reset_persistent_id : unit -> unit
+
+  (** If the variable has not yet been copied within the same [copy_scope],
+      [copy] copies all reachable variables whose level lies within the window
+      \[[copy_from_level], [copy_below_level]). If [copy_to_level] is given, the
+      copies are placed at that level; this is only allowed for windows of size
+      1). If not given, copies keep the levels of their originals. If
+      [persistent] (default false), copies receive negative ids from a dedicated
+      counter (see [reset_persistent_id]). Returns either the freshly copied
+      mode, or the copy cached in [copy_scope]. *)
+  val copy :
+    copy_scope:copy_scope ->
+    copy_from_level:int ->
+    copy_below_level:int ->
+    ?copy_to_level:int ->
+    ?persistent:bool ->
+    'a obj ->
+    ('a, 'l * 'r) mode ->
+    ('a, 'l * 'r) mode
 
   (** Creates a new mode variable above the given mode and returns [true]. In
       the speical case where the given mode is top, returns the constant top and

--- a/external/merlin/upstream/ocaml_flambda/typing/solver.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/solver.ml
@@ -327,6 +327,9 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
          - for all [f u \in v.vlower] and [g w \in v.vupper] we
            have either [g'f \in w.vlower] or [f'g \in u.vupper]. *)
       id : int;  (** For identification/printing *)
+      mutable subst : 'a var option;
+          (** Similar to Tsubst in a type, the [subst] field holds an optional
+              copy used during instantiation *)
       mutable gencopy : 'a var option
           (** Calls to [generalize_structure] creates additional copies to make
               sure the bounds of a generalize structure is rigid: [gencopy]
@@ -379,6 +382,11 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   (** [append_changes l0 l1] returns a log that's equivalent to [l0] followed by
       [l1]. *)
   let append_changes l0 l1 = l1 @ l0
+
+  type copy_change =
+    | Coptcopy : 'a C.obj * int * 'a var * 'a var option -> copy_change
+
+  type copy_scope = { mutable saved_copies : copy_change list }
 
   type ('a, 'd) mode =
     | Amode :
@@ -687,6 +695,14 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | None -> ()
     | Some log -> log := Cvupper (v, v.vupper) :: !log);
     v.vupper <- vupper
+
+  (** Function used internally by copy, where [changes] maintains the cleanup
+      once the copy is done. Unlike other setters, the [changes] is here
+      mandatory *)
+  let set_optcopy ~changes obj ~target_level v copy =
+    changes.saved_copies
+      <- Coptcopy (obj, target_level, v, v.subst) :: changes.saved_copies;
+    v.subst <- copy
 
   (** Function used internally by generalize_structure to cache newly created
       copies *)
@@ -1216,10 +1232,30 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       update_level_finalize ~log dst level u
     end
 
-  let vars = ref (0, [])
+  let vars = ref []
 
-  let fresh ?upper ?upper_hint ?lower ?lower_hint ?vlower ?vupper ~level obj =
-    let id, l = !vars in
+  let live_id = ref 0
+
+  let next_live_id () =
+    let id = !live_id in
+    incr live_id;
+    id
+
+  (* Ids for persistent copies of variables (as stored in cmi files).
+     This mirrors [Subst.new_type_id] for types. *)
+  let persistent_id = ref (-1)
+
+  (* Resets the counter for persistent copies *)
+  let reset_persistent_id () = persistent_id := -1
+
+  let next_persistent_id () =
+    let id = !persistent_id in
+    decr persistent_id;
+    id
+
+  let fresh ?(persistent = false) ?upper ?upper_hint ?lower ?lower_hint ?vlower
+      ?vupper ~level obj =
+    let id = if persistent then next_persistent_id () else next_live_id () in
     let upper, upper_hint =
       match upper, upper_hint with
       | None, None -> C.max obj, Comp_hint.Max
@@ -1237,6 +1273,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     let vlower = Option.value vlower ~default:VarMap.empty in
     let vupper = Option.value vupper ~default:VarMap.empty in
     let gencopy = None in
+    let subst = None in
     let var =
       { level;
         upper;
@@ -1246,10 +1283,11 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         vlower;
         vupper;
         id;
-        gencopy
+        gencopy;
+        subst
       }
     in
-    vars := id + 1, Var var :: l;
+    vars := Var var :: !vars;
     var
 
   let unhint_morphvar (Amorphvar (v, f, _)) =
@@ -1261,9 +1299,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     v.vlower <- VarMap.map unhint_morphvar v.vlower;
     v.vupper <- VarMap.map unhint_morphvar v.vupper
 
-  let erase_hints () =
-    let _, l = !vars in
-    List.iter (fun (Var v) -> unhint_var v) l
+  let erase_hints () = List.iter (fun (Var v) -> unhint_var v) !vars
 
   type ('a, 'd) hint_raw = ('a, 'd) Comp_hint.t
 
@@ -1437,6 +1473,139 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           let obj = C.src obj f in
           generalize_structure_v ~log obj ~current_level v)
         mvs
+
+  let fresh_mode_copy_scope () = { saved_copies = [] }
+
+  let undo_copy_change = function
+    | Coptcopy (dst, update_to_level, v, copy) ->
+      Option.iter
+        (fun u -> update_level_finalize ~log:None dst update_to_level u)
+        v.subst;
+      v.subst <- copy
+
+  let cleanup_mode_copy_scope l = List.iter undo_copy_change l.saved_copies
+
+  let with_copy_scope f =
+    let scope = fresh_mode_copy_scope () in
+    Fun.protect
+      ~finally:(fun () -> cleanup_mode_copy_scope scope)
+      (fun () -> f scope)
+
+  let rec trace_gencopy ~target_level v =
+    match v.gencopy with
+    | None -> None
+    | Some v' when v'.level = target_level -> Some v'
+    | Some v' -> trace_gencopy ~target_level v'
+
+  let rec copy_v : type a.
+      copy_scope:_ ->
+      copy_from_level:int ->
+      copy_below_level:int ->
+      copy_to_level:int option ->
+      persistent:bool ->
+      a C.obj ->
+      a var ->
+      a var =
+   fun ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level ~persistent
+       obj v ->
+    let in_window = v.level >= copy_from_level && v.level < copy_below_level in
+    if not in_window
+    then v
+    else
+      (* generalize_structure might have already created a copy, cached in [gencopy].
+         If such a copy exist, we return it *)
+      let target_level = Option.value copy_to_level ~default:v.level in
+      let gencopy = trace_gencopy ~target_level v in
+      begin match gencopy with
+      | Some v' -> v'
+      | None -> (
+        match v.subst with
+        | Some v' -> v'
+        | None ->
+          let copy =
+            fresh ~persistent ~upper:v.upper ~lower:v.lower ~level:v.level obj
+          in
+          set_optcopy ~changes:copy_scope obj ~target_level v (Some copy);
+          let vupper =
+            VarMap.fold
+              (fun _ (Amorphvar (u, f, f_hint)) acc ->
+                let src = C.src obj f in
+                let ucopy =
+                  copy_v ~copy_scope ~copy_from_level ~copy_below_level
+                    ~copy_to_level ~persistent src u
+                in
+                let x = Amorphvar (ucopy, f, f_hint) in
+                VarMap.add (get_key obj x) x acc)
+              v.vupper VarMap.empty
+          in
+          let vlower =
+            VarMap.fold
+              (fun _ (Amorphvar (u, f, f_hint)) acc ->
+                let src = C.src obj f in
+                let ucopy =
+                  copy_v ~copy_scope ~copy_from_level ~copy_below_level
+                    ~copy_to_level ~persistent src u
+                in
+                let x = Amorphvar (ucopy, f, f_hint) in
+                VarMap.add (get_key obj x) x acc)
+              v.vlower VarMap.empty
+          in
+          copy.vupper <- vupper;
+          copy.vlower <- vlower;
+          set_level ~log:None copy target_level;
+          copy)
+      end
+
+  let copy (type a l r) ~copy_scope ~copy_from_level ~copy_below_level
+      ?copy_to_level ?(persistent = false) (obj : a C.obj) (a : (a, l * r) mode)
+      : (a, l * r) mode =
+    (* We never want to copy variables above [generic_level]. *)
+    assert (copy_below_level <= generic_level + 1);
+    Option.iter
+      (fun l ->
+        (* If we copy to a specific level, the copy window must be size 1 to
+       preserve graph invariants *)
+        assert (copy_below_level - copy_from_level = 1);
+        (* We never copy to levels above [generic_level] *)
+        assert (l <= generic_level))
+      copy_to_level;
+    match a with
+    | Amodevar (Amorphvar (v, f, f_hint)) ->
+      let obj = C.src obj f in
+      let vcopy =
+        copy_v ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level
+          ~persistent obj v
+      in
+      if vcopy == v then a else Amodevar (Amorphvar (vcopy, f, f_hint))
+    | Amode _ -> a
+    | Amodejoin (a, a_hint, mvs) ->
+      let mvscopy =
+        VarMap.fold
+          (fun _ (Amorphvar (v, f, f_hint)) acc ->
+            let src = C.src obj f in
+            let vcopy =
+              copy_v ~copy_scope ~copy_from_level ~copy_below_level
+                ~copy_to_level ~persistent src v
+            in
+            let x = Amorphvar (vcopy, f, f_hint) in
+            VarMap.add (get_key obj x) x acc)
+          mvs VarMap.empty
+      in
+      Amodejoin (a, a_hint, mvscopy)
+    | Amodemeet (a, a_hint, mvs) ->
+      let mvscopy =
+        VarMap.fold
+          (fun _ (Amorphvar (v, f, f_hint)) acc ->
+            let src = C.src obj f in
+            let vcopy =
+              copy_v ~copy_scope ~copy_from_level ~copy_below_level
+                ~copy_to_level ~persistent src v
+            in
+            let x = Amorphvar (vcopy, f, f_hint) in
+            VarMap.add (get_key obj x) x acc)
+          mvs VarMap.empty
+      in
+      Amodemeet (a, a_hint, mvscopy)
 
   let update_level (type a l r) (level : int) (obj : a C.obj)
       (a : (a, l * r) mode) ~log =

--- a/external/merlin/upstream/ocaml_flambda/typing/solver_intf.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/solver_intf.mli
@@ -194,6 +194,15 @@ module type Solver_mono = sig
 
   type pinpoint
 
+  (** Represents a sequence of local changes to the copying scope of a mode
+      variable. Copying a mode takes a [copy_scope], and it is up to the caller
+      to create a new copy scope, and reset it once all copies have been made *)
+  type copy_scope
+
+  (** Runs a function [f] in a fresh mode copy scope, which gets cleaned up once
+      [f] is finished *)
+  val with_copy_scope : (copy_scope -> 'a) -> 'a
+
   type 'd hint_morph constraint 'd = 'l * 'r
 
   type 'd hint_const constraint 'd = 'l * 'r
@@ -316,6 +325,29 @@ module type Solver_mono = sig
     ('a, 'l * 'r) mode ->
     log:changes ref option ->
     unit
+
+  (** Resets the counter used to allocate the (negative) ids of persistent
+      copies of mode variables. Mirrors [Subst.reset_additional_action_id] for
+      types, and is called at the start of every cmi save. *)
+  val reset_persistent_id : unit -> unit
+
+  (** If the variable has not yet been copied within the same [copy_scope],
+      [copy] copies all reachable variables whose level lies within the window
+      \[[copy_from_level], [copy_below_level]). If [copy_to_level] is given, the
+      copies are placed at that level; this is only allowed for windows of size
+      1). If not given, copies keep the levels of their originals. If
+      [persistent] (default false), copies receive negative ids from a dedicated
+      counter (see [reset_persistent_id]). Returns either the freshly copied
+      mode, or the copy cached in [copy_scope]. *)
+  val copy :
+    copy_scope:copy_scope ->
+    copy_from_level:int ->
+    copy_below_level:int ->
+    ?copy_to_level:int ->
+    ?persistent:bool ->
+    'a obj ->
+    ('a, 'l * 'r) mode ->
+    ('a, 'l * 'r) mode
 
   (** Creates a new mode variable above the given mode and returns [true]. In
       the speical case where the given mode is top, returns the constant top and

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -1501,24 +1501,26 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           let copy = fresh ~upper:v.upper ~lower:v.lower ~level:v.level obj in
           set_optcopy ~changes:copy_scope obj ~copy_to_level v (Some copy);
           let vupper =
-            VarMap.map
-              (fun (Amorphvar (u, f, f_hint)) ->
+            VarMap.fold
+              (fun _ (Amorphvar (u, f, f_hint)) acc ->
                 let src = C.src obj f in
                 let ucopy =
                   copy_v ~copy_scope ~copy_from_level ~copy_to_level src u
                 in
-                Amorphvar (ucopy, f, f_hint))
-              v.vupper
+                let x = Amorphvar (ucopy, f, f_hint) in
+                VarMap.add (get_key obj x) x acc)
+              v.vupper VarMap.empty
           in
           let vlower =
-            VarMap.map
-              (fun (Amorphvar (u, f, f_hint)) ->
+            VarMap.fold
+              (fun _ (Amorphvar (u, f, f_hint)) acc ->
                 let src = C.src obj f in
                 let ucopy =
                   copy_v ~copy_scope ~copy_from_level ~copy_to_level src u
                 in
-                Amorphvar (ucopy, f, f_hint))
-              v.vlower
+                let x = Amorphvar (ucopy, f, f_hint) in
+                VarMap.add (get_key obj x) x acc)
+              v.vlower VarMap.empty
           in
           copy.vupper <- vupper;
           copy.vlower <- vlower;
@@ -1536,26 +1538,28 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | Amode _ -> a
     | Amodejoin (a, a_hint, mvs) ->
       let mvscopy =
-        VarMap.map
-          (fun (Amorphvar (v, f, f_hint)) ->
-            let obj = C.src obj f in
+        VarMap.fold
+          (fun _ (Amorphvar (v, f, f_hint)) acc ->
+            let src = C.src obj f in
             let vcopy =
-              copy_v ~copy_scope ~copy_from_level ~copy_to_level obj v
+              copy_v ~copy_scope ~copy_from_level ~copy_to_level src v
             in
-            Amorphvar (vcopy, f, f_hint))
-          mvs
+            let x = Amorphvar (vcopy, f, f_hint) in
+            VarMap.add (get_key obj x) x acc)
+          mvs VarMap.empty
       in
       Amodejoin (a, a_hint, mvscopy)
     | Amodemeet (a, a_hint, mvs) ->
       let mvscopy =
-        VarMap.map
-          (fun (Amorphvar (v, f, f_hint)) ->
-            let obj = C.src obj f in
+        VarMap.fold
+          (fun _ (Amorphvar (v, f, f_hint)) acc ->
+            let src = C.src obj f in
             let vcopy =
-              copy_v ~copy_scope ~copy_from_level ~copy_to_level obj v
+              copy_v ~copy_scope ~copy_from_level ~copy_to_level src v
             in
-            Amorphvar (vcopy, f, f_hint))
-          mvs
+            let x = Amorphvar (vcopy, f, f_hint) in
+            VarMap.add (get_key obj x) x acc)
+          mvs VarMap.empty
       in
       Amodemeet (a, a_hint, mvscopy)
 

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -327,6 +327,9 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
          - for all [f u \in v.vlower] and [g w \in v.vupper] we
            have either [g'f \in w.vlower] or [f'g \in u.vupper]. *)
       id : int;  (** For identification/printing *)
+      mutable subst : 'a var option;
+          (** Similar to Tsubst in a type, the [subst] field holds an optional
+              copy used during instantiation *)
       mutable gencopy : 'a var option
           (** Calls to [generalize_structure] creates additional copies to make
               sure the bounds of a generalize structure is rigid: [gencopy]
@@ -379,6 +382,11 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   (** [append_changes l0 l1] returns a log that's equivalent to [l0] followed by
       [l1]. *)
   let append_changes l0 l1 = l1 @ l0
+
+  type copy_change =
+    | Coptcopy : 'a C.obj * int * 'a var * 'a var option -> copy_change
+
+  type copy_scope = { mutable saved_copies : copy_change list }
 
   type ('a, 'd) mode =
     | Amode :
@@ -687,6 +695,14 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     | None -> ()
     | Some log -> log := Cvupper (v, v.vupper) :: !log);
     v.vupper <- vupper
+
+  (** Function used internally by copy, where [changes] maintains the cleanup
+      once the copy is done. Unlike other setters, the [changes] is here
+      mandatory *)
+  let set_optcopy ~changes obj ~copy_to_level v copy =
+    changes.saved_copies
+      <- Coptcopy (obj, copy_to_level, v, v.subst) :: changes.saved_copies;
+    v.subst <- copy
 
   (** Function used internally by generalize_structure to cache newly created
       copies *)
@@ -1237,6 +1253,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     let vlower = Option.value vlower ~default:VarMap.empty in
     let vupper = Option.value vupper ~default:VarMap.empty in
     let gencopy = None in
+    let subst = None in
     let var =
       { level;
         upper;
@@ -1246,7 +1263,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         vlower;
         vupper;
         id;
-        gencopy
+        gencopy;
+        subst
       }
     in
     vars := id + 1, Var var :: l;
@@ -1437,6 +1455,103 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           let obj = C.src obj f in
           generalize_structure_v ~log obj ~current_level v)
         mvs
+
+  let fresh_mode_copy_scope () = { saved_copies = [] }
+
+  let undo_copy_change = function
+    | Coptcopy (dst, update_to_level, v, copy) ->
+      Option.iter
+        (fun u -> update_level_finalize ~log:None dst update_to_level u)
+        v.subst;
+      v.subst <- copy
+
+  let cleanup_mode_copy_scope l = List.iter undo_copy_change l.saved_copies
+
+  let with_copy_scope f =
+    let scope = fresh_mode_copy_scope () in
+    Fun.protect
+      ~finally:(fun () -> cleanup_mode_copy_scope scope)
+      (fun () -> f scope)
+
+  let rec copy_v : type a.
+      copy_scope:_ ->
+      copy_from_level:int ->
+      copy_to_level:int ->
+      a C.obj ->
+      a var ->
+      a var =
+   fun ~copy_scope ~copy_from_level ~copy_to_level obj v ->
+    if v.level < copy_from_level
+    then v
+    else
+      (* generalize_structure might have already created a copy, cached in [gencopy].
+         If such a copy exist, we return it *)
+      begin match v.gencopy with
+      | Some v' -> v'
+      | None -> (
+        match v.subst with
+        | Some v' -> v'
+        | None ->
+          let copy = fresh ~upper:v.upper ~lower:v.lower ~level:v.level obj in
+          set_optcopy ~changes:copy_scope obj ~copy_to_level v (Some copy);
+          let vupper =
+            VarMap.map
+              (fun (Amorphvar (u, f, f_hint)) ->
+                let src = C.src obj f in
+                let ucopy =
+                  copy_v ~copy_scope ~copy_from_level ~copy_to_level src u
+                in
+                Amorphvar (ucopy, f, f_hint))
+              v.vupper
+          in
+          let vlower =
+            VarMap.map
+              (fun (Amorphvar (u, f, f_hint)) ->
+                let src = C.src obj f in
+                let ucopy =
+                  copy_v ~copy_scope ~copy_from_level ~copy_to_level src u
+                in
+                Amorphvar (ucopy, f, f_hint))
+              v.vlower
+          in
+          copy.vupper <- vupper;
+          copy.vlower <- vlower;
+          set_level ~log:None copy copy_to_level;
+          copy)
+      end
+
+  let copy (type a l r) ~copy_scope ~copy_from_level ~copy_to_level
+      (obj : a C.obj) (a : (a, l * r) mode) : (a, l * r) mode =
+    match a with
+    | Amodevar (Amorphvar (v, f, f_hint)) ->
+      let obj = C.src obj f in
+      let vcopy = copy_v ~copy_scope ~copy_from_level ~copy_to_level obj v in
+      if vcopy == v then a else Amodevar (Amorphvar (vcopy, f, f_hint))
+    | Amode _ -> a
+    | Amodejoin (a, a_hint, mvs) ->
+      let mvscopy =
+        VarMap.map
+          (fun (Amorphvar (v, f, f_hint)) ->
+            let obj = C.src obj f in
+            let vcopy =
+              copy_v ~copy_scope ~copy_from_level ~copy_to_level obj v
+            in
+            Amorphvar (vcopy, f, f_hint))
+          mvs
+      in
+      Amodejoin (a, a_hint, mvscopy)
+    | Amodemeet (a, a_hint, mvs) ->
+      let mvscopy =
+        VarMap.map
+          (fun (Amorphvar (v, f, f_hint)) ->
+            let obj = C.src obj f in
+            let vcopy =
+              copy_v ~copy_scope ~copy_from_level ~copy_to_level obj v
+            in
+            Amorphvar (vcopy, f, f_hint))
+          mvs
+      in
+      Amodemeet (a, a_hint, mvscopy)
 
   let update_level (type a l r) (level : int) (obj : a C.obj)
       (a : (a, l * r) mode) ~log =

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -699,9 +699,9 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
   (** Function used internally by copy, where [changes] maintains the cleanup
       once the copy is done. Unlike other setters, the [changes] is here
       mandatory *)
-  let set_optcopy ~changes obj ~copy_to_level v copy =
+  let set_optcopy ~changes obj ~target_level v copy =
     changes.saved_copies
-      <- Coptcopy (obj, copy_to_level, v, v.subst) :: changes.saved_copies;
+      <- Coptcopy (obj, target_level, v, v.subst) :: changes.saved_copies;
     v.subst <- copy
 
   (** Function used internally by generalize_structure to cache newly created
@@ -1232,10 +1232,30 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       update_level_finalize ~log dst level u
     end
 
-  let vars = ref (0, [])
+  let vars = ref []
 
-  let fresh ?upper ?upper_hint ?lower ?lower_hint ?vlower ?vupper ~level obj =
-    let id, l = !vars in
+  let live_id = ref 0
+
+  let next_live_id () =
+    let id = !live_id in
+    incr live_id;
+    id
+
+  (* Ids for persistent copies of variables (as stored in cmi files).
+     This mirrors [Subst.new_type_id] for types. *)
+  let persistent_id = ref (-1)
+
+  (* Resets the counter for persistent copies *)
+  let reset_persistent_id () = persistent_id := -1
+
+  let next_persistent_id () =
+    let id = !persistent_id in
+    decr persistent_id;
+    id
+
+  let fresh ?(persistent = false) ?upper ?upper_hint ?lower ?lower_hint ?vlower
+      ?vupper ~level obj =
+    let id = if persistent then next_persistent_id () else next_live_id () in
     let upper, upper_hint =
       match upper, upper_hint with
       | None, None -> C.max obj, Comp_hint.Max
@@ -1267,7 +1287,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         subst
       }
     in
-    vars := id + 1, Var var :: l;
+    vars := Var var :: !vars;
     var
 
   let unhint_morphvar (Amorphvar (v, f, _)) =
@@ -1279,9 +1299,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     v.vlower <- VarMap.map unhint_morphvar v.vlower;
     v.vupper <- VarMap.map unhint_morphvar v.vupper
 
-  let erase_hints () =
-    let _, l = !vars in
-    List.iter (fun (Var v) -> unhint_var v) l
+  let erase_hints () = List.iter (fun (Var v) -> unhint_var v) !vars
 
   type ('a, 'd) hint_raw = ('a, 'd) Comp_hint.t
 
@@ -1473,39 +1491,48 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       ~finally:(fun () -> cleanup_mode_copy_scope scope)
       (fun () -> f scope)
 
-  let rec trace_gencopy ~copy_to_level v =
+  let rec trace_gencopy ~target_level v =
     match v.gencopy with
     | None -> None
-    | Some v' when v'.level = copy_to_level -> Some v'
-    | Some v' -> trace_gencopy ~copy_to_level v'
+    | Some v' when v'.level = target_level -> Some v'
+    | Some v' -> trace_gencopy ~target_level v'
 
   let rec copy_v : type a.
       copy_scope:_ ->
       copy_from_level:int ->
-      copy_to_level:int ->
+      copy_below_level:int ->
+      copy_to_level:int option ->
+      persistent:bool ->
       a C.obj ->
       a var ->
       a var =
-   fun ~copy_scope ~copy_from_level ~copy_to_level obj v ->
-    if v.level < copy_from_level
+   fun ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level ~persistent
+       obj v ->
+    let in_window = v.level >= copy_from_level && v.level < copy_below_level in
+    if not in_window
     then v
     else
       (* generalize_structure might have already created a copy, cached in [gencopy].
          If such a copy exist, we return it *)
-      begin match trace_gencopy ~copy_to_level v with
+      let target_level = Option.value copy_to_level ~default:v.level in
+      let gencopy = trace_gencopy ~target_level v in
+      begin match gencopy with
       | Some v' -> v'
       | None -> (
         match v.subst with
         | Some v' -> v'
         | None ->
-          let copy = fresh ~upper:v.upper ~lower:v.lower ~level:v.level obj in
-          set_optcopy ~changes:copy_scope obj ~copy_to_level v (Some copy);
+          let copy =
+            fresh ~persistent ~upper:v.upper ~lower:v.lower ~level:v.level obj
+          in
+          set_optcopy ~changes:copy_scope obj ~target_level v (Some copy);
           let vupper =
             VarMap.fold
               (fun _ (Amorphvar (u, f, f_hint)) acc ->
                 let src = C.src obj f in
                 let ucopy =
-                  copy_v ~copy_scope ~copy_from_level ~copy_to_level src u
+                  copy_v ~copy_scope ~copy_from_level ~copy_below_level
+                    ~copy_to_level ~persistent src u
                 in
                 let x = Amorphvar (ucopy, f, f_hint) in
                 VarMap.add (get_key obj x) x acc)
@@ -1516,7 +1543,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
               (fun _ (Amorphvar (u, f, f_hint)) acc ->
                 let src = C.src obj f in
                 let ucopy =
-                  copy_v ~copy_scope ~copy_from_level ~copy_to_level src u
+                  copy_v ~copy_scope ~copy_from_level ~copy_below_level
+                    ~copy_to_level ~persistent src u
                 in
                 let x = Amorphvar (ucopy, f, f_hint) in
                 VarMap.add (get_key obj x) x acc)
@@ -1524,16 +1552,30 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           in
           copy.vupper <- vupper;
           copy.vlower <- vlower;
-          set_level ~log:None copy copy_to_level;
+          set_level ~log:None copy target_level;
           copy)
       end
 
-  let copy (type a l r) ~copy_scope ~copy_from_level ~copy_to_level
-      (obj : a C.obj) (a : (a, l * r) mode) : (a, l * r) mode =
+  let copy (type a l r) ~copy_scope ~copy_from_level ~copy_below_level
+      ?copy_to_level ?(persistent = false) (obj : a C.obj) (a : (a, l * r) mode)
+      : (a, l * r) mode =
+    (* We never want to copy variables above [generic_level]. *)
+    assert (copy_below_level <= generic_level + 1);
+    Option.iter
+      (fun l ->
+        (* If we copy to a specific level, the copy window must be size 1 to
+       preserve graph invariants *)
+        assert (copy_below_level - copy_from_level = 1);
+        (* We never copy to levels above [generic_level] *)
+        assert (l <= generic_level))
+      copy_to_level;
     match a with
     | Amodevar (Amorphvar (v, f, f_hint)) ->
       let obj = C.src obj f in
-      let vcopy = copy_v ~copy_scope ~copy_from_level ~copy_to_level obj v in
+      let vcopy =
+        copy_v ~copy_scope ~copy_from_level ~copy_below_level ~copy_to_level
+          ~persistent obj v
+      in
       if vcopy == v then a else Amodevar (Amorphvar (vcopy, f, f_hint))
     | Amode _ -> a
     | Amodejoin (a, a_hint, mvs) ->
@@ -1542,7 +1584,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           (fun _ (Amorphvar (v, f, f_hint)) acc ->
             let src = C.src obj f in
             let vcopy =
-              copy_v ~copy_scope ~copy_from_level ~copy_to_level src v
+              copy_v ~copy_scope ~copy_from_level ~copy_below_level
+                ~copy_to_level ~persistent src v
             in
             let x = Amorphvar (vcopy, f, f_hint) in
             VarMap.add (get_key obj x) x acc)
@@ -1555,7 +1598,8 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
           (fun _ (Amorphvar (v, f, f_hint)) acc ->
             let src = C.src obj f in
             let vcopy =
-              copy_v ~copy_scope ~copy_from_level ~copy_to_level src v
+              copy_v ~copy_scope ~copy_from_level ~copy_below_level
+                ~copy_to_level ~persistent src v
             in
             let x = Amorphvar (vcopy, f, f_hint) in
             VarMap.add (get_key obj x) x acc)

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -1473,6 +1473,12 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
       ~finally:(fun () -> cleanup_mode_copy_scope scope)
       (fun () -> f scope)
 
+  let rec trace_gencopy ~copy_to_level v =
+    match v.gencopy with
+    | None -> None
+    | Some v' when v'.level = copy_to_level -> Some v'
+    | Some v' -> trace_gencopy ~copy_to_level v'
+
   let rec copy_v : type a.
       copy_scope:_ ->
       copy_from_level:int ->
@@ -1486,7 +1492,7 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     else
       (* generalize_structure might have already created a copy, cached in [gencopy].
          If such a copy exist, we return it *)
-      begin match v.gencopy with
+      begin match trace_gencopy ~copy_to_level v with
       | Some v' -> v'
       | None -> (
         match v.subst with

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -194,6 +194,15 @@ module type Solver_mono = sig
 
   type pinpoint
 
+  (** Represents a sequence of local changes to the copying scope of a mode
+      variable. Copying a mode takes a [copy_scope], and it is up to the caller
+      to create a new copy scope, and reset it once all copies have been made *)
+  type copy_scope
+
+  (** Runs a function [f] in a fresh mode copy scope, which gets cleaned up once
+      [f] is finished *)
+  val with_copy_scope : (copy_scope -> 'a) -> 'a
+
   type 'd hint_morph constraint 'd = 'l * 'r
 
   type 'd hint_const constraint 'd = 'l * 'r
@@ -316,6 +325,17 @@ module type Solver_mono = sig
     ('a, 'l * 'r) mode ->
     log:changes ref option ->
     unit
+
+  (** Copies all reachable variables whose level is at or above
+      [copy_from_level], and enforces that the copy is below [copy_to_level].
+      Returns the copied mode *)
+  val copy :
+    copy_scope:copy_scope ->
+    copy_from_level:int ->
+    copy_to_level:int ->
+    'a obj ->
+    ('a, 'l * 'r) mode ->
+    ('a, 'l * 'r) mode
 
   (** Creates a new mode variable above the given mode and returns [true]. In
       the speical case where the given mode is top, returns the constant top and

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -326,9 +326,11 @@ module type Solver_mono = sig
     log:changes ref option ->
     unit
 
-  (** Copies all reachable variables whose level is at or above
+  (** If the variable has not yet been copied within the same [copy_scope],
+      [copy] copies all reachable variables whose level is at or above
       [copy_from_level], and enforces that the copy is below [copy_to_level].
-      Returns the copied mode *)
+      Returns either the freshly copied mode, or the copy cached in
+      [copy_scope]. *)
   val copy :
     copy_scope:copy_scope ->
     copy_from_level:int ->

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -326,15 +326,25 @@ module type Solver_mono = sig
     log:changes ref option ->
     unit
 
+  (** Resets the counter used to allocate the (negative) ids of persistent
+      copies of mode variables. Mirrors [Subst.reset_additional_action_id] for
+      types, and is called at the start of every cmi save. *)
+  val reset_persistent_id : unit -> unit
+
   (** If the variable has not yet been copied within the same [copy_scope],
-      [copy] copies all reachable variables whose level is at or above
-      [copy_from_level], and enforces that the copy is below [copy_to_level].
-      Returns either the freshly copied mode, or the copy cached in
-      [copy_scope]. *)
+      [copy] copies all reachable variables whose level lies within the window
+      \[[copy_from_level], [copy_below_level]). If [copy_to_level] is given, the
+      copies are placed at that level; this is only allowed for windows of size
+      1). If not given, copies keep the levels of their originals. If
+      [persistent] (default false), copies receive negative ids from a dedicated
+      counter (see [reset_persistent_id]). Returns either the freshly copied
+      mode, or the copy cached in [copy_scope]. *)
   val copy :
     copy_scope:copy_scope ->
     copy_from_level:int ->
-    copy_to_level:int ->
+    copy_below_level:int ->
+    ?copy_to_level:int ->
+    ?persistent:bool ->
     'a obj ->
     ('a, 'l * 'r) mode ->
     ('a, 'l * 'r) mode


### PR DESCRIPTION
Implements the `copy` operation in the solver, to be used later for instantiation. 

`copy` copies all (reachable) mode variables from some `copy_from_level`. The copy is created by updating a new `optcopy` field in mode variables, which is set back to its original value once copying is done via a `copy_scope`.

The copy is created set to some target level `copy_to_level`. While the copy has not yet resolved (the `copy_scope` is non empty), the graph might be temporarily broken, since the copy might point to variables at higher levels. Resolving the `copy_scope` finalizes the copy by fixing all such arrows and push down relevant bounds.