### PR TITLE
Alloc mode

### DIFF
--- a/chamelon/compat/compat.ox.ml
+++ b/chamelon/compat/compat.ox.ml
@@ -35,7 +35,12 @@ let dummy_value_mode = Value.disallow_right Value.legacy
 
 let dummy_scannable_sort = Jkind.Sort.scannable
 
-let dummy_alloc_mode = Alloc.disallow_left Alloc.legacy
+let dummy_alloc_mode_r = Locality.disallow_left Locality.legacy
+
+let dummy_alloc_mode_l = Locality.disallow_right Locality.legacy
+
+let dummy_return_mode =
+  create_return_mode (Locality.disallow_right Locality.legacy)
 
 let dummy_ctor_repres = Constructor_uniform_value
 
@@ -61,14 +66,14 @@ type nonrec apply_arg = apply_arg
 
 type texp_apply_identifier =
   apply_position
-  * Locality.l
+  * return_mode
   * Yielding.l
   * Builtin_attributes.zero_alloc_assume option
 
 let mkTexp_apply
     ?id:(pos, mode, yielding, za =
         ( Default,
-          Locality.disallow_right Locality.legacy,
+          dummy_return_mode,
           Yielding.disallow_right Yielding.yielding,
           None )) (exp, args) =
   let args =
@@ -76,27 +81,28 @@ let mkTexp_apply
   in
   Texp_apply (exp, args, pos, mode, yielding, za)
 
-type texp_tuple_identifier = string option list * alloc_mode
+type texp_tuple_identifier = string option list * alloc_mode_r
 
 let mkTexp_tuple ?id exps =
   let labels, alloc =
     match id with
-    | None -> List.map (fun _ -> None) exps, dummy_alloc_mode
+    | None -> List.map (fun _ -> None) exps, dummy_alloc_mode_r
     | Some id -> id
   in
   let exps = List.combine labels exps in
   Texp_tuple (exps, alloc)
 
-type texp_construct_identifier = alloc_mode option * constructor_representation
+type texp_construct_identifier =
+  alloc_mode_r option * constructor_representation
 
 type texp_construct_arg_identifier = Jkind.Sort.t
 
 let mkTexp_construct
-    ?id:(mode, repres = Some dummy_alloc_mode, dummy_ctor_repres)
+    ?id:(mode, repres = Some dummy_alloc_mode_r, dummy_ctor_repres)
     (name, desc, args) =
   Texp_construct (name, desc, repres, args, mode)
 
-type texp_record_identifier = Types.record_representation * alloc_mode option
+type texp_record_identifier = Types.record_representation * alloc_mode_r option
 
 type texp_record_field_identifier = Jkind.Sort.t
 
@@ -108,7 +114,7 @@ let mkTexp_record ~id:(representation, alloc_mode) (fields, extended_expression)
 
 type texp_function_param_identifier =
   { param_sort : Jkind.Sort.t;
-    param_mode : Alloc.l;
+    param_mode : alloc_mode_l;
     param_curry : function_curry;
     param_newtypes :
       (Ident.t
@@ -128,7 +134,7 @@ type texp_function_param =
   }
 
 type texp_function_cases_identifier =
-  { last_arg_mode : Alloc.l;
+  { last_arg_mode : alloc_mode_l;
     last_arg_sort : Jkind.Sort.t;
     last_arg_exp_extra : exp_extra list;
     last_arg_attributes : attributes;
@@ -151,14 +157,14 @@ type texp_function =
   }
 
 type texp_function_identifier =
-  { alloc_mode : alloc_mode;
+  { alloc_mode : alloc_mode_r;
     ret_sort : Jkind.sort;
-    ret_mode : Alloc.l;
+    ret_mode : return_mode;
     zero_alloc : Zero_alloc.t
   }
 
 let texp_function_cases_identifier_defaults =
-  { last_arg_mode = Alloc.disallow_right Alloc.legacy;
+  { last_arg_mode = dummy_alloc_mode_l;
     last_arg_sort = Jkind.Sort.scannable;
     last_arg_exp_extra = [];
     last_arg_attributes = [];
@@ -168,15 +174,15 @@ let texp_function_cases_identifier_defaults =
 
 let texp_function_param_identifier_defaults =
   { param_sort = Jkind.Sort.scannable;
-    param_mode = Alloc.disallow_right Alloc.legacy;
-    param_curry = More_args { partial_mode = Alloc.disallow_right Alloc.legacy };
+    param_mode = dummy_alloc_mode_l;
+    param_curry = More_args { partial_mode = dummy_alloc_mode_l };
     param_newtypes = []
   }
 
 let texp_function_defaults =
-  { alloc_mode = dummy_alloc_mode;
+  { alloc_mode = dummy_alloc_mode_r;
     ret_sort = Jkind.Sort.scannable;
-    ret_mode = Alloc.disallow_right Alloc.legacy;
+    ret_mode = dummy_return_mode;
     zero_alloc = Zero_alloc.default
   }
 

--- a/chamelon/compat/compat.ox.ml
+++ b/chamelon/compat/compat.ox.ml
@@ -35,7 +35,12 @@ let dummy_value_mode = Value.disallow_right Value.legacy
 
 let dummy_scannable_sort = Jkind.Sort.scannable
 
-let dummy_alloc_mode = Alloc.disallow_left Alloc.legacy
+let dummy_alloc_mode_r = Locality.disallow_left Locality.legacy
+
+let dummy_alloc_mode_l = Locality.disallow_right Locality.legacy
+
+let dummy_return_mode =
+  create_return_mode (Locality.disallow_right Locality.legacy)
 
 let dummy_ctor_repres = Constructor_uniform_value
 
@@ -63,14 +68,14 @@ type nonrec apply_arg = apply_arg
 
 type texp_apply_identifier =
   apply_position
-  * Locality.l
+  * return_mode
   * Yielding.l
   * Builtin_attributes.zero_alloc_assume option
 
 let mkTexp_apply
     ?id:(pos, mode, yielding, za =
         ( Default,
-          Locality.disallow_right Locality.legacy,
+          dummy_return_mode,
           Yielding.disallow_right Yielding.yielding,
           None )) (exp, args) =
   let args =
@@ -78,27 +83,28 @@ let mkTexp_apply
   in
   Texp_apply (exp, args, pos, mode, yielding, za)
 
-type texp_tuple_identifier = string option list * alloc_mode
+type texp_tuple_identifier = string option list * alloc_mode_r
 
 let mkTexp_tuple ?id exps =
   let labels, alloc =
     match id with
-    | None -> List.map (fun _ -> None) exps, dummy_alloc_mode
+    | None -> List.map (fun _ -> None) exps, dummy_alloc_mode_r
     | Some id -> id
   in
   let exps = List.combine labels exps in
   Texp_tuple (exps, alloc)
 
-type texp_construct_identifier = alloc_mode option * constructor_representation
+type texp_construct_identifier =
+  alloc_mode_r option * constructor_representation
 
 type texp_construct_arg_identifier = Jkind.Sort.t
 
 let mkTexp_construct
-    ?id:(mode, repres = Some dummy_alloc_mode, dummy_ctor_repres)
+    ?id:(mode, repres = Some dummy_alloc_mode_r, dummy_ctor_repres)
     (name, desc, args) =
   Texp_construct (name, desc, repres, args, mode)
 
-type texp_record_identifier = Types.record_representation * alloc_mode option
+type texp_record_identifier = Types.record_representation * alloc_mode_r option
 
 type texp_record_field_identifier = Jkind.Sort.t
 
@@ -110,7 +116,7 @@ let mkTexp_record ~id:(representation, alloc_mode) (fields, extended_expression)
 
 type texp_function_param_identifier =
   { param_sort : Jkind.Sort.t;
-    param_mode : Alloc.l;
+    param_mode : alloc_mode_l;
     param_curry : function_curry;
     param_newtypes :
       (Ident.t
@@ -130,7 +136,7 @@ type texp_function_param =
   }
 
 type texp_function_cases_identifier =
-  { last_arg_mode : Alloc.l;
+  { last_arg_mode : alloc_mode_l;
     last_arg_sort : Jkind.Sort.t;
     last_arg_exp_extra : exp_extra list;
     last_arg_attributes : attributes;
@@ -153,14 +159,14 @@ type texp_function =
   }
 
 type texp_function_identifier =
-  { alloc_mode : alloc_mode;
+  { alloc_mode : alloc_mode_r;
     ret_sort : Jkind.sort;
-    ret_mode : Alloc.l;
+    ret_mode : return_mode;
     zero_alloc : Zero_alloc.t
   }
 
 let texp_function_cases_identifier_defaults =
-  { last_arg_mode = Alloc.disallow_right Alloc.legacy;
+  { last_arg_mode = dummy_alloc_mode_l;
     last_arg_sort = Jkind.Sort.scannable;
     last_arg_exp_extra = [];
     last_arg_attributes = [];
@@ -170,15 +176,15 @@ let texp_function_cases_identifier_defaults =
 
 let texp_function_param_identifier_defaults =
   { param_sort = Jkind.Sort.scannable;
-    param_mode = Alloc.disallow_right Alloc.legacy;
-    param_curry = More_args { partial_mode = Alloc.disallow_right Alloc.legacy };
+    param_mode = dummy_alloc_mode_l;
+    param_curry = More_args { partial_mode = dummy_alloc_mode_l };
     param_newtypes = []
   }
 
 let texp_function_defaults =
-  { alloc_mode = dummy_alloc_mode;
+  { alloc_mode = dummy_alloc_mode_r;
     ret_sort = Jkind.Sort.scannable;
-    ret_mode = Alloc.disallow_right Alloc.legacy;
+    ret_mode = dummy_return_mode;
     zero_alloc = Zero_alloc.default
   }
 

--- a/chamelon/compat/compat.ox.ml
+++ b/chamelon/compat/compat.ox.ml
@@ -35,9 +35,11 @@ let dummy_value_mode = Value.disallow_right Value.legacy
 
 let dummy_scannable_sort = Jkind.Sort.scannable
 
-let dummy_alloc_mode_r = Locality.disallow_left Locality.legacy
+let dummy_alloc_mode_r =
+  create_alloc_mode_r (Locality.disallow_left Locality.legacy)
 
-let dummy_alloc_mode_l = Locality.disallow_right Locality.legacy
+let dummy_alloc_mode_l =
+  create_alloc_mode_l (Locality.disallow_right Locality.legacy)
 
 let dummy_return_mode =
   create_return_mode (Locality.disallow_right Locality.legacy)

--- a/external/merlin/src/analysis/signature_help.ml
+++ b/external/merlin/src/analysis/signature_help.ml
@@ -84,9 +84,18 @@ let print_parameter_offset ~arg:argument ppf buffer env label ty =
   { label; param_start; param_end; argument }
 
 let omitted : Typedtree.omitted_parameter =
-  let mode_closure = Mode.Alloc.disallow_left Mode.Alloc.legacy in
-  let mode_arg = Mode.Alloc.disallow_right Mode.Alloc.legacy in
-  let mode_ret = Mode.Alloc.disallow_right Mode.Alloc.legacy in
+  let mode_closure =
+    Typedtree.create_alloc_mode_r
+      (Mode.Locality.disallow_left Mode.Locality.legacy)
+  in
+  let mode_arg =
+    Typedtree.create_alloc_mode_l
+      (Mode.Locality.disallow_right Mode.Locality.legacy)
+  in
+  let mode_ret =
+    Typedtree.create_return_mode
+      (Mode.Locality.disallow_right Mode.Locality.legacy)
+  in
   let sort_arg = Jkind.Sort.scannable in
   let sort_ret = Jkind.Sort.scannable in
   { mode_closure; mode_arg; mode_ret; sort_arg; sort_ret }

--- a/external/merlin/src/analysis/stack_or_heap_enclosing.ml
+++ b/external/merlin/src/analysis/stack_or_heap_enclosing.ml
@@ -4,7 +4,7 @@ let log_section = "stack-or-heap-enclosing"
 let { Logger.log = _ } = Logger.for_section log_section
 
 type stack_or_heap =
-  | Alloc_mode of Mode.Alloc.r
+  | Alloc_mode of Typedtree.alloc_mode_r
   | No_alloc of { reason : string }
   | Unexpected_no_alloc
 
@@ -118,7 +118,7 @@ let from_nodes ~lsp_compat ~pos ~path =
         | Non_boxing _ -> None)
       | Texp_variant (_, maybe_exp_and_alloc_mode) ->
         maybe_exp_and_alloc_mode
-        |> Option.map ~f:(fun (_, (alloc_mode : Typedtree.alloc_mode)) ->
+        |> Option.map ~f:(fun (_, (alloc_mode : Typedtree.alloc_mode_r)) ->
             alloc_mode)
         |> ret_maybe_alloc "variant without argument"
       | _ -> None)

--- a/external/merlin/src/analysis/stack_or_heap_enclosing.mli
+++ b/external/merlin/src/analysis/stack_or_heap_enclosing.mli
@@ -20,7 +20,7 @@
 val log_section : string
 
 type stack_or_heap =
-  | Alloc_mode of Mode.Alloc.r
+  | Alloc_mode of Typedtree.alloc_mode_r
   | No_alloc of { reason : string }
   | Unexpected_no_alloc
 

--- a/external/merlin/src/frontend/query_commands.ml
+++ b/external/merlin/src/frontend/query_commands.ml
@@ -250,9 +250,8 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
             ret (`String ("not an allocation (" ^ reason ^ ")"))
           | Stack_or_heap_enclosing.Alloc_mode alloc_mode, true ->
             let locality =
-              alloc_mode
-              |> Mode.Alloc.proj_comonadic Areality
-              |> Mode.Locality.Guts.check_const_conservative
+              Typedtree.alloc_mode_r_map
+                Mode.Locality.Guts.check_const_conservative alloc_mode
             in
             let str =
               match locality with

--- a/external/merlin/src/ocaml/typing/ctype.ml
+++ b/external/merlin/src/ocaml/typing/ctype.ml
@@ -382,18 +382,20 @@ module Pattern_env : sig
     { mutable env : Env.t;
       equations_scope : int;
       in_counterexample : bool;
-      mutable env_alloc_mode : Mode.Alloc.r option; }
-  val make: ?env_alloc_mode:Mode.Alloc.r -> Env.t -> equations_scope:int
+      mutable env_alloc_mode : Mode.Locality.r option; }
+  val make:
+    ?env_alloc_mode:Mode.Locality.r
+    -> Env.t -> equations_scope:int
     -> in_counterexample:bool -> t
   val copy: ?equations_scope:int -> t -> t
   val set_env: t -> Env.t -> unit
-  val set_env_alloc_mode : t -> Mode.Alloc.r option -> unit
+  val set_env_alloc_mode : t -> Mode.Locality.r option -> unit
 end = struct
   type t =
     { mutable env : Env.t;
       equations_scope : int;
       in_counterexample : bool;
-      mutable env_alloc_mode : Mode.Alloc.r option; }
+      mutable env_alloc_mode : Mode.Locality.r option; }
   let make ?env_alloc_mode env ~equations_scope ~in_counterexample =
     { env;
       equations_scope;

--- a/external/merlin/src/ocaml/typing/ctype.mli
+++ b/external/merlin/src/ocaml/typing/ctype.mli
@@ -206,15 +206,17 @@ module Pattern_env : sig
       (* scope for local type declarations *)
       in_counterexample : bool;
       (* true iff checking counter examples *)
-      mutable env_alloc_mode : Mode.Alloc.r option;
+      mutable env_alloc_mode : Mode.Locality.r option;
       (** [Some m] if the pattern is under [let poly_], where [m] is the
          allocation mode of the captured environment *)
     }
-  val make: ?env_alloc_mode:Mode.Alloc.r -> Env.t -> equations_scope:int
+  val make:
+    ?env_alloc_mode:Mode.Locality.r
+    -> Env.t -> equations_scope:int
     -> in_counterexample:bool -> t
   val copy: ?equations_scope:int -> t -> t
   val set_env: t -> Env.t -> unit
-  val set_env_alloc_mode : t -> Mode.Alloc.r option -> unit
+  val set_env_alloc_mode : t -> Mode.Locality.r option -> unit
 end
 
 type existential_treatment =

--- a/external/merlin/src/ocaml/typing/mode.ml
+++ b/external/merlin/src/ocaml/typing/mode.ml
@@ -5517,6 +5517,8 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let print ?verbose () ppf m = S.print ?verbose obj ppf m
 
+  let check_const_or_level_0 m = S.check_const_or_level_0 m
+
   let zap_to_ceil m = with_log (S.zap_to_ceil obj m)
 
   let zap_to_floor m = with_log (S.zap_to_floor obj m)
@@ -5623,6 +5625,8 @@ module Monadic_gen (Obj : Obj) = struct
   let equate_exn m1 m2 = equate m1 m2 |> Result.get_ok
 
   let print ?verbose () ppf m = S.print ?verbose obj ppf m
+
+  let check_const_or_level_0 m = S.check_const_or_level_0 m
 
   let zap_to_ceil m = with_log (S.zap_to_floor obj m)
 
@@ -6718,6 +6722,10 @@ module Value_with (Areality : Areality) = struct
       match Monadic.submode_log ?pp monadic1 monadic2 ~log with
       | Error e -> Error (Monadic e)
       | Ok () -> Ok ())
+
+  let check_const_or_level_0 { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.check_const_or_level_0 monadic0
+    && Comonadic.check_const_or_level_0 comonadic0
 
   let submode ?pp a b = try_with_log (submode_log ?pp a b)
 

--- a/external/merlin/src/ocaml/typing/mode_intf.mli
+++ b/external/merlin/src/ocaml/typing/mode_intf.mli
@@ -191,6 +191,9 @@ module type Common = sig
 
   val newvar_below : ('l * allowed) t -> ('l_ * 'r) t * bool
 
+  (** Returns true if the mode is a constant or a mode variable at level 0 *)
+  val check_const_or_level_0 : ('l * 'r) t -> bool
+
   val print : ?verbose:bool -> unit -> Fmt.formatter -> ('l * 'r) t -> unit
 
   val zap_to_ceil : ('l * allowed) t -> Const.t

--- a/external/merlin/src/ocaml/typing/patterns.ml
+++ b/external/merlin/src/ocaml/typing/patterns.ml
@@ -92,7 +92,7 @@ module General = struct
     | `Var of Ident.t * string loc * Uid.t * Jkind.Sort.t * Mode.Value.l
     | `Fun_layout of Ident.t * string loc * Uid.t
                    * Jkind.Sort.t * Mode.Value.l * Types.Lpoly.t
-                   * alloc_mode
+                   * alloc_mode_r
     | `Alias of pattern * Ident.t * string loc
                 * Uid.t * Jkind.Sort.t * Mode.Value.l * Types.type_expr
   ]

--- a/external/merlin/src/ocaml/typing/patterns.mli
+++ b/external/merlin/src/ocaml/typing/patterns.mli
@@ -77,7 +77,7 @@ module General : sig
     | `Var of Ident.t * string loc * Uid.t * Jkind.Sort.t * Mode.Value.l
     | `Fun_layout of Ident.t * string loc * Uid.t
                    * Jkind.Sort.t * Mode.Value.l * Types.Lpoly.t
-                   * alloc_mode
+                   * alloc_mode_r
     | `Alias of pattern * Ident.t * string loc * Uid.t
                 * Jkind.Sort.t * Mode.Value.l * Types.type_expr
   ]

--- a/external/merlin/src/ocaml/typing/printtyped.ml
+++ b/external/merlin/src/ocaml/typing/printtyped.ml
@@ -329,9 +329,15 @@ let alloc_modes_opt i ppf ms =
 
 let alloc_modes_var i ppf ms =
   let print_alloc_modes_var i ppf m =
-    line i ppf "%a\n" (Format_doc.compat (Mode.Alloc.print ())) m
+    line i ppf "%a\n" print_alloc_mode_l m
   in
   modes ~pr:print_alloc_modes_var i ppf ms
+
+let return_mode i ppf m =
+  line i ppf "return_mode %a\n" print_return_mode m
+
+let return_modes i ppf ms =
+  modes ~pr:return_mode i ppf ms
 
 let value_modes_var i ppf ms =
   let print_value_modes_var i ppf m =
@@ -607,7 +613,7 @@ and function_body i ppf (body : function_body) =
         fmt_partiality fc_partial
         fmt_location fc_loc;
       let i = i+1 in
-      alloc_mode_raw i ppf fc_arg_mode;
+      alloc_mode_l i ppf fc_arg_mode;
       line i ppf "%a\n" fmt_sort fc_arg_sort;
       attributes i ppf fc_attributes;
       List.iter (fun e -> expression_extra i ppf (e, fc_loc, [])) fc_exp_extra;
@@ -650,15 +656,16 @@ and expression_extra i ppf (extra, loc, attrs) =
       attributes i ppf attrs;
       type_inspection (i+1) ppf ti
 
-and alloc_mode_raw: type l r. _ -> _ -> (l * r) Mode.Alloc.t -> _
-  = fun i ppf m ->
-    line i ppf "alloc_mode %a\n" (Format_doc.compat (Mode.Alloc.print ())) m
-
-and alloc_mode i ppf (m : alloc_mode) = alloc_mode_raw i ppf m
+and alloc_mode i ppf (m : alloc_mode_r) =
+  line i ppf "alloc_mode %a\n" print_alloc_mode_r m
 
 and alloc_mode_option i ppf m = Option.iter (alloc_mode i ppf) m
 
-and locality_mode i ppf m =
+and alloc_mode_l i ppf (m : alloc_mode_l) =
+  line i ppf "locality_mode %a\n" print_alloc_mode_l m
+
+and locality_mode : type l r. _ -> _ -> (l * r) Mode.Locality.t -> _ =
+ fun i ppf m ->
   line i ppf "locality_mode %a\n"
     (Format_doc.compat (Mode.Locality.print ())) m
 
@@ -704,7 +711,7 @@ and expression i ppf x =
       line i ppf "Texp_function\n";
       alloc_mode i ppf am;
       yielding_mode i ppf ym;
-      alloc_modes_var i ppf ret_mode;
+      return_modes i ppf ret_mode;
       list i function_param ppf params;
       function_body i ppf body;
   | Texp_apply (e, l, m, am, ym, za) ->
@@ -714,7 +721,7 @@ and expression i ppf x =
          | Tail -> "Tail"
          | Nontail -> "Nontail"
          | Default -> "Default");
-      locality_mode i ppf am;
+      return_mode i ppf am;
       yielding_mode i ppf ym;
       Option.iter (zero_alloc_assume i ppf) za;
       expression i ppf e;

--- a/external/merlin/src/ocaml/typing/solver.ml
+++ b/external/merlin/src/ocaml/typing/solver.ml
@@ -573,6 +573,19 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     in
     Amode (a, hint, hint)
 
+  let check_level_morphvar : type a l r. (a, l * r) morphvar -> int -> bool =
+   fun (Amorphvar (v, _, _)) i -> v.level = i
+
+  let check_const_or_level_0 : type a l r. (a, l * r) mode -> bool =
+   fun m ->
+    match m with
+    | Amode _ -> true
+    | Amodevar mv -> check_level_morphvar mv 0
+    | Amodemeet (_, _, mvs) ->
+      VarMap.for_all (fun _ mv -> check_level_morphvar mv 0) mvs
+    | Amodejoin (_, _, mvs) ->
+      VarMap.for_all (fun _ mv -> check_level_morphvar mv 0) mvs
+
   let apply_morphvar dst morph morph_hint (Amorphvar (var, morph', morph'_hint))
       =
     Amorphvar

--- a/external/merlin/src/ocaml/typing/solver_intf.mli
+++ b/external/merlin/src/ocaml/typing/solver_intf.mli
@@ -390,6 +390,9 @@ module type Solver_mono = sig
   val print :
     ?verbose:bool -> 'a obj -> Fmt.formatter -> ('a, 'l * 'r) mode -> unit
 
+  (** Returns true if the mode is a constant or a mode variable at level 0 *)
+  val check_const_or_level_0 : ('a, 'l * 'r) mode -> bool
+
   (** Apply a monotone morphism explained by an optional hint *)
   val apply :
     'b obj ->

--- a/external/merlin/src/ocaml/typing/typeclass.ml
+++ b/external/merlin/src/ocaml/typing/typeclass.ml
@@ -1405,13 +1405,26 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                     else if Btype.is_position l && is_erased () then
                       eliminate_position_arg ()
                     else begin
-                      let mode_closure = Mode.Alloc.disallow_left Mode.Alloc.legacy in
-                      let mode_arg = Mode.Alloc.disallow_right Mode.Alloc.legacy in
-                      let mode_ret = Mode.Alloc.disallow_right Mode.Alloc.legacy in
+                      let mode_closure =
+                        Mode.Locality.disallow_left Mode.Locality.legacy
+                        |> Typedtree.create_alloc_mode_r
+                      in
+                      let mode_arg =
+                        Mode.Locality.disallow_right Mode.Locality.legacy
+                        |> Typedtree.create_alloc_mode_l
+                      in
+                      let mode_ret =
+                        Mode.Locality.disallow_right Mode.Locality.legacy
+                        |> Typedtree.create_return_mode
+                      in
                       let sort_arg = Jkind.Sort.scannable in
                       let sort_ret = Jkind.Sort.scannable in
-                      Omitted { mode_closure; mode_arg; mode_ret; sort_arg;
-                                sort_ret }
+                      Omitted
+                        { mode_closure;
+                          mode_arg;
+                          mode_ret;
+                          sort_arg;
+                          sort_ret }
                     end
             in
             let omitted =

--- a/external/merlin/src/ocaml/typing/typecore.ml
+++ b/external/merlin/src/ocaml/typing/typecore.ml
@@ -937,17 +937,18 @@ let dynamic_pat_mode pat_mode =
   in
   {pat_mode with mode}
 
-let allocations : Alloc.r list ref = Local_store.s_ref []
+let allocations : Locality.r list ref = Local_store.s_ref []
 
 let reset_allocations () = allocations := []
 
 let register_allocation_mode alloc_mode =
-  let alloc_mode = Alloc.disallow_left alloc_mode in
   allocations := alloc_mode :: !allocations
 
 let register_allocation_value_mode ~loc
     ?(desc  = (Unknown : Mode.Hint.allocation_desc)) mode =
-  let alloc_mode = value_to_alloc_r2g mode in
+  let alloc_mode =
+    Alloc.proj_comonadic Areality (value_to_alloc_r2g mode)
+  in
   register_allocation_mode alloc_mode;
   (* We must apply each morphism separately so that their hints correspond to
      the correct morphism *)
@@ -963,16 +964,18 @@ let register_allocation_value_mode ~loc
    parameter function needs to be made global if its partial application
    to one argument must be global. As a result, a function gets an
    [Alloc.lr] allocation mode that can be further constrained. *)
-let register_closure_allocation (mode : Value.r) ~loc : Alloc.lr * Value.r =
+let register_closure_allocation (mode : Value.r) ~loc
+  : Locality.lr * Alloc.lr * Value.r =
   let allocation : Hint.allocation = {loc; txt = Unknown} in
-  let (alloc_mode : Alloc.lr), _ =
+  let (mode : Alloc.lr), _ =
     Alloc.newvar_below (value_to_alloc_r2g ~allocation mode)
   in
-  register_allocation_mode (Alloc.disallow_left alloc_mode);
+  let alloc_mode = Alloc.proj_comonadic Areality mode in
   let closed_over_mode =
-    alloc_as_value ~allocation (Alloc.disallow_left alloc_mode)
+    alloc_as_value ~allocation (Alloc.disallow_left mode)
   in
-  alloc_mode, closed_over_mode
+  register_allocation_mode (Locality.disallow_left alloc_mode);
+  alloc_mode, mode, closed_over_mode
 
 (** Register as allocation the expression constrained by the given
     [expected_mode]. Returns the mode of the allocation, and the expected mode
@@ -992,7 +995,7 @@ let optimise_allocations () =
   - Add it back when middle-end can really utilize this information. *)
   List.iter
     (fun mode ->
-      Locality.zap_to_ceil (Alloc.proj_comonadic Areality mode)
+      Locality.zap_to_ceil mode
       |> ignore)
     !allocations;
   reset_allocations ()
@@ -3685,7 +3688,9 @@ and type_pat_aux
               sp.ppat_attributes sort
           in
           Tpat_fun_layout { id; name; uid; sort;
-                            mode = alloc_mode; lpoly; env_alloc_mode }
+                            mode = alloc_mode; lpoly;
+                            env_alloc_mode =
+                              Typedtree.create_alloc_mode_r env_alloc_mode }
         | None ->
           let lpoly = Lpoly.determined [] in
           let id, uid =
@@ -5302,21 +5307,35 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
              let open_args = [] in
              let mode_closed_args = List.map Alloc.close_over closed_args in
              let mode_partial_fun = Alloc.partial_apply mode_fun in
-             let mode_closure, _ =
+             let mode_cls, _ =
                Alloc.newvar_above (Alloc.join
                 (mode_partial_fun:: mode_closed_args))
+             in
+             let mode_closure =
+               Alloc.disallow_left mode_cls
+               |> Alloc.proj_comonadic Areality
+             in
+             let mode_arg =
+               Alloc.disallow_right mode_arg
+               |> Alloc.proj_comonadic Areality
+               |> Typedtree.create_alloc_mode_l
+             in
+             let mode_ret =
+               Alloc.disallow_right mode_ret
+               |> Alloc.proj_comonadic Areality
+               |> Typedtree.create_return_mode
              in
              register_allocation_mode mode_closure;
              let arg =
               Omitted {
-                mode_closure = Alloc.disallow_left mode_closure;
-                mode_arg = Alloc.disallow_right mode_arg;
-                mode_ret = Alloc.disallow_right mode_ret;
+                mode_closure = Typedtree.create_alloc_mode_r mode_closure;
+                mode_arg;
+                mode_ret;
                 sort_arg;
                 sort_ret }
              in
              let args = (lbl, arg, None) :: args in
-             (ty_ret, mode_closure, open_args, closed_args, args))
+             (ty_ret, mode_cls, open_args, closed_args, args))
       (ty_ret, mode_ret, [], [], []) (List.rev args)
   in
   ty_ret, mode_ret, args
@@ -6424,10 +6443,14 @@ type split_function_ty =
       *)
     expected_pat_mode: expected_pat_mode;
     expected_inner_mode: expected_mode;
-    (* [alloc_mode] is the mode of [fun x_i ... x_n -> e].
-       This needs to be a left mode for the construction of the [fp_curry] field
-       of the outer function. *)
-    alloc_mode: Mode.Alloc.lr;
+    (* [closure_mode] is the mode of [fun x_i ... x_n -> e].
+       This needs to be a left mode for making sure that nested
+       closures have a mode greater than outer closures, and it
+       needs to be a right mode for making sure
+       arguments generate a lower bound for subsequent closures.
+       [alloc_mode] tracks the locality component to store in the Typedtree. *)
+    closure_mode: Mode.Alloc.lr;
+    alloc_mode: Locality.lr;
     really_poly: bool
   }
 
@@ -6449,12 +6472,12 @@ let split_function_ty
     env (expected_mode : expected_mode) ty_expected loc ~arg_label ~has_poly
     ~mode_annots ~ret_mode_annots ~in_function ~is_first_val_param ~is_final_val_param
   =
-  let alloc_mode, closed_over_mode =
+  let alloc_mode, closure_mode, closed_over_mode =
     register_closure_allocation ~loc (as_single_mode expected_mode)
   in
   if expected_mode.strictly_local then
     Locality.submode_exn ~pp:(loc, Function) Locality.local
-      (Alloc.proj_comonadic Areality alloc_mode);
+      (Alloc.proj_comonadic Areality closure_mode);
   let { ty = ty_fun; explanation }, loc_fun = in_function in
   let separate = !Clflags.principal || Env.has_local_constraints env in
   let { ty_arg; ty_ret; arg_mode; ret_mode } as filtered_arrow =
@@ -6537,14 +6560,20 @@ let split_function_ty
   let ret_sort = type_sort ~why:Function_result ty_ret in
   env,
   { filtered_arrow; arg_sort; ret_sort;
-    alloc_mode; ty_arg_mono;
+    alloc_mode; closure_mode; ty_arg_mono;
     expected_inner_mode; expected_pat_mode;
     really_poly
   }
 
 type type_function_result_param =
   { param : function_param;
+    param_yielding : Mode.Yielding.l;
     has_poly : bool;
+  }
+
+type fun_alloc_mode =
+  { alloc_mode: Locality.lr;
+    fun_closure_mode: Mode.Alloc.lr;
   }
 
 module Calling_convention_sort : sig
@@ -6640,10 +6669,11 @@ type type_function_result =
     params_contain_gadt: contains_gadt;
     (* The alloc mode of the "rest of the function". None only for recursive
        calls to [type_function] when there are no parameters left. This needs to
-       be a left mode for the construction of the [fp_curry] field of the outer
-       function.
+       carry the full [Alloc] closure mode, against which the curry constraints
+       are checked, together with the locality component stored as [fp_curry]'s
+       [partial_mode].
     *)
-    fun_alloc_mode: Mode.Alloc.lr option;
+    fun_alloc_mode: fun_alloc_mode option;
     (* Information about the return of the function. None only for
        recursive calls to [type_function] when there are no parameters
        left.
@@ -6658,6 +6688,7 @@ and type_function_ret_info =
     ret_mode: Mode.Alloc.l modes;
     (* The sort returned by the function. *)
     ret_sort: Jkind.sort;
+    cases_arg_yielding: Mode.Yielding.l option;
   }
 
 (* value binding elaboration *)
@@ -6986,7 +7017,7 @@ and type_expect_
           let alloc_mode, record_mode =
             register_allocation ~loc expected_mode
           in
-          Some alloc_mode, record_mode
+          Some (Typedtree.create_alloc_mode_r alloc_mode), record_mode
         else
           None, expected_mode
       in
@@ -7620,7 +7651,8 @@ and type_expect_
       in
       let args = List.map (fun (lbl, arg, _) -> (lbl, arg)) args in
       let exp = rue {
-        exp_desc = Texp_apply(funct, args, pm.apply_position, ap_mode,
+        exp_desc = Texp_apply(funct, args, pm.apply_position,
+                              Typedtree.create_return_mode ap_mode,
                               ap_yielding, zero_alloc);
         exp_loc = loc; exp_extra;
         exp_type = ty_ret;
@@ -7793,6 +7825,7 @@ and type_expect_
               let arg =
                 type_argument ~overwrite:No_overwrite env argument_mode sarg ty ty0
               in
+              let alloc_mode = Typedtree.create_alloc_mode_r alloc_mode in
               re { exp_desc = Texp_variant(l, Some (arg, alloc_mode));
                    exp_loc = loc; exp_extra = [];
                    exp_type = ty_expected0;
@@ -7814,7 +7847,7 @@ and type_expect_
             let arg =
               type_expect env argument_mode sarg (mk_expected ty_expected)
             in
-            Some (arg, alloc_mode)
+            Some (arg, Typedtree.create_alloc_mode_r alloc_mode)
         in
         let arg_type = Option.map (fun (arg, _) -> arg.exp_type) arg in
         let row =
@@ -7881,7 +7914,7 @@ and type_expect_
           let uu =
             unique_use ~loc ~env mode (as_single_mode argument_mode)
           in
-          Boxing (alloc_mode, uu)
+          Boxing (Typedtree.create_alloc_mode_r alloc_mode, uu)
         | false ->
           let mode = cross_left env ty_arg mode in
           submode ~loc ~env mode expected_mode;
@@ -8039,6 +8072,7 @@ and type_expect_
         | Immutable -> Immutable
       in
       let alloc_mode, array_mode = register_allocation ~loc expected_mode in
+      let alloc_mode = Typedtree.create_alloc_mode_r alloc_mode in
       let modalities = Typemode.mutable_modalities mutability in
       let is_contained_by : Mode.Hint.is_contained_by =
         {containing = Array Modality; container = (loc, Expression)}
@@ -8949,7 +8983,7 @@ and type_expect_
                   record_repres;
                   lid;
                   label;
-                  alloc_mode
+                  alloc_mode = Typedtree.create_alloc_mode_r alloc_mode
                 };
               exp_loc = loc;
               exp_extra = [];
@@ -8989,11 +9023,9 @@ and type_expect_
             Value.(of_const ~hint_comonadic:Stack_expression
               { Const.min with areality = Local })
             expected_mode;
-          let local =
-            Alloc.(of_const ~hint_comonadic:Stack_expression
-              { Const.min with areality = Local })
-          in
-          Alloc.submode_err (exp.exp_loc, Allocation) local alloc_mode
+          Typedtree.alloc_mode_r_submode_err (exp.exp_loc, Allocation)
+            (Locality.of_const ~hint:Stack_expression Local)
+            alloc_mode
         end
       | Texp_list_comprehension _ -> always_heap List_comprehension
       | Texp_array_comprehension _ -> always_heap Array_comprehension
@@ -9551,7 +9583,8 @@ and type_ident env ?(recarg=Rejected) lid =
        (* if the locality of returned value of the primitive is poly
           we then register allocation for further optimization *)
        | (Prim_poly, _), Some mode ->
-           register_allocation_mode (Alloc.max_with_comonadic Areality mode)
+           let mode = Locality.disallow_left mode in
+           register_allocation_mode mode
        | _ -> ()
        end;
        let yielding =
@@ -9772,7 +9805,7 @@ and type_function_
           { filtered_arrow = { ty_arg; arg_mode; ty_ret; ret_mode };
             arg_sort; ret_sort;
             ty_arg_mono; expected_pat_mode; expected_inner_mode;
-            alloc_mode; really_poly
+            alloc_mode; closure_mode; really_poly
           } =
         split_function_ty env expected_mode ty_expected loc
           ~is_first_val_param:first ~is_final_val_param
@@ -9855,7 +9888,7 @@ and type_function_
                 | None ->
                   assert(is_final_val_param);
                   Final_arg
-                | Some fun_alloc_mode ->
+                | Some { fun_closure_mode; alloc_mode } ->
                   assert(not is_final_val_param);
                   (* Handle mode crossing of [arg_mode]. Note that [close_over]
                      uses the [arg_mode.comonadic] as a left mode, and
@@ -9863,20 +9896,25 @@ and type_function_
                      mode-crossed differently. *)
                   let arg_mode = alloc_mode_cross_to_max_min env ty_arg arg_mode in
                   begin match
-                    Alloc.submode (Alloc.close_over arg_mode) fun_alloc_mode
+                    Alloc.submode (Alloc.close_over arg_mode) fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
                       raise (error(loc, env, Uncurried_function_escapes e))
                   end;
                   begin match
-                    Alloc.submode (Alloc.partial_apply alloc_mode) fun_alloc_mode
+                    Alloc.submode
+                      (Alloc.partial_apply closure_mode)
+                      fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
                       raise (error(loc, env, Uncurried_function_escapes e))
                   end;
-                  More_args {partial_mode = Alloc.disallow_right fun_alloc_mode}
+                  More_args
+                    { partial_mode =
+                        Typedtree.create_alloc_mode_l
+                          (Locality.disallow_right alloc_mode) }
               in
               pat, params_suffix, body, ret_info, newtypes, contains_gadt,
               curry, ext_env, calling_convention_sorts
@@ -9968,8 +10006,17 @@ and type_function_
             param,
             param_uid
       in
+      let param_yielding =
+        Alloc.proj_comonadic Yielding (Alloc.disallow_right arg_mode)
+      in
+      let arg_locality =
+        Alloc.disallow_right arg_mode
+        |> Alloc.proj_comonadic Areality
+        |> Typedtree.create_alloc_mode_l
+      in
       let param =
         { has_poly;
+          param_yielding;
           param =
             { fp_kind;
               fp_arg_label = typed_arg_label;
@@ -9980,7 +10027,8 @@ and type_function_
                 List.map (fun (id, t, loc, uid) -> (id, t, loc, uid)) newtypes;
               fp_sort = arg_sort;
               fp_mode =
-                { mode_annots with mode_modes = Alloc.disallow_right arg_mode };
+                { mode_annots with
+                  mode_modes = arg_locality };
               fp_curry = curry;
               fp_loc = pparam_loc;
             };
@@ -10017,11 +10065,15 @@ and type_function_
           let ret_mode =
             {ret_mode_annots with mode_modes = Alloc.disallow_right ret_mode }
           in
-          Some { ret_sort ; ret_mode }
+          Some { ret_sort ; ret_mode; cases_arg_yielding = None }
+      in
+      let fun_alloc_mode =
+        { fun_closure_mode = closure_mode;
+          alloc_mode }
       in
       { function_ = exp_type, param :: params, body;
         newtypes = []; params_contain_gadt = contains_gadt;
-        ret_info; fun_alloc_mode = Some alloc_mode;
+        ret_info; fun_alloc_mode = Some fun_alloc_mode;
         calling_convention_sorts;
       }
   | [] ->
@@ -10506,7 +10558,7 @@ and type_option_some env expected_mode sarg ty ty0 =
   let sort = Jkind.Sort.scannable in
   let repres = Types.Constructor_uniform_value in
   mkexp (Texp_construct(mknoloc lid , csome, repres, [sort, arg],
-                        Some alloc_mode))
+                        Some (Typedtree.create_alloc_mode_r alloc_mode)))
     (type_option arg.exp_type) arg.exp_loc arg.exp_env
 
 (* [expected_mode] is the expected mode of the field. It's already adjusted for
@@ -10724,6 +10776,15 @@ and type_argument_ ?explanation ?recarg ~overwrite env (mode : expected_mode) sa
       let arg_sort = type_sort ~why:Function_argument ty_arg in
       let ret_sort = type_sort ~why:Function_result ty_res in
       let eta_pat, eta_var = var_pair ~mode:eta_mode "eta" ty_arg arg_sort in
+      let fc_arg_mode =
+        Alloc.disallow_right marg
+        |> Alloc.proj_comonadic Areality
+        |> Typedtree.create_alloc_mode_l
+      in
+      let fc_ret_mode =
+        Alloc.proj_comonadic Areality (Alloc.disallow_right mret)
+        |> Typedtree.create_return_mode
+      in
       (* CR layouts v10: When we add abstract jkinds, the eta expansion here
          becomes impossible in some cases - we'll need better errors.  For test
          cases, look toward the end of
@@ -10735,7 +10796,7 @@ and type_argument_ ?explanation ?recarg ~overwrite env (mode : expected_mode) sa
              (texp,
               args @ [Nolabel, Arg (eta_var, arg_sort)],
               Nontail,
-              Alloc.proj_comonadic Areality (Alloc.disallow_right mret),
+              fc_ret_mode,
               Yielding.disallow_right Yielding.yielding,
               None)}
         in
@@ -10754,13 +10815,14 @@ and type_argument_ ?explanation ?recarg ~overwrite env (mode : expected_mode) sa
                     fc_param_debug_uid = param_uid; fc_env = env;
                     fc_ret_type = ty_res; fc_loc = cases_loc;
                     fc_exp_extra = []; fc_attributes = [];
-                    fc_arg_mode = Alloc.disallow_right marg;
+                    fc_arg_mode;
                     fc_arg_sort = arg_sort;
                   };
               ret_mode =
-                { mode_modes = Alloc.disallow_right mret; mode_desc = [] };
+                { mode_modes = fc_ret_mode;
+                  mode_desc = [] };
               ret_sort;
-              alloc_mode;
+              alloc_mode = Typedtree.create_alloc_mode_r alloc_mode;
               yielding = Yielding.disallow_right Yielding.yielding;
               zero_alloc = Zero_alloc.default
             }
@@ -11088,7 +11150,8 @@ and type_tuple ~overwrite ~loc ~env ~(expected_mode : expected_mode) ~ty_expecte
       sexpl types_and_modes overwrites
   in
   re {
-    exp_desc = Texp_tuple (expl, alloc_mode);
+    exp_desc =
+      Texp_tuple (expl, Typedtree.create_alloc_mode_r alloc_mode);
     exp_loc = loc; exp_extra = [];
     (* Keep sharing *)
     exp_type = newty (Ttuple (List.map (fun (label, e) -> label, e.exp_type) expl));
@@ -11279,7 +11342,7 @@ and type_construct ~overwrite ~sexp env (expected_mode : expected_mode) lid sarg
        let alloc_mode, argument_mode =
          register_allocation ~loc:sexp.pexp_loc expected_mode
        in
-       argument_mode, Some alloc_mode
+       argument_mode, Some (Typedtree.create_alloc_mode_r alloc_mode)
   in
   begin match overwrite, constr.cstr_repr with
   | Overwriting(_, _, _), Variant_unboxed ->
@@ -11750,7 +11813,7 @@ and type_function_cases_expect
   Builtin_attributes.warning_scope attrs begin fun () ->
     let env,
         { filtered_arrow = { ty_arg; ty_ret; arg_mode; ret_mode };
-          arg_sort; ret_sort;
+          arg_sort; ret_sort; closure_mode;
           ty_arg_mono; expected_pat_mode; expected_inner_mode; alloc_mode;
         } =
       split_function_ty env expected_mode ty_expected loc ~arg_label:Nolabel
@@ -11768,7 +11831,22 @@ and type_function_cases_expect
         (newgenty
            (Tarrow ((Nolabel, arg_mode, ret_mode), ty_arg, ty_ret, commu_ok)))
     in
+<<<<<<< Merlin:ageorges/mode-polymorphism-alloc-mode
     let param, param_uid =
+||||||| Compiler:last-imported
+    unify_exp_types loc env ty_fun (instance ty_expected);
+    let param , param_uid =
+=======
+    unify_exp_types loc env ty_fun (instance ty_expected);
+    let fc_arg_mode =
+      Alloc.proj_comonadic Areality (Alloc.disallow_right arg_mode)
+      |> Typedtree.create_alloc_mode_l
+    in
+    let yielding_mode =
+      Alloc.proj_comonadic Yielding (Alloc.disallow_right arg_mode)
+    in
+    let param , param_uid =
+>>>>>>> Compiler:HEAD
       name_cases ~pattern_kind:Value_pattern_in_argument "param" cases
     in
     let cases =
@@ -11781,10 +11859,11 @@ and type_function_cases_expect
         fc_env = env;
         fc_ret_type = ty_ret;
         fc_attributes = [];
-        fc_arg_mode = Alloc.disallow_right arg_mode;
+        fc_arg_mode;
         fc_arg_sort = arg_sort;
       }
     in
+<<<<<<< Merlin:ageorges/mode-polymorphism-alloc-mode
     let () =
       try unify_exp_types loc env ty_fun (instance ty_expected)
       with exn ->
@@ -11808,16 +11887,24 @@ and type_function_cases_expect
             exp_env = env;
           }
     in
+||||||| Compiler:last-imported
+=======
+    let fun_alloc_mode =
+      { fun_closure_mode = closure_mode;
+        alloc_mode }
+    in
+>>>>>>> Compiler:HEAD
     let calling_convention_sorts =
       [ { Calling_convention_sort.ccs_ty = ty_arg; ccs_sort = arg_sort;
           ccs_env = env; ccs_loc = loc; ccs_kind = `Argument };
         { Calling_convention_sort.ccs_ty = ty_ret; ccs_sort = ret_sort;
           ccs_env = env; ccs_loc = loc; ccs_kind = `Result } ]
     in
-    cases, ty_fun, alloc_mode,
+    cases, ty_fun, fun_alloc_mode,
       { ret_sort;
         ret_mode =
-          {mode_modes = Alloc.disallow_right ret_mode; mode_desc = []} },
+          {mode_modes = Alloc.disallow_right ret_mode; mode_desc = []};
+        cases_arg_yielding = Some yielding_mode },
       calling_convention_sorts
   end
 
@@ -12362,7 +12449,7 @@ and type_n_ary_function
       type_function env expected_mode ty_expected params constraint_ body
         ~in_function ~first:true
     in
-    let fun_alloc_mode, { ret_mode; ret_sort } =
+    let fun_alloc_mode, { ret_mode; ret_sort; cases_arg_yielding } =
       match fun_alloc_mode, ret_info with
       | Some x, Some y -> x, y
       | None, _ ->
@@ -12459,31 +12546,45 @@ and type_n_ary_function
       | (Check _ | Assume _ | Ignore_assert_all) ->
         Zero_alloc.create_const zero_alloc
     in
-    let alloc_mode = Mode.Alloc.disallow_left fun_alloc_mode in
+    let ret_mode_modes =
+      Alloc.proj_comonadic Areality ret_mode.mode_modes
+      |> Typedtree.create_return_mode
+    in
+    let ret_mode =
+      { ret_mode with
+        mode_modes = ret_mode_modes }
+    in
     (* [yielding] records whether *fully applying* this function can perform a
        free effect: the closure may yield if it closes over a yielding value
        (its own mode), or if any argument it is given is yielding (the
        parameter modes). [Value_rec_compiler]'s eta-expanding wrapper uses
        this, since the wrapper is exactly a full application. *)
-    let param_alloc_modes =
-      List.map (fun (p : function_param) -> p.fp_mode.mode_modes) params
+    let param_yieldings =
+      List.map
+        (fun (p : type_function_result_param) -> p.param_yielding)
+        result_params
     in
     (* A [function | ...] body takes an extra implicit parameter that is not in
        [params]; if that argument is yielding then the closure is yielding. *)
-    let param_alloc_modes =
-      match body with
-      | Tfunction_body _ -> param_alloc_modes
-      | Tfunction_cases fc -> fc.fc_arg_mode :: param_alloc_modes
+    let param_yieldings =
+      match cases_arg_yielding with
+      | None -> param_yieldings
+      | Some yielding -> yielding :: param_yieldings
     in
     let yielding =
-      Alloc.proj_comonadic Yielding
-        (Alloc.join (Alloc.disallow_right fun_alloc_mode :: param_alloc_modes))
+      Yielding.join
+        (Alloc.proj_comonadic Yielding
+           (Alloc.disallow_right fun_alloc_mode.fun_closure_mode)
+         :: param_yieldings)
     in
     re
       { exp_desc =
           Texp_function
             { params; body; ret_sort;
-              alloc_mode; ret_mode; yielding;
+              alloc_mode =
+                Typedtree.create_alloc_mode_r
+                  (Locality.disallow_left fun_alloc_mode.alloc_mode);
+              ret_mode; yielding;
               zero_alloc
             };
         exp_loc = loc;

--- a/external/merlin/src/ocaml/typing/typecore.ml
+++ b/external/merlin/src/ocaml/typing/typecore.ml
@@ -7668,7 +7668,7 @@ and type_expect_
                   funct,
                   args,
                   pm.apply_position,
-                  ap_mode,
+                  Typedtree.create_return_mode ap_mode,
                   Mode.Yielding.newvar (),
                   None
                 );
@@ -9665,12 +9665,15 @@ and type_function
       let ret_info =
         { ret_mode = { mode_modes = Alloc.newvar (); mode_desc = [] };
           ret_sort = Var (Jkind.Sort.new_var ~level:(Ctype.get_current_level ()));
+          cases_arg_yielding = None;
         }
       in
       { function_ = fun_ty, [], fun_body;
         newtypes = [];
         params_contain_gadt = No_gadt;
-        fun_alloc_mode = Some (Alloc.newvar ());
+        fun_alloc_mode =
+          Some { alloc_mode = Locality.newvar ();
+                 fun_closure_mode = Alloc.newvar () };
         ret_info = Some ret_info;
         calling_convention_sorts = []
       })
@@ -9731,15 +9734,23 @@ and type_function_
                (let params = List.map (fun { param; _ } -> param) params in
                 let ret_mode, ret_sort =
                   match ret_info with
-                  | Some { ret_mode; ret_sort } -> ret_mode, ret_sort
+                  | Some { ret_mode; ret_sort; _ } ->
+                    { ret_mode with
+                      mode_modes =
+                        Alloc.proj_comonadic Areality ret_mode.mode_modes
+                        |> Typedtree.create_return_mode },
+                    ret_sort
                   | None ->
-                    ({ mode_modes = Alloc.newvar (); mode_desc = [] },
+                    ({ mode_modes =
+                         Typedtree.create_return_mode (Locality.newvar ());
+                       mode_desc = [] },
                      Var (Jkind.Sort.new_var ~level:(Ctype.get_current_level ())))
                 in
-                let alloc_mode = Alloc.disallow_left @@
+                let alloc_mode =
+                  Typedtree.create_alloc_mode_r @@ Locality.disallow_left @@
                   match fun_alloc_mode with
-                  | Some alloc_mode -> alloc_mode
-                  | None -> Alloc.newvar ()
+                  | Some { alloc_mode; _ } -> alloc_mode
+                  | None -> Locality.newvar ()
                 in
                 Texp_function
                   { params;
@@ -9948,14 +9959,25 @@ and type_function_
                (let params = List.map (fun { param; _ } -> param) params in
                 let ret_mode, ret_sort =
                   match ret_info with
-                  | Some { ret_mode; ret_sort } -> ret_mode, ret_sort
+                  | Some { ret_mode; ret_sort; _ } ->
+                    { ret_mode with
+                      mode_modes =
+                        Alloc.proj_comonadic Areality ret_mode.mode_modes
+                        |> Typedtree.create_return_mode },
+                    ret_sort
                   | None ->
-                    ( { mode_modes = Alloc.disallow_right ret_mode; mode_desc = [] }
+                    ( { mode_modes =
+                          Alloc.proj_comonadic Areality
+                            (Alloc.disallow_right ret_mode)
+                          |> Typedtree.create_return_mode;
+                        mode_desc = [] }
                     , ret_sort )
                 in
                 Texp_function
                   { params; body; ret_mode; ret_sort;
-                    alloc_mode = Alloc.disallow_left alloc_mode;
+                    alloc_mode =
+                      Typedtree.create_alloc_mode_r
+                        (Locality.disallow_left alloc_mode);
                     zero_alloc = Zero_alloc.default;
                     yielding = Yielding.newvar () });
               exp_loc = loc;
@@ -11831,13 +11853,6 @@ and type_function_cases_expect
         (newgenty
            (Tarrow ((Nolabel, arg_mode, ret_mode), ty_arg, ty_ret, commu_ok)))
     in
-<<<<<<< Merlin:ageorges/mode-polymorphism-alloc-mode
-    let param, param_uid =
-||||||| Compiler:last-imported
-    unify_exp_types loc env ty_fun (instance ty_expected);
-    let param , param_uid =
-=======
-    unify_exp_types loc env ty_fun (instance ty_expected);
     let fc_arg_mode =
       Alloc.proj_comonadic Areality (Alloc.disallow_right arg_mode)
       |> Typedtree.create_alloc_mode_l
@@ -11845,8 +11860,7 @@ and type_function_cases_expect
     let yielding_mode =
       Alloc.proj_comonadic Yielding (Alloc.disallow_right arg_mode)
     in
-    let param , param_uid =
->>>>>>> Compiler:HEAD
+    let param, param_uid =
       name_cases ~pattern_kind:Value_pattern_in_argument "param" cases
     in
     let cases =
@@ -11863,7 +11877,6 @@ and type_function_cases_expect
         fc_arg_sort = arg_sort;
       }
     in
-<<<<<<< Merlin:ageorges/mode-polymorphism-alloc-mode
     let () =
       try unify_exp_types loc env ty_fun (instance ty_expected)
       with exn ->
@@ -11874,9 +11887,15 @@ and type_function_cases_expect
                 { params = [];
                   body = Tfunction_cases cases;
                   ret_mode =
-                    { mode_modes = Alloc.disallow_right ret_mode; mode_desc = []};
+                    { mode_modes =
+                        Alloc.proj_comonadic Areality
+                          (Alloc.disallow_right ret_mode)
+                        |> Typedtree.create_return_mode;
+                      mode_desc = []};
                   ret_sort;
-                  alloc_mode = Alloc.disallow_left alloc_mode;
+                  alloc_mode =
+                    Typedtree.create_alloc_mode_r
+                      (Locality.disallow_left alloc_mode);
                   zero_alloc = Zero_alloc.default;
                   yielding = Yielding.newvar ()
                 };
@@ -11887,13 +11906,10 @@ and type_function_cases_expect
             exp_env = env;
           }
     in
-||||||| Compiler:last-imported
-=======
     let fun_alloc_mode =
       { fun_closure_mode = closure_mode;
         alloc_mode }
     in
->>>>>>> Compiler:HEAD
     let calling_convention_sorts =
       [ { Calling_convention_sort.ccs_ty = ty_arg; ccs_sort = arg_sort;
           ccs_env = env; ccs_loc = loc; ccs_kind = `Argument };

--- a/external/merlin/src/ocaml/typing/typedtree.ml
+++ b/external/merlin/src/ocaml/typing/typedtree.ml
@@ -141,6 +141,8 @@ let alloc_mode_r_zap_to_ceil m = Mode.Locality.zap_to_ceil m
 
 let alloc_mode_r_submode_err pp m t = Mode.Locality.submode_err pp m t
 
+let alloc_mode_r_map f m = f m
+
 let print_alloc_mode_r ppf m =
   Format_doc.compat (Mode.Locality.print ()) ppf m
 
@@ -150,6 +152,8 @@ let create_alloc_mode_l m =
   assert (Mode.Locality.check_const_or_level_0 m); m
 
 let alloc_mode_l_zap_to_floor m = Mode.Locality.zap_to_floor m
+
+let alloc_mode_l_map f m = f m
 
 let print_alloc_mode_l ppf m =
   Format_doc.compat (Mode.Locality.print ()) ppf m

--- a/external/merlin/src/ocaml/typing/typedtree.ml
+++ b/external/merlin/src/ocaml/typing/typedtree.ml
@@ -132,10 +132,40 @@ let print_unique_use ppf (u,l) =
     (Format_doc.compat (Mode.Uniqueness.print ())) u
     (Format_doc.compat (Mode.Linearity.print ())) l
 
-type alloc_mode = Mode.Alloc.r
+type alloc_mode_r = Mode.Locality.r
+
+let create_alloc_mode_r m =
+  assert (Mode.Locality.check_const_or_level_0 m); m
+
+let alloc_mode_r_zap_to_ceil m = Mode.Locality.zap_to_ceil m
+
+let alloc_mode_r_submode_err pp m t = Mode.Locality.submode_err pp m t
+
+let print_alloc_mode_r ppf m =
+  Format_doc.compat (Mode.Locality.print ()) ppf m
+
+type alloc_mode_l = Mode.Locality.l
+
+let create_alloc_mode_l m =
+  assert (Mode.Locality.check_const_or_level_0 m); m
+
+let alloc_mode_l_zap_to_floor m = Mode.Locality.zap_to_floor m
+
+let print_alloc_mode_l ppf m =
+  Format_doc.compat (Mode.Locality.print ()) ppf m
+
+type return_mode = Mode.Locality.l
+
+let create_return_mode m =
+  assert (Mode.Locality.check_const_or_level_0 m); m
+
+let return_mode_zap_to_floor m = Mode.Locality.zap_to_floor m
+
+let print_return_mode ppf m =
+  Format_doc.compat (Mode.Locality.print ()) ppf m
 
 type texp_field_boxing =
-  | Boxing of alloc_mode * unique_use
+  | Boxing of alloc_mode_r * unique_use
   | Non_boxing of unique_use
 
 let aliased_many_use =
@@ -202,7 +232,7 @@ and 'k pattern_desc =
       sort: Jkind_types.Sort.t;
       mode: Mode.Value.l;
       lpoly: Lpoly.t;
-      env_alloc_mode: alloc_mode;
+      env_alloc_mode: alloc_mode_r;
     } -> value pattern_desc
   | Tpat_constant : constant -> value pattern_desc
   | Tpat_unboxed_unit : value pattern_desc
@@ -287,9 +317,9 @@ and expression_desc =
   | Texp_function of
       { params : function_param list;
         body : function_body;
-        ret_mode : Mode.Alloc.l modes;
+        ret_mode : return_mode modes;
         ret_sort : Jkind.sort;
-        alloc_mode : alloc_mode;
+        alloc_mode : alloc_mode_r;
         yielding : Mode.Yielding.l;
         zero_alloc : Zero_alloc.t;
       }
@@ -302,19 +332,20 @@ and expression_desc =
   | Texp_try of expression * value case list * value case list
   | Texp_unboxed_unit
   | Texp_unboxed_bool of bool
-  | Texp_tuple of (string option * expression) list * alloc_mode
+  | Texp_tuple of (string option * expression) list * alloc_mode_r
   | Texp_unboxed_tuple of (string option * expression * Jkind.sort) list
   | Texp_construct of
       Longident.t loc * constructor_description * constructor_representation *
-      (Jkind.sort * expression) list * alloc_mode option
-  | Texp_variant of label * (expression * alloc_mode) option
+      (Jkind.sort * expression) list
+      * alloc_mode_r option
+  | Texp_variant of label * (expression * alloc_mode_r) option
   | Texp_record of {
       fields :
         ( Data_types.label_description * Jkind.sort * record_label_definition )
           array;
       representation : Types.record_representation;
       extended_expression : (expression * Jkind.sort * Unique_barrier.t) option;
-      alloc_mode : alloc_mode option
+      alloc_mode : alloc_mode_r option
     }
   | Texp_record_unboxed_product of {
       fields :
@@ -329,7 +360,7 @@ and expression_desc =
       record_repres : Types.record_representation;
       lid : Longident.t loc;
       label : Data_types.label_description;
-      alloc_mode : alloc_mode;
+      alloc_mode : alloc_mode_r;
     }
   | Texp_field of {
       record : expression;
@@ -356,7 +387,7 @@ and expression_desc =
       label : Data_types.label_description;
       newval : expression;
     }
-  | Texp_array of mutability * Jkind.Sort.t * expression list * alloc_mode
+  | Texp_array of mutability * Jkind.Sort.t * expression list * alloc_mode_r
   | Texp_idx of block_access * unboxed_access list
   | Texp_list_comprehension of comprehension
   | Texp_array_comprehension of mutability * Jkind.sort * comprehension
@@ -473,7 +504,7 @@ and 'k case =
     }
 
 and function_curry =
-  | More_args of { partial_mode : Mode.Alloc.l }
+  | More_args of { partial_mode : alloc_mode_l }
   | Final_arg
 
 and function_param =
@@ -484,7 +515,7 @@ and function_param =
     fp_partial: partial;
     fp_kind: function_param_kind;
     fp_sort: Jkind.sort;
-    fp_mode: Mode.Alloc.l modes;
+    fp_mode: alloc_mode_l modes;
     fp_curry: function_curry;
     fp_newtypes: (Ident.t * string loc *
                   Parsetree.jkind_annotation option * Uid.t) list;
@@ -502,7 +533,7 @@ and function_body =
 and function_cases =
   { fc_cases: value case list;
     fc_env : Env.t;
-    fc_arg_mode: Mode.Alloc.l;
+    fc_arg_mode: alloc_mode_l;
     fc_arg_sort: Jkind.sort;
     fc_ret_type : Types.type_expr;
     fc_partial: partial;
@@ -534,9 +565,9 @@ and ('a, 'b) arg_or_omitted =
   | Omitted of 'b
 
 and omitted_parameter =
-  { mode_closure : Mode.Alloc.r;
-    mode_arg : Mode.Alloc.l;
-    mode_ret : Mode.Alloc.l;
+  { mode_closure : alloc_mode_r;
+    mode_arg : alloc_mode_l;
+    mode_ret : return_mode;
     sort_arg : Jkind.sort;
     sort_ret : Jkind.sort }
 

--- a/external/merlin/src/ocaml/typing/typedtree.mli
+++ b/external/merlin/src/ocaml/typing/typedtree.mli
@@ -113,7 +113,32 @@ type unique_use = Mode.Uniqueness.r * Mode.Linearity.l
 
 val print_unique_use : Format.formatter -> unique_use -> unit
 
-type alloc_mode = Mode.Alloc.r
+type alloc_mode_r
+
+val create_alloc_mode_r : Mode.Locality.r -> alloc_mode_r
+
+val alloc_mode_r_zap_to_ceil : alloc_mode_r -> Mode.Locality.Const.t
+
+val alloc_mode_r_submode_err :
+  Mode.Hint.pinpoint -> Mode.Locality.l -> alloc_mode_r -> unit
+
+val print_alloc_mode_r : Format.formatter -> alloc_mode_r -> unit
+
+type alloc_mode_l
+
+val create_alloc_mode_l : Mode.Locality.l -> alloc_mode_l
+
+val alloc_mode_l_zap_to_floor : alloc_mode_l -> Mode.Locality.Const.t
+
+val print_alloc_mode_l : Format.formatter -> alloc_mode_l -> unit
+
+type return_mode
+
+val create_return_mode : Mode.Locality.l -> return_mode
+
+val return_mode_zap_to_floor : return_mode -> Mode.Locality.Const.t
+
+val print_return_mode : Format.formatter -> return_mode -> unit
 
 (* CR-someday liam923: We'd like to split this into an arrow_modes and
    value_modes type. *)
@@ -128,7 +153,7 @@ type modalities = Typemode.modalities =
   }
 
 type texp_field_boxing =
-  | Boxing of alloc_mode * unique_use
+  | Boxing of alloc_mode_r * unique_use
   (** Projection requires boxing. [unique_use] describes the usage of the
       unboxed field as argument to boxing. *)
   | Non_boxing of unique_use
@@ -248,7 +273,7 @@ and 'k pattern_desc =
       the allocation mode of the captured environment. [pending] during
       type-checking; guaranteed [determined] of a non-empty list of generic sort
       variables after [type_let] returns. *)
-      env_alloc_mode: alloc_mode;
+      env_alloc_mode: alloc_mode_r;
       (** The allocation mode of the environment captured by the layout
       function.
 
@@ -482,11 +507,12 @@ and expression_desc =
   | Texp_function of
       { params : function_param list;
         body : function_body;
-        ret_mode : Mode.Alloc.l modes;
-        (* Mode where the function allocates, ie local for a function of
-           type 'a -> local_ 'b, and heap for a function of type 'a -> 'b *)
+        ret_mode : return_mode modes;
+        (* Whether the function may return a value allocated in its caller's
+           region: [local] for ['a -> 'b @ local], [global] for ['a -> 'b].
+           Becomes [Lambda.return_mode] via [Translmode.transl_ret_mode]. *)
         ret_sort : Jkind.sort;
-        alloc_mode : alloc_mode;
+        alloc_mode : alloc_mode_r;
         (* Mode at which the closure is allocated *)
         yielding : Mode.Yielding.l;
         (* Whether fully applying this function can perform a free effect. This
@@ -505,7 +531,7 @@ and expression_desc =
       *)
   | Texp_apply of
       expression * (arg_label * apply_arg) list * apply_position *
-        Mode.Locality.l * Mode.Yielding.l * Zero_alloc.assume option
+        return_mode * Mode.Yielding.l * Zero_alloc.assume option
         (** E0 ~l1:E1 ... ~ln:En
 
             The expression can be Omitted if the expression is abstracted over
@@ -549,7 +575,7 @@ and expression_desc =
         (** #() *)
   | Texp_unboxed_bool of bool
         (** #false, #true *)
-  | Texp_tuple of (string option * expression) list * alloc_mode
+  | Texp_tuple of (string option * expression) list * alloc_mode_r
         (** [Texp_tuple(el)] represents
             - [(E1, ..., En)]
                 when [el] is [(None, E1);...;(None, En)],
@@ -570,7 +596,7 @@ and expression_desc =
   | Texp_construct of
       Longident.t loc * Data_types.constructor_description *
       Types.constructor_representation * (Jkind.sort * expression) list *
-      alloc_mode option
+      alloc_mode_r option
         (** C                []
             C E              [E]
             C (E1, ..., En)  [E1;...;En]
@@ -579,7 +605,7 @@ and expression_desc =
             or [None] if the constructor is [Cstr_unboxed] or [Cstr_constant],
             in which case it does not need allocation.
          *)
-  | Texp_variant of label * (expression * alloc_mode) option
+  | Texp_variant of label * (expression * alloc_mode_r) option
         (** [alloc_mode] is the allocation mode of the variant,
             or [None] if the variant has no argument,
             in which case it does not need allocation.
@@ -590,7 +616,7 @@ and expression_desc =
           array;
       representation : Types.record_representation;
       extended_expression : (expression * Jkind.sort * Unique_barrier.t) option;
-      alloc_mode : alloc_mode option
+      alloc_mode : alloc_mode_r option
     }
         (** { l1=P1; ...; ln=Pn }           (extended_expression = None)
             { E0 with l1=P1; ...; ln=Pn }   (extended_expression = Some E0)
@@ -629,7 +655,7 @@ and expression_desc =
       record_repres : Types.record_representation;
       lid : Longident.t loc;
       label : Data_types.label_description;
-      alloc_mode : alloc_mode;
+      alloc_mode : alloc_mode_r;
     }
   | Texp_field of {
       record : expression;
@@ -661,7 +687,8 @@ and expression_desc =
       newval : expression;
     }
     (** [alloc_mode] translates to the [modify_mode] of the record *)
-  | Texp_array of Types.mutability * Jkind.Sort.t * expression list * alloc_mode
+  | Texp_array of
+      Types.mutability * Jkind.Sort.t * expression list * alloc_mode_r
   | Texp_idx of block_access * unboxed_access list
   | Texp_list_comprehension of comprehension
   (* CR layouts-scannable: The sort here is no longer used. Instead, a layout is
@@ -738,7 +765,7 @@ and meth =
   | Tmeth_ancestor of Ident.t * Path.t
 
 and function_curry =
-  | More_args of { partial_mode : Mode.Alloc.l }
+  | More_args of { partial_mode : alloc_mode_l }
   | Final_arg
 
 and 'k case =
@@ -765,7 +792,7 @@ and function_param =
     *)
     fp_kind: function_param_kind;
     fp_sort: Jkind.sort;
-    fp_mode: Mode.Alloc.l modes;
+    fp_mode: alloc_mode_l modes;
     fp_curry: function_curry;
     fp_newtypes: (Ident.t * string loc *
                   Parsetree.jkind_annotation option * Uid.t) list;
@@ -806,7 +833,7 @@ and function_cases =
     (** [fc_env] contains entries from all parameters except
         for the last one being matched by the cases.
     *)
-    fc_arg_mode: Mode.Alloc.l;
+    fc_arg_mode: alloc_mode_l;
     fc_arg_sort: Jkind.sort;
     fc_ret_type : Types.type_expr;
     fc_partial: partial;
@@ -899,9 +926,9 @@ and ('a, 'b) arg_or_omitted =
 and apply_arg = (expression * Jkind.sort, omitted_parameter) arg_or_omitted
 
 and omitted_parameter =
-  { mode_closure : Mode.Alloc.r;
-    mode_arg : Mode.Alloc.l;
-    mode_ret : Mode.Alloc.l;
+  { mode_closure : alloc_mode_r;
+    mode_arg : alloc_mode_l;
+    mode_ret : return_mode;
     sort_arg : Jkind.sort;
     sort_ret : Jkind.sort }
 

--- a/external/merlin/src/ocaml/typing/typedtree.mli
+++ b/external/merlin/src/ocaml/typing/typedtree.mli
@@ -122,6 +122,8 @@ val alloc_mode_r_zap_to_ceil : alloc_mode_r -> Mode.Locality.Const.t
 val alloc_mode_r_submode_err :
   Mode.Hint.pinpoint -> Mode.Locality.l -> alloc_mode_r -> unit
 
+val alloc_mode_r_map : (Mode.Locality.r -> 'a) -> alloc_mode_r -> 'a
+
 val print_alloc_mode_r : Format.formatter -> alloc_mode_r -> unit
 
 type alloc_mode_l
@@ -129,6 +131,8 @@ type alloc_mode_l
 val create_alloc_mode_l : Mode.Locality.l -> alloc_mode_l
 
 val alloc_mode_l_zap_to_floor : alloc_mode_l -> Mode.Locality.Const.t
+
+val alloc_mode_l_map : (Mode.Locality.l -> 'a) -> alloc_mode_l -> 'a
 
 val print_alloc_mode_l : Format.formatter -> alloc_mode_l -> unit
 

--- a/external/merlin/tests/test-dirs/function-recovery.t
+++ b/external/merlin/tests/test-dirs/function-recovery.t
@@ -40,9 +40,9 @@
                     None
                   expression (test.ml[3,104+11]..test.ml[3,104+28])
                     Texp_function
-                    alloc_mode id(modevar#19<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful]);id(modevar#1a<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+                    alloc_mode id(modevar#1b<0>[global .. local])
                     yielding_mode unyielding
-                    id(modevar#17<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful]);id(modevar#18<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+                    return_mode proj_Locality(modevar#17<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful])
                     []
                     []
                     Tfunction_body
@@ -85,9 +85,9 @@
             extra (type.ml[1,0+18]..type.ml[1,0+19])
               Texp_newtype  t
             Texp_function
-            alloc_mode id(modevar#4<0>[global,many,portable,forkable,unyielding,stateless .. global,once,nonportable,unforkable,yielding,stateful]);id(modevar#5<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+            alloc_mode global
             yielding_mode unyielding
-            id(modevar#8<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful]);id(modevar#9<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+            return_mode proj_Locality(modevar#8<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful])
             []
             [
               Nolabel
@@ -108,7 +108,7 @@
                   Tpat_var \"foo\"
                   sort value
                   value_mode meet(local,once,nonportable,unforkable,yielding,stateful) . local_to_regional_full(modevar#6<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful]);meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#7<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
-                id(modevar#6<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful]);id(modevar#7<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+                proj_Locality(modevar#6<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful])
                 []
             ]
             Tfunction_body

--- a/external/merlin/tests/test-dirs/type-enclosing/underscore-ids.t
+++ b/external/merlin/tests/test-dirs/type-enclosing/underscore-ids.t
@@ -459,9 +459,9 @@ We try several places in the identifier to check the result stability
             value_mode meet(local,once,nonportable,unforkable,yielding,stateful)(modevar#9<0>[global,many,portable,forkable,unyielding,stateless .. global,once,nonportable,unforkable,yielding,stateful]);meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#a<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
           expression (under.ml[2,13+6]..under.ml[5,70+17]) ghost
             Texp_function
-            alloc_mode id(modevar#b<0>[global,many,portable,forkable,unyielding,stateless .. global,once,nonportable,unforkable,yielding,stateful]);id(modevar#c<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+            alloc_mode global
             yielding_mode unyielding
-            id(modevar#1d<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful]);id(modevar#1e<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+            return_mode proj_Locality(modevar#1d<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful])
             []
             [
               Nolabel
@@ -470,7 +470,7 @@ We try several places in the identifier to check the result stability
                   Tpat_var \"x\"
                   sort '_representable_layout_1
                   value_mode meet(local,once,nonportable,unforkable,yielding,stateful) . local_to_regional_full(modevar#d<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful]);meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#e<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
-                id(modevar#d<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful]);id(modevar#e<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+                proj_Locality(modevar#d<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful])
                 []
             ]
             Tfunction_body

--- a/external/merlin/tests/test-dirs/typing-recovery.t
+++ b/external/merlin/tests/test-dirs/typing-recovery.t
@@ -98,9 +98,9 @@
             value_mode meet(local,once,nonportable,unforkable,yielding,stateful)(modevar#4<0>[global,many,portable,forkable,unyielding,stateless .. global,once,nonportable,unforkable,yielding,stateful]);meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#5<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
           expression (test.ml[2,15+6]..test.ml[6,69+12]) ghost
             Texp_function
-            alloc_mode id(modevar#6<0>[global,many,portable,forkable,unyielding,stateless .. global,once,nonportable,unforkable,yielding,stateful]);id(modevar#7<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+            alloc_mode global
             yielding_mode unyielding
-            id(modevar#a<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful]);id(modevar#b<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,dynamic])
+            return_mode proj_Locality(modevar#a<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful])
             []
             [
               Nolabel
@@ -117,7 +117,7 @@
                   Tpat_var \"x\"
                   sort value
                   value_mode global,many,portable,forkable,unyielding,stateless;meet(unique,uncontended,read_write,static,imply(aliased,contended,immutable,static)(modevar#9<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
-                id(modevar#8<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful]);id(modevar#9<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+                proj_Locality(modevar#8<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful])
                 []
             ]
             Tfunction_body
@@ -285,9 +285,9 @@
             value_mode meet(local,once,nonportable,unforkable,yielding,stateful)(modevar#4<0>[global,many,portable,forkable,unyielding,stateless .. global,once,nonportable,unforkable,yielding,stateful]);meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#5<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
           expression (test2.ml[2,15+6]..test2.ml[2,15+24]) ghost
             Texp_function
-            alloc_mode id(modevar#6<0>[global,many,portable,forkable,unyielding,stateless .. global,once,nonportable,unforkable,yielding,stateful]);id(modevar#7<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+            alloc_mode global
             yielding_mode unyielding
-            id(modevar#a<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful]);id(modevar#b<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+            return_mode proj_Locality(modevar#a<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful])
             []
             [
               Nolabel
@@ -304,7 +304,7 @@
                     global,many,nonportable,forkable,unyielding,stateful,aliased,uncontended,read_write,dynamic
                     []
                   Tpat_any
-                id(modevar#8<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful]);id(modevar#9<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+                proj_Locality(modevar#8<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful])
                 []
             ]
             Tfunction_body
@@ -677,7 +677,7 @@ make sure we also handle that correctly in structures:
                     None
                 ]
             Texp_tuple
-            alloc_mode meet(local,once,nonportable,unforkable,yielding,stateful,regional_to_global_full . imply(local,once,nonportable,unforkable,yielding,stateful)(modevar#9<0>[global,many,portable,forkable,unyielding,stateless .. global,once,nonportable,unforkable,yielding,stateful]));meet(unique,uncontended,read_write,static)(modevar#a<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+            alloc_mode global
             [
               Label: None
                 expression (test_ct.ml[3,20+24]..test_ct.ml[3,20+25])
@@ -728,7 +728,7 @@ make sure we also handle that correctly in structures:
                     []
                 ]
             Texp_tuple
-            alloc_mode global,once,nonportable,unforkable,yielding,stateful;meet(unique,contended,immutable,static)(modevar#11<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+            alloc_mode global
             [
               Label: None
                 expression (test_ct.ml[5,50+23]..test_ct.ml[5,50+24])

--- a/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
@@ -363,18 +363,20 @@ module Pattern_env : sig
     { mutable env : Env.t;
       equations_scope : int;
       in_counterexample : bool;
-      mutable env_alloc_mode : Mode.Alloc.r option; }
-  val make: ?env_alloc_mode:Mode.Alloc.r -> Env.t -> equations_scope:int
+      mutable env_alloc_mode : Mode.Locality.r option; }
+  val make:
+    ?env_alloc_mode:Mode.Locality.r
+    -> Env.t -> equations_scope:int
     -> in_counterexample:bool -> t
   val copy: ?equations_scope:int -> t -> t
   val set_env: t -> Env.t -> unit
-  val set_env_alloc_mode : t -> Mode.Alloc.r option -> unit
+  val set_env_alloc_mode : t -> Mode.Locality.r option -> unit
 end = struct
   type t =
     { mutable env : Env.t;
       equations_scope : int;
       in_counterexample : bool;
-      mutable env_alloc_mode : Mode.Alloc.r option; }
+      mutable env_alloc_mode : Mode.Locality.r option; }
   let make ?env_alloc_mode env ~equations_scope ~in_counterexample =
     { env;
       equations_scope;

--- a/external/merlin/upstream/ocaml_flambda/typing/ctype.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/ctype.mli
@@ -201,15 +201,17 @@ module Pattern_env : sig
       (* scope for local type declarations *)
       in_counterexample : bool;
       (* true iff checking counter examples *)
-      mutable env_alloc_mode : Mode.Alloc.r option;
+      mutable env_alloc_mode : Mode.Locality.r option;
       (** [Some m] if the pattern is under [let poly_], where [m] is the
          allocation mode of the captured environment *)
     }
-  val make: ?env_alloc_mode:Mode.Alloc.r -> Env.t -> equations_scope:int
+  val make:
+    ?env_alloc_mode:Mode.Locality.r
+    -> Env.t -> equations_scope:int
     -> in_counterexample:bool -> t
   val copy: ?equations_scope:int -> t -> t
   val set_env: t -> Env.t -> unit
-  val set_env_alloc_mode : t -> Mode.Alloc.r option -> unit
+  val set_env_alloc_mode : t -> Mode.Locality.r option -> unit
 end
 
 type existential_treatment =

--- a/external/merlin/upstream/ocaml_flambda/typing/mode.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode.ml
@@ -5517,6 +5517,8 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let print ?verbose () ppf m = S.print ?verbose obj ppf m
 
+  let check_const_or_level_0 m = S.check_const_or_level_0 m
+
   let zap_to_ceil m = with_log (S.zap_to_ceil obj m)
 
   let zap_to_floor m = with_log (S.zap_to_floor obj m)
@@ -5623,6 +5625,8 @@ module Monadic_gen (Obj : Obj) = struct
   let equate_exn m1 m2 = equate m1 m2 |> Result.get_ok
 
   let print ?verbose () ppf m = S.print ?verbose obj ppf m
+
+  let check_const_or_level_0 m = S.check_const_or_level_0 m
 
   let zap_to_ceil m = with_log (S.zap_to_floor obj m)
 
@@ -6718,6 +6722,10 @@ module Value_with (Areality : Areality) = struct
       match Monadic.submode_log ?pp monadic1 monadic2 ~log with
       | Error e -> Error (Monadic e)
       | Ok () -> Ok ())
+
+  let check_const_or_level_0 { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.check_const_or_level_0 monadic0
+    && Comonadic.check_const_or_level_0 comonadic0
 
   let submode ?pp a b = try_with_log (submode_log ?pp a b)
 

--- a/external/merlin/upstream/ocaml_flambda/typing/mode_intf.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode_intf.mli
@@ -191,6 +191,9 @@ module type Common = sig
 
   val newvar_below : ('l * allowed) t -> ('l_ * 'r) t * bool
 
+  (** Returns true if the mode is a constant or a mode variable at level 0 *)
+  val check_const_or_level_0 : ('l * 'r) t -> bool
+
   val print : ?verbose:bool -> unit -> Fmt.formatter -> ('l * 'r) t -> unit
 
   val zap_to_ceil : ('l * allowed) t -> Const.t

--- a/external/merlin/upstream/ocaml_flambda/typing/patterns.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/patterns.ml
@@ -92,7 +92,7 @@ module General = struct
     | `Var of Ident.t * string loc * Uid.t * Jkind.Sort.t * Mode.Value.l
     | `Fun_layout of Ident.t * string loc * Uid.t
                    * Jkind.Sort.t * Mode.Value.l * Types.Lpoly.t
-                   * alloc_mode
+                   * alloc_mode_r
     | `Alias of pattern * Ident.t * string loc
                 * Uid.t * Jkind.Sort.t * Mode.Value.l * Types.type_expr
   ]

--- a/external/merlin/upstream/ocaml_flambda/typing/patterns.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/patterns.mli
@@ -77,7 +77,7 @@ module General : sig
     | `Var of Ident.t * string loc * Uid.t * Jkind.Sort.t * Mode.Value.l
     | `Fun_layout of Ident.t * string loc * Uid.t
                    * Jkind.Sort.t * Mode.Value.l * Types.Lpoly.t
-                   * alloc_mode
+                   * alloc_mode_r
     | `Alias of pattern * Ident.t * string loc * Uid.t
                 * Jkind.Sort.t * Mode.Value.l * Types.type_expr
   ]

--- a/external/merlin/upstream/ocaml_flambda/typing/printtyped.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/printtyped.ml
@@ -326,9 +326,15 @@ let alloc_modes_opt i ppf ms =
 
 let alloc_modes_var i ppf ms =
   let print_alloc_modes_var i ppf m =
-    line i ppf "%a\n" (Format_doc.compat (Mode.Alloc.print ())) m
+    line i ppf "%a\n" print_alloc_mode_l m
   in
   modes ~pr:print_alloc_modes_var i ppf ms
+
+let return_mode i ppf m =
+  line i ppf "return_mode %a\n" print_return_mode m
+
+let return_modes i ppf ms =
+  modes ~pr:return_mode i ppf ms
 
 let value_modes_var i ppf ms =
   let print_value_modes_var i ppf m =
@@ -604,7 +610,7 @@ and function_body i ppf (body : function_body) =
         fmt_partiality fc_partial
         fmt_location fc_loc;
       let i = i+1 in
-      alloc_mode_raw i ppf fc_arg_mode;
+      alloc_mode_l i ppf fc_arg_mode;
       line i ppf "%a\n" fmt_sort fc_arg_sort;
       attributes i ppf fc_attributes;
       List.iter (fun e -> expression_extra i ppf (e, fc_loc, [])) fc_exp_extra;
@@ -647,15 +653,16 @@ and expression_extra i ppf (extra, loc, attrs) =
       attributes i ppf attrs;
       type_inspection (i+1) ppf ti
 
-and alloc_mode_raw: type l r. _ -> _ -> (l * r) Mode.Alloc.t -> _
-  = fun i ppf m ->
-    line i ppf "alloc_mode %a\n" (Format_doc.compat (Mode.Alloc.print ())) m
-
-and alloc_mode i ppf (m : alloc_mode) = alloc_mode_raw i ppf m
+and alloc_mode i ppf (m : alloc_mode_r) =
+  line i ppf "alloc_mode %a\n" print_alloc_mode_r m
 
 and alloc_mode_option i ppf m = Option.iter (alloc_mode i ppf) m
 
-and locality_mode i ppf m =
+and alloc_mode_l i ppf (m : alloc_mode_l) =
+  line i ppf "locality_mode %a\n" print_alloc_mode_l m
+
+and locality_mode : type l r. _ -> _ -> (l * r) Mode.Locality.t -> _ =
+ fun i ppf m ->
   line i ppf "locality_mode %a\n"
     (Format_doc.compat (Mode.Locality.print ())) m
 
@@ -701,7 +708,7 @@ and expression i ppf x =
       line i ppf "Texp_function\n";
       alloc_mode i ppf am;
       yielding_mode i ppf ym;
-      alloc_modes_var i ppf ret_mode;
+      return_modes i ppf ret_mode;
       list i function_param ppf params;
       function_body i ppf body;
   | Texp_apply (e, l, m, am, ym, za) ->
@@ -711,7 +718,7 @@ and expression i ppf x =
          | Tail -> "Tail"
          | Nontail -> "Nontail"
          | Default -> "Default");
-      locality_mode i ppf am;
+      return_mode i ppf am;
       yielding_mode i ppf ym;
       Option.iter (zero_alloc_assume i ppf) za;
       expression i ppf e;

--- a/external/merlin/upstream/ocaml_flambda/typing/solver.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/solver.ml
@@ -573,6 +573,19 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     in
     Amode (a, hint, hint)
 
+  let check_level_morphvar : type a l r. (a, l * r) morphvar -> int -> bool =
+   fun (Amorphvar (v, _, _)) i -> v.level = i
+
+  let check_const_or_level_0 : type a l r. (a, l * r) mode -> bool =
+   fun m ->
+    match m with
+    | Amode _ -> true
+    | Amodevar mv -> check_level_morphvar mv 0
+    | Amodemeet (_, _, mvs) ->
+      VarMap.for_all (fun _ mv -> check_level_morphvar mv 0) mvs
+    | Amodejoin (_, _, mvs) ->
+      VarMap.for_all (fun _ mv -> check_level_morphvar mv 0) mvs
+
   let apply_morphvar dst morph morph_hint (Amorphvar (var, morph', morph'_hint))
       =
     Amorphvar

--- a/external/merlin/upstream/ocaml_flambda/typing/solver_intf.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/solver_intf.mli
@@ -390,6 +390,9 @@ module type Solver_mono = sig
   val print :
     ?verbose:bool -> 'a obj -> Fmt.formatter -> ('a, 'l * 'r) mode -> unit
 
+  (** Returns true if the mode is a constant or a mode variable at level 0 *)
+  val check_const_or_level_0 : ('a, 'l * 'r) mode -> bool
+
   (** Apply a monotone morphism explained by an optional hint *)
   val apply :
     'b obj ->

--- a/external/merlin/upstream/ocaml_flambda/typing/typeclass.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typeclass.ml
@@ -1404,13 +1404,26 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                     else if Btype.is_position l && is_erased () then
                       eliminate_position_arg ()
                     else begin
-                      let mode_closure = Mode.Alloc.disallow_left Mode.Alloc.legacy in
-                      let mode_arg = Mode.Alloc.disallow_right Mode.Alloc.legacy in
-                      let mode_ret = Mode.Alloc.disallow_right Mode.Alloc.legacy in
+                      let mode_closure =
+                        Mode.Locality.disallow_left Mode.Locality.legacy
+                        |> Typedtree.create_alloc_mode_r
+                      in
+                      let mode_arg =
+                        Mode.Locality.disallow_right Mode.Locality.legacy
+                        |> Typedtree.create_alloc_mode_l
+                      in
+                      let mode_ret =
+                        Mode.Locality.disallow_right Mode.Locality.legacy
+                        |> Typedtree.create_return_mode
+                      in
                       let sort_arg = Jkind.Sort.scannable in
                       let sort_ret = Jkind.Sort.scannable in
-                      Omitted { mode_closure; mode_arg; mode_ret; sort_arg;
-                                sort_ret }
+                      Omitted
+                        { mode_closure;
+                          mode_arg;
+                          mode_ret;
+                          sort_arg;
+                          sort_ret }
                     end
             in
             let omitted =

--- a/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
@@ -821,17 +821,18 @@ let dynamic_pat_mode pat_mode =
   in
   {pat_mode with mode}
 
-let allocations : Alloc.r list ref = Local_store.s_ref []
+let allocations : Locality.r list ref = Local_store.s_ref []
 
 let reset_allocations () = allocations := []
 
 let register_allocation_mode alloc_mode =
-  let alloc_mode = Alloc.disallow_left alloc_mode in
   allocations := alloc_mode :: !allocations
 
 let register_allocation_value_mode ~loc
     ?(desc  = (Unknown : Mode.Hint.allocation_desc)) mode =
-  let alloc_mode = value_to_alloc_r2g mode in
+  let alloc_mode =
+    Alloc.proj_comonadic Areality (value_to_alloc_r2g mode)
+  in
   register_allocation_mode alloc_mode;
   (* We must apply each morphism separately so that their hints correspond to
      the correct morphism *)
@@ -847,16 +848,18 @@ let register_allocation_value_mode ~loc
    parameter function needs to be made global if its partial application
    to one argument must be global. As a result, a function gets an
    [Alloc.lr] allocation mode that can be further constrained. *)
-let register_closure_allocation (mode : Value.r) ~loc : Alloc.lr * Value.r =
+let register_closure_allocation (mode : Value.r) ~loc
+  : Locality.lr * Alloc.lr * Value.r =
   let allocation : Hint.allocation = {loc; txt = Unknown} in
-  let (alloc_mode : Alloc.lr), _ =
+  let (mode : Alloc.lr), _ =
     Alloc.newvar_below (value_to_alloc_r2g ~allocation mode)
   in
-  register_allocation_mode (Alloc.disallow_left alloc_mode);
+  let alloc_mode = Alloc.proj_comonadic Areality mode in
   let closed_over_mode =
-    alloc_as_value ~allocation (Alloc.disallow_left alloc_mode)
+    alloc_as_value ~allocation (Alloc.disallow_left mode)
   in
-  alloc_mode, closed_over_mode
+  register_allocation_mode (Locality.disallow_left alloc_mode);
+  alloc_mode, mode, closed_over_mode
 
 (** Register as allocation the expression constrained by the given
     [expected_mode]. Returns the mode of the allocation, and the expected mode
@@ -876,7 +879,7 @@ let optimise_allocations () =
   - Add it back when middle-end can really utilize this information. *)
   List.iter
     (fun mode ->
-      Locality.zap_to_ceil (Alloc.proj_comonadic Areality mode)
+      Locality.zap_to_ceil mode
       |> ignore)
     !allocations;
   reset_allocations ()
@@ -3542,7 +3545,9 @@ and type_pat_aux
               sp.ppat_attributes sort
           in
           Tpat_fun_layout { id; name; uid; sort;
-                            mode = alloc_mode; lpoly; env_alloc_mode }
+                            mode = alloc_mode; lpoly;
+                            env_alloc_mode =
+                              Typedtree.create_alloc_mode_r env_alloc_mode }
         | None ->
           let lpoly = Lpoly.determined [] in
           let id, uid =
@@ -5148,21 +5153,35 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
              let open_args = [] in
              let mode_closed_args = List.map Alloc.close_over closed_args in
              let mode_partial_fun = Alloc.partial_apply mode_fun in
-             let mode_closure, _ =
+             let mode_cls, _ =
                Alloc.newvar_above (Alloc.join
                 (mode_partial_fun:: mode_closed_args))
+             in
+             let mode_closure =
+               Alloc.disallow_left mode_cls
+               |> Alloc.proj_comonadic Areality
+             in
+             let mode_arg =
+               Alloc.disallow_right mode_arg
+               |> Alloc.proj_comonadic Areality
+               |> Typedtree.create_alloc_mode_l
+             in
+             let mode_ret =
+               Alloc.disallow_right mode_ret
+               |> Alloc.proj_comonadic Areality
+               |> Typedtree.create_return_mode
              in
              register_allocation_mode mode_closure;
              let arg =
               Omitted {
-                mode_closure = Alloc.disallow_left mode_closure;
-                mode_arg = Alloc.disallow_right mode_arg;
-                mode_ret = Alloc.disallow_right mode_ret;
+                mode_closure = Typedtree.create_alloc_mode_r mode_closure;
+                mode_arg;
+                mode_ret;
                 sort_arg;
                 sort_ret }
              in
              let args = (lbl, arg, None) :: args in
-             (ty_ret, mode_closure, open_args, closed_args, args))
+             (ty_ret, mode_cls, open_args, closed_args, args))
       (ty_ret, mode_ret, [], [], []) (List.rev args)
   in
   ty_ret, mode_ret, args
@@ -6264,10 +6283,14 @@ type split_function_ty =
       *)
     expected_pat_mode: expected_pat_mode;
     expected_inner_mode: expected_mode;
-    (* [alloc_mode] is the mode of [fun x_i ... x_n -> e].
-       This needs to be a left mode for the construction of the [fp_curry] field
-       of the outer function. *)
-    alloc_mode: Mode.Alloc.lr;
+    (* [closure_mode] is the mode of [fun x_i ... x_n -> e].
+       This needs to be a left mode for making sure that nested
+       closures have a mode greater than outer closures, and it
+       needs to be a right mode for making sure
+       arguments generate a lower bound for subsequent closures.
+       [alloc_mode] tracks the locality component to store in the Typedtree. *)
+    closure_mode: Mode.Alloc.lr;
+    alloc_mode: Locality.lr;
     really_poly: bool
   }
 
@@ -6289,12 +6312,12 @@ let split_function_ty
     env (expected_mode : expected_mode) ty_expected loc ~arg_label ~has_poly
     ~mode_annots ~ret_mode_annots ~in_function ~is_first_val_param ~is_final_val_param
   =
-  let alloc_mode, closed_over_mode =
+  let alloc_mode, closure_mode, closed_over_mode =
     register_closure_allocation ~loc (as_single_mode expected_mode)
   in
   if expected_mode.strictly_local then
     Locality.submode_exn ~pp:(loc, Function) Locality.local
-      (Alloc.proj_comonadic Areality alloc_mode);
+      (Alloc.proj_comonadic Areality closure_mode);
   let { ty = ty_fun; explanation }, loc_fun = in_function in
   let separate = !Clflags.principal || Env.has_local_constraints env in
   let { ty_arg; ty_ret; arg_mode; ret_mode } as filtered_arrow =
@@ -6368,14 +6391,20 @@ let split_function_ty
   let ret_sort = type_sort ~why:Function_result ty_ret in
   env,
   { filtered_arrow; arg_sort; ret_sort;
-    alloc_mode; ty_arg_mono;
+    alloc_mode; closure_mode; ty_arg_mono;
     expected_inner_mode; expected_pat_mode;
     really_poly
   }
 
 type type_function_result_param =
   { param : function_param;
+    param_yielding : Mode.Yielding.l;
     has_poly : bool;
+  }
+
+type fun_alloc_mode =
+  { alloc_mode: Locality.lr;
+    fun_closure_mode: Mode.Alloc.lr;
   }
 
 module Calling_convention_sort : sig
@@ -6471,10 +6500,11 @@ type type_function_result =
     params_contain_gadt: contains_gadt;
     (* The alloc mode of the "rest of the function". None only for recursive
        calls to [type_function] when there are no parameters left. This needs to
-       be a left mode for the construction of the [fp_curry] field of the outer
-       function.
+       carry the full [Alloc] closure mode, against which the curry constraints
+       are checked, together with the locality component stored as [fp_curry]'s
+       [partial_mode].
     *)
-    fun_alloc_mode: Mode.Alloc.lr option;
+    fun_alloc_mode: fun_alloc_mode option;
     (* Information about the return of the function. None only for
        recursive calls to [type_function] when there are no parameters
        left.
@@ -6489,6 +6519,7 @@ and type_function_ret_info =
     ret_mode: Mode.Alloc.l modes;
     (* The sort returned by the function. *)
     ret_sort: Jkind.sort;
+    cases_arg_yielding: Mode.Yielding.l option;
   }
 
 (* value binding elaboration *)
@@ -6782,7 +6813,7 @@ and type_expect_
           let alloc_mode, record_mode =
             register_allocation ~loc expected_mode
           in
-          Some alloc_mode, record_mode
+          Some (Typedtree.create_alloc_mode_r alloc_mode), record_mode
         else
           None, expected_mode
       in
@@ -7402,7 +7433,8 @@ and type_expect_
       in
       let args = List.map (fun (lbl, arg, _) -> (lbl, arg)) args in
       let exp = rue {
-        exp_desc = Texp_apply(funct, args, pm.apply_position, ap_mode,
+        exp_desc = Texp_apply(funct, args, pm.apply_position,
+                              Typedtree.create_return_mode ap_mode,
                               ap_yielding, zero_alloc);
         exp_loc = loc; exp_extra;
         exp_type = ty_ret;
@@ -7556,6 +7588,7 @@ and type_expect_
               let arg =
                 type_argument ~overwrite:No_overwrite env argument_mode sarg ty ty0
               in
+              let alloc_mode = Typedtree.create_alloc_mode_r alloc_mode in
               re { exp_desc = Texp_variant(l, Some (arg, alloc_mode));
                    exp_loc = loc; exp_extra = [];
                    exp_type = ty_expected0;
@@ -7577,7 +7610,7 @@ and type_expect_
             let arg =
               type_expect env argument_mode sarg (mk_expected ty_expected)
             in
-            Some (arg, alloc_mode)
+            Some (arg, Typedtree.create_alloc_mode_r alloc_mode)
         in
         let arg_type = Option.map (fun (arg, _) -> arg.exp_type) arg in
         let row =
@@ -7644,7 +7677,7 @@ and type_expect_
           let uu =
             unique_use ~loc ~env mode (as_single_mode argument_mode)
           in
-          Boxing (alloc_mode, uu)
+          Boxing (Typedtree.create_alloc_mode_r alloc_mode, uu)
         | false ->
           let mode = cross_left env ty_arg mode in
           submode ~loc ~env mode expected_mode;
@@ -7802,6 +7835,7 @@ and type_expect_
         | Immutable -> Immutable
       in
       let alloc_mode, array_mode = register_allocation ~loc expected_mode in
+      let alloc_mode = Typedtree.create_alloc_mode_r alloc_mode in
       let modalities = Typemode.mutable_modalities mutability in
       let is_contained_by : Mode.Hint.is_contained_by =
         {containing = Array Modality; container = (loc, Expression)}
@@ -8681,7 +8715,7 @@ and type_expect_
                   record_repres;
                   lid;
                   label;
-                  alloc_mode
+                  alloc_mode = Typedtree.create_alloc_mode_r alloc_mode
                 };
               exp_loc = loc;
               exp_extra = [];
@@ -8721,11 +8755,9 @@ and type_expect_
             Value.(of_const ~hint_comonadic:Stack_expression
               { Const.min with areality = Local })
             expected_mode;
-          let local =
-            Alloc.(of_const ~hint_comonadic:Stack_expression
-              { Const.min with areality = Local })
-          in
-          Alloc.submode_err (exp.exp_loc, Allocation) local alloc_mode
+          Typedtree.alloc_mode_r_submode_err (exp.exp_loc, Allocation)
+            (Locality.of_const ~hint:Stack_expression Local)
+            alloc_mode
         end
       | Texp_list_comprehension _ -> always_heap List_comprehension
       | Texp_array_comprehension _ -> always_heap Array_comprehension
@@ -9265,7 +9297,8 @@ and type_ident env ?(recarg=Rejected) lid =
        (* if the locality of returned value of the primitive is poly
           we then register allocation for further optimization *)
        | (Prim_poly, _), Some mode ->
-           register_allocation_mode (Alloc.max_with_comonadic Areality mode)
+           let mode = Locality.disallow_left mode in
+           register_allocation_mode mode
        | _ -> ()
        end;
        let yielding =
@@ -9412,7 +9445,7 @@ and type_function
           { filtered_arrow = { ty_arg; arg_mode; ty_ret; ret_mode };
             arg_sort; ret_sort;
             ty_arg_mono; expected_pat_mode; expected_inner_mode;
-            alloc_mode; really_poly
+            alloc_mode; closure_mode; really_poly
           } =
         split_function_ty env expected_mode ty_expected loc
           ~is_first_val_param:first ~is_final_val_param
@@ -9495,7 +9528,7 @@ and type_function
                 | None ->
                   assert(is_final_val_param);
                   Final_arg
-                | Some fun_alloc_mode ->
+                | Some { fun_closure_mode; alloc_mode } ->
                   assert(not is_final_val_param);
                   (* Handle mode crossing of [arg_mode]. Note that [close_over]
                      uses the [arg_mode.comonadic] as a left mode, and
@@ -9503,20 +9536,25 @@ and type_function
                      mode-crossed differently. *)
                   let arg_mode = alloc_mode_cross_to_max_min env ty_arg arg_mode in
                   begin match
-                    Alloc.submode (Alloc.close_over arg_mode) fun_alloc_mode
+                    Alloc.submode (Alloc.close_over arg_mode) fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
                       raise (Error(loc_fun, env, Uncurried_function_escapes e))
                   end;
                   begin match
-                    Alloc.submode (Alloc.partial_apply alloc_mode) fun_alloc_mode
+                    Alloc.submode
+                      (Alloc.partial_apply closure_mode)
+                      fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
                       raise (Error(loc_fun, env, Uncurried_function_escapes e))
                   end;
-                  More_args {partial_mode = Alloc.disallow_right fun_alloc_mode}
+                  More_args
+                    { partial_mode =
+                        Typedtree.create_alloc_mode_l
+                          (Locality.disallow_right alloc_mode) }
               in
               pat, params_suffix, body, ret_info, newtypes, contains_gadt,
               curry, ext_env, calling_convention_sorts
@@ -9583,8 +9621,17 @@ and type_function
             param,
             param_uid
       in
+      let param_yielding =
+        Alloc.proj_comonadic Yielding (Alloc.disallow_right arg_mode)
+      in
+      let arg_locality =
+        Alloc.disallow_right arg_mode
+        |> Alloc.proj_comonadic Areality
+        |> Typedtree.create_alloc_mode_l
+      in
       let param =
         { has_poly;
+          param_yielding;
           param =
             { fp_kind;
               fp_arg_label = typed_arg_label;
@@ -9594,7 +9641,8 @@ and type_function
               fp_newtypes = newtypes;
               fp_sort = arg_sort;
               fp_mode =
-                { mode_annots with mode_modes = Alloc.disallow_right arg_mode };
+                { mode_annots with
+                  mode_modes = arg_locality };
               fp_curry = curry;
               fp_loc = pparam_loc;
             };
@@ -9631,11 +9679,15 @@ and type_function
           let ret_mode =
             {ret_mode_annots with mode_modes = Alloc.disallow_right ret_mode }
           in
-          Some { ret_sort ; ret_mode }
+          Some { ret_sort ; ret_mode; cases_arg_yielding = None }
+      in
+      let fun_alloc_mode =
+        { fun_closure_mode = closure_mode;
+          alloc_mode }
       in
       { function_ = exp_type, param :: params, body;
         newtypes = []; params_contain_gadt = contains_gadt;
-        ret_info; fun_alloc_mode = Some alloc_mode;
+        ret_info; fun_alloc_mode = Some fun_alloc_mode;
         calling_convention_sorts;
       }
   | [] ->
@@ -10092,7 +10144,7 @@ and type_option_some env expected_mode sarg ty ty0 =
   let sort = Jkind.Sort.scannable in
   let repres = Types.Constructor_uniform_value in
   mkexp (Texp_construct(mknoloc lid , csome, repres, [sort, arg],
-                        Some alloc_mode))
+                        Some (Typedtree.create_alloc_mode_r alloc_mode)))
     (type_option arg.exp_type) arg.exp_loc arg.exp_env
 
 (* [expected_mode] is the expected mode of the field. It's already adjusted for
@@ -10310,6 +10362,15 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
       let arg_sort = type_sort ~why:Function_argument ty_arg in
       let ret_sort = type_sort ~why:Function_result ty_res in
       let eta_pat, eta_var = var_pair ~mode:eta_mode "eta" ty_arg arg_sort in
+      let fc_arg_mode =
+        Alloc.disallow_right marg
+        |> Alloc.proj_comonadic Areality
+        |> Typedtree.create_alloc_mode_l
+      in
+      let fc_ret_mode =
+        Alloc.proj_comonadic Areality (Alloc.disallow_right mret)
+        |> Typedtree.create_return_mode
+      in
       (* CR layouts v10: When we add abstract jkinds, the eta expansion here
          becomes impossible in some cases - we'll need better errors.  For test
          cases, look toward the end of
@@ -10321,7 +10382,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
              (texp,
               args @ [Nolabel, Arg (eta_var, arg_sort)],
               Nontail,
-              Alloc.proj_comonadic Areality (Alloc.disallow_right mret),
+              fc_ret_mode,
               Yielding.disallow_right Yielding.yielding,
               None)}
         in
@@ -10340,13 +10401,14 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
                     fc_param_debug_uid = param_uid; fc_env = env;
                     fc_ret_type = ty_res; fc_loc = cases_loc;
                     fc_exp_extra = []; fc_attributes = [];
-                    fc_arg_mode = Alloc.disallow_right marg;
+                    fc_arg_mode;
                     fc_arg_sort = arg_sort;
                   };
               ret_mode =
-                { mode_modes = Alloc.disallow_right mret; mode_desc = [] };
+                { mode_modes = fc_ret_mode;
+                  mode_desc = [] };
               ret_sort;
-              alloc_mode;
+              alloc_mode = Typedtree.create_alloc_mode_r alloc_mode;
               yielding = Yielding.disallow_right Yielding.yielding;
               zero_alloc = Zero_alloc.default
             }
@@ -10658,7 +10720,8 @@ and type_tuple ~overwrite ~loc ~env ~(expected_mode : expected_mode) ~ty_expecte
       sexpl types_and_modes overwrites
   in
   re {
-    exp_desc = Texp_tuple (expl, alloc_mode);
+    exp_desc =
+      Texp_tuple (expl, Typedtree.create_alloc_mode_r alloc_mode);
     exp_loc = loc; exp_extra = [];
     (* Keep sharing *)
     exp_type = newty (Ttuple (List.map (fun (label, e) -> label, e.exp_type) expl));
@@ -10848,7 +10911,7 @@ and type_construct ~overwrite ~sexp env (expected_mode : expected_mode) lid sarg
        let alloc_mode, argument_mode =
          register_allocation ~loc:sexp.pexp_loc expected_mode
        in
-       argument_mode, Some alloc_mode
+       argument_mode, Some (Typedtree.create_alloc_mode_r alloc_mode)
   in
   begin match overwrite, constr.cstr_repr with
   | Overwriting(_, _, _), Variant_unboxed ->
@@ -11315,7 +11378,7 @@ and type_function_cases_expect
   Builtin_attributes.warning_scope attrs begin fun () ->
     let env,
         { filtered_arrow = { ty_arg; ty_ret; arg_mode; ret_mode };
-          arg_sort; ret_sort;
+          arg_sort; ret_sort; closure_mode;
           ty_arg_mono; expected_pat_mode; expected_inner_mode; alloc_mode;
         } =
       split_function_ty env expected_mode ty_expected loc ~arg_label:Nolabel
@@ -11334,6 +11397,13 @@ and type_function_cases_expect
            (Tarrow ((Nolabel, arg_mode, ret_mode), ty_arg, ty_ret, commu_ok)))
     in
     unify_exp_types loc env ty_fun (instance ty_expected);
+    let fc_arg_mode =
+      Alloc.proj_comonadic Areality (Alloc.disallow_right arg_mode)
+      |> Typedtree.create_alloc_mode_l
+    in
+    let yielding_mode =
+      Alloc.proj_comonadic Yielding (Alloc.disallow_right arg_mode)
+    in
     let param , param_uid =
       name_cases ~pattern_kind:Value_pattern_in_argument "param" cases
     in
@@ -11347,9 +11417,13 @@ and type_function_cases_expect
         fc_env = env;
         fc_ret_type = ty_ret;
         fc_attributes = [];
-        fc_arg_mode = Alloc.disallow_right arg_mode;
+        fc_arg_mode;
         fc_arg_sort = arg_sort;
       }
+    in
+    let fun_alloc_mode =
+      { fun_closure_mode = closure_mode;
+        alloc_mode }
     in
     let calling_convention_sorts =
       [ { Calling_convention_sort.ccs_ty = ty_arg; ccs_sort = arg_sort;
@@ -11357,10 +11431,11 @@ and type_function_cases_expect
         { Calling_convention_sort.ccs_ty = ty_ret; ccs_sort = ret_sort;
           ccs_env = env; ccs_loc = loc; ccs_kind = `Result } ]
     in
-    cases, ty_fun, alloc_mode,
+    cases, ty_fun, fun_alloc_mode,
       { ret_sort;
         ret_mode =
-          {mode_modes = Alloc.disallow_right ret_mode; mode_desc = []} },
+          {mode_modes = Alloc.disallow_right ret_mode; mode_desc = []};
+        cases_arg_yielding = Some yielding_mode },
       calling_convention_sorts
   end
 
@@ -11905,7 +11980,7 @@ and type_n_ary_function
       type_function env expected_mode ty_expected params constraint_ body
         ~in_function ~first:true
     in
-    let fun_alloc_mode, { ret_mode; ret_sort } =
+    let fun_alloc_mode, { ret_mode; ret_sort; cases_arg_yielding } =
       match fun_alloc_mode, ret_info with
       | Some x, Some y -> x, y
       | None, _ ->
@@ -12002,31 +12077,45 @@ and type_n_ary_function
       | (Check _ | Assume _ | Ignore_assert_all) ->
         Zero_alloc.create_const zero_alloc
     in
-    let alloc_mode = Mode.Alloc.disallow_left fun_alloc_mode in
+    let ret_mode_modes =
+      Alloc.proj_comonadic Areality ret_mode.mode_modes
+      |> Typedtree.create_return_mode
+    in
+    let ret_mode =
+      { ret_mode with
+        mode_modes = ret_mode_modes }
+    in
     (* [yielding] records whether *fully applying* this function can perform a
        free effect: the closure may yield if it closes over a yielding value
        (its own mode), or if any argument it is given is yielding (the
        parameter modes). [Value_rec_compiler]'s eta-expanding wrapper uses
        this, since the wrapper is exactly a full application. *)
-    let param_alloc_modes =
-      List.map (fun (p : function_param) -> p.fp_mode.mode_modes) params
+    let param_yieldings =
+      List.map
+        (fun (p : type_function_result_param) -> p.param_yielding)
+        result_params
     in
     (* A [function | ...] body takes an extra implicit parameter that is not in
        [params]; if that argument is yielding then the closure is yielding. *)
-    let param_alloc_modes =
-      match body with
-      | Tfunction_body _ -> param_alloc_modes
-      | Tfunction_cases fc -> fc.fc_arg_mode :: param_alloc_modes
+    let param_yieldings =
+      match cases_arg_yielding with
+      | None -> param_yieldings
+      | Some yielding -> yielding :: param_yieldings
     in
     let yielding =
-      Alloc.proj_comonadic Yielding
-        (Alloc.join (Alloc.disallow_right fun_alloc_mode :: param_alloc_modes))
+      Yielding.join
+        (Alloc.proj_comonadic Yielding
+           (Alloc.disallow_right fun_alloc_mode.fun_closure_mode)
+         :: param_yieldings)
     in
     re
       { exp_desc =
           Texp_function
             { params; body; ret_sort;
-              alloc_mode; ret_mode; yielding;
+              alloc_mode =
+                Typedtree.create_alloc_mode_r
+                  (Locality.disallow_left fun_alloc_mode.alloc_mode);
+              ret_mode; yielding;
               zero_alloc
             };
         exp_loc = loc;

--- a/external/merlin/upstream/ocaml_flambda/typing/typedtree.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typedtree.ml
@@ -141,6 +141,8 @@ let alloc_mode_r_zap_to_ceil m = Mode.Locality.zap_to_ceil m
 
 let alloc_mode_r_submode_err pp m t = Mode.Locality.submode_err pp m t
 
+let alloc_mode_r_map f m = f m
+
 let print_alloc_mode_r ppf m =
   Format_doc.compat (Mode.Locality.print ()) ppf m
 
@@ -150,6 +152,8 @@ let create_alloc_mode_l m =
   assert (Mode.Locality.check_const_or_level_0 m); m
 
 let alloc_mode_l_zap_to_floor m = Mode.Locality.zap_to_floor m
+
+let alloc_mode_l_map f m = f m
 
 let print_alloc_mode_l ppf m =
   Format_doc.compat (Mode.Locality.print ()) ppf m

--- a/external/merlin/upstream/ocaml_flambda/typing/typedtree.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typedtree.ml
@@ -132,10 +132,40 @@ let print_unique_use ppf (u,l) =
     (Format_doc.compat (Mode.Uniqueness.print ())) u
     (Format_doc.compat (Mode.Linearity.print ())) l
 
-type alloc_mode = Mode.Alloc.r
+type alloc_mode_r = Mode.Locality.r
+
+let create_alloc_mode_r m =
+  assert (Mode.Locality.check_const_or_level_0 m); m
+
+let alloc_mode_r_zap_to_ceil m = Mode.Locality.zap_to_ceil m
+
+let alloc_mode_r_submode_err pp m t = Mode.Locality.submode_err pp m t
+
+let print_alloc_mode_r ppf m =
+  Format_doc.compat (Mode.Locality.print ()) ppf m
+
+type alloc_mode_l = Mode.Locality.l
+
+let create_alloc_mode_l m =
+  assert (Mode.Locality.check_const_or_level_0 m); m
+
+let alloc_mode_l_zap_to_floor m = Mode.Locality.zap_to_floor m
+
+let print_alloc_mode_l ppf m =
+  Format_doc.compat (Mode.Locality.print ()) ppf m
+
+type return_mode = Mode.Locality.l
+
+let create_return_mode m =
+  assert (Mode.Locality.check_const_or_level_0 m); m
+
+let return_mode_zap_to_floor m = Mode.Locality.zap_to_floor m
+
+let print_return_mode ppf m =
+  Format_doc.compat (Mode.Locality.print ()) ppf m
 
 type texp_field_boxing =
-  | Boxing of alloc_mode * unique_use
+  | Boxing of alloc_mode_r * unique_use
   | Non_boxing of unique_use
 
 let aliased_many_use =
@@ -202,7 +232,7 @@ and 'k pattern_desc =
       sort: Jkind_types.Sort.t;
       mode: Mode.Value.l;
       lpoly: Lpoly.t;
-      env_alloc_mode: alloc_mode;
+      env_alloc_mode: alloc_mode_r;
     } -> value pattern_desc
   | Tpat_constant : constant -> value pattern_desc
   | Tpat_unboxed_unit : value pattern_desc
@@ -287,9 +317,9 @@ and expression_desc =
   | Texp_function of
       { params : function_param list;
         body : function_body;
-        ret_mode : Mode.Alloc.l modes;
+        ret_mode : return_mode modes;
         ret_sort : Jkind.sort;
-        alloc_mode : alloc_mode;
+        alloc_mode : alloc_mode_r;
         yielding : Mode.Yielding.l;
         zero_alloc : Zero_alloc.t;
       }
@@ -302,19 +332,20 @@ and expression_desc =
   | Texp_try of expression * value case list * value case list
   | Texp_unboxed_unit
   | Texp_unboxed_bool of bool
-  | Texp_tuple of (string option * expression) list * alloc_mode
+  | Texp_tuple of (string option * expression) list * alloc_mode_r
   | Texp_unboxed_tuple of (string option * expression * Jkind.sort) list
   | Texp_construct of
       Longident.t loc * constructor_description * constructor_representation *
-      (Jkind.sort * expression) list * alloc_mode option
-  | Texp_variant of label * (expression * alloc_mode) option
+      (Jkind.sort * expression) list
+      * alloc_mode_r option
+  | Texp_variant of label * (expression * alloc_mode_r) option
   | Texp_record of {
       fields :
         ( Data_types.label_description * Jkind.sort * record_label_definition )
           array;
       representation : Types.record_representation;
       extended_expression : (expression * Jkind.sort * Unique_barrier.t) option;
-      alloc_mode : alloc_mode option
+      alloc_mode : alloc_mode_r option
     }
   | Texp_record_unboxed_product of {
       fields :
@@ -329,7 +360,7 @@ and expression_desc =
       record_repres : Types.record_representation;
       lid : Longident.t loc;
       label : Data_types.label_description;
-      alloc_mode : alloc_mode;
+      alloc_mode : alloc_mode_r;
     }
   | Texp_field of {
       record : expression;
@@ -356,7 +387,7 @@ and expression_desc =
       label : Data_types.label_description;
       newval : expression;
     }
-  | Texp_array of mutability * Jkind.Sort.t * expression list * alloc_mode
+  | Texp_array of mutability * Jkind.Sort.t * expression list * alloc_mode_r
   | Texp_idx of block_access * unboxed_access list
   | Texp_list_comprehension of comprehension
   | Texp_array_comprehension of mutability * Jkind.sort * comprehension
@@ -472,7 +503,7 @@ and 'k case =
     }
 
 and function_curry =
-  | More_args of { partial_mode : Mode.Alloc.l }
+  | More_args of { partial_mode : alloc_mode_l }
   | Final_arg
 
 and function_param =
@@ -483,7 +514,7 @@ and function_param =
     fp_partial: partial;
     fp_kind: function_param_kind;
     fp_sort: Jkind.sort;
-    fp_mode: Mode.Alloc.l modes;
+    fp_mode: alloc_mode_l modes;
     fp_curry: function_curry;
     fp_newtypes: (Ident.t * string loc *
                   Parsetree.jkind_annotation option * Uid.t) list;
@@ -501,7 +532,7 @@ and function_body =
 and function_cases =
   { fc_cases: value case list;
     fc_env : Env.t;
-    fc_arg_mode: Mode.Alloc.l;
+    fc_arg_mode: alloc_mode_l;
     fc_arg_sort: Jkind.sort;
     fc_ret_type : Types.type_expr;
     fc_partial: partial;
@@ -533,9 +564,9 @@ and ('a, 'b) arg_or_omitted =
   | Omitted of 'b
 
 and omitted_parameter =
-  { mode_closure : Mode.Alloc.r;
-    mode_arg : Mode.Alloc.l;
-    mode_ret : Mode.Alloc.l;
+  { mode_closure : alloc_mode_r;
+    mode_arg : alloc_mode_l;
+    mode_ret : return_mode;
     sort_arg : Jkind.sort;
     sort_ret : Jkind.sort }
 

--- a/external/merlin/upstream/ocaml_flambda/typing/typedtree.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/typedtree.mli
@@ -113,7 +113,32 @@ type unique_use = Mode.Uniqueness.r * Mode.Linearity.l
 
 val print_unique_use : Format.formatter -> unique_use -> unit
 
-type alloc_mode = Mode.Alloc.r
+type alloc_mode_r
+
+val create_alloc_mode_r : Mode.Locality.r -> alloc_mode_r
+
+val alloc_mode_r_zap_to_ceil : alloc_mode_r -> Mode.Locality.Const.t
+
+val alloc_mode_r_submode_err :
+  Mode.Hint.pinpoint -> Mode.Locality.l -> alloc_mode_r -> unit
+
+val print_alloc_mode_r : Format.formatter -> alloc_mode_r -> unit
+
+type alloc_mode_l
+
+val create_alloc_mode_l : Mode.Locality.l -> alloc_mode_l
+
+val alloc_mode_l_zap_to_floor : alloc_mode_l -> Mode.Locality.Const.t
+
+val print_alloc_mode_l : Format.formatter -> alloc_mode_l -> unit
+
+type return_mode
+
+val create_return_mode : Mode.Locality.l -> return_mode
+
+val return_mode_zap_to_floor : return_mode -> Mode.Locality.Const.t
+
+val print_return_mode : Format.formatter -> return_mode -> unit
 
 (* CR-someday liam923: We'd like to split this into an arrow_modes and
    value_modes type. *)
@@ -128,7 +153,7 @@ type modalities = Typemode.modalities =
   }
 
 type texp_field_boxing =
-  | Boxing of alloc_mode * unique_use
+  | Boxing of alloc_mode_r * unique_use
   (** Projection requires boxing. [unique_use] describes the usage of the
       unboxed field as argument to boxing. *)
   | Non_boxing of unique_use
@@ -248,7 +273,7 @@ and 'k pattern_desc =
       the allocation mode of the captured environment. [pending] during
       type-checking; guaranteed [determined] of a non-empty list of generic sort
       variables after [type_let] returns. *)
-      env_alloc_mode: alloc_mode;
+      env_alloc_mode: alloc_mode_r;
       (** The allocation mode of the environment captured by the layout
       function.
 
@@ -482,11 +507,12 @@ and expression_desc =
   | Texp_function of
       { params : function_param list;
         body : function_body;
-        ret_mode : Mode.Alloc.l modes;
-        (* Mode where the function allocates, ie local for a function of
-           type 'a -> local_ 'b, and heap for a function of type 'a -> 'b *)
+        ret_mode : return_mode modes;
+        (* Whether the function may return a value allocated in its caller's
+           region: [local] for ['a -> 'b @ local], [global] for ['a -> 'b].
+           Becomes [Lambda.return_mode] via [Translmode.transl_ret_mode]. *)
         ret_sort : Jkind.sort;
-        alloc_mode : alloc_mode;
+        alloc_mode : alloc_mode_r;
         (* Mode at which the closure is allocated *)
         yielding : Mode.Yielding.l;
         (* Whether fully applying this function can perform a free effect. This
@@ -505,7 +531,7 @@ and expression_desc =
       *)
   | Texp_apply of
       expression * (arg_label * apply_arg) list * apply_position *
-        Mode.Locality.l * Mode.Yielding.l * Zero_alloc.assume option
+        return_mode * Mode.Yielding.l * Zero_alloc.assume option
         (** E0 ~l1:E1 ... ~ln:En
 
             The expression can be Omitted if the expression is abstracted over
@@ -549,7 +575,7 @@ and expression_desc =
         (** #() *)
   | Texp_unboxed_bool of bool
         (** #false, #true *)
-  | Texp_tuple of (string option * expression) list * alloc_mode
+  | Texp_tuple of (string option * expression) list * alloc_mode_r
         (** [Texp_tuple(el)] represents
             - [(E1, ..., En)]
                 when [el] is [(None, E1);...;(None, En)],
@@ -570,7 +596,7 @@ and expression_desc =
   | Texp_construct of
       Longident.t loc * Data_types.constructor_description *
       Types.constructor_representation * (Jkind.sort * expression) list *
-      alloc_mode option
+      alloc_mode_r option
         (** C                []
             C E              [E]
             C (E1, ..., En)  [E1;...;En]
@@ -579,7 +605,7 @@ and expression_desc =
             or [None] if the constructor is [Cstr_unboxed] or [Cstr_constant],
             in which case it does not need allocation.
          *)
-  | Texp_variant of label * (expression * alloc_mode) option
+  | Texp_variant of label * (expression * alloc_mode_r) option
         (** [alloc_mode] is the allocation mode of the variant,
             or [None] if the variant has no argument,
             in which case it does not need allocation.
@@ -590,7 +616,7 @@ and expression_desc =
           array;
       representation : Types.record_representation;
       extended_expression : (expression * Jkind.sort * Unique_barrier.t) option;
-      alloc_mode : alloc_mode option
+      alloc_mode : alloc_mode_r option
     }
         (** { l1=P1; ...; ln=Pn }           (extended_expression = None)
             { E0 with l1=P1; ...; ln=Pn }   (extended_expression = Some E0)
@@ -629,7 +655,7 @@ and expression_desc =
       record_repres : Types.record_representation;
       lid : Longident.t loc;
       label : Data_types.label_description;
-      alloc_mode : alloc_mode;
+      alloc_mode : alloc_mode_r;
     }
   | Texp_field of {
       record : expression;
@@ -661,7 +687,8 @@ and expression_desc =
       newval : expression;
     }
     (** [alloc_mode] translates to the [modify_mode] of the record *)
-  | Texp_array of Types.mutability * Jkind.Sort.t * expression list * alloc_mode
+  | Texp_array of
+      Types.mutability * Jkind.Sort.t * expression list * alloc_mode_r
   | Texp_idx of block_access * unboxed_access list
   | Texp_list_comprehension of comprehension
   (* CR layouts-scannable: The sort here is no longer used. Instead, a layout is
@@ -734,7 +761,7 @@ and meth =
   | Tmeth_ancestor of Ident.t * Path.t
 
 and function_curry =
-  | More_args of { partial_mode : Mode.Alloc.l }
+  | More_args of { partial_mode : alloc_mode_l }
   | Final_arg
 
 and 'k case =
@@ -761,7 +788,7 @@ and function_param =
     *)
     fp_kind: function_param_kind;
     fp_sort: Jkind.sort;
-    fp_mode: Mode.Alloc.l modes;
+    fp_mode: alloc_mode_l modes;
     fp_curry: function_curry;
     fp_newtypes: (Ident.t * string loc *
                   Parsetree.jkind_annotation option * Uid.t) list;
@@ -802,7 +829,7 @@ and function_cases =
     (** [fc_env] contains entries from all parameters except
         for the last one being matched by the cases.
     *)
-    fc_arg_mode: Mode.Alloc.l;
+    fc_arg_mode: alloc_mode_l;
     fc_arg_sort: Jkind.sort;
     fc_ret_type : Types.type_expr;
     fc_partial: partial;
@@ -895,9 +922,9 @@ and ('a, 'b) arg_or_omitted =
 and apply_arg = (expression * Jkind.sort, omitted_parameter) arg_or_omitted
 
 and omitted_parameter =
-  { mode_closure : Mode.Alloc.r;
-    mode_arg : Mode.Alloc.l;
-    mode_ret : Mode.Alloc.l;
+  { mode_closure : alloc_mode_r;
+    mode_arg : alloc_mode_l;
+    mode_ret : return_mode;
     sort_arg : Jkind.sort;
     sort_ret : Jkind.sort }
 

--- a/external/merlin/upstream/ocaml_flambda/typing/typedtree.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/typedtree.mli
@@ -122,6 +122,8 @@ val alloc_mode_r_zap_to_ceil : alloc_mode_r -> Mode.Locality.Const.t
 val alloc_mode_r_submode_err :
   Mode.Hint.pinpoint -> Mode.Locality.l -> alloc_mode_r -> unit
 
+val alloc_mode_r_map : (Mode.Locality.r -> 'a) -> alloc_mode_r -> 'a
+
 val print_alloc_mode_r : Format.formatter -> alloc_mode_r -> unit
 
 type alloc_mode_l
@@ -129,6 +131,8 @@ type alloc_mode_l
 val create_alloc_mode_l : Mode.Locality.l -> alloc_mode_l
 
 val alloc_mode_l_zap_to_floor : alloc_mode_l -> Mode.Locality.Const.t
+
+val alloc_mode_l_map : (Mode.Locality.l -> 'a) -> alloc_mode_l -> 'a
 
 val print_alloc_mode_l : Format.formatter -> alloc_mode_l -> unit
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -4830,7 +4830,7 @@ let for_let ~scopes ~arg_sort ~return_layout loc param mutable_flag pat body =
     let kind_params =
       List.map Slambdaident.of_sort_var (Lpoly.get_exn lpoly)
     in
-    let env_alloc_mode = Translmode.transl_alloc_mode env_alloc_mode in
+    let env_alloc_mode = Translmode.transl_alloc_mode_r env_alloc_mode in
     let free_vars =
       Lambda.free_variables param
       |> Ident.Set.to_list

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -4819,7 +4819,7 @@ let for_let ~scopes ~arg_sort ~return_layout loc param mutable_flag pat body =
     let kind_params =
       List.map Slambdaident.of_sort_var (Lpoly.get_exn lpoly)
     in
-    let env_alloc_mode = Translmode.transl_alloc_mode env_alloc_mode in
+    let env_alloc_mode = Translmode.transl_alloc_mode_r env_alloc_mode in
     let free_vars =
       Lambda.free_variables param
       |> Ident.Set.to_list

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -227,7 +227,7 @@ let function_attribute_disallowing_arity_fusion =
 (** [curried_function_kind p] checks the well-formedness of the list and returns
   the corresponding [curried_function_kind]. *)
 let curried_function_kind
-    : (function_curry * Mode.Alloc.l) list
+    : (function_curry * Typedtree.alloc_mode_l) list
       -> return_mode:return_mode
       -> mode:locality_mode
       -> curried_function_kind
@@ -334,7 +334,7 @@ let fuse_method_arity (parent : fusable_function) : fusable_function =
         (function (Texp_poly _, _, _) -> true | _ -> false)
         exp_extra
     ->
-      begin match transl_alloc_mode method_.alloc_mode with
+      begin match transl_alloc_mode_r method_.alloc_mode with
       | Alloc_heap -> ()
       | Alloc_local ->
           (* If we support locally-allocated objects, we'll also have to
@@ -346,7 +346,7 @@ let fuse_method_arity (parent : fusable_function) : fusable_function =
         { self_param
           with fp_curry = More_args
             { partial_mode =
-              Mode.Alloc.disallow_right Mode.Alloc.legacy }
+              Mode.Locality.disallow_right Mode.Locality.legacy }
         }
       in
       let return_sort =
@@ -537,7 +537,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
         let inlined = Translattribute.get_inlined_attribute funct in
         let specialised = Translattribute.get_specialised_attribute funct in
         let position = transl_apply_position pos in
-        let mode = transl_return_mode_l ap_mode in
+        let mode = transl_ret_mode ap_mode in
         event_after ~scopes e
           (transl_apply ~scopes ~tailcall ~inlined ~specialised
              ~assume_zero_alloc
@@ -551,7 +551,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
       let inlined = Translattribute.get_inlined_attribute funct in
       let specialised = Translattribute.get_specialised_attribute funct in
       let position = transl_apply_position position in
-      let mode = transl_return_mode_l ap_mode in
+      let mode = transl_ret_mode ap_mode in
       let yielding = transl_yielding_mode_l ap_yielding in
       let assume_zero_alloc =
         zero_alloc_of_application ~num_args:(List.length oargs) zero_alloc funct
@@ -620,7 +620,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
       with Not_constant ->
         Lprim(Pmakeblock(0, Immutable,
                          Lambda.block_shape_of_value_kinds (Some shape),
-                         transl_alloc_mode alloc_mode),
+                         transl_alloc_mode_r alloc_mode),
               ll,
               (of_location ~scopes e.exp_loc))
       end
@@ -710,7 +710,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
           begin match constant with
           | Some constant -> Lconst constant
           | None ->
-              let alloc_mode = transl_alloc_mode (Option.get alloc_mode) in
+              let alloc_mode = transl_alloc_mode_r (Option.get alloc_mode) in
               let makeblock =
                 match shape with
                 | Constructor_uniform_value ->
@@ -746,7 +746,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
                that the list is empty *)
             lam)
           else
-            let alloc_mode = transl_alloc_mode (Option.get alloc_mode) in
+            let alloc_mode = transl_alloc_mode_r (Option.get alloc_mode) in
             (* CR mshinwell: why are we using generic_value and not an immediate
                value kind for the poly variant hash? *)
             let makeblock =
@@ -795,7 +795,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
                                    extract_constant lam]))
           with Not_constant ->
             Lprim(Pmakeblock(0, Immutable, All_value,
-                             transl_alloc_mode alloc_mode),
+                             transl_alloc_mode_r alloc_mode),
                   [tagged_immediate tag; lam],
                   of_location ~scopes e.exp_loc)
       end
@@ -805,7 +805,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
           representation
       in
       transl_record ~scopes e.exp_loc e.exp_env
-        (Option.map transl_alloc_mode alloc_mode)
+        (Option.map transl_alloc_mode_r alloc_mode)
         fields representation extended_expression
   | Texp_record_unboxed_product
         {fields; representation; extended_expression } ->
@@ -841,7 +841,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
       let arg_layout = layout_exp arg_sort arg in
       let (arg, lbl) = transl_atomic_loc ~scopes arg arg_layout lbl repres in
       let loc = of_location ~scopes e.exp_loc in
-      Lprim (Pmakeblock (0, Immutable, shape, transl_alloc_mode alloc_mode),
+      Lprim (Pmakeblock (0, Immutable, shape, transl_alloc_mode_r alloc_mode),
              [arg; lbl], loc)
   | Texp_field { record = arg; record_sort = arg_sort;
                  record_repres; lid = _; label = lbl; boxing = float;
@@ -878,7 +878,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
             | Boxing (alloc_mode, _) -> alloc_mode
             | Non_boxing _ -> assert false
           in
-          let mode = transl_alloc_mode alloc_mode in
+          let mode = transl_alloc_mode_r alloc_mode in
           Some (Pfloatfield (lbl.lbl_pos, sem, mode), [targ])
         | Record_ufloat ->
           Some (Pufloatfield (lbl.lbl_pos, sem), [targ])
@@ -914,7 +914,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
                 if i <> lbl.lbl_pos then Lambda.alloc_heap
                 else
                   match float with
-                    | Boxing (mode, _) -> transl_alloc_mode mode
+                    | Boxing (mode, _) -> transl_alloc_mode_r mode
                     | Non_boxing _ ->
                         Misc.fatal_error
                           "expected typechecking to make [float] boxing mode\
@@ -1063,7 +1063,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
       in
       Lprim(prim, args, of_location ~scopes e.exp_loc)
   | Texp_array (amut, element_sort, expr_list, alloc_mode) ->
-      let mode = transl_alloc_mode alloc_mode in
+      let mode = transl_alloc_mode_r alloc_mode in
       let element_sort = Jkind.Sort.default_for_transl_and_get element_sort in
       let kind = array_kind e in
       let ll =
@@ -2267,7 +2267,7 @@ and transl_function ~in_new_scope ~scopes e params body
       ~alloc_mode ~ret_mode:sreturn_mode ~ret_sort:sreturn_sort ~region:sregion
       ~zero_alloc ~yielding =
   let attrs = e.exp_attributes in
-  let mode = transl_alloc_mode alloc_mode in
+  let mode = transl_alloc_mode_r alloc_mode in
   let zero_alloc = Zero_alloc.get zero_alloc in
   let assume_zero_alloc =
     match zero_alloc with
@@ -2954,7 +2954,7 @@ and transl_match ~scopes ~arg_sort ~return_layout e arg pat_expr_list partial =
          bytecode means unboxed tuple are slightly worse than normal tuples
          there. Consider adding it for unboxed tuples. *)
       assert (static_handlers = []);
-      let mode = transl_alloc_mode alloc_mode in
+      let mode = transl_alloc_mode_r alloc_mode in
       let argl =
         List.map (fun (_, a) -> (a, Jkind.Sort.Const.for_tuple_element)) argl
       in
@@ -2976,7 +2976,7 @@ and transl_match ~scopes ~arg_sort ~return_layout e arg pat_expr_list partial =
             argl
           |> List.split
         in
-        let mode = transl_alloc_mode alloc_mode in
+        let mode = transl_alloc_mode_r alloc_mode in
         static_catch (transl_list ~scopes argl) val_ids
           (Matching.for_multiple_match ~scopes ~return_layout e.exp_loc
              lvars mode val_cases partial)
@@ -3199,7 +3199,8 @@ and transl_letop ~scopes loc env let_ ands param param_debug_uid param_sort case
                 { fc_cases = [case]; fc_param = param;
                   fc_param_debug_uid = param_debug_uid; fc_partial = partial;
                   fc_loc = ghost_loc; fc_exp_extra = []; fc_attributes = [];
-                  fc_arg_mode = Mode.Alloc.disallow_right Mode.Alloc.legacy;
+                  fc_arg_mode =
+                    Mode.Locality.disallow_right Mode.Locality.legacy;
                   fc_arg_sort = param_sort; fc_env = env;
                   fc_ret_type = case.c_rhs.exp_type;
                 }))

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -346,7 +346,8 @@ let fuse_method_arity (parent : fusable_function) : fusable_function =
         { self_param
           with fp_curry = More_args
             { partial_mode =
-              Mode.Locality.disallow_right Mode.Locality.legacy }
+              create_alloc_mode_l
+                (Mode.Locality.disallow_right Mode.Locality.legacy) }
         }
       in
       let return_sort =
@@ -3200,7 +3201,8 @@ and transl_letop ~scopes loc env let_ ands param param_debug_uid param_sort case
                   fc_param_debug_uid = param_debug_uid; fc_partial = partial;
                   fc_loc = ghost_loc; fc_exp_extra = []; fc_attributes = [];
                   fc_arg_mode =
-                    Mode.Locality.disallow_right Mode.Locality.legacy;
+                    create_alloc_mode_l
+                      (Mode.Locality.disallow_right Mode.Locality.legacy);
                   fc_arg_sort = param_sort; fc_env = env;
                   fc_ret_type = case.c_rhs.exp_type;
                 }))

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -226,7 +226,7 @@ let function_attribute_disallowing_arity_fusion =
 (** [curried_function_kind p] checks the well-formedness of the list and returns
   the corresponding [curried_function_kind]. *)
 let curried_function_kind
-    : (function_curry * Mode.Alloc.l) list
+    : (function_curry * Typedtree.alloc_mode_l) list
       -> return_mode:return_mode
       -> mode:locality_mode
       -> curried_function_kind
@@ -333,7 +333,7 @@ let fuse_method_arity (parent : fusable_function) : fusable_function =
         (function (Texp_poly _, _, _) -> true | _ -> false)
         exp_extra
     ->
-      begin match transl_alloc_mode method_.alloc_mode with
+      begin match transl_alloc_mode_r method_.alloc_mode with
       | Alloc_heap -> ()
       | Alloc_local ->
           (* If we support locally-allocated objects, we'll also have to
@@ -345,7 +345,7 @@ let fuse_method_arity (parent : fusable_function) : fusable_function =
         { self_param
           with fp_curry = More_args
             { partial_mode =
-              Mode.Alloc.disallow_right Mode.Alloc.legacy }
+              Mode.Locality.disallow_right Mode.Locality.legacy }
         }
       in
       let return_sort =
@@ -536,7 +536,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
         let inlined = Translattribute.get_inlined_attribute funct in
         let specialised = Translattribute.get_specialised_attribute funct in
         let position = transl_apply_position pos in
-        let mode = transl_return_mode_l ap_mode in
+        let mode = transl_ret_mode ap_mode in
         event_after ~scopes e
           (transl_apply ~scopes ~tailcall ~inlined ~specialised
              ~assume_zero_alloc
@@ -550,7 +550,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
       let inlined = Translattribute.get_inlined_attribute funct in
       let specialised = Translattribute.get_specialised_attribute funct in
       let position = transl_apply_position position in
-      let mode = transl_return_mode_l ap_mode in
+      let mode = transl_ret_mode ap_mode in
       let yielding = transl_yielding_mode_l ap_yielding in
       let assume_zero_alloc =
         zero_alloc_of_application ~num_args:(List.length oargs) zero_alloc funct
@@ -616,7 +616,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
       with Not_constant ->
         Lprim(Pmakeblock(0, Immutable,
                          Lambda.block_shape_of_value_kinds (Some shape),
-                         transl_alloc_mode alloc_mode),
+                         transl_alloc_mode_r alloc_mode),
               ll,
               (of_location ~scopes e.exp_loc))
       end
@@ -698,7 +698,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
           begin match constant with
           | Some constant -> Lconst constant
           | None ->
-              let alloc_mode = transl_alloc_mode (Option.get alloc_mode) in
+              let alloc_mode = transl_alloc_mode_r (Option.get alloc_mode) in
               let makeblock =
                 match shape with
                 | Constructor_uniform_value ->
@@ -734,7 +734,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
                that the list is empty *)
             lam)
           else
-            let alloc_mode = transl_alloc_mode (Option.get alloc_mode) in
+            let alloc_mode = transl_alloc_mode_r (Option.get alloc_mode) in
             (* CR mshinwell: why are we using generic_value and not an immediate
                value kind for the poly variant hash? *)
             let makeblock =
@@ -783,13 +783,13 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
                                    extract_constant lam]))
           with Not_constant ->
             Lprim(Pmakeblock(0, Immutable, All_value,
-                             transl_alloc_mode alloc_mode),
+                             transl_alloc_mode_r alloc_mode),
                   [tagged_immediate tag; lam],
                   of_location ~scopes e.exp_loc)
       end
   | Texp_record {fields; representation; extended_expression; alloc_mode} ->
       transl_record ~scopes e.exp_loc e.exp_env
-        (Option.map transl_alloc_mode alloc_mode)
+        (Option.map transl_alloc_mode_r alloc_mode)
         fields representation extended_expression
   | Texp_record_unboxed_product
         {fields; representation; extended_expression } ->
@@ -819,7 +819,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
       let arg_layout = layout_exp arg_sort arg in
       let (arg, lbl) = transl_atomic_loc ~scopes arg arg_layout lbl repres in
       let loc = of_location ~scopes e.exp_loc in
-      Lprim (Pmakeblock (0, Immutable, shape, transl_alloc_mode alloc_mode),
+      Lprim (Pmakeblock (0, Immutable, shape, transl_alloc_mode_r alloc_mode),
              [arg; lbl], loc)
   | Texp_field { record = arg; record_sort = arg_sort; record_repres;
                  lid = _; label = lbl; boxing = float;
@@ -852,7 +852,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
             | Boxing (alloc_mode, _) -> alloc_mode
             | Non_boxing _ -> assert false
           in
-          let mode = transl_alloc_mode alloc_mode in
+          let mode = transl_alloc_mode_r alloc_mode in
           Some (Pfloatfield (lbl.lbl_pos, sem, mode), [targ])
         | Record_ufloat ->
           Some (Pufloatfield (lbl.lbl_pos, sem), [targ])
@@ -888,7 +888,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
                 if i <> lbl.lbl_pos then Lambda.alloc_heap
                 else
                   match float with
-                    | Boxing (mode, _) -> transl_alloc_mode mode
+                    | Boxing (mode, _) -> transl_alloc_mode_r mode
                     | Non_boxing _ ->
                         Misc.fatal_error
                           "expected typechecking to make [float] boxing mode\
@@ -1030,7 +1030,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
       in
       Lprim(prim, args, of_location ~scopes e.exp_loc)
   | Texp_array (amut, element_sort, expr_list, alloc_mode) ->
-      let mode = transl_alloc_mode alloc_mode in
+      let mode = transl_alloc_mode_r alloc_mode in
       let element_sort = Jkind.Sort.default_for_transl_and_get element_sort in
       let kind = array_kind e in
       let ll =
@@ -2201,7 +2201,7 @@ and transl_function ~in_new_scope ~scopes e params body
       ~alloc_mode ~ret_mode:sreturn_mode ~ret_sort:sreturn_sort ~region:sregion
       ~zero_alloc ~yielding =
   let attrs = e.exp_attributes in
-  let mode = transl_alloc_mode alloc_mode in
+  let mode = transl_alloc_mode_r alloc_mode in
   let zero_alloc = Zero_alloc.get zero_alloc in
   let assume_zero_alloc =
     match zero_alloc with
@@ -2876,7 +2876,7 @@ and transl_match ~scopes ~arg_sort ~return_layout e arg pat_expr_list partial =
          bytecode means unboxed tuple are slightly worse than normal tuples
          there. Consider adding it for unboxed tuples. *)
       assert (static_handlers = []);
-      let mode = transl_alloc_mode alloc_mode in
+      let mode = transl_alloc_mode_r alloc_mode in
       let argl =
         List.map (fun (_, a) -> (a, Jkind.Sort.Const.for_tuple_element)) argl
       in
@@ -2895,7 +2895,7 @@ and transl_match ~scopes ~arg_sort ~return_layout e arg pat_expr_list partial =
             argl
           |> List.split
         in
-        let mode = transl_alloc_mode alloc_mode in
+        let mode = transl_alloc_mode_r alloc_mode in
         static_catch (transl_list ~scopes argl) val_ids
           (Matching.for_multiple_match ~scopes ~return_layout e.exp_loc
              lvars mode val_cases partial)
@@ -3110,7 +3110,8 @@ and transl_letop ~scopes loc env let_ ands param param_debug_uid param_sort case
                 { fc_cases = [case]; fc_param = param;
                   fc_param_debug_uid = param_debug_uid; fc_partial = partial;
                   fc_loc = ghost_loc; fc_exp_extra = []; fc_attributes = [];
-                  fc_arg_mode = Mode.Alloc.disallow_right Mode.Alloc.legacy;
+                  fc_arg_mode =
+                    Mode.Locality.disallow_right Mode.Locality.legacy;
                   fc_arg_sort = param_sort; fc_env = env;
                   fc_ret_type = case.c_rhs.exp_type;
                 }))

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -345,7 +345,8 @@ let fuse_method_arity (parent : fusable_function) : fusable_function =
         { self_param
           with fp_curry = More_args
             { partial_mode =
-              Mode.Locality.disallow_right Mode.Locality.legacy }
+              create_alloc_mode_l
+                (Mode.Locality.disallow_right Mode.Locality.legacy) }
         }
       in
       let return_sort =
@@ -3111,7 +3112,8 @@ and transl_letop ~scopes loc env let_ ands param param_debug_uid param_sort case
                   fc_param_debug_uid = param_debug_uid; fc_partial = partial;
                   fc_loc = ghost_loc; fc_exp_extra = []; fc_attributes = [];
                   fc_arg_mode =
-                    Mode.Locality.disallow_right Mode.Locality.legacy;
+                    create_alloc_mode_l
+                      (Mode.Locality.disallow_right Mode.Locality.legacy);
                   fc_arg_sort = param_sort; fc_env = env;
                   fc_ret_type = case.c_rhs.exp_type;
                 }))

--- a/lambda/translmode.ml
+++ b/lambda/translmode.ml
@@ -29,28 +29,21 @@ let transl_locality_mode_l locality =
 let transl_return_mode_l locality =
   Locality.zap_to_floor locality |> transl_ret_mode
 
-let transl_locality_mode_r locality =
+let transl_alloc_mode_l mode =
+  Locality.zap_to_floor mode |> transl_locality_mode
+
+let transl_alloc_mode_r mode =
   (* r mode are for allocations; [optimise_allocations] should have pushed it
      to ceil and determined; here we push it again just to get the constant. *)
-  Locality.zap_to_ceil locality |> transl_locality_mode
+  Locality.zap_to_ceil mode |> transl_locality_mode
 
 let transl_yielding_mode_l yielding =
   match Yielding.zap_to_floor yielding with
   | Yielding.Const.Unyielding -> Unyielding
   | Yielding.Const.Yielding -> May_yield
 
-let transl_alloc_mode_l mode =
-  (* we only take the locality axis *)
-  Alloc.proj_comonadic Areality mode |> transl_locality_mode_l
-
-let transl_alloc_mode_r mode =
-  (* we only take the locality axis *)
-  Alloc.proj_comonadic Areality mode |> transl_locality_mode_r
-
-let transl_alloc_mode (mode : Typedtree.alloc_mode) = transl_alloc_mode_r mode
-
 let transl_ret_mode mode =
-  Alloc.proj_comonadic Areality mode |> Locality.zap_to_floor |> transl_ret_mode
+  Typedtree.return_mode_zap_to_floor mode |> transl_ret_mode
 
 let transl_modify_mode locality =
   match Locality.zap_to_floor locality with

--- a/lambda/translmode.ml
+++ b/lambda/translmode.ml
@@ -30,12 +30,12 @@ let transl_return_mode_l locality =
   Locality.zap_to_floor locality |> transl_ret_mode
 
 let transl_alloc_mode_l mode =
-  Locality.zap_to_floor mode |> transl_locality_mode
+  Typedtree.alloc_mode_l_zap_to_floor mode |> transl_locality_mode
 
 let transl_alloc_mode_r mode =
   (* r mode are for allocations; [optimise_allocations] should have pushed it
      to ceil and determined; here we push it again just to get the constant. *)
-  Locality.zap_to_ceil mode |> transl_locality_mode
+  Typedtree.alloc_mode_r_zap_to_ceil mode |> transl_locality_mode
 
 let transl_yielding_mode_l yielding =
   match Yielding.zap_to_floor yielding with

--- a/lambda/translmode.mli
+++ b/lambda/translmode.mli
@@ -20,13 +20,11 @@ val transl_yielding_mode_l : (allowed * 'r) Yielding.t -> Lambda.yielding_kind
 
 val transl_return_mode_l : (allowed * 'r) Locality.t -> Lambda.return_mode
 
-val transl_alloc_mode_l : (allowed * 'r) Alloc.t -> Lambda.locality_mode
+val transl_alloc_mode_l : Typedtree.alloc_mode_l -> Lambda.locality_mode
 
-val transl_alloc_mode_r : ('l * allowed) Alloc.t -> Lambda.locality_mode
+val transl_alloc_mode_r : Typedtree.alloc_mode_r -> Lambda.locality_mode
 
-val transl_ret_mode : (allowed * 'r) Alloc.t -> Lambda.return_mode
-
-val transl_alloc_mode : Typedtree.alloc_mode -> Lambda.locality_mode
+val transl_ret_mode : Typedtree.return_mode -> Lambda.return_mode
 
 val transl_modify_mode : (allowed * 'r) Locality.t -> Lambda.modify_mode
 

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -103,13 +103,13 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
           value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
-          alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#9<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+          alloc_mode global
           yielding_mode unyielding
-          global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
+          return_mode global
           []
           []
           Tfunction_cases (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
-            alloc_mode global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
+            locality_mode global
             value
             [
               <case>
@@ -129,7 +129,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                 expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+34])
                   Texp_apply
                   apply_mode Tail
-                  locality_mode global
+                  return_mode global
                   yielding_mode unyielding
                   expression (test_locations.ml[19,572+21]..test_locations.ml[19,572+22])
                     Texp_ident "Stdlib!.+"
@@ -139,7 +139,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                       expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+20])
                         Texp_apply
                         apply_mode Default
-                        locality_mode global
+                        return_mode global
                         yielding_mode unyielding
                         expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+12])
                           Texp_ident "fib"
@@ -149,7 +149,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                             expression (test_locations.ml[19,572+13]..test_locations.ml[19,572+20])
                               Texp_apply
                               apply_mode Default
-                              locality_mode global
+                              return_mode global
                               yielding_mode unyielding
                               expression (test_locations.ml[19,572+16]..test_locations.ml[19,572+17])
                                 Texp_ident "Stdlib!.-"
@@ -169,7 +169,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                       expression (test_locations.ml[19,572+23]..test_locations.ml[19,572+34])
                         Texp_apply
                         apply_mode Default
-                        locality_mode global
+                        return_mode global
                         yielding_mode unyielding
                         expression (test_locations.ml[19,572+23]..test_locations.ml[19,572+26])
                           Texp_ident "fib"
@@ -179,7 +179,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                             expression (test_locations.ml[19,572+27]..test_locations.ml[19,572+34])
                               Texp_apply
                               apply_mode Default
-                              locality_mode global
+                              return_mode global
                               yielding_mode unyielding
                               expression (test_locations.ml[19,572+30]..test_locations.ml[19,572+31])
                                 Texp_ident "Stdlib!.-"

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -103,13 +103,13 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
           value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression 
           Texp_function
-          alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#9<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+          alloc_mode global
           yielding_mode unyielding
-          global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
+          return_mode global
           []
           []
           Tfunction_cases 
-            alloc_mode global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
+            locality_mode global
             value
             [
               <case>
@@ -129,7 +129,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                 expression 
                   Texp_apply
                   apply_mode Tail
-                  locality_mode global
+                  return_mode global
                   yielding_mode unyielding
                   expression 
                     Texp_ident "Stdlib!.+"
@@ -139,7 +139,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                       expression 
                         Texp_apply
                         apply_mode Default
-                        locality_mode global
+                        return_mode global
                         yielding_mode unyielding
                         expression 
                           Texp_ident "fib"
@@ -149,7 +149,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                             expression 
                               Texp_apply
                               apply_mode Default
-                              locality_mode global
+                              return_mode global
                               yielding_mode unyielding
                               expression 
                                 Texp_ident "Stdlib!.-"
@@ -169,7 +169,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                       expression 
                         Texp_apply
                         apply_mode Default
-                        locality_mode global
+                        return_mode global
                         yielding_mode unyielding
                         expression 
                           Texp_ident "fib"
@@ -179,7 +179,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                             expression 
                               Texp_apply
                               apply_mode Default
-                              locality_mode global
+                              return_mode global
                               yielding_mode unyielding
                               expression 
                                 Texp_ident "Stdlib!.-"

--- a/testsuite/tests/typing-modes/currying.ml
+++ b/testsuite/tests/typing-modes/currying.ml
@@ -254,6 +254,20 @@ Error: This value is "local"
          because it is a function return value.
          Hint: Use exclave_ to return a local value.
 |}]
+let app7 (f : a:int -> b:'b @ unique -> unit) (y @ unique) : (a:int -> unit) @ many = f ~b:y
+[%%expect{|
+Line 1, characters 86-92:
+1 | let app7 (f : a:int -> b:'b @ unique -> unit) (y @ unique) : (a:int -> unit) @ many = f ~b:y
+                                                                                          ^^^^^^
+Error: This value is "once" but is expected to be "many".
+|}]
+let app8 (f : a:int -> b:'b @ uncontended -> unit) (y @ uncontended) : (a:int -> unit) @ portable = f ~b:y
+[%%expect{|
+Line 1, characters 100-106:
+1 | let app8 (f : a:int -> b:'b @ uncontended -> unit) (y @ uncontended) : (a:int -> unit) @ portable = f ~b:y
+                                                                                                        ^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
 
 let bug1 () =
   let foo : a:local_ string -> b:local_ string -> c:int -> unit =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -363,18 +363,20 @@ module Pattern_env : sig
     { mutable env : Env.t;
       equations_scope : int;
       in_counterexample : bool;
-      mutable env_alloc_mode : Mode.Alloc.r option; }
-  val make: ?env_alloc_mode:Mode.Alloc.r -> Env.t -> equations_scope:int
+      mutable env_alloc_mode : Typedtree.alloc_mode_r option; }
+  val make:
+    ?env_alloc_mode:Typedtree.alloc_mode_r
+    -> Env.t -> equations_scope:int
     -> in_counterexample:bool -> t
   val copy: ?equations_scope:int -> t -> t
   val set_env: t -> Env.t -> unit
-  val set_env_alloc_mode : t -> Mode.Alloc.r option -> unit
+  val set_env_alloc_mode : t -> Typedtree.alloc_mode_r option -> unit
 end = struct
   type t =
     { mutable env : Env.t;
       equations_scope : int;
       in_counterexample : bool;
-      mutable env_alloc_mode : Mode.Alloc.r option; }
+      mutable env_alloc_mode : Typedtree.alloc_mode_r option; }
   let make ?env_alloc_mode env ~equations_scope ~in_counterexample =
     { env;
       equations_scope;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -363,20 +363,20 @@ module Pattern_env : sig
     { mutable env : Env.t;
       equations_scope : int;
       in_counterexample : bool;
-      mutable env_alloc_mode : Typedtree.alloc_mode_r option; }
+      mutable env_alloc_mode : Mode.Locality.r option; }
   val make:
-    ?env_alloc_mode:Typedtree.alloc_mode_r
+    ?env_alloc_mode:Mode.Locality.r
     -> Env.t -> equations_scope:int
     -> in_counterexample:bool -> t
   val copy: ?equations_scope:int -> t -> t
   val set_env: t -> Env.t -> unit
-  val set_env_alloc_mode : t -> Typedtree.alloc_mode_r option -> unit
+  val set_env_alloc_mode : t -> Mode.Locality.r option -> unit
 end = struct
   type t =
     { mutable env : Env.t;
       equations_scope : int;
       in_counterexample : bool;
-      mutable env_alloc_mode : Typedtree.alloc_mode_r option; }
+      mutable env_alloc_mode : Mode.Locality.r option; }
   let make ?env_alloc_mode env ~equations_scope ~in_counterexample =
     { env;
       equations_scope;

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -201,15 +201,17 @@ module Pattern_env : sig
       (* scope for local type declarations *)
       in_counterexample : bool;
       (* true iff checking counter examples *)
-      mutable env_alloc_mode : Mode.Alloc.r option;
+      mutable env_alloc_mode : Typedtree.alloc_mode_r option;
       (** [Some m] if the pattern is under [let poly_], where [m] is the
          allocation mode of the captured environment *)
     }
-  val make: ?env_alloc_mode:Mode.Alloc.r -> Env.t -> equations_scope:int
+  val make:
+    ?env_alloc_mode:Typedtree.alloc_mode_r
+    -> Env.t -> equations_scope:int
     -> in_counterexample:bool -> t
   val copy: ?equations_scope:int -> t -> t
   val set_env: t -> Env.t -> unit
-  val set_env_alloc_mode : t -> Mode.Alloc.r option -> unit
+  val set_env_alloc_mode : t -> Typedtree.alloc_mode_r option -> unit
 end
 
 type existential_treatment =

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -201,17 +201,17 @@ module Pattern_env : sig
       (* scope for local type declarations *)
       in_counterexample : bool;
       (* true iff checking counter examples *)
-      mutable env_alloc_mode : Typedtree.alloc_mode_r option;
+      mutable env_alloc_mode : Mode.Locality.r option;
       (** [Some m] if the pattern is under [let poly_], where [m] is the
          allocation mode of the captured environment *)
     }
   val make:
-    ?env_alloc_mode:Typedtree.alloc_mode_r
+    ?env_alloc_mode:Mode.Locality.r
     -> Env.t -> equations_scope:int
     -> in_counterexample:bool -> t
   val copy: ?equations_scope:int -> t -> t
   val set_env: t -> Env.t -> unit
-  val set_env_alloc_mode : t -> Typedtree.alloc_mode_r option -> unit
+  val set_env_alloc_mode : t -> Mode.Locality.r option -> unit
 end
 
 type existential_treatment =

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5517,6 +5517,8 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let print ?verbose () ppf m = S.print ?verbose obj ppf m
 
+  let check_const_or_level_0 m = S.check_const_or_level_0 m
+
   let zap_to_ceil m = with_log (S.zap_to_ceil obj m)
 
   let zap_to_floor m = with_log (S.zap_to_floor obj m)
@@ -5623,6 +5625,8 @@ module Monadic_gen (Obj : Obj) = struct
   let equate_exn m1 m2 = equate m1 m2 |> Result.get_ok
 
   let print ?verbose () ppf m = S.print ?verbose obj ppf m
+
+  let check_const_or_level_0 m = S.check_const_or_level_0 m
 
   let zap_to_ceil m = with_log (S.zap_to_floor obj m)
 
@@ -6718,6 +6722,10 @@ module Value_with (Areality : Areality) = struct
       match Monadic.submode_log ?pp monadic1 monadic2 ~log with
       | Error e -> Error (Monadic e)
       | Ok () -> Ok ())
+
+  let check_const_or_level_0 { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.check_const_or_level_0 monadic0
+    && Comonadic.check_const_or_level_0 comonadic0
 
   let submode ?pp a b = try_with_log (submode_log ?pp a b)
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5454,6 +5454,8 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let print ?verbose () ppf m = S.print ?verbose obj ppf m
 
+  let check_const_or_level_0 m = S.check_const_or_level_0 m
+
   let zap_to_ceil m = with_log (S.zap_to_ceil obj m)
 
   let zap_to_floor m = with_log (S.zap_to_floor obj m)
@@ -5555,6 +5557,8 @@ module Monadic_gen (Obj : Obj) = struct
   let equate_exn m1 m2 = equate m1 m2 |> Result.get_ok
 
   let print ?verbose () ppf m = S.print ?verbose obj ppf m
+
+  let check_const_or_level_0 m = S.check_const_or_level_0 m
 
   let zap_to_ceil m = with_log (S.zap_to_floor obj m)
 
@@ -6628,6 +6632,10 @@ module Value_with (Areality : Areality) = struct
       match Monadic.submode_log ?pp monadic1 monadic2 ~log with
       | Error e -> Error (Monadic e)
       | Ok () -> Ok ())
+
+  let check_const_or_level_0 { monadic = monadic0; comonadic = comonadic0 } =
+    Monadic.check_const_or_level_0 monadic0
+    && Comonadic.check_const_or_level_0 comonadic0
 
   let submode ?pp a b = try_with_log (submode_log ?pp a b)
 

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -191,6 +191,9 @@ module type Common = sig
 
   val newvar_below : ('l * allowed) t -> ('l_ * 'r) t * bool
 
+  (** Returns true if the mode is a constant or a mode variable at level 0 *)
+  val check_const_or_level_0 : ('l * 'r) t -> bool
+
   val print : ?verbose:bool -> unit -> Fmt.formatter -> ('l * 'r) t -> unit
 
   val zap_to_ceil : ('l * allowed) t -> Const.t

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -187,6 +187,9 @@ module type Common = sig
 
   val newvar_below : ('l * allowed) t -> ('l_ * 'r) t * bool
 
+  (** Returns true if the mode is a constant or a mode variable at level 0 *)
+  val check_const_or_level_0 : ('l * 'r) t -> bool
+
   val print : ?verbose:bool -> unit -> Fmt.formatter -> ('l * 'r) t -> unit
 
   val zap_to_ceil : ('l * allowed) t -> Const.t

--- a/typing/patterns.ml
+++ b/typing/patterns.ml
@@ -93,7 +93,7 @@ module General = struct
     | `Var of Ident.t * string loc * Uid.t * Jkind.Sort.t * Mode.Value.l
     | `Fun_layout of Ident.t * string loc * Uid.t
                    * Jkind.Sort.t * Mode.Value.l * Types.Lpoly.t
-                   * alloc_mode
+                   * alloc_mode_r
     | `Alias of pattern * Ident.t * string loc
                 * Uid.t * Jkind.Sort.t * Mode.Value.l * Types.type_expr
   ]

--- a/typing/patterns.ml
+++ b/typing/patterns.ml
@@ -92,7 +92,7 @@ module General = struct
     | `Var of Ident.t * string loc * Uid.t * Jkind.Sort.t * Mode.Value.l
     | `Fun_layout of Ident.t * string loc * Uid.t
                    * Jkind.Sort.t * Mode.Value.l * Types.Lpoly.t
-                   * alloc_mode
+                   * alloc_mode_r
     | `Alias of pattern * Ident.t * string loc
                 * Uid.t * Jkind.Sort.t * Mode.Value.l * Types.type_expr
   ]

--- a/typing/patterns.mli
+++ b/typing/patterns.mli
@@ -77,7 +77,7 @@ module General : sig
     | `Var of Ident.t * string loc * Uid.t * Jkind.Sort.t * Mode.Value.l
     | `Fun_layout of Ident.t * string loc * Uid.t
                    * Jkind.Sort.t * Mode.Value.l * Types.Lpoly.t
-                   * alloc_mode
+                   * alloc_mode_r
     | `Alias of pattern * Ident.t * string loc * Uid.t
                 * Jkind.Sort.t * Mode.Value.l * Types.type_expr
   ]

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -326,7 +326,7 @@ let alloc_modes_opt i ppf ms =
 
 let alloc_modes_var i ppf ms =
   let print_alloc_modes_var i ppf m =
-    line i ppf "%a\n" (Format_doc.compat (Mode.Locality.print ())) m
+    line i ppf "%a\n" print_alloc_mode_l m
   in
   modes ~pr:print_alloc_modes_var i ppf ms
 
@@ -610,7 +610,7 @@ and function_body i ppf (body : function_body) =
         fmt_partiality fc_partial
         fmt_location fc_loc;
       let i = i+1 in
-      locality_mode i ppf fc_arg_mode;
+      alloc_mode_l i ppf fc_arg_mode;
       line i ppf "%a\n" fmt_sort fc_arg_sort;
       attributes i ppf fc_attributes;
       List.iter (fun e -> expression_extra i ppf (e, fc_loc, [])) fc_exp_extra;
@@ -654,11 +654,12 @@ and expression_extra i ppf (extra, loc, attrs) =
       type_inspection (i+1) ppf ti
 
 and alloc_mode i ppf (m : alloc_mode_r) =
-  line i ppf "alloc_mode %a\n"
-    (Format_doc.compat (Mode.Locality.print ()))
-    m
+  line i ppf "alloc_mode %a\n" print_alloc_mode_r m
 
 and alloc_mode_option i ppf m = Option.iter (alloc_mode i ppf) m
+
+and alloc_mode_l i ppf (m : alloc_mode_l) =
+  line i ppf "locality_mode %a\n" print_alloc_mode_l m
 
 and locality_mode : type l r. _ -> _ -> (l * r) Mode.Locality.t -> _ =
  fun i ppf m ->

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -326,9 +326,15 @@ let alloc_modes_opt i ppf ms =
 
 let alloc_modes_var i ppf ms =
   let print_alloc_modes_var i ppf m =
-    line i ppf "%a\n" (Format_doc.compat (Mode.Alloc.print ())) m
+    line i ppf "%a\n" (Format_doc.compat (Mode.Locality.print ())) m
   in
   modes ~pr:print_alloc_modes_var i ppf ms
+
+let return_mode i ppf m =
+  line i ppf "return_mode %a\n" print_return_mode m
+
+let return_modes i ppf ms =
+  modes ~pr:return_mode i ppf ms
 
 let value_modes_var i ppf ms =
   let print_value_modes_var i ppf m =
@@ -604,7 +610,7 @@ and function_body i ppf (body : function_body) =
         fmt_partiality fc_partial
         fmt_location fc_loc;
       let i = i+1 in
-      alloc_mode_raw i ppf fc_arg_mode;
+      locality_mode i ppf fc_arg_mode;
       line i ppf "%a\n" fmt_sort fc_arg_sort;
       attributes i ppf fc_attributes;
       List.iter (fun e -> expression_extra i ppf (e, fc_loc, [])) fc_exp_extra;
@@ -647,15 +653,15 @@ and expression_extra i ppf (extra, loc, attrs) =
       attributes i ppf attrs;
       type_inspection (i+1) ppf ti
 
-and alloc_mode_raw: type l r. _ -> _ -> (l * r) Mode.Alloc.t -> _
-  = fun i ppf m ->
-    line i ppf "alloc_mode %a\n" (Format_doc.compat (Mode.Alloc.print ())) m
-
-and alloc_mode i ppf (m : alloc_mode) = alloc_mode_raw i ppf m
+and alloc_mode i ppf (m : alloc_mode_r) =
+  line i ppf "alloc_mode %a\n"
+    (Format_doc.compat (Mode.Locality.print ()))
+    m
 
 and alloc_mode_option i ppf m = Option.iter (alloc_mode i ppf) m
 
-and locality_mode i ppf m =
+and locality_mode : type l r. _ -> _ -> (l * r) Mode.Locality.t -> _ =
+ fun i ppf m ->
   line i ppf "locality_mode %a\n"
     (Format_doc.compat (Mode.Locality.print ())) m
 
@@ -701,7 +707,7 @@ and expression i ppf x =
       line i ppf "Texp_function\n";
       alloc_mode i ppf am;
       yielding_mode i ppf ym;
-      alloc_modes_var i ppf ret_mode;
+      return_modes i ppf ret_mode;
       list i function_param ppf params;
       function_body i ppf body;
   | Texp_apply (e, l, m, am, ym, za) ->
@@ -711,7 +717,7 @@ and expression i ppf x =
          | Tail -> "Tail"
          | Nontail -> "Nontail"
          | Default -> "Default");
-      locality_mode i ppf am;
+      return_mode i ppf am;
       yielding_mode i ppf ym;
       Option.iter (zero_alloc_assume i ppf) za;
       expression i ppf e;

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -316,9 +316,15 @@ let alloc_modes_opt i ppf ms =
 
 let alloc_modes_var i ppf ms =
   let print_alloc_modes_var i ppf m =
-    line i ppf "%a\n" (Format_doc.compat (Mode.Alloc.print ())) m
+    line i ppf "%a\n" (Format_doc.compat (Mode.Locality.print ())) m
   in
   modes ~pr:print_alloc_modes_var i ppf ms
+
+let return_mode i ppf m =
+  line i ppf "return_mode %a\n" print_return_mode m
+
+let return_modes i ppf ms =
+  modes ~pr:return_mode i ppf ms
 
 let value_modes_var i ppf ms =
   let print_value_modes_var i ppf m =
@@ -594,7 +600,7 @@ and function_body i ppf (body : function_body) =
         fmt_partiality fc_partial
         fmt_location fc_loc;
       let i = i+1 in
-      alloc_mode_raw i ppf fc_arg_mode;
+      locality_mode i ppf fc_arg_mode;
       line i ppf "%a\n" fmt_sort fc_arg_sort;
       attributes i ppf fc_attributes;
       List.iter (fun e -> expression_extra i ppf (e, fc_loc, [])) fc_exp_extra;
@@ -637,15 +643,15 @@ and expression_extra i ppf (extra, loc, attrs) =
       attributes i ppf attrs;
       type_inspection (i+1) ppf ti
 
-and alloc_mode_raw: type l r. _ -> _ -> (l * r) Mode.Alloc.t -> _
-  = fun i ppf m ->
-    line i ppf "alloc_mode %a\n" (Format_doc.compat (Mode.Alloc.print ())) m
-
-and alloc_mode i ppf (m : alloc_mode) = alloc_mode_raw i ppf m
+and alloc_mode i ppf (m : alloc_mode_r) =
+  line i ppf "alloc_mode %a\n"
+    (Format_doc.compat (Mode.Locality.print ()))
+    m
 
 and alloc_mode_option i ppf m = Option.iter (alloc_mode i ppf) m
 
-and locality_mode i ppf m =
+and locality_mode : type l r. _ -> _ -> (l * r) Mode.Locality.t -> _ =
+ fun i ppf m ->
   line i ppf "locality_mode %a\n"
     (Format_doc.compat (Mode.Locality.print ())) m
 
@@ -691,7 +697,7 @@ and expression i ppf x =
       line i ppf "Texp_function\n";
       alloc_mode i ppf am;
       yielding_mode i ppf ym;
-      alloc_modes_var i ppf ret_mode;
+      return_modes i ppf ret_mode;
       list i function_param ppf params;
       function_body i ppf body;
   | Texp_apply (e, l, m, am, ym, za) ->
@@ -701,7 +707,7 @@ and expression i ppf x =
          | Tail -> "Tail"
          | Nontail -> "Nontail"
          | Default -> "Default");
-      locality_mode i ppf am;
+      return_mode i ppf am;
       yielding_mode i ppf ym;
       Option.iter (zero_alloc_assume i ppf) za;
       expression i ppf e;

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -316,7 +316,7 @@ let alloc_modes_opt i ppf ms =
 
 let alloc_modes_var i ppf ms =
   let print_alloc_modes_var i ppf m =
-    line i ppf "%a\n" (Format_doc.compat (Mode.Locality.print ())) m
+    line i ppf "%a\n" print_alloc_mode_l m
   in
   modes ~pr:print_alloc_modes_var i ppf ms
 
@@ -600,7 +600,7 @@ and function_body i ppf (body : function_body) =
         fmt_partiality fc_partial
         fmt_location fc_loc;
       let i = i+1 in
-      locality_mode i ppf fc_arg_mode;
+      alloc_mode_l i ppf fc_arg_mode;
       line i ppf "%a\n" fmt_sort fc_arg_sort;
       attributes i ppf fc_attributes;
       List.iter (fun e -> expression_extra i ppf (e, fc_loc, [])) fc_exp_extra;
@@ -644,11 +644,12 @@ and expression_extra i ppf (extra, loc, attrs) =
       type_inspection (i+1) ppf ti
 
 and alloc_mode i ppf (m : alloc_mode_r) =
-  line i ppf "alloc_mode %a\n"
-    (Format_doc.compat (Mode.Locality.print ()))
-    m
+  line i ppf "alloc_mode %a\n" print_alloc_mode_r m
 
 and alloc_mode_option i ppf m = Option.iter (alloc_mode i ppf) m
+
+and alloc_mode_l i ppf (m : alloc_mode_l) =
+  line i ppf "locality_mode %a\n" print_alloc_mode_l m
 
 and locality_mode : type l r. _ -> _ -> (l * r) Mode.Locality.t -> _ =
  fun i ppf m ->

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -573,6 +573,19 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
     in
     Amode (a, hint, hint)
 
+  let check_level_morphvar : type a l r. (a, l * r) morphvar -> int -> bool =
+   fun (Amorphvar (v, _, _)) i -> v.level = i
+
+  let check_const_or_level_0 : type a l r. (a, l * r) mode -> bool =
+   fun m ->
+    match m with
+    | Amode _ -> true
+    | Amodevar mv -> check_level_morphvar mv 0
+    | Amodemeet (_, _, mvs) ->
+      VarMap.for_all (fun _ mv -> check_level_morphvar mv 0) mvs
+    | Amodejoin (_, _, mvs) ->
+      VarMap.for_all (fun _ mv -> check_level_morphvar mv 0) mvs
+
   let apply_morphvar dst morph morph_hint (Amorphvar (var, morph', morph'_hint))
       =
     Amorphvar

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -390,6 +390,9 @@ module type Solver_mono = sig
   val print :
     ?verbose:bool -> 'a obj -> Fmt.formatter -> ('a, 'l * 'r) mode -> unit
 
+  (** Returns true if the mode is a constant or a mode variable at level 0 *)
+  val check_const_or_level_0 : ('a, 'l * 'r) mode -> bool
+
   (** Apply a monotone morphism explained by an optional hint *)
   val apply :
     'b obj ->

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1404,13 +1404,24 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                     else if Btype.is_position l && is_erased () then
                       eliminate_position_arg ()
                     else begin
-                      let mode_closure = Mode.Alloc.disallow_left Mode.Alloc.legacy in
-                      let mode_arg = Mode.Alloc.disallow_right Mode.Alloc.legacy in
-                      let mode_ret = Mode.Alloc.disallow_right Mode.Alloc.legacy in
+                      let mode_closure =
+                        Mode.Locality.disallow_left Mode.Locality.legacy
+                      in
+                      let mode_arg =
+                        Mode.Locality.disallow_right Mode.Locality.legacy
+                      in
+                      let mode_ret =
+                        Mode.Locality.disallow_right Mode.Locality.legacy
+                        |> Typedtree.create_return_mode
+                      in
                       let sort_arg = Jkind.Sort.scannable in
                       let sort_ret = Jkind.Sort.scannable in
-                      Omitted { mode_closure; mode_arg; mode_ret; sort_arg;
-                                sort_ret }
+                      Omitted
+                        { mode_closure;
+                          mode_arg;
+                          mode_ret;
+                          sort_arg;
+                          sort_ret }
                     end
             in
             let omitted =

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1406,9 +1406,11 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                     else begin
                       let mode_closure =
                         Mode.Locality.disallow_left Mode.Locality.legacy
+                        |> Typedtree.create_alloc_mode_r
                       in
                       let mode_arg =
                         Mode.Locality.disallow_right Mode.Locality.legacy
+                        |> Typedtree.create_alloc_mode_l
                       in
                       let mode_ret =
                         Mode.Locality.disallow_right Mode.Locality.legacy

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -821,7 +821,7 @@ let dynamic_pat_mode pat_mode =
   in
   {pat_mode with mode}
 
-let allocations : Typedtree.alloc_mode_r list ref = Local_store.s_ref []
+let allocations : Locality.r list ref = Local_store.s_ref []
 
 let reset_allocations () = allocations := []
 
@@ -3545,7 +3545,9 @@ and type_pat_aux
               sp.ppat_attributes sort
           in
           Tpat_fun_layout { id; name; uid; sort;
-                            mode = alloc_mode; lpoly; env_alloc_mode }
+                            mode = alloc_mode; lpoly;
+                            env_alloc_mode =
+                              Typedtree.create_alloc_mode_r env_alloc_mode }
         | None ->
           let lpoly = Lpoly.determined [] in
           let id, uid =
@@ -5156,10 +5158,13 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
                 (mode_partial_fun:: mode_closed_args))
              in
              let mode_closure =
-               Alloc.proj_comonadic Areality (Alloc.disallow_left mode_cls)
+               Alloc.disallow_left mode_cls
+               |> Alloc.proj_comonadic Areality
              in
              let mode_arg =
-               Alloc.proj_comonadic Areality (Alloc.disallow_right mode_arg)
+               Alloc.disallow_right mode_arg
+               |> Alloc.proj_comonadic Areality
+               |> Typedtree.create_alloc_mode_l
              in
              let mode_ret =
                Alloc.disallow_right mode_ret
@@ -5169,7 +5174,7 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
              register_allocation_mode mode_closure;
              let arg =
               Omitted {
-                mode_closure;
+                mode_closure = Typedtree.create_alloc_mode_r mode_closure;
                 mode_arg;
                 mode_ret;
                 sort_arg;
@@ -6807,7 +6812,7 @@ and type_expect_
           let alloc_mode, record_mode =
             register_allocation ~loc expected_mode
           in
-          Some alloc_mode, record_mode
+          Some (Typedtree.create_alloc_mode_r alloc_mode), record_mode
         else
           None, expected_mode
       in
@@ -7582,6 +7587,7 @@ and type_expect_
               let arg =
                 type_argument ~overwrite:No_overwrite env argument_mode sarg ty ty0
               in
+              let alloc_mode = Typedtree.create_alloc_mode_r alloc_mode in
               re { exp_desc = Texp_variant(l, Some (arg, alloc_mode));
                    exp_loc = loc; exp_extra = [];
                    exp_type = ty_expected0;
@@ -7603,7 +7609,7 @@ and type_expect_
             let arg =
               type_expect env argument_mode sarg (mk_expected ty_expected)
             in
-            Some (arg, alloc_mode)
+            Some (arg, Typedtree.create_alloc_mode_r alloc_mode)
         in
         let arg_type = Option.map (fun (arg, _) -> arg.exp_type) arg in
         let row =
@@ -7670,7 +7676,7 @@ and type_expect_
           let uu =
             unique_use ~loc ~env mode (as_single_mode argument_mode)
           in
-          Boxing (alloc_mode, uu)
+          Boxing (Typedtree.create_alloc_mode_r alloc_mode, uu)
         | false ->
           let mode = cross_left env ty_arg mode in
           submode ~loc ~env mode expected_mode;
@@ -7828,6 +7834,7 @@ and type_expect_
         | Immutable -> Immutable
       in
       let alloc_mode, array_mode = register_allocation ~loc expected_mode in
+      let alloc_mode = Typedtree.create_alloc_mode_r alloc_mode in
       let modalities = Typemode.mutable_modalities mutability in
       let is_contained_by : Mode.Hint.is_contained_by =
         {containing = Array Modality; container = (loc, Expression)}
@@ -8707,7 +8714,7 @@ and type_expect_
                   record_repres;
                   lid;
                   label;
-                  alloc_mode
+                  alloc_mode = Typedtree.create_alloc_mode_r alloc_mode
                 };
               exp_loc = loc;
               exp_extra = [];
@@ -8747,7 +8754,7 @@ and type_expect_
             Value.(of_const ~hint_comonadic:Stack_expression
               { Const.min with areality = Local })
             expected_mode;
-          Locality.submode_err (exp.exp_loc, Allocation)
+          Typedtree.alloc_mode_r_submode_err (exp.exp_loc, Allocation)
             (Locality.of_const ~hint:Stack_expression Local)
             alloc_mode
         end
@@ -9544,7 +9551,9 @@ and type_function
                       raise (Error(loc_fun, env, Uncurried_function_escapes e))
                   end;
                   More_args
-                    { partial_mode = Locality.disallow_right alloc_mode }
+                    { partial_mode =
+                        Typedtree.create_alloc_mode_l
+                          (Locality.disallow_right alloc_mode) }
               in
               pat, params_suffix, body, ret_info, newtypes, contains_gadt,
               curry, ext_env, calling_convention_sorts
@@ -9615,7 +9624,9 @@ and type_function
         Alloc.proj_comonadic Yielding (Alloc.disallow_right arg_mode)
       in
       let arg_mode =
-        Alloc.proj_comonadic Areality (Alloc.disallow_right arg_mode)
+        Alloc.disallow_right arg_mode
+        |> Alloc.proj_comonadic Areality
+        |> Typedtree.create_alloc_mode_l
       in
       let param =
         { has_poly;
@@ -9629,7 +9640,8 @@ and type_function
               fp_newtypes = newtypes;
               fp_sort = arg_sort;
               fp_mode =
-                { mode_annots with mode_modes = arg_mode };
+                { mode_annots with
+                  mode_modes = arg_mode };
               fp_curry = curry;
               fp_loc = pparam_loc;
             };
@@ -10131,7 +10143,7 @@ and type_option_some env expected_mode sarg ty ty0 =
   let sort = Jkind.Sort.scannable in
   let repres = Types.Constructor_uniform_value in
   mkexp (Texp_construct(mknoloc lid , csome, repres, [sort, arg],
-                        Some alloc_mode))
+                        Some (Typedtree.create_alloc_mode_r alloc_mode)))
     (type_option arg.exp_type) arg.exp_loc arg.exp_env
 
 (* [expected_mode] is the expected mode of the field. It's already adjusted for
@@ -10350,7 +10362,9 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
       let ret_sort = type_sort ~why:Function_result ty_res in
       let eta_pat, eta_var = var_pair ~mode:eta_mode "eta" ty_arg arg_sort in
       let fc_arg_mode =
-        Alloc.proj_comonadic Areality (Alloc.disallow_right marg)
+        Alloc.disallow_right marg
+        |> Alloc.proj_comonadic Areality
+        |> Typedtree.create_alloc_mode_l
       in
       let fc_ret_mode =
         Alloc.proj_comonadic Areality (Alloc.disallow_right mret)
@@ -10393,7 +10407,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
                 { mode_modes = fc_ret_mode;
                   mode_desc = [] };
               ret_sort;
-              alloc_mode;
+              alloc_mode = Typedtree.create_alloc_mode_r alloc_mode;
               yielding = Yielding.disallow_right Yielding.yielding;
               zero_alloc = Zero_alloc.default
             }
@@ -10705,7 +10719,8 @@ and type_tuple ~overwrite ~loc ~env ~(expected_mode : expected_mode) ~ty_expecte
       sexpl types_and_modes overwrites
   in
   re {
-    exp_desc = Texp_tuple (expl, alloc_mode);
+    exp_desc =
+      Texp_tuple (expl, Typedtree.create_alloc_mode_r alloc_mode);
     exp_loc = loc; exp_extra = [];
     (* Keep sharing *)
     exp_type = newty (Ttuple (List.map (fun (label, e) -> label, e.exp_type) expl));
@@ -10895,7 +10910,7 @@ and type_construct ~overwrite ~sexp env (expected_mode : expected_mode) lid sarg
        let alloc_mode, argument_mode =
          register_allocation ~loc:sexp.pexp_loc expected_mode
        in
-       argument_mode, Some alloc_mode
+       argument_mode, Some (Typedtree.create_alloc_mode_r alloc_mode)
   in
   begin match overwrite, constr.cstr_repr with
   | Overwriting(_, _, _), Variant_unboxed ->
@@ -11383,6 +11398,7 @@ and type_function_cases_expect
     unify_exp_types loc env ty_fun (instance ty_expected);
     let fc_arg_mode =
       Alloc.proj_comonadic Areality (Alloc.disallow_right arg_mode)
+      |> Typedtree.create_alloc_mode_l
     in
     let yielding_mode =
       Alloc.proj_comonadic Yielding (Alloc.disallow_right arg_mode)
@@ -12096,7 +12112,8 @@ and type_n_ary_function
           Texp_function
             { params; body; ret_sort;
               alloc_mode =
-                Locality.disallow_left fun_alloc_mode.alloc_mode;
+                Typedtree.create_alloc_mode_r
+                  (Locality.disallow_left fun_alloc_mode.alloc_mode);
               ret_mode; yielding;
               zero_alloc
             };

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -821,17 +821,18 @@ let dynamic_pat_mode pat_mode =
   in
   {pat_mode with mode}
 
-let allocations : Alloc.r list ref = Local_store.s_ref []
+let allocations : Typedtree.alloc_mode_r list ref = Local_store.s_ref []
 
 let reset_allocations () = allocations := []
 
 let register_allocation_mode alloc_mode =
-  let alloc_mode = Alloc.disallow_left alloc_mode in
   allocations := alloc_mode :: !allocations
 
 let register_allocation_value_mode ~loc
     ?(desc  = (Unknown : Mode.Hint.allocation_desc)) mode =
-  let alloc_mode = value_to_alloc_r2g mode in
+  let alloc_mode =
+    Alloc.proj_comonadic Areality (value_to_alloc_r2g mode)
+  in
   register_allocation_mode alloc_mode;
   (* We must apply each morphism separately so that their hints correspond to
      the correct morphism *)
@@ -847,16 +848,18 @@ let register_allocation_value_mode ~loc
    parameter function needs to be made global if its partial application
    to one argument must be global. As a result, a function gets an
    [Alloc.lr] allocation mode that can be further constrained. *)
-let register_closure_allocation (mode : Value.r) ~loc : Alloc.lr * Value.r =
+let register_closure_allocation (mode : Value.r) ~loc
+  : Locality.lr * Alloc.lr * Value.r =
   let allocation : Hint.allocation = {loc; txt = Unknown} in
-  let (alloc_mode : Alloc.lr), _ =
+  let (mode : Alloc.lr), _ =
     Alloc.newvar_below (value_to_alloc_r2g ~allocation mode)
   in
-  register_allocation_mode (Alloc.disallow_left alloc_mode);
+  let alloc_mode = Alloc.proj_comonadic Areality mode in
   let closed_over_mode =
-    alloc_as_value ~allocation (Alloc.disallow_left alloc_mode)
+    alloc_as_value ~allocation (Alloc.disallow_left mode)
   in
-  alloc_mode, closed_over_mode
+  register_allocation_mode (Locality.disallow_left alloc_mode);
+  alloc_mode, mode, closed_over_mode
 
 (** Register as allocation the expression constrained by the given
     [expected_mode]. Returns the mode of the allocation, and the expected mode
@@ -876,7 +879,7 @@ let optimise_allocations () =
   - Add it back when middle-end can really utilize this information. *)
   List.iter
     (fun mode ->
-      Locality.zap_to_ceil (Alloc.proj_comonadic Areality mode)
+      Locality.zap_to_ceil mode
       |> ignore)
     !allocations;
   reset_allocations ()
@@ -5148,21 +5151,32 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
              let open_args = [] in
              let mode_closed_args = List.map Alloc.close_over closed_args in
              let mode_partial_fun = Alloc.partial_apply mode_fun in
-             let mode_closure, _ =
+             let mode_cls, _ =
                Alloc.newvar_above (Alloc.join
                 (mode_partial_fun:: mode_closed_args))
+             in
+             let mode_closure =
+               Alloc.proj_comonadic Areality (Alloc.disallow_left mode_cls)
+             in
+             let mode_arg =
+               Alloc.proj_comonadic Areality (Alloc.disallow_right mode_arg)
+             in
+             let mode_ret =
+               Alloc.disallow_right mode_ret
+               |> Alloc.proj_comonadic Areality
+               |> Typedtree.create_return_mode
              in
              register_allocation_mode mode_closure;
              let arg =
               Omitted {
-                mode_closure = Alloc.disallow_left mode_closure;
-                mode_arg = Alloc.disallow_right mode_arg;
-                mode_ret = Alloc.disallow_right mode_ret;
+                mode_closure;
+                mode_arg;
+                mode_ret;
                 sort_arg;
                 sort_ret }
              in
              let args = (lbl, arg, None) :: args in
-             (ty_ret, mode_closure, open_args, closed_args, args))
+             (ty_ret, mode_cls, open_args, closed_args, args))
       (ty_ret, mode_ret, [], [], []) (List.rev args)
   in
   ty_ret, mode_ret, args
@@ -6264,10 +6278,14 @@ type split_function_ty =
       *)
     expected_pat_mode: expected_pat_mode;
     expected_inner_mode: expected_mode;
-    (* [alloc_mode] is the mode of [fun x_i ... x_n -> e].
-       This needs to be a left mode for the construction of the [fp_curry] field
-       of the outer function. *)
-    alloc_mode: Mode.Alloc.lr;
+    (* [closure_mode] is the mode of [fun x_i ... x_n -> e].
+       This needs to be a left mode for making sure that nested
+       closures have a mode greater than outer closures, and it
+       needs to be a right mode for making sure
+       arguments generate a lower bound for subsequent closures.
+       [alloc_mode] tracks the locality component to store in the Typedtree. *)
+    closure_mode: Mode.Alloc.lr;
+    alloc_mode: Locality.lr;
     really_poly: bool
   }
 
@@ -6289,12 +6307,12 @@ let split_function_ty
     env (expected_mode : expected_mode) ty_expected loc ~arg_label ~has_poly
     ~mode_annots ~ret_mode_annots ~in_function ~is_first_val_param ~is_final_val_param
   =
-  let alloc_mode, closed_over_mode =
+  let alloc_mode, closure_mode, closed_over_mode =
     register_closure_allocation ~loc (as_single_mode expected_mode)
   in
   if expected_mode.strictly_local then
     Locality.submode_exn ~pp:(loc, Function) Locality.local
-      (Alloc.proj_comonadic Areality alloc_mode);
+      (Alloc.proj_comonadic Areality closure_mode);
   let { ty = ty_fun; explanation }, loc_fun = in_function in
   let separate = !Clflags.principal || Env.has_local_constraints env in
   let { ty_arg; ty_ret; arg_mode; ret_mode } as filtered_arrow =
@@ -6368,14 +6386,20 @@ let split_function_ty
   let ret_sort = type_sort ~why:Function_result ty_ret in
   env,
   { filtered_arrow; arg_sort; ret_sort;
-    alloc_mode; ty_arg_mono;
+    alloc_mode; closure_mode; ty_arg_mono;
     expected_inner_mode; expected_pat_mode;
     really_poly
   }
 
 type type_function_result_param =
   { param : function_param;
+    param_yielding : Mode.Yielding.l;
     has_poly : bool;
+  }
+
+type fun_alloc_mode =
+  { alloc_mode: Locality.lr;
+    fun_closure_mode: Mode.Alloc.lr;
   }
 
 module Calling_convention_sort : sig
@@ -6474,7 +6498,7 @@ type type_function_result =
        be a left mode for the construction of the [fp_curry] field of the outer
        function.
     *)
-    fun_alloc_mode: Mode.Alloc.lr option;
+    fun_alloc_mode: fun_alloc_mode option;
     (* Information about the return of the function. None only for
        recursive calls to [type_function] when there are no parameters
        left.
@@ -6489,6 +6513,7 @@ and type_function_ret_info =
     ret_mode: Mode.Alloc.l modes;
     (* The sort returned by the function. *)
     ret_sort: Jkind.sort;
+    cases_arg_yielding: Mode.Yielding.l option;
   }
 
 (* value binding elaboration *)
@@ -7402,7 +7427,8 @@ and type_expect_
       in
       let args = List.map (fun (lbl, arg, _) -> (lbl, arg)) args in
       let exp = rue {
-        exp_desc = Texp_apply(funct, args, pm.apply_position, ap_mode,
+        exp_desc = Texp_apply(funct, args, pm.apply_position,
+                              Typedtree.create_return_mode ap_mode,
                               ap_yielding, zero_alloc);
         exp_loc = loc; exp_extra;
         exp_type = ty_ret;
@@ -8721,11 +8747,9 @@ and type_expect_
             Value.(of_const ~hint_comonadic:Stack_expression
               { Const.min with areality = Local })
             expected_mode;
-          let local =
-            Alloc.(of_const ~hint_comonadic:Stack_expression
-              { Const.min with areality = Local })
-          in
-          Alloc.submode_err (exp.exp_loc, Allocation) local alloc_mode
+          Locality.submode_err (exp.exp_loc, Allocation)
+            (Locality.of_const ~hint:Stack_expression Local)
+            alloc_mode
         end
       | Texp_list_comprehension _ -> always_heap List_comprehension
       | Texp_array_comprehension _ -> always_heap Array_comprehension
@@ -9265,7 +9289,8 @@ and type_ident env ?(recarg=Rejected) lid =
        (* if the locality of returned value of the primitive is poly
           we then register allocation for further optimization *)
        | (Prim_poly, _), Some mode ->
-           register_allocation_mode (Alloc.max_with_comonadic Areality mode)
+           let mode = Locality.disallow_left mode in
+           register_allocation_mode mode
        | _ -> ()
        end;
        let yielding =
@@ -9412,7 +9437,7 @@ and type_function
           { filtered_arrow = { ty_arg; arg_mode; ty_ret; ret_mode };
             arg_sort; ret_sort;
             ty_arg_mono; expected_pat_mode; expected_inner_mode;
-            alloc_mode; really_poly
+            alloc_mode; closure_mode; really_poly
           } =
         split_function_ty env expected_mode ty_expected loc
           ~is_first_val_param:first ~is_final_val_param
@@ -9495,7 +9520,7 @@ and type_function
                 | None ->
                   assert(is_final_val_param);
                   Final_arg
-                | Some fun_alloc_mode ->
+                | Some { fun_closure_mode; alloc_mode } ->
                   assert(not is_final_val_param);
                   (* Handle mode crossing of [arg_mode]. Note that [close_over]
                      uses the [arg_mode.comonadic] as a left mode, and
@@ -9503,20 +9528,23 @@ and type_function
                      mode-crossed differently. *)
                   let arg_mode = alloc_mode_cross_to_max_min env ty_arg arg_mode in
                   begin match
-                    Alloc.submode (Alloc.close_over arg_mode) fun_alloc_mode
+                    Alloc.submode (Alloc.close_over arg_mode) fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
                       raise (Error(loc_fun, env, Uncurried_function_escapes e))
                   end;
                   begin match
-                    Alloc.submode (Alloc.partial_apply alloc_mode) fun_alloc_mode
+                    Alloc.submode
+                      (Alloc.partial_apply closure_mode)
+                      fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
                       raise (Error(loc_fun, env, Uncurried_function_escapes e))
                   end;
-                  More_args {partial_mode = Alloc.disallow_right fun_alloc_mode}
+                  More_args
+                    { partial_mode = Locality.disallow_right alloc_mode }
               in
               pat, params_suffix, body, ret_info, newtypes, contains_gadt,
               curry, ext_env, calling_convention_sorts
@@ -9583,8 +9611,15 @@ and type_function
             param,
             param_uid
       in
+      let param_yielding =
+        Alloc.proj_comonadic Yielding (Alloc.disallow_right arg_mode)
+      in
+      let arg_mode =
+        Alloc.proj_comonadic Areality (Alloc.disallow_right arg_mode)
+      in
       let param =
         { has_poly;
+          param_yielding;
           param =
             { fp_kind;
               fp_arg_label = typed_arg_label;
@@ -9594,7 +9629,7 @@ and type_function
               fp_newtypes = newtypes;
               fp_sort = arg_sort;
               fp_mode =
-                { mode_annots with mode_modes = Alloc.disallow_right arg_mode };
+                { mode_annots with mode_modes = arg_mode };
               fp_curry = curry;
               fp_loc = pparam_loc;
             };
@@ -9631,11 +9666,15 @@ and type_function
           let ret_mode =
             {ret_mode_annots with mode_modes = Alloc.disallow_right ret_mode }
           in
-          Some { ret_sort ; ret_mode }
+          Some { ret_sort ; ret_mode; cases_arg_yielding = None }
+      in
+      let fun_alloc_mode =
+        { fun_closure_mode = closure_mode;
+          alloc_mode }
       in
       { function_ = exp_type, param :: params, body;
         newtypes = []; params_contain_gadt = contains_gadt;
-        ret_info; fun_alloc_mode = Some alloc_mode;
+        ret_info; fun_alloc_mode = Some fun_alloc_mode;
         calling_convention_sorts;
       }
   | [] ->
@@ -10310,6 +10349,13 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
       let arg_sort = type_sort ~why:Function_argument ty_arg in
       let ret_sort = type_sort ~why:Function_result ty_res in
       let eta_pat, eta_var = var_pair ~mode:eta_mode "eta" ty_arg arg_sort in
+      let fc_arg_mode =
+        Alloc.proj_comonadic Areality (Alloc.disallow_right marg)
+      in
+      let fc_ret_mode =
+        Alloc.proj_comonadic Areality (Alloc.disallow_right mret)
+        |> Typedtree.create_return_mode
+      in
       (* CR layouts v10: When we add abstract jkinds, the eta expansion here
          becomes impossible in some cases - we'll need better errors.  For test
          cases, look toward the end of
@@ -10321,7 +10367,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
              (texp,
               args @ [Nolabel, Arg (eta_var, arg_sort)],
               Nontail,
-              Alloc.proj_comonadic Areality (Alloc.disallow_right mret),
+              fc_ret_mode,
               Yielding.disallow_right Yielding.yielding,
               None)}
         in
@@ -10340,11 +10386,12 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
                     fc_param_debug_uid = param_uid; fc_env = env;
                     fc_ret_type = ty_res; fc_loc = cases_loc;
                     fc_exp_extra = []; fc_attributes = [];
-                    fc_arg_mode = Alloc.disallow_right marg;
+                    fc_arg_mode;
                     fc_arg_sort = arg_sort;
                   };
               ret_mode =
-                { mode_modes = Alloc.disallow_right mret; mode_desc = [] };
+                { mode_modes = fc_ret_mode;
+                  mode_desc = [] };
               ret_sort;
               alloc_mode;
               yielding = Yielding.disallow_right Yielding.yielding;
@@ -11315,7 +11362,7 @@ and type_function_cases_expect
   Builtin_attributes.warning_scope attrs begin fun () ->
     let env,
         { filtered_arrow = { ty_arg; ty_ret; arg_mode; ret_mode };
-          arg_sort; ret_sort;
+          arg_sort; ret_sort; closure_mode;
           ty_arg_mono; expected_pat_mode; expected_inner_mode; alloc_mode;
         } =
       split_function_ty env expected_mode ty_expected loc ~arg_label:Nolabel
@@ -11334,6 +11381,12 @@ and type_function_cases_expect
            (Tarrow ((Nolabel, arg_mode, ret_mode), ty_arg, ty_ret, commu_ok)))
     in
     unify_exp_types loc env ty_fun (instance ty_expected);
+    let fc_arg_mode =
+      Alloc.proj_comonadic Areality (Alloc.disallow_right arg_mode)
+    in
+    let yielding_mode =
+      Alloc.proj_comonadic Yielding (Alloc.disallow_right arg_mode)
+    in
     let param , param_uid =
       name_cases ~pattern_kind:Value_pattern_in_argument "param" cases
     in
@@ -11347,9 +11400,13 @@ and type_function_cases_expect
         fc_env = env;
         fc_ret_type = ty_ret;
         fc_attributes = [];
-        fc_arg_mode = Alloc.disallow_right arg_mode;
+        fc_arg_mode;
         fc_arg_sort = arg_sort;
       }
+    in
+    let fun_alloc_mode =
+      { fun_closure_mode = closure_mode;
+        alloc_mode }
     in
     let calling_convention_sorts =
       [ { Calling_convention_sort.ccs_ty = ty_arg; ccs_sort = arg_sort;
@@ -11357,10 +11414,11 @@ and type_function_cases_expect
         { Calling_convention_sort.ccs_ty = ty_ret; ccs_sort = ret_sort;
           ccs_env = env; ccs_loc = loc; ccs_kind = `Result } ]
     in
-    cases, ty_fun, alloc_mode,
+    cases, ty_fun, fun_alloc_mode,
       { ret_sort;
         ret_mode =
-          {mode_modes = Alloc.disallow_right ret_mode; mode_desc = []} },
+          {mode_modes = Alloc.disallow_right ret_mode; mode_desc = []};
+        cases_arg_yielding = Some yielding_mode },
       calling_convention_sorts
   end
 
@@ -11905,7 +11963,7 @@ and type_n_ary_function
       type_function env expected_mode ty_expected params constraint_ body
         ~in_function ~first:true
     in
-    let fun_alloc_mode, { ret_mode; ret_sort } =
+    let fun_alloc_mode, { ret_mode; ret_sort; cases_arg_yielding } =
       match fun_alloc_mode, ret_info with
       | Some x, Some y -> x, y
       | None, _ ->
@@ -12002,31 +12060,44 @@ and type_n_ary_function
       | (Check _ | Assume _ | Ignore_assert_all) ->
         Zero_alloc.create_const zero_alloc
     in
-    let alloc_mode = Mode.Alloc.disallow_left fun_alloc_mode in
+    let ret_mode_modes =
+      Alloc.proj_comonadic Areality ret_mode.mode_modes
+      |> Typedtree.create_return_mode
+    in
+    let ret_mode =
+      { ret_mode with
+        mode_modes = ret_mode_modes }
+    in
     (* [yielding] records whether *fully applying* this function can perform a
        free effect: the closure may yield if it closes over a yielding value
        (its own mode), or if any argument it is given is yielding (the
        parameter modes). [Value_rec_compiler]'s eta-expanding wrapper uses
        this, since the wrapper is exactly a full application. *)
-    let param_alloc_modes =
-      List.map (fun (p : function_param) -> p.fp_mode.mode_modes) params
+    let param_yieldings =
+      List.map
+        (fun (p : type_function_result_param) -> p.param_yielding)
+        result_params
     in
     (* A [function | ...] body takes an extra implicit parameter that is not in
        [params]; if that argument is yielding then the closure is yielding. *)
-    let param_alloc_modes =
-      match body with
-      | Tfunction_body _ -> param_alloc_modes
-      | Tfunction_cases fc -> fc.fc_arg_mode :: param_alloc_modes
+    let param_yieldings =
+      match cases_arg_yielding with
+      | None -> param_yieldings
+      | Some yielding -> yielding :: param_yieldings
     in
     let yielding =
-      Alloc.proj_comonadic Yielding
-        (Alloc.join (Alloc.disallow_right fun_alloc_mode :: param_alloc_modes))
+      Yielding.join
+        (Alloc.proj_comonadic Yielding
+           (Alloc.disallow_right fun_alloc_mode.fun_closure_mode)
+         :: param_yieldings)
     in
     re
       { exp_desc =
           Texp_function
             { params; body; ret_sort;
-              alloc_mode; ret_mode; yielding;
+              alloc_mode =
+                Locality.disallow_left fun_alloc_mode.alloc_mode;
+              ret_mode; yielding;
               zero_alloc
             };
         exp_loc = loc;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6500,8 +6500,9 @@ type type_function_result =
     params_contain_gadt: contains_gadt;
     (* The alloc mode of the "rest of the function". None only for recursive
        calls to [type_function] when there are no parameters left. This needs to
-       be a left mode for the construction of the [fp_curry] field of the outer
-       function.
+       carry the full [Alloc] closure mode, against which the curry constraints
+       are checked, together with the locality component stored as [fp_curry]'s
+       [partial_mode].
     *)
     fun_alloc_mode: fun_alloc_mode option;
     (* Information about the return of the function. None only for

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -9624,7 +9624,7 @@ and type_function
       let param_yielding =
         Alloc.proj_comonadic Yielding (Alloc.disallow_right arg_mode)
       in
-      let arg_mode =
+      let arg_locality =
         Alloc.disallow_right arg_mode
         |> Alloc.proj_comonadic Areality
         |> Typedtree.create_alloc_mode_l
@@ -9642,7 +9642,7 @@ and type_function
               fp_sort = arg_sort;
               fp_mode =
                 { mode_annots with
-                  mode_modes = arg_mode };
+                  mode_modes = arg_locality };
               fp_curry = curry;
               fp_loc = pparam_loc;
             };

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -9488,7 +9488,7 @@ and type_function
       let param_yielding =
         Alloc.proj_comonadic Yielding (Alloc.disallow_right arg_mode)
       in
-      let arg_mode =
+      let arg_locality =
         Alloc.disallow_right arg_mode
         |> Alloc.proj_comonadic Areality
         |> Typedtree.create_alloc_mode_l
@@ -9506,7 +9506,7 @@ and type_function
               fp_sort = arg_sort;
               fp_mode =
                 { mode_annots with
-                  mode_modes = arg_mode };
+                  mode_modes = arg_locality };
               fp_curry = curry;
               fp_loc = pparam_loc;
             };

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6390,8 +6390,9 @@ type type_function_result =
     params_contain_gadt: contains_gadt;
     (* The alloc mode of the "rest of the function". None only for recursive
        calls to [type_function] when there are no parameters left. This needs to
-       be a left mode for the construction of the [fp_curry] field of the outer
-       function.
+       carry the full [Alloc] closure mode, against which the curry constraints
+       are checked, together with the locality component stored as [fp_curry]'s
+       [partial_mode].
     *)
     fun_alloc_mode: fun_alloc_mode option;
     (* Information about the return of the function. None only for

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -816,7 +816,7 @@ let dynamic_pat_mode pat_mode =
   in
   {pat_mode with mode}
 
-let allocations : Typedtree.alloc_mode_r list ref = Local_store.s_ref []
+let allocations : Locality.r list ref = Local_store.s_ref []
 
 let reset_allocations () = allocations := []
 
@@ -3532,7 +3532,9 @@ and type_pat_aux
               sp.ppat_attributes sort
           in
           Tpat_fun_layout { id; name; uid; sort;
-                            mode = alloc_mode; lpoly; env_alloc_mode }
+                            mode = alloc_mode; lpoly;
+                            env_alloc_mode =
+                              Typedtree.create_alloc_mode_r env_alloc_mode }
         | None ->
           let lpoly = Lpoly.determined [] in
           let id, uid =
@@ -5143,10 +5145,13 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
                 (mode_partial_fun:: mode_closed_args))
              in
              let mode_closure =
-               Alloc.proj_comonadic Areality (Alloc.disallow_left mode_cls)
+               Alloc.disallow_left mode_cls
+               |> Alloc.proj_comonadic Areality
              in
              let mode_arg =
-               Alloc.proj_comonadic Areality (Alloc.disallow_right mode_arg)
+               Alloc.disallow_right mode_arg
+               |> Alloc.proj_comonadic Areality
+               |> Typedtree.create_alloc_mode_l
              in
              let mode_ret =
                Alloc.disallow_right mode_ret
@@ -5156,7 +5161,7 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
              register_allocation_mode mode_closure;
              let arg =
               Omitted {
-                mode_closure;
+                mode_closure = Typedtree.create_alloc_mode_r mode_closure;
                 mode_arg;
                 mode_ret;
                 sort_arg;
@@ -6693,7 +6698,7 @@ and type_expect_
           let alloc_mode, record_mode =
             register_allocation ~loc expected_mode
           in
-          Some alloc_mode, record_mode
+          Some (Typedtree.create_alloc_mode_r alloc_mode), record_mode
         else
           None, expected_mode
       in
@@ -7478,6 +7483,7 @@ and type_expect_
               let arg =
                 type_argument ~overwrite:No_overwrite env argument_mode sarg ty ty0
               in
+              let alloc_mode = Typedtree.create_alloc_mode_r alloc_mode in
               re { exp_desc = Texp_variant(l, Some (arg, alloc_mode));
                    exp_loc = loc; exp_extra = [];
                    exp_type = ty_expected0;
@@ -7499,7 +7505,7 @@ and type_expect_
             let arg =
               type_expect env argument_mode sarg (mk_expected ty_expected)
             in
-            Some (arg, alloc_mode)
+            Some (arg, Typedtree.create_alloc_mode_r alloc_mode)
         in
         let arg_type = Option.map (fun (arg, _) -> arg.exp_type) arg in
         let row =
@@ -7562,7 +7568,7 @@ and type_expect_
           let uu =
             unique_use ~loc ~env mode (as_single_mode argument_mode)
           in
-          Boxing (alloc_mode, uu)
+          Boxing (Typedtree.create_alloc_mode_r alloc_mode, uu)
         | false ->
           let mode = cross_left env ty_arg mode in
           submode ~loc ~env mode expected_mode;
@@ -7721,6 +7727,7 @@ and type_expect_
         | Immutable -> Immutable
       in
       let alloc_mode, array_mode = register_allocation ~loc expected_mode in
+      let alloc_mode = Typedtree.create_alloc_mode_r alloc_mode in
       let modalities = Typemode.mutable_modalities mutability in
       let is_contained_by : Mode.Hint.is_contained_by =
         {containing = Array Modality; container = (loc, Expression)}
@@ -8589,7 +8596,7 @@ and type_expect_
                   record_repres;
                   lid;
                   label;
-                  alloc_mode
+                  alloc_mode = Typedtree.create_alloc_mode_r alloc_mode
                 };
               exp_loc = loc;
               exp_extra = [];
@@ -8629,7 +8636,7 @@ and type_expect_
             Value.(of_const ~hint_comonadic:Stack_expression
               { Const.min with areality = Local })
             expected_mode;
-          Locality.submode_err (exp.exp_loc, Allocation)
+          Typedtree.alloc_mode_r_submode_err (exp.exp_loc, Allocation)
             (Locality.of_const ~hint:Stack_expression Local)
             alloc_mode
         end
@@ -9415,7 +9422,9 @@ and type_function
                       raise (Error(loc_fun, env, Uncurried_function_escapes e))
                   end;
                   More_args
-                    { partial_mode = Locality.disallow_right alloc_mode }
+                    { partial_mode =
+                        Typedtree.create_alloc_mode_l
+                          (Locality.disallow_right alloc_mode) }
               in
               pat, params_suffix, body, ret_info, newtypes, contains_gadt, curry
           end
@@ -9479,7 +9488,9 @@ and type_function
         Alloc.proj_comonadic Yielding (Alloc.disallow_right arg_mode)
       in
       let arg_mode =
-        Alloc.proj_comonadic Areality (Alloc.disallow_right arg_mode)
+        Alloc.disallow_right arg_mode
+        |> Alloc.proj_comonadic Areality
+        |> Typedtree.create_alloc_mode_l
       in
       let param =
         { has_poly;
@@ -9493,7 +9504,8 @@ and type_function
               fp_newtypes = newtypes;
               fp_sort = arg_sort;
               fp_mode =
-                { mode_annots with mode_modes = arg_mode };
+                { mode_annots with
+                  mode_modes = arg_mode };
               fp_curry = curry;
               fp_loc = pparam_loc;
             };
@@ -9963,7 +9975,7 @@ and type_option_some env expected_mode sarg ty ty0 =
   let sort = Jkind.Sort.scannable in
   let repres = Types.Constructor_uniform_value in
   mkexp (Texp_construct(mknoloc lid , csome, repres, [sort, arg],
-                        Some alloc_mode))
+                        Some (Typedtree.create_alloc_mode_r alloc_mode)))
     (type_option arg.exp_type) arg.exp_loc arg.exp_env
 
 (* [expected_mode] is the expected mode of the field. It's already adjusted for
@@ -10182,7 +10194,9 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
       let ret_sort = type_sort ~why:Function_result ty_res in
       let eta_pat, eta_var = var_pair ~mode:eta_mode "eta" ty_arg arg_sort in
       let fc_arg_mode =
-        Alloc.proj_comonadic Areality (Alloc.disallow_right marg)
+        Alloc.disallow_right marg
+        |> Alloc.proj_comonadic Areality
+        |> Typedtree.create_alloc_mode_l
       in
       let fc_ret_mode =
         Alloc.proj_comonadic Areality (Alloc.disallow_right mret)
@@ -10223,7 +10237,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
                 { mode_modes = fc_ret_mode;
                   mode_desc = [] };
               ret_sort;
-              alloc_mode;
+              alloc_mode = Typedtree.create_alloc_mode_r alloc_mode;
               yielding = Yielding.disallow_right Yielding.yielding;
               zero_alloc = Zero_alloc.default
             }
@@ -10535,7 +10549,8 @@ and type_tuple ~overwrite ~loc ~env ~(expected_mode : expected_mode) ~ty_expecte
       sexpl types_and_modes overwrites
   in
   re {
-    exp_desc = Texp_tuple (expl, alloc_mode);
+    exp_desc =
+      Texp_tuple (expl, Typedtree.create_alloc_mode_r alloc_mode);
     exp_loc = loc; exp_extra = [];
     (* Keep sharing *)
     exp_type = newty (Ttuple (List.map (fun (label, e) -> label, e.exp_type) expl));
@@ -10725,7 +10740,7 @@ and type_construct ~overwrite ~sexp env (expected_mode : expected_mode) lid sarg
        let alloc_mode, argument_mode =
          register_allocation ~loc:sexp.pexp_loc expected_mode
        in
-       argument_mode, Some alloc_mode
+       argument_mode, Some (Typedtree.create_alloc_mode_r alloc_mode)
   in
   begin match overwrite, constr.cstr_repr with
   | Overwriting(_, _, _), Variant_unboxed ->
@@ -11214,6 +11229,7 @@ and type_function_cases_expect
     unify_exp_types loc env ty_fun (instance ty_expected);
     let fc_arg_mode =
       Alloc.proj_comonadic Areality (Alloc.disallow_right arg_mode)
+      |> Typedtree.create_alloc_mode_l
     in
     let yielding_mode =
       Alloc.proj_comonadic Yielding (Alloc.disallow_right arg_mode)
@@ -11918,7 +11934,8 @@ and type_n_ary_function
           Texp_function
             { params; body; ret_sort;
               alloc_mode =
-                Locality.disallow_left fun_alloc_mode.alloc_mode;
+                Typedtree.create_alloc_mode_r
+                  (Locality.disallow_left fun_alloc_mode.alloc_mode);
               ret_mode; yielding;
               zero_alloc
             };

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -816,17 +816,18 @@ let dynamic_pat_mode pat_mode =
   in
   {pat_mode with mode}
 
-let allocations : Alloc.r list ref = Local_store.s_ref []
+let allocations : Typedtree.alloc_mode_r list ref = Local_store.s_ref []
 
 let reset_allocations () = allocations := []
 
 let register_allocation_mode alloc_mode =
-  let alloc_mode = Alloc.disallow_left alloc_mode in
   allocations := alloc_mode :: !allocations
 
 let register_allocation_value_mode ~loc
     ?(desc  = (Unknown : Mode.Hint.allocation_desc)) mode =
-  let alloc_mode = value_to_alloc_r2g mode in
+  let alloc_mode =
+    Alloc.proj_comonadic Areality (value_to_alloc_r2g mode)
+  in
   register_allocation_mode alloc_mode;
   (* We must apply each morphism separately so that their hints correspond to
      the correct morphism *)
@@ -842,16 +843,18 @@ let register_allocation_value_mode ~loc
    parameter function needs to be made global if its partial application
    to one argument must be global. As a result, a function gets an
    [Alloc.lr] allocation mode that can be further constrained. *)
-let register_closure_allocation (mode : Value.r) ~loc : Alloc.lr * Value.r =
+let register_closure_allocation (mode : Value.r) ~loc
+  : Locality.lr * Alloc.lr * Value.r =
   let allocation : Hint.allocation = {loc; txt = Unknown} in
-  let (alloc_mode : Alloc.lr), _ =
+  let (mode : Alloc.lr), _ =
     Alloc.newvar_below (value_to_alloc_r2g ~allocation mode)
   in
-  register_allocation_mode (Alloc.disallow_left alloc_mode);
+  let alloc_mode = Alloc.proj_comonadic Areality mode in
   let closed_over_mode =
-    alloc_as_value ~allocation (Alloc.disallow_left alloc_mode)
+    alloc_as_value ~allocation (Alloc.disallow_left mode)
   in
-  alloc_mode, closed_over_mode
+  register_allocation_mode (Locality.disallow_left alloc_mode);
+  alloc_mode, mode, closed_over_mode
 
 (** Register as allocation the expression constrained by the given
     [expected_mode]. Returns the mode of the allocation, and the expected mode
@@ -871,7 +874,7 @@ let optimise_allocations () =
   - Add it back when middle-end can really utilize this information. *)
   List.iter
     (fun mode ->
-      Locality.zap_to_ceil (Alloc.proj_comonadic Areality mode)
+      Locality.zap_to_ceil mode
       |> ignore)
     !allocations;
   reset_allocations ()
@@ -5135,21 +5138,32 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
              let open_args = [] in
              let mode_closed_args = List.map Alloc.close_over closed_args in
              let mode_partial_fun = Alloc.partial_apply mode_fun in
-             let mode_closure, _ =
+             let mode_cls, _ =
                Alloc.newvar_above (Alloc.join
                 (mode_partial_fun:: mode_closed_args))
+             in
+             let mode_closure =
+               Alloc.proj_comonadic Areality (Alloc.disallow_left mode_cls)
+             in
+             let mode_arg =
+               Alloc.proj_comonadic Areality (Alloc.disallow_right mode_arg)
+             in
+             let mode_ret =
+               Alloc.disallow_right mode_ret
+               |> Alloc.proj_comonadic Areality
+               |> Typedtree.create_return_mode
              in
              register_allocation_mode mode_closure;
              let arg =
               Omitted {
-                mode_closure = Alloc.disallow_left mode_closure;
-                mode_arg = Alloc.disallow_right mode_arg;
-                mode_ret = Alloc.disallow_right mode_ret;
+                mode_closure;
+                mode_arg;
+                mode_ret;
                 sort_arg;
                 sort_ret }
              in
              let args = (lbl, arg, None) :: args in
-             (ty_ret, mode_closure, open_args, closed_args, args))
+             (ty_ret, mode_cls, open_args, closed_args, args))
       (ty_ret, mode_ret, [], [], []) (List.rev args)
   in
   ty_ret, mode_ret, args
@@ -6232,10 +6246,14 @@ type split_function_ty =
       *)
     expected_pat_mode: expected_pat_mode;
     expected_inner_mode: expected_mode;
-    (* [alloc_mode] is the mode of [fun x_i ... x_n -> e].
-       This needs to be a left mode for the construction of the [fp_curry] field
-       of the outer function. *)
-    alloc_mode: Mode.Alloc.lr;
+    (* [closure_mode] is the mode of [fun x_i ... x_n -> e].
+       This needs to be a left mode for making sure that nested
+       closures have a mode greater than outer closures, and it
+       needs to be a right mode for making sure
+       arguments generate a lower bound for subsequent closures.
+       [alloc_mode] tracks the locality component to store in the Typedtree. *)
+    closure_mode: Mode.Alloc.lr;
+    alloc_mode: Locality.lr;
     really_poly: bool
   }
 
@@ -6257,12 +6275,12 @@ let split_function_ty
     env (expected_mode : expected_mode) ty_expected loc ~arg_label ~has_poly
     ~mode_annots ~ret_mode_annots ~in_function ~is_first_val_param ~is_final_val_param
   =
-  let alloc_mode, closed_over_mode =
+  let alloc_mode, closure_mode, closed_over_mode =
     register_closure_allocation ~loc (as_single_mode expected_mode)
   in
   if expected_mode.strictly_local then
     Locality.submode_exn ~pp:(loc, Function) Locality.local
-      (Alloc.proj_comonadic Areality alloc_mode);
+      (Alloc.proj_comonadic Areality closure_mode);
   let { ty = ty_fun; explanation }, loc_fun = in_function in
   let separate = !Clflags.principal || Env.has_local_constraints env in
   let { ty_arg; ty_ret; arg_mode; ret_mode } as filtered_arrow =
@@ -6336,14 +6354,20 @@ let split_function_ty
   let ret_sort = type_sort ~why:Function_result ty_ret in
   env,
   { filtered_arrow; arg_sort; ret_sort;
-    alloc_mode; ty_arg_mono;
+    alloc_mode; closure_mode; ty_arg_mono;
     expected_inner_mode; expected_pat_mode;
     really_poly
   }
 
 type type_function_result_param =
   { param : function_param;
+    param_yielding : Mode.Yielding.l;
     has_poly : bool;
+  }
+
+type fun_alloc_mode =
+  { alloc_mode: Locality.lr;
+    fun_closure_mode: Mode.Alloc.lr;
   }
 
 (* The result of calling [type_function]. For the outer call to
@@ -6364,7 +6388,7 @@ type type_function_result =
        be a left mode for the construction of the [fp_curry] field of the outer
        function.
     *)
-    fun_alloc_mode: Mode.Alloc.lr option;
+    fun_alloc_mode: fun_alloc_mode option;
     (* Information about the return of the function. None only for
        recursive calls to [type_function] when there are no parameters
        left.
@@ -6377,6 +6401,7 @@ and type_function_ret_info =
     ret_mode: Mode.Alloc.l modes;
     (* The sort returned by the function. *)
     ret_sort: Jkind.sort;
+    cases_arg_yielding: Mode.Yielding.l option;
   }
 
 (* value binding elaboration *)
@@ -7298,7 +7323,8 @@ and type_expect_
       in
       let args = List.map (fun (lbl, arg, _) -> (lbl, arg)) args in
       let exp = rue {
-        exp_desc = Texp_apply(funct, args, pm.apply_position, ap_mode,
+        exp_desc = Texp_apply(funct, args, pm.apply_position,
+                              Typedtree.create_return_mode ap_mode,
                               ap_yielding, zero_alloc);
         exp_loc = loc; exp_extra;
         exp_type = ty_ret;
@@ -8603,11 +8629,9 @@ and type_expect_
             Value.(of_const ~hint_comonadic:Stack_expression
               { Const.min with areality = Local })
             expected_mode;
-          let local =
-            Alloc.(of_const ~hint_comonadic:Stack_expression
-              { Const.min with areality = Local })
-          in
-          Alloc.submode_err (exp.exp_loc, Allocation) local alloc_mode
+          Locality.submode_err (exp.exp_loc, Allocation)
+            (Locality.of_const ~hint:Stack_expression Local)
+            alloc_mode
         end
       | Texp_list_comprehension _ -> always_heap List_comprehension
       | Texp_array_comprehension _ -> always_heap Array_comprehension
@@ -9139,7 +9163,8 @@ and type_ident env ?(recarg=Rejected) lid =
        (* if the locality of returned value of the primitive is poly
           we then register allocation for further optimization *)
        | (Prim_poly, _), Some mode ->
-           register_allocation_mode (Alloc.max_with_comonadic Areality mode)
+           let mode = Locality.disallow_left mode in
+           register_allocation_mode mode
        | _ -> ()
        end;
        let yielding =
@@ -9284,7 +9309,7 @@ and type_function
           { filtered_arrow = { ty_arg; arg_mode; ty_ret; ret_mode };
             arg_sort; ret_sort;
             ty_arg_mono; expected_pat_mode; expected_inner_mode;
-            alloc_mode; really_poly
+            alloc_mode; closure_mode; really_poly
           } =
         split_function_ty env expected_mode ty_expected loc
           ~is_first_val_param:first ~is_final_val_param
@@ -9366,7 +9391,7 @@ and type_function
                 | None ->
                   assert(is_final_val_param);
                   Final_arg
-                | Some fun_alloc_mode ->
+                | Some { fun_closure_mode; alloc_mode } ->
                   assert(not is_final_val_param);
                   (* Handle mode crossing of [arg_mode]. Note that [close_over]
                      uses the [arg_mode.comonadic] as a left mode, and
@@ -9374,20 +9399,23 @@ and type_function
                      mode-crossed differently. *)
                   let arg_mode = alloc_mode_cross_to_max_min env ty_arg arg_mode in
                   begin match
-                    Alloc.submode (Alloc.close_over arg_mode) fun_alloc_mode
+                    Alloc.submode (Alloc.close_over arg_mode) fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
                       raise (Error(loc_fun, env, Uncurried_function_escapes e))
                   end;
                   begin match
-                    Alloc.submode (Alloc.partial_apply alloc_mode) fun_alloc_mode
+                    Alloc.submode
+                      (Alloc.partial_apply closure_mode)
+                      fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
                       raise (Error(loc_fun, env, Uncurried_function_escapes e))
                   end;
-                  More_args {partial_mode = Alloc.disallow_right fun_alloc_mode}
+                  More_args
+                    { partial_mode = Locality.disallow_right alloc_mode }
               in
               pat, params_suffix, body, ret_info, newtypes, contains_gadt, curry
           end
@@ -9447,8 +9475,15 @@ and type_function
             param,
             param_uid
       in
+      let param_yielding =
+        Alloc.proj_comonadic Yielding (Alloc.disallow_right arg_mode)
+      in
+      let arg_mode =
+        Alloc.proj_comonadic Areality (Alloc.disallow_right arg_mode)
+      in
       let param =
         { has_poly;
+          param_yielding;
           param =
             { fp_kind;
               fp_arg_label = typed_arg_label;
@@ -9458,7 +9493,7 @@ and type_function
               fp_newtypes = newtypes;
               fp_sort = arg_sort;
               fp_mode =
-                { mode_annots with mode_modes = Alloc.disallow_right arg_mode };
+                { mode_annots with mode_modes = arg_mode };
               fp_curry = curry;
               fp_loc = pparam_loc;
             };
@@ -9471,11 +9506,15 @@ and type_function
           let ret_mode =
             {ret_mode_annots with mode_modes = Alloc.disallow_right ret_mode }
           in
-          Some { ret_sort ; ret_mode }
+          Some { ret_sort ; ret_mode; cases_arg_yielding = None }
+      in
+      let fun_alloc_mode =
+        { fun_closure_mode = closure_mode;
+          alloc_mode }
       in
       { function_ = exp_type, param :: params, body;
         newtypes = []; params_contain_gadt = contains_gadt;
-        ret_info; fun_alloc_mode = Some alloc_mode;
+        ret_info; fun_alloc_mode = Some fun_alloc_mode;
       }
   | [] ->
     let exp_type, body, fun_alloc_mode, ret_info =
@@ -10142,6 +10181,13 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
       let arg_sort = type_sort ~why:Function_argument ty_arg in
       let ret_sort = type_sort ~why:Function_result ty_res in
       let eta_pat, eta_var = var_pair ~mode:eta_mode "eta" ty_arg arg_sort in
+      let fc_arg_mode =
+        Alloc.proj_comonadic Areality (Alloc.disallow_right marg)
+      in
+      let fc_ret_mode =
+        Alloc.proj_comonadic Areality (Alloc.disallow_right mret)
+        |> Typedtree.create_return_mode
+      in
       (* CR layouts v10: When we add abstract jkinds, the eta expansion here
          becomes impossible in some cases - we'll need better errors.  For test
          cases, look toward the end of
@@ -10153,7 +10199,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
              (texp,
               args @ [Nolabel, Arg (eta_var, arg_sort)],
               Nontail,
-              Alloc.proj_comonadic Areality (Alloc.disallow_right mret),
+              fc_ret_mode,
               Yielding.disallow_right Yielding.yielding,
               None)}
         in
@@ -10170,11 +10216,12 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
                     fc_param_debug_uid = param_uid; fc_env = env;
                     fc_ret_type = ty_res; fc_loc = cases_loc;
                     fc_exp_extra = []; fc_attributes = [];
-                    fc_arg_mode = Alloc.disallow_right marg;
+                    fc_arg_mode;
                     fc_arg_sort = arg_sort;
                   };
               ret_mode =
-                { mode_modes = Alloc.disallow_right mret; mode_desc = [] };
+                { mode_modes = fc_ret_mode;
+                  mode_desc = [] };
               ret_sort;
               alloc_mode;
               yielding = Yielding.disallow_right Yielding.yielding;
@@ -11146,7 +11193,7 @@ and type_function_cases_expect
   Builtin_attributes.warning_scope attrs begin fun () ->
     let env,
         { filtered_arrow = { ty_arg; ty_ret; arg_mode; ret_mode };
-          arg_sort; ret_sort;
+          arg_sort; ret_sort; closure_mode;
           ty_arg_mono; expected_pat_mode; expected_inner_mode; alloc_mode;
         } =
       split_function_ty env expected_mode ty_expected loc ~arg_label:Nolabel
@@ -11165,6 +11212,12 @@ and type_function_cases_expect
            (Tarrow ((Nolabel, arg_mode, ret_mode), ty_arg, ty_ret, commu_ok)))
     in
     unify_exp_types loc env ty_fun (instance ty_expected);
+    let fc_arg_mode =
+      Alloc.proj_comonadic Areality (Alloc.disallow_right arg_mode)
+    in
+    let yielding_mode =
+      Alloc.proj_comonadic Yielding (Alloc.disallow_right arg_mode)
+    in
     let param , param_uid = name_cases "param" cases in
     let cases =
       { fc_cases = cases;
@@ -11176,14 +11229,19 @@ and type_function_cases_expect
         fc_env = env;
         fc_ret_type = ty_ret;
         fc_attributes = [];
-        fc_arg_mode = Alloc.disallow_right arg_mode;
+        fc_arg_mode;
         fc_arg_sort = arg_sort;
       }
     in
-    cases, ty_fun, alloc_mode,
+    let fun_alloc_mode =
+      { fun_closure_mode = closure_mode;
+        alloc_mode }
+    in
+    cases, ty_fun, fun_alloc_mode,
       { ret_sort;
         ret_mode =
-          {mode_modes = Alloc.disallow_right ret_mode; mode_desc = []} }
+          {mode_modes = Alloc.disallow_right ret_mode; mode_desc = []};
+        cases_arg_yielding = Some yielding_mode }
   end
 
 and type_effect_cases
@@ -11727,7 +11785,7 @@ and type_n_ary_function
       type_function env expected_mode ty_expected params constraint_ body
         ~in_function ~first:true
     in
-    let fun_alloc_mode, { ret_mode; ret_sort } =
+    let fun_alloc_mode, { ret_mode; ret_sort; cases_arg_yielding } =
       match fun_alloc_mode, ret_info with
       | Some x, Some y -> x, y
       | None, _ ->
@@ -11824,31 +11882,44 @@ and type_n_ary_function
       | (Check _ | Assume _ | Ignore_assert_all) ->
         Zero_alloc.create_const zero_alloc
     in
-    let alloc_mode = Mode.Alloc.disallow_left fun_alloc_mode in
+    let ret_mode_modes =
+      Alloc.proj_comonadic Areality ret_mode.mode_modes
+      |> Typedtree.create_return_mode
+    in
+    let ret_mode =
+      { ret_mode with
+        mode_modes = ret_mode_modes }
+    in
     (* [yielding] records whether *fully applying* this function can perform a
        free effect: the closure may yield if it closes over a yielding value
        (its own mode), or if any argument it is given is yielding (the
        parameter modes). [Value_rec_compiler]'s eta-expanding wrapper uses
        this, since the wrapper is exactly a full application. *)
-    let param_alloc_modes =
-      List.map (fun (p : function_param) -> p.fp_mode.mode_modes) params
+    let param_yieldings =
+      List.map
+        (fun (p : type_function_result_param) -> p.param_yielding)
+        result_params
     in
     (* A [function | ...] body takes an extra implicit parameter that is not in
        [params]; if that argument is yielding then the closure is yielding. *)
-    let param_alloc_modes =
-      match body with
-      | Tfunction_body _ -> param_alloc_modes
-      | Tfunction_cases fc -> fc.fc_arg_mode :: param_alloc_modes
+    let param_yieldings =
+      match cases_arg_yielding with
+      | None -> param_yieldings
+      | Some yielding -> yielding :: param_yieldings
     in
     let yielding =
-      Alloc.proj_comonadic Yielding
-        (Alloc.join (Alloc.disallow_right fun_alloc_mode :: param_alloc_modes))
+      Yielding.join
+        (Alloc.proj_comonadic Yielding
+           (Alloc.disallow_right fun_alloc_mode.fun_closure_mode)
+         :: param_yieldings)
     in
     re
       { exp_desc =
           Texp_function
             { params; body; ret_sort;
-              alloc_mode; ret_mode; yielding;
+              alloc_mode =
+                Locality.disallow_left fun_alloc_mode.alloc_mode;
+              ret_mode; yielding;
               zero_alloc
             };
         exp_loc = loc;

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -141,6 +141,8 @@ let alloc_mode_r_zap_to_ceil m = Mode.Locality.zap_to_ceil m
 
 let alloc_mode_r_submode_err pp m t = Mode.Locality.submode_err pp m t
 
+let alloc_mode_r_map f m = f m
+
 let print_alloc_mode_r ppf m =
   Format_doc.compat (Mode.Locality.print ()) ppf m
 
@@ -150,6 +152,8 @@ let create_alloc_mode_l m =
   assert (Mode.Locality.check_const_or_level_0 m); m
 
 let alloc_mode_l_zap_to_floor m = Mode.Locality.zap_to_floor m
+
+let alloc_mode_l_map f m = f m
 
 let print_alloc_mode_l ppf m =
   Format_doc.compat (Mode.Locality.print ()) ppf m

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -132,10 +132,21 @@ let print_unique_use ppf (u,l) =
     (Format_doc.compat (Mode.Uniqueness.print ())) u
     (Format_doc.compat (Mode.Linearity.print ())) l
 
-type alloc_mode = Mode.Alloc.r
+type alloc_mode_r = Mode.Locality.r
+
+type alloc_mode_l = Mode.Locality.l
+
+type return_mode = Mode.Locality.l
+
+let create_return_mode m = m
+
+let return_mode_zap_to_floor m = Mode.Locality.zap_to_floor m
+
+let print_return_mode ppf m =
+  Format_doc.compat (Mode.Locality.print ()) ppf m
 
 type texp_field_boxing =
-  | Boxing of alloc_mode * unique_use
+  | Boxing of alloc_mode_r * unique_use
   | Non_boxing of unique_use
 
 let aliased_many_use =
@@ -206,7 +217,7 @@ and 'k pattern_desc =
       sort: Jkind_types.Sort.t;
       mode: Mode.Value.l;
       lpoly: Lpoly.t;
-      env_alloc_mode: alloc_mode;
+      env_alloc_mode: alloc_mode_r;
     } -> value pattern_desc
   | Tpat_constant : constant -> value pattern_desc
   | Tpat_unboxed_unit : value pattern_desc
@@ -292,9 +303,9 @@ and expression_desc =
   | Texp_function of
       { params : function_param list;
         body : function_body;
-        ret_mode : Mode.Alloc.l modes;
+        ret_mode : return_mode modes;
         ret_sort : Jkind.sort;
-        alloc_mode : alloc_mode;
+        alloc_mode : alloc_mode_r;
         yielding : Mode.Yielding.l;
         zero_alloc : Zero_alloc.t;
       }
@@ -307,19 +318,20 @@ and expression_desc =
   | Texp_try of expression * value case list * value case list
   | Texp_unboxed_unit
   | Texp_unboxed_bool of bool
-  | Texp_tuple of (string option * expression) list * alloc_mode
+  | Texp_tuple of (string option * expression) list * alloc_mode_r
   | Texp_unboxed_tuple of (string option * expression * Jkind.sort) list
   | Texp_construct of
       Longident.t loc * constructor_description * constructor_representation *
-      (Jkind.sort * expression) list * alloc_mode option
-  | Texp_variant of label * (expression * alloc_mode) option
+      (Jkind.sort * expression) list
+      * alloc_mode_r option
+  | Texp_variant of label * (expression * alloc_mode_r) option
   | Texp_record of {
       fields :
         ( Data_types.label_description * Jkind.sort * record_label_definition )
           array;
       representation : Types.record_representation;
       extended_expression : (expression * Jkind.sort * Unique_barrier.t) option;
-      alloc_mode : alloc_mode option
+      alloc_mode : alloc_mode_r option
     }
   | Texp_record_unboxed_product of {
       fields :
@@ -334,7 +346,7 @@ and expression_desc =
       record_repres : Types.record_representation;
       lid : Longident.t loc;
       label : Data_types.label_description;
-      alloc_mode : alloc_mode;
+      alloc_mode : alloc_mode_r;
     }
   | Texp_field of {
       record : expression;
@@ -363,7 +375,7 @@ and expression_desc =
       label : Data_types.label_description;
       newval : expression;
     }
-  | Texp_array of mutability * Jkind.Sort.t * expression list * alloc_mode
+  | Texp_array of mutability * Jkind.Sort.t * expression list * alloc_mode_r
   | Texp_idx of block_access * unboxed_access list
   | Texp_list_comprehension of comprehension
   | Texp_array_comprehension of mutability * Jkind.sort * comprehension
@@ -478,7 +490,7 @@ and 'k case =
     }
 
 and function_curry =
-  | More_args of { partial_mode : Mode.Alloc.l }
+  | More_args of { partial_mode : alloc_mode_l }
   | Final_arg
 
 and function_param =
@@ -489,7 +501,7 @@ and function_param =
     fp_partial: partial;
     fp_kind: function_param_kind;
     fp_sort: Jkind.sort;
-    fp_mode: Mode.Alloc.l modes;
+    fp_mode: alloc_mode_l modes;
     fp_curry: function_curry;
     fp_newtypes: (Ident.t * string loc *
                   Parsetree.jkind_annotation option * Uid.t) list;
@@ -507,7 +519,7 @@ and function_body =
 and function_cases =
   { fc_cases: value case list;
     fc_env : Env.t;
-    fc_arg_mode: Mode.Alloc.l;
+    fc_arg_mode: alloc_mode_l;
     fc_arg_sort: Jkind.sort;
     fc_ret_type : Types.type_expr;
     fc_partial: partial;
@@ -539,9 +551,9 @@ and ('a, 'b) arg_or_omitted =
   | Omitted of 'b
 
 and omitted_parameter =
-  { mode_closure : Mode.Alloc.r;
-    mode_arg : Mode.Alloc.l;
-    mode_ret : Mode.Alloc.l;
+  { mode_closure : alloc_mode_r;
+    mode_arg : alloc_mode_l;
+    mode_ret : return_mode;
     sort_arg : Jkind.sort;
     sort_ret : Jkind.sort }
 

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -134,11 +134,30 @@ let print_unique_use ppf (u,l) =
 
 type alloc_mode_r = Mode.Locality.r
 
+let create_alloc_mode_r m =
+  assert (Mode.Locality.check_const_or_level_0 m); m
+
+let alloc_mode_r_zap_to_ceil m = Mode.Locality.zap_to_ceil m
+
+let alloc_mode_r_submode_err pp m t = Mode.Locality.submode_err pp m t
+
+let print_alloc_mode_r ppf m =
+  Format_doc.compat (Mode.Locality.print ()) ppf m
+
 type alloc_mode_l = Mode.Locality.l
+
+let create_alloc_mode_l m =
+  assert (Mode.Locality.check_const_or_level_0 m); m
+
+let alloc_mode_l_zap_to_floor m = Mode.Locality.zap_to_floor m
+
+let print_alloc_mode_l ppf m =
+  Format_doc.compat (Mode.Locality.print ()) ppf m
 
 type return_mode = Mode.Locality.l
 
-let create_return_mode m = m
+let create_return_mode m =
+  assert (Mode.Locality.check_const_or_level_0 m); m
 
 let return_mode_zap_to_floor m = Mode.Locality.zap_to_floor m
 

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -132,10 +132,21 @@ let print_unique_use ppf (u,l) =
     (Format_doc.compat (Mode.Uniqueness.print ())) u
     (Format_doc.compat (Mode.Linearity.print ())) l
 
-type alloc_mode = Mode.Alloc.r
+type alloc_mode_r = Mode.Locality.r
+
+type alloc_mode_l = Mode.Locality.l
+
+type return_mode = Mode.Locality.l
+
+let create_return_mode m = m
+
+let return_mode_zap_to_floor m = Mode.Locality.zap_to_floor m
+
+let print_return_mode ppf m =
+  Format_doc.compat (Mode.Locality.print ()) ppf m
 
 type texp_field_boxing =
-  | Boxing of alloc_mode * unique_use
+  | Boxing of alloc_mode_r * unique_use
   | Non_boxing of unique_use
 
 let aliased_many_use =
@@ -202,7 +213,7 @@ and 'k pattern_desc =
       sort: Jkind_types.Sort.t;
       mode: Mode.Value.l;
       lpoly: Lpoly.t;
-      env_alloc_mode: alloc_mode;
+      env_alloc_mode: alloc_mode_r;
     } -> value pattern_desc
   | Tpat_constant : constant -> value pattern_desc
   | Tpat_unboxed_unit : value pattern_desc
@@ -287,9 +298,9 @@ and expression_desc =
   | Texp_function of
       { params : function_param list;
         body : function_body;
-        ret_mode : Mode.Alloc.l modes;
+        ret_mode : return_mode modes;
         ret_sort : Jkind.sort;
-        alloc_mode : alloc_mode;
+        alloc_mode : alloc_mode_r;
         yielding : Mode.Yielding.l;
         zero_alloc : Zero_alloc.t;
       }
@@ -302,19 +313,20 @@ and expression_desc =
   | Texp_try of expression * value case list * value case list
   | Texp_unboxed_unit
   | Texp_unboxed_bool of bool
-  | Texp_tuple of (string option * expression) list * alloc_mode
+  | Texp_tuple of (string option * expression) list * alloc_mode_r
   | Texp_unboxed_tuple of (string option * expression * Jkind.sort) list
   | Texp_construct of
       Longident.t loc * constructor_description * constructor_representation *
-      (Jkind.sort * expression) list * alloc_mode option
-  | Texp_variant of label * (expression * alloc_mode) option
+      (Jkind.sort * expression) list
+      * alloc_mode_r option
+  | Texp_variant of label * (expression * alloc_mode_r) option
   | Texp_record of {
       fields :
         ( Data_types.label_description * Jkind.sort * record_label_definition )
           array;
       representation : Types.record_representation;
       extended_expression : (expression * Jkind.sort * Unique_barrier.t) option;
-      alloc_mode : alloc_mode option
+      alloc_mode : alloc_mode_r option
     }
   | Texp_record_unboxed_product of {
       fields :
@@ -329,7 +341,7 @@ and expression_desc =
       record_repres : Types.record_representation;
       lid : Longident.t loc;
       label : Data_types.label_description;
-      alloc_mode : alloc_mode;
+      alloc_mode : alloc_mode_r;
     }
   | Texp_field of {
       record : expression;
@@ -356,7 +368,7 @@ and expression_desc =
       label : Data_types.label_description;
       newval : expression;
     }
-  | Texp_array of mutability * Jkind.Sort.t * expression list * alloc_mode
+  | Texp_array of mutability * Jkind.Sort.t * expression list * alloc_mode_r
   | Texp_idx of block_access * unboxed_access list
   | Texp_list_comprehension of comprehension
   | Texp_array_comprehension of mutability * Jkind.sort * comprehension
@@ -472,7 +484,7 @@ and 'k case =
     }
 
 and function_curry =
-  | More_args of { partial_mode : Mode.Alloc.l }
+  | More_args of { partial_mode : alloc_mode_l }
   | Final_arg
 
 and function_param =
@@ -483,7 +495,7 @@ and function_param =
     fp_partial: partial;
     fp_kind: function_param_kind;
     fp_sort: Jkind.sort;
-    fp_mode: Mode.Alloc.l modes;
+    fp_mode: alloc_mode_l modes;
     fp_curry: function_curry;
     fp_newtypes: (Ident.t * string loc *
                   Parsetree.jkind_annotation option * Uid.t) list;
@@ -501,7 +513,7 @@ and function_body =
 and function_cases =
   { fc_cases: value case list;
     fc_env : Env.t;
-    fc_arg_mode: Mode.Alloc.l;
+    fc_arg_mode: alloc_mode_l;
     fc_arg_sort: Jkind.sort;
     fc_ret_type : Types.type_expr;
     fc_partial: partial;
@@ -533,9 +545,9 @@ and ('a, 'b) arg_or_omitted =
   | Omitted of 'b
 
 and omitted_parameter =
-  { mode_closure : Mode.Alloc.r;
-    mode_arg : Mode.Alloc.l;
-    mode_ret : Mode.Alloc.l;
+  { mode_closure : alloc_mode_r;
+    mode_arg : alloc_mode_l;
+    mode_ret : return_mode;
     sort_arg : Jkind.sort;
     sort_ret : Jkind.sort }
 

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -520,8 +520,9 @@ and expression_desc =
       { params : function_param list;
         body : function_body;
         ret_mode : return_mode modes;
-        (* Mode where the function allocates, ie local for a function of
-           type 'a -> local_ 'b, and heap for a function of type 'a -> 'b *)
+        (* Whether the function may return a value allocated in its caller's
+           region: [local] for ['a -> 'b @ local], [global] for ['a -> 'b].
+           Becomes [Lambda.return_mode] via [Translmode.transl_ret_mode]. *)
         ret_sort : Jkind.sort;
         alloc_mode : alloc_mode_r;
         (* Mode at which the closure is allocated *)

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -113,7 +113,17 @@ type unique_use = Mode.Uniqueness.r * Mode.Linearity.l
 
 val print_unique_use : Format.formatter -> unique_use -> unit
 
-type alloc_mode = Mode.Alloc.r
+type alloc_mode_r = Mode.Locality.r
+
+type alloc_mode_l = Mode.Locality.l
+
+type return_mode
+
+val create_return_mode : Mode.Locality.l -> return_mode
+
+val return_mode_zap_to_floor : return_mode -> Mode.Locality.Const.t
+
+val print_return_mode : Format.formatter -> return_mode -> unit
 
 (* CR-someday liam923: We'd like to split this into an arrow_modes and
    value_modes type. *)
@@ -128,7 +138,7 @@ type modalities = Typemode.modalities =
   }
 
 type texp_field_boxing =
-  | Boxing of alloc_mode * unique_use
+  | Boxing of alloc_mode_r * unique_use
   (** Projection requires boxing. [unique_use] describes the usage of the
       unboxed field as argument to boxing. *)
   | Non_boxing of unique_use
@@ -248,7 +258,7 @@ and 'k pattern_desc =
       the allocation mode of the captured environment. [pending] during
       type-checking; guaranteed [determined] of a non-empty list of generic sort
       variables after [type_let] returns. *)
-      env_alloc_mode: alloc_mode;
+      env_alloc_mode: alloc_mode_r;
       (** The allocation mode of the environment captured by the layout
       function.
 
@@ -482,11 +492,11 @@ and expression_desc =
   | Texp_function of
       { params : function_param list;
         body : function_body;
-        ret_mode : Mode.Alloc.l modes;
+        ret_mode : return_mode modes;
         (* Mode where the function allocates, ie local for a function of
            type 'a -> local_ 'b, and heap for a function of type 'a -> 'b *)
         ret_sort : Jkind.sort;
-        alloc_mode : alloc_mode;
+        alloc_mode : alloc_mode_r;
         (* Mode at which the closure is allocated *)
         yielding : Mode.Yielding.l;
         (* Whether fully applying this function can perform a free effect. This
@@ -505,7 +515,7 @@ and expression_desc =
       *)
   | Texp_apply of
       expression * (arg_label * apply_arg) list * apply_position *
-        Mode.Locality.l * Mode.Yielding.l * Zero_alloc.assume option
+        return_mode * Mode.Yielding.l * Zero_alloc.assume option
         (** E0 ~l1:E1 ... ~ln:En
 
             The expression can be Omitted if the expression is abstracted over
@@ -549,7 +559,7 @@ and expression_desc =
         (** #() *)
   | Texp_unboxed_bool of bool
         (** #false, #true *)
-  | Texp_tuple of (string option * expression) list * alloc_mode
+  | Texp_tuple of (string option * expression) list * alloc_mode_r
         (** [Texp_tuple(el)] represents
             - [(E1, ..., En)]
                 when [el] is [(None, E1);...;(None, En)],
@@ -570,7 +580,7 @@ and expression_desc =
   | Texp_construct of
       Longident.t loc * Data_types.constructor_description *
       Types.constructor_representation * (Jkind.sort * expression) list *
-      alloc_mode option
+      alloc_mode_r option
         (** C                []
             C E              [E]
             C (E1, ..., En)  [E1;...;En]
@@ -579,7 +589,7 @@ and expression_desc =
             or [None] if the constructor is [Cstr_unboxed] or [Cstr_constant],
             in which case it does not need allocation.
          *)
-  | Texp_variant of label * (expression * alloc_mode) option
+  | Texp_variant of label * (expression * alloc_mode_r) option
         (** [alloc_mode] is the allocation mode of the variant,
             or [None] if the variant has no argument,
             in which case it does not need allocation.
@@ -590,7 +600,7 @@ and expression_desc =
           array;
       representation : Types.record_representation;
       extended_expression : (expression * Jkind.sort * Unique_barrier.t) option;
-      alloc_mode : alloc_mode option
+      alloc_mode : alloc_mode_r option
     }
         (** { l1=P1; ...; ln=Pn }           (extended_expression = None)
             { E0 with l1=P1; ...; ln=Pn }   (extended_expression = Some E0)
@@ -629,7 +639,7 @@ and expression_desc =
       record_repres : Types.record_representation;
       lid : Longident.t loc;
       label : Data_types.label_description;
-      alloc_mode : alloc_mode;
+      alloc_mode : alloc_mode_r;
     }
   | Texp_field of {
       record : expression;
@@ -661,7 +671,8 @@ and expression_desc =
       newval : expression;
     }
     (** [alloc_mode] translates to the [modify_mode] of the record *)
-  | Texp_array of Types.mutability * Jkind.Sort.t * expression list * alloc_mode
+  | Texp_array of
+      Types.mutability * Jkind.Sort.t * expression list * alloc_mode_r
   | Texp_idx of block_access * unboxed_access list
   | Texp_list_comprehension of comprehension
   (* CR layouts-scannable: The sort here is no longer used. Instead, a layout is
@@ -734,7 +745,7 @@ and meth =
   | Tmeth_ancestor of Ident.t * Path.t
 
 and function_curry =
-  | More_args of { partial_mode : Mode.Alloc.l }
+  | More_args of { partial_mode : alloc_mode_l }
   | Final_arg
 
 and 'k case =
@@ -761,7 +772,7 @@ and function_param =
     *)
     fp_kind: function_param_kind;
     fp_sort: Jkind.sort;
-    fp_mode: Mode.Alloc.l modes;
+    fp_mode: alloc_mode_l modes;
     fp_curry: function_curry;
     fp_newtypes: (Ident.t * string loc *
                   Parsetree.jkind_annotation option * Uid.t) list;
@@ -802,7 +813,7 @@ and function_cases =
     (** [fc_env] contains entries from all parameters except
         for the last one being matched by the cases.
     *)
-    fc_arg_mode: Mode.Alloc.l;
+    fc_arg_mode: alloc_mode_l;
     fc_arg_sort: Jkind.sort;
     fc_ret_type : Types.type_expr;
     fc_partial: partial;
@@ -895,9 +906,9 @@ and ('a, 'b) arg_or_omitted =
 and apply_arg = (expression * Jkind.sort, omitted_parameter) arg_or_omitted
 
 and omitted_parameter =
-  { mode_closure : Mode.Alloc.r;
-    mode_arg : Mode.Alloc.l;
-    mode_ret : Mode.Alloc.l;
+  { mode_closure : alloc_mode_r;
+    mode_arg : alloc_mode_l;
+    mode_ret : return_mode;
     sort_arg : Jkind.sort;
     sort_ret : Jkind.sort }
 

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -508,8 +508,9 @@ and expression_desc =
       { params : function_param list;
         body : function_body;
         ret_mode : return_mode modes;
-        (* Mode where the function allocates, ie local for a function of
-           type 'a -> local_ 'b, and heap for a function of type 'a -> 'b *)
+        (* Whether the function may return a value allocated in its caller's
+           region: [local] for ['a -> 'b @ local], [global] for ['a -> 'b].
+           Becomes [Lambda.return_mode] via [Translmode.transl_ret_mode]. *)
         ret_sort : Jkind.sort;
         alloc_mode : alloc_mode_r;
         (* Mode at which the closure is allocated *)

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -113,9 +113,24 @@ type unique_use = Mode.Uniqueness.r * Mode.Linearity.l
 
 val print_unique_use : Format.formatter -> unique_use -> unit
 
-type alloc_mode_r = Mode.Locality.r
+type alloc_mode_r
 
-type alloc_mode_l = Mode.Locality.l
+val create_alloc_mode_r : Mode.Locality.r -> alloc_mode_r
+
+val alloc_mode_r_zap_to_ceil : alloc_mode_r -> Mode.Locality.Const.t
+
+val alloc_mode_r_submode_err :
+  Mode.Hint.pinpoint -> Mode.Locality.l -> alloc_mode_r -> unit
+
+val print_alloc_mode_r : Format.formatter -> alloc_mode_r -> unit
+
+type alloc_mode_l
+
+val create_alloc_mode_l : Mode.Locality.l -> alloc_mode_l
+
+val alloc_mode_l_zap_to_floor : alloc_mode_l -> Mode.Locality.Const.t
+
+val print_alloc_mode_l : Format.formatter -> alloc_mode_l -> unit
 
 type return_mode
 

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -122,6 +122,8 @@ val alloc_mode_r_zap_to_ceil : alloc_mode_r -> Mode.Locality.Const.t
 val alloc_mode_r_submode_err :
   Mode.Hint.pinpoint -> Mode.Locality.l -> alloc_mode_r -> unit
 
+val alloc_mode_r_map : (Mode.Locality.r -> 'a) -> alloc_mode_r -> 'a
+
 val print_alloc_mode_r : Format.formatter -> alloc_mode_r -> unit
 
 type alloc_mode_l
@@ -129,6 +131,8 @@ type alloc_mode_l
 val create_alloc_mode_l : Mode.Locality.l -> alloc_mode_l
 
 val alloc_mode_l_zap_to_floor : alloc_mode_l -> Mode.Locality.Const.t
+
+val alloc_mode_l_map : (Mode.Locality.l -> 'a) -> alloc_mode_l -> 'a
 
 val print_alloc_mode_l : Format.formatter -> alloc_mode_l -> unit
 

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -113,7 +113,17 @@ type unique_use = Mode.Uniqueness.r * Mode.Linearity.l
 
 val print_unique_use : Format.formatter -> unique_use -> unit
 
-type alloc_mode = Mode.Alloc.r
+type alloc_mode_r = Mode.Locality.r
+
+type alloc_mode_l = Mode.Locality.l
+
+type return_mode
+
+val create_return_mode : Mode.Locality.l -> return_mode
+
+val return_mode_zap_to_floor : return_mode -> Mode.Locality.Const.t
+
+val print_return_mode : Format.formatter -> return_mode -> unit
 
 (* CR-someday liam923: We'd like to split this into an arrow_modes and
    value_modes type. *)
@@ -128,7 +138,7 @@ type modalities = Typemode.modalities =
   }
 
 type texp_field_boxing =
-  | Boxing of alloc_mode * unique_use
+  | Boxing of alloc_mode_r * unique_use
   (** Projection requires boxing. [unique_use] describes the usage of the
       unboxed field as argument to boxing. *)
   | Non_boxing of unique_use
@@ -259,7 +269,7 @@ and 'k pattern_desc =
       the allocation mode of the captured environment. [pending] during
       type-checking; guaranteed [determined] of a non-empty list of generic sort
       variables after [type_let] returns. *)
-      env_alloc_mode: alloc_mode;
+      env_alloc_mode: alloc_mode_r;
       (** The allocation mode of the environment captured by the layout
       function.
 
@@ -494,11 +504,11 @@ and expression_desc =
   | Texp_function of
       { params : function_param list;
         body : function_body;
-        ret_mode : Mode.Alloc.l modes;
+        ret_mode : return_mode modes;
         (* Mode where the function allocates, ie local for a function of
            type 'a -> local_ 'b, and heap for a function of type 'a -> 'b *)
         ret_sort : Jkind.sort;
-        alloc_mode : alloc_mode;
+        alloc_mode : alloc_mode_r;
         (* Mode at which the closure is allocated *)
         yielding : Mode.Yielding.l;
         (* Whether fully applying this function can perform a free effect. This
@@ -517,7 +527,7 @@ and expression_desc =
       *)
   | Texp_apply of
       expression * (arg_label * apply_arg) list * apply_position *
-        Mode.Locality.l * Mode.Yielding.l * Zero_alloc.assume option
+        return_mode * Mode.Yielding.l * Zero_alloc.assume option
         (** E0 ~l1:E1 ... ~ln:En
 
             The expression can be Omitted if the expression is abstracted over
@@ -561,7 +571,7 @@ and expression_desc =
         (** #() *)
   | Texp_unboxed_bool of bool
         (** #false, #true *)
-  | Texp_tuple of (string option * expression) list * alloc_mode
+  | Texp_tuple of (string option * expression) list * alloc_mode_r
         (** [Texp_tuple(el)] represents
             - [(E1, ..., En)]
                 when [el] is [(None, E1);...;(None, En)],
@@ -582,7 +592,7 @@ and expression_desc =
   | Texp_construct of
       Longident.t loc * Data_types.constructor_description *
       Types.constructor_representation * (Jkind.sort * expression) list *
-      alloc_mode option
+      alloc_mode_r option
         (** C                []
             C E              [E]
             C (E1, ..., En)  [E1;...;En]
@@ -591,7 +601,7 @@ and expression_desc =
             or [None] if the constructor is [Cstr_unboxed] or [Cstr_constant],
             in which case it does not need allocation.
          *)
-  | Texp_variant of label * (expression * alloc_mode) option
+  | Texp_variant of label * (expression * alloc_mode_r) option
         (** [alloc_mode] is the allocation mode of the variant,
             or [None] if the variant has no argument,
             in which case it does not need allocation.
@@ -602,7 +612,7 @@ and expression_desc =
           array;
       representation : Types.record_representation;
       extended_expression : (expression * Jkind.sort * Unique_barrier.t) option;
-      alloc_mode : alloc_mode option
+      alloc_mode : alloc_mode_r option
     }
         (** { l1=P1; ...; ln=Pn }           (extended_expression = None)
             { E0 with l1=P1; ...; ln=Pn }   (extended_expression = Some E0)
@@ -641,7 +651,7 @@ and expression_desc =
       record_repres : Types.record_representation;
       lid : Longident.t loc;
       label : Data_types.label_description;
-      alloc_mode : alloc_mode;
+      alloc_mode : alloc_mode_r;
     }
   | Texp_field of {
       record : expression;
@@ -675,7 +685,8 @@ and expression_desc =
       newval : expression;
     }
     (** [alloc_mode] translates to the [modify_mode] of the record *)
-  | Texp_array of Types.mutability * Jkind.Sort.t * expression list * alloc_mode
+  | Texp_array of
+      Types.mutability * Jkind.Sort.t * expression list * alloc_mode_r
   | Texp_idx of block_access * unboxed_access list
   | Texp_list_comprehension of comprehension
   (* CR layouts-scannable: The sort here is no longer used. Instead, a layout is
@@ -748,7 +759,7 @@ and meth =
   | Tmeth_ancestor of Ident.t * Path.t
 
 and function_curry =
-  | More_args of { partial_mode : Mode.Alloc.l }
+  | More_args of { partial_mode : alloc_mode_l }
   | Final_arg
 
 and 'k case =
@@ -775,7 +786,7 @@ and function_param =
     *)
     fp_kind: function_param_kind;
     fp_sort: Jkind.sort;
-    fp_mode: Mode.Alloc.l modes;
+    fp_mode: alloc_mode_l modes;
     fp_curry: function_curry;
     fp_newtypes: (Ident.t * string loc *
                   Parsetree.jkind_annotation option * Uid.t) list;
@@ -816,7 +827,7 @@ and function_cases =
     (** [fc_env] contains entries from all parameters except
         for the last one being matched by the cases.
     *)
-    fc_arg_mode: Mode.Alloc.l;
+    fc_arg_mode: alloc_mode_l;
     fc_arg_sort: Jkind.sort;
     fc_ret_type : Types.type_expr;
     fc_partial: partial;
@@ -908,9 +919,9 @@ and ('a, 'b) arg_or_omitted =
 and apply_arg = (expression * Jkind.sort, omitted_parameter) arg_or_omitted
 
 and omitted_parameter =
-  { mode_closure : Mode.Alloc.r;
-    mode_arg : Mode.Alloc.l;
-    mode_ret : Mode.Alloc.l;
+  { mode_closure : alloc_mode_r;
+    mode_arg : alloc_mode_l;
+    mode_ret : return_mode;
     sort_arg : Jkind.sort;
     sort_ret : Jkind.sort }
 


### PR DESCRIPTION
Change the `alloc_mode` (both a left- and right- version) to be a `locality` mode in `Typedtree.ml`. This is necessary due to the zapping strategy in mode polymorphism:
1) Without generic mode variables, there were phases where all undecided but visible mode variables were zapped to legacy to decide their final mode.
2) We naturally do not want to zap any generic mode variables. However, a generic mode variable might now point to mode variables at level 0 that should no longer remain open. The mode polymorphism feature employs the following strategy: if a mode is reachable from generic mode variables, zap it to floor if it only appears as a lower bound, zap to ceil if it only appears as an upper bound, and zap it to legacy if it appears as both.
3) A mode typically found at level 0 is the various allocation modes that become part of a type tree.
4) One such allocation mode is the allocation of the curry-mode, which is necessary to determine the allocation of a partially applied function. 
5) However, curry modes appear both as lower bound and an upper bound (by nature of the curry mode!)
6) As a result, they currently get zapped to legacy (by default, a function with multiple arguments will impose a default `global` mode to the curried function)
7) Due to current technical limitations, it is difficult to maintain the various projection morphisms when zapping allocation modes to legacy.
8) As a result, the naive zapping strategy zaps the full allocation mode to legacy, thus breaking mode polymorphism entirely as soon as there is a curry mode. 
9) Instead, we choose to make the allocation mode a locality mode in the type tree.

Furthermore, this PR makes a distinction between the allocation mode and the return mode, so that we can easily identify the exact modes that flow to a `Lambda.return_mode`. `Typedtree.return_mode` is kept abstract to make this distinction explicit.

Invariant: all allocation modes and return modes bust be at level 0.